### PR TITLE
fix(api): scope list_executions to workflow_id (#286, #288, #328)

### DIFF
--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -73,12 +73,14 @@ pub async fn list_executions(
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to count executions: {}", e)))?;
 
-    // TODO: list_running() returns ALL running execution IDs with no workflow filter.
-    // Replace with a workflow-scoped query once ExecutionRepo gains a list(workflow_id)
-    // method. The `workflow_id` parameter is validated above but not yet applied.
+    // Scope the list to the requested workflow (#286, #288, #328). Using the
+    // global `list_running()` here would leak execution IDs from every other
+    // workflow on the instance — a contained info leak today (shared-trust
+    // JWT) but a tenant-crossing read the moment real multi-tenant auth
+    // lands.
     let running_ids = state
         .execution_repo
-        .list_running()
+        .list_running_for_workflow(workflow_id_parsed)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to list executions: {}", e)))?;
 

--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -67,12 +67,6 @@ pub async fn list_executions(
     let workflow_id_parsed = WorkflowId::parse(&workflow_id)
         .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
 
-    let total = state
-        .execution_repo
-        .count(Some(workflow_id_parsed))
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to count executions: {}", e)))?;
-
     // Scope the list to the requested workflow (#286, #288, #328). Using the
     // global `list_running()` here would leak execution IDs from every other
     // workflow on the instance — a contained info leak today (shared-trust
@@ -84,6 +78,7 @@ pub async fn list_executions(
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to list executions: {}", e)))?;
 
+    let total = running_ids.len();
     let offset = params.offset();
     let limit = params.limit();
     let executions: Vec<RunningExecutionSummary> = running_ids
@@ -95,7 +90,7 @@ pub async fn list_executions(
 
     Ok(Json(ListExecutionsResponse {
         executions,
-        total: total as usize,
+        total,
         page: params.page,
         page_size: params.limit(),
     }))

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2121,3 +2121,75 @@ async fn cancel_terminal_execution_does_not_enqueue() {
         "control queue must be empty after rejected cancel of terminal execution"
     );
 }
+
+/// Regression for #286/#288/#328: `GET /api/v1/workflows/:id/executions`
+/// must scope running IDs to the requested workflow, not leak running
+/// executions from other workflows on the instance.
+#[tokio::test]
+async fn list_executions_scopes_to_workflow_id() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use nebula_core::{ExecutionId, WorkflowId};
+    use tower::ServiceExt;
+
+    let state = create_test_state().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let wid_a = WorkflowId::new();
+    let wid_b = WorkflowId::new();
+    let exec_a = ExecutionId::new();
+    let exec_b1 = ExecutionId::new();
+    let exec_b2 = ExecutionId::new();
+
+    state
+        .execution_repo
+        .create(exec_a, wid_a, serde_json::json!({"status": "running"}))
+        .await
+        .unwrap();
+    state
+        .execution_repo
+        .create(exec_b1, wid_b, serde_json::json!({"status": "running"}))
+        .await
+        .unwrap();
+    state
+        .execution_repo
+        .create(exec_b2, wid_b, serde_json::json!({"status": "cancelling"}))
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/workflows/{}/executions", wid_a))
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let ids: Vec<String> = json["executions"]
+        .as_array()
+        .expect("executions must be an array")
+        .iter()
+        .map(|e| e["id"].as_str().expect("id is string").to_string())
+        .collect();
+
+    assert_eq!(
+        ids.len(),
+        1,
+        "listing workflow A must not leak workflow B's IDs, got: {:?}",
+        ids
+    );
+    assert_eq!(ids[0], exec_a.to_string());
+}

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -4130,6 +4130,13 @@ mod tests {
             self.inner.list_running().await
         }
 
+        async fn list_running_for_workflow(
+            &self,
+            workflow_id: WorkflowId,
+        ) -> Result<Vec<ExecutionId>, nebula_storage::ExecutionRepoError> {
+            self.inner.list_running_for_workflow(workflow_id).await
+        }
+
         async fn count(
             &self,
             workflow_id: Option<WorkflowId>,

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -335,6 +335,23 @@ impl ExecutionRepo for PgExecutionRepo {
         Ok(rows.into_iter().map(|(id,)| id).collect())
     }
 
+    async fn list_running_for_workflow(
+        &self,
+        workflow_id: WorkflowId,
+    ) -> Result<Vec<ExecutionId>, ExecutionRepoError> {
+        let rows = sqlx::query_as::<_, (ExecutionId,)>(
+            "SELECT id FROM executions \
+             WHERE workflow_id = $1 \
+               AND state->>'status' IN ('created', 'running', 'paused', 'cancelling')",
+        )
+        .bind(workflow_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(map_err)?;
+
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     async fn count(&self, workflow_id: Option<WorkflowId>) -> Result<u64, ExecutionRepoError> {
         let count: i64 = match workflow_id {
             Some(wid) => {

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -199,6 +199,17 @@ pub trait ExecutionRepo: Send + Sync {
     /// Lists execution IDs in non-terminal states.
     async fn list_running(&self) -> Result<Vec<ExecutionId>, ExecutionRepoError>;
 
+    /// Lists execution IDs in non-terminal states for a specific workflow.
+    ///
+    /// Same status filter as [`Self::list_running`] but scoped to a single
+    /// `workflow_id`. Used by the per-workflow API endpoints so callers
+    /// cannot enumerate IDs from workflows they did not ask for (see #286,
+    /// #288, #328).
+    async fn list_running_for_workflow(
+        &self,
+        workflow_id: WorkflowId,
+    ) -> Result<Vec<ExecutionId>, ExecutionRepoError>;
+
     /// Counts executions, optionally filtered by workflow_id.
     async fn count(&self, workflow_id: Option<WorkflowId>) -> Result<u64, ExecutionRepoError>;
 
@@ -516,6 +527,26 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         let state = self.state.read().await;
         let running = state
             .iter()
+            .filter(|(_, (_, val))| {
+                matches!(
+                    val.get("status").and_then(|s| s.as_str()),
+                    Some("created" | "running" | "paused" | "cancelling")
+                )
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        Ok(running)
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        workflow_id: WorkflowId,
+    ) -> Result<Vec<ExecutionId>, ExecutionRepoError> {
+        let workflows = self.workflows.read().await;
+        let state = self.state.read().await;
+        let running = state
+            .iter()
+            .filter(|(id, _)| workflows.get(*id) == Some(&workflow_id))
             .filter(|(_, (_, val))| {
                 matches!(
                     val.get("status").and_then(|s| s.as_str()),
@@ -1064,5 +1095,47 @@ mod tests {
         assert_eq!(running.len(), 2);
         assert!(running.contains(&e1));
         assert!(running.contains(&e3));
+    }
+
+    /// Regression for #286/#288/#328: `list_running_for_workflow` must scope
+    /// to a single workflow_id AND apply the non-terminal status filter.
+    #[tokio::test]
+    async fn list_running_for_workflow_scopes_to_workflow_id() {
+        let repo = InMemoryExecutionRepo::default();
+        let wid_a = WorkflowId::new();
+        let wid_b = WorkflowId::new();
+        let e_a_running = ExecutionId::new();
+        let e_a_completed = ExecutionId::new();
+        let e_b_running = ExecutionId::new();
+        let e_b_cancelling = ExecutionId::new();
+        repo.create(e_a_running, wid_a, serde_json::json!({"status": "running"}))
+            .await
+            .unwrap();
+        repo.create(
+            e_a_completed,
+            wid_a,
+            serde_json::json!({"status": "completed"}),
+        )
+        .await
+        .unwrap();
+        repo.create(e_b_running, wid_b, serde_json::json!({"status": "running"}))
+            .await
+            .unwrap();
+        repo.create(
+            e_b_cancelling,
+            wid_b,
+            serde_json::json!({"status": "cancelling"}),
+        )
+        .await
+        .unwrap();
+
+        let a = repo.list_running_for_workflow(wid_a).await.unwrap();
+        assert_eq!(a.len(), 1, "workflow A must not leak workflow B's IDs");
+        assert!(a.contains(&e_a_running));
+
+        let b = repo.list_running_for_workflow(wid_b).await.unwrap();
+        assert_eq!(b.len(), 2, "workflow B must return both non-terminal IDs");
+        assert!(b.contains(&e_b_running));
+        assert!(b.contains(&e_b_cancelling));
     }
 }

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -726,8 +726,8 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         &self,
         workflow_id: WorkflowId,
     ) -> Result<Vec<ExecutionId>, ExecutionRepoError> {
-        let workflows = self.workflows.read().await;
         let state = self.state.read().await;
+        let workflows = self.workflows.read().await;
         let running = state
             .iter()
             .filter(|(id, _)| workflows.get(*id) == Some(&workflow_id))


### PR DESCRIPTION
## Summary

Group B from the 2026-04-18 stale-issue audit. [#286](https://github.com/vanyastaff/nebula/issues/286), [#288](https://github.com/vanyastaff/nebula/issues/288), and [#328](https://github.com/vanyastaff/nebula/issues/328) are three duplicate issues describing the same bug: `GET /api/v1/workflows/:workflow_id/executions` validates the path parameter but then calls `ExecutionRepo::list_running()` globally and returns execution IDs from every workflow on the instance.

Contained today by the shared-trust JWT, but escalates to a tenant-crossing read the moment real multi-tenant auth lands (per [#286](https://github.com/vanyastaff/nebula/issues/286) body).

## Changes

### Storage (`nebula-storage`)

- New trait method `ExecutionRepo::list_running_for_workflow(workflow_id)`.
- `InMemoryExecutionRepo`: joins the existing per-execution `workflows` map with the status filter.
- `PostgresExecutionRepo`: `WHERE workflow_id = $1 AND state->>'status' IN (...)` — parity with the SQL `list_running` already uses.
- Unit test `list_running_for_workflow_scopes_to_workflow_id` seeds two workflows with mixed terminal/non-terminal executions and asserts no cross-workflow leak.

### API (`nebula-api`)

- `list_executions` handler now calls `list_running_for_workflow` instead of global `list_running`. Removed the stale TODO.
- Integration test `list_executions_scopes_to_workflow_id` exercises the HTTP path: workflow A with 1 running execution, workflow B with 2 non-terminal; asserts `GET /workflows/A/executions` returns only A's.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — **3191 passed**, 13 skipped

## Closes

Closes #286
Closes #288
Closes #328

## Context

- Audit doc: [docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md](https://github.com/vanyastaff/nebula/blob/main/docs/superpowers/specs/2026-04-18-stale-issue-audit-and-real-bugs.md) §2 Group B

🤖 Generated with [Claude Code](https://claude.com/claude-code)