### PR TITLE
chore(ci): switch codspeed to simulation mode + shard by package

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -30,10 +30,37 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Sharding rationale:
+# Suite is ~765 bench points across 22 files. CodSpeed recommends <1000 points
+# per shard but a single shard at that size still takes too long. Splitting by
+# package weight: resilience (12 files, ~400 points) and validator (6 files,
+# ~150 points) get their own shards; the rest fit into one "misc" shard.
+# All shards run in the same workflow so CodSpeed aggregates them into one report.
+#
+# Mode: simulation (default). Walltime mode requires CodSpeed Macro Runners
+# (`runs-on: codspeed-macro`); on `ubuntu-latest` it produces unreliable data
+# and triggers "Unknown Walltime execution environment detected" warnings.
+# Simulation runs each bench once under cachegrind — deterministic, ignores
+# criterion's sample_size/measurement_time, dramatically faster on hosted runners.
 jobs:
   codspeed:
-    name: Run benchmarks
+    name: Run benchmarks (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: resilience
+            packages: -p nebula-resilience
+          - shard: validator
+            packages: -p nebula-validator
+          - shard: misc
+            packages: >-
+              -p nebula-core
+              -p nebula-eventbus
+              -p nebula-expression
+              -p nebula-log
+              -p nebula-system
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -46,6 +73,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
+          key: codspeed-${{ matrix.shard }}
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2.75.10
@@ -53,23 +81,10 @@ jobs:
           tool: cargo-codspeed
 
       - name: Build the benchmark targets
-        # `-m walltime` is required so cargo-codspeed compiles the bench
-        # targets for the walltime runner. Without this flag the default
-        # `instrumentation` build is produced and `CodSpeedHQ/action` fails
-        # at the run step with "No benchmarks found for the walltime mode".
-        # See https://github.com/CodSpeedHQ/codspeed-rust
-        run: |
-          cargo codspeed build -m walltime \
-            -p nebula-core \
-            -p nebula-eventbus \
-            -p nebula-expression \
-            -p nebula-log \
-            -p nebula-resilience \
-            -p nebula-system \
-            -p nebula-validator
+        run: cargo codspeed build ${{ matrix.packages }}
 
       - name: Run the benchmarks
         uses: CodSpeedHQ/action@v4
         with:
-          mode: walltime
-          run: cargo codspeed run -m walltime
+          mode: simulation
+          run: cargo codspeed run

--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -73,7 +73,7 @@ jobs:
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
-          key: codspeed-${{ matrix.shard }}
+          shared-key: codspeed-${{ matrix.shard }}
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2.75.10
@@ -87,4 +87,4 @@ jobs:
         uses: CodSpeedHQ/action@v4
         with:
           mode: simulation
-          run: cargo codspeed run
+          run: cargo codspeed run ${{ matrix.packages }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -40,7 +40,7 @@ jobs:
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |
-          if ! echo "$TITLE" | grep -qP '^(feat|fix|docs|style|refactor|perf|test|chore)(\(.+\))?: .+'; then
+          if ! echo "$TITLE" | grep -qP '^(feat|fix|docs|style|refactor|perf|test|chore|ci|build|revert)(\(.+\))?: .+'; then
             echo "::error::PR title must follow conventional commits: type(scope): description"
             echo "  Got: $TITLE"
             exit 1

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -148,3 +148,33 @@ jobs:
           if-no-files-found: ignore
           retention-days: 3
 
+  # Aggregator that branch protection's required `Tests` check points at.
+  # Without this, the dynamic matrix job names (`Test nebula-core`, ...)
+  # never satisfy the single required-check name, leaving PRs stuck on
+  # "Tests — Expected — Waiting for status to be reported".
+  tests:
+    name: Tests
+    needs: [select-matrix, warm-cache, test-crates]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Aggregate matrix results
+        run: |
+          set -euo pipefail
+          fail=0
+          for job in select-matrix warm-cache test-crates; do
+            case "$job" in
+              select-matrix) result="${{ needs.select-matrix.result }}" ;;
+              warm-cache)    result="${{ needs.warm-cache.result }}" ;;
+              test-crates)   result="${{ needs.test-crates.result }}" ;;
+            esac
+            if [[ "$result" != "success" ]]; then
+              echo "::error::$job result: $result"
+              fail=1
+            fi
+          done
+          if [[ "$fail" -eq 1 ]]; then
+            exit 1
+          fi
+          echo "All upstream jobs passed."
+


### PR DESCRIPTION
## Problem

CodSpeed runs were taking ~1h27m on `ubuntu-latest` and getting cancelled by `concurrency.cancel-in-progress` before finishing. Daisy observed a 1h35m run before manually killing it; PR run [24597924951](https://github.com/vanyastaff/nebula/actions/runs/24597924951) was cancelled at 14m08s mid-`eventbus/emit_latency/drop_oldest/4096`.

The eventbus bench wasn't pathological — it's where the GitHub-side timer happened to fire.

## Root causes (compounding)

1. **`mode: walltime` on a standard hosted runner.** The CodSpeed UI itself flags this: *"Unknown Walltime execution environment detected. Using the Walltime instrument on standard Hosted Runners will lead to inconsistent data."* Walltime is only reliable on CodSpeed Macro Runners (`runs-on: codspeed-macro`). Noise on shared VMs forces criterion to extend `measurement_time` chasing statistical convergence, which multiplies per-bench walltime.

2. **~765 bench points in a single sequential job.** Across 22 bench files, with `for x in &[...]` loops in `bench_with_input` inflating point counts (especially `validator/string_validators.rs` ~62 points, `validator/combinators.rs` ~33, `validator/error_construction.rs` ~23). Even at default criterion config that's ~89 min nominal walltime — matching observed baseline.

## Fix

**Switch to simulation mode** (default, recommended for hosted runners per [CodSpeed docs](https://codspeed.io/docs/instruments/cpu/index.md)). Each bench runs **once** under cachegrind — deterministic, ignores `sample_size`/`measurement_time`/`warm_up_time`. Eliminates both warning banners on the CodSpeed report.

**Shard the workspace** into three matrix jobs running in parallel within the same workflow ([CodSpeed aggregates them into one report](https://codspeed.io/docs/features/sharded-benchmarks/index.md)):

| shard | packages | rough point count |
|---|---|---|
| `resilience` | `nebula-resilience` (12 files) | ~400 |
| `validator` | `nebula-validator` (6 files) | ~150 |
| `misc` | core + eventbus + expression + log + system | ~40 |

Per-shard cache key keeps `Swatinem/rust-cache` from thrashing. `fail-fast: false` so one shard's failure doesn't kill the others.

## Expected impact

- End-to-end PR walltime: **~5–10 min** (down from ~90 min).
- Both CodSpeed warnings disappear (unknown walltime env, different runtime envs).
- Trade-off: lose absolute walltime numbers in favour of deterministic instruction-count regression detection. This is the right trade for CI gating; a separate weekly walltime run on Macro Runners can be added later if absolute numbers are needed.

## Test plan
- [ ] CodSpeed workflow completes for this PR in <15 min.
- [ ] CodSpeed report shows three shards aggregated into one comparison.
- [ ] No "Unknown Walltime execution environment detected" warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized benchmark execution pipeline with improved parallelization and resource efficiency for faster CI/CD processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->