### PR TITLE
fix(telemetry): label dedupe, histogram bucket conflict warn, interner caveats

### DIFF
--- a/crates/telemetry/src/labels.rs
+++ b/crates/telemetry/src/labels.rs
@@ -100,8 +100,23 @@ impl LabelSet {
 /// Thread-safe string interner for label keys and values.
 ///
 /// Backed by [`lasso::ThreadedRodeo`].  Cheaply cloneable via `Arc`.
-/// All interning operations are lock-free for reads; first-time registrations  
+/// All interning operations are lock-free for reads; first-time registrations
 /// acquire an internal write lock.
+///
+/// # Memory semantics
+///
+/// The underlying `ThreadedRodeo` is **append-only**: once a string has been
+/// interned it remains resident for the lifetime of the `LabelInterner`
+/// (and all its `Arc` clones), even if every `LabelSet` referencing it has
+/// been dropped. This means that metric eviction via
+/// [`crate::metrics::MetricsRegistry::retain_recent`] reclaims the series
+/// maps but **does not** reclaim interned strings — high-cardinality label
+/// values (e.g. `execution_id`, per-user dimensions) will grow the interner
+/// monotonically.
+///
+/// Use [`Self::len`] to monitor interner cardinality. If bounded memory is
+/// required under high label churn, replace the `MetricsRegistry` (and its
+/// interner) wholesale rather than relying on `retain_recent`.
 ///
 /// # Examples
 ///
@@ -154,18 +169,54 @@ impl LabelInterner {
         self.rodeo.try_resolve(&spur)
     }
 
+    /// Number of distinct strings currently interned.
+    ///
+    /// The interner is append-only, so this value is monotonically
+    /// non-decreasing over the lifetime of a given `LabelInterner`. Use
+    /// it for cardinality monitoring and as a leading indicator that a
+    /// metric registry should be rebuilt.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.rodeo.len()
+    }
+
+    /// Whether the interner has never observed any string.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.rodeo.is_empty()
+    }
+
     /// Build a [`LabelSet`] from string key-value pairs.
     ///
     /// All keys and values are interned; the resulting set is sorted by key.
+    ///
+    /// If the same key appears multiple times in `pairs` the **last**
+    /// occurrence wins. Prometheus text exposition forbids duplicate label
+    /// names on a single sample line, so deduplication here guarantees
+    /// deterministic, parser-safe series identity regardless of duplicate
+    /// input at the call site.
     #[must_use]
     pub fn label_set(&self, pairs: &[(&str, &str)]) -> LabelSet {
         let mut kv: Vec<(LabelKey, LabelValue)> = pairs
             .iter()
             .map(|(k, v)| (self.intern(k), self.intern(v)))
             .collect();
-        // Sort by key Spur so equal label sets compare and hash identically
-        // regardless of insertion order.
-        kv.sort_unstable_by_key(|(k, _)| *k);
+        // Stable sort by key so that when we collapse duplicate-key runs
+        // the surviving value is the *last* one from the original input
+        // (Prometheus-style last-wins).
+        kv.sort_by_key(|(k, _)| *k);
+        if kv.len() > 1 {
+            let mut write = 0usize;
+            for read in 1..kv.len() {
+                if kv[read].0 == kv[write].0 {
+                    kv[write].1 = kv[read].1;
+                } else {
+                    write += 1;
+                    kv[write] = kv[read];
+                }
+            }
+            kv.truncate(write + 1);
+        }
         LabelSet { pairs: kv }
     }
 
@@ -291,6 +342,51 @@ mod tests {
         let interner = LabelInterner::new();
         let ls = interner.label_set(&[("k1", "v1"), ("k2", "v2"), ("k3", "v3")]);
         assert_eq!(ls.len(), 3);
+    }
+
+    #[test]
+    fn label_set_dedupes_duplicate_keys_last_wins() {
+        let interner = LabelInterner::new();
+        let ls = interner.label_set(&[("status", "ok"), ("status", "error")]);
+        assert_eq!(ls.len(), 1, "duplicate key must collapse to one entry");
+        let pairs = ls.resolve(&interner);
+        assert_eq!(pairs, vec![("status", "error")]);
+    }
+
+    #[test]
+    fn label_set_dedupe_preserves_other_keys() {
+        let interner = LabelInterner::new();
+        let ls = interner.label_set(&[
+            ("status", "ok"),
+            ("action", "http.request"),
+            ("status", "error"),
+            ("env", "prod"),
+        ]);
+        assert_eq!(ls.len(), 3);
+        let pairs = ls.resolve(&interner);
+        assert!(pairs.contains(&("action", "http.request")));
+        assert!(pairs.contains(&("env", "prod")));
+        assert!(pairs.contains(&("status", "error")));
+        assert!(!pairs.iter().any(|(_, v)| *v == "ok"));
+    }
+
+    #[test]
+    fn label_set_dedupe_three_values_same_key() {
+        let interner = LabelInterner::new();
+        let ls = interner.label_set(&[("k", "a"), ("k", "b"), ("k", "c")]);
+        assert_eq!(ls.len(), 1);
+        assert_eq!(ls.resolve(&interner), vec![("k", "c")]);
+    }
+
+    #[test]
+    fn interner_len_tracks_distinct_strings_and_is_monotonic() {
+        let interner = LabelInterner::new();
+        assert!(interner.is_empty());
+        interner.intern("a");
+        interner.intern("b");
+        interner.intern("a"); // duplicate
+        assert_eq!(interner.len(), 2);
+        assert!(!interner.is_empty());
     }
 
     #[test]

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -359,6 +359,15 @@ impl Histogram {
     pub fn last_updated_ms(&self) -> u64 {
         self.last_updated_ms.load(Ordering::Relaxed)
     }
+
+    /// Upper-bound boundaries configured for this histogram (excludes +Inf).
+    ///
+    /// Useful for callers that need to verify that a pre-existing histogram
+    /// series matches the bucket layout they expect.
+    #[must_use]
+    pub fn boundaries(&self) -> &[f64] {
+        &self.boundaries
+    }
 }
 
 impl Default for Histogram {
@@ -476,6 +485,14 @@ impl MetricsRegistry {
     }
 
     /// Get or create a histogram with custom bucket boundaries and a label set.
+    ///
+    /// Bucket boundaries are bound to the series at **first registration**.
+    /// If a subsequent call targets an already-registered `(name, labels)`
+    /// series with *different* `boundaries`, the existing histogram is
+    /// returned unchanged and a `tracing::warn!` is emitted — the later
+    /// layout is silently ignored, which can cause split-brain behaviour
+    /// between crates that disagree on bucket schemas. Callers that need
+    /// multiple layouts for the same metric name must vary the label set.
     pub fn histogram_with_buckets_labeled(
         &self,
         name: &str,
@@ -483,11 +500,21 @@ impl MetricsRegistry {
         boundaries: Vec<f64>,
     ) -> Histogram {
         let key = MetricKey::labeled(self.interner.intern(name), labels.clone());
-        self.histograms
+        let existing = self
+            .histograms
             .entry(key)
-            .or_insert_with(|| Histogram::with_buckets(boundaries))
+            .or_insert_with(|| Histogram::with_buckets(boundaries.clone()))
             .value()
-            .clone()
+            .clone();
+        if existing.boundaries() != boundaries.as_slice() {
+            tracing::warn!(
+                metric = name,
+                requested = ?boundaries,
+                existing = ?existing.boundaries(),
+                "histogram_with_buckets_labeled: ignoring new boundaries for already-registered series"
+            );
+        }
+        existing
     }
 
     // ── Snapshot / export ───────────────────────────────────────────────────
@@ -522,10 +549,24 @@ impl MetricsRegistry {
 
     /// Remove all metric series that have not been updated within `max_age`.
     ///
-    /// This prevents unbounded memory growth when dynamic labels (e.g.
-    /// `action_type`, `workflow_id`) create many high-cardinality series over
-    /// time. Stable global metrics (unlabeled or with a fixed label set) are
-    /// naturally retained because they are written to continuously.
+    /// Reclaims the counter / gauge / histogram entries for stale series so
+    /// that dynamic labels (e.g. `action_type`, `workflow_id`) do not grow
+    /// the series maps without bound. Stable global metrics (unlabeled or
+    /// with a fixed label set) are naturally retained because they are
+    /// written to continuously.
+    ///
+    /// # Memory caveat
+    ///
+    /// This method reclaims *series*, not *interned strings*. The label
+    /// interner behind [`LabelInterner`] is append-only: any label key or
+    /// value that has ever been observed remains resident for the lifetime
+    /// of the registry. Under sustained high-cardinality label churn,
+    /// resident memory can therefore still grow over time despite repeated
+    /// `retain_recent` calls.
+    ///
+    /// Monitor interner pressure with [`Self::interner_len`] and, if
+    /// needed, replace the entire `MetricsRegistry` wholesale (dropping the
+    /// old interner) rather than relying on `retain_recent` alone.
     ///
     /// Call this periodically from a background task or at the end of a
     /// logical time window (e.g. after completing a batch of executions).
@@ -560,6 +601,18 @@ impl MetricsRegistry {
     #[must_use]
     pub fn metric_count(&self) -> usize {
         self.counters.len() + self.gauges.len() + self.histograms.len()
+    }
+
+    /// Number of distinct strings held by the label interner.
+    ///
+    /// Unlike [`Self::metric_count`], this value is **monotonically
+    /// non-decreasing** for the lifetime of the registry: the underlying
+    /// `ThreadedRodeo` is append-only and is not reclaimed by
+    /// [`Self::retain_recent`]. Use it to detect unbounded interner growth
+    /// under high-cardinality label churn.
+    #[must_use]
+    pub fn interner_len(&self) -> usize {
+        self.interner.len()
     }
 }
 
@@ -824,6 +877,50 @@ mod tests {
         reg.gauge("g1").set(1);
         reg.histogram("h1").observe(1.0);
         assert_eq!(reg.metric_count(), 3);
+    }
+
+    #[test]
+    fn histogram_with_buckets_labeled_returns_first_layout_on_conflict() {
+        let reg = MetricsRegistry::new();
+        let labels = reg.interner().label_set(&[("route", "/health")]);
+
+        let first = reg.histogram_with_buckets_labeled("nebula_req", &labels, vec![0.1, 0.5, 1.0]);
+        assert_eq!(first.boundaries(), &[0.1, 0.5, 1.0]);
+
+        // Re-registering the same series with different boundaries must
+        // return the original histogram (bucket identity is pinned at
+        // first registration).
+        let second = reg.histogram_with_buckets_labeled("nebula_req", &labels, vec![2.0, 4.0, 8.0]);
+        assert_eq!(second.boundaries(), &[0.1, 0.5, 1.0]);
+
+        // And they must be the same underlying histogram.
+        first.observe(0.3);
+        assert_eq!(second.count(), 1);
+    }
+
+    #[test]
+    fn histogram_boundaries_accessor_excludes_inf() {
+        let h = Histogram::with_buckets(vec![1.0, 2.0, 3.0]);
+        assert_eq!(h.boundaries(), &[1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn interner_len_survives_retain_recent() {
+        // Documents the caveat in the retain_recent docstring: series go
+        // away but interned strings stay resident. Guard against a silent
+        // future change that would claim full reclaim without actually
+        // rebuilding the interner.
+        let reg = MetricsRegistry::new();
+        let labels = reg.interner().label_set(&[("k", "v1")]);
+        reg.counter_labeled("m", &labels).inc();
+        let before = reg.interner_len();
+        assert!(before >= 3); // at least "m", "k", "v1"
+
+        std::thread::sleep(Duration::from_millis(2));
+        reg.retain_recent(Duration::ZERO);
+        assert_eq!(reg.metric_count(), 0);
+        // Interner is append-only, so the strings must still be resident.
+        assert_eq!(reg.interner_len(), before);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes three open issues in `nebula-telemetry`:

- **#376** (MEDIUM) — `LabelInterner::label_set` no longer produces `LabelSet`s containing duplicate label keys. Last-wins dedupe after a stable sort guarantees parser-safe Prometheus series identity even when the caller passes duplicate keys.
- **#381** (LOW) — `MetricsRegistry::histogram_with_buckets_labeled` now emits a `tracing::warn!` when a subsequent registration of the same `(name, labels)` series requests different bucket boundaries than the ones pinned at first registration, instead of silently dropping the new layout. Added `Histogram::boundaries()` accessor.
- **#347** (HIGH) — The underlying `ThreadedRodeo` is append-only, so `MetricsRegistry::retain_recent` reclaims series but never interned strings. This PR does not change the append-only semantics (a bounded/epoch interner is a larger design change that would invalidate client-held `LabelSet`s), but:
  - Adds `LabelInterner::len`/`is_empty` and `MetricsRegistry::interner_len` for cardinality monitoring.
  - Clearly documents the caveat on both `LabelInterner` and `retain_recent` so callers stop relying on `retain_recent` alone to bound memory under high label churn.
  - Adds a regression test that pins the append-only semantics so a future silent change to these docs requires updating the test.

## Test plan

- [x] `cargo nextest run -p nebula-telemetry` — 38 unit tests pass (31 original + 7 new)
- [x] `cargo test --doc -p nebula-telemetry` — 7 doctests pass
- [x] `cargo clippy -p nebula-telemetry --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt` applied
- [x] `cargo nextest run --workspace` — 3426 tests pass, 13 skipped
- [x] `cargo check --workspace` — clean

Closes #376
Closes #381
Refs #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes series identity construction by deduping duplicate label keys (last-wins) and adds runtime warnings when histogram bucket layouts conflict, which could alter metric cardinality/aggregation and produce new logs. No changes to data persistence or security, but affects core telemetry semantics and memory behavior visibility.
> 
> **Overview**
> **Fixes telemetry series correctness and improves observability of metric schema/memory pitfalls.** `LabelInterner::label_set` now performs *last-wins* deduplication of duplicate label keys (using a stable sort + collapse) to ensure deterministic, Prometheus-safe label sets.
> 
> Adds `LabelInterner::len`/`is_empty` and `MetricsRegistry::interner_len`, plus expanded docs clarifying the interner is append-only so `retain_recent` evicts series but not interned strings. `Histogram` exposes `boundaries()`, and `histogram_with_buckets_labeled` now warns when re-registering an existing series with different bucket boundaries while returning the originally-registered layout; new unit tests cover these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c15b6b45d0fb945515d74a373171038e40024987. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->