### PR TITLE
fix(mergify): address review feedback from #437

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -44,8 +44,8 @@ pull_request_rules:
       - "-draft"
       - "-conflict"
       - or:
-          - 'title~=^chore\(deps\): bump the .+ group'
-          - 'title~=^chore\(ci\): bump the .+ group'
+          - 'title~=(?i)^chore\(deps\): bump the .+ group'
+          - 'title~=(?i)^chore\(ci\): bump the .+ group'
     actions:
       queue:
         name: default
@@ -62,8 +62,8 @@ pull_request_rules:
           - conflicts
       comment:
         message: |
-          :warning: @{{author}} this PR has merge conflicts with `main`.
-          Rebase or merge `main` into your branch to resolve.
+          :warning: @{{author}} this PR has merge conflicts with `{{base}}`.
+          Rebase or merge `{{base}}` into your branch to resolve.
 
   - name: Remove conflicts label when resolved
     conditions:
@@ -91,10 +91,13 @@ pull_request_rules:
           This PR has been inactive for 14 days. Push new commits or remove the
           `stale` label to keep it open; otherwise it may be closed after 30 days.
 
-  - name: Remove stale label on new activity
+  # Keys off `commits[*].date_committer`, not `updated-at`: the latter is bumped
+  # by Mergify's own label/comment actions and would remove the `stale` label
+  # immediately after it was applied. Commit-time checks fire only on real pushes.
+  - name: Remove stale label on new commits
     conditions:
       - label=stale
-      - updated-at>=1 day ago
+      - commits[*].date_committer>=1 day ago
     actions:
       label:
         remove:


### PR DESCRIPTION
## Summary

Follow-up to #437 (already merged). Addresses three review comments from CodeRabbit and Copilot that landed just before the merge.

## Related issues

- Follow-up to #437

## Type of change

- [x] `fix` — bug fix

## Affected crates / areas

- `.mergify.yml`

## Changes

- **Case-insensitive Dependabot regex** (CodeRabbit):
  Dependabot alternates between `Bump` and `bump` in grouped-update titles (e.g. #413/#245 use `Bump`, #214/#215 use `bump`). The current lowercase-only patterns would miss roughly half the groups and drop them into manual review. Prefix both with `(?i)`.

- **Conflict message uses `{{base}}` template** (Copilot):
  The conflict notification hard-coded `` `main` `` in the message but the rule has no `base=main` gate. Templatize so the comment reflects whatever base branch the PR actually targets.

- **Stale-removal keyed off commit time, not `updated-at`** (Copilot):
  The preceding mark-stale rule adds a label + posts a comment, which bumps `updated-at` to "now". That made `updated-at>=1 day ago` immediately true, so Mergify would unlabel `stale` within seconds of setting it — breaking the close-at-30-days flow entirely. Swap to `commits[*].date_committer>=1 day ago`, which only reacts to real pushes by the author.

## Testing

- Pre-push hook (lefthook mirror of CI) ran locally: shear, doctests, docs, check-all-features, check-no-default, nextest all green.
- Mergify's own "Configuration changed" check will validate the YAML on this PR (it failed on the first rev of #437 and caught both invalid-operator and YAML-parse issues, so we trust it to catch regressions here).

### Local verification

- [x] `cargo nextest run` — 3213/3213 pass (via pre-push hook)
- [x] `cargo test --doc` — pass
- [x] `cargo doc` — pass
- [x] `cargo check --all-features` — pass
- [x] `cargo check --no-default-features` — pass

## Breaking changes

None.

## Notes for reviewers

- Race-condition reasoning for the stale fix: Mergify's label/comment actions trigger the GraphQL event that Mergify itself consumes on the next rule evaluation pass. Keying off `updated-at` therefore always self-cancels. Commit-time attributes (`commits[*].date_committer`) are only advanced by `git push`, which is what we actually want to detect.
- Regex `(?i)` is Python/PCRE-style; Mergify's `title~=` uses Python's `re` module, so this flag is supported.