### PR TITLE
fix(claude): decision-gate directional answers, stop duplicating canonical commands

### DIFF
--- a/.claude/skills/architectural-fit/SKILL.md
+++ b/.claude/skills/architectural-fit/SKILL.md
@@ -19,7 +19,7 @@ Unsure? Invoke anyway.
 
 ## Checklist
 
-1. **Canon decision gate.** Walk the six questions in root `CLAUDE.md` §"Decision gate (before proposing an architectural change)". Any "yes" → STOP and open an ADR per `docs/PRODUCT_CANON.md §0.2`. Do not restate the six questions — read them from `CLAUDE.md` each time.
+1. **Canon decision gate.** Walk the six questions in root `CLAUDE.md` §"Decision gate (before proposing an architectural change)". Some are directional (Q1 golden-path: "strengthens" is fine, "diverts" is not); others are yes/no hazards (Q2–Q6: a "yes" names a violation). Any **blocked or hazard** answer → STOP and open an ADR per `docs/PRODUCT_CANON.md §0.2`. Do not restate the six questions — read them from `CLAUDE.md` each time.
 
 2. **Bounded-context mapping.** Name the context the change lands in:
    - **Core** — core / validator / parameter / expression / workflow / execution

--- a/.claude/skills/verify-evidence/SKILL.md
+++ b/.claude/skills/verify-evidence/SKILL.md
@@ -26,24 +26,13 @@ Required phrases: actual tool output — a test summary line, a clippy "0 warnin
 
 ### 1. Canonical fast gate (root `CLAUDE.md`)
 
-Run and capture:
+Read the current fast-gate commands from root `CLAUDE.md` §"Canonical Commands", then run each one and capture the output. Every listed `cargo` invocation. Every time. Capture the last ~10 lines of each, especially the summary line from `nextest`.
 
-```bash
-cargo +nightly fmt --all
-cargo clippy --workspace -- -D warnings
-cargo nextest run --workspace
-```
-
-Every `cargo` invocation. Every time. Capture the last ~10 lines of each, especially the summary line from `nextest`.
+Do not hardcode the command list here — it would drift from the canon. `CLAUDE.md` is the source of truth for the gate.
 
 ### 2. Full gate (before PR)
 
-Match root `CLAUDE.md` §"Canonical Commands" "Full validation" exactly. Add to §1:
-
-```bash
-cargo test --workspace --doc
-cargo deny check
-```
+Use the current "Full validation" commands from root `CLAUDE.md` §"Canonical Commands".
 
 `lefthook` pre-push additionally runs `cargo check --workspace --all-features --all-targets`, `cargo check --no-default-features` for selected crates, `cargo doc`, and `cargo shear`. You do not need to run those by hand — the push-time mirror handles them. If CI fails on one, diagnose root cause (do not `--no-verify`).
 

--- a/.claude/skills/verify-evidence/SKILL.md
+++ b/.claude/skills/verify-evidence/SKILL.md
@@ -85,16 +85,19 @@ Paste **actual tool output**. Do not paraphrase. Do not summarize "all green" wi
 ```
 ## Verification evidence
 
+(One section per fast-gate / full-gate command you ran, using the current
+canonical list from root `CLAUDE.md`. Headers are named after the step,
+not the exact invocation — the command itself lives in `CLAUDE.md`.)
+
 ### fmt
-<last 3 lines of `cargo +nightly fmt --all`, or "(no output — clean)">
+<last 3 lines of the fmt step's output, or "(no output — clean)">
 
 ### clippy
-<last 10 lines of `cargo clippy --workspace -- -D warnings`>
+<last 10 lines of the clippy step's output>
 (clippy: 0 warnings across <N> crates)
 
 ### nextest
-<the "Summary" line at minimum:
- "Summary [  X.YZs] N tests run: N passed, 0 failed, 0 skipped">
+<at minimum the final Summary line, e.g. "Summary [  X.YZs] N tests run: N passed, 0 failed, 0 skipped">
 
 ### doctests (if ran)
 <summary>


### PR DESCRIPTION
## Summary

Follow-up to [#420](https://github.com/vanyastaff/nebula/pull/420). Addresses two coderabbitai review comments that landed after the merge.

- `.claude/skills/architectural-fit/SKILL.md` — clarify that the canon decision gate is not a flat "any yes → STOP". Q1 (golden path) is directional: "strengthens" is fine, only "diverts" is a hazard. Q2–Q6 are yes/no hazards. Wording now says "any blocked or hazard answer → STOP".
- `.claude/skills/verify-evidence/SKILL.md` — remove the hard-coded `cargo` command blocks from §1 and §2 that duplicated root `CLAUDE.md`. The skill now points to `CLAUDE.md §"Canonical Commands"` as the single source of truth, so the canon cannot silently drift from the skill. Pre-push additions note retained.

## Rationale

coderabbitai correctly pointed out:

1. Directional vs. hazard questions were being conflated. "Strengthens the golden path" is a "yes" answer you want, not a blocker. Fixed wording keeps the rigor (hazards stop you) without triggering false stops.
2. The fast-gate and full-gate command blocks in `verify-evidence` were a second source of truth for the same commands already in root `CLAUDE.md`. If one changed, the other would drift silently. Replaced with a reference to the canon section.

## Test plan

- [x] `lefthook` pre-commit: typos + convco pass; fmt/clippy/taplo/cargo-deny skipped (no matching staged files)
- [x] `lefthook` pre-push: nextest 3185 passed, 13 skipped; doctests / check-all-features / check-no-default / docs / shear all green
- [ ] Visual review that both files read sensibly with the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)