### PR TITLE
fix(storage): validate PostgresStorage table name (#276)

### DIFF
--- a/crates/storage/src/backend/postgres.rs
+++ b/crates/storage/src/backend/postgres.rs
@@ -95,6 +95,8 @@ impl PostgresStorage {
 
     /// Create a new [`PostgresStorage`] using explicit configuration.
     pub async fn with_config(config: PostgresStorageConfig) -> Result<Self, StorageError> {
+        validate_table_name(&config.table)?;
+
         let pool = PgPoolOptions::new()
             .max_connections(config.max_connections)
             .min_connections(config.min_connections)
@@ -123,6 +125,40 @@ impl PostgresStorage {
             exists_sql: Arc::from(exists_sql),
         })
     }
+}
+
+/// Validates a PostgreSQL table name before interpolating it into SQL.
+///
+/// Accepts only simple unquoted identifiers matching
+/// `[A-Za-z_][A-Za-z0-9_]{0,62}` — the safe subset of PostgreSQL identifiers
+/// that require no double-quoting and cannot contain SQL-injection payloads.
+/// Schema-qualified names (`schema.table`), quoted identifiers, and non-ASCII
+/// characters are rejected; if those are needed, add a dedicated code path
+/// that uses `sqlx::QueryBuilder::push_bind` or a safe quoter rather than
+/// loosening this regex.
+fn validate_table_name(name: &str) -> Result<(), StorageError> {
+    let bad = |reason: &str| {
+        StorageError::Configuration(format!(
+            "invalid table name {name:?}: {reason} (must match [A-Za-z_][A-Za-z0-9_]{{0,62}})"
+        ))
+    };
+    let bytes = name.as_bytes();
+    if bytes.is_empty() {
+        return Err(bad("empty"));
+    }
+    if bytes.len() > 63 {
+        return Err(bad("exceeds PostgreSQL identifier length (63)"));
+    }
+    let first = bytes[0];
+    if !(first.is_ascii_alphabetic() || first == b'_') {
+        return Err(bad("must start with an ASCII letter or underscore"));
+    }
+    for &b in &bytes[1..] {
+        if !(b.is_ascii_alphanumeric() || b == b'_') {
+            return Err(bad("may only contain [A-Za-z0-9_]"));
+        }
+    }
+    Ok(())
 }
 
 /// Postgres-backed workflow repository.
@@ -329,6 +365,68 @@ impl WorkflowRepo for PgWorkflowRepo {
 #[cfg(all(test, feature = "postgres"))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_table_name_accepts_valid_identifiers() {
+        for name in ["storage_kv", "kv", "_kv", "Kv1", "a", "_", "_9"] {
+            validate_table_name(name).unwrap_or_else(|e| panic!("{name:?} should be valid: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_table_name_accepts_max_length() {
+        let ok = "a".repeat(63);
+        validate_table_name(&ok).expect("63-char identifier should be valid");
+    }
+
+    #[test]
+    fn validate_table_name_rejects_empty() {
+        let err = validate_table_name("").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_sql_injection_shape() {
+        let err = validate_table_name("kv; DROP TABLE workflows; --").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_leading_digit() {
+        let err = validate_table_name("1kv").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_dash() {
+        let err = validate_table_name("kv-1").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_schema_qualified() {
+        let err = validate_table_name("audit.kv").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_double_quotes() {
+        let err = validate_table_name("\"kv\"").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_overlong() {
+        let too_long = "a".repeat(64);
+        let err = validate_table_name(&too_long).unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
+
+    #[test]
+    fn validate_table_name_rejects_whitespace() {
+        let err = validate_table_name("kv table").unwrap_err();
+        assert!(matches!(err, StorageError::Configuration(_)));
+    }
 
     #[tokio::test]
     async fn postgres_new_from_connection_string() {

--- a/crates/storage/src/backend/postgres.rs
+++ b/crates/storage/src/backend/postgres.rs
@@ -134,8 +134,10 @@ impl PostgresStorage {
 /// that require no double-quoting and cannot contain SQL-injection payloads.
 /// Schema-qualified names (`schema.table`), quoted identifiers, and non-ASCII
 /// characters are rejected; if those are needed, add a dedicated code path
-/// that uses `sqlx::QueryBuilder::push_bind` or a safe quoter rather than
-/// loosening this regex.
+/// that applies proper identifier quoting (PostgreSQL double-quoting with
+/// embedded `"` escaped as `""`) rather than loosening this regex. Note that
+/// SQL bind parameters (`$1`, `push_bind`, etc.) are for values only and
+/// cannot be used to substitute identifiers.
 fn validate_table_name(name: &str) -> Result<(), StorageError> {
     let bad = |reason: &str| {
         StorageError::Configuration(format!(


### PR DESCRIPTION
## Summary

- Validate `PostgresStorageConfig::table` against `[A-Za-z_][A-Za-z0-9_]{0,62}` in `PostgresStorage::with_config` **before** the pool connects, rejecting bad input with the existing typed `StorageError::Configuration`.
- Closes the SQL-injection-adjacent gap flagged in #276 where the table name was interpolated via `format!()` straight into `SELECT`/`INSERT`/`DELETE`/`EXISTS`.
- No new dependency: pure ASCII-byte validation matching the safe PostgreSQL unquoted identifier subset.

## Why this shape

- `StorageError::Configuration(String)` already existed; no new variant needed.
- Validation runs before `PgPoolOptions::connect` so invalid config fails fast without touching the database.
- Schema-qualified names (`audit.kv`) and quoted identifiers are rejected; if operators need them later, that warrants a dedicated safely-quoted path, not a looser regex here (per CLAUDE.md "no features beyond what the task requires").
- `PgWorkflowRepo` hardcodes `workflows` and therefore isn't affected — the issue flagged the divergence as context, not as a required fix.

## Test plan

- [x] `cargo +nightly fmt --all --check` — clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings.
- [x] `cargo nextest run --workspace` — 3262 passed, 13 skipped.
- [x] `cargo nextest run -p nebula-storage --features postgres -E 'not test(/shared::/)'` — 114 passed, 6 skipped. The six `backend::postgres::tests::shared::*` tests are pre-existing (they `.expect("DATABASE_URL required...")`) and fail on HEAD without my changes — unrelated.
- [x] Lefthook pre-push: shear / check-all-features / docs / check-no-default / doctests / nextest all green.
- [x] 10 new unit tests cover valid identifiers, max length, empty, SQL-injection shape, leading digit, dash, schema dot, double quotes, overlong, whitespace.

Closes #276.

🤖 Generated with [Claude Code](https://claude.com/claude-code)