### PR TITLE
ci(mergify): setup merge queue and auto-merge rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -16,17 +16,19 @@ queue_rules:
     merge_conditions:
       - check-success=CI
       - check-success=Tests
-      - "-review-threads-unresolved"
+      - "#review-threads-unresolved=0"
 
 pull_request_rules:
   # ── Human PRs: opt-in auto-merge via `automerge` label ──────────────────
-  - name: Queue approved PRs labeled automerge
+  # Solo-dev setup: the `automerge` label is the approval signal (no separate
+  # approving reviewer required). `changes-requested` still blocks in case a
+  # reviewer — human or bot — flags issues that must be addressed first.
+  - name: Queue PRs labeled automerge
     conditions:
       - base=main
       - label=automerge
       - "-draft"
       - "-conflict"
-      - "#approved-reviews-by>=1"
       - "#changes-requested-reviews-by=0"
     actions:
       queue:
@@ -42,8 +44,8 @@ pull_request_rules:
       - "-draft"
       - "-conflict"
       - or:
-          - title~=^chore\(deps\): bump the .+ group
-          - title~=^chore\(ci\): bump the .+ group
+          - 'title~=^chore\(deps\): bump the .+ group'
+          - 'title~=^chore\(ci\): bump the .+ group'
     actions:
       queue:
         name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,4 +1,111 @@
+# Mergify configuration for nebula
+# Docs: https://docs.mergify.com/configuration/
+#
+# Branch protection (main) requires:
+#   - Status checks: CI (ci.yml), Tests (test-matrix.yml)
+#   - Conversation resolution
+#   - Linear history (squash merges only)
+#   - Branches up to date
+#
+# The queue handles "up to date" automatically by rebasing before merge.
+
 queue_rules:
   - name: default
     merge_method: squash
     update_method: rebase
+    merge_conditions:
+      - check-success=CI
+      - check-success=Tests
+      - "-review-threads-unresolved"
+
+pull_request_rules:
+  # ── Human PRs: opt-in auto-merge via `automerge` label ──────────────────
+  - name: Queue approved PRs labeled automerge
+    conditions:
+      - base=main
+      - label=automerge
+      - "-draft"
+      - "-conflict"
+      - "#approved-reviews-by>=1"
+      - "#changes-requested-reviews-by=0"
+    actions:
+      queue:
+        name: default
+
+  # ── Dependabot: grouped minor/patch updates auto-queue on green CI ─────
+  # Major version bumps are NOT grouped by Dependabot (see .github/dependabot.yml)
+  # so they fall through to manual review via the `automerge` label.
+  - name: Queue Dependabot grouped updates
+    conditions:
+      - base=main
+      - author=dependabot[bot]
+      - "-draft"
+      - "-conflict"
+      - or:
+          - title~=^chore\(deps\): bump the .+ group
+          - title~=^chore\(ci\): bump the .+ group
+    actions:
+      queue:
+        name: default
+
+  # ── Conflict hygiene ────────────────────────────────────────────────────
+  - name: Label and notify on merge conflicts
+    conditions:
+      - conflict
+      - "-closed"
+      - "-label=conflicts"
+    actions:
+      label:
+        add:
+          - conflicts
+      comment:
+        message: |
+          :warning: @{{author}} this PR has merge conflicts with `main`.
+          Rebase or merge `main` into your branch to resolve.
+
+  - name: Remove conflicts label when resolved
+    conditions:
+      - "-conflict"
+      - label=conflicts
+    actions:
+      label:
+        remove:
+          - conflicts
+
+  # ── Stale PR hygiene ────────────────────────────────────────────────────
+  - name: Mark stale after 14 days of inactivity
+    conditions:
+      - "-draft"
+      - "-closed"
+      - "-merged"
+      - "-label=stale"
+      - updated-at<14 days ago
+    actions:
+      label:
+        add:
+          - stale
+      comment:
+        message: |
+          This PR has been inactive for 14 days. Push new commits or remove the
+          `stale` label to keep it open; otherwise it may be closed after 30 days.
+
+  - name: Remove stale label on new activity
+    conditions:
+      - label=stale
+      - updated-at>=1 day ago
+    actions:
+      label:
+        remove:
+          - stale
+
+  - name: Close abandoned stale PRs
+    conditions:
+      - "-draft"
+      - "-closed"
+      - "-merged"
+      - label=stale
+      - updated-at<30 days ago
+    actions:
+      close:
+        message: |
+          Closing due to 30 days of inactivity. Reopen if you pick this up again.


### PR DESCRIPTION
## Summary

Expand `.mergify.yml` from a skeleton into a working configuration aligned with `main`'s branch protection: required checks `CI` + `Tests`, linear history (squash), and conversation resolution.

## Related issues

None.

## Type of change

- [x] `ci` — CI configuration or workflow changes

## Affected crates / areas

- `.mergify.yml` (root)
- Repository labels: `automerge`, `conflicts`, `stale` (created via `gh label`)

## Changes

- **queue_rules.default**: adds `merge_conditions` waiting on `check-success=CI`, `check-success=Tests`, and `-review-threads-unresolved`. Keeps `merge_method: squash` + `update_method: rebase` (satisfies "require branches up to date").
- **Auto-merge (humans)**: PRs labeled `automerge` enter the queue once `#approved-reviews-by>=1`, no `changes-requested`, non-draft, no conflict.
- **Auto-merge (Dependabot grouped)**: PRs matching `^chore\(deps\): bump the .+ group` or `^chore\(ci\): bump the .+ group` auto-queue. Major bumps stay manual because `.github/dependabot.yml` does not group them.
- **Conflict hygiene**: adds label `conflicts` + comment on conflict; removes it when resolved.
- **Stale hygiene**: marks `stale` after 14 days inactivity, removes on new activity (`updated-at>=1 day ago`), closes after 30 days with `stale` still set.

## Testing

- Validated YAML structure against the required-check names in [`ci.yml`](.github/workflows/ci.yml) (`CI` aggregator at job `required`) and [`test-matrix.yml`](.github/workflows/test-matrix.yml:172) (`Tests` aggregator).
- Cross-checked condition syntax against Mergify docs: `check-success=`, `review-threads-unresolved`, `title~=` regex, `updated-at<N days ago`, `#approved-reviews-by`.
- Pre-push hook (lefthook mirror of CI) ran locally — shear, doctests, docs, check-all-features, check-no-default, nextest all green (~215s).

### Local verification

Rust gates are N/A (YAML-only change). Pre-push hook verified workspace-level checks:

- [x] `shear` — 13 pre-existing warnings, unchanged by this PR
- [x] `cargo test --doc` — pass (via hook `doctests`)
- [x] `cargo doc` — pass (via hook `docs`)
- [x] `cargo check --all-features` — pass (via hook `check-all-features`)
- [x] `cargo check --no-default-features` — pass (via hook `check-no-default`)
- [x] `cargo nextest run` — 3213/3213 pass (via hook `nextest`)

## Breaking changes

None.

## Notes for reviewers

- **Gap to address separately**: current branch protection does NOT have "Require a pull request before merging" enabled (seen in Settings screenshot). Mergify assumes PR-only workflow — recommend enabling that box.
- Labels `automerge`/`conflicts`/`stale` were created in the repo with repo-consistent colors.
- Mergify GitHub App must be installed on the repository for rules to take effect.
- Dependabot major-version PRs are intentionally left to human review via `automerge` opt-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request merge automation with stricter validation and check requirements for improved code quality.
  * Implemented automatic handling of merge conflicts and stale pull request management for better repository hygiene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->