### PR TITLE
fix(api/workflow): guard immutable fields & parse canonical timestamps

### DIFF
--- a/crates/api/src/handlers/workflow.rs
+++ b/crates/api/src/handlers/workflow.rs
@@ -8,6 +8,7 @@ use axum::{
 use chrono::Utc;
 use nebula_core::{ExecutionId, WorkflowId};
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::{
     errors::{ApiError, ApiResult},
@@ -17,6 +18,49 @@ use crate::{
     },
     state::AppState,
 };
+
+/// Identity and control fields inside a stored workflow definition that the
+/// API must never let a client overwrite via `update_workflow`.
+///
+/// Mutating these drifts the stored identity away from the repository key and
+/// corrupts downstream consumers that rely on canonical `WorkflowDefinition`
+/// invariants (version, ownership, schema version). See issue #344.
+const IMMUTABLE_DEFINITION_FIELDS: &[&str] = &[
+    "id",
+    "version",
+    "owner_id",
+    "schema_version",
+    "created_at",
+    "updated_at",
+    // `name` / `description` have dedicated top-level payload fields already,
+    // so they must not be smuggled through a nested `definition` update either.
+    "name",
+    "description",
+];
+
+/// Extract a Unix-epoch timestamp from a workflow definition field.
+///
+/// Canonical `WorkflowDefinition` serializes timestamps as RFC3339 strings
+/// (because `chrono::DateTime<Utc>` uses string representation), while the
+/// current API write path still stores them as raw i64 unix seconds. This
+/// helper accepts **both** shapes so responses remain correct regardless of
+/// which path produced the stored blob.
+///
+/// Returns `None` when the field is absent or has an unsupported shape — the
+/// caller decides whether to fall back to `0`, surface an internal error, or
+/// omit the field. Fixes issue #343.
+fn extract_timestamp(definition: &Value, key: &str) -> Option<i64> {
+    let field = definition.get(key)?;
+    if let Some(n) = field.as_i64() {
+        return Some(n);
+    }
+    if let Some(s) = field.as_str()
+        && let Ok(dt) = chrono::DateTime::parse_from_rfc3339(s)
+    {
+        return Some(dt.timestamp());
+    }
+    None
+}
 
 /// Pagination query parameters
 #[derive(Debug, Deserialize)]
@@ -81,15 +125,8 @@ pub async fn list_workflows(
                 .and_then(|v| v.as_str())
                 .map(|s| s.to_string());
 
-            let created_at = definition
-                .get("created_at")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
-
-            let updated_at = definition
-                .get("updated_at")
-                .and_then(|v| v.as_i64())
-                .unwrap_or(0);
+            let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
+            let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
 
             WorkflowResponse {
                 id: id.to_string(),
@@ -146,15 +183,8 @@ pub async fn get_workflow(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let created_at = definition
-        .get("created_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let updated_at = definition
-        .get("updated_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
+    let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
 
     Ok(Json(WorkflowResponse {
         id,
@@ -266,15 +296,25 @@ pub async fn update_workflow(
             obj.insert("description".to_string(), serde_json::json!(desc));
         }
 
-        // Merge definition if provided
+        // Merge definition if provided.
+        //
+        // Reject any attempt to mutate immutable identity/control fields
+        // inside the nested `definition` payload (issue #344). A client that
+        // wants a different identity must create a new workflow — otherwise
+        // the stored id/version/owner would silently diverge from the
+        // repository key used to route the request.
         if let Some(new_def) = &payload.definition
             && let Some(new_obj) = new_def.as_object()
         {
-            for (key, value) in new_obj {
-                // Don't allow overwriting metadata fields
-                if !["name", "description", "created_at", "updated_at"].contains(&key.as_str()) {
-                    obj.insert(key.clone(), value.clone());
+            for key in new_obj.keys() {
+                if IMMUTABLE_DEFINITION_FIELDS.contains(&key.as_str()) {
+                    return Err(ApiError::validation_message(format!(
+                        "Cannot modify immutable workflow field '{key}'",
+                    )));
                 }
+            }
+            for (key, value) in new_obj {
+                obj.insert(key.clone(), value.clone());
             }
         }
 
@@ -313,15 +353,8 @@ pub async fn update_workflow(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let created_at = definition
-        .get("created_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let updated_at = definition
-        .get("updated_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
+    let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
 
     Ok(Json(WorkflowResponse {
         id,
@@ -417,15 +450,8 @@ pub async fn activate_workflow(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
-    let created_at = definition
-        .get("created_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let updated_at = definition
-        .get("updated_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
+    let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
+    let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
 
     Ok(Json(WorkflowResponse {
         id,
@@ -549,5 +575,57 @@ pub async fn validate_workflow_handler(
             valid: false,
             errors: error_messages,
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::{IMMUTABLE_DEFINITION_FIELDS, extract_timestamp};
+
+    #[test]
+    fn extract_timestamp_parses_i64() {
+        let v = json!({ "created_at": 1_700_000_000_i64 });
+        assert_eq!(extract_timestamp(&v, "created_at"), Some(1_700_000_000));
+    }
+
+    #[test]
+    fn extract_timestamp_parses_rfc3339_string() {
+        // Regression for #343: canonical WorkflowDefinition stores
+        // `DateTime<Utc>` as an RFC3339 string, not a unix-seconds i64.
+        let v = json!({ "updated_at": "2024-01-15T12:34:56Z" });
+        let ts = extract_timestamp(&v, "updated_at").expect("rfc3339 parses");
+        assert_eq!(ts, 1_705_322_096);
+    }
+
+    #[test]
+    fn extract_timestamp_rejects_garbage() {
+        let v = json!({ "created_at": "not-a-date" });
+        assert_eq!(extract_timestamp(&v, "created_at"), None);
+    }
+
+    #[test]
+    fn extract_timestamp_handles_missing_field() {
+        let v = json!({});
+        assert_eq!(extract_timestamp(&v, "created_at"), None);
+    }
+
+    #[test]
+    fn immutable_fields_cover_identity_and_metadata() {
+        // Regression for #344: identity/control fields must be in the
+        // blocklist so a nested `definition` payload cannot overwrite them.
+        for key in ["id", "version", "owner_id", "schema_version"] {
+            assert!(
+                IMMUTABLE_DEFINITION_FIELDS.contains(&key),
+                "identity field `{key}` must be immutable in update_workflow",
+            );
+        }
+        for key in ["name", "description", "created_at", "updated_at"] {
+            assert!(
+                IMMUTABLE_DEFINITION_FIELDS.contains(&key),
+                "metadata field `{key}` must be immutable in update_workflow",
+            );
+        }
     }
 }

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -1700,8 +1700,15 @@ async fn update_workflow_rejects_immutable_identity_fields() {
 
     // Every protected field must cause a 4xx rejection.
     for field in ["id", "version", "owner_id", "schema_version"] {
+        // NOTE: in `serde_json::json!`, bare identifiers on the left of `:`
+        // are stringified literally. Wrap the loop variable in parentheses
+        // so the macro interpolates the *value* ("id", "version", ...) as
+        // the object key, otherwise every iteration would test the same
+        // literal key `"field"`. (Flagged by Copilot on PR #406.)
+        let mut inner = serde_json::Map::new();
+        inner.insert(field.to_string(), serde_json::json!("attacker-supplied"));
         let update_request = serde_json::json!({
-            "definition": { field: "attacker-supplied" }
+            "definition": serde_json::Value::Object(inner),
         });
         let app = app::build_app(state.clone(), &api_config);
         let response = app

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -1656,3 +1656,123 @@ async fn cors_preflight_allows_authorization() {
         "authorization must appear in allow-headers, got: {allow_headers}"
     );
 }
+
+#[tokio::test]
+async fn update_workflow_rejects_immutable_identity_fields() {
+    // Regression for #344: update_workflow must refuse payloads that try to
+    // overwrite identity/control fields (id, version, owner_id, schema_version)
+    // smuggled inside the nested `definition` object.
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let state = create_test_state().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // Create a workflow to update.
+    let create_request = serde_json::json!({
+        "name": "Identity Guard",
+        "description": "immutable-fields regression",
+        "definition": { "nodes": [], "edges": [] }
+    });
+    let app = app::build_app(state.clone(), &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/workflows")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_string(&create_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let workflow_id = created["id"].as_str().unwrap().to_string();
+
+    // Every protected field must cause a 4xx rejection.
+    for field in ["id", "version", "owner_id", "schema_version"] {
+        let update_request = serde_json::json!({
+            "definition": { field: "attacker-supplied" }
+        });
+        let app = app::build_app(state.clone(), &api_config);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/workflows/{workflow_id}"))
+                    .header("content-type", "application/json")
+                    .header("authorization", format!("Bearer {}", token))
+                    .body(Body::from(serde_json::to_string(&update_request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            response.status().is_client_error(),
+            "update with `{field}` must be rejected, got status {}",
+            response.status()
+        );
+    }
+}
+
+#[tokio::test]
+async fn get_workflow_parses_rfc3339_timestamps() {
+    // Regression for #343: a stored workflow whose timestamps are RFC3339
+    // strings (canonical `WorkflowDefinition` shape) must round-trip through
+    // the API without collapsing to 0.
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use nebula_core::WorkflowId;
+    use tower::ServiceExt;
+
+    let state = create_test_state().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // Write directly through the repo with canonical string timestamps so we
+    // skip the create_workflow handler's i64 write path and exercise the read
+    // path against exactly the shape that `WorkflowDefinition` serializes.
+    let workflow_id = WorkflowId::new();
+    let canonical = serde_json::json!({
+        "name": "Canonical Timestamps",
+        "description": "rfc3339-regression",
+        "created_at": "2024-01-15T12:34:56Z",
+        "updated_at": "2024-02-20T08:00:00Z",
+    });
+    state
+        .workflow_repo
+        .save(workflow_id, 0, canonical)
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/workflows/{}", workflow_id))
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let workflow: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(workflow["created_at"].as_i64(), Some(1_705_322_096));
+    assert_eq!(workflow["updated_at"].as_i64(), Some(1_708_416_000));
+}


### PR DESCRIPTION
## Summary

Closes #344, #343. Also confirms #339 is already fixed in `crates/workflow/src/validate.rs` (existing `detects_duplicate_connection` test covers it; PR just closes the tracking issue).

### #344 — update_workflow could overwrite immutable identity fields

Previously `update_workflow` merged any key from a nested `definition` payload except a small metadata denylist (`name`, `description`, `created_at`, `updated_at`). A client could smuggle `id`, `version`, `owner_id`, or `schema_version` through and drift the stored identity away from the repository key used to route the request.

Replaced with an explicit \`IMMUTABLE_DEFINITION_FIELDS\` list covering identity, control, and metadata keys. The handler now rejects the request with a 4xx validation error when any of them appear in the payload.

### #343 — Workflow API misparses canonical timestamps

Canonical \`WorkflowDefinition\` serializes \`created_at\` / \`updated_at\` as RFC3339 strings (because \`DateTime<Utc>\` uses string representation), but every read path (\`list_workflows\`, \`get_workflow\`, \`update_workflow\`, \`activate_workflow\`) used \`as_i64().unwrap_or(0)\` and silently returned \`0\` for valid canonically-stored blobs.

Added a single \`extract_timestamp\` helper that accepts both i64 unix seconds (legacy write path) and RFC3339 strings (canonical \`WorkflowDefinition\`), and routed all four read sites through it.

### #339 — validate_workflow duplicate-connection detection

Already implemented: [crates/workflow/src/validate.rs:59-68](crates/workflow/src/validate.rs#L59-L68) serializes each \`Connection\` to a canonical JSON key and tracks duplicates via a \`HashSet<String>\`. Both \`detects_duplicate_connection\` and \`distinct_multi_edges_are_not_duplicate\` tests pass. No code change needed — closing the tracking issue via this PR.

## Test plan

- [x] \`cargo nextest run -p nebula-api -p nebula-workflow\` — 154 passed
- [x] \`cargo clippy -p nebula-api -p nebula-workflow --tests -- -D warnings\`
- [x] \`cargo +nightly fmt --all\`
- New unit tests: \`extract_timestamp\` for i64/RFC3339/garbage/missing shapes, immutable-field coverage assertion
- New integration tests: \`update_workflow_rejects_immutable_identity_fields\` and \`get_workflow_parses_rfc3339_timestamps\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow read/update handlers; behavior changes include new 4xx validation failures for certain update payloads and different timestamp parsing, which could affect clients relying on previous permissive merges or `0` timestamps.
> 
> **Overview**
> **Workflow update hardening:** `update_workflow` now rejects any nested `definition` update that attempts to modify immutable identity/control/metadata fields (via `IMMUTABLE_DEFINITION_FIELDS`), returning a client validation error instead of silently merging.
> 
> **Timestamp parsing fix:** workflow response construction (`list_workflows`, `get_workflow`, `update_workflow`, `activate_workflow`) now uses `extract_timestamp` to accept both legacy i64 unix seconds and canonical RFC3339 string timestamps.
> 
> Adds unit tests for `extract_timestamp`/immutable-field coverage and integration tests ensuring immutable-field update rejection and RFC3339 timestamp round-tripping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880250580fec33da30f39339e3c90764013b1543. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->