### PR TITLE
fix(validator): surface type_mismatch from Rule::validate_value (#264)

### DIFF
--- a/crates/validator/src/rule/value.rs
+++ b/crates/validator/src/rule/value.rs
@@ -1,9 +1,12 @@
 //! Value-validation rules — operate on a single JSON value, no context.
 //!
-//! Silent-pass on JSON type mismatch (e.g. `MinLength` on a number
-//! returns `Ok`) is preserved as documented ergonomic. Cross-kind
-//! silent-pass (predicate returning `Ok` from `validate_value`) is
-//! eliminated by the type split.
+//! **Strict on JSON type mismatch.** A value rule bound to a JSON kind
+//! (`MinLength` → string, `Min` → number, `MinItems` → array, …) returns
+//! `ValidationError::type_mismatch` when the input's JSON kind does not
+//! match. `null` is a distinct kind and does not match any typed rule —
+//! schema layers are expected to filter optional/nullable fields upstream
+//! before dispatching rules (see `nebula-schema::validated`). Strictness
+//! here aligns with PRODUCT_CANON §4.2 ("no silent shape mismatches").
 
 use serde::{Deserialize, Serialize};
 
@@ -49,12 +52,37 @@ pub enum ValueRule {
     Url,
 }
 
+/// JSON kind name for error reporting — stable across rustc versions.
+fn json_type_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "boolean",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
+/// Builds a `type_mismatch` error with the rule-wide `{value}` param so
+/// templates can still render the offending input.
+fn type_mismatch(value: &serde_json::Value, expected: &'static str) -> ValidationError {
+    ValidationError::type_mismatch("", expected, json_type_name(value))
+        .with_param("value", format!("{value}"))
+}
+
 impl ValueRule {
-    /// Validates a JSON value against this rule. Returns `Ok(())` silently
-    /// when the JSON type doesn't match the rule's expected type.
+    /// Validates a JSON value against this rule.
     ///
-    /// Errors carry rule-specific `params` for message-template rendering:
-    /// `{min}`, `{max}`, `{pattern}`, `{allowed}`, plus always `{value}`.
+    /// Returns `ValidationError::type_mismatch` (code `type_mismatch`,
+    /// params `expected` / `actual` / `value`) when the input's JSON kind
+    /// does not match this rule's expected kind. Callers that want
+    /// tolerant behaviour on mismatched kinds should check the shape
+    /// upstream — see `nebula-schema::validated` for the canonical pattern.
+    ///
+    /// Successful rule-specific failures carry `params` for
+    /// message-template rendering: `{min}`, `{max}`, `{pattern}`,
+    /// `{allowed}`, plus always `{value}`.
     ///
     /// Exception: when `Pattern` holds a malformed regex, this returns a
     /// compile-time error with code `invalid_pattern` — no `{value}` param,
@@ -62,38 +90,39 @@ impl ValueRule {
     pub fn validate_value(&self, value: &serde_json::Value) -> Result<(), ValidationError> {
         match self {
             Self::MinLength(n) => {
-                if let Some(s) = value.as_str() {
-                    min_length(*n).validate(s).map_err(|e| {
-                        e.with_param("min", n.to_string())
-                            .with_param("value", format!("{value}"))
-                    })?;
-                }
-                Ok(())
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| type_mismatch(value, "string"))?;
+                min_length(*n).validate(s).map_err(|e| {
+                    e.with_param("min", n.to_string())
+                        .with_param("value", format!("{value}"))
+                })
             },
             Self::MaxLength(n) => {
-                if let Some(s) = value.as_str() {
-                    max_length(*n).validate(s).map_err(|e| {
-                        e.with_param("max", n.to_string())
-                            .with_param("value", format!("{value}"))
-                    })?;
-                }
-                Ok(())
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| type_mismatch(value, "string"))?;
+                max_length(*n).validate(s).map_err(|e| {
+                    e.with_param("max", n.to_string())
+                        .with_param("value", format!("{value}"))
+                })
             },
             Self::Pattern(p) => {
-                if let Some(s) = value.as_str() {
-                    let re = compile_regex(p)?;
-                    if !re.is_match(s) {
-                        return Err(ValidationError::invalid_format("", "regex")
-                            .with_param("pattern", p.clone())
-                            .with_param("value", format!("{value}")));
-                    }
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| type_mismatch(value, "string"))?;
+                let re = compile_regex(p)?;
+                if !re.is_match(s) {
+                    return Err(ValidationError::invalid_format("", "regex")
+                        .with_param("pattern", p.clone())
+                        .with_param("value", format!("{value}")));
                 }
                 Ok(())
             },
             Self::Min(bound) => {
-                if let Some(ord) = json_number_cmp(value, bound)
-                    && ord.is_lt()
-                {
+                let ord =
+                    json_number_cmp(value, bound).ok_or_else(|| type_mismatch(value, "number"))?;
+                if ord.is_lt() {
                     return Err(ValidationError::new("min", "Value must be at least {min}")
                         .with_param("min", format_json_number(bound))
                         .with_param("value", format!("{value}")));
@@ -101,9 +130,9 @@ impl ValueRule {
                 Ok(())
             },
             Self::Max(bound) => {
-                if let Some(ord) = json_number_cmp(value, bound)
-                    && ord.is_gt()
-                {
+                let ord =
+                    json_number_cmp(value, bound).ok_or_else(|| type_mismatch(value, "number"))?;
+                if ord.is_gt() {
                     return Err(ValidationError::new("max", "Value must be at most {max}")
                         .with_param("max", format_json_number(bound))
                         .with_param("value", format!("{value}")));
@@ -111,9 +140,9 @@ impl ValueRule {
                 Ok(())
             },
             Self::GreaterThan(bound) => {
-                if let Some(ord) = json_number_cmp(value, bound)
-                    && !ord.is_gt()
-                {
+                let ord =
+                    json_number_cmp(value, bound).ok_or_else(|| type_mismatch(value, "number"))?;
+                if !ord.is_gt() {
                     return Err(ValidationError::new(
                         "greater_than",
                         "Value must be greater than {min}",
@@ -124,9 +153,9 @@ impl ValueRule {
                 Ok(())
             },
             Self::LessThan(bound) => {
-                if let Some(ord) = json_number_cmp(value, bound)
-                    && !ord.is_lt()
-                {
+                let ord =
+                    json_number_cmp(value, bound).ok_or_else(|| type_mismatch(value, "number"))?;
+                if !ord.is_lt() {
                     return Err(
                         ValidationError::new("less_than", "Value must be less than {max}")
                             .with_param("max", format_json_number(bound))
@@ -135,75 +164,73 @@ impl ValueRule {
                 }
                 Ok(())
             },
+            // OneOf is kind-agnostic: the allowed set defines both the
+            // accepted kinds and the accepted values, so a mismatched kind
+            // is just "not one of the allowed values" — no need for a
+            // separate type_mismatch path.
             Self::OneOf(values) => {
                 if values.is_empty() {
                     return Ok(());
                 }
-                let has_same_type = values
-                    .iter()
-                    .any(|v| std::mem::discriminant(v) == std::mem::discriminant(value));
-                if !has_same_type {
+                if values.contains(value) {
                     return Ok(());
                 }
-                if !values.contains(value) {
-                    let allowed = values
-                        .iter()
-                        .map(|v| format!("{v}"))
-                        .collect::<Vec<_>>()
-                        .join(", ");
-                    return Err(
-                        ValidationError::new("one_of", "Value must be one of {allowed}")
-                            .with_param("allowed", allowed)
-                            .with_param("value", format!("{value}")),
-                    );
-                }
-                Ok(())
+                let allowed = values
+                    .iter()
+                    .map(|v| format!("{v}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                Err(
+                    ValidationError::new("one_of", "Value must be one of {allowed}")
+                        .with_param("allowed", allowed)
+                        .with_param("value", format!("{value}")),
+                )
             },
             Self::MinItems(n) => {
-                if let Some(items) = value.as_array() {
-                    min_size::<serde_json::Value>(*n)
-                        .validate(items.as_slice())
-                        .map_err(|e| {
-                            e.with_param("min", n.to_string())
-                                .with_param("value", format!("{value}"))
-                        })?;
-                }
-                Ok(())
+                let items = value
+                    .as_array()
+                    .ok_or_else(|| type_mismatch(value, "array"))?;
+                min_size::<serde_json::Value>(*n)
+                    .validate(items.as_slice())
+                    .map_err(|e| {
+                        e.with_param("min", n.to_string())
+                            .with_param("value", format!("{value}"))
+                    })
             },
             Self::MaxItems(n) => {
-                if let Some(items) = value.as_array() {
-                    max_size::<serde_json::Value>(*n)
-                        .validate(items.as_slice())
-                        .map_err(|e| {
-                            e.with_param("max", n.to_string())
-                                .with_param("value", format!("{value}"))
-                        })?;
-                }
-                Ok(())
+                let items = value
+                    .as_array()
+                    .ok_or_else(|| type_mismatch(value, "array"))?;
+                max_size::<serde_json::Value>(*n)
+                    .validate(items.as_slice())
+                    .map_err(|e| {
+                        e.with_param("max", n.to_string())
+                            .with_param("value", format!("{value}"))
+                    })
             },
             Self::Email => {
-                if let Some(s) = value.as_str() {
-                    static EMAIL_RE: std::sync::LazyLock<regex::Regex> =
-                        std::sync::LazyLock::new(|| {
-                            regex::Regex::new(EMAIL_PATTERN).expect("email regex")
-                        });
-                    if !EMAIL_RE.is_match(s) {
-                        return Err(ValidationError::invalid_format("", "email")
-                            .with_param("value", format!("{value}")));
-                    }
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| type_mismatch(value, "string"))?;
+                static EMAIL_RE: std::sync::LazyLock<regex::Regex> =
+                    std::sync::LazyLock::new(|| {
+                        regex::Regex::new(EMAIL_PATTERN).expect("email regex")
+                    });
+                if !EMAIL_RE.is_match(s) {
+                    return Err(ValidationError::invalid_format("", "email")
+                        .with_param("value", format!("{value}")));
                 }
                 Ok(())
             },
             Self::Url => {
-                if let Some(s) = value.as_str() {
-                    static URL_RE: std::sync::LazyLock<regex::Regex> =
-                        std::sync::LazyLock::new(|| {
-                            regex::Regex::new(URL_PATTERN).expect("url regex")
-                        });
-                    if !URL_RE.is_match(s) {
-                        return Err(ValidationError::invalid_format("", "url")
-                            .with_param("value", format!("{value}")));
-                    }
+                let s = value
+                    .as_str()
+                    .ok_or_else(|| type_mismatch(value, "string"))?;
+                static URL_RE: std::sync::LazyLock<regex::Regex> =
+                    std::sync::LazyLock::new(|| regex::Regex::new(URL_PATTERN).expect("url regex"));
+                if !URL_RE.is_match(s) {
+                    return Err(ValidationError::invalid_format("", "url")
+                        .with_param("value", format!("{value}")));
                 }
                 Ok(())
             },
@@ -232,8 +259,13 @@ mod tests {
     }
 
     #[test]
-    fn min_length_silent_pass_on_non_string() {
-        assert!(ValueRule::MinLength(3).validate_value(&json!(42)).is_ok());
+    fn min_length_rejects_non_string_with_type_mismatch() {
+        let err = ValueRule::MinLength(3)
+            .validate_value(&json!(42))
+            .unwrap_err();
+        assert_eq!(err.code.as_ref(), "type_mismatch");
+        assert_eq!(err.param("expected"), Some("string"));
+        assert_eq!(err.param("actual"), Some("number"));
     }
 
     #[test]
@@ -244,8 +276,51 @@ mod tests {
     }
 
     #[test]
+    fn min_rejects_non_number_with_type_mismatch() {
+        let err = ValueRule::Min(serde_json::Number::from(10))
+            .validate_value(&json!("hi"))
+            .unwrap_err();
+        assert_eq!(err.code.as_ref(), "type_mismatch");
+        assert_eq!(err.param("expected"), Some("number"));
+        assert_eq!(err.param("actual"), Some("string"));
+    }
+
+    #[test]
+    fn min_items_rejects_non_array_with_type_mismatch() {
+        let err = ValueRule::MinItems(1)
+            .validate_value(&json!("not-an-array"))
+            .unwrap_err();
+        assert_eq!(err.code.as_ref(), "type_mismatch");
+        assert_eq!(err.param("expected"), Some("array"));
+    }
+
+    #[test]
+    fn email_rejects_non_string_with_type_mismatch() {
+        let err = ValueRule::Email.validate_value(&json!(42)).unwrap_err();
+        assert_eq!(err.code.as_ref(), "type_mismatch");
+        assert_eq!(err.param("expected"), Some("string"));
+    }
+
+    #[test]
+    fn one_of_rejects_wrong_type_instead_of_silent_pass() {
+        // Issue #264: OneOf(["a","b"]).validate(42) must not silently pass.
+        let rule = ValueRule::OneOf(vec![json!("a"), json!("b")]);
+        let err = rule.validate_value(&json!(42)).unwrap_err();
+        assert_eq!(err.code.as_ref(), "one_of");
+    }
+
+    #[test]
     fn one_of_empty_passes() {
         assert!(ValueRule::OneOf(vec![]).validate_value(&json!("x")).is_ok());
+    }
+
+    #[test]
+    fn null_rejected_as_type_mismatch() {
+        let err = ValueRule::MinLength(3)
+            .validate_value(&json!(null))
+            .unwrap_err();
+        assert_eq!(err.code.as_ref(), "type_mismatch");
+        assert_eq!(err.param("actual"), Some("null"));
     }
 
     #[test]

--- a/crates/validator/src/rule/value.rs
+++ b/crates/validator/src/rule/value.rs
@@ -74,13 +74,19 @@ fn type_mismatch(value: &serde_json::Value, expected: &'static str) -> Validatio
 impl ValueRule {
     /// Validates a JSON value against this rule.
     ///
-    /// Returns `ValidationError::type_mismatch` (code `type_mismatch`,
-    /// params `expected` / `actual` / `value`) when the input's JSON kind
-    /// does not match this rule's expected kind. Callers that want
-    /// tolerant behaviour on mismatched kinds should check the shape
-    /// upstream — see `nebula-schema::validated` for the canonical pattern.
+    /// Kind-bound rules (`MinLength`, `MaxLength`, `Pattern`, `Email`, `Url`
+    /// → string; `Min`, `Max`, `GreaterThan`, `LessThan` → number;
+    /// `MinItems`, `MaxItems` → array) return `ValidationError::type_mismatch`
+    /// (code `type_mismatch`, params `expected` / `actual` / `value`) when
+    /// the input's JSON kind does not match. Callers that want tolerant
+    /// behaviour on mismatched kinds should check the shape upstream — see
+    /// `nebula-schema::validated` for the canonical pattern.
     ///
-    /// Successful rule-specific failures carry `params` for
+    /// `OneOf` is kind-agnostic: a value that is not in the allowed set
+    /// reports `one_of` regardless of kind (mismatched kind is just a
+    /// non-member). An empty allowed set passes.
+    ///
+    /// Rule-specific validation failures carry `params` for
     /// message-template rendering: `{min}`, `{max}`, `{pattern}`,
     /// `{allowed}`, plus always `{value}`.
     ///

--- a/crates/validator/tests/integration/api_payload.rs
+++ b/crates/validator/tests/integration/api_payload.rs
@@ -108,10 +108,16 @@ fn combinator_rules_short_circuit_on_any() {
 }
 
 #[test]
-fn type_mismatch_passes_silently_by_design() {
-    // A number input does not trigger string rules; this is the documented
-    // "permissive" behaviour that keeps rules composable across fields
-    // with varying types.
+fn type_mismatch_surfaces_as_error() {
+    // Issue #264: a number input against string rules must surface a
+    // typed `type_mismatch` failure rather than silently passing. Schema
+    // layers that want tolerant behaviour type-check upstream (see
+    // `nebula-schema::validated`) before dispatching rules.
     let rules = username_rules();
-    assert!(validate_rules(&json!(42), &rules, ExecutionMode::StaticOnly).is_ok());
+    let errors = expect_errors(validate_rules(
+        &json!(42),
+        &rules,
+        ExecutionMode::StaticOnly,
+    ));
+    assert_has_code(&errors, "type_mismatch");
 }


### PR DESCRIPTION
## Summary
- Closes #264. Kind-bound `ValueRule` branches (`MinLength`, `MaxLength`, `Pattern`, `Email`, `Url`, `Min`, `Max`, `GreaterThan`, `LessThan`, `MinItems`, `MaxItems`) now return `ValidationError::type_mismatch` when the input JSON kind does not match the rule's expected kind, instead of silently passing.
- `OneOf` is **kind-agnostic**: it reports `one_of` on any non-member value (including cross-kind inputs). The prior `has_same_type` shortcut is gone — mismatched kinds are just non-members.
- Aligns with PRODUCT_CANON §4.2 ("no silent shape mismatches"). `nebula-schema::validated` already type-checks upstream before dispatching rules, so the stricter semantics do not regress the golden-path schema flow.

## Test plan
- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run --workspace` — 3267 passed, 13 skipped (pre-push full gate)
- [x] `cargo test --workspace --doc`
- [x] New unit tests in `crates/validator/src/rule/value.rs`:
      `min_length_rejects_non_string_with_type_mismatch`,
      `min_rejects_non_number_with_type_mismatch`,
      `min_items_rejects_non_array_with_type_mismatch`,
      `email_rejects_non_string_with_type_mismatch`,
      `one_of_rejects_wrong_type_instead_of_silent_pass`,
      `null_rejected_as_type_mismatch`.
- [x] Integration test `api_payload::type_mismatch_surfaces_as_error` replaces the prior `type_mismatch_passes_silently_by_design` which documented the buggy behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)