### PR TITLE
fix(engine): batch 2 execution-state correctness (#299, #300, #301, #311, #321)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1195,11 +1195,16 @@ impl WorkflowEngine {
                 )
                 .await;
 
-                self.emit_event(ExecutionEvent::NodeFailed {
-                    execution_id,
-                    node_key: node_key.clone(),
-                    error: setup_err_msg.clone(),
-                });
+                if exec_state
+                    .node_state(node_key.clone())
+                    .is_some_and(|ns| ns.state == NodeState::Failed)
+                {
+                    self.emit_event(ExecutionEvent::NodeFailed {
+                        execution_id,
+                        node_key: node_key.clone(),
+                        error: setup_err_msg.clone(),
+                    });
+                }
 
                 if let Some(err_msg) = abort {
                     cancel_token.cancel();

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -434,6 +434,15 @@ impl WorkflowEngine {
         // the version move (issue #255).
         let mut exec_state = ExecutionState::new(execution_id, workflow.id, &node_ids);
         exec_state.transition_status(ExecutionStatus::Running)?;
+        // Use override inputs if provided — computed up front so the
+        // same value is persisted on the execution state (issue #311)
+        // and fed to the frontier loop.
+        let input = plan
+            .input_overrides
+            .get(&plan.replay_from)
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        exec_state.set_workflow_input(input.clone());
         for node_key in &pinned {
             // NOTE: errors are intentionally discarded here. Pinned nodes are
             // forced through Ready→Running→Completed for bookkeeping; the
@@ -462,13 +471,6 @@ impl WorkflowEngine {
             })
             .cloned()
             .collect();
-
-        // Use override inputs if provided.
-        let input = plan
-            .input_overrides
-            .get(&plan.replay_from)
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
 
         let error_strategy = workflow.config.error_strategy;
 
@@ -566,6 +568,10 @@ impl WorkflowEngine {
         let node_ids: Vec<NodeKey> = workflow.nodes.iter().map(|n| n.id.clone()).collect();
         let mut exec_state = ExecutionState::new(execution_id, workflow.id, &node_ids);
         exec_state.transition_status(ExecutionStatus::Running)?;
+        // Persist the original trigger payload so that resume can
+        // feed entry nodes the same input instead of substituting
+        // Null (issue #311).
+        exec_state.set_workflow_input(input.clone());
 
         // 4b. Persist initial execution state
         let mut repo_version: u64 = 0;
@@ -873,13 +879,22 @@ impl WorkflowEngine {
             .inc();
 
         let error_strategy = workflow.config.error_strategy;
-        // TODO: the original workflow input is not persisted in ExecutionState.
-        // Resume passes Null, which means re-running entry nodes will not receive
-        // the original trigger data. Entry nodes that have already completed are
-        // skipped via idempotency, so this only affects entry nodes that crashed
-        // mid-execution without completing. To fix, persist `workflow_input` in
-        // ExecutionState alongside the execution ID.
-        let workflow_input = serde_json::Value::Null;
+        // Restore the original trigger payload from the persisted
+        // execution state. Legacy states that predate #311 deserialize
+        // the field as `None` — fall back to `Null` with a warning so
+        // the regression is visible in logs.
+        let workflow_input = match exec_state.workflow_input.clone() {
+            Some(v) => v,
+            None => {
+                tracing::warn!(
+                    %execution_id,
+                    "resume: persisted execution state is missing workflow_input; \
+                     falling back to Null — entry nodes that did not complete \
+                     on the original run will receive Null input"
+                );
+                serde_json::Value::Null
+            },
+        };
         let failed_node = self
             .run_frontier(
                 &graph,
@@ -1014,11 +1029,15 @@ impl WorkflowEngine {
             ready_queue.push_back(node_key);
         }
 
-        // In-flight tasks
+        // In-flight tasks + a side map from tokio task id → NodeKey so
+        // that panics (where the inner future's `(NodeKey, _)` payload
+        // is lost) can still be attributed to the real node instead
+        // of a synthesized placeholder (issue #301).
         let mut join_set: JoinSet<(
             NodeKey,
             Result<ActionResult<serde_json::Value>, EngineError>,
         )> = JoinSet::new();
+        let mut task_nodes: HashMap<tokio::task::Id, NodeKey> = HashMap::new();
 
         // Main frontier loop
         loop {
@@ -1087,6 +1106,7 @@ impl WorkflowEngine {
                     input,
                     &activated_edges,
                     &mut join_set,
+                    &mut task_nodes,
                 );
                 if spawned {
                     let action_key = node_map
@@ -1101,10 +1121,19 @@ impl WorkflowEngine {
                     continue;
                 }
 
-                // Node failed during setup (e.g., param resolution).
+                // Node failed during setup (e.g., param resolution, invalid
+                // state machine position, missing node definition). Read the
+                // error message the setup path recorded on the node state;
+                // fall back to a generic message if absent.
+                let setup_err_msg = exec_state
+                    .node_states
+                    .get(&node_key)
+                    .and_then(|ns| ns.error_message.clone())
+                    .unwrap_or_else(|| "node setup failed".to_owned());
+
                 let abort = handle_node_failure(
                     node_key.clone(),
-                    "parameter resolution failed",
+                    &setup_err_msg,
                     error_strategy,
                     graph,
                     outputs,
@@ -1114,6 +1143,25 @@ impl WorkflowEngine {
                     &mut ready_queue,
                     exec_state,
                 );
+
+                // Checkpoint *after* handle_node_failure so the persisted
+                // node state reflects the final resolved state — symmetrical
+                // to the runtime-failure branch below (issue #321).
+                self.checkpoint_node(
+                    execution_id,
+                    node_key.clone(),
+                    outputs,
+                    exec_state,
+                    repo_version,
+                )
+                .await;
+
+                self.emit_event(ExecutionEvent::NodeFailed {
+                    execution_id,
+                    node_key: node_key.clone(),
+                    error: setup_err_msg.clone(),
+                });
+
                 if let Some(err_msg) = abort {
                     cancel_token.cancel();
                     return Some((node_key, err_msg));
@@ -1127,7 +1175,8 @@ impl WorkflowEngine {
 
             if cancel_token.is_cancelled() {
                 join_set.abort_all();
-                while join_set.join_next().await.is_some() {}
+                while join_set.join_next_with_id().await.is_some() {}
+                task_nodes.clear();
                 break;
             }
 
@@ -1148,14 +1197,15 @@ impl WorkflowEngine {
             tokio::pin!(sleep_fut);
 
             let join_result = tokio::select! {
-                result = join_set.join_next() => match result {
+                result = join_set.join_next_with_id() => match result {
                     Some(r) => r,
                     None => break,
                 },
                 () = &mut sleep_fut => {
                     cancel_token.cancel();
                     join_set.abort_all();
-                    while join_set.join_next().await.is_some() {}
+                    while join_set.join_next_with_id().await.is_some() {}
+                    task_nodes.clear();
                     return Some((
                         node_key!("_timeout"),
                         "execution budget exceeded: max_duration".to_string(),
@@ -1163,14 +1213,16 @@ impl WorkflowEngine {
                 }
                 () = cancel_token.cancelled() => {
                     join_set.abort_all();
-                    while join_set.join_next().await.is_some() {}
+                    while join_set.join_next_with_id().await.is_some() {}
+                    task_nodes.clear();
                     break;
                 }
             };
 
             // Phase 3: Process the completed task
             match join_result {
-                Ok((node_key, Ok(ActionResult::Retry { .. }))) => {
+                Ok((task_id, (node_key, Ok(ActionResult::Retry { .. })))) => {
+                    task_nodes.remove(&task_id);
                     // ActionResult::Retry has no scheduler yet; treat it as a node
                     // failure for at-least-once semantics (#290/#296 short-term).
                     total_retries.fetch_add(1, Ordering::Relaxed);
@@ -1216,7 +1268,8 @@ impl WorkflowEngine {
                         });
                     }
                 },
-                Ok((node_key, Ok(action_result))) => {
+                Ok((task_id, (node_key, Ok(action_result)))) => {
+                    task_nodes.remove(&task_id);
                     mark_node_completed(exec_state, node_key.clone());
 
                     // Track output size for budget enforcement
@@ -1242,6 +1295,22 @@ impl WorkflowEngine {
                     self.record_idempotency(execution_id, node_key.clone())
                         .await;
 
+                    // Persist the full ActionResult alongside the raw
+                    // output so that idempotent replay can reconstruct
+                    // the exact routing semantics (issue #299).
+                    let attempt = exec_state
+                        .node_states
+                        .get(&node_key)
+                        .map(|ns| ns.attempt_count().max(1) as u32)
+                        .unwrap_or(1);
+                    self.record_node_result(
+                        execution_id,
+                        node_key.clone(),
+                        attempt,
+                        &action_result,
+                    )
+                    .await;
+
                     self.emit_event(ExecutionEvent::NodeCompleted {
                         execution_id,
                         node_key: node_key.clone(),
@@ -1261,10 +1330,11 @@ impl WorkflowEngine {
                         exec_state,
                     );
                 },
-                Ok((node_key, Err(ref err))) => {
+                Ok((task_id, (node_key, Err(ref err)))) => {
+                    task_nodes.remove(&task_id);
                     // Node failed at runtime — persist before any observer
                     // learns the node is done and before successors advance
-                    // (#297).
+                    // (#297). Delegate to the strategy-aware handler.
                     mark_node_failed(exec_state, node_key.clone(), err);
                     let abort = handle_node_failure(
                         node_key.clone(),
@@ -1304,9 +1374,53 @@ impl WorkflowEngine {
                     }
                 },
                 Err(join_err) => {
-                    tracing::error!(?join_err, "node task panicked");
+                    // Recover the real NodeKey via the task-id side
+                    // map; falling back to a synthetic key would
+                    // report a phantom node and lose the identity of
+                    // the actually-panicked task (issue #301).
+                    let task_id = join_err.id();
+                    let panicked_node = task_nodes.remove(&task_id);
+                    let err_msg = join_err.to_string();
+                    tracing::error!(
+                        ?task_id,
+                        ?panicked_node,
+                        error = %err_msg,
+                        "node task panicked"
+                    );
+
+                    if let Some(node_key) = panicked_node {
+                        // Best-effort accounting so the panicked node
+                        // ends up Failed with a real error message
+                        // and its final state is persisted — same
+                        // shape as the runtime-failure branch above.
+                        let panic_err = EngineError::TaskPanicked(err_msg.clone());
+                        mark_node_failed(exec_state, node_key.clone(), &panic_err);
+                        self.checkpoint_node(
+                            execution_id,
+                            node_key.clone(),
+                            outputs,
+                            exec_state,
+                            repo_version,
+                        )
+                        .await;
+                        self.emit_event(ExecutionEvent::NodeFailed {
+                            execution_id,
+                            node_key: node_key.clone(),
+                            error: err_msg.clone(),
+                        });
+                        cancel_token.cancel();
+                        return Some((node_key, err_msg));
+                    }
+
+                    // No matching task id — this should be unreachable
+                    // as we insert every spawn into `task_nodes`, but
+                    // fall through defensively rather than inventing
+                    // a node identity.
                     cancel_token.cancel();
-                    return Some((node_key!("_panicked"), join_err.to_string()));
+                    return Some((
+                        node_key!("_panicked"),
+                        format!("panicked task with unknown id: {err_msg}"),
+                    ));
                 },
             }
         }
@@ -1336,8 +1450,16 @@ impl WorkflowEngine {
             NodeKey,
             Result<ActionResult<serde_json::Value>, EngineError>,
         )>,
+        task_nodes: &mut HashMap<tokio::task::Id, NodeKey>,
     ) -> bool {
         let Some(node_def) = node_map.get(&node_key) else {
+            // Unknown node — route through the setup-failure path so
+            // the frontier loop records the error and checkpoints the
+            // state (issues #300, #321).
+            let _ = exec_state.mark_setup_failed(
+                node_key.clone(),
+                format!("node {node_key} is not in the workflow's node map"),
+            );
             return false;
         };
         let action_key = node_def.action_key.as_str().to_owned();
@@ -1361,32 +1483,29 @@ impl WorkflowEngine {
                 Ok(Some(resolved_params)) => resolved_params,
                 Ok(None) => node_input, // No parameters → use predecessor output
                 Err(e) => {
-                    // Mark node as failed. Using `override_node_state`
-                    // rather than a Ready→Running→Failed sequence
-                    // because (a) parameter resolution failed BEFORE
-                    // the node was scheduled so it is still Pending
-                    // here, and Pending→Failed is not a valid forward
-                    // transition; (b) we know for a fact the node
-                    // failed and want it in the Failed state
-                    // regardless of its current position. Version is
-                    // still bumped per issue #255.
-                    let _ = exec_state.override_node_state(node_key.clone(), NodeState::Failed);
-                    if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
-                        ns.error_message = Some(e.to_string());
-                    }
+                    // Parameter resolution failed. `mark_setup_failed`
+                    // handles the Pending/Failed/Retrying source states
+                    // uniformly via `override_node_state` (Pending →
+                    // Failed is not a valid forward transition) and
+                    // bumps the parent version for CAS readers
+                    // (issues #255, #300).
+                    let _ = exec_state.mark_setup_failed(node_key.clone(), e.to_string());
                     return false;
                 },
             };
 
-        // Mark node as running in execution state (versioned).
-        // Log on failure so a rejected transition is not silently
-        // swallowed — callers of the frontier loop need to know if
-        // the execution state got out of sync with the scheduler.
-        if let Err(err) = exec_state.transition_node(node_key.clone(), NodeState::Ready) {
-            tracing::warn!(%node_key, %err, "failed to transition node to Ready");
-        }
-        if let Err(err) = exec_state.transition_node(node_key.clone(), NodeState::Running) {
-            tracing::warn!(%node_key, %err, "failed to transition node to Running");
+        // Drive the node to Running via the typed state-machine
+        // helper. `start_node_attempt` models the legal transitions
+        // (Pending → Ready → Running, Failed → Retrying → Running,
+        // Retrying → Running) and returns an error for anything else.
+        // On error we do NOT silently spawn the task on stale state —
+        // route through the setup-failure path instead (issue #300).
+        if let Err(err) = exec_state.start_node_attempt(node_key.clone()) {
+            let _ = exec_state.mark_setup_failed(
+                node_key.clone(),
+                format!("cannot start node attempt: {err}"),
+            );
+            return false;
         }
 
         let runtime = self.runtime.clone();
@@ -1448,7 +1567,7 @@ impl WorkflowEngine {
                 .map(Arc::new)
         });
 
-        join_set.spawn(
+        let handle = join_set.spawn(
             NodeTask {
                 runtime,
                 cancel,
@@ -1468,6 +1587,7 @@ impl WorkflowEngine {
             }
             .run(),
         );
+        task_nodes.insert(handle.id(), node_key);
 
         true
     }
@@ -1543,10 +1663,54 @@ impl WorkflowEngine {
         outputs.insert(node_key.clone(), output_value.clone());
         mark_node_completed(exec_state, node_key.clone());
 
-        let fake_result = ActionResult::success(output_value);
+        // Prefer the fully-typed persisted ActionResult when
+        // available. Falling back to a synthesized `Success` loses
+        // Branch/Route/MultiOutput/Skip routing semantics on replay —
+        // every branch edge would fire unconditionally (issue #299).
+        let stored_result = match repo.load_node_result(execution_id, node_key.clone()).await {
+            Ok(Some(raw)) => match serde_json::from_value::<ActionResult<serde_json::Value>>(raw) {
+                Ok(result) => Some(result),
+                Err(e) => {
+                    tracing::warn!(
+                        %execution_id,
+                        %node_key,
+                        error = %e,
+                        "failed to deserialize persisted action result; \
+                         falling back to synthesized Success"
+                    );
+                    None
+                },
+            },
+            Ok(None) => {
+                // Backend has no stored result (legacy rows, or a
+                // backend that does not override save_node_result).
+                // Fall back to the old behaviour but log so the
+                // regression is visible.
+                tracing::warn!(
+                    %execution_id,
+                    %node_key,
+                    "idempotency replay has no persisted ActionResult; \
+                     synthesizing Success — Branch/Route/MultiOutput \
+                     routing will not be preserved"
+                );
+                None
+            },
+            Err(e) => {
+                tracing::warn!(
+                    %execution_id,
+                    %node_key,
+                    error = %e,
+                    "failed to load persisted action result; \
+                     falling back to synthesized Success"
+                );
+                None
+            },
+        };
+
+        let effective_result = stored_result.unwrap_or_else(|| ActionResult::success(output_value));
         process_outgoing_edges(
             node_key.clone(),
-            Some(&fake_result),
+            Some(&effective_result),
             None,
             graph,
             activated_edges,
@@ -1557,6 +1721,49 @@ impl WorkflowEngine {
         );
 
         true
+    }
+
+    /// Persist the full [`ActionResult`] variant for a successfully
+    /// executed node so that idempotent replay can reconstruct the
+    /// exact routing semantics (Branch/Route/MultiOutput/Skip) instead
+    /// of synthesising a flat `Success` (issue #299).
+    ///
+    /// Best-effort: failures are logged and ignored. Backends that do
+    /// not override `save_node_result` no-op via the default trait
+    /// implementation.
+    async fn record_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        attempt: u32,
+        action_result: &ActionResult<serde_json::Value>,
+    ) {
+        let Some(repo) = &self.execution_repo else {
+            return;
+        };
+        let value = match serde_json::to_value(action_result) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    %execution_id,
+                    %node_key,
+                    error = %e,
+                    "failed to serialize action result for persistence"
+                );
+                return;
+            },
+        };
+        if let Err(e) = repo
+            .save_node_result(execution_id, node_key.clone(), attempt, value)
+            .await
+        {
+            tracing::warn!(
+                %execution_id,
+                %node_key,
+                error = %e,
+                "failed to persist action result"
+            );
+        }
     }
 
     /// Record an idempotency key for a successfully executed node (best-effort).
@@ -3859,7 +4066,6 @@ mod tests {
         registry.register_stateless(EchoHandler {
             meta: ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
         });
-
         let (engine, _) = make_engine(registry);
 
         let a = node_key!("a");
@@ -4315,6 +4521,325 @@ mod tests {
             result.is_success(),
             "repeated with_action_credentials must merge, not replace. errors: {:?}",
             result.node_errors
+        );
+    }
+
+    // -- Regression tests for batch 2 (#299, #300, #301, #311, #321) --
+
+    /// Issue #321 — the setup-failure path (parameter resolution error,
+    /// missing node definition, invalid state-machine start) must
+    /// checkpoint the execution state, symmetrical with the runtime-
+    /// failure path. Previously only the runtime branch checkpointed,
+    /// so a setup failure left the persisted state describing the node
+    /// as Pending even though it was Failed in memory.
+    #[tokio::test]
+    async fn setup_failure_checkpoints_execution_state() {
+        // Force parameter resolution to fail by referencing a node
+        // that has no output in the shared outputs map.
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(EchoHandler {
+            meta: ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        });
+
+        let repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+        let (engine, _) = make_engine(registry);
+        let engine = engine.with_execution_repo(repo.clone());
+
+        let n1 = node_key!("n1");
+        let ghost = node_key!("ghost");
+        let mut params: HashMap<String, nebula_workflow::ParamValue> = HashMap::new();
+        params.insert(
+            "input".into(),
+            nebula_workflow::ParamValue::Reference {
+                node_key: ghost,
+                output_path: String::new(),
+            },
+        );
+        let mut node = NodeDefinition::new(n1.clone(), "A", "echo").unwrap();
+        node.parameters = params;
+
+        let wf = make_workflow(vec![node], vec![]);
+
+        let result = engine
+            .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+            .await
+            .unwrap();
+
+        assert!(result.is_failure(), "setup failure should fail execution");
+
+        // The critical assertion: the execution state was checkpointed
+        // after the setup failure. The persisted status must be
+        // `failed` and the failed node's state must be `failed` with
+        // an error_message populated.
+        let (_version, state_json) = repo
+            .get_state(result.execution_id)
+            .await
+            .unwrap()
+            .expect("execution state should be persisted after setup failure");
+        assert_eq!(
+            state_json.get("status").and_then(|s| s.as_str()),
+            Some("failed"),
+            "execution status should be persisted as failed"
+        );
+        let node_state = state_json
+            .pointer(&format!("/node_states/{n1}/state"))
+            .and_then(|v| v.as_str());
+        assert_eq!(
+            node_state,
+            Some("failed"),
+            "node state should be persisted as failed after setup failure (issue #321)"
+        );
+        let err_msg = state_json
+            .pointer(&format!("/node_states/{n1}/error_message"))
+            .and_then(|v| v.as_str());
+        assert!(
+            err_msg.is_some(),
+            "setup-failure error message should be persisted, got state: {state_json}"
+        );
+    }
+
+    /// Issue #311 — resume_execution must restore the original
+    /// workflow input from the persisted state, not substitute Null.
+    /// Regression: `ExecutionState::workflow_input` is now persisted
+    /// at execution start and read back on resume.
+    #[tokio::test]
+    async fn resume_restores_original_workflow_input() {
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(EchoHandler {
+            meta: ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        });
+
+        let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+        let (engine, _) = make_engine(registry);
+
+        let n1 = node_key!("n1");
+        let wf = make_workflow(
+            vec![NodeDefinition::new(n1.clone(), "A", "echo").unwrap()],
+            vec![],
+        );
+        let workflow_repo = save_workflow_to_repo(&wf).await;
+
+        // Build a partial execution state for a FRESH execution where
+        // the entry node has not yet run. Persist it with the original
+        // trigger payload set via `set_workflow_input`.
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, wf.id, std::slice::from_ref(&n1));
+        exec_state
+            .transition_status(ExecutionStatus::Running)
+            .unwrap();
+        exec_state.set_workflow_input(serde_json::json!({"trigger": "webhook-payload"}));
+        let state_json = serde_json::to_value(&exec_state).unwrap();
+        exec_repo
+            .create(execution_id, wf.id, state_json)
+            .await
+            .unwrap();
+
+        let engine = engine
+            .with_execution_repo(exec_repo.clone())
+            .with_workflow_repo(workflow_repo);
+
+        let result = engine.resume_execution(execution_id).await.unwrap();
+
+        assert!(result.is_success());
+        // Echo pipes the input through — so n1's output is exactly
+        // the workflow input the engine restored from storage.
+        assert_eq!(
+            result.node_output(&n1),
+            Some(&serde_json::json!({"trigger": "webhook-payload"})),
+            "resume should feed the entry node the persisted trigger payload, not Null (issue #311)"
+        );
+    }
+
+    /// Issue #300 — spawn_node must NOT silently spawn a task on a
+    /// node whose state machine cannot reach Running from its current
+    /// position. When the engine is asked to spawn a node that is
+    /// already Completed (e.g. via a manually-manipulated state), the
+    /// typed `start_node_attempt` helper rejects the transition and
+    /// the node is routed through the setup-failure path.
+    #[test]
+    fn start_node_attempt_rejects_terminal_state() {
+        let n1 = node_key!("n1");
+        let mut state = ExecutionState::new(
+            ExecutionId::new(),
+            WorkflowId::new(),
+            std::slice::from_ref(&n1),
+        );
+        // Drive n1 to Completed via the legal transition chain.
+        state.transition_node(n1.clone(), NodeState::Ready).unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Running)
+            .unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Completed)
+            .unwrap();
+
+        let err = state
+            .start_node_attempt(n1.clone())
+            .expect_err("start_node_attempt must reject Completed source state");
+        assert!(
+            err.to_string().contains("invalid transition"),
+            "error should be InvalidTransition, got: {err}"
+        );
+        // State must not have moved.
+        assert_eq!(state.node_state(n1).unwrap().state, NodeState::Completed);
+    }
+
+    /// Issue #301 — when a node task panics, the engine must report
+    /// the real NodeKey, not a synthesized placeholder. Regression
+    /// verified via a panicking handler.
+    #[tokio::test]
+    async fn panicked_task_reports_real_node_id() {
+        struct PanicHandler {
+            meta: ActionMetadata,
+        }
+
+        impl ActionDependencies for PanicHandler {}
+        impl Action for PanicHandler {
+            fn metadata(&self) -> &ActionMetadata {
+                &self.meta
+            }
+        }
+
+        impl StatelessAction for PanicHandler {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            async fn execute(
+                &self,
+                _input: Self::Input,
+                _ctx: &impl Context,
+            ) -> Result<ActionResult<Self::Output>, ActionError> {
+                panic!("intentional panic for test");
+            }
+        }
+
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(PanicHandler {
+            meta: ActionMetadata::new(action_key!("boom"), "Boom", "panics"),
+        });
+
+        let repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+        let (engine, _) = make_engine(registry);
+        let engine = engine.with_execution_repo(repo.clone());
+
+        let n1 = node_key!("n1");
+        let wf = make_workflow(
+            vec![NodeDefinition::new(n1.clone(), "Boom", "boom").unwrap()],
+            vec![],
+        );
+
+        let result = engine
+            .execute_workflow(
+                &wf,
+                serde_json::json!("ignored"),
+                ExecutionBudget::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(result.is_failure(), "panicked workflow must fail");
+
+        // The node errors map must list the real n1 key with a
+        // non-empty message, not some synthetic NodeKey.
+        let err_msg = result
+            .node_errors
+            .get(&n1)
+            .expect("panicked node must be recorded under its real NodeKey (issue #301)");
+        assert!(
+            !err_msg.is_empty(),
+            "panic error message should not be empty, got: {err_msg:?}"
+        );
+
+        // Persisted state should also reflect n1 as the failed node.
+        let (_v, state_json) = repo
+            .get_state(result.execution_id)
+            .await
+            .unwrap()
+            .expect("state persisted after panic");
+        let node_state = state_json
+            .pointer(&format!("/node_states/{n1}/state"))
+            .and_then(|v| v.as_str());
+        assert_eq!(
+            node_state,
+            Some("failed"),
+            "panicked node should be checkpointed as Failed"
+        );
+    }
+
+    /// Issue #299 — idempotency replay must reconstruct the exact
+    /// ActionResult variant so that Branch edges gate correctly.
+    /// Regression: with the old code a persisted Branch result was
+    /// replayed as a flat `Success`, and every branch edge fired
+    /// regardless of `branch_key`, causing unintended downstream
+    /// execution on replay.
+    #[tokio::test]
+    async fn idempotency_replay_preserves_branch_routing() {
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(BranchHandler {
+            meta: ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
+            selected: "true".into(),
+        });
+        registry.register_stateless(EchoHandler {
+            meta: ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
+        });
+
+        let repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+        let (engine, _) = make_engine(registry);
+        let engine = engine.with_execution_repo(repo.clone());
+
+        // A → B (branch_key="true") / C (branch_key="false")
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let c = node_key!("c");
+        let wf = make_workflow(
+            vec![
+                NodeDefinition::new(a.clone(), "A", "branch").unwrap(),
+                NodeDefinition::new(b.clone(), "B", "echo").unwrap(),
+                NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+            ],
+            vec![
+                Connection::new(a.clone(), b.clone()).with_branch_key("true"),
+                Connection::new(a.clone(), c.clone()).with_branch_key("false"),
+            ],
+        );
+
+        // First run: A emits Branch{selected=true}. Only B fires.
+        let first = engine
+            .execute_workflow(
+                &wf,
+                serde_json::json!("payload"),
+                ExecutionBudget::default(),
+            )
+            .await
+            .unwrap();
+
+        assert!(first.is_success());
+        assert!(
+            first.node_output(&b).is_some(),
+            "B should run on first pass"
+        );
+        assert!(
+            first.node_output(&c).is_none(),
+            "C should NOT run on first pass (false branch)"
+        );
+
+        // Verify the persisted ActionResult encodes a Branch variant
+        // rather than bare output — this is the byte-level check
+        // behind issue #299's fix.
+        let persisted_result = repo
+            .load_node_result(first.execution_id, a.clone())
+            .await
+            .unwrap()
+            .expect("load_node_result should return the persisted ActionResult after #299");
+        assert_eq!(
+            persisted_result.get("type").and_then(|v| v.as_str()),
+            Some("Branch"),
+            "persisted ActionResult for A should be the Branch variant, got: {persisted_result}"
+        );
+        assert_eq!(
+            persisted_result.get("selected").and_then(|v| v.as_str()),
+            Some("true"),
+            "Branch selector should be persisted verbatim"
         );
     }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1197,7 +1197,10 @@ impl WorkflowEngine {
                     return Some((node_key, e.to_string()));
                 }
 
-                if outcome == FailureOutcome::Fail {
+                if exec_state
+                    .node_state(node_key.clone())
+                    .is_some_and(|ns| ns.state == NodeState::Failed)
+                {
                     self.emit_event(ExecutionEvent::NodeFailed {
                         execution_id,
                         node_key: node_key.clone(),
@@ -1218,30 +1221,6 @@ impl WorkflowEngine {
                     &mut ready_queue,
                     exec_state,
                 );
-
-                // Checkpoint *after* handle_node_failure so the persisted
-                // node state reflects the final resolved state — symmetrical
-                // to the runtime-failure branch below (issue #321).
-                self.checkpoint_node(
-                    execution_id,
-                    node_key.clone(),
-                    outputs,
-                    exec_state,
-                    repo_version,
-                )
-                .await;
-
-                if exec_state
-                    .node_state(node_key.clone())
-                    .is_some_and(|ns| ns.state == NodeState::Failed)
-                {
-                    self.emit_event(ExecutionEvent::NodeFailed {
-                        execution_id,
-                        node_key: node_key.clone(),
-                        error: setup_err_msg.clone(),
-                    });
-                }
-
                 if let Some(err_msg) = abort {
                     cancel_token.cancel();
                     return Some((node_key, err_msg));
@@ -1313,7 +1292,8 @@ impl WorkflowEngine {
                 // handed to the generic `Ok(action_result)` success arm.
                 // Handling stays a synthetic failure until the real scheduler
                 // lands (#290 / #296).
-                Ok((node_key, Ok(ref action_result))) if action_result.is_retry() => {
+                Ok((task_id, (node_key, Ok(ref action_result)))) if action_result.is_retry() => {
+                    task_nodes.remove(&task_id);
                     total_retries.fetch_add(1, Ordering::Relaxed);
                     let err = EngineError::Runtime(nebula_runtime::RuntimeError::ActionError(
                         nebula_action::error::ActionError::retryable(
@@ -1438,7 +1418,8 @@ impl WorkflowEngine {
                         exec_state,
                     );
                 },
-                Ok((node_key, Err(ref err))) => {
+                Ok((task_id, (node_key, Err(ref err)))) => {
+                    task_nodes.remove(&task_id);
                     // Node failed at runtime. Ordering (§11.5, #297):
                     //   1. `mark_node_failed`  — in-memory state mutation
                     //   2. classify + apply    — IgnoreErrors recovery (in-memory)
@@ -1512,25 +1493,15 @@ impl WorkflowEngine {
                     );
 
                     if let Some(node_key) = panicked_node {
-                        // Best-effort accounting so the panicked node
-                        // ends up Failed with a real error message
-                        // and its final state is persisted — same
-                        // shape as the runtime-failure branch above.
-                        let panic_err = EngineError::TaskPanicked(err_msg.clone());
-                        mark_node_failed(exec_state, node_key.clone(), &panic_err);
-                        self.checkpoint_node(
+                        self.handle_panicked_node(
                             execution_id,
                             node_key.clone(),
+                            &err_msg,
                             outputs,
                             exec_state,
                             repo_version,
                         )
                         .await;
-                        self.emit_event(ExecutionEvent::NodeFailed {
-                            execution_id,
-                            node_key: node_key.clone(),
-                            error: err_msg.clone(),
-                        });
                         cancel_token.cancel();
                         return Some((node_key, err_msg));
                     }
@@ -1791,18 +1762,20 @@ impl WorkflowEngine {
         // Branch/Route/MultiOutput/Skip routing semantics on replay —
         // every branch edge would fire unconditionally (issue #299).
         let stored_result = match repo.load_node_result(execution_id, node_key.clone()).await {
-            Ok(Some(raw)) => match serde_json::from_value::<ActionResult<serde_json::Value>>(raw) {
-                Ok(result) => Some(result),
-                Err(e) => {
-                    tracing::warn!(
-                        %execution_id,
-                        %node_key,
-                        error = %e,
-                        "failed to deserialize persisted action result; \
-                         falling back to synthesized Success"
-                    );
-                    None
-                },
+            Ok(Some(record)) => {
+                match serde_json::from_value::<ActionResult<serde_json::Value>>(record.result) {
+                    Ok(result) => Some(result),
+                    Err(e) => {
+                        tracing::warn!(
+                            %execution_id,
+                            %node_key,
+                            error = %e,
+                            "failed to deserialize persisted action result; \
+                             falling back to synthesized Success"
+                        );
+                        None
+                    },
+                }
             },
             Ok(None) => {
                 // Backend has no stored result (legacy rows, or a
@@ -1876,8 +1849,14 @@ impl WorkflowEngine {
                 return;
             },
         };
+        let kind = value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or("Unknown")
+            .to_owned();
+        let record = nebula_storage::NodeResultRecord::new(kind, value);
         if let Err(e) = repo
-            .save_node_result(execution_id, node_key.clone(), attempt, value)
+            .save_node_result(execution_id, node_key.clone(), attempt, record)
             .await
         {
             tracing::warn!(
@@ -1919,6 +1898,48 @@ impl WorkflowEngine {
     /// `run_frontier` MUST abort the node's progression (no edge routing,
     /// no event emission) on `Err` so that observers and the frontier
     /// never act on an unpersisted transition (§11.5, §12.4, #297).
+    /// Persist final Failed state + emit NodeFailed for a panicked task.
+    ///
+    /// Best-effort: checkpoint failures are logged at `warn!` level (not
+    /// propagated) so that the engine still returns a cohesive panic
+    /// error to `run_frontier`'s caller. The real durability gap —
+    /// `save_node_output` after panic — is already logged by
+    /// `checkpoint_node` itself.
+    async fn handle_panicked_node(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        err_msg: &str,
+        outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
+        exec_state: &mut ExecutionState,
+        repo_version: &mut u64,
+    ) {
+        let panic_err = EngineError::TaskPanicked(err_msg.to_owned());
+        mark_node_failed(exec_state, node_key.clone(), &panic_err);
+        let checkpoint_result = self
+            .checkpoint_node(
+                execution_id,
+                node_key.clone(),
+                outputs,
+                exec_state,
+                repo_version,
+            )
+            .await;
+        if let Err(e) = checkpoint_result {
+            tracing::warn!(
+                %execution_id,
+                %node_key,
+                error = %e,
+                "failed to checkpoint panicked node state"
+            );
+        }
+        self.emit_event(ExecutionEvent::NodeFailed {
+            execution_id,
+            node_key,
+            error: err_msg.to_owned(),
+        });
+    }
+
     async fn checkpoint_node(
         &self,
         execution_id: ExecutionId,
@@ -5786,18 +5807,21 @@ mod tests {
         // Verify the persisted ActionResult encodes a Branch variant
         // rather than bare output — this is the byte-level check
         // behind issue #299's fix.
-        let persisted_result = repo
+        let persisted_record = repo
             .load_node_result(first.execution_id, a.clone())
             .await
             .unwrap()
             .expect("load_node_result should return the persisted ActionResult after #299");
         assert_eq!(
-            persisted_result.get("type").and_then(|v| v.as_str()),
-            Some("Branch"),
-            "persisted ActionResult for A should be the Branch variant, got: {persisted_result}"
+            persisted_record.kind, "Branch",
+            "persisted ActionResult for A should be the Branch variant, got: {:?}",
+            persisted_record
         );
         assert_eq!(
-            persisted_result.get("selected").and_then(|v| v.as_str()),
+            persisted_record
+                .result
+                .get("selected")
+                .and_then(|v| v.as_str()),
             Some("true"),
             "Branch selector should be persisted verbatim"
         );

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -83,6 +83,30 @@ impl NodeExecutionState {
 
         Ok(())
     }
+
+    /// Drive a node to `Running` for a fresh attempt, covering both the
+    /// first dispatch (`Pending → Ready → Running`) and retry paths
+    /// (`Failed → Retrying → Running`, `Retrying → Running`). Any other
+    /// source state is an invalid transition and returned as such — the
+    /// engine must route the node through the setup-failure path
+    /// instead of silently spawning a task on stale state (issue #300).
+    pub fn start_attempt(&mut self) -> Result<(), ExecutionError> {
+        match self.state {
+            NodeState::Pending => {
+                self.transition_to(NodeState::Ready)?;
+                self.transition_to(NodeState::Running)
+            },
+            NodeState::Failed => {
+                self.transition_to(NodeState::Retrying)?;
+                self.transition_to(NodeState::Running)
+            },
+            NodeState::Retrying => self.transition_to(NodeState::Running),
+            from => Err(ExecutionError::InvalidTransition {
+                from: from.to_string(),
+                to: NodeState::Running.to_string(),
+            }),
+        }
+    }
 }
 
 impl Default for NodeExecutionState {
@@ -121,6 +145,15 @@ pub struct ExecutionState {
     /// Execution-level variables.
     #[serde(default)]
     pub variables: serde_json::Map<String, serde_json::Value>,
+    /// The original workflow-level input (trigger payload) for this
+    /// execution. Persisted so that `resume_execution` can feed entry
+    /// nodes the same payload the original run saw, rather than
+    /// silently substituting `Null` (issue #311).
+    ///
+    /// Legacy persisted states that predate this field deserialize as
+    /// `None` and the engine falls back to `Null` with a warning log.
+    #[serde(default)]
+    pub workflow_input: Option<serde_json::Value>,
 }
 
 impl ExecutionState {
@@ -146,7 +179,17 @@ impl ExecutionState {
             total_retries: 0,
             total_output_bytes: 0,
             variables: serde_json::Map::new(),
+            workflow_input: None,
         }
+    }
+
+    /// Attach the original workflow-level input to this execution.
+    ///
+    /// Called by the engine at execution start so that
+    /// `resume_execution` can feed entry nodes the same payload the
+    /// original run saw (issue #311).
+    pub fn set_workflow_input(&mut self, input: serde_json::Value) {
+        self.workflow_input = Some(input);
     }
 
     /// Get a node's execution state.
@@ -230,6 +273,57 @@ impl ExecutionState {
         ns.transition_to(new_state)?;
         self.version += 1;
         self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Drive a node to `Running` for a fresh attempt (first dispatch
+    /// or retry). Delegates to
+    /// [`NodeExecutionState::start_attempt`] and bumps the parent
+    /// version on success so CAS readers observe the transition.
+    ///
+    /// # Errors
+    ///
+    /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
+    /// - [`ExecutionError::InvalidTransition`] if the node is not in a state from which a fresh
+    ///   attempt is legal. Callers must route the node through the setup-failure path on `Err` —
+    ///   they must NOT silently spawn a task on stale state (issue #300).
+    pub fn start_node_attempt(&mut self, node_key: NodeKey) -> Result<(), ExecutionError> {
+        let ns = self
+            .node_states
+            .get_mut(&node_key)
+            .ok_or(ExecutionError::NodeNotFound(node_key))?;
+        let before_version = self.version;
+        // `start_attempt` may bump through two per-node transitions;
+        // count the parent version by one logical "attempt start".
+        ns.start_attempt()?;
+        self.version = before_version + 1;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Move a node to `Failed` for a setup-time failure (parameter
+    /// resolution, missing node definition, etc.) and record the error
+    /// message. Handles both first-dispatch Pending-state failures and
+    /// retry-path failures where the node is already Failed or
+    /// Retrying.
+    ///
+    /// Uses `override_node_state` because Pending → Failed is not a
+    /// valid forward transition — setup fails before the node has
+    /// reached Running — but the version is still bumped so CAS
+    /// readers observe the change (issue #255, #300).
+    ///
+    /// # Errors
+    ///
+    /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
+    pub fn mark_setup_failed(
+        &mut self,
+        node_key: NodeKey,
+        error_message: impl Into<String>,
+    ) -> Result<(), ExecutionError> {
+        self.override_node_state(node_key.clone(), NodeState::Failed)?;
+        if let Some(ns) = self.node_states.get_mut(&node_key) {
+            ns.error_message = Some(error_message.into());
+        }
         Ok(())
     }
 
@@ -468,6 +562,102 @@ mod tests {
         assert!(matches!(err, ExecutionError::NodeNotFound(_)));
         // Version unchanged.
         assert_eq!(state.version, 0);
+    }
+
+    #[test]
+    fn start_attempt_pending_path() {
+        let mut ns = NodeExecutionState::new();
+        ns.start_attempt()
+            .expect("pending -> running should be legal");
+        assert_eq!(ns.state, NodeState::Running);
+        assert!(ns.scheduled_at.is_some());
+        assert!(ns.started_at.is_some());
+    }
+
+    #[test]
+    fn start_attempt_retry_path() {
+        let mut ns = NodeExecutionState::new();
+        // Drive to Failed via the legal transition chain.
+        ns.transition_to(NodeState::Ready).unwrap();
+        ns.transition_to(NodeState::Running).unwrap();
+        ns.transition_to(NodeState::Failed).unwrap();
+        ns.start_attempt()
+            .expect("failed -> running via retrying should be legal");
+        assert_eq!(ns.state, NodeState::Running);
+    }
+
+    #[test]
+    fn start_attempt_rejects_completed() {
+        let mut ns = NodeExecutionState::new();
+        ns.transition_to(NodeState::Ready).unwrap();
+        ns.transition_to(NodeState::Running).unwrap();
+        ns.transition_to(NodeState::Completed).unwrap();
+        let err = ns
+            .start_attempt()
+            .expect_err("completed nodes cannot start a fresh attempt");
+        assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
+        assert_eq!(
+            ns.state,
+            NodeState::Completed,
+            "state must not move on error"
+        );
+    }
+
+    #[test]
+    fn execution_state_start_node_attempt_bumps_version() {
+        let (mut state, n1, _n2) = make_state();
+        let v0 = state.version;
+        state.start_node_attempt(n1.clone()).unwrap();
+        assert_eq!(state.node_state(n1).unwrap().state, NodeState::Running);
+        assert_eq!(state.version, v0 + 1);
+    }
+
+    #[test]
+    fn mark_setup_failed_records_error_and_bumps_version() {
+        let (mut state, n1, _n2) = make_state();
+        let v0 = state.version;
+        state
+            .mark_setup_failed(n1.clone(), "param resolution: missing credential")
+            .unwrap();
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::Failed);
+        assert_eq!(
+            ns.error_message.as_deref(),
+            Some("param resolution: missing credential")
+        );
+        assert_eq!(state.version, v0 + 1);
+    }
+
+    #[test]
+    fn workflow_input_roundtrip_via_serde() {
+        let (mut state, _n1, _n2) = make_state();
+        assert!(state.workflow_input.is_none());
+        state.set_workflow_input(serde_json::json!({"trigger": "webhook"}));
+        let json = serde_json::to_string(&state).unwrap();
+        let back: ExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.workflow_input,
+            Some(serde_json::json!({"trigger": "webhook"}))
+        );
+    }
+
+    #[test]
+    fn workflow_input_missing_field_deserializes_as_none() {
+        // Legacy stored states that predate `workflow_input` must
+        // still deserialize — we rely on `#[serde(default)]`.
+        let legacy = serde_json::json!({
+            "execution_id": ExecutionId::new(),
+            "workflow_id": WorkflowId::new(),
+            "status": "created",
+            "node_states": {},
+            "version": 0,
+            "created_at": chrono::Utc::now(),
+            "updated_at": chrono::Utc::now(),
+            "total_retries": 0,
+            "total_output_bytes": 0,
+        });
+        let state: ExecutionState = serde_json::from_value(legacy).unwrap();
+        assert!(state.workflow_input.is_none());
     }
 
     #[test]

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -202,6 +202,39 @@ pub trait ExecutionRepo: Send + Sync {
     /// Counts executions, optionally filtered by workflow_id.
     async fn count(&self, workflow_id: Option<WorkflowId>) -> Result<u64, ExecutionRepoError>;
 
+    /// Persists the full [`ActionResult`](serde_json::Value)-encoded
+    /// variant for an idempotent node, keyed by attempt. Enables the
+    /// engine to replay the exact routing semantics (Branch, Route,
+    /// MultiOutput, Skip, etc.) on resume instead of synthesising a
+    /// flat `Success` that leaks every branch edge (issue #299).
+    ///
+    /// Stored value is the JSON-serialized `ActionResult<Value>`. The
+    /// default implementation is a no-op so backends can opt into this
+    /// feature at their own pace; the engine falls back to output-only
+    /// behaviour when [`load_node_result`](Self::load_node_result)
+    /// returns `Ok(None)`.
+    async fn save_node_result(
+        &self,
+        _execution_id: ExecutionId,
+        _node_key: NodeKey,
+        _attempt: u32,
+        _result: serde_json::Value,
+    ) -> Result<(), ExecutionRepoError> {
+        Ok(())
+    }
+
+    /// Loads the full serialized `ActionResult<Value>` for a node
+    /// (latest attempt), if any. Returns `Ok(None)` when the backend
+    /// has no stored result — the engine falls back to the
+    /// output-only path with a warning log.
+    async fn load_node_result(
+        &self,
+        _execution_id: ExecutionId,
+        _node_key: NodeKey,
+    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        Ok(None)
+    }
+
     /// Returns true if this idempotency key has been recorded.
     async fn check_idempotency(&self, key: &str) -> Result<bool, ExecutionRepoError>;
 
@@ -330,6 +363,7 @@ pub struct InMemoryExecutionRepo {
     leases: Arc<RwLock<HashMap<ExecutionId, LeaseEntry>>>,
     workflows: Arc<RwLock<HashMap<ExecutionId, WorkflowId>>>,
     node_outputs: Arc<RwLock<HashMap<NodeOutputKey, serde_json::Value>>>,
+    node_results: Arc<RwLock<HashMap<NodeOutputKey, serde_json::Value>>>,
     idempotency: Arc<RwLock<HashSet<String>>>,
     stateful_checkpoints: Arc<RwLock<HashMap<StatefulCheckpointKey, StatefulCheckpointRecord>>>,
 }
@@ -535,6 +569,34 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         let workflows = self.workflows.read().await;
         let n = workflows.values().filter(|v| **v == wid).count() as u64;
         Ok(n)
+    }
+
+    async fn save_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        attempt: u32,
+        result: serde_json::Value,
+    ) -> Result<(), ExecutionRepoError> {
+        self.node_results
+            .write()
+            .await
+            .insert((execution_id, node_key, attempt), result);
+        Ok(())
+    }
+
+    async fn load_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        let results = self.node_results.read().await;
+        let best = results
+            .iter()
+            .filter(|((eid, nid, _), _)| *eid == execution_id && *nid == node_key)
+            .max_by_key(|((_, _, attempt), _)| *attempt)
+            .map(|(_, v)| v.clone());
+        Ok(best)
     }
 
     async fn check_idempotency(&self, key: &str) -> Result<bool, ExecutionRepoError> {

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -320,39 +320,6 @@ pub trait ExecutionRepo: Send + Sync {
     /// Counts executions, optionally filtered by workflow_id.
     async fn count(&self, workflow_id: Option<WorkflowId>) -> Result<u64, ExecutionRepoError>;
 
-    /// Persists the full [`ActionResult`](serde_json::Value)-encoded
-    /// variant for an idempotent node, keyed by attempt. Enables the
-    /// engine to replay the exact routing semantics (Branch, Route,
-    /// MultiOutput, Skip, etc.) on resume instead of synthesising a
-    /// flat `Success` that leaks every branch edge (issue #299).
-    ///
-    /// Stored value is the JSON-serialized `ActionResult<Value>`. The
-    /// default implementation is a no-op so backends can opt into this
-    /// feature at their own pace; the engine falls back to output-only
-    /// behaviour when [`load_node_result`](Self::load_node_result)
-    /// returns `Ok(None)`.
-    async fn save_node_result(
-        &self,
-        _execution_id: ExecutionId,
-        _node_key: NodeKey,
-        _attempt: u32,
-        _result: serde_json::Value,
-    ) -> Result<(), ExecutionRepoError> {
-        Ok(())
-    }
-
-    /// Loads the full serialized `ActionResult<Value>` for a node
-    /// (latest attempt), if any. Returns `Ok(None)` when the backend
-    /// has no stored result — the engine falls back to the
-    /// output-only path with a warning log.
-    async fn load_node_result(
-        &self,
-        _execution_id: ExecutionId,
-        _node_key: NodeKey,
-    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
-        Ok(None)
-    }
-
     /// Returns true if this idempotency key has been recorded.
     async fn check_idempotency(&self, key: &str) -> Result<bool, ExecutionRepoError>;
 
@@ -545,7 +512,6 @@ pub struct InMemoryExecutionRepo {
     leases: Arc<RwLock<HashMap<ExecutionId, LeaseEntry>>>,
     workflows: Arc<RwLock<HashMap<ExecutionId, WorkflowId>>>,
     node_outputs: Arc<RwLock<HashMap<NodeOutputKey, serde_json::Value>>>,
-    node_results: Arc<RwLock<HashMap<NodeOutputKey, serde_json::Value>>>,
     idempotency: Arc<RwLock<HashSet<String>>>,
     stateful_checkpoints: Arc<RwLock<HashMap<StatefulCheckpointKey, StatefulCheckpointRecord>>>,
     workflow_inputs: Arc<RwLock<HashMap<ExecutionId, serde_json::Value>>>,
@@ -753,34 +719,6 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         let workflows = self.workflows.read().await;
         let n = workflows.values().filter(|v| **v == wid).count() as u64;
         Ok(n)
-    }
-
-    async fn save_node_result(
-        &self,
-        execution_id: ExecutionId,
-        node_key: NodeKey,
-        attempt: u32,
-        result: serde_json::Value,
-    ) -> Result<(), ExecutionRepoError> {
-        self.node_results
-            .write()
-            .await
-            .insert((execution_id, node_key, attempt), result);
-        Ok(())
-    }
-
-    async fn load_node_result(
-        &self,
-        execution_id: ExecutionId,
-        node_key: NodeKey,
-    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
-        let results = self.node_results.read().await;
-        let best = results
-            .iter()
-            .filter(|((eid, nid, _), _)| *eid == execution_id && *nid == node_key)
-            .max_by_key(|((_, _, attempt), _)| *attempt)
-            .map(|(_, v)| v.clone());
-        Ok(best)
     }
 
     async fn check_idempotency(&self, key: &str) -> Result<bool, ExecutionRepoError> {


### PR DESCRIPTION
## Summary

Resurrection of [PR #346](https://github.com/vanyastaff/nebula/pull/346) ("batch 2 execution-state correctness"), which was approved in spirit, **closed without merging**, and never came back. Subsequent PRs (e.g. `6c12a127` / batch 5C) referenced #346 as if it had landed — spot-checking main at `2b205abf` confirmed the phantom-fix belief and that the five tracked bugs are genuinely still real. Per tech-lead's 2026-04-18 directive: "Resurrect, don't re-derive."

Single commit cherry-picked from `0f29b62b` and adapted for current main — primarily the `NodeId → NodeKey` rename from [#412](https://github.com/vanyastaff/nebula/pull/412).

## Five fixes

- **#321 — setup-failure path now checkpoints.** `run_frontier`'s setup-failure branch calls `checkpoint_node` + emits `NodeFailed`, matching the runtime-failure ordering. Previously in-memory state moved to `Failed` while the persisted row still said `Pending`, producing ghost-pending nodes visible to CAS readers and `resume_execution`.
- **#300 — typed node transitions.** `spawn_node` drives state through a new `NodeExecutionState::start_attempt` helper modelling the legal paths (`Pending → Ready → Running`, `Failed → Retrying → Running`, `Retrying → Running`). `ExecutionState::start_node_attempt` wraps it with a parent version bump. Invalid transitions return `InvalidTransition` instead of being swallowed by `let _ = transition_to(Ready)`. On error the node is routed through `mark_setup_failed` rather than dispatched on stale `Failed` state.
- **#301 — panicked tasks report their real NodeKey.** `run_frontier` tracks a `HashMap<tokio::task::Id, NodeKey>` alongside the `JoinSet`, uses `join_next_with_id()`, and looks up the real `NodeKey` via `JoinError::id()`. Panicked nodes are marked `Failed`, checkpointed, and reported via `NodeFailed` with the correct identity instead of a sentinel.
- **#311 — workflow input survives resume.** `ExecutionState` gains `Option<Value> workflow_input` (with `#[serde(default)]` for legacy states). `execute_workflow` and `replay_execution` set it at execution start; `resume_execution` reads it back so entry nodes that crashed mid-run receive the original trigger payload instead of `Null`. Legacy states fall through to `Null` with a WARN log.
- **#299 — idempotency replay preserves routing.** `check_and_apply_idempotency` no longer synthesizes `ActionResult::Success` on replay. It loads the full persisted `ActionResult` via new `ExecutionRepo::save_node_result` / `load_node_result` hooks (default no-op so existing backends compile unchanged; `InMemoryExecutionRepo` overrides both), and hands it to `process_outgoing_edges`. `Branch`/`Route`/`MultiOutput` semantics survive idempotency replay; previously every branch edge fired unconditionally.

## Adaptations against current main

The original #346 diff predated several refactors. Changes this PR absorbed (beyond the direct conflicts):

1. **`NodeId` → `NodeKey` throughout.** PR #412 renamed the identifier; the in-memory `HashMap<tokio::task::Id, NodeId>` became `HashMap<tokio::task::Id, NodeKey>`, `NodeId::new()` sentinels became `node_key!("...")` in tests, and every consumed `NodeKey` needed `.clone()` at first use (it's not `Copy` like the old ULID).
2. **`.project/context/*.md` files deleted on main** (`9fe50c7e` / `#398`). Dropped the incoming updates.
3. **HEAD's `run_frontier` wraps `join_next` in a `select!` against `wall_clock_remaining`.** Kept that shape, switched all three drain sites (timeout, cancel, normal) to `join_next_with_id()`, and added `task_nodes.clear()` on drain.
4. **HEAD's Phase 3 match kept a separate `ActionResult::Retry` arm** (#346 folded it into success). Kept the 4-arm shape, added `task_nodes.remove(&task_id)` at each `Ok(…)` entry.
5. **`replay_execution` path updated** — added the `input_overrides.get(&plan.replay_from)` + `set_workflow_input(...)` computation at the top of the pinned-node loop so #311 fires on replay too.

## Test plan (fresh this turn)

- [x] `cargo +nightly fmt --all` — clean (no diff)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — **3197 passed**, 13 skipped, 0 failed
- [x] All 5 regression tests from the original #346 pass under the NodeKey rename:
  - `setup_failure_checkpoints_execution_state` (#321)
  - `start_node_attempt_rejects_terminal_state` (#300)
  - `panicked_task_reports_real_node_id` (#301)
  - `resume_restores_original_workflow_input` (#311)
  - `idempotency_replay_preserves_branch_routing` (#299)

## Closes

Closes #299
Closes #300
Closes #301
Closes #311
Closes #321

## Context / evidence trail

- Audit doc: [docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md](https://github.com/vanyastaff/nebula/blob/main/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md) §2 Group C
- Original PR (closed): [#346](https://github.com/vanyastaff/nebula/pull/346)
- Phantom-fix evidence at `main @ 2b205abf`: `crates/engine/src/engine.rs:1546` — `let fake_result = ActionResult::success(output_value);` — [pinned permalink](https://github.com/vanyastaff/nebula/blob/2b205abf/crates/engine/src/engine.rs#L1546)

🤖 Generated with [Claude Code](https://claude.com/claude-code)