### PR TITLE
chore(github): expand PR template with canon and safety sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,87 @@
-## Description
+<!--
+PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
+  type(scope): description
+  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
+-->
 
-<!-- What does this PR do? What problem does it solve? -->
+## Summary
+
+<!-- What does this PR do, and why? Keep it to a few sentences. -->
+
+## Related issues
+
+<!-- Link issues this PR closes or references. Leave blank if none. -->
+
+- Closes #
+- Refs #
+
+## Type of change
+
+<!-- Tick all that apply. -->
+
+- [ ] `feat` — new capability
+- [ ] `fix` — bug fix
+- [ ] `refactor` — internal restructuring, no behavior change
+- [ ] `perf` — performance improvement
+- [ ] `docs` — documentation only
+- [ ] `test` — tests only
+- [ ] `chore` / `ci` / `build` — tooling, infra, dependencies
+
+## Affected crates / areas
+
+<!-- e.g. nebula-engine, nebula-runtime, nebula-credential, docs/, .github/ -->
+
+-
 
 ## Changes
 
-<!-- Brief list of what was changed -->
+<!-- Concrete list of what changed. Bullet points, not prose. -->
 
 -
 
 ## Testing
 
-<!-- How did you test this change? -->
+<!-- How did you verify this change? Name the tests or scenarios, not just "ran CI". -->
 
-- [ ] Tests pass locally (`cargo nextest run --workspace`)
-- [ ] Clippy passes (`cargo clippy --workspace -- -D warnings`)
-- [ ] Code is formatted (`cargo fmt`)
+-
 
-## Breaking Changes
+### Local verification
 
-<!-- If this PR includes breaking changes, describe them here. Otherwise write "None" -->
+- [ ] `cargo +nightly fmt --all` — formatted
+- [ ] `cargo clippy --workspace -- -D warnings` — clean
+- [ ] `cargo nextest run --workspace` — passes
+- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
+- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)
+
+## Breaking changes
+
+<!-- If yes: what breaks, who is affected, migration path. Otherwise write "None". -->
 
 None
+
+## Canon alignment
+
+<!--
+Required for non-trivial design or execution-lifecycle changes.
+See docs/PRODUCT_CANON.md §17 (Definition of Done).
+Delete this section for pure bug fixes, docs, or mechanical refactors.
+-->
+
+- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
+- [ ] Layer direction preserved (core ← business ← exec ← api; no upward deps)
+- [ ] If an L2 invariant moved: ADR added under `docs/adr/`
+- [ ] `docs/MATURITY.md` row updated if crate maturity changed
+- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed
+
+## Safety checklist
+
+- [ ] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
+- [ ] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
+- [ ] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
+- [ ] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
+- [ ] New `unsafe` blocks carry a `SAFETY:` comment with justification
+
+## Notes for reviewers
+
+<!-- Anything reviewers should focus on, known follow-ups, or out-of-scope items. Optional. -->
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
-  type(scope): description
+  type(scope)?: description    — scope is optional
   types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
 -->
 
@@ -21,11 +21,15 @@ PR title must follow Conventional Commits (enforced by .github/workflows/pr-vali
 
 - [ ] `feat` — new capability
 - [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `style` — formatting / non-functional style change
 - [ ] `refactor` — internal restructuring, no behavior change
 - [ ] `perf` — performance improvement
-- [ ] `docs` — documentation only
 - [ ] `test` — tests only
-- [ ] `chore` / `ci` / `build` — tooling, infra, dependencies
+- [ ] `chore` — tooling, maintenance, dependencies
+- [ ] `ci` — CI configuration or workflow changes
+- [ ] `build` — build system or packaging changes
+- [ ] `revert` — reverts a previous change
 
 ## Affected crates / areas
 


### PR DESCRIPTION
## Summary

The existing `.github/PULL_REQUEST_TEMPLATE.md` was a minimal stub (description, changes, 3 checkboxes, breaking changes). This PR expands it to reflect the conventions the repo already enforces elsewhere, so contributors see the checks reviewers actually run before they open a PR.

## Related issues

None.

## Type of change

- [x] `chore` — tooling / infra (no code changes)

## Affected crates / areas

- `.github/PULL_REQUEST_TEMPLATE.md`

## Changes

- Header comment reminding contributors that the PR title must match the Conventional Commits regex enforced by [`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml).
- New sections: **Summary**, **Related issues**, **Type of change**, **Affected crates / areas**, **Changes**, **Testing**, **Breaking changes**, **Canon alignment**, **Safety checklist**, **Notes for reviewers**.
- **Local verification** block uses the canonical commands from [`CLAUDE.md`](CLAUDE.md): `cargo +nightly fmt --all`, `cargo clippy --workspace -- -D warnings`, `cargo nextest run --workspace`, `cargo test --workspace --doc`, `cargo deny check`.
- **Canon alignment** checklist derived from [`docs/PRODUCT_CANON.md`](docs/PRODUCT_CANON.md) §17 (Definition of Done): layer direction, ADR requirement for L2 moves, `docs/MATURITY.md`, crate README / `lib.rs //!`.
- **Safety checklist** covers recurring review hot-spots: `unwrap` / `expect` / `panic!` in library code, silent error suppression, direct state mutation in `execution` / `engine` bypassing `transition_node()` (#255), credential zeroization, `SAFETY:` comments on new `unsafe`.

## Testing

Docs-only change — no runtime behavior.

- Pre-push hook ran locally and passed: `shear`, `check-all-features` (75s), `doctests` (175s), `docs` (185s), `check-no-default` (234s), `nextest` (300s, 3202 passed / 13 skipped).
- PR-title format verified against the regex in [`.github/workflows/pr-validation.yml`](.github/workflows/pr-validation.yml): `chore(github): …` matches.

## Breaking changes

None.

## Notes for reviewers

- Template stays English — matches every other file under `.github/`.
- The **Canon alignment** section is explicitly marked as deletable for pure bug fixes / docs / mechanical refactors, so it doesn't become noise on trivial PRs.
- No change to `CODEOWNERS`, labels, or workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)