### PR TITLE
chore(claude): add workflow skills and secret-guard hook for Claude Code

### DIFF
--- a/.claude/hooks/guard-secrets.sh
+++ b/.claude/hooks/guard-secrets.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Bash commands that read, print, or exfiltrate obvious
+# secret files and environment variables. Complements guard-bash.sh (which
+# blocks destructive operations). This one is focused on credential leaks.
+#
+# Contract: receives JSON on stdin with tool_input.command. Exit 0 = allow;
+# exit 2 = block (Claude Code's deny signal). stderr is shown to the user.
+
+set -euo pipefail
+
+INPUT=$(cat)
+
+CMD=""
+# Prefer jq; fall back to python3; last resort is a brittle sed.
+if command -v jq >/dev/null 2>&1; then
+  CMD=$(printf '%s' "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null || true)
+fi
+
+if [[ -z "$CMD" ]] && command -v python3 >/dev/null 2>&1; then
+  CMD=$(printf '%s' "$INPUT" | python3 -c '
+import json, sys
+try:
+    payload = json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+print(payload.get("tool_input", {}).get("command", "") or "")
+' 2>/dev/null || true)
+fi
+
+if [[ -z "$CMD" ]]; then
+  CMD=$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+fi
+
+if [[ -z "$CMD" ]]; then
+  exit 0
+fi
+
+# --- 1. Block reads of common secret-file extensions via pager/printer tools.
+#        Narrow to whole-token matches so "catalog.md" is not a false positive.
+if printf '%s' "$CMD" | grep -qE '\b(cat|less|more|head|tail|bat|xxd)\b[^|;&]*\.(env|pem|key|p12|pfx)(\s|$|\|)'; then
+  echo "Blocked by guard-secrets.sh: reading a likely-secret file (.env/.pem/.key/.p12/.pfx)." >&2
+  echo "If legitimate (for example, a test fixture), narrow the command or add an allow entry in .claude/settings.local.json." >&2
+  exit 2
+fi
+
+# --- 2. Block reads of well-known secret paths.
+if printf '%s' "$CMD" | grep -qE '\b(cat|less|more|head|tail|bat)\b[^|;&]*/(id_rsa|id_ed25519|id_ecdsa|credentials\.json|service-account\.json|\.npmrc|\.pypirc|\.netrc)(\s|$|\|)'; then
+  echo "Blocked by guard-secrets.sh: reading a well-known secret file." >&2
+  exit 2
+fi
+
+# --- 3. Block unfiltered env / printenv dumps (easy to leak tokens into tool output).
+#        Allow `printenv PATH` / `env | grep ...` / `env SOMEVAR=...`.
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]]|;|&&|\|\|)\s*(printenv|env)([[:space:]]*$|[[:space:]]*\|\s*$)'; then
+  echo "Blocked by guard-secrets.sh: 'env' / 'printenv' without a filter can leak secrets to tool output." >&2
+  echo "Narrow the command: 'printenv PATH', 'env | grep RUST_LOG', or similar." >&2
+  exit 2
+fi
+
+# --- 4. Block echoing / printing env vars that look like secrets.
+if printf '%s' "$CMD" | grep -qE '\b(echo|printf)[[:space:]]+("[^"]*)?\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD|PASS|CREDENTIAL|API_KEY)[A-Z_]*\}?'; then
+  echo "Blocked by guard-secrets.sh: echoing an environment variable that looks like a secret." >&2
+  echo "If this is intentional (e.g., a dev script printing a non-sensitive token), inline-document why and allow via settings.local.json." >&2
+  exit 2
+fi
+
+# --- 5. Block curl/wget exfiltration with a secret-looking var in the URL or body.
+if printf '%s' "$CMD" | grep -qE '\b(curl|wget)\b[^|;&]*(\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD)[A-Z_]*\}?|Authorization:[[:space:]]*Bearer[[:space:]]+\$)'; then
+  echo "Blocked by guard-secrets.sh: curl/wget with a secret-looking variable interpolated." >&2
+  echo "If legitimate (automation pushing a token to an internal service), run it outside the agent." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/hooks/guard-secrets.sh
+++ b/.claude/hooks/guard-secrets.sh
@@ -36,37 +36,41 @@ if [[ -z "$CMD" ]]; then
   exit 0
 fi
 
+# Regexes below use POSIX ERE only (no `\b`, no `\s`) so they match identically
+# under GNU grep, BSD grep, and busybox grep. Word boundaries are emulated with
+# `(^|[^[:alnum:]_])` before a token; whitespace with `[[:space:]]`.
+
 # --- 1. Block reads of common secret-file extensions via pager/printer tools.
 #        Narrow to whole-token matches so "catalog.md" is not a false positive.
-if printf '%s' "$CMD" | grep -qE '\b(cat|less|more|head|tail|bat|xxd)\b[^|;&]*\.(env|pem|key|p12|pfx)(\s|$|\|)'; then
+if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])(cat|less|more|head|tail|bat|xxd)[[:space:]][^|;&]*\.(env|pem|key|p12|pfx)([[:space:]]|$|\|)'; then
   echo "Blocked by guard-secrets.sh: reading a likely-secret file (.env/.pem/.key/.p12/.pfx)." >&2
   echo "If legitimate (for example, a test fixture), narrow the command or add an allow entry in .claude/settings.local.json." >&2
   exit 2
 fi
 
 # --- 2. Block reads of well-known secret paths.
-if printf '%s' "$CMD" | grep -qE '\b(cat|less|more|head|tail|bat)\b[^|;&]*/(id_rsa|id_ed25519|id_ecdsa|credentials\.json|service-account\.json|\.npmrc|\.pypirc|\.netrc)(\s|$|\|)'; then
+if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])(cat|less|more|head|tail|bat)[[:space:]][^|;&]*/(id_rsa|id_ed25519|id_ecdsa|credentials\.json|service-account\.json|\.npmrc|\.pypirc|\.netrc)([[:space:]]|$|\|)'; then
   echo "Blocked by guard-secrets.sh: reading a well-known secret file." >&2
   exit 2
 fi
 
 # --- 3. Block unfiltered env / printenv dumps (easy to leak tokens into tool output).
-#        Allow `printenv PATH` / `env | grep ...` / `env SOMEVAR=...`.
-if printf '%s' "$CMD" | grep -qE '(^|[[:space:]]|;|&&|\|\|)\s*(printenv|env)([[:space:]]*$|[[:space:]]*\|\s*$)'; then
+#        Allow `printenv PATH`, `env | grep ...`, `env SOMEVAR=...`.
+if printf '%s' "$CMD" | grep -qE '(^|[[:space:]]|;|&|\|)[[:space:]]*(printenv|env)([[:space:]]*$|[[:space:]]*\|[[:space:]]*$)'; then
   echo "Blocked by guard-secrets.sh: 'env' / 'printenv' without a filter can leak secrets to tool output." >&2
   echo "Narrow the command: 'printenv PATH', 'env | grep RUST_LOG', or similar." >&2
   exit 2
 fi
 
 # --- 4. Block echoing / printing env vars that look like secrets.
-if printf '%s' "$CMD" | grep -qE '\b(echo|printf)[[:space:]]+("[^"]*)?\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD|PASS|CREDENTIAL|API_KEY)[A-Z_]*\}?'; then
+if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])(echo|printf)[[:space:]]+("[^"]*)?\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD|PASS|CREDENTIAL|API_KEY)[A-Z_]*\}?'; then
   echo "Blocked by guard-secrets.sh: echoing an environment variable that looks like a secret." >&2
   echo "If this is intentional (e.g., a dev script printing a non-sensitive token), inline-document why and allow via settings.local.json." >&2
   exit 2
 fi
 
 # --- 5. Block curl/wget exfiltration with a secret-looking var in the URL or body.
-if printf '%s' "$CMD" | grep -qE '\b(curl|wget)\b[^|;&]*(\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD)[A-Z_]*\}?|Authorization:[[:space:]]*Bearer[[:space:]]+\$)'; then
+if printf '%s' "$CMD" | grep -qE '(^|[^[:alnum:]_])(curl|wget)([^[:alnum:]_]|$)[^|;&]*(\$\{?[A-Z_]*(TOKEN|SECRET|KEY|PASSWORD)[A-Z_]*\}?|Authorization:[[:space:]]*Bearer[[:space:]]+\$)'; then
   echo "Blocked by guard-secrets.sh: curl/wget with a secret-looking variable interpolated." >&2
   echo "If legitimate (automation pushing a token to an internal service), run it outside the agent." >&2
   exit 2

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,6 +8,11 @@
             "type": "command",
             "command": "bash -lc 'root=\"${WORKSPACE_ROOT:-}\"; if [ -z \"$root\" ]; then root=$(git rev-parse --show-toplevel 2>/dev/null || true); fi; if command -v cygpath >/dev/null 2>&1; then root=$(cygpath -u \"$root\" 2>/dev/null || printf \"%s\" \"$root\"); fi; if [ -n \"$root\" ] && [ -f \"$root/.claude/hooks/guard-bash.sh\" ]; then bash \"$root/.claude/hooks/guard-bash.sh\"; else exit 0; fi'",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "bash -lc 'root=\"${WORKSPACE_ROOT:-}\"; if [ -z \"$root\" ]; then root=$(git rev-parse --show-toplevel 2>/dev/null || true); fi; if command -v cygpath >/dev/null 2>&1; then root=$(cygpath -u \"$root\" 2>/dev/null || printf \"%s\" \"$root\"); fi; if [ -n \"$root\" ] && [ -f \"$root/.claude/hooks/guard-secrets.sh\" ]; then bash \"$root/.claude/hooks/guard-secrets.sh\"; else exit 0; fi'",
+            "timeout": 5
           }
         ]
       }

--- a/.claude/skills/architectural-fit/SKILL.md
+++ b/.claude/skills/architectural-fit/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: architectural-fit
+description: Use BEFORE writing code for non-trivial Nebula changes — adding a new public type / trait / module / crate; touching execution lifecycle, storage, credentials, integration model, plugin packaging, or layer boundaries; forcing a new concept into an existing abstraction. Walks the canon decision gate plus bounded-context check. Prevents quick-win patches that silently drift canon.
+---
+
+# architectural-fit
+
+## When to invoke
+
+Invoke before coding when the change:
+
+- Adds a new public type, trait, module, or crate.
+- Touches the integration model (Resource / Credential / Action / Schema / Plugin).
+- Touches execution lifecycle, storage CAS, durable outbox, checkpoints, leases, or journal.
+- Shifts a layer boundary or cross-cutting dep.
+- Force-fits a new concept into an existing abstraction.
+
+Unsure? Invoke anyway.
+
+## Checklist
+
+1. **Canon decision gate.** Walk the six questions in root `CLAUDE.md` §"Decision gate (before proposing an architectural change)". Any "yes" → STOP and open an ADR per `docs/PRODUCT_CANON.md §0.2`. Do not restate the six questions — read them from `CLAUDE.md` each time.
+
+2. **Bounded-context mapping.** Name the context the change lands in:
+   - **Core** — core / validator / parameter / expression / workflow / execution
+   - **Business** — credential / resource / action / plugin
+   - **Exec** — engine / runtime / storage / sandbox / sdk / plugin-sdk
+   - **API** — api + webhook
+   - **Cross-cutting** — log / system / eventbus / telemetry / metrics / config / resilience / error / schema
+
+   No upward deps (enforced by `deny.toml`). If the concept fits two contexts, it is probably two concepts — split.
+
+3. **Concept-promotion severity.** Is this a new semantic concept or a specialization?
+   - 🟢 existing abstraction fits as-is
+   - 🟡 extend existing abstraction, document in crate README
+   - 🟠 new module / trait inside existing crate
+   - 🔴 new crate, or L2 invariant change — ADR required in the same PR
+
+4. **Quick-Win trap scan.** Re-read root `CLAUDE.md` §"Quick Win trap catalog". Confirm none of the listed traps applies. When tempted, remember: the rationalization is the trap.
+
+## Output
+
+```
+## Architectural fit: <change>
+
+Decision gate:     [all green / blocked at Q# — description]
+Bounded context:   <name>
+Concept promotion: 🟢 / 🟡 / 🟠 / 🔴 — <1-sentence rationale>
+Quick-Win traps:   [none / list]
+
+Next step: [proceed / open ADR and hand off to tech-lead for review]
+```
+
+Under 150 words. Do not proceed to code until "next step" is concrete.

--- a/.claude/skills/credential-security-review/SKILL.md
+++ b/.claude/skills/credential-security-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: credential-security-review
+description: Use when touching code that handles credentials, secrets, tokens, auth schemes, or logging that could include sensitive values. Fast checklist against Nebula's §4.2 safety invariants and §12.5 encryption rules. Complements the security-lead agent — this is the self-review pass before you'd invoke security-lead for a deeper look.
+---
+
+# credential-security-review
+
+## When to invoke
+
+- Editing `crates/credential/`, `crates/api/` (auth paths), `crates/plugin/`, `crates/sandbox/`, or any action crate that handles auth material.
+- Adding a new auth scheme, token type, or credential variant.
+- Touching `tracing::*!` in any crate that carries credential IDs, tokens, or secret material.
+- Writing or modifying error types that could include a secret.
+- Adding or changing `Clone` on a type that holds secret material.
+
+## Why this exists
+
+Credentials in Nebula are **engine-owned** (PRODUCT_CANON §4.2). The stored-state vs projected-auth-material split protects node authors from hand-rolling refresh and operators from credential theft via log leak, memory dump, or debug output. This skill catches the common mistakes before they reach `security-lead`.
+
+## Checklist
+
+### 1. Secret types
+
+- [ ] Every secret value uses `SecretString` / `SecretToken` / `CredentialGuard` — never plain `String` / `Vec<u8>`.
+- [ ] Types holding secrets derive `Zeroize + ZeroizeOnDrop`.
+- [ ] `Debug` is redacted — `fmt::Debug` never prints the raw secret.
+- [ ] `Display` is not implemented on secret types, or is redacted.
+- [ ] `Clone` on a secret type: each clone is another zeroization point. Is this clone necessary? Document why if kept.
+
+### 2. Logging and errors
+
+- [ ] No `println!`, `eprintln!`, `dbg!` in library code (even under `#[cfg(debug_assertions)]`).
+- [ ] `tracing::*!` macros that take a credential ID or token use the redacted form (canon §12.5).
+- [ ] Error types never carry plaintext secrets in the message. Use redacted reasons (`CredentialError::TokenRefreshFailed { credential_id, reason: RedactedReason }`).
+- [ ] `anyhow::Error` is not used in library crates — it can capture backtraces that include secret-bearing locals.
+
+### 3. Credential lifecycle
+
+- [ ] No direct read from the credential store. All access through `CredentialAccessor` (engine-owned).
+- [ ] Refresh / rotation is engine-owned. Action authors do not implement it.
+- [ ] Stored state (encrypted) vs projected auth material (to action) split is preserved.
+- [ ] `CredentialRotatedEvent` is published via `EventBus<T>`, not an ad-hoc channel.
+
+### 4. Transport and persistence (§12.5)
+
+- [ ] At-rest encryption: AES-256-GCM. Credential ID bound as AAD.
+- [ ] KDF: Argon2id. No raw hashing, no truncated KDF output.
+- [ ] Intermediate plaintext lives in `Zeroizing<Vec<u8>>`, dropped before the function returns.
+- [ ] No secret in URLs, query strings, or unredacted metric labels.
+
+### 5. Async and cancellation
+
+- [ ] Futures that hold plaintext secrets are cancel-safe. If not, document that cancellation may drop plaintext before zeroize runs.
+- [ ] No `MutexGuard` holding a secret across `.await` — deadlock and leak risk.
+- [ ] `spawn_blocking` for CPU-heavy crypto work so the async runtime isn't starved.
+
+### 6. Supply chain
+
+- [ ] Any new crypto dep: confirm allowed license in `deny.toml`, no advisories, no `unsafe` without `// SAFETY:`.
+- [ ] No `openssl` (Nebula prefers `rustls`; `deny.toml` enforces).
+
+## Severity rubric
+
+- 🔴 **CRITICAL** — plaintext secret leaving process boundary (log, error, network, disk).
+- 🟠 **HIGH** — exploitable defense-in-depth gap (timing side channel, missing validation, unredacted metric).
+- 🟡 **MEDIUM** — hardening opportunity, non-ideal pattern.
+- ✅ **GOOD** — positive observation worth preserving (call it out to avoid accidental removal later).
+
+## Output format
+
+```
+## Credential security review: [change]
+
+🔴 CRITICAL: [list, or "none"]
+🟠 HIGH:     [list, or "none"]
+🟡 MEDIUM:   [list, or "none"]
+✅ GOOD:     [positive observations]
+
+### Action
+[proceed / fix 🔴s first / handoff: security-lead for <reason>]
+```
+
+If any 🔴 appears — STOP and hand off to `security-lead`. Do not self-approve critical security changes.

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: docs-sync
+description: Use after a non-trivial change, before commit. Walks PRODUCT_CANON §17 definition of done — MATURITY.md row, ADR if L2 moved, crate README, CLAUDE.md toolchain, INTEGRATION_MODEL, STYLE, GLOSSARY, plan/spec archival. Prevents the "code moved, docs lied" failure that rots canon truthfulness.
+---
+
+# docs-sync
+
+## When to invoke
+
+- Immediately after implementation, before `git commit` on non-trivial work.
+- Always before a PR that changes public API, crate boundary, or any L1/L2 invariant.
+- When you moved files between crates or renamed public items.
+
+## Why this exists
+
+Canon §17 defines DoD as "relevant tests/commands green **and** alignment with `docs/PRODUCT_CANON.md`". A PR that ships code with stale docs is, by definition, incomplete. This skill is the mechanical walk-through so nothing is quietly dropped.
+
+## Checklist
+
+### 1. Crate maturity — `docs/MATURITY.md`
+
+For each crate the PR touched, review its row along five axes:
+
+- [ ] **API stability** — `stable` / `frontier` / `partial`. Did this PR move it?
+- [ ] **Test coverage** — did this PR add new behavior without covering it?
+- [ ] **Doc completeness** — did new public items get `///` docs and a `lib.rs //!` mention?
+- [ ] **Engine integration** — if the crate plumbs into engine/runtime, did this PR change that?
+- [ ] **SLI readiness** — if the crate emits metrics/events, did this PR change that?
+
+If any axis moved: update the row. If unchanged: confirm the row is still truthful.
+
+### 2. Invariant changes — `docs/PRODUCT_CANON.md` + `docs/adr/`
+
+If this PR touches any L2 invariant (execution lifecycle, storage CAS, durable outbox, structural contract, plugin packaging, schema proof-token pipeline, credential stored-state split):
+
+- [ ] An ADR exists at `docs/adr/NNNN-<slug>.md` describing the decision.
+- [ ] The canon section is either updated OR confirmed unchanged because the ADR preserves it.
+- [ ] The seam test covering the invariant is updated **in the same PR** (§17 DoD requirement).
+
+If touching L1 (pillars, principles) — that is a product-level revision. Hand off to `architect`.
+
+### 3. Crate README + `lib.rs //!`
+
+If the PR changed a crate's public surface (added / removed / re-shaped items):
+
+- [ ] `crates/<name>/README.md` reflects the new surface.
+- [ ] `canon-invariants:` YAML frontmatter (if present in the README) is still truthful.
+- [ ] `lib.rs //!` doc comment is current — no dangling references to removed items.
+
+### 4. Toolchain / workflow — root `CLAUDE.md`
+
+If this PR changes:
+
+- MSRV, edition, rustfmt config, clippy config
+- CI required jobs
+- Canonical commands
+- Layer boundaries (`deny.toml` update)
+
+…update root `CLAUDE.md` accordingly. Canonical commands must never drift from CI reality.
+
+### 5. Integration / style / glossary
+
+- [ ] `docs/INTEGRATION_MODEL.md` — updated if Resource / Credential / Action / Schema / Plugin mechanics shifted.
+- [ ] `docs/STYLE.md` — updated if a new idiom, antipattern, naming convention, or type-design bet was introduced.
+- [ ] `docs/GLOSSARY.md` — updated if a new architectural term was introduced.
+
+### 6. Plan / spec archival
+
+If this PR implements a plan or spec:
+
+- [ ] Plan file under `docs/plans/` is marked implemented or moved to `archive/`.
+- [ ] Spec file under `docs/superpowers/specs/` is linked from the ADR or PR body.
+
+### 7. Observability contracts
+
+If the PR added / removed / changed:
+
+- Lifecycle events on `execution_journal`
+- SLI / SLO definitions
+- Metric names or labels
+
+…confirm `docs/OBSERVABILITY.md` is in sync. Operators read that doc first when a run misbehaves.
+
+## Output format
+
+```
+## docs-sync: [change]
+
+MATURITY.md:   [rows updated / no change needed]
+Canon / ADR:   [ADR NNNN drafted / canon §X updated / none]
+Crate READMEs: [list / none]
+lib.rs //!:    [list / none]
+Root CLAUDE.md: [updated / no change]
+INTEGRATION / STYLE / GLOSSARY: [list / none]
+OBSERVABILITY: [updated / none]
+Plans / specs: [archived <path> / linked <path> / none]
+
+### Residual drift
+[items the PR should have updated but didn't, with reasoning]
+```
+
+If any residual drift is listed — fix it before committing. Canon §17 makes this non-optional.

--- a/.claude/skills/docs-sync/SKILL.md
+++ b/.claude/skills/docs-sync/SKILL.md
@@ -37,7 +37,7 @@ If this PR touches any L2 invariant (execution lifecycle, storage CAS, durable o
 - [ ] The canon section is either updated OR confirmed unchanged because the ADR preserves it.
 - [ ] The seam test covering the invariant is updated **in the same PR** (§17 DoD requirement).
 
-If touching L1 (pillars, principles) — that is a product-level revision. Hand off to `architect`.
+If touching L1 (pillars, principles) — that is a product-level revision. Hand off to `tech-lead` and open an ADR per `docs/PRODUCT_CANON.md §0.2`.
 
 ### 3. Crate README + `lib.rs //!`
 

--- a/.claude/skills/verify-evidence/SKILL.md
+++ b/.claude/skills/verify-evidence/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: verify-evidence
+description: Use before claiming a task is "done" / "fixed" / "working" / ready for review. Requires fresh command output, not memory. Prevents completion theatre and silently skipped work. This is the Iron Law gate — no completion claims without evidence from commands run this turn.
+---
+
+# verify-evidence
+
+## When to invoke
+
+- You are about to say "done" / "fixed" / "working" / "ready for review".
+- You are about to create a commit, open a PR, or hand off.
+- The user asked "did it work?" and you haven't run the commands this session.
+- You are tempted to say "I believe the tests pass" — especially then.
+
+## The Iron Law
+
+**No completion claim without fresh command evidence.**
+
+Memory of a green run from 30 minutes ago is not evidence — the state may have changed, you may have edited files since, CI may have different gates. Run the commands this turn, capture the output, paste it into your reply.
+
+Banned phrases: *should work*, *no issues expected*, *I believe it's fine*, *the tests passed earlier*, *it compiles in my head*.
+
+Required phrases: actual tool output — a test summary line, a clippy "0 warnings" line, a fmt no-diff confirmation.
+
+## Checklist
+
+### 1. Canonical fast gate (root `CLAUDE.md`)
+
+Run and capture:
+
+```bash
+cargo +nightly fmt --all
+cargo clippy --workspace -- -D warnings
+cargo nextest run --workspace
+```
+
+Every `cargo` invocation. Every time. Capture the last ~10 lines of each, especially the summary line from `nextest`.
+
+### 2. Full gate (before PR)
+
+Add:
+
+```bash
+cargo test --workspace --doc
+cargo deny check
+cargo check --workspace --all-features --all-targets
+```
+
+### 3. Single-crate iteration mode
+
+If iterating fast:
+
+```bash
+cargo check -p nebula-<crate>
+cargo nextest run -p nebula-<crate>
+```
+
+…but the **fast gate (§1) still runs before declaring done**. Crate-scoped checks are for the dev loop, not for claiming completion.
+
+### 4. Intentionally skipped steps
+
+If any canonical step was skipped (for example, `--all-features` is slow locally), say so **explicitly**:
+
+> Skipped `cargo check --workspace --all-features` because [reason]. Will be enforced in CI via `pre-push`.
+
+Never silently drop a step.
+
+### 5. New / modified tests
+
+- [ ] New tests are in the suite and **PASSED** — not `#[ignore]`'d to move the green line.
+- [ ] Any new `#[should_panic]` / `#[ignore]` has a 1-line comment explaining why.
+- [ ] If the work claims a behavior change, at least one test exercises the new behavior.
+
+### 6. Planned deletions
+
+Per memory `feedback_incomplete_work.md` — if the plan said to remove X, confirm X is gone:
+
+- [ ] `git grep "X"` returns only legitimate references (tests asserting removal, changelog).
+- [ ] `cargo build` does not reference X.
+
+### 7. Doctest discipline
+
+Per memory `feedback_intra_doc_links.md`:
+
+- [ ] No newly-introduced intra-doc-link brackets to out-of-scope paths in `//!` / attribute docs — `rustdoc -D warnings` will fail.
+
+### 8. Lefthook mirror check
+
+Per memory `feedback_lefthook_mirrors_ci.md`:
+
+- [ ] Pre-push is the local mirror of CI required jobs.
+- [ ] If this PR adds a CI required job, `lefthook.yml` pre-push gains the same check.
+
+## Output format
+
+Paste **actual tool output**. Do not paraphrase. Do not summarize "all green" without the evidence.
+
+```
+## Verification evidence
+
+### fmt
+<last 3 lines of `cargo +nightly fmt --all`, or "(no output — clean)">
+
+### clippy
+<last 10 lines of `cargo clippy --workspace -- -D warnings`>
+(clippy: 0 warnings across <N> crates)
+
+### nextest
+<the "Summary" line at minimum:
+ "Summary [  X.YZs] N tests run: N passed, 0 failed, 0 skipped">
+
+### doctests (if ran)
+<summary>
+
+### deny (if ran)
+<summary>
+
+### Skipped steps
+- none
+OR
+- <step>: <reason>
+
+### Deletions confirmed (if applicable)
+- X: removed from <crate>, grep clean
+```
+
+Only after this evidence block is **fresh and complete** are you allowed to say "done" / "working" / "ready for review".

--- a/.claude/skills/verify-evidence/SKILL.md
+++ b/.claude/skills/verify-evidence/SKILL.md
@@ -38,13 +38,14 @@ Every `cargo` invocation. Every time. Capture the last ~10 lines of each, especi
 
 ### 2. Full gate (before PR)
 
-Add:
+Match root `CLAUDE.md` §"Canonical Commands" "Full validation" exactly. Add to §1:
 
 ```bash
 cargo test --workspace --doc
 cargo deny check
-cargo check --workspace --all-features --all-targets
 ```
+
+`lefthook` pre-push additionally runs `cargo check --workspace --all-features --all-targets`, `cargo check --no-default-features` for selected crates, `cargo doc`, and `cargo shear`. You do not need to run those by hand — the push-time mirror handles them. If CI fails on one, diagnose root cause (do not `--no-verify`).
 
 ### 3. Single-crate iteration mode
 
@@ -73,23 +74,20 @@ Never silently drop a step.
 
 ### 6. Planned deletions
 
-Per memory `feedback_incomplete_work.md` — if the plan said to remove X, confirm X is gone:
+If the plan said to remove X, confirm X is actually gone — do not ship a partial removal:
 
 - [ ] `git grep "X"` returns only legitimate references (tests asserting removal, changelog).
 - [ ] `cargo build` does not reference X.
 
 ### 7. Doctest discipline
 
-Per memory `feedback_intra_doc_links.md`:
-
-- [ ] No newly-introduced intra-doc-link brackets to out-of-scope paths in `//!` / attribute docs — `rustdoc -D warnings` will fail.
+- [ ] No newly-introduced intra-doc-link brackets to out-of-scope paths in `//!` / attribute docs — `rustdoc -D warnings` will fail on paths it cannot resolve.
 
 ### 8. Lefthook mirror check
 
-Per memory `feedback_lefthook_mirrors_ci.md`:
+`lefthook.yml` pre-push is the local mirror of CI required jobs (see root `CLAUDE.md` §"Canonical Commands" and the repo's own `lefthook.yml`):
 
-- [ ] Pre-push is the local mirror of CI required jobs.
-- [ ] If this PR adds a CI required job, `lefthook.yml` pre-push gains the same check.
+- [ ] If this PR adds a CI required job, `lefthook.yml` pre-push gains the same check in the same PR, so local push and CI cannot diverge.
 
 ## Output format
 


### PR DESCRIPTION
## Summary

- Add four Claude Code skills covering the phases where agent-assisted work drifts canon: `architectural-fit` (pre-code canon gate), `credential-security-review` (§4.2/§12.5 self-review), `docs-sync` (canon §17 DoD walkthrough), `verify-evidence` (Iron Law — fresh command output required before claiming done).
- Add `guard-secrets.sh` PreToolUse Bash hook blocking secret-file reads, unfiltered `env`/`printenv` dumps, echoes of secret-named variables, and curl exfil with secret-looking variables. Registered alongside the existing `guard-bash.sh`.
- No change to root `CLAUDE.md` or `docs/PRODUCT_CANON.md`. Skills point to canon sections by reference, do not duplicate them.

## Rationale

Every new file maps to a specific Nebula failure mode and is expected to be used weekly or more. The four-skill set is the minimum that still protects against quick wins, architecture drift, fake completion, docs drift, secret leakage, and cross-bounded-context leaks, when combined with the existing five agents (`tech-lead`, `rust-senior`, `security-lead`, `devops`, `dx-tester`), `deny.toml` layer enforcement, and `guard-bash.sh`.

Design explicitly rejects: a second `CLAUDE.md` under `.claude/` (would duplicate the root one); a separate `architect` agent (overlaps with `tech-lead`); spec/clarify/reshape/runtime-invariant skills (either monthly-use or covered by existing agents/canon sections). Both `.claude/CLAUDE.md` and `.claude/rules/` remain available as supported locations if Nebula later needs them — today there is no unique content that belongs there.

## Test plan

- [x] `lefthook` pre-commit: typos clean; fmt/clippy/taplo/cargo-deny skipped (no matching staged files)
- [x] `lefthook` pre-push: `cargo nextest run --workspace --profile agent` — 3185 tests passed, 13 skipped
- [x] `lefthook` pre-push: `cargo test --workspace --doc` passed
- [x] `lefthook` pre-push: `cargo check --workspace --all-features --all-targets` passed
- [x] `lefthook` pre-push: `cargo check --no-default-features` for resilience/log/expression passed
- [x] `lefthook` pre-push: `cargo doc --workspace --no-deps --all-features` passed with `-D warnings`
- [x] `lefthook` pre-push: `cargo shear` passed
- [x] `guard-secrets.sh` live-tested this session: blocks `cat .env`, bare `printenv`, secret-var echo; allows `cat README.md`, `printenv PATH`
- [ ] Human sanity-check of the four `SKILL.md` descriptions and the hook regex categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic detection and blocking of commands that could accidentally leak secrets (credentials, SSH keys, API tokens, environment variables).
  * Added new workflow documentation: architectural review guidance, credential security checklist, documentation sync verification, and evidence-based completion process.

* **Chores**
  * Integrated new security protections into configuration system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->