### PR TITLE
fix(expression): correct Negate evaluation for floats and i64::MIN

### DIFF
--- a/crates/expression/src/eval.rs
+++ b/crates/expression/src/eval.rs
@@ -234,10 +234,35 @@ impl Evaluator {
                 let val = self.eval_with_frame(expr, context, frame)?;
                 match val {
                     Value::Number(ref n) => {
-                        if let Some(i) = crate::value_utils::number_as_i64(n) {
-                            Ok(Value::Number((-i).into()))
-                        } else if let Some(f) = crate::value_utils::number_as_f64(n) {
+                        // Dispatch on the concrete representation: floats must never be
+                        // routed through the i64 path (silent truncation of `-3.7` → `-3`),
+                        // and i64 negation must be checked to surface `-(i64::MIN)` as a
+                        // typed error instead of panicking in debug / wrapping in release.
+                        if n.is_f64() {
+                            let f = n.as_f64().ok_or_else(|| {
+                                ExpressionError::expression_eval_error("Cannot negate number")
+                            })?;
                             Ok(serde_json::json!(-f))
+                        } else if let Some(i) = n.as_i64() {
+                            let neg = i.checked_neg().ok_or_else(|| {
+                                ExpressionError::expression_eval_error(
+                                    "Integer overflow: cannot negate i64::MIN",
+                                )
+                            })?;
+                            Ok(Value::Number(neg.into()))
+                        } else if let Some(u) = n.as_u64() {
+                            // u64 values above i64::MAX cannot be represented as negated i64.
+                            let as_i: i64 = u.try_into().map_err(|_| {
+                                ExpressionError::expression_eval_error(
+                                    "Integer overflow: unsigned value exceeds i64 range",
+                                )
+                            })?;
+                            let neg = as_i.checked_neg().ok_or_else(|| {
+                                ExpressionError::expression_eval_error(
+                                    "Integer overflow: cannot negate i64::MIN",
+                                )
+                            })?;
+                            Ok(Value::Number(neg.into()))
                         } else {
                             Err(ExpressionError::expression_eval_error(
                                 "Cannot negate number",
@@ -2456,5 +2481,71 @@ mod tests {
         assert_eq!(arr.len(), 100);
         assert_eq!(arr.first().and_then(|v| v.as_i64()), Some(1));
         assert_eq!(arr.last().and_then(|v| v.as_i64()), Some(100));
+    }
+
+    #[test]
+    fn test_negate_integer() {
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let expr = Expr::Negate(Box::new(Expr::Literal(Value::Number(42.into()))));
+        let result = evaluator.eval(&expr, &context).unwrap();
+        assert_eq!(result.as_i64(), Some(-42));
+    }
+
+    #[test]
+    fn test_negate_float_preserves_fraction() {
+        // Regression for #280: `-3.7` must NOT truncate to `-3`.
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let expr = Expr::Negate(Box::new(Expr::Literal(serde_json::json!(3.7))));
+        let result = evaluator.eval(&expr, &context).unwrap();
+        assert_eq!(result.as_f64(), Some(-3.7));
+    }
+
+    #[test]
+    fn test_negate_negative_float() {
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let expr = Expr::Negate(Box::new(Expr::Literal(serde_json::json!(-2.5))));
+        let result = evaluator.eval(&expr, &context).unwrap();
+        assert_eq!(result.as_f64(), Some(2.5));
+    }
+
+    #[test]
+    fn test_negate_i64_min_errors() {
+        // Regression for #280: negating `i64::MIN` must surface a typed error,
+        // not panic (debug) or silently wrap (release).
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let expr = Expr::Negate(Box::new(Expr::Literal(Value::Number(i64::MIN.into()))));
+        let err = evaluator.eval(&expr, &context).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("overflow"),
+            "expected overflow error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_negate_u64_above_i64_max_errors() {
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let big = (i64::MAX as u64) + 1;
+        let expr = Expr::Negate(Box::new(Expr::Literal(Value::Number(big.into()))));
+        let err = evaluator.eval(&expr, &context).unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.to_lowercase().contains("overflow"),
+            "expected overflow error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_negate_non_number_type_error() {
+        let evaluator = create_evaluator();
+        let context = EvaluationContext::new();
+        let expr = Expr::Negate(Box::new(Expr::Literal(Value::Bool(true))));
+        let err = evaluator.eval(&expr, &context).unwrap_err();
+        assert!(format!("{err}").to_lowercase().contains("type"));
     }
 }

--- a/crates/expression/src/eval.rs
+++ b/crates/expression/src/eval.rs
@@ -250,19 +250,13 @@ impl Evaluator {
                                 )
                             })?;
                             Ok(Value::Number(neg.into()))
-                        } else if let Some(u) = n.as_u64() {
-                            // u64 values above i64::MAX cannot be represented as negated i64.
-                            let as_i: i64 = u.try_into().map_err(|_| {
-                                ExpressionError::expression_eval_error(
-                                    "Integer overflow: unsigned value exceeds i64 range",
-                                )
-                            })?;
-                            let neg = as_i.checked_neg().ok_or_else(|| {
-                                ExpressionError::expression_eval_error(
-                                    "Integer overflow: cannot negate i64::MIN",
-                                )
-                            })?;
-                            Ok(Value::Number(neg.into()))
+                        } else if n.as_u64().is_some() {
+                            // Reached only when the number is a u64 strictly greater than
+                            // i64::MAX (otherwise the `as_i64()` branch above would have
+                            // matched). Such a value has no representable negation in i64.
+                            Err(ExpressionError::expression_eval_error(
+                                "Integer overflow: unsigned value exceeds i64 range",
+                            ))
                         } else {
                             Err(ExpressionError::expression_eval_error(
                                 "Cannot negate number",


### PR DESCRIPTION
## Summary

Fixes #280 — two correctness bugs in `Expr::Negate` evaluation:

1. **Float truncation.** `-3.7` routed through `number_as_i64`, which cast `3.7 as i64 = 3` before negating, silently dropping the fraction.
2. **i64::MIN overflow.** `-i` on `i64::MIN` panics in debug / wraps in release, so `-(-9223372036854775808)` crashed or returned the same negative value.

The Negate arm now dispatches on the concrete `serde_json::Number` representation:

- `n.is_f64()` → take the float path directly (no i64 detour).
- `n.as_i64()` → `checked_neg()`, surfacing `i64::MIN` as a typed overflow error.
- `n.as_u64()` above `i64::MAX` → typed overflow error instead of a lossy cast.

## Test plan

- [x] `cargo nextest run -p nebula-expression` — 281 passed (6 new regression tests added)
- [x] `cargo test -p nebula-expression --doc`
- [x] `cargo clippy -p nebula-expression -- -D warnings`
- [x] `cargo +nightly fmt`
- New tests cover: integer negation, float fraction preservation, negative floats, `i64::MIN` overflow, `u64` above `i64::MAX`, non-number type error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: isolated change to unary negation evaluation plus new regression tests; main behavior change is returning typed overflow errors instead of panicking/wrapping for edge-case integers.
> 
> **Overview**
> Fixes `Expr::Negate` evaluation to **preserve float values** (no silent truncation) and to **safely handle integer edge cases** by using `checked_neg()` and returning explicit overflow errors for `i64::MIN` and out-of-range `u64` values.
> 
> Adds regression tests covering integer negation, float fraction preservation, negating negative floats, overflow error cases, and non-number type errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f294058abbef27aaa150c9db22a279f4d8bfef9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->