### PR TITLE
style(credential): apply rustfmt wrapping after oauth2 doc links fix

### DIFF
--- a/.project/context/crates/execution.md
+++ b/.project/context/crates/execution.md
@@ -24,4 +24,4 @@ Execution state machine types — persistent state, journals, idempotency, plans
 
 <!-- reviewed: 2026-04-14 — #247 added ExecutionTerminationReason + ExecutionTerminationCode newtype and ExecutionResult::termination_reason field; Phase 0 wiring is partial (local edge gate only, full scheduler propagation deferred) -->
 
-<!-- reviewed: 2026-04-14 -->
+<!-- reviewed: 2026-04-14 — fixed rustdoc intra-doc link in ExecutionBudget docs (`tokio::sync::Semaphore` referenced as code, not unresolved intra-doc link) -->

--- a/crates/config/src/watchers/polling.rs
+++ b/crates/config/src/watchers/polling.rs
@@ -356,7 +356,10 @@ impl ConfigWatcher for PollingWatcher {
             // on timeout, abort explicitly so the runtime reclaims the task
             // rather than leaving a zombie behind.
             let abort_handle = handle.abort_handle();
-            if tokio::time::timeout(self.interval * 2, handle).await.is_err() {
+            if tokio::time::timeout(self.interval * 2, handle)
+                .await
+                .is_err()
+            {
                 nebula_log::warn!("Polling task did not exit within timeout; aborting");
                 abort_handle.abort();
             }

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -381,12 +381,8 @@ impl Credential for OAuth2Credential {
                 let challenge = crate::crypto::generate_code_challenge(&verifier);
                 let state_token = crate::crypto::generate_random_state();
 
-                let url = oauth2_flow::build_auth_url(
-                    &config,
-                    client_id,
-                    &challenge,
-                    &state_token,
-                )?;
+                let url =
+                    oauth2_flow::build_auth_url(&config, client_id, &challenge, &state_token)?;
 
                 // `build_config` rejects missing `redirect_uri` for this
                 // grant type, so this `clone()` unwraps a value that was

--- a/crates/credential/src/credentials/oauth2_config.rs
+++ b/crates/credential/src/credentials/oauth2_config.rs
@@ -3,12 +3,13 @@
 //! The builder surface enforces grant-type-specific requirements at
 //! compile time:
 //!
-//! - `AuthCodeBuilder` requires `redirect_uri` as a constructor
-//!   argument (RFC 6749 §4.1.3), and unconditionally enables PKCE S256
-//!   (RFC 7636 + RFC 8252 §6).
-//! - `ClientCredentialsBuilder` has no `redirect_uri` method and no
-//!   `pkce` method — neither concept applies.
-//! - `DeviceCodeBuilder` likewise has no `redirect_uri`/`pkce` methods.
+//! - [`AuthCodeBuilder`](crate::credentials::oauth2_config::AuthCodeBuilder) requires
+//!   `redirect_uri` as a constructor argument (RFC 6749 §4.1.3), and unconditionally enables PKCE
+//!   S256 (RFC 7636 + RFC 8252 §6).
+//! - [`ClientCredentialsBuilder`](crate::credentials::oauth2_config::ClientCredentialsBuilder) has
+//!   no `redirect_uri` method and no `pkce` method — neither concept applies.
+//! - [`DeviceCodeBuilder`](crate::credentials::oauth2_config::DeviceCodeBuilder) likewise has no
+//!   `redirect_uri`/`pkce` methods.
 //!
 //! Closes the missing-`redirect_uri` / missing-`state` / missing-PKCE
 //! holes from GitHub issues #250 and #251.
@@ -70,8 +71,8 @@ impl PkceMethod {
 ///
 /// # AuthorizationCode invariants
 ///
-/// - `redirect_uri == Some(_)` — the exact URI registered with the
-///   provider; echoed on the token-exchange request per RFC 6749 §4.1.3.
+/// - `redirect_uri == Some(_)` — the exact URI registered with the provider; echoed on the
+///   token-exchange request per RFC 6749 §4.1.3.
 /// - `pkce == Some(PkceMethod::S256)` — PKCE protection is mandatory.
 ///
 /// For other grant types both fields are `None`.

--- a/crates/credential/src/credentials/oauth2_flow.rs
+++ b/crates/credential/src/credentials/oauth2_flow.rs
@@ -52,9 +52,10 @@ pub(crate) fn build_auth_url(
     code_challenge: &str,
     state: &str,
 ) -> Result<String, CredentialError> {
-    let redirect_uri = config.redirect_uri.as_deref().ok_or_else(|| {
-        provider_error("authorization_code config missing redirect_uri".into())
-    })?;
+    let redirect_uri = config
+        .redirect_uri
+        .as_deref()
+        .ok_or_else(|| provider_error("authorization_code config missing redirect_uri".into()))?;
     let pkce_method = config
         .pkce
         .ok_or_else(|| provider_error("authorization_code config missing pkce method".into()))?;
@@ -616,14 +617,7 @@ mod tests {
 
     #[test]
     fn compose_auth_code_form_post_body_style_appends_client_credentials() {
-        let form = compose_auth_code_form(
-            "c",
-            "v",
-            "r",
-            "cid",
-            "csecret",
-            AuthStyle::PostBody,
-        );
+        let form = compose_auth_code_form("c", "v", "r", "cid", "csecret", AuthStyle::PostBody);
         assert_eq!(
             form,
             vec![

--- a/crates/credential/src/resolver.rs
+++ b/crates/credential/src/resolver.rs
@@ -175,9 +175,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
         // true expiry so callers can react immediately.
         if self.refresh_coordinator.is_circuit_open(credential_id) {
             let now = chrono::Utc::now();
-            let truly_expired = state
-                .expires_at()
-                .is_some_and(|exp| exp <= now);
+            let truly_expired = state.expires_at().is_some_and(|exp| exp <= now);
             if truly_expired {
                 tracing::warn!(
                     credential_id,
@@ -234,19 +232,15 @@ impl<S: CredentialStore> CredentialResolver<S> {
                 // lost and we would stall until timeout.
                 //
                 // Mitigations:
-                // 1. Eagerly construct and `enable()` the `Notified` future —
-                //    this registers the waiter immediately, narrowing the
-                //    race window from "await-first-poll" down to "the handful
-                //    of instructions between returning from try_refresh and
-                //    enable()".
-                // 2. Short (5 s) timeout — the post-wait `resolve` re-read
-                //    always fetches the fresh value from the store, so the
-                //    timeout is not fatal. Staying on 60 s meant a lost
-                //    wakeup produced a 60-second latency spike. 5 s bounds
-                //    worst-case waiter latency to a value humans still
-                //    tolerate while leaving room for a slow legitimate
-                //    refresh (which itself holds a `refresh_semaphore`
-                //    permit and is normally sub-second).
+                // 1. Eagerly construct and `enable()` the `Notified` future — this registers the
+                //    waiter immediately, narrowing the race window from "await-first-poll" down to
+                //    "the handful of instructions between returning from try_refresh and enable()".
+                // 2. Short (5 s) timeout — the post-wait `resolve` re-read always fetches the fresh
+                //    value from the store, so the timeout is not fatal. Staying on 60 s meant a
+                //    lost wakeup produced a 60-second latency spike. 5 s bounds worst-case waiter
+                //    latency to a value humans still tolerate while leaving room for a slow
+                //    legitimate refresh (which itself holds a `refresh_semaphore` permit and is
+                //    normally sub-second).
                 let notified = notify.notified();
                 tokio::pin!(notified);
                 // Pre-register before any await so a concurrent
@@ -813,10 +807,7 @@ mod tests {
             .resolve::<ApiKeyCredential>("non-expiring")
             .await
             .expect("non-expiring credential should resolve under any circuit state");
-        let value = handle
-            .snapshot()
-            .token()
-            .expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
         assert_eq!(value, "forever");
     }
 
@@ -902,9 +893,7 @@ mod tests {
 
         // Open the circuit.
         for _ in 0..5 {
-            resolver
-                .refresh_coordinator
-                .record_failure("soon-expiring");
+            resolver.refresh_coordinator.record_failure("soon-expiring");
         }
         assert!(
             resolver

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -701,9 +701,8 @@ impl WorkflowEngine {
             .map_err(|e| EngineError::PlanningFailed(e.to_string()))?;
 
         // 7. Reconstruct the execution state, resetting non-terminal nodes. Nodes that were Running
-        //    at crash time need to be re-executed. This is a recovery
-        //    path, so the reset bypasses the forward state machine via
-        //    `override_node_state` but still bumps the version per
+        //    at crash time need to be re-executed. This is a recovery path, so the reset bypasses
+        //    the forward state machine via `override_node_state` but still bumps the version per
         //    transition so CAS readers see the change (issue #255).
         let mut exec_state = exec_state;
         let non_terminal: Vec<NodeId> = exec_state

--- a/crates/execution/src/context.rs
+++ b/crates/execution/src/context.rs
@@ -42,7 +42,7 @@ where
 pub struct ExecutionBudget {
     /// Maximum nodes executing in parallel.
     ///
-    /// Must be at least **1**. The workflow engine uses a [`tokio::sync::Semaphore`]
+    /// Must be at least **1**. The workflow engine uses a `tokio::sync::Semaphore`
     /// with this many permits; `0` leaves no permits and deadlocks scheduling.
     #[serde(
         default = "default_max_concurrent_nodes",

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -215,11 +215,9 @@ impl ExecutionState {
     ///
     /// # Errors
     ///
-    /// - [`ExecutionError::NodeNotFound`] if `node_id` is not in this
-    ///   execution's node map.
-    /// - Any error returned by [`NodeExecutionState::transition_to`]
-    ///   for invalid transitions — in which case the version is NOT
-    ///   bumped (the state did not actually change).
+    /// - [`ExecutionError::NodeNotFound`] if `node_id` is not in this execution's node map.
+    /// - Any error returned by [`NodeExecutionState::transition_to`] for invalid transitions — in
+    ///   which case the version is NOT bumped (the state did not actually change).
     pub fn transition_node(
         &mut self,
         node_id: NodeId,

--- a/crates/expression/src/eval.rs
+++ b/crates/expression/src/eval.rs
@@ -39,13 +39,12 @@ const MAX_REGEX_CACHE_SIZE: usize = 100;
 /// [`EvaluationContext`]). Every recursive path inside the evaluator
 /// threads `&mut EvalFrame` instead of a bare `depth: usize`, so:
 ///
-/// - Concurrent `Arc<Evaluator>` users each get their own frame with
-///   zero synchronization — no shared atomics, no thread-local state.
-/// - Nested lambda evaluation cannot accidentally reset the counter
-///   (the old `self.eval(...)` re-entry pattern that did
-///   `self.steps.store(0)` at the top of every call is gone).
-/// - One top-level `eval` call = one step budget, regardless of how
-///   many lambdas / reduces / pipelines it recurses through.
+/// - Concurrent `Arc<Evaluator>` users each get their own frame with zero synchronization — no
+///   shared atomics, no thread-local state.
+/// - Nested lambda evaluation cannot accidentally reset the counter (the old `self.eval(...)`
+///   re-entry pattern that did `self.steps.store(0)` at the top of every call is gone).
+/// - One top-level `eval` call = one step budget, regardless of how many lambdas / reduces /
+///   pipelines it recurses through.
 ///
 /// Closes CO-C1-01 (issue #252): `max_eval_steps` bypass via lambdas.
 pub(crate) struct EvalFrame {
@@ -2335,9 +2334,9 @@ mod tests {
             name: Arc::from("map"),
             args: vec![literal_array(100), increment_lambda()],
         };
-        let err = evaluator.eval(&expr, &context).expect_err(
-            "context-level budget of 5 must also bound a map over 100 elements",
-        );
+        let err = evaluator
+            .eval(&expr, &context)
+            .expect_err("context-level budget of 5 must also bound a map over 100 elements");
         assert!(err.to_string().contains("Maximum evaluation steps"));
     }
 

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -1241,14 +1241,13 @@ impl Manager {
     /// The loop uses a `register-then-check` ordering to avoid the classic
     /// `Notify::notify_waiters` lost-wakeup:
     ///
-    /// 1. Construct + pin + `enable()` a fresh `Notified` future. Calling
-    ///    `enable()` registers this waiter on the `Notify` queue without
-    ///    requiring a `.await`, so any subsequent `notify_waiters()` (fired
-    ///    when a handle's `Drop` decrements the counter from 1 → 0) will
+    /// 1. Construct + pin + `enable()` a fresh `Notified` future. Calling `enable()` registers this
+    ///    waiter on the `Notify` queue without requiring a `.await`, so any subsequent
+    ///    `notify_waiters()` (fired when a handle's `Drop` decrements the counter from 1 → 0) will
     ///    reach us.
-    /// 2. Re-check the counter. If it already hit 0 between the outer
-    ///    initial check and our registration, return now — the wakeup we
-    ///    would otherwise wait for has already been consumed.
+    /// 2. Re-check the counter. If it already hit 0 between the outer initial check and our
+    ///    registration, return now — the wakeup we would otherwise wait for has already been
+    ///    consumed.
     /// 3. Only then await the `Notified` future.
     ///
     /// Without this ordering, a burst of handle drops that completes the

--- a/crates/runtime/src/queue.rs
+++ b/crates/runtime/src/queue.rs
@@ -176,7 +176,10 @@ mod tests {
     async fn nack_waits_for_capacity_and_preserves_task() {
         let queue = Arc::new(MemoryQueue::new(1));
 
-        let first_id = queue.enqueue(serde_json::json!({"task":"first"})).await.unwrap();
+        let first_id = queue
+            .enqueue(serde_json::json!({"task":"first"}))
+            .await
+            .unwrap();
         let (dequeued_id, _) = queue
             .dequeue(Duration::from_millis(50))
             .await

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -335,17 +335,15 @@ impl ActionRuntime {
     ///
     /// - `Success` / `Continue` / `Break` / `Route` — their single output
     /// - `Skip` / `Wait` — the optional partial output
-    /// - `Branch` — the selected output **and** every alternative (previews
-    ///   are still shipped downstream; a misbehaving node must not smuggle
-    ///   a GB-sized alternative past the limit)
+    /// - `Branch` — the selected output **and** every alternative (previews are still shipped
+    ///   downstream; a misbehaving node must not smuggle a GB-sized alternative past the limit)
     /// - `MultiOutput` — the optional main output **and** every fan-out port
     ///
     /// For each inline `Value` slot that exceeds the limit, applies the
     /// configured strategy:
     /// - `Reject` → returns `DataLimitExceeded` on the first offender
-    /// - `SpillToBlob` → writes the payload to blob storage and rewrites
-    ///   the slot to an `ActionOutput::Reference` so the large inline
-    ///   value is no longer carried downstream
+    /// - `SpillToBlob` → writes the payload to blob storage and rewrites the slot to an
+    ///   `ActionOutput::Reference` so the large inline value is no longer carried downstream
     ///
     /// Non-`Value` variants (`Binary` / `Reference` / `Deferred`) are
     /// skipped — their size is managed by the owning storage backend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

This PR is a clean replacement branch to unblock CI where commitlint failed on a historical non-conventional merge commit in the previous branch.

## Changes

- Keeps the OAuth2 builder intra-doc links in `oauth2_config`.
- Applies rustfmt-expected wrapping in the module docs so `Formatting` passes.
- Uses only conventional commit types in branch history (no `merge:` commit subject).

## Testing

- [x] `cargo +nightly fmt --all -- --check` target file formatting aligned with CI expectations
- [ ] Tests pass locally (`cargo nextest run --workspace`)
- [ ] Clippy passes (`cargo clippy --workspace -- -D warnings`)
- [ ] Code is formatted (`cargo fmt`)

## Breaking Changes

None
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-67fed00b-9b6a-4a52-9c50-b8dd369be26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-67fed00b-9b6a-4a52-9c50-b8dd369be26a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

