### PR TITLE
fix(credential): OAuth2 safe errors, refresh validation, bounded circuit breakers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3845,6 +3845,7 @@ dependencies = [
  "chrono",
  "futures",
  "humantime-serde",
+ "lru",
  "moka",
  "nebula-core",
  "nebula-credential-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ tracing-subscriber = { version = "0.3.23", default-features = false }
 
 # Concurrency and synchronization
 dashmap = { version = "6.1.0", default-features = false }
+lru = { version = "0.16.3", default-features = false }
 parking_lot = { version = "0.12.5", default-features = false }
 moka = { version = "0.12", default-features = false }
 once_cell = "1.21"

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -57,6 +57,7 @@ tracing = { workspace = true }
 humantime-serde = "1.1"
 
 # Caching
+lru = { workspace = true }
 moka = { workspace = true, features = ["future"] }
 
 # Synchronization

--- a/crates/credential/src/credentials/oauth2_flow.rs
+++ b/crates/credential/src/credentials/oauth2_flow.rs
@@ -443,9 +443,10 @@ fn oauth_token_error_summary(body_text: &str) -> String {
     let mut out = error.to_owned();
     if let Some(desc) = value.get("error_description").and_then(Value::as_str) {
         out.push_str(": ");
-        let truncated: String = desc.chars().take(256).collect();
-        out.push_str(&truncated);
-        if desc.chars().count() > 256 {
+        // Bound work: at most 257 scalar values, never scan the full provider string.
+        let prefix: Vec<char> = desc.chars().take(257).collect();
+        out.extend(prefix.iter().take(256).copied());
+        if prefix.len() > 256 {
             out.push('…');
         }
     }

--- a/crates/credential/src/credentials/oauth2_flow.rs
+++ b/crates/credential/src/credentials/oauth2_flow.rs
@@ -422,11 +422,40 @@ pub(crate) async fn refresh_token(
         .map_err(|e| provider_error(format!("refresh token request failed: {e}")))?;
 
     let body: Value = parse_token_response(resp).await?;
-    update_state_from_token_response(state, &body);
+    update_state_from_token_response(state, &body)?;
     Ok(())
 }
 
 // ── Internal helpers ────────────────────────────────────────────────────
+
+/// Builds a log-safe summary for a non-2xx OAuth2 token endpoint body.
+///
+/// Never interpolates the raw response body: some providers echo submitted
+/// secrets in error JSON. Only RFC 6749 §5.2 fields are included, with
+/// `error_description` truncated (see GitHub issue #277).
+fn oauth_token_error_summary(body_text: &str) -> String {
+    let Ok(value) = serde_json::from_str::<Value>(body_text) else {
+        return "<non-json body>".to_owned();
+    };
+    let Some(error) = value.get("error").and_then(Value::as_str) else {
+        return "<no error code>".to_owned();
+    };
+    let mut out = error.to_owned();
+    if let Some(desc) = value.get("error_description").and_then(Value::as_str) {
+        out.push_str(": ");
+        let truncated: String = desc.chars().take(256).collect();
+        out.push_str(&truncated);
+        if desc.chars().count() > 256 {
+            out.push('…');
+        }
+    }
+    if let Some(uri) = value.get("error_uri").and_then(Value::as_str) {
+        out.push_str(" (error_uri=");
+        out.push_str(uri);
+        out.push(')');
+    }
+    out
+}
 
 /// Parse an HTTP response as a JSON token response.
 ///
@@ -435,8 +464,9 @@ async fn parse_token_response(resp: reqwest::Response) -> Result<Value, Credenti
     let status = resp.status();
     if !status.is_success() {
         let body_text = resp.text().await.unwrap_or_default();
+        let summary = oauth_token_error_summary(&body_text);
         return Err(provider_error(format!(
-            "token endpoint returned {status}: {body_text}"
+            "token endpoint returned {status}: {summary}"
         )));
     }
     resp.json::<Value>()
@@ -499,12 +529,22 @@ fn state_from_token_response(
 
 /// Update an existing [`OAuth2State`] from a refresh token response.
 ///
-/// Only overwrites fields present in the response. A missing `refresh_token`
+/// RFC 6749 §5.1 requires `access_token` in a successful token response; a 2xx
+/// body without it is treated as an error so we do not bump `expires_at` while
+/// leaving a stale access token (GitHub issue #274).
+///
+/// Other fields are only overwritten when present. A missing `refresh_token`
 /// preserves the existing one (per RFC 6749 Section 6).
-fn update_state_from_token_response(state: &mut OAuth2State, body: &Value) {
-    if let Some(token) = body.get("access_token").and_then(Value::as_str) {
-        state.access_token = SecretString::new(token);
-    }
+fn update_state_from_token_response(
+    state: &mut OAuth2State,
+    body: &Value,
+) -> Result<(), CredentialError> {
+    let Some(token) = body.get("access_token").and_then(Value::as_str) else {
+        return Err(provider_error(
+            "refresh response missing required 'access_token' field".into(),
+        ));
+    };
+    state.access_token = SecretString::new(token);
     if let Some(tt) = body.get("token_type").and_then(Value::as_str) {
         state.token_type = tt.to_owned();
     }
@@ -517,6 +557,7 @@ fn update_state_from_token_response(state: &mut OAuth2State, body: &Value) {
     if let Some(scope) = body.get("scope").and_then(Value::as_str) {
         state.scopes = scope.split_whitespace().map(str::to_owned).collect();
     }
+    Ok(())
 }
 
 /// Build a `CredentialError::Provider` from an HTTP/network-related message.
@@ -707,7 +748,7 @@ mod tests {
             "access_token": "new_tok"
         });
 
-        update_state_from_token_response(&mut state, &body);
+        update_state_from_token_response(&mut state, &body).unwrap();
         state
             .access_token
             .expose_secret(|s| assert_eq!(s, "new_tok"));
@@ -740,7 +781,7 @@ mod tests {
             "scope": "write"
         });
 
-        update_state_from_token_response(&mut state, &body);
+        update_state_from_token_response(&mut state, &body).unwrap();
         state
             .access_token
             .expose_secret(|s| assert_eq!(s, "new_tok"));
@@ -752,6 +793,40 @@ mod tests {
             .expose_secret(|s| assert_eq!(s, "new_rt"));
         assert!(state.expires_at.is_some());
         assert_eq!(state.scopes, vec!["write"]);
+    }
+
+    #[test]
+    fn oauth_token_error_summary_omits_raw_body_and_echoed_secrets() {
+        let body = r#"{"error":"invalid_client","client_secret":"hunter2"}"#;
+        let summary = super::oauth_token_error_summary(body);
+        assert!(
+            !summary.contains("hunter2"),
+            "secret echoed by provider must not appear: {summary}"
+        );
+        assert!(summary.contains("invalid_client"), "{summary}");
+    }
+
+    #[test]
+    fn update_state_errors_when_access_token_missing() {
+        let mut state = OAuth2State {
+            access_token: SecretString::new("stale"),
+            token_type: "Bearer".into(),
+            refresh_token: None,
+            expires_at: None,
+            scopes: vec![],
+            client_id: SecretString::new("cid"),
+            client_secret: SecretString::new("cs"),
+            token_url: "https://t.com/token".into(),
+            auth_style: AuthStyle::default(),
+        };
+
+        let body = serde_json::json!({
+            "expires_in": 3600
+        });
+
+        let err = update_state_from_token_response(&mut state, &body).unwrap_err();
+        assert!(matches!(err, CredentialError::Provider(_)));
+        state.access_token.expose_secret(|s| assert_eq!(s, "stale"));
     }
 
     #[test]

--- a/crates/credential/src/refresh.rs
+++ b/crates/credential/src/refresh.rs
@@ -119,13 +119,19 @@ pub enum RefreshAttempt {
 /// Default maximum number of concurrent refresh operations.
 const DEFAULT_MAX_CONCURRENT_REFRESHES: usize = 32;
 
+/// Raw LRU cap for per-credential circuit breakers (must stay > 0).
+const MAX_TRACKED_CIRCUIT_BREAKERS_CAP: usize = 4096;
+
 /// Maximum number of per-credential circuit breakers kept in memory.
 ///
 /// Failed refreshes insert entries that are only removed on success; without a
 /// cap, unbounded churn of distinct credential IDs could grow this map
 /// forever (see GitHub issue #278). Eviction follows LRU semantics: the least
 /// recently touched breaker may be dropped when the cap is exceeded.
-const MAX_TRACKED_CIRCUIT_BREAKERS: NonZeroUsize = NonZeroUsize::new(4096).unwrap();
+///
+/// The `unwrap` is evaluated at compile time: [`MAX_TRACKED_CIRCUIT_BREAKERS_CAP`] is non-zero.
+const MAX_TRACKED_CIRCUIT_BREAKERS: NonZeroUsize =
+    NonZeroUsize::new(MAX_TRACKED_CIRCUIT_BREAKERS_CAP).unwrap();
 
 /// Configuration errors returned by [`RefreshCoordinator`] constructors.
 ///
@@ -207,7 +213,20 @@ impl RefreshCoordinator {
             min_operations: 1,
             ..Default::default()
         };
-        let cb = Arc::new(CircuitBreaker::new(config).expect("valid CB config"));
+        let inner = CircuitBreaker::new(config).unwrap_or_else(|err| {
+            tracing::error!(
+                error = %err,
+                "unexpected: static refresh circuit breaker config invalid; using defaults"
+            );
+            CircuitBreaker::new(CircuitBreakerConfig::default()).unwrap_or_else(|err2| {
+                tracing::error!(
+                    error = %err2,
+                    "unexpected: default circuit breaker config invalid"
+                );
+                unreachable!("CircuitBreakerConfig::default must validate in nebula-resilience")
+            })
+        });
+        let cb = Arc::new(inner);
         cbs.put(credential_id.to_string(), Arc::clone(&cb));
         cb
     }
@@ -315,7 +334,7 @@ mod tests {
             coord.record_failure(&format!("cred-{i}"));
         }
         assert!(
-            coord.circuit_breaker_len_for_test() <= 4096,
+            coord.circuit_breaker_len_for_test() <= MAX_TRACKED_CIRCUIT_BREAKERS.get(),
             "LRU cap should prevent unbounded growth (issue #278)"
         );
     }

--- a/crates/credential/src/refresh.rs
+++ b/crates/credential/src/refresh.rs
@@ -33,8 +33,9 @@
 //! }
 //! ```
 
-use std::{collections::HashMap, fmt, sync::Arc, time::Duration};
+use std::{collections::HashMap, fmt, num::NonZeroUsize, sync::Arc, time::Duration};
 
+use lru::LruCache;
 use nebula_resilience::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, Outcome};
 use tokio::sync::Notify;
 
@@ -74,7 +75,7 @@ pub struct RefreshCoordinator {
     /// critical for calling it from a `scopeguard` drop (B8 fix).
     in_flight: parking_lot::Mutex<HashMap<String, Arc<Notify>>>,
     /// Per-credential circuit breakers via `nebula-resilience`.
-    circuit_breakers: parking_lot::Mutex<HashMap<String, Arc<CircuitBreaker>>>,
+    circuit_breakers: parking_lot::Mutex<LruCache<String, Arc<CircuitBreaker>>>,
     /// Global concurrency limiter for refresh operations.
     ///
     /// Prevents cascading failures when many credentials expire simultaneously
@@ -117,6 +118,14 @@ pub enum RefreshAttempt {
 
 /// Default maximum number of concurrent refresh operations.
 const DEFAULT_MAX_CONCURRENT_REFRESHES: usize = 32;
+
+/// Maximum number of per-credential circuit breakers kept in memory.
+///
+/// Failed refreshes insert entries that are only removed on success; without a
+/// cap, unbounded churn of distinct credential IDs could grow this map
+/// forever (see GitHub issue #278). Eviction follows LRU semantics: the least
+/// recently touched breaker may be dropped when the cap is exceeded.
+const MAX_TRACKED_CIRCUIT_BREAKERS: NonZeroUsize = NonZeroUsize::new(4096).unwrap();
 
 /// Configuration errors returned by [`RefreshCoordinator`] constructors.
 ///
@@ -181,7 +190,7 @@ impl RefreshCoordinator {
         debug_assert!(max > 0, "with_max_concurrent_unchecked requires max >= 1");
         Self {
             in_flight: parking_lot::Mutex::new(HashMap::new()),
-            circuit_breakers: parking_lot::Mutex::new(HashMap::new()),
+            circuit_breakers: parking_lot::Mutex::new(LruCache::new(MAX_TRACKED_CIRCUIT_BREAKERS)),
             refresh_semaphore: Arc::new(tokio::sync::Semaphore::new(max)),
         }
     }
@@ -189,17 +198,18 @@ impl RefreshCoordinator {
     /// Returns or creates a per-credential circuit breaker.
     fn get_or_create_cb(&self, credential_id: &str) -> Arc<CircuitBreaker> {
         let mut cbs = self.circuit_breakers.lock();
-        cbs.entry(credential_id.to_string())
-            .or_insert_with(|| {
-                let config = CircuitBreakerConfig {
-                    failure_threshold: 5,
-                    reset_timeout: Duration::from_secs(300),
-                    min_operations: 1,
-                    ..Default::default()
-                };
-                Arc::new(CircuitBreaker::new(config).expect("valid CB config"))
-            })
-            .clone()
+        if let Some(cb) = cbs.get(credential_id) {
+            return Arc::clone(cb);
+        }
+        let config = CircuitBreakerConfig {
+            failure_threshold: 5,
+            reset_timeout: Duration::from_secs(300),
+            min_operations: 1,
+            ..Default::default()
+        };
+        let cb = Arc::new(CircuitBreaker::new(config).expect("valid CB config"));
+        cbs.put(credential_id.to_string(), Arc::clone(&cb));
+        cb
     }
 
     /// Attempts to begin a refresh for the given credential.
@@ -269,12 +279,12 @@ impl RefreshCoordinator {
     /// Records a successful refresh, resetting the circuit breaker.
     pub fn record_success(&self, credential_id: &str) {
         // Remove the CB entirely on success — full reset.
-        self.circuit_breakers.lock().remove(credential_id);
+        self.circuit_breakers.lock().pop(credential_id);
     }
 
     /// Returns `true` if the circuit breaker is open (too many failures).
     pub fn is_circuit_open(&self, credential_id: &str) -> bool {
-        let cbs = self.circuit_breakers.lock();
+        let mut cbs = self.circuit_breakers.lock();
         cbs.get(credential_id)
             .is_some_and(|cb| cb.try_acquire::<()>().is_err())
     }
@@ -287,8 +297,28 @@ impl Default for RefreshCoordinator {
 }
 
 #[cfg(test)]
+impl RefreshCoordinator {
+    /// Returns the number of circuit breaker entries currently tracked (test-only).
+    fn circuit_breaker_len_for_test(&self) -> usize {
+        self.circuit_breakers.lock().len()
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn circuit_breaker_tracking_is_bounded() {
+        let coord = RefreshCoordinator::new();
+        for i in 0..6000 {
+            coord.record_failure(&format!("cred-{i}"));
+        }
+        assert!(
+            coord.circuit_breaker_len_for_test() <= 4096,
+            "LRU cap should prevent unbounded growth (issue #278)"
+        );
+    }
 
     #[tokio::test]
     async fn first_caller_wins() {


### PR DESCRIPTION
## Summary

Addresses three open **nebula-credential** issues from the audit.

### Issues closed

- [#277](https://github.com/vanyastaff/nebula/issues/277): Non-2xx token responses no longer interpolate the raw body into errors. Only RFC 6749 error fields are summarized (error code, truncated error_description, error_uri).
- [#274](https://github.com/vanyastaff/nebula/issues/274): Refresh responses must include `access_token`; otherwise we return `CredentialError::Provider` and do not update expiry while leaving a stale token.
- [#278](https://github.com/vanyastaff/nebula/issues/278): Per-credential circuit breakers are stored in an LRU capped at 4096 entries (dependency: `lru` 0.16.3 for advisory alignment with the rest of the lockfile).

### Tests added

- Safe OAuth2 error summary does not echo provider-echoed secrets in sibling JSON keys.
- Missing `access_token` on refresh body yields error and preserves prior token.
- Circuit breaker map stays bounded under churn.

### Follow-ups (still open)

Other `nebula-credential` issues not covered here: #265, #268, #281, #282, #348.

Closes #274
Closes #277
Closes #278

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth2 token refresh/error handling and refresh coordination logic; regressions could affect credential refresh reliability, though changes add validation, safer logging, and tests.
> 
> **Overview**
> Prevents leaking provider error bodies in OAuth2 token endpoint failures by replacing raw-body interpolation with a log-safe RFC 6749 error summary (including truncated `error_description`).
> 
> Tightens refresh handling by requiring `access_token` in successful refresh responses and returning `CredentialError::Provider` otherwise, avoiding updates that would keep a stale token.
> 
> Bounds refresh circuit breaker tracking by switching to an LRU cache capped at 4096 entries (adds `lru` dependency) and adds targeted tests for secret-safe error summaries, missing-token refresh responses, and bounded breaker growth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fc54afd96ff8a84cc9b9f50c6e40e27b1684ccd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security in OAuth2 error handling to prevent sensitive authentication information from being inadvertently logged
  * Enhanced validation logic to ensure access tokens are present in token refresh responses
  * Fixed potential unbounded memory growth in credential refresh mechanisms by implementing bounded tracking for circuit breakers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->