### PR TITLE
feat(schema): typed DX layer — builder DSL, HasSchema, unified metadata, derive macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4096,6 +4096,7 @@ dependencies = [
  "nebula-metrics",
  "nebula-resilience",
  "nebula-resource-macros",
+ "nebula-schema",
  "nebula-telemetry",
  "smallvec",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3709,6 +3709,7 @@ dependencies = [
  "nebula-core",
  "nebula-credential",
  "nebula-error",
+ "nebula-metadata",
  "nebula-resource",
  "nebula-schema",
  "parking_lot",
@@ -3842,6 +3843,7 @@ dependencies = [
  "nebula-credential-macros",
  "nebula-error",
  "nebula-eventbus",
+ "nebula-metadata",
  "nebula-metrics",
  "nebula-resilience",
  "nebula-schema",
@@ -4021,6 +4023,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-metadata"
+version = "0.1.0"
+dependencies = [
+ "nebula-schema",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "nebula-metrics"
 version = "0.1.0"
 dependencies = [
@@ -4093,6 +4105,7 @@ dependencies = [
  "dashmap",
  "nebula-core",
  "nebula-error",
+ "nebula-metadata",
  "nebula-metrics",
  "nebula-resilience",
  "nebula-resource-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "crates/execution",
   "crates/expression",
   "crates/log",
+  "crates/metadata",
   "crates/metrics",
   "crates/plugin",
   "crates/schema",

--- a/apps/cli/src/commands/actions.rs
+++ b/apps/cli/src/commands/actions.rs
@@ -37,10 +37,10 @@ pub fn list(args: ActionsListArgs) {
                 .filter_map(|k| registry.get(k))
                 .map(|(meta, _)| {
                     serde_json::json!({
-                        "key": meta.key.as_str(),
-                        "name": meta.name,
-                        "description": meta.description,
-                        "version": meta.version.to_string(),
+                        "key": meta.base.key.as_str(),
+                        "name": meta.base.name,
+                        "description": meta.base.description,
+                        "version": meta.base.version.to_string(),
                     })
                 })
                 .collect();
@@ -54,10 +54,10 @@ pub fn list(args: ActionsListArgs) {
                 if let Some((meta, _)) = registry.get(key) {
                     println!(
                         "{:<12} {:<10} {:<8} {}",
-                        meta.key.as_str(),
-                        meta.name,
-                        meta.version,
-                        meta.description,
+                        meta.base.key.as_str(),
+                        meta.base.name,
+                        meta.base.version,
+                        meta.base.description,
                     );
                 }
             }
@@ -74,23 +74,23 @@ pub fn info(args: ActionsInfoArgs) {
         Some((meta, _)) => match format {
             OutputFormat::Json => {
                 let json = serde_json::json!({
-                    "key": meta.key.as_str(),
-                    "name": meta.name,
-                    "version": meta.version.to_string(),
-                    "description": meta.description,
+                    "key": meta.base.key.as_str(),
+                    "name": meta.base.name,
+                    "version": meta.base.version.to_string(),
+                    "description": meta.base.description,
                     "isolation": format!("{:?}", meta.isolation_level),
                 });
                 println!("{}", serde_json::to_string_pretty(&json).expect("json"));
             },
             OutputFormat::Text => {
-                println!("Key:         {}", meta.key.as_str());
-                println!("Name:        {}", meta.name);
-                println!("Version:     {}", meta.version);
-                println!("Description: {}", meta.description);
+                println!("Key:         {}", meta.base.key.as_str());
+                println!("Name:        {}", meta.base.name);
+                println!("Version:     {}", meta.base.version);
+                println!("Description: {}", meta.base.description);
                 println!("Isolation:   {:?}", meta.isolation_level);
                 println!(
                     "Parameters:  {}",
-                    if meta.parameters.fields().is_empty() {
+                    if meta.base.schema.fields().is_empty() {
                         "none"
                     } else {
                         "(defined)"
@@ -151,7 +151,7 @@ pub async fn test(args: ActionsTestArgs) {
         CancellationToken::new(),
     );
 
-    eprintln!("Testing: {} ({})", meta.name, meta.key);
+    eprintln!("Testing: {} ({})", meta.base.name, meta.base.key);
     eprintln!(
         "Input:   {}",
         serde_json::to_string(&input).unwrap_or_default()

--- a/apps/cli/src/commands/plugin.rs
+++ b/apps/cli/src/commands/plugin.rs
@@ -31,7 +31,11 @@ pub async fn list() {
         for (name, handlers) in &plugins {
             println!("  {name}");
             for (meta, _handler) in handlers {
-                println!("    action: {:<30} {}", meta.key.as_str(), meta.description);
+                println!(
+                    "    action: {:<30} {}",
+                    meta.base.key.as_str(),
+                    meta.base.description
+                );
             }
             total += handlers.len();
             println!();

--- a/apps/cli/src/plugins.rs
+++ b/apps/cli/src/plugins.rs
@@ -35,8 +35,8 @@ pub async fn discover_and_register(registry: &ActionRegistry) -> usize {
 
         for (plugin_name, handlers) in plugins {
             for (metadata, handler) in handlers {
-                let key = metadata.key.as_str().to_owned();
-                if registry.get(&metadata.key).is_some() {
+                let key = metadata.base.key.as_str().to_owned();
+                if registry.get(&metadata.base.key).is_some() {
                     tracing::warn!(
                         action = %key,
                         plugin = %plugin_name,

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -24,6 +24,7 @@ nebula-action-macros = { path = "macros" }
 nebula-core = { path = "../core" }
 nebula-credential = { path = "../credential" }
 nebula-error = { workspace = true }
+nebula-metadata = { path = "../metadata" }
 nebula-schema = { path = "../schema" }
 nebula-resource = { path = "../resource" }
 semver = { workspace = true }

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -507,7 +507,7 @@ where
 impl<A: ControlAction> fmt::Debug for ControlActionAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ControlActionAdapter")
-            .field("action", &self.cached_metadata.key)
+            .field("action", &self.cached_metadata.base.key)
             .field("category", &self.cached_metadata.category)
             .finish_non_exhaustive()
     }
@@ -839,7 +839,7 @@ mod tests {
     #[test]
     fn adapter_preserves_action_key() {
         let adapter = ControlActionAdapter::new(TestIf::new());
-        assert_eq!(adapter.metadata().key, action_key!("test.if"));
+        assert_eq!(adapter.metadata().base.key, action_key!("test.if"));
     }
 
     #[tokio::test]
@@ -927,7 +927,7 @@ mod tests {
     fn adapter_into_inner_returns_action() {
         let adapter = ControlActionAdapter::new(TestIf::new());
         let action = adapter.into_inner();
-        assert_eq!(action.metadata().key, action_key!("test.if"));
+        assert_eq!(action.metadata().base.key, action_key!("test.if"));
     }
 
     #[test]

--- a/crates/action/src/handler.rs
+++ b/crates/action/src/handler.rs
@@ -131,11 +131,26 @@ impl ActionHandler {
 impl fmt::Debug for ActionHandler {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Stateless(h) => f.debug_tuple("Stateless").field(&h.metadata().key).finish(),
-            Self::Stateful(h) => f.debug_tuple("Stateful").field(&h.metadata().key).finish(),
-            Self::Trigger(h) => f.debug_tuple("Trigger").field(&h.metadata().key).finish(),
-            Self::Resource(h) => f.debug_tuple("Resource").field(&h.metadata().key).finish(),
-            Self::Agent(h) => f.debug_tuple("Agent").field(&h.metadata().key).finish(),
+            Self::Stateless(h) => f
+                .debug_tuple("Stateless")
+                .field(&h.metadata().base.key)
+                .finish(),
+            Self::Stateful(h) => f
+                .debug_tuple("Stateful")
+                .field(&h.metadata().base.key)
+                .finish(),
+            Self::Trigger(h) => f
+                .debug_tuple("Trigger")
+                .field(&h.metadata().base.key)
+                .finish(),
+            Self::Resource(h) => f
+                .debug_tuple("Resource")
+                .field(&h.metadata().base.key)
+                .finish(),
+            Self::Agent(h) => f
+                .debug_tuple("Agent")
+                .field(&h.metadata().base.key)
+                .finish(),
         }
     }
 }
@@ -353,7 +368,7 @@ mod tests {
 
         for (expected_key, handler) in &cases {
             assert_eq!(
-                handler.metadata().key,
+                handler.metadata().base.key,
                 nebula_core::ActionKey::new(expected_key).expect("valid test key")
             );
         }

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -148,6 +148,90 @@ impl ActionMetadata {
         }
     }
 
+    /// Create metadata whose `parameters` schema is auto-derived from a
+    /// [`StatelessAction`](crate::StatelessAction) implementation's `Input`
+    /// type.
+    ///
+    /// Prefer this over [`ActionMetadata::new`] + [`ActionMetadata::with_parameters`]
+    /// when the author owns a typed `Input` struct — the compiler then
+    /// enforces that the declared `Input` type agrees with the schema the
+    /// engine, UI, and validator will see.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use nebula_action::{ActionMetadata, StatelessAction};
+    /// use nebula_core::action_key;
+    ///
+    /// struct MyAction;
+    /// impl StatelessAction for MyAction {
+    ///     type Input = MyInput;  // must impl HasSchema
+    ///     type Output = MyOutput;
+    ///     // ...
+    /// }
+    ///
+    /// let meta = ActionMetadata::for_stateless::<MyAction>(
+    ///     action_key!("my.action"), "My Action", "desc",
+    /// );
+    /// ```
+    #[must_use]
+    pub fn for_stateless<A>(
+        key: ActionKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        A: crate::stateless::StatelessAction,
+    {
+        Self::new(key, name, description)
+            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+    }
+
+    /// Create metadata whose `parameters` schema is auto-derived from a
+    /// [`StatefulAction`](crate::StatefulAction)'s `Input` type.
+    #[must_use]
+    pub fn for_stateful<A>(
+        key: ActionKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        A: crate::stateful::StatefulAction,
+    {
+        Self::new(key, name, description)
+            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+    }
+
+    /// Create metadata whose `parameters` schema is auto-derived from a
+    /// [`PaginatedAction`](crate::PaginatedAction)'s `Input` type.
+    #[must_use]
+    pub fn for_paginated<A>(
+        key: ActionKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        A: crate::stateful::PaginatedAction,
+    {
+        Self::new(key, name, description)
+            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+    }
+
+    /// Create metadata whose `parameters` schema is auto-derived from a
+    /// [`BatchAction`](crate::BatchAction)'s `Input` type.
+    #[must_use]
+    pub fn for_batch<A>(
+        key: ActionKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        A: crate::stateful::BatchAction,
+    {
+        Self::new(key, name, description)
+            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+    }
+
     /// Set the interface version from `(major, minor)` components.
     ///
     /// Equivalent to `with_version_full(Version::new(major, minor, 0))`.

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -1,4 +1,5 @@
 use nebula_core::ActionKey;
+use nebula_metadata::{BaseMetadata, Metadata};
 use nebula_schema::ValidSchema;
 use semver::Version;
 use serde::{Deserialize, Serialize};
@@ -95,29 +96,25 @@ pub enum MetadataCompatibilityError {
 ///
 /// Used by the engine for action discovery, capability checks, schema
 /// validation, and interface versioning.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+///
+/// The shared catalog prefix (`key`, `name`, `description`, `schema`, `icon`,
+/// `documentation_url`, `tags`, `maturity`, `deprecation`) lives on the
+/// composed [`BaseMetadata`](nebula_metadata::BaseMetadata). Entity-specific
+/// fields (`version`, ports, `isolation_level`, `category`) stay on this
+/// struct.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionMetadata {
-    /// Unique key identifying this action type (e.g. `"http.request"`).
-    pub key: ActionKey,
-    /// Human-readable display name (e.g. `"HTTP Request"`).
-    pub name: String,
-    /// Short description of what this action does.
-    pub description: String,
-    /// Interface version — changes only when input/output schema changes.
-    ///
-    /// Stored as a full `semver::Version`. Exact-match dispatch is used by
-    /// the engine (see [`crate::handler::ActionHandler`]). Range-based pinning
-    /// (`^1.0`, `~1.2`) is a future-work item — see the
-    /// `2026-04-17-replace-interfaceversion-with-semver` spec.
-    pub version: Version,
+    /// Shared catalog prefix — see [`BaseMetadata`]. Carries `version`
+    /// (bumped when schema/ports change; exact-match dispatch in the engine).
+    #[serde(flatten)]
+    pub base: BaseMetadata<ActionKey>,
     /// Input ports this action accepts.
     /// Defaults to a single flow input `"in"`.
     pub inputs: Vec<InputPort>,
     /// Output ports this action produces.
     /// Defaults to a single main flow output `"out"`.
     pub outputs: Vec<OutputPort>,
-    /// Parameter definitions for this action (schema).
-    pub parameters: ValidSchema,
     /// Isolation level for this action's execution.
     pub isolation_level: IsolationLevel,
     /// Broad category of this action for UI grouping, validator rules,
@@ -129,20 +126,35 @@ pub struct ActionMetadata {
     pub category: ActionCategory,
 }
 
+impl PartialEq for ActionMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.base.key == other.base.key
+            && self.base.name == other.base.name
+            && self.base.description == other.base.description
+            && self.base.schema == other.base.schema
+            && self.base.version == other.base.version
+            && self.inputs == other.inputs
+            && self.outputs == other.outputs
+            && self.isolation_level == other.isolation_level
+            && self.category == other.category
+    }
+}
+
+impl Metadata for ActionMetadata {
+    type Key = ActionKey;
+    fn base(&self) -> &BaseMetadata<ActionKey> {
+        &self.base
+    }
+}
+
 impl ActionMetadata {
     /// Create metadata with the minimum required fields.
     #[must_use]
     pub fn new(key: ActionKey, name: impl Into<String>, description: impl Into<String>) -> Self {
         Self {
-            key,
-            name: name.into(),
-            description: description.into(),
-            version: Version::new(1, 0, 0),
+            base: BaseMetadata::new(key, name, description, ValidSchema::empty()),
             inputs: port::default_input_ports(),
             outputs: port::default_output_ports(),
-            parameters: nebula_schema::Schema::builder()
-                .build()
-                .expect("empty schema is always valid"),
             isolation_level: IsolationLevel::None,
             category: ActionCategory::Data,
         }
@@ -184,7 +196,7 @@ impl ActionMetadata {
         A: crate::stateless::StatelessAction,
     {
         Self::new(key, name, description)
-            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
     }
 
     /// Create metadata whose `parameters` schema is auto-derived from a
@@ -199,7 +211,7 @@ impl ActionMetadata {
         A: crate::stateful::StatefulAction,
     {
         Self::new(key, name, description)
-            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
     }
 
     /// Create metadata whose `parameters` schema is auto-derived from a
@@ -214,7 +226,7 @@ impl ActionMetadata {
         A: crate::stateful::PaginatedAction,
     {
         Self::new(key, name, description)
-            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
     }
 
     /// Create metadata whose `parameters` schema is auto-derived from a
@@ -229,7 +241,7 @@ impl ActionMetadata {
         A: crate::stateful::BatchAction,
     {
         Self::new(key, name, description)
-            .with_parameters(<A::Input as nebula_schema::HasSchema>::schema())
+            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
     }
 
     /// Set the interface version from `(major, minor)` components.
@@ -237,14 +249,14 @@ impl ActionMetadata {
     /// Equivalent to `with_version_full(Version::new(major, minor, 0))`.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_version(mut self, major: u64, minor: u64) -> Self {
-        self.version = Version::new(major, minor, 0);
+        self.base.version = Version::new(major, minor, 0);
         self
     }
 
     /// Set the full interface version, including patch and pre-release data.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_version_full(mut self, version: Version) -> Self {
-        self.version = version;
+        self.base.version = version;
         self
     }
 
@@ -255,6 +267,13 @@ impl ActionMetadata {
         self
     }
 
+    /// Append a single input port, preserving already-declared ones.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn add_input(mut self, port: InputPort) -> Self {
+        self.inputs.push(port);
+        self
+    }
+
     /// Set the output port definitions for this action.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_outputs(mut self, outputs: Vec<OutputPort>) -> Self {
@@ -262,10 +281,39 @@ impl ActionMetadata {
         self
     }
 
-    /// Set the parameter definitions for this action.
+    /// Append a single output port, preserving already-declared ones.
     #[must_use = "builder methods must be chained or built"]
-    pub fn with_parameters(mut self, parameters: ValidSchema) -> Self {
-        self.parameters = parameters;
+    pub fn add_output(mut self, port: OutputPort) -> Self {
+        self.outputs.push(port);
+        self
+    }
+
+    /// Bump the major version to `new_major`, zeroing minor and patch.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn bump_major(mut self, new_major: u64) -> Self {
+        self.base.version = Version::new(new_major, 0, 0);
+        self
+    }
+
+    /// Bump the minor version to `new_minor`, zeroing patch.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn bump_minor(mut self, new_minor: u64) -> Self {
+        self.base.version = Version::new(self.base.version.major, new_minor, 0);
+        self
+    }
+
+    /// Bump the patch version to `new_patch`.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn bump_patch(mut self, new_patch: u64) -> Self {
+        self.base.version =
+            Version::new(self.base.version.major, self.base.version.minor, new_patch);
+        self
+    }
+
+    /// Set the parameter schema for this action.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_schema(mut self, schema: ValidSchema) -> Self {
+        self.base.schema = schema;
         self
     }
 
@@ -297,24 +345,24 @@ impl ActionMetadata {
         &self,
         previous: &Self,
     ) -> Result<(), MetadataCompatibilityError> {
-        if self.key != previous.key {
+        if self.base.key != previous.base.key {
             return Err(MetadataCompatibilityError::KeyChanged {
-                previous: previous.key.clone(),
-                current: self.key.clone(),
+                previous: previous.base.key.clone(),
+                current: self.base.key.clone(),
             });
         }
 
-        if self.version < previous.version {
+        if self.base.version < previous.base.version {
             return Err(MetadataCompatibilityError::VersionRegressed {
-                previous: previous.version.clone(),
-                current: self.version.clone(),
+                previous: previous.base.version.clone(),
+                current: self.base.version.clone(),
             });
         }
 
         let schema_changed = self.inputs != previous.inputs
             || self.outputs != previous.outputs
-            || self.parameters != previous.parameters;
-        if schema_changed && self.version.major == previous.version.major {
+            || self.base.schema != previous.base.schema;
+        if schema_changed && self.base.version.major == previous.base.version.major {
             return Err(MetadataCompatibilityError::BreakingChangeWithoutMajorBump);
         }
 
@@ -337,9 +385,9 @@ mod tests {
         )
         .with_version(2, 1);
 
-        assert_eq!(meta.key, action_key!("http.request"));
-        assert_eq!(meta.name, "HTTP Request");
-        assert_eq!(meta.version, Version::new(2, 1, 0));
+        assert_eq!(meta.base.key, action_key!("http.request"));
+        assert_eq!(meta.base.name, "HTTP Request");
+        assert_eq!(meta.base.version, Version::new(2, 1, 0));
     }
 
     #[test]
@@ -425,7 +473,7 @@ mod tests {
     #[test]
     fn default_metadata_values() {
         let meta = ActionMetadata::new(action_key!("test"), "Test", "A test action");
-        assert_eq!(meta.version, Version::new(1, 0, 0));
+        assert_eq!(meta.base.version, Version::new(1, 0, 0));
         // Default ports
         assert_eq!(meta.inputs.len(), 1);
         assert!(meta.inputs[0].is_flow());
@@ -434,7 +482,7 @@ mod tests {
         assert!(meta.outputs[0].is_flow());
         assert_eq!(meta.outputs[0].key(), "out");
         // Default parameters
-        assert!(meta.parameters.fields().is_empty());
+        assert!(meta.base.schema.fields().is_empty());
     }
 
     // ── Port builder tests ──────────────────────────────────────────
@@ -511,7 +559,7 @@ mod tests {
             .with_inputs(vec![InputPort::flow("in")])
             .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
 
-        assert_eq!(meta.version, Version::new(2, 0, 0));
+        assert_eq!(meta.base.version, Version::new(2, 0, 0));
         assert_eq!(meta.inputs.len(), 1);
         assert_eq!(meta.outputs.len(), 2);
     }

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -99,7 +99,7 @@ pub enum MetadataCompatibilityError {
 ///
 /// The shared catalog prefix (`key`, `name`, `description`, `schema`, `icon`,
 /// `documentation_url`, `tags`, `maturity`, `deprecation`) lives on the
-/// composed [`BaseMetadata`](nebula_metadata::BaseMetadata). Entity-specific
+/// composed [`BaseMetadata`]. Entity-specific
 /// fields (`version`, ports, `isolation_level`, `category`) stay on this
 /// struct.
 #[non_exhaustive]
@@ -164,7 +164,7 @@ impl ActionMetadata {
     /// [`StatelessAction`](crate::StatelessAction) implementation's `Input`
     /// type.
     ///
-    /// Prefer this over [`ActionMetadata::new`] + [`ActionMetadata::with_parameters`]
+    /// Prefer this over [`ActionMetadata::new`] + [`ActionMetadata::with_schema`]
     /// when the author owns a typed `Input` struct — the compiler then
     /// enforces that the declared `Input` type agrees with the schema the
     /// engine, UI, and validator will see.

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -103,7 +103,7 @@ pub enum MetadataCompatibilityError {
 /// fields (`version`, ports, `isolation_level`, `category`) stay on this
 /// struct.
 #[non_exhaustive]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionMetadata {
     /// Shared catalog prefix — see [`BaseMetadata`]. Carries `version`
     /// (bumped when schema/ports change; exact-match dispatch in the engine).
@@ -124,20 +124,6 @@ pub struct ActionMetadata {
     /// with metadata serialized before this field existed.
     #[serde(default)]
     pub category: ActionCategory,
-}
-
-impl PartialEq for ActionMetadata {
-    fn eq(&self, other: &Self) -> bool {
-        self.base.key == other.base.key
-            && self.base.name == other.base.name
-            && self.base.description == other.base.description
-            && self.base.schema == other.base.schema
-            && self.base.version == other.base.version
-            && self.inputs == other.inputs
-            && self.outputs == other.outputs
-            && self.isolation_level == other.isolation_level
-            && self.category == other.category
-    }
 }
 
 impl Metadata for ActionMetadata {

--- a/crates/action/src/poll.rs
+++ b/crates/action/src/poll.rs
@@ -1129,7 +1129,7 @@ impl<A: PollAction> PollTriggerAdapter<A> {
                             &format!(
                                 "poll trigger {}: partial with no events, \
                                  retryable error: {error}",
-                                self.action.metadata().key,
+                                self.action.metadata().base.key,
                             ),
                         );
                     }
@@ -1166,7 +1166,7 @@ impl<A: PollAction> PollTriggerAdapter<A> {
                             return Err(ActionError::fatal(format!(
                                 "poll trigger {}: dispatch failed, \
                                  stopping (StopTrigger policy)",
-                                self.action.metadata().key,
+                                self.action.metadata().base.key,
                             )));
                         },
                     }
@@ -1182,7 +1182,7 @@ impl<A: PollAction> PollTriggerAdapter<A> {
                         &format!(
                             "poll trigger {}: partial error \
                              after dispatching {event_count} events: {error}",
-                            self.action.metadata().key,
+                            self.action.metadata().base.key,
                         ),
                     );
                 }
@@ -1229,7 +1229,7 @@ impl<A: PollAction> PollTriggerAdapter<A> {
             }),
             EmitFailurePolicy::StopTrigger => Err(ActionError::fatal(format!(
                 "poll trigger {}: dispatch failed, stopping (StopTrigger policy)",
-                self.action.metadata().key,
+                self.action.metadata().base.key,
             ))),
         }
     }
@@ -1243,7 +1243,7 @@ impl<A: PollAction> PollTriggerAdapter<A> {
     where
         A::Event: Send + Sync,
     {
-        let action_key = &self.action.metadata().key;
+        let action_key = &self.action.metadata().base.key;
         let mut emitted: usize = 0;
         let mut dropped: usize = 0;
         for event in events {
@@ -1307,7 +1307,7 @@ where
 
         self.action.validate(ctx).await?;
 
-        let action_key = self.action.metadata().key.clone();
+        let action_key = self.action.metadata().base.key.clone();
         let mut config = self.action.poll_config();
         config.validate_and_clamp(&*ctx.logger, &action_key);
 
@@ -1438,7 +1438,7 @@ where
 impl<A: PollAction> std::fmt::Debug for PollTriggerAdapter<A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PollTriggerAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }

--- a/crates/action/src/resource.rs
+++ b/crates/action/src/resource.rs
@@ -176,7 +176,7 @@ where
 impl<A: Action> fmt::Debug for ResourceActionAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ResourceActionAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }
@@ -287,7 +287,7 @@ mod tests {
         let adapter = ResourceActionAdapter::new(MockResourceAction::new());
         let action = adapter.into_inner();
         assert_eq!(
-            action.metadata().key,
+            action.metadata().base.key,
             nebula_core::action_key!("test.resource_action")
         );
     }

--- a/crates/action/src/stateful.rs
+++ b/crates/action/src/stateful.rs
@@ -592,7 +592,7 @@ where
                 // Log the serde failure forensically and let the original
                 // error propagate — masking it would break retry classification.
                 tracing::error!(
-                    action = %self.action.metadata().key,
+                    action = %self.action.metadata().base.key,
                     serialization_error = %ser_err,
                     action_error = %action_err,
                     "stateful adapter: state serialization failed on error path; \
@@ -613,7 +613,7 @@ where
 impl<A: Action> fmt::Debug for StatefulActionAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StatefulActionAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }
@@ -887,7 +887,7 @@ mod tests {
         let adapter = StatefulActionAdapter::new(CounterAction::new());
         let action = adapter.into_inner();
         assert_eq!(
-            action.metadata().key,
+            action.metadata().base.key,
             nebula_core::action_key!("test.counter")
         );
     }

--- a/crates/action/src/stateful.rs
+++ b/crates/action/src/stateful.rs
@@ -34,7 +34,10 @@ use crate::{
 /// [`StatelessAction`](crate::stateless::StatelessAction)).
 pub trait StatefulAction: Action {
     /// Input type for each iteration.
-    type Input: Send + Sync;
+    ///
+    /// Must implement [`HasSchema`](nebula_schema::HasSchema) so the action
+    /// metadata can auto-derive its parameter schema from the input type.
+    type Input: nebula_schema::HasSchema + Send + Sync;
     /// Output type (wrapped in [`ActionResult`]); `Continue` and `Break` carry output.
     type Output: Send + Sync;
     /// Persistent state type (saved between iterations by the engine).
@@ -114,7 +117,10 @@ pub struct PaginationState<C> {
 /// ```
 pub trait PaginatedAction: Action {
     /// Input type for the paginated request.
-    type Input: Send + Sync;
+    ///
+    /// Must implement [`HasSchema`](nebula_schema::HasSchema) so the action
+    /// metadata can auto-derive its parameter schema from the input type.
+    type Input: nebula_schema::HasSchema + Send + Sync;
     /// Output type produced per page.
     type Output: Send + Sync;
     /// Cursor type for tracking pagination position.
@@ -257,7 +263,10 @@ pub struct BatchState<I, T> {
 /// Other errors are captured as [`BatchItemResult::Failed`].
 pub trait BatchAction: Action {
     /// Input type containing the items to process.
-    type Input: Send + Sync;
+    ///
+    /// Must implement [`HasSchema`](nebula_schema::HasSchema) so the action
+    /// metadata can auto-derive its parameter schema from the input type.
+    type Input: nebula_schema::HasSchema + Send + Sync;
     /// Individual work item type.
     type Item: Serialize + DeserializeOwned + Clone + Send + Sync;
     /// Output type per item and as the final merged result.

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -164,7 +164,7 @@ pub fn stateless_fn<F, Input, Output>(
 impl<F, Input, Output> std::fmt::Debug for FnStatelessAction<F, Input, Output> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FnStatelessAction")
-            .field("action", &self.metadata.key)
+            .field("action", &self.metadata.base.key)
             .finish_non_exhaustive()
     }
 }
@@ -304,7 +304,7 @@ pub fn stateless_ctx_fn<F, Input, Output>(
 impl<F, Input, Output> fmt::Debug for FnStatelessCtxAction<F, Input, Output> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FnStatelessCtxAction")
-            .field("action", &self.metadata.key)
+            .field("action", &self.metadata.base.key)
             .field(
                 "base_ctx",
                 if self.base_ctx.is_some() {
@@ -406,7 +406,7 @@ where
 impl<A: Action> fmt::Debug for StatelessActionAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("StatelessActionAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }
@@ -596,7 +596,7 @@ mod tests {
     async fn adapter_exposes_metadata() {
         let adapter = StatelessActionAdapter::new(AddAction::new());
         assert_eq!(
-            StatelessHandler::metadata(&adapter).key,
+            StatelessHandler::metadata(&adapter).base.key,
             nebula_core::action_key!("math.add")
         );
     }
@@ -630,6 +630,9 @@ mod tests {
     fn stateless_adapter_into_inner_returns_action() {
         let adapter = StatelessActionAdapter::new(AddAction::new());
         let action = adapter.into_inner();
-        assert_eq!(action.metadata().key, nebula_core::action_key!("math.add"));
+        assert_eq!(
+            action.metadata().base.key,
+            nebula_core::action_key!("math.add")
+        );
     }
 }

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -67,7 +67,12 @@ use crate::{
 /// ```
 pub trait StatelessAction: Action {
     /// Input type for this action.
-    type Input: Send + Sync;
+    ///
+    /// Must implement [`HasSchema`](nebula_schema::HasSchema) so the action
+    /// metadata can auto-derive its parameter schema from the input type.
+    /// Use `()` / `serde_json::Value` for schema-less inputs — both have
+    /// baseline `HasSchema` impls returning an empty schema.
+    type Input: nebula_schema::HasSchema + Send + Sync;
     /// Output type produced on success (wrapped in [`ActionResult`]).
     type Output: Send + Sync;
 
@@ -131,7 +136,7 @@ impl<F, Fut, Input, Output> StatelessAction for FnStatelessAction<F, Input, Outp
 where
     F: Fn(Input) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<Output, ActionError>> + Send + 'static,
-    Input: Send + Sync + 'static,
+    Input: nebula_schema::HasSchema + Send + Sync + 'static,
     Output: Send + Sync + 'static,
 {
     type Input = Input;
@@ -236,7 +241,7 @@ impl<F, Fut, Input, Output> StatelessAction for FnStatelessCtxAction<F, Input, O
 where
     F: Fn(Input, ActionContext) -> Fut + Send + Sync + 'static,
     Fut: Future<Output = Result<Output, ActionError>> + Send + 'static,
-    Input: Send + Sync + 'static,
+    Input: nebula_schema::HasSchema + Send + Sync + 'static,
     Output: Send + Sync + 'static,
 {
     type Input = Input;
@@ -498,6 +503,17 @@ mod tests {
     struct AddInput {
         a: i64,
         b: i64,
+    }
+
+    impl nebula_schema::HasSchema for AddInput {
+        fn schema() -> nebula_schema::ValidSchema {
+            use nebula_schema::{FieldCollector, Schema};
+            Schema::builder()
+                .integer("a", |n| n)
+                .integer("b", |n| n)
+                .build()
+                .expect("AddInput schema is valid")
+        }
     }
 
     #[derive(Debug, Serialize, Deserialize, PartialEq)]

--- a/crates/action/src/trigger.rs
+++ b/crates/action/src/trigger.rs
@@ -422,7 +422,7 @@ where
 impl<A: Action> fmt::Debug for TriggerActionAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("TriggerActionAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }
@@ -514,7 +514,7 @@ mod tests {
         let adapter = TriggerActionAdapter::new(MockTriggerAction::new());
         let action = adapter.into_inner();
         assert_eq!(
-            action.metadata().key,
+            action.metadata().base.key,
             nebula_core::action_key!("test.trigger_action")
         );
     }

--- a/crates/action/src/validation.rs
+++ b/crates/action/src/validation.rs
@@ -76,13 +76,13 @@ pub fn validate_action_package(
 ) -> Result<(), ActionPackageValidationErrors> {
     let mut errors = Vec::new();
 
-    if metadata.key.as_str().is_empty() {
+    if metadata.base.key.as_str().is_empty() {
         errors.push(ActionPackageValidationError::EmptyMetadataField { field: "key" });
     }
-    if metadata.name.trim().is_empty() {
+    if metadata.base.name.trim().is_empty() {
         errors.push(ActionPackageValidationError::EmptyMetadataField { field: "name" });
     }
-    if metadata.description.trim().is_empty() {
+    if metadata.base.description.trim().is_empty() {
         errors.push(ActionPackageValidationError::EmptyMetadataField {
             field: "description",
         });

--- a/crates/action/src/webhook.rs
+++ b/crates/action/src/webhook.rs
@@ -781,7 +781,7 @@ where
         if let Some(orphan) = rollback_state {
             if let Err(e) = self.action.on_deactivate(orphan, ctx).await {
                 tracing::warn!(
-                    action = %self.action.metadata().key,
+                    action = %self.action.metadata().base.key,
                     error = %e,
                     "webhook rollback on_deactivate failed after double-start race; \
                      external hook may leak"
@@ -964,7 +964,7 @@ where
 impl<A: WebhookAction> fmt::Debug for WebhookTriggerAdapter<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("WebhookTriggerAdapter")
-            .field("action", &self.action.metadata().key)
+            .field("action", &self.action.metadata().base.key)
             .finish_non_exhaustive()
     }
 }

--- a/crates/action/tests/derive_action.rs
+++ b/crates/action/tests/derive_action.rs
@@ -30,9 +30,9 @@ fn no_credentials_returns_empty_resources() {
 fn metadata_key_matches_attribute() {
     let action = NoCredAction;
     let meta = action.metadata();
-    assert_eq!(meta.key.as_str(), "test.no_cred");
-    assert_eq!(meta.name, "No Cred");
-    assert_eq!(meta.description, "no credentials");
+    assert_eq!(meta.base.key.as_str(), "test.no_cred");
+    assert_eq!(meta.base.name, "No Cred");
+    assert_eq!(meta.base.description, "no credentials");
 }
 
 // -- Struct with fields -----------------------------------------------------
@@ -58,8 +58,8 @@ fn derive_works_on_struct_with_fields() {
         timeout: 30,
     };
     let meta = action.metadata();
-    assert_eq!(meta.key.as_str(), "with_fields");
-    assert_eq!(meta.name, "Fields Action");
+    assert_eq!(meta.base.key.as_str(), "with_fields");
+    assert_eq!(meta.base.name, "Fields Action");
 }
 
 // -- Credential type IDs (compile-time verification) ------------------------

--- a/crates/action/tests/dx_batch.rs
+++ b/crates/action/tests/dx_batch.rs
@@ -27,6 +27,16 @@ struct NumberList {
     numbers: Vec<i32>,
 }
 
+impl nebula_schema::HasSchema for NumberList {
+    fn schema() -> nebula_schema::ValidSchema {
+        use nebula_schema::{FieldCollector, Schema};
+        Schema::builder()
+            .list("numbers", |l| l.item_number("n", |n| n.integer()))
+            .build()
+            .expect("NumberList schema is valid")
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 struct BatchOutput {
     processed: Vec<i32>,

--- a/crates/action/tests/dx_control.rs
+++ b/crates/action/tests/dx_control.rs
@@ -678,7 +678,10 @@ fn all_demo_fixtures_are_dyn_stateless_handlers() {
     assert_eq!(handlers.len(), 7);
 
     // Each must report its own distinct action key.
-    let keys: Vec<_> = handlers.iter().map(|h| h.metadata().key.clone()).collect();
+    let keys: Vec<_> = handlers
+        .iter()
+        .map(|h| h.metadata().base.key.clone())
+        .collect();
     let unique: std::collections::HashSet<_> = keys.iter().collect();
     assert_eq!(unique.len(), 7, "action keys must be distinct");
 }
@@ -716,7 +719,7 @@ fn category_inference_matches_expectation() {
             handler.metadata().category,
             *expected,
             "unexpected category for {}",
-            handler.metadata().key
+            handler.metadata().base.key
         );
     }
 }

--- a/crates/action/tests/type_sizes.rs
+++ b/crates/action/tests/type_sizes.rs
@@ -44,10 +44,13 @@ fn top_level_type_sizes_are_stable() {
          that drives this size, check it first."
     );
     assert_eq!(size_of::<ActionContext>(), 128);
-    // NOTE: ActionMetadata.parameters migrated from nebula-parameter
-    // ParameterCollection (Vec-backed) to nebula-schema ValidSchema (Arc-backed
-    // proof-token, 8 bytes). Net shrink of 16 bytes — from 200 to 184.
-    assert_eq!(size_of::<ActionMetadata>(), 184);
+    // NOTE: ActionMetadata was flattened into a composed `BaseMetadata<ActionKey>`
+    // plus action-specific fields (version / inputs / outputs / isolation / category).
+    // The shared prefix brings Icon, documentation_url, tags (Box<[String]>),
+    // MaturityLevel, and Option<DeprecationNotice>. Allocation is once-per-action
+    // type — not a hot path — so we accept the growth in exchange for the
+    // unified catalog contract.
+    assert_eq!(size_of::<ActionMetadata>(), 376);
     assert_eq!(size_of::<ActionError>(), 64);
     assert_eq!(size_of::<ActionHandler>(), 24);
 

--- a/crates/api/src/handlers/catalog.rs
+++ b/crates/api/src/handlers/catalog.rs
@@ -36,10 +36,10 @@ pub async fn list_actions(State(state): State<AppState>) -> ApiResult<Json<ListA
             let entry = registry.get(&key);
             let name = entry
                 .as_ref()
-                .map(|(meta, _)| meta.name.clone())
+                .map(|(meta, _)| meta.base.name.clone())
                 .unwrap_or_else(|| key.as_str().to_string());
             let version = entry
-                .map(|(meta, _)| meta.version.to_string())
+                .map(|(meta, _)| meta.base.version.to_string())
                 .unwrap_or_else(|| "1.0.0".to_string());
             ActionSummary {
                 key: key.as_str().to_string(),
@@ -78,10 +78,10 @@ pub async fn get_action(
         .ok_or_else(|| ApiError::NotFound(format!("Action '{}' not found", key)))?;
 
     Ok(Json(ActionDetailResponse {
-        key: meta.key.as_str().to_string(),
-        name: meta.name.clone(),
-        description: meta.description.clone(),
-        version: meta.version.to_string(),
+        key: meta.base.key.as_str().to_string(),
+        name: meta.base.name.clone(),
+        description: meta.base.description.clone(),
+        version: meta.base.version.to_string(),
         // IsolationLevel does not implement Display; {:?} produces the variant name.
         isolation_level: format!("{:?}", meta.isolation_level),
     }))

--- a/crates/api/src/webhook/routing.rs
+++ b/crates/api/src/webhook/routing.rs
@@ -33,7 +33,7 @@ pub(crate) struct ActivationEntry {
 impl std::fmt::Debug for ActivationEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ActivationEntry")
-            .field("handler_key", &self.handler.metadata().key)
+            .field("handler_key", &self.handler.metadata().base.key)
             .field("trigger_id", &self.ctx.trigger_id)
             .field("workflow_id", &self.ctx.workflow_id)
             .finish_non_exhaustive()

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -26,6 +26,7 @@ subtle = { workspace = true }
 # Core types
 nebula-credential-macros = { path = "macros" }
 nebula-core = { path = "../core" }
+nebula-metadata = { path = "../metadata" }
 
 # Schema definitions
 nebula-schema = { path = "../schema" }

--- a/crates/credential/examples/credential_metadata.rs
+++ b/crates/credential/examples/credential_metadata.rs
@@ -1,14 +1,18 @@
-//! Example: Defining credential types using CredentialMetadata
+//! Example: Defining credential types using `CredentialMetadata`.
 //!
-//! This example demonstrates how to define credential type schemas
-//! that can be used for type registry and documentation.
+//! Builds on the shared [`nebula_metadata::BaseMetadata`] prefix — the
+//! catalog-level fields (`key`, `name`, `description`, `schema`, `icon`,
+//! `documentation_url`, `tags`, `maturity`, `deprecation`) are uniform
+//! across action/credential/resource. Credential-specific details
+//! (`pattern`) stay on [`CredentialMetadata`] itself.
 
 use nebula_credential::CredentialMetadata;
+use nebula_metadata::Metadata;
 use nebula_schema::{Field, Schema};
 
 fn main() {
     // Example 1: GitHub OAuth2 credential type
-    let github_properties = Schema::builder()
+    let github_schema = Schema::builder()
         .add(Field::string("client_id").label("Client ID").required())
         .add(
             Field::secret("client_secret")
@@ -19,30 +23,27 @@ fn main() {
         .expect("github schema is always valid");
 
     let github_oauth2 = CredentialMetadata::builder()
-        .key("github_oauth2")
+        .key(nebula_core::credential_key!("github_oauth2"))
         .name("GitHub OAuth2")
         .description("OAuth2 authentication for GitHub API")
         .icon("github")
         .documentation_url("https://docs.github.com/en/apps/oauth-apps")
-        .properties(github_properties)
+        .schema(github_schema)
         .pattern(nebula_core::AuthPattern::OAuth2)
         .build()
         .expect("Failed to build GitHub OAuth2 credential metadata");
 
     println!("GitHub OAuth2 Credential Type:");
-    println!("  Key: {}", github_oauth2.key);
-    println!("  Name: {}", github_oauth2.name);
-    println!("  Description: {}", github_oauth2.description);
-    println!("  Icon: {:?}", github_oauth2.icon);
-    println!("  Documentation: {:?}", github_oauth2.documentation_url);
-    println!(
-        "  Properties: {} fields",
-        github_oauth2.properties.fields().len()
-    );
+    println!("  Key: {}", github_oauth2.key().as_str());
+    println!("  Name: {}", github_oauth2.name());
+    println!("  Description: {}", github_oauth2.description());
+    println!("  Icon: {:?}", github_oauth2.icon());
+    println!("  Documentation: {:?}", github_oauth2.documentation_url());
+    println!("  Schema fields: {}", github_oauth2.schema().fields().len());
     println!();
 
     // Example 2: PostgreSQL database credential type
-    let postgres_properties = Schema::builder()
+    let postgres_schema = Schema::builder()
         .add(Field::string("host").label("Host").required())
         .add(Field::string("username").label("Username").required())
         .add(Field::secret("password").label("Password").required())
@@ -50,39 +51,38 @@ fn main() {
         .expect("postgres schema is always valid");
 
     let postgres_db = CredentialMetadata::builder()
-        .key("postgres_db")
+        .key(nebula_core::credential_key!("postgres_db"))
         .name("PostgreSQL Database")
         .description("PostgreSQL database connection credentials")
         .icon("database")
-        .properties(postgres_properties)
+        .schema(postgres_schema)
         .pattern(nebula_core::AuthPattern::IdentityPassword)
         .build()
         .expect("Failed to build PostgreSQL credential metadata");
 
     println!("PostgreSQL Database Credential Type:");
-    println!("  Key: {}", postgres_db.key);
-    println!("  Name: {}", postgres_db.name);
-    println!("  Description: {}", postgres_db.description);
+    println!("  Key: {}", postgres_db.key().as_str());
+    println!("  Name: {}", postgres_db.name());
+    println!("  Description: {}", postgres_db.description());
     println!();
 
-    // Example 3: Simple API Key credential type (direct construction)
-    let api_key = CredentialMetadata {
-        key: "api_key".to_string(),
-        name: "API Key".to_string(),
-        description: "Simple API key authentication".to_string(),
-        icon: Some("key".to_string()),
-        icon_url: None,
-        documentation_url: None,
-        properties: Schema::builder()
-            .add(Field::secret("api_key").label("API Key").required())
-            .build()
-            .expect("api_key schema is always valid"),
-        pattern: nebula_core::AuthPattern::SecretToken,
-    };
+    // Example 3: Simple API Key credential type via the `new` constructor.
+    let api_key_schema = Schema::builder()
+        .add(Field::secret("api_key").label("API Key").required())
+        .build()
+        .expect("api_key schema is always valid");
+
+    let api_key = CredentialMetadata::new(
+        nebula_core::credential_key!("api_key"),
+        "API Key",
+        "Simple API key authentication",
+        api_key_schema,
+        nebula_core::AuthPattern::SecretToken,
+    );
 
     println!("API Key Credential Type:");
-    println!("  Key: {}", api_key.key);
-    println!("  Name: {}", api_key.name);
+    println!("  Key: {}", api_key.key().as_str());
+    println!("  Name: {}", api_key.name());
     println!();
 
     // Serialization example

--- a/crates/credential/src/credential.rs
+++ b/crates/credential/src/credential.rs
@@ -92,6 +92,15 @@ use crate::{
 /// }
 /// ```
 pub trait Credential: Send + Sync + 'static {
+    /// Typed shape of the setup-form fields.
+    ///
+    /// The canonical [`parameters()`](Credential::parameters) schema is
+    /// auto-derived via `<Self::Input as HasSchema>::schema()`. Use
+    /// [`FieldValues`] for legacy credentials that do not yet declare a
+    /// typed input (the blanket [`HasSchema`](nebula_schema::HasSchema)
+    /// impl returns an empty schema).
+    type Input: nebula_schema::HasSchema + Send + Sync + 'static;
+
     /// What this credential produces -- the consumer-facing auth material.
     type Scheme: AuthScheme;
 
@@ -133,9 +142,16 @@ pub trait Credential: Send + Sync + 'static {
         Self: Sized;
 
     /// Parameter schema for the setup form.
+    ///
+    /// The default implementation derives the schema from [`Self::Input`],
+    /// which must implement [`HasSchema`](nebula_schema::HasSchema). Override
+    /// only if the form layout must differ from the `Input` struct (rare).
     fn parameters() -> ValidSchema
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        <Self::Input as nebula_schema::HasSchema>::schema()
+    }
 
     /// Extract consumer-facing auth material from stored state.
     fn project(state: &Self::State) -> Self::Scheme

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -4,13 +4,40 @@
 //! input. State and Scheme are the same type ([`SecretToken`]) via
 //! [`identity_state!`](crate::identity_state).
 
-use nebula_schema::{Field, FieldValues, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
 
 use crate::{
     SecretString, context::CredentialContext, credential::Credential, error::CredentialError,
     metadata::CredentialMetadata, pending::NoPendingState, resolve::StaticResolveResult,
     scheme::SecretToken,
 };
+
+/// Typed shape of the `api_key` credential setup form.
+///
+/// Used solely as the [`Credential::Input`] — the value is carried through
+/// the resolver as [`FieldValues`] for now; this struct exists to advertise
+/// the canonical schema via [`HasSchema`].
+pub struct ApiKeyInput;
+
+impl HasSchema for ApiKeyInput {
+    fn schema() -> ValidSchema {
+        Schema::builder()
+            .add(
+                Field::string("server")
+                    .label("Server URL")
+                    .description("Base URL of the service (e.g. https://api.example.com)")
+                    .placeholder("https://api.example.com"),
+            )
+            .add(
+                Field::secret("api_key")
+                    .label("API Key")
+                    .description("Secret API token or personal access token")
+                    .required(),
+            )
+            .build()
+            .expect("api_key schema is always valid")
+    }
+}
 
 /// API Key credential -- resolves a single token into a [`SecretToken`].
 ///
@@ -31,6 +58,7 @@ use crate::{
 pub struct ApiKeyCredential;
 
 impl Credential for ApiKeyCredential {
+    type Input = ApiKeyInput;
     type Scheme = SecretToken;
     type State = SecretToken;
     type Pending = NoPendingState;
@@ -48,24 +76,6 @@ impl Credential for ApiKeyCredential {
             properties: Self::parameters(),
             pattern: nebula_core::AuthPattern::SecretToken,
         }
-    }
-
-    fn parameters() -> ValidSchema {
-        Schema::builder()
-            .add(
-                Field::string("server")
-                    .label("Server URL")
-                    .description("Base URL of the service (e.g. https://api.example.com)")
-                    .placeholder("https://api.example.com"),
-            )
-            .add(
-                Field::secret("api_key")
-                    .label("API Key")
-                    .description("Secret API token or personal access token")
-                    .required(),
-            )
-            .build()
-            .expect("api_key schema is always valid")
     }
 
     fn project(state: &SecretToken) -> SecretToken {

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -66,16 +66,15 @@ impl Credential for ApiKeyCredential {
     const KEY: &'static str = "api_key";
 
     fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "API Key".to_owned(),
-            description: "Static API key or bearer token for HTTP APIs.".to_owned(),
-            icon: Some("key".to_owned()),
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::SecretToken,
-        }
+        CredentialMetadata::builder()
+            .key(nebula_core::credential_key!("api_key"))
+            .name("API Key")
+            .description("Static API key or bearer token for HTTP APIs.")
+            .schema(Self::parameters())
+            .pattern(nebula_core::AuthPattern::SecretToken)
+            .icon("key")
+            .build()
+            .expect("api_key metadata is valid")
     }
 
     fn project(state: &SecretToken) -> SecretToken {

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -3,13 +3,36 @@
 //! Resolves a username + password pair into [`IdentityPassword`]. State and
 //! Scheme are the same type via [`identity_state!`](crate::identity_state).
 
-use nebula_schema::{Field, FieldValues, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
 
 use crate::{
     SecretString, context::CredentialContext, credential::Credential, error::CredentialError,
     metadata::CredentialMetadata, pending::NoPendingState, resolve::StaticResolveResult,
     scheme::IdentityPassword,
 };
+
+/// Typed shape of the `basic_auth` credential setup form.
+pub struct BasicAuthInput;
+
+impl HasSchema for BasicAuthInput {
+    fn schema() -> ValidSchema {
+        Schema::builder()
+            .add(
+                Field::string("username")
+                    .label("Username")
+                    .description("Username for HTTP Basic authentication")
+                    .required(),
+            )
+            .add(
+                Field::secret("password")
+                    .label("Password")
+                    .description("Password for HTTP Basic authentication")
+                    .required(),
+            )
+            .build()
+            .expect("basic_auth schema is always valid")
+    }
+}
 
 /// HTTP Basic Auth credential -- resolves username + password into
 /// [`IdentityPassword`].
@@ -20,6 +43,7 @@ use crate::{
 pub struct BasicAuthCredential;
 
 impl Credential for BasicAuthCredential {
+    type Input = BasicAuthInput;
     type Scheme = IdentityPassword;
     type State = IdentityPassword;
     type Pending = NoPendingState;
@@ -37,24 +61,6 @@ impl Credential for BasicAuthCredential {
             properties: Self::parameters(),
             pattern: nebula_core::AuthPattern::IdentityPassword,
         }
-    }
-
-    fn parameters() -> ValidSchema {
-        Schema::builder()
-            .add(
-                Field::string("username")
-                    .label("Username")
-                    .description("Username for HTTP Basic authentication")
-                    .required(),
-            )
-            .add(
-                Field::secret("password")
-                    .label("Password")
-                    .description("Password for HTTP Basic authentication")
-                    .required(),
-            )
-            .build()
-            .expect("basic_auth schema is always valid")
     }
 
     fn project(state: &IdentityPassword) -> IdentityPassword {

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -51,16 +51,15 @@ impl Credential for BasicAuthCredential {
     const KEY: &'static str = "basic_auth";
 
     fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "Basic Auth".to_owned(),
-            description: "HTTP Basic authentication (username + password).".to_owned(),
-            icon: Some("lock".to_owned()),
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::IdentityPassword,
-        }
+        CredentialMetadata::builder()
+            .key(nebula_core::credential_key!("basic_auth"))
+            .name("Basic Auth")
+            .description("HTTP Basic authentication (username + password).")
+            .schema(Self::parameters())
+            .pattern(nebula_core::AuthPattern::IdentityPassword)
+            .icon("lock")
+            .build()
+            .expect("basic_auth metadata is valid")
     }
 
     fn project(state: &IdentityPassword) -> IdentityPassword {

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -337,16 +337,15 @@ impl Credential for OAuth2Credential {
     const REFRESHABLE: bool = true;
 
     fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "OAuth2".to_owned(),
-            description: "OAuth2 authentication supporting Authorization Code, Client Credentials, and Device Code grant types.".to_owned(),
-            icon: Some("oauth2".to_owned()),
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::OAuth2,
-        }
+        CredentialMetadata::builder()
+            .key(nebula_core::credential_key!("oauth2"))
+            .name("OAuth2")
+            .description("OAuth2 authentication supporting Authorization Code, Client Credentials, and Device Code grant types.")
+            .schema(Self::parameters())
+            .pattern(nebula_core::AuthPattern::OAuth2)
+            .icon("oauth2")
+            .build()
+            .expect("oauth2 metadata is valid")
     }
 
     fn project(state: &OAuth2State) -> OAuth2Token {
@@ -721,10 +720,11 @@ mod tests {
 
     #[test]
     fn metadata_has_correct_fields() {
+        use nebula_metadata::Metadata;
         let meta = OAuth2Credential::metadata();
-        assert_eq!(meta.key, "oauth2");
-        assert_eq!(meta.name, "OAuth2");
-        assert!(meta.description.contains("OAuth2"));
+        assert_eq!(meta.key().as_str(), "oauth2");
+        assert_eq!(meta.name(), "OAuth2");
+        assert!(meta.description().contains("OAuth2"));
     }
 
     #[test]

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -11,7 +11,7 @@
 use std::{fmt, fmt::Formatter, time::Duration};
 
 use chrono::{DateTime, Utc};
-use nebula_schema::{Field, FieldValues, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
 use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
@@ -269,29 +269,11 @@ impl PendingState for OAuth2Pending {
 /// ```
 pub struct OAuth2Credential;
 
-impl Credential for OAuth2Credential {
-    type Scheme = OAuth2Token;
-    type State = OAuth2State;
-    type Pending = OAuth2Pending;
+/// Typed shape of the `oauth2` credential setup form.
+pub struct OAuth2Input;
 
-    const KEY: &'static str = "oauth2";
-    const INTERACTIVE: bool = true;
-    const REFRESHABLE: bool = true;
-
-    fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "OAuth2".to_owned(),
-            description: "OAuth2 authentication supporting Authorization Code, Client Credentials, and Device Code grant types.".to_owned(),
-            icon: Some("oauth2".to_owned()),
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::OAuth2,
-        }
-    }
-
-    fn parameters() -> ValidSchema {
+impl HasSchema for OAuth2Input {
+    fn schema() -> ValidSchema {
         Schema::builder()
             .add(
                 Field::string("client_id")
@@ -341,6 +323,30 @@ impl Credential for OAuth2Credential {
             )
             .build()
             .expect("oauth2 schema is always valid")
+    }
+}
+
+impl Credential for OAuth2Credential {
+    type Input = OAuth2Input;
+    type Scheme = OAuth2Token;
+    type State = OAuth2State;
+    type Pending = OAuth2Pending;
+
+    const KEY: &'static str = "oauth2";
+    const INTERACTIVE: bool = true;
+    const REFRESHABLE: bool = true;
+
+    fn metadata() -> CredentialMetadata {
+        CredentialMetadata {
+            key: Self::KEY.to_owned(),
+            name: "OAuth2".to_owned(),
+            description: "OAuth2 authentication supporting Authorization Code, Client Credentials, and Device Code grant types.".to_owned(),
+            icon: Some("oauth2".to_owned()),
+            icon_url: None,
+            documentation_url: None,
+            properties: Self::parameters(),
+            pattern: nebula_core::AuthPattern::OAuth2,
+        }
     }
 
     fn project(state: &OAuth2State) -> OAuth2Token {

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -1,153 +1,164 @@
-use nebula_core::AuthPattern;
+use nebula_core::{AuthPattern, CredentialKey};
+use nebula_metadata::{BaseMetadata, Metadata};
 use nebula_schema::ValidSchema;
 use serde::{Deserialize, Serialize};
 
 /// Describes a credential type (OAuth2, API Key, Database, etc.)
 ///
-/// This is the static schema that defines what fields a credential type requires.
-/// Used for:
-/// - UI form generation
-/// - Validation of user input
-/// - Type registry
-/// - Auto-generated documentation
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use nebula_core::AuthPattern;
-/// use nebula_credential::CredentialMetadata;
-/// use nebula_schema::{Field, Schema};
-///
-/// let properties = Schema::builder()
-///     .add(Field::string("client_id").label("Client ID").required())
-///     .add(Field::secret("client_secret").label("Client Secret").required())
-///     .build()
-///     .expect("static schema is valid");
-///
-/// let github_oauth2 = CredentialMetadata {
-///     key: "github_oauth2".to_string(),
-///     name: "GitHub OAuth2".to_string(),
-///     description: "OAuth2 authentication for GitHub API".to_string(),
-///     icon: Some("github".to_string()),
-///     icon_url: None,
-///     documentation_url: Some("https://docs.github.com/en/apps/oauth-apps".to_string()),
-///     properties,
-///     pattern: AuthPattern::OAuth2,
-/// };
-/// ```
+/// Used for UI form generation, input validation, type registry, and
+/// auto-generated documentation. The shared catalog prefix (`key`, `name`,
+/// `description`, `schema`, `icon`, `documentation_url`, `tags`,
+/// `maturity`, `deprecation`) lives on the composed [`BaseMetadata`];
+/// `pattern` is the credential-specific classifier.
+#[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialMetadata {
-    /// Unique identifier for this credential type (e.g., "github_oauth2", "postgres_db")
-    pub key: String,
-
-    /// Human-readable name (e.g., "GitHub OAuth2", "PostgreSQL Database")
-    pub name: String,
-
-    /// Description of what this credential is used for
-    pub description: String,
-
-    /// Optional icon identifier (e.g., "github", "database")
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon: Option<String>,
-
-    /// Optional icon URL for custom icons
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon_url: Option<String>,
-
-    /// Optional documentation URL
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub documentation_url: Option<String>,
-
-    /// Parameter definitions — what fields this credential type requires.
-    pub properties: ValidSchema,
-
+    /// Shared catalog prefix.
+    #[serde(flatten)]
+    pub base: BaseMetadata<CredentialKey>,
     /// Authentication pattern classification for UI and tooling.
     pub pattern: AuthPattern,
 }
 
+impl Metadata for CredentialMetadata {
+    type Key = CredentialKey;
+    fn base(&self) -> &BaseMetadata<CredentialKey> {
+        &self.base
+    }
+}
+
 impl CredentialMetadata {
-    /// Create a new credential metadata builder
+    /// Create credential metadata whose schema is pulled from a
+    /// [`Credential`](crate::credential::Credential) implementation's
+    /// `Input` type.
+    #[must_use]
+    pub fn for_credential<C>(
+        key: CredentialKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        pattern: AuthPattern,
+    ) -> Self
+    where
+        C: crate::credential::Credential,
+    {
+        Self {
+            base: BaseMetadata::new(
+                key,
+                name,
+                description,
+                <C::Input as nebula_schema::HasSchema>::schema(),
+            ),
+            pattern,
+        }
+    }
+
+    /// Start building credential metadata with the given required fields.
+    #[must_use]
+    pub fn new(
+        key: CredentialKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        schema: ValidSchema,
+        pattern: AuthPattern,
+    ) -> Self {
+        Self {
+            base: BaseMetadata::new(key, name, description, schema),
+            pattern,
+        }
+    }
+
+    /// Builder entry point.
+    #[must_use]
     pub fn builder() -> CredentialMetadataBuilder {
         CredentialMetadataBuilder::default()
     }
 }
 
-/// Builder for CredentialMetadata
+/// Imperative builder for [`CredentialMetadata`] — useful when the fields
+/// come from a config file or generated catalog entry rather than a
+/// compile-time [`Credential`](crate::credential::Credential) impl.
 #[derive(Debug, Default)]
 pub struct CredentialMetadataBuilder {
-    key: Option<String>,
+    key: Option<CredentialKey>,
     name: Option<String>,
     description: Option<String>,
-    icon: Option<String>,
-    icon_url: Option<String>,
-    documentation_url: Option<String>,
-    properties: Option<ValidSchema>,
+    schema: Option<ValidSchema>,
     pattern: Option<AuthPattern>,
+    icon: Option<nebula_metadata::Icon>,
+    documentation_url: Option<String>,
 }
 
 impl CredentialMetadataBuilder {
-    /// Set the unique identifier for this credential type
-    pub fn key(mut self, key: impl Into<String>) -> Self {
-        self.key = Some(key.into());
+    /// Set the typed credential key.
+    #[must_use]
+    pub fn key(mut self, key: CredentialKey) -> Self {
+        self.key = Some(key);
         self
     }
 
-    /// Set the human-readable name
+    /// Set the human-readable name.
+    #[must_use]
     pub fn name(mut self, name: impl Into<String>) -> Self {
         self.name = Some(name.into());
         self
     }
 
-    /// Set the description
+    /// Set the description.
+    #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
         self
     }
 
-    /// Set the icon identifier
-    pub fn icon(mut self, icon: impl Into<String>) -> Self {
-        self.icon = Some(icon.into());
+    /// Set the schema.
+    #[must_use]
+    pub fn schema(mut self, schema: ValidSchema) -> Self {
+        self.schema = Some(schema);
         self
     }
 
-    /// Set the icon URL
-    pub fn icon_url(mut self, icon_url: impl Into<String>) -> Self {
-        self.icon_url = Some(icon_url.into());
-        self
-    }
-
-    /// Set the documentation URL
-    pub fn documentation_url(mut self, documentation_url: impl Into<String>) -> Self {
-        self.documentation_url = Some(documentation_url.into());
-        self
-    }
-
-    /// Set the parameter schema
-    pub fn properties(mut self, properties: ValidSchema) -> Self {
-        self.properties = Some(properties);
-        self
-    }
-
-    /// Set the authentication pattern
+    /// Set the authentication pattern.
+    #[must_use]
     pub fn pattern(mut self, pattern: AuthPattern) -> Self {
         self.pattern = Some(pattern);
         self
     }
 
-    /// Build the CredentialMetadata
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if required fields (key, name, description, properties) are not set
-    pub fn build(self) -> Result<CredentialMetadata, String> {
+    /// Set an inline icon identifier.
+    #[must_use]
+    pub fn icon(mut self, icon: impl Into<String>) -> Self {
+        self.icon = Some(nebula_metadata::Icon::inline(icon));
+        self
+    }
+
+    /// Set a URL-backed icon.
+    #[must_use]
+    pub fn icon_url(mut self, url: impl Into<String>) -> Self {
+        self.icon = Some(nebula_metadata::Icon::url(url));
+        self
+    }
+
+    /// Set the documentation URL.
+    #[must_use]
+    pub fn documentation_url(mut self, url: impl Into<String>) -> Self {
+        self.documentation_url = Some(url.into());
+        self
+    }
+
+    /// Finalise, returning an error when a required field is missing.
+    pub fn build(self) -> Result<CredentialMetadata, &'static str> {
+        let mut base = BaseMetadata::new(
+            self.key.ok_or("key is required")?,
+            self.name.ok_or("name is required")?,
+            self.description.ok_or("description is required")?,
+            self.schema.ok_or("schema is required")?,
+        );
+        if let Some(icon) = self.icon {
+            base.icon = icon;
+        }
+        base.documentation_url = self.documentation_url;
         Ok(CredentialMetadata {
-            key: self.key.ok_or("key is required")?,
-            name: self.name.ok_or("name is required")?,
-            description: self.description.ok_or("description is required")?,
-            icon: self.icon,
-            icon_url: self.icon_url,
-            documentation_url: self.documentation_url,
-            properties: self.properties.ok_or("properties is required")?,
+            base,
             pattern: self.pattern.ok_or("pattern is required")?,
         })
     }

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -2,6 +2,29 @@ use nebula_core::{AuthPattern, CredentialKey};
 use nebula_metadata::{BaseMetadata, Metadata};
 use nebula_schema::ValidSchema;
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Error returned by [`CredentialMetadataBuilder::build`] when a required
+/// field is missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Error)]
+#[non_exhaustive]
+pub enum CredentialMetadataBuildError {
+    /// `key` was never set on the builder.
+    #[error("credential metadata `key` is required")]
+    MissingKey,
+    /// `name` was never set on the builder.
+    #[error("credential metadata `name` is required")]
+    MissingName,
+    /// `description` was never set on the builder.
+    #[error("credential metadata `description` is required")]
+    MissingDescription,
+    /// `schema` was never set on the builder.
+    #[error("credential metadata `schema` is required")]
+    MissingSchema,
+    /// `pattern` was never set on the builder.
+    #[error("credential metadata `pattern` is required")]
+    MissingPattern,
+}
 
 /// Describes a credential type (OAuth2, API Key, Database, etc.)
 ///
@@ -145,13 +168,16 @@ impl CredentialMetadataBuilder {
         self
     }
 
-    /// Finalise, returning an error when a required field is missing.
-    pub fn build(self) -> Result<CredentialMetadata, &'static str> {
+    /// Finalise, returning a typed [`CredentialMetadataBuildError`] variant
+    /// when a required field is missing.
+    pub fn build(self) -> Result<CredentialMetadata, CredentialMetadataBuildError> {
         let mut base = BaseMetadata::new(
-            self.key.ok_or("key is required")?,
-            self.name.ok_or("name is required")?,
-            self.description.ok_or("description is required")?,
-            self.schema.ok_or("schema is required")?,
+            self.key.ok_or(CredentialMetadataBuildError::MissingKey)?,
+            self.name.ok_or(CredentialMetadataBuildError::MissingName)?,
+            self.description
+                .ok_or(CredentialMetadataBuildError::MissingDescription)?,
+            self.schema
+                .ok_or(CredentialMetadataBuildError::MissingSchema)?,
         );
         if let Some(icon) = self.icon {
             base.icon = icon;
@@ -159,7 +185,9 @@ impl CredentialMetadataBuilder {
         base.documentation_url = self.documentation_url;
         Ok(CredentialMetadata {
             base,
-            pattern: self.pattern.ok_or("pattern is required")?,
+            pattern: self
+                .pattern
+                .ok_or(CredentialMetadataBuildError::MissingPattern)?,
         })
     }
 }

--- a/crates/credential/src/resolver.rs
+++ b/crates/credential/src/resolver.rs
@@ -464,7 +464,7 @@ pub enum ResolveError {
 
 #[cfg(test)]
 mod tests {
-    use nebula_schema::{FieldValues, Schema, ValidSchema};
+    use nebula_schema::FieldValues;
 
     use super::*;
     // ── Test credential for early refresh ──────────────────────────────
@@ -515,22 +515,13 @@ mod tests {
         };
 
         fn metadata() -> CredentialMetadata {
-            CredentialMetadata {
-                key: Self::KEY.to_owned(),
-                name: "Refreshable Test".to_owned(),
-                description: "Test credential for early refresh".to_owned(),
-                icon: None,
-                icon_url: None,
-                documentation_url: None,
-                properties: Self::parameters(),
-                pattern: nebula_core::AuthPattern::SecretToken,
-            }
-        }
-
-        fn parameters() -> ValidSchema {
-            Schema::builder()
-                .build()
-                .expect("empty schema is always valid")
+            CredentialMetadata::new(
+                nebula_core::credential_key!("refreshable_test"),
+                "Refreshable Test",
+                "Test credential for early refresh",
+                Self::parameters(),
+                nebula_core::AuthPattern::SecretToken,
+            )
         }
 
         fn project(state: &ExpiringState) -> SecretToken {
@@ -574,16 +565,13 @@ mod tests {
         };
 
         fn metadata() -> CredentialMetadata {
-            CredentialMetadata {
-                key: Self::KEY.to_owned(),
-                name: "Tiny Jitter Refreshable Test".to_owned(),
-                description: "Test credential with sub-ms jitter".to_owned(),
-                icon: None,
-                icon_url: None,
-                documentation_url: None,
-                properties: Self::parameters(),
-                pattern: nebula_core::AuthPattern::SecretToken,
-            }
+            CredentialMetadata::new(
+                nebula_core::credential_key!("tiny_jitter_refreshable_test"),
+                "Tiny Jitter Refreshable Test",
+                "Test credential with sub-ms jitter",
+                Self::parameters(),
+                nebula_core::AuthPattern::SecretToken,
+            )
         }
 
         fn project(state: &ExpiringState) -> SecretToken {
@@ -1076,16 +1064,13 @@ mod tests {
         };
 
         fn metadata() -> CredentialMetadata {
-            CredentialMetadata {
-                key: Self::KEY.to_owned(),
-                name: "CAS Retry Test".to_owned(),
-                description: "Test credential for CAS retry".to_owned(),
-                icon: None,
-                icon_url: None,
-                documentation_url: None,
-                properties: Self::parameters(),
-                pattern: nebula_core::AuthPattern::SecretToken,
-            }
+            CredentialMetadata::new(
+                nebula_core::credential_key!("cas_retry_test"),
+                "CAS Retry Test",
+                "Test credential for CAS retry",
+                Self::parameters(),
+                nebula_core::AuthPattern::SecretToken,
+            )
         }
 
         fn project(state: &ExpiringState) -> SecretToken {

--- a/crates/credential/src/resolver.rs
+++ b/crates/credential/src/resolver.rs
@@ -502,6 +502,7 @@ mod tests {
     struct RefreshableTestCredential;
 
     impl Credential for RefreshableTestCredential {
+        type Input = FieldValues;
         type Scheme = SecretToken;
         type State = ExpiringState;
         type Pending = NoPendingState;
@@ -559,6 +560,7 @@ mod tests {
     struct TinyJitterRefreshableTestCredential;
 
     impl Credential for TinyJitterRefreshableTestCredential {
+        type Input = FieldValues;
         type Scheme = SecretToken;
         type State = ExpiringState;
         type Pending = NoPendingState;
@@ -582,12 +584,6 @@ mod tests {
                 properties: Self::parameters(),
                 pattern: nebula_core::AuthPattern::SecretToken,
             }
-        }
-
-        fn parameters() -> ValidSchema {
-            Schema::builder()
-                .build()
-                .expect("empty schema is always valid")
         }
 
         fn project(state: &ExpiringState) -> SecretToken {
@@ -1066,6 +1062,7 @@ mod tests {
     struct CasRetryTestCredential;
 
     impl Credential for CasRetryTestCredential {
+        type Input = FieldValues;
         type Scheme = SecretToken;
         type State = ExpiringState;
         type Pending = NoPendingState;
@@ -1089,12 +1086,6 @@ mod tests {
                 properties: Self::parameters(),
                 pattern: nebula_core::AuthPattern::SecretToken,
             }
-        }
-
-        fn parameters() -> ValidSchema {
-            Schema::builder()
-                .build()
-                .expect("empty schema is always valid")
         }
 
         fn project(state: &ExpiringState) -> SecretToken {

--- a/crates/credential/src/static_protocol.rs
+++ b/crates/credential/src/static_protocol.rs
@@ -74,15 +74,27 @@ use crate::error::CredentialError;
 /// }
 /// ```
 pub trait StaticProtocol: Send + Sync + 'static {
+    /// Typed shape of the setup-form fields — same role as
+    /// [`Credential::Input`](crate::credential::Credential::Input).
+    ///
+    /// The default [`parameters()`](StaticProtocol::parameters) impl derives
+    /// the schema from this type. Use [`FieldValues`] for legacy protocols
+    /// that do not declare a typed input.
+    type Input: nebula_schema::HasSchema + Send + Sync + 'static;
+
     /// The auth scheme this protocol produces.
     type Scheme: AuthScheme;
 
     /// Parameter schema for the credential setup form.
     ///
-    /// Returned as JSON to the frontend for form rendering.
+    /// Returned as JSON to the frontend for form rendering. Default impl
+    /// delegates to [`<Self::Input as HasSchema>::schema()`](nebula_schema::HasSchema::schema).
     fn parameters() -> ValidSchema
     where
-        Self: Sized;
+        Self: Sized,
+    {
+        <Self::Input as nebula_schema::HasSchema>::schema()
+    }
 
     /// Extract parameters and build auth material.
     ///
@@ -99,7 +111,7 @@ pub trait StaticProtocol: Send + Sync + 'static {
 
 #[cfg(test)]
 mod tests {
-    use nebula_schema::{FieldValues, Schema};
+    use nebula_schema::FieldValues;
 
     use super::*;
     use crate::{SecretString, scheme::SecretToken};
@@ -107,11 +119,8 @@ mod tests {
     struct TestProtocol;
 
     impl StaticProtocol for TestProtocol {
+        type Input = FieldValues;
         type Scheme = SecretToken;
-
-        fn parameters() -> ValidSchema {
-            Schema::builder().build().expect("empty schema is valid")
-        }
 
         fn build(values: &FieldValues) -> Result<SecretToken, CredentialError> {
             let token = values

--- a/crates/credential/tests/units/pending_lifecycle_tests.rs
+++ b/crates/credential/tests/units/pending_lifecycle_tests.rs
@@ -66,16 +66,13 @@ impl Credential for InteractiveTestCredential {
     const INTERACTIVE: bool = true;
 
     fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "Interactive Test".to_owned(),
-            description: "Test credential for pending lifecycle".to_owned(),
-            icon: None,
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::SecretToken,
-        }
+        CredentialMetadata::new(
+            nebula_core::credential_key!("interactive_test"),
+            "Interactive Test",
+            "Test credential for pending lifecycle",
+            Self::parameters(),
+            nebula_core::AuthPattern::SecretToken,
+        )
     }
 
     fn project(state: &TestInteractiveState) -> SecretToken {

--- a/crates/credential/tests/units/pending_lifecycle_tests.rs
+++ b/crates/credential/tests/units/pending_lifecycle_tests.rs
@@ -17,7 +17,7 @@ use nebula_credential::{
     resolve::{DisplayData, InteractionRequest, RefreshOutcome, ResolveResult, UserInput},
     scheme::SecretToken,
 };
-use nebula_schema::{FieldValues, Schema, ValidSchema};
+use nebula_schema::FieldValues;
 
 // ── Test pending state ───────────────────────────────────────────────
 
@@ -57,6 +57,7 @@ impl nebula_credential::state::CredentialState for TestInteractiveState {
 struct InteractiveTestCredential;
 
 impl Credential for InteractiveTestCredential {
+    type Input = FieldValues;
     type Scheme = SecretToken;
     type State = TestInteractiveState;
     type Pending = TestPending;
@@ -75,12 +76,6 @@ impl Credential for InteractiveTestCredential {
             properties: Self::parameters(),
             pattern: nebula_core::AuthPattern::SecretToken,
         }
-    }
-
-    fn parameters() -> ValidSchema {
-        Schema::builder()
-            .build()
-            .expect("empty schema is always valid")
     }
 
     fn project(state: &TestInteractiveState) -> SecretToken {

--- a/crates/credential/tests/units/thundering_herd_tests.rs
+++ b/crates/credential/tests/units/thundering_herd_tests.rs
@@ -19,7 +19,7 @@ use nebula_credential::{
     scheme::SecretToken,
     store::{PutMode, StoredCredential},
 };
-use nebula_schema::{FieldValues, Schema, ValidSchema};
+use nebula_schema::FieldValues;
 
 /// Global counter tracking how many times `refresh()` is actually called.
 static REFRESH_COUNT: AtomicU32 = AtomicU32::new(0);
@@ -46,6 +46,7 @@ impl nebula_credential::state::CredentialState for ThunderingHerdState {
 struct ThunderingHerdCredential;
 
 impl Credential for ThunderingHerdCredential {
+    type Input = FieldValues;
     type Scheme = SecretToken;
     type State = ThunderingHerdState;
     type Pending = NoPendingState;
@@ -69,12 +70,6 @@ impl Credential for ThunderingHerdCredential {
             properties: Self::parameters(),
             pattern: nebula_core::AuthPattern::SecretToken,
         }
-    }
-
-    fn parameters() -> ValidSchema {
-        Schema::builder()
-            .build()
-            .expect("empty schema is always valid")
     }
 
     fn project(state: &ThunderingHerdState) -> SecretToken {

--- a/crates/credential/tests/units/thundering_herd_tests.rs
+++ b/crates/credential/tests/units/thundering_herd_tests.rs
@@ -60,16 +60,13 @@ impl Credential for ThunderingHerdCredential {
     };
 
     fn metadata() -> CredentialMetadata {
-        CredentialMetadata {
-            key: Self::KEY.to_owned(),
-            name: "Thundering Herd Test".to_owned(),
-            description: "Test credential for thundering herd prevention".to_owned(),
-            icon: None,
-            icon_url: None,
-            documentation_url: None,
-            properties: Self::parameters(),
-            pattern: nebula_core::AuthPattern::SecretToken,
-        }
+        CredentialMetadata::new(
+            nebula_core::credential_key!("thundering_herd_test"),
+            "Thundering Herd Test",
+            "Test credential for thundering herd prevention",
+            Self::parameters(),
+            nebula_core::AuthPattern::SecretToken,
+        )
     }
 
     fn project(state: &ThunderingHerdState) -> SecretToken {

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "nebula-metadata"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+authors.workspace = true
+description = "Shared metadata types for named, schematized Nebula entities (actions, credentials, resources, triggers)."
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[dependencies]
+nebula-schema = { path = "../schema" }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/metadata/src/base.rs
+++ b/crates/metadata/src/base.rs
@@ -27,7 +27,7 @@ fn is_default_version(v: &Version) -> bool {
 /// fields (API catalog, search, UI listings) can work generically
 /// against any `M: Metadata`.
 #[non_exhaustive]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct BaseMetadata<K> {
     /// Unique typed identifier of this entity.
     pub key: K,

--- a/crates/metadata/src/base.rs
+++ b/crates/metadata/src/base.rs
@@ -1,0 +1,323 @@
+//! [`BaseMetadata`] — the shared prefix of every catalog-entity metadata.
+
+use nebula_schema::ValidSchema;
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+use crate::{deprecation::DeprecationNotice, icon::Icon, maturity::MaturityLevel};
+
+fn default_version() -> Version {
+    Version::new(1, 0, 0)
+}
+
+fn is_default_version(v: &Version) -> bool {
+    v == &default_version()
+}
+
+/// Shared shape held by every catalog entity's metadata.
+///
+/// Composed via `#[serde(flatten)] pub base: BaseMetadata<K>` on the
+/// concrete metadata struct (for example `ActionMetadata`), so the wire
+/// format of the shared prefix is identical across action/credential/
+/// resource and any future entity kind.
+///
+/// Entity-specific extras (ports on an action, auth pattern on a
+/// credential, pool settings on a resource) live on the outer struct
+/// — `BaseMetadata` stays stable so consumers that only need the common
+/// fields (API catalog, search, UI listings) can work generically
+/// against any `M: Metadata`.
+#[non_exhaustive]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BaseMetadata<K> {
+    /// Unique typed identifier of this entity.
+    pub key: K,
+    /// Human-readable display name.
+    pub name: String,
+    /// Short description shown in catalog cards and tooltips.
+    pub description: String,
+    /// Schema describing the user-configurable inputs of this entity.
+    pub schema: ValidSchema,
+    /// Interface version — bumped when `schema` or any entity-specific
+    /// surface breaks wire-compatibility. Default is `1.0.0`.
+    #[serde(
+        default = "default_version",
+        skip_serializing_if = "is_default_version"
+    )]
+    pub version: Version,
+    /// Catalog icon (inline identifier or URL).
+    #[serde(default, skip_serializing_if = "Icon::is_none")]
+    pub icon: Icon,
+    /// Optional documentation URL.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+    /// Freeform tags used for UI filtering and discovery.
+    #[serde(default, skip_serializing_if = "<[String]>::is_empty")]
+    pub tags: Box<[String]>,
+    /// Declared stability level.
+    #[serde(default, skip_serializing_if = "is_default_maturity")]
+    pub maturity: MaturityLevel,
+    /// Deprecation notice, if this entity is being phased out.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deprecation: Option<DeprecationNotice>,
+}
+
+fn is_default_maturity(m: &MaturityLevel) -> bool {
+    *m == MaturityLevel::default()
+}
+
+impl<K> BaseMetadata<K> {
+    /// Create a new base metadata with the minimum required fields set.
+    ///
+    /// Version defaults to `1.0.0` — use [`with_version`](Self::with_version)
+    /// or the `bump_*` helpers on the outer metadata type to change it.
+    #[must_use]
+    pub fn new(
+        key: K,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        schema: ValidSchema,
+    ) -> Self {
+        Self {
+            key,
+            name: name.into(),
+            description: description.into(),
+            schema,
+            version: default_version(),
+            icon: Icon::default(),
+            documentation_url: None,
+            tags: Box::default(),
+            maturity: MaturityLevel::default(),
+            deprecation: None,
+        }
+    }
+
+    /// Set the interface version.
+    #[must_use]
+    pub fn with_version(mut self, version: Version) -> Self {
+        self.version = version;
+        self
+    }
+
+    /// Set the catalog icon.
+    #[must_use]
+    pub fn with_icon(mut self, icon: Icon) -> Self {
+        self.icon = icon;
+        self
+    }
+
+    /// Set the documentation URL.
+    #[must_use]
+    pub fn with_documentation_url(mut self, url: impl Into<String>) -> Self {
+        self.documentation_url = Some(url.into());
+        self
+    }
+
+    /// Replace all tags with the given iterator.
+    #[must_use]
+    pub fn with_tags<I, S>(mut self, tags: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tags = tags.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Append a single tag, preserving already-declared ones.
+    #[must_use]
+    pub fn add_tag(mut self, tag: impl Into<String>) -> Self {
+        let mut v: Vec<String> = Vec::from(std::mem::take(&mut self.tags));
+        v.push(tag.into());
+        self.tags = v.into_boxed_slice();
+        self
+    }
+
+    /// Set an inline-identifier icon (e.g. `"github"`, `"🔑"`).
+    #[must_use]
+    pub fn with_inline_icon(mut self, name: impl Into<String>) -> Self {
+        self.icon = crate::icon::Icon::inline(name);
+        self
+    }
+
+    /// Set a URL-backed icon.
+    #[must_use]
+    pub fn with_url_icon(mut self, url: impl Into<String>) -> Self {
+        self.icon = crate::icon::Icon::url(url);
+        self
+    }
+
+    /// Mark this entity as experimental.
+    #[must_use]
+    pub fn mark_experimental(mut self) -> Self {
+        self.maturity = MaturityLevel::Experimental;
+        self
+    }
+
+    /// Mark this entity as beta.
+    #[must_use]
+    pub fn mark_beta(mut self) -> Self {
+        self.maturity = MaturityLevel::Beta;
+        self
+    }
+
+    /// Mark this entity as stable (the default — explicit for clarity).
+    #[must_use]
+    pub fn mark_stable(mut self) -> Self {
+        self.maturity = MaturityLevel::Stable;
+        self
+    }
+
+    /// Shortcut for attaching a minimal [`DeprecationNotice`] that only
+    /// records the version the entity was deprecated in. For a richer
+    /// notice use [`Self::with_deprecation`].
+    #[must_use]
+    pub fn deprecate(self, since: semver::Version) -> Self {
+        self.with_deprecation(DeprecationNotice::new(since))
+    }
+
+    /// Set the declared maturity level.
+    #[must_use]
+    pub fn with_maturity(mut self, maturity: MaturityLevel) -> Self {
+        self.maturity = maturity;
+        self
+    }
+
+    /// Attach a deprecation notice (also implies `maturity = Deprecated`).
+    #[must_use]
+    pub fn with_deprecation(mut self, notice: DeprecationNotice) -> Self {
+        self.deprecation = Some(notice);
+        self.maturity = MaturityLevel::Deprecated;
+        self
+    }
+}
+
+/// Interface every catalog entity's metadata exposes.
+///
+/// Impls only need to provide [`base`](Metadata::base); the remaining
+/// accessors are defaulted to delegate through it. This keeps each
+/// per-entity impl to a single line and eliminates the copy-paste bugs
+/// that happen when every type has eight getters delegating to
+/// different field names.
+///
+/// Prefer generic bounds `fn f<M: Metadata>(m: &M)` over `dyn Metadata` —
+/// the associated [`Key`](Metadata::Key) type makes dyn dispatch awkward
+/// and in Nebula's architecture we never actually need a heterogeneous
+/// runtime collection of actions + credentials + resources in one vec.
+pub trait Metadata {
+    /// Typed identifier of the entity (e.g. `ActionKey`, `CredentialKey`).
+    type Key;
+
+    /// Borrow the shared metadata block.
+    fn base(&self) -> &BaseMetadata<Self::Key>;
+
+    /// Typed entity key.
+    fn key(&self) -> &Self::Key {
+        &self.base().key
+    }
+
+    /// Human-readable display name.
+    fn name(&self) -> &str {
+        &self.base().name
+    }
+
+    /// Short description.
+    fn description(&self) -> &str {
+        &self.base().description
+    }
+
+    /// Canonical input schema.
+    fn schema(&self) -> &ValidSchema {
+        &self.base().schema
+    }
+
+    /// Interface version.
+    fn version(&self) -> &Version {
+        &self.base().version
+    }
+
+    /// Cheap `Arc`-clone of the input schema — useful for consumers
+    /// that need to own a `ValidSchema` without borrowing.
+    fn schema_arc(&self) -> ValidSchema {
+        self.base().schema.clone()
+    }
+
+    /// Catalog icon.
+    fn icon(&self) -> &Icon {
+        &self.base().icon
+    }
+
+    /// Documentation URL, if any.
+    fn documentation_url(&self) -> Option<&str> {
+        self.base().documentation_url.as_deref()
+    }
+
+    /// Tags for filtering / discovery.
+    fn tags(&self) -> &[String] {
+        &self.base().tags
+    }
+
+    /// Declared maturity level.
+    fn maturity(&self) -> MaturityLevel {
+        self.base().maturity
+    }
+
+    /// Deprecation notice, if any.
+    fn deprecation(&self) -> Option<&DeprecationNotice> {
+        self.base().deprecation.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_schema::Schema;
+
+    use super::*;
+
+    fn empty_schema() -> ValidSchema {
+        Schema::builder()
+            .build()
+            .expect("empty schema always valid")
+    }
+
+    struct DummyKey(&'static str);
+
+    struct DummyMetadata {
+        base: BaseMetadata<DummyKey>,
+    }
+
+    impl Metadata for DummyMetadata {
+        type Key = DummyKey;
+        fn base(&self) -> &BaseMetadata<Self::Key> {
+            &self.base
+        }
+    }
+
+    #[test]
+    fn defaults_delegate_through_base() {
+        let md = DummyMetadata {
+            base: BaseMetadata::new(DummyKey("k"), "Name", "Desc", empty_schema()),
+        };
+        assert_eq!(md.key().0, "k");
+        assert_eq!(md.name(), "Name");
+        assert_eq!(md.description(), "Desc");
+        assert!(md.icon().is_none());
+        assert!(md.documentation_url().is_none());
+        assert_eq!(md.tags().len(), 0);
+        assert_eq!(md.maturity(), MaturityLevel::Stable);
+        assert!(md.deprecation().is_none());
+    }
+
+    #[test]
+    fn with_tags_accepts_strings_and_literals() {
+        let base =
+            BaseMetadata::new(DummyKey("k"), "n", "d", empty_schema()).with_tags(["http", "io"]);
+        assert_eq!(&*base.tags, &["http".to_owned(), "io".to_owned()]);
+    }
+
+    #[test]
+    fn deprecation_forces_maturity() {
+        let base = BaseMetadata::new(DummyKey("k"), "n", "d", empty_schema())
+            .with_deprecation(DeprecationNotice::new(semver::Version::new(1, 0, 0)));
+        assert_eq!(base.maturity, MaturityLevel::Deprecated);
+    }
+}

--- a/crates/metadata/src/compat.rs
+++ b/crates/metadata/src/compat.rs
@@ -1,0 +1,9 @@
+//! Version-compatibility helpers shared across metadata families.
+//!
+//! For v1 the only family that versions its metadata is
+//! [`ActionMetadata`](../../nebula_action/struct.ActionMetadata.html); the
+//! canonical compatibility rules live in `nebula-action` because they
+//! reference action-specific fields (ports, isolation level).
+//!
+//! This module reserves the name and is expected to grow as credentials
+//! and resources gain their own versioned evolution stories.

--- a/crates/metadata/src/deprecation.rs
+++ b/crates/metadata/src/deprecation.rs
@@ -1,0 +1,93 @@
+//! Structured deprecation notice attached to metadata entries.
+
+use semver::Version;
+use serde::{Deserialize, Serialize};
+
+/// Deprecation payload describing when a catalog entity became deprecated,
+/// when it will be removed, and what replaces it.
+///
+/// Attached to [`BaseMetadata::deprecation`](crate::BaseMetadata::deprecation);
+/// present implies [`MaturityLevel::Deprecated`](crate::MaturityLevel::Deprecated)
+/// is usually also set.
+///
+/// Fields are intentionally permissive strings where a typed value would
+/// force premature precision: `sunset` can be an ISO date, a version, or a
+/// milestone identifier depending on how the team plans removal.
+/// `replacement` is a serialized entity key (e.g. `"http.request.v2"`),
+/// not a typed key, because the replacement may live in a different
+/// entity family (an `action` deprecated in favor of a `resource`).
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeprecationNotice {
+    /// Version in which the deprecation was introduced.
+    pub since: Version,
+    /// When the entity will be removed — ISO date, version string, or
+    /// free-form milestone. `None` if no removal date is set yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sunset: Option<String>,
+    /// Serialized key of the replacement entity, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub replacement: Option<String>,
+    /// Human-readable reason shown in the catalog UI.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl DeprecationNotice {
+    /// Build a deprecation notice with only the required `since` version set.
+    #[must_use]
+    pub fn new(since: Version) -> Self {
+        Self {
+            since,
+            sunset: None,
+            replacement: None,
+            reason: None,
+        }
+    }
+
+    /// Declare when the entity is scheduled for removal.
+    #[must_use]
+    pub fn sunset(mut self, sunset: impl Into<String>) -> Self {
+        self.sunset = Some(sunset.into());
+        self
+    }
+
+    /// Declare the replacement entity key.
+    #[must_use]
+    pub fn replacement(mut self, key: impl Into<String>) -> Self {
+        self.replacement = Some(key.into());
+        self
+    }
+
+    /// Set the human-readable reason.
+    #[must_use]
+    pub fn reason(mut self, reason: impl Into<String>) -> Self {
+        self.reason = Some(reason.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minimal_notice_roundtrip() {
+        let notice = DeprecationNotice::new(Version::new(1, 2, 0));
+        let s = serde_json::to_string(&notice).unwrap();
+        // `sunset`/`replacement`/`reason` skip-serialize when None.
+        assert_eq!(s, r#"{"since":"1.2.0"}"#);
+        let back: DeprecationNotice = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, notice);
+    }
+
+    #[test]
+    fn full_notice_builder() {
+        let notice = DeprecationNotice::new(Version::new(2, 0, 0))
+            .sunset("2026-07-01")
+            .replacement("http.request.v2")
+            .reason("superseded by unified HTTP node");
+        assert_eq!(notice.sunset.as_deref(), Some("2026-07-01"));
+        assert_eq!(notice.replacement.as_deref(), Some("http.request.v2"));
+    }
+}

--- a/crates/metadata/src/icon.rs
+++ b/crates/metadata/src/icon.rs
@@ -1,0 +1,104 @@
+//! Catalog icon — exactly one valid representation at a time.
+
+use serde::{Deserialize, Serialize};
+
+/// Icon for a catalog entity (action, credential, resource, …).
+///
+/// Replaces the earlier `icon: Option<String> + icon_url: Option<String>`
+/// pair, which allowed invalid combinations (both set, inconsistent).
+///
+/// Serialized untagged so the wire format stays compact:
+/// - [`Icon::None`] → omitted when the field uses `skip_serializing_if`; otherwise serializes as
+///   `null`.
+/// - [`Icon::Inline`] → a bare string, e.g. `"github"` or `"🔑"`.
+/// - [`Icon::Url`] → a `{ "url": "https://..." }` object.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Icon {
+    /// No icon declared.
+    #[default]
+    None,
+    /// Inline identifier — an icon name understood by the UI catalog, a
+    /// Material icon id, or a raw emoji glyph.
+    Inline(String),
+    /// Absolute or root-relative URL pointing to a custom icon asset.
+    Url {
+        /// Icon URL (absolute or root-relative).
+        url: String,
+    },
+}
+
+impl Icon {
+    /// Build an inline icon (e.g. `"github"`, `"🔑"`).
+    #[must_use]
+    pub fn inline(name: impl Into<String>) -> Self {
+        Self::Inline(name.into())
+    }
+
+    /// Build a URL-backed icon.
+    #[must_use]
+    pub fn url(url: impl Into<String>) -> Self {
+        Self::Url { url: url.into() }
+    }
+
+    /// Return the inline icon name, if this variant is [`Icon::Inline`].
+    #[must_use]
+    pub fn as_inline(&self) -> Option<&str> {
+        match self {
+            Icon::Inline(s) => Some(s.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Return the icon URL, if this variant is [`Icon::Url`].
+    #[must_use]
+    pub fn as_url(&self) -> Option<&str> {
+        match self {
+            Icon::Url { url } => Some(url.as_str()),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` iff this is [`Icon::None`].
+    #[must_use]
+    pub fn is_none(&self) -> bool {
+        matches!(self, Icon::None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_roundtrip() {
+        let i = Icon::inline("github");
+        let s = serde_json::to_string(&i).unwrap();
+        assert_eq!(s, r#""github""#);
+        let back: Icon = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn url_roundtrip() {
+        let i = Icon::url("https://example.com/icon.svg");
+        let s = serde_json::to_string(&i).unwrap();
+        assert_eq!(s, r#"{"url":"https://example.com/icon.svg"}"#);
+        let back: Icon = serde_json::from_str(&s).unwrap();
+        assert_eq!(back, i);
+    }
+
+    #[test]
+    fn accessors_match_variant() {
+        let inline = Icon::inline("x");
+        assert_eq!(inline.as_inline(), Some("x"));
+        assert_eq!(inline.as_url(), None);
+
+        let url = Icon::url("/a");
+        assert_eq!(url.as_url(), Some("/a"));
+        assert_eq!(url.as_inline(), None);
+
+        assert!(Icon::None.is_none());
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -19,7 +19,6 @@
 //!
 //! ```no_run
 //! use nebula_metadata::{BaseMetadata, Icon, MaturityLevel, Metadata};
-//! # use nebula_schema::{Schema, ValidSchema};
 //!
 //! pub struct MyKey;
 //!

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -9,7 +9,7 @@
 //!   inputs,
 //! - optional catalog ornaments — [`icon`](Metadata::icon), documentation URL,
 //!   [`tags`](Metadata::tags),
-//! - a [`MaturityLevel`](MaturityLevel) and optional [`DeprecationNotice`](DeprecationNotice).
+//! - a [`MaturityLevel`] and optional [`DeprecationNotice`].
 //!
 //! This crate owns those shared concerns as concrete types and a small trait,
 //! so each business-layer crate (action, credential, resource, …) composes
@@ -21,7 +21,8 @@
 //! use nebula_metadata::{BaseMetadata, Icon, MaturityLevel, Metadata};
 //! # use nebula_schema::{Schema, ValidSchema};
 //!
-//! # struct MyKey;
+//! pub struct MyKey;
+//!
 //! pub struct MyEntityMetadata {
 //!     pub base: BaseMetadata<MyKey>,
 //!     pub extra_field: u32,

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -1,0 +1,55 @@
+//! `nebula-metadata` — shared metadata shapes for named, schematized entities.
+//!
+//! Every "catalog citizen" in Nebula — an action, a credential, a resource,
+//! a trigger, a future plugin — shares the same surface:
+//!
+//! - a typed [`key`](Metadata::key) that identifies it,
+//! - a human-readable [`name`](Metadata::name) and [`description`](Metadata::description),
+//! - a canonical [`ValidSchema`](nebula_schema::ValidSchema) describing its user-configurable
+//!   inputs,
+//! - optional catalog ornaments — [`icon`](Metadata::icon), documentation URL,
+//!   [`tags`](Metadata::tags),
+//! - a [`MaturityLevel`](MaturityLevel) and optional [`DeprecationNotice`](DeprecationNotice).
+//!
+//! This crate owns those shared concerns as concrete types and a small trait,
+//! so each business-layer crate (action, credential, resource, …) composes
+//! them instead of redeclaring the same prefix with incompatible field names.
+//!
+//! # Shape
+//!
+//! ```no_run
+//! use nebula_metadata::{BaseMetadata, Icon, MaturityLevel, Metadata};
+//! # use nebula_schema::{Schema, ValidSchema};
+//!
+//! # struct MyKey;
+//! pub struct MyEntityMetadata {
+//!     pub base: BaseMetadata<MyKey>,
+//!     pub extra_field: u32,
+//! }
+//!
+//! impl Metadata for MyEntityMetadata {
+//!     type Key = MyKey;
+//!     fn base(&self) -> &BaseMetadata<Self::Key> {
+//!         &self.base
+//!     }
+//! }
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+/// Core [`BaseMetadata`] struct and [`Metadata`] trait.
+pub mod base;
+/// Version-compatibility helpers shared across metadata families.
+pub mod compat;
+/// [`DeprecationNotice`] — standard deprecation payload.
+pub mod deprecation;
+/// [`Icon`] enum — one valid representation for catalog icons.
+pub mod icon;
+/// [`MaturityLevel`] — `Experimental / Beta / Stable / Deprecated`.
+pub mod maturity;
+
+pub use base::{BaseMetadata, Metadata};
+pub use deprecation::DeprecationNotice;
+pub use icon::Icon;
+pub use maturity::MaturityLevel;

--- a/crates/metadata/src/maturity.rs
+++ b/crates/metadata/src/maturity.rs
@@ -1,0 +1,66 @@
+//! Maturity level for a catalog entity.
+//!
+//! Mirrors the vocabulary used in `docs/MATURITY.md` — the per-crate table
+//! that tracks which surfaces are frontier-experimental vs. stable. Every
+//! metadata entry now declares its own maturity in code, not only in docs.
+
+use serde::{Deserialize, Serialize};
+
+/// Declared stability level of a catalog entity.
+///
+/// Default is [`MaturityLevel::Stable`] so authors that never touch the
+/// field don't accidentally ship experimental code as frontier — if a
+/// surface is experimental, the author must state it explicitly.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MaturityLevel {
+    /// Actively iterated, public surface may break without notice.
+    Experimental,
+    /// Stabilizing — breaking changes require a deprecation cycle.
+    Beta,
+    /// Stable surface — breaking changes require a major version bump.
+    #[default]
+    Stable,
+    /// Scheduled for removal — use [`DeprecationNotice`](crate::DeprecationNotice)
+    /// to describe when and what replaces it.
+    Deprecated,
+}
+
+impl MaturityLevel {
+    /// Returns `true` for [`Self::Experimental`] and [`Self::Beta`] — the
+    /// levels where breaking changes can land without a major bump.
+    #[must_use]
+    pub fn is_unstable(self) -> bool {
+        matches!(self, Self::Experimental | Self::Beta)
+    }
+
+    /// Returns `true` for [`Self::Deprecated`].
+    #[must_use]
+    pub fn is_deprecated(self) -> bool {
+        matches!(self, Self::Deprecated)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_stable() {
+        assert_eq!(MaturityLevel::default(), MaturityLevel::Stable);
+        assert!(!MaturityLevel::default().is_unstable());
+    }
+
+    #[test]
+    fn serde_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&MaturityLevel::Experimental).unwrap(),
+            r#""experimental""#
+        );
+        assert_eq!(
+            serde_json::from_str::<MaturityLevel>(r#""deprecated""#).unwrap(),
+            MaturityLevel::Deprecated
+        );
+    }
+}

--- a/crates/metadata/src/maturity.rs
+++ b/crates/metadata/src/maturity.rs
@@ -53,7 +53,7 @@ mod tests {
     }
 
     #[test]
-    fn serde_kebab_case() {
+    fn serde_snake_case() {
         assert_eq!(
             serde_json::to_string(&MaturityLevel::Experimental).unwrap(),
             r#""experimental""#

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -19,6 +19,7 @@ default = []
 nebula-core = { path = "../core" }
 nebula-metrics = { path = "../metrics" }
 nebula-resilience = { path = "../resilience" }
+nebula-metadata = { path = "../metadata" }
 nebula-resource-macros = { path = "macros" }
 nebula-schema = { path = "../schema" }
 nebula-telemetry = { path = "../telemetry" }

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -20,6 +20,7 @@ nebula-core = { path = "../core" }
 nebula-metrics = { path = "../metrics" }
 nebula-resilience = { path = "../resilience" }
 nebula-resource-macros = { path = "macros" }
+nebula-schema = { path = "../schema" }
 nebula-telemetry = { path = "../telemetry" }
 
 # Async runtime

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -28,7 +28,12 @@ pub trait AnyResource: Send + Sync + 'static {
 ///
 /// Implementors typically derive `serde::Deserialize` and hold fields like
 /// host, port, pool size, timeouts, etc.
-pub trait ResourceConfig: Send + Sync + Clone + 'static {
+///
+/// Must implement [`HasSchema`](nebula_schema::HasSchema) so the resource
+/// metadata can auto-derive its configuration schema from the config type.
+/// Use `()` / `bool` / `String` for schema-less stubs — baseline impls in
+/// `nebula-schema` cover primitives with empty schemas.
+pub trait ResourceConfig: nebula_schema::HasSchema + Send + Sync + Clone + 'static {
     /// Validates the configuration, returning an error if invalid.
     ///
     /// The default implementation accepts all configurations.

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -51,27 +51,67 @@ pub trait ResourceConfig: nebula_schema::HasSchema + Send + Sync + Clone + 'stat
 }
 
 /// Resource metadata for UI and diagnostics.
+///
+/// The shared catalog prefix (`key`, `name`, `description`, `schema`, `icon`,
+/// `documentation_url`, `tags`, `maturity`, `deprecation`) lives on the
+/// composed [`BaseMetadata`](nebula_metadata::BaseMetadata). Resource has no
+/// additional top-level metadata fields today — every catalog-level concern
+/// lives on the shared base.
+#[non_exhaustive]
 #[derive(Debug, Clone)]
 pub struct ResourceMetadata {
-    /// The unique key identifying this resource type.
-    pub key: ResourceKey,
-    /// Human-readable name.
-    pub name: String,
-    /// Optional longer description.
-    pub description: Option<String>,
-    /// Freeform tags for categorization.
-    pub tags: Vec<String>,
+    /// Shared catalog prefix.
+    pub base: nebula_metadata::BaseMetadata<ResourceKey>,
+}
+
+impl nebula_metadata::Metadata for ResourceMetadata {
+    type Key = ResourceKey;
+    fn base(&self) -> &nebula_metadata::BaseMetadata<ResourceKey> {
+        &self.base
+    }
 }
 
 impl ResourceMetadata {
-    /// Creates metadata with defaults derived from a resource key.
-    pub fn from_key(key: &ResourceKey) -> Self {
+    /// Build resource metadata with explicit catalog-level fields.
+    pub fn new(
+        key: ResourceKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+        schema: nebula_schema::ValidSchema,
+    ) -> Self {
         Self {
-            key: key.clone(),
-            name: key.to_string(),
-            description: None,
-            tags: Vec::new(),
+            base: nebula_metadata::BaseMetadata::new(key, name, description, schema),
         }
+    }
+
+    /// Build resource metadata whose schema is auto-derived from a
+    /// [`Resource`] implementation's `Config` type.
+    pub fn for_resource<R>(
+        key: ResourceKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self
+    where
+        R: Resource,
+    {
+        Self::new(
+            key,
+            name,
+            description,
+            <R::Config as nebula_schema::HasSchema>::schema(),
+        )
+    }
+
+    /// Create minimal metadata derived from a key — uses the key as the
+    /// display name, an empty description, and an empty schema. Convenient
+    /// for in-process resources that never show up in a user-facing catalog.
+    pub fn from_key(key: &ResourceKey) -> Self {
+        Self::new(
+            key.clone(),
+            key.to_string(),
+            String::new(),
+            nebula_schema::ValidSchema::empty(),
+        )
     }
 }
 

--- a/crates/resource/src/runtime/daemon.rs
+++ b/crates/resource/src/runtime/daemon.rs
@@ -278,6 +278,8 @@ mod tests {
     #[derive(Clone, Debug, Default)]
     struct EmptyCfg;
 
+    nebula_schema::impl_empty_has_schema!(EmptyCfg);
+
     impl ResourceConfig for EmptyCfg {
         fn fingerprint(&self) -> u64 {
             0

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -986,6 +986,8 @@ mod tests {
     #[derive(Clone)]
     struct PoolTestConfig;
 
+    nebula_schema::impl_empty_has_schema!(PoolTestConfig);
+
     impl ResourceConfig for PoolTestConfig {
         fn validate(&self) -> Result<(), Error> {
             Ok(())

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -65,6 +65,8 @@ struct TestConfig {
     name: String,
 }
 
+nebula_schema::impl_empty_has_schema!(TestConfig);
+
 impl ResourceConfig for TestConfig {
     fn validate(&self) -> Result<(), Error> {
         if self.name.is_empty() {
@@ -3556,6 +3558,8 @@ struct ReloadConfig {
     fingerprint: u64,
     valid: bool,
 }
+
+nebula_schema::impl_empty_has_schema!(ReloadConfig);
 
 impl ReloadConfig {
     fn new(fingerprint: u64) -> Self {

--- a/crates/resource/tests/dx_audit.rs
+++ b/crates/resource/tests/dx_audit.rs
@@ -102,6 +102,8 @@ struct HttpClientConfig {
     pool_size: u32,
 }
 
+nebula_schema::impl_empty_has_schema!(HttpClientConfig);
+
 impl ResourceConfig for HttpClientConfig {}
 
 // FRICTION NOTE [ResourceConfig::validate]: The default impl accepts
@@ -279,6 +281,8 @@ struct ConfigStoreConfig {
     path: String,
 }
 
+nebula_schema::impl_empty_has_schema!(ConfigStoreConfig);
+
 impl ResourceConfig for ConfigStoreConfig {}
 
 #[derive(Clone)]
@@ -400,6 +404,8 @@ struct FakeDbConnection {
 struct DbConfig {
     host: String,
 }
+
+nebula_schema::impl_empty_has_schema!(DbConfig);
 
 impl ResourceConfig for DbConfig {
     fn validate(&self) -> Result<(), Error> {
@@ -598,6 +604,7 @@ async fn error_handling_invalid_config_validate() {
 
     #[derive(Clone)]
     struct AlwaysInvalidConfig;
+    nebula_schema::impl_empty_has_schema!(AlwaysInvalidConfig);
     impl ResourceConfig for AlwaysInvalidConfig {
         fn validate(&self) -> Result<(), Error> {
             Err(Error::permanent("invalid config"))

--- a/crates/resource/tests/dx_evaluation.rs
+++ b/crates/resource/tests/dx_evaluation.rs
@@ -60,6 +60,8 @@ struct HttpConfig {
     base_url: String,
 }
 
+nebula_schema::impl_empty_has_schema!(HttpConfig);
+
 impl ResourceConfig for HttpConfig {
     fn validate(&self) -> Result<(), Error> {
         if self.base_url.is_empty() {
@@ -201,6 +203,8 @@ struct ConfigStoreConfig {
     env: String,
 }
 
+nebula_schema::impl_empty_has_schema!(ConfigStoreConfig);
+
 impl ResourceConfig for ConfigStoreConfig {}
 
 /// Our config store runtime — an in-memory map.
@@ -304,6 +308,8 @@ struct DbConfig {
     dsn: String,
     pool_size: u32,
 }
+
+nebula_schema::impl_empty_has_schema!(DbConfig);
 
 impl ResourceConfig for DbConfig {
     fn validate(&self) -> Result<(), Error> {

--- a/crates/runtime/src/registry.rs
+++ b/crates/runtime/src/registry.rs
@@ -57,14 +57,17 @@ impl ActionRegistry {
     /// is appended. Entries are kept sorted from lowest to highest version so
     /// that [`get`](Self::get) can return the latest in O(1).
     pub fn register(&self, metadata: ActionMetadata, handler: ActionHandler) {
-        let version = metadata.version.clone();
-        let mut entries = self.actions.entry(metadata.key.clone()).or_default();
+        let version = metadata.base.version.clone();
+        let mut entries = self.actions.entry(metadata.base.key.clone()).or_default();
 
-        if let Some(pos) = entries.iter().position(|e| e.metadata.version == version) {
+        if let Some(pos) = entries
+            .iter()
+            .position(|e| e.metadata.base.version == version)
+        {
             entries[pos] = ActionEntry { metadata, handler };
         } else {
             entries.push(ActionEntry { metadata, handler });
-            entries.sort_by(|a, b| a.metadata.version.cmp(&b.metadata.version));
+            entries.sort_by(|a, b| a.metadata.base.version.cmp(&b.metadata.base.version));
         }
     }
 
@@ -97,7 +100,9 @@ impl ActionRegistry {
         version: &Version,
     ) -> Option<(ActionMetadata, ActionHandler)> {
         let entries = self.actions.get(key)?;
-        let entry = entries.iter().find(|e| e.metadata.version == *version)?;
+        let entry = entries
+            .iter()
+            .find(|e| e.metadata.base.version == *version)?;
         Some((entry.metadata.clone(), entry.handler.clone()))
     }
 
@@ -316,6 +321,6 @@ mod tests {
         assert!(registry.get_versioned(&key, &v2).is_some());
 
         let (meta, _) = registry.get(&key).unwrap();
-        assert_eq!(meta.version, v2);
+        assert_eq!(meta.base.version, v2);
     }
 }

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -419,7 +419,7 @@ impl ActionRuntime {
             // fail-closed until we explicitly wire dispatch for it.
             _ => Err(ActionError::fatal(format!(
                 "unknown isolation level for action '{}' — refusing to dispatch",
-                metadata.key.as_str()
+                metadata.base.key.as_str()
             ))),
         }
     }
@@ -501,7 +501,7 @@ impl ActionRuntime {
                 Ok(None) => (handler.init_state()?, 0u32),
                 Err(load_err) => {
                     tracing::warn!(
-                        action_key = %metadata.key.as_str(),
+                        action_key = %metadata.base.key.as_str(),
                         execution_id = %context.execution_id,
                         node_key = %context.node_key,
                         error = %load_err,
@@ -523,7 +523,7 @@ impl ActionRuntime {
             if iteration >= MAX_ITERATIONS {
                 return Err(ActionError::fatal(format!(
                     "stateful action '{}' exceeded max iterations ({MAX_ITERATIONS})",
-                    metadata.key.as_str()
+                    metadata.base.key.as_str()
                 )));
             }
 
@@ -589,7 +589,7 @@ impl ActionRuntime {
                         && let Err(clear_err) = sink.clear().await
                     {
                         tracing::warn!(
-                            action_key = %metadata.key.as_str(),
+                            action_key = %metadata.base.key.as_str(),
                             execution_id = %context.execution_id,
                             node_key = %context.node_key,
                             error = %clear_err,

--- a/crates/sandbox/src/discovery.rs
+++ b/crates/sandbox/src/discovery.rs
@@ -281,7 +281,7 @@ mod tests {
 
         let handlers = create_handlers(&plugin, sandbox);
         assert_eq!(handlers.len(), 1);
-        assert_eq!(handlers[0].0.key.as_str(), "com.good.plugin.echo");
+        assert_eq!(handlers[0].0.base.key.as_str(), "com.good.plugin.echo");
     }
 
     #[test]
@@ -303,8 +303,8 @@ mod tests {
 
         let handlers = create_handlers(&plugin, sandbox);
         assert_eq!(handlers.len(), 1);
-        assert_eq!(handlers[0].0.version.major, 2);
-        assert_eq!(handlers[0].0.version.minor, 7);
-        assert_eq!(handlers[0].0.version.patch, 3);
+        assert_eq!(handlers[0].0.base.version.major, 2);
+        assert_eq!(handlers[0].0.base.version.minor, 7);
+        assert_eq!(handlers[0].0.base.version.patch, 3);
     }
 }

--- a/crates/sandbox/src/in_process.rs
+++ b/crates/sandbox/src/in_process.rs
@@ -35,13 +35,13 @@ impl SandboxRunner for InProcessSandbox {
         input: serde_json::Value,
     ) -> Result<ActionResult<serde_json::Value>, ActionError> {
         tracing::debug!(
-            action_key = %metadata.key,
+            action_key = %metadata.base.key,
             "executing action in-process"
         );
         context.check_cancelled()?;
         let result = (self.executor)(context, metadata, input).await;
         if let Err(e) = &result {
-            tracing::warn!(action_key = %metadata.key, error = %e, "action failed");
+            tracing::warn!(action_key = %metadata.base.key, error = %e, "action failed");
         }
         result
     }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -610,7 +610,7 @@ impl SandboxRunner for ProcessSandbox {
     ) -> Result<ActionResult<serde_json::Value>, ActionError> {
         context.check_cancelled()?;
 
-        let action_key = metadata.key.as_str();
+        let action_key = metadata.base.key.as_str();
 
         tracing::debug!(
             action_key = %action_key,

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -1,0 +1,356 @@
+//! Attribute parsers for `#[derive(Schema)]` / `#[derive(EnumSelect)]`.
+//!
+//! Three namespaces are recognised:
+//!
+//! - `#[param(...)]`     — UI / metadata options (label, hint, default, secret, multiline…)
+//! - `#[validate(...)]`  — value rules (required, length, range, pattern, url, email)
+//! - `#[schema(...)]`    — struct-level (rename_all, custom)
+//!
+//! The parsers are intentionally forgiving on ordering and strict on
+//! semantics: unknown keys inside a namespace produce a compile error at
+//! the offending token, not a silent skip.
+
+use syn::{
+    Attribute, Expr, ExprLit, Lit, LitInt, LitStr, Token,
+    parse::{Parse, ParseStream},
+    punctuated::Punctuated,
+};
+
+/// Options gathered from `#[param(...)]` on a struct field or enum variant.
+#[derive(Default, Debug)]
+pub(crate) struct ParamAttrs {
+    pub label: Option<String>,
+    pub description: Option<String>,
+    pub placeholder: Option<String>,
+    pub default: Option<String>,
+    pub hint: Option<String>,
+    pub secret: bool,
+    pub multiline: bool,
+    pub no_expression: bool,
+    pub expression_required: bool,
+    pub group: Option<String>,
+    pub skip: bool,
+}
+
+/// Options gathered from `#[validate(...)]`.
+#[derive(Default, Debug)]
+pub(crate) struct ValidateAttrs {
+    pub required: bool,
+    pub min_length: Option<usize>,
+    pub max_length: Option<usize>,
+    pub min: Option<i64>,
+    pub max: Option<i64>,
+    pub pattern: Option<String>,
+    pub url: bool,
+    pub email: bool,
+}
+
+/// Struct-level `#[schema(...)]` options.
+#[derive(Default, Debug)]
+pub(crate) struct SchemaAttrs {
+    pub rename_all: Option<String>,
+}
+
+impl ParamAttrs {
+    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        let mut out = Self::default();
+        for attr in attrs.iter().filter(|a| a.path().is_ident("param")) {
+            let entries: Punctuated<ParamEntry, Token![,]> =
+                attr.parse_args_with(Punctuated::parse_terminated)?;
+            for entry in entries {
+                entry.apply(&mut out)?;
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl ValidateAttrs {
+    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        let mut out = Self::default();
+        for attr in attrs.iter().filter(|a| a.path().is_ident("validate")) {
+            let entries: Punctuated<ValidateEntry, Token![,]> =
+                attr.parse_args_with(Punctuated::parse_terminated)?;
+            for entry in entries {
+                entry.apply(&mut out)?;
+            }
+        }
+        Ok(out)
+    }
+}
+
+impl SchemaAttrs {
+    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+        let mut out = Self::default();
+        for attr in attrs.iter().filter(|a| a.path().is_ident("schema")) {
+            let entries: Punctuated<SchemaEntry, Token![,]> =
+                attr.parse_args_with(Punctuated::parse_terminated)?;
+            for entry in entries {
+                entry.apply(&mut out)?;
+            }
+        }
+        Ok(out)
+    }
+}
+
+// ── Per-namespace entry enums ─────────────────────────────────────────────
+
+enum ParamEntry {
+    KeyValue { name: syn::Ident, value: Lit },
+    Flag(syn::Ident),
+}
+
+impl ParamEntry {
+    fn apply(self, out: &mut ParamAttrs) -> syn::Result<()> {
+        match self {
+            ParamEntry::KeyValue { name, value } => {
+                let key = name.to_string();
+                let string_lit = |lit: &Lit, field: &str| -> syn::Result<String> {
+                    if let Lit::Str(s) = lit {
+                        Ok(s.value())
+                    } else {
+                        Err(syn::Error::new(
+                            name.span(),
+                            format!("`{field}` expects a string literal"),
+                        ))
+                    }
+                };
+                match key.as_str() {
+                    "label" => out.label = Some(string_lit(&value, "label")?),
+                    "description" => out.description = Some(string_lit(&value, "description")?),
+                    "placeholder" => out.placeholder = Some(string_lit(&value, "placeholder")?),
+                    "default" => out.default = Some(string_lit(&value, "default")?),
+                    "hint" => out.hint = Some(string_lit(&value, "hint")?),
+                    "group" => out.group = Some(string_lit(&value, "group")?),
+                    other => {
+                        return Err(syn::Error::new(
+                            name.span(),
+                            format!("unknown #[param(..)] option `{other}`"),
+                        ));
+                    },
+                }
+                Ok(())
+            },
+            ParamEntry::Flag(name) => {
+                match name.to_string().as_str() {
+                    "secret" => out.secret = true,
+                    "multiline" => out.multiline = true,
+                    "no_expression" => out.no_expression = true,
+                    "expression_required" => out.expression_required = true,
+                    "skip" => out.skip = true,
+                    other => {
+                        return Err(syn::Error::new(
+                            name.span(),
+                            format!("unknown #[param(..)] flag `{other}`"),
+                        ));
+                    },
+                }
+                Ok(())
+            },
+        }
+    }
+}
+
+impl Parse for ParamEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: syn::Ident = input.parse()?;
+        if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            let value: Lit = input.parse()?;
+            Ok(ParamEntry::KeyValue { name, value })
+        } else {
+            Ok(ParamEntry::Flag(name))
+        }
+    }
+}
+
+enum ValidateEntry {
+    Flag(syn::Ident),
+    Length {
+        min: Option<usize>,
+        max: Option<usize>,
+    },
+    Range {
+        min: Option<i64>,
+        max: Option<i64>,
+    },
+    Pattern(String),
+}
+
+impl ValidateEntry {
+    fn apply(self, out: &mut ValidateAttrs) -> syn::Result<()> {
+        match self {
+            ValidateEntry::Flag(name) => {
+                match name.to_string().as_str() {
+                    "required" => out.required = true,
+                    "url" => out.url = true,
+                    "email" => out.email = true,
+                    other => {
+                        return Err(syn::Error::new(
+                            name.span(),
+                            format!("unknown #[validate(..)] flag `{other}`"),
+                        ));
+                    },
+                }
+                Ok(())
+            },
+            ValidateEntry::Length { min, max } => {
+                out.min_length = min;
+                out.max_length = max;
+                Ok(())
+            },
+            ValidateEntry::Range { min, max } => {
+                out.min = min;
+                out.max = max;
+                Ok(())
+            },
+            ValidateEntry::Pattern(pat) => {
+                out.pattern = Some(pat);
+                Ok(())
+            },
+        }
+    }
+}
+
+impl Parse for ValidateEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: syn::Ident = input.parse()?;
+        let key = name.to_string();
+        if input.peek(syn::token::Paren) {
+            // e.g. `length(min = 1, max = 100)` or `range(1..=300)`
+            let content;
+            syn::parenthesized!(content in input);
+            match key.as_str() {
+                "length" => parse_length(&content),
+                "range" => parse_range(&content),
+                other => Err(syn::Error::new(
+                    name.span(),
+                    format!("unknown #[validate(..)] function `{other}`"),
+                )),
+            }
+        } else if input.peek(Token![=]) {
+            input.parse::<Token![=]>()?;
+            let lit: Lit = input.parse()?;
+            if key == "pattern" {
+                if let Lit::Str(s) = &lit {
+                    let _ = name;
+                    Ok(ValidateEntry::Pattern(s.value()))
+                } else {
+                    Err(syn::Error::new(
+                        name.span(),
+                        "#[validate(pattern = ..)] expects a string literal",
+                    ))
+                }
+            } else {
+                Err(syn::Error::new(
+                    name.span(),
+                    format!("unknown #[validate(..)] option `{key}`"),
+                ))
+            }
+        } else {
+            Ok(ValidateEntry::Flag(name))
+        }
+    }
+}
+
+fn parse_length(input: ParseStream) -> syn::Result<ValidateEntry> {
+    let mut min = None;
+    let mut max = None;
+    let entries: Punctuated<LengthEntry, Token![,]> = Punctuated::parse_terminated(input)?;
+    for entry in entries {
+        match entry {
+            LengthEntry::Min(v) => min = Some(v),
+            LengthEntry::Max(v) => max = Some(v),
+        }
+    }
+    Ok(ValidateEntry::Length { min, max })
+}
+
+enum LengthEntry {
+    Min(usize),
+    Max(usize),
+}
+
+impl Parse for LengthEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: syn::Ident = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let lit: LitInt = input.parse()?;
+        let v: usize = lit.base10_parse()?;
+        match name.to_string().as_str() {
+            "min" => Ok(LengthEntry::Min(v)),
+            "max" => Ok(LengthEntry::Max(v)),
+            other => Err(syn::Error::new(
+                name.span(),
+                format!("#[validate(length(..))] key must be `min` or `max`, got `{other}`"),
+            )),
+        }
+    }
+}
+
+fn parse_range(input: ParseStream) -> syn::Result<ValidateEntry> {
+    // Accept `min..=max`, `min..max`, or standalone ranges.
+    let expr: Expr = input.parse()?;
+    let (min, max) = match expr {
+        Expr::Range(r) => {
+            let min = r.start.as_deref().and_then(lit_to_i64);
+            let max = match (r.end.as_deref(), r.limits) {
+                (Some(end), syn::RangeLimits::Closed(_)) => lit_to_i64(end),
+                (Some(end), syn::RangeLimits::HalfOpen(_)) => lit_to_i64(end).map(|v| v - 1),
+                (None, _) => None,
+            };
+            (min, max)
+        },
+        other => {
+            return Err(syn::Error::new_spanned(
+                other,
+                "#[validate(range(..))] expects a range expression",
+            ));
+        },
+    };
+    Ok(ValidateEntry::Range { min, max })
+}
+
+fn lit_to_i64(expr: &Expr) -> Option<i64> {
+    if let Expr::Lit(ExprLit {
+        lit: Lit::Int(i), ..
+    }) = expr
+    {
+        i.base10_parse::<i64>().ok()
+    } else {
+        None
+    }
+}
+
+enum SchemaEntry {
+    RenameAll(String),
+}
+
+impl SchemaEntry {
+    fn apply(self, out: &mut SchemaAttrs) -> syn::Result<()> {
+        match self {
+            SchemaEntry::RenameAll(v) => {
+                out.rename_all = Some(v);
+                Ok(())
+            },
+        }
+    }
+}
+
+impl Parse for SchemaEntry {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let name: syn::Ident = input.parse()?;
+        input.parse::<Token![=]>()?;
+        let lit: LitStr = input.parse()?;
+        match name.to_string().as_str() {
+            "rename_all" => {
+                let _ = name;
+                Ok(SchemaEntry::RenameAll(lit.value()))
+            },
+            other => Err(syn::Error::new(
+                name.span(),
+                format!("unknown #[schema(..)] option `{other}`"),
+            )),
+        }
+    }
+}

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -1,10 +1,13 @@
 //! Attribute parsers for `#[derive(Schema)]` / `#[derive(EnumSelect)]`.
 //!
-//! Three namespaces are recognised:
+//! Two namespaces are recognised today:
 //!
 //! - `#[param(...)]`     — UI / metadata options (label, hint, default, secret, multiline…)
 //! - `#[validate(...)]`  — value rules (required, length, range, pattern, url, email)
-//! - `#[schema(...)]`    — struct-level (rename_all, custom)
+//!
+//! Struct-level `#[schema(...)]` is reserved for a future pass (no options
+//! functional today) — removed from the derive's attribute list so the
+//! name stays free until the implementation lands.
 //!
 //! The parsers are intentionally forgiving on ordering and strict on
 //! semantics: unknown keys inside a namespace produce a compile error at

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -11,7 +11,7 @@
 //! the offending token, not a silent skip.
 
 use syn::{
-    Attribute, Expr, ExprLit, Lit, LitInt, LitStr, Token,
+    Attribute, Expr, ExprLit, Lit, LitInt, Token,
     parse::{Parse, ParseStream},
     punctuated::Punctuated,
 };
@@ -45,12 +45,6 @@ pub(crate) struct ValidateAttrs {
     pub email: bool,
 }
 
-/// Struct-level `#[schema(...)]` options.
-#[derive(Default, Debug)]
-pub(crate) struct SchemaAttrs {
-    pub rename_all: Option<String>,
-}
-
 impl ParamAttrs {
     pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         let mut out = Self::default();
@@ -70,20 +64,6 @@ impl ValidateAttrs {
         let mut out = Self::default();
         for attr in attrs.iter().filter(|a| a.path().is_ident("validate")) {
             let entries: Punctuated<ValidateEntry, Token![,]> =
-                attr.parse_args_with(Punctuated::parse_terminated)?;
-            for entry in entries {
-                entry.apply(&mut out)?;
-            }
-        }
-        Ok(out)
-    }
-}
-
-impl SchemaAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
-        let mut out = Self::default();
-        for attr in attrs.iter().filter(|a| a.path().is_ident("schema")) {
-            let entries: Punctuated<SchemaEntry, Token![,]> =
                 attr.parse_args_with(Punctuated::parse_terminated)?;
             for entry in entries {
                 entry.apply(&mut out)?;
@@ -254,6 +234,7 @@ impl Parse for ValidateEntry {
 }
 
 fn parse_length(input: ParseStream) -> syn::Result<ValidateEntry> {
+    let span = input.span();
     let mut min = None;
     let mut max = None;
     let entries: Punctuated<LengthEntry, Token![,]> = Punctuated::parse_terminated(input)?;
@@ -262,6 +243,14 @@ fn parse_length(input: ParseStream) -> syn::Result<ValidateEntry> {
             LengthEntry::Min(v) => min = Some(v),
             LengthEntry::Max(v) => max = Some(v),
         }
+    }
+    if let (Some(min_v), Some(max_v)) = (min, max)
+        && min_v > max_v
+    {
+        return Err(syn::Error::new(
+            span,
+            format!("#[validate(length(..))]: min ({min_v}) cannot exceed max ({max_v})"),
+        ));
     }
     Ok(ValidateEntry::Length { min, max })
 }
@@ -289,6 +278,7 @@ impl Parse for LengthEntry {
 }
 
 fn parse_range(input: ParseStream) -> syn::Result<ValidateEntry> {
+    let span = input.span();
     // Accept `min..=max`, `min..max`, or standalone ranges.
     let expr: Expr = input.parse()?;
     let (min, max) = match expr {
@@ -308,6 +298,14 @@ fn parse_range(input: ParseStream) -> syn::Result<ValidateEntry> {
             ));
         },
     };
+    if let (Some(min_v), Some(max_v)) = (min, max)
+        && min_v > max_v
+    {
+        return Err(syn::Error::new(
+            span,
+            format!("#[validate(range(..))]: min ({min_v}) cannot exceed max ({max_v})"),
+        ));
+    }
     Ok(ValidateEntry::Range { min, max })
 }
 
@@ -319,38 +317,5 @@ fn lit_to_i64(expr: &Expr) -> Option<i64> {
         i.base10_parse::<i64>().ok()
     } else {
         None
-    }
-}
-
-enum SchemaEntry {
-    RenameAll(String),
-}
-
-impl SchemaEntry {
-    fn apply(self, out: &mut SchemaAttrs) -> syn::Result<()> {
-        match self {
-            SchemaEntry::RenameAll(v) => {
-                out.rename_all = Some(v);
-                Ok(())
-            },
-        }
-    }
-}
-
-impl Parse for SchemaEntry {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
-        let name: syn::Ident = input.parse()?;
-        input.parse::<Token![=]>()?;
-        let lit: LitStr = input.parse()?;
-        match name.to_string().as_str() {
-            "rename_all" => {
-                let _ = name;
-                Ok(SchemaEntry::RenameAll(lit.value()))
-            },
-            other => Err(syn::Error::new(
-                name.span(),
-                format!("unknown #[schema(..)] option `{other}`"),
-            )),
-        }
     }
 }

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -25,7 +25,10 @@ pub(crate) struct ParamAttrs {
     pub label: Option<String>,
     pub description: Option<String>,
     pub placeholder: Option<String>,
-    pub default: Option<String>,
+    /// Default value — stored as a typed literal so the derive can emit
+    /// a correctly-typed `serde_json::Value` for the target field kind
+    /// (number → `Value::Number`, bool → `Value::Bool`, string → `Value::String`).
+    pub default: Option<DefaultLit>,
     pub hint: Option<String>,
     pub secret: bool,
     pub multiline: bool,
@@ -33,6 +36,15 @@ pub(crate) struct ParamAttrs {
     pub expression_required: bool,
     pub group: Option<String>,
     pub skip: bool,
+}
+
+/// Typed literal carried by `#[param(default = ...)]`.
+#[derive(Debug, Clone)]
+pub(crate) enum DefaultLit {
+    Str(String),
+    Int(i64),
+    Float(f64),
+    Bool(bool),
 }
 
 /// Options gathered from `#[validate(...)]`.
@@ -102,7 +114,21 @@ impl ParamEntry {
                     "label" => out.label = Some(string_lit(&value, "label")?),
                     "description" => out.description = Some(string_lit(&value, "description")?),
                     "placeholder" => out.placeholder = Some(string_lit(&value, "placeholder")?),
-                    "default" => out.default = Some(string_lit(&value, "default")?),
+                    "default" => {
+                        out.default = Some(match &value {
+                            Lit::Str(s) => DefaultLit::Str(s.value()),
+                            Lit::Int(i) => DefaultLit::Int(i.base10_parse::<i64>()?),
+                            Lit::Float(f) => DefaultLit::Float(f.base10_parse::<f64>()?),
+                            Lit::Bool(b) => DefaultLit::Bool(b.value),
+                            other => {
+                                return Err(syn::Error::new_spanned(
+                                    other,
+                                    "#[param(default = ..)] expects a string, integer, \
+                                     float, or bool literal",
+                                ));
+                            },
+                        });
+                    },
                     "hint" => out.hint = Some(string_lit(&value, "hint")?),
                     "group" => out.group = Some(string_lit(&value, "group")?),
                     other => {
@@ -286,10 +312,21 @@ fn parse_range(input: ParseStream) -> syn::Result<ValidateEntry> {
     let expr: Expr = input.parse()?;
     let (min, max) = match expr {
         Expr::Range(r) => {
-            let min = r.start.as_deref().and_then(lit_to_i64);
+            let min = match r.start.as_deref() {
+                Some(start) => Some(lit_to_i64(start)?),
+                None => None,
+            };
             let max = match (r.end.as_deref(), r.limits) {
-                (Some(end), syn::RangeLimits::Closed(_)) => lit_to_i64(end),
-                (Some(end), syn::RangeLimits::HalfOpen(_)) => lit_to_i64(end).map(|v| v - 1),
+                (Some(end), syn::RangeLimits::Closed(_)) => Some(lit_to_i64(end)?),
+                (Some(end_expr), syn::RangeLimits::HalfOpen(_)) => {
+                    let end_val = lit_to_i64(end_expr)?;
+                    Some(end_val.checked_sub(1).ok_or_else(|| {
+                        syn::Error::new_spanned(
+                            end_expr,
+                            "#[validate(range(..))]: half-open upper bound underflows i64::MIN",
+                        )
+                    })?)
+                },
                 (None, _) => None,
             };
             (min, max)
@@ -312,13 +349,22 @@ fn parse_range(input: ParseStream) -> syn::Result<ValidateEntry> {
     Ok(ValidateEntry::Range { min, max })
 }
 
-fn lit_to_i64(expr: &Expr) -> Option<i64> {
+/// Parse an integer literal bound for `#[validate(range(..))]`.
+///
+/// Returns a `syn::Error` anchored at the offending expression when the
+/// bound is not an integer literal or does not fit in `i64`; this is
+/// strictly better than the earlier `Option` signature, which silently
+/// dropped invalid bounds and weakened the enforced range.
+fn lit_to_i64(expr: &Expr) -> syn::Result<i64> {
     if let Expr::Lit(ExprLit {
         lit: Lit::Int(i), ..
     }) = expr
     {
-        i.base10_parse::<i64>().ok()
+        i.base10_parse::<i64>()
     } else {
-        None
+        Err(syn::Error::new_spanned(
+            expr,
+            "#[validate(range(..))]: bounds must be integer literals",
+        ))
     }
 }

--- a/crates/schema/macros/src/derive_enum.rs
+++ b/crates/schema/macros/src/derive_enum.rs
@@ -1,0 +1,80 @@
+//! Implementation of `#[derive(EnumSelect)]`.
+//!
+//! Generates `impl HasSelectOptions for T { fn select_options() -> Vec<SelectOption> { ... } }`
+//! — one [`SelectOption`](nebula_schema::SelectOption) per unit variant. Only
+//! unit-style enums are supported; the derive rejects variants that carry
+//! payloads with a compile error.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Data, DataEnum, DeriveInput, Fields};
+
+use crate::attrs::ParamAttrs;
+
+pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let crate_path = crate::crate_path();
+    let ty_name = &input.ident;
+    let generics = &input.generics;
+    let (impl_g, ty_g, where_g) = generics.split_for_impl();
+
+    let variants = match &input.data {
+        Data::Enum(DataEnum { variants, .. }) => variants,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                ty_name,
+                "#[derive(EnumSelect)] only supports enums",
+            ));
+        },
+    };
+
+    let mut option_exprs = Vec::with_capacity(variants.len());
+    for variant in variants {
+        if !matches!(variant.fields, Fields::Unit) {
+            return Err(syn::Error::new_spanned(
+                variant,
+                "#[derive(EnumSelect)] only supports unit variants (no payloads)",
+            ));
+        }
+        let variant_name = &variant.ident;
+        let value = snake_case(&variant_name.to_string());
+        let param = ParamAttrs::from_attrs(&variant.attrs)?;
+        let label = param.label.unwrap_or_else(|| variant_name.to_string());
+        let description = param.description;
+        let mut expr = quote! {
+            #crate_path::SelectOption::new(::serde_json::Value::String(#value.to_owned()), #label)
+        };
+        if let Some(desc) = description {
+            expr = quote! { #expr.with_description(#desc) };
+        }
+        option_exprs.push(expr);
+    }
+
+    Ok(quote! {
+        impl #impl_g #crate_path::HasSelectOptions for #ty_name #ty_g #where_g {
+            fn select_options() -> ::std::vec::Vec<#crate_path::SelectOption> {
+                ::std::vec![
+                    #( #option_exprs ),*
+                ]
+            }
+        }
+    })
+}
+
+/// Convert a `CamelCase` identifier to `snake_case`.
+fn snake_case(ident: &str) -> String {
+    let mut out = String::with_capacity(ident.len() + 4);
+    let mut prev_lower = false;
+    for (i, ch) in ident.chars().enumerate() {
+        if ch.is_ascii_uppercase() {
+            if i > 0 && prev_lower {
+                out.push('_');
+            }
+            out.push(ch.to_ascii_lowercase());
+            prev_lower = false;
+        } else {
+            out.push(ch);
+            prev_lower = ch.is_ascii_lowercase() || ch.is_ascii_digit();
+        }
+    }
+    out
+}

--- a/crates/schema/macros/src/derive_enum.rs
+++ b/crates/schema/macros/src/derive_enum.rs
@@ -4,6 +4,18 @@
 //! — one [`SelectOption`](nebula_schema::SelectOption) per unit variant. Only
 //! unit-style enums are supported; the derive rejects variants that carry
 //! payloads with a compile error.
+//!
+//! # Value encoding
+//!
+//! Each variant's stored value is `snake_case(variant_name)` — this is
+//! **hardcoded** and does not read `serde` attributes. If an enum also
+//! derives `Serialize` / `Deserialize` and intends the catalog options
+//! to round-trip back into the enum, the enum author must pin
+//! `#[serde(rename_all = "snake_case")]` (or `#[serde(rename = "...")]`
+//! per variant) to match. Reading serde attrs here is tracked for a
+//! follow-up — at this point in the lifecycle the only consumers of
+//! `EnumSelect` are not also `Serialize`-derivers, so hardcoding the
+//! safe default is the simplest honest implementation.
 
 use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -8,7 +8,7 @@ use quote::quote;
 use syn::{Data, DataStruct, DeriveInput, Fields, Ident};
 
 use crate::{
-    attrs::{ParamAttrs, SchemaAttrs, ValidateAttrs},
+    attrs::{ParamAttrs, ValidateAttrs},
     type_infer::{FieldKind, classify},
 };
 
@@ -17,8 +17,6 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
     let ty_name = &input.ident;
     let generics = &input.generics;
     let (impl_g, ty_g, where_g) = generics.split_for_impl();
-
-    let _schema_attrs = SchemaAttrs::from_attrs(&input.attrs)?;
 
     let fields = match &input.data {
         Data::Struct(DataStruct {
@@ -55,6 +53,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         field_exprs.push(expr);
     }
 
+    let ty_name_str = ty_name.to_string();
     Ok(quote! {
         impl #impl_g #crate_path::HasSchema for #ty_name #ty_g #where_g {
             fn schema() -> #crate_path::ValidSchema {
@@ -62,10 +61,20 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
                     ::std::sync::OnceLock::new();
                 __CACHE
                     .get_or_init(|| {
-                        #crate_path::Schema::builder()
+                        match #crate_path::Schema::builder()
                             #( .add(#field_exprs) )*
                             .build()
-                            .expect("#[derive(Schema)] produced an invalid schema — this is a bug")
+                        {
+                            ::core::result::Result::Ok(s) => s,
+                            ::core::result::Result::Err(report) => ::core::panic!(
+                                "#[derive(Schema)] on `{}` produced an invalid schema — \
+                                 attribute combinations conflict with a schema-level lint. \
+                                 Fix the `#[param(..)]` / `#[validate(..)]` attributes on this type. \
+                                 Report: {:?}",
+                                #ty_name_str,
+                                report,
+                            ),
+                        }
                     })
                     .clone()
             }

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -1,0 +1,258 @@
+//! Implementation of `#[derive(Schema)]`.
+//!
+//! Generates `impl HasSchema for T { fn schema() -> ValidSchema { ... } }`
+//! where the schema is computed once and cached behind a `OnceLock`.
+
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Data, DataStruct, DeriveInput, Fields, Ident};
+
+use crate::{
+    attrs::{ParamAttrs, SchemaAttrs, ValidateAttrs},
+    type_infer::{FieldKind, classify},
+};
+
+pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
+    let crate_path = crate::crate_path();
+    let ty_name = &input.ident;
+    let generics = &input.generics;
+    let (impl_g, ty_g, where_g) = generics.split_for_impl();
+
+    let _schema_attrs = SchemaAttrs::from_attrs(&input.attrs)?;
+
+    let fields = match &input.data {
+        Data::Struct(DataStruct {
+            fields: Fields::Named(named),
+            ..
+        }) => &named.named,
+        Data::Struct(_) => {
+            return Err(syn::Error::new_spanned(
+                ty_name,
+                "#[derive(Schema)] only supports structs with named fields",
+            ));
+        },
+        Data::Enum(_) | Data::Union(_) => {
+            return Err(syn::Error::new_spanned(
+                ty_name,
+                "#[derive(Schema)] only supports structs; use #[derive(EnumSelect)] for enums",
+            ));
+        },
+    };
+
+    let mut field_exprs = Vec::with_capacity(fields.len());
+    for f in fields {
+        let field_name = f
+            .ident
+            .as_ref()
+            .ok_or_else(|| syn::Error::new_spanned(f, "anonymous struct field"))?;
+        let param = ParamAttrs::from_attrs(&f.attrs)?;
+        if param.skip {
+            continue;
+        }
+        let validate = ValidateAttrs::from_attrs(&f.attrs)?;
+        let kind = classify(&f.ty);
+        let expr = build_field_expr(field_name, &kind, &param, &validate, &crate_path)?;
+        field_exprs.push(expr);
+    }
+
+    Ok(quote! {
+        impl #impl_g #crate_path::HasSchema for #ty_name #ty_g #where_g {
+            fn schema() -> #crate_path::ValidSchema {
+                static __CACHE: ::std::sync::OnceLock<#crate_path::ValidSchema> =
+                    ::std::sync::OnceLock::new();
+                __CACHE
+                    .get_or_init(|| {
+                        #crate_path::Schema::builder()
+                            #( .add(#field_exprs) )*
+                            .build()
+                            .expect("#[derive(Schema)] produced an invalid schema — this is a bug")
+                    })
+                    .clone()
+            }
+        }
+    })
+}
+
+/// Build the token-stream expression that produces a `Field` for one struct field.
+fn build_field_expr(
+    field_name: &Ident,
+    kind: &FieldKind,
+    param: &ParamAttrs,
+    validate: &ValidateAttrs,
+    crate_path: &TokenStream2,
+) -> syn::Result<TokenStream2> {
+    let key = field_name.to_string();
+    let optional = kind.is_optional();
+    let inner = kind.inner();
+
+    // Pick the constructor by inner kind. `param.secret` forces String → Secret.
+    let mut expr = match inner {
+        FieldKind::String if param.secret => quote! {
+            #crate_path::Field::secret(#key)
+        },
+        FieldKind::String => quote! {
+            #crate_path::Field::string(#key)
+        },
+        FieldKind::Boolean => quote! {
+            #crate_path::Field::boolean(#key)
+        },
+        FieldKind::IntegerNumber => quote! {
+            #crate_path::Field::integer(#key)
+        },
+        FieldKind::FloatNumber => quote! {
+            #crate_path::Field::number(#key)
+        },
+        FieldKind::List(item_kind) => list_field_expr(field_name, item_kind, crate_path)?,
+        FieldKind::Optional(_) => {
+            // Cannot nest `Option<Option<T>>`; classify already flattened one layer.
+            return Err(syn::Error::new_spanned(
+                field_name,
+                "nested `Option<Option<..>>` is not supported",
+            ));
+        },
+        FieldKind::UserDefined(ty) => quote! {
+            #crate_path::Field::object(#key).add_many(
+                <#ty as #crate_path::HasSchema>::schema()
+                    .fields()
+                    .iter()
+                    .cloned(),
+            )
+        },
+    };
+
+    if let Some(label) = &param.label {
+        expr = quote! { #expr.label(#label) };
+    }
+    if let Some(desc) = &param.description {
+        expr = quote! { #expr.description(#desc) };
+    }
+    if let Some(placeholder) = &param.placeholder {
+        expr = quote! { #expr.placeholder(#placeholder) };
+    }
+    if let Some(default) = &param.default {
+        expr = quote! {
+            #expr.default(::serde_json::Value::String(#default.to_owned()))
+        };
+    }
+    if let Some(hint) = &param.hint {
+        let hint_ident = input_hint_ident(hint, field_name)?;
+        expr = quote! { #expr.hint(#crate_path::InputHint::#hint_ident) };
+    }
+    if let Some(group) = &param.group {
+        expr = quote! { #expr.group(#group) };
+    }
+    if param.multiline && matches!(inner, FieldKind::String) && !param.secret {
+        expr = quote! { #expr.widget(#crate_path::StringWidget::Multiline) };
+    }
+    if param.no_expression {
+        expr = quote! { #expr.no_expression() };
+    }
+    if param.expression_required {
+        expr = quote! {
+            #expr.expression_mode(#crate_path::ExpressionMode::Required)
+        };
+    }
+
+    // Required: mark when `#[validate(required)]` or the Rust type is not Option.
+    if validate.required || !optional {
+        expr = quote! { #expr.required() };
+    }
+
+    // Length rules apply to String / Secret.
+    if let Some(min) = validate.min_length {
+        expr = quote! { #expr.min_length(#min) };
+    }
+    if let Some(max) = validate.max_length {
+        expr = quote! { #expr.max_length(#max) };
+    }
+
+    // Range rules apply to Number.
+    if let Some(min) = validate.min
+        && matches!(inner, FieldKind::IntegerNumber | FieldKind::FloatNumber)
+    {
+        expr = quote! { #expr.min(#min) };
+    }
+    if let Some(max) = validate.max
+        && matches!(inner, FieldKind::IntegerNumber | FieldKind::FloatNumber)
+    {
+        expr = quote! { #expr.max(#max) };
+    }
+
+    if let Some(pattern) = &validate.pattern
+        && matches!(inner, FieldKind::String)
+    {
+        expr = quote! { #expr.pattern(#pattern) };
+    }
+    if validate.url && matches!(inner, FieldKind::String) {
+        expr = quote! { #expr.url() };
+    }
+    if validate.email && matches!(inner, FieldKind::String) {
+        expr = quote! { #expr.email() };
+    }
+
+    Ok(quote! { #expr.into_field() })
+}
+
+fn list_field_expr(
+    field_name: &Ident,
+    item_kind: &FieldKind,
+    crate_path: &TokenStream2,
+) -> syn::Result<TokenStream2> {
+    let key = field_name.to_string();
+    let item_key = format!("{key}_item");
+    let item_expr = match item_kind {
+        FieldKind::String => quote! { #crate_path::Field::string(#item_key) },
+        FieldKind::Boolean => quote! { #crate_path::Field::boolean(#item_key) },
+        FieldKind::IntegerNumber => quote! { #crate_path::Field::integer(#item_key) },
+        FieldKind::FloatNumber => quote! { #crate_path::Field::number(#item_key) },
+        FieldKind::UserDefined(ty) => quote! {
+            #crate_path::Field::object(#item_key).add_many(
+                <#ty as #crate_path::HasSchema>::schema()
+                    .fields()
+                    .iter()
+                    .cloned(),
+            )
+        },
+        FieldKind::List(_) | FieldKind::Optional(_) => {
+            return Err(syn::Error::new_spanned(
+                field_name,
+                "nested `Vec<Vec<..>>` or `Vec<Option<..>>` are not supported yet",
+            ));
+        },
+    };
+    Ok(quote! {
+        #crate_path::Field::list(#key).item(#item_expr.into_field())
+    })
+}
+
+/// Map `#[param(hint = "...")]` string to the corresponding `InputHint` variant.
+fn input_hint_ident(hint: &str, span_source: &Ident) -> syn::Result<Ident> {
+    let variant = match hint {
+        "text" => "Text",
+        "url" => "Url",
+        "email" => "Email",
+        "password" => "Password",
+        "phone" | "tel" => "Phone",
+        "ip" => "Ip",
+        "regex" => "Regex",
+        "markdown" => "Markdown",
+        "cron" => "Cron",
+        "date" => "Date",
+        "date_time" | "datetime" => "DateTime",
+        "time" => "Time",
+        "color" => "Color",
+        "duration" => "Duration",
+        "uuid" => "Uuid",
+        other => {
+            return Err(syn::Error::new(
+                span_source.span(),
+                format!(
+                    "unknown #[param(hint = \"{other}\")]; expected one of: \
+                     text, url, email, password, phone, ip, regex, markdown, cron, \
+                     date, date_time, time, color, duration, uuid"
+                ),
+            ));
+        },
+    };
+    Ok(Ident::new(variant, span_source.span()))
+}

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -8,7 +8,7 @@ use quote::quote;
 use syn::{Data, DataStruct, DeriveInput, Fields, Ident};
 
 use crate::{
-    attrs::{ParamAttrs, ValidateAttrs},
+    attrs::{DefaultLit, ParamAttrs, ValidateAttrs},
     type_infer::{FieldKind, classify},
 };
 
@@ -127,6 +127,17 @@ fn build_field_expr(
                     .cloned(),
             )
         },
+        FieldKind::UnsupportedInteger(name) => {
+            return Err(syn::Error::new_spanned(
+                field_name,
+                format!(
+                    "#[derive(Schema)]: integer type `{name}` is not yet supported \
+                     because `serde_json::Number` only round-trips through `i64`/`u64`. \
+                     Use a narrower integer type (`i8`..`i64`, `u8`..`u64`) or wrap \
+                     the value in a newtype that implements `HasSchema` manually."
+                ),
+            ));
+        },
     };
 
     if let Some(label) = &param.label {
@@ -139,9 +150,8 @@ fn build_field_expr(
         expr = quote! { #expr.placeholder(#placeholder) };
     }
     if let Some(default) = &param.default {
-        expr = quote! {
-            #expr.default(::serde_json::Value::String(#default.to_owned()))
-        };
+        let default_tokens = default_lit_tokens(default, inner, field_name)?;
+        expr = quote! { #expr.default(#default_tokens) };
     }
     if let Some(hint) = &param.hint {
         let hint_ident = input_hint_ident(hint, field_name)?;
@@ -228,10 +238,75 @@ fn list_field_expr(
                 "nested `Vec<Vec<..>>` or `Vec<Option<..>>` are not supported yet",
             ));
         },
+        FieldKind::UnsupportedInteger(name) => {
+            return Err(syn::Error::new_spanned(
+                field_name,
+                format!(
+                    "#[derive(Schema)]: `Vec<{name}>` is not supported because \
+                     `{name}` does not round-trip through `serde_json::Number`."
+                ),
+            ));
+        },
     };
     Ok(quote! {
         #crate_path::Field::list(#key).item(#item_expr.into_field())
     })
+}
+
+/// Emit the correct `serde_json::Value` constructor for a typed default,
+/// rejecting combinations that would ship a wrong-typed default (e.g.
+/// `default = "42"` on a `bool` field).
+fn default_lit_tokens(
+    lit: &DefaultLit,
+    inner: &FieldKind,
+    field_name: &Ident,
+) -> syn::Result<TokenStream2> {
+    let mismatch = |expected: &str, got: &str| {
+        syn::Error::new_spanned(
+            field_name,
+            format!("#[param(default = ..)]: field expects {expected}, got {got}"),
+        )
+    };
+    match (inner, lit) {
+        // String-ish targets accept only string defaults.
+        (FieldKind::String, DefaultLit::Str(s)) => Ok(quote! {
+            ::serde_json::Value::String(#s.to_owned())
+        }),
+        (FieldKind::String, _) => Err(mismatch("a string literal", "non-string literal")),
+
+        // Integer targets accept integer defaults.
+        (FieldKind::IntegerNumber, DefaultLit::Int(i)) => Ok(quote! {
+            ::serde_json::Value::Number(::serde_json::Number::from(#i))
+        }),
+        (FieldKind::IntegerNumber, _) => Err(mismatch("an integer literal", "non-integer literal")),
+
+        // Float targets accept both integer (coerced) and float literals.
+        (FieldKind::FloatNumber, DefaultLit::Float(f)) => Ok(quote! {
+            ::serde_json::Value::Number(
+                ::serde_json::Number::from_f64(#f)
+                    .expect("derive-provided float default is finite")
+            )
+        }),
+        (FieldKind::FloatNumber, DefaultLit::Int(i)) => Ok(quote! {
+            ::serde_json::Value::Number(::serde_json::Number::from(#i))
+        }),
+        (FieldKind::FloatNumber, _) => Err(mismatch("a numeric literal", "non-numeric literal")),
+
+        (FieldKind::Boolean, DefaultLit::Bool(b)) => Ok(quote! {
+            ::serde_json::Value::Bool(#b)
+        }),
+        (FieldKind::Boolean, _) => Err(mismatch("a bool literal", "non-bool literal")),
+
+        // List / Optional / UserDefined / UnsupportedInteger defaults are
+        // explicitly out of scope — container defaults need JSON literals,
+        // which aren't expressible through the simple-literal attribute
+        // surface. Callers should drop `#[param(default = ..)]` for those.
+        _ => Err(syn::Error::new_spanned(
+            field_name,
+            "#[param(default = ..)] is only supported on String / Number / Boolean fields; \
+             Vec / nested object / Option fields cannot carry a literal default",
+        )),
+    }
 }
 
 /// Map `#[param(hint = "...")]` string to the corresponding `InputHint` variant.

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -49,7 +49,7 @@ pub fn field_key(input: TokenStream) -> TokenStream {
     out.into()
 }
 
-/// Derive [`HasSchema`](nebula_schema::HasSchema) for a struct.
+/// Derive `HasSchema` (from `nebula-schema`) for a struct.
 ///
 /// See the `nebula-schema` crate docs for supported attributes:
 /// `#[param(...)]`, `#[validate(...)]`, and struct-level `#[schema(...)]`.
@@ -61,8 +61,8 @@ pub fn derive_schema(input: TokenStream) -> TokenStream {
         .into()
 }
 
-/// Derive [`HasSelectOptions`](nebula_schema::HasSelectOptions) for a unit-only
-/// enum. Variant names snake_case into stored values; use
+/// Derive `HasSelectOptions` (from `nebula-schema`) for a unit-only enum.
+/// Variant names snake_case into stored values; use
 /// `#[param(label = "...")]` to override the display label.
 #[proc_macro_derive(EnumSelect, attributes(param))]
 pub fn derive_enum_select(input: TokenStream) -> TokenStream {

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -51,9 +51,14 @@ pub fn field_key(input: TokenStream) -> TokenStream {
 
 /// Derive `HasSchema` (from `nebula-schema`) for a struct.
 ///
-/// See the `nebula-schema` crate docs for supported attributes:
-/// `#[param(...)]`, `#[validate(...)]`, and struct-level `#[schema(...)]`.
-#[proc_macro_derive(Schema, attributes(param, validate, schema))]
+/// Supported attributes:
+/// - `#[param(...)]` — label/description/placeholder/default/hint/secret/
+///   multiline/no_expression/expression_required/skip/group.
+/// - `#[validate(...)]` — required/length(min,max)/range(min..=max)/ pattern/url/email.
+///
+/// Struct-level `#[schema(...)]` is reserved for a future pass (no options
+/// functional today).
+#[proc_macro_derive(Schema, attributes(param, validate))]
 pub fn derive_schema(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     derive_schema::expand(input)

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -2,9 +2,26 @@
 
 use proc_macro::TokenStream;
 use proc_macro_crate::{FoundCrate, crate_name};
-use proc_macro2::Span;
+use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::quote;
-use syn::{LitStr, parse_macro_input};
+use syn::{DeriveInput, LitStr, parse_macro_input};
+
+mod attrs;
+mod derive_enum;
+mod derive_schema;
+mod type_infer;
+
+/// Resolve an absolute path to the `nebula-schema` crate so the generated
+/// code works whether the caller renamed the dependency or not.
+pub(crate) fn crate_path() -> TokenStream2 {
+    match crate_name("nebula-schema") {
+        Ok(FoundCrate::Itself) | Err(_) => quote!(::nebula_schema),
+        Ok(FoundCrate::Name(name)) => {
+            let ident = syn::Ident::new(&name, Span::call_site());
+            quote!(::#ident)
+        },
+    }
+}
 
 /// Build a `FieldKey` from a string literal, validated at compile time.
 ///
@@ -23,25 +40,36 @@ pub fn field_key(input: TokenStream) -> TokenStream {
             .into();
     }
 
-    // Resolve the crate path robustly: supports renamed dependencies.
-    //
-    // We do NOT use `crate::` for FoundCrate::Itself because proc-macro
-    // doctests are compiled as external crates — `crate` would resolve to
-    // the synthetic doctest crate, not to nebula_schema.  Using the
-    // absolute path `::nebula_schema` is safe for all call sites.
-    let crate_path = match crate_name("nebula-schema") {
-        Ok(FoundCrate::Itself) | Err(_) => quote!(::nebula_schema),
-        Ok(FoundCrate::Name(name)) => {
-            let ident = syn::Ident::new(&name, Span::call_site());
-            quote!(::#ident)
-        },
-    };
+    let crate_path = crate_path();
 
     let out = quote! {
         #crate_path::FieldKey::new(#lit)
             .expect("field_key! validated at compile time")
     };
     out.into()
+}
+
+/// Derive [`HasSchema`](nebula_schema::HasSchema) for a struct.
+///
+/// See the `nebula-schema` crate docs for supported attributes:
+/// `#[param(...)]`, `#[validate(...)]`, and struct-level `#[schema(...)]`.
+#[proc_macro_derive(Schema, attributes(param, validate, schema))]
+pub fn derive_schema(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_schema::expand(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
+}
+
+/// Derive [`HasSelectOptions`](nebula_schema::HasSelectOptions) for a unit-only
+/// enum. Variant names snake_case into stored values; use
+/// `#[param(label = "...")]` to override the display label.
+#[proc_macro_derive(EnumSelect, attributes(param))]
+pub fn derive_enum_select(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    derive_enum::expand(input)
+        .unwrap_or_else(|e| e.to_compile_error())
+        .into()
 }
 
 fn validate(value: &str) -> Result<(), &'static str> {

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -11,8 +11,19 @@ mod derive_enum;
 mod derive_schema;
 mod type_infer;
 
-/// Resolve an absolute path to the `nebula-schema` crate so the generated
-/// code works whether the caller renamed the dependency or not.
+/// Resolve the path to the `nebula-schema` crate so the generated code
+/// works whether the caller renamed the dependency or derives are
+/// expanded from inside `nebula-schema` itself.
+///
+/// Both [`FoundCrate::Itself`] and `Err(_)` map to the absolute path
+/// `::nebula_schema`, **not** `crate` — `cargo test --doc` compiles
+/// every doctest as a separate binary that links against nebula-schema
+/// as an external dependency, so from that binary's perspective `crate`
+/// resolves to the synthetic doctest crate, not to `nebula_schema`.
+/// Using the absolute path is safe for all call sites (doctests,
+/// integration tests, external crates) and was the original design —
+/// restoring it here after an earlier review suggestion that missed
+/// the doctest linkage.
 pub(crate) fn crate_path() -> TokenStream2 {
     match crate_name("nebula-schema") {
         Ok(FoundCrate::Itself) | Err(_) => quote!(::nebula_schema),

--- a/crates/schema/macros/src/type_infer.rs
+++ b/crates/schema/macros/src/type_infer.rs
@@ -1,0 +1,93 @@
+//! Rust-type → nebula-schema field kind mapping.
+//!
+//! The derive path needs two decisions per struct field:
+//!
+//! 1. Which `Field::*` constructor to emit.
+//! 2. Whether to mark the resulting field `required` by default (i.e. is it wrapped in
+//!    `Option<T>`?).
+//!
+//! Both answers fall out of syntactic inspection of the `syn::Type`. The
+//! matcher looks at the last path segment of the type (so `std::string::String`
+//! and plain `String` both resolve to the same bucket) and recognises a fixed
+//! vocabulary of standard-library primitives plus the `Option<_>` / `Vec<_>`
+//! wrappers. Unknown types fall through to [`FieldKind::UserDefined`], which
+//! the derive layer uses to require the type to implement
+//! [`HasSchema`](nebula_schema::HasSchema).
+
+use syn::{GenericArgument, PathArguments, Type, TypePath};
+
+/// Classification of a Rust type for schema-derivation purposes.
+#[derive(Clone)]
+pub(crate) enum FieldKind {
+    String,
+    Boolean,
+    IntegerNumber,
+    FloatNumber,
+    /// `Option<T>` — marks the field optional and recurses into `T`.
+    Optional(Box<FieldKind>),
+    /// `Vec<T>` — emits a `ListField` whose item is the inner kind.
+    List(Box<FieldKind>),
+    /// Any other concrete type. The derive uses this as the signal to call
+    /// `<T as HasSchema>::schema()` at runtime (Task 10 blanket object
+    /// inference).
+    UserDefined(Box<Type>),
+}
+
+impl FieldKind {
+    pub fn is_optional(&self) -> bool {
+        matches!(self, FieldKind::Optional(_))
+    }
+
+    pub fn inner(&self) -> &FieldKind {
+        match self {
+            FieldKind::Optional(inner) => inner,
+            other => other,
+        }
+    }
+}
+
+/// Inspect a `syn::Type` and return its [`FieldKind`] classification.
+pub(crate) fn classify(ty: &Type) -> FieldKind {
+    if let Some(inner) = unwrap_single_generic(ty, "Option") {
+        return FieldKind::Optional(Box::new(classify(inner)));
+    }
+    if let Some(inner) = unwrap_single_generic(ty, "Vec") {
+        return FieldKind::List(Box::new(classify(inner)));
+    }
+    match last_segment_ident(ty) {
+        Some(name) => match name.as_str() {
+            "String" | "str" => FieldKind::String,
+            "bool" => FieldKind::Boolean,
+            "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
+            | "u128" | "usize" => FieldKind::IntegerNumber,
+            "f32" | "f64" => FieldKind::FloatNumber,
+            _ => FieldKind::UserDefined(Box::new(ty.clone())),
+        },
+        None => FieldKind::UserDefined(Box::new(ty.clone())),
+    }
+}
+
+/// Return the final path segment identifier of a type, if any.
+///
+/// Handles both bare idents (`String`, `bool`) and fully-qualified paths
+/// (`std::string::String`).
+fn last_segment_ident(ty: &Type) -> Option<String> {
+    if let Type::Path(TypePath { qself: None, path }) = ty {
+        path.segments.last().map(|s| s.ident.to_string())
+    } else {
+        None
+    }
+}
+
+/// If `ty` is `Wrapper<Inner>`, return the inner type.
+fn unwrap_single_generic<'t>(ty: &'t Type, wrapper: &str) -> Option<&'t Type> {
+    if let Type::Path(TypePath { qself: None, path }) = ty
+        && let Some(seg) = path.segments.last()
+        && seg.ident == wrapper
+        && let PathArguments::AngleBracketed(args) = &seg.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner);
+    }
+    None
+}

--- a/crates/schema/macros/src/type_infer.rs
+++ b/crates/schema/macros/src/type_infer.rs
@@ -31,6 +31,12 @@ pub(crate) enum FieldKind {
     /// `<T as HasSchema>::schema()` at runtime (Task 10 blanket object
     /// inference).
     UserDefined(Box<Type>),
+    /// Unsupported integer width — the schema layer's rules only handle
+    /// values that fit in `i64` / `u64` (via `serde_json::Number`), so
+    /// wider integer types like `i128`/`u128`/`isize`/`usize` are
+    /// rejected at macro expansion rather than silently mapped to
+    /// `IntegerNumber` and breaking at runtime.
+    UnsupportedInteger(String),
 }
 
 impl FieldKind {
@@ -58,9 +64,14 @@ pub(crate) fn classify(ty: &Type) -> FieldKind {
         Some(name) => match name.as_str() {
             "String" | "str" => FieldKind::String,
             "bool" => FieldKind::Boolean,
-            "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
-            | "u128" | "usize" => FieldKind::IntegerNumber,
+            // Narrow integer types that round-trip cleanly through
+            // `serde_json::Number` (via `From<i64>` / `From<u64>`).
+            "i8" | "i16" | "i32" | "i64" | "u8" | "u16" | "u32" | "u64" => FieldKind::IntegerNumber,
             "f32" | "f64" => FieldKind::FloatNumber,
+            // Wider integer widths — no `Number::from_i128/u128` impl
+            // without the `serde_json/arbitrary_precision` feature, and
+            // the validator's rule layer is `i64`-bounded anyway.
+            "i128" | "u128" | "isize" | "usize" => FieldKind::UnsupportedInteger(name),
             _ => FieldKind::UserDefined(Box::new(ty.clone())),
         },
         None => FieldKind::UserDefined(Box::new(ty.clone())),

--- a/crates/schema/src/builder/group.rs
+++ b/crates/schema/src/builder/group.rs
@@ -1,0 +1,184 @@
+//! Typed-closure builder for grouped fields with shared visible/required rules.
+//!
+//! A group is not a single [`Field`](crate::field::Field) — it is a collection
+//! of sibling fields that share a common label prefix and common
+//! `visible_when` / `required_when` conditions. At finish time each child
+//! inherits the shared conditions (AND-composed with any per-child condition).
+
+use nebula_validator::Rule;
+
+use crate::{
+    builder::FieldCollector,
+    field::Field,
+    mode::{RequiredMode, VisibilityMode},
+};
+
+/// Builder that accumulates grouped child fields with shared conditions.
+pub struct GroupBuilder {
+    name: String,
+    visible_when: Option<Rule>,
+    required_when: Option<Rule>,
+    fields: Vec<Field>,
+}
+
+impl GroupBuilder {
+    /// Start a new group with the given label.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            visible_when: None,
+            required_when: None,
+            fields: Vec::new(),
+        }
+    }
+
+    /// Borrow the group label.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Require every child of this group when the given predicate holds.
+    #[must_use]
+    pub fn required_when(mut self, rule: Rule) -> Self {
+        self.required_when = Some(rule);
+        self
+    }
+
+    /// Show every child of this group only when the given predicate holds.
+    #[must_use]
+    pub fn visible_when(mut self, rule: Rule) -> Self {
+        self.visible_when = Some(rule);
+        self
+    }
+
+    /// Consume the group and return its children with shared conditions applied.
+    #[must_use]
+    pub fn into_fields(self) -> Vec<Field> {
+        let GroupBuilder {
+            name,
+            visible_when,
+            required_when,
+            fields,
+        } = self;
+        fields
+            .into_iter()
+            .map(|field| apply_group(field, &name, visible_when.as_ref(), required_when.as_ref()))
+            .collect()
+    }
+}
+
+impl FieldCollector for GroupBuilder {
+    fn push_field(mut self, field: Field) -> Self {
+        self.fields.push(field);
+        self
+    }
+}
+
+/// Apply shared group label + shared visible/required conditions to a field.
+fn apply_group(
+    field: Field,
+    group: &str,
+    visible_when: Option<&Rule>,
+    required_when: Option<&Rule>,
+) -> Field {
+    let mut field = field;
+    set_group(&mut field, group);
+    if let Some(rule) = visible_when {
+        set_visible(&mut field, rule.clone());
+    }
+    if let Some(rule) = required_when {
+        set_required(&mut field, rule.clone());
+    }
+    field
+}
+
+/// Helper enum used by the three `set_*` functions — each match arm is fully
+/// mechanical (apply the same mutation to every per-type inner struct).
+macro_rules! for_each_field {
+    ($field:expr, $mutation:expr) => {
+        match $field {
+            Field::String(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Secret(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Number(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Boolean(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Select(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Object(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::List(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Mode(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Code(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::File(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Computed(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Dynamic(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+            Field::Notice(inner) => {
+                $mutation(&mut inner.group, &mut inner.visible, &mut inner.required)
+            },
+        }
+    };
+}
+
+fn set_group(field: &mut Field, group: &str) {
+    for_each_field!(field, |g: &mut Option<String>,
+                            _v: &mut VisibilityMode,
+                            _r: &mut RequiredMode| {
+        if g.is_none() {
+            *g = Some(group.to_owned());
+        }
+    });
+}
+
+fn set_visible(field: &mut Field, rule: Rule) {
+    for_each_field!(field, |_g: &mut Option<String>,
+                            v: &mut VisibilityMode,
+                            _r: &mut RequiredMode| {
+        *v = compose_visible(v.clone(), rule.clone());
+    });
+}
+
+fn set_required(field: &mut Field, rule: Rule) {
+    for_each_field!(field, |_g: &mut Option<String>,
+                            _v: &mut VisibilityMode,
+                            r: &mut RequiredMode| {
+        *r = compose_required(r.clone(), rule.clone());
+    });
+}
+
+fn compose_visible(existing: VisibilityMode, shared: Rule) -> VisibilityMode {
+    match existing {
+        VisibilityMode::Always => VisibilityMode::When(shared),
+        VisibilityMode::Never => VisibilityMode::Never,
+        VisibilityMode::When(child) => VisibilityMode::When(Rule::all([child, shared])),
+    }
+}
+
+fn compose_required(existing: RequiredMode, shared: Rule) -> RequiredMode {
+    match existing {
+        RequiredMode::Never => RequiredMode::When(shared),
+        RequiredMode::Always => RequiredMode::Always,
+        RequiredMode::When(child) => RequiredMode::When(Rule::all([child, shared])),
+    }
+}

--- a/crates/schema/src/builder/list.rs
+++ b/crates/schema/src/builder/list.rs
@@ -1,0 +1,212 @@
+//! Typed-closure builder for [`ListField`](crate::field::ListField).
+
+use nebula_validator::Rule;
+
+use crate::{
+    builder::ObjectBuilder,
+    field::{
+        BooleanField, CodeField, Field, ListField, NumberField, SecretField, SelectField,
+        StringField,
+    },
+    mode::{ExpressionMode, VisibilityMode},
+    widget::ListWidget,
+};
+
+/// Builder that produces a [`ListField`] with typed-closure item methods.
+///
+/// Unlike [`ObjectBuilder`], `ListBuilder` holds a single item schema — not a
+/// collection of children — so its `item_*` methods replace the previous item
+/// rather than appending.
+pub struct ListBuilder {
+    inner: ListField,
+}
+
+impl ListBuilder {
+    /// Create a new list builder bound to the given field key.
+    pub fn new(key: impl AsRef<str>) -> Self {
+        Self {
+            inner: ListField::new(key),
+        }
+    }
+
+    /// Set the list widget variant.
+    #[must_use]
+    pub fn widget(mut self, widget: ListWidget) -> Self {
+        self.inner = self.inner.widget(widget);
+        self
+    }
+
+    /// Set a human-readable label.
+    #[must_use]
+    pub fn label(mut self, value: impl Into<String>) -> Self {
+        self.inner = self.inner.label(value);
+        self
+    }
+
+    /// Set a help description.
+    #[must_use]
+    pub fn description(mut self, value: impl Into<String>) -> Self {
+        self.inner = self.inner.description(value);
+        self
+    }
+
+    /// Mark this list field as always required.
+    #[must_use]
+    pub fn required(mut self) -> Self {
+        self.inner = self.inner.required();
+        self
+    }
+
+    /// Require this list only when the given predicate holds.
+    #[must_use]
+    pub fn required_when(mut self, rule: Rule) -> Self {
+        self.inner = self.inner.required_when(rule);
+        self
+    }
+
+    /// Set the visibility mode directly.
+    #[must_use]
+    pub fn visible(mut self, mode: VisibilityMode) -> Self {
+        self.inner = self.inner.visible(mode);
+        self
+    }
+
+    /// Show this list only when the given predicate holds.
+    #[must_use]
+    pub fn visible_when(mut self, rule: Rule) -> Self {
+        self.inner = self.inner.visible_when(rule);
+        self
+    }
+
+    /// Set the expression mode.
+    #[must_use]
+    pub fn expression_mode(mut self, mode: ExpressionMode) -> Self {
+        self.inner = self.inner.expression_mode(mode);
+        self
+    }
+
+    /// Forbid expression values on this field.
+    #[must_use]
+    pub fn no_expression(mut self) -> Self {
+        self.inner = self.inner.no_expression();
+        self
+    }
+
+    /// Set minimum item count.
+    #[must_use]
+    pub fn min_items(mut self, count: u32) -> Self {
+        self.inner = self.inner.min_items(count);
+        self
+    }
+
+    /// Set maximum item count.
+    #[must_use]
+    pub fn max_items(mut self, count: u32) -> Self {
+        self.inner = self.inner.max_items(count);
+        self
+    }
+
+    /// Require items to be unique.
+    #[must_use]
+    pub fn unique(mut self) -> Self {
+        self.inner = self.inner.unique();
+        self
+    }
+
+    /// Set the item schema from an already-built field.
+    #[must_use]
+    pub fn item(mut self, item: impl Into<Field>) -> Self {
+        self.inner = self.inner.item(item);
+        self
+    }
+
+    /// Set a string item schema via a typed closure.
+    #[must_use]
+    pub fn item_string(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(StringField) -> StringField,
+    ) -> Self {
+        let built = f(StringField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a number item schema via a typed closure.
+    #[must_use]
+    pub fn item_number(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(NumberField) -> NumberField,
+    ) -> Self {
+        let built = f(NumberField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a boolean item schema via a typed closure.
+    #[must_use]
+    pub fn item_boolean(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(BooleanField) -> BooleanField,
+    ) -> Self {
+        let built = f(BooleanField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a select item schema via a typed closure.
+    #[must_use]
+    pub fn item_select(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(SelectField) -> SelectField,
+    ) -> Self {
+        let built = f(SelectField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a code item schema via a typed closure.
+    #[must_use]
+    pub fn item_code(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(CodeField) -> CodeField,
+    ) -> Self {
+        let built = f(CodeField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a secret item schema via a typed closure.
+    #[must_use]
+    pub fn item_secret(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(SecretField) -> SecretField,
+    ) -> Self {
+        let built = f(SecretField::new(key));
+        self.inner = self.inner.item(built);
+        self
+    }
+
+    /// Set a nested object item schema via a typed closure.
+    #[must_use]
+    pub fn item_object(
+        mut self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(ObjectBuilder) -> ObjectBuilder,
+    ) -> Self {
+        let built = f(ObjectBuilder::new(key));
+        self.inner = self.inner.item(built.into_field());
+        self
+    }
+
+    /// Consume the builder and wrap the result in the top-level [`Field`] enum.
+    #[must_use]
+    pub fn into_field(self) -> Field {
+        self.inner.into()
+    }
+}

--- a/crates/schema/src/builder/mod.rs
+++ b/crates/schema/src/builder/mod.rs
@@ -1,0 +1,100 @@
+//! Typed-closure builder DSL on top of the per-type field structs.
+//!
+//! Leaf field builders are re-exports of the per-type structs — they already
+//! enforce compile-time type safety via distinct method surfaces (e.g.
+//! `StringField::min_length` exists but `BooleanField::min_length` does not).
+//! The `Schema::builder().string("k", |s| ...)` closure form pins the argument
+//! type, so a `.min_length` call on a `BooleanBuilder` is a compile error.
+//!
+//! Composite builders ([`ObjectBuilder`], [`ListBuilder`], [`GroupBuilder`])
+//! are real types that expose nested closure-based child methods that the
+//! leaf fields don't support.
+
+mod group;
+mod list;
+mod object;
+
+pub use group::GroupBuilder;
+pub use list::ListBuilder;
+pub use object::ObjectBuilder;
+
+use crate::field::{
+    BooleanField, CodeField, Field, NumberField, SecretField, SelectField, StringField,
+};
+// Leaf builders — type aliases onto the existing per-type structs.
+pub use crate::field::{
+    BooleanField as BooleanBuilder, CodeField as CodeBuilder, NumberField as NumberBuilder,
+    SecretField as SecretBuilder, SelectField as SelectBuilder, StringField as StringBuilder,
+};
+
+/// Collection sink for typed-closure child field methods.
+///
+/// Implemented by any builder that appends a single [`Field`] value per child
+/// method call. Default method implementations provide the closure-based
+/// `.string / .number / .boolean / .select / .code / .secret / .object / .list`
+/// API that `SchemaBuilder`, `ObjectBuilder`, and `GroupBuilder` share.
+pub trait FieldCollector: Sized {
+    /// Append a single built field to the underlying collection.
+    #[doc(hidden)]
+    fn push_field(self, field: Field) -> Self;
+
+    /// Append a string child built via a typed closure.
+    #[must_use]
+    fn string(self, key: impl AsRef<str>, f: impl FnOnce(StringBuilder) -> StringBuilder) -> Self {
+        self.push_field(f(StringField::new(key)).into())
+    }
+
+    /// Append a secret child built via a typed closure.
+    #[must_use]
+    fn secret(self, key: impl AsRef<str>, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self {
+        self.push_field(f(SecretField::new(key)).into())
+    }
+
+    /// Append a number child built via a typed closure.
+    #[must_use]
+    fn number(self, key: impl AsRef<str>, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
+        self.push_field(f(NumberField::new(key)).into())
+    }
+
+    /// Append an integer child (NumberField with `integer=true`) via a typed closure.
+    #[must_use]
+    fn integer(self, key: impl AsRef<str>, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
+        self.push_field(f(NumberField::new(key).integer()).into())
+    }
+
+    /// Append a boolean child built via a typed closure.
+    #[must_use]
+    fn boolean(
+        self,
+        key: impl AsRef<str>,
+        f: impl FnOnce(BooleanBuilder) -> BooleanBuilder,
+    ) -> Self {
+        self.push_field(f(BooleanField::new(key)).into())
+    }
+
+    /// Append a select child built via a typed closure.
+    #[must_use]
+    fn select(self, key: impl AsRef<str>, f: impl FnOnce(SelectBuilder) -> SelectBuilder) -> Self {
+        self.push_field(f(SelectField::new(key)).into())
+    }
+
+    /// Append a code child built via a typed closure.
+    #[must_use]
+    fn code(self, key: impl AsRef<str>, f: impl FnOnce(CodeBuilder) -> CodeBuilder) -> Self {
+        self.push_field(f(CodeField::new(key)).into())
+    }
+
+    /// Append a nested object child built via a typed closure.
+    #[must_use]
+    fn object(self, key: impl AsRef<str>, f: impl FnOnce(ObjectBuilder) -> ObjectBuilder) -> Self {
+        let built = f(ObjectBuilder::new(key));
+        self.push_field(built.into_field())
+    }
+
+    /// Append a list child built via a typed closure.
+    #[must_use]
+    fn list(self, key: impl AsRef<str>, f: impl FnOnce(ListBuilder) -> ListBuilder) -> Self {
+        let built = f(ListBuilder::new(key));
+        self.push_field(built.into_field())
+    }
+}

--- a/crates/schema/src/builder/mod.rs
+++ b/crates/schema/src/builder/mod.rs
@@ -38,6 +38,19 @@ pub trait FieldCollector: Sized {
     #[doc(hidden)]
     fn push_field(self, field: Field) -> Self;
 
+    /// Append many built fields at once — works on any collector
+    /// (`SchemaBuilder` / `ObjectBuilder` / `GroupBuilder`).
+    #[must_use]
+    fn extend<I, F>(self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = F>,
+        F: Into<Field>,
+    {
+        fields
+            .into_iter()
+            .fold(self, |acc, f| acc.push_field(f.into()))
+    }
+
     /// Append a string child built via a typed closure.
     #[must_use]
     fn string(self, key: impl AsRef<str>, f: impl FnOnce(StringBuilder) -> StringBuilder) -> Self {

--- a/crates/schema/src/builder/object.rs
+++ b/crates/schema/src/builder/object.rs
@@ -1,0 +1,118 @@
+//! Typed-closure builder for [`ObjectField`](crate::field::ObjectField).
+
+use nebula_validator::Rule;
+
+use crate::{
+    builder::FieldCollector,
+    field::{Field, ObjectField},
+    mode::{ExpressionMode, RequiredMode, VisibilityMode},
+    widget::ObjectWidget,
+};
+
+/// Builder that produces an [`ObjectField`] with typed-closure child methods.
+pub struct ObjectBuilder {
+    inner: ObjectField,
+}
+
+impl ObjectBuilder {
+    /// Create a new object builder bound to the given field key.
+    pub fn new(key: impl AsRef<str>) -> Self {
+        Self {
+            inner: ObjectField::new(key),
+        }
+    }
+
+    /// Set the object widget variant.
+    #[must_use]
+    pub fn widget(mut self, widget: ObjectWidget) -> Self {
+        self.inner = self.inner.widget(widget);
+        self
+    }
+
+    /// Set a human-readable label.
+    #[must_use]
+    pub fn label(mut self, value: impl Into<String>) -> Self {
+        self.inner = self.inner.label(value);
+        self
+    }
+
+    /// Set a help description.
+    #[must_use]
+    pub fn description(mut self, value: impl Into<String>) -> Self {
+        self.inner = self.inner.description(value);
+        self
+    }
+
+    /// Mark this object field as always required.
+    #[must_use]
+    pub fn required(mut self) -> Self {
+        self.inner = self.inner.required();
+        self
+    }
+
+    /// Set required mode directly.
+    #[must_use]
+    pub fn required_mode(mut self, mode: RequiredMode) -> Self {
+        self.inner.required = mode;
+        self
+    }
+
+    /// Require this object only when the given predicate holds.
+    #[must_use]
+    pub fn required_when(mut self, rule: Rule) -> Self {
+        self.inner = self.inner.required_when(rule);
+        self
+    }
+
+    /// Set the visibility mode directly.
+    #[must_use]
+    pub fn visible(mut self, mode: VisibilityMode) -> Self {
+        self.inner = self.inner.visible(mode);
+        self
+    }
+
+    /// Show this object only when the given predicate holds.
+    #[must_use]
+    pub fn visible_when(mut self, rule: Rule) -> Self {
+        self.inner = self.inner.visible_when(rule);
+        self
+    }
+
+    /// Set the expression mode.
+    #[must_use]
+    pub fn expression_mode(mut self, mode: ExpressionMode) -> Self {
+        self.inner = self.inner.expression_mode(mode);
+        self
+    }
+
+    /// Forbid expression values on this field.
+    #[must_use]
+    pub fn no_expression(mut self) -> Self {
+        self.inner = self.inner.no_expression();
+        self
+    }
+
+    /// Append an already-built field.
+    #[must_use]
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "builder API mirrors add-style schema DSL"
+    )]
+    pub fn add(mut self, field: impl Into<Field>) -> Self {
+        self.inner = self.inner.add(field);
+        self
+    }
+
+    /// Consume the builder and wrap the result in the top-level [`Field`] enum.
+    #[must_use]
+    pub fn into_field(self) -> Field {
+        self.inner.into()
+    }
+}
+
+impl FieldCollector for ObjectBuilder {
+    fn push_field(mut self, field: Field) -> Self {
+        self.inner.fields.push(field);
+        self
+    }
+}

--- a/crates/schema/src/builder/object.rs
+++ b/crates/schema/src/builder/object.rs
@@ -103,6 +103,17 @@ impl ObjectBuilder {
         self
     }
 
+    /// Append many already-built fields at once.
+    #[must_use]
+    pub fn add_many<I, F>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = F>,
+        F: Into<Field>,
+    {
+        self.inner.fields.extend(fields.into_iter().map(Into::into));
+        self
+    }
+
     /// Consume the builder and wrap the result in the top-level [`Field`] enum.
     #[must_use]
     pub fn into_field(self) -> Field {

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -444,6 +444,17 @@ impl ObjectField {
         self.fields.push(field.into());
         self
     }
+
+    /// Append many nested fields at once.
+    #[must_use]
+    pub fn add_many<I, F>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = F>,
+        F: Into<Field>,
+    {
+        self.fields.extend(fields.into_iter().map(Into::into));
+        self
+    }
 }
 
 define_field!(ListField {

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -1,0 +1,96 @@
+//! Traits linking Rust types to schema definitions.
+//!
+//! A type that implements [`HasSchema`] advertises a canonical [`ValidSchema`]
+//! that describes its structure. A type that implements [`HasSelectOptions`]
+//! advertises an ordered list of [`SelectOption`] values suitable for a
+//! [`SelectField`](crate::field::SelectField).
+//!
+//! These traits are the bridge between the derive layer (`#[derive(Schema)]`,
+//! `#[derive(EnumSelect)]`) and the validator / engine — given a type `T`, a
+//! caller can always obtain the schema by name without referring to the derive.
+
+use crate::{option::SelectOption, validated::ValidSchema};
+
+/// Types that expose a canonical [`ValidSchema`].
+///
+/// The returned value is cheap to clone — `ValidSchema` is `Arc`-backed.
+/// Implementations are expected to be pure: the schema must not depend on
+/// runtime state. For dynamic schemas, construct the value explicitly via
+/// [`crate::schema::Schema::builder`] and avoid `HasSchema`.
+pub trait HasSchema {
+    /// Return the canonical schema for this type.
+    fn schema() -> ValidSchema;
+}
+
+/// Types that expose an ordered list of [`SelectOption`] values.
+///
+/// Typically derived on `enum` types via `#[derive(EnumSelect)]`.
+pub trait HasSelectOptions {
+    /// Return the options for this type.
+    fn select_options() -> Vec<SelectOption>;
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+    use crate::{field::Field, key::FieldKey, schema::Schema};
+
+    struct Dummy;
+
+    impl HasSchema for Dummy {
+        fn schema() -> ValidSchema {
+            Schema::builder()
+                .add(Field::string(FieldKey::new("name").unwrap()).required())
+                .add(Field::number(FieldKey::new("age").unwrap()))
+                .build()
+                .expect("dummy schema builds")
+        }
+    }
+
+    #[derive(Clone, Copy)]
+    #[allow(
+        dead_code,
+        reason = "variants exercised via HasSelectOptions impl only"
+    )]
+    enum Color {
+        Red,
+        Green,
+        Blue,
+    }
+
+    impl HasSelectOptions for Color {
+        fn select_options() -> Vec<SelectOption> {
+            vec![
+                SelectOption::new(json!("red"), "Red"),
+                SelectOption::new(json!("green"), "Green"),
+                SelectOption::new(json!("blue"), "Blue"),
+            ]
+        }
+    }
+
+    #[test]
+    fn has_schema_returns_valid_schema() {
+        let schema = Dummy::schema();
+        assert_eq!(schema.fields().len(), 2);
+        assert_eq!(schema.fields()[0].key().as_str(), "name");
+        assert_eq!(schema.fields()[1].key().as_str(), "age");
+    }
+
+    #[test]
+    fn has_schema_arc_clone_is_cheap() {
+        let a = Dummy::schema();
+        let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn has_select_options_returns_ordered_list() {
+        let options = Color::select_options();
+        assert_eq!(options.len(), 3);
+        assert_eq!(options[0].label, "Red");
+        assert_eq!(options[1].value, json!("green"));
+        assert_eq!(options[2].label, "Blue");
+    }
+}

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -9,7 +9,9 @@
 //! `#[derive(EnumSelect)]`) and the validator / engine — given a type `T`, a
 //! caller can always obtain the schema by name without referring to the derive.
 
-use crate::{option::SelectOption, validated::ValidSchema};
+use std::sync::OnceLock;
+
+use crate::{option::SelectOption, schema::Schema, validated::ValidSchema, value::FieldValues};
 
 /// Types that expose a canonical [`ValidSchema`].
 ///
@@ -28,6 +30,87 @@ pub trait HasSchema {
 pub trait HasSelectOptions {
     /// Return the options for this type.
     fn select_options() -> Vec<SelectOption>;
+}
+
+/// Shared empty schema — cheap `Arc` clone for all baseline impls.
+fn empty_schema() -> ValidSchema {
+    static EMPTY: OnceLock<ValidSchema> = OnceLock::new();
+    EMPTY
+        .get_or_init(|| {
+            Schema::builder()
+                .build()
+                .expect("empty schema always builds")
+        })
+        .clone()
+}
+
+/// Baseline `HasSchema` impl for the unit type — actions / credentials /
+/// resources that have no user-configurable parameters can use `()` as their
+/// `Input` / `Config` without forcing authors to implement the trait.
+impl HasSchema for () {
+    fn schema() -> ValidSchema {
+        empty_schema()
+    }
+}
+
+/// Baseline `HasSchema` impl for dynamic JSON values — authors using untyped
+/// `serde_json::Value` as their `Input` advertise an empty schema. They remain
+/// responsible for documenting the expected shape out-of-band. Use a concrete
+/// typed struct with `#[derive(Schema)]` to get a real schema.
+impl HasSchema for serde_json::Value {
+    fn schema() -> ValidSchema {
+        empty_schema()
+    }
+}
+
+/// Baseline `HasSchema` impl for [`FieldValues`] — legacy code paths that
+/// still treat the raw value bag as the input type advertise an empty schema.
+impl HasSchema for FieldValues {
+    fn schema() -> ValidSchema {
+        empty_schema()
+    }
+}
+
+/// Baseline `HasSchema` impls for common primitives — useful when a trait
+/// (e.g. [`ResourceConfig`](nebula_resource::ResourceConfig)) requires a
+/// `HasSchema` bound and the implementer is using a primitive as a stub.
+/// Any production usage should wrap the primitive in a struct with
+/// `#[derive(Schema)]` instead.
+macro_rules! empty_has_schema_for {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl HasSchema for $t {
+                fn schema() -> ValidSchema {
+                    empty_schema()
+                }
+            }
+        )*
+    };
+}
+
+empty_has_schema_for!(
+    bool, String, i8, i16, i32, i64, i128, isize, u8, u16, u32, u64, u128, usize, f32, f64
+);
+
+/// Convenience macro: `nebula_schema::impl_empty_has_schema!(MyStub);`
+///
+/// Emits a [`HasSchema`] implementation that returns an empty [`ValidSchema`].
+/// Suitable for test fixtures / legacy types that don't yet declare a real
+/// schema. In production code, prefer `#[derive(Schema)]` (Phase 2b) so the
+/// schema matches the actual struct shape.
+#[macro_export]
+macro_rules! impl_empty_has_schema {
+    ($($t:ty),* $(,)?) => {
+        $(
+            impl $crate::has_schema::HasSchema for $t {
+                fn schema() -> $crate::validated::ValidSchema {
+                    $crate::schema::Schema::builder()
+                        .build()
+                        .expect("empty schema is always valid")
+                }
+            }
+        )*
+    };
 }
 
 #[cfg(test)]
@@ -82,6 +165,29 @@ mod tests {
     fn has_schema_arc_clone_is_cheap() {
         let a = Dummy::schema();
         let b = a.clone();
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn unit_has_empty_schema() {
+        assert_eq!(<() as HasSchema>::schema().fields().len(), 0);
+    }
+
+    #[test]
+    fn json_value_has_empty_schema() {
+        assert_eq!(<serde_json::Value as HasSchema>::schema().fields().len(), 0);
+    }
+
+    #[test]
+    fn field_values_has_empty_schema() {
+        assert_eq!(<FieldValues as HasSchema>::schema().fields().len(), 0);
+    }
+
+    #[test]
+    fn empty_schema_is_cached() {
+        let a = <() as HasSchema>::schema();
+        let b = <serde_json::Value as HasSchema>::schema();
+        // Same Arc — shared cache entry.
         assert_eq!(a, b);
     }
 

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -9,9 +9,7 @@
 //! `#[derive(EnumSelect)]`) and the validator / engine — given a type `T`, a
 //! caller can always obtain the schema by name without referring to the derive.
 
-use std::sync::OnceLock;
-
-use crate::{option::SelectOption, schema::Schema, validated::ValidSchema, value::FieldValues};
+use crate::{option::SelectOption, validated::ValidSchema, value::FieldValues};
 
 /// Types that expose a canonical [`ValidSchema`].
 ///
@@ -32,16 +30,9 @@ pub trait HasSelectOptions {
     fn select_options() -> Vec<SelectOption>;
 }
 
-/// Shared empty schema — cheap `Arc` clone for all baseline impls.
+/// Shared empty schema — delegates to [`ValidSchema::empty`].
 fn empty_schema() -> ValidSchema {
-    static EMPTY: OnceLock<ValidSchema> = OnceLock::new();
-    EMPTY
-        .get_or_init(|| {
-            Schema::builder()
-                .build()
-                .expect("empty schema always builds")
-        })
-        .clone()
+    ValidSchema::empty()
 }
 
 /// Baseline `HasSchema` impl for the unit type — actions / credentials /
@@ -104,9 +95,7 @@ macro_rules! impl_empty_has_schema {
         $(
             impl $crate::has_schema::HasSchema for $t {
                 fn schema() -> $crate::validated::ValidSchema {
-                    $crate::schema::Schema::builder()
-                        .build()
-                        .expect("empty schema is always valid")
+                    $crate::validated::ValidSchema::empty()
                 }
             }
         )*

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -88,7 +88,7 @@ pub use loader::{
     Loader, LoaderContext, LoaderFuture, LoaderRegistry, LoaderResult, OptionLoader, RecordLoader,
 };
 pub use mode::{ExpressionMode, RequiredMode, VisibilityMode};
-pub use nebula_schema_macros::field_key;
+pub use nebula_schema_macros::{EnumSelect, Schema, field_key};
 pub use option::SelectOption;
 pub use path::{FieldPath, PathSegment};
 pub use schema::{Schema, SchemaBuilder};

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -29,6 +29,8 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+/// Typed-closure builder DSL (leaf aliases + Object/List/Group composite builders).
+pub mod builder;
 /// [`nebula_validator::RuleContext`] adapters backed by [`FieldValues`].
 pub(crate) mod context;
 /// Error types for schema operations.
@@ -37,6 +39,8 @@ pub mod error;
 pub mod expression;
 /// Typed field definitions and wrappers.
 pub mod field;
+/// Traits linking Rust types to schema definitions.
+pub mod has_schema;
 /// UI hints for string input rendering.
 pub mod input_hint;
 /// Strongly typed field identifiers.
@@ -64,6 +68,10 @@ pub mod value;
 /// Typed widget hints by field family.
 pub mod widget;
 
+pub use builder::{
+    BooleanBuilder, CodeBuilder, FieldCollector, GroupBuilder, ListBuilder, NumberBuilder,
+    ObjectBuilder, SecretBuilder, SelectBuilder, StringBuilder,
+};
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };
@@ -73,6 +81,7 @@ pub use field::{
     ListField, ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField,
     SecretField, SelectField, StringField,
 };
+pub use has_schema::{HasSchema, HasSelectOptions};
 pub use input_hint::InputHint;
 pub use key::FieldKey;
 pub use loader::{

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -180,6 +180,19 @@ impl SchemaBuilder {
         self
     }
 
+    /// Append many fields at once — accepts `Vec<Field>`, `[Field; N]`,
+    /// iterators, and anything `Into<Field>` per item. Preferred over
+    /// chaining `.add(...)` for statically known bulk additions.
+    #[must_use]
+    pub fn add_many<I, F>(mut self, fields: I) -> Self
+    where
+        I: IntoIterator<Item = F>,
+        F: Into<Field>,
+    {
+        self.fields.extend(fields.into_iter().map(Into::into));
+        self
+    }
+
     /// Append a group of fields that share a common label and optional
     /// `visible_when` / `required_when` conditions.
     ///

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -180,6 +180,41 @@ impl SchemaBuilder {
         self
     }
 
+    /// Append a group of fields that share a common label and optional
+    /// `visible_when` / `required_when` conditions.
+    ///
+    /// ```rust
+    /// use nebula_schema::{FieldCollector, Schema, StringWidget};
+    /// use nebula_validator::{Predicate, Rule};
+    ///
+    /// let rule = Rule::predicate(Predicate::eq("method", "POST").unwrap());
+    /// let schema = Schema::builder()
+    ///     .string("method", |s| s.required())
+    ///     .group("body_section", |g| {
+    ///         g.visible_when(rule)
+    ///             .string("body", |s| s.widget(StringWidget::Multiline))
+    ///     })
+    ///     .build()
+    ///     .unwrap();
+    /// assert_eq!(schema.fields().len(), 2);
+    /// ```
+    #[must_use]
+    pub fn group(
+        mut self,
+        name: impl Into<String>,
+        f: impl FnOnce(crate::builder::GroupBuilder) -> crate::builder::GroupBuilder,
+    ) -> Self {
+        let builder = f(crate::builder::GroupBuilder::new(name));
+        self.fields.extend(builder.into_fields());
+        self
+    }
+
+    /// Borrow the fields currently staged on the builder.
+    #[must_use]
+    pub fn fields(&self) -> &[Field] {
+        &self.fields
+    }
+
     /// Run lint passes and produce a validated schema, or a report of errors.
     pub fn build(self) -> Result<ValidSchema, ValidationReport> {
         let mut report = ValidationReport::new();
@@ -208,6 +243,13 @@ impl SchemaBuilder {
             index,
             flags,
         }))
+    }
+}
+
+impl crate::builder::FieldCollector for SchemaBuilder {
+    fn push_field(mut self, field: Field) -> Self {
+        self.fields.push(field);
+        self
     }
 }
 

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -97,6 +97,25 @@ impl ValidSchema {
         Self(Arc::new(inner))
     }
 
+    /// Shared empty `ValidSchema` — cheap `Arc` clone.
+    ///
+    /// Use this anywhere a `ValidSchema` is required but the entity has no
+    /// user-configurable inputs (actions that take `()`, stub credentials,
+    /// baseline `HasSchema` impls for primitives). Avoids the
+    /// `Schema::builder().build().expect("empty schema always valid")`
+    /// incantation in three dozen call sites.
+    pub fn empty() -> Self {
+        use std::sync::OnceLock;
+        static EMPTY: OnceLock<ValidSchema> = OnceLock::new();
+        EMPTY
+            .get_or_init(|| {
+                crate::schema::Schema::builder()
+                    .build()
+                    .expect("empty schema always builds")
+            })
+            .clone()
+    }
+
     /// Borrow all top-level fields in insertion order.
     pub fn fields(&self) -> &[Field] {
         &self.0.fields

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -102,16 +102,20 @@ impl ValidSchema {
     /// Use this anywhere a `ValidSchema` is required but the entity has no
     /// user-configurable inputs (actions that take `()`, stub credentials,
     /// baseline `HasSchema` impls for primitives). Avoids the
-    /// `Schema::builder().build().expect("empty schema always valid")`
-    /// incantation in three dozen call sites.
+    /// `Schema::builder().build().expect(..)` incantation in several dozen
+    /// call sites, and — unlike that pattern — cannot panic: the empty
+    /// `ValidSchemaInner` is constructed directly, bypassing lint passes
+    /// whose only job is to reject non-empty schemas.
     pub fn empty() -> Self {
         use std::sync::OnceLock;
         static EMPTY: OnceLock<ValidSchema> = OnceLock::new();
         EMPTY
             .get_or_init(|| {
-                crate::schema::Schema::builder()
-                    .build()
-                    .expect("empty schema always builds")
+                Self::from_inner(ValidSchemaInner {
+                    fields: Vec::new(),
+                    index: IndexMap::new(),
+                    flags: SchemaFlags::default(),
+                })
             })
             .clone()
     }

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -120,6 +120,15 @@ impl ValidSchema {
             .clone()
     }
 
+    /// Return `true` when two `ValidSchema` values share the same backing
+    /// `Arc` — i.e. they're the same instance, not just structurally
+    /// equivalent. Used to assert identity-preserving caches (e.g. the
+    /// `OnceLock` inside `#[derive(Schema)]`).
+    #[must_use]
+    pub fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+
     /// Borrow all top-level fields in insertion order.
     pub fn fields(&self) -> &[Field] {
         &self.0.fields

--- a/crates/schema/tests/builder_dsl.rs
+++ b/crates/schema/tests/builder_dsl.rs
@@ -1,0 +1,236 @@
+//! Integration tests for the typed-closure builder DSL.
+
+use nebula_schema::{
+    Field, FieldCollector, FieldValues, GroupBuilder, InputHint, RequiredMode, Schema,
+    StringWidget, VisibilityMode,
+};
+use nebula_validator::{Predicate, Rule};
+
+fn eq_rule(path: &str, value: impl Into<serde_json::Value>) -> Rule {
+    Rule::predicate(Predicate::eq(path, value).expect("valid path"))
+}
+use serde_json::json;
+
+#[test]
+fn closure_string_produces_equivalent_schema() {
+    let via_closure = Schema::builder()
+        .string("name", |s| {
+            s.label("Name")
+                .required()
+                .min_length(1)
+                .max_length(64)
+                .hint(InputHint::Email)
+        })
+        .build()
+        .unwrap();
+
+    let via_direct = Schema::builder()
+        .add(
+            Field::string("name")
+                .label("Name")
+                .required()
+                .min_length(1)
+                .max_length(64)
+                .hint(InputHint::Email),
+        )
+        .build()
+        .unwrap();
+
+    assert_eq!(via_closure, via_direct);
+}
+
+#[test]
+fn closure_number_integer_flag_applied() {
+    let schema = Schema::builder()
+        .integer("count", |n| n.min(0_i64).max(100_i64))
+        .build()
+        .unwrap();
+    match &schema.fields()[0] {
+        Field::Number(n) => {
+            assert!(n.integer);
+            assert!(n.rules.len() >= 2);
+        },
+        other => panic!("expected NumberField, got {other:?}"),
+    }
+}
+
+#[test]
+fn closure_boolean_chainable() {
+    let schema = Schema::builder()
+        .boolean("flag", |b| b.label("Flag").no_expression())
+        .build()
+        .unwrap();
+    match &schema.fields()[0] {
+        Field::Boolean(b) => {
+            assert_eq!(b.label.as_deref(), Some("Flag"));
+            assert!(matches!(
+                b.expression,
+                nebula_schema::ExpressionMode::Forbidden
+            ));
+        },
+        other => panic!("expected BooleanField, got {other:?}"),
+    }
+}
+
+#[test]
+fn closure_nested_object_holds_children() {
+    let schema = Schema::builder()
+        .object("user", |o| {
+            o.label("User")
+                .string("name", |s| s.required())
+                .number("age", |n| n.integer().min(0_i64))
+        })
+        .build()
+        .unwrap();
+
+    match &schema.fields()[0] {
+        Field::Object(obj) => {
+            assert_eq!(obj.fields.len(), 2);
+            assert_eq!(obj.fields[0].key().as_str(), "name");
+            assert_eq!(obj.fields[1].key().as_str(), "age");
+        },
+        other => panic!("expected ObjectField, got {other:?}"),
+    }
+}
+
+#[test]
+fn closure_list_item_via_closure() {
+    let schema = Schema::builder()
+        .list("tags", |l| {
+            l.min_items(1)
+                .max_items(10)
+                .item_string("entry", |s| s.max_length(32))
+        })
+        .build()
+        .unwrap();
+
+    match &schema.fields()[0] {
+        Field::List(list) => {
+            assert_eq!(list.min_items, Some(1));
+            assert_eq!(list.max_items, Some(10));
+            assert!(list.item.is_some());
+            match list.item.as_deref().unwrap() {
+                Field::String(s) => assert_eq!(s.key.as_str(), "entry"),
+                other => panic!("expected String item, got {other:?}"),
+            }
+        },
+        other => panic!("expected ListField, got {other:?}"),
+    }
+}
+
+#[test]
+fn builder_full_example_from_spec() {
+    let schema = Schema::builder()
+        .string("url", |s| {
+            s.label("URL")
+                .hint(InputHint::Url)
+                .required()
+                .max_length(8192)
+        })
+        .integer("timeout", |n| {
+            n.label("Timeout (s)").min(1_i64).max(300_i64)
+        })
+        .boolean("verbose", |b| b.no_expression())
+        .build()
+        .unwrap();
+
+    assert_eq!(schema.fields().len(), 3);
+    let values =
+        FieldValues::from_json(json!({ "url": "https://x.test/", "timeout": 5, "verbose": false }))
+            .unwrap();
+    assert!(schema.validate(&values).is_ok());
+}
+
+#[test]
+fn group_propagates_visible_when_to_children() {
+    let rule = eq_rule("method", "POST");
+    let schema = Schema::builder()
+        .string("method", |s| s.required())
+        .group("body_section", |g| {
+            g.visible_when(rule.clone())
+                .string("body", |s| s.widget(StringWidget::Multiline))
+                .integer("content_length", |n| n)
+        })
+        .build()
+        .unwrap();
+
+    // Group children are flattened into the top-level schema fields.
+    assert_eq!(schema.fields().len(), 3);
+    // First is the ungrouped `method`; the next two are grouped.
+    let body = &schema.fields()[1];
+    let content_length = &schema.fields()[2];
+
+    match body {
+        Field::String(s) => {
+            assert_eq!(s.group.as_deref(), Some("body_section"));
+            assert!(matches!(s.visible, VisibilityMode::When(_)));
+        },
+        other => panic!("expected grouped StringField, got {other:?}"),
+    }
+    match content_length {
+        Field::Number(n) => {
+            assert_eq!(n.group.as_deref(), Some("body_section"));
+            assert!(matches!(n.visible, VisibilityMode::When(_)));
+        },
+        other => panic!("expected grouped NumberField, got {other:?}"),
+    }
+}
+
+#[test]
+fn group_propagates_required_when_to_children() {
+    let rule = eq_rule("enabled", true);
+    let schema = Schema::builder()
+        .boolean("enabled", |b| b)
+        .group("details", |g| {
+            g.required_when(rule.clone())
+                .string("detail_a", |s| s)
+                .string("detail_b", |s| s)
+        })
+        .build()
+        .unwrap();
+
+    for f in schema.fields().iter().skip(1) {
+        match f {
+            Field::String(s) => {
+                assert_eq!(s.group.as_deref(), Some("details"));
+                assert!(matches!(s.required, RequiredMode::When(_)));
+            },
+            other => panic!("unexpected field: {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn group_composes_existing_child_visible_when() {
+    let group_rule = eq_rule("section", "A");
+    let child_rule = eq_rule("mode", "advanced");
+    let schema = Schema::builder()
+        .string("section", |s| s)
+        .string("mode", |s| s)
+        .group("g", |g| {
+            g.visible_when(group_rule.clone())
+                .string("x", |s| s.visible_when(child_rule.clone()))
+        })
+        .build()
+        .unwrap();
+
+    // The grouped `x` is the third field (after `section` and `mode`).
+    match &schema.fields()[2] {
+        Field::String(s) => match &s.visible {
+            VisibilityMode::When(rule) => {
+                // The composed rule must mention both field paths.
+                let debug = format!("{rule:?}");
+                assert!(debug.contains("section"));
+                assert!(debug.contains("mode"));
+            },
+            other => panic!("expected composed visible_when, got {other:?}"),
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+}
+
+#[test]
+fn group_builder_name_accessor() {
+    let g = GroupBuilder::new("g-label").visible_when(eq_rule("x", "y"));
+    assert_eq!(g.name(), "g-label");
+}

--- a/crates/schema/tests/builder_dsl.rs
+++ b/crates/schema/tests/builder_dsl.rs
@@ -234,3 +234,62 @@ fn group_builder_name_accessor() {
     let g = GroupBuilder::new("g-label").visible_when(eq_rule("x", "y"));
     assert_eq!(g.name(), "g-label");
 }
+
+#[test]
+fn group_required_when_composes_with_always_and_never_children() {
+    let rule = eq_rule("enabled", true);
+    let schema = Schema::builder()
+        .boolean("enabled", |b| b)
+        // A field declared `.required()` before the group applies its
+        // `required_when` must stay `Always` (compose_required's
+        // `Always` branch).
+        .group("details", |g| {
+            g.required_when(rule.clone())
+                .string("always_required", |s| s.required())
+                .string("optional_by_default", |s| s)
+        })
+        .build()
+        .unwrap();
+
+    match &schema.fields()[1] {
+        Field::String(s) => {
+            assert!(
+                matches!(s.required, RequiredMode::Always),
+                "an explicitly-required child must stay Always after group compose"
+            );
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+    match &schema.fields()[2] {
+        Field::String(s) => {
+            assert!(
+                matches!(s.required, RequiredMode::When(_)),
+                "an optional child must flip to When(..) after group compose"
+            );
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+}
+
+#[test]
+fn group_preserves_explicit_child_group_label() {
+    let schema = Schema::builder()
+        .group("outer", |g| {
+            g.string("inherits", |s| s)
+                .string("overrides", |s| s.group("inner"))
+        })
+        .build()
+        .unwrap();
+
+    // Child without an explicit `.group(..)` inherits the group label.
+    match &schema.fields()[0] {
+        Field::String(s) => assert_eq!(s.group.as_deref(), Some("outer")),
+        other => panic!("expected StringField, got {other:?}"),
+    }
+    // Child with its own `.group("inner")` is preserved — `set_group`'s
+    // None-guard must not overwrite it.
+    match &schema.fields()[1] {
+        Field::String(s) => assert_eq!(s.group.as_deref(), Some("inner")),
+        other => panic!("expected StringField, got {other:?}"),
+    }
+}

--- a/crates/schema/tests/compile_fail/boolean_no_pattern.stderr
+++ b/crates/schema/tests/compile_fail/boolean_no_pattern.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no method named `pattern` found for struct `BooleanField` in the current scope
+error[E0599]: no method named `pattern` found for struct `BooleanBuilder` in the current scope
  --> tests/compile_fail/boolean_no_pattern.rs:2:54
   |
 2 |     let _ = nebula_schema::Field::boolean("enabled").pattern("yes|no");
-  |                                                      ^^^^^^^ method not found in `BooleanField`
+  |                                                      ^^^^^^^ method not found in `BooleanBuilder`

--- a/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.rs
@@ -1,0 +1,9 @@
+use nebula_schema::{FieldCollector, Schema};
+use serde_json::json;
+
+fn main() {
+    // `option` belongs to SelectField, not BooleanField/BooleanBuilder.
+    let _ = Schema::builder()
+        .boolean("flag", |b| b.option(json!(1), "X"))
+        .build();
+}

--- a/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `option` found for struct `BooleanBuilder` in the current scope
+ --> tests/compile_fail/builder_closure_boolean_no_option.rs:7:32
+  |
+7 |         .boolean("flag", |b| b.option(json!(1), "X"))
+  |                                ^^^^^^ method not found in `BooleanBuilder`

--- a/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.rs
@@ -1,0 +1,8 @@
+use nebula_schema::{FieldCollector, Schema, StringWidget};
+
+fn main() {
+    // StringWidget::Multiline is specific to StringField; NumberField takes NumberWidget.
+    let _ = Schema::builder()
+        .number("n", |n| n.widget(StringWidget::Multiline))
+        .build();
+}

--- a/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.stderr
@@ -1,0 +1,13 @@
+error[E0308]: mismatched types
+ --> tests/compile_fail/builder_closure_number_no_widget_multiline.rs:6:35
+  |
+6 |         .number("n", |n| n.widget(StringWidget::Multiline))
+  |                            ------ ^^^^^^^^^^^^^^^^^^^^^^^ expected `NumberWidget`, found `StringWidget`
+  |                            |
+  |                            arguments to this method are incorrect
+  |
+note: method defined here
+ --> src/field.rs
+  |
+  |     pub fn widget(mut self, widget: NumberWidget) -> Self {
+  |            ^^^^^^

--- a/crates/schema/tests/compile_fail/builder_closure_string_no_min.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_string_no_min.rs
@@ -1,0 +1,6 @@
+use nebula_schema::{FieldCollector, Schema};
+
+fn main() {
+    // `min` belongs to NumberField, not StringField/StringBuilder.
+    let _ = Schema::builder().string("name", |s| s.min(1)).build();
+}

--- a/crates/schema/tests/compile_fail/builder_closure_string_no_min.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_string_no_min.stderr
@@ -1,8 +1,8 @@
 error[E0599]: the method `min` exists for struct `StringBuilder`, but its trait bounds were not satisfied
- --> tests/compile_fail/string_no_min.rs:2:50
+ --> tests/compile_fail/builder_closure_string_no_min.rs:5:52
   |
-2 |       let _ = nebula_schema::Field::string("name").min(1);
-  |                                                    ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
+5 |       let _ = Schema::builder().string("name", |s| s.min(1)).build();
+  |                                                      ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
   |
  ::: src/field.rs
   |

--- a/crates/schema/tests/compile_fail/builder_group_no_item_method.rs
+++ b/crates/schema/tests/compile_fail/builder_group_no_item_method.rs
@@ -1,0 +1,8 @@
+use nebula_schema::{FieldCollector, Schema};
+
+fn main() {
+    // `item` is on ListBuilder, not GroupBuilder.
+    let _ = Schema::builder()
+        .group("g", |g| g.item("x"))
+        .build();
+}

--- a/crates/schema/tests/compile_fail/builder_group_no_item_method.rs
+++ b/crates/schema/tests/compile_fail/builder_group_no_item_method.rs
@@ -1,4 +1,4 @@
-use nebula_schema::{FieldCollector, Schema};
+use nebula_schema::Schema;
 
 fn main() {
     // `item` is on ListBuilder, not GroupBuilder.

--- a/crates/schema/tests/compile_fail/builder_group_no_item_method.stderr
+++ b/crates/schema/tests/compile_fail/builder_group_no_item_method.stderr
@@ -1,0 +1,13 @@
+warning: unused import: `FieldCollector`
+ --> tests/compile_fail/builder_group_no_item_method.rs:1:21
+  |
+1 | use nebula_schema::{FieldCollector, Schema};
+  |                     ^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+error[E0599]: no method named `item` found for struct `GroupBuilder` in the current scope
+ --> tests/compile_fail/builder_group_no_item_method.rs:6:27
+  |
+6 |         .group("g", |g| g.item("x"))
+  |                           ^^^^ method not found in `GroupBuilder`

--- a/crates/schema/tests/compile_fail/builder_group_no_item_method.stderr
+++ b/crates/schema/tests/compile_fail/builder_group_no_item_method.stderr
@@ -1,11 +1,3 @@
-warning: unused import: `FieldCollector`
- --> tests/compile_fail/builder_group_no_item_method.rs:1:21
-  |
-1 | use nebula_schema::{FieldCollector, Schema};
-  |                     ^^^^^^^^^^^^^^
-  |
-  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
-
 error[E0599]: no method named `item` found for struct `GroupBuilder` in the current scope
  --> tests/compile_fail/builder_group_no_item_method.rs:6:27
   |

--- a/crates/schema/tests/compile_fail/derive_default_type_mismatch.rs
+++ b/crates/schema/tests/compile_fail/derive_default_type_mismatch.rs
@@ -1,0 +1,15 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    // A bool field with a string default — derive must reject this,
+    // otherwise we'd ship `Value::String("42")` as a bool default and
+    // hit validation errors on first use.
+    #[param(default = "42")]
+    flag: bool,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_default_type_mismatch.stderr
+++ b/crates/schema/tests/compile_fail/derive_default_type_mismatch.stderr
@@ -1,0 +1,18 @@
+error: #[param(default = ..)]: field expects a bool literal, got non-bool literal
+  --> tests/compile_fail/derive_default_type_mismatch.rs:10:5
+   |
+10 |     flag: bool,
+   |     ^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_default_type_mismatch.rs:14:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+14 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_length_min_gt_max.rs
+++ b/crates/schema/tests/compile_fail/derive_length_min_gt_max.rs
@@ -1,0 +1,12 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    #[validate(length(min = 100, max = 50))]
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_length_min_gt_max.stderr
+++ b/crates/schema/tests/compile_fail/derive_length_min_gt_max.stderr
@@ -1,0 +1,18 @@
+error: #[validate(length(..))]: min (100) cannot exceed max (50)
+ --> tests/compile_fail/derive_length_min_gt_max.rs:6:23
+  |
+6 |     #[validate(length(min = 100, max = 50))]
+  |                       ^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_length_min_gt_max.rs:11:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+11 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_range_min_gt_max.rs
+++ b/crates/schema/tests/compile_fail/derive_range_min_gt_max.rs
@@ -1,0 +1,12 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    #[validate(range(100..=50))]
+    count: u32,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_range_min_gt_max.stderr
+++ b/crates/schema/tests/compile_fail/derive_range_min_gt_max.stderr
@@ -1,0 +1,18 @@
+error: #[validate(range(..))]: min (100) cannot exceed max (50)
+ --> tests/compile_fail/derive_range_min_gt_max.rs:6:22
+  |
+6 |     #[validate(range(100..=50))]
+  |                      ^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_range_min_gt_max.rs:11:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+11 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_range_non_literal.rs
+++ b/crates/schema/tests/compile_fail/derive_range_non_literal.rs
@@ -1,0 +1,14 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    // A non-literal range bound — derive must surface a clear error
+    // instead of silently dropping the bound.
+    #[validate(range("low".."high"))]
+    count: u32,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_range_non_literal.stderr
+++ b/crates/schema/tests/compile_fail/derive_range_non_literal.stderr
@@ -1,0 +1,18 @@
+error: #[validate(range(..))]: bounds must be integer literals
+ --> tests/compile_fail/derive_range_non_literal.rs:8:22
+  |
+8 |     #[validate(range("low".."high"))]
+  |                      ^^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_range_non_literal.rs:13:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+13 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_unsupported_int_width.rs
+++ b/crates/schema/tests/compile_fail/derive_unsupported_int_width.rs
@@ -1,0 +1,13 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    // i128 doesn't round-trip through serde_json::Number — the derive
+    // must reject this at macro-expansion time.
+    count: i128,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_unsupported_int_width.stderr
+++ b/crates/schema/tests/compile_fail/derive_unsupported_int_width.stderr
@@ -1,0 +1,18 @@
+error: #[derive(Schema)]: integer type `i128` is not yet supported because `serde_json::Number` only round-trips through `i64`/`u64`. Use a narrower integer type (`i8`..`i64`, `u8`..`u64`) or wrap the value in a newtype that implements `HasSchema` manually.
+ --> tests/compile_fail/derive_unsupported_int_width.rs:8:5
+  |
+8 |     count: i128,
+  |     ^^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_unsupported_int_width.rs:12:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+12 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/number_no_multiline.stderr
+++ b/crates/schema/tests/compile_fail/number_no_multiline.stderr
@@ -1,5 +1,5 @@
-error[E0599]: no method named `multiline` found for struct `NumberField` in the current scope
+error[E0599]: no method named `multiline` found for struct `NumberBuilder` in the current scope
  --> tests/compile_fail/number_no_multiline.rs:2:51
   |
 2 |     let _ = nebula_schema::Field::number("count").multiline();
-  |                                                   ^^^^^^^^^ method not found in `NumberField`
+  |                                                   ^^^^^^^^^ method not found in `NumberBuilder`

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -107,8 +107,12 @@ fn derive_schema_matches_hand_written_schema() {
 fn derive_schema_is_cached() {
     let a = HttpInput::schema();
     let b = HttpInput::schema();
-    // Both reads return the same Arc.
-    assert_eq!(a, b);
+    // `PartialEq` would succeed on structural equality even if the cache
+    // is broken — `ptr_eq` is the actual invariant we care about.
+    assert!(
+        a.ptr_eq(&b),
+        "derive(Schema) must cache the built schema behind a shared Arc"
+    );
 }
 
 #[derive(Schema)]

--- a/crates/schema/tests/derive_schema.rs
+++ b/crates/schema/tests/derive_schema.rs
@@ -1,0 +1,213 @@
+//! Integration tests for `#[derive(Schema)]` and `#[derive(EnumSelect)]`.
+
+use nebula_schema::{
+    EnumSelect, Field, HasSchema, HasSelectOptions, InputHint, RequiredMode, Schema, StringWidget,
+};
+use serde_json::json;
+
+// ── #[derive(Schema)] ──────────────────────────────────────────────────────
+
+#[derive(Schema)]
+#[allow(dead_code, reason = "fields are exercised via HasSchema::schema")]
+struct HttpInput {
+    #[param(label = "URL", hint = "url")]
+    #[validate(required, url, length(max = 8192))]
+    url: String,
+
+    #[param(label = "Method", description = "HTTP method", default = "GET")]
+    method: String,
+
+    #[param(label = "Body", multiline)]
+    #[validate(length(max = 1024))]
+    body: Option<String>,
+
+    #[param(label = "Timeout (seconds)")]
+    #[validate(range(1..=300))]
+    timeout: Option<u32>,
+
+    #[param(label = "Verbose", no_expression)]
+    verbose: bool,
+
+    #[param(secret, label = "API Key")]
+    #[validate(required)]
+    api_key: String,
+}
+
+#[test]
+fn derive_schema_matches_hand_written_schema() {
+    let derived = HttpInput::schema();
+    // 6 fields declared (skip would exclude).
+    assert_eq!(derived.fields().len(), 6);
+
+    // url — required String with url + max_length.
+    match &derived.fields()[0] {
+        Field::String(s) => {
+            assert_eq!(s.key.as_str(), "url");
+            assert_eq!(s.label.as_deref(), Some("URL"));
+            assert!(matches!(s.required, RequiredMode::Always));
+            assert!(matches!(s.hint, InputHint::Url));
+            assert!(s.rules.len() >= 2);
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+
+    // method — plain string with default "GET".
+    match &derived.fields()[1] {
+        Field::String(s) => {
+            assert_eq!(s.key.as_str(), "method");
+            assert_eq!(s.default.as_ref(), Some(&json!("GET")));
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+
+    // body — Option<String> + multiline widget.
+    match &derived.fields()[2] {
+        Field::String(s) => {
+            assert_eq!(s.key.as_str(), "body");
+            assert!(matches!(s.required, RequiredMode::Never));
+            assert!(matches!(s.widget, StringWidget::Multiline));
+        },
+        other => panic!("expected StringField, got {other:?}"),
+    }
+
+    // timeout — Option<u32> with range.
+    match &derived.fields()[3] {
+        Field::Number(n) => {
+            assert_eq!(n.key.as_str(), "timeout");
+            assert!(n.integer);
+            assert!(matches!(n.required, RequiredMode::Never));
+            assert!(n.rules.len() >= 2);
+        },
+        other => panic!("expected NumberField, got {other:?}"),
+    }
+
+    // verbose — bool with no_expression.
+    match &derived.fields()[4] {
+        Field::Boolean(b) => {
+            assert_eq!(b.key.as_str(), "verbose");
+            assert!(matches!(
+                b.expression,
+                nebula_schema::ExpressionMode::Forbidden
+            ));
+        },
+        other => panic!("expected BooleanField, got {other:?}"),
+    }
+
+    // api_key — secret, because #[param(secret)] switched String → SecretField.
+    match &derived.fields()[5] {
+        Field::Secret(s) => {
+            assert_eq!(s.key.as_str(), "api_key");
+            assert!(matches!(s.required, RequiredMode::Always));
+        },
+        other => panic!("expected SecretField, got {other:?}"),
+    }
+}
+
+#[test]
+fn derive_schema_is_cached() {
+    let a = HttpInput::schema();
+    let b = HttpInput::schema();
+    // Both reads return the same Arc.
+    assert_eq!(a, b);
+}
+
+#[derive(Schema)]
+#[allow(dead_code, reason = "fields exercised via derive")]
+struct Tag {
+    name: String,
+}
+
+#[derive(Schema)]
+#[allow(dead_code, reason = "fields exercised via derive")]
+struct TagList {
+    tags: Vec<String>,
+    owner: Option<Tag>,
+}
+
+#[test]
+fn derive_handles_vec_and_nested_user_type() {
+    let schema = TagList::schema();
+    assert_eq!(schema.fields().len(), 2);
+
+    match &schema.fields()[0] {
+        Field::List(l) => {
+            assert_eq!(l.key.as_str(), "tags");
+            assert!(l.item.is_some());
+            match l.item.as_deref().unwrap() {
+                Field::String(_) => {},
+                other => panic!("expected String list item, got {other:?}"),
+            }
+        },
+        other => panic!("expected ListField, got {other:?}"),
+    }
+
+    match &schema.fields()[1] {
+        Field::Object(o) => {
+            assert_eq!(o.key.as_str(), "owner");
+            // Tag has one field (name) — inlined via user-defined object.
+            assert_eq!(o.fields.len(), 1);
+            assert_eq!(o.fields[0].key().as_str(), "name");
+        },
+        other => panic!("expected ObjectField, got {other:?}"),
+    }
+}
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct WithSkip {
+    keep: String,
+    #[param(skip)]
+    _internal: u64,
+}
+
+#[test]
+fn derive_respects_skip() {
+    let s = WithSkip::schema();
+    assert_eq!(s.fields().len(), 1);
+    assert_eq!(s.fields()[0].key().as_str(), "keep");
+}
+
+// ── #[derive(EnumSelect)] ──────────────────────────────────────────────────
+
+#[derive(EnumSelect, Clone, Copy)]
+#[allow(dead_code, reason = "variants exercised via derive")]
+enum HttpMethod {
+    Get,
+    Post,
+    Put,
+    #[param(label = "HTTP DELETE")]
+    Delete,
+}
+
+#[test]
+fn derive_enum_select_generates_options() {
+    let options = HttpMethod::select_options();
+    assert_eq!(options.len(), 4);
+    assert_eq!(options[0].value, json!("get"));
+    assert_eq!(options[0].label, "Get");
+    assert_eq!(options[1].value, json!("post"));
+    assert_eq!(options[3].value, json!("delete"));
+    assert_eq!(options[3].label, "HTTP DELETE");
+}
+
+// Mixed: a derived struct can use a derived enum for its schema, albeit via
+// HasSelectOptions lookup on the builder side (the derive itself maps the
+// enum as a UserDefined object — refining to proper select-field inference
+// is Phase 2b T10's follow-up).
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Uses {
+    #[param(label = "Plain string")]
+    value: String,
+}
+
+#[test]
+fn sanity_build_many_fields_via_derive() {
+    // Confirm that `.add(Uses::schema().into())` also works via builder.
+    let s = Schema::builder()
+        .add_many(Uses::schema().fields().iter().cloned())
+        .build()
+        .expect("derived fields build into a new Schema");
+    assert_eq!(s.fields().len(), 1);
+}

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -152,8 +152,8 @@ mod tests {
             .with_version(2, 1)
             .build();
 
-        assert_eq!(metadata.key, action_key!("test.action"));
-        assert_eq!(metadata.name, "Test Action");
-        assert_eq!(metadata.description, "A test action");
+        assert_eq!(metadata.base.key, action_key!("test.action"));
+        assert_eq!(metadata.base.name, "Test Action");
+        assert_eq!(metadata.base.description, "A test action");
     }
 }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -19,7 +19,7 @@
 //!     .add_node("greet", "example_greet")
 //!     .build();
 //!
-//! assert_eq!(metadata.name, "Greet");
+//! assert_eq!(metadata.base.name, "Greet");
 //! assert!(workflow.is_ok());
 //! ```
 //!


### PR DESCRIPTION
## Summary

Completes Phase 2 of the `nebula-schema` roadmap — the authoring-side DX layer that turns schema declaration from an error-prone `Field::*` incantation into a typed, `#[derive]`-driven contract unified across actions, credentials, and resources.

**Five commits, each a self-contained architectural unit:**

1. **Phase 2a** (`0531aecc`) — Typed-closure builder DSL + `HasSchema` trait. `Schema::builder().string("k", |s| s.label(...).required())` form, `ObjectBuilder`/`ListBuilder`/`GroupBuilder` composite builders, 4 compile-fail fixtures for type safety.

2. **Phase 2-bridge** (`7e9e9879`) — `HasSchema` bound across `StatelessAction`/`StatefulAction`/`PaginatedAction`/`BatchAction::Input`, `Credential::Input`, and `ResourceConfig`. Baseline impls for `()`, `serde_json::Value`, `FieldValues`, and primitives. `ActionMetadata::for_stateless::<A>()` / sibling helpers auto-derive `parameters` from `A::Input::schema()`.

3. **`nebula-metadata` unification** (`390339d7`) — New crate owning `BaseMetadata<K>` + `Metadata` trait + `Icon` enum + `MaturityLevel` + `DeprecationNotice`. `ActionMetadata` / `CredentialMetadata` / `ResourceMetadata` migrate to compose the shared prefix via `#[serde(flatten)] pub base`. Closes the field-naming drift (`parameters` vs `properties` vs missing) and the key-typing drift (`String` vs `ActionKey`/`ResourceKey`). Adds full DX pass — `SchemaBuilder::add_many`, `FieldCollector::extend`, `BaseMetadata::add_tag`/`mark_experimental`/`deprecate`, `ActionMetadata::add_input`/`bump_major`.

4. **Phase 2b** (`65d49461`) — `#[derive(Schema)]` and `#[derive(EnumSelect)]` proc macros. Supports `#[param(label/description/placeholder/default/hint/secret/multiline/no_expression/expression_required/skip/group)]` + `#[validate(required/length/range/pattern/url/email)]`. Cached via `OnceLock`, nested user types resolved via `<T as HasSchema>::schema()`.

5. **Doc-link fixes** (`185effea`) — lefthook `docs`/`doctests` gates.

## Non-negotiables preserved

- Canon §4.5 end-to-end honor — every typed `Input` the engine sees now flows from the derived schema; no hidden drift between declared type and separately-written schema.
- Shim discipline — the three `*Input` stub structs in built-in credentials (`ApiKeyInput`/`BasicAuthInput`/`OAuth2Input`) exist only as schema-declaration scaffolds until Phase 2c rewrites `Credential::resolve` to take a typed `Input` directly; not retained as permanent adapters.
- Docs §17 definition of done — rustdoc + intra-doc links fixed in the push fix commit.

## Verification

- `cargo nextest run --workspace` — **3260/3260 passed**, 13 skipped.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo test --workspace --doc` — green.
- `cargo check --workspace --all-features --all-targets` — green (covered by lefthook pre-push).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — green.

## Test plan

- [ ] Review ADR implications — BaseMetadata<K> as a Core-layer crate, not Business; confirm no upward dep created.
- [ ] Confirm naming: `parameters → schema` everywhere (legacy from `nebula-parameter`).
- [ ] Spot-check the three credential migrations (`api_key`/`basic_auth`/`oauth2`) — stub `*Input` structs are recognised as temporary scaffolding.
- [ ] Confirm `ActionMetadata` size growth (184 → 376 bytes) is acceptable given allocation is once-per-action-type.
- [ ] Gate Phase 2c (`Credential::resolve(input: &Self::Input)`) and Phase 3 (SecretValue + Zeroize) as follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added schema derivation macros (`#[derive(Schema)]`, `#[derive(EnumSelect)]`) for automatic input schema generation.
  * Introduced fluent builder DSL for constructing schemas programmatically.
  * Added `HasSchema` trait for typed input schema support.

* **Refactor**
  * Consolidated action, credential, and resource metadata structures with shared base metadata handling.
  * Enhanced metadata APIs with unified accessor methods across entity types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->