### PR TITLE
fix(resource): land + verify all open nebula-resource issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -346,3 +346,6 @@ logs/security/
 
 # Claude Code local agent memory (per-developer, not shared)
 .claude/agent-memory-local/
+
+# Git worktrees created by superpowers workflow
+.worktrees/

--- a/crates/resource/src/integration/resilience.rs
+++ b/crates/resource/src/integration/resilience.rs
@@ -92,27 +92,32 @@ impl AcquireResilience {
     /// Convert to a [`RetryConfig`] for use with [`nebula_resilience::retry_with`].
     ///
     /// Maps exponential backoff (2× multiplier) and optional wall-clock
-    /// timeout budget. When no retry config is set, returns a single-attempt
-    /// config with optional timeout budget.
-    pub(crate) fn to_retry_config<E: 'static>(&self) -> RetryConfig<E> {
+    /// timeout budget. Returns `None` if [`RetryConfig::new`] rejects the
+    /// (clamped, `>= 1`) attempt count — today that path is unreachable,
+    /// but a future version of `nebula-resilience` might add new
+    /// validation and we prefer "skip retry" over "panic the manager".
+    /// Callers that receive `None` should run the operation without
+    /// retry (the existing `None` branch in [`execute_with_resilience`]).
+    pub(crate) fn to_retry_config<E: 'static>(&self) -> Option<RetryConfig<E>> {
+        // #383: clamp a user-supplied `max_attempts: 0` to 1 so we
+        // degrade to a single attempt instead of panicking. Clamping is
+        // documented on `AcquireRetryConfig::max_attempts`.
         let max_attempts = self.retry.as_ref().map_or(1, |r| r.max_attempts.max(1));
-        let cfg = RetryConfig::new(max_attempts).expect("max_attempts clamped to >=1 above");
+        let mut cfg = RetryConfig::new(max_attempts).ok()?;
 
-        let cfg = if let Some(ref retry) = self.retry {
-            cfg.backoff(BackoffConfig::Exponential {
+        if let Some(ref retry) = self.retry {
+            cfg = cfg.backoff(BackoffConfig::Exponential {
                 base: retry.initial_backoff,
                 multiplier: 2.0,
                 max: retry.max_backoff,
-            })
-        } else {
-            cfg
-        };
+            });
+        }
 
         if let Some(timeout) = self.timeout {
-            cfg.total_budget(timeout)
-        } else {
-            cfg
+            cfg = cfg.total_budget(timeout);
         }
+
+        Some(cfg)
     }
 }
 

--- a/crates/resource/src/integration/resilience.rs
+++ b/crates/resource/src/integration/resilience.rs
@@ -36,7 +36,7 @@ pub struct AcquireRetryConfig {
     /// Maximum total number of attempts (including the initial try).
     ///
     /// For example, `max_attempts: 3` means 1 initial try + 2 retries.
-    /// Values below 1 are clamped to 1 by the manager.
+    /// Values below 1 are clamped to 1 at conversion time.
     pub max_attempts: u32,
     /// Initial backoff duration before the first retry.
     pub initial_backoff: Duration,
@@ -95,9 +95,6 @@ impl AcquireResilience {
     /// timeout budget. When no retry config is set, returns a single-attempt
     /// config with optional timeout budget.
     pub(crate) fn to_retry_config<E: 'static>(&self) -> RetryConfig<E> {
-        // #383: a misconfigured `max_attempts: 0` from a config file used to
-        // panic here via `expect`. Clamp to `1` so we degrade to a single
-        // attempt rather than killing the process during acquire.
         let max_attempts = self.retry.as_ref().map_or(1, |r| r.max_attempts.max(1));
         let cfg = RetryConfig::new(max_attempts).expect("max_attempts clamped to >=1 above");
 

--- a/crates/resource/src/integration/resilience.rs
+++ b/crates/resource/src/integration/resilience.rs
@@ -36,6 +36,7 @@ pub struct AcquireRetryConfig {
     /// Maximum total number of attempts (including the initial try).
     ///
     /// For example, `max_attempts: 3` means 1 initial try + 2 retries.
+    /// Values below 1 are clamped to 1 by the manager.
     pub max_attempts: u32,
     /// Initial backoff duration before the first retry.
     pub initial_backoff: Duration,
@@ -94,8 +95,11 @@ impl AcquireResilience {
     /// timeout budget. When no retry config is set, returns a single-attempt
     /// config with optional timeout budget.
     pub(crate) fn to_retry_config<E: 'static>(&self) -> RetryConfig<E> {
-        let max_attempts = self.retry.as_ref().map_or(1, |r| r.max_attempts);
-        let cfg = RetryConfig::new(max_attempts).expect("max_attempts validated at construction");
+        // #383: a misconfigured `max_attempts: 0` from a config file used to
+        // panic here via `expect`. Clamp to `1` so we degrade to a single
+        // attempt rather than killing the process during acquire.
+        let max_attempts = self.retry.as_ref().map_or(1, |r| r.max_attempts.max(1));
+        let cfg = RetryConfig::new(max_attempts).expect("max_attempts clamped to >=1 above");
 
         let cfg = if let Some(ref retry) = self.retry {
             cfg.backoff(BackoffConfig::Exponential {
@@ -145,5 +149,20 @@ mod tests {
         let c = AcquireResilience::none();
         assert!(c.timeout.is_none());
         assert!(c.retry.is_none());
+    }
+
+    #[test]
+    fn to_retry_config_handles_zero_max_attempts_without_panic() {
+        let cfg = AcquireResilience {
+            timeout: None,
+            retry: Some(AcquireRetryConfig {
+                max_attempts: 0,
+                initial_backoff: Duration::from_millis(10),
+                max_backoff: Duration::from_millis(50),
+            }),
+        };
+
+        // Must not panic. Behaviour: degrade to a single attempt.
+        let _ = cfg.to_retry_config::<crate::error::Error>();
     }
 }

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -379,6 +379,8 @@ impl Manager {
     {
         use crate::resource::ResourceConfig as _;
 
+        validate_pool_config(&pool_config)?;
+
         let fingerprint = config.fingerprint();
         self.register(
             resource,
@@ -534,6 +536,9 @@ impl Manager {
         R: Resource<Auth = ()>,
     {
         use crate::resource::ResourceConfig as _;
+
+        validate_pool_config(&pool_config)?;
+
         let fingerprint = config.fingerprint();
         self.register(
             resource,
@@ -1730,6 +1735,24 @@ where
             },
             other => Error::transient(other.to_string()),
         })
+}
+
+/// Validates pool config invariants at registration time.
+///
+/// Catches obviously broken configs (`max_size == 0`, `min_size > max_size`)
+/// before they reach [`PoolRuntime`], so warmup never inflates beyond
+/// `max_size` and callers cannot deadlock on an empty semaphore (#390).
+fn validate_pool_config(cfg: &crate::topology::pooled::config::Config) -> Result<(), Error> {
+    if cfg.max_size == 0 {
+        return Err(Error::permanent("pool max_size must be > 0"));
+    }
+    if cfg.min_size > cfg.max_size {
+        return Err(Error::permanent(format!(
+            "pool min_size ({}) must be <= max_size ({})",
+            cfg.min_size, cfg.max_size,
+        )));
+    }
+    Ok(())
 }
 
 impl Default for Manager {

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -1771,6 +1771,47 @@ impl std::fmt::Debug for Manager {
 }
 
 #[cfg(test)]
+mod gate_admission_tests {
+    use super::*;
+    use crate::recovery::gate::RecoveryGateConfig;
+
+    /// #322: after `Failed { retry_at = past }`, concurrent callers must
+    /// see **exactly one** `Probe` ticket, not a stampede. The CAS-based
+    /// single-probe claim lives in `admit_through_gate`.
+    #[tokio::test]
+    async fn expired_failed_state_admits_only_one_probe() {
+        let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig {
+            max_attempts: 16,
+            base_backoff: Duration::from_millis(5),
+        }));
+
+        // Drive the gate into Failed { retry_at ≈ past }.
+        let ticket = gate.try_begin().expect("first ticket");
+        ticket.fail_transient("seed");
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        // Concurrently fire 32 admit_through_gate calls.
+        let some_gate: Option<Arc<RecoveryGate>> = Some(Arc::clone(&gate));
+        let mut probes = 0;
+        let mut blocked = 0;
+        for _ in 0..32 {
+            match admit_through_gate(&some_gate) {
+                Ok(GateAdmission::Probe(_t)) => probes += 1,
+                Ok(GateAdmission::Open) | Ok(GateAdmission::OpenGated(_)) => blocked += 1,
+                Err(_) => blocked += 1,
+            }
+        }
+
+        assert_eq!(probes, 1, "exactly one Probe ticket must be granted (#322)");
+        assert_eq!(
+            probes + blocked,
+            32,
+            "every call must be accounted for: probes={probes}, blocked={blocked}",
+        );
+    }
+}
+
+#[cfg(test)]
 mod drain_race_tests {
     use super::*;
 
@@ -1866,5 +1907,52 @@ mod drain_race_tests {
             elapsed < Duration::from_secs(1),
             "wait_for_drain must return promptly even under race, took {elapsed:?}"
         );
+    }
+
+    /// #302: Abort policy must return a typed `DrainTimeout` error and
+    /// leave the registry untouched. Before the policy split
+    /// `graceful_shutdown` would log a warning and proceed to
+    /// `registry.clear()` anyway, turning a cooperative shutdown into a
+    /// logical use-after-free.
+    #[tokio::test]
+    async fn graceful_shutdown_abort_policy_returns_drain_timeout_error() {
+        let mgr = Manager::new();
+        // Simulate an outstanding handle.
+        mgr.drain_tracker.0.fetch_add(1, AtomicOrdering::Release);
+
+        let cfg = ShutdownConfig::default()
+            .with_drain_timeout(Duration::from_millis(50))
+            .with_drain_timeout_policy(DrainTimeoutPolicy::Abort);
+
+        let err = mgr
+            .graceful_shutdown(cfg)
+            .await
+            .expect_err("Abort policy must surface drain timeout");
+        match err {
+            ShutdownError::DrainTimeout { outstanding } => {
+                assert_eq!(outstanding, 1, "outstanding count mismatch");
+            },
+            other => panic!("wrong error variant: {other:?}"),
+        }
+    }
+
+    /// #302: Force policy must clear the registry and report the
+    /// outstanding-handle count in `ShutdownReport` so operators can see
+    /// exactly how much in-flight work was abandoned.
+    #[tokio::test]
+    async fn graceful_shutdown_force_policy_clears_registry_with_outstanding_count() {
+        let mgr = Manager::new();
+        mgr.drain_tracker.0.fetch_add(2, AtomicOrdering::Release);
+
+        let cfg = ShutdownConfig::default()
+            .with_drain_timeout(Duration::from_millis(50))
+            .with_drain_timeout_policy(DrainTimeoutPolicy::Force);
+
+        let report = mgr
+            .graceful_shutdown(cfg)
+            .await
+            .expect("Force policy must succeed");
+        assert!(report.registry_cleared);
+        assert_eq!(report.outstanding_handles_after_drain, 2);
     }
 }

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -1399,6 +1399,14 @@ impl Manager {
                         "resource manager: drain timeout, policy=Abort — \
                          registry preserved, returning DrainTimeout"
                     );
+                    // #387 / PR #399 review: we already flipped every
+                    // resource to `Draining` above. The Abort policy
+                    // preserves the "graceful" guarantee and keeps live
+                    // handles valid, so we must also restore the phase
+                    // back to `Ready` — otherwise `is_accepting()` would
+                    // falsely keep returning `false` and the manager
+                    // would reject new acquires forever.
+                    self.set_phase_all(crate::state::ResourcePhase::Ready);
                     self.shutting_down.store(false, AtomicOrdering::Release);
                     return Err(ShutdownError::DrainTimeout { outstanding });
                 },

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -1287,9 +1287,11 @@ impl Manager {
             .generation
             .fetch_add(1, std::sync::atomic::Ordering::Release);
 
-        // #387: return to `Ready` with the new generation baked into
-        // `ResourceStatus.generation` (this is what `health_check`
-        // surfaces to operators).
+        // #387: return to `Ready` after publishing the new atomic
+        // generation so pollers see the phase transition alongside the
+        // config change. `health_check` reads the atomic directly, but
+        // `ResourceStatus.generation` is also refreshed by `set_phase`
+        // so `status()` snapshots stay self-consistent.
         managed.set_phase(crate::state::ResourcePhase::Ready);
 
         let _ = self
@@ -1724,7 +1726,13 @@ where
         return operation().await;
     };
 
-    let retry_cfg = config.to_retry_config();
+    // #383: `to_retry_config` returns `None` only if the underlying
+    // `RetryConfig::new` rejects the clamped attempt count. That path is
+    // unreachable today; if it ever fires we prefer to fall through to a
+    // single un-retried attempt rather than panic the manager.
+    let Some(retry_cfg) = config.to_retry_config() else {
+        return operation().await;
+    };
     nebula_resilience::retry_with(retry_cfg, operation)
         .await
         .map_err(|call_err| match call_err {
@@ -1777,8 +1785,10 @@ mod gate_admission_tests {
 
     /// #322: after `Failed { retry_at = past }`, concurrent callers must
     /// see **exactly one** `Probe` ticket, not a stampede. The CAS-based
-    /// single-probe claim lives in `admit_through_gate`.
-    #[tokio::test]
+    /// single-probe claim lives in `admit_through_gate`. Each spawned
+    /// task parks on a `Barrier` before calling so the 32 attempts
+    /// really contend, instead of being serviced one at a time.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
     async fn expired_failed_state_admits_only_one_probe() {
         let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig {
             max_attempts: 16,
@@ -1790,16 +1800,43 @@ mod gate_admission_tests {
         ticket.fail_transient("seed");
         tokio::time::sleep(Duration::from_millis(20)).await;
 
-        // Concurrently fire 32 admit_through_gate calls.
-        let some_gate: Option<Arc<RecoveryGate>> = Some(Arc::clone(&gate));
-        let mut probes = 0;
-        let mut blocked = 0;
-        for _ in 0..32 {
+        async fn contend(
+            gate: Arc<RecoveryGate>,
+            barrier: Arc<tokio::sync::Barrier>,
+        ) -> (u32, u32) {
+            // Park here until every task is ready so we really stress
+            // the CAS claim.
+            barrier.wait().await;
+            let some_gate: Option<Arc<RecoveryGate>> = Some(gate);
             match admit_through_gate(&some_gate) {
-                Ok(GateAdmission::Probe(_t)) => probes += 1,
-                Ok(GateAdmission::Open) | Ok(GateAdmission::OpenGated(_)) => blocked += 1,
-                Err(_) => blocked += 1,
+                Ok(GateAdmission::Probe(ticket)) => {
+                    // Hold the probe until the test is done counting so
+                    // a second caller can't race in after a fast
+                    // resolve/fail cycle.
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                    drop(ticket);
+                    (1, 0)
+                },
+                Ok(GateAdmission::Open) | Ok(GateAdmission::OpenGated(_)) => (0, 1),
+                Err(_) => (0, 1),
             }
+        }
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(32));
+        let mut handles = Vec::with_capacity(32);
+        for _ in 0..32 {
+            handles.push(tokio::spawn(contend(
+                Arc::clone(&gate),
+                Arc::clone(&barrier),
+            )));
+        }
+
+        let mut probes = 0u32;
+        let mut blocked = 0u32;
+        for h in handles {
+            let (p, b) = h.await.expect("admission task");
+            probes += p;
+            blocked += b;
         }
 
         assert_eq!(probes, 1, "exactly one Probe ticket must be granted (#322)");

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -341,6 +341,12 @@ impl Manager {
         self.registry
             .register(key.clone(), type_id, scope, managed.clone());
 
+        // #387: everything below `register()` is a single funnel — the
+        // resource is installed, so advance its phase from `Initializing`
+        // to `Ready`. Failures are surfaced by `config.validate()` above,
+        // which aborts before we reach this line.
+        managed.set_phase(crate::state::ResourcePhase::Ready);
+
         if let Some(m) = &self.metrics {
             m.record_create();
         }
@@ -1256,6 +1262,10 @@ impl Manager {
 
         let managed = self.lookup::<R>(scope)?;
 
+        // #387: visible `Reloading` phase for operators polling health
+        // mid-swap.
+        managed.set_phase(crate::state::ResourcePhase::Reloading);
+
         // Compute fingerprint before swap so we don't clone config.
         let new_fp = new_config.fingerprint();
 
@@ -1271,6 +1281,11 @@ impl Manager {
         managed
             .generation
             .fetch_add(1, std::sync::atomic::Ordering::Release);
+
+        // #387: return to `Ready` with the new generation baked into
+        // `ResourceStatus.generation` (this is what `health_check`
+        // surfaces to operators).
+        managed.set_phase(crate::state::ResourcePhase::Ready);
 
         let _ = self
             .event_tx
@@ -1358,6 +1373,11 @@ impl Manager {
         //      (they share this token via `ReleaseQueue::with_cancel`).
         self.cancel.cancel();
 
+        // #387: mark every registered resource as `Draining` so operators
+        // polling `health_check` during the drain window see the correct
+        // lifecycle phase instead of a stale `Ready`.
+        self.set_phase_all(crate::state::ResourcePhase::Draining);
+
         // Phase 2: DRAIN — wait for in-flight handles to be released.
         // On timeout, respect the policy: Abort preserves "graceful"
         // (returns Err *without* clearing the registry), Force proceeds
@@ -1385,6 +1405,12 @@ impl Manager {
                 },
             },
         }
+
+        // #387: drain has completed (or been force-released). Mark every
+        // resource as `ShuttingDown` so a health snapshot captured in the
+        // narrow window between here and `registry.clear()` reflects the
+        // real lifecycle state.
+        self.set_phase_all(crate::state::ResourcePhase::ShuttingDown);
 
         // Phase 3: CLEAR — drop all ManagedResources so their
         // Arc<ReleaseQueue> refs are released.
@@ -1418,6 +1444,17 @@ impl Manager {
             // work to drain — either way the contract is "drained".
             release_queue_drained: true,
         })
+    }
+
+    /// Drives every registered resource to the given lifecycle phase.
+    ///
+    /// Type-erased bulk update used during graceful shutdown so that
+    /// `health_check` returns the correct phase while the drain/cleanup
+    /// is in flight (#387).
+    fn set_phase_all(&self, phase: crate::state::ResourcePhase) {
+        for managed in self.registry.all_managed() {
+            managed.set_phase_erased(phase);
+        }
     }
 
     /// Waits until all active `ResourceHandle`s are dropped or timeout expires.

--- a/crates/resource/src/options.rs
+++ b/crates/resource/src/options.rs
@@ -33,7 +33,10 @@ pub enum AcquireIntent {
     },
     /// Prefetch — low priority, may be deferred.
     Prefetch,
-    /// Critical — bypass queues if possible, never throttle.
+    /// Critical — reserved for future use. Will allow callers to
+    /// bypass queues or skip throttling once engine integration lands;
+    /// today it is informational only (see the enum-level `Status`
+    /// note, #391).
     Critical,
 }
 

--- a/crates/resource/src/options.rs
+++ b/crates/resource/src/options.rs
@@ -13,8 +13,12 @@ use smallvec::SmallVec;
 
 /// The caller's intent when acquiring a resource lease.
 ///
-/// Topologies may use this to select different pools, apply different
-/// timeouts, or skip health checks for critical requests.
+/// **Status:** reserved for future engine integration. The field is
+/// preserved on [`AcquireOptions`] for forward compatibility, but no
+/// topology in `nebula-resource` currently reads it (#391). Setting
+/// [`AcquireIntent::Critical`] does not bypass queues or change
+/// throttling today — only [`AcquireOptions::deadline`] affects acquire
+/// behaviour.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AcquireIntent {
@@ -47,11 +51,13 @@ pub enum AcquireIntent {
 /// ```
 #[derive(Debug, Clone)]
 pub struct AcquireOptions {
-    /// The caller's intent.
+    /// The caller's intent. Currently informational only — see
+    /// [`AcquireIntent`] (#391).
     pub intent: AcquireIntent,
     /// Absolute deadline for the acquire operation.
     pub deadline: Option<Instant>,
-    /// Freeform key-value tags for routing and diagnostics.
+    /// Freeform key-value tags. Reserved for future routing/diagnostics;
+    /// not read by any topology in `nebula-resource` today (#391).
     pub tags: SmallVec<[(Cow<'static, str>, Cow<'static, str>); 2]>,
 }
 

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -98,11 +98,15 @@ impl Registry {
         managed: Arc<dyn AnyManagedResource>,
     ) {
         // Lock order is **strictly one-way**: `entries → (release) → type_index`.
-        // `get_typed` takes `type_index` first and then `entries`; if this
-        // function also held both simultaneously in either order we would
-        // race into an AB-BA deadlock on the dashmap shards. So we do all
-        // `entries` work in a scoped block, drop the guard, and only then
-        // touch `type_index`.
+        //
+        // `get_typed` takes the `type_index` shard read lock first and only
+        // then touches `entries`. If `register` ever held both dashmap
+        // shards simultaneously in the opposite order, two concurrent
+        // callers (one here, one in `get_typed`) could each be waiting on
+        // the shard the other already holds — a classic lock-ordering
+        // reversal. We prevent that by doing all `entries` work in a
+        // scoped block, dropping the guard, and only *then* touching
+        // `type_index`.
         let stale_type_id = {
             let mut entries = self.entries.entry(key.clone()).or_default();
 

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -23,6 +23,13 @@ pub trait AnyManagedResource: Send + Sync + 'static {
 
     /// Returns a reference to `self` as `&dyn Any` for downcasting.
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
+
+    /// Returns the concrete `TypeId` used as the secondary index key.
+    ///
+    /// For real `ManagedResource<R>` this is `TypeId::of::<ManagedResource<R>>()`.
+    /// Used by [`Registry::register`] to scrub stale rows from `type_index`
+    /// when an entry is replaced in place (#382).
+    fn managed_type_id(&self) -> TypeId;
 }
 
 impl<R: Resource> AnyManagedResource for ManagedResource<R> {
@@ -32,6 +39,10 @@ impl<R: Resource> AnyManagedResource for ManagedResource<R> {
 
     fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
         self
+    }
+
+    fn managed_type_id(&self) -> TypeId {
+        TypeId::of::<ManagedResource<R>>()
     }
 }
 
@@ -74,15 +85,23 @@ impl Registry {
         scope: ScopeLevel,
         managed: Arc<dyn AnyManagedResource>,
     ) {
-        self.type_index.insert(type_id, key.clone());
+        let mut entries = self.entries.entry(key.clone()).or_default();
 
-        let mut entries = self.entries.entry(key).or_default();
-        // Replace existing entry with same scope, if any.
+        // #382: if we're replacing an entry at the same scope whose concrete
+        // TypeId differs from the new one, scrub the prior TypeId row from
+        // type_index before installing the new mapping. Otherwise the stale
+        // row leaks and `get_typed::<OldR>` finds a key it can't downcast.
         if let Some(pos) = entries.iter().position(|e| e.scope == scope) {
+            let prev_type_id = entries[pos].managed.managed_type_id();
+            if prev_type_id != type_id {
+                self.type_index.remove_if(&prev_type_id, |_, k| k == &key);
+            }
             entries[pos] = RegistryEntry { scope, managed };
         } else {
             entries.push(RegistryEntry { scope, managed });
         }
+
+        self.type_index.insert(type_id, key);
     }
 
     /// Looks up a managed resource by key and scope.
@@ -170,5 +189,67 @@ impl Registry {
 impl Default for Registry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct FakeA;
+    struct FakeB;
+
+    impl AnyManagedResource for FakeA {
+        fn resource_key(&self) -> ResourceKey {
+            ResourceKey::new("fake").unwrap()
+        }
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+            self
+        }
+        fn managed_type_id(&self) -> TypeId {
+            TypeId::of::<FakeA>()
+        }
+    }
+
+    impl AnyManagedResource for FakeB {
+        fn resource_key(&self) -> ResourceKey {
+            ResourceKey::new("fake").unwrap()
+        }
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+            self
+        }
+        fn managed_type_id(&self) -> TypeId {
+            TypeId::of::<FakeB>()
+        }
+    }
+
+    #[test]
+    fn register_replace_drops_stale_type_id_row() {
+        let reg = Registry::new();
+        let key = ResourceKey::new("fake").unwrap();
+        let scope = ScopeLevel::Global;
+
+        reg.register(
+            key.clone(),
+            TypeId::of::<FakeA>(),
+            scope.clone(),
+            Arc::new(FakeA),
+        );
+        assert!(reg.type_index.contains_key(&TypeId::of::<FakeA>()));
+
+        // Replace at the same key+scope with a different concrete type.
+        reg.register(
+            key.clone(),
+            TypeId::of::<FakeB>(),
+            scope.clone(),
+            Arc::new(FakeB),
+        );
+
+        // The stale TypeId row for FakeA must be gone (#382).
+        assert!(
+            !reg.type_index.contains_key(&TypeId::of::<FakeA>()),
+            "stale TypeId for FakeA still in type_index after replace"
+        );
+        assert!(reg.type_index.contains_key(&TypeId::of::<FakeB>()));
     }
 }

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -30,6 +30,14 @@ pub trait AnyManagedResource: Send + Sync + 'static {
     /// Used by [`Registry::register`] to scrub stale rows from `type_index`
     /// when an entry is replaced in place (#382).
     fn managed_type_id(&self) -> TypeId;
+
+    /// Type-erased lifecycle phase mutation (#387).
+    ///
+    /// Lets the manager drive phase transitions on all registered
+    /// resources without needing a typed handle, which matters during
+    /// graceful shutdown where only the type-erased registry iteration
+    /// is available.
+    fn set_phase_erased(&self, phase: crate::state::ResourcePhase);
 }
 
 impl<R: Resource> AnyManagedResource for ManagedResource<R> {
@@ -43,6 +51,10 @@ impl<R: Resource> AnyManagedResource for ManagedResource<R> {
 
     fn managed_type_id(&self) -> TypeId {
         TypeId::of::<ManagedResource<R>>()
+    }
+
+    fn set_phase_erased(&self, phase: crate::state::ResourcePhase) {
+        self.set_phase(phase);
     }
 }
 
@@ -149,6 +161,21 @@ impl Registry {
         self.entries.iter().map(|r| r.key().clone()).collect()
     }
 
+    /// Returns every registered managed resource across all scopes.
+    ///
+    /// Used by the manager to drive lifecycle transitions (e.g. shifting
+    /// every resource to `Draining` / `ShuttingDown` during graceful
+    /// shutdown, #387) without needing typed access to each entry.
+    pub(crate) fn all_managed(&self) -> Vec<Arc<dyn AnyManagedResource>> {
+        let mut out = Vec::new();
+        for row in self.entries.iter() {
+            for entry in row.value().iter() {
+                out.push(Arc::clone(&entry.managed));
+            }
+        }
+        out
+    }
+
     /// Returns `true` if a resource with the given key is registered.
     pub fn contains(&self, key: &ResourceKey) -> bool {
         self.entries.contains_key(key)
@@ -209,6 +236,7 @@ mod tests {
         fn managed_type_id(&self) -> TypeId {
             TypeId::of::<FakeA>()
         }
+        fn set_phase_erased(&self, _phase: crate::state::ResourcePhase) {}
     }
 
     impl AnyManagedResource for FakeB {
@@ -221,6 +249,7 @@ mod tests {
         fn managed_type_id(&self) -> TypeId {
             TypeId::of::<FakeB>()
         }
+        fn set_phase_erased(&self, _phase: crate::state::ResourcePhase) {}
     }
 
     #[test]

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -107,18 +107,31 @@ impl Registry {
         // reversal. We prevent that by doing all `entries` work in a
         // scoped block, dropping the guard, and only *then* touching
         // `type_index`.
+        //
+        // #382 nuance: it's not enough to compare the replaced entry's
+        // prior `TypeId` to the new one. If *another* scope under the
+        // same key still holds a `ManagedResource<OldR>` instance, we
+        // must NOT remove `OldR -> key` from `type_index` — doing so
+        // would break `get_typed::<OldR>` for that other scope. So we
+        // scan the rest of the entries while still holding the guard
+        // and only mark the stale row for removal if nobody else uses
+        // it.
         let stale_type_id = {
             let mut entries = self.entries.entry(key.clone()).or_default();
 
-            // #382: if we're replacing an entry at the same scope whose
-            // concrete `TypeId` differs from the new one, remember the
-            // prior id so we can scrub its `type_index` row below.
-            // Otherwise the stale row leaks and `get_typed::<OldR>` finds
-            // a key it can't downcast.
             if let Some(pos) = entries.iter().position(|e| e.scope == scope) {
                 let prev_type_id = entries[pos].managed.managed_type_id();
                 entries[pos] = RegistryEntry { scope, managed };
-                (prev_type_id != type_id).then_some(prev_type_id)
+
+                if prev_type_id != type_id
+                    && !entries
+                        .iter()
+                        .any(|e| e.managed.managed_type_id() == prev_type_id)
+                {
+                    Some(prev_type_id)
+                } else {
+                    None
+                }
             } else {
                 entries.push(RegistryEntry { scope, managed });
                 None
@@ -266,6 +279,44 @@ mod tests {
             TypeId::of::<FakeB>()
         }
         fn set_phase_erased(&self, _phase: crate::state::ResourcePhase) {}
+    }
+
+    #[test]
+    fn register_replace_preserves_type_id_still_used_by_another_scope() {
+        // Regression for a correctness hole raised in PR #399 review:
+        // if scope A and scope B both hold `TypeA`, replacing scope A
+        // with `TypeB` must NOT scrub `TypeA -> key` from `type_index`,
+        // otherwise `get_typed::<TypeA>(B)` would break.
+        let reg = Registry::new();
+        let key = ResourceKey::new("fake").unwrap();
+
+        reg.register(
+            key.clone(),
+            TypeId::of::<FakeA>(),
+            ScopeLevel::Global,
+            Arc::new(FakeA),
+        );
+        reg.register(
+            key.clone(),
+            TypeId::of::<FakeA>(),
+            ScopeLevel::Project("p".into()),
+            Arc::new(FakeA),
+        );
+
+        // Replace only the Global entry with FakeB. Workflow still
+        // holds FakeA, so the TypeA row in type_index must survive.
+        reg.register(
+            key.clone(),
+            TypeId::of::<FakeB>(),
+            ScopeLevel::Global,
+            Arc::new(FakeB),
+        );
+
+        assert!(
+            reg.type_index.contains_key(&TypeId::of::<FakeA>()),
+            "TypeA row must survive because the Project scope still uses it",
+        );
+        assert!(reg.type_index.contains_key(&TypeId::of::<FakeB>()));
     }
 
     #[test]

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -97,22 +97,34 @@ impl Registry {
         scope: ScopeLevel,
         managed: Arc<dyn AnyManagedResource>,
     ) {
-        let mut entries = self.entries.entry(key.clone()).or_default();
+        // Lock order is **strictly one-way**: `entries → (release) → type_index`.
+        // `get_typed` takes `type_index` first and then `entries`; if this
+        // function also held both simultaneously in either order we would
+        // race into an AB-BA deadlock on the dashmap shards. So we do all
+        // `entries` work in a scoped block, drop the guard, and only then
+        // touch `type_index`.
+        let stale_type_id = {
+            let mut entries = self.entries.entry(key.clone()).or_default();
 
-        // #382: if we're replacing an entry at the same scope whose concrete
-        // TypeId differs from the new one, scrub the prior TypeId row from
-        // type_index before installing the new mapping. Otherwise the stale
-        // row leaks and `get_typed::<OldR>` finds a key it can't downcast.
-        if let Some(pos) = entries.iter().position(|e| e.scope == scope) {
-            let prev_type_id = entries[pos].managed.managed_type_id();
-            if prev_type_id != type_id {
-                self.type_index.remove_if(&prev_type_id, |_, k| k == &key);
+            // #382: if we're replacing an entry at the same scope whose
+            // concrete `TypeId` differs from the new one, remember the
+            // prior id so we can scrub its `type_index` row below.
+            // Otherwise the stale row leaks and `get_typed::<OldR>` finds
+            // a key it can't downcast.
+            if let Some(pos) = entries.iter().position(|e| e.scope == scope) {
+                let prev_type_id = entries[pos].managed.managed_type_id();
+                entries[pos] = RegistryEntry { scope, managed };
+                (prev_type_id != type_id).then_some(prev_type_id)
+            } else {
+                entries.push(RegistryEntry { scope, managed });
+                None
             }
-            entries[pos] = RegistryEntry { scope, managed };
-        } else {
-            entries.push(RegistryEntry { scope, managed });
-        }
+            // entries guard drops here.
+        };
 
+        if let Some(stale) = stale_type_id {
+            self.type_index.remove_if(&stale, |_, k| k == &key);
+        }
         self.type_index.insert(type_id, key);
     }
 

--- a/crates/resource/src/runtime/daemon.rs
+++ b/crates/resource/src/runtime/daemon.rs
@@ -257,3 +257,216 @@ async fn daemon_loop<R>(
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::atomic::{AtomicU32, Ordering},
+        time::Duration,
+    };
+
+    use nebula_core::{ExecutionId, ResourceKey};
+
+    use super::*;
+    use crate::{
+        ctx::BasicCtx,
+        error::Error as ResourceError,
+        resource::{Resource, ResourceConfig, ResourceMetadata},
+        topology::daemon::{Daemon, RestartPolicy, config::Config as DaemonCfg},
+    };
+
+    #[derive(Clone, Debug, Default)]
+    struct EmptyCfg;
+
+    impl ResourceConfig for EmptyCfg {
+        fn fingerprint(&self) -> u64 {
+            0
+        }
+    }
+
+    #[derive(Debug, thiserror::Error)]
+    #[error("daemon-test: {0}")]
+    struct TestError(&'static str);
+
+    impl From<TestError> for ResourceError {
+        fn from(e: TestError) -> Self {
+            ResourceError::transient(e.to_string())
+        }
+    }
+
+    #[derive(Clone)]
+    struct FlakyDaemon {
+        attempts: Arc<AtomicU32>,
+    }
+
+    impl Resource for FlakyDaemon {
+        type Config = EmptyCfg;
+        type Runtime = ();
+        type Lease = ();
+        type Error = TestError;
+        type Auth = ();
+
+        fn key() -> ResourceKey {
+            ResourceKey::new("daemon-flaky").unwrap()
+        }
+
+        async fn create(
+            &self,
+            _config: &Self::Config,
+            _auth: &(),
+            _ctx: &dyn Ctx,
+        ) -> Result<(), TestError> {
+            Ok(())
+        }
+
+        fn metadata() -> ResourceMetadata {
+            ResourceMetadata::from_key(&Self::key())
+        }
+    }
+
+    impl Daemon for FlakyDaemon {
+        async fn run(
+            &self,
+            _runtime: &Self::Runtime,
+            _ctx: &dyn Ctx,
+            _cancel: CancellationToken,
+        ) -> Result<(), TestError> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            Err(TestError("intentional"))
+        }
+    }
+
+    #[derive(Clone)]
+    struct OneShotDaemon;
+
+    impl Resource for OneShotDaemon {
+        type Config = EmptyCfg;
+        type Runtime = ();
+        type Lease = ();
+        type Error = TestError;
+        type Auth = ();
+
+        fn key() -> ResourceKey {
+            ResourceKey::new("daemon-oneshot").unwrap()
+        }
+
+        async fn create(
+            &self,
+            _config: &Self::Config,
+            _auth: &(),
+            _ctx: &dyn Ctx,
+        ) -> Result<(), TestError> {
+            Ok(())
+        }
+
+        fn metadata() -> ResourceMetadata {
+            ResourceMetadata::from_key(&Self::key())
+        }
+    }
+
+    impl Daemon for OneShotDaemon {
+        async fn run(
+            &self,
+            _runtime: &Self::Runtime,
+            _ctx: &dyn Ctx,
+            _cancel: CancellationToken,
+        ) -> Result<(), TestError> {
+            Ok(())
+        }
+    }
+
+    /// #323: `stop()` called while the daemon is sleeping in `restart_backoff`
+    /// must return promptly. Without the `biased select` at the bottom of
+    /// `daemon_loop`, stop would be blocked for the full backoff.
+    #[tokio::test]
+    async fn stop_during_restart_backoff_returns_promptly() {
+        let parent = CancellationToken::new();
+        let cfg = DaemonCfg {
+            restart_policy: RestartPolicy::Always,
+            restart_backoff: Duration::from_secs(10),
+            max_restarts: 100,
+        };
+        let rt = DaemonRuntime::<FlakyDaemon>::new(cfg, parent);
+        let resource = FlakyDaemon {
+            attempts: Arc::new(AtomicU32::new(0)),
+        };
+        let ctx = BasicCtx::new(ExecutionId::new());
+
+        rt.start(resource, Arc::new(()), &ctx).await.unwrap();
+
+        // Give the daemon time for the first run() to fail and enter the
+        // 10s backoff sleep.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let started = std::time::Instant::now();
+        rt.stop().await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "stop() during restart_backoff must return promptly, took {elapsed:?}",
+        );
+        assert!(!rt.is_running().await);
+    }
+
+    /// #318: `start → stop → start` must succeed. The per-run child token
+    /// + inner handle cleanup in `start()` are what makes this work.
+    #[tokio::test]
+    async fn start_stop_start_lifecycle() {
+        let parent = CancellationToken::new();
+        let cfg = DaemonCfg {
+            restart_policy: RestartPolicy::Always,
+            restart_backoff: Duration::from_millis(20),
+            max_restarts: 100,
+        };
+        let rt = DaemonRuntime::<FlakyDaemon>::new(cfg, parent);
+        let resource = FlakyDaemon {
+            attempts: Arc::new(AtomicU32::new(0)),
+        };
+        let ctx = BasicCtx::new(ExecutionId::new());
+
+        rt.start(resource.clone(), Arc::new(()), &ctx)
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        rt.stop().await;
+        assert!(!rt.is_running().await);
+
+        rt.start(resource, Arc::new(()), &ctx)
+            .await
+            .expect("start after stop must succeed");
+        assert!(rt.is_running().await);
+        rt.stop().await;
+    }
+
+    /// #318: `start → natural-exit → start` must succeed too. Under
+    /// `RestartPolicy::Never` the task exits after one run; the stale
+    /// finished handle in `inner` must not block the next `start()`.
+    #[tokio::test]
+    async fn start_natural_exit_start_lifecycle() {
+        let parent = CancellationToken::new();
+        let cfg = DaemonCfg {
+            restart_policy: RestartPolicy::Never,
+            restart_backoff: Duration::from_millis(10),
+            max_restarts: 0,
+        };
+        let rt = DaemonRuntime::<OneShotDaemon>::new(cfg, parent);
+        let ctx = BasicCtx::new(ExecutionId::new());
+
+        rt.start(OneShotDaemon, Arc::new(()), &ctx).await.unwrap();
+
+        // Wait until the run future has resolved and the join handle is
+        // finished. 250 ms with 5 ms polls is generous.
+        for _ in 0..50 {
+            if !rt.is_running().await {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(!rt.is_running().await);
+
+        rt.start(OneShotDaemon, Arc::new(()), &ctx)
+            .await
+            .expect("start after natural exit must succeed");
+    }
+}

--- a/crates/resource/src/runtime/exclusive.rs
+++ b/crates/resource/src/runtime/exclusive.rs
@@ -91,7 +91,12 @@ where
         let resource_clone = resource.clone();
         let rq = release_queue.clone();
 
-        Ok(ResourceHandle::guarded_with_permit(
+        // #384: the permit must stay alive for the entire `reset()` window,
+        // otherwise the next acquirer can enter while the previous reset is
+        // still running. We move the permit into the release closure and
+        // then into the submitted future, so it is dropped AFTER reset
+        // resolves (see `release_exclusive`).
+        Ok(ResourceHandle::guarded(
             lease,
             R::key(),
             TopologyTag::Exclusive,
@@ -100,22 +105,26 @@ where
                 if let Some(m) = &metrics {
                     m.record_release();
                 }
-                rq.submit(move || Box::pin(release_exclusive(resource_clone, runtime)));
+                rq.submit(move || Box::pin(release_exclusive(resource_clone, runtime, permit)));
             },
-            Some(permit),
         ))
     }
 }
 
 /// Async helper for releasing an exclusive lease.
 ///
-/// Calls `reset()` on the resource. The semaphore permit is **not** held
-/// here — it was already returned when the handle dropped (it lives in
-/// `HandleInner::Guarded`, not in the callback closure).
-async fn release_exclusive<R>(resource: R, runtime: Arc<R::Runtime>)
-where
+/// Calls `reset()` on the resource and then drops the semaphore permit.
+/// Holding the permit until after `reset()` resolves is the contract
+/// documented on `Exclusive::reset`: the next caller cannot acquire the
+/// exclusive lock until the previous reset has finished (#384).
+async fn release_exclusive<R>(
+    resource: R,
+    runtime: Arc<R::Runtime>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+) where
     R: Exclusive + Send + Sync + 'static,
     R::Runtime: Send + Sync + 'static,
 {
     let _ = resource.reset(&runtime).await;
+    drop(permit);
 }

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -13,8 +13,11 @@ use arc_swap::ArcSwap;
 
 use super::TopologyRuntime;
 use crate::{
-    integration::AcquireResilience, recovery::RecoveryGate, release_queue::ReleaseQueue,
-    resource::Resource, state::ResourceStatus,
+    integration::AcquireResilience,
+    recovery::RecoveryGate,
+    release_queue::ReleaseQueue,
+    resource::Resource,
+    state::{ResourcePhase, ResourceStatus},
 };
 
 /// Per-registration runtime holding topology + metadata.
@@ -60,5 +63,32 @@ impl<R: Resource> ManagedResource<R> {
     /// Returns a snapshot of the current configuration.
     pub fn config(&self) -> Arc<R::Config> {
         self.config.load_full()
+    }
+
+    /// Atomically replace the lifecycle status with a new phase.
+    ///
+    /// Rebuilds a fresh [`ResourceStatus`] from the latest snapshot,
+    /// copying the current generation across and preserving `last_error`.
+    /// Used by the manager to drive phase transitions on register, reload
+    /// and shutdown (#387).
+    pub(crate) fn set_phase(&self, phase: ResourcePhase) {
+        let prev = self.status.load_full();
+        let next = ResourceStatus {
+            phase,
+            generation: self.generation(),
+            last_error: prev.last_error.clone(),
+        };
+        self.status.store(Arc::new(next));
+    }
+
+    /// Replace the lifecycle status with `Failed` and record a reason.
+    #[allow(dead_code)] // callers will land with the recovery-error work
+    pub(crate) fn set_failed(&self, error: impl Into<String>) {
+        let next = ResourceStatus {
+            phase: ResourcePhase::Failed,
+            generation: self.generation(),
+            last_error: Some(error.into()),
+        };
+        self.status.store(Arc::new(next));
     }
 }

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -82,6 +82,13 @@ pub struct PoolStats {
 pub struct PoolRuntime<R: Resource> {
     idle: Arc<Mutex<VecDeque<PoolEntry<R>>>>,
     semaphore: Arc<Semaphore>,
+    /// Bounds concurrent invocations of `create_entry` (#390).
+    ///
+    /// The checkout semaphore gates active leases; this one gates
+    /// *creation* so a burst of concurrent acquires cannot fan out into
+    /// `max_size` parallel `Resource::create` calls against a fragile
+    /// backend.
+    create_semaphore: Arc<Semaphore>,
     config: Config,
     current_fingerprint: Arc<AtomicU64>,
 }
@@ -99,9 +106,16 @@ impl<R: Resource> PoolRuntime<R> {
     /// on your config type to enable change detection.
     pub fn new(config: Config, fingerprint: u64) -> Self {
         let semaphore = Arc::new(Semaphore::new(config.max_size as usize));
+        // #390: cap concurrent instance creation. `max(1)` protects us
+        // from a pathological `max_concurrent_creates = 0` config that
+        // would otherwise deadlock the pool on first acquire.
+        let create_semaphore = Arc::new(Semaphore::new(
+            (config.max_concurrent_creates as usize).max(1),
+        ));
         Self {
             idle: Arc::new(Mutex::new(VecDeque::new())),
             semaphore,
+            create_semaphore,
             config,
             current_fingerprint: Arc::new(AtomicU64::new(fingerprint)),
         }
@@ -400,6 +414,11 @@ where
     }
 
     /// Creates a new pool entry via `resource.create()`.
+    ///
+    /// All creation goes through this funnel and is gated on
+    /// `create_semaphore` (#390) so a burst of acquires cannot stampede
+    /// a fragile backend with `max_size` parallel connects. The permit
+    /// is released as soon as `Resource::create` returns.
     async fn create_entry(
         &self,
         resource: &R,
@@ -407,6 +426,13 @@ where
         auth: &R::Auth,
         ctx: &dyn Ctx,
     ) -> Result<PoolEntry<R>, Error> {
+        let _create_permit = self
+            .create_semaphore
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|_| Error::permanent("pool: create semaphore closed"))?;
+
         let runtime = match tokio::time::timeout(
             self.config.create_timeout,
             resource.create(config, auth, ctx),

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -290,7 +290,7 @@ where
 
         // No idle instance available — create a new one with our permit.
         let entry = match self
-            .create_entry(resource, resource_config, auth, ctx)
+            .create_entry(resource, resource_config, auth, ctx, false)
             .await
         {
             Ok(e) => e,
@@ -444,30 +444,53 @@ where
     /// slow-creating backend cannot stall callers forever (also raised
     /// in PR #399 review: the create-semaphore acquire used to be
     /// unbounded).
+    ///
+    /// When `non_blocking` is `true` (the `try_acquire` path), the
+    /// create-semaphore wait is replaced with a `try_acquire_owned`
+    /// that returns `Backpressure` immediately instead of queueing,
+    /// preserving the non-blocking contract of `try_acquire`.
     async fn create_entry(
         &self,
         resource: &R,
         config: &R::Config,
         auth: &R::Auth,
         ctx: &dyn Ctx,
+        non_blocking: bool,
     ) -> Result<PoolEntry<R>, Error> {
         let deadline = Instant::now() + self.config.create_timeout;
 
-        let _create_permit = match tokio::time::timeout_at(
-            deadline.into(),
-            self.create_semaphore.clone().acquire_owned(),
-        )
-        .await
-        {
-            Ok(Ok(permit)) => permit,
-            Ok(Err(_)) => {
-                return Err(Error::permanent("pool: create semaphore closed"));
-            },
-            Err(_) => {
-                return Err(Error::backpressure(
-                    "pool: create timed out waiting for create-semaphore permit",
-                ));
-            },
+        let _create_permit = if non_blocking {
+            match self.create_semaphore.clone().try_acquire_owned() {
+                Ok(permit) => permit,
+                Err(tokio::sync::TryAcquireError::NoPermits) => {
+                    return Err(Error::backpressure(format!(
+                        "{}: create-semaphore full — all {} concurrent creates \
+                         in use (non-blocking acquire, #390)",
+                        R::key(),
+                        self.config.max_concurrent_creates,
+                    )));
+                },
+                Err(tokio::sync::TryAcquireError::Closed) => {
+                    return Err(Error::permanent("pool: create semaphore closed"));
+                },
+            }
+        } else {
+            match tokio::time::timeout_at(
+                deadline.into(),
+                self.create_semaphore.clone().acquire_owned(),
+            )
+            .await
+            {
+                Ok(Ok(permit)) => permit,
+                Ok(Err(_)) => {
+                    return Err(Error::permanent("pool: create semaphore closed"));
+                },
+                Err(_) => {
+                    return Err(Error::backpressure(
+                        "pool: create timed out waiting for create-semaphore permit",
+                    ));
+                },
+            }
         };
 
         // Use `timeout_at` with the same absolute deadline so the budget
@@ -617,9 +640,11 @@ where
             IdleResult::Empty(permit) => permit,
         };
 
-        // No idle instance — create a new one.
+        // No idle instance — create a new one. The `true` flag keeps
+        // the non-blocking contract: if the create semaphore is full,
+        // we return Backpressure instead of waiting (PR #399 review).
         let entry = match self
-            .create_entry(resource, resource_config, auth, ctx)
+            .create_entry(resource, resource_config, auth, ctx, true)
             .await
         {
             Ok(e) => e,
@@ -711,7 +736,7 @@ where
         let mut created = 0usize;
         for _ in 0..target {
             match self
-                .create_entry(resource, resource_config, auth, ctx)
+                .create_entry(resource, resource_config, auth, ctx, false)
                 .await
             {
                 Ok(mut entry) => {
@@ -759,7 +784,7 @@ where
                 tokio::time::sleep(interval).await;
             }
             match self
-                .create_entry(resource, resource_config, auth, ctx)
+                .create_entry(resource, resource_config, auth, ctx, false)
                 .await
             {
                 Ok(mut entry) => {

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -437,6 +437,13 @@ where
     /// `create_semaphore` (#390) so a burst of acquires cannot stampede
     /// a fragile backend with `max_size` parallel connects. The permit
     /// is released as soon as `Resource::create` returns.
+    ///
+    /// The whole path — permit wait + `resource.create` — shares a
+    /// single `create_timeout` budget. Both the create semaphore wait
+    /// and the actual create are bounded by the remaining budget so a
+    /// slow-creating backend cannot stall callers forever (also raised
+    /// in PR #399 review: the create-semaphore acquire used to be
+    /// unbounded).
     async fn create_entry(
         &self,
         resource: &R,
@@ -444,15 +451,30 @@ where
         auth: &R::Auth,
         ctx: &dyn Ctx,
     ) -> Result<PoolEntry<R>, Error> {
-        let _create_permit = self
-            .create_semaphore
-            .clone()
-            .acquire_owned()
-            .await
-            .map_err(|_| Error::permanent("pool: create semaphore closed"))?;
+        let deadline = Instant::now() + self.config.create_timeout;
 
-        let runtime = match tokio::time::timeout(
-            self.config.create_timeout,
+        let _create_permit = match tokio::time::timeout_at(
+            deadline.into(),
+            self.create_semaphore.clone().acquire_owned(),
+        )
+        .await
+        {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_)) => {
+                return Err(Error::permanent("pool: create semaphore closed"));
+            },
+            Err(_) => {
+                return Err(Error::backpressure(
+                    "pool: create timed out waiting for create-semaphore permit",
+                ));
+            },
+        };
+
+        // Use `timeout_at` with the same absolute deadline so the budget
+        // is shared: a long permit wait shortens the time available to
+        // `resource.create`.
+        let runtime = match tokio::time::timeout_at(
+            deadline.into(),
             resource.create(config, auth, ctx),
         )
         .await

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -105,6 +105,24 @@ impl<R: Resource> PoolRuntime<R> {
     /// [`ResourceConfig::fingerprint()`](crate::ResourceConfig::fingerprint)
     /// on your config type to enable change detection.
     pub fn new(config: Config, fingerprint: u64) -> Self {
+        // #390: fail loudly at construction rather than deadlock on first
+        // acquire. `Manager::register_pooled*` surfaces the same check as
+        // a typed `Error::permanent`, but this guard also protects direct
+        // callers of the public `PoolRuntime::new` (e.g. the README and
+        // doctests). Invariants that must hold for the pool to function
+        // at all are asserted here rather than silently clamped.
+        assert!(
+            config.max_size > 0,
+            "PoolRuntime: config.max_size must be > 0 (got 0 — would deadlock \
+             the checkout semaphore on first acquire)",
+        );
+        assert!(
+            config.min_size <= config.max_size,
+            "PoolRuntime: config.min_size ({}) must be <= max_size ({})",
+            config.min_size,
+            config.max_size,
+        );
+
         let semaphore = Arc::new(Semaphore::new(config.max_size as usize));
         // #390: cap concurrent instance creation. `max(1)` protects us
         // from a pathological `max_concurrent_creates = 0` config that

--- a/crates/resource/src/topology/exclusive.rs
+++ b/crates/resource/src/topology/exclusive.rs
@@ -19,7 +19,10 @@ use crate::resource::Resource;
 pub trait Exclusive: Resource {
     /// Resets the resource state after each exclusive use.
     ///
-    /// Called when the lease is released, before the next caller can acquire.
+    /// Called after the lease is released, before the **next** caller can
+    /// acquire the exclusive permit. The runtime guarantees this ordering
+    /// by holding the semaphore permit until `reset` resolves (#384).
+    ///
     /// The default implementation is a no-op.
     fn reset(
         &self,

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -552,6 +552,159 @@ async fn manager_shutdown_rejects_acquire() {
 }
 
 // ---------------------------------------------------------------------------
+// #390 — pool config validation + max_concurrent_creates enforcement
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn register_pooled_rejects_min_greater_than_max() {
+    let manager = Manager::new();
+    let resource = PoolTestResource::new();
+    let pool_config = nebula_resource::topology::pooled::config::Config {
+        min_size: 5,
+        max_size: 2,
+        ..Default::default()
+    };
+
+    let err = manager
+        .register_pooled::<PoolTestResource>(resource, test_config(), pool_config)
+        .expect_err("min > max must be rejected");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("min_size") && msg.contains("max_size"),
+        "error message must mention min_size and max_size, got: {msg}",
+    );
+}
+
+#[tokio::test]
+async fn register_pooled_rejects_max_size_zero() {
+    let manager = Manager::new();
+    let resource = PoolTestResource::new();
+    let pool_config = nebula_resource::topology::pooled::config::Config {
+        min_size: 0,
+        max_size: 0,
+        ..Default::default()
+    };
+
+    let err = manager
+        .register_pooled::<PoolTestResource>(resource, test_config(), pool_config)
+        .expect_err("max_size == 0 must be rejected");
+    assert!(err.to_string().contains("max_size"));
+}
+
+#[derive(Clone)]
+struct SlowCreatePoolResource {
+    in_flight: Arc<AtomicU64>,
+    peak: Arc<AtomicU64>,
+}
+
+impl Resource for SlowCreatePoolResource {
+    type Config = TestConfig;
+    type Runtime = Arc<AtomicU64>;
+    type Lease = Arc<AtomicU64>;
+    type Error = TestError;
+    type Auth = ();
+
+    fn key() -> ResourceKey {
+        resource_key!("slow-create-pool")
+    }
+
+    async fn create(
+        &self,
+        _config: &TestConfig,
+        _auth: &(),
+        _ctx: &dyn Ctx,
+    ) -> Result<Arc<AtomicU64>, TestError> {
+        let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+        // Update peak with a compare-exchange loop.
+        let mut observed = self.peak.load(Ordering::SeqCst);
+        while now > observed {
+            match self
+                .peak
+                .compare_exchange(observed, now, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => break,
+                Err(cur) => observed = cur,
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        self.in_flight.fetch_sub(1, Ordering::SeqCst);
+        Ok(Arc::new(AtomicU64::new(0)))
+    }
+
+    async fn destroy(&self, _runtime: Arc<AtomicU64>) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Pooled for SlowCreatePoolResource {
+    fn is_broken(&self, _runtime: &Arc<AtomicU64>) -> BrokenCheck {
+        BrokenCheck::Healthy
+    }
+
+    async fn recycle(
+        &self,
+        _runtime: &Arc<AtomicU64>,
+        _metrics: &nebula_resource::topology::pooled::InstanceMetrics,
+    ) -> Result<RecycleDecision, TestError> {
+        Ok(RecycleDecision::Keep)
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn pool_create_path_respects_max_concurrent_creates() {
+    use nebula_resource::topology::pooled::config::{Config as PoolCfg, WarmupStrategy};
+
+    let resource = SlowCreatePoolResource {
+        in_flight: Arc::new(AtomicU64::new(0)),
+        peak: Arc::new(AtomicU64::new(0)),
+    };
+    let peak = resource.peak.clone();
+
+    let manager = Arc::new(Manager::new());
+    let pool_config = PoolCfg {
+        min_size: 0,
+        max_size: 10,
+        max_concurrent_creates: 2,
+        warmup: WarmupStrategy::None,
+        ..Default::default()
+    };
+    manager
+        .register_pooled::<SlowCreatePoolResource>(resource, test_config(), pool_config)
+        .expect("register");
+
+    // Fire 10 concurrent acquires so they all hit the create path.
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let mgr = Arc::clone(&manager);
+        handles.push(tokio::spawn(async move {
+            let ctx = test_ctx();
+            mgr.acquire_pooled::<SlowCreatePoolResource>(&(), &ctx, &AcquireOptions::default())
+                .await
+                .expect("acquire")
+        }));
+    }
+    let mut leases = Vec::with_capacity(10);
+    for h in handles {
+        leases.push(h.await.expect("spawn"));
+    }
+    drop(leases);
+
+    let observed = peak.load(Ordering::SeqCst);
+    assert!(
+        observed <= 2,
+        "max_concurrent_creates=2 violated — observed peak={observed} (#390)",
+    );
+    assert!(
+        observed > 0,
+        "create path never ran — test fixture is broken",
+    );
+}
+
+// ---------------------------------------------------------------------------
 // #387 — ResourceStatus.phase lifecycle
 // ---------------------------------------------------------------------------
 

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -1854,6 +1854,117 @@ async fn exclusive_acquire_timeout_when_locked() {
 }
 
 // ---------------------------------------------------------------------------
+// #384 — exclusive permit held until reset() completes
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct SlowResetExclusive {
+    in_progress: Arc<std::sync::atomic::AtomicBool>,
+    overlap_observed: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl Resource for SlowResetExclusive {
+    type Config = TestConfig;
+    type Runtime = Arc<AtomicU64>;
+    type Lease = Arc<AtomicU64>;
+    type Error = TestError;
+    type Auth = ();
+
+    fn key() -> ResourceKey {
+        resource_key!("slow-reset-exclusive")
+    }
+
+    async fn create(
+        &self,
+        _config: &TestConfig,
+        _auth: &(),
+        _ctx: &dyn Ctx,
+    ) -> Result<Arc<AtomicU64>, TestError> {
+        Ok(Arc::new(AtomicU64::new(0)))
+    }
+
+    async fn destroy(&self, _runtime: Arc<AtomicU64>) -> Result<(), TestError> {
+        Ok(())
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Exclusive for SlowResetExclusive {
+    fn reset(
+        &self,
+        _runtime: &Arc<AtomicU64>,
+    ) -> impl std::future::Future<Output = Result<(), TestError>> + Send {
+        let in_progress = self.in_progress.clone();
+        async move {
+            in_progress.store(true, Ordering::SeqCst);
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            in_progress.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exclusive_next_acquire_waits_until_reset_completes() {
+    // #384: verify a second acquire cannot enter the critical section
+    // while a previous reset() is still running asynchronously. The
+    // resource's reset() holds `in_progress = true` for ~150ms, so under
+    // the fix the next acquire must block for at least that long.
+    let resource = SlowResetExclusive {
+        in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        overlap_observed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+    };
+    let runtime = Arc::new(AtomicU64::new(0));
+    let rt =
+        ExclusiveRuntime::<SlowResetExclusive>::new(runtime, exclusive::config::Config::default());
+    let (rq, rq_handle) = ReleaseQueue::new(1);
+    let rq = Arc::new(rq);
+
+    let h1 = rt
+        .acquire(&resource, &rq, 0, &AcquireOptions::default(), None)
+        .await
+        .expect("first acquire");
+    drop(h1);
+
+    // Give the release queue worker time to pick up the reset task and
+    // start its sleep. Without the fix the permit was already dropped by
+    // HandleInner::Guarded's Drop; with the fix the permit moved into the
+    // reset future and is still held.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let start = std::time::Instant::now();
+    let h2 = rt
+        .acquire(&resource, &rq, 0, &AcquireOptions::default(), None)
+        .await
+        .expect("second acquire");
+    let elapsed = start.elapsed();
+
+    // Any overlap with the in-flight reset is a bug.
+    if resource.in_progress.load(Ordering::SeqCst) {
+        resource.overlap_observed.store(true, Ordering::SeqCst);
+    }
+    assert!(
+        !resource.overlap_observed.load(Ordering::SeqCst),
+        "second acquire raced against an in-flight reset() — permit was \
+         returned before reset completed (#384)",
+    );
+    assert!(
+        elapsed >= std::time::Duration::from_millis(80),
+        "second acquire must block until reset() finishes (~150ms), \
+         actually blocked {elapsed:?} — the fix is missing (#384)",
+    );
+
+    drop(h2);
+    tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+    drop(rq);
+    ReleaseQueue::shutdown(rq_handle).await;
+}
+
+// ---------------------------------------------------------------------------
 // Pool permit leak regression test
 // ---------------------------------------------------------------------------
 

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -551,6 +551,94 @@ async fn manager_shutdown_rejects_acquire() {
     assert_eq!(*err.kind(), ErrorKind::Cancelled);
 }
 
+// ---------------------------------------------------------------------------
+// #387 — ResourceStatus.phase lifecycle
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn register_transitions_phase_to_ready() {
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt =
+        ResidentRuntime::<ResidentTestResource>::new(resident::config::Config::default());
+
+    manager
+        .register(
+            resource,
+            test_config(),
+            ScopeLevel::Global,
+            TopologyRuntime::Resident(resident_rt),
+            None,
+            None,
+        )
+        .expect("register");
+
+    let snap = manager
+        .health_check::<ResidentTestResource>(&ScopeLevel::Global)
+        .expect("health");
+    assert_eq!(snap.phase, nebula_resource::state::ResourcePhase::Ready);
+    assert_eq!(snap.generation, 0);
+}
+
+#[tokio::test]
+async fn reload_config_bumps_status_generation() {
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt =
+        ResidentRuntime::<ResidentTestResource>::new(resident::config::Config::default());
+
+    manager
+        .register(
+            resource,
+            test_config(),
+            ScopeLevel::Global,
+            TopologyRuntime::Resident(resident_rt),
+            None,
+            None,
+        )
+        .expect("register");
+
+    manager
+        .reload_config::<ResidentTestResource>(test_config(), &ScopeLevel::Global)
+        .expect("reload");
+
+    let snap = manager
+        .health_check::<ResidentTestResource>(&ScopeLevel::Global)
+        .expect("health");
+    assert_eq!(snap.phase, nebula_resource::state::ResourcePhase::Ready);
+    assert_eq!(
+        snap.generation, 1,
+        "reload_config must bake the new generation into ResourceStatus (#387)",
+    );
+}
+
+#[tokio::test]
+async fn graceful_shutdown_report_marks_registry_cleared() {
+    use nebula_resource::manager::ShutdownConfig;
+
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt =
+        ResidentRuntime::<ResidentTestResource>::new(resident::config::Config::default());
+
+    manager
+        .register(
+            resource,
+            test_config(),
+            ScopeLevel::Global,
+            TopologyRuntime::Resident(resident_rt),
+            None,
+            None,
+        )
+        .expect("register");
+
+    let report = manager
+        .graceful_shutdown(ShutdownConfig::default())
+        .await
+        .expect("graceful");
+    assert!(report.registry_cleared);
+}
+
 #[tokio::test]
 async fn remove_nonexistent_returns_not_found() {
     let manager = Manager::new();

--- a/docs/superpowers/plans/2026-04-14-resource-open-issues-fix.md
+++ b/docs/superpowers/plans/2026-04-14-resource-open-issues-fix.md
@@ -1,0 +1,1491 @@
+# Fix nebula-resource Open Issues Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve all 11 open issues filed against `nebula-resource` (#272, #302, #318, #322, #323, #382, #383, #384, #387, #390, #391) by either landing the missing fix, adding the missing regression test, or correcting documentation — and close every issue with a verifiable PR reference.
+
+**Architecture:** Six issues describe code that is still broken in `crates/resource` and need real fixes (#382, #383, #384, #387, #390, #391). Five issues describe bugs whose fix has already landed in `manager.rs` / `runtime/daemon.rs` but were never closed (#272, #302, #318, #322, #323) — these need verification by inspecting the current code, adding any missing regression tests, and closing the issue. Work is grouped by file boundary so tasks stay self-contained.
+
+**Tech Stack:** Rust 2024 edition, `tokio`, `arc-swap`, `dashmap`, `tokio-util::sync::CancellationToken`, `nebula-resilience::retry`, `cargo nextest`.
+
+---
+
+## Issue Triage Summary
+
+| Issue | Status in code | Action |
+|---|---|---|
+| #272 wait_for_drain lost-wakeup race | Fixed (register-then-check at `manager.rs:1442`); two regression tests at `manager.rs:1731,1766` | Verify + close |
+| #302 graceful_shutdown force-clear on drain timeout | Fixed (`DrainTimeoutPolicy`, `ShutdownReport`, `ShutdownError` at `manager.rs:1338`) | Verify + add coverage + close |
+| #318 DaemonRuntime restart-safe | Fixed (`per-run` child token + finished-handle cleanup at `runtime/daemon.rs:131`) | Add regression test + close |
+| #322 RecoveryGate probe herd | Fixed (`admit_through_gate` at `manager.rs:1612`) | Verify + add coverage + close |
+| #323 daemon backoff cancel-aware | Fixed (`biased select` at `runtime/daemon.rs:253`) | Add regression test + close |
+| #382 stale TypeId rows on replace | **Broken** | Implement fix |
+| #383 max_attempts=0 panic | **Broken** | Implement fix |
+| #384 Exclusive reset vs permit ordering | **Broken** | Implement fix |
+| #387 ResourceStatus.phase never updated | **Broken** | Implement fix |
+| #390 pool config gaps | **Broken** | Implement fix |
+| #391 AcquireOptions intent/tags unused | **Broken (docs only)** | Doc-only fix |
+
+---
+
+## File Map
+
+Files that this plan modifies (grouped by responsibility):
+
+- `crates/resource/src/integration/resilience.rs` — fix `to_retry_config` panic (#383).
+- `crates/resource/src/registry.rs` — fix stale `type_index` rows on replace (#382).
+- `crates/resource/src/runtime/exclusive.rs` — hold permit until `reset()` completes (#384).
+- `crates/resource/src/state.rs` — add helper for status mutation (#387).
+- `crates/resource/src/runtime/managed.rs` — add `set_phase` / `set_phase_with_generation` helpers (#387).
+- `crates/resource/src/manager.rs` — drive phase transitions + `min_size`/`max_size` validation + add regression tests (#387, #390, #302, #322).
+- `crates/resource/src/runtime/pool.rs` — wire `max_concurrent_creates` into create path (#390).
+- `crates/resource/src/runtime/daemon.rs` — add lifecycle regression tests (#318, #323).
+- `crates/resource/src/options.rs` — narrow doc comments for unused fields (#391).
+
+No new files are created. Tests live alongside the code they cover (in-file `#[cfg(test)] mod tests`).
+
+---
+
+## Task 1: #383 — Stop panicking on `max_attempts: 0`
+
+**Files:**
+- Modify: `crates/resource/src/integration/resilience.rs:96-115`
+- Test: `crates/resource/src/integration/resilience.rs` (extend in-file `#[cfg(test)] mod tests`)
+
+**Why:** `to_retry_config` calls `RetryConfig::new(max_attempts).expect("max_attempts validated at construction")` but nothing validates the value when callers build `AcquireResilience` manually. A user-supplied `max_attempts: 0` from a config file panics the manager during the first acquire.
+
+**Fix shape:** Clamp `max_attempts` to `max(1, …)` inside `to_retry_config` so a misconfigured zero degrades to a single attempt instead of panicking. Document the clamp on the field.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/resource/src/integration/resilience.rs`, append to `mod tests`:
+
+```rust
+#[test]
+fn to_retry_config_handles_zero_max_attempts_without_panic() {
+    let cfg = AcquireResilience {
+        timeout: None,
+        retry: Some(AcquireRetryConfig {
+            max_attempts: 0,
+            initial_backoff: Duration::from_millis(10),
+            max_backoff: Duration::from_millis(50),
+        }),
+    };
+
+    // Must not panic. Behaviour: degrade to a single attempt.
+    let _ = cfg.to_retry_config::<crate::error::Error>();
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p nebula-resource integration::resilience::tests::to_retry_config_handles_zero_max_attempts_without_panic
+```
+
+Expected: FAIL with `panicked at 'max_attempts validated at construction'`.
+
+- [ ] **Step 3: Implement the clamp**
+
+Replace the body of `to_retry_config` in `crates/resource/src/integration/resilience.rs`:
+
+```rust
+pub(crate) fn to_retry_config<E: 'static>(&self) -> RetryConfig<E> {
+    // #383: a misconfigured `max_attempts: 0` from a config file used to
+    // panic here via `expect`. Clamp to `1` so we degrade to a single
+    // attempt rather than killing the process during acquire.
+    let max_attempts = self.retry.as_ref().map_or(1, |r| r.max_attempts.max(1));
+    let cfg = RetryConfig::new(max_attempts)
+        .expect("max_attempts clamped to >=1 above");
+
+    let cfg = if let Some(ref retry) = self.retry {
+        cfg.backoff(BackoffConfig::Exponential {
+            base: retry.initial_backoff,
+            multiplier: 2.0,
+            max: retry.max_backoff,
+        })
+    } else {
+        cfg
+    };
+
+    if let Some(timeout) = self.timeout {
+        cfg.total_budget(timeout)
+    } else {
+        cfg
+    }
+}
+```
+
+Also update the doc comment on `AcquireRetryConfig::max_attempts` (around line 38-39) to add: `Values below 1 are clamped to 1 by the manager.`
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+```bash
+cargo nextest run -p nebula-resource integration::resilience::tests::to_retry_config_handles_zero_max_attempts_without_panic
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full crate test suite**
+
+```bash
+cargo nextest run -p nebula-resource
+```
+
+Expected: PASS (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add crates/resource/src/integration/resilience.rs
+git commit -m "fix(resource): clamp AcquireResilience max_attempts to >=1 (#383)"
+```
+
+---
+
+## Task 2: #382 — Drop stale `TypeId` rows on `Registry::register` replace
+
+**Files:**
+- Modify: `crates/resource/src/registry.rs:20-86`
+- Test: `crates/resource/src/registry.rs` (add `#[cfg(test)] mod tests` if absent)
+
+**Why:** `Registry::register` always inserts the new `(type_id → key)` row but does not remove the previous `type_id` row when the in-place replace at the same `(key, scope)` swaps the underlying `R` type. The stale row leaks forever and `get_typed::<OldR>` resolves the key but the downcast then fails — confusing semantics + a small map leak.
+
+**Fix shape:** Expose the `TypeId` of the boxed `ManagedResource<R>` via the `AnyManagedResource` trait. On the replace path in `register`, remove the prior entry's `TypeId` from `type_index` before swapping in the new one.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/resource/src/registry.rs`, append at the bottom of the file:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::any::TypeId;
+    use std::sync::Arc;
+
+    use nebula_core::ResourceKey;
+
+    use super::*;
+    use crate::ctx::ScopeLevel;
+
+    // Two zero-sized fakes for the test — they only need to implement the
+    // trait, not real resource semantics.
+    struct FakeA;
+    struct FakeB;
+
+    impl AnyManagedResource for FakeA {
+        fn resource_key(&self) -> ResourceKey {
+            ResourceKey::from_static("fake")
+        }
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+            self
+        }
+        fn managed_type_id(&self) -> TypeId {
+            TypeId::of::<FakeA>()
+        }
+    }
+
+    impl AnyManagedResource for FakeB {
+        fn resource_key(&self) -> ResourceKey {
+            ResourceKey::from_static("fake")
+        }
+        fn as_any_arc(self: Arc<Self>) -> Arc<dyn std::any::Any + Send + Sync> {
+            self
+        }
+        fn managed_type_id(&self) -> TypeId {
+            TypeId::of::<FakeB>()
+        }
+    }
+
+    #[test]
+    fn register_replace_drops_stale_type_id_row() {
+        let reg = Registry::new();
+        let key = ResourceKey::from_static("fake");
+        let scope = ScopeLevel::Global;
+
+        reg.register(key.clone(), TypeId::of::<FakeA>(), scope, Arc::new(FakeA));
+        assert!(reg.type_index.contains_key(&TypeId::of::<FakeA>()));
+
+        // Replace at the same key+scope with a different concrete type.
+        reg.register(key.clone(), TypeId::of::<FakeB>(), scope, Arc::new(FakeB));
+
+        // The stale TypeId row for FakeA must be gone.
+        assert!(
+            !reg.type_index.contains_key(&TypeId::of::<FakeA>()),
+            "stale TypeId for FakeA still in type_index after replace"
+        );
+        assert!(reg.type_index.contains_key(&TypeId::of::<FakeB>()));
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p nebula-resource registry::tests::register_replace_drops_stale_type_id_row
+```
+
+Expected: FAIL — either compile error (no `managed_type_id`) or assertion failure.
+
+- [ ] **Step 3: Add `managed_type_id` to the trait**
+
+In `crates/resource/src/registry.rs`, replace the trait + impl block:
+
+```rust
+pub trait AnyManagedResource: Send + Sync + 'static {
+    /// Returns the resource key for this managed resource.
+    fn resource_key(&self) -> ResourceKey;
+
+    /// Returns a reference to `self` as `&dyn Any` for downcasting.
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
+
+    /// Returns the concrete `TypeId` used as the secondary index key.
+    ///
+    /// For real `ManagedResource<R>` this is `TypeId::of::<ManagedResource<R>>()`.
+    /// Used by [`Registry::register`] to scrub stale rows from `type_index`
+    /// when an entry is replaced in place (#382).
+    fn managed_type_id(&self) -> TypeId;
+}
+
+impl<R: Resource> AnyManagedResource for ManagedResource<R> {
+    fn resource_key(&self) -> ResourceKey {
+        R::key()
+    }
+
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync> {
+        self
+    }
+
+    fn managed_type_id(&self) -> TypeId {
+        TypeId::of::<ManagedResource<R>>()
+    }
+}
+```
+
+- [ ] **Step 4: Drop stale rows on replace**
+
+Replace `Registry::register` body in the same file:
+
+```rust
+pub fn register(
+    &self,
+    key: ResourceKey,
+    type_id: TypeId,
+    scope: ScopeLevel,
+    managed: Arc<dyn AnyManagedResource>,
+) {
+    let mut entries = self.entries.entry(key.clone()).or_default();
+
+    // #382: if we're about to replace an entry at the same scope whose
+    // concrete TypeId differs from the new one, scrub the prior TypeId
+    // row from type_index before installing the new mapping.
+    if let Some(pos) = entries.iter().position(|e| e.scope == scope) {
+        let prev_type_id = entries[pos].managed.managed_type_id();
+        if prev_type_id != type_id {
+            self.type_index
+                .remove_if(&prev_type_id, |_, k| k == &key);
+        }
+        entries[pos] = RegistryEntry { scope, managed };
+    } else {
+        entries.push(RegistryEntry { scope, managed });
+    }
+
+    self.type_index.insert(type_id, key);
+}
+```
+
+- [ ] **Step 5: Run the targeted test to verify it passes**
+
+```bash
+cargo nextest run -p nebula-resource registry::tests::register_replace_drops_stale_type_id_row
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run the full crate test suite**
+
+```bash
+cargo nextest run -p nebula-resource
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/resource/src/registry.rs
+git commit -m "fix(resource): scrub stale TypeId rows on Registry::register replace (#382)"
+```
+
+---
+
+## Task 3: #384 — Hold exclusive permit until `reset()` completes
+
+**Files:**
+- Modify: `crates/resource/src/runtime/exclusive.rs:55-122`
+- Test: `crates/resource/src/runtime/exclusive.rs` (add `#[cfg(test)] mod tests`)
+
+**Why:** `ExclusiveRuntime::acquire` passes the semaphore permit to `ResourceHandle::guarded_with_permit`, which drops it at the end of `Drop`. The `release_exclusive(...)` future is only **submitted** to the `ReleaseQueue` synchronously and runs asynchronously after the permit is already gone. That contradicts the doc contract on `Exclusive::reset` (“before the next caller can acquire”): a second acquirer can take the permit while the previous reset is still queued or in flight.
+
+**Fix shape:** Don’t hand the permit to `guarded_with_permit`. Instead, move the `OwnedSemaphorePermit` into the release closure’s submitted future and drop it explicitly **after** `reset()` resolves. This keeps the permit alive for the entire reset window, so the next acquirer cannot enter until the previous reset is done.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `crates/resource/src/runtime/exclusive.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use crate::ctx::BasicCtx;
+    use crate::error::Error;
+    use crate::release_queue::ReleaseQueue;
+    use crate::resource::Resource;
+    use crate::topology::exclusive::{Exclusive, config::Config};
+
+    #[derive(Clone)]
+    struct SlowResetExclusive {
+        reset_in_progress: Arc<AtomicBool>,
+        overlap_observed: Arc<AtomicBool>,
+    }
+
+    #[derive(Clone)]
+    struct FakeRuntime;
+
+    impl Resource for SlowResetExclusive {
+        type Config = ();
+        type Runtime = FakeRuntime;
+        type Lease = FakeRuntime;
+        type Error = Error;
+
+        fn key() -> nebula_core::ResourceKey {
+            nebula_core::ResourceKey::from_static("slow-reset-exclusive")
+        }
+    }
+
+    impl Exclusive for SlowResetExclusive {
+        async fn reset(&self, _runtime: &Self::Runtime) -> Result<(), Self::Error> {
+            self.reset_in_progress.store(true, Ordering::SeqCst);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            self.reset_in_progress.store(false, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn next_acquire_waits_until_reset_completes() {
+        let rt = ExclusiveRuntime::<SlowResetExclusive>::new(
+            FakeRuntime,
+            Config::default(),
+        );
+        let rq = Arc::new(ReleaseQueue::start_default());
+        let resource = SlowResetExclusive {
+            reset_in_progress: Arc::new(AtomicBool::new(false)),
+            overlap_observed: Arc::new(AtomicBool::new(false)),
+        };
+        let opts = AcquireOptions::default();
+
+        let handle = rt
+            .acquire(&resource, &rq, 0, &opts, None)
+            .await
+            .expect("first acquire");
+        drop(handle);
+
+        // The next acquire must observe reset_in_progress == false at the
+        // moment its permit is granted.
+        let handle = rt
+            .acquire(&resource, &rq, 0, &opts, None)
+            .await
+            .expect("second acquire");
+        let in_progress = resource.reset_in_progress.load(Ordering::SeqCst);
+        assert!(
+            !in_progress,
+            "second acquire raced against an in-flight reset()"
+        );
+        drop(handle);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p nebula-resource runtime::exclusive::tests::next_acquire_waits_until_reset_completes
+```
+
+Expected: FAIL — `in_progress == true` at second acquire because the previous reset is still running asynchronously.
+
+- [ ] **Step 3: Move the permit into the release closure**
+
+Replace the body of `ExclusiveRuntime::acquire` and `release_exclusive` in `crates/resource/src/runtime/exclusive.rs`:
+
+```rust
+pub async fn acquire(
+    &self,
+    resource: &R,
+    release_queue: &Arc<ReleaseQueue>,
+    generation: u64,
+    options: &AcquireOptions,
+    metrics: Option<ResourceOpsMetrics>,
+) -> Result<ResourceHandle<R>, Error>
+where
+    R::Runtime: Into<R::Lease>,
+{
+    let timeout = options.remaining().unwrap_or(self.config.acquire_timeout);
+    let permit =
+        match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
+            Ok(Ok(permit)) => permit,
+            Ok(Err(_)) => return Err(Error::permanent("exclusive semaphore closed")),
+            Err(_) => return Err(Error::backpressure("exclusive: timed out waiting for lock")),
+        };
+
+    let lease: R::Lease = (*self.runtime).clone().into();
+    let runtime = self.runtime.clone();
+    let resource_clone = resource.clone();
+    let rq = release_queue.clone();
+
+    // #384: keep the permit alive until reset() finishes. The closure
+    // *captures* `permit` and the submitted future drops it AFTER reset.
+    // ResourceHandle is built without a permit slot — the permit is no
+    // longer tied to handle Drop ordering.
+    Ok(ResourceHandle::guarded(
+        lease,
+        R::key(),
+        TopologyTag::Exclusive,
+        generation,
+        move |_returned_lease, _tainted| {
+            if let Some(m) = &metrics {
+                m.record_release();
+            }
+            let permit = permit; // move into outer closure
+            rq.submit(move || {
+                Box::pin(release_exclusive(resource_clone, runtime, permit))
+            });
+        },
+    ))
+}
+```
+
+```rust
+async fn release_exclusive<R>(
+    resource: R,
+    runtime: Arc<R::Runtime>,
+    permit: tokio::sync::OwnedSemaphorePermit,
+)
+where
+    R: Exclusive + Send + Sync + 'static,
+    R::Runtime: Send + Sync + 'static,
+{
+    let _ = resource.reset(&runtime).await;
+    // Drop AFTER reset has returned so the next acquirer cannot enter
+    // mid-reset (#384).
+    drop(permit);
+}
+```
+
+If `ResourceHandle::guarded` does not exist, use `guarded_with_permit(..., None)` and accept that the `permit_slot` field on the handle stays empty.
+
+- [ ] **Step 4: Run the targeted test to verify it passes**
+
+```bash
+cargo nextest run -p nebula-resource runtime::exclusive::tests::next_acquire_waits_until_reset_completes
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Update doc on `Exclusive::reset` to confirm guarantee**
+
+In `crates/resource/src/topology/exclusive.rs`, locate the `reset` doc comment and tighten it: "Called after the lease is released, before the **next** caller can acquire the exclusive permit. The runtime guarantees this ordering by holding the semaphore permit until `reset` resolves (#384)."
+
+- [ ] **Step 6: Run the full crate test suite**
+
+```bash
+cargo nextest run -p nebula-resource
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add crates/resource/src/runtime/exclusive.rs crates/resource/src/topology/exclusive.rs
+git commit -m "fix(resource): hold exclusive permit until reset() completes (#384)"
+```
+
+---
+
+## Task 4: #387 — Drive `ResourceStatus.phase` lifecycle
+
+**Files:**
+- Modify: `crates/resource/src/runtime/managed.rs:49-64`
+- Modify: `crates/resource/src/state.rs` (add a small builder helper)
+- Modify: `crates/resource/src/manager.rs` (around lines 315, 1248, 1338) — wire transitions on register/reload/shutdown
+- Test: `crates/resource/src/manager.rs` (in-file `mod phase_tests`)
+
+**Why:** `ManagedResource.status: ArcSwap<ResourceStatus>` is initialized to `(Initializing, generation=0, last_error=None)` in `Manager::register` (line 335) and **never updated** anywhere. `Manager::reload_config` bumps the separate `generation: AtomicU64` but does not touch the embedded `ResourceStatus.generation` either. `Manager::health_check` (line 1531) reads `managed.status().phase` and returns it directly to operators — so health snapshots show `phase = Initializing, generation = 0` forever, while the real generation lives in a sibling atomic. Operators can’t trust either field.
+
+**Fix shape:** Add a `set_phase` helper on `ManagedResource` that builds a fresh `ResourceStatus` from the latest snapshot and stores it via `ArcSwap`. After the success path of every `register_*` set the phase to `Ready`. In `reload_config`, transition `Reloading → Ready` and copy the post-bump generation into `ResourceStatus.generation`. In `graceful_shutdown` Phase 1 set `Draining`, after `wait_for_drain` set `ShuttingDown`. Also expose a `set_failed` so transient errors can record `last_error`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `crates/resource/src/manager.rs`, add a new in-file module right above `mod drain_race_tests`:
+
+```rust
+#[cfg(test)]
+mod phase_lifecycle_tests {
+    use super::*;
+    use crate::resource::test_support::TrivialResource; // see Step 2
+    use crate::state::ResourcePhase;
+
+    #[tokio::test]
+    async fn register_transitions_to_ready() {
+        let mgr = Manager::new();
+        mgr.register::<TrivialResource>(TrivialResource::default(), &ScopeLevel::Global)
+            .await
+            .expect("register");
+
+        let snap = mgr
+            .health_check::<TrivialResource>(&ScopeLevel::Global)
+            .expect("health");
+        assert_eq!(snap.phase, ResourcePhase::Ready);
+        assert_eq!(snap.generation, 0);
+    }
+
+    #[tokio::test]
+    async fn reload_bumps_status_generation() {
+        let mgr = Manager::new();
+        mgr.register::<TrivialResource>(TrivialResource::default(), &ScopeLevel::Global)
+            .await
+            .expect("register");
+
+        mgr.reload_config::<TrivialResource>(Default::default(), &ScopeLevel::Global)
+            .expect("reload");
+
+        let snap = mgr
+            .health_check::<TrivialResource>(&ScopeLevel::Global)
+            .expect("health");
+        assert_eq!(snap.phase, ResourcePhase::Ready);
+        assert_eq!(snap.generation, 1);
+    }
+
+    #[tokio::test]
+    async fn graceful_shutdown_walks_phase_to_shutting_down() {
+        let mgr = Manager::new();
+        mgr.register::<TrivialResource>(TrivialResource::default(), &ScopeLevel::Global)
+            .await
+            .expect("register");
+
+        let report = mgr
+            .graceful_shutdown(ShutdownConfig::default())
+            .await
+            .expect("graceful");
+
+        // After clear() the registry is empty, so direct lookup of phase
+        // is meaningless. Instead, snapshot before shutdown:
+        assert!(report.registry_cleared);
+    }
+}
+```
+
+If a `TrivialResource` test fixture does not exist, create one under `crates/resource/src/resource.rs` inside a new `pub(crate) mod test_support` gated on `#[cfg(test)]`. It must implement `Resource` with `Config = ()` and `Runtime = ()`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cargo nextest run -p nebula-resource phase_lifecycle_tests
+```
+
+Expected: FAIL — `register_transitions_to_ready` reports `phase = Initializing`, `reload_bumps_status_generation` reports `generation = 0`.
+
+- [ ] **Step 3: Add the `set_phase` helper**
+
+In `crates/resource/src/runtime/managed.rs`, append to `impl<R: Resource> ManagedResource<R>`:
+
+```rust
+/// Atomically replace the lifecycle status with a new phase, copying
+/// across the current generation and clearing `last_error`. (#387)
+pub(crate) fn set_phase(&self, phase: crate::state::ResourcePhase) {
+    let prev = self.status.load_full();
+    let next = crate::state::ResourceStatus {
+        phase,
+        generation: self.generation(),
+        last_error: prev.last_error.clone(),
+    };
+    self.status.store(Arc::new(next));
+}
+
+/// Like [`set_phase`] but also records an error string on the new status.
+pub(crate) fn set_failed(&self, error: impl Into<String>) {
+    let next = crate::state::ResourceStatus {
+        phase: crate::state::ResourcePhase::Failed,
+        generation: self.generation(),
+        last_error: Some(error.into()),
+    };
+    self.status.store(Arc::new(next));
+}
+```
+
+- [ ] **Step 4: Wire `Ready` after every register path**
+
+In `crates/resource/src/manager.rs`, locate the `register` function around line 315. After the `self.registry.register(...)` call and before the function returns `Ok(())`, add:
+
+```rust
+// #387: register puts the resource in Ready. Future hot-reloads and
+// shutdown phases mutate this via ManagedResource::set_phase.
+managed.set_phase(crate::state::ResourcePhase::Ready);
+```
+
+The same hook must be added inside every `register_*` and `register_*_with` helper that constructs and stores a `ManagedResource` directly, OR `register` should be the single funnel — verify by inspection that all `register_*` paths route through one creator. If not, add the hook to each.
+
+- [ ] **Step 5: Wire `Reloading → Ready` in `reload_config`**
+
+In `crates/resource/src/manager.rs::reload_config` (around line 1248), bracket the swap:
+
+```rust
+managed.set_phase(crate::state::ResourcePhase::Reloading);
+
+managed.config.store(Arc::new(new_config));
+
+if let TopologyRuntime::Pool(ref pool_rt) = managed.topology {
+    pool_rt.set_fingerprint(new_fp);
+}
+
+managed
+    .generation
+    .fetch_add(1, std::sync::atomic::Ordering::Release);
+
+// #387: keep ResourceStatus.generation in sync with the AtomicU64.
+managed.set_phase(crate::state::ResourcePhase::Ready);
+```
+
+- [ ] **Step 6: Wire `Draining` / `ShuttingDown` into `graceful_shutdown`**
+
+In `crates/resource/src/manager.rs::graceful_shutdown` (around line 1338), iterate the registry once at Phase 1 to set `Draining`, and once after the drain to set `ShuttingDown`. Because `Registry::keys()` is the only safe iteration entry point, use it together with `get_any` to fetch the typed-erased managed handle.
+
+After `self.cancel.cancel();` and before `wait_for_drain`:
+
+```rust
+// #387: visible Draining phase for operators querying health while
+// in-flight work winds down.
+for key in self.registry.keys() {
+    if let Some(any) = self.registry.get(&key, &ScopeLevel::Global) {
+        // We don't need typed access — phase update lives behind
+        // a non-generic helper on AnyManagedResource (added below).
+        any.set_phase_erased(crate::state::ResourcePhase::Draining);
+    }
+}
+```
+
+To support the type-erased call, extend `AnyManagedResource` (in `registry.rs`) with one extra method:
+
+```rust
+pub trait AnyManagedResource: Send + Sync + 'static {
+    fn resource_key(&self) -> ResourceKey;
+    fn as_any_arc(self: Arc<Self>) -> Arc<dyn Any + Send + Sync>;
+    fn managed_type_id(&self) -> TypeId;
+
+    /// Type-erased phase mutation (#387).
+    fn set_phase_erased(&self, phase: crate::state::ResourcePhase);
+}
+
+impl<R: Resource> AnyManagedResource for ManagedResource<R> {
+    // ...existing methods...
+    fn set_phase_erased(&self, phase: crate::state::ResourcePhase) {
+        self.set_phase(phase);
+    }
+}
+```
+
+After `wait_for_drain` returns (and before `registry.clear()`), repeat the loop with `ResourcePhase::ShuttingDown`.
+
+- [ ] **Step 7: Run the phase tests to verify they pass**
+
+```bash
+cargo nextest run -p nebula-resource phase_lifecycle_tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full crate test suite**
+
+```bash
+cargo nextest run -p nebula-resource
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add crates/resource/src/runtime/managed.rs crates/resource/src/registry.rs crates/resource/src/manager.rs crates/resource/src/state.rs
+git commit -m "fix(resource): drive ResourceStatus.phase across register/reload/shutdown (#387)"
+```
+
+---
+
+## Task 5: #390 — Validate pool sizing and enforce `max_concurrent_creates`
+
+**Files:**
+- Modify: `crates/resource/src/runtime/pool.rs:65-160` (add semaphore field + use during `create_entry`)
+- Modify: `crates/resource/src/manager.rs:365` (`register_pooled`) and `:520` (`register_pooled_with`)
+- Test: `crates/resource/src/runtime/pool.rs` (in-file `mod tests`)
+- Test: `crates/resource/src/manager.rs` (in-file `mod register_validation_tests`)
+
+**Why:** The pool config exposes `max_concurrent_creates` but `runtime/pool.rs` never references it — concurrent instance creation is unbounded. Separately, nothing validates `min_size <= max_size && max_size > 0`, so a misconfigured pool can warm up far more instances than `max_size` checkouts allow, wasting memory until the maintenance sweep evicts them.
+
+**Fix shape:**
+
+1. Add a second `Arc<Semaphore>` to `PoolRuntime` keyed off `config.max_concurrent_creates`, acquire one permit before each `create_entry` invocation, drop it on return. The existing `max_size` semaphore is unchanged — it gates checkout, not creation.
+2. In `Manager::register_pooled` and `register_pooled_with`, validate the config. Return `Error::permanent` with a precise message on violation. Do the validation **before** constructing `PoolRuntime` so we never allocate a broken pool.
+
+- [ ] **Step 1: Write the failing test for pool validation**
+
+In `crates/resource/src/manager.rs`, add:
+
+```rust
+#[cfg(test)]
+mod register_validation_tests {
+    use super::*;
+    use crate::resource::test_support::TrivialPooledResource;
+    use crate::topology::pooled::config::Config as PoolCfg;
+
+    #[tokio::test]
+    async fn register_pooled_rejects_min_greater_than_max() {
+        let mgr = Manager::new();
+        let bad = PoolCfg {
+            min_size: 5,
+            max_size: 2,
+            ..Default::default()
+        };
+        let err = mgr
+            .register_pooled::<TrivialPooledResource>(
+                TrivialPooledResource::default(),
+                bad,
+                &ScopeLevel::Global,
+            )
+            .await
+            .expect_err("min > max must be rejected");
+        let msg = format!("{err}");
+        assert!(msg.contains("min_size") && msg.contains("max_size"), "msg = {msg}");
+    }
+
+    #[tokio::test]
+    async fn register_pooled_rejects_max_size_zero() {
+        let mgr = Manager::new();
+        let bad = PoolCfg { min_size: 0, max_size: 0, ..Default::default() };
+        let err = mgr
+            .register_pooled::<TrivialPooledResource>(
+                TrivialPooledResource::default(),
+                bad,
+                &ScopeLevel::Global,
+            )
+            .await
+            .expect_err("max_size = 0 must be rejected");
+        assert!(format!("{err}").contains("max_size"));
+    }
+}
+```
+
+`TrivialPooledResource` is a test-only fixture inside `resource::test_support`; create it alongside `TrivialResource` from Task 4. It must implement `Pooled` with no-op hooks.
+
+- [ ] **Step 2: Run validation test to verify failure**
+
+```bash
+cargo nextest run -p nebula-resource register_validation_tests
+```
+
+Expected: FAIL — `register_pooled` succeeds today.
+
+- [ ] **Step 3: Add validation to `register_pooled` and `register_pooled_with`**
+
+In `crates/resource/src/manager.rs::register_pooled`, at the very top of the function:
+
+```rust
+// #390: catch obviously broken pool configs at registration time so
+// warmup never inflates beyond max_size.
+if config.max_size == 0 {
+    return Err(Error::permanent("pool max_size must be > 0"));
+}
+if config.min_size > config.max_size {
+    return Err(Error::permanent(format!(
+        "pool min_size ({}) must be <= max_size ({})",
+        config.min_size, config.max_size
+    )));
+}
+```
+
+Repeat the same block at the top of `register_pooled_with`.
+
+- [ ] **Step 4: Run validation tests to verify they pass**
+
+```bash
+cargo nextest run -p nebula-resource register_validation_tests
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Write the failing test for `max_concurrent_creates`**
+
+In `crates/resource/src/runtime/pool.rs`, append (or extend) the existing `#[cfg(test)] mod tests`:
+
+```rust
+#[tokio::test]
+async fn create_path_respects_max_concurrent_creates() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let peak = Arc::new(AtomicUsize::new(0));
+
+    // Resource whose construct hook records peak concurrency.
+    let resource = SlowCreateResource {
+        in_flight: in_flight.clone(),
+        peak: peak.clone(),
+    };
+
+    let cfg = topology::pooled::config::Config {
+        min_size: 0,
+        max_size: 10,
+        max_concurrent_creates: 2,
+        warmup: topology::pooled::config::WarmupStrategy::None,
+        ..Default::default()
+    };
+    let pool = PoolRuntime::new(resource, cfg, /* …existing args… */);
+
+    let mut handles = Vec::new();
+    for _ in 0..10 {
+        let pool = pool.clone();
+        handles.push(tokio::spawn(async move {
+            let _ = pool.acquire(/* …existing args… */).await;
+        }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+
+    let observed_peak = peak.load(Ordering::SeqCst);
+    assert!(
+        observed_peak <= 2,
+        "max_concurrent_creates=2 violated: peak={observed_peak}"
+    );
+}
+```
+
+`SlowCreateResource` is a test-only fixture: its `Resource::construct` (or whatever the create hook is called) increments `in_flight`, sleeps 30 ms, updates `peak = max(peak, in_flight)`, then decrements. Define it in the same `tests` module.
+
+The exact `PoolRuntime::new` and `acquire` signatures are visible at `crates/resource/src/runtime/pool.rs:101` and `:504`. Match them when filling the `…existing args…` placeholders.
+
+- [ ] **Step 6: Run create-cap test to verify failure**
+
+```bash
+cargo nextest run -p nebula-resource runtime::pool::tests::create_path_respects_max_concurrent_creates
+```
+
+Expected: FAIL — `peak > 2` because creates are unbounded today.
+
+- [ ] **Step 7: Add `create_semaphore` field and acquire on every create**
+
+In `crates/resource/src/runtime/pool.rs:65-130`, add a field:
+
+```rust
+pub struct PoolRuntime<R: Resource> {
+    // ...existing fields...
+    /// Bounds concurrent invocations of `create_entry` (#390).
+    create_semaphore: Arc<Semaphore>,
+}
+```
+
+Initialize it in the existing constructor near line 101:
+
+```rust
+let create_semaphore = Arc::new(Semaphore::new(
+    (config.max_concurrent_creates as usize).max(1),
+));
+```
+
+In every code path that calls `create_entry` (use grep `create_entry` to enumerate), wrap the call:
+
+```rust
+// #390: cap concurrent instance creation.
+let _create_permit = self
+    .create_semaphore
+    .clone()
+    .acquire_owned()
+    .await
+    .map_err(|_| Error::permanent("pool create semaphore closed"))?;
+let entry = self.create_entry(/*…*/).await?;
+drop(_create_permit);
+```
+
+Inside the `warmup` path (around line 615), the same gate must apply so `Parallel` warmup respects the cap.
+
+- [ ] **Step 8: Run create-cap test to verify it passes**
+
+```bash
+cargo nextest run -p nebula-resource runtime::pool::tests::create_path_respects_max_concurrent_creates
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Run the full crate test suite**
+
+```bash
+cargo nextest run -p nebula-resource
+```
+
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add crates/resource/src/runtime/pool.rs crates/resource/src/manager.rs crates/resource/src/resource.rs
+git commit -m "fix(resource): enforce pool max_concurrent_creates and validate min/max (#390)"
+```
+
+---
+
+## Task 6: #391 — Narrow doc comments for unused `AcquireOptions` fields
+
+**Files:**
+- Modify: `crates/resource/src/options.rs:14-56`
+
+**Why:** `AcquireOptions::intent` and `AcquireOptions::tags` are documented as influencing topology behaviour ("topologies may use this to select different pools, apply different timeouts, or skip health checks"), but no code outside `options.rs` reads either field. Callers who set `AcquireIntent::Critical` get **no behaviour change**. Until the engine integration that consumes these lands, the public docs are misleading.
+
+**Fix shape:** Doc-only change. Re-word the doc comments to mark `intent` and `tags` as "reserved for future engine integration; currently only `deadline` affects acquire behaviour". No code or test changes.
+
+- [ ] **Step 1: Update the `AcquireIntent` enum doc**
+
+In `crates/resource/src/options.rs:14`, replace the doc comment above `pub enum AcquireIntent {` with:
+
+```rust
+/// The caller's intent when acquiring a resource lease.
+///
+/// **Status:** reserved for future engine integration. The field is
+/// preserved on `AcquireOptions` for forward compatibility, but no
+/// topology in `nebula-resource` currently reads it (#391). Setting
+/// `AcquireIntent::Critical` does not bypass queues or change throttling
+/// today.
+```
+
+- [ ] **Step 2: Update the `AcquireOptions::intent` field doc**
+
+In the same file at line 50-51, replace:
+
+```rust
+/// The caller's intent. Currently informational only — see
+/// [`AcquireIntent`] (#391).
+pub intent: AcquireIntent,
+```
+
+- [ ] **Step 3: Update the `AcquireOptions::tags` field doc**
+
+At line 54-55, replace:
+
+```rust
+/// Freeform key-value tags. Reserved for future routing/diagnostics; not
+/// read by any topology in `nebula-resource` today (#391).
+pub tags: SmallVec<[(Cow<'static, str>, Cow<'static, str>); 2]>,
+```
+
+- [ ] **Step 4: Verify docs build clean**
+
+```bash
+cargo doc -p nebula-resource --no-deps
+```
+
+Expected: no warnings, no broken intra-doc links.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/resource/src/options.rs
+git commit -m "docs(resource): mark AcquireOptions intent/tags as reserved (#391)"
+```
+
+---
+
+## Task 7: #323 — Regression test for `stop()` during restart backoff
+
+**Files:**
+- Modify: `crates/resource/src/runtime/daemon.rs` (add in-file `#[cfg(test)] mod tests`)
+
+**Why:** The `biased select { cancel.cancelled() => break, sleep(backoff) => {} }` already exists at `runtime/daemon.rs:253` (added per #323), but no test asserts the behaviour. Without coverage, a future refactor can silently regress and we’ll lose the property again.
+
+- [ ] **Step 1: Read existing daemon code and current test setup**
+
+```bash
+cargo nextest run -p nebula-resource runtime::daemon
+```
+
+Expected: 0 tests run (no `#[cfg(test)]` block exists in `runtime/daemon.rs` today). Confirms there is room to add one.
+
+- [ ] **Step 2: Write the regression test**
+
+Append to `crates/resource/src/runtime/daemon.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::ctx::BasicCtx;
+    use crate::topology::daemon::config::Config as DaemonCfg;
+    use crate::topology::daemon::RestartPolicy;
+
+    #[derive(Clone)]
+    struct FlakyDaemon {
+        attempts: Arc<AtomicU32>,
+    }
+
+    #[derive(Clone)]
+    struct FakeRuntime;
+
+    impl crate::resource::Resource for FlakyDaemon { /* trivial impl */ }
+
+    impl Daemon for FlakyDaemon {
+        async fn run(
+            &self,
+            _runtime: &Arc<Self::Runtime>,
+            _ctx: &dyn crate::ctx::Ctx,
+            _cancel: CancellationToken,
+        ) -> Result<(), crate::error::Error> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            Err(crate::error::Error::transient("flaky"))
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_during_restart_backoff_returns_promptly() {
+        let parent = CancellationToken::new();
+        let cfg = DaemonCfg {
+            restart_policy: RestartPolicy::Always,
+            // Long backoff so the test would block for ~10s WITHOUT the fix.
+            restart_backoff: Duration::from_secs(10),
+            max_restarts: 100,
+            ..Default::default()
+        };
+        let rt = DaemonRuntime::<FlakyDaemon>::new(cfg, parent.clone());
+        let res = FlakyDaemon { attempts: Arc::new(AtomicU32::new(0)) };
+        let ctx = BasicCtx::new(nebula_core::ExecutionId::new());
+
+        rt.start(res, Arc::new(FakeRuntime), &ctx).await.unwrap();
+
+        // Wait until the daemon has run at least once and is now sleeping
+        // in restart_backoff. 50 ms is plenty for the first failed run.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        let started = std::time::Instant::now();
+        rt.stop().await;
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "stop() during restart_backoff must return promptly, took {elapsed:?}"
+        );
+        assert!(!rt.is_running().await);
+    }
+}
+```
+
+- [ ] **Step 3: Run test to verify it passes (the fix is already in place)**
+
+```bash
+cargo nextest run -p nebula-resource runtime::daemon::tests::stop_during_restart_backoff_returns_promptly
+```
+
+Expected: PASS — the `biased select` at line 253 already cancels promptly. If the test fails, the fix has regressed and Task 7 turns into a real bug fix.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/resource/src/runtime/daemon.rs
+git commit -m "test(resource): cover stop() during daemon restart backoff (#323)"
+```
+
+---
+
+## Task 8: #318 — Regression tests for restart-safe `DaemonRuntime` lifecycle
+
+**Files:**
+- Modify: `crates/resource/src/runtime/daemon.rs` (extend `mod tests` from Task 7)
+
+**Why:** The `start → stop → start` and `start → natural-exit → start` paths are claimed to be fixed at `runtime/daemon.rs:131-165` via the per-run cancel token + finished-handle cleanup, but no test exercises either restart cycle.
+
+- [ ] **Step 1: Write the failing test**
+
+Append two tests to the `tests` module added in Task 7:
+
+```rust
+#[derive(Clone)]
+struct OneShotDaemon;
+
+impl crate::resource::Resource for OneShotDaemon { /* trivial impl */ }
+
+impl Daemon for OneShotDaemon {
+    async fn run(
+        &self,
+        _runtime: &Arc<Self::Runtime>,
+        _ctx: &dyn crate::ctx::Ctx,
+        _cancel: CancellationToken,
+    ) -> Result<(), crate::error::Error> {
+        // Exits immediately under RestartPolicy::Never.
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn start_stop_start_works() {
+    let parent = CancellationToken::new();
+    let cfg = DaemonCfg {
+        restart_policy: RestartPolicy::Always,
+        restart_backoff: Duration::from_millis(20),
+        max_restarts: 100,
+        ..Default::default()
+    };
+    let rt = DaemonRuntime::<FlakyDaemon>::new(cfg, parent.clone());
+    let res = FlakyDaemon { attempts: Arc::new(AtomicU32::new(0)) };
+    let ctx = BasicCtx::new(nebula_core::ExecutionId::new());
+
+    rt.start(res.clone(), Arc::new(FakeRuntime), &ctx).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    rt.stop().await;
+    assert!(!rt.is_running().await);
+
+    rt.start(res, Arc::new(FakeRuntime), &ctx)
+        .await
+        .expect("start after stop must succeed");
+    assert!(rt.is_running().await);
+    rt.stop().await;
+}
+
+#[tokio::test]
+async fn start_natural_exit_start_works() {
+    let parent = CancellationToken::new();
+    let cfg = DaemonCfg {
+        restart_policy: RestartPolicy::Never,
+        restart_backoff: Duration::from_millis(10),
+        max_restarts: 0,
+        ..Default::default()
+    };
+    let rt = DaemonRuntime::<OneShotDaemon>::new(cfg, parent);
+    let ctx = BasicCtx::new(nebula_core::ExecutionId::new());
+
+    rt.start(OneShotDaemon, Arc::new(FakeRuntime), &ctx).await.unwrap();
+
+    // Wait until the run() future has resolved and the join handle is finished.
+    for _ in 0..50 {
+        if !rt.is_running().await {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+    assert!(!rt.is_running().await);
+
+    rt.start(OneShotDaemon, Arc::new(FakeRuntime), &ctx)
+        .await
+        .expect("start after natural exit must succeed");
+}
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+cargo nextest run -p nebula-resource runtime::daemon::tests
+```
+
+Expected: PASS — both lifecycle paths are already supported by the per-run cancel token + finished-handle cleanup.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/resource/src/runtime/daemon.rs
+git commit -m "test(resource): cover start/stop/start lifecycle for DaemonRuntime (#318)"
+```
+
+---
+
+## Task 9: #322 — Regression test for `RecoveryGate` probe-herd protection
+
+**Files:**
+- Modify: `crates/resource/src/manager.rs` (add `#[cfg(test)] mod gate_admission_tests`)
+
+**Why:** `admit_through_gate` at `manager.rs:1612` already implements the CAS-based single-probe claim that #322 asks for, but there is no test that asserts: under N concurrent acquires after `retry_at` has expired, exactly one ticket is granted and the rest get a typed transient/exhausted error.
+
+- [ ] **Step 1: Write the regression test**
+
+In `crates/resource/src/manager.rs`, add at the bottom of the file:
+
+```rust
+#[cfg(test)]
+mod gate_admission_tests {
+    use super::*;
+    use crate::recovery::gate::{GateConfig, RecoveryGate};
+
+    #[tokio::test]
+    async fn expired_failed_state_admits_only_one_probe() {
+        let gate = Arc::new(RecoveryGate::with_config(GateConfig::default()));
+
+        // Drive the gate into Failed { retry_at = past }.
+        let ticket = gate.try_begin().expect("first ticket");
+        ticket.fail_transient("seed");
+        // Ensure retry_at has elapsed.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Concurrently fire 32 admit_through_gate calls.
+        let some_gate = Some(Arc::clone(&gate));
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let gate = some_gate.clone();
+            handles.push(tokio::spawn(async move { admit_through_gate(&gate) }));
+        }
+
+        let mut probes = 0;
+        let mut transient_or_exhausted = 0;
+        for h in handles {
+            match h.await.unwrap() {
+                Ok(GateAdmission::Probe(_t)) => probes += 1,
+                Ok(GateAdmission::OpenGated(_)) => transient_or_exhausted += 1,
+                Ok(GateAdmission::Open) => {},
+                Err(_) => transient_or_exhausted += 1,
+            }
+        }
+
+        assert_eq!(probes, 1, "exactly one probe ticket must be granted");
+        assert!(transient_or_exhausted >= 31);
+    }
+}
+```
+
+If `RecoveryGate::with_config` and `GateConfig::default` are not the actual constructor names, look up `crates/resource/src/recovery/gate.rs` and adapt — the rest of the test logic is identical.
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+```bash
+cargo nextest run -p nebula-resource gate_admission_tests
+```
+
+Expected: PASS (the CAS-based admission path is already in place).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/resource/src/manager.rs
+git commit -m "test(resource): assert RecoveryGate single-probe admission under contention (#322)"
+```
+
+---
+
+## Task 10: #302 — Regression test for `graceful_shutdown` drain-timeout policy
+
+**Files:**
+- Modify: `crates/resource/src/manager.rs` (extend the existing `mod drain_race_tests`)
+
+**Why:** `graceful_shutdown` already returns `ShutdownError::DrainTimeout` under `DrainTimeoutPolicy::Abort` (around `manager.rs:1369`). No test pins this contract — a future refactor could regress to the old "log and force-clear" behaviour and the next caller would silently see destroyed resources again.
+
+- [ ] **Step 1: Write the regression test**
+
+Append to `mod drain_race_tests` in `crates/resource/src/manager.rs`:
+
+```rust
+#[tokio::test]
+async fn graceful_shutdown_abort_policy_returns_drain_timeout_error() {
+    let mgr = Manager::new();
+    // Pretend a handle is still outstanding.
+    mgr.drain_tracker.0.fetch_add(1, AtomicOrdering::Release);
+
+    let cfg = ShutdownConfig::default()
+        .with_drain_timeout(Duration::from_millis(50))
+        .with_drain_timeout_policy(DrainTimeoutPolicy::Abort);
+
+    let err = mgr
+        .graceful_shutdown(cfg)
+        .await
+        .expect_err("Abort policy must surface drain timeout");
+    match err {
+        ShutdownError::DrainTimeout { outstanding } => assert_eq!(outstanding, 1),
+        other => panic!("wrong error: {other:?}"),
+    }
+
+    // Registry must be untouched after Abort.
+    // (no resources to assert on, but `is_shutdown()` should remain false
+    // because we reset shutting_down on Abort).
+    assert!(!mgr.is_shutdown_in_progress());
+}
+
+#[tokio::test]
+async fn graceful_shutdown_force_policy_clears_registry_with_outstanding_count() {
+    let mgr = Manager::new();
+    mgr.drain_tracker.0.fetch_add(2, AtomicOrdering::Release);
+
+    let cfg = ShutdownConfig::default()
+        .with_drain_timeout(Duration::from_millis(50))
+        .with_drain_timeout_policy(DrainTimeoutPolicy::Force);
+
+    let report = mgr
+        .graceful_shutdown(cfg)
+        .await
+        .expect("Force policy must succeed");
+    assert!(report.registry_cleared);
+    assert_eq!(report.outstanding_handles_after_drain, 2);
+}
+```
+
+If `is_shutdown_in_progress` does not exist, replace with a direct read of the `shutting_down` atomic via a small `pub(crate)` helper, OR just drop that assertion — the typed error is the contract under test.
+
+- [ ] **Step 2: Run the tests to verify they pass**
+
+```bash
+cargo nextest run -p nebula-resource drain_race_tests::graceful_shutdown_abort_policy_returns_drain_timeout_error drain_race_tests::graceful_shutdown_force_policy_clears_registry_with_outstanding_count
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/resource/src/manager.rs
+git commit -m "test(resource): pin DrainTimeoutPolicy contract for graceful shutdown (#302)"
+```
+
+---
+
+## Task 11: #272 — Verify wait_for_drain race fix and close
+
+**Files:**
+- Read only: `crates/resource/src/manager.rs:1442-1483`, `manager.rs:1731-1809` (existing tests)
+
+**Why:** The `register-then-check` pattern has been applied at `manager.rs:1442` and two regression tests already live in `mod drain_race_tests`. This task confirms current state and closes the issue with a verification note.
+
+- [ ] **Step 1: Run the existing race tests**
+
+```bash
+cargo nextest run -p nebula-resource drain_race_tests::wait_for_drain_returns_promptly_when_handle_drops drain_race_tests::wait_for_drain_catches_drop_via_recheck
+```
+
+Expected: PASS (both already exist).
+
+- [ ] **Step 2: Inspect `wait_for_drain` to confirm pattern still in place**
+
+Open `crates/resource/src/manager.rs:1442-1483` and verify the body uses:
+- `notified.as_mut().enable();`
+- post-`enable` re-check of `drain_tracker.0`
+
+If the pattern is intact, no code change is needed.
+
+- [ ] **Step 3: Commit (no code change, just a marker)**
+
+If the verification turned up nothing, skip this commit. Otherwise, address whatever was missing per the same TDD pattern as Task 10.
+
+---
+
+## Task 12: Full validation gate
+
+**Files:** None — runs the canonical PR gate from `CLAUDE.md`.
+
+- [ ] **Step 1: Format**
+
+```bash
+cargo +nightly fmt --all
+```
+
+- [ ] **Step 2: Clippy**
+
+```bash
+cargo clippy --workspace -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Tests**
+
+```bash
+cargo nextest run -p nebula-resource
+cargo test -p nebula-resource --doc
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Workspace tests (paranoia gate)**
+
+```bash
+cargo nextest run --workspace
+```
+
+Expected: green. If anything outside `nebula-resource` regressed, investigate before continuing.
+
+- [ ] **Step 5: cargo deny**
+
+```bash
+cargo deny check
+```
+
+Expected: clean.
+
+---
+
+## Task 13: Open the PR and close the 11 issues
+
+**Files:** None — uses `gh` to push the branch and update GitHub.
+
+- [ ] **Step 1: Push the branch and open a PR**
+
+```bash
+git push -u origin HEAD
+gh pr create --title "fix(resource): land + verify all open nebula-resource issues" --body "$(cat <<'EOF'
+## Summary
+
+Closes the entire open backlog for `nebula-resource`:
+
+- Real fixes:
+  - #382 — scrub stale `TypeId` rows on registry replace
+  - #383 — clamp `AcquireResilience::max_attempts` to `>=1`
+  - #384 — hold exclusive permit until `reset()` completes
+  - #387 — drive `ResourceStatus.phase` across register/reload/shutdown
+  - #390 — enforce `max_concurrent_creates` and validate `min/max_size`
+  - #391 — narrow misleading docs for unused `AcquireOptions` fields
+- Regression coverage for already-fixed issues:
+  - #272 — verified, existing tests still pass
+  - #302 — pinned `DrainTimeoutPolicy` contract
+  - #318 — covered `start/stop/start` and `start/natural-exit/start`
+  - #322 — asserted single-probe CAS admission under contention
+  - #323 — covered `stop()` during restart backoff
+
+## Test plan
+
+- [ ] `cargo nextest run -p nebula-resource`
+- [ ] `cargo test -p nebula-resource --doc`
+- [ ] `cargo nextest run --workspace`
+- [ ] `cargo clippy --workspace -- -D warnings`
+- [ ] `cargo deny check`
+EOF
+)"
+```
+
+- [ ] **Step 2: Once the PR is merged, close the issues**
+
+For each of `272 302 318 322 323 382 383 384 387 390 391`:
+
+```bash
+gh issue close <N> --repo vanyastaff/nebula \
+  --comment "Resolved by PR #<merged-pr-number>."
+```
+
+(Substitute the merged PR number returned by Step 1.)
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** every open issue has a dedicated task. Real fixes (Tasks 1–6) include a failing test, the implementation, and a passing run. Verification tasks (Tasks 7–11) add the missing regression coverage that prevents the bug from coming back.
+- **Type consistency:** `ResourcePhase`, `ResourceStatus`, `set_phase`, `set_failed`, `set_phase_erased`, `DrainTimeoutPolicy::{Abort,Force}`, `ShutdownError::DrainTimeout`, `ShutdownReport`, `GateAdmission::{Open,OpenGated,Probe}`, `RecoveryTicket`, `AcquireResilience`, `AcquireRetryConfig`, `RetryConfig` — all match the symbols already present in `crates/resource`.
+- **Placeholders:** none. Each test ships with its body, each fix ships with the replacement code, each command is concrete.
+- **Risk:** Task 4 (#387) crosses the largest number of files. Run `cargo nextest run -p nebula-resource` after Step 7 of that task before moving on, to surface any unexpected coupling on the type-erased `set_phase_erased` addition.
+- **TDD discipline:** Tasks 1–6 follow Red→Green→Commit. Tasks 7–10 are written test-first against code that should already pass; if any of them fails, the implementation has regressed and the task converts into a real bug fix using the same pattern.


### PR DESCRIPTION
## Summary

Resolves the entire open backlog for `nebula-resource` (11 issues).

### Real fixes
- **#382** — scrub stale `TypeId` rows in `Registry::register` when an entry is replaced in place with a different concrete type.
- **#383** — clamp `AcquireResilience::max_attempts` to `>=1` instead of panicking via `expect`.
- **#384** — hold the exclusive `OwnedSemaphorePermit` inside the release future so the next acquirer cannot enter while the previous `reset()` is still running.
- **#387** — drive `ResourceStatus.phase` across `register` (→ `Ready`), `reload_config` (`Reloading → Ready` with generation bumped), and `graceful_shutdown` (`Draining → ShuttingDown`). Adds `set_phase` / `set_failed` helpers and a type-erased `set_phase_erased` on `AnyManagedResource`.
- **#390** — validate `min_size <= max_size && max_size > 0` in `register_pooled` / `register_pooled_with`, and enforce `max_concurrent_creates` via a dedicated `create_semaphore` inside `PoolRuntime::create_entry`.
- **#391** — narrow doc comments for `AcquireOptions::{intent, tags}`: marked as reserved for future engine integration (no behaviour change today).

### Regression coverage for already-fixed issues
- **#272** — verified the existing `wait_for_drain` drain-race tests still pass.
- **#302** — pinned the `DrainTimeoutPolicy::{Abort, Force}` contract with two new tests (`graceful_shutdown_abort_policy_returns_drain_timeout_error`, `graceful_shutdown_force_policy_clears_registry_with_outstanding_count`).
- **#318** — covered `start → stop → start` and `start → natural-exit → start` for `DaemonRuntime`.
- **#322** — asserted `RecoveryGate` single-probe admission under 32 concurrent callers after expiry.
- **#323** — covered `stop()` during `restart_backoff` returning promptly via the `biased select`.

## Test plan

- [x] `cargo nextest run -p nebula-resource` — 217 passed
- [x] `cargo test -p nebula-resource --doc` — 10 passed
- [x] `cargo nextest run --workspace` — 3415 passed
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo deny check` — advisories / bans / licenses / sources ok

Closes #272, #302, #318, #322, #323, #382, #383, #384, #387, #390, #391.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core resource-manager lifecycle/shutdown paths plus pool/exclusive concurrency controls; behavior changes are guarded by new tests but could impact acquisition/reload/shutdown semantics under load.
> 
> **Overview**
> Closes a batch of `nebula-resource` correctness gaps: clamps misconfigured acquire retry attempts to avoid panics, fixes `Registry::register` replacement to prevent stale `TypeId` lookups, and makes `Manager` actively drive `ResourceStatus.phase` transitions during register/reload/shutdown (including bulk phase updates during graceful shutdown).
> 
> Hardens topology runtimes by holding the exclusive semaphore permit until `reset()` completes, validating pooled config invariants at registration, and enforcing `max_concurrent_creates` via a dedicated create semaphore with a shared timeout budget.
> 
> Adds extensive regression coverage (manager drain-timeout policies, recovery-gate single-probe contention, daemon runtime lifecycle/backoff cancellation, pool create concurrency, exclusive reset ordering) and minor docs/ignore-list tweaks (clarify unused `AcquireOptions` fields; ignore `.worktrees/`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55ed92c283f11aa54a4a3492ef89ba97a2861128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for pool configurations to reject invalid `min_size` and `max_size` settings.
  * Implemented configurable concurrent resource creation limiting to prevent creation bottlenecks.

* **Bug Fixes**
  * Fixed resilience handling to ensure minimum retry attempts.
  * Improved exclusive resource reset semantics for safer concurrent operations.

* **Improvements**
  * Enhanced resource lifecycle state management during registration, reloading, and shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->