### PR TITLE
refactor: rename NodeId (ULID) → NodeKey (string Key<NodeDomain>)

### DIFF
--- a/apps/cli/src/commands/actions.rs
+++ b/apps/cli/src/commands/actions.rs
@@ -3,7 +3,10 @@ use std::{sync::Arc, time::Duration};
 use nebula_action::{
     ActionContext, ActionHandler, ActionResult, BreakReason, TriggerContext, testing::SpyEmitter,
 };
-use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{
+    id::{ExecutionId, WorkflowId},
+    node_key,
+};
 use nebula_runtime::ActionRegistry;
 use tokio_util::sync::CancellationToken;
 
@@ -143,7 +146,7 @@ pub async fn test(args: ActionsTestArgs) {
     // Build a minimal ActionContext.
     let ctx = ActionContext::new(
         ExecutionId::new(),
-        NodeId::new(),
+        node_key!("test"),
         WorkflowId::new(),
         CancellationToken::new(),
     );
@@ -278,7 +281,7 @@ async fn run_trigger(
 
     let cancel = CancellationToken::new();
     let spy = Arc::new(SpyEmitter::new());
-    let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), cancel.clone())
+    let ctx = TriggerContext::new(WorkflowId::new(), node_key!("test"), cancel.clone())
         .with_emitter(spy.clone());
 
     eprintln!("  trigger window: {timeout_ms}ms");

--- a/apps/cli/src/commands/replay.rs
+++ b/apps/cli/src/commands/replay.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, process::ExitCode, sync::Arc};
 
 use anyhow::Context;
-use nebula_core::id::{ExecutionId, NodeId};
+use nebula_core::{NodeKey, id::ExecutionId};
 use nebula_engine::WorkflowEngine;
 use nebula_execution::{ExecutionStatus, ReplayPlan, context::ExecutionBudget};
 use nebula_runtime::{ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessSandbox};
@@ -31,7 +31,7 @@ pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> 
         })?;
 
     // 3. Load pinned outputs (from file or empty).
-    let pinned_outputs: HashMap<NodeId, serde_json::Value> = if let Some(ref outputs_file) =
+    let pinned_outputs: HashMap<NodeKey, serde_json::Value> = if let Some(ref outputs_file) =
         args.outputs_file
     {
         let content = std::fs::read_to_string(outputs_file)
@@ -39,10 +39,10 @@ pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> 
         let raw: HashMap<String, serde_json::Value> =
             serde_json::from_str(&content).context("invalid outputs JSON")?;
         raw.into_iter()
-                .filter_map(|(k, v)| match k.parse::<NodeId>() {
+                .filter_map(|(k, v)| match k.parse::<NodeKey>() {
                     Ok(id) => Some((id, v)),
                     Err(e) => {
-                        tracing::warn!(key = %k, error = %e, "skipping pinned output with unparsable NodeId");
+                        tracing::warn!(key = %k, error = %e, "skipping pinned output with unparsable NodeKey");
                         None
                     },
                 })
@@ -55,10 +55,11 @@ pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> 
     let input_override: serde_json::Value =
         serde_json::from_str(&args.input).context("failed to parse --input as JSON")?;
 
-    let mut plan = ReplayPlan::new(ExecutionId::new(), target_node.id);
+    let mut plan = ReplayPlan::new(ExecutionId::new(), target_node.id.clone());
     plan.pinned_outputs = pinned_outputs;
     if input_override != serde_json::Value::Object(serde_json::Map::new()) {
-        plan.input_overrides.insert(target_node.id, input_override);
+        plan.input_overrides
+            .insert(target_node.id.clone(), input_override);
     }
 
     // 5. Build engine.
@@ -95,7 +96,8 @@ pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> 
     if !quiet {
         eprintln!(
             "Replaying from node \"{}\" ({})",
-            target_node.name, target_node.id
+            target_node.name,
+            target_node.id.clone()
         );
     }
 

--- a/apps/cli/src/commands/replay.rs
+++ b/apps/cli/src/commands/replay.rs
@@ -96,8 +96,7 @@ pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> 
     if !quiet {
         eprintln!(
             "Replaying from node \"{}\" ({})",
-            target_node.name,
-            target_node.id.clone()
+            target_node.name, target_node.id
         );
     }
 

--- a/apps/cli/src/commands/run.rs
+++ b/apps/cli/src/commands/run.rs
@@ -199,7 +199,7 @@ fn print_text_result(result: &nebula_engine::ExecutionResult) {
 
     if !result.node_outputs.is_empty() {
         println!("\nNode outputs:");
-        for (node_id, output) in &result.node_outputs {
+        for (node_key, output) in &result.node_outputs {
             let json = serde_json::to_string(output).unwrap_or_else(|_| "???".to_owned());
             let truncated = if json.len() > 200 {
                 let end = json.char_indices().nth(200).map_or(json.len(), |(i, _)| i);
@@ -207,14 +207,14 @@ fn print_text_result(result: &nebula_engine::ExecutionResult) {
             } else {
                 json
             };
-            println!("  {node_id}: {truncated}");
+            println!("  {node_key}: {truncated}");
         }
     }
 
     if !result.node_errors.is_empty() {
         println!("\nNode errors:");
-        for (node_id, error) in &result.node_errors {
-            println!("  {node_id}: {error}");
+        for (node_key, error) in &result.node_errors {
+            println!("  {node_key}: {error}");
         }
     }
 }
@@ -351,14 +351,14 @@ fn dry_run(
             // Show node details per group.
             for (i, group) in plan.parallel_groups.iter().enumerate() {
                 println!("  Level {}:", i + 1);
-                for node_id in group {
+                for node_key in group {
                     let name = workflow
                         .nodes
                         .iter()
-                        .find(|n| n.id == *node_id)
+                        .find(|n| n.id == *node_key)
                         .map(|n| format!("{} ({})", n.name, n.action_key))
-                        .unwrap_or_else(|| node_id.to_string());
-                    println!("    {node_id}  {name}");
+                        .unwrap_or_else(|| node_key.to_string());
+                    println!("    {node_key}  {name}");
                 }
             }
         },
@@ -372,18 +372,20 @@ fn print_stream_event(event: &nebula_engine::ExecutionEvent) {
     use nebula_engine::ExecutionEvent;
     match event {
         ExecutionEvent::NodeStarted {
-            node_id,
+            node_key,
             action_key,
             ..
-        } => eprintln!("  ▶ {node_id} ({action_key}) started"),
+        } => eprintln!("  ▶ {node_key} ({action_key}) started"),
         ExecutionEvent::NodeCompleted {
-            node_id, elapsed, ..
-        } => eprintln!("  ✓ {node_id} completed ({elapsed:?})"),
-        ExecutionEvent::NodeFailed { node_id, error, .. } => {
-            eprintln!("  ✗ {node_id} failed: {error}")
+            node_key, elapsed, ..
+        } => eprintln!("  ✓ {node_key} completed ({elapsed:?})"),
+        ExecutionEvent::NodeFailed {
+            node_key, error, ..
+        } => {
+            eprintln!("  ✗ {node_key} failed: {error}")
         },
-        ExecutionEvent::NodeSkipped { node_id, .. } => {
-            eprintln!("  ⊘ {node_id} skipped");
+        ExecutionEvent::NodeSkipped { node_key, .. } => {
+            eprintln!("  ⊘ {node_key} skipped");
         },
         ExecutionEvent::ExecutionFinished {
             success, elapsed, ..
@@ -427,7 +429,7 @@ async fn run_tui_live(
     let node_order: Vec<_> = workflow
         .nodes
         .iter()
-        .map(|n| (n.id, n.name.clone(), n.action_key.to_string()))
+        .map(|n| (n.id.clone(), n.name.clone(), n.action_key.to_string()))
         .collect();
 
     let (_tui_tx, tui_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -441,31 +443,31 @@ async fn run_tui_live(
     while let Ok(event) = engine_rx.try_recv() {
         let tui_event = match event {
             nebula_engine::ExecutionEvent::NodeStarted {
-                node_id,
+                node_key,
                 action_key,
                 ..
             } => TuiEvent::NodeStarted {
-                node_id,
+                node_key,
                 name: String::new(),
                 action_key,
             },
             nebula_engine::ExecutionEvent::NodeCompleted {
-                node_id, elapsed, ..
+                node_key, elapsed, ..
             } => TuiEvent::NodeCompleted {
-                node_id,
+                node_key,
                 elapsed,
                 output: serde_json::Value::Null,
             },
-            nebula_engine::ExecutionEvent::NodeFailed { node_id, error, .. } => {
-                TuiEvent::NodeFailed {
-                    node_id,
-                    elapsed: std::time::Duration::ZERO,
-                    error,
-                }
+            nebula_engine::ExecutionEvent::NodeFailed {
+                node_key, error, ..
+            } => TuiEvent::NodeFailed {
+                node_key,
+                elapsed: std::time::Duration::ZERO,
+                error,
             },
-            nebula_engine::ExecutionEvent::NodeSkipped { node_id, .. } => TuiEvent::Log {
+            nebula_engine::ExecutionEvent::NodeSkipped { node_key, .. } => TuiEvent::Log {
                 level: LogLevel::Info,
-                message: format!("node {node_id} skipped"),
+                message: format!("node {node_key} skipped"),
             },
             nebula_engine::ExecutionEvent::ExecutionFinished {
                 success, elapsed, ..
@@ -479,13 +481,13 @@ async fn run_tui_live(
     }
 
     // Also populate outputs/errors from result (events don't carry output data).
-    for (node_id, output) in &result.node_outputs {
-        if let Some(&idx) = app.node_index.get(node_id) {
+    for (node_key, output) in &result.node_outputs {
+        if let Some(&idx) = app.node_index.get(node_key) {
             app.nodes[idx].1.output = Some(output.clone());
         }
     }
-    for (node_id, error) in &result.node_errors {
-        if let Some(&idx) = app.node_index.get(node_id) {
+    for (node_key, error) in &result.node_errors {
+        if let Some(&idx) = app.node_index.get(node_key) {
             app.nodes[idx].1.error = Some(error.clone());
         }
     }

--- a/apps/cli/src/commands/watch.rs
+++ b/apps/cli/src/commands/watch.rs
@@ -164,8 +164,8 @@ async fn run_workflow(path: &Path, args: &WatchArgs) {
             );
 
             // Show errors if any.
-            for (node_id, error) in &result.node_errors {
-                eprintln!("  error {node_id}: {error}");
+            for (node_key, error) in &result.node_errors {
+                eprintln!("  error {node_key}: {error}");
             }
 
             // Show suggestions.

--- a/apps/cli/src/suggestions.rs
+++ b/apps/cli/src/suggestions.rs
@@ -8,7 +8,7 @@ use nebula_engine::ExecutionResult;
 /// A recovery suggestion for a failed node.
 pub struct Suggestion {
     /// Node ID that failed.
-    pub node_id: String,
+    pub node_key: String,
     /// What went wrong (short).
     pub problem: String,
     /// What to do about it.
@@ -21,14 +21,14 @@ pub struct Suggestion {
 pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
     let mut suggestions = Vec::new();
 
-    for (node_id, error) in &result.node_errors {
+    for (node_key, error) in &result.node_errors {
         let error_lower = error.to_lowercase();
-        let nid = node_id.to_string();
+        let nid = node_key.to_string();
 
         // HTTP 429 — Too Many Requests
         if error_lower.contains("429") || error_lower.contains("rate limit") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "HTTP 429 Too Many Requests".into(),
                 fix: "Add a rate_limit to this node to throttle requests.".into(),
                 yaml: Some("    rate_limit:\n      max_requests: 30\n      window_secs: 60".into()),
@@ -38,7 +38,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
         // Timeout
         if error_lower.contains("timeout") || error_lower.contains("timed out") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Request timed out".into(),
                 fix: "Increase the node timeout or the --timeout flag.".into(),
                 yaml: Some("    timeout: 60s".into()),
@@ -51,7 +51,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
             || error_lower.contains("connect error")
         {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Connection failed".into(),
                 fix: "Check that the target service is running and the URL is correct.".into(),
                 yaml: None,
@@ -61,7 +61,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
         // DNS resolution
         if error_lower.contains("dns") || error_lower.contains("resolve") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "DNS resolution failed".into(),
                 fix: "Check the hostname in the URL. Is it spelled correctly?".into(),
                 yaml: None,
@@ -78,7 +78,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
                 .unwrap_or("unknown");
 
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: format!("Action \"{key}\" is not registered"),
                 fix: format!(
                     "Check the action_key in your workflow.\n\
@@ -96,7 +96,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
             || error_lower.contains("invalid input")
         {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Input validation failed".into(),
                 fix: "Check the parameters for this node. \
                       Run `nebula actions info <key>` to see expected parameters."
@@ -108,7 +108,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
         // HTTP 401/403
         if error_lower.contains("401") || error_lower.contains("unauthorized") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Authentication failed (HTTP 401)".into(),
                 fix: "Check your credentials. Is the API key or token expired?".into(),
                 yaml: None,
@@ -116,7 +116,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
         }
         if error_lower.contains("403") || error_lower.contains("forbidden") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Access denied (HTTP 403)".into(),
                 fix: "Check permissions for your API key. Does it have the required scopes?".into(),
                 yaml: None,
@@ -130,7 +130,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
             || error_lower.contains("internal server error")
         {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Server error (5xx)".into(),
                 fix: "The remote service returned a server error. \
                       This is usually temporary — add a retry policy."
@@ -144,7 +144,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
         // Plugin process crashed
         if error_lower.contains("plugin exited with") {
             suggestions.push(Suggestion {
-                node_id: nid.clone(),
+                node_key: nid.clone(),
                 problem: "Plugin process crashed".into(),
                 fix: "The community plugin binary exited with a non-zero status.\n\
                       Run the plugin binary directly to debug:\n\
@@ -169,7 +169,7 @@ pub fn print_suggestions(suggestions: &[Suggestion]) {
     eprintln!();
 
     for (i, s) in suggestions.iter().enumerate() {
-        eprintln!("  {}. Node {}", i + 1, s.node_id);
+        eprintln!("  {}. Node {}", i + 1, s.node_key);
         eprintln!("     Problem: {}", s.problem);
         eprintln!("     Fix:     {}", s.fix);
         if let Some(yaml) = &s.yaml {

--- a/apps/cli/src/suggestions.rs
+++ b/apps/cli/src/suggestions.rs
@@ -7,7 +7,7 @@ use nebula_engine::ExecutionResult;
 
 /// A recovery suggestion for a failed node.
 pub struct Suggestion {
-    /// Node ID that failed.
+    /// Node key that failed.
     pub node_key: String,
     /// What went wrong (short).
     pub problem: String,

--- a/apps/cli/src/tui/app.rs
+++ b/apps/cli/src/tui/app.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 use crossterm::event::{self, Event, KeyCode, KeyEventKind};
-use nebula_core::id::NodeId;
+use nebula_core::NodeKey;
 use tokio::sync::mpsc;
 
 use super::{
@@ -49,8 +49,8 @@ pub struct App {
     pub workflow_name: String,
     pub execution_id: String,
     pub started_at: Instant,
-    pub nodes: Vec<(NodeId, NodeInfo)>,
-    pub node_index: HashMap<NodeId, usize>,
+    pub nodes: Vec<(NodeKey, NodeInfo)>,
+    pub node_index: HashMap<NodeKey, usize>,
     pub selected_node: usize,
     pub logs: Vec<LogEntry>,
     #[allow(dead_code)]
@@ -64,13 +64,13 @@ impl App {
     pub fn new(
         workflow_name: String,
         execution_id: String,
-        node_order: Vec<(NodeId, String, String)>,
+        node_order: Vec<(NodeKey, String, String)>,
     ) -> Self {
         let mut nodes = Vec::with_capacity(node_order.len());
         let mut node_index = HashMap::new();
 
         for (i, (id, name, action_key)) in node_order.into_iter().enumerate() {
-            node_index.insert(id, i);
+            node_index.insert(id.clone(), i);
             nodes.push((
                 id,
                 NodeInfo {
@@ -130,11 +130,11 @@ impl App {
                 }
             },
             TuiEvent::NodeStarted {
-                node_id,
+                node_key,
                 name: _,
                 action_key: _,
             } => {
-                if let Some(&idx) = self.node_index.get(&node_id) {
+                if let Some(&idx) = self.node_index.get(&node_key) {
                     self.nodes[idx].1.status = NodeStatus::Running;
                     self.push_log(
                         LogLevel::Info,
@@ -143,11 +143,11 @@ impl App {
                 }
             },
             TuiEvent::NodeCompleted {
-                node_id,
+                node_key,
                 elapsed,
                 output,
             } => {
-                if let Some(&idx) = self.node_index.get(&node_id) {
+                if let Some(&idx) = self.node_index.get(&node_key) {
                     let name = self.nodes[idx].1.name.clone();
                     let info = &mut self.nodes[idx].1;
                     info.status = NodeStatus::Completed;
@@ -160,11 +160,11 @@ impl App {
                 }
             },
             TuiEvent::NodeFailed {
-                node_id,
+                node_key,
                 elapsed,
                 error,
             } => {
-                if let Some(&idx) = self.node_index.get(&node_id) {
+                if let Some(&idx) = self.node_index.get(&node_key) {
                     let name = self.nodes[idx].1.name.clone();
                     let info = &mut self.nodes[idx].1;
                     info.status = NodeStatus::Failed;

--- a/apps/cli/src/tui/event.rs
+++ b/apps/cli/src/tui/event.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use nebula_core::id::NodeId;
+use nebula_core::NodeKey;
 
 /// All events the TUI handles.
 #[allow(dead_code)] // Variants used when real-time engine events are wired.
@@ -15,19 +15,19 @@ pub enum TuiEvent {
     Tick,
     /// A workflow node started executing.
     NodeStarted {
-        node_id: NodeId,
+        node_key: NodeKey,
         name: String,
         action_key: String,
     },
     /// A workflow node completed successfully.
     NodeCompleted {
-        node_id: NodeId,
+        node_key: NodeKey,
         elapsed: Duration,
         output: serde_json::Value,
     },
     /// A workflow node failed.
     NodeFailed {
-        node_id: NodeId,
+        node_key: NodeKey,
         elapsed: Duration,
         error: String,
     },

--- a/crates/action/src/context.rs
+++ b/crates/action/src/context.rs
@@ -7,8 +7,8 @@
 use std::{any::Any, fmt, sync::Arc};
 
 use nebula_core::{
-    AuthScheme,
-    id::{ExecutionId, NodeId, WorkflowId},
+    AuthScheme, NodeKey,
+    id::{ExecutionId, WorkflowId},
 };
 use nebula_credential::{
     CredentialAccessor, CredentialGuard, CredentialSnapshot, default_credential_accessor,
@@ -31,7 +31,7 @@ pub trait Context: Send + Sync {
     /// Execution identity.
     fn execution_id(&self) -> ExecutionId;
     /// Node identity within the workflow.
-    fn node_id(&self) -> NodeId;
+    fn node_key(&self) -> NodeKey;
     /// Workflow identity.
     fn workflow_id(&self) -> WorkflowId;
     /// Cancellation token; action may check before or during work.
@@ -48,7 +48,7 @@ pub struct ActionContext {
     /// Execution identity.
     pub execution_id: ExecutionId,
     /// Node identity within the workflow.
-    pub node_id: NodeId,
+    pub node_key: NodeKey,
     /// Workflow identity.
     pub workflow_id: WorkflowId,
     /// Cancellation token.
@@ -65,8 +65,8 @@ impl Context for ActionContext {
     fn execution_id(&self) -> ExecutionId {
         self.execution_id
     }
-    fn node_id(&self) -> NodeId {
-        self.node_id
+    fn node_key(&self) -> NodeKey {
+        self.node_key.clone()
     }
     fn workflow_id(&self) -> WorkflowId {
         self.workflow_id
@@ -81,13 +81,13 @@ impl ActionContext {
     #[must_use]
     pub fn new(
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         workflow_id: WorkflowId,
         cancellation: CancellationToken,
     ) -> Self {
         Self {
             execution_id,
-            node_id,
+            node_key,
             workflow_id,
             cancellation,
             resources: default_resource_accessor(),
@@ -132,7 +132,7 @@ impl fmt::Debug for ActionContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ActionContext")
             .field("execution_id", &self.execution_id)
-            .field("node_id", &self.node_id)
+            .field("node_key", &self.node_key)
             .field("workflow_id", &self.workflow_id)
             .field("cancellation", &self.cancellation)
             .field("resources", &"<dyn ResourceAccessor>")
@@ -152,7 +152,7 @@ pub struct TriggerContext {
     /// Workflow this trigger belongs to.
     pub workflow_id: WorkflowId,
     /// Trigger (node) identity.
-    pub trigger_id: NodeId,
+    pub trigger_id: NodeKey,
     /// Cancellation token.
     pub cancellation: CancellationToken,
     /// Trigger scheduling capability.
@@ -180,7 +180,7 @@ impl TriggerContext {
     #[must_use]
     pub fn new(
         workflow_id: WorkflowId,
-        trigger_id: NodeId,
+        trigger_id: NodeKey,
         cancellation: CancellationToken,
     ) -> Self {
         Self {
@@ -427,6 +427,7 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use nebula_core::node_key;
     use nebula_credential::{
         CredentialAccessError, CredentialMetadata, CredentialSnapshot, SecretString, SecretToken,
         scheme::ConnectionUri,
@@ -449,8 +450,8 @@ mod tests {
         fn execution_id(&self) -> ExecutionId {
             ExecutionId::nil()
         }
-        fn node_id(&self) -> NodeId {
-            NodeId::nil()
+        fn node_key(&self) -> NodeKey {
+            node_key!("test")
         }
         fn workflow_id(&self) -> WorkflowId {
             WorkflowId::nil()
@@ -470,7 +471,7 @@ mod tests {
     async fn action_context_defaults_to_noop_capabilities() {
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         );
@@ -524,11 +525,15 @@ mod tests {
 
     #[tokio::test]
     async fn trigger_context_with_capabilities_can_schedule_and_emit() {
-        let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new())
-            .with_scheduler(Arc::new(TestScheduler))
-            .with_emitter(Arc::new(TestEmitter))
-            .with_credentials(Arc::new(TestCredentialAccessor))
-            .with_logger(Arc::new(TestLogger));
+        let ctx = TriggerContext::new(
+            WorkflowId::new(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
+        .with_scheduler(Arc::new(TestScheduler))
+        .with_emitter(Arc::new(TestEmitter))
+        .with_credentials(Arc::new(TestCredentialAccessor))
+        .with_logger(Arc::new(TestLogger));
 
         assert!(ctx.schedule_after(Duration::from_millis(5)).await.is_ok());
         assert!(
@@ -544,7 +549,7 @@ mod tests {
     async fn action_context_credential_typed_returns_projected_scheme() {
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         )
@@ -561,7 +566,7 @@ mod tests {
     async fn action_context_credential_typed_mismatch_returns_fatal() {
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         )
@@ -576,8 +581,12 @@ mod tests {
 
     #[tokio::test]
     async fn trigger_context_credential_typed_returns_projected_scheme() {
-        let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new())
-            .with_credentials(Arc::new(TestCredentialAccessor));
+        let ctx = TriggerContext::new(
+            WorkflowId::new(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
+        .with_credentials(Arc::new(TestCredentialAccessor));
 
         let token: SecretToken = ctx
             .credential_typed::<SecretToken>("api_key")
@@ -588,8 +597,12 @@ mod tests {
 
     #[tokio::test]
     async fn trigger_context_credential_typed_mismatch_returns_fatal() {
-        let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new())
-            .with_credentials(Arc::new(TestCredentialAccessor));
+        let ctx = TriggerContext::new(
+            WorkflowId::new(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
+        .with_credentials(Arc::new(TestCredentialAccessor));
 
         let result = ctx.credential_typed::<ConnectionUri>("api_key").await;
         assert!(result.is_err());
@@ -658,7 +671,7 @@ mod tests {
     async fn action_context_credential_returns_guard() {
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         )
@@ -670,8 +683,12 @@ mod tests {
 
     #[tokio::test]
     async fn trigger_context_credential_returns_guard() {
-        let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new())
-            .with_credentials(Arc::new(TypedCredentialAccessor));
+        let ctx = TriggerContext::new(
+            WorkflowId::new(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
+        .with_credentials(Arc::new(TypedCredentialAccessor));
 
         let guard = ctx.credential::<ZeroizableToken>().await.unwrap();
         assert_eq!(guard.value, "secret-42");
@@ -681,7 +698,7 @@ mod tests {
     async fn credential_noop_accessor_returns_not_supported() {
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         );

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -535,7 +535,8 @@ fn derive_category(meta: &ActionMetadata) -> ActionCategory {
 mod tests {
     use nebula_core::{
         action_key,
-        id::{ExecutionId, NodeId, WorkflowId},
+        id::{ExecutionId, WorkflowId},
+        node_key,
     };
     use tokio_util::sync::CancellationToken;
 
@@ -548,7 +549,7 @@ mod tests {
     fn make_ctx() -> ActionContext {
         ActionContext::new(
             ExecutionId::nil(),
-            NodeId::nil(),
+            node_key!("test"),
             WorkflowId::nil(),
             CancellationToken::new(),
         )

--- a/crates/action/src/poll.rs
+++ b/crates/action/src/poll.rs
@@ -946,7 +946,7 @@ fn apply_jitter(secs: f64, jitter_fraction: f64, identity_seed: u64) -> f64 {
 fn trigger_seed(
     action_key: &nebula_core::ActionKey,
     workflow_id: &nebula_core::WorkflowId,
-    trigger_id: &nebula_core::NodeId,
+    trigger_id: &nebula_core::NodeKey,
 ) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325; // FNV-1a offset basis
     let mix = |h: &mut u64, bytes: &[u8]| {
@@ -957,7 +957,7 @@ fn trigger_seed(
     };
     mix(&mut h, action_key.as_str().as_bytes());
     mix(&mut h, &workflow_id.get().to_bytes());
-    mix(&mut h, &trigger_id.get().to_bytes());
+    mix(&mut h, trigger_id.as_str().as_bytes());
     h
 }
 

--- a/crates/action/src/resource.rs
+++ b/crates/action/src/resource.rs
@@ -187,7 +187,10 @@ impl<A: Action> fmt::Debug for ResourceActionAdapter<A> {
 mod tests {
     use std::sync::Arc;
 
-    use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+    use nebula_core::{
+        id::{ExecutionId, WorkflowId},
+        node_key,
+    };
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -232,7 +235,7 @@ mod tests {
     fn make_ctx() -> ActionContext {
         ActionContext::new(
             ExecutionId::nil(),
-            NodeId::nil(),
+            node_key!("test"),
             WorkflowId::nil(),
             CancellationToken::new(),
         )

--- a/crates/action/src/stateful.rs
+++ b/crates/action/src/stateful.rs
@@ -615,7 +615,10 @@ impl<A: Action> fmt::Debug for StatefulActionAdapter<A> {
 mod tests {
     use std::sync::Arc;
 
-    use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+    use nebula_core::{
+        id::{ExecutionId, WorkflowId},
+        node_key,
+    };
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -624,7 +627,7 @@ mod tests {
     fn make_ctx() -> ActionContext {
         ActionContext::new(
             ExecutionId::nil(),
-            NodeId::nil(),
+            node_key!("test"),
             WorkflowId::nil(),
             CancellationToken::new(),
         )

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -250,7 +250,7 @@ where
         let action_ctx = match &self.base_ctx {
             Some(base) => ActionContext::new(
                 ctx.execution_id(),
-                ctx.node_id(),
+                ctx.node_key(),
                 ctx.workflow_id(),
                 ctx.cancellation().clone(),
             )
@@ -259,7 +259,7 @@ where
             .with_logger(Arc::clone(&base.logger)),
             None => ActionContext::new(
                 ctx.execution_id(),
-                ctx.node_id(),
+                ctx.node_key(),
                 ctx.workflow_id(),
                 ctx.cancellation().clone(),
             ),
@@ -408,7 +408,10 @@ impl<A: Action> fmt::Debug for StatelessActionAdapter<A> {
 
 #[cfg(test)]
 mod tests {
-    use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+    use nebula_core::{
+        id::{ExecutionId, WorkflowId},
+        node_key,
+    };
     use serde::{Deserialize, Serialize};
     use tokio_util::sync::CancellationToken;
 
@@ -417,7 +420,7 @@ mod tests {
     fn make_ctx() -> ActionContext {
         ActionContext::new(
             ExecutionId::nil(),
-            NodeId::nil(),
+            node_key!("test"),
             WorkflowId::nil(),
             CancellationToken::new(),
         )
@@ -436,7 +439,7 @@ mod tests {
 
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         );
@@ -472,7 +475,7 @@ mod tests {
 
         let ctx = ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         );

--- a/crates/action/src/testing.rs
+++ b/crates/action/src/testing.rs
@@ -14,7 +14,10 @@ use std::{
 };
 
 use async_trait::async_trait;
-use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{
+    id::{ExecutionId, WorkflowId},
+    node_key,
+};
 use nebula_credential::{CredentialAccessError, CredentialAccessor, CredentialSnapshot};
 use tokio_util::sync::CancellationToken;
 
@@ -167,7 +170,7 @@ impl TestContextBuilder {
     pub fn build(self) -> ActionContext {
         ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             CancellationToken::new(),
         )
@@ -189,14 +192,18 @@ impl TestContextBuilder {
     pub fn build_trigger(self) -> (TriggerContext, Arc<SpyEmitter>, Arc<SpyScheduler>) {
         let emitter = Arc::new(SpyEmitter::new());
         let scheduler = Arc::new(SpyScheduler::new());
-        let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new())
-            .with_credentials(Arc::new(TestCredentialAccessor {
-                credentials: self.credentials,
-                typed_credentials: self.typed_credentials,
-            }))
-            .with_emitter(Arc::clone(&emitter) as Arc<dyn ExecutionEmitter>)
-            .with_scheduler(Arc::clone(&scheduler) as Arc<dyn TriggerScheduler>)
-            .with_logger(self.logs);
+        let ctx = TriggerContext::new(
+            WorkflowId::new(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
+        .with_credentials(Arc::new(TestCredentialAccessor {
+            credentials: self.credentials,
+            typed_credentials: self.typed_credentials,
+        }))
+        .with_emitter(Arc::clone(&emitter) as Arc<dyn ExecutionEmitter>)
+        .with_scheduler(Arc::clone(&scheduler) as Arc<dyn TriggerScheduler>)
+        .with_logger(self.logs);
         (ctx, emitter, scheduler)
     }
 }
@@ -651,7 +658,7 @@ mod tests {
         let builder = TestContextBuilder::new();
         let ctx = builder.build();
         let _ = ctx.execution_id;
-        let _ = ctx.node_id;
+        let _ = ctx.node_key;
     }
 
     #[test]

--- a/crates/action/src/trigger.rs
+++ b/crates/action/src/trigger.rs
@@ -436,7 +436,7 @@ mod tests {
         atomic::{AtomicBool, Ordering},
     };
 
-    use nebula_core::id::{NodeId, WorkflowId};
+    use nebula_core::{id::WorkflowId, node_key};
     use tokio_util::sync::CancellationToken;
 
     use super::*;
@@ -483,7 +483,11 @@ mod tests {
     }
 
     fn make_trigger_ctx() -> TriggerContext {
-        TriggerContext::new(WorkflowId::nil(), NodeId::nil(), CancellationToken::new())
+        TriggerContext::new(
+            WorkflowId::nil(),
+            node_key!("test"),
+            CancellationToken::new(),
+        )
     }
 
     #[test]

--- a/crates/action/tests/dx_control.rs
+++ b/crates/action/tests/dx_control.rs
@@ -24,7 +24,8 @@ use nebula_action::{
 };
 use nebula_core::{
     action_key,
-    id::{ExecutionId, NodeId, WorkflowId},
+    id::{ExecutionId, WorkflowId},
+    node_key,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -33,7 +34,7 @@ use tokio_util::sync::CancellationToken;
 fn make_ctx() -> ActionContext {
     ActionContext::new(
         ExecutionId::nil(),
-        NodeId::nil(),
+        node_key!("test"),
         WorkflowId::nil(),
         CancellationToken::new(),
     )

--- a/crates/action/tests/dx_poll.rs
+++ b/crates/action/tests/dx_poll.rs
@@ -14,7 +14,7 @@ use nebula_action::{
     EmitFailurePolicy, ExecutionEmitter, PollAction, PollConfig, PollCursor, PollOutcome,
     PollResult, PollTriggerAdapter, TestContextBuilder, TriggerContext, TriggerHandler,
 };
-use nebula_core::ExecutionId;
+use nebula_core::{ExecutionId, node_key};
 
 struct TickPoller {
     meta: ActionMetadata,
@@ -1076,7 +1076,7 @@ fn jitter_seed_differs_for_different_trigger_identities() {
     // need direct access to the private seed function via a
     // `#[cfg(test)]` pub-export. Current test just asserts that
     // the adapter doesn't panic and that both instances poll.
-    use nebula_core::{NodeId, WorkflowId};
+    use nebula_core::WorkflowId;
     use tokio_util::sync::CancellationToken;
 
     // We verify the public contract by running both adapters and
@@ -1086,10 +1086,10 @@ fn jitter_seed_differs_for_different_trigger_identities() {
     // confirms the plumbing reaches TriggerContext IDs.
     let wf1 = WorkflowId::new();
     let wf2 = WorkflowId::new();
-    let n1 = NodeId::new();
-    let n2 = NodeId::new();
+    let n1 = node_key!("trigger_a");
+    let n2 = node_key!("trigger_b");
     assert_ne!(wf1, wf2, "WorkflowId::new must produce unique ids");
-    assert_ne!(n1, n2, "NodeId::new must produce unique ids");
+    assert_ne!(n1, n2, "different node keys must differ");
 
     // Build two TriggerContexts with different identities and run
     // them through the adapter briefly; no panic, no fatal, and

--- a/crates/action/tests/execution_integration.rs
+++ b/crates/action/tests/execution_integration.rs
@@ -11,7 +11,8 @@ use nebula_action::{
 };
 use nebula_core::{
     action_key,
-    id::{ExecutionId, NodeId, WorkflowId},
+    id::{ExecutionId, WorkflowId},
+    node_key,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -49,7 +50,7 @@ async fn stateless_action_execute_returns_success() {
     };
     let ctx = ActionContext::new(
         ExecutionId::new(),
-        NodeId::new(),
+        node_key!("test"),
         WorkflowId::new(),
         CancellationToken::new(),
     );
@@ -117,7 +118,7 @@ async fn stateful_action_continue_then_break() {
     };
     let ctx = ActionContext::new(
         ExecutionId::new(),
-        NodeId::new(),
+        node_key!("test"),
         WorkflowId::new(),
         CancellationToken::new(),
     );
@@ -185,7 +186,11 @@ async fn trigger_action_start_stop_succeed() {
             "Start/stop no-op",
         ),
     };
-    let ctx = TriggerContext::new(WorkflowId::new(), NodeId::new(), CancellationToken::new());
+    let ctx = TriggerContext::new(
+        WorkflowId::new(),
+        node_key!("test"),
+        CancellationToken::new(),
+    );
     action.start(&ctx).await.unwrap();
     action.stop(&ctx).await.unwrap();
 }
@@ -259,7 +264,7 @@ async fn migrate_state_succeeds_from_v1() {
     let adapter = StatefulActionAdapter::new(action);
     let ctx = ActionContext::new(
         ExecutionId::new(),
-        NodeId::new(),
+        node_key!("test"),
         WorkflowId::new(),
         CancellationToken::new(),
     );
@@ -282,7 +287,7 @@ async fn migrate_state_propagates_error_when_none() {
     let adapter = StatefulActionAdapter::new(action);
     let ctx = ActionContext::new(
         ExecutionId::new(),
-        NodeId::new(),
+        node_key!("test"),
         WorkflowId::new(),
         CancellationToken::new(),
     );

--- a/crates/action/tests/type_sizes.rs
+++ b/crates/action/tests/type_sizes.rs
@@ -43,7 +43,7 @@ fn top_level_type_sizes_are_stable() {
         "ActionOutput<Value> grew — `BinaryData` is the inline variant \
          that drives this size, check it first."
     );
-    assert_eq!(size_of::<ActionContext>(), 112);
+    assert_eq!(size_of::<ActionContext>(), 128);
     assert_eq!(size_of::<ActionMetadata>(), 168);
     assert_eq!(size_of::<ActionError>(), 64);
     assert_eq!(size_of::<ActionHandler>(), 24);

--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -99,7 +99,7 @@ pub async fn list_executions(
 
 /// Get all node outputs for an execution.
 ///
-/// Returns a map of `node_id → output_value` for every node that has
+/// Returns a map of `node_key → output_value` for every node that has
 /// completed at least one attempt.
 ///
 /// # Errors
@@ -128,10 +128,10 @@ pub async fn get_execution_outputs(
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to load outputs: {}", e)))?;
 
-    // Convert NodeId keys to strings for JSON serialisation.
+    // Convert NodeKey keys to strings for JSON serialisation.
     let string_outputs: std::collections::HashMap<String, serde_json::Value> = outputs
         .into_iter()
-        .map(|(node_id, val)| (node_id.to_string(), val))
+        .map(|(node_key, val)| (node_key.to_string(), val))
         .collect();
 
     Ok(Json(ExecutionOutputsResponse {

--- a/crates/api/src/models/execution.rs
+++ b/crates/api/src/models/execution.rs
@@ -69,7 +69,7 @@ pub struct ExecutionOutputsResponse {
     /// Execution ID
     pub execution_id: String,
 
-    /// Map of node_id (string) → latest output value
+    /// Map of node_key (string) → latest output value
     pub outputs: HashMap<String, serde_json::Value>,
 }
 

--- a/crates/api/src/webhook/routing.rs
+++ b/crates/api/src/webhook/routing.rs
@@ -93,6 +93,7 @@ impl RoutingMap {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     // A minimal dummy TriggerHandler for the routing tests so we
@@ -125,7 +126,7 @@ mod tests {
         });
         let ctx = TriggerContext::new(
             nebula_core::WorkflowId::new(),
-            nebula_core::NodeId::new(),
+            nebula_core::node_key!("test"),
             CancellationToken::new(),
         );
         ActivationEntry { handler, ctx }

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -138,7 +138,7 @@ async fn register_webhook(
 
     let ctx_template = TriggerContext::new(
         nebula_core::WorkflowId::new(),
-        nebula_core::NodeId::new(),
+        nebula_core::node_key!("test"),
         CancellationToken::new(),
     );
 
@@ -342,7 +342,7 @@ async fn handler_timeout_returns_504() {
     }));
     let ctx_template = TriggerContext::new(
         nebula_core::WorkflowId::new(),
-        nebula_core::NodeId::new(),
+        nebula_core::node_key!("test"),
         CancellationToken::new(),
     );
     let handle = transport.activate(adapter.clone(), ctx_template).unwrap();

--- a/crates/core/benches/id_parse_serialize.rs
+++ b/crates/core/benches/id_parse_serialize.rs
@@ -5,7 +5,7 @@
 use std::hint::black_box;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use nebula_core::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{ExecutionId, NodeKey, WorkflowId, node_key};
 
 fn id_new(c: &mut Criterion) {
     let mut group = c.benchmark_group("id/new");
@@ -15,7 +15,7 @@ fn id_new(c: &mut Criterion) {
     group.bench_function("WorkflowId::new", |b| {
         b.iter(|| black_box(WorkflowId::new()));
     });
-    group.bench_function("NodeId::new", |b| b.iter(|| black_box(NodeId::new())));
+    group.bench_function("NodeKey::new", |b| b.iter(|| black_box(node_key!("test"))));
     group.finish();
 }
 
@@ -23,7 +23,7 @@ fn id_parse(c: &mut Criterion) {
     // Use actual prefixed ULID strings for parse benchmarks
     let exe_s = ExecutionId::new().to_string();
     let wf_s = WorkflowId::new().to_string();
-    let node_s = NodeId::new().to_string();
+    let node_s = node_key!("test").to_string();
     let mut group = c.benchmark_group("id/parse");
     group.bench_function("ExecutionId::parse", |b| {
         b.iter(|| {
@@ -42,12 +42,12 @@ fn id_parse(c: &mut Criterion) {
             )
         });
     });
-    group.bench_function("NodeId::parse", |b| {
+    group.bench_function("NodeKey::parse", |b| {
         b.iter(|| {
             black_box(
                 node_s
-                    .parse::<NodeId>()
-                    .expect("pre-generated NodeId string must parse"),
+                    .parse::<NodeKey>()
+                    .expect("pre-generated NodeKey string must parse"),
             )
         });
     });

--- a/crates/core/benches/id_parse_serialize.rs
+++ b/crates/core/benches/id_parse_serialize.rs
@@ -15,7 +15,9 @@ fn id_new(c: &mut Criterion) {
     group.bench_function("WorkflowId::new", |b| {
         b.iter(|| black_box(WorkflowId::new()));
     });
-    group.bench_function("NodeKey::new", |b| b.iter(|| black_box(node_key!("test"))));
+    group.bench_function("NodeKey::new", |b| {
+        b.iter(|| black_box(NodeKey::new("test").unwrap()));
+    });
     group.finish();
 }
 
@@ -26,56 +28,34 @@ fn id_parse(c: &mut Criterion) {
     let node_s = node_key!("test").to_string();
     let mut group = c.benchmark_group("id/parse");
     group.bench_function("ExecutionId::parse", |b| {
-        b.iter(|| {
-            black_box(
-                exe_s
-                    .parse::<ExecutionId>()
-                    .expect("pre-generated ExecutionId string must parse"),
-            )
-        });
+        b.iter(|| black_box(exe_s.parse::<ExecutionId>().unwrap()));
     });
     group.bench_function("WorkflowId::parse", |b| {
-        b.iter(|| {
-            black_box(
-                wf_s.parse::<WorkflowId>()
-                    .expect("pre-generated WorkflowId string must parse"),
-            )
-        });
+        b.iter(|| black_box(wf_s.parse::<WorkflowId>().unwrap()));
     });
     group.bench_function("NodeKey::parse", |b| {
-        b.iter(|| {
-            black_box(
-                node_s
-                    .parse::<NodeKey>()
-                    .expect("pre-generated NodeKey string must parse"),
-            )
-        });
+        b.iter(|| black_box(node_s.parse::<NodeKey>().unwrap()));
     });
     group.finish();
 }
 
 fn id_serde_json_roundtrip(c: &mut Criterion) {
     let id = ExecutionId::new();
-    let json = serde_json::to_string(&id).expect("ExecutionId must serialize");
+    let json = serde_json::to_string(&id).unwrap();
     let mut group = c.benchmark_group("id/serde_json");
     group.bench_function("to_string", |b| {
-        b.iter(|| {
-            black_box(serde_json::to_string(black_box(&id)).expect("ExecutionId must serialize"))
-        });
+        b.iter(|| black_box(serde_json::to_string(black_box(&id)).unwrap()));
     });
     group.bench_function("from_str", |b| {
         b.iter(|| {
-            let parsed: ExecutionId = serde_json::from_str(black_box(&json))
-                .expect("pre-serialized ExecutionId JSON must deserialize");
+            let parsed: ExecutionId = serde_json::from_str(black_box(&json)).unwrap();
             black_box(parsed)
         });
     });
     group.bench_function("roundtrip", |b| {
         b.iter(|| {
-            let json = serde_json::to_string(black_box(&id))
-                .expect("ExecutionId must serialize in roundtrip");
-            let parsed: ExecutionId = serde_json::from_str(&json)
-                .expect("freshly-serialized ExecutionId must deserialize");
+            let json = serde_json::to_string(black_box(&id)).unwrap();
+            let parsed: ExecutionId = serde_json::from_str(&json).unwrap();
             black_box(parsed)
         });
     });

--- a/crates/core/src/id/types.rs
+++ b/crates/core/src/id/types.rs
@@ -10,8 +10,6 @@ define_ulid!(pub WorkspaceIdDomain => WorkspaceId, prefix = "ws");
 define_ulid!(pub WorkflowIdDomain => WorkflowId, prefix = "wf");
 define_ulid!(pub WorkflowVersionIdDomain => WorkflowVersionId, prefix = "wfv");
 define_ulid!(pub ExecutionIdDomain => ExecutionId, prefix = "exe");
-// TODO(spec-24): NodeId is superseded by NodeKey. Migrate all consumers then remove.
-define_ulid!(pub NodeIdDomain => NodeId, prefix = "node");
 
 define_ulid!(pub AttemptIdDomain => AttemptId, prefix = "att");
 define_ulid!(pub InstanceIdDomain => InstanceId, prefix = "nbl");
@@ -54,9 +52,9 @@ mod tests {
 
     #[test]
     fn id_serde_json_roundtrip() {
-        let id = NodeId::new();
+        let id = ExecutionId::new();
         let json = serde_json::to_string(&id).unwrap();
-        let deserialized: NodeId = serde_json::from_str(&json).unwrap();
+        let deserialized: ExecutionId = serde_json::from_str(&json).unwrap();
         assert_eq!(id, deserialized);
     }
 
@@ -117,7 +115,6 @@ mod tests {
         let _ = WorkflowId::new();
         let _ = WorkflowVersionId::new();
         let _ = ExecutionId::new();
-        let _ = NodeId::new();
         let _ = AttemptId::new();
         let _ = InstanceId::new();
         let _ = TriggerId::new();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -9,7 +9,7 @@
 //! ## Key Components
 //!
 //! - **Identifiers**: Prefixed ULID types -- `ExecutionId` (`exe_01J9...`), `WorkflowId`
-//!   (`wf_01J9...`), `NodeId` (`node_01J9...`), etc.
+//!   (`wf_01J9...`), etc.
 //! - **Keys**: `PluginKey`, `ActionKey`, `ParameterKey`, `CredentialKey`, `ResourceKey`, `NodeKey`
 //!   -- normalized string keys.
 //! - **Scope System**: `ScopeLevel`, `Scope`, `Principal`, `ScopeResolver`.
@@ -79,8 +79,8 @@ pub mod prelude {
     // Identifiers (ULID-backed)
     #[allow(deprecated)] // OrganizationId re-exported for migration period
     pub use crate::id::{
-        AttemptId, CredentialId, ExecutionId, InstanceId, NodeId, OrgId, OrganizationId,
-        ResourceId, ServiceAccountId, SessionId, TriggerEventId, TriggerId, UserId, WorkflowId,
+        AttemptId, CredentialId, ExecutionId, InstanceId, OrgId, OrganizationId, ResourceId,
+        ServiceAccountId, SessionId, TriggerEventId, TriggerId, UserId, WorkflowId,
         WorkflowVersionId, WorkspaceId,
     };
     // Domain keys (normalized string keys)

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -393,6 +393,12 @@ impl WorkflowEngine {
         let mut exec_state = ExecutionState::new(execution_id, workflow.id, &node_ids);
         exec_state.transition_status(ExecutionStatus::Running)?;
         for node_key in &pinned {
+            // NOTE: errors are intentionally discarded here. Pinned nodes are
+            // forced through Ready→Running→Completed for bookkeeping; the
+            // transitions are best-effort. A failure (e.g. unexpected current
+            // state) is non-fatal because the node was already completed in a
+            // prior run. TODO: log a warning on failure once the engine has a
+            // structured logger handle.
             let _ = exec_state.transition_node(node_key.clone(), NodeState::Ready);
             let _ = exec_state.transition_node(node_key.clone(), NodeState::Running);
             let _ = exec_state.transition_node(node_key.clone(), NodeState::Completed);
@@ -2463,7 +2469,7 @@ mod tests {
             .unwrap();
 
         assert!(result.is_success());
-        assert_eq!(result.node_output(n), Some(&serde_json::json!("hello")));
+        assert_eq!(result.node_output(&n), Some(&serde_json::json!("hello")));
     }
 
     #[tokio::test]
@@ -2491,9 +2497,9 @@ mod tests {
             .unwrap();
 
         assert!(result.is_success());
-        assert_eq!(result.node_output(n1), Some(&serde_json::json!(42)));
+        assert_eq!(result.node_output(&n1), Some(&serde_json::json!(42)));
         // B echoes its input, which is A's output (42)
-        assert_eq!(result.node_output(n2), Some(&serde_json::json!(42)));
+        assert_eq!(result.node_output(&n2), Some(&serde_json::json!(42)));
     }
 
     #[tokio::test]
@@ -2531,11 +2537,11 @@ mod tests {
 
         assert!(result.is_success());
         assert_eq!(result.node_outputs.len(), 4);
-        assert_eq!(result.node_output(a), Some(&serde_json::json!("start")));
-        assert_eq!(result.node_output(b), Some(&serde_json::json!("start")));
-        assert_eq!(result.node_output(c), Some(&serde_json::json!("start")));
+        assert_eq!(result.node_output(&a), Some(&serde_json::json!("start")));
+        assert_eq!(result.node_output(&b), Some(&serde_json::json!("start")));
+        assert_eq!(result.node_output(&c), Some(&serde_json::json!("start")));
         // Join node gets merged outputs from b and c
-        let d_output = result.node_output(d).unwrap();
+        let d_output = result.node_output(&d).unwrap();
         assert!(d_output.is_object());
     }
 
@@ -2572,9 +2578,9 @@ mod tests {
             .unwrap();
 
         assert!(result.is_failure());
-        assert!(result.node_output(n1).is_some());
-        assert!(result.node_output(n2).is_none());
-        assert!(result.node_output(n3).is_none());
+        assert!(result.node_output(&n1).is_some());
+        assert!(result.node_output(&n2).is_none());
+        assert!(result.node_output(&n3).is_none());
     }
 
     #[tokio::test]
@@ -2797,13 +2803,13 @@ mod tests {
 
         assert!(result.is_success());
         // A executed (branch node)
-        assert!(result.node_output(a).is_some());
+        assert!(result.node_output(&a).is_some());
         // B executed (true branch)
-        assert!(result.node_output(b).is_some());
+        assert!(result.node_output(&b).is_some());
         // C was NOT executed (false branch, skipped)
-        assert!(result.node_output(c).is_none());
+        assert!(result.node_output(&c).is_none());
         // D executed (received input from B only)
-        assert!(result.node_output(d).is_some());
+        assert!(result.node_output(&d).is_some());
     }
 
     /// A → B(skip) → C. Verify C is skipped and doesn't execute.
@@ -2842,11 +2848,11 @@ mod tests {
         // Execution succeeds overall (skip is not a failure)
         assert!(result.is_success());
         // A executed
-        assert!(result.node_output(a).is_some());
+        assert!(result.node_output(&a).is_some());
         // B executed but produced Skip result (no output stored since skip has no output)
-        assert!(result.node_output(b).is_none());
+        assert!(result.node_output(&b).is_none());
         // C was skipped (never executed)
-        assert!(result.node_output(c).is_none());
+        assert!(result.node_output(&c).is_none());
     }
 
     /// A → B(fails) --OnError--> C. Verify C receives error data and execution succeeds.
@@ -2887,11 +2893,11 @@ mod tests {
         // Execution succeeds because the error was handled
         assert!(result.is_success());
         // A executed
-        assert!(result.node_output(a).is_some());
+        assert!(result.node_output(&a).is_some());
         // B failed but error data was stored
-        assert!(result.node_output(b).is_some());
+        assert!(result.node_output(&b).is_some());
         // C executed with error data from B
-        let c_output = result.node_output(c).unwrap();
+        let c_output = result.node_output(&c).unwrap();
         assert!(c_output.get("error").is_some());
     }
 
@@ -2929,9 +2935,9 @@ mod tests {
             .unwrap();
 
         assert!(result.is_failure());
-        assert!(result.node_output(a).is_some());
+        assert!(result.node_output(&a).is_some());
         // B failed, no error handler → fail-fast
-        assert!(result.node_output(c).is_none());
+        assert!(result.node_output(&c).is_none());
     }
 
     /// A → B with OnResult(Success) condition. B should run when A succeeds.
@@ -2964,8 +2970,8 @@ mod tests {
             .unwrap();
 
         assert!(result.is_success());
-        assert_eq!(result.node_output(a), Some(&serde_json::json!("hello")));
-        assert_eq!(result.node_output(b), Some(&serde_json::json!("hello")));
+        assert_eq!(result.node_output(&a), Some(&serde_json::json!("hello")));
+        assert_eq!(result.node_output(&b), Some(&serde_json::json!("hello")));
     }
 
     /// Diamond with mixed conditions:
@@ -3008,11 +3014,11 @@ mod tests {
 
         assert!(result.is_success());
         assert_eq!(result.node_outputs.len(), 4);
-        assert!(result.node_output(a).is_some());
-        assert!(result.node_output(b).is_some());
-        assert!(result.node_output(c).is_some());
+        assert!(result.node_output(&a).is_some());
+        assert!(result.node_output(&b).is_some());
+        assert!(result.node_output(&c).is_some());
         // D should have merged input from B and C
-        let d_output = result.node_output(d).unwrap();
+        let d_output = result.node_output(&d).unwrap();
         assert!(d_output.is_object());
     }
 
@@ -3283,11 +3289,11 @@ mod tests {
         // Workflow completes (not fail-fast)
         assert!(result.is_success() || result.status == ExecutionStatus::Completed);
         // Entry ran
-        assert!(result.node_output(entry).is_some());
+        assert!(result.node_output(&entry).is_some());
         // C is independent and should have run
-        assert!(result.node_output(c).is_some());
+        assert!(result.node_output(&c).is_some());
         // B depends on the failed node — should be skipped (no output)
-        assert!(result.node_output(b).is_none());
+        assert!(result.node_output(&b).is_none());
     }
 
     #[tokio::test]
@@ -3329,10 +3335,10 @@ mod tests {
         // Workflow should complete successfully
         assert_eq!(result.status, ExecutionStatus::Completed);
         // A's output was replaced with null
-        assert_eq!(result.node_output(a), Some(&serde_json::json!(null)));
+        assert_eq!(result.node_output(&a), Some(&serde_json::json!(null)));
         // B ran and received null as input
-        assert!(result.node_output(b.clone()).is_some());
-        assert_eq!(result.node_output(b), Some(&serde_json::json!(null)));
+        assert!(result.node_output(&b).is_some());
+        assert_eq!(result.node_output(&b), Some(&serde_json::json!(null)));
     }
 
     // -- resume_execution tests --
@@ -3518,14 +3524,14 @@ mod tests {
         assert!(result.is_success(), "resume should complete successfully");
         assert_eq!(result.execution_id, execution_id);
         // n1's output comes from the persisted outputs
-        assert_eq!(result.node_output(n1), Some(&serde_json::json!("from_n1")));
+        assert_eq!(result.node_output(&n1), Some(&serde_json::json!("from_n1")));
         // n2 and n3 should have been executed and produced outputs
         assert!(
-            result.node_output(n2).is_some(),
+            result.node_output(&n2).is_some(),
             "n2 should have been re-executed"
         );
         assert!(
-            result.node_output(n3).is_some(),
+            result.node_output(&n3).is_some(),
             "n3 should have been re-executed"
         );
     }
@@ -3718,12 +3724,12 @@ mod tests {
 
         assert!(result.is_success());
         assert_eq!(
-            result.node_output(n1),
+            result.node_output(&n1),
             Some(&serde_json::json!("v1")),
             "n1 should use the v1 handler"
         );
         assert_eq!(
-            result.node_output(n2),
+            result.node_output(&n2),
             Some(&serde_json::json!("v2")),
             "n2 should use the v2 handler"
         );
@@ -3838,7 +3844,7 @@ mod tests {
             result.status
         );
         assert!(
-            result.node_output(b).is_some(),
+            result.node_output(&b).is_some(),
             "target node B must execute and produce output"
         );
     }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -20,7 +20,11 @@ use dashmap::DashMap;
 // TODO: ExecutionBudget moved to nebula-execution
 use nebula_action::capability::{ResourceAccessor, default_resource_accessor};
 use nebula_action::{ActionContext, ActionError, ActionResult};
-use nebula_core::id::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{
+    NodeKey,
+    id::{ExecutionId, WorkflowId},
+    node_key,
+};
 use nebula_credential::{CredentialAccessor, default_credential_accessor};
 // ScopeLevel removed from ActionContext
 // use nebula_core::scope::ScopeLevel;
@@ -335,9 +339,9 @@ impl WorkflowEngine {
         // Build graph and node map.
         let graph = DependencyGraph::from_definition(workflow)
             .map_err(|e| EngineError::PlanningFailed(e.to_string()))?;
-        let node_ids: Vec<NodeId> = workflow.nodes.iter().map(|n| n.id).collect();
-        let node_map: HashMap<NodeId, &nebula_workflow::NodeDefinition> =
-            workflow.nodes.iter().map(|n| (n.id, n)).collect();
+        let node_ids: Vec<NodeKey> = workflow.nodes.iter().map(|n| n.id.clone()).collect();
+        let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
+            workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
 
         // Build both predecessor AND successor maps.
         //
@@ -347,17 +351,17 @@ impl WorkflowEngine {
         //   `replay_from` and identify the re-run set. Issue #254 — the old predecessor-only
         //   partition classified unrelated sibling branches as rerun, duplicating their side
         //   effects on every replay.
-        let mut predecessors: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
-        let mut successors: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+        let mut predecessors: HashMap<NodeKey, Vec<NodeKey>> = HashMap::new();
+        let mut successors: HashMap<NodeKey, Vec<NodeKey>> = HashMap::new();
         for conn in &workflow.connections {
             predecessors
-                .entry(conn.to_node)
+                .entry(conn.to_node.clone())
                 .or_default()
-                .push(conn.from_node);
+                .push(conn.from_node.clone());
             successors
-                .entry(conn.from_node)
+                .entry(conn.from_node.clone())
                 .or_default()
-                .push(conn.to_node);
+                .push(conn.to_node.clone());
         }
 
         // Partition nodes into pinned (use stored outputs) and rerun.
@@ -372,15 +376,15 @@ impl WorkflowEngine {
         // frontier loop silently feed `Null` to a downstream node. The
         // previous filter-in-map-keys approach hid missing pins the
         // same way `#[serde(skip)]` on `pinned_outputs` did (#253).
-        let outputs: Arc<DashMap<NodeId, serde_json::Value>> = Arc::new(DashMap::new());
-        for node_id in &pinned {
-            let Some(output) = plan.pinned_outputs.get(node_id) else {
+        let outputs: Arc<DashMap<NodeKey, serde_json::Value>> = Arc::new(DashMap::new());
+        for node_key in &pinned {
+            let Some(output) = plan.pinned_outputs.get(node_key) else {
                 return Err(EngineError::PlanningFailed(format!(
-                    "replay plan is missing pinned output for node {node_id}; \
+                    "replay plan is missing pinned output for node {node_key}; \
                      every node in the partition's pinned set must have a stored output"
                 )));
             };
-            outputs.insert(*node_id, output.clone());
+            outputs.insert(node_key.clone(), output.clone());
         }
 
         // Build execution state — mark pinned nodes as Completed via
@@ -388,10 +392,10 @@ impl WorkflowEngine {
         // the version move (issue #255).
         let mut exec_state = ExecutionState::new(execution_id, workflow.id, &node_ids);
         exec_state.transition_status(ExecutionStatus::Running)?;
-        for &node_id in &pinned {
-            let _ = exec_state.transition_node(node_id, NodeState::Ready);
-            let _ = exec_state.transition_node(node_id, NodeState::Running);
-            let _ = exec_state.transition_node(node_id, NodeState::Completed);
+        for node_key in &pinned {
+            let _ = exec_state.transition_node(node_key.clone(), NodeState::Ready);
+            let _ = exec_state.transition_node(node_key.clone(), NodeState::Running);
+            let _ = exec_state.transition_node(node_key.clone(), NodeState::Completed);
         }
 
         let semaphore = Arc::new(Semaphore::new(budget.max_concurrent_nodes));
@@ -399,16 +403,16 @@ impl WorkflowEngine {
         let mut repo_version = 0u64;
 
         // Determine seed nodes: nodes in rerun set whose predecessors are all pinned.
-        let seed_nodes: Vec<NodeId> = node_ids
+        let seed_nodes: Vec<NodeKey> = node_ids
             .iter()
-            .copied()
-            .filter(|n| !pinned.contains(n))
+            .filter(|n| !pinned.contains(*n))
             .filter(|n| {
                 predecessors
-                    .get(n)
+                    .get(*n)
                     .map(|preds| preds.iter().all(|p| pinned.contains(p)))
                     .unwrap_or(true) // no predecessors = entry node
             })
+            .cloned()
             .collect();
 
         // Use override inputs if provided.
@@ -455,15 +459,19 @@ impl WorkflowEngine {
             elapsed,
         });
 
-        let node_outputs: HashMap<NodeId, serde_json::Value> = outputs
+        let node_outputs: HashMap<NodeKey, serde_json::Value> = outputs
             .iter()
-            .map(|r| (*r.key(), r.value().clone()))
+            .map(|r| (r.key().clone(), r.value().clone()))
             .collect();
 
-        let node_errors: HashMap<NodeId, String> = exec_state
+        let node_errors: HashMap<NodeKey, String> = exec_state
             .node_states
             .iter()
-            .filter_map(|(&id, ns)| ns.error_message.as_ref().map(|msg| (id, msg.clone())))
+            .filter_map(|(id, ns)| {
+                ns.error_message
+                    .as_ref()
+                    .map(|msg| (id.clone(), msg.clone()))
+            })
             .collect();
 
         Ok(ExecutionResult {
@@ -507,7 +515,7 @@ impl WorkflowEngine {
 
         // 3. Validate action key mappings exist for all nodes
         // 4. Initialize execution state
-        let node_ids: Vec<NodeId> = workflow.nodes.iter().map(|n| n.id).collect();
+        let node_ids: Vec<NodeKey> = workflow.nodes.iter().map(|n| n.id.clone()).collect();
         let mut exec_state = ExecutionState::new(execution_id, workflow.id, &node_ids);
         exec_state.transition_status(ExecutionStatus::Running)?;
 
@@ -531,16 +539,16 @@ impl WorkflowEngine {
             .inc();
 
         // 7. Build node lookup map
-        let node_map: HashMap<NodeId, &nebula_workflow::NodeDefinition> =
-            workflow.nodes.iter().map(|n| (n.id, n)).collect();
+        let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
+            workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
 
         // 8. Shared output storage (concurrent access from worker tasks)
-        let outputs: Arc<DashMap<NodeId, serde_json::Value>> = Arc::new(DashMap::new());
+        let outputs: Arc<DashMap<NodeKey, serde_json::Value>> = Arc::new(DashMap::new());
         let semaphore = Arc::new(Semaphore::new(budget.max_concurrent_nodes));
 
         // 9. Execute using frontier-based loop
         let error_strategy = workflow.config.error_strategy;
-        let seed_nodes: Vec<NodeId> = graph.entry_nodes();
+        let seed_nodes: Vec<NodeKey> = graph.entry_nodes();
         let failed_node = self
             .run_frontier(
                 &graph,
@@ -603,15 +611,19 @@ impl WorkflowEngine {
         });
 
         // 11. Collect outputs and errors
-        let node_outputs: HashMap<NodeId, serde_json::Value> = outputs
+        let node_outputs: HashMap<NodeKey, serde_json::Value> = outputs
             .iter()
-            .map(|r| (*r.key(), r.value().clone()))
+            .map(|r| (r.key().clone(), r.value().clone()))
             .collect();
 
-        let node_errors: HashMap<NodeId, String> = exec_state
+        let node_errors: HashMap<NodeKey, String> = exec_state
             .node_states
             .iter()
-            .filter_map(|(&id, ns)| ns.error_message.as_ref().map(|msg| (id, msg.clone())))
+            .filter_map(|(id, ns)| {
+                ns.error_message
+                    .as_ref()
+                    .map(|msg| (id.clone(), msg.clone()))
+            })
             .collect();
 
         Ok(ExecutionResult {
@@ -665,7 +677,11 @@ impl WorkflowEngine {
                 EngineError::PlanningFailed(format!("execution not found: {execution_id}"))
             })?;
 
-        let exec_state: ExecutionState = serde_json::from_value(state_json)
+        // Deserialize via JSON string to avoid `serde_json::from_value` issues
+        // with Key<D> types that expect borrowed strings (domain-key serde impl).
+        let state_str = serde_json::to_string(&state_json)
+            .map_err(|e| EngineError::PlanningFailed(format!("serialize state: {e}")))?;
+        let exec_state: ExecutionState = serde_json::from_str(&state_str)
             .map_err(|e| EngineError::PlanningFailed(format!("deserialize state: {e}")))?;
 
         // 3. Guard against resuming a terminal execution.
@@ -709,11 +725,11 @@ impl WorkflowEngine {
         //    the forward state machine via `override_node_state` but still bumps the version per
         //    transition so CAS readers see the change (issue #255).
         let mut exec_state = exec_state;
-        let non_terminal: Vec<NodeId> = exec_state
+        let non_terminal: Vec<NodeKey> = exec_state
             .node_states
             .iter()
             .filter(|(_, ns)| !ns.state.is_terminal())
-            .map(|(id, _)| *id)
+            .map(|(id, _)| id.clone())
             .collect();
         for id in non_terminal {
             let _ = exec_state.override_node_state(id, NodeState::Pending);
@@ -728,9 +744,9 @@ impl WorkflowEngine {
         }
 
         // 8. Populate shared output map from persisted outputs.
-        let outputs: Arc<DashMap<NodeId, serde_json::Value>> = Arc::new(DashMap::new());
-        for (node_id, value) in persisted_outputs {
-            outputs.insert(node_id, value);
+        let outputs: Arc<DashMap<NodeKey, serde_json::Value>> = Arc::new(DashMap::new());
+        for (node_key, value) in persisted_outputs {
+            outputs.insert(node_key.clone(), value);
         }
 
         // 9. Compute the resume frontier and pre-populate edge-tracking maps.
@@ -742,28 +758,31 @@ impl WorkflowEngine {
         //    We also rebuild `activated_edges` and `resolved_edges` for terminal
         //    nodes so that `run_frontier`'s bookkeeping stays consistent when
         //    it evaluates edges from the frontier.
-        let node_map: HashMap<NodeId, &nebula_workflow::NodeDefinition> =
-            workflow.nodes.iter().map(|n| (n.id, n)).collect();
+        let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
+            workflow.nodes.iter().map(|n| (n.id.clone(), n)).collect();
 
-        let mut activated_edges: HashMap<NodeId, HashSet<NodeId>> = HashMap::new();
-        let mut resolved_edges: HashMap<NodeId, usize> = HashMap::new();
-        let mut seed_nodes: Vec<NodeId> = Vec::new();
+        let mut activated_edges: HashMap<NodeKey, HashSet<NodeKey>> = HashMap::new();
+        let mut resolved_edges: HashMap<NodeKey, usize> = HashMap::new();
+        let mut seed_nodes: Vec<NodeKey> = Vec::new();
 
         // Mark edges from terminal nodes as resolved (and activated, since they
         // completed successfully or were skipped).
-        for (&node_id, ns) in &exec_state.node_states {
+        for (node_key, ns) in &exec_state.node_states {
             if !ns.state.is_terminal() {
                 continue;
             }
-            for conn in graph.outgoing_connections(node_id) {
-                let target = conn.to_node;
+            for conn in graph.outgoing_connections(node_key.clone()) {
+                let target = conn.to_node.clone();
                 // Increment per-edge count so multiple edges from the same terminal
                 // source to the same target are each counted during resume.
-                *resolved_edges.entry(target).or_insert(0) += 1;
+                *resolved_edges.entry(target.clone()).or_insert(0) += 1;
                 // Completed and Skipped nodes activate their outgoing edges so
                 // that downstream nodes see a resolved predecessor.
                 if matches!(ns.state, NodeState::Completed | NodeState::Skipped) {
-                    activated_edges.entry(target).or_default().insert(node_id);
+                    activated_edges
+                        .entry(target.clone())
+                        .or_default()
+                        .insert(node_key.clone());
                 }
             }
         }
@@ -779,16 +798,16 @@ impl WorkflowEngine {
         // the activated_edges map reconstructed above from Completed/Skipped
         // predecessors gives run_frontier the correct activation context to
         // evaluate edge conditions normally once the node is dispatched.
-        for (&node_id, ns) in &exec_state.node_states {
+        for (node_key, ns) in &exec_state.node_states {
             if ns.state.is_terminal() {
                 continue;
             }
-            let incoming = graph.incoming_connections(node_id);
+            let incoming = graph.incoming_connections(node_key.clone());
             let required = incoming.len();
-            let resolved = resolved_edges.get(&node_id).copied().unwrap_or(0);
+            let resolved = resolved_edges.get(node_key).cloned().unwrap_or(0);
 
             if required == 0 || resolved == required {
-                seed_nodes.push(node_id);
+                seed_nodes.push(node_key.clone());
             }
         }
 
@@ -867,15 +886,19 @@ impl WorkflowEngine {
             elapsed,
         });
 
-        let node_outputs: HashMap<NodeId, serde_json::Value> = outputs
+        let node_outputs: HashMap<NodeKey, serde_json::Value> = outputs
             .iter()
-            .map(|r| (*r.key(), r.value().clone()))
+            .map(|r| (r.key().clone(), r.value().clone()))
             .collect();
 
-        let node_errors: HashMap<NodeId, String> = exec_state
+        let node_errors: HashMap<NodeKey, String> = exec_state
             .node_states
             .iter()
-            .filter_map(|(&id, ns)| ns.error_message.as_ref().map(|msg| (id, msg.clone())))
+            .filter_map(|(id, ns)| {
+                ns.error_message
+                    .as_ref()
+                    .map(|msg| (id.clone(), msg.clone()))
+            })
             .collect();
 
         Ok(ExecutionResult {
@@ -901,14 +924,14 @@ impl WorkflowEngine {
     /// state derived from already-completed nodes (populated for resume; empty
     /// for fresh executions).
     ///
-    /// Returns `Some((node_id, error))` if a node failed without an error handler,
+    /// Returns `Some((node_key, error))` if a node failed without an error handler,
     /// `None` if all reachable nodes completed (or were skipped).
     #[allow(clippy::too_many_arguments)]
     async fn run_frontier(
         &self,
         graph: &DependencyGraph,
-        node_map: &HashMap<NodeId, &nebula_workflow::NodeDefinition>,
-        outputs: &Arc<DashMap<NodeId, serde_json::Value>>,
+        node_map: &HashMap<NodeKey, &nebula_workflow::NodeDefinition>,
+        outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         semaphore: &Arc<Semaphore>,
         cancel_token: &CancellationToken,
         exec_state: &mut ExecutionState,
@@ -919,16 +942,16 @@ impl WorkflowEngine {
         budget: &ExecutionBudget,
         started: &Instant,
         error_strategy: nebula_workflow::ErrorStrategy,
-        seed_nodes: Vec<NodeId>,
-        initial_activated: HashMap<NodeId, HashSet<NodeId>>,
-        initial_resolved: HashMap<NodeId, usize>,
-    ) -> Option<(NodeId, String)> {
+        seed_nodes: Vec<NodeKey>,
+        initial_activated: HashMap<NodeKey, HashSet<NodeKey>>,
+        initial_resolved: HashMap<NodeKey, usize>,
+    ) -> Option<(NodeKey, String)> {
         let total_output_bytes = Arc::new(AtomicU64::new(0));
         let total_retries = Arc::new(AtomicU32::new(0));
         // Precompute how many incoming edges each node has
-        let required_count: HashMap<NodeId, usize> = node_map
+        let required_count: HashMap<NodeKey, usize> = node_map
             .keys()
-            .map(|&nid| (nid, graph.incoming_connections(nid).len()))
+            .map(|nid| (nid.clone(), graph.incoming_connections(nid.clone()).len()))
             .collect();
 
         // Track edge resolution state (pre-populated for resume)
@@ -936,21 +959,23 @@ impl WorkflowEngine {
         let mut resolved_edges = initial_resolved;
 
         // Queue of nodes ready to execute
-        let mut ready_queue: VecDeque<NodeId> = VecDeque::new();
+        let mut ready_queue: VecDeque<NodeKey> = VecDeque::new();
 
         // Seed with the provided nodes (entry nodes for fresh; frontier for resume)
-        for node_id in seed_nodes {
-            ready_queue.push_back(node_id);
+        for node_key in seed_nodes {
+            ready_queue.push_back(node_key);
         }
 
         // In-flight tasks
-        let mut join_set: JoinSet<(NodeId, Result<ActionResult<serde_json::Value>, EngineError>)> =
-            JoinSet::new();
+        let mut join_set: JoinSet<(
+            NodeKey,
+            Result<ActionResult<serde_json::Value>, EngineError>,
+        )> = JoinSet::new();
 
         // Main frontier loop
         loop {
             // Phase 1: Drain ready queue → spawn into join_set
-            while let Some(node_id) = ready_queue.pop_front() {
+            while let Some(node_key) = ready_queue.pop_front() {
                 if cancel_token.is_cancelled() {
                     break;
                 }
@@ -960,15 +985,15 @@ impl WorkflowEngine {
                     check_budget(budget, started, &total_output_bytes, &total_retries)
                 {
                     cancel_token.cancel();
-                    return Some((node_id, violation));
+                    return Some((node_key, violation));
                 }
 
                 // Skip disabled nodes: mark as Skipped and activate outgoing edges
                 // with null output so successors continue normally.
-                if node_map.get(&node_id).is_some_and(|nd| !nd.enabled) {
-                    mark_node_skipped(exec_state, node_id);
+                if node_map.get(&node_key).is_some_and(|nd| !nd.enabled) {
+                    mark_node_skipped(exec_state, node_key.clone());
                     process_outgoing_edges(
-                        node_id,
+                        node_key.clone(),
                         None, // null output — Always edges activate
                         None, // not failed
                         graph,
@@ -987,7 +1012,7 @@ impl WorkflowEngine {
                 if self
                     .check_and_apply_idempotency(
                         execution_id,
-                        node_id,
+                        node_key.clone(),
                         outputs,
                         exec_state,
                         graph,
@@ -1002,7 +1027,7 @@ impl WorkflowEngine {
                 }
 
                 let spawned = self.spawn_node(
-                    node_id,
+                    node_key.clone(),
                     node_map,
                     graph,
                     outputs,
@@ -1017,12 +1042,12 @@ impl WorkflowEngine {
                 );
                 if spawned {
                     let action_key = node_map
-                        .get(&node_id)
+                        .get(&node_key)
                         .map(|n| n.action_key.to_string())
                         .unwrap_or_default();
                     self.emit_event(ExecutionEvent::NodeStarted {
                         execution_id,
-                        node_id,
+                        node_key: node_key.clone(),
                         action_key,
                     });
                     continue;
@@ -1030,7 +1055,7 @@ impl WorkflowEngine {
 
                 // Node failed during setup (e.g., param resolution).
                 let abort = handle_node_failure(
-                    node_id,
+                    node_key.clone(),
                     "parameter resolution failed",
                     error_strategy,
                     graph,
@@ -1043,7 +1068,7 @@ impl WorkflowEngine {
                 );
                 if let Some(err_msg) = abort {
                     cancel_token.cancel();
-                    return Some((node_id, err_msg));
+                    return Some((node_key, err_msg));
                 }
             }
 
@@ -1084,7 +1109,7 @@ impl WorkflowEngine {
                     join_set.abort_all();
                     while join_set.join_next().await.is_some() {}
                     return Some((
-                        NodeId::nil(),
+                        node_key!("_timeout"),
                         "execution budget exceeded: max_duration".to_string(),
                     ));
                 }
@@ -1097,7 +1122,7 @@ impl WorkflowEngine {
 
             // Phase 3: Process the completed task
             match join_result {
-                Ok((node_id, Ok(ActionResult::Retry { .. }))) => {
+                Ok((node_key, Ok(ActionResult::Retry { .. }))) => {
                     // ActionResult::Retry has no scheduler yet; treat it as a node
                     // failure for at-least-once semantics (#290/#296 short-term).
                     total_retries.fetch_add(1, Ordering::Relaxed);
@@ -1106,9 +1131,9 @@ impl WorkflowEngine {
                             "Action retry is not supported by the engine",
                         ),
                     ));
-                    mark_node_failed(exec_state, node_id, &err);
+                    mark_node_failed(exec_state, node_key.clone(), &err);
                     let abort = handle_node_failure(
-                        node_id,
+                        node_key.clone(),
                         &err.to_string(),
                         error_strategy,
                         graph,
@@ -1121,16 +1146,16 @@ impl WorkflowEngine {
                     );
                     if let Some(err_msg) = abort {
                         cancel_token.cancel();
-                        return Some((node_id, err_msg));
+                        return Some((node_key.clone(), err_msg));
                     }
 
                     if exec_state
-                        .node_state(node_id)
+                        .node_state(node_key.clone())
                         .is_some_and(|ns| ns.state == NodeState::Failed)
                     {
                         self.checkpoint_node(
                             execution_id,
-                            node_id,
+                            node_key.clone(),
                             outputs,
                             exec_state,
                             repo_version,
@@ -1138,16 +1163,16 @@ impl WorkflowEngine {
                         .await;
                         self.emit_event(ExecutionEvent::NodeFailed {
                             execution_id,
-                            node_id,
+                            node_key: node_key.clone(),
                             error: err.to_string(),
                         });
                     }
                 },
-                Ok((node_id, Ok(action_result))) => {
-                    mark_node_completed(exec_state, node_id);
+                Ok((node_key, Ok(action_result))) => {
+                    mark_node_completed(exec_state, node_key.clone());
 
                     // Track output size for budget enforcement
-                    if let Some(output) = outputs.get(&node_id) {
+                    if let Some(output) = outputs.get(&node_key) {
                         let bytes = serde_json::to_string(output.value())
                             .map(|s| s.len() as u64)
                             .unwrap_or(0);
@@ -1158,19 +1183,26 @@ impl WorkflowEngine {
                     // idempotency key, before any external observer learns the
                     // node is done. This guarantees durability precedes
                     // visibility (#297).
-                    self.checkpoint_node(execution_id, node_id, outputs, exec_state, repo_version)
+                    self.checkpoint_node(
+                        execution_id,
+                        node_key.clone(),
+                        outputs,
+                        exec_state,
+                        repo_version,
+                    )
+                    .await;
+                    self.record_idempotency(execution_id, node_key.clone())
                         .await;
-                    self.record_idempotency(execution_id, node_id).await;
 
                     self.emit_event(ExecutionEvent::NodeCompleted {
                         execution_id,
-                        node_id,
+                        node_key: node_key.clone(),
                         elapsed: started.elapsed(),
                     });
 
                     // Evaluate outgoing edges and update frontier
                     process_outgoing_edges(
-                        node_id,
+                        node_key.clone(),
                         Some(&action_result),
                         None, // not failed
                         graph,
@@ -1181,13 +1213,13 @@ impl WorkflowEngine {
                         exec_state,
                     );
                 },
-                Ok((node_id, Err(ref err))) => {
+                Ok((node_key, Err(ref err))) => {
                     // Node failed at runtime — persist before any observer
                     // learns the node is done and before successors advance
                     // (#297).
-                    mark_node_failed(exec_state, node_id, err);
+                    mark_node_failed(exec_state, node_key.clone(), err);
                     let abort = handle_node_failure(
-                        node_id,
+                        node_key.clone(),
                         &err.to_string(),
                         error_strategy,
                         graph,
@@ -1201,16 +1233,16 @@ impl WorkflowEngine {
 
                     if let Some(err_msg) = abort {
                         cancel_token.cancel();
-                        return Some((node_id, err_msg));
+                        return Some((node_key.clone(), err_msg));
                     }
 
                     if exec_state
-                        .node_state(node_id)
+                        .node_state(node_key.clone())
                         .is_some_and(|ns| ns.state == NodeState::Failed)
                     {
                         self.checkpoint_node(
                             execution_id,
-                            node_id,
+                            node_key.clone(),
                             outputs,
                             exec_state,
                             repo_version,
@@ -1218,7 +1250,7 @@ impl WorkflowEngine {
                         .await;
                         self.emit_event(ExecutionEvent::NodeFailed {
                             execution_id,
-                            node_id,
+                            node_key: node_key.clone(),
                             error: err.to_string(),
                         });
                     }
@@ -1226,7 +1258,7 @@ impl WorkflowEngine {
                 Err(join_err) => {
                     tracing::error!(?join_err, "node task panicked");
                     cancel_token.cancel();
-                    return Some((NodeId::new(), join_err.to_string()));
+                    return Some((node_key!("_panicked"), join_err.to_string()));
                 },
             }
         }
@@ -1241,34 +1273,42 @@ impl WorkflowEngine {
     #[allow(clippy::too_many_arguments)]
     fn spawn_node(
         &self,
-        node_id: NodeId,
-        node_map: &HashMap<NodeId, &nebula_workflow::NodeDefinition>,
+        node_key: NodeKey,
+        node_map: &HashMap<NodeKey, &nebula_workflow::NodeDefinition>,
         graph: &DependencyGraph,
-        outputs: &Arc<DashMap<NodeId, serde_json::Value>>,
+        outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         semaphore: &Arc<Semaphore>,
         cancel_token: &CancellationToken,
         exec_state: &mut ExecutionState,
         execution_id: ExecutionId,
         workflow_id: WorkflowId,
         input: &serde_json::Value,
-        activated_edges: &HashMap<NodeId, HashSet<NodeId>>,
-        join_set: &mut JoinSet<(NodeId, Result<ActionResult<serde_json::Value>, EngineError>)>,
+        activated_edges: &HashMap<NodeKey, HashSet<NodeKey>>,
+        join_set: &mut JoinSet<(
+            NodeKey,
+            Result<ActionResult<serde_json::Value>, EngineError>,
+        )>,
     ) -> bool {
-        let Some(node_def) = node_map.get(&node_id) else {
+        let Some(node_def) = node_map.get(&node_key) else {
             return false;
         };
         let action_key = node_def.action_key.as_str().to_owned();
         let interface_version = node_def.interface_version;
 
         // Partition incoming connections into flow (to_port=None) and support (to_port=Some)
-        let (node_input, support_inputs) =
-            resolve_node_input_with_support(node_id, graph, outputs, input, activated_edges);
+        let (node_input, support_inputs) = resolve_node_input_with_support(
+            node_key.clone(),
+            graph,
+            outputs,
+            input,
+            activated_edges,
+        );
 
         // Resolve node parameters (expressions, templates, references)
         let action_input =
             match self
                 .resolver
-                .resolve(node_id, &node_def.parameters, &node_input, outputs)
+                .resolve(&node_key, &node_def.parameters, &node_input, outputs)
             {
                 Ok(Some(resolved_params)) => resolved_params,
                 Ok(None) => node_input, // No parameters → use predecessor output
@@ -1282,8 +1322,8 @@ impl WorkflowEngine {
                     // failed and want it in the Failed state
                     // regardless of its current position. Version is
                     // still bumped per issue #255.
-                    let _ = exec_state.override_node_state(node_id, NodeState::Failed);
-                    if let Some(ns) = exec_state.node_states.get_mut(&node_id) {
+                    let _ = exec_state.override_node_state(node_key.clone(), NodeState::Failed);
+                    if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
                         ns.error_message = Some(e.to_string());
                     }
                     return false;
@@ -1294,11 +1334,11 @@ impl WorkflowEngine {
         // Log on failure so a rejected transition is not silently
         // swallowed — callers of the frontier loop need to know if
         // the execution state got out of sync with the scheduler.
-        if let Err(err) = exec_state.transition_node(node_id, NodeState::Ready) {
-            tracing::warn!(%node_id, %err, "failed to transition node to Ready");
+        if let Err(err) = exec_state.transition_node(node_key.clone(), NodeState::Ready) {
+            tracing::warn!(%node_key, %err, "failed to transition node to Ready");
         }
-        if let Err(err) = exec_state.transition_node(node_id, NodeState::Running) {
-            tracing::warn!(%node_id, %err, "failed to transition node to Running");
+        if let Err(err) = exec_state.transition_node(node_key.clone(), NodeState::Running) {
+            tracing::warn!(%node_key, %err, "failed to transition node to Running");
         }
 
         let runtime = self.runtime.clone();
@@ -1358,7 +1398,7 @@ impl WorkflowEngine {
                 sem,
                 outputs: outputs_ref,
                 execution_id,
-                node_id,
+                node_key: node_key.clone(),
                 workflow_id,
                 action_key,
                 interface_version,
@@ -1386,27 +1426,27 @@ impl WorkflowEngine {
     async fn check_and_apply_idempotency(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
-        outputs: &Arc<DashMap<NodeId, serde_json::Value>>,
+        node_key: NodeKey,
+        outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         exec_state: &mut ExecutionState,
         graph: &DependencyGraph,
-        activated_edges: &mut HashMap<NodeId, HashSet<NodeId>>,
-        resolved_edges: &mut HashMap<NodeId, usize>,
-        required_count: &HashMap<NodeId, usize>,
-        ready_queue: &mut VecDeque<NodeId>,
+        activated_edges: &mut HashMap<NodeKey, HashSet<NodeKey>>,
+        resolved_edges: &mut HashMap<NodeKey, usize>,
+        required_count: &HashMap<NodeKey, usize>,
+        ready_queue: &mut VecDeque<NodeKey>,
     ) -> bool {
         let Some(repo) = &self.execution_repo else {
             return false;
         };
 
-        let idem_key = format!("{execution_id}:{node_id}:1");
+        let idem_key = format!("{execution_id}:{node_key}:1");
 
         let already_done = match repo.check_idempotency(&idem_key).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(
                     %execution_id,
-                    %node_id,
+                    %node_key,
                     error = %e,
                     "idempotency check failed; proceeding with execution"
                 );
@@ -1419,7 +1459,7 @@ impl WorkflowEngine {
         }
 
         // Node was already executed — load the persisted output.
-        let output_value = match repo.load_node_output(execution_id, node_id).await {
+        let output_value = match repo.load_node_output(execution_id, node_key.clone()).await {
             Ok(Some(v)) => v,
             Ok(None) => {
                 // Idempotency key exists but no output was persisted. This indicates
@@ -1427,7 +1467,7 @@ impl WorkflowEngine {
                 // but before saving the output). Re-execute to produce a clean result.
                 tracing::warn!(
                     %execution_id,
-                    %node_id,
+                    %node_key,
                     "idempotency key present but output missing; re-executing node"
                 );
                 return false;
@@ -1435,7 +1475,7 @@ impl WorkflowEngine {
             Err(e) => {
                 tracing::warn!(
                     %execution_id,
-                    %node_id,
+                    %node_key,
                     error = %e,
                     "failed to load idempotent node output; re-executing"
                 );
@@ -1443,12 +1483,12 @@ impl WorkflowEngine {
             },
         };
 
-        outputs.insert(node_id, output_value.clone());
-        mark_node_completed(exec_state, node_id);
+        outputs.insert(node_key.clone(), output_value.clone());
+        mark_node_completed(exec_state, node_key.clone());
 
         let fake_result = ActionResult::success(output_value);
         process_outgoing_edges(
-            node_id,
+            node_key.clone(),
             Some(&fake_result),
             None,
             graph,
@@ -1466,15 +1506,18 @@ impl WorkflowEngine {
     ///
     /// Silently logs and ignores errors — idempotency key recording failures
     /// must not abort an otherwise healthy execution.
-    async fn record_idempotency(&self, execution_id: ExecutionId, node_id: NodeId) {
+    async fn record_idempotency(&self, execution_id: ExecutionId, node_key: NodeKey) {
         let Some(repo) = &self.execution_repo else {
             return;
         };
-        let idem_key = format!("{execution_id}:{node_id}:1");
-        if let Err(e) = repo.mark_idempotent(&idem_key, execution_id, node_id).await {
+        let idem_key = format!("{execution_id}:{node_key}:1");
+        if let Err(e) = repo
+            .mark_idempotent(&idem_key, execution_id, node_key.clone())
+            .await
+        {
             tracing::warn!(
                 %execution_id,
-                %node_id,
+                %node_key,
                 error = %e,
                 "failed to mark node as idempotent"
             );
@@ -1488,8 +1531,8 @@ impl WorkflowEngine {
     async fn checkpoint_node(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
-        outputs: &Arc<DashMap<NodeId, serde_json::Value>>,
+        node_key: NodeKey,
+        outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         exec_state: &ExecutionState,
         repo_version: &mut u64,
     ) {
@@ -1498,17 +1541,22 @@ impl WorkflowEngine {
         };
 
         // Save node output individually
-        if let Some(output) = outputs.get(&node_id) {
+        if let Some(output) = outputs.get(&node_key) {
             let attempt = exec_state
                 .node_states
-                .get(&node_id)
+                .get(&node_key)
                 .map(|ns| ns.attempt_count().max(1) as u32)
                 .unwrap_or(1);
             if let Err(e) = repo
-                .save_node_output(execution_id, node_id, attempt, output.value().clone())
+                .save_node_output(
+                    execution_id,
+                    node_key.clone(),
+                    attempt,
+                    output.value().clone(),
+                )
                 .await
             {
-                tracing::warn!(%execution_id, %node_id, error = %e, "failed to persist node output");
+                tracing::warn!(%execution_id, %node_key, error = %e, "failed to persist node output");
             }
         }
 
@@ -1546,7 +1594,7 @@ impl WorkflowEngine {
         _execution_id: ExecutionId,
         status: ExecutionStatus,
         elapsed: std::time::Duration,
-        _failed_node: &Option<(NodeId, String)>,
+        _failed_node: &Option<(NodeKey, String)>,
     ) {
         match status {
             ExecutionStatus::Completed => {
@@ -1573,9 +1621,9 @@ struct NodeTask {
     runtime: Arc<ActionRuntime>,
     cancel: CancellationToken,
     sem: Arc<Semaphore>,
-    outputs: Arc<DashMap<NodeId, serde_json::Value>>,
+    outputs: Arc<DashMap<NodeKey, serde_json::Value>>,
     execution_id: ExecutionId,
-    node_id: NodeId,
+    node_key: NodeKey,
     workflow_id: WorkflowId,
     action_key: String,
     /// Pinned interface version for versioned action lookup.
@@ -1607,14 +1655,19 @@ struct NodeTask {
 
 impl NodeTask {
     /// Execute this node: acquire semaphore, check cancellation, run action.
-    async fn run(self) -> (NodeId, Result<ActionResult<serde_json::Value>, EngineError>) {
+    async fn run(
+        self,
+    ) -> (
+        NodeKey,
+        Result<ActionResult<serde_json::Value>, EngineError>,
+    ) {
         let _permit = match self.sem.acquire().await {
             Ok(permit) => permit,
-            Err(_) => return (self.node_id, Err(EngineError::Cancelled)),
+            Err(_) => return (self.node_key, Err(EngineError::Cancelled)),
         };
 
         if self.cancel.is_cancelled() {
-            return (self.node_id, Err(EngineError::Cancelled));
+            return (self.node_key, Err(EngineError::Cancelled));
         }
 
         // Proactive credential refresh: call the hook before the action runs
@@ -1636,7 +1689,7 @@ impl NodeTask {
             let refresh_result = tokio::select! {
                 biased;
                 () = self.cancel.cancelled() => {
-                    return (self.node_id, Err(EngineError::Cancelled));
+                    return (self.node_key, Err(EngineError::Cancelled));
                 }
                 res = &mut refresh_fut => res,
             };
@@ -1646,14 +1699,14 @@ impl NodeTask {
                 Err(source) => {
                     let action_err =
                         ActionError::credential_refresh_failed(self.action_key.to_string(), source);
-                    return (self.node_id, Err(EngineError::Action(action_err)));
+                    return (self.node_key, Err(EngineError::Action(action_err)));
                 },
             }
         }
 
         let action_ctx = ActionContext::new(
             self.execution_id,
-            self.node_id,
+            self.node_key.clone(),
             self.workflow_id,
             self.cancel.child_token(),
         )
@@ -1666,7 +1719,7 @@ impl NodeTask {
             use nebula_resilience::rate_limiter::RateLimiter;
             if let Err(e) = limiter.acquire().await {
                 tracing::warn!(
-                    node_id = %self.node_id,
+                    node_key = %self.node_key.clone(),
                     action_key = %self.action_key,
                     error = ?e,
                     "rate limit exceeded; failing node"
@@ -1676,7 +1729,7 @@ impl NodeTask {
                     nebula_action::error::RetryHintCode::RateLimited,
                 );
                 return (
-                    self.node_id,
+                    self.node_key.clone(),
                     Err(EngineError::Runtime(
                         nebula_runtime::RuntimeError::ActionError(action_err),
                     )),
@@ -1700,11 +1753,11 @@ impl NodeTask {
             Ok(action_result) => {
                 // Extract the primary output for downstream node input resolution.
                 if let Some(output) = extract_primary_output(&action_result) {
-                    self.outputs.insert(self.node_id, output);
+                    self.outputs.insert(self.node_key.clone(), output);
                 }
-                (self.node_id, Ok(action_result))
+                (self.node_key, Ok(action_result))
             },
-            Err(e) => (self.node_id, Err(EngineError::Runtime(e))),
+            Err(e) => (self.node_key, Err(EngineError::Runtime(e))),
         }
     }
 }
@@ -1720,37 +1773,40 @@ impl NodeTask {
 /// Returns `true` if the error was handled (at least one OnError edge activated).
 #[allow(clippy::too_many_arguments)]
 fn process_outgoing_edges(
-    source_id: NodeId,
+    source_id: NodeKey,
     result: Option<&ActionResult<serde_json::Value>>,
     error_msg: Option<&str>,
     graph: &DependencyGraph,
-    activated_edges: &mut HashMap<NodeId, HashSet<NodeId>>,
-    resolved_edges: &mut HashMap<NodeId, usize>,
-    required_count: &HashMap<NodeId, usize>,
-    ready_queue: &mut VecDeque<NodeId>,
+    activated_edges: &mut HashMap<NodeKey, HashSet<NodeKey>>,
+    resolved_edges: &mut HashMap<NodeKey, usize>,
+    required_count: &HashMap<NodeKey, usize>,
+    ready_queue: &mut VecDeque<NodeKey>,
     exec_state: &mut ExecutionState,
 ) -> bool {
-    let outgoing = graph.outgoing_connections(source_id);
+    let outgoing = graph.outgoing_connections(source_id.clone());
     let node_failed = error_msg.is_some();
     let mut error_handled = false;
 
     for conn in &outgoing {
-        let target = conn.to_node;
+        let target = conn.to_node.clone();
         let activate = evaluate_edge(conn, result, node_failed);
 
         // Increment the per-edge resolved count (not per-source, so that multiple
         // edges from the same source node to the same target are each counted).
-        *resolved_edges.entry(target).or_insert(0) += 1;
+        *resolved_edges.entry(target.clone()).or_insert(0) += 1;
         if activate {
-            activated_edges.entry(target).or_default().insert(source_id);
+            activated_edges
+                .entry(target.clone())
+                .or_default()
+                .insert(source_id.clone());
             if node_failed {
                 error_handled = true;
             }
         }
 
         // Check if target is now fully resolved
-        let resolved = resolved_edges.get(&target).copied().unwrap_or(0);
-        let required = required_count.get(&target).copied().unwrap_or(0);
+        let resolved = resolved_edges.get(&target).cloned().unwrap_or(0);
+        let required = required_count.get(&target).cloned().unwrap_or(0);
         let activated = activated_edges.get(&target).map_or(0, |s| s.len());
 
         if resolved == required {
@@ -1912,33 +1968,33 @@ fn evaluate_expression_condition(
 
 /// Recursively mark a node and its unreachable successors as skipped.
 fn propagate_skip(
-    node_id: NodeId,
+    node_key: NodeKey,
     graph: &DependencyGraph,
     exec_state: &mut ExecutionState,
-    resolved_edges: &mut HashMap<NodeId, usize>,
-    activated_edges: &HashMap<NodeId, HashSet<NodeId>>,
-    required_count: &HashMap<NodeId, usize>,
-    ready_queue: &mut VecDeque<NodeId>,
+    resolved_edges: &mut HashMap<NodeKey, usize>,
+    activated_edges: &HashMap<NodeKey, HashSet<NodeKey>>,
+    required_count: &HashMap<NodeKey, usize>,
+    ready_queue: &mut VecDeque<NodeKey>,
 ) {
     // Guard against double-processing
-    if let Some(ns) = exec_state.node_states.get(&node_id)
+    if let Some(ns) = exec_state.node_states.get(&node_key)
         && ns.state.is_terminal()
     {
         return;
     }
 
     // Versioned transition (issue #255).
-    let _ = exec_state.transition_node(node_id, NodeState::Skipped);
+    let _ = exec_state.transition_node(node_key.clone(), NodeState::Skipped);
 
     // Mark all outgoing edges as resolved (dead) for their targets
-    for conn in graph.outgoing_connections(node_id) {
-        let target = conn.to_node;
+    for conn in graph.outgoing_connections(node_key) {
+        let target = conn.to_node.clone();
         // Increment per-edge count (not per-source) so that multiple edges from
         // the same skipped source to the same target are each counted.
-        *resolved_edges.entry(target).or_insert(0) += 1;
+        *resolved_edges.entry(target.clone()).or_insert(0) += 1;
 
-        let resolved = resolved_edges.get(&target).copied().unwrap_or(0);
-        let required = required_count.get(&target).copied().unwrap_or(0);
+        let resolved = resolved_edges.get(&target).cloned().unwrap_or(0);
+        let required = required_count.get(&target).cloned().unwrap_or(0);
         let activated = activated_edges.get(&target).map_or(0, |s| s.len());
 
         if resolved == required {
@@ -1994,15 +2050,15 @@ fn check_budget(
 /// (i.e., fail-fast), or `None` when execution may continue.
 #[allow(clippy::too_many_arguments)]
 fn handle_node_failure(
-    node_id: NodeId,
+    node_key: NodeKey,
     error_msg: &str,
     error_strategy: nebula_workflow::ErrorStrategy,
     graph: &DependencyGraph,
-    outputs: &Arc<DashMap<NodeId, serde_json::Value>>,
-    activated_edges: &mut HashMap<NodeId, HashSet<NodeId>>,
-    resolved_edges: &mut HashMap<NodeId, usize>,
-    required_count: &HashMap<NodeId, usize>,
-    ready_queue: &mut VecDeque<NodeId>,
+    outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
+    activated_edges: &mut HashMap<NodeKey, HashSet<NodeKey>>,
+    resolved_edges: &mut HashMap<NodeKey, usize>,
+    required_count: &HashMap<NodeKey, usize>,
+    ready_queue: &mut VecDeque<NodeKey>,
     exec_state: &mut ExecutionState,
 ) -> Option<String> {
     // IgnoreErrors: treat the failure as a successful null result so
@@ -2013,13 +2069,13 @@ fn handle_node_failure(
         // `Failed → Completed` is not a valid forward transition, so this
         // uses `override_node_state` to reset the state; the version is
         // still bumped so CAS readers observe the recovery (issue #255).
-        let _ = exec_state.override_node_state(node_id, NodeState::Completed);
-        if let Some(ns) = exec_state.node_states.get_mut(&node_id) {
+        let _ = exec_state.override_node_state(node_key.clone(), NodeState::Completed);
+        if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
             ns.error_message = None;
         }
-        outputs.insert(node_id, serde_json::json!(null));
+        outputs.insert(node_key.clone(), serde_json::json!(null));
         process_outgoing_edges(
-            node_id,
+            node_key.clone(),
             Some(&ActionResult::success(serde_json::json!(null))),
             None,
             graph,
@@ -2035,7 +2091,7 @@ fn handle_node_failure(
     // For FailFast / ContinueOnError: evaluate edges as a failure to
     // check for OnError handlers.
     let error_handled = process_outgoing_edges(
-        node_id,
+        node_key.clone(),
         None,
         Some(error_msg),
         graph,
@@ -2049,10 +2105,10 @@ fn handle_node_failure(
     if error_handled {
         // Store error info for the OnError handler's input.
         outputs.insert(
-            node_id,
+            node_key.clone(),
             serde_json::json!({
                 "error": error_msg,
-                "node_id": node_id.to_string(),
+                "node_key": node_key.to_string(),
             }),
         );
         return None;
@@ -2073,26 +2129,26 @@ fn handle_node_failure(
 ///
 /// Uses the versioned transition API (issue #255) so CAS readers see
 /// the parent version move.
-fn mark_node_skipped(exec_state: &mut ExecutionState, node_id: NodeId) {
-    let _ = exec_state.transition_node(node_id, NodeState::Skipped);
+fn mark_node_skipped(exec_state: &mut ExecutionState, node_key: NodeKey) {
+    let _ = exec_state.transition_node(node_key.clone(), NodeState::Skipped);
 }
 
 /// Mark a node as completed in the execution state.
-fn mark_node_completed(exec_state: &mut ExecutionState, node_id: NodeId) {
-    let _ = exec_state.transition_node(node_id, NodeState::Completed);
+fn mark_node_completed(exec_state: &mut ExecutionState, node_key: NodeKey) {
+    let _ = exec_state.transition_node(node_key.clone(), NodeState::Completed);
 }
 
 /// Mark a node as failed in the execution state.
-fn mark_node_failed(exec_state: &mut ExecutionState, node_id: NodeId, err: &EngineError) {
-    let _ = exec_state.transition_node(node_id, NodeState::Failed);
-    if let Some(ns) = exec_state.node_states.get_mut(&node_id) {
+fn mark_node_failed(exec_state: &mut ExecutionState, node_key: NodeKey, err: &EngineError) {
+    let _ = exec_state.transition_node(node_key.clone(), NodeState::Failed);
+    if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
         ns.error_message = Some(err.to_string());
     }
 }
 
 /// Determine the final execution status.
 fn determine_final_status(
-    failed_node: &Option<(NodeId, String)>,
+    failed_node: &Option<(NodeKey, String)>,
     cancel_token: &CancellationToken,
     exec_state: &ExecutionState,
 ) -> ExecutionStatus {
@@ -2109,7 +2165,7 @@ fn determine_final_status(
             .node_states
             .iter()
             .filter(|(_, ns)| !ns.state.is_terminal())
-            .map(|(&id, ns)| (id, ns.state))
+            .map(|(id, ns)| (id, ns.state))
             .collect();
         tracing::warn!(
             execution_id = %exec_state.execution_id,
@@ -2132,21 +2188,21 @@ fn determine_final_status(
 /// Connections with `to_port = Some(port_name)` are collected into a per-port
 /// map of values, delivered to the action via `ActionContext::support_inputs`.
 fn resolve_node_input_with_support(
-    node_id: NodeId,
+    node_key: NodeKey,
     graph: &DependencyGraph,
-    outputs: &DashMap<NodeId, serde_json::Value>,
+    outputs: &DashMap<NodeKey, serde_json::Value>,
     workflow_input: &serde_json::Value,
-    activated_edges: &HashMap<NodeId, HashSet<NodeId>>,
+    activated_edges: &HashMap<NodeKey, HashSet<NodeKey>>,
 ) -> (serde_json::Value, HashMap<String, Vec<serde_json::Value>>) {
-    let activated: HashSet<NodeId> = activated_edges.get(&node_id).cloned().unwrap_or_default();
+    let activated: HashSet<NodeKey> = activated_edges.get(&node_key).cloned().unwrap_or_default();
 
     // Partition incoming connections by to_port
-    let incoming = graph.incoming_connections(node_id);
-    let mut flow_predecessors: Vec<NodeId> = Vec::new();
+    let incoming = graph.incoming_connections(node_key);
+    let mut flow_predecessors: Vec<NodeKey> = Vec::new();
     let mut support_inputs: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
 
     for conn in &incoming {
-        let source = conn.from_node;
+        let source = conn.from_node.clone();
         if !activated.contains(&source) {
             continue;
         }
@@ -2395,9 +2451,9 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
-            vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
+            vec![NodeDefinition::new(n.clone(), "echo", "echo").unwrap()],
             vec![],
         );
 
@@ -2419,14 +2475,14 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "A", "echo").unwrap(),
-                NodeDefinition::new(n2, "B", "echo").unwrap(),
+                NodeDefinition::new(n1.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(n2.clone(), "B", "echo").unwrap(),
             ],
-            vec![Connection::new(n1, n2)],
+            vec![Connection::new(n1.clone(), n2.clone())],
         );
 
         let result = engine
@@ -2449,22 +2505,22 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
-        let d = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let d = node_key!("d");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
-                NodeDefinition::new(d, "D", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+                NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b),
-                Connection::new(a, c),
-                Connection::new(b, d),
-                Connection::new(c, d),
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(a.clone(), c.clone()),
+                Connection::new(b.clone(), d.clone()),
+                Connection::new(c.clone(), d.clone()),
             ],
         );
 
@@ -2495,16 +2551,19 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
-        let n3 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+        let n3 = node_key!("n3");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "A", "echo").unwrap(),
-                NodeDefinition::new(n2, "B", "fail").unwrap(),
-                NodeDefinition::new(n3, "C", "echo").unwrap(),
+                NodeDefinition::new(n1.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(n2.clone(), "B", "fail").unwrap(),
+                NodeDefinition::new(n3.clone(), "C", "echo").unwrap(),
             ],
-            vec![Connection::new(n1, n2), Connection::new(n2, n3)],
+            vec![
+                Connection::new(n1.clone(), n2.clone()),
+                Connection::new(n2.clone(), n3.clone()),
+            ],
         );
 
         let result = engine
@@ -2523,7 +2582,7 @@ mod tests {
         let registry = Arc::new(ActionRegistry::new());
         let (engine, _) = make_engine(registry);
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "A", "unknown").unwrap()],
             vec![],
@@ -2560,7 +2619,7 @@ mod tests {
 
         let (engine, metrics) = make_engine(registry);
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
             vec![],
@@ -2594,7 +2653,7 @@ mod tests {
 
         let (engine, metrics) = make_engine(registry);
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "fail", "fail").unwrap()],
             vec![],
@@ -2624,7 +2683,7 @@ mod tests {
     async fn trigger_context_construction_is_usable_in_engine() {
         let ctx = TriggerContext::new(
             WorkflowId::new(),
-            NodeId::new(),
+            node_key!("test"),
             tokio_util::sync::CancellationToken::new(),
         );
         assert!(!ctx.has_credential_id("missing").await);
@@ -2712,22 +2771,22 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
-        let d = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let d = node_key!("d");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "branch").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
-                NodeDefinition::new(d, "D", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "branch").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+                NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b).with_branch_key("true"),
-                Connection::new(a, c).with_branch_key("false"),
-                Connection::new(b, d),
-                Connection::new(c, d),
+                Connection::new(a.clone(), b.clone()).with_branch_key("true"),
+                Connection::new(a.clone(), c.clone()).with_branch_key("false"),
+                Connection::new(b.clone(), d.clone()),
+                Connection::new(c.clone(), d.clone()),
             ],
         );
 
@@ -2760,16 +2819,19 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "skip").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "skip").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
             ],
-            vec![Connection::new(a, b), Connection::new(b, c)],
+            vec![
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(b.clone(), c.clone()),
+            ],
         );
 
         let result = engine
@@ -2800,18 +2862,18 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "fail").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "fail").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b),
-                Connection::new(b, c).with_condition(EdgeCondition::OnError {
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(b.clone(), c.clone()).with_condition(EdgeCondition::OnError {
                     matcher: ErrorMatcher::Any,
                 }),
             ],
@@ -2846,16 +2908,19 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "fail").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "fail").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
             ],
-            vec![Connection::new(a, b), Connection::new(b, c)],
+            vec![
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(b, c.clone()),
+            ],
         );
 
         let result = engine
@@ -2879,15 +2944,15 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b).with_condition(EdgeCondition::OnResult {
+                Connection::new(a.clone(), b.clone()).with_condition(EdgeCondition::OnResult {
                     matcher: ResultMatcher::Success,
                 }),
             ],
@@ -2915,24 +2980,24 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
-        let d = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let d = node_key!("d");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
-                NodeDefinition::new(d, "D", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+                NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b), // Always
-                Connection::new(a, c).with_condition(EdgeCondition::OnResult {
+                Connection::new(a.clone(), b.clone()), // Always
+                Connection::new(a.clone(), c.clone()).with_condition(EdgeCondition::OnResult {
                     matcher: ResultMatcher::Success,
                 }),
-                Connection::new(b, d),
-                Connection::new(c, d),
+                Connection::new(b.clone(), d.clone()),
+                Connection::new(c.clone(), d.clone()),
             ],
         );
 
@@ -2964,9 +3029,9 @@ mod tests {
         let (engine, _) = make_engine(registry);
         let engine = engine.with_execution_repo(repo.clone());
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
-            vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
+            vec![NodeDefinition::new(n.clone(), "echo", "echo").unwrap()],
             vec![],
         );
 
@@ -3003,7 +3068,7 @@ mod tests {
         let (engine, _) = make_engine(registry);
         let engine = engine.with_execution_repo(repo.clone());
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "fail", "fail").unwrap()],
             vec![],
@@ -3034,14 +3099,14 @@ mod tests {
         let (engine, _) = make_engine(registry);
         let engine = engine.with_execution_repo(repo.clone());
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "A", "echo").unwrap(),
-                NodeDefinition::new(n2, "B", "echo").unwrap(),
+                NodeDefinition::new(n1.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(n2.clone(), "B", "echo").unwrap(),
             ],
-            vec![Connection::new(n1, n2)],
+            vec![Connection::new(n1.clone(), n2.clone())],
         );
 
         let result = engine
@@ -3074,12 +3139,12 @@ mod tests {
         let (engine, _) = make_engine(registry);
 
         // Slow → Echo. Budget allows only 1ms.
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "Slow", "slow").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "Slow", "slow").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
             ],
             vec![Connection::new(a, b)],
         );
@@ -3106,12 +3171,12 @@ mod tests {
         let (engine, _) = make_engine(registry);
 
         // A → B. Each echoes a payload. Budget allows very few bytes.
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
             ],
             vec![Connection::new(a, b)],
         );
@@ -3185,10 +3250,10 @@ mod tests {
         // Entry → [Fail, Echo(C)]
         // Fail → B
         // With ContinueOnError: Fail fails, B is skipped, C still runs.
-        let entry = NodeId::new();
-        let fail_node = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let entry = node_key!("entry");
+        let fail_node = node_key!("fail_node");
+        let b = node_key!("b");
+        let c = node_key!("c");
 
         let config = WorkflowConfig {
             error_strategy: ErrorStrategy::ContinueOnError,
@@ -3197,15 +3262,15 @@ mod tests {
 
         let wf = make_workflow_with_config(
             vec![
-                NodeDefinition::new(entry, "Entry", "echo").unwrap(),
-                NodeDefinition::new(fail_node, "Fail", "fail").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
-                NodeDefinition::new(c, "C", "echo").unwrap(),
+                NodeDefinition::new(entry.clone(), "Entry", "echo").unwrap(),
+                NodeDefinition::new(fail_node.clone(), "Fail", "fail").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
             ],
             vec![
-                Connection::new(entry, fail_node),
-                Connection::new(entry, c),
-                Connection::new(fail_node, b),
+                Connection::new(entry.clone(), fail_node.clone()),
+                Connection::new(entry.clone(), c.clone()),
+                Connection::new(fail_node, b.clone()),
             ],
             config,
         );
@@ -3239,8 +3304,8 @@ mod tests {
 
         // A(fail) → B(echo)
         // With IgnoreErrors: A fails but B should still run with null input
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
 
         let config = WorkflowConfig {
             error_strategy: ErrorStrategy::IgnoreErrors,
@@ -3249,10 +3314,10 @@ mod tests {
 
         let wf = make_workflow_with_config(
             vec![
-                NodeDefinition::new(a, "A", "fail").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "fail").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
             ],
-            vec![Connection::new(a, b)],
+            vec![Connection::new(a.clone(), b.clone())],
             config,
         );
 
@@ -3266,7 +3331,7 @@ mod tests {
         // A's output was replaced with null
         assert_eq!(result.node_output(a), Some(&serde_json::json!(null)));
         // B ran and received null as input
-        assert!(result.node_output(b).is_some());
+        assert!(result.node_output(b.clone()).is_some());
         assert_eq!(result.node_output(b), Some(&serde_json::json!(null)));
     }
 
@@ -3319,7 +3384,7 @@ mod tests {
         let registry = Arc::new(ActionRegistry::new());
         let (engine, _) = make_engine(registry);
         let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
             vec![],
@@ -3347,7 +3412,7 @@ mod tests {
         });
         let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
         let (engine, _) = make_engine(registry);
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
             vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
             vec![],
@@ -3388,23 +3453,26 @@ mod tests {
         let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
         let (engine, _) = make_engine(registry);
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
-        let n3 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+        let n3 = node_key!("n3");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "A", "echo").unwrap(),
-                NodeDefinition::new(n2, "B", "echo").unwrap(),
-                NodeDefinition::new(n3, "C", "echo").unwrap(),
+                NodeDefinition::new(n1.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(n2.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(n3.clone(), "C", "echo").unwrap(),
             ],
-            vec![Connection::new(n1, n2), Connection::new(n2, n3)],
+            vec![
+                Connection::new(n1.clone(), n2.clone()),
+                Connection::new(n2.clone(), n3.clone()),
+            ],
         );
         let workflow_repo = save_workflow_to_repo(&wf).await;
 
         // Manually build a partial execution state where n1 is Completed but
         // n2 and n3 are still Pending (simulating a crash after n1 finished).
         let execution_id = ExecutionId::new();
-        let node_ids = vec![n1, n2, n3];
+        let node_ids = vec![n1.clone(), n2.clone(), n3.clone()];
         let mut exec_state = ExecutionState::new(execution_id, wf.id, &node_ids);
         exec_state
             .transition_status(ExecutionStatus::Running)
@@ -3437,7 +3505,7 @@ mod tests {
 
         // Persist n1's output.
         exec_repo
-            .save_node_output(execution_id, n1, 1, serde_json::json!("from_n1"))
+            .save_node_output(execution_id, n1.clone(), 1, serde_json::json!("from_n1"))
             .await
             .unwrap();
 
@@ -3510,9 +3578,9 @@ mod tests {
         let (engine, _) = make_engine(registry);
         let engine = engine.with_execution_repo(exec_repo.clone());
 
-        let n = NodeId::new();
+        let n = node_key!("n");
         let wf = make_workflow(
-            vec![NodeDefinition::new(n, "count_node", "counting").unwrap()],
+            vec![NodeDefinition::new(n.clone(), "count_node", "counting").unwrap()],
             vec![],
         );
 
@@ -3535,7 +3603,7 @@ mod tests {
 
         // Manually inject the same execution_id's idempotency key so that if
         // we simulate re-running the same execution, the node is skipped.
-        // (The engine generates the key as "{execution_id}:{node_id}:1".)
+        // (The engine generates the key as "{execution_id}:{node_key}:1".)
         let execution_id = result1.execution_id;
         let idem_key = format!("{execution_id}:{n}:1");
 
@@ -3628,15 +3696,15 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
 
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "pinned_v1", "versioned")
+                NodeDefinition::new(n1.clone(), "pinned_v1", "versioned")
                     .unwrap()
                     .with_interface_version(v1),
-                NodeDefinition::new(n2, "pinned_v2", "versioned")
+                NodeDefinition::new(n2.clone(), "pinned_v2", "versioned")
                     .unwrap()
                     .with_interface_version(v2),
             ],
@@ -3692,12 +3760,12 @@ mod tests {
                 }
             });
 
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(n1, "A", "echo").unwrap(),
-                NodeDefinition::new(n2, "B", "echo").unwrap(),
+                NodeDefinition::new(n1.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(n2.clone(), "B", "echo").unwrap(),
             ],
             vec![Connection::new(n1, n2)],
         );
@@ -3721,10 +3789,10 @@ mod tests {
     /// Regression: two distinct edges from the same source to the same target
     /// must not stall the target node.
     ///
-    /// Previously, `resolved_edges` used `HashSet<NodeId>` (source-node cardinality)
+    /// Previously, `resolved_edges` used `HashSet<NodeKey>` (source-node cardinality)
     /// while `required_count` counted edges. With two edges A → B, the set deduped
     /// them to one entry, so `resolved(1) != required(2)` forever and B never ran.
-    /// The fix changes `resolved_edges` to `HashMap<NodeId, usize>` (edge-count
+    /// The fix changes `resolved_edges` to `HashMap<NodeKey, usize>` (edge-count
     /// cardinality), so both increments are counted and B correctly becomes ready.
     #[tokio::test]
     async fn multi_edge_from_same_source_executes_target() {
@@ -3737,19 +3805,19 @@ mod tests {
 
         let (engine, _) = make_engine(registry);
 
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
 
         // Two distinct (non-identical) edges from A to B: one unconditional,
         // one via a named source port. Both activate on success.
         let wf = make_workflow(
             vec![
-                NodeDefinition::new(a, "A", "echo").unwrap(),
-                NodeDefinition::new(b, "B", "echo").unwrap(),
+                NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
             ],
             vec![
-                Connection::new(a, b).with_condition(EdgeCondition::Always),
-                Connection::new(a, b)
+                Connection::new(a.clone(), b.clone()).with_condition(EdgeCondition::Always),
+                Connection::new(a, b.clone())
                     .with_condition(EdgeCondition::Always)
                     .with_from_port("alt"),
             ],
@@ -3786,11 +3854,11 @@ mod tests {
     fn final_status_guard_returns_failed_for_non_terminal_nodes() {
         let exec_id = ExecutionId::new();
         let wf_id = WorkflowId::new();
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
 
         // n1 completed, n2 still Pending (simulates a stalled node).
-        let mut exec_state = ExecutionState::new(exec_id, wf_id, &[n1, n2]);
+        let mut exec_state = ExecutionState::new(exec_id, wf_id, &[n1.clone(), n2]);
         exec_state.node_states.get_mut(&n1).unwrap().state = NodeState::Completed;
         // n2 stays NodeState::Pending
 
@@ -3810,10 +3878,10 @@ mod tests {
     fn final_status_completed_when_all_terminal() {
         let exec_id = ExecutionId::new();
         let wf_id = WorkflowId::new();
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
 
-        let mut exec_state = ExecutionState::new(exec_id, wf_id, &[n1, n2]);
+        let mut exec_state = ExecutionState::new(exec_id, wf_id, &[n1.clone(), n2.clone()]);
         exec_state.node_states.get_mut(&n1).unwrap().state = NodeState::Completed;
         exec_state.node_states.get_mut(&n2).unwrap().state = NodeState::Skipped;
 
@@ -3892,8 +3960,11 @@ mod tests {
                 Err(ActionError::retryable("credential store down"))
             });
 
-        let n1 = NodeId::new();
-        let wf = make_workflow(vec![NodeDefinition::new(n1, "A", "never").unwrap()], vec![]);
+        let n1 = node_key!("n1");
+        let wf = make_workflow(
+            vec![NodeDefinition::new(n1.clone(), "A", "never").unwrap()],
+            vec![],
+        );
 
         let result = engine
             .execute_workflow(&wf, serde_json::json!("x"), ExecutionBudget::default())

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2108,7 +2108,7 @@ fn handle_node_failure(
             node_key.clone(),
             serde_json::json!({
                 "error": error_msg,
-                "node_key": node_key.to_string(),
+                "node_id": node_key.to_string(),
             }),
         );
         return None;

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -1,16 +1,16 @@
 //! Engine error types.
 
 use nebula_action::ActionError;
-use nebula_core::id::NodeId;
+use nebula_core::NodeKey;
 
 /// Errors from the engine layer.
 #[derive(Debug, thiserror::Error)]
 pub enum EngineError {
     /// A referenced node was not found in the workflow.
-    #[error("node not found: {node_id}")]
+    #[error("node not found: {node_key}")]
     NodeNotFound {
         /// The missing node ID.
-        node_id: NodeId,
+        node_key: NodeKey,
     },
 
     /// Execution planning failed.
@@ -18,10 +18,10 @@ pub enum EngineError {
     PlanningFailed(String),
 
     /// A node failed during execution.
-    #[error("node {node_id} failed: {error}")]
+    #[error("node {node_key} failed: {error}")]
     NodeFailed {
         /// The node that failed.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// The error message.
         error: String,
     },
@@ -31,10 +31,10 @@ pub enum EngineError {
     Cancelled,
 
     /// Parameter resolution failed (expression eval, reference lookup, etc.)
-    #[error("parameter resolution failed for node {node_id}, param '{param_key}': {error}")]
+    #[error("parameter resolution failed for node {node_key}, param '{param_key}': {error}")]
     ParameterResolution {
         /// The node whose parameter could not be resolved.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// The parameter key that failed.
         param_key: String,
         /// The underlying error.
@@ -42,10 +42,10 @@ pub enum EngineError {
     },
 
     /// Parameter validation failed against the action's schema.
-    #[error("parameter validation failed for node {node_id}: {errors}")]
+    #[error("parameter validation failed for node {node_key}: {errors}")]
     ParameterValidation {
         /// The node whose parameters failed validation.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Combined validation error messages.
         errors: String,
     },
@@ -54,9 +54,9 @@ pub enum EngineError {
     #[error("edge evaluation failed from {from_node} to {to_node}: {error}")]
     EdgeEvaluationFailed {
         /// Source node of the edge.
-        from_node: NodeId,
+        from_node: NodeKey,
         /// Target node of the edge.
-        to_node: NodeId,
+        to_node: NodeKey,
         /// The underlying error.
         error: String,
     },
@@ -136,6 +136,8 @@ impl nebula_error::Classify for EngineError {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -158,9 +160,9 @@ mod tests {
 
     #[test]
     fn node_failed_display() {
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let err = EngineError::NodeFailed {
-            node_id,
+            node_key,
             error: "timeout".into(),
         };
         let msg = err.to_string();

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -6,7 +6,7 @@
 
 use std::time::Duration;
 
-use nebula_core::id::{ExecutionId, NodeId};
+use nebula_core::{NodeKey, id::ExecutionId};
 
 /// Events emitted during workflow execution.
 #[derive(Debug, Clone)]
@@ -17,7 +17,7 @@ pub enum ExecutionEvent {
         /// Execution this node belongs to.
         execution_id: ExecutionId,
         /// The node that started.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Action key being executed.
         action_key: String,
     },
@@ -27,7 +27,7 @@ pub enum ExecutionEvent {
         /// Execution this node belongs to.
         execution_id: ExecutionId,
         /// The node that completed.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// How long the node took.
         elapsed: Duration,
     },
@@ -37,7 +37,7 @@ pub enum ExecutionEvent {
         /// Execution this node belongs to.
         execution_id: ExecutionId,
         /// The node that failed.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Error message.
         error: String,
     },
@@ -47,7 +47,7 @@ pub enum ExecutionEvent {
         /// Execution this node belongs to.
         execution_id: ExecutionId,
         /// The node that was skipped.
-        node_id: NodeId,
+        node_key: NodeKey,
     },
 
     /// Workflow execution completed.

--- a/crates/engine/src/resolver.rs
+++ b/crates/engine/src/resolver.rs
@@ -9,7 +9,7 @@
 use std::{collections::HashMap, sync::Arc};
 
 use dashmap::DashMap;
-use nebula_core::id::NodeId;
+use nebula_core::NodeKey;
 use nebula_expression::{EvaluationContext, ExpressionEngine};
 use nebula_workflow::ParamValue;
 
@@ -32,10 +32,10 @@ impl ParamResolver {
     /// predecessor output as-is for backward compatibility).
     pub(crate) fn resolve(
         &self,
-        node_id: NodeId,
+        node_key: &NodeKey,
         params: &HashMap<String, ParamValue>,
         predecessor_input: &serde_json::Value,
-        outputs: &DashMap<NodeId, serde_json::Value>,
+        outputs: &DashMap<NodeKey, serde_json::Value>,
     ) -> Result<Option<serde_json::Value>, EngineError> {
         if params.is_empty() {
             return Ok(None);
@@ -47,13 +47,13 @@ impl ParamResolver {
 
         // Populate $node with all available outputs
         for entry in outputs.iter() {
-            ctx.set_node_data(entry.key().to_string(), entry.value().clone());
+            ctx.set_node_data(entry.key(), entry.value().clone());
         }
 
         // Resolve each parameter
         let mut resolved = serde_json::Map::new();
         for (key, param_value) in params {
-            let value = self.resolve_param(node_id, key, param_value, &ctx, outputs)?;
+            let value = self.resolve_param(node_key, key, param_value, &ctx, outputs)?;
             resolved.insert(key.clone(), value);
         }
 
@@ -63,11 +63,11 @@ impl ParamResolver {
     /// Resolve a single parameter value.
     fn resolve_param(
         &self,
-        node_id: NodeId,
+        node_key: &NodeKey,
         key: &str,
         param: &ParamValue,
         ctx: &EvaluationContext,
-        outputs: &DashMap<NodeId, serde_json::Value>,
+        outputs: &DashMap<NodeKey, serde_json::Value>,
     ) -> Result<serde_json::Value, EngineError> {
         match param {
             ParamValue::Literal { value } => Ok(value.clone()),
@@ -75,7 +75,7 @@ impl ParamResolver {
             ParamValue::Expression { expr } => {
                 self.expression_engine.evaluate(expr, ctx).map_err(|e| {
                     EngineError::ParameterResolution {
-                        node_id,
+                        node_key: node_key.clone(),
                         param_key: key.to_owned(),
                         error: e.to_string(),
                     }
@@ -87,7 +87,7 @@ impl ParamResolver {
                     .expression_engine
                     .parse_template(template)
                     .map_err(|e| EngineError::ParameterResolution {
-                        node_id,
+                        node_key: node_key.clone(),
                         param_key: key.to_owned(),
                         error: format!("template parse error: {e}"),
                     })?;
@@ -95,7 +95,7 @@ impl ParamResolver {
                     .expression_engine
                     .render_template(&tmpl, ctx)
                     .map_err(|e| EngineError::ParameterResolution {
-                        node_id,
+                        node_key: node_key.clone(),
                         param_key: key.to_owned(),
                         error: format!("template render error: {e}"),
                     })?;
@@ -103,14 +103,14 @@ impl ParamResolver {
             },
 
             ParamValue::Reference {
-                node_id: ref_node,
+                node_key: ref_node,
                 output_path,
             } => {
                 let output =
                     outputs
                         .get(ref_node)
                         .ok_or_else(|| EngineError::ParameterResolution {
-                            node_id,
+                            node_key: node_key.clone(),
                             param_key: key.to_owned(),
                             error: format!("referenced node {} has no output", ref_node),
                         })?;
@@ -119,7 +119,7 @@ impl ParamResolver {
             },
 
             _ => Err(EngineError::ParameterResolution {
-                node_id,
+                node_key: node_key.clone(),
                 param_key: key.to_owned(),
                 error: format!("unsupported parameter type for key `{key}`"),
             }),
@@ -159,6 +159,7 @@ fn navigate_path(value: &serde_json::Value, path: &str) -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
     use serde_json::json;
 
     use super::*;
@@ -219,7 +220,7 @@ mod tests {
         let resolver = make_resolver();
         let outputs = DashMap::new();
         let result = resolver
-            .resolve(NodeId::new(), &HashMap::new(), &json!(null), &outputs)
+            .resolve(&node_key!("test"), &HashMap::new(), &json!(null), &outputs)
             .unwrap();
         assert!(result.is_none());
     }
@@ -235,7 +236,7 @@ mod tests {
         );
 
         let result = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap()
             .unwrap();
         assert_eq!(result["url"], json!("https://example.com"));
@@ -253,7 +254,7 @@ mod tests {
 
         let input = json!({"count": 5});
         let result = resolver
-            .resolve(NodeId::new(), &params, &input, &outputs)
+            .resolve(&node_key!("test"), &params, &input, &outputs)
             .unwrap()
             .unwrap();
         assert_eq!(result["count"], json!(6));
@@ -271,7 +272,7 @@ mod tests {
 
         let input = json!({"name": "World"});
         let result = resolver
-            .resolve(NodeId::new(), &params, &input, &outputs)
+            .resolve(&node_key!("test"), &params, &input, &outputs)
             .unwrap()
             .unwrap();
         assert_eq!(result["greeting"], json!("Hello World!"));
@@ -280,15 +281,15 @@ mod tests {
     #[test]
     fn reference_resolution_looks_up_output() {
         let resolver = make_resolver();
-        let source_id = NodeId::new();
+        let source_id = node_key!("source");
         let outputs = DashMap::new();
-        outputs.insert(source_id, json!({"data": "fetched"}));
+        outputs.insert(source_id.clone(), json!({"data": "fetched"}));
 
         let mut params = HashMap::new();
         params.insert("input".to_owned(), ParamValue::reference(source_id, ""));
 
         let result = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap()
             .unwrap();
         assert_eq!(result["input"], json!({"data": "fetched"}));
@@ -297,9 +298,9 @@ mod tests {
     #[test]
     fn reference_with_path_navigates_output() {
         let resolver = make_resolver();
-        let source_id = NodeId::new();
+        let source_id = node_key!("source");
         let outputs = DashMap::new();
-        outputs.insert(source_id, json!({"nested": {"value": 42}}));
+        outputs.insert(source_id.clone(), json!({"nested": {"value": 42}}));
 
         let mut params = HashMap::new();
         params.insert(
@@ -308,7 +309,7 @@ mod tests {
         );
 
         let result = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap()
             .unwrap();
         assert_eq!(result["val"], json!(42));
@@ -317,14 +318,14 @@ mod tests {
     #[test]
     fn reference_to_missing_node_returns_error() {
         let resolver = make_resolver();
-        let missing_id = NodeId::new();
+        let missing_id = node_key!("missing");
         let outputs = DashMap::new();
 
         let mut params = HashMap::new();
         params.insert("data".to_owned(), ParamValue::reference(missing_id, ""));
 
         let err = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap_err();
         assert!(matches!(err, EngineError::ParameterResolution { .. }));
         assert!(err.to_string().contains("has no output"));
@@ -342,7 +343,7 @@ mod tests {
         );
 
         let err = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap_err();
         assert!(matches!(err, EngineError::ParameterResolution { .. }));
     }
@@ -356,7 +357,7 @@ mod tests {
         params.insert("bad".to_owned(), ParamValue::template("Hello {{ unclosed"));
 
         let err = resolver
-            .resolve(NodeId::new(), &params, &json!(null), &outputs)
+            .resolve(&node_key!("test"), &params, &json!(null), &outputs)
             .unwrap_err();
         assert!(matches!(err, EngineError::ParameterResolution { .. }));
     }

--- a/crates/engine/src/result.rs
+++ b/crates/engine/src/result.rs
@@ -35,8 +35,8 @@ impl ExecutionResult {
 
     /// Get a specific node's output.
     #[must_use]
-    pub fn node_output(&self, node_key: NodeKey) -> Option<&serde_json::Value> {
-        self.node_outputs.get(&node_key)
+    pub fn node_output(&self, node_key: &NodeKey) -> Option<&serde_json::Value> {
+        self.node_outputs.get(node_key)
     }
 }
 
@@ -86,7 +86,7 @@ mod tests {
             duration: Duration::from_millis(10),
         };
 
-        assert_eq!(result.node_output(node_key), Some(&serde_json::json!(42)));
-        assert!(result.node_output(node_key!("test")).is_none());
+        assert_eq!(result.node_output(&node_key), Some(&serde_json::json!(42)));
+        assert!(result.node_output(&node_key!("test")).is_none());
     }
 }

--- a/crates/engine/src/result.rs
+++ b/crates/engine/src/result.rs
@@ -2,7 +2,7 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use nebula_core::id::{ExecutionId, NodeId};
+use nebula_core::{NodeKey, id::ExecutionId};
 use nebula_execution::ExecutionStatus;
 
 /// The final result of a workflow execution.
@@ -13,9 +13,9 @@ pub struct ExecutionResult {
     /// Final execution status.
     pub status: ExecutionStatus,
     /// Per-node output values (only for successfully completed nodes).
-    pub node_outputs: HashMap<NodeId, serde_json::Value>,
+    pub node_outputs: HashMap<NodeKey, serde_json::Value>,
     /// Per-node error messages (only for failed nodes).
-    pub node_errors: HashMap<NodeId, String>,
+    pub node_errors: HashMap<NodeKey, String>,
     /// Wall-clock duration of the execution.
     pub duration: Duration,
 }
@@ -35,13 +35,15 @@ impl ExecutionResult {
 
     /// Get a specific node's output.
     #[must_use]
-    pub fn node_output(&self, node_id: NodeId) -> Option<&serde_json::Value> {
-        self.node_outputs.get(&node_id)
+    pub fn node_output(&self, node_key: NodeKey) -> Option<&serde_json::Value> {
+        self.node_outputs.get(&node_key)
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -72,9 +74,9 @@ mod tests {
 
     #[test]
     fn node_output_lookup() {
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let mut outputs = HashMap::new();
-        outputs.insert(node_id, serde_json::json!(42));
+        outputs.insert(node_key.clone(), serde_json::json!(42));
 
         let result = ExecutionResult {
             execution_id: ExecutionId::new(),
@@ -84,7 +86,7 @@ mod tests {
             duration: Duration::from_millis(10),
         };
 
-        assert_eq!(result.node_output(node_id), Some(&serde_json::json!(42)));
-        assert!(result.node_output(NodeId::new()).is_none());
+        assert_eq!(result.node_output(node_key), Some(&serde_json::json!(42)));
+        assert!(result.node_output(node_key!("test")).is_none());
     }
 }

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -313,8 +313,8 @@ async fn linear_pipeline_data_flows_through() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.node_output(a), Some(&serde_json::json!(5)));
-    assert_eq!(result.node_output(b), Some(&serde_json::json!(10)));
+    assert_eq!(result.node_output(&a), Some(&serde_json::json!(5)));
+    assert_eq!(result.node_output(&b), Some(&serde_json::json!(10)));
 }
 
 /// Three-node fan-out: A → B and A → C (parallel).
@@ -355,9 +355,9 @@ async fn fan_out_parallel_execution() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.node_output(a), Some(&serde_json::json!(7)));
-    assert_eq!(result.node_output(b), Some(&serde_json::json!(14)));
-    assert_eq!(result.node_output(c), Some(&serde_json::json!(17)));
+    assert_eq!(result.node_output(&a), Some(&serde_json::json!(7)));
+    assert_eq!(result.node_output(&b), Some(&serde_json::json!(14)));
+    assert_eq!(result.node_output(&c), Some(&serde_json::json!(17)));
 }
 
 /// Diamond workflow: A → B, A → C, B → D, C → D.
@@ -402,12 +402,12 @@ async fn diamond_merge_receives_combined_outputs() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.node_output(a), Some(&serde_json::json!(3)));
-    assert_eq!(result.node_output(b.clone()), Some(&serde_json::json!(6)));
-    assert_eq!(result.node_output(c.clone()), Some(&serde_json::json!(13)));
+    assert_eq!(result.node_output(&a), Some(&serde_json::json!(3)));
+    assert_eq!(result.node_output(&b), Some(&serde_json::json!(6)));
+    assert_eq!(result.node_output(&c), Some(&serde_json::json!(13)));
 
     // D is a join node — its input is a merged object keyed by predecessor node IDs
-    let d_output = result.node_output(d).expect("D should have output");
+    let d_output = result.node_output(&d).expect("D should have output");
     assert!(d_output.is_object(), "join node output should be an object");
     let obj = d_output.as_object().unwrap();
     assert_eq!(obj.len(), 2, "should have outputs from B and C");
@@ -452,11 +452,11 @@ async fn error_propagation_stops_downstream() {
     assert!(result.is_failure());
     assert_eq!(result.status, ExecutionStatus::Failed);
     // A completed before B failed
-    assert!(result.node_output(a).is_some());
+    assert!(result.node_output(&a).is_some());
     // B failed, no output
-    assert!(result.node_output(b).is_none());
+    assert!(result.node_output(&b).is_none());
     // C was never reached
-    assert!(result.node_output(c).is_none());
+    assert!(result.node_output(&c).is_none());
 }
 
 /// Cancellation via sibling failure: parallel nodes A(slow) and B(fail).
@@ -510,11 +510,11 @@ async fn cancellation_via_sibling_failure() {
     let result = result.unwrap();
     assert!(result.is_failure());
     // Entry ran successfully
-    assert!(result.node_output(entry).is_some());
+    assert!(result.node_output(&entry).is_some());
     // Slow was cancelled (no output stored)
-    assert!(result.node_output(slow).is_none());
+    assert!(result.node_output(&slow).is_none());
     // Downstream never ran
-    assert!(result.node_output(downstream).is_none());
+    assert!(result.node_output(&downstream).is_none());
 }
 
 /// Verify metrics cover the full lifecycle.
@@ -666,10 +666,10 @@ async fn deep_chain_propagates_outputs() {
         .unwrap();
 
     assert!(result.is_success());
-    assert_eq!(result.node_output(a), Some(&serde_json::json!(2)));
-    assert_eq!(result.node_output(b), Some(&serde_json::json!(4)));
-    assert_eq!(result.node_output(c), Some(&serde_json::json!(8)));
-    assert_eq!(result.node_output(d), Some(&serde_json::json!(16)));
+    assert_eq!(result.node_output(&a), Some(&serde_json::json!(2)));
+    assert_eq!(result.node_output(&b), Some(&serde_json::json!(4)));
+    assert_eq!(result.node_output(&c), Some(&serde_json::json!(8)));
+    assert_eq!(result.node_output(&d), Some(&serde_json::json!(16)));
 }
 
 /// Metrics are accurate after a failed workflow.
@@ -757,19 +757,19 @@ async fn disabled_node_is_skipped_and_successor_executes() {
     );
     // A executed and produced its output
     assert_eq!(
-        result.node_output(a),
+        result.node_output(&a),
         Some(&serde_json::json!("hello")),
         "A should execute normally"
     );
     // B was skipped — no output entry
     assert!(
-        result.node_output(b).is_none(),
+        result.node_output(&b).is_none(),
         "B should be skipped (no output)"
     );
     // C executed — B's disabled-skip activated the B→C edge so C entered the frontier.
     // C receives null because B produced no output.
     assert_eq!(
-        result.node_output(c),
+        result.node_output(&c),
         Some(&serde_json::json!(null)),
         "C should execute after B is skipped, receiving null (B produced no output)"
     );

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -15,10 +15,7 @@ use nebula_action::{
     ActionError, action::Action, context::Context, dependency::ActionDependencies,
     metadata::ActionMetadata, result::ActionResult, stateless::StatelessAction,
 };
-use nebula_core::{
-    ActionKey, action_key,
-    id::{NodeId, WorkflowId},
-};
+use nebula_core::{ActionKey, NodeKey, action_key, id::WorkflowId, node_key};
 use nebula_engine::WorkflowEngine;
 use nebula_execution::{ExecutionStatus, context::ExecutionBudget};
 use nebula_metrics::naming::{
@@ -263,7 +260,7 @@ async fn engine_and_runtime_share_metrics_registry() {
     ));
     let engine = WorkflowEngine::new(runtime, metrics.clone());
 
-    let n = NodeId::new();
+    let n = node_key!("n");
     let wf = make_workflow(
         vec![NodeDefinition::new(n, "echo", "echo").unwrap()],
         vec![],
@@ -300,14 +297,14 @@ async fn linear_pipeline_data_flows_through() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "double").unwrap(),
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "double").unwrap(),
         ],
-        vec![Connection::new(a, b)],
+        vec![Connection::new(a.clone(), b.clone())],
     );
 
     let result = engine
@@ -337,16 +334,19 @@ async fn fan_out_parallel_execution() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
-    let c = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "double").unwrap(),
-            NodeDefinition::new(c, "C", "add10").unwrap(),
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "double").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "add10").unwrap(),
         ],
-        vec![Connection::new(a, b), Connection::new(a, c)],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(a.clone(), c.clone()),
+        ],
     );
 
     let result = engine
@@ -377,22 +377,22 @@ async fn diamond_merge_receives_combined_outputs() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
-    let c = NodeId::new();
-    let d = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
+    let d = node_key!("d");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "double").unwrap(),
-            NodeDefinition::new(c, "C", "add10").unwrap(),
-            NodeDefinition::new(d, "D", "echo").unwrap(), // echoes merged input
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "double").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "add10").unwrap(),
+            NodeDefinition::new(d.clone(), "D", "echo").unwrap(), // echoes merged input
         ],
         vec![
-            Connection::new(a, b),
-            Connection::new(a, c),
-            Connection::new(b, d),
-            Connection::new(c, d),
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(a.clone(), c.clone()),
+            Connection::new(b.clone(), d.clone()),
+            Connection::new(c.clone(), d.clone()),
         ],
     );
 
@@ -403,8 +403,8 @@ async fn diamond_merge_receives_combined_outputs() {
 
     assert!(result.is_success());
     assert_eq!(result.node_output(a), Some(&serde_json::json!(3)));
-    assert_eq!(result.node_output(b), Some(&serde_json::json!(6)));
-    assert_eq!(result.node_output(c), Some(&serde_json::json!(13)));
+    assert_eq!(result.node_output(b.clone()), Some(&serde_json::json!(6)));
+    assert_eq!(result.node_output(c.clone()), Some(&serde_json::json!(13)));
 
     // D is a join node — its input is a merged object keyed by predecessor node IDs
     let d_output = result.node_output(d).expect("D should have output");
@@ -429,16 +429,19 @@ async fn error_propagation_stops_downstream() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
-    let c = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "fail").unwrap(),
-            NodeDefinition::new(c, "C", "echo").unwrap(),
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "fail").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
         ],
-        vec![Connection::new(a, b), Connection::new(b, c)],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(b.clone(), c.clone()),
+        ],
     );
 
     let result = engine
@@ -478,22 +481,22 @@ async fn cancellation_via_sibling_failure() {
     // Entry → [Slow, Fail] → Downstream
     // Entry runs first, then Slow and Fail run in parallel,
     // Fail dies immediately, cancelling Slow. Downstream never runs.
-    let entry = NodeId::new();
-    let slow = NodeId::new();
-    let fail = NodeId::new();
-    let downstream = NodeId::new();
+    let entry = node_key!("entry");
+    let slow = node_key!("slow");
+    let fail = node_key!("fail");
+    let downstream = node_key!("downstream");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(entry, "Entry", "echo").unwrap(),
-            NodeDefinition::new(slow, "Slow", "slow").unwrap(),
-            NodeDefinition::new(fail, "Fail", "fail").unwrap(),
-            NodeDefinition::new(downstream, "Down", "echo").unwrap(),
+            NodeDefinition::new(entry.clone(), "Entry", "echo").unwrap(),
+            NodeDefinition::new(slow.clone(), "Slow", "slow").unwrap(),
+            NodeDefinition::new(fail.clone(), "Fail", "fail").unwrap(),
+            NodeDefinition::new(downstream.clone(), "Down", "echo").unwrap(),
         ],
         vec![
-            Connection::new(entry, slow),
-            Connection::new(entry, fail),
-            Connection::new(slow, downstream),
-            Connection::new(fail, downstream),
+            Connection::new(entry.clone(), slow.clone()),
+            Connection::new(entry.clone(), fail.clone()),
+            Connection::new(slow.clone(), downstream.clone()),
+            Connection::new(fail, downstream.clone()),
         ],
     );
 
@@ -524,12 +527,12 @@ async fn metrics_cover_full_lifecycle() {
 
     let (engine, metrics) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "echo").unwrap(),
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
         ],
         vec![Connection::new(a, b)],
     );
@@ -572,7 +575,14 @@ async fn bounded_concurrency_with_multiple_parallel_nodes() {
 
     // Create 8 independent nodes (all entry nodes, no connections)
     let nodes: Vec<NodeDefinition> = (0..8)
-        .map(|i| NodeDefinition::new(NodeId::new(), format!("N{i}"), "counter").unwrap())
+        .map(|i| {
+            NodeDefinition::new(
+                NodeKey::new(format!("node_{i}")).unwrap(),
+                format!("N{i}"),
+                "counter",
+            )
+            .unwrap()
+        })
         .collect();
 
     let wf = make_workflow(nodes, vec![]);
@@ -599,7 +609,7 @@ async fn zero_concurrency_budget_returns_planning_error() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
+    let a = node_key!("a");
     let wf = make_workflow(vec![NodeDefinition::new(a, "A", "echo").unwrap()], vec![]);
 
     let budget = ExecutionBudget {
@@ -632,21 +642,21 @@ async fn deep_chain_propagates_outputs() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
-    let c = NodeId::new();
-    let d = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
+    let d = node_key!("d");
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(), // echo(2) = 2
-            NodeDefinition::new(b, "B", "double").unwrap(), // double(2) = 4
-            NodeDefinition::new(c, "C", "double").unwrap(), // double(4) = 8
-            NodeDefinition::new(d, "D", "double").unwrap(), // double(8) = 16
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(), // echo(2) = 2
+            NodeDefinition::new(b.clone(), "B", "double").unwrap(), // double(2) = 4
+            NodeDefinition::new(c.clone(), "C", "double").unwrap(), // double(4) = 8
+            NodeDefinition::new(d.clone(), "D", "double").unwrap(), // double(8) = 16
         ],
         vec![
-            Connection::new(a, b),
-            Connection::new(b, c),
-            Connection::new(c, d),
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(b.clone(), c.clone()),
+            Connection::new(c.clone(), d.clone()),
         ],
     );
 
@@ -672,7 +682,7 @@ async fn metrics_accurate_on_failure() {
 
     let (engine, metrics) = make_engine(registry);
 
-    let a = NodeId::new();
+    let a = node_key!("a");
     let wf = make_workflow(
         vec![NodeDefinition::new(a, "fail-node", "fail").unwrap()],
         vec![],
@@ -718,17 +728,22 @@ async fn disabled_node_is_skipped_and_successor_executes() {
 
     let (engine, _) = make_engine(registry);
 
-    let a = NodeId::new();
-    let b = NodeId::new();
-    let c = NodeId::new();
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
 
     let wf = make_workflow(
         vec![
-            NodeDefinition::new(a, "A", "echo").unwrap(),
-            NodeDefinition::new(b, "B", "echo").unwrap().disabled(),
-            NodeDefinition::new(c, "C", "echo").unwrap(),
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "echo")
+                .unwrap()
+                .disabled(),
+            NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
         ],
-        vec![Connection::new(a, b), Connection::new(b, c)],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(b.clone(), c.clone()),
+        ],
     );
 
     let result = engine

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -133,7 +133,7 @@ async fn action_acquires_resource_through_engine() {
 
     // 5. Verify the action successfully acquired and used the resource
     assert!(result.is_success(), "workflow should succeed");
-    let output = result.node_output(node).expect("node should have output");
+    let output = result.node_output(&node).expect("node should have output");
     assert_eq!(
         output.get("resource_value").and_then(|v| v.as_str()),
         Some("mock-instance"),
@@ -180,7 +180,7 @@ async fn full_resource_lifecycle_with_shutdown() {
 
     // 5. Verify execution succeeded
     assert!(result.is_success(), "workflow should succeed");
-    let output = result.node_output(node).expect("node should have output");
+    let output = result.node_output(&node).expect("node should have output");
     assert_eq!(
         output.get("resource_value").and_then(|v| v.as_str()),
         Some("mock-instance"),

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -13,10 +13,7 @@ use nebula_action::{
     ActionError, action::Action, context::Context, dependency::ActionDependencies,
     metadata::ActionMetadata, result::ActionResult, stateless::StatelessAction,
 };
-use nebula_core::{
-    ActionKey, action_key,
-    id::{NodeId, WorkflowId},
-};
+use nebula_core::{ActionKey, action_key, id::WorkflowId, node_key};
 use nebula_engine::WorkflowEngine;
 use nebula_execution::context::ExecutionBudget;
 use nebula_resource::Manager;
@@ -124,9 +121,9 @@ async fn action_acquires_resource_through_engine() {
     let engine = WorkflowEngine::new(runtime, metrics).with_resource_manager(manager);
 
     // 4. Build and execute a single-node workflow
-    let node = NodeId::new();
+    let node = node_key!("test");
     let wf = make_workflow(vec![
-        NodeDefinition::new(node, "A", "resource-consumer").unwrap(),
+        NodeDefinition::new(node.clone(), "A", "resource-consumer").unwrap(),
     ]);
 
     let result = engine
@@ -171,9 +168,9 @@ async fn full_resource_lifecycle_with_shutdown() {
     let engine = WorkflowEngine::new(runtime, metrics).with_resource_manager(manager.clone());
 
     // 4. Execute a single-node workflow
-    let node = NodeId::new();
+    let node = node_key!("test");
     let wf = make_workflow(vec![
-        NodeDefinition::new(node, "A", "resource-consumer").unwrap(),
+        NodeDefinition::new(node.clone(), "A", "resource-consumer").unwrap(),
     ]);
 
     let result = engine
@@ -222,7 +219,7 @@ async fn action_resource_fails_without_manager() {
     let engine = WorkflowEngine::new(runtime, metrics);
     // No .with_resource_manager() — intentionally omitted
 
-    let node = NodeId::new();
+    let node = node_key!("test");
     let wf = make_workflow(vec![
         NodeDefinition::new(node, "A", "resource-consumer").unwrap(),
     ]);

--- a/crates/error/src/detail_types.rs
+++ b/crates/error/src/detail_types.rs
@@ -187,7 +187,7 @@ pub struct PreconditionViolation {
 ///
 /// let mut details = ErrorDetails::new();
 /// details.insert(ExecutionContext {
-///     node_id: Some("http-fetch-1".into()),
+///     node_key: Some("http-fetch-1".into()),
 ///     workflow_id: Some("wf-daily-report".into()),
 ///     correlation_id: Some("req-abc-123".into()),
 ///     attempt: Some(2),
@@ -196,7 +196,7 @@ pub struct PreconditionViolation {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ExecutionContext {
     /// The node that produced this error, if known.
-    pub node_id: Option<String>,
+    pub node_key: Option<String>,
     /// The workflow run that this error belongs to.
     pub workflow_id: Option<String>,
     /// A correlation ID for distributed tracing (e.g. OTel trace ID).
@@ -421,14 +421,14 @@ mod tests {
     fn execution_context_stored_and_retrieved() {
         let mut details = ErrorDetails::new();
         details.insert(ExecutionContext {
-            node_id: Some("http-fetch-1".into()),
+            node_key: Some("http-fetch-1".into()),
             workflow_id: Some("wf-daily-report".into()),
             correlation_id: Some("req-abc-123".into()),
             attempt: Some(2),
         });
 
         let ctx = details.get::<ExecutionContext>().unwrap();
-        assert_eq!(ctx.node_id.as_deref(), Some("http-fetch-1"));
+        assert_eq!(ctx.node_key.as_deref(), Some("http-fetch-1"));
         assert_eq!(ctx.attempt, Some(2));
     }
 

--- a/crates/execution/src/attempt.rs
+++ b/crates/execution/src/attempt.rs
@@ -86,12 +86,12 @@ impl NodeAttempt {
 
 #[cfg(test)]
 mod tests {
-    use nebula_core::{ExecutionId, NodeId};
+    use nebula_core::{ExecutionId, node_key};
 
     use super::*;
 
     fn test_key() -> IdempotencyKey {
-        IdempotencyKey::generate(ExecutionId::new(), NodeId::new(), 0)
+        IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 0)
     }
 
     #[test]

--- a/crates/execution/src/error.rs
+++ b/crates/execution/src/error.rs
@@ -1,6 +1,6 @@
 //! Execution error types.
 
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use thiserror::Error;
 
 use crate::status::ExecutionStatus;
@@ -21,7 +21,7 @@ pub enum ExecutionError {
     /// A referenced node does not exist in the execution state.
     #[classify(category = "not_found", code = "EXECUTION:NODE_NOT_FOUND")]
     #[error("node not found: {0}")]
-    NodeNotFound(NodeId),
+    NodeNotFound(NodeKey),
 
     /// The execution plan failed validation.
     #[classify(category = "validation", code = "EXECUTION:PLAN_VALIDATION")]
@@ -61,6 +61,8 @@ impl ExecutionError {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -77,7 +79,7 @@ mod tests {
 
     #[test]
     fn node_not_found_display() {
-        let id = NodeId::new();
+        let id = node_key!("test");
         let err = ExecutionError::NodeNotFound(id);
         assert!(err.to_string().contains("node not found"));
     }

--- a/crates/execution/src/idempotency.rs
+++ b/crates/execution/src/idempotency.rs
@@ -7,7 +7,7 @@
 
 use std::{collections::HashSet, fmt};
 
-use nebula_core::{ExecutionId, NodeId};
+use nebula_core::{ExecutionId, NodeKey};
 use serde::{Deserialize, Serialize};
 
 /// A deterministic key used to ensure exactly-once execution of a node attempt.
@@ -17,8 +17,8 @@ pub struct IdempotencyKey(String);
 impl IdempotencyKey {
     /// Generate a deterministic idempotency key from execution context.
     #[must_use]
-    pub fn generate(execution_id: ExecutionId, node_id: NodeId, attempt: u32) -> Self {
-        Self(format!("{execution_id}:{node_id}:{attempt}"))
+    pub fn generate(execution_id: ExecutionId, node_key: NodeKey, attempt: u32) -> Self {
+        Self(format!("{execution_id}:{node_key}:{attempt}"))
     }
 
     /// Get the underlying key string.
@@ -88,40 +88,42 @@ impl IdempotencyManager {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
     fn generate_deterministic_key() {
         let exec_id = ExecutionId::new();
-        let node_id = NodeId::new();
-        let key1 = IdempotencyKey::generate(exec_id, node_id, 0);
-        let key2 = IdempotencyKey::generate(exec_id, node_id, 0);
+        let node_key = node_key!("test_node");
+        let key1 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
+        let key2 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
         assert_eq!(key1, key2);
     }
 
     #[test]
     fn different_attempts_different_keys() {
         let exec_id = ExecutionId::new();
-        let node_id = NodeId::new();
-        let key0 = IdempotencyKey::generate(exec_id, node_id, 0);
-        let key1 = IdempotencyKey::generate(exec_id, node_id, 1);
+        let node_key = node_key!("test_node");
+        let key0 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
+        let key1 = IdempotencyKey::generate(exec_id, node_key.clone(), 1);
         assert_ne!(key0, key1);
     }
 
     #[test]
     fn key_display() {
         let exec_id = ExecutionId::new();
-        let node_id = NodeId::new();
-        let key = IdempotencyKey::generate(exec_id, node_id, 2);
+        let node_key = node_key!("test_node");
+        let key = IdempotencyKey::generate(exec_id, node_key.clone(), 2);
         let display = key.to_string();
         assert!(display.contains(&exec_id.to_string()));
-        assert!(display.contains(&node_id.to_string()));
+        assert!(display.contains(&node_key.to_string()));
         assert!(display.ends_with(":2"));
     }
 
     #[test]
     fn serde_roundtrip() {
-        let key = IdempotencyKey::generate(ExecutionId::new(), NodeId::new(), 3);
+        let key = IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 3);
         let json = serde_json::to_string(&key).expect("serialize");
         let back: IdempotencyKey = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(key, back);
@@ -131,7 +133,7 @@ mod tests {
     #[test]
     fn manager_check_and_mark_new_key() {
         let mut mgr = IdempotencyManager::new();
-        let key = IdempotencyKey::generate(ExecutionId::new(), NodeId::new(), 0);
+        let key = IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 0);
         assert!(mgr.check_and_mark(&key));
         assert!(!mgr.check_and_mark(&key));
     }
@@ -140,7 +142,7 @@ mod tests {
     #[test]
     fn manager_clear_resets() {
         let mut mgr = IdempotencyManager::new();
-        let key = IdempotencyKey::generate(ExecutionId::new(), NodeId::new(), 0);
+        let key = IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 0);
         mgr.check_and_mark(&key);
         assert_eq!(mgr.len(), 1);
         mgr.clear();

--- a/crates/execution/src/journal.rs
+++ b/crates/execution/src/journal.rs
@@ -1,7 +1,7 @@
 //! Execution journal for audit and replay.
 
 use chrono::{DateTime, Utc};
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use serde::{Deserialize, Serialize};
 
 use crate::status::ExecutionStatus;
@@ -21,7 +21,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node that was scheduled.
-        node_id: NodeId,
+        node_key: NodeKey,
     },
 
     /// A node started executing.
@@ -29,7 +29,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node that started.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Which attempt number (0-indexed).
         attempt: u32,
     },
@@ -39,7 +39,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node that completed.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Output size in bytes.
         output_bytes: u64,
     },
@@ -49,7 +49,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node that failed.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Error message.
         error: String,
     },
@@ -59,7 +59,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node that was skipped.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Reason for skipping.
         reason: String,
     },
@@ -69,7 +69,7 @@ pub enum JournalEntry {
         /// When the event occurred.
         timestamp: DateTime<Utc>,
         /// The node being retried.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// Which attempt is being made (0-indexed).
         attempt: u32,
     },
@@ -119,14 +119,14 @@ impl JournalEntry {
 
     /// Get the node ID associated with this entry, if any.
     #[must_use]
-    pub fn node_id(&self) -> Option<NodeId> {
+    pub fn node_key(&self) -> Option<NodeKey> {
         match self {
-            Self::NodeScheduled { node_id, .. }
-            | Self::NodeStarted { node_id, .. }
-            | Self::NodeCompleted { node_id, .. }
-            | Self::NodeFailed { node_id, .. }
-            | Self::NodeSkipped { node_id, .. }
-            | Self::NodeRetrying { node_id, .. } => Some(*node_id),
+            Self::NodeScheduled { node_key, .. }
+            | Self::NodeStarted { node_key, .. }
+            | Self::NodeCompleted { node_key, .. }
+            | Self::NodeFailed { node_key, .. }
+            | Self::NodeSkipped { node_key, .. }
+            | Self::NodeRetrying { node_key, .. } => Some(node_key.clone()),
             Self::ExecutionStarted { .. }
             | Self::ExecutionCompleted { .. }
             | Self::ExecutionFailed { .. }
@@ -137,13 +137,13 @@ impl JournalEntry {
     /// Returns `true` if this is a node-level event.
     #[must_use]
     pub fn is_node_event(&self) -> bool {
-        self.node_id().is_some()
+        self.node_key().is_some()
     }
 
     /// Returns `true` if this is an execution-level event.
     #[must_use]
     pub fn is_execution_event(&self) -> bool {
-        self.node_id().is_none()
+        self.node_key().is_none()
     }
 
     /// Serialize this entry to JSON.
@@ -159,6 +159,8 @@ impl JournalEntry {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     fn now() -> DateTime<Utc> {
@@ -172,18 +174,18 @@ mod tests {
         assert_eq!(entry.timestamp(), ts);
         assert!(entry.is_execution_event());
         assert!(!entry.is_node_event());
-        assert!(entry.node_id().is_none());
+        assert!(entry.node_key().is_none());
     }
 
     #[test]
     fn node_scheduled_entry() {
         let ts = now();
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
         let entry = JournalEntry::NodeScheduled {
             timestamp: ts,
-            node_id: nid,
+            node_key: nid.clone(),
         };
-        assert_eq!(entry.node_id(), Some(nid));
+        assert_eq!(entry.node_key(), Some(nid));
         assert!(entry.is_node_event());
         assert!(!entry.is_execution_event());
     }
@@ -192,7 +194,7 @@ mod tests {
     fn node_started_entry() {
         let entry = JournalEntry::NodeStarted {
             timestamp: now(),
-            node_id: NodeId::new(),
+            node_key: node_key!("test"),
             attempt: 0,
         };
         assert!(entry.is_node_event());
@@ -200,20 +202,20 @@ mod tests {
 
     #[test]
     fn node_completed_entry() {
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
         let entry = JournalEntry::NodeCompleted {
             timestamp: now(),
-            node_id: nid,
+            node_key: nid.clone(),
             output_bytes: 1024,
         };
-        assert_eq!(entry.node_id(), Some(nid));
+        assert_eq!(entry.node_key(), Some(nid));
     }
 
     #[test]
     fn node_failed_entry() {
         let entry = JournalEntry::NodeFailed {
             timestamp: now(),
-            node_id: NodeId::new(),
+            node_key: node_key!("test"),
             error: "timeout".into(),
         };
         assert!(entry.is_node_event());
@@ -223,7 +225,7 @@ mod tests {
     fn node_skipped_entry() {
         let entry = JournalEntry::NodeSkipped {
             timestamp: now(),
-            node_id: NodeId::new(),
+            node_key: node_key!("test"),
             reason: "condition not met".into(),
         };
         assert!(entry.is_node_event());
@@ -233,7 +235,7 @@ mod tests {
     fn node_retrying_entry() {
         let entry = JournalEntry::NodeRetrying {
             timestamp: now(),
-            node_id: NodeId::new(),
+            node_key: node_key!("test"),
             attempt: 2,
         };
         assert!(entry.is_node_event());
@@ -255,43 +257,43 @@ mod tests {
             reason: "user requested".into(),
         };
         assert!(entry.is_execution_event());
-        assert!(entry.node_id().is_none());
+        assert!(entry.node_key().is_none());
     }
 
     #[test]
     fn serde_roundtrip_all_variants() {
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
         let ts = now();
 
         let entries = vec![
             JournalEntry::ExecutionStarted { timestamp: ts },
             JournalEntry::NodeScheduled {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid.clone(),
             },
             JournalEntry::NodeStarted {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid.clone(),
                 attempt: 0,
             },
             JournalEntry::NodeCompleted {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid.clone(),
                 output_bytes: 512,
             },
             JournalEntry::NodeFailed {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid.clone(),
                 error: "err".into(),
             },
             JournalEntry::NodeSkipped {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid.clone(),
                 reason: "skip".into(),
             },
             JournalEntry::NodeRetrying {
                 timestamp: ts,
-                node_id: nid,
+                node_key: nid,
                 attempt: 1,
             },
             JournalEntry::ExecutionCompleted {
@@ -312,7 +314,7 @@ mod tests {
             let json = entry.to_json().unwrap();
             let back = JournalEntry::from_json(&json).unwrap();
             assert_eq!(entry.timestamp(), back.timestamp());
-            assert_eq!(entry.node_id(), back.node_id());
+            assert_eq!(entry.node_key(), back.node_key());
         }
     }
 }

--- a/crates/execution/src/plan.rs
+++ b/crates/execution/src/plan.rs
@@ -1,7 +1,7 @@
 //! Execution planning — builds a parallel execution schedule from a workflow.
 
 use chrono::{DateTime, Utc};
-use nebula_core::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 use nebula_workflow::{DependencyGraph, WorkflowDefinition};
 use serde::{Deserialize, Serialize};
 
@@ -15,11 +15,11 @@ pub struct ExecutionPlan {
     /// Workflow this plan was derived from.
     pub workflow_id: WorkflowId,
     /// Parallel execution groups (each group can run concurrently).
-    pub parallel_groups: Vec<Vec<NodeId>>,
+    pub parallel_groups: Vec<Vec<NodeKey>>,
     /// Nodes with no predecessors (start points).
-    pub entry_nodes: Vec<NodeId>,
+    pub entry_nodes: Vec<NodeKey>,
     /// Nodes with no successors (end points).
-    pub exit_nodes: Vec<NodeId>,
+    pub exit_nodes: Vec<NodeKey>,
     /// Total number of nodes in the plan.
     pub total_nodes: usize,
     /// Resource budget for this execution.
@@ -70,7 +70,7 @@ impl ExecutionPlan {
 mod tests {
     use std::collections::HashMap;
 
-    use nebula_core::WorkflowId;
+    use nebula_core::{WorkflowId, node_key};
     use nebula_workflow::{
         Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
     };
@@ -101,18 +101,21 @@ mod tests {
         }
     }
 
-    fn node(id: NodeId) -> NodeDefinition {
+    fn node(id: NodeKey) -> NodeDefinition {
         NodeDefinition::new(id, "n", "n").unwrap()
     }
 
     #[test]
     fn plan_from_linear_workflow() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
         let wf = make_workflow(
-            vec![node(a), node(b), node(c)],
-            vec![Connection::new(a, b), Connection::new(b, c)],
+            vec![node(a.clone()), node(b.clone()), node(c.clone())],
+            vec![
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(b, c.clone()),
+            ],
         );
         let plan =
             ExecutionPlan::from_workflow(ExecutionId::new(), &wf, ExecutionBudget::default())
@@ -126,16 +129,21 @@ mod tests {
 
     #[test]
     fn plan_from_diamond_workflow() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
-        let d = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let d = node_key!("d");
         let wf = make_workflow(
-            vec![node(a), node(b), node(c), node(d)],
             vec![
-                Connection::new(a, b),
-                Connection::new(a, c),
-                Connection::new(b, d),
+                node(a.clone()),
+                node(b.clone()),
+                node(c.clone()),
+                node(d.clone()),
+            ],
+            vec![
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(a, c.clone()),
+                Connection::new(b, d.clone()),
                 Connection::new(c, d),
             ],
         );
@@ -160,7 +168,7 @@ mod tests {
     #[test]
     fn plan_preserves_ids() {
         let exec_id = ExecutionId::new();
-        let a = NodeId::new();
+        let a = node_key!("a");
         let wf = make_workflow(vec![node(a)], vec![]);
         let plan = ExecutionPlan::from_workflow(exec_id, &wf, ExecutionBudget::default()).unwrap();
 
@@ -170,23 +178,26 @@ mod tests {
 
     #[test]
     fn plan_single_node() {
-        let a = NodeId::new();
-        let wf = make_workflow(vec![node(a)], vec![]);
+        let a = node_key!("a");
+        let wf = make_workflow(vec![node(a.clone())], vec![]);
         let plan =
             ExecutionPlan::from_workflow(ExecutionId::new(), &wf, ExecutionBudget::default())
                 .unwrap();
 
         assert_eq!(plan.total_nodes, 1);
         assert_eq!(plan.parallel_groups.len(), 1);
-        assert_eq!(plan.entry_nodes, vec![a]);
+        assert_eq!(plan.entry_nodes, vec![a.clone()]);
         assert_eq!(plan.exit_nodes, vec![a]);
     }
 
     #[test]
     fn plan_serde_roundtrip() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let wf = make_workflow(vec![node(a), node(b)], vec![Connection::new(a, b)]);
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let wf = make_workflow(
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a, b)],
+        );
         let plan =
             ExecutionPlan::from_workflow(ExecutionId::new(), &wf, ExecutionBudget::default())
                 .unwrap();

--- a/crates/execution/src/replay.rs
+++ b/crates/execution/src/replay.rs
@@ -21,7 +21,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use nebula_core::id::{ExecutionId, NodeId};
+use nebula_core::{NodeKey, id::ExecutionId};
 use serde::{Deserialize, Serialize};
 
 /// Plan for replaying a workflow execution from a specific node.
@@ -36,10 +36,10 @@ pub struct ReplayPlan {
     /// The source execution to replay from.
     pub source_execution_id: ExecutionId,
     /// The node to start re-executing from.
-    pub replay_from: NodeId,
+    pub replay_from: NodeKey,
     /// Optional input overrides for specific nodes.
     #[serde(default)]
-    pub input_overrides: HashMap<NodeId, serde_json::Value>,
+    pub input_overrides: HashMap<NodeKey, serde_json::Value>,
     /// Stored outputs from the source execution, keyed by node id.
     ///
     /// Populated at construction from the source execution's node-output
@@ -52,12 +52,12 @@ pub struct ReplayPlan {
     /// would have nothing to feed downstream nodes and the whole
     /// workflow would silently be re-executed (#253).
     #[serde(default)]
-    pub pinned_outputs: HashMap<NodeId, serde_json::Value>,
+    pub pinned_outputs: HashMap<NodeKey, serde_json::Value>,
 }
 
 impl ReplayPlan {
     /// Create a new replay plan.
-    pub fn new(source_execution_id: ExecutionId, replay_from: NodeId) -> Self {
+    pub fn new(source_execution_id: ExecutionId, replay_from: NodeKey) -> Self {
         Self {
             source_execution_id,
             replay_from,
@@ -68,14 +68,14 @@ impl ReplayPlan {
 
     /// Override input for a specific node.
     #[must_use]
-    pub fn with_override(mut self, node_id: NodeId, input: serde_json::Value) -> Self {
-        self.input_overrides.insert(node_id, input);
+    pub fn with_override(mut self, node_key: NodeKey, input: serde_json::Value) -> Self {
+        self.input_overrides.insert(node_key, input);
         self
     }
 
     /// Set pinned outputs from the source execution.
     #[must_use]
-    pub fn with_pinned_outputs(mut self, outputs: HashMap<NodeId, serde_json::Value>) -> Self {
+    pub fn with_pinned_outputs(mut self, outputs: HashMap<NodeKey, serde_json::Value>) -> Self {
         self.pinned_outputs = outputs;
         self
     }
@@ -108,27 +108,28 @@ impl ReplayPlan {
     /// membership before relying on this.
     pub fn partition_nodes(
         &self,
-        all_nodes: &[NodeId],
-        successors: &HashMap<NodeId, Vec<NodeId>>,
-    ) -> (HashSet<NodeId>, HashSet<NodeId>) {
+        all_nodes: &[NodeKey],
+        successors: &HashMap<NodeKey, Vec<NodeKey>>,
+    ) -> (HashSet<NodeKey>, HashSet<NodeKey>) {
         // Forward traversal: every node reachable from replay_from is
         // in the rerun set, including replay_from itself.
         let mut rerun = HashSet::new();
-        let mut frontier = vec![self.replay_from];
+        let mut frontier = vec![self.replay_from.clone()];
         while let Some(node) = frontier.pop() {
+            let succs = successors.get(&node);
             if rerun.insert(node)
-                && let Some(succs) = successors.get(&node)
+                && let Some(succs) = succs
             {
-                frontier.extend(succs.iter().copied());
+                frontier.extend(succs.iter().cloned());
             }
         }
 
         // Everything NOT in rerun is pinned — ancestors, unrelated
         // siblings, and any disconnected branch.
-        let pinned: HashSet<NodeId> = all_nodes
+        let pinned: HashSet<NodeKey> = all_nodes
             .iter()
-            .copied()
-            .filter(|n| !rerun.contains(n))
+            .filter(|n| !rerun.contains(*n))
+            .cloned()
             .collect();
 
         (pinned, rerun)
@@ -139,15 +140,15 @@ impl ReplayPlan {
 mod tests {
     use super::*;
 
-    fn nid(n: u128) -> NodeId {
-        NodeId::from(n.to_be_bytes())
+    fn nid(n: u128) -> NodeKey {
+        NodeKey::new(format!("node_{n}")).unwrap()
     }
 
     /// Build a successors map from `(from, to)` connection pairs.
-    fn successors_from(edges: &[(NodeId, NodeId)]) -> HashMap<NodeId, Vec<NodeId>> {
-        let mut out: HashMap<NodeId, Vec<NodeId>> = HashMap::new();
+    fn successors_from(edges: &[(NodeKey, NodeKey)]) -> HashMap<NodeKey, Vec<NodeKey>> {
+        let mut out: HashMap<NodeKey, Vec<NodeKey>> = HashMap::new();
         for (from, to) in edges {
-            out.entry(*from).or_default().push(*to);
+            out.entry(from.clone()).or_default().push(to.clone());
         }
         out
     }
@@ -159,10 +160,10 @@ mod tests {
         let a = nid(1);
         let b = nid(2);
         let c = nid(3);
-        let succ = successors_from(&[(a, b), (b, c)]);
+        let succ = successors_from(&[(a.clone(), b.clone()), (b.clone(), c.clone())]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), b);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b, c], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), b.clone());
+        let (pinned, rerun) = plan.partition_nodes(&[a.clone(), b.clone(), c.clone()], &succ);
 
         assert!(pinned.contains(&a));
         assert!(rerun.contains(&b));
@@ -179,10 +180,16 @@ mod tests {
         let b = nid(2);
         let c = nid(3);
         let d = nid(4);
-        let succ = successors_from(&[(a, b), (a, c), (b, d), (c, d)]);
+        let succ = successors_from(&[
+            (a.clone(), b.clone()),
+            (a.clone(), c.clone()),
+            (b.clone(), d.clone()),
+            (c.clone(), d.clone()),
+        ]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), d);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b, c, d], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), d.clone());
+        let (pinned, rerun) =
+            plan.partition_nodes(&[a.clone(), b.clone(), c.clone(), d.clone()], &succ);
 
         assert!(pinned.contains(&a));
         assert!(pinned.contains(&b));
@@ -205,10 +212,16 @@ mod tests {
         let b = nid(2);
         let c = nid(3);
         let d = nid(4);
-        let succ = successors_from(&[(a, b), (a, c), (b, d), (c, d)]);
+        let succ = successors_from(&[
+            (a.clone(), b.clone()),
+            (a.clone(), c.clone()),
+            (b.clone(), d.clone()),
+            (c.clone(), d.clone()),
+        ]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), b);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b, c, d], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), b.clone());
+        let (pinned, rerun) =
+            plan.partition_nodes(&[a.clone(), b.clone(), c.clone(), d.clone()], &succ);
 
         assert!(pinned.contains(&a), "ancestor A must be pinned");
         assert!(
@@ -231,10 +244,11 @@ mod tests {
         let b = nid(2);
         let x = nid(10);
         let y = nid(11);
-        let succ = successors_from(&[(a, b), (x, y)]);
+        let succ = successors_from(&[(a.clone(), b.clone()), (x.clone(), y.clone())]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), a);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b, x, y], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), a.clone());
+        let (pinned, rerun) =
+            plan.partition_nodes(&[a.clone(), b.clone(), x.clone(), y.clone()], &succ);
 
         assert!(pinned.contains(&x));
         assert!(pinned.contains(&y));
@@ -249,8 +263,8 @@ mod tests {
         let b = nid(2);
         let succ = HashMap::new();
 
-        let plan = ReplayPlan::new(ExecutionId::new(), a);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), a.clone());
+        let (pinned, rerun) = plan.partition_nodes(&[a.clone(), b.clone()], &succ);
 
         // A is re-executed; B is unrelated (no edge A→B in this fixture).
         assert!(rerun.contains(&a));
@@ -263,9 +277,9 @@ mod tests {
         let a = nid(1);
         let b = nid(2);
         let c = nid(3);
-        let succ = successors_from(&[(a, b), (b, c)]);
+        let succ = successors_from(&[(a.clone(), b.clone()), (b.clone(), c.clone())]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), a);
+        let plan = ReplayPlan::new(ExecutionId::new(), a.clone());
         let (pinned, rerun) = plan.partition_nodes(&[a, b, c], &succ);
 
         assert!(pinned.is_empty());
@@ -280,10 +294,11 @@ mod tests {
         let a = nid(1);
         let b = nid(2);
         let mut outputs = HashMap::new();
-        outputs.insert(a, serde_json::json!({"result": "from_a"}));
-        outputs.insert(b, serde_json::json!(42));
+        outputs.insert(a.clone(), serde_json::json!({"result": "from_a"}));
+        outputs.insert(b.clone(), serde_json::json!(42));
 
-        let plan = ReplayPlan::new(ExecutionId::new(), b).with_pinned_outputs(outputs.clone());
+        let plan =
+            ReplayPlan::new(ExecutionId::new(), b.clone()).with_pinned_outputs(outputs.clone());
 
         let json = serde_json::to_string(&plan).expect("serialize");
         let restored: ReplayPlan = serde_json::from_str(&json).expect("deserialize");
@@ -310,9 +325,13 @@ mod tests {
         let a = nid(1);
         let b = nid(2);
         let c = nid(3);
-        let succ = successors_from(&[(a, b), (b, c), (c, a)]);
+        let succ = successors_from(&[
+            (a.clone(), b.clone()),
+            (b.clone(), c.clone()),
+            (c.clone(), a.clone()),
+        ]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), a);
+        let plan = ReplayPlan::new(ExecutionId::new(), a.clone());
         let (pinned, rerun) = plan.partition_nodes(&[a, b, c], &succ);
 
         // Whole cycle is forward-reachable from A.
@@ -331,10 +350,10 @@ mod tests {
         let a = nid(1);
         let b = nid(2);
         let ghost = nid(99);
-        let succ = successors_from(&[(a, b)]);
+        let succ = successors_from(&[(a.clone(), b.clone())]);
 
-        let plan = ReplayPlan::new(ExecutionId::new(), ghost);
-        let (pinned, rerun) = plan.partition_nodes(&[a, b], &succ);
+        let plan = ReplayPlan::new(ExecutionId::new(), ghost.clone());
+        let (pinned, rerun) = plan.partition_nodes(&[a.clone(), b.clone()], &succ);
 
         // The unknown node is the only rerun entry; real nodes are pinned.
         assert!(rerun.contains(&ghost));

--- a/crates/execution/src/result.rs
+++ b/crates/execution/src/result.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use chrono::{DateTime, Utc};
-use nebula_core::{ExecutionId, NodeId};
+use nebula_core::{ExecutionId, NodeKey};
 use serde::{Deserialize, Serialize};
 
 use crate::status::{ExecutionStatus, ExecutionTerminationReason};
@@ -48,7 +48,7 @@ pub struct ExecutionResult {
     pub nodes_skipped: usize,
     /// Collected outputs from terminal nodes (nodes with no outgoing edges).
     #[serde(default)]
-    pub outputs: HashMap<NodeId, serde_json::Value>,
+    pub outputs: HashMap<NodeKey, serde_json::Value>,
     /// Why this execution reached its terminal state.
     ///
     /// `None` for in-flight executions and for results serialised before
@@ -114,7 +114,7 @@ impl ExecutionResult {
 
     /// Set terminal-node outputs.
     #[must_use = "builder methods must be chained or built"]
-    pub fn with_outputs(mut self, outputs: HashMap<NodeId, serde_json::Value>) -> Self {
+    pub fn with_outputs(mut self, outputs: HashMap<NodeKey, serde_json::Value>) -> Self {
         self.outputs = outputs;
         self
     }
@@ -122,6 +122,8 @@ impl ExecutionResult {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -164,28 +166,28 @@ mod tests {
 
     #[test]
     fn builder_sets_outputs() {
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let mut outputs = HashMap::new();
-        outputs.insert(node_id, serde_json::json!({"key": "value"}));
+        outputs.insert(node_key.clone(), serde_json::json!({"key": "value"}));
 
         let result = ExecutionResult::new(ExecutionId::new(), ExecutionStatus::Completed)
             .with_outputs(outputs.clone());
 
         assert_eq!(result.outputs.len(), 1);
         assert_eq!(
-            result.outputs[&node_id],
+            result.outputs[&node_key],
             serde_json::json!({"key": "value"})
         );
     }
 
     #[test]
     fn serde_roundtrip() {
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let start = Utc::now();
         let end = start + chrono::Duration::seconds(42);
 
         let mut outputs = HashMap::new();
-        outputs.insert(node_id, serde_json::json!(42));
+        outputs.insert(node_key, serde_json::json!(42));
 
         let original = ExecutionResult::new(ExecutionId::new(), ExecutionStatus::Failed)
             .with_timing(start, end)
@@ -212,15 +214,15 @@ mod tests {
 
     #[test]
     fn with_termination_reason_builder() {
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let result = ExecutionResult::new(ExecutionId::new(), ExecutionStatus::Completed)
             .with_termination_reason(ExecutionTerminationReason::ExplicitStop {
-                by_node: node_id,
+                by_node: node_key.clone(),
                 note: Some("done early".into()),
             });
         match result.termination_reason {
             Some(ExecutionTerminationReason::ExplicitStop { by_node, note }) => {
-                assert_eq!(by_node, node_id);
+                assert_eq!(by_node, node_key);
                 assert_eq!(note.as_deref(), Some("done early"));
             },
             _ => panic!("expected ExplicitStop"),
@@ -231,7 +233,7 @@ mod tests {
     fn termination_reason_serde_roundtrip() {
         let original = ExecutionResult::new(ExecutionId::new(), ExecutionStatus::Failed)
             .with_termination_reason(ExecutionTerminationReason::ExplicitFail {
-                by_node: NodeId::new(),
+                by_node: node_key!("test"),
                 code: "E_BAD".into(),
                 message: "broken".into(),
             });

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
-use nebula_core::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 use nebula_workflow::NodeState;
 use serde::{Deserialize, Serialize};
 
@@ -101,7 +101,7 @@ pub struct ExecutionState {
     /// Current execution status.
     pub status: ExecutionStatus,
     /// Per-node execution states.
-    pub node_states: HashMap<NodeId, NodeExecutionState>,
+    pub node_states: HashMap<NodeKey, NodeExecutionState>,
     /// Optimistic concurrency version (bumped on each state change).
     pub version: u64,
     /// When the execution was created.
@@ -126,11 +126,11 @@ pub struct ExecutionState {
 impl ExecutionState {
     /// Create a new execution state.
     #[must_use]
-    pub fn new(execution_id: ExecutionId, workflow_id: WorkflowId, node_ids: &[NodeId]) -> Self {
+    pub fn new(execution_id: ExecutionId, workflow_id: WorkflowId, node_ids: &[NodeKey]) -> Self {
         let now = Utc::now();
         let mut node_states = HashMap::new();
-        for &nid in node_ids {
-            node_states.insert(nid, NodeExecutionState::new());
+        for nid in node_ids {
+            node_states.insert(nid.clone(), NodeExecutionState::new());
         }
 
         Self {
@@ -151,8 +151,8 @@ impl ExecutionState {
 
     /// Get a node's execution state.
     #[must_use]
-    pub fn node_state(&self, node_id: NodeId) -> Option<&NodeExecutionState> {
-        self.node_states.get(&node_id)
+    pub fn node_state(&self, node_key: NodeKey) -> Option<&NodeExecutionState> {
+        self.node_states.get(&node_key)
     }
 
     /// Set a node's execution state directly.
@@ -165,8 +165,8 @@ impl ExecutionState {
     /// tracking the parent [`ExecutionState::version`].
     ///
     /// [`transition_node`]: Self::transition_node
-    pub fn set_node_state(&mut self, node_id: NodeId, state: NodeExecutionState) {
-        self.node_states.insert(node_id, state);
+    pub fn set_node_state(&mut self, node_key: NodeKey, state: NodeExecutionState) {
+        self.node_states.insert(node_key, state);
     }
 
     /// Override a node's raw state without running transition
@@ -185,16 +185,16 @@ impl ExecutionState {
     /// [`transition_node`](Self::transition_node) instead — it
     /// enforces the transition rules.
     ///
-    /// Returns an error only if `node_id` is unknown.
+    /// Returns an error only if `node_key` is unknown.
     pub fn override_node_state(
         &mut self,
-        node_id: NodeId,
+        node_key: NodeKey,
         new_state: NodeState,
     ) -> Result<(), ExecutionError> {
         let ns = self
             .node_states
-            .get_mut(&node_id)
-            .ok_or(ExecutionError::NodeNotFound(node_id))?;
+            .get_mut(&node_key)
+            .ok_or(ExecutionError::NodeNotFound(node_key))?;
         ns.state = new_state;
         self.version += 1;
         self.updated_at = Utc::now();
@@ -215,18 +215,18 @@ impl ExecutionState {
     ///
     /// # Errors
     ///
-    /// - [`ExecutionError::NodeNotFound`] if `node_id` is not in this execution's node map.
+    /// - [`ExecutionError::NodeNotFound`] if `node_key` is not in this execution's node map.
     /// - Any error returned by [`NodeExecutionState::transition_to`] for invalid transitions — in
     ///   which case the version is NOT bumped (the state did not actually change).
     pub fn transition_node(
         &mut self,
-        node_id: NodeId,
+        node_key: NodeKey,
         new_state: NodeState,
     ) -> Result<(), ExecutionError> {
         let ns = self
             .node_states
-            .get_mut(&node_id)
-            .ok_or(ExecutionError::NodeNotFound(node_id))?;
+            .get_mut(&node_key)
+            .ok_or(ExecutionError::NodeNotFound(node_key))?;
         ns.transition_to(new_state)?;
         self.version += 1;
         self.updated_at = Utc::now();
@@ -241,31 +241,31 @@ impl ExecutionState {
 
     /// Get the IDs of all currently active (running/retrying) nodes.
     #[must_use]
-    pub fn active_node_ids(&self) -> Vec<NodeId> {
+    pub fn active_node_ids(&self) -> Vec<NodeKey> {
         self.node_states
             .iter()
             .filter(|(_, ns)| ns.state.is_active())
-            .map(|(&id, _)| id)
+            .map(|(id, _)| id.clone())
             .collect()
     }
 
     /// Get the IDs of all completed nodes.
     #[must_use]
-    pub fn completed_node_ids(&self) -> Vec<NodeId> {
+    pub fn completed_node_ids(&self) -> Vec<NodeKey> {
         self.node_states
             .iter()
             .filter(|(_, ns)| ns.state == NodeState::Completed)
-            .map(|(&id, _)| id)
+            .map(|(id, _)| id.clone())
             .collect()
     }
 
     /// Get the IDs of all failed nodes.
     #[must_use]
-    pub fn failed_node_ids(&self) -> Vec<NodeId> {
+    pub fn failed_node_ids(&self) -> Vec<NodeKey> {
         self.node_states
             .iter()
             .filter(|(_, ns)| ns.state == NodeState::Failed)
-            .map(|(&id, _)| id)
+            .map(|(id, _)| id.clone())
             .collect()
     }
 
@@ -289,12 +289,18 @@ impl ExecutionState {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
-    fn make_state() -> (ExecutionState, NodeId, NodeId) {
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
-        let state = ExecutionState::new(ExecutionId::new(), WorkflowId::new(), &[n1, n2]);
+    fn make_state() -> (ExecutionState, NodeKey, NodeKey) {
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+        let state = ExecutionState::new(
+            ExecutionId::new(),
+            WorkflowId::new(),
+            &[n1.clone(), n2.clone()],
+        );
         (state, n1, n2)
     }
 
@@ -397,8 +403,8 @@ mod tests {
     #[test]
     fn set_node_state() {
         let (mut state, _n1, _n2) = make_state();
-        let new_node = NodeId::new();
-        state.set_node_state(new_node, NodeExecutionState::new());
+        let new_node = node_key!("new_node");
+        state.set_node_state(new_node.clone(), NodeExecutionState::new());
         assert!(state.node_state(new_node).is_some());
     }
 
@@ -415,16 +421,23 @@ mod tests {
         let t0 = state.updated_at;
 
         state
-            .transition_node(n1, NodeState::Ready)
+            .transition_node(n1.clone(), NodeState::Ready)
             .expect("valid transition");
-        assert_eq!(state.node_state(n1).unwrap().state, NodeState::Ready);
+        assert_eq!(
+            state.node_state(n1.clone()).unwrap().state,
+            NodeState::Ready
+        );
         assert_eq!(state.version, v0 + 1, "version must be bumped");
         assert!(state.updated_at >= t0, "updated_at must move forward");
 
         // Chained transitions each bump the version once.
-        state.transition_node(n1, NodeState::Running).unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Running)
+            .unwrap();
         assert_eq!(state.version, v0 + 2);
-        state.transition_node(n1, NodeState::Completed).unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Completed)
+            .unwrap();
         assert_eq!(state.version, v0 + 3);
         assert!(state.node_state(n1).unwrap().state.is_terminal());
     }
@@ -435,7 +448,7 @@ mod tests {
         let v0 = state.version;
         // Pending -> Completed is invalid (must pass through Ready/Running).
         let err = state
-            .transition_node(n1, NodeState::Completed)
+            .transition_node(n1.clone(), NodeState::Completed)
             .expect_err("invalid transition must error");
         assert!(err.to_string().contains("invalid transition"));
         // Version must NOT move on a rejected transition — if it did,
@@ -448,7 +461,7 @@ mod tests {
     #[test]
     fn transition_node_unknown_node_is_error() {
         let (mut state, _n1, _n2) = make_state();
-        let ghost = NodeId::new();
+        let ghost = node_key!("ghost");
         let err = state
             .transition_node(ghost, NodeState::Ready)
             .expect_err("unknown node id");

--- a/crates/execution/src/status.rs
+++ b/crates/execution/src/status.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use serde::{Deserialize, Serialize};
 
 /// The overall status of a workflow execution.
@@ -107,7 +107,7 @@ pub enum ExecutionTerminationReason {
     /// Parallel branches still running at the time are cancelled cleanly.
     ExplicitStop {
         /// The node that requested termination.
-        by_node: NodeId,
+        by_node: NodeKey,
         /// Optional note describing why the node chose to stop early.
         note: Option<String>,
     },
@@ -119,7 +119,7 @@ pub enum ExecutionTerminationReason {
     /// Parallel branches still running at the time are cancelled cleanly.
     ExplicitFail {
         /// The node that requested termination.
-        by_node: NodeId,
+        by_node: NodeKey,
         /// Opaque error code identifier.
         ///
         /// See [`ExecutionTerminationCode`] — a thin newtype over
@@ -194,6 +194,8 @@ impl std::fmt::Display for ExecutionTerminationCode {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -298,7 +300,7 @@ mod tests {
     #[test]
     fn termination_reason_explicit_stop_roundtrip() {
         let reason = ExecutionTerminationReason::ExplicitStop {
-            by_node: NodeId::new(),
+            by_node: node_key!("test"),
             note: Some("duplicate detected".into()),
         };
         let json = serde_json::to_string(&reason).unwrap();
@@ -314,7 +316,7 @@ mod tests {
     #[test]
     fn termination_reason_explicit_fail_roundtrip() {
         let reason = ExecutionTerminationReason::ExplicitFail {
-            by_node: NodeId::new(),
+            by_node: node_key!("test"),
             code: "E_VALIDATION".into(),
             message: "field `name` is required".into(),
         };

--- a/crates/expression/src/context.rs
+++ b/crates/expression/src/context.rs
@@ -41,14 +41,14 @@ impl EvaluationContext {
     }
 
     /// Set data for a specific node
-    pub fn set_node_data(&mut self, node_id: impl AsRef<str>, data: Value) {
-        let key: Arc<str> = Arc::from(node_id.as_ref());
+    pub fn set_node_data(&mut self, node_key: impl AsRef<str>, data: Value) {
+        let key: Arc<str> = Arc::from(node_key.as_ref());
         self.nodes.insert(key, Arc::new(data));
     }
 
     /// Get data for a specific node
-    pub fn get_node_data(&self, node_id: &str) -> Option<Arc<Value>> {
-        self.nodes.get(node_id).cloned()
+    pub fn get_node_data(&self, node_key: &str) -> Option<Arc<Value>> {
+        self.nodes.get(node_key).cloned()
     }
 
     /// Set an execution variable
@@ -176,8 +176,8 @@ impl EvaluationContextBuilder {
     }
 
     /// Add node data
-    pub fn node(mut self, node_id: impl AsRef<str>, data: Value) -> Self {
-        let key: Arc<str> = Arc::from(node_id.as_ref());
+    pub fn node(mut self, node_key: impl AsRef<str>, data: Value) -> Self {
+        let key: Arc<str> = Arc::from(node_key.as_ref());
         self.nodes.insert(key, Arc::new(data));
         self
     }

--- a/crates/expression/src/context.rs
+++ b/crates/expression/src/context.rs
@@ -47,7 +47,7 @@ impl EvaluationContext {
     }
 
     /// Get data for a specific node
-    pub fn get_node_data(&self, node_key: &str) -> Option<Arc<Value>> {
+    pub fn node_data(&self, node_key: &str) -> Option<Arc<Value>> {
         self.nodes.get(node_key).cloned()
     }
 
@@ -239,7 +239,7 @@ mod tests {
     fn test_set_and_get_node_data() {
         let mut ctx = EvaluationContext::new();
         ctx.set_node_data("node1", Value::String("test".to_string()));
-        assert_eq!(ctx.get_node_data("node1").unwrap().as_str(), Some("test"));
+        assert_eq!(ctx.node_data("node1").unwrap().as_str(), Some("test"));
     }
 
     #[test]
@@ -251,7 +251,7 @@ mod tests {
             .input(Value::Number(42.into()))
             .build();
 
-        assert_eq!(ctx.get_node_data("node1").unwrap().as_str(), Some("test"));
+        assert_eq!(ctx.node_data("node1").unwrap().as_str(), Some("test"));
         assert_eq!(
             ctx.get_execution_var("id").unwrap().as_str(),
             Some("exec-123")

--- a/crates/log/benches/log_hot_path.rs
+++ b/crates/log/benches/log_hot_path.rs
@@ -54,7 +54,7 @@ impl ObservabilityEvent for BenchEvent {
             match index {
                 0 => visitor.record("operation", ObservabilityFieldValue::Str("http.request")),
                 1 => visitor.record("context", ObservabilityFieldValue::Str("workflow.execute")),
-                2 => visitor.record("node_id", ObservabilityFieldValue::Str("node-42")),
+                2 => visitor.record("node_key", ObservabilityFieldValue::Str("node-42")),
                 3 => visitor.record("tenant_id", ObservabilityFieldValue::Str("tenant-a")),
                 4 => visitor.record("attempt", ObservabilityFieldValue::U64(3)),
                 5 => visitor.record("success", ObservabilityFieldValue::Bool(false)),

--- a/crates/log/examples/resource_based_observability.rs
+++ b/crates/log/examples/resource_based_observability.rs
@@ -44,7 +44,7 @@ impl ResourceAwareHook for WebhookNotificationHook {
         {
             println!(
                 "[WEBHOOK] Node {} - Event: {} -> [CONFIGURED]",
-                ctx.node_id,
+                ctx.node_key,
                 event.name(),
             );
         }

--- a/crates/log/examples/span_like_resources.rs
+++ b/crates/log/examples/span_like_resources.rs
@@ -65,7 +65,7 @@ fn main() {
                 .with_resource(
                     LoggerResource::new()
                         .with_webhook("https://hooks.slack.com/payment-team")
-                        .with_tag("node_id", "node-payment")
+                        .with_tag("node_key", "node-payment")
                         .with_tag("action_id", "validate-card"),
                 )
                 .scope_sync(|| {

--- a/crates/log/src/observability/context.rs
+++ b/crates/log/src/observability/context.rs
@@ -3,7 +3,7 @@
 //! This module provides a hierarchical context system with three levels:
 //! - **GlobalContext**: Application-wide settings (service name, version, environment)
 //! - **ExecutionContext**: Workflow execution scope (execution_id, workflow_id, tenant_id)
-//! - **NodeContext**: Individual node execution (node_id, action_id, resource access)
+//! - **NodeContext**: Individual node execution (node_key, action_id, resource access)
 //!
 //! # Async-Safe Context Propagation
 //!
@@ -340,7 +340,7 @@ impl ExecutionContext {
 #[derive(Debug, Clone)]
 pub struct NodeContext {
     /// Node instance ID
-    pub node_id: String,
+    pub node_key: String,
     /// Action type ID (e.g., "http.request")
     pub action_id: String,
     /// Retry attempt number (0 for first attempt)
@@ -352,9 +352,9 @@ pub struct NodeContext {
 
 impl NodeContext {
     /// Create a new node context
-    pub fn new(node_id: impl Into<String>, action_id: impl Into<String>) -> Self {
+    pub fn new(node_key: impl Into<String>, action_id: impl Into<String>) -> Self {
         Self {
-            node_id: node_id.into(),
+            node_key: node_key.into(),
             action_id: action_id.into(),
             retry_count: 0,
             resources: Arc::new(ResourceMap::new()),
@@ -505,13 +505,13 @@ mod tests {
         let ctx2 = NodeContext::new("node-2", "action-2");
 
         ctx1.scope_sync(|| {
-            assert_eq!(NodeContext::current().unwrap().node_id, "node-1");
+            assert_eq!(NodeContext::current().unwrap().node_key, "node-1");
 
             ctx2.scope_sync(|| {
-                assert_eq!(NodeContext::current().unwrap().node_id, "node-2");
+                assert_eq!(NodeContext::current().unwrap().node_key, "node-2");
             });
 
-            assert_eq!(NodeContext::current().unwrap().node_id, "node-1");
+            assert_eq!(NodeContext::current().unwrap().node_key, "node-1");
         });
 
         assert!(NodeContext::current().is_none());
@@ -533,7 +533,7 @@ mod tests {
                 // service_name depends on test ordering.
                 assert!(snapshot.global.is_some());
                 assert_eq!(snapshot.execution.unwrap().execution_id, "exec-1");
-                assert_eq!(snapshot.node.unwrap().node_id, "node-1");
+                assert_eq!(snapshot.node.unwrap().node_key, "node-1");
             });
         });
     }
@@ -572,11 +572,11 @@ mod tests {
     mod async_tests {
         use super::*;
 
-        async fn assert_node_context_persists(node_id: &str) {
+        async fn assert_node_context_persists(node_key: &str) {
             assert!(ExecutionContext::current().is_some());
-            assert_eq!(NodeContext::current().unwrap().node_id, node_id);
+            assert_eq!(NodeContext::current().unwrap().node_key, node_key);
             tokio::task::yield_now().await;
-            assert_eq!(NodeContext::current().unwrap().node_id, node_id);
+            assert_eq!(NodeContext::current().unwrap().node_key, node_key);
         }
 
         async fn send_current_execution_id(tx: tokio::sync::mpsc::Sender<String>) {
@@ -607,9 +607,9 @@ mod tests {
         async fn test_node_context_survives_await() {
             let ctx = NodeContext::new("node-async", "action-async");
             ctx.scope(async {
-                assert_eq!(NodeContext::current().unwrap().node_id, "node-async");
+                assert_eq!(NodeContext::current().unwrap().node_key, "node-async");
                 tokio::task::yield_now().await;
-                assert_eq!(NodeContext::current().unwrap().node_id, "node-async");
+                assert_eq!(NodeContext::current().unwrap().node_key, "node-async");
             })
             .await;
         }

--- a/crates/log/src/observability/semantic.rs
+++ b/crates/log/src/observability/semantic.rs
@@ -21,7 +21,7 @@ pub mod field {
     /// Distributed trace ID
     pub const TRACE_ID: &str = "trace_id";
     /// Node instance ID
-    pub const NODE_ID: &str = "node_id";
+    pub const NODE_ID: &str = "node_key";
     /// Action type ID (e.g., "http.request")
     pub const ACTION_ID: &str = "action_id";
     /// Retry attempt count

--- a/crates/log/src/observability/semantic.rs
+++ b/crates/log/src/observability/semantic.rs
@@ -20,8 +20,12 @@ pub mod field {
     pub const PARENT_EXECUTION_ID: &str = "parent_execution_id";
     /// Distributed trace ID
     pub const TRACE_ID: &str = "trace_id";
-    /// Node instance ID
-    pub const NODE_ID: &str = "node_key";
+    /// Node key (author-defined workflow node identifier).
+    pub const NODE_KEY: &str = "node_key";
+
+    /// Deprecated alias -- use [`NODE_KEY`] instead.
+    #[deprecated(since = "0.1.0", note = "renamed to NODE_KEY")]
+    pub const NODE_ID: &str = NODE_KEY;
     /// Action type ID (e.g., "http.request")
     pub const ACTION_ID: &str = "action_id";
     /// Retry attempt count

--- a/crates/log/src/observability/span.rs
+++ b/crates/log/src/observability/span.rs
@@ -115,7 +115,7 @@ mod tests {
                     .with_resource(
                         LoggerResource::new()
                             .with_webhook("https://hooks.slack.com/...")
-                            .with_tag("node_id", "node-1"),
+                            .with_tag("node_key", "node-1"),
                     )
                     .scope_sync(|| {
                         let merged = get_current_logger_resource().unwrap();
@@ -126,7 +126,7 @@ mod tests {
                         let tag_keys: Vec<_> =
                             merged.tags.iter().map(|(k, _)| k.as_str()).collect();
                         assert!(tag_keys.contains(&"execution_id"));
-                        assert!(tag_keys.contains(&"node_id"));
+                        assert!(tag_keys.contains(&"node_key"));
                     });
             });
     }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -490,7 +490,7 @@ impl ActionRuntime {
         //      pre-validate here — the handler owns the schema.
         //
         // Any error from the sink itself (transport, serialization, etc.)
-        // is logged at WARN with full (action_key, execution_id, node_id)
+        // is logged at WARN with full (action_key, execution_id, node_key)
         // context and we fall through to init_state. This is the
         // "checkpoint-deser-failure" contract: the runtime MUST NOT
         // silently swallow sink errors — losing iteration progress has to
@@ -503,7 +503,7 @@ impl ActionRuntime {
                     tracing::warn!(
                         action_key = %metadata.key.as_str(),
                         execution_id = %context.execution_id,
-                        node_id = %context.node_id,
+                        node_key = %context.node_key,
                         error = %load_err,
                         "stateful checkpoint load failed — falling back to init_state, \
                          iteration progress (if any) is lost"
@@ -591,7 +591,7 @@ impl ActionRuntime {
                         tracing::warn!(
                             action_key = %metadata.key.as_str(),
                             execution_id = %context.execution_id,
-                            node_id = %context.node_id,
+                            node_key = %context.node_key,
                             error = %clear_err,
                             "stateful checkpoint clear failed on terminal iteration; \
                              orphaned row left for engine GC"
@@ -879,7 +879,8 @@ mod tests {
     };
     use nebula_core::{
         action_key,
-        id::{ExecutionId, NodeId, WorkflowId},
+        id::{ExecutionId, WorkflowId},
+        node_key,
     };
 
     use super::*;
@@ -936,7 +937,7 @@ mod tests {
     fn test_context() -> ActionContext {
         ActionContext::new(
             ExecutionId::new(),
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             tokio_util::sync::CancellationToken::new(),
         )
@@ -945,7 +946,7 @@ mod tests {
     fn test_trigger_context() -> TriggerContext {
         TriggerContext::new(
             WorkflowId::new(),
-            NodeId::new(),
+            node_key!("test"),
             tokio_util::sync::CancellationToken::new(),
         )
     }
@@ -1006,7 +1007,7 @@ mod tests {
         let eid = ExecutionId::new();
         let ctx = ActionContext::new(
             eid,
-            NodeId::new(),
+            node_key!("test"),
             WorkflowId::new(),
             tokio_util::sync::CancellationToken::new(),
         );

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -165,7 +165,7 @@ macro_rules! workflow {
     (
         name: $name:expr,
         nodes: [
-            $($node_id:ident: $action:ty $(=> $next:ident)?),* $(,)?
+            $($node_key:ident: $action:ty $(=> $next:ident)?),* $(,)?
         ]
     ) => {{
         use $crate::workflow::WorkflowBuilder;
@@ -173,11 +173,11 @@ macro_rules! workflow {
         let mut builder = WorkflowBuilder::new($name);
         $(
             builder = builder.add_node(
-                stringify!($node_id),
+                stringify!($node_key),
                 stringify!($action)
             );
             $(
-                builder = builder.connect(stringify!($node_id), stringify!($next));
+                builder = builder.connect(stringify!($node_key), stringify!($next));
             )?
         )*
         builder

--- a/crates/sdk/src/prelude.rs
+++ b/crates/sdk/src/prelude.rs
@@ -41,7 +41,7 @@ pub use nebula_action::{
 // without reaching into `nebula_action::`.
 pub use nebula_action::{impl_batch_action, impl_paginated_action};
 pub use nebula_core::{
-    ActionKey, ExecutionId, NodeId, PluginKey, ScopeLevel, WorkflowId, action_key,
+    ActionKey, ExecutionId, NodeKey, PluginKey, ScopeLevel, WorkflowId, action_key,
 };
 // Credential types (v2)
 pub use nebula_credential::{

--- a/crates/sdk/src/testing.rs
+++ b/crates/sdk/src/testing.rs
@@ -119,12 +119,11 @@ impl<A> ActionTester<A> {
 // input: I,
 // ) -> Result<nebula_action::ActionResult<O>, nebula_action::ActionError> {
 // use nebula_action::ActionContext;
-// use nebula_core::{ExecutionId, NodeId, WorkflowId};
-//
+// use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 // let workflow_id = WorkflowId::new();
 // let ctx = ActionContext::new(
 // ExecutionId::new(),
-// NodeId::new(),
+// node_key!("test"),
 // workflow_id,
 // tokio_util::sync::CancellationToken::new(),
 // );

--- a/crates/sdk/src/workflow.rs
+++ b/crates/sdk/src/workflow.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use nebula_core::{ActionKey, NodeId, WorkflowId};
+use nebula_core::{ActionKey, NodeKey, WorkflowId, node_key};
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, ParamValue, Version, WorkflowConfig, WorkflowDefinition,
     connection::{Connection, EdgeCondition},
@@ -170,10 +170,10 @@ impl WorkflowBuilder {
         }
 
         // Stable mapping between user-facing node ids and typed ids.
-        let node_id_by_name: HashMap<String, NodeId> = self
+        let node_id_by_name: HashMap<String, NodeKey> = self
             .nodes
             .iter()
-            .map(|node| (node.id.clone(), NodeId::new()))
+            .map(|node| (node.id.clone(), node_key!("test")))
             .collect();
 
         // Validate all edge references.
@@ -197,7 +197,7 @@ impl WorkflowBuilder {
             .nodes
             .into_iter()
             .map(|config| -> crate::Result<NodeDefinition> {
-                let node_id = node_id_by_name.get(&config.id).copied().ok_or_else(|| {
+                let node_key = node_id_by_name.get(&config.id).cloned().ok_or_else(|| {
                     crate::Error::workflow(format!("Node id not found in mapping: {}", config.id))
                 })?;
 
@@ -209,7 +209,7 @@ impl WorkflowBuilder {
                 })?;
 
                 Ok(NodeDefinition {
-                    id: node_id,
+                    id: node_key,
                     name: config.name,
                     action_key,
                     interface_version: None,
@@ -228,10 +228,10 @@ impl WorkflowBuilder {
             .connections
             .into_iter()
             .map(|(from, to)| -> crate::Result<Connection> {
-                let from_node = node_id_by_name.get(&from).copied().ok_or_else(|| {
+                let from_node = node_id_by_name.get(&from).cloned().ok_or_else(|| {
                     crate::Error::workflow(format!("Unknown source node in connection: {}", from))
                 })?;
-                let to_node = node_id_by_name.get(&to).copied().ok_or_else(|| {
+                let to_node = node_id_by_name.get(&to).cloned().ok_or_else(|| {
                     crate::Error::workflow(format!("Unknown target node in connection: {}", to))
                 })?;
 

--- a/crates/sdk/src/workflow.rs
+++ b/crates/sdk/src/workflow.rs
@@ -173,7 +173,10 @@ impl WorkflowBuilder {
         let node_id_by_name: HashMap<String, NodeKey> = self
             .nodes
             .iter()
-            .map(|node| (node.id.clone(), node_key!("test")))
+            .map(|node| {
+                let key = NodeKey::new(&node.id).unwrap_or_else(|_| node_key!("fallback"));
+                (node.id.clone(), key)
+            })
             .collect();
 
         // Validate all edge references.

--- a/crates/sdk/src/workflow.rs
+++ b/crates/sdk/src/workflow.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use nebula_core::{ActionKey, NodeKey, WorkflowId, node_key};
+use nebula_core::{ActionKey, NodeKey, WorkflowId};
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, ParamValue, Version, WorkflowConfig, WorkflowDefinition,
     connection::{Connection, EdgeCondition},
@@ -173,8 +173,14 @@ impl WorkflowBuilder {
         let node_id_by_name: HashMap<String, NodeKey> = self
             .nodes
             .iter()
-            .map(|node| {
-                let key = NodeKey::new(&node.id).unwrap_or_else(|_| node_key!("fallback"));
+            .enumerate()
+            .map(|(i, node)| {
+                let key = NodeKey::new(&node.id).unwrap_or_else(|_| {
+                    // Node id is not a valid key (e.g. contains uppercase or special
+                    // chars). Generate a unique fallback so nodes never collide.
+                    let fallback = format!("node_{i}");
+                    NodeKey::new(&fallback).unwrap()
+                });
                 (node.id.clone(), key)
             })
             .collect();

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -6,7 +6,9 @@
 use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
-use nebula_core::{ExecutionId, NodeKey, WorkflowId, node_key};
+#[cfg(all(test, feature = "postgres"))]
+use nebula_core::node_key;
+use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 use sqlx::{Pool, Postgres, types::Json};
 
 use crate::execution_repo::{ExecutionRepo, ExecutionRepoError};
@@ -266,7 +268,7 @@ impl ExecutionRepo for PgExecutionRepo {
         sqlx::query(
             "INSERT INTO node_outputs (execution_id, node_id, attempt, output) \
              VALUES ($1, $2, $3, $4) \
-             ON CONFLICT (execution_id, node_key, attempt) \
+             ON CONFLICT (execution_id, node_id, attempt) \
              DO UPDATE SET output = EXCLUDED.output",
         )
         .bind(execution_id)
@@ -287,7 +289,7 @@ impl ExecutionRepo for PgExecutionRepo {
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
         let row = sqlx::query_as::<_, (Json<serde_json::Value>,)>(
             "SELECT output FROM node_outputs \
-             WHERE execution_id = $1 AND node_key = $2 \
+             WHERE execution_id = $1 AND node_id = $2 \
              ORDER BY attempt DESC \
              LIMIT 1",
         )
@@ -308,7 +310,7 @@ impl ExecutionRepo for PgExecutionRepo {
             "SELECT DISTINCT ON (node_id) node_id, output \
              FROM node_outputs \
              WHERE execution_id = $1 \
-             ORDER BY node_key, attempt DESC",
+             ORDER BY node_id, attempt DESC",
         )
         .bind(execution_id)
         .fetch_all(&self.pool)
@@ -495,12 +497,12 @@ mod tests {
         repo.create(exec_id, wf_id, serde_json::json!({}))
             .await
             .expect("create");
-        repo.save_node_output(exec_id, node_key, 0, output.clone())
+        repo.save_node_output(exec_id, node_key.clone(), 0, output.clone())
             .await
             .expect("save output");
 
         let got = repo
-            .load_node_output(exec_id, node_key)
+            .load_node_output(exec_id, node_key.clone())
             .await
             .expect("load")
             .expect("some");
@@ -519,15 +521,18 @@ mod tests {
         repo.create(exec_id, wf_id, serde_json::json!({}))
             .await
             .expect("create");
-        repo.save_node_output(exec_id, node_key, 0, serde_json::json!("attempt0"))
+        repo.save_node_output(exec_id, node_key.clone(), 0, serde_json::json!("attempt0"))
             .await
             .expect("save attempt 0");
-        repo.save_node_output(exec_id, node_key, 1, serde_json::json!("attempt1"))
+        repo.save_node_output(exec_id, node_key.clone(), 1, serde_json::json!("attempt1"))
             .await
             .expect("save attempt 1");
 
         let all = repo.load_all_outputs(exec_id).await.expect("load all");
-        assert_eq!(all.get(&node_key), Some(&serde_json::json!("attempt1")));
+        assert_eq!(
+            all.get(&node_key.clone()),
+            Some(&serde_json::json!("attempt1"))
+        );
     }
 
     #[tokio::test]
@@ -548,7 +553,7 @@ mod tests {
             "key should not exist yet"
         );
 
-        repo.mark_idempotent(&key, exec_id, node_key)
+        repo.mark_idempotent(&key, exec_id, node_key.clone())
             .await
             .expect("first mark");
 
@@ -560,7 +565,7 @@ mod tests {
         );
 
         // Second mark with same key should be idempotent (ON CONFLICT DO NOTHING).
-        repo.mark_idempotent(&key, exec_id, node_key)
+        repo.mark_idempotent(&key, exec_id, node_key.clone())
             .await
             .expect("second mark should not fail");
 

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -6,7 +6,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use async_trait::async_trait;
-use nebula_core::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{ExecutionId, NodeKey, WorkflowId, node_key};
 use sqlx::{Pool, Postgres, types::Json};
 
 use crate::execution_repo::{ExecutionRepo, ExecutionRepoError};
@@ -256,7 +256,7 @@ impl ExecutionRepo for PgExecutionRepo {
     async fn save_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
         output: serde_json::Value,
     ) -> Result<(), ExecutionRepoError> {
@@ -266,11 +266,11 @@ impl ExecutionRepo for PgExecutionRepo {
         sqlx::query(
             "INSERT INTO node_outputs (execution_id, node_id, attempt, output) \
              VALUES ($1, $2, $3, $4) \
-             ON CONFLICT (execution_id, node_id, attempt) \
+             ON CONFLICT (execution_id, node_key, attempt) \
              DO UPDATE SET output = EXCLUDED.output",
         )
         .bind(execution_id)
-        .bind(node_id)
+        .bind(node_key)
         .bind(attempt_i32)
         .bind(Json(&output))
         .execute(&self.pool)
@@ -283,16 +283,16 @@ impl ExecutionRepo for PgExecutionRepo {
     async fn load_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
         let row = sqlx::query_as::<_, (Json<serde_json::Value>,)>(
             "SELECT output FROM node_outputs \
-             WHERE execution_id = $1 AND node_id = $2 \
+             WHERE execution_id = $1 AND node_key = $2 \
              ORDER BY attempt DESC \
              LIMIT 1",
         )
         .bind(execution_id)
-        .bind(node_id)
+        .bind(node_key)
         .fetch_optional(&self.pool)
         .await
         .map_err(map_err)?;
@@ -303,12 +303,12 @@ impl ExecutionRepo for PgExecutionRepo {
     async fn load_all_outputs(
         &self,
         execution_id: ExecutionId,
-    ) -> Result<HashMap<NodeId, serde_json::Value>, ExecutionRepoError> {
-        let rows = sqlx::query_as::<_, (NodeId, Json<serde_json::Value>)>(
+    ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError> {
+        let rows = sqlx::query_as::<_, (NodeKey, Json<serde_json::Value>)>(
             "SELECT DISTINCT ON (node_id) node_id, output \
              FROM node_outputs \
              WHERE execution_id = $1 \
-             ORDER BY node_id, attempt DESC",
+             ORDER BY node_key, attempt DESC",
         )
         .bind(execution_id)
         .fetch_all(&self.pool)
@@ -317,7 +317,7 @@ impl ExecutionRepo for PgExecutionRepo {
 
         Ok(rows
             .into_iter()
-            .map(|(node_id, output)| (node_id, output.0))
+            .map(|(node_key, output)| (node_key, output.0))
             .collect())
     }
 
@@ -366,7 +366,7 @@ impl ExecutionRepo for PgExecutionRepo {
         &self,
         key: &str,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
     ) -> Result<(), ExecutionRepoError> {
         sqlx::query(
             "INSERT INTO idempotency_keys (key, execution_id, node_id) \
@@ -375,7 +375,7 @@ impl ExecutionRepo for PgExecutionRepo {
         )
         .bind(key)
         .bind(execution_id)
-        .bind(node_id)
+        .bind(node_key)
         .execute(&self.pool)
         .await
         .map_err(|e| map_idempotency_err(e, execution_id))?;
@@ -489,18 +489,18 @@ mod tests {
         };
         let exec_id = ExecutionId::new();
         let wf_id = WorkflowId::new();
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         let output = serde_json::json!({"result": 42});
 
         repo.create(exec_id, wf_id, serde_json::json!({}))
             .await
             .expect("create");
-        repo.save_node_output(exec_id, node_id, 0, output.clone())
+        repo.save_node_output(exec_id, node_key, 0, output.clone())
             .await
             .expect("save output");
 
         let got = repo
-            .load_node_output(exec_id, node_id)
+            .load_node_output(exec_id, node_key)
             .await
             .expect("load")
             .expect("some");
@@ -514,20 +514,20 @@ mod tests {
         };
         let exec_id = ExecutionId::new();
         let wf_id = WorkflowId::new();
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
 
         repo.create(exec_id, wf_id, serde_json::json!({}))
             .await
             .expect("create");
-        repo.save_node_output(exec_id, node_id, 0, serde_json::json!("attempt0"))
+        repo.save_node_output(exec_id, node_key, 0, serde_json::json!("attempt0"))
             .await
             .expect("save attempt 0");
-        repo.save_node_output(exec_id, node_id, 1, serde_json::json!("attempt1"))
+        repo.save_node_output(exec_id, node_key, 1, serde_json::json!("attempt1"))
             .await
             .expect("save attempt 1");
 
         let all = repo.load_all_outputs(exec_id).await.expect("load all");
-        assert_eq!(all.get(&node_id), Some(&serde_json::json!("attempt1")));
+        assert_eq!(all.get(&node_key), Some(&serde_json::json!("attempt1")));
     }
 
     #[tokio::test]
@@ -538,7 +538,7 @@ mod tests {
         let key = format!("test-idempotency-{}", ExecutionId::new());
         let exec_id = ExecutionId::new();
         let wf_id = WorkflowId::new();
-        let node_id = NodeId::new();
+        let node_key = node_key!("test_node");
         repo.create(exec_id, wf_id, serde_json::json!({"status":"created"}))
             .await
             .expect("create execution for idempotency");
@@ -548,7 +548,7 @@ mod tests {
             "key should not exist yet"
         );
 
-        repo.mark_idempotent(&key, exec_id, node_id)
+        repo.mark_idempotent(&key, exec_id, node_key)
             .await
             .expect("first mark");
 
@@ -560,7 +560,7 @@ mod tests {
         );
 
         // Second mark with same key should be idempotent (ON CONFLICT DO NOTHING).
-        repo.mark_idempotent(&key, exec_id, node_id)
+        repo.mark_idempotent(&key, exec_id, node_key)
             .await
             .expect("second mark should not fail");
 
@@ -581,7 +581,7 @@ mod tests {
             .mark_idempotent(
                 &format!("test-idempotency-missing-{}", ExecutionId::new()),
                 ExecutionId::new(),
-                NodeId::new(),
+                node_key!("test"),
             )
             .await
             .expect_err("missing execution should reject idempotency mark");

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use async_trait::async_trait;
-use nebula_core::{ExecutionId, NodeId, WorkflowId};
+use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 use thiserror::Error;
 use tokio::{sync::RwLock, time::Instant};
 
@@ -178,7 +178,7 @@ pub trait ExecutionRepo: Send + Sync {
     async fn save_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
         output: serde_json::Value,
     ) -> Result<(), ExecutionRepoError>;
@@ -187,14 +187,14 @@ pub trait ExecutionRepo: Send + Sync {
     async fn load_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError>;
 
     /// Loads all node outputs for an execution (latest attempt per node).
     async fn load_all_outputs(
         &self,
         execution_id: ExecutionId,
-    ) -> Result<HashMap<NodeId, serde_json::Value>, ExecutionRepoError>;
+    ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError>;
 
     /// Lists execution IDs in non-terminal states.
     async fn list_running(&self) -> Result<Vec<ExecutionId>, ExecutionRepoError>;
@@ -210,7 +210,7 @@ pub trait ExecutionRepo: Send + Sync {
         &self,
         key: &str,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
     ) -> Result<(), ExecutionRepoError>;
 
     // ── Stateful action checkpoints (#308) ──────────────────────────────────
@@ -226,18 +226,18 @@ pub trait ExecutionRepo: Send + Sync {
 
     /// Persist a stateful iteration checkpoint.
     ///
-    /// The key is `(execution_id, node_id, attempt)`. Calling twice with
+    /// The key is `(execution_id, node_key, attempt)`. Calling twice with
     /// the same key overwrites the prior checkpoint — only the latest
     /// iteration boundary is persisted.
     async fn save_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
         iteration: u32,
         state: serde_json::Value,
     ) -> Result<(), ExecutionRepoError> {
-        let _ = (execution_id, node_id, attempt, iteration, state);
+        let _ = (execution_id, node_key, attempt, iteration, state);
         Err(ExecutionRepoError::Internal(
             "save_stateful_checkpoint not implemented for this backend".to_owned(),
         ))
@@ -248,15 +248,15 @@ pub trait ExecutionRepo: Send + Sync {
     /// Returns `Ok(None)` when no checkpoint exists yet (fresh dispatch).
     /// Returns `Err` when the backend cannot be queried (connection,
     /// serialization, etc.) — the runtime logs WARN with full
-    /// `(action_key, execution_id, node_id)` context and falls through to
+    /// `(action_key, execution_id, node_key)` context and falls through to
     /// `init_state` so iteration progress loss is visible, never swallowed.
     async fn load_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
     ) -> Result<Option<StatefulCheckpointRecord>, ExecutionRepoError> {
-        let _ = (execution_id, node_id, attempt);
+        let _ = (execution_id, node_key, attempt);
         Err(ExecutionRepoError::Internal(
             "load_stateful_checkpoint not implemented for this backend".to_owned(),
         ))
@@ -270,10 +270,10 @@ pub trait ExecutionRepo: Send + Sync {
     async fn delete_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
     ) -> Result<(), ExecutionRepoError> {
-        let _ = (execution_id, node_id, attempt);
+        let _ = (execution_id, node_key, attempt);
         Err(ExecutionRepoError::Internal(
             "delete_stateful_checkpoint not implemented for this backend".to_owned(),
         ))
@@ -302,11 +302,11 @@ impl StatefulCheckpointRecord {
     }
 }
 
-/// Key for node output storage: `(execution_id, node_id, attempt)`.
-type NodeOutputKey = (ExecutionId, NodeId, u32);
+/// Key for node output storage: `(execution_id, node_key, attempt)`.
+type NodeOutputKey = (ExecutionId, NodeKey, u32);
 
-/// Key for stateful checkpoint storage: `(execution_id, node_id, attempt)`.
-type StatefulCheckpointKey = (ExecutionId, NodeId, u32);
+/// Key for stateful checkpoint storage: `(execution_id, node_key, attempt)`.
+type StatefulCheckpointKey = (ExecutionId, NodeKey, u32);
 
 /// Lease entry: `(holder, expires_at)`. Expiration is monotonic via
 /// [`tokio::time::Instant`] so paused-time tests behave deterministically.
@@ -469,26 +469,26 @@ impl ExecutionRepo for InMemoryExecutionRepo {
     async fn save_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
         output: serde_json::Value,
     ) -> Result<(), ExecutionRepoError> {
         self.node_outputs
             .write()
             .await
-            .insert((execution_id, node_id, attempt), output);
+            .insert((execution_id, node_key, attempt), output);
         Ok(())
     }
 
     async fn load_node_output(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
         let outputs = self.node_outputs.read().await;
         let best = outputs
             .iter()
-            .filter(|((eid, nid, _), _)| *eid == execution_id && *nid == node_id)
+            .filter(|((eid, nid, _), _)| *eid == execution_id && *nid == node_key)
             .max_by_key(|((_, _, attempt), _)| *attempt)
             .map(|(_, v)| v.clone());
         Ok(best)
@@ -497,14 +497,14 @@ impl ExecutionRepo for InMemoryExecutionRepo {
     async fn load_all_outputs(
         &self,
         execution_id: ExecutionId,
-    ) -> Result<HashMap<NodeId, serde_json::Value>, ExecutionRepoError> {
+    ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError> {
         let outputs = self.node_outputs.read().await;
-        let mut best: HashMap<NodeId, (u32, serde_json::Value)> = HashMap::new();
+        let mut best: HashMap<NodeKey, (u32, serde_json::Value)> = HashMap::new();
         for ((eid, nid, attempt), val) in outputs.iter() {
             if *eid != execution_id {
                 continue;
             }
-            let entry = best.entry(*nid).or_insert((*attempt, val.clone()));
+            let entry = best.entry(nid.clone()).or_insert((*attempt, val.clone()));
             if *attempt > entry.0 {
                 *entry = (*attempt, val.clone());
             }
@@ -546,7 +546,7 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         &self,
         key: &str,
         execution_id: ExecutionId,
-        _node_id: NodeId,
+        _node_id: NodeKey,
     ) -> Result<(), ExecutionRepoError> {
         let state = self.state.read().await;
         let workflows = self.workflows.read().await;
@@ -564,14 +564,14 @@ impl ExecutionRepo for InMemoryExecutionRepo {
     async fn save_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
         iteration: u32,
         state: serde_json::Value,
     ) -> Result<(), ExecutionRepoError> {
         let mut cps = self.stateful_checkpoints.write().await;
         cps.insert(
-            (execution_id, node_id, attempt),
+            (execution_id, node_key, attempt),
             StatefulCheckpointRecord::new(iteration, state),
         );
         Ok(())
@@ -580,27 +580,29 @@ impl ExecutionRepo for InMemoryExecutionRepo {
     async fn load_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
     ) -> Result<Option<StatefulCheckpointRecord>, ExecutionRepoError> {
         let cps = self.stateful_checkpoints.read().await;
-        Ok(cps.get(&(execution_id, node_id, attempt)).cloned())
+        Ok(cps.get(&(execution_id, node_key, attempt)).cloned())
     }
 
     async fn delete_stateful_checkpoint(
         &self,
         execution_id: ExecutionId,
-        node_id: NodeId,
+        node_key: NodeKey,
         attempt: u32,
     ) -> Result<(), ExecutionRepoError> {
         let mut cps = self.stateful_checkpoints.write().await;
-        cps.remove(&(execution_id, node_id, attempt));
+        cps.remove(&(execution_id, node_key, attempt));
         Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[tokio::test]
@@ -679,9 +681,9 @@ mod tests {
     async fn node_output_save_and_load() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
         let output = serde_json::json!({"result": 42});
-        repo.save_node_output(eid, nid, 1, output.clone())
+        repo.save_node_output(eid, nid.clone(), 1, output.clone())
             .await
             .unwrap();
         let loaded = repo.load_node_output(eid, nid).await.unwrap();
@@ -692,11 +694,11 @@ mod tests {
     async fn node_output_returns_latest_attempt() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let nid = NodeId::new();
-        repo.save_node_output(eid, nid, 1, serde_json::json!("first"))
+        let nid = node_key!("nid");
+        repo.save_node_output(eid, nid.clone(), 1, serde_json::json!("first"))
             .await
             .unwrap();
-        repo.save_node_output(eid, nid, 2, serde_json::json!("second"))
+        repo.save_node_output(eid, nid.clone(), 2, serde_json::json!("second"))
             .await
             .unwrap();
         let loaded = repo.load_node_output(eid, nid).await.unwrap();
@@ -707,15 +709,15 @@ mod tests {
     async fn load_all_outputs_returns_latest_per_node() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let n1 = NodeId::new();
-        let n2 = NodeId::new();
-        repo.save_node_output(eid, n1, 1, serde_json::json!("n1_v1"))
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+        repo.save_node_output(eid, n1.clone(), 1, serde_json::json!("n1_v1"))
             .await
             .unwrap();
-        repo.save_node_output(eid, n1, 2, serde_json::json!("n1_v2"))
+        repo.save_node_output(eid, n1.clone(), 2, serde_json::json!("n1_v2"))
             .await
             .unwrap();
-        repo.save_node_output(eid, n2, 1, serde_json::json!("n2_v1"))
+        repo.save_node_output(eid, n2.clone(), 1, serde_json::json!("n2_v1"))
             .await
             .unwrap();
         let all = repo.load_all_outputs(eid).await.unwrap();
@@ -734,7 +736,9 @@ mod tests {
             .await
             .unwrap();
         assert!(!repo.check_idempotency(key).await.unwrap());
-        repo.mark_idempotent(key, eid, NodeId::new()).await.unwrap();
+        repo.mark_idempotent(key, eid, node_key!("test"))
+            .await
+            .unwrap();
         assert!(repo.check_idempotency(key).await.unwrap());
     }
 
@@ -743,7 +747,7 @@ mod tests {
         let repo = InMemoryExecutionRepo::default();
         let missing = ExecutionId::new();
         let err = repo
-            .mark_idempotent("k", missing, NodeId::new())
+            .mark_idempotent("k", missing, node_key!("test"))
             .await
             .unwrap_err();
         assert!(matches!(
@@ -759,16 +763,18 @@ mod tests {
     async fn stateful_checkpoint_save_load_round_trip() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
         let state = serde_json::json!({"cursor": "page-2", "count": 42u32});
 
         // Empty before first save.
         assert_eq!(
-            repo.load_stateful_checkpoint(eid, nid, 0).await.unwrap(),
+            repo.load_stateful_checkpoint(eid, nid.clone(), 0)
+                .await
+                .unwrap(),
             None
         );
 
-        repo.save_stateful_checkpoint(eid, nid, 0, 5, state.clone())
+        repo.save_stateful_checkpoint(eid, nid.clone(), 0, 5, state.clone())
             .await
             .unwrap();
         let loaded = repo
@@ -784,20 +790,24 @@ mod tests {
     async fn stateful_checkpoint_delete_removes_row() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
 
-        repo.save_stateful_checkpoint(eid, nid, 2, 1, serde_json::json!({"k": 1}))
+        repo.save_stateful_checkpoint(eid, nid.clone(), 2, 1, serde_json::json!({"k": 1}))
             .await
             .unwrap();
         assert!(
-            repo.load_stateful_checkpoint(eid, nid, 2)
+            repo.load_stateful_checkpoint(eid, nid.clone(), 2)
                 .await
                 .unwrap()
                 .is_some()
         );
-        repo.delete_stateful_checkpoint(eid, nid, 2).await.unwrap();
+        repo.delete_stateful_checkpoint(eid, nid.clone(), 2)
+            .await
+            .unwrap();
         assert_eq!(
-            repo.load_stateful_checkpoint(eid, nid, 2).await.unwrap(),
+            repo.load_stateful_checkpoint(eid, nid.clone(), 2)
+                .await
+                .unwrap(),
             None
         );
         // Double-delete is idempotent.
@@ -808,22 +818,22 @@ mod tests {
     async fn stateful_checkpoint_is_scoped_by_attempt() {
         let repo = InMemoryExecutionRepo::default();
         let eid = ExecutionId::new();
-        let nid = NodeId::new();
+        let nid = node_key!("nid");
 
-        repo.save_stateful_checkpoint(eid, nid, 0, 1, serde_json::json!("attempt-0"))
+        repo.save_stateful_checkpoint(eid, nid.clone(), 0, 1, serde_json::json!("attempt-0"))
             .await
             .unwrap();
-        repo.save_stateful_checkpoint(eid, nid, 1, 1, serde_json::json!("attempt-1"))
+        repo.save_stateful_checkpoint(eid, nid.clone(), 1, 1, serde_json::json!("attempt-1"))
             .await
             .unwrap();
 
         let a0 = repo
-            .load_stateful_checkpoint(eid, nid, 0)
+            .load_stateful_checkpoint(eid, nid.clone(), 0)
             .await
             .unwrap()
             .unwrap();
         let a1 = repo
-            .load_stateful_checkpoint(eid, nid, 1)
+            .load_stateful_checkpoint(eid, nid.clone(), 1)
             .await
             .unwrap()
             .unwrap();
@@ -831,9 +841,13 @@ mod tests {
         assert_eq!(a1.state, serde_json::json!("attempt-1"));
 
         // Deleting one attempt does not touch the other.
-        repo.delete_stateful_checkpoint(eid, nid, 0).await.unwrap();
+        repo.delete_stateful_checkpoint(eid, nid.clone(), 0)
+            .await
+            .unwrap();
         assert_eq!(
-            repo.load_stateful_checkpoint(eid, nid, 0).await.unwrap(),
+            repo.load_stateful_checkpoint(eid, nid.clone(), 0)
+                .await
+                .unwrap(),
             None
         );
         assert!(

--- a/crates/workflow/src/builder.rs
+++ b/crates/workflow/src/builder.rs
@@ -179,11 +179,11 @@ impl WorkflowBuilder {
             return Err(WorkflowError::NoNodes);
         }
 
-        // Check duplicate node IDs
+        // Check duplicate node keys
         let mut seen = std::collections::HashSet::new();
         for node in &self.nodes {
             if !seen.insert(node.id.clone()) {
-                return Err(WorkflowError::DuplicateNodeId(node.id.clone()));
+                return Err(WorkflowError::DuplicateNodeKey(node.id.clone()));
             }
         }
 
@@ -298,7 +298,7 @@ mod tests {
             .add_node(node(a))
             .build()
             .unwrap_err();
-        assert!(matches!(err, WorkflowError::DuplicateNodeId(_)));
+        assert!(matches!(err, WorkflowError::DuplicateNodeKey(_)));
     }
 
     #[test]

--- a/crates/workflow/src/builder.rs
+++ b/crates/workflow/src/builder.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use chrono::Utc;
-use nebula_core::{NodeId, WorkflowId};
+use nebula_core::{NodeKey, WorkflowId};
 
 use crate::{
     Version,
@@ -79,7 +79,7 @@ impl WorkflowBuilder {
 
     /// Add an unconditional connection between two nodes.
     #[must_use]
-    pub fn connect(mut self, from: NodeId, to: NodeId) -> Self {
+    pub fn connect(mut self, from: NodeKey, to: NodeKey) -> Self {
         self.connections.push(Connection::new(from, to));
         self
     }
@@ -88,8 +88,8 @@ impl WorkflowBuilder {
     #[must_use]
     pub fn connect_with_condition(
         mut self,
-        from: NodeId,
-        to: NodeId,
+        from: NodeKey,
+        to: NodeKey,
         condition: EdgeCondition,
     ) -> Self {
         self.connections
@@ -101,9 +101,9 @@ impl WorkflowBuilder {
     #[must_use]
     pub fn connect_port(
         mut self,
-        from: NodeId,
+        from: NodeKey,
         from_port: impl Into<String>,
-        to: NodeId,
+        to: NodeKey,
         to_port: impl Into<String>,
     ) -> Self {
         self.connections
@@ -182,15 +182,15 @@ impl WorkflowBuilder {
         // Check duplicate node IDs
         let mut seen = std::collections::HashSet::new();
         for node in &self.nodes {
-            if !seen.insert(node.id) {
-                return Err(WorkflowError::DuplicateNodeId(node.id));
+            if !seen.insert(node.id.clone()) {
+                return Err(WorkflowError::DuplicateNodeId(node.id.clone()));
             }
         }
 
         // Check self-loops
         for conn in &self.connections {
             if conn.is_self_loop() {
-                return Err(WorkflowError::SelfLoop(conn.from_node));
+                return Err(WorkflowError::SelfLoop(conn.from_node.clone()));
             }
         }
 
@@ -223,25 +223,25 @@ impl WorkflowBuilder {
 
 #[cfg(test)]
 mod tests {
-    use nebula_core::NodeId;
+    use nebula_core::{NodeKey, node_key};
 
     use super::*;
 
-    fn node(id: NodeId) -> NodeDefinition {
+    fn node(id: NodeKey) -> NodeDefinition {
         NodeDefinition::new(id, "n", "n").unwrap()
     }
 
     #[test]
     fn build_linear_workflow() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
 
         let def = WorkflowBuilder::new("linear")
-            .add_node(node(a))
-            .add_node(node(b))
-            .add_node(node(c))
-            .connect(a, b)
+            .add_node(node(a.clone()))
+            .add_node(node(b.clone()))
+            .add_node(node(c.clone()))
+            .connect(a, b.clone())
             .connect(b, c)
             .build()
             .unwrap();
@@ -253,19 +253,19 @@ mod tests {
 
     #[test]
     fn build_diamond_workflow() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let c = NodeId::new();
-        let d = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let d = node_key!("d");
 
         let def = WorkflowBuilder::new("diamond")
-            .add_node(node(a))
-            .add_node(node(b))
-            .add_node(node(c))
-            .add_node(node(d))
-            .connect(a, b)
-            .connect(a, c)
-            .connect(b, d)
+            .add_node(node(a.clone()))
+            .add_node(node(b.clone()))
+            .add_node(node(c.clone()))
+            .add_node(node(d.clone()))
+            .connect(a.clone(), b.clone())
+            .connect(a, c.clone())
+            .connect(b, d.clone())
             .connect(c, d)
             .build()
             .unwrap();
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn build_empty_name_fails() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let err = WorkflowBuilder::new("")
             .add_node(node(a))
             .build()
@@ -292,9 +292,9 @@ mod tests {
 
     #[test]
     fn build_duplicate_node_ids_fails() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let err = WorkflowBuilder::new("dup")
-            .add_node(node(a))
+            .add_node(node(a.clone()))
             .add_node(node(a))
             .build()
             .unwrap_err();
@@ -303,10 +303,10 @@ mod tests {
 
     #[test]
     fn build_self_loop_fails() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let err = WorkflowBuilder::new("loop")
-            .add_node(node(a))
-            .connect(a, a)
+            .add_node(node(a.clone()))
+            .connect(a.clone(), a)
             .build()
             .unwrap_err();
         assert!(matches!(err, WorkflowError::SelfLoop(_)));
@@ -314,12 +314,12 @@ mod tests {
 
     #[test]
     fn build_cycle_detected() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let err = WorkflowBuilder::new("cycle")
-            .add_node(node(a))
-            .add_node(node(b))
-            .connect(a, b)
+            .add_node(node(a.clone()))
+            .add_node(node(b.clone()))
+            .connect(a.clone(), b.clone())
             .connect(b, a)
             .build()
             .unwrap_err();
@@ -328,7 +328,7 @@ mod tests {
 
     #[test]
     fn build_with_variables_tags_config() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let def = WorkflowBuilder::new("configured")
             .description("A test workflow")
             .version(Version::new(1, 0, 0))
@@ -366,7 +366,7 @@ mod tests {
 
     #[test]
     fn owner_accepts_valid_string() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let def = WorkflowBuilder::new("owned")
             .owner("user_123")
             .unwrap()

--- a/crates/workflow/src/connection.rs
+++ b/crates/workflow/src/connection.rs
@@ -1,15 +1,15 @@
 //! Edge (connection) types linking workflow nodes.
 
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use serde::{Deserialize, Serialize};
 
 /// A directed edge from one node to another, optionally conditional.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Connection {
     /// Source node.
-    pub from_node: NodeId,
+    pub from_node: NodeKey,
     /// Target node.
-    pub to_node: NodeId,
+    pub to_node: NodeKey,
     /// When the edge should be traversed.
     #[serde(default)]
     pub condition: EdgeCondition,
@@ -27,7 +27,7 @@ pub struct Connection {
 impl Connection {
     /// Create an unconditional connection.
     #[must_use]
-    pub fn new(from_node: NodeId, to_node: NodeId) -> Self {
+    pub fn new(from_node: NodeKey, to_node: NodeKey) -> Self {
         Self {
             from_node,
             to_node,
@@ -148,13 +148,15 @@ pub enum ErrorMatcher {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
     fn connection_new() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let conn = Connection::new(a, b);
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let conn = Connection::new(a.clone(), b.clone());
         assert_eq!(conn.from_node, a);
         assert_eq!(conn.to_node, b);
         assert!(matches!(conn.condition, EdgeCondition::Always));
@@ -165,16 +167,16 @@ mod tests {
 
     #[test]
     fn connection_is_self_loop() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        assert!(Connection::new(a, a).is_self_loop());
+        let a = node_key!("a");
+        let b = node_key!("b");
+        assert!(Connection::new(a.clone(), a.clone()).is_self_loop());
         assert!(!Connection::new(a, b).is_self_loop());
     }
 
     #[test]
     fn connection_builder_methods() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let conn = Connection::new(a, b)
             .with_condition(EdgeCondition::Expression {
                 expr: "x > 0".into(),
@@ -211,9 +213,9 @@ mod tests {
 
     #[test]
     fn connection_serde_roundtrip() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let conn = Connection::new(a, b)
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let conn = Connection::new(a.clone(), b.clone())
             .with_condition(EdgeCondition::OnResult {
                 matcher: ResultMatcher::FieldEquals {
                     field: "status".into(),

--- a/crates/workflow/src/definition.rs
+++ b/crates/workflow/src/definition.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use chrono::{DateTime, Utc};
-use nebula_core::{NodeId, WorkflowId};
+use nebula_core::{NodeKey, WorkflowId};
 use serde::{Deserialize, Serialize};
 
 use crate::{Version, connection::Connection, node::NodeDefinition};
@@ -220,7 +220,7 @@ fn default_schema_version() -> u32 {
 pub struct UiMetadata {
     /// Per-node visual properties (position, color, collapsed state).
     #[serde(default)]
-    pub node_positions: HashMap<NodeId, NodePosition>,
+    pub node_positions: HashMap<NodeKey, NodePosition>,
     /// Editor viewport (zoom, scroll position).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub viewport: Option<Viewport>,
@@ -265,6 +265,8 @@ pub struct Annotation {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
@@ -405,7 +407,7 @@ mod tests {
     fn ui_metadata_round_trips() {
         let mut ui = UiMetadata::default();
         ui.node_positions
-            .insert(NodeId::new(), NodePosition { x: 100.0, y: 200.0 });
+            .insert(node_key!("test"), NodePosition { x: 100.0, y: 200.0 });
         ui.viewport = Some(Viewport {
             x: 0.0,
             y: 0.0,

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -1,6 +1,6 @@
 //! Workflow-specific error types.
 
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use thiserror::Error;
 
 /// Errors that can occur during workflow definition, validation, or graph construction.
@@ -19,17 +19,17 @@ pub enum WorkflowError {
     /// Duplicate node id found.
     #[classify(category = "validation", code = "WORKFLOW:DUPLICATE_NODE_ID")]
     #[error("duplicate node id: {0}")]
-    DuplicateNodeId(NodeId),
+    DuplicateNodeId(NodeKey),
 
     /// Connection references a node that does not exist.
     #[classify(category = "validation", code = "WORKFLOW:UNKNOWN_NODE")]
     #[error("connection references unknown node: {0}")]
-    UnknownNode(NodeId),
+    UnknownNode(NodeKey),
 
     /// A connection has the same source and target node.
     #[classify(category = "validation", code = "WORKFLOW:SELF_LOOP")]
     #[error("self-loop detected on node: {0}")]
-    SelfLoop(NodeId),
+    SelfLoop(NodeKey),
 
     /// The workflow graph contains a cycle and is not a DAG.
     #[classify(category = "validation", code = "WORKFLOW:CYCLE_DETECTED")]
@@ -43,12 +43,12 @@ pub enum WorkflowError {
 
     /// A parameter reference points to a node that does not exist.
     #[classify(category = "validation", code = "WORKFLOW:INVALID_PARAM_REF")]
-    #[error("node {node_id} references unknown parameter source node: {source_node_id}")]
+    #[error("node {node_key} references unknown parameter source node: {source_node_key}")]
     InvalidParameterReference {
         /// The node containing the bad reference.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// The referenced node that does not exist.
-        source_node_id: NodeId,
+        source_node_key: NodeKey,
     },
 
     /// Invalid action key format.
@@ -99,8 +99,8 @@ pub enum WorkflowError {
     #[error("duplicate connection from {from} to {to}")]
     DuplicateConnection {
         /// Source node of the duplicated connection.
-        from: NodeId,
+        from: NodeKey,
         /// Target node of the duplicated connection.
-        to: NodeId,
+        to: NodeKey,
     },
 }

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -16,10 +16,10 @@ pub enum WorkflowError {
     #[error("workflow must have at least one node")]
     NoNodes,
 
-    /// Duplicate node id found.
-    #[classify(category = "validation", code = "WORKFLOW:DUPLICATE_NODE_ID")]
-    #[error("duplicate node id: {0}")]
-    DuplicateNodeId(NodeKey),
+    /// Duplicate node key found.
+    #[classify(category = "validation", code = "WORKFLOW:DUPLICATE_NODE_KEY")]
+    #[error("duplicate node key: {0}")]
+    DuplicateNodeKey(NodeKey),
 
     /// Connection references a node that does not exist.
     #[classify(category = "validation", code = "WORKFLOW:UNKNOWN_NODE")]

--- a/crates/workflow/src/graph.rs
+++ b/crates/workflow/src/graph.rs
@@ -2,7 +2,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use nebula_core::NodeId;
+use nebula_core::NodeKey;
 use petgraph::{
     Direction, algo,
     graph::{DiGraph, NodeIndex},
@@ -13,8 +13,8 @@ use crate::{connection::Connection, definition::WorkflowDefinition, error::Workf
 /// A directed acyclic graph representing the execution dependencies between workflow nodes.
 #[derive(Debug)]
 pub struct DependencyGraph {
-    graph: DiGraph<NodeId, Connection>,
-    index_map: HashMap<NodeId, NodeIndex>,
+    graph: DiGraph<NodeKey, Connection>,
+    index_map: HashMap<NodeKey, NodeIndex>,
 }
 
 impl DependencyGraph {
@@ -26,26 +26,26 @@ impl DependencyGraph {
         let mut index_map = HashMap::new();
 
         for node in &definition.nodes {
-            let idx = graph.add_node(node.id);
+            let idx = graph.add_node(node.id.clone());
             // `validate_workflow` also checks duplicates, but plan builders
             // call this constructor directly without that pass, so an
             // unchecked `insert` would orphan the first of two duplicate
             // nodes inside `petgraph` while silently losing it from the
             // index map. Fail loudly here.
-            if index_map.insert(node.id, idx).is_some() {
-                return Err(WorkflowError::DuplicateNodeId(node.id));
+            if index_map.insert(node.id.clone(), idx).is_some() {
+                return Err(WorkflowError::DuplicateNodeId(node.id.clone()));
             }
         }
 
         for conn in &definition.connections {
             let from_idx = index_map
                 .get(&conn.from_node)
-                .ok_or(WorkflowError::UnknownNode(conn.from_node))?;
+                .ok_or(WorkflowError::UnknownNode(conn.from_node.clone()))?;
             let to_idx = index_map
                 .get(&conn.to_node)
-                .ok_or(WorkflowError::UnknownNode(conn.to_node))?;
+                .ok_or(WorkflowError::UnknownNode(conn.to_node.clone()))?;
             if conn.from_node == conn.to_node {
-                return Err(WorkflowError::SelfLoop(conn.from_node));
+                return Err(WorkflowError::SelfLoop(conn.from_node.clone()));
             }
             graph.add_edge(*from_idx, *to_idx, conn.clone());
         }
@@ -60,16 +60,19 @@ impl DependencyGraph {
     }
 
     /// Topological sort of the graph. Returns an error if a cycle exists.
-    pub fn topological_sort(&self) -> Result<Vec<NodeId>, WorkflowError> {
+    pub fn topological_sort(&self) -> Result<Vec<NodeKey>, WorkflowError> {
         let sorted = algo::toposort(&self.graph, None).map_err(|_| WorkflowError::CycleDetected)?;
-        Ok(sorted.into_iter().map(|idx| self.graph[idx]).collect())
+        Ok(sorted
+            .into_iter()
+            .map(|idx| self.graph[idx].clone())
+            .collect())
     }
 
     /// Compute parallel execution levels using Kahn's algorithm.
     ///
     /// Each level contains nodes whose predecessors all appear in earlier levels,
     /// meaning the nodes within a single level can execute concurrently.
-    pub fn compute_levels(&self) -> Result<Vec<Vec<NodeId>>, WorkflowError> {
+    pub fn compute_levels(&self) -> Result<Vec<Vec<NodeKey>>, WorkflowError> {
         let mut in_degree: HashMap<NodeIndex, usize> = HashMap::new();
         for idx in self.graph.node_indices() {
             in_degree.insert(
@@ -108,7 +111,7 @@ impl DependencyGraph {
             levels.push(
                 current_level
                     .into_iter()
-                    .map(|idx| self.graph[idx])
+                    .map(|idx| self.graph[idx].clone())
                     .collect(),
             );
         }
@@ -118,7 +121,7 @@ impl DependencyGraph {
 
     /// Get all incoming connections (edges pointing TO this node).
     #[must_use]
-    pub fn incoming_connections(&self, id: NodeId) -> Vec<&Connection> {
+    pub fn incoming_connections(&self, id: NodeKey) -> Vec<&Connection> {
         let Some(&idx) = self.index_map.get(&id) else {
             return Vec::new();
         };
@@ -130,7 +133,7 @@ impl DependencyGraph {
 
     /// Get all outgoing connections (edges leaving FROM this node).
     #[must_use]
-    pub fn outgoing_connections(&self, id: NodeId) -> Vec<&Connection> {
+    pub fn outgoing_connections(&self, id: NodeKey) -> Vec<&Connection> {
         let Some(&idx) = self.index_map.get(&id) else {
             return Vec::new();
         };
@@ -142,7 +145,7 @@ impl DependencyGraph {
 
     /// Nodes with no incoming edges (start points of the DAG).
     #[must_use]
-    pub fn entry_nodes(&self) -> Vec<NodeId> {
+    pub fn entry_nodes(&self) -> Vec<NodeKey> {
         self.graph
             .node_indices()
             .filter(|&idx| {
@@ -151,13 +154,13 @@ impl DependencyGraph {
                     .count()
                     == 0
             })
-            .map(|idx| self.graph[idx])
+            .map(|idx| self.graph[idx].clone())
             .collect()
     }
 
     /// Nodes with no outgoing edges (end points of the DAG).
     #[must_use]
-    pub fn exit_nodes(&self) -> Vec<NodeId> {
+    pub fn exit_nodes(&self) -> Vec<NodeKey> {
         self.graph
             .node_indices()
             .filter(|&idx| {
@@ -166,17 +169,17 @@ impl DependencyGraph {
                     .count()
                     == 0
             })
-            .map(|idx| self.graph[idx])
+            .map(|idx| self.graph[idx].clone())
             .collect()
     }
 
     /// Get the predecessor (upstream) node IDs of a given node.
     #[must_use]
-    pub fn predecessors(&self, id: NodeId) -> Vec<NodeId> {
+    pub fn predecessors(&self, id: NodeKey) -> Vec<NodeKey> {
         if let Some(&idx) = self.index_map.get(&id) {
             self.graph
                 .neighbors_directed(idx, Direction::Incoming)
-                .map(|i| self.graph[i])
+                .map(|i| self.graph[i].clone())
                 .collect()
         } else {
             Vec::new()
@@ -185,11 +188,11 @@ impl DependencyGraph {
 
     /// Get the successor (downstream) node IDs of a given node.
     #[must_use]
-    pub fn successors(&self, id: NodeId) -> Vec<NodeId> {
+    pub fn successors(&self, id: NodeKey) -> Vec<NodeKey> {
         if let Some(&idx) = self.index_map.get(&id) {
             self.graph
                 .neighbors_directed(idx, Direction::Outgoing)
-                .map(|i| self.graph[i])
+                .map(|i| self.graph[i].clone())
                 .collect()
         } else {
             Vec::new()
@@ -225,7 +228,7 @@ mod tests {
     use std::collections::HashMap;
 
     use chrono::Utc;
-    use nebula_core::{NodeId, WorkflowId};
+    use nebula_core::{NodeKey, WorkflowId, node_key};
 
     use super::*;
     use crate::{
@@ -260,36 +263,46 @@ mod tests {
         }
     }
 
-    fn node(id: NodeId) -> NodeDefinition {
+    fn node(id: NodeKey) -> NodeDefinition {
         NodeDefinition::new(id, "n", "n").unwrap()
     }
 
     // --- linear graph: A -> B -> C ---
 
-    fn linear_ids() -> (NodeId, NodeId, NodeId) {
-        (NodeId::new(), NodeId::new(), NodeId::new())
+    fn linear_ids() -> (NodeKey, NodeKey, NodeKey) {
+        (node_key!("a"), node_key!("b"), node_key!("c"))
     }
 
-    fn linear_definition(a: NodeId, b: NodeId, c: NodeId) -> WorkflowDefinition {
+    fn linear_definition(a: NodeKey, b: NodeKey, c: NodeKey) -> WorkflowDefinition {
         make_definition(
-            vec![node(a), node(b), node(c)],
-            vec![Connection::new(a, b), Connection::new(b, c)],
+            vec![node(a.clone()), node(b.clone()), node(c.clone())],
+            vec![Connection::new(a, b.clone()), Connection::new(b, c)],
         )
     }
 
     // --- diamond graph: A -> B, A -> C, B -> D, C -> D ---
 
-    fn diamond_ids() -> (NodeId, NodeId, NodeId, NodeId) {
-        (NodeId::new(), NodeId::new(), NodeId::new(), NodeId::new())
+    fn diamond_ids() -> (NodeKey, NodeKey, NodeKey, NodeKey) {
+        (
+            node_key!("a"),
+            node_key!("b"),
+            node_key!("c"),
+            node_key!("d"),
+        )
     }
 
-    fn diamond_definition(a: NodeId, b: NodeId, c: NodeId, d: NodeId) -> WorkflowDefinition {
+    fn diamond_definition(a: NodeKey, b: NodeKey, c: NodeKey, d: NodeKey) -> WorkflowDefinition {
         make_definition(
-            vec![node(a), node(b), node(c), node(d)],
             vec![
-                Connection::new(a, b),
-                Connection::new(a, c),
-                Connection::new(b, d),
+                node(a.clone()),
+                node(b.clone()),
+                node(c.clone()),
+                node(d.clone()),
+            ],
+            vec![
+                Connection::new(a.clone(), b.clone()),
+                Connection::new(a, c.clone()),
+                Connection::new(b, d.clone()),
                 Connection::new(c, d),
             ],
         )
@@ -315,28 +328,28 @@ mod tests {
 
     #[test]
     fn from_definition_rejects_unknown_node() {
-        let a = NodeId::new();
-        let unknown = NodeId::new();
-        let def = make_definition(vec![node(a)], vec![Connection::new(a, unknown)]);
+        let a = node_key!("a");
+        let unknown = node_key!("unknown");
+        let def = make_definition(vec![node(a.clone())], vec![Connection::new(a, unknown)]);
         let err = DependencyGraph::from_definition(&def).unwrap_err();
         assert!(matches!(err, WorkflowError::UnknownNode(_)));
     }
 
     #[test]
     fn from_definition_rejects_self_loop() {
-        let a = NodeId::new();
-        let def = make_definition(vec![node(a)], vec![Connection::new(a, a)]);
+        let a = node_key!("a");
+        let def = make_definition(vec![node(a.clone())], vec![Connection::new(a.clone(), a)]);
         let err = DependencyGraph::from_definition(&def).unwrap_err();
         assert!(matches!(err, WorkflowError::SelfLoop(_)));
     }
 
     #[test]
     fn has_cycle_detects_cycle() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let def = make_definition(
-            vec![node(a), node(b)],
-            vec![Connection::new(a, b), Connection::new(b, a)],
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a.clone(), b.clone()), Connection::new(b, a)],
         );
         let graph = DependencyGraph::from_definition(&def).unwrap();
         assert!(graph.has_cycle());
@@ -353,7 +366,7 @@ mod tests {
     #[test]
     fn topological_sort_linear() {
         let (a, b, c) = linear_ids();
-        let def = linear_definition(a, b, c);
+        let def = linear_definition(a.clone(), b.clone(), c.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
         let sorted = graph.topological_sort().unwrap();
         assert_eq!(sorted, vec![a, b, c]);
@@ -362,7 +375,7 @@ mod tests {
     #[test]
     fn topological_sort_diamond() {
         let (a, b, c, d) = diamond_ids();
-        let def = diamond_definition(a, b, c, d);
+        let def = diamond_definition(a.clone(), b.clone(), c.clone(), d.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
         let sorted = graph.topological_sort().unwrap();
 
@@ -377,7 +390,7 @@ mod tests {
     #[test]
     fn compute_levels_linear() {
         let (a, b, c) = linear_ids();
-        let def = linear_definition(a, b, c);
+        let def = linear_definition(a.clone(), b.clone(), c.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
         let levels = graph.compute_levels().unwrap();
 
@@ -390,7 +403,7 @@ mod tests {
     #[test]
     fn compute_levels_diamond() {
         let (a, b, c, d) = diamond_ids();
-        let def = diamond_definition(a, b, c, d);
+        let def = diamond_definition(a.clone(), b.clone(), c.clone(), d.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
         let levels = graph.compute_levels().unwrap();
 
@@ -406,7 +419,7 @@ mod tests {
     #[test]
     fn entry_and_exit_nodes() {
         let (a, b, c, d) = diamond_ids();
-        let def = diamond_definition(a, b, c, d);
+        let def = diamond_definition(a.clone(), b, c, d.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
 
         let entries = graph.entry_nodes();
@@ -421,18 +434,18 @@ mod tests {
     #[test]
     fn predecessors_and_successors() {
         let (a, b, c, d) = diamond_ids();
-        let def = diamond_definition(a, b, c, d);
+        let def = diamond_definition(a.clone(), b.clone(), c.clone(), d.clone());
         let graph = DependencyGraph::from_definition(&def).unwrap();
 
         // a has no predecessors, two successors
-        assert!(graph.predecessors(a).is_empty());
+        assert!(graph.predecessors(a.clone()).is_empty());
         let a_succ = graph.successors(a);
         assert_eq!(a_succ.len(), 2);
         assert!(a_succ.contains(&b));
         assert!(a_succ.contains(&c));
 
         // d has two predecessors, no successors
-        let d_pred = graph.predecessors(d);
+        let d_pred = graph.predecessors(d.clone());
         assert_eq!(d_pred.len(), 2);
         assert!(d_pred.contains(&b));
         assert!(d_pred.contains(&c));
@@ -441,10 +454,10 @@ mod tests {
 
     #[test]
     fn predecessors_unknown_node_returns_empty() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let def = make_definition(vec![node(a)], vec![]);
         let graph = DependencyGraph::from_definition(&def).unwrap();
-        assert!(graph.predecessors(NodeId::new()).is_empty());
+        assert!(graph.predecessors(node_key!("test")).is_empty());
     }
 
     #[test]
@@ -457,11 +470,11 @@ mod tests {
 
     #[test]
     fn validate_cyclic_graph() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let def = make_definition(
-            vec![node(a), node(b)],
-            vec![Connection::new(a, b), Connection::new(b, a)],
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a.clone(), b.clone()), Connection::new(b, a)],
         );
         let graph = DependencyGraph::from_definition(&def).unwrap();
         let err = graph.validate().unwrap_err();

--- a/crates/workflow/src/graph.rs
+++ b/crates/workflow/src/graph.rs
@@ -33,7 +33,7 @@ impl DependencyGraph {
             // nodes inside `petgraph` while silently losing it from the
             // index map. Fail loudly here.
             if index_map.insert(node.id.clone(), idx).is_some() {
-                return Err(WorkflowError::DuplicateNodeId(node.id.clone()));
+                return Err(WorkflowError::DuplicateNodeKey(node.id.clone()));
             }
         }
 

--- a/crates/workflow/src/node.rs
+++ b/crates/workflow/src/node.rs
@@ -3,7 +3,7 @@
 use std::{collections::HashMap, time::Duration};
 
 use nebula_action::InterfaceVersion;
-use nebula_core::{ActionKey, NodeId, prelude::KeyParseError};
+use nebula_core::{ActionKey, NodeKey, prelude::KeyParseError};
 use serde::{Deserialize, Serialize};
 
 use crate::definition::RetryConfig;
@@ -12,7 +12,7 @@ use crate::definition::RetryConfig;
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct NodeDefinition {
     /// Unique node identifier within this workflow.
-    pub id: NodeId,
+    pub id: NodeKey,
     /// Human-readable label.
     pub name: String,
     /// Which action/plugin this node runs (e.g. `"http_request"`, `"echo"`).
@@ -74,7 +74,7 @@ impl NodeDefinition {
     /// Returns [`InvalidActionKey`](crate::WorkflowError::InvalidActionKey) if `action_key` is not
     /// a valid [`ActionKey`] (lowercase alphanumeric, underscores, dots, hyphens).
     pub fn new(
-        id: NodeId,
+        id: NodeKey,
         name: impl Into<String>,
         action_key: impl AsRef<str>,
     ) -> Result<Self, crate::WorkflowError> {
@@ -166,7 +166,7 @@ pub enum ParamValue {
     /// A reference to the output of another node.
     Reference {
         /// The source node producing the output.
-        node_id: NodeId,
+        node_key: NodeKey,
         /// JSONPath-like path into the source node's output.
         output_path: String,
     },
@@ -195,9 +195,9 @@ impl ParamValue {
 
     /// Construct a reference parameter.
     #[must_use]
-    pub fn reference(node_id: NodeId, output_path: impl Into<String>) -> Self {
+    pub fn reference(node_key: NodeKey, output_path: impl Into<String>) -> Self {
         Self::Reference {
-            node_id,
+            node_key,
             output_path: output_path.into(),
         }
     }
@@ -205,24 +205,26 @@ impl ParamValue {
 
 #[cfg(test)]
 mod tests {
+    use nebula_core::node_key;
+
     use super::*;
 
     #[test]
     fn new_rejects_invalid_action_key() {
-        let result = NodeDefinition::new(NodeId::new(), "test", "INVALID KEY!!!");
+        let result = NodeDefinition::new(node_key!("test"), "test", "INVALID KEY!!!");
         assert!(result.is_err());
     }
 
     #[test]
     fn new_accepts_valid_action_key() {
-        let result = NodeDefinition::new(NodeId::new(), "test", "http_request");
+        let result = NodeDefinition::new(node_key!("test"), "test", "http_request");
         assert!(result.is_ok());
     }
 
     #[test]
     fn node_definition_new() {
-        let id = NodeId::new();
-        let node = NodeDefinition::new(id, "fetch", "http_request").unwrap();
+        let id = node_key!("test");
+        let node = NodeDefinition::new(id.clone(), "fetch", "http_request").unwrap();
 
         assert_eq!(node.id, id);
         assert_eq!(node.name, "fetch");
@@ -236,7 +238,7 @@ mod tests {
 
     #[test]
     fn node_definition_builder_methods() {
-        let id = NodeId::new();
+        let id = node_key!("test");
         let node = NodeDefinition::new(id, "fetch", "http_request")
             .unwrap()
             .with_interface_version(InterfaceVersion::new(1, 0))
@@ -289,14 +291,14 @@ mod tests {
 
     #[test]
     fn param_value_reference() {
-        let source = NodeId::new();
-        let pv = ParamValue::reference(source, "$.data.items");
+        let source = node_key!("source");
+        let pv = ParamValue::reference(source.clone(), "$.data.items");
         match pv {
             ParamValue::Reference {
-                node_id,
+                node_key,
                 output_path,
             } => {
-                assert_eq!(node_id, source);
+                assert_eq!(node_key, source);
                 assert_eq!(output_path, "$.data.items");
             },
             _ => panic!("expected Reference"),
@@ -305,7 +307,7 @@ mod tests {
 
     #[test]
     fn param_value_serde_roundtrip_all_variants() {
-        let source = NodeId::new();
+        let source = node_key!("source");
         let values = [
             ParamValue::literal(serde_json::json!({"key": "value"})),
             ParamValue::expression("1 + 2"),
@@ -332,8 +334,8 @@ mod tests {
 
     #[test]
     fn node_definition_serde_roundtrip() {
-        let id = NodeId::new();
-        let node = NodeDefinition::new(id, "transform", "echo")
+        let id = node_key!("test");
+        let node = NodeDefinition::new(id.clone(), "transform", "echo")
             .unwrap()
             .with_parameter("input", ParamValue::literal(serde_json::json!("data")))
             .with_timeout(Duration::from_secs(30));
@@ -350,7 +352,7 @@ mod tests {
 
     #[test]
     fn interface_version_serde_roundtrip_in_node() {
-        let id = NodeId::new();
+        let id = node_key!("test");
         let iv = InterfaceVersion::new(2, 3);
         let node = NodeDefinition::new(id, "versioned", "echo")
             .unwrap()

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -32,21 +32,21 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
     // 3. Check duplicate node IDs
     let mut seen_ids = HashSet::new();
     for node in &definition.nodes {
-        if !seen_ids.insert(node.id) {
-            errors.push(WorkflowError::DuplicateNodeId(node.id));
+        if !seen_ids.insert(node.id.clone()) {
+            errors.push(WorkflowError::DuplicateNodeId(node.id.clone()));
         }
     }
 
     // 4. Check connections reference valid nodes and detect self-loops
     for conn in &definition.connections {
         if !seen_ids.contains(&conn.from_node) {
-            errors.push(WorkflowError::UnknownNode(conn.from_node));
+            errors.push(WorkflowError::UnknownNode(conn.from_node.clone()));
         }
         if !seen_ids.contains(&conn.to_node) {
-            errors.push(WorkflowError::UnknownNode(conn.to_node));
+            errors.push(WorkflowError::UnknownNode(conn.to_node.clone()));
         }
         if conn.is_self_loop() {
-            errors.push(WorkflowError::SelfLoop(conn.from_node));
+            errors.push(WorkflowError::SelfLoop(conn.from_node.clone()));
         }
     }
 
@@ -61,8 +61,8 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
         let key = serde_json::to_string(conn).unwrap_or_default();
         if !seen_connections.insert(key) {
             errors.push(WorkflowError::DuplicateConnection {
-                from: conn.from_node,
-                to: conn.to_node,
+                from: conn.from_node.clone(),
+                to: conn.to_node.clone(),
             });
         }
     }
@@ -70,12 +70,12 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
     // 5. Check parameter references
     for node in &definition.nodes {
         for param in node.parameters.values() {
-            if let ParamValue::Reference { node_id, .. } = param
-                && !seen_ids.contains(node_id)
+            if let ParamValue::Reference { node_key, .. } = param
+                && !seen_ids.contains(node_key)
             {
                 errors.push(WorkflowError::InvalidParameterReference {
-                    node_id: node.id,
-                    source_node_id: *node_id,
+                    node_key: node.id.clone(),
+                    source_node_key: node_key.clone(),
                 });
             }
         }
@@ -127,7 +127,7 @@ mod tests {
     use std::collections::HashMap;
 
     use chrono::Utc;
-    use nebula_core::{NodeId, WorkflowId};
+    use nebula_core::{NodeKey, WorkflowId, node_key};
 
     use super::*;
     use crate::{
@@ -162,22 +162,26 @@ mod tests {
         }
     }
 
-    fn node(id: NodeId) -> NodeDefinition {
+    fn node(id: NodeKey) -> NodeDefinition {
         NodeDefinition::new(id, "n", "n").unwrap()
     }
 
     #[test]
     fn valid_workflow_returns_empty() {
-        let a = NodeId::new();
-        let b = NodeId::new();
-        let def = make_definition("ok", vec![node(a), node(b)], vec![Connection::new(a, b)]);
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let def = make_definition(
+            "ok",
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a, b)],
+        );
         let errors = validate_workflow(&def);
         assert!(errors.is_empty(), "expected no errors, got: {errors:?}");
     }
 
     #[test]
     fn detects_empty_name() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let def = make_definition("", vec![node(a)], vec![]);
         let errors = validate_workflow(&def);
         assert!(errors.iter().any(|e| matches!(e, WorkflowError::EmptyName)));
@@ -192,9 +196,13 @@ mod tests {
 
     #[test]
     fn detects_unknown_node_in_connection() {
-        let a = NodeId::new();
-        let unknown = NodeId::new();
-        let def = make_definition("bad", vec![node(a)], vec![Connection::new(a, unknown)]);
+        let a = node_key!("a");
+        let unknown = node_key!("unknown");
+        let def = make_definition(
+            "bad",
+            vec![node(a.clone())],
+            vec![Connection::new(a, unknown)],
+        );
         let errors = validate_workflow(&def);
         assert!(
             errors
@@ -205,8 +213,12 @@ mod tests {
 
     #[test]
     fn detects_self_loop() {
-        let a = NodeId::new();
-        let def = make_definition("loop", vec![node(a)], vec![Connection::new(a, a)]);
+        let a = node_key!("a");
+        let def = make_definition(
+            "loop",
+            vec![node(a.clone())],
+            vec![Connection::new(a.clone(), a)],
+        );
         let errors = validate_workflow(&def);
         assert!(
             errors
@@ -217,8 +229,8 @@ mod tests {
 
     #[test]
     fn detects_invalid_parameter_reference() {
-        let a = NodeId::new();
-        let ghost = NodeId::new();
+        let a = node_key!("a");
+        let ghost = node_key!("ghost");
         let mut n = node(a);
         n.parameters
             .insert("input".into(), ParamValue::reference(ghost, "$.data"));
@@ -234,12 +246,15 @@ mod tests {
     #[test]
     fn collects_multiple_errors() {
         // empty name + self-loop + unknown node
-        let a = NodeId::new();
-        let unknown = NodeId::new();
+        let a = node_key!("a");
+        let unknown = node_key!("unknown");
         let def = make_definition(
             "",
-            vec![node(a)],
-            vec![Connection::new(a, a), Connection::new(a, unknown)],
+            vec![node(a.clone())],
+            vec![
+                Connection::new(a.clone(), a.clone()),
+                Connection::new(a, unknown),
+            ],
         );
         let errors = validate_workflow(&def);
         // Should have at least: EmptyName, SelfLoop, UnknownNode
@@ -248,12 +263,12 @@ mod tests {
 
     #[test]
     fn detects_cycle() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         let def = make_definition(
             "cycle",
-            vec![node(a), node(b)],
-            vec![Connection::new(a, b), Connection::new(b, a)],
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a.clone(), b.clone()), Connection::new(b, a)],
         );
         let errors = validate_workflow(&def);
         assert!(
@@ -265,7 +280,7 @@ mod tests {
 
     #[test]
     fn trigger_validation_rejects_invalid_webhook_path() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let mut def = make_definition("webhook-test", vec![node(a)], vec![]);
         def.trigger = Some(crate::definition::TriggerDefinition::Webhook {
             method: "POST".into(),
@@ -282,7 +297,7 @@ mod tests {
 
     #[test]
     fn trigger_validation_rejects_empty_cron_expression() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let mut def = make_definition("cron-test", vec![node(a)], vec![]);
         def.trigger = Some(crate::definition::TriggerDefinition::Cron {
             expression: String::new(),
@@ -298,7 +313,7 @@ mod tests {
 
     #[test]
     fn trigger_validation_accepts_valid_webhook() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let mut def = make_definition("webhook-ok", vec![node(a)], vec![]);
         def.trigger = Some(crate::definition::TriggerDefinition::Webhook {
             method: "POST".into(),
@@ -315,7 +330,7 @@ mod tests {
 
     #[test]
     fn trigger_validation_accepts_valid_cron() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let mut def = make_definition("cron-ok", vec![node(a)], vec![]);
         def.trigger = Some(crate::definition::TriggerDefinition::Cron {
             expression: "0 */5 * * *".into(),
@@ -331,7 +346,7 @@ mod tests {
 
     #[test]
     fn detects_unsupported_schema_version() {
-        let a = NodeId::new();
+        let a = node_key!("a");
         let mut def = make_definition("schema-test", vec![node(a)], vec![]);
         def.schema_version = 99;
         let errors = validate_workflow(&def);
@@ -345,10 +360,10 @@ mod tests {
 
     #[test]
     fn detects_duplicate_connection() {
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         // Two identical connections: same from/to, same condition, same ports.
-        let conn = Connection::new(a, b);
+        let conn = Connection::new(a.clone(), b.clone());
         let def = make_definition("dup-conn", vec![node(a), node(b)], vec![conn.clone(), conn]);
         let errors = validate_workflow(&def);
         assert!(
@@ -362,15 +377,15 @@ mod tests {
     #[test]
     fn distinct_multi_edges_are_not_duplicate() {
         use crate::connection::EdgeCondition;
-        let a = NodeId::new();
-        let b = NodeId::new();
+        let a = node_key!("a");
+        let b = node_key!("b");
         // Two edges from A to B but with different conditions — these are
         // distinct (not duplicates) and must not trigger a validation error.
         let def = make_definition(
             "multi-edge",
-            vec![node(a), node(b)],
+            vec![node(a.clone()), node(b.clone())],
             vec![
-                Connection::new(a, b).with_condition(EdgeCondition::Always),
+                Connection::new(a.clone(), b.clone()).with_condition(EdgeCondition::Always),
                 Connection::new(a, b).with_from_port("alt"),
             ],
         );

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -29,11 +29,11 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
         return errors; // Cannot check further without nodes
     }
 
-    // 3. Check duplicate node IDs
+    // 3. Check duplicate node keys
     let mut seen_ids = HashSet::new();
     for node in &definition.nodes {
         if !seen_ids.insert(node.id.clone()) {
-            errors.push(WorkflowError::DuplicateNodeId(node.id.clone()));
+            errors.push(WorkflowError::DuplicateNodeKey(node.id.clone()));
         }
     }
 


### PR DESCRIPTION
## Summary

- **NodeId** (ULID, system-generated) → **NodeKey** (string `Key<NodeDomain>`, author-defined)
- Establishes naming convention: `*Key` = authored string, `*Id` = system-generated ULID
- 64 files, ~390 usage sites renamed
- NodeKey is Clone (not Copy like ULID was) — added `.clone()` at ~100 call sites
- SQL column names preserved as `node_id` (DB migration separate)

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 3429 tests pass
- [x] All `NodeId::new()` replaced with descriptive `node_key!("name")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across CLI/API/engine/action context types that changes node identity and serialization paths; regressions could surface in execution tracking, replay/resume, and persisted state compatibility.
> 
> **Overview**
> Replaces workflow node identification throughout the CLI, action runtime contexts, engine events/results, and API models/handlers from ULID `NodeId` to authored string `NodeKey`, updating prints, error messages, pinned-output parsing, and TUI event wiring accordingly.
> 
> Removes `NodeId` from `nebula_core` ID types/re-exports, updates benchmarks/tests to construct node keys via `node_key!`, and adjusts engine internals (maps/queues/idempotency keys, poll jitter seeding, and output/error maps) to use cloned `NodeKey` values.
> 
> Tweaks engine resume-state loading to deserialize via JSON string (instead of `from_value`) to avoid `domain-key` serde borrowing issues with key types.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f577c9b3b59b9119ee24a183a8328829a0977056. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal node identification system from `NodeId` to `NodeKey` throughout the platform, including CLI outputs, API responses, and execution tracking. Node references in error messages and execution results now use the updated identifier format. This change improves consistency in how nodes are identified and referenced across all components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->