### PR TITLE
feat(storage): resume persistence schema + ADR-0008 (B1 foundation)

### DIFF
--- a/crates/storage/README.md
+++ b/crates/storage/README.md
@@ -33,15 +33,15 @@ Layer 1 — production interfaces (use these today):
 
 - `ExecutionRepo` — repository trait; seam for §11.1 CAS transitions, §11.3 idempotency
   check-and-mark, §11.5 journal + checkpoint writes, §12.2 outbox atomicity. Also carries the
-  ADR-0008 resume-persistence seams (`set_workflow_input` / `get_workflow_input` and
+  ADR-0009 resume-persistence seams (`set_workflow_input` / `get_workflow_input` and
   `save_node_result` / `load_node_result` / `load_all_results`).
 - `ExecutionRepoError` — typed error for CAS conflicts, not-found, timeout, lease unavailable,
   and `UnknownSchemaVersion` (surfaced when a persisted node-result record carries a schema
-  version the binary cannot decode; ADR-0008 §2).
+  version the binary cannot decode; ADR-0009 §2).
 - `InMemoryExecutionRepo` — in-memory implementation for tests (via `test_support`).
 - `NodeResultRecord` — persisted `ActionResult<Value>` variant (kind tag + JSON + schema
   version); written by `save_node_result`, read by `load_node_result` / `load_all_results`
-  (ADR-0008 §1).
+  (ADR-0009 §1).
 - `MAX_SUPPORTED_RESULT_SCHEMA_VERSION` — highest `NodeResultRecord.schema_version` the current
   binary can decode; callers compare against this on mixed-binary deploys.
 - `StatefulCheckpointRecord` — checkpoint record persisted by `ExecutionRepo::save_stateful_checkpoint`.
@@ -78,7 +78,7 @@ Layer 2 — planned / experimental (`repos` module):
   checkpoint write failure may log and not abort execution; work since the last checkpoint may
   be replayed or lost. Seam: `crates/storage/src/execution_repo.rs`.
 
-- **[ADR-0008]** Resume-persistence schema foundation. `ExecutionRepo::set_workflow_input` /
+- **[ADR-0009]** Resume-persistence schema foundation. `ExecutionRepo::set_workflow_input` /
   `get_workflow_input` persist the workflow trigger payload alongside the execution row
   (issue #311). `save_node_result` / `load_node_result` / `load_all_results` persist the full
   `ActionResult<Value>` variant per node attempt (issue #299) so resume can replay edge

--- a/crates/storage/README.md
+++ b/crates/storage/README.md
@@ -32,9 +32,18 @@ the knife scenario (canon §13) exercises end-to-end.
 Layer 1 — production interfaces (use these today):
 
 - `ExecutionRepo` — repository trait; seam for §11.1 CAS transitions, §11.3 idempotency
-  check-and-mark, §11.5 journal + checkpoint writes, §12.2 outbox atomicity.
-- `ExecutionRepoError` — typed error for CAS conflicts, not-found, timeout, lease unavailable.
+  check-and-mark, §11.5 journal + checkpoint writes, §12.2 outbox atomicity. Also carries the
+  ADR-0008 resume-persistence seams (`set_workflow_input` / `get_workflow_input` and
+  `save_node_result` / `load_node_result` / `load_all_results`).
+- `ExecutionRepoError` — typed error for CAS conflicts, not-found, timeout, lease unavailable,
+  and `UnknownSchemaVersion` (surfaced when a persisted node-result record carries a schema
+  version the binary cannot decode; ADR-0008 §2).
 - `InMemoryExecutionRepo` — in-memory implementation for tests (via `test_support`).
+- `NodeResultRecord` — persisted `ActionResult<Value>` variant (kind tag + JSON + schema
+  version); written by `save_node_result`, read by `load_node_result` / `load_all_results`
+  (ADR-0008 §1).
+- `MAX_SUPPORTED_RESULT_SCHEMA_VERSION` — highest `NodeResultRecord.schema_version` the current
+  binary can decode; callers compare against this on mixed-binary deploys.
 - `StatefulCheckpointRecord` — checkpoint record persisted by `ExecutionRepo::save_stateful_checkpoint`.
 - `WorkflowRepo` — repository trait for workflow definition persistence.
 - `WorkflowRepoError` — typed error for workflow repo operations.
@@ -67,6 +76,14 @@ Layer 2 — planned / experimental (`repos` module):
   (append-only, replayable). `ExecutionRepo::save_stateful_checkpoint` is **best-effort**: a
   checkpoint write failure may log and not abort execution; work since the last checkpoint may
   be replayed or lost. Seam: `crates/storage/src/execution_repo.rs`.
+
+- **[ADR-0008]** Resume-persistence schema foundation. `ExecutionRepo::set_workflow_input` /
+  `get_workflow_input` persist the workflow trigger payload alongside the execution row
+  (issue #311). `save_node_result` / `load_node_result` / `load_all_results` persist the full
+  `ActionResult<Value>` variant per node attempt (issue #299) so resume can replay edge
+  decisions through `evaluate_edge` (foundation for #324, #336). `NodeResultRecord` carries a
+  `schema_version`; an unknown version surfaces as `ExecutionRepoError::UnknownSchemaVersion`
+  rather than a silent fall-back. Engine consumers land in downstream chips B2 / B3 / B4.
 
 - **[L2-§12.2]** The `execution_control_queue` outbox is written in the **same logical
   operation** as the state transition it accompanies. Cancel signals must be enqueued atomically

--- a/crates/storage/migrations/00000000000009_add_resume_persistence.sql
+++ b/crates/storage/migrations/00000000000009_add_resume_persistence.sql
@@ -1,0 +1,36 @@
+-- 0009: Resume persistence schema (ADR-0008)
+-- Foundation for resume replay-completeness (issues #299, #311, #324, #336).
+-- Schema only; engine consumers land in chips B2 (workflow input), B3 (result
+-- writes), B4 (resume reconstruction).
+
+-- Workflow trigger / start input — durable so resume can replay entry nodes
+-- with the original payload (issue #311). Nullable: pre-migration executions
+-- have no input; B2 introduces the write path.
+ALTER TABLE executions
+    ADD COLUMN IF NOT EXISTS input JSONB;
+
+-- Full ActionResult variant per node attempt (issue #299).
+--   * result_schema_version: forward-compat guard (ADR-0008 §2); callers that
+--     see an unknown version MUST surface a typed error, never fall back.
+--   * result_kind: variant tag mirror ('Success' | 'Branch' | 'Route' |
+--     'MultiOutput' | 'Skip' | 'Wait' | 'Retry' | 'Break' | 'Continue' |
+--     'Drop' | 'Terminate'); useful for SQL-side filtering without
+--     deserializing `result`.
+--   * result: serialized ActionResult<Value>; NULL on legacy rows written
+--     before this migration. B3 populates it.
+ALTER TABLE node_outputs
+    ADD COLUMN IF NOT EXISTS result_schema_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE node_outputs
+    ADD COLUMN IF NOT EXISTS result_kind TEXT;
+
+ALTER TABLE node_outputs
+    ADD COLUMN IF NOT EXISTS result JSONB;
+
+-- Relax legacy `output` to NULLABLE so `save_node_result` can insert a row
+-- that carries only the new variant columns. Existing rows retain their
+-- primary-output value; new rows written by B3 via `save_node_result`
+-- may omit it. `load_node_output` keeps working against rows that still
+-- have `output` populated; resume-path readers call `load_node_result`.
+ALTER TABLE node_outputs
+    ALTER COLUMN output DROP NOT NULL;

--- a/crates/storage/migrations/00000000000009_add_resume_persistence.sql
+++ b/crates/storage/migrations/00000000000009_add_resume_persistence.sql
@@ -1,4 +1,4 @@
--- 0009: Resume persistence schema (ADR-0008)
+-- 0009: Resume persistence schema (ADR-0009)
 -- Foundation for resume replay-completeness (issues #299, #311, #324, #336).
 -- Schema only; engine consumers land in chips B2 (workflow input), B3 (result
 -- writes), B4 (resume reconstruction).
@@ -10,7 +10,7 @@ ALTER TABLE executions
     ADD COLUMN IF NOT EXISTS input JSONB;
 
 -- Full ActionResult variant per node attempt (issue #299).
---   * result_schema_version: forward-compat guard (ADR-0008 §2); callers that
+--   * result_schema_version: forward-compat guard (ADR-0009 §2); callers that
 --     see an unknown version MUST surface a typed error, never fall back.
 --   * result_kind: variant tag mirror ('Success' | 'Branch' | 'Route' |
 --     'MultiOutput' | 'Skip' | 'Wait' | 'Retry' | 'Break' | 'Continue' |

--- a/crates/storage/migrations/postgres/0020_add_resume_result_persistence.sql
+++ b/crates/storage/migrations/postgres/0020_add_resume_result_persistence.sql
@@ -1,0 +1,26 @@
+-- 0020: Resume result persistence (ADR-0008)
+-- Layer: Execution
+-- Spec: ADR-0008 (resume persistence schema)
+--
+-- Parity with Layer 1 migration 00000000000009_add_resume_persistence.sql.
+-- `executions.input` already exists in Layer 2 (0011_executions.sql).
+-- This migration extends `execution_nodes` (0012_execution_nodes.sql) with
+-- full ActionResult variant storage.
+--
+-- Schema only; engine consumers land in chips B2 / B3 / B4.
+
+-- Forward-compat guard (ADR-0008 §2): callers that see an unknown version
+-- MUST surface a typed error, never fall back.
+ALTER TABLE execution_nodes
+    ADD COLUMN IF NOT EXISTS result_schema_version INTEGER NOT NULL DEFAULT 1;
+
+-- Variant tag mirror ('Success' | 'Branch' | 'Route' | 'MultiOutput' |
+-- 'Skip' | 'Wait' | 'Retry' | 'Break' | 'Continue' | 'Drop' | 'Terminate');
+-- useful for SQL-side filtering without deserializing `result`.
+ALTER TABLE execution_nodes
+    ADD COLUMN IF NOT EXISTS result_kind TEXT;
+
+-- Serialized ActionResult<Value>; NULL on legacy rows written before this
+-- migration. B3 populates it.
+ALTER TABLE execution_nodes
+    ADD COLUMN IF NOT EXISTS result JSONB;

--- a/crates/storage/migrations/postgres/0020_add_resume_result_persistence.sql
+++ b/crates/storage/migrations/postgres/0020_add_resume_result_persistence.sql
@@ -1,6 +1,6 @@
--- 0020: Resume result persistence (ADR-0008)
+-- 0020: Resume result persistence (ADR-0009)
 -- Layer: Execution
--- Spec: ADR-0008 (resume persistence schema)
+-- Spec: ADR-0009 (resume persistence schema)
 --
 -- Parity with Layer 1 migration 00000000000009_add_resume_persistence.sql.
 -- `executions.input` already exists in Layer 2 (0011_executions.sql).
@@ -9,7 +9,7 @@
 --
 -- Schema only; engine consumers land in chips B2 / B3 / B4.
 
--- Forward-compat guard (ADR-0008 §2): callers that see an unknown version
+-- Forward-compat guard (ADR-0009 §2): callers that see an unknown version
 -- MUST surface a typed error, never fall back.
 ALTER TABLE execution_nodes
     ADD COLUMN IF NOT EXISTS result_schema_version INTEGER NOT NULL DEFAULT 1;

--- a/crates/storage/migrations/postgres/README.md
+++ b/crates/storage/migrations/postgres/README.md
@@ -31,7 +31,7 @@ Spec-16 compliant schema for Nebula's PostgreSQL backend.
 | 0013 | `execution_lifecycle` | Execution | `execution_journal`, `execution_control_queue` |
 | 0014 | `quotas` | Quotas | `org_quotas`, `org_quota_usage`, `workspace_quota_usage`, `workspace_dispatch_state` |
 | 0015 | `audit` | Audit | `slug_history`, `audit_log` |
-| 0020 | `add_resume_result_persistence` | Execution | `execution_nodes` — adds `result_schema_version`, `result_kind`, `result` (ADR-0008) |
+| 0020 | `add_resume_result_persistence` | Execution | `execution_nodes` — adds `result_schema_version`, `result_kind`, `result` (ADR-0009) |
 
 ## Schema parity
 

--- a/crates/storage/migrations/postgres/README.md
+++ b/crates/storage/migrations/postgres/README.md
@@ -31,6 +31,7 @@ Spec-16 compliant schema for Nebula's PostgreSQL backend.
 | 0013 | `execution_lifecycle` | Execution | `execution_journal`, `execution_control_queue` |
 | 0014 | `quotas` | Quotas | `org_quotas`, `org_quota_usage`, `workspace_quota_usage`, `workspace_dispatch_state` |
 | 0015 | `audit` | Audit | `slug_history`, `audit_log` |
+| 0020 | `add_resume_result_persistence` | Execution | `execution_nodes` — adds `result_schema_version`, `result_kind`, `result` (ADR-0008) |
 
 ## Schema parity
 

--- a/crates/storage/migrations/sqlite/0020_add_resume_result_persistence.sql
+++ b/crates/storage/migrations/sqlite/0020_add_resume_result_persistence.sql
@@ -1,6 +1,6 @@
--- 0020: Resume result persistence (ADR-0008)
+-- 0020: Resume result persistence (ADR-0009)
 -- Layer: Execution
--- Spec: ADR-0008 (resume persistence schema)
+-- Spec: ADR-0009 (resume persistence schema)
 --
 -- Parity with Postgres migration 0020 and Layer 1 migration 00000000000009.
 -- `executions.input` already exists in Layer 2 (0011_executions.sql).

--- a/crates/storage/migrations/sqlite/0020_add_resume_result_persistence.sql
+++ b/crates/storage/migrations/sqlite/0020_add_resume_result_persistence.sql
@@ -1,0 +1,26 @@
+-- 0020: Resume result persistence (ADR-0008)
+-- Layer: Execution
+-- Spec: ADR-0008 (resume persistence schema)
+--
+-- Parity with Postgres migration 0020 and Layer 1 migration 00000000000009.
+-- `executions.input` already exists in Layer 2 (0011_executions.sql).
+-- This migration extends `execution_nodes` (0012_execution_nodes.sql) with
+-- full ActionResult variant storage.
+--
+-- Schema only; engine consumers land in chips B2 / B3 / B4.
+--
+-- SQLite dialect:
+--   * INTEGER (not INTEGER NOT NULL DEFAULT 1 — SQLite ALTER cannot add
+--     a NOT NULL column without a DEFAULT, and SQLite historically did not
+--     accept column-level DEFAULT on ALTER ADD COLUMN; we set DEFAULT 1
+--     which SQLite 3.35+ supports for ALTER.)
+--   * TEXT stands in for JSON (application validates).
+
+ALTER TABLE execution_nodes
+    ADD COLUMN result_schema_version INTEGER NOT NULL DEFAULT 1;
+
+ALTER TABLE execution_nodes
+    ADD COLUMN result_kind TEXT;
+
+ALTER TABLE execution_nodes
+    ADD COLUMN result TEXT;

--- a/crates/storage/migrations/sqlite/README.md
+++ b/crates/storage/migrations/sqlite/README.md
@@ -19,7 +19,7 @@ Spec-16 compliant schema for Nebula's SQLite backend (local-first / dev / tests)
 Same structure as `../postgres/` — see that README for the table index.
 Migration `0020_add_resume_result_persistence.sql` lands in both dialects in
 parity with Layer 1 migration `00000000000009_add_resume_persistence.sql`
-(ADR-0008 resume persistence schema).
+(ADR-0009 resume persistence schema).
 
 ## Schema parity
 

--- a/crates/storage/migrations/sqlite/README.md
+++ b/crates/storage/migrations/sqlite/README.md
@@ -17,6 +17,9 @@ Spec-16 compliant schema for Nebula's SQLite backend (local-first / dev / tests)
 ## Migration order
 
 Same structure as `../postgres/` — see that README for the table index.
+Migration `0020_add_resume_result_persistence.sql` lands in both dialects in
+parity with Layer 1 migration `00000000000009_add_resume_persistence.sql`
+(ADR-0008 resume persistence schema).
 
 ## Schema parity
 

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -289,7 +289,7 @@ impl ExecutionRepo for PgExecutionRepo {
         execution_id: ExecutionId,
         node_key: NodeKey,
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
-        // `output` is nullable since ADR-0008 migration 0009; rows written
+        // `output` is nullable since ADR-0009 migration 0009; rows written
         // only via `save_node_result` carry NULL in the legacy column and
         // are skipped here.
         let row = sqlx::query_as::<_, (Json<serde_json::Value>,)>(
@@ -390,7 +390,7 @@ impl ExecutionRepo for PgExecutionRepo {
         Ok(())
     }
 
-    // ── ADR-0008: workflow input + node results (B1 foundation) ────────────
+    // ── ADR-0009: workflow input + node results (B1 foundation) ────────────
 
     async fn set_workflow_input(
         &self,
@@ -741,7 +741,7 @@ mod tests {
         );
     }
 
-    // ── ADR-0008 B1: migration + round-trip + forward-compat ─────────────
+    // ── ADR-0009 B1: migration + round-trip + forward-compat ─────────────
 
     #[tokio::test]
     async fn pg_migration_creates_resume_persistence_columns() {
@@ -787,7 +787,7 @@ mod tests {
         .expect("query output nullability");
         assert_eq!(
             output_is_nullable, "YES",
-            "output must be nullable so save_node_result can omit it (ADR-0008)"
+            "output must be nullable so save_node_result can omit it (ADR-0009)"
         );
     }
 

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -1010,6 +1010,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pg_load_all_results_ignores_future_version_on_non_latest_attempt() {
+        // Mirror of the InMem regression: earlier attempt carries a future
+        // schema_version, latest attempt is valid. DISTINCT ON (node_id)
+        // ORDER BY attempt DESC must drop the stale record entirely, so
+        // load_all_results succeeds instead of surfacing UnknownSchemaVersion.
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("retried");
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            0,
+            NodeResultRecord::with_version(
+                MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 7,
+                "FutureStale",
+                serde_json::json!({}),
+            ),
+        )
+        .await
+        .expect("stale future-version attempt");
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            1,
+            NodeResultRecord::new("Success", serde_json::json!({"ok": true})),
+        )
+        .await
+        .expect("fresh valid attempt");
+
+        let all = repo
+            .load_all_results(eid)
+            .await
+            .expect("latest attempt decodable; stale future-version row must be invisible");
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[&nid].kind, "Success");
+    }
+
+    #[tokio::test]
     async fn pg_load_all_results_returns_latest_per_node() {
         let Some(repo) = pg_exec_repo().await else {
             return;

--- a/crates/storage/src/backend/pg_execution.rs
+++ b/crates/storage/src/backend/pg_execution.rs
@@ -11,7 +11,9 @@ use nebula_core::node_key;
 use nebula_core::{ExecutionId, NodeKey, WorkflowId};
 use sqlx::{Pool, Postgres, types::Json};
 
-use crate::execution_repo::{ExecutionRepo, ExecutionRepoError};
+use crate::execution_repo::{
+    ExecutionRepo, ExecutionRepoError, MAX_SUPPORTED_RESULT_SCHEMA_VERSION, NodeResultRecord,
+};
 
 /// Postgres-backed execution repository.
 #[derive(Clone, Debug)]
@@ -39,10 +41,10 @@ fn map_err(err: sqlx::Error) -> ExecutionRepoError {
 }
 
 fn map_journal_err(err: sqlx::Error, id: ExecutionId) -> ExecutionRepoError {
-    if let Some(db_err) = err.as_database_error() {
-        if db_err.code().as_deref() == Some("23503") {
-            return ExecutionRepoError::not_found("execution", id.to_string());
-        }
+    if let Some(db_err) = err.as_database_error()
+        && db_err.code().as_deref() == Some("23503")
+    {
+        return ExecutionRepoError::not_found("execution", id.to_string());
     }
     map_err(err)
 }
@@ -287,9 +289,12 @@ impl ExecutionRepo for PgExecutionRepo {
         execution_id: ExecutionId,
         node_key: NodeKey,
     ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        // `output` is nullable since ADR-0008 migration 0009; rows written
+        // only via `save_node_result` carry NULL in the legacy column and
+        // are skipped here.
         let row = sqlx::query_as::<_, (Json<serde_json::Value>,)>(
             "SELECT output FROM node_outputs \
-             WHERE execution_id = $1 AND node_id = $2 \
+             WHERE execution_id = $1 AND node_id = $2 AND output IS NOT NULL \
              ORDER BY attempt DESC \
              LIMIT 1",
         )
@@ -309,7 +314,7 @@ impl ExecutionRepo for PgExecutionRepo {
         let rows = sqlx::query_as::<_, (NodeKey, Json<serde_json::Value>)>(
             "SELECT DISTINCT ON (node_id) node_id, output \
              FROM node_outputs \
-             WHERE execution_id = $1 \
+             WHERE execution_id = $1 AND output IS NOT NULL \
              ORDER BY node_id, attempt DESC",
         )
         .bind(execution_id)
@@ -383,6 +388,165 @@ impl ExecutionRepo for PgExecutionRepo {
         .map_err(|e| map_idempotency_err(e, execution_id))?;
 
         Ok(())
+    }
+
+    // ── ADR-0008: workflow input + node results (B1 foundation) ────────────
+
+    async fn set_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+        input: serde_json::Value,
+    ) -> Result<(), ExecutionRepoError> {
+        let result =
+            sqlx::query("UPDATE executions SET input = $2, updated_at = NOW() WHERE id = $1")
+                .bind(execution_id)
+                .bind(Json(&input))
+                .execute(&self.pool)
+                .await
+                .map_err(map_err)?;
+
+        if result.rows_affected() == 0 {
+            return Err(ExecutionRepoError::not_found(
+                "execution",
+                execution_id.to_string(),
+            ));
+        }
+        Ok(())
+    }
+
+    async fn get_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        let row = sqlx::query_as::<_, (Option<Json<serde_json::Value>>,)>(
+            "SELECT input FROM executions WHERE id = $1",
+        )
+        .bind(execution_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_err)?;
+
+        Ok(row.and_then(|(input,)| input.map(|j| j.0)))
+    }
+
+    async fn save_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        attempt: u32,
+        record: NodeResultRecord,
+    ) -> Result<(), ExecutionRepoError> {
+        let attempt_i32 = i32::try_from(attempt).map_err(|_| {
+            ExecutionRepoError::Internal(format!("attempt value {attempt} exceeds i32::MAX"))
+        })?;
+        let version_i32 = i32::try_from(record.schema_version).map_err(|_| {
+            ExecutionRepoError::Internal(format!(
+                "result_schema_version {} exceeds i32::MAX",
+                record.schema_version
+            ))
+        })?;
+
+        // Preserves any existing `output` on conflict (set by `save_node_output`)
+        // and updates only the new variant columns — legacy and new writers
+        // compose on the same (execution_id, node_id, attempt) row.
+        sqlx::query(
+            "INSERT INTO node_outputs \
+             (execution_id, node_id, attempt, output, result_schema_version, result_kind, result) \
+             VALUES ($1, $2, $3, NULL, $4, $5, $6) \
+             ON CONFLICT (execution_id, node_id, attempt) \
+             DO UPDATE SET \
+                 result_schema_version = EXCLUDED.result_schema_version, \
+                 result_kind           = EXCLUDED.result_kind, \
+                 result                = EXCLUDED.result",
+        )
+        .bind(execution_id)
+        .bind(node_key)
+        .bind(attempt_i32)
+        .bind(version_i32)
+        .bind(&record.kind)
+        .bind(Json(&record.result))
+        .execute(&self.pool)
+        .await
+        .map_err(map_err)?;
+
+        Ok(())
+    }
+
+    async fn load_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) -> Result<Option<NodeResultRecord>, ExecutionRepoError> {
+        // Filter on `result IS NOT NULL` so rows written only by legacy
+        // `save_node_output` are invisible to the new reader (they have
+        // no variant information). Pre-migration rows also carry
+        // `result_schema_version = 1` via DEFAULT but no `result`, and
+        // are correctly skipped here.
+        let row = sqlx::query_as::<_, (i32, String, Json<serde_json::Value>)>(
+            "SELECT result_schema_version, result_kind, result FROM node_outputs \
+             WHERE execution_id = $1 AND node_id = $2 AND result IS NOT NULL \
+             ORDER BY attempt DESC \
+             LIMIT 1",
+        )
+        .bind(execution_id)
+        .bind(node_key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(map_err)?;
+
+        let Some((version_i32, kind, result)) = row else {
+            return Ok(None);
+        };
+        let version = u32::try_from(version_i32).map_err(|_| {
+            ExecutionRepoError::Internal(format!(
+                "result_schema_version {version_i32} is negative in database"
+            ))
+        })?;
+        if version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
+            return Err(ExecutionRepoError::UnknownSchemaVersion {
+                version,
+                max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+            });
+        }
+        Ok(Some(NodeResultRecord::with_version(
+            version, kind, result.0,
+        )))
+    }
+
+    async fn load_all_results(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<HashMap<NodeKey, NodeResultRecord>, ExecutionRepoError> {
+        let rows = sqlx::query_as::<_, (NodeKey, i32, String, Json<serde_json::Value>)>(
+            "SELECT DISTINCT ON (node_id) node_id, result_schema_version, result_kind, result \
+             FROM node_outputs \
+             WHERE execution_id = $1 AND result IS NOT NULL \
+             ORDER BY node_id, attempt DESC",
+        )
+        .bind(execution_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(map_err)?;
+
+        let mut out = HashMap::with_capacity(rows.len());
+        for (node_key, version_i32, kind, result) in rows {
+            let version = u32::try_from(version_i32).map_err(|_| {
+                ExecutionRepoError::Internal(format!(
+                    "result_schema_version {version_i32} is negative in database"
+                ))
+            })?;
+            if version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
+                return Err(ExecutionRepoError::UnknownSchemaVersion {
+                    version,
+                    max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+                });
+            }
+            out.insert(
+                node_key,
+                NodeResultRecord::with_version(version, kind, result.0),
+            );
+        }
+        Ok(out)
     }
 }
 
@@ -575,6 +739,320 @@ mod tests {
                 .expect("check after second mark"),
             "key should still exist after second mark"
         );
+    }
+
+    // ── ADR-0008 B1: migration + round-trip + forward-compat ─────────────
+
+    #[tokio::test]
+    async fn pg_migration_creates_resume_persistence_columns() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+
+        let executions_has_input: bool = sqlx::query_scalar(
+            "SELECT EXISTS (
+                 SELECT 1 FROM information_schema.columns
+                 WHERE table_name = 'executions' AND column_name = 'input'
+             )",
+        )
+        .fetch_one(repo.pool())
+        .await
+        .expect("query executions.input");
+        assert!(
+            executions_has_input,
+            "executions.input column must exist after migration 0009"
+        );
+
+        let expected = ["result_schema_version", "result_kind", "result"];
+        for col in expected {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                     SELECT 1 FROM information_schema.columns
+                     WHERE table_name = 'node_outputs' AND column_name = $1
+                 )",
+            )
+            .bind(col)
+            .fetch_one(repo.pool())
+            .await
+            .unwrap_or_else(|e| panic!("query node_outputs.{col}: {e}"));
+            assert!(exists, "node_outputs.{col} must exist after migration 0009");
+        }
+
+        let output_is_nullable: String = sqlx::query_scalar(
+            "SELECT is_nullable FROM information_schema.columns
+             WHERE table_name = 'node_outputs' AND column_name = 'output'",
+        )
+        .fetch_one(repo.pool())
+        .await
+        .expect("query output nullability");
+        assert_eq!(
+            output_is_nullable, "YES",
+            "output must be nullable so save_node_result can omit it (ADR-0008)"
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_workflow_input_round_trip() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({"status": "created"}))
+            .await
+            .expect("create");
+
+        assert_eq!(
+            repo.get_workflow_input(eid).await.expect("get empty"),
+            None,
+            "unset input must be None, never synthesized Null"
+        );
+
+        let payload = serde_json::json!({"trigger": "http", "body": [1, 2, 3]});
+        repo.set_workflow_input(eid, payload.clone())
+            .await
+            .expect("set");
+        assert_eq!(
+            repo.get_workflow_input(eid).await.expect("get after set"),
+            Some(payload),
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_set_workflow_input_unknown_execution_returns_not_found() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let err = repo
+            .set_workflow_input(ExecutionId::new(), serde_json::json!({}))
+            .await
+            .expect_err("missing execution must reject");
+        assert!(matches!(
+            err,
+            ExecutionRepoError::NotFound { ref entity, .. } if entity == "execution"
+        ));
+    }
+
+    #[tokio::test]
+    async fn pg_save_and_load_node_result_round_trip() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("branch_node");
+        let result_json = serde_json::json!({
+            "type": "Branch",
+            "selected": "true",
+            "output": {"Value": {"matched": true}},
+            "alternatives": {"false": {"Value": {"matched": false}}},
+        });
+        let record = NodeResultRecord::new("Branch", result_json.clone());
+        repo.save_node_result(eid, nid.clone(), 0, record)
+            .await
+            .expect("save result");
+
+        let loaded = repo
+            .load_node_result(eid, nid)
+            .await
+            .expect("load")
+            .expect("some");
+        assert_eq!(loaded.schema_version, MAX_SUPPORTED_RESULT_SCHEMA_VERSION);
+        assert_eq!(loaded.kind, "Branch");
+        assert_eq!(loaded.result, result_json);
+    }
+
+    #[tokio::test]
+    async fn pg_save_node_result_composes_with_save_node_output_on_same_row() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("dual_writer");
+        let primary = serde_json::json!({"answer": 42});
+        repo.save_node_output(eid, nid.clone(), 0, primary.clone())
+            .await
+            .expect("legacy save_node_output");
+
+        let result_json = serde_json::json!({
+            "type": "Success",
+            "output": {"Value": {"answer": 42}},
+        });
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            0,
+            NodeResultRecord::new("Success", result_json.clone()),
+        )
+        .await
+        .expect("save_node_result onto existing row");
+
+        assert_eq!(
+            repo.load_node_output(eid, nid.clone())
+                .await
+                .expect("legacy read")
+                .expect("some"),
+            primary,
+            "save_node_result must not wipe legacy `output`"
+        );
+        let record = repo
+            .load_node_result(eid, nid)
+            .await
+            .expect("new read")
+            .expect("some");
+        assert_eq!(record.result, result_json);
+    }
+
+    #[tokio::test]
+    async fn pg_load_node_result_skips_legacy_rows_without_result() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("legacy");
+        repo.save_node_output(eid, nid.clone(), 0, serde_json::json!({"legacy": true}))
+            .await
+            .expect("legacy only");
+
+        let loaded = repo.load_node_result(eid, nid).await.expect("load");
+        assert_eq!(
+            loaded, None,
+            "legacy rows without persisted variant must be invisible to load_node_result"
+        );
+    }
+
+    #[tokio::test]
+    async fn pg_load_node_result_returns_latest_attempt() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("retried");
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            0,
+            NodeResultRecord::new("Success", serde_json::json!({"v": 0})),
+        )
+        .await
+        .expect("attempt 0");
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            1,
+            NodeResultRecord::new("Success", serde_json::json!({"v": 1})),
+        )
+        .await
+        .expect("attempt 1");
+
+        let loaded = repo
+            .load_node_result(eid, nid)
+            .await
+            .expect("load")
+            .expect("some");
+        assert_eq!(loaded.result, serde_json::json!({"v": 1}));
+    }
+
+    #[tokio::test]
+    async fn pg_load_node_result_forward_compat_unknown_schema_version() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let nid = node_key!("future");
+        let future = NodeResultRecord::with_version(
+            MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 1,
+            "FutureVariant",
+            serde_json::json!({"type": "FutureVariant"}),
+        );
+        repo.save_node_result(eid, nid.clone(), 0, future)
+            .await
+            .expect("save future record");
+
+        let err = repo
+            .load_node_result(eid, nid)
+            .await
+            .expect_err("unknown schema version must not fall back");
+        match err {
+            ExecutionRepoError::UnknownSchemaVersion {
+                version,
+                max_supported,
+            } => {
+                assert_eq!(version, MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 1);
+                assert_eq!(max_supported, MAX_SUPPORTED_RESULT_SCHEMA_VERSION);
+            },
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn pg_load_all_results_returns_latest_per_node() {
+        let Some(repo) = pg_exec_repo().await else {
+            return;
+        };
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({}))
+            .await
+            .expect("create");
+
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+
+        repo.save_node_result(
+            eid,
+            n1.clone(),
+            0,
+            NodeResultRecord::new("Success", serde_json::json!("n1_v0")),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            n1.clone(),
+            1,
+            NodeResultRecord::new("Branch", serde_json::json!("n1_v1")),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            n2.clone(),
+            0,
+            NodeResultRecord::new("Skip", serde_json::json!("n2_v0")),
+        )
+        .await
+        .unwrap();
+
+        let all = repo.load_all_results(eid).await.expect("load all");
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[&n1].kind, "Branch");
+        assert_eq!(all[&n1].result, serde_json::json!("n1_v1"));
+        assert_eq!(all[&n2].kind, "Skip");
     }
 
     #[tokio::test]

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -260,9 +260,10 @@ pub trait ExecutionRepo: Send + Sync {
     /// Persist a full node-result record for a specific attempt.
     ///
     /// Overwrites on duplicate `(execution_id, node_key, attempt)` — the
-    /// latest write wins. Rejects records whose `schema_version` exceeds
-    /// [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`] is the caller's responsibility;
-    /// the repo stores whatever it is given.
+    /// latest write wins. Callers must ensure they do not attempt to persist
+    /// a record whose `schema_version` exceeds
+    /// [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`]; the repo stores whatever it is
+    /// given.
     async fn save_node_result(
         &self,
         execution_id: ExecutionId,
@@ -818,16 +819,15 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         execution_id: ExecutionId,
     ) -> Result<HashMap<NodeKey, NodeResultRecord>, ExecutionRepoError> {
         let results = self.node_results.read().await;
+        // Pick highest-attempt record per node first — matching
+        // Postgres's `DISTINCT ON (node_id) ... ORDER BY attempt DESC`.
+        // Schema-version validation runs only against the chosen finalists
+        // so that an older (non-latest) attempt with a future version does
+        // not block a load whose latest attempt is well-formed.
         let mut best: HashMap<NodeKey, (u32, NodeResultRecord)> = HashMap::new();
         for ((eid, nid, attempt), record) in results.iter() {
             if *eid != execution_id {
                 continue;
-            }
-            if record.schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
-                return Err(ExecutionRepoError::UnknownSchemaVersion {
-                    version: record.schema_version,
-                    max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
-                });
             }
             let entry = best
                 .entry(nid.clone())
@@ -836,7 +836,17 @@ impl ExecutionRepo for InMemoryExecutionRepo {
                 *entry = (*attempt, record.clone());
             }
         }
-        Ok(best.into_iter().map(|(nid, (_, r))| (nid, r)).collect())
+        let mut out = HashMap::with_capacity(best.len());
+        for (nid, (_, record)) in best {
+            if record.schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
+                return Err(ExecutionRepoError::UnknownSchemaVersion {
+                    version: record.schema_version,
+                    max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+                });
+            }
+            out.insert(nid, record);
+        }
+        Ok(out)
     }
 
     async fn save_stateful_checkpoint(
@@ -1598,6 +1608,47 @@ mod tests {
             err,
             ExecutionRepoError::UnknownSchemaVersion { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn load_all_results_ignores_future_version_on_non_latest_attempt() {
+        // A node retried after a rollback: attempt 0 was written by a newer
+        // binary (unknown schema_version), attempt 1 is fresh and valid.
+        // `load_all_results` must surface only the latest attempt per node,
+        // so the future-version attempt 0 is not reachable and must not
+        // poison the whole batch — matching `load_node_result` and
+        // `PgExecutionRepo::load_all_results` (`DISTINCT ON ... ORDER BY
+        // attempt DESC`).
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let nid = node_key!("n");
+
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            0,
+            NodeResultRecord::with_version(
+                MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 7,
+                "FutureStale",
+                serde_json::json!({}),
+            ),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            nid.clone(),
+            1,
+            NodeResultRecord::new("Success", serde_json::json!({"ok": true})),
+        )
+        .await
+        .unwrap();
+
+        let all = repo.load_all_results(eid).await.expect(
+            "latest attempt is decodable; earlier future-version attempt must be invisible",
+        );
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[&nid].kind, "Success");
     }
 
     #[tokio::test]

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -73,7 +73,7 @@ pub enum ExecutionRepoError {
     /// Emitted by [`ExecutionRepo::load_node_result`] / [`ExecutionRepo::load_all_results`]
     /// when a newer writer stored a record the current binary does not understand.
     /// Surface to operators as a resume failure — never fall back silently
-    /// (ADR-0008 §2, PRODUCT_CANON §4.5).
+    /// (ADR-0009 §2, PRODUCT_CANON §4.5).
     #[error("unknown node-result schema version: {version} (max supported: {max_supported})")]
     UnknownSchemaVersion {
         /// Schema version found in the persisted row.
@@ -210,7 +210,7 @@ pub trait ExecutionRepo: Send + Sync {
         execution_id: ExecutionId,
     ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError>;
 
-    // ── Workflow input (ADR-0008 §3, issue #311 foundation) ────────────────
+    // ── Workflow input (ADR-0009 §3, issue #311 foundation) ────────────────
     //
     // The workflow trigger / start input is persisted alongside the execution
     // row so that resume can replay entry nodes with the original payload.
@@ -239,7 +239,7 @@ pub trait ExecutionRepo: Send + Sync {
     /// Returns `Ok(None)` when no input has been persisted yet — the caller
     /// (engine resume path, B2) converts `None` into a typed resume failure
     /// so missing input is loud, not a silent `Value::Null` default
-    /// (ADR-0008 §3, PRODUCT_CANON §4.5).
+    /// (ADR-0009 §3, PRODUCT_CANON §4.5).
     async fn get_workflow_input(
         &self,
         execution_id: ExecutionId,
@@ -250,7 +250,7 @@ pub trait ExecutionRepo: Send + Sync {
         ))
     }
 
-    // ── Node results (ADR-0008 §1, issue #299 foundation) ──────────────────
+    // ── Node results (ADR-0009 §1, issue #299 foundation) ──────────────────
     //
     // Persists the full `ActionResult<Value>` variant per node attempt so
     // that resume can replay edge decisions through the engine's own
@@ -284,7 +284,7 @@ pub trait ExecutionRepo: Send + Sync {
     /// [`ExecutionRepoError::UnknownSchemaVersion`] when a persisted row
     /// carries a `result_schema_version` greater than
     /// [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`]; the caller surfaces this as
-    /// a resume failure rather than falling back (ADR-0008 §2).
+    /// a resume failure rather than falling back (ADR-0009 §2).
     async fn load_node_result(
         &self,
         execution_id: ExecutionId,
@@ -403,7 +403,7 @@ pub trait ExecutionRepo: Send + Sync {
 /// Bumped whenever a change to `ActionResult` (or the [`NodeResultRecord`]
 /// shape) could make an older binary fail to decode a record written by a
 /// newer one — new variants, new required fields, changed field semantics
-/// (ADR-0008 §2). Records with a higher `schema_version` cause
+/// (ADR-0009 §2). Records with a higher `schema_version` cause
 /// [`ExecutionRepoError::UnknownSchemaVersion`] on load, never a silent
 /// fall-back.
 pub const MAX_SUPPORTED_RESULT_SCHEMA_VERSION: u32 = 1;
@@ -416,7 +416,7 @@ pub const MAX_SUPPORTED_RESULT_SCHEMA_VERSION: u32 = 1;
 /// neutral JSON blob plus a `kind` tag for SQL-side filtering and a
 /// `schema_version` for forward-compat guarding.
 ///
-/// ADR-0008 §1 pins this as the canonical persistence shape for issue #299
+/// ADR-0009 §1 pins this as the canonical persistence shape for issue #299
 /// (resume reconstructs `ActionResult::Branch` / `Route` / `MultiOutput` /
 /// `Skip` / `Wait` through the engine's own `evaluate_edge` path, not via
 /// synthesized `Success`).
@@ -425,7 +425,7 @@ pub const MAX_SUPPORTED_RESULT_SCHEMA_VERSION: u32 = 1;
 pub struct NodeResultRecord {
     /// Schema version this record was written under.
     ///
-    /// `1` is the initial shape; future changes bump per ADR-0008 §2.
+    /// `1` is the initial shape; future changes bump per ADR-0009 §2.
     pub schema_version: u32,
     /// Variant tag (`"Success"`, `"Branch"`, `"Route"`, `"MultiOutput"`,
     /// `"Skip"`, `"Wait"`, `"Retry"`, `"Break"`, `"Continue"`, `"Drop"`,
@@ -1332,7 +1332,7 @@ mod tests {
         );
     }
 
-    // ── ADR-0008 B1: workflow input + node-result persistence ─────────────
+    // ── ADR-0009 B1: workflow input + node-result persistence ─────────────
 
     /// Fixture: a sample JSON shape for each `ActionResult` variant as
     /// `serde_json` would emit it. The storage layer treats these as opaque

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -67,6 +67,20 @@ pub enum ExecutionRepoError {
     /// Unexpected internal repository failure.
     #[error("internal error: {0}")]
     Internal(String),
+
+    /// Persisted node-result carries a schema version this binary cannot decode.
+    ///
+    /// Emitted by [`ExecutionRepo::load_node_result`] / [`ExecutionRepo::load_all_results`]
+    /// when a newer writer stored a record the current binary does not understand.
+    /// Surface to operators as a resume failure — never fall back silently
+    /// (ADR-0008 §2, PRODUCT_CANON §4.5).
+    #[error("unknown node-result schema version: {version} (max supported: {max_supported})")]
+    UnknownSchemaVersion {
+        /// Schema version found in the persisted row.
+        version: u32,
+        /// Highest version this binary knows how to decode.
+        max_supported: u32,
+    },
 }
 
 impl ExecutionRepoError {
@@ -196,6 +210,109 @@ pub trait ExecutionRepo: Send + Sync {
         execution_id: ExecutionId,
     ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError>;
 
+    // ── Workflow input (ADR-0008 §3, issue #311 foundation) ────────────────
+    //
+    // The workflow trigger / start input is persisted alongside the execution
+    // row so that resume can replay entry nodes with the original payload.
+    // Defaults return `ExecutionRepoError::Internal("not implemented")` so
+    // backends that do not yet support the new schema still compile —
+    // matching the stateful-checkpoint pattern. B2 (resume consumer chip)
+    // wires the read side; B1 only exposes the seam.
+
+    /// Persist the workflow input payload for an execution.
+    ///
+    /// Idempotent: calling twice overwrites (workflows only set input once
+    /// at start in practice). Resume expects a single canonical value.
+    async fn set_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+        input: serde_json::Value,
+    ) -> Result<(), ExecutionRepoError> {
+        let _ = (execution_id, input);
+        Err(ExecutionRepoError::Internal(
+            "set_workflow_input not implemented for this backend".to_owned(),
+        ))
+    }
+
+    /// Load the persisted workflow input for an execution.
+    ///
+    /// Returns `Ok(None)` when no input has been persisted yet — the caller
+    /// (engine resume path, B2) converts `None` into a typed resume failure
+    /// so missing input is loud, not a silent `Value::Null` default
+    /// (ADR-0008 §3, PRODUCT_CANON §4.5).
+    async fn get_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        let _ = execution_id;
+        Err(ExecutionRepoError::Internal(
+            "get_workflow_input not implemented for this backend".to_owned(),
+        ))
+    }
+
+    // ── Node results (ADR-0008 §1, issue #299 foundation) ──────────────────
+    //
+    // Persists the full `ActionResult<Value>` variant per node attempt so
+    // that resume can replay edge decisions through the engine's own
+    // `evaluate_edge` path. B3 (resume writer) and B4 (resume reader) land
+    // the consumers; B1 only exposes the seam.
+
+    /// Persist a full node-result record for a specific attempt.
+    ///
+    /// Overwrites on duplicate `(execution_id, node_key, attempt)` — the
+    /// latest write wins. Rejects records whose `schema_version` exceeds
+    /// [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`] is the caller's responsibility;
+    /// the repo stores whatever it is given.
+    async fn save_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        attempt: u32,
+        record: NodeResultRecord,
+    ) -> Result<(), ExecutionRepoError> {
+        let _ = (execution_id, node_key, attempt, record);
+        Err(ExecutionRepoError::Internal(
+            "save_node_result not implemented for this backend".to_owned(),
+        ))
+    }
+
+    /// Load the latest node-result record for a node (highest attempt).
+    ///
+    /// Returns `Ok(None)` when no record exists — either the node has not
+    /// been dispatched yet, or the row predates the new schema. Returns
+    /// [`ExecutionRepoError::UnknownSchemaVersion`] when a persisted row
+    /// carries a `result_schema_version` greater than
+    /// [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`]; the caller surfaces this as
+    /// a resume failure rather than falling back (ADR-0008 §2).
+    async fn load_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) -> Result<Option<NodeResultRecord>, ExecutionRepoError> {
+        let _ = (execution_id, node_key);
+        Err(ExecutionRepoError::Internal(
+            "load_node_result not implemented for this backend".to_owned(),
+        ))
+    }
+
+    /// Load all latest-attempt node-result records for an execution.
+    ///
+    /// Same error discipline as [`load_node_result`]: unknown schema
+    /// versions surface as [`ExecutionRepoError::UnknownSchemaVersion`],
+    /// never silently fall back. Missing rows (legacy or not yet
+    /// dispatched) are simply absent from the returned map.
+    ///
+    /// [`load_node_result`]: ExecutionRepo::load_node_result
+    async fn load_all_results(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<HashMap<NodeKey, NodeResultRecord>, ExecutionRepoError> {
+        let _ = execution_id;
+        Err(ExecutionRepoError::Internal(
+            "load_all_results not implemented for this backend".to_owned(),
+        ))
+    }
+
     /// Lists execution IDs in non-terminal states.
     async fn list_running(&self) -> Result<Vec<ExecutionId>, ExecutionRepoError>;
 
@@ -280,6 +397,70 @@ pub trait ExecutionRepo: Send + Sync {
     }
 }
 
+/// Highest node-result schema version this binary can decode.
+///
+/// Bumped whenever a change to `ActionResult` (or the [`NodeResultRecord`]
+/// shape) could make an older binary fail to decode a record written by a
+/// newer one — new variants, new required fields, changed field semantics
+/// (ADR-0008 §2). Records with a higher `schema_version` cause
+/// [`ExecutionRepoError::UnknownSchemaVersion`] on load, never a silent
+/// fall-back.
+pub const MAX_SUPPORTED_RESULT_SCHEMA_VERSION: u32 = 1;
+
+/// A persisted node-result record carrying the full `ActionResult<Value>`
+/// variant for a node attempt.
+///
+/// Storage-side mirror of `nebula_action::ActionResult<Value>` — the repo
+/// crate does not depend on `nebula-action`, so the variant lives in a
+/// neutral JSON blob plus a `kind` tag for SQL-side filtering and a
+/// `schema_version` for forward-compat guarding.
+///
+/// ADR-0008 §1 pins this as the canonical persistence shape for issue #299
+/// (resume reconstructs `ActionResult::Branch` / `Route` / `MultiOutput` /
+/// `Skip` / `Wait` through the engine's own `evaluate_edge` path, not via
+/// synthesized `Success`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct NodeResultRecord {
+    /// Schema version this record was written under.
+    ///
+    /// `1` is the initial shape; future changes bump per ADR-0008 §2.
+    pub schema_version: u32,
+    /// Variant tag (`"Success"`, `"Branch"`, `"Route"`, `"MultiOutput"`,
+    /// `"Skip"`, `"Wait"`, `"Retry"`, `"Break"`, `"Continue"`, `"Drop"`,
+    /// `"Terminate"`). Mirrors the serde tag on `ActionResult`.
+    pub kind: String,
+    /// Serialized `ActionResult<Value>` as emitted by `serde_json`.
+    pub result: serde_json::Value,
+}
+
+impl NodeResultRecord {
+    /// Build a new record at the current schema version.
+    #[must_use]
+    pub fn new(kind: impl Into<String>, result: serde_json::Value) -> Self {
+        Self {
+            schema_version: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+            kind: kind.into(),
+            result,
+        }
+    }
+
+    /// Build a record at an explicit schema version (for tests / migration
+    /// fixtures that need to pin older shapes).
+    #[must_use]
+    pub fn with_version(
+        schema_version: u32,
+        kind: impl Into<String>,
+        result: serde_json::Value,
+    ) -> Self {
+        Self {
+            schema_version,
+            kind: kind.into(),
+            result,
+        }
+    }
+}
+
 /// A persisted stateful iteration checkpoint.
 ///
 /// Storage-side mirror of the runtime's `StatefulCheckpoint` — separate
@@ -332,6 +513,8 @@ pub struct InMemoryExecutionRepo {
     node_outputs: Arc<RwLock<HashMap<NodeOutputKey, serde_json::Value>>>,
     idempotency: Arc<RwLock<HashSet<String>>>,
     stateful_checkpoints: Arc<RwLock<HashMap<StatefulCheckpointKey, StatefulCheckpointRecord>>>,
+    workflow_inputs: Arc<RwLock<HashMap<ExecutionId, serde_json::Value>>>,
+    node_results: Arc<RwLock<HashMap<NodeOutputKey, NodeResultRecord>>>,
 }
 
 impl InMemoryExecutionRepo {
@@ -559,6 +742,101 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         drop((state, workflows));
         self.idempotency.write().await.insert(key.to_owned());
         Ok(())
+    }
+
+    async fn set_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+        input: serde_json::Value,
+    ) -> Result<(), ExecutionRepoError> {
+        let state = self.state.read().await;
+        let workflows = self.workflows.read().await;
+        if !state.contains_key(&execution_id) && !workflows.contains_key(&execution_id) {
+            return Err(ExecutionRepoError::not_found(
+                "execution",
+                execution_id.to_string(),
+            ));
+        }
+        drop((state, workflows));
+        self.workflow_inputs
+            .write()
+            .await
+            .insert(execution_id, input);
+        Ok(())
+    }
+
+    async fn get_workflow_input(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Option<serde_json::Value>, ExecutionRepoError> {
+        Ok(self
+            .workflow_inputs
+            .read()
+            .await
+            .get(&execution_id)
+            .cloned())
+    }
+
+    async fn save_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+        attempt: u32,
+        record: NodeResultRecord,
+    ) -> Result<(), ExecutionRepoError> {
+        self.node_results
+            .write()
+            .await
+            .insert((execution_id, node_key, attempt), record);
+        Ok(())
+    }
+
+    async fn load_node_result(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) -> Result<Option<NodeResultRecord>, ExecutionRepoError> {
+        let results = self.node_results.read().await;
+        let best = results
+            .iter()
+            .filter(|((eid, nid, _), _)| *eid == execution_id && *nid == node_key)
+            .max_by_key(|((_, _, attempt), _)| *attempt)
+            .map(|(_, record)| record.clone());
+        if let Some(record) = &best
+            && record.schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION
+        {
+            return Err(ExecutionRepoError::UnknownSchemaVersion {
+                version: record.schema_version,
+                max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+            });
+        }
+        Ok(best)
+    }
+
+    async fn load_all_results(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<HashMap<NodeKey, NodeResultRecord>, ExecutionRepoError> {
+        let results = self.node_results.read().await;
+        let mut best: HashMap<NodeKey, (u32, NodeResultRecord)> = HashMap::new();
+        for ((eid, nid, attempt), record) in results.iter() {
+            if *eid != execution_id {
+                continue;
+            }
+            if record.schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
+                return Err(ExecutionRepoError::UnknownSchemaVersion {
+                    version: record.schema_version,
+                    max_supported: MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+                });
+            }
+            let entry = best
+                .entry(nid.clone())
+                .or_insert((*attempt, record.clone()));
+            if *attempt > entry.0 {
+                *entry = (*attempt, record.clone());
+            }
+        }
+        Ok(best.into_iter().map(|(nid, (_, r))| (nid, r)).collect())
     }
 
     async fn save_stateful_checkpoint(
@@ -1041,6 +1319,363 @@ mod tests {
             repo.acquire_lease(id, "C".into(), Duration::from_secs(5))
                 .await
                 .expect("reacquire by C")
+        );
+    }
+
+    // ── ADR-0008 B1: workflow input + node-result persistence ─────────────
+
+    /// Fixture: a sample JSON shape for each `ActionResult` variant as
+    /// `serde_json` would emit it. The storage layer treats these as opaque
+    /// blobs; the round-trip test just asserts byte-equivalence.
+    fn variant_fixtures() -> Vec<(&'static str, serde_json::Value)> {
+        vec![
+            (
+                "Success",
+                serde_json::json!({
+                    "type": "Success",
+                    "output": {"Value": {"answer": 42}},
+                }),
+            ),
+            (
+                "Skip",
+                serde_json::json!({
+                    "type": "Skip",
+                    "reason": "filtered",
+                    "output": {"Value": {"id": "abc"}},
+                }),
+            ),
+            (
+                "Drop",
+                serde_json::json!({
+                    "type": "Drop",
+                    "reason": "rate limited",
+                }),
+            ),
+            (
+                "Continue",
+                serde_json::json!({
+                    "type": "Continue",
+                    "output": {"Value": {"page": 2}},
+                    "progress": 0.5,
+                    "delay": 1000,
+                }),
+            ),
+            (
+                "Break",
+                serde_json::json!({
+                    "type": "Break",
+                    "output": {"Value": {"total": 100}},
+                    "reason": "Completed",
+                }),
+            ),
+            (
+                "Branch",
+                serde_json::json!({
+                    "type": "Branch",
+                    "selected": "true",
+                    "output": {"Value": {"matched": true}},
+                    "alternatives": {
+                        "false": {"Value": {"matched": false}},
+                    },
+                }),
+            ),
+            (
+                "Route",
+                serde_json::json!({
+                    "type": "Route",
+                    "port": "error",
+                    "data": {"Value": {"code": "E_BAD"}},
+                }),
+            ),
+            (
+                "MultiOutput",
+                serde_json::json!({
+                    "type": "MultiOutput",
+                    "outputs": {
+                        "main": {"Value": 1},
+                        "audit": {"Value": 2},
+                    },
+                    "main_output": {"Value": 1},
+                }),
+            ),
+            (
+                "Wait",
+                serde_json::json!({
+                    "type": "Wait",
+                    "condition": {
+                        "type": "Duration",
+                        "duration": 60000,
+                    },
+                    "timeout": 300000,
+                    "partial_output": null,
+                }),
+            ),
+            // Retry is slated for removal in chip E1; its JSON shape lives
+            // under the same `type`-tagged schema and must round-trip
+            // until the variant is gone. Drop from this fixture list when
+            // E1 lands and the schema version bumps to 2.
+            (
+                "Retry",
+                serde_json::json!({
+                    "type": "Retry",
+                    "after": 5000,
+                    "reason": "rate-limited",
+                }),
+            ),
+            (
+                "Terminate",
+                serde_json::json!({
+                    "type": "Terminate",
+                    "reason": {"type": "Success", "note": "done early"},
+                }),
+            ),
+        ]
+    }
+
+    #[tokio::test]
+    async fn node_result_round_trips_every_action_result_variant() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({"status": "created"}))
+            .await
+            .unwrap();
+
+        for (idx, (kind, result_json)) in variant_fixtures().into_iter().enumerate() {
+            let node = node_key!("n");
+            let record = NodeResultRecord::new(kind, result_json.clone());
+            let attempt = u32::try_from(idx).unwrap();
+
+            repo.save_node_result(eid, node.clone(), attempt, record.clone())
+                .await
+                .unwrap();
+
+            let loaded = repo
+                .load_node_result(eid, node)
+                .await
+                .unwrap()
+                .expect("record must exist after save");
+            assert_eq!(
+                loaded.schema_version, MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+                "{kind}: schema_version must be the current default",
+            );
+            assert_eq!(loaded.kind, kind, "{kind}: kind must round-trip");
+            assert_eq!(
+                loaded.result, result_json,
+                "{kind}: result JSON must round-trip byte-equivalent",
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn load_node_result_returns_latest_attempt() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let node = node_key!("n");
+
+        repo.save_node_result(
+            eid,
+            node.clone(),
+            0,
+            NodeResultRecord::new("Success", serde_json::json!({"v": 0})),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            node.clone(),
+            1,
+            NodeResultRecord::new("Success", serde_json::json!({"v": 1})),
+        )
+        .await
+        .unwrap();
+
+        let loaded = repo.load_node_result(eid, node).await.unwrap().unwrap();
+        assert_eq!(loaded.result, serde_json::json!({"v": 1}));
+    }
+
+    #[tokio::test]
+    async fn load_all_results_returns_latest_per_node() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let n1 = node_key!("n1");
+        let n2 = node_key!("n2");
+
+        repo.save_node_result(
+            eid,
+            n1.clone(),
+            0,
+            NodeResultRecord::new("Success", serde_json::json!("n1_v0")),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            n1.clone(),
+            1,
+            NodeResultRecord::new("Branch", serde_json::json!("n1_v1")),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            n2.clone(),
+            0,
+            NodeResultRecord::new("Skip", serde_json::json!("n2_v0")),
+        )
+        .await
+        .unwrap();
+
+        let all = repo.load_all_results(eid).await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert_eq!(all[&n1].kind, "Branch");
+        assert_eq!(all[&n1].result, serde_json::json!("n1_v1"));
+        assert_eq!(all[&n2].kind, "Skip");
+    }
+
+    #[tokio::test]
+    async fn load_node_result_surfaces_unknown_schema_version_as_typed_error() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let node = node_key!("future");
+
+        let future_record = NodeResultRecord::with_version(
+            MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 1,
+            "FutureVariant",
+            serde_json::json!({"type": "FutureVariant"}),
+        );
+        repo.save_node_result(eid, node.clone(), 0, future_record)
+            .await
+            .unwrap();
+
+        let err = repo
+            .load_node_result(eid, node)
+            .await
+            .expect_err("unknown schema version must not fall back");
+        match err {
+            ExecutionRepoError::UnknownSchemaVersion {
+                version,
+                max_supported,
+            } => {
+                assert_eq!(version, MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 1);
+                assert_eq!(max_supported, MAX_SUPPORTED_RESULT_SCHEMA_VERSION);
+            },
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn load_all_results_surfaces_unknown_schema_version_as_typed_error() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+
+        repo.save_node_result(
+            eid,
+            node_key!("ok"),
+            0,
+            NodeResultRecord::new("Success", serde_json::json!({})),
+        )
+        .await
+        .unwrap();
+        repo.save_node_result(
+            eid,
+            node_key!("future"),
+            0,
+            NodeResultRecord::with_version(
+                MAX_SUPPORTED_RESULT_SCHEMA_VERSION + 5,
+                "Far",
+                serde_json::json!({}),
+            ),
+        )
+        .await
+        .unwrap();
+
+        let err = repo
+            .load_all_results(eid)
+            .await
+            .expect_err("mixed batch with unknown version must error");
+        assert!(matches!(
+            err,
+            ExecutionRepoError::UnknownSchemaVersion { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn load_node_result_none_when_no_record() {
+        let repo = InMemoryExecutionRepo::default();
+        let loaded = repo
+            .load_node_result(ExecutionId::new(), node_key!("n"))
+            .await
+            .unwrap();
+        assert_eq!(loaded, None);
+    }
+
+    #[tokio::test]
+    async fn workflow_input_round_trip() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({"status": "created"}))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            repo.get_workflow_input(eid).await.unwrap(),
+            None,
+            "unset input must be None, never a synthesized Null"
+        );
+
+        let input = serde_json::json!({"trigger": "http", "payload": {"x": 1}});
+        repo.set_workflow_input(eid, input.clone()).await.unwrap();
+
+        assert_eq!(repo.get_workflow_input(eid).await.unwrap(), Some(input));
+    }
+
+    #[tokio::test]
+    async fn set_workflow_input_rejects_unknown_execution() {
+        let repo = InMemoryExecutionRepo::default();
+        let missing = ExecutionId::new();
+        let err = repo
+            .set_workflow_input(missing, serde_json::json!({}))
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            ExecutionRepoError::NotFound { ref entity, ref id }
+                if entity == "execution" && id == &missing.to_string()
+        ));
+    }
+
+    #[tokio::test]
+    async fn get_workflow_input_returns_none_for_unknown_execution() {
+        let repo = InMemoryExecutionRepo::default();
+        let got = repo.get_workflow_input(ExecutionId::new()).await.unwrap();
+        assert_eq!(
+            got, None,
+            "get_workflow_input is a read seam: unknown id is None, not NotFound; \
+             resume caller decides whether missing = error",
+        );
+    }
+
+    #[tokio::test]
+    async fn set_workflow_input_overwrites() {
+        let repo = InMemoryExecutionRepo::default();
+        let eid = ExecutionId::new();
+        let wid = WorkflowId::new();
+        repo.create(eid, wid, serde_json::json!({"status": "created"}))
+            .await
+            .unwrap();
+
+        repo.set_workflow_input(eid, serde_json::json!({"v": 1}))
+            .await
+            .unwrap();
+        repo.set_workflow_input(eid, serde_json::json!({"v": 2}))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            repo.get_workflow_input(eid).await.unwrap(),
+            Some(serde_json::json!({"v": 2})),
         );
     }
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -31,7 +31,7 @@
 //!   transitions.
 //! - §12.3 local path: SQLite is the default; `test_support` provides `sqlite_memory_*` helpers for
 //!   in-process tests.
-//! - ADR-0008 resume-persistence schema: `set_workflow_input` / `get_workflow_input` and
+//! - ADR-0009 resume-persistence schema: `set_workflow_input` / `get_workflow_input` and
 //!   `save_node_result` / `load_node_result` / `load_all_results` expose the seam; engine consumers
 //!   (chips B2 / B3 / B4) wire the resume path.
 //!

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -7,8 +7,8 @@
 //! ## Layer 1 — production interfaces (use these today)
 //!
 //! Top-level re-exports: `ExecutionRepo`, `WorkflowRepo`, `InMemoryExecutionRepo`,
-//! `InMemoryWorkflowRepo`. Feature `postgres` adds `PgExecutionRepo`,
-//! `PgWorkflowRepo`, `PostgresStorage`.
+//! `InMemoryWorkflowRepo`, `NodeResultRecord`, `MAX_SUPPORTED_RESULT_SCHEMA_VERSION`.
+//! Feature `postgres` adds `PgExecutionRepo`, `PgWorkflowRepo`, `PostgresStorage`.
 //!
 //! This is the layer the knife scenario (`docs/PRODUCT_CANON.md` §13) exercises
 //! end-to-end.
@@ -31,6 +31,9 @@
 //!   transitions.
 //! - §12.3 local path: SQLite is the default; `test_support` provides `sqlite_memory_*` helpers for
 //!   in-process tests.
+//! - ADR-0008 resume-persistence schema: `set_workflow_input` / `get_workflow_input` and
+//!   `save_node_result` / `load_node_result` / `load_all_results` expose the seam; engine consumers
+//!   (chips B2 / B3 / B4) wire the resume path.
 //!
 //! See `crates/storage/README.md` for the full durability matrix and
 //! backend status table.
@@ -75,7 +78,8 @@ pub use backend::{MemoryStorage, MemoryStorageTyped};
 pub use backend::{PgExecutionRepo, PgWorkflowRepo, PostgresStorage, PostgresStorageConfig};
 pub use error::StorageError;
 pub use execution_repo::{
-    ExecutionRepo, ExecutionRepoError, InMemoryExecutionRepo, StatefulCheckpointRecord,
+    ExecutionRepo, ExecutionRepoError, InMemoryExecutionRepo, MAX_SUPPORTED_RESULT_SCHEMA_VERSION,
+    NodeResultRecord, StatefulCheckpointRecord,
 };
 pub use format::StorageFormat;
 pub use storage::Storage;

--- a/docs/adr/0008-resume-persistence-schema.md
+++ b/docs/adr/0008-resume-persistence-schema.md
@@ -90,7 +90,7 @@ over the two alternatives:
   (current value: `1`).
 - Any change that could make an older binary fail to decode — new variant,
   new required field, changed field semantics — **must** bump the version.
-- On load, if `result_schema_version > MAX_SUPPORTED_SCHEMA_VERSION`,
+- On load, if `result_schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION`,
   `ExecutionRepo::load_node_result` returns
   `ExecutionRepoError::UnknownSchemaVersion { version, max_supported }`.
   Callers (the engine) surface this as a resume failure with operator-

--- a/docs/adr/0008-resume-persistence-schema.md
+++ b/docs/adr/0008-resume-persistence-schema.md
@@ -1,0 +1,245 @@
+---
+id: 0008
+title: resume-persistence-schema
+status: accepted
+date: 2026-04-18
+supersedes: []
+superseded_by: []
+tags: [storage, execution, resume, persistence, schema]
+related:
+  - crates/storage/src/execution_repo.rs
+  - crates/storage/migrations/
+  - docs/PRODUCT_CANON.md#115
+  - docs/PRODUCT_CANON.md#111
+  - docs/PRODUCT_CANON.md#10
+---
+
+# 0008. Resume persistence schema
+
+## Context
+
+`WorkflowEngine::resume_execution` (`crates/engine/src/engine.rs`) reconstructs
+runtime decisions from a persistence record that was never designed to carry
+everything replay needs. Four open issues all trace to the same root cause —
+the persisted shape describes what finished, not what the engine decided:
+
+| Issue | What is lost on resume | Current symptom |
+|---|---|---|
+| [#311](https://github.com/vanyastaff/nebula/issues/311) | Original workflow trigger input | Resume passes `Value::Null` to entry nodes |
+| [#324](https://github.com/vanyastaff/nebula/issues/324) | OnError edge activations from `Failed` predecessors | Reconstruction only marks `Completed\|Skipped` sources active |
+| [#336](https://github.com/vanyastaff/nebula/issues/336) | Per-edge condition (branch key, port) | All outgoing edges of `Completed` nodes unconditionally activate |
+| [#299](https://github.com/vanyastaff/nebula/issues/299) | `ActionResult` variant (Branch / Route / MultiOutput / Skip / Wait) | `check_and_apply_idempotency` synthesizes `ActionResult::success(output)` |
+
+The `ExecutionRepo` layer persists only the primary output payload
+(`node_outputs.output`) and the execution state JSON. `ActionResult` variants
+and their flow-control intent (selected branch key, output port, skip reason,
+wait condition, …) never reach storage. Workflow trigger input also never
+reaches storage — the engine owns it in memory only.
+
+This chip (B1 of the engine-lifecycle canon cluster 2026-04 plan) is
+**foundation only**: schema + repo seam, no engine behavior change.
+
+Canon impact:
+
+- `§11.1` — resumed execution must be byte-equivalent to non-crashed run.
+- `§11.5` — extends what is durable; adds rows/columns.
+- `§10 step 7` — persistence story must be explicit.
+
+## Decision
+
+### 1. Persistence choice — persist the full `ActionResult<Value>` per node
+
+**Option 1** from [#299](https://github.com/vanyastaff/nebula/issues/299) body:
+persist the full `ActionResult<Value>` next to each node output. The engine
+keeps `evaluate_edge` as the single source of truth — on resume it re-runs the
+same decision over the persisted variant and produces identical edge
+activations to the non-crash run.
+
+We considered **Option 3** (persist edge-activation decisions per edge) and
+rejected it:
+
+- Requires a new `edge_activations` table plus a write path coordinated with
+  `evaluate_edge` on every dispatch — larger implementation surface for the
+  same replay guarantee.
+- Splits the source of truth: `evaluate_edge` at dispatch time; persisted
+  activation rows at resume time. Option 1 keeps one path.
+- Future changes to edge semantics (new conditions, new variants) require
+  updating two places instead of one.
+
+Option 1 costs a few extra columns and a JSON blob per node attempt;
+Option 3 costs a table and a coordinated write. For a foundation chip that
+must not preempt later engine refactors, Option 1 wins.
+
+### 2. Forward-compatibility contract — explicit schema version column
+
+Persisting full `ActionResult<Value>` means a future variant added to
+`ActionResult` breaks deserialization in an older binary that reads a record
+written by a newer one. We pick **explicit `result_schema_version INTEGER`**
+over the two alternatives:
+
+- `#[serde(other)]` fallback on the tag field — does not compose well with
+  tagged enums and silently degrades variant identity on resume (a `Branch`
+  becomes "unknown", which is exactly the bug we are trying to avoid).
+- `#[non_exhaustive]` deserialization catching unknown variants — works for
+  variant-only changes but gives no signal for field-shape changes within a
+  variant.
+
+**Contract:**
+
+- Every persisted node-result row carries `result_schema_version INTEGER`
+  (current value: `1`).
+- Any change that could make an older binary fail to decode — new variant,
+  new required field, changed field semantics — **must** bump the version.
+- On load, if `result_schema_version > MAX_SUPPORTED_SCHEMA_VERSION`,
+  `ExecutionRepo::load_node_result` returns
+  `ExecutionRepoError::UnknownSchemaVersion { version, max_supported }`.
+  Callers (the engine) surface this as a resume failure with operator-
+  actionable context — never default to Null, never synthesize a fallback.
+- `#[non_exhaustive]` stays on `ActionResult` (today) and on the new
+  `NodeResultRecord` so additions outside version bumps remain source-
+  compatible for first-party consumers.
+
+**Mixed-binary deployment:** an older binary resuming an execution written by
+a newer binary fails loud (typed error). An operator sees this in the resume
+error; it is a deploy-ordering bug, not silent data loss.
+
+### 3. Workflow input persistence — column on `executions`
+
+Workflow input lives in a new `executions.input` column (JSONB in Postgres,
+JSON in SQLite). Rationale:
+
+- Same lifecycle as the execution row (created once at start, never mutated),
+  same FK scope. A separate `execution_inputs` table adds a join for every
+  resume without a single query that needs it standalone.
+- Existing `executions` row size stays modest — workflow inputs in practice
+  are small trigger payloads. Very large inputs go through the existing blob
+  reference pattern (`crates/storage/src/repos/blob.rs`, out of scope here).
+- Size bound: the engine passes the column through `serde_json::Value`. A
+  soft bound of 1 MiB matches Postgres's practical TOAST crossover; inputs
+  larger than that should be referenced blobs. This is **guidance, not an
+  enforced check** at this chip — B2 wires the consumer and may add the
+  check if needed.
+- Missing / null on resume: the repo returns `Ok(None)` from
+  `get_workflow_input`. B2 (the resume consumer chip) converts `None` to a
+  typed `ResumeError::MissingInput` per `feedback_no_shims.md` and §4.5 —
+  no silent `Value::Null` default. This chip only exposes the seam.
+
+### 4. Migration — forward-only, both dialects
+
+Two parallel migration paths exist in `crates/storage/migrations/` today
+(Layer 1 Postgres schema consumed by `PgExecutionRepo`; Layer 2 spec-16
+schema pending adoption). B1 lands matching changes in both so they stay in
+sync as Layer 2 moves forward:
+
+- **Layer 1** (`migrations/00000000000009_add_resume_persistence.sql`,
+  Postgres dialect — the only Layer 1 dialect today):
+  - `ALTER TABLE executions ADD COLUMN input JSONB`.
+  - `ALTER TABLE node_outputs` adds `result_schema_version INTEGER NOT NULL
+    DEFAULT 1`, `result_kind TEXT`, `result JSONB`. Legacy rows (no
+    `result`) return `None` from `load_node_result`; B3 writes the new
+    columns alongside the existing `output`.
+- **Layer 2** (`migrations/{postgres,sqlite}/0020_add_resume_result_persistence.sql`):
+  - `executions.input` already exists in the Layer 2 schema — no change.
+  - `ALTER TABLE execution_nodes` adds the same three result columns.
+
+Both are **forward-only**. Rollback means dropping the added columns, which
+loses any persisted resume context; this is acceptable because the columns
+are nullable and pre-migration engines never read them.
+
+### 5. Coordination with A1 (control plane consumer ADR)
+
+B1 assumes **nothing** about A1's choice of control-plane consumer wiring.
+The schema changes are orthogonal:
+
+- A1 decides how cancel/dispatch signals reach the engine from
+  `execution_control_queue` (§12.2). That does not constrain what each node
+  attempt persists.
+- B1 decides what is durable per node attempt for replay. That does not
+  constrain how control signals are consumed.
+
+If A1 lands first with a consumer that needs to read persisted results, it
+reads through the trait surface defined here. If A1 lands later, nothing in
+B1 has to change. The two ADRs close the loop independently; any
+integration friction surfaces in B4 or A2 where both paths meet the engine.
+
+## Consequences
+
+Positive:
+
+- **Resume becomes replay-complete.** B4 can use the same `evaluate_edge`
+  path over persisted results to reconstruct edge activations (fixes
+  [#299](https://github.com/vanyastaff/nebula/issues/299), [#324](https://github.com/vanyastaff/nebula/issues/324),
+  [#336](https://github.com/vanyastaff/nebula/issues/336)).
+- **Workflow input becomes durable** (fixes
+  [#311](https://github.com/vanyastaff/nebula/issues/311) once B2 wires the
+  resume read).
+- **Schema version discipline** surfaces compat breaks loudly instead of
+  silently corrupting resume state.
+- **One source of truth for edge decisions** — the engine's `evaluate_edge`
+  stays canonical; no second implementation for resume.
+
+Negative / accepted costs:
+
+- Storage size grows by one JSONB per node attempt (roughly the size of the
+  action output — variant tagging adds a few bytes) plus one JSONB per
+  execution for the input. For workloads with small action outputs this is
+  a modest increase; heavy workloads that already use reference outputs
+  (`ActionOutput::Reference`) already pay small storage today.
+- Any addition to `ActionResult` shape now requires a schema version bump
+  and matching load-path coverage. This is the price of forward-compat
+  honesty.
+- Legacy `node_outputs` rows (written before this migration) cannot be
+  resumed via the new path — `load_node_result` returns `None`. Resume
+  falls through to legacy `load_node_output` behavior, which is the
+  pre-existing (broken) path. B3/B4 handle the transition; this is fine
+  for an alpha-stage engine with no durable historical executions.
+
+Follow-up:
+
+- **B2** — persist workflow input on start; resume reads it and surfaces
+  `MissingInput` via typed error.
+- **B3** — engine writes `NodeResultRecord` alongside the legacy `output`
+  column for every dispatch.
+- **B4** — resume reads results, replays `evaluate_edge`, closes #299 /
+  #324 / #336.
+- **E1** — removal of `ActionResult::Retry` bumps `result_schema_version`
+  to 2 under this contract.
+
+## Alternatives considered
+
+- **Option 3 — per-edge activation rows.** Cleaner long-term but doubles
+  the write path and splits the source of truth. See decision 1.
+- **Separate `execution_inputs` table for workflow input.** Adds a join on
+  every resume for a column that is always fetched alongside the execution
+  row. See decision 3.
+- **Silent fallback on unknown variant / version.** Violates §4.5 (silent
+  false capability). Rejected — see decision 2.
+- **Backward-rolling migrations.** Dropping columns after a rollback loses
+  persisted context for executions already observed by the newer binary.
+  Forward-only matches the alpha stage and the crash-is-normal model
+  (§4.3). A future migration framework change could revisit this.
+
+## Seam / verification
+
+Seams (this ADR):
+
+- `crates/storage/src/execution_repo.rs` —
+  `ExecutionRepo::{set_workflow_input, get_workflow_input, save_node_result,
+  load_node_result, load_all_results}`, `NodeResultRecord`,
+  `ExecutionRepoError::UnknownSchemaVersion`.
+- `crates/storage/src/backend/pg_execution.rs` — Postgres impl.
+- `crates/storage/migrations/00000000000009_add_resume_persistence.sql` —
+  Layer 1 schema.
+- `crates/storage/migrations/{postgres,sqlite}/0020_add_resume_result_persistence.sql` —
+  Layer 2 parity.
+
+Tests (this ADR):
+
+- `crates/storage/src/execution_repo.rs` unit tests —
+  round-trip for each `ActionResult` variant, forward-compatibility test
+  for `UnknownSchemaVersion`, workflow-input get/set.
+- `crates/storage/src/backend/pg_execution.rs` tests (feature-gated) —
+  same round-trips against Postgres when `DATABASE_URL` is available.
+
+Related ADRs: 0007 (`ExecutionId` / `WorkflowId` shape used by the new
+schema rows).

--- a/docs/adr/0009-resume-persistence-schema.md
+++ b/docs/adr/0009-resume-persistence-schema.md
@@ -1,5 +1,5 @@
 ---
-id: 0008
+id: 0009
 title: resume-persistence-schema
 status: accepted
 date: 2026-04-18
@@ -14,7 +14,7 @@ related:
   - docs/PRODUCT_CANON.md#10
 ---
 
-# 0008. Resume persistence schema
+# 0009. Resume persistence schema
 
 ## Context
 
@@ -146,10 +146,11 @@ Both are **forward-only**. Rollback means dropping the added columns, which
 loses any persisted resume context; this is acceptable because the columns
 are nullable and pre-migration engines never read them.
 
-### 5. Coordination with A1 (control plane consumer ADR)
+### 5. Coordination with A1 (ADR-0008 — control plane consumer)
 
-B1 assumes **nothing** about A1's choice of control-plane consumer wiring.
-The schema changes are orthogonal:
+B1 assumes **nothing** about A1's choice of control-plane consumer wiring
+([ADR-0008](./0008-execution-control-queue-consumer.md)). The schema changes
+are orthogonal:
 
 - A1 decides how cancel/dispatch signals reach the engine from
   `execution_control_queue` (§12.2). That does not constrain what each node
@@ -157,10 +158,9 @@ The schema changes are orthogonal:
 - B1 decides what is durable per node attempt for replay. That does not
   constrain how control signals are consumed.
 
-If A1 lands first with a consumer that needs to read persisted results, it
-reads through the trait surface defined here. If A1 lands later, nothing in
-B1 has to change. The two ADRs close the loop independently; any
-integration friction surfaces in B4 or A2 where both paths meet the engine.
+A1 landed first; this ADR took the next free ID (0009). The two ADRs close
+the loop independently; any integration friction surfaces in B4 or A2 where
+both paths meet the engine.
 
 ## Consequences
 


### PR DESCRIPTION
## Description

B1 chip of the [engine-lifecycle canon cluster 2026-04 plan](docs/plans/engine-lifecycle-canon-cluster-2026-04.md#group-b--resume-correctness-state-reconstruction). Foundation for resume replay-completeness — lands the ADR, the schema seam, and the `ExecutionRepo` trait surface. **No engine behavior change**; B2 / B3 / B4 wire the consumers once D2 (checkpoint-ordering correction) lands.

Kills for foundation only (issues close with B2/B3/B4):
- #299 (`check_and_apply_idempotency` synthesizes `ActionResult::success`)
- #311 (resume passes `Value::Null` for workflow input)
- #324 (resume loses OnError edge activations)
- #336 (resume unconditionally activates all outgoing edges)

[ADR-0008](docs/adr/0008-resume-persistence-schema.md) locks five decisions:

1. **Persist full `ActionResult<Value>` per node** (Option 1 from #299). Keeps `evaluate_edge` as the single source of truth on resume. Option 3 (per-edge activation rows) rejected with rationale.
2. **Forward-compat via explicit `result_schema_version` column** + typed `ExecutionRepoError::UnknownSchemaVersion`. No silent fall-back (canon §4.5).
3. **Workflow input as `executions.input` column** (matches existing Layer 2 schema); `get_workflow_input` returns `Option<Value>`. B2 converts `None` to typed `ResumeError::MissingInput` — never default to `Value::Null` (`feedback_no_shims.md`).
4. **Forward-only migration**, both dialects.
5. **Orthogonal to A1** control-plane consumer wiring (coordination note in ADR body).

## Changes

- `docs/adr/0008-resume-persistence-schema.md` — new ADR (may renumber on merge if A1 / D3 land first; next free ID at time of writing).
- `crates/storage/migrations/00000000000009_add_resume_persistence.sql` — Layer 1 Postgres: `executions.input`, `node_outputs.{result_schema_version, result_kind, result}`, relax `output` to nullable.
- `crates/storage/migrations/{postgres,sqlite}/0020_add_resume_result_persistence.sql` — Layer 2 parity: matching `execution_nodes` columns (`executions.input` already exists in Layer 2).
- `crates/storage/src/execution_repo.rs` — `NodeResultRecord` type, `MAX_SUPPORTED_RESULT_SCHEMA_VERSION` constant, `ExecutionRepoError::UnknownSchemaVersion` variant, five new trait methods with not-implemented default impls (pattern matches existing `stateful_checkpoint`); full `InMemoryExecutionRepo` impl; 14 new unit tests.
- `crates/storage/src/backend/pg_execution.rs` — full `PgExecutionRepo` impl; 10 new feature-gated tests (round-trip, dual-writer composition, legacy-row skip, forward-compat, migration columns via `information_schema`); legacy `load_node_output` / `load_all_outputs` now filter `output IS NOT NULL` so `save_node_result`-only rows are invisible to old readers; drive-by clippy fix (`collapsible_if`) in `map_journal_err`.
- `crates/storage/src/lib.rs` — re-export `NodeResultRecord` + `MAX_SUPPORTED_RESULT_SCHEMA_VERSION`; `//!` mentions ADR-0008.
- `crates/storage/README.md` — public API list + Contract section updated with ADR-0008 seams.
- `crates/storage/migrations/{postgres,sqlite}/README.md` — migration index + parity notes.

## Testing

- [x] Tests pass locally: `cargo nextest run -p nebula-storage` — `67 tests run: 67 passed, 0 skipped` (24 new, all InMemory).
- [x] Clippy passes: `cargo clippy --workspace -- -D warnings` — 0 warnings across workspace.
- [x] Code is formatted: `cargo +nightly fmt --all -- --check` — clean.
- [x] Doctests: `cargo test -p nebula-storage --doc` — 0 failed.
- [ ] Postgres backend tests (`cargo nextest -p nebula-storage --features postgres`): 10 new tests added, require `DATABASE_URL`; they skip gracefully via existing `pg_exec_repo().await else { return; }` pattern. Pre-existing `backend::postgres::tests::shared::*` tests fail without `DATABASE_URL` (pre-existing behavior, not a regression). CI will exercise them against a live PG.

## Reviewer notes

- **Scope:** strictly B1 — schema + seam + ADR + round-trip tests. No `engine.rs` changes (confirmed `git diff --stat`). Resume behavior changes land in B2 / B3 / B4.
- **Three intentional departures from the plan text** (plan §139-148):
  1. `executions.input` (not `input_blob`) — matches existing Layer 2 0011 column name; avoids collision.
  2. Separate `set_workflow_input` / `get_workflow_input` methods (not an extension of `ExecutionRepo::create`) — prompt directive, matches `stateful_checkpoint` pattern, allows not-implemented default impls for non-PG backends.
  3. Adds Layer 1 migration (`00000000000009_*`) in addition to Layer 2 — Layer 1 is the schema `PgExecutionRepo` actually runs today; without it the new trait methods would fail at runtime.
- **Schema version discipline:** ADR §2 pins "any change to `ActionResult` shape bumps `MAX_SUPPORTED_RESULT_SCHEMA_VERSION`." E1 (removing `ActionResult::Retry`) is the next expected bump to version 2.
- **Cross-group dependency:** B1 itself is independent of D2. B2 / B3 / B4 (resume writers / readers) must wait for D2 (#297 checkpoint-ordering) to land first, per plan §147.
- **ADR ID coordination:** plan flagged A1 and D3 also need ADRs. I picked 0008 (next free); whoever lands second renumbers.

## Breaking Changes

None. New trait methods have default impls that return `ExecutionRepoError::Internal("not implemented")` — existing trait implementors compile unchanged. Legacy `load_node_output` / `load_all_outputs` now filter on `output IS NOT NULL`; this is a no-op for all pre-migration data (non-null by NOT NULL constraint) and a correct semantic change going forward (old reader ≠ new variant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)