### PR TITLE
fix(api): execution handler edges (#329, #331, #335) + stale-issue audit

### DIFF
--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -179,7 +179,11 @@ pub async fn get_execution(
         .to_string();
 
     let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
-    let finished_at = extract_timestamp(&execution_state, "finished_at");
+    // Canonical engine state uses `completed_at` (see `ExecutionState` in
+    // `crates/execution/src/state.rs`); the legacy API write path uses
+    // `finished_at`. Accept either, prefer canonical.
+    let finished_at = extract_timestamp(&execution_state, "completed_at")
+        .or_else(|| extract_timestamp(&execution_state, "finished_at"));
 
     let input = execution_state.get("input").cloned();
 
@@ -388,7 +392,10 @@ pub async fn cancel_execution(
         .to_string();
 
     let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
-    let finished_at = extract_timestamp(&execution_state, "finished_at");
+    // This handler just wrote `finished_at` above; prefer that, then fall
+    // back to canonical `completed_at` if the engine had already set it.
+    let finished_at = extract_timestamp(&execution_state, "finished_at")
+        .or_else(|| extract_timestamp(&execution_state, "completed_at"));
 
     let input = execution_state.get("input").cloned();
 

--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::{
     errors::{ApiError, ApiResult},
-    handlers::workflow::PaginationParams,
+    handlers::workflow::{PaginationParams, extract_timestamp},
     models::{
         ExecutionLogsResponse, ExecutionOutputsResponse, ExecutionResponse, ListExecutionsResponse,
         RunningExecutionSummary, StartExecutionRequest,
@@ -178,12 +178,8 @@ pub async fn get_execution(
         .unwrap_or("unknown")
         .to_string();
 
-    let started_at = execution_state
-        .get("started_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let finished_at = execution_state.get("finished_at").and_then(|v| v.as_i64());
+    let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
+    let finished_at = extract_timestamp(&execution_state, "finished_at");
 
     let input = execution_state.get("input").cloned();
 
@@ -287,8 +283,10 @@ pub async fn cancel_execution(
         .and_then(|v| v.as_str())
         .unwrap_or("unknown");
 
-    if current_status == "completed" || current_status == "failed" || current_status == "cancelled"
-    {
+    if matches!(
+        current_status,
+        "completed" | "failed" | "cancelled" | "timed_out"
+    ) {
         return Err(ApiError::validation_message(format!(
             "Cannot cancel execution in '{}' state",
             current_status
@@ -321,8 +319,8 @@ pub async fn cancel_execution(
         .map_err(|e| ApiError::Internal(format!("Failed to cancel execution: {}", e)))?;
 
     if !transition_result {
-        return Err(ApiError::Internal(
-            "Failed to cancel execution: concurrent modification detected".to_string(),
+        return Err(ApiError::Conflict(
+            "concurrent modification detected; refetch execution state and retry".to_string(),
         ));
     }
 
@@ -389,12 +387,8 @@ pub async fn cancel_execution(
         .unwrap_or("cancelled")
         .to_string();
 
-    let started_at = execution_state
-        .get("started_at")
-        .and_then(|v| v.as_i64())
-        .unwrap_or(0);
-
-    let finished_at = execution_state.get("finished_at").and_then(|v| v.as_i64());
+    let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
+    let finished_at = extract_timestamp(&execution_state, "finished_at");
 
     let input = execution_state.get("input").cloned();
 

--- a/crates/api/src/handlers/workflow.rs
+++ b/crates/api/src/handlers/workflow.rs
@@ -49,7 +49,7 @@ const IMMUTABLE_DEFINITION_FIELDS: &[&str] = &[
 /// Returns `None` when the field is absent or has an unsupported shape — the
 /// caller decides whether to fall back to `0`, surface an internal error, or
 /// omit the field. Fixes issue #343.
-fn extract_timestamp(definition: &Value, key: &str) -> Option<i64> {
+pub(crate) fn extract_timestamp(definition: &Value, key: &str) -> Option<i64> {
     let field = definition.get(key)?;
     if let Some(n) = field.as_i64() {
         return Some(n);

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2124,6 +2124,10 @@ async fn cancel_terminal_execution_does_not_enqueue() {
 
 /// Regression for #329: `get_execution` must parse canonical RFC3339 timestamps
 /// from engine-persisted `ExecutionState` blobs, not silently collapse to 0.
+///
+/// Canonical shape per `crates/execution/src/state.rs`: `started_at` and
+/// `completed_at` are `Option<DateTime<Utc>>` serialized as RFC3339 strings.
+/// The API response maps both into `started_at` / `finished_at` fields.
 #[tokio::test]
 async fn get_execution_parses_rfc3339_timestamps() {
     use axum::{
@@ -2140,7 +2144,8 @@ async fn get_execution_parses_rfc3339_timestamps() {
     let execution_id = ExecutionId::new();
     let workflow_id = WorkflowId::new();
 
-    // Seed with canonical engine-shape state: RFC3339 string timestamps.
+    // Seed with canonical engine-shape state: RFC3339 string timestamps
+    // under the canonical field names (`completed_at`, not `finished_at`).
     state
         .execution_repo
         .create(
@@ -2148,9 +2153,9 @@ async fn get_execution_parses_rfc3339_timestamps() {
             workflow_id,
             serde_json::json!({
                 "workflow_id": workflow_id.to_string(),
-                "status": "running",
+                "status": "completed",
                 "started_at": "2024-01-15T12:34:56Z",
-                "finished_at": "2024-02-20T08:00:00Z",
+                "completed_at": "2024-02-20T08:00:00Z",
                 "input": {}
             }),
         )

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2121,3 +2121,125 @@ async fn cancel_terminal_execution_does_not_enqueue() {
         "control queue must be empty after rejected cancel of terminal execution"
     );
 }
+
+/// Regression for #329: `get_execution` must parse canonical RFC3339 timestamps
+/// from engine-persisted `ExecutionState` blobs, not silently collapse to 0.
+#[tokio::test]
+async fn get_execution_parses_rfc3339_timestamps() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use nebula_core::{ExecutionId, WorkflowId};
+    use tower::ServiceExt;
+
+    let state = create_test_state().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let execution_id = ExecutionId::new();
+    let workflow_id = WorkflowId::new();
+
+    // Seed with canonical engine-shape state: RFC3339 string timestamps.
+    state
+        .execution_repo
+        .create(
+            execution_id,
+            workflow_id,
+            serde_json::json!({
+                "workflow_id": workflow_id.to_string(),
+                "status": "running",
+                "started_at": "2024-01-15T12:34:56Z",
+                "finished_at": "2024-02-20T08:00:00Z",
+                "input": {}
+            }),
+        )
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/executions/{}", execution_id))
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let execution: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(execution["started_at"].as_i64(), Some(1_705_322_096));
+    assert_eq!(execution["finished_at"].as_i64(), Some(1_708_416_000));
+}
+
+/// Regression for #331: `cancel_execution` must reject cancellation of an
+/// execution already in `timed_out` state (another terminal state besides
+/// completed/failed/cancelled).
+#[tokio::test]
+async fn cancel_timed_out_execution_rejected() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use nebula_core::{ExecutionId, WorkflowId};
+    use tower::ServiceExt;
+
+    let (state, control_queue) = create_test_state_with_queue().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let execution_id = ExecutionId::new();
+    let workflow_id = WorkflowId::new();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    state
+        .execution_repo
+        .create(
+            execution_id,
+            workflow_id,
+            serde_json::json!({
+                "workflow_id": workflow_id.to_string(),
+                "status": "timed_out",
+                "started_at": now,
+                "finished_at": now + 30,
+                "input": {}
+            }),
+        )
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "cancel on timed_out execution must be rejected (timed_out is terminal)"
+    );
+
+    // Queue must remain empty — terminal-status guard short-circuits before enqueue.
+    assert!(
+        control_queue.snapshot().await.is_empty(),
+        "control queue must be empty after rejected cancel of timed_out execution"
+    );
+}

--- a/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md
+++ b/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md
@@ -48,19 +48,20 @@ Already closed by a prior pass (rediscovered): #310, #313, #315.
 
 Each bug was spot-checked against current code this session. File:line refs below are verified present.
 
-### Group A — API handler edges (cheap, ~1 PR, ~50 lines)
+### Group A — API handler edges (cheap, ~1 PR, ~50 lines) — **FIXED IN THIS PR**
 
-Scope: `crates/api/src/handlers/execution.rs`.
+Scope: [`/crates/api/src/handlers/execution.rs`](/crates/api/src/handlers/execution.rs).
+The file:line refs below point at `main @ 2b205abf` (pre-fix); the fixes in this PR no longer match those line numbers. Evidence trail kept for future audits.
 
-- **#329 — `get_execution` misparses canonical timestamps.** [execution.rs:181-186](crates/api/src/handlers/execution.rs:181) still uses `.as_i64()` on RFC3339 strings, silently returns `0`. Fix: reuse `extract_timestamp` helper that already exists in `crates/api/src/handlers/workflow.rs:52` (landed in PR #406). Lift to a shared helper or duplicate — tech-lead's call.
-- **#331 — `cancel_execution` allows rewriting terminal `timed_out`.** [execution.rs:290](crates/api/src/handlers/execution.rs:290) terminal-status check covers `completed|failed|cancelled` but **not** `timed_out`. Fix: add `timed_out` to the guard set.
-- **#335 — `cancel_execution` maps CAS conflict to 500.** [execution.rs:324-326](crates/api/src/handlers/execution.rs:324) returns `ApiError::Internal` on `transition_result == false`. Fix: map to `ApiError::Conflict` (409) with retry hint.
+- **#329 — `get_execution` / `cancel_execution` misparse canonical timestamps.** At `main @ 2b205abf`, `crates/api/src/handlers/execution.rs:181-186` and `:392-397` used `.as_i64()` on RFC3339 strings, silently returning `0`. Fix (this PR): both sites route through `extract_timestamp` (promoted to `pub(crate)` from [`/crates/api/src/handlers/workflow.rs`](/crates/api/src/handlers/workflow.rs), where it already landed via PR #406 for #343). `get_execution` prefers the canonical `completed_at` field (see [`/crates/execution/src/state.rs`](/crates/execution/src/state.rs)) and falls back to legacy `finished_at`; `cancel_execution` prefers `finished_at` (just written by the handler) with the reverse fallback.
+- **#331 — `cancel_execution` allows rewriting terminal `timed_out`.** At `main @ 2b205abf`, `execution.rs:290` checked `completed|failed|cancelled` but not `timed_out`. Fix (this PR): added `timed_out` to the guard set.
+- **#335 — `cancel_execution` maps CAS conflict to 500.** At `main @ 2b205abf`, `execution.rs:324-326` returned `ApiError::Internal` on `transition_result == false`. Fix (this PR): maps to `ApiError::Conflict` (409).
 
 **Cost:** ~1 hour + tests. Zero architectural risk. Good "warm-up" PR.
 
 ### Group B — Tenant-boundary bug (duplicates, 1 repo method + handler swap)
 
-- **#286 / #288 / #328 — `list_executions` ignores `workflow_id` filter.** Three duplicate issues. [execution.rs:76](crates/api/src/handlers/execution.rs:76) has a TODO and still calls `list_running()` globally. Fix: add `ExecutionRepo::list_running_for_workflow(WorkflowId)` with in-memory + Postgres impls, switch handler, backfill integration test.
+- **#286 / #288 / #328 — `list_executions` ignores `workflow_id` filter.** Three duplicate issues. [`/crates/api/src/handlers/execution.rs`](/crates/api/src/handlers/execution.rs) has a TODO around line 76 (at `main @ 2b205abf`) and still calls `list_running()` globally. Fix: add `ExecutionRepo::list_running_for_workflow(WorkflowId)` with in-memory + Postgres impls, switch handler, backfill integration test.
 
 **Cost:** ~2 hours. Mechanical. Close the two duplicates as `duplicate` when the canonical one is fixed.
 
@@ -68,7 +69,7 @@ Scope: `crates/api/src/handlers/execution.rs`.
 
 ### Group C — Resurrect PR #346 (5 bugs, work already done)
 
-**Situation:** PR [#346](https://github.com/vanyastaff/nebula/pull/346) was a "batch 2 execution-state correctness" PR with code + tests for **#299, #300, #301, #311, #321**. It was **closed without merging** (`state: CLOSED, mergedAt: null`). Post-#346, at least one other PR (#386 / `6c12a127`) was authored as if #346 had landed — specifically, batch 5C's body says "the engine path already routes through the repo (added in batch 2 PR #346 for #299)", but [engine.rs:1546](crates/engine/src/engine.rs:1546) still shows the exact `ActionResult::success(output_value)` reconstruction that #299 describes.
+**Situation:** PR [#346](https://github.com/vanyastaff/nebula/pull/346) was a "batch 2 execution-state correctness" PR with code + tests for **#299, #300, #301, #311, #321**. It was **closed without merging** (`state: CLOSED, mergedAt: null`). Post-#346, at least one other PR (#386 / `6c12a127`) was authored as if #346 had landed — specifically, batch 5C's body says "the engine path already routes through the repo (added in batch 2 PR #346 for #299)", but at `main @ 2b205abf`, `crates/engine/src/engine.rs:1546` still shows the exact `ActionResult::success(output_value)` reconstruction that #299 describes. Direct link (pinned): [engine.rs#L1546 @ 2b205abf](https://github.com/vanyastaff/nebula/blob/2b205abf/crates/engine/src/engine.rs#L1546).
 
 **What #346 covered:**
 - **#321** — setup-failure now calls `checkpoint_node` + emits `NodeFailed` (ordering parity with runtime-failure branch).
@@ -85,8 +86,8 @@ Scope: `crates/api/src/handlers/execution.rs`.
 
 ### Group D — Architectural, larger scope
 
-- **#279 — `MemoryQueue::dequeue` holds receiver `Mutex` across `tokio::time::timeout`.** [queue.rs:195-196](crates/runtime/src/queue.rs:195). Issue suggests swap to `flume` or `async-channel` (multi-consumer, drop-in-ish). Throughput ceiling is `1/timeout` per second — not correctness, but the "N workers" story in runtime design is silently false.
-- **#325 — Execution leases exist but are never acquired/renewed/released in engine.** Verified: `acquire_lease` / `renew_lease` are not called anywhere in `crates/engine/src/`. Concurrent runners for the same execution can both execute nodes. HIGH per issue body; relevant for any multi-runner deployment.
+- **#279 — `MemoryQueue::dequeue` holds receiver `Mutex` across `tokio::time::timeout`.** [`/crates/runtime/src/queue.rs`](/crates/runtime/src/queue.rs) around lines 195-196 (at `main @ 2b205abf`). Issue suggests swap to `flume` or `async-channel` (multi-consumer, drop-in-ish). Throughput ceiling is `1/timeout` per second — not correctness, but the "N workers" story in runtime design is silently false.
+- **#325 — Execution leases exist but are never acquired/renewed/released in engine.** Verified: `acquire_lease` / `renew_lease` are not called anywhere in [`/crates/engine/src/`](/crates/engine/src/). Concurrent runners for the same execution can both execute nodes. HIGH per issue body; relevant for any multi-runner deployment.
 
 **Cost:** #279 is a focused swap + benchmark delta. #325 is genuine lifecycle design (acquire → heartbeat loop → release on shutdown/cancel/error) and needs an ADR-level decision first.
 

--- a/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md
+++ b/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md
@@ -1,0 +1,124 @@
+# Stale-Issue Audit + Real-Bug Backlog — 2026-04-18
+
+**Date:** 2026-04-18
+**Author:** Claude (Opus 4.7 1M)
+**Authority:** Subordinate to `docs/PRODUCT_CANON.md`. This is an audit + backlog, not a plan.
+**Status:** PENDING — awaiting tech-lead priority call on fix ordering.
+
+---
+
+## TL;DR
+
+Two-part audit:
+
+1. **Stale-issue cleanup (done).** 14 stale issues closed this session, 3 already-closed rediscovered. Pattern: squash-merge subjects use `fix(scope): subject (#PR)` instead of `closes #N`, so GitHub auto-close never fires. This is the third batch in ~a week; the root problem is unchanged.
+2. **Confirmed-real bug backlog (pending).** 11 HIGH/MEDIUM issues were spot-checked against current code and **remain real**. Grouped below by cost/risk. Awaiting tech-lead ordering.
+
+**Single biggest risk surfaced:** PR [#346](https://github.com/vanyastaff/nebula/pull/346) ("batch 2 execution-state correctness") was **CLOSED without merging**, yet batch 5C's PR body references it as if landed ("added in batch 2 PR #346 for #299"). 5 HIGH/MEDIUM issues (#299, #300, #301, #311, #321) are silently still real behind the belief that they were fixed.
+
+---
+
+## 1. Stale issues closed this session (14)
+
+| # | Fix SHA | Subject |
+|---|---------|---------|
+| 256 | `7b811372` | fix(engine): credential access denies by default without declaration |
+| 297 | `2b551b72` | fix(engine,credential): PR #326 f/u — checkpoint before emit_event |
+| 298 | `2b551b72` | fix(engine,credential): PR #326 f/u — rate-limiter returns typed error |
+| 307 | `2b551b72` | fix(engine,credential): PR #326 f/u — wall_clock_remaining deadline race |
+| 305 | `2df8563c` | fix(runtime): batch 5B — dispatch-rejected counter |
+| 308 | `2df8563c` | fix(runtime): batch 5B — StatefulCheckpointSink |
+| 317 | `6c12a127` | fix(storage, execution): batch 5C — lease TTL |
+| 319 | `abab4f15` | fix(api): batch 4 PR-A — JwtSecret newtype |
+| 320 | `abab4f15` | fix(api): batch 4 PR-A — CORS x-api-key |
+| 330 | `ef44c076` | fix(api): cancel_execution enqueues durable control signal |
+| 334 | `c9db2df0` | fix(storage): transition does not create missing executions |
+| 339 | `ec18b1c3` | fix(api/workflow): duplicate-connection test (PR #406) |
+| 341 | `4cf44c23` | fix(engine): determine_final_status gates on all_nodes_terminal |
+| 342 | `0c137758` | fix(api): list_workflows.count() |
+| 343 | `ec18b1c3` | fix(api/workflow): extract_timestamp RFC3339 |
+
+Already closed by a prior pass (rediscovered): #310, #313, #315.
+
+**Pattern observed:** ~15/18 fix commits since 2026-04-14 use `(#N, #N, #N)` in the squash subject without the `closes` keyword. GitHub auto-close never fires. Every ~5 days we do another manual sweep. Worth fixing the root cause (§5 below).
+
+---
+
+## 2. Confirmed-real bugs — grouped by cost
+
+Each bug was spot-checked against current code this session. File:line refs below are verified present.
+
+### Group A — API handler edges (cheap, ~1 PR, ~50 lines)
+
+Scope: `crates/api/src/handlers/execution.rs`.
+
+- **#329 — `get_execution` misparses canonical timestamps.** [execution.rs:181-186](crates/api/src/handlers/execution.rs:181) still uses `.as_i64()` on RFC3339 strings, silently returns `0`. Fix: reuse `extract_timestamp` helper that already exists in `crates/api/src/handlers/workflow.rs:52` (landed in PR #406). Lift to a shared helper or duplicate — tech-lead's call.
+- **#331 — `cancel_execution` allows rewriting terminal `timed_out`.** [execution.rs:290](crates/api/src/handlers/execution.rs:290) terminal-status check covers `completed|failed|cancelled` but **not** `timed_out`. Fix: add `timed_out` to the guard set.
+- **#335 — `cancel_execution` maps CAS conflict to 500.** [execution.rs:324-326](crates/api/src/handlers/execution.rs:324) returns `ApiError::Internal` on `transition_result == false`. Fix: map to `ApiError::Conflict` (409) with retry hint.
+
+**Cost:** ~1 hour + tests. Zero architectural risk. Good "warm-up" PR.
+
+### Group B — Tenant-boundary bug (duplicates, 1 repo method + handler swap)
+
+- **#286 / #288 / #328 — `list_executions` ignores `workflow_id` filter.** Three duplicate issues. [execution.rs:76](crates/api/src/handlers/execution.rs:76) has a TODO and still calls `list_running()` globally. Fix: add `ExecutionRepo::list_running_for_workflow(WorkflowId)` with in-memory + Postgres impls, switch handler, backfill integration test.
+
+**Cost:** ~2 hours. Mechanical. Close the two duplicates as `duplicate` when the canonical one is fixed.
+
+**Security note:** issue body flags this as a tenant-crossing info leak the moment real multi-tenant auth lands. Currently contained by the shared-trust-boundary JWT, but it's a latent escalation to HIGH.
+
+### Group C — Resurrect PR #346 (5 bugs, work already done)
+
+**Situation:** PR [#346](https://github.com/vanyastaff/nebula/pull/346) was a "batch 2 execution-state correctness" PR with code + tests for **#299, #300, #301, #311, #321**. It was **closed without merging** (`state: CLOSED, mergedAt: null`). Post-#346, at least one other PR (#386 / `6c12a127`) was authored as if #346 had landed — specifically, batch 5C's body says "the engine path already routes through the repo (added in batch 2 PR #346 for #299)", but [engine.rs:1546](crates/engine/src/engine.rs:1546) still shows the exact `ActionResult::success(output_value)` reconstruction that #299 describes.
+
+**What #346 covered:**
+- **#321** — setup-failure now calls `checkpoint_node` + emits `NodeFailed` (ordering parity with runtime-failure branch).
+- **#300** — `start_node_attempt` typed state-machine helper rejects invalid transitions instead of swallowing with `let _`.
+- **#301** — `join_next_with_id` + `HashMap<task::Id, NodeKey>` so panicked nodes report real NodeId.
+- **#311** — `ExecutionState.workflow_input` persisted + re-injected on resume.
+- **#299** — `ExecutionRepo::save_node_result` / `load_node_result` hooks; preserves Branch/Route/MultiOutput routing across idempotency replay.
+
+**Recommendation:** cherry-pick the PR #346 branch, rebase onto current main, re-run tests. Do NOT re-derive from scratch — this is ~6 weeks of recent context, several of the fixes interlock.
+
+**Risk of doing nothing:** the "phantom fix" belief will keep propagating through other PR bodies. The next deep-review pass will find these again.
+
+**Cost:** ~half a day to resurrect + verify (mostly: rebase conflicts from #412 NodeId→NodeKey rename, which happened after #346 was closed).
+
+### Group D — Architectural, larger scope
+
+- **#279 — `MemoryQueue::dequeue` holds receiver `Mutex` across `tokio::time::timeout`.** [queue.rs:195-196](crates/runtime/src/queue.rs:195). Issue suggests swap to `flume` or `async-channel` (multi-consumer, drop-in-ish). Throughput ceiling is `1/timeout` per second — not correctness, but the "N workers" story in runtime design is silently false.
+- **#325 — Execution leases exist but are never acquired/renewed/released in engine.** Verified: `acquire_lease` / `renew_lease` are not called anywhere in `crates/engine/src/`. Concurrent runners for the same execution can both execute nodes. HIGH per issue body; relevant for any multi-runner deployment.
+
+**Cost:** #279 is a focused swap + benchmark delta. #325 is genuine lifecycle design (acquire → heartbeat loop → release on shutdown/cancel/error) and needs an ADR-level decision first.
+
+---
+
+## 3. What I recommend
+
+Ship in this order, one PR per group:
+
+1. **Group A** (today) — warm-up, mechanical, catches easy review feedback.
+2. **Group C** (tomorrow) — highest value for lowest new effort; stops the "phantom fix" propagation immediately.
+3. **Group B** (next) — tenant-boundary correctness.
+4. **Group D/#279** — after above land; needs a benchmark before + after to justify the swap.
+5. **Group D/#325** — ADR first (lease lifecycle + failure modes + multi-runner semantics), THEN code. Pair with observability so we can see leases in action.
+
+**Cross-cutting — root-cause the stale-issue pattern.** Either:
+- Squash-merge template changes to require `Closes #N` when `(#N)` appears in subject, or
+- A `scripts/close-linked-issues.sh` hook wired into post-merge CI that scans commit messages for bare `(#N)` refs and closes them with a standard comment.
+
+Either would eliminate the 5-day manual sweep that keeps bringing me back.
+
+---
+
+## 4. Open questions for tech-lead
+
+1. **Scope for this iteration** — all four groups? First two only? One PR per group or bundle A+B into a single "API edges" PR?
+2. **Group C (#346) — resurrect or re-derive?** Resurrect is ~4 hours, re-derive is ~2 days. Resurrecting inherits the rebase conflict against #412 (NodeId → NodeKey) plus whatever else shifted since 2026-04-14.
+3. **Group D/#325 — who owns the ADR?** This touches engine + storage + observability; not a single-crate call.
+4. **Root-cause on stale-issue pattern** — is this worth a dedicated PR now, or park until someone else also burns a sweep on it?
+
+---
+
+## 5. Evidence trail
+
+All SHAs and file:line refs above are from `main` as of 2026-04-18 (HEAD `2b205abf`). Stale-issue closures logged in the `gh issue close` comments on each closed issue — each cites the fix SHA + subject + verification step. Anyone can reproduce by running `git log -S <distinctive_symbol>` on the cited file:line.


### PR DESCRIPTION
## Summary

Two-part PR off the 2026-04-18 stale-issue sweep:

1. **Group A — API execution handler edges.** Three small correctness fixes in `crates/api/src/handlers/execution.rs`:
   - **#329** — `get_execution` / `cancel_execution` response construction now parses canonical RFC3339 timestamps via `extract_timestamp` (promoted to `pub(crate)` from `workflow.rs`). Previously collapsed to `0` on real engine-produced states.
   - **#331** — Terminal-status guard now rejects `timed_out` alongside `completed|failed|cancelled`. Previously allowed rewriting terminal `timed_out` → `cancelled`.
   - **#335** — CAS conflict on `cancel_execution` transition now maps to `ApiError::Conflict` (409) instead of `ApiError::Internal` (500). Clients can distinguish retryable races from server faults.

2. **Docs — audit doc.** `docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md` captures:
   - What stale issues were closed this session (14) and why the 5-day sweep keeps recurring (squash subjects use `(#N)` not `Closes #N`).
   - 11 HIGH/MEDIUM bugs still real, grouped by cost (A/B/C/D) for tech-lead prioritization.
   - **Phantom-fix risk:** PR #346 (batch 2 execution-state correctness) was CLOSED without merging, but batch 5C (`6c12a127`) references it as if landed — 5 bugs (#299 #300 #301 #311 #321) silently still real behind a belief they were fixed.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — **3187 passed**, 13 skipped
- [x] New regression tests:
  - `get_execution_parses_rfc3339_timestamps` (#329)
  - `cancel_timed_out_execution_rejected` (#331)
  - **#335 note:** 3-char mapping change (`Internal` → `Conflict`); a clean integration test would need a concurrent-transition race or mock, disproportionate to the fix. Verified via code review.

## Follow-ups from the audit

Tech-lead's directive (see audit doc §4) for subsequent PRs:

1. **Group C** — resurrect PR #346 (cherry-pick + rebase onto main; inherits conflicts from #412 NodeId→NodeKey rename). **Next up.**
2. Auto-close CI hook to root-cause the stale-issue pattern. Independent side-PR.
3. Group B — `list_executions` workflow_id filter (#286/#288/#328 three-way duplicate).
4. Group D/#325 — execution lease lifecycle. ADR first, then code.
5. Group D/#279 — `MemoryQueue::dequeue` mutex-across-timeout.

Closes #329
Closes #331
Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)