### PR TITLE
fix(execution): #273 transition edges + #261 drop IdempotencyManager

### DIFF
--- a/crates/execution/src/idempotency.rs
+++ b/crates/execution/src/idempotency.rs
@@ -5,7 +5,7 @@
 //! [`IdempotencyKey::generate`] and routes the dedup decision through the
 //! repository so that durability and the key namespace stay in lock-step.
 
-use std::{collections::HashSet, fmt};
+use std::fmt;
 
 use nebula_core::{ExecutionId, NodeKey};
 use serde::{Deserialize, Serialize};
@@ -31,58 +31,6 @@ impl IdempotencyKey {
 impl fmt::Display for IdempotencyKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.0)
-    }
-}
-
-/// Tracks idempotency keys in-memory.
-///
-/// This manager is retained as a compatibility shim while deduplication lives
-/// in `ExecutionRepo` implementations.
-#[derive(Debug, Default)]
-#[deprecated(
-    since = "0.1.0",
-    note = "Use `nebula_storage::ExecutionRepo::{check_idempotency, mark_idempotent}` for durable deduplication."
-)]
-pub struct IdempotencyManager {
-    seen: HashSet<String>,
-}
-
-#[allow(deprecated)]
-impl IdempotencyManager {
-    /// Create a new empty manager.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Check if the key has been seen before, and mark it as seen.
-    ///
-    /// Returns `true` when key is new; `false` for duplicates.
-    pub fn check_and_mark(&mut self, key: &IdempotencyKey) -> bool {
-        self.seen.insert(key.0.clone())
-    }
-
-    /// Check if a key has been seen without marking it.
-    #[must_use]
-    pub fn is_seen(&self, key: &IdempotencyKey) -> bool {
-        self.seen.contains(&key.0)
-    }
-
-    /// Clear all tracked keys.
-    pub fn clear(&mut self) {
-        self.seen.clear();
-    }
-
-    /// Number of tracked keys.
-    #[must_use]
-    pub fn len(&self) -> usize {
-        self.seen.len()
-    }
-
-    /// Returns `true` when no keys are tracked.
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.seen.is_empty()
     }
 }
 
@@ -127,26 +75,5 @@ mod tests {
         let json = serde_json::to_string(&key).expect("serialize");
         let back: IdempotencyKey = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(key, back);
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn manager_check_and_mark_new_key() {
-        let mut mgr = IdempotencyManager::new();
-        let key = IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 0);
-        assert!(mgr.check_and_mark(&key));
-        assert!(!mgr.check_and_mark(&key));
-    }
-
-    #[allow(deprecated)]
-    #[test]
-    fn manager_clear_resets() {
-        let mut mgr = IdempotencyManager::new();
-        let key = IdempotencyKey::generate(ExecutionId::new(), node_key!("test"), 0);
-        mgr.check_and_mark(&key);
-        assert_eq!(mgr.len(), 1);
-        mgr.clear();
-        assert!(mgr.is_empty());
-        assert!(!mgr.is_seen(&key));
     }
 }

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -51,8 +51,6 @@ pub use attempt::NodeAttempt;
 pub use context::{ExecutionBudget, ExecutionContext};
 pub use error::ExecutionError;
 pub use idempotency::IdempotencyKey;
-#[allow(deprecated)]
-pub use idempotency::IdempotencyManager;
 pub use journal::JournalEntry;
 /// Re-export the shared serde helper so internal `crate::serde_duration_opt` still resolves.
 pub(crate) use nebula_core::serde_helpers::duration_opt_ms as serde_duration_opt;

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -5,11 +5,17 @@ use nebula_workflow::NodeState;
 use crate::{error::ExecutionError, status::ExecutionStatus};
 
 /// Returns `true` if the execution-level transition from `from` to `to` is valid.
+///
+/// `Created → Cancelled`, `Paused → Failed`, and `Paused → TimedOut` are
+/// reachable under normal operation (pre-start cancel, out-of-band failure
+/// on a paused run, global deadline firing on a paused run) and must not
+/// force a phantom `Running` bridge into the audit trail (issue #273).
 #[must_use]
 pub fn can_transition_execution(from: ExecutionStatus, to: ExecutionStatus) -> bool {
     matches!(
         (from, to),
         (ExecutionStatus::Created, ExecutionStatus::Running)
+            | (ExecutionStatus::Created, ExecutionStatus::Cancelled)
             | (ExecutionStatus::Running, ExecutionStatus::Paused)
             | (ExecutionStatus::Running, ExecutionStatus::Cancelling)
             | (ExecutionStatus::Running, ExecutionStatus::Completed)
@@ -17,6 +23,8 @@ pub fn can_transition_execution(from: ExecutionStatus, to: ExecutionStatus) -> b
             | (ExecutionStatus::Running, ExecutionStatus::TimedOut)
             | (ExecutionStatus::Paused, ExecutionStatus::Running)
             | (ExecutionStatus::Paused, ExecutionStatus::Cancelling)
+            | (ExecutionStatus::Paused, ExecutionStatus::Failed)
+            | (ExecutionStatus::Paused, ExecutionStatus::TimedOut)
             | (ExecutionStatus::Cancelling, ExecutionStatus::Cancelled)
             | (ExecutionStatus::Cancelling, ExecutionStatus::Failed)
             | (ExecutionStatus::Cancelling, ExecutionStatus::Completed)
@@ -143,6 +151,76 @@ mod tests {
         assert!(!can_transition_execution(
             ExecutionStatus::Created,
             ExecutionStatus::Created
+        ));
+    }
+
+    /// Regression for issue #273: out-of-band failures (credential rotation,
+    /// downstream outage, supervisor death) can land on a Paused execution;
+    /// they must be expressible without a phantom `Paused → Running → Failed`
+    /// detour that pollutes the audit trail.
+    #[test]
+    fn paused_can_transition_to_failed() {
+        assert!(can_transition_execution(
+            ExecutionStatus::Paused,
+            ExecutionStatus::Failed
+        ));
+    }
+
+    /// Regression for issue #273: global deadline timers fire regardless of
+    /// execution status. A paused execution that blows its deadline must
+    /// reach TimedOut directly.
+    #[test]
+    fn paused_can_transition_to_timed_out() {
+        assert!(can_transition_execution(
+            ExecutionStatus::Paused,
+            ExecutionStatus::TimedOut
+        ));
+    }
+
+    /// Regression for issue #273: cancelling a scheduled execution before
+    /// the worker picks it up must be expressible in one step; the previous
+    /// table forced `Created → Running → Cancelling → Cancelled`, which lies
+    /// in the audit log about the run ever having run.
+    #[test]
+    fn created_can_transition_to_cancelled() {
+        assert!(can_transition_execution(
+            ExecutionStatus::Created,
+            ExecutionStatus::Cancelled
+        ));
+    }
+
+    /// Guard: the three new edges must not leak into illegal targets.
+    /// `Created → Completed/Failed/TimedOut/Paused` stay invalid — only
+    /// pre-start cancellation is allowed from `Created`.
+    #[test]
+    fn created_still_cannot_reach_other_terminals_directly() {
+        assert!(!can_transition_execution(
+            ExecutionStatus::Created,
+            ExecutionStatus::Completed
+        ));
+        assert!(!can_transition_execution(
+            ExecutionStatus::Created,
+            ExecutionStatus::Failed
+        ));
+        assert!(!can_transition_execution(
+            ExecutionStatus::Created,
+            ExecutionStatus::TimedOut
+        ));
+        assert!(!can_transition_execution(
+            ExecutionStatus::Created,
+            ExecutionStatus::Paused
+        ));
+    }
+
+    /// Guard: `Paused → Completed` is deliberately *not* in the table yet —
+    /// the semantics of "done from paused" need engine-level agreement
+    /// (see issue #273 "worth considering" note). Keep it rejected until
+    /// that decision is explicit.
+    #[test]
+    fn paused_cannot_transition_to_completed_yet() {
+        assert!(!can_transition_execution(
+            ExecutionStatus::Paused,
+            ExecutionStatus::Completed
         ));
     }
 


### PR DESCRIPTION
## Summary

Triage batch for `nebula-execution` fixing two of three medium-priority open issues. Both confirmed still open on HEAD via `git log --grep`.

- **#273** — `can_transition_execution` now permits `Paused → Failed`, `Paused → TimedOut`, and `Created → Cancelled`. These edges are reachable under normal operation (out-of-band failure on a paused run, global deadline firing on a paused run, pre-start cancel of a scheduled execution) and were previously forcing callers through a phantom `Running` bridge that lies in the audit trail. Engine sites like `let _ = state.set_status(...)` silently drop the rejected transition today, leaving executions forever-Paused. Guard tests pin the new edges without opening `Paused → Completed` (which needs engine-level semantic agreement per issue note).
- **#261** — `IdempotencyManager` was a `#[deprecated]` `HashSet<String>` with no eviction. No production callers: grep confirms only its own two unit tests used it; durable dedup lives in `nebula_storage::ExecutionRepo::{check_idempotency, mark_idempotent}`. Deleted the struct + impl + tests + re-export. `IdempotencyKey` (the canonical key generator) stays untouched.
- **#283** — deferred. `#255` already landed the version bump; `resume_execution` now uses `override_node_state` at [engine.rs:831](https://github.com/vanyastaff/nebula/blob/main/crates/engine/src/engine.rs#L831). The remaining concern (attempt_count not incremented on resume) interacts with `#266` (hardcoded `:1` in idempotency key) and should be fixed in the same pass.

## Canon fit

- #273 is a bug fix against §4.5 (public surface the engine needs end-to-end), not a schema invariant change — no ADR required.
- #261 is a deletion of a deprecated shim; breaking change in `nebula-execution` public API acceptable per CLAUDE.md §Development Mode (alpha).

## Test plan

- [x] `cargo nextest run -p nebula-execution` — 116/116 pass (5 new tests: 3 regression for the added edges, 2 guards for rejected edges)
- [x] `cargo check --workspace` — clean after `IdempotencyManager` removal
- [x] `cargo clippy -p nebula-execution --all-targets -- -D warnings` — clean
- [x] `cargo +nightly fmt --all` — applied
- [x] `lefthook` pre-commit (typos + fmt-check + clippy) + commit-msg (convco) — green on both commits
- [ ] CI full workspace gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)