### PR TITLE
fix(engine): route idempotency keys through ExecutionState helper (#266)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1404,7 +1404,7 @@ impl WorkflowEngine {
                         cancel_token.cancel();
                         return Some((node_key.clone(), e.to_string()));
                     }
-                    self.record_idempotency(execution_id, node_key.clone())
+                    self.record_idempotency(exec_state, execution_id, node_key.clone())
                         .await;
 
                     // Persist the full ActionResult alongside the raw
@@ -1748,9 +1748,9 @@ impl WorkflowEngine {
             return false;
         };
 
-        let idem_key = format!("{execution_id}:{node_key}:1");
+        let idem_key = exec_state.idempotency_key_for_node(execution_id, node_key.clone());
 
-        let already_done = match repo.check_idempotency(&idem_key).await {
+        let already_done = match repo.check_idempotency(idem_key.as_str()).await {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(
@@ -1910,13 +1910,18 @@ impl WorkflowEngine {
     ///
     /// Silently logs and ignores errors — idempotency key recording failures
     /// must not abort an otherwise healthy execution.
-    async fn record_idempotency(&self, execution_id: ExecutionId, node_key: NodeKey) {
+    async fn record_idempotency(
+        &self,
+        exec_state: &ExecutionState,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) {
         let Some(repo) = &self.execution_repo else {
             return;
         };
-        let idem_key = format!("{execution_id}:{node_key}:1");
+        let idem_key = exec_state.idempotency_key_for_node(execution_id, node_key.clone());
         if let Err(e) = repo
-            .mark_idempotent(&idem_key, execution_id, node_key.clone())
+            .mark_idempotent(idem_key.as_str(), execution_id, node_key.clone())
             .await
         {
             tracing::warn!(
@@ -4867,14 +4872,29 @@ mod tests {
             "handler should be called exactly once on first run"
         );
 
-        // Manually inject the same execution_id's idempotency key so that if
-        // we simulate re-running the same execution, the node is skipped.
-        // (The engine generates the key as "{execution_id}:{node_key}:1".)
+        // Reconstruct the idempotency key via the same seam the engine
+        // uses (issue #266) — `ExecutionState::idempotency_key_for_node`
+        // — so the test is not coupled to a literal `:1` suffix and
+        // still asserts the key was durably recorded by the first run.
+        //
+        // Deserializing via a JSON string (rather than `from_value`)
+        // avoids `#[serde(borrow)]` issues on domain keys — the same
+        // workaround `resume_execution` applies when loading state.
         let execution_id = result1.execution_id;
-        let idem_key = format!("{execution_id}:{n}:1");
+        let (_, state_json) = exec_repo
+            .get_state(execution_id)
+            .await
+            .unwrap()
+            .expect("execution state must be persisted after first run");
+        let state_str = serde_json::to_string(&state_json).unwrap();
+        let exec_state: nebula_execution::state::ExecutionState =
+            serde_json::from_str(&state_str).expect("deserialize persisted execution state");
+        let idem_key = exec_state.idempotency_key_for_node(execution_id, n.clone());
 
-        // Verify the key was recorded by the first run.
-        let already_marked = exec_repo.check_idempotency(&idem_key).await.unwrap();
+        let already_marked = exec_repo
+            .check_idempotency(idem_key.as_str())
+            .await
+            .unwrap();
         assert!(
             already_marked,
             "idempotency key should be recorded after first execution"

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1748,7 +1748,7 @@ impl WorkflowEngine {
             return false;
         };
 
-        let idem_key = exec_state.idempotency_key_for_node(execution_id, node_key.clone());
+        let idem_key = exec_state.idempotency_key_for_node(node_key.clone());
 
         let already_done = match repo.check_idempotency(idem_key.as_str()).await {
             Ok(v) => v,
@@ -1919,7 +1919,7 @@ impl WorkflowEngine {
         let Some(repo) = &self.execution_repo else {
             return;
         };
-        let idem_key = exec_state.idempotency_key_for_node(execution_id, node_key.clone());
+        let idem_key = exec_state.idempotency_key_for_node(node_key.clone());
         if let Err(e) = repo
             .mark_idempotent(idem_key.as_str(), execution_id, node_key.clone())
             .await
@@ -4889,7 +4889,7 @@ mod tests {
         let state_str = serde_json::to_string(&state_json).unwrap();
         let exec_state: nebula_execution::state::ExecutionState =
             serde_json::from_str(&state_str).expect("deserialize persisted execution state");
-        let idem_key = exec_state.idempotency_key_for_node(execution_id, n.clone());
+        let idem_key = exec_state.idempotency_key_for_node(n.clone());
 
         let already_marked = exec_repo
             .check_idempotency(idem_key.as_str())

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -206,25 +206,30 @@ impl ExecutionState {
     /// retried or restart-replayed attempt does not collide with a
     /// previous attempt's persisted output (issue #266, canon §11.3).
     ///
-    /// When `attempts` is empty (the common case while engine-level
-    /// retry accounting is still `planned` per §11.2), the key uses
-    /// attempt number `1` — matching what `save_node_output` records
-    /// via `attempt_count().max(1)`. When the retry scheduler lands and
-    /// begins pushing [`NodeAttempt`]s into `attempts`, this helper
-    /// automatically starts differentiating attempts without any engine
-    /// change.
+    /// The execution id is taken from `self` — callers cannot pass a
+    /// mismatched id by accident.
+    ///
+    /// When the node's `attempts` is empty (the common case while
+    /// engine-level retry accounting is still `planned` per §11.2), the
+    /// key uses attempt number `1` — matching what `save_node_output`
+    /// records via `attempt_count().max(1)`. When the retry scheduler
+    /// lands and begins pushing [`NodeAttempt`]s into `attempts`, this
+    /// helper automatically starts differentiating attempts without any
+    /// engine change.
+    ///
+    /// If `node_key` is not present in `node_states` (a programming
+    /// error in practice — the engine only generates keys for nodes it
+    /// has dispatched), the helper also defaults to attempt number `1`,
+    /// mirroring the `.unwrap_or(1)` fallback `save_node_output` uses
+    /// for the same input.
     #[must_use]
-    pub fn idempotency_key_for_node(
-        &self,
-        execution_id: ExecutionId,
-        node_key: NodeKey,
-    ) -> IdempotencyKey {
+    pub fn idempotency_key_for_node(&self, node_key: NodeKey) -> IdempotencyKey {
         let attempt = self
             .node_states
             .get(&node_key)
             .map(|ns| ns.attempt_count().max(1) as u32)
             .unwrap_or(1);
-        IdempotencyKey::generate(execution_id, node_key, attempt)
+        IdempotencyKey::generate(self.execution_id, node_key, attempt)
     }
 
     /// Set a node's execution state directly.
@@ -711,7 +716,7 @@ mod tests {
         let (mut state, n1, _n2) = make_state();
         let eid = state.execution_id;
 
-        let fresh = state.idempotency_key_for_node(eid, n1.clone());
+        let fresh = state.idempotency_key_for_node(n1.clone());
         assert_eq!(
             fresh,
             IdempotencyKey::generate(eid, n1.clone(), 1),
@@ -726,7 +731,7 @@ mod tests {
             IdempotencyKey::generate(eid, n1.clone(), 2),
         ));
 
-        let after_two = state.idempotency_key_for_node(eid, n1.clone());
+        let after_two = state.idempotency_key_for_node(n1.clone());
         assert_eq!(
             after_two,
             IdempotencyKey::generate(eid, n1, 2),
@@ -742,7 +747,7 @@ mod tests {
         let phantom = node_key!("not_in_state");
         let eid = state.execution_id;
 
-        let key = state.idempotency_key_for_node(eid, phantom.clone());
+        let key = state.idempotency_key_for_node(phantom.clone());
         assert_eq!(key, IdempotencyKey::generate(eid, phantom, 1));
     }
 }

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     attempt::NodeAttempt,
     error::ExecutionError,
+    idempotency::IdempotencyKey,
     output::NodeOutput,
     status::ExecutionStatus,
     transition::{validate_execution_transition, validate_node_transition},
@@ -196,6 +197,34 @@ impl ExecutionState {
     #[must_use]
     pub fn node_state(&self, node_key: NodeKey) -> Option<&NodeExecutionState> {
         self.node_states.get(&node_key)
+    }
+
+    /// Build the idempotency key for a node at its current attempt
+    /// count. This is the single source of truth the engine uses on
+    /// both the check and mark sides of the canonical
+    /// (`check_idempotency` → act → `mark_idempotent`) flow, so that a
+    /// retried or restart-replayed attempt does not collide with a
+    /// previous attempt's persisted output (issue #266, canon §11.3).
+    ///
+    /// When `attempts` is empty (the common case while engine-level
+    /// retry accounting is still `planned` per §11.2), the key uses
+    /// attempt number `1` — matching what `save_node_output` records
+    /// via `attempt_count().max(1)`. When the retry scheduler lands and
+    /// begins pushing [`NodeAttempt`]s into `attempts`, this helper
+    /// automatically starts differentiating attempts without any engine
+    /// change.
+    #[must_use]
+    pub fn idempotency_key_for_node(
+        &self,
+        execution_id: ExecutionId,
+        node_key: NodeKey,
+    ) -> IdempotencyKey {
+        let attempt = self
+            .node_states
+            .get(&node_key)
+            .map(|ns| ns.attempt_count().max(1) as u32)
+            .unwrap_or(1);
+        IdempotencyKey::generate(execution_id, node_key, attempt)
     }
 
     /// Set a node's execution state directly.
@@ -669,5 +698,51 @@ mod tests {
         assert_eq!(back.workflow_id, state.workflow_id);
         assert_eq!(back.status, state.status);
         assert_eq!(back.node_states.len(), state.node_states.len());
+    }
+
+    // Regression for #266: idempotency key must reflect the node's real
+    // attempt count, not a hardcoded ":1". The engine calls this helper on
+    // both check and record paths so that cross-restart replay does not
+    // collapse all attempts into one key.
+    #[test]
+    fn idempotency_key_for_node_uses_attempt_count() {
+        use crate::{attempt::NodeAttempt, idempotency::IdempotencyKey};
+
+        let (mut state, n1, _n2) = make_state();
+        let eid = state.execution_id;
+
+        let fresh = state.idempotency_key_for_node(eid, n1.clone());
+        assert_eq!(
+            fresh,
+            IdempotencyKey::generate(eid, n1.clone(), 1),
+            "a node with no attempts should key on attempt=1 (first dispatch)"
+        );
+
+        let ns = state.node_states.get_mut(&n1).unwrap();
+        let seed_key = IdempotencyKey::generate(eid, n1.clone(), 1);
+        ns.attempts.push(NodeAttempt::new(0, seed_key));
+        ns.attempts.push(NodeAttempt::new(
+            1,
+            IdempotencyKey::generate(eid, n1.clone(), 2),
+        ));
+
+        let after_two = state.idempotency_key_for_node(eid, n1.clone());
+        assert_eq!(
+            after_two,
+            IdempotencyKey::generate(eid, n1, 2),
+            "a node with two prior attempts should key on attempt=2"
+        );
+    }
+
+    #[test]
+    fn idempotency_key_for_node_unknown_node_defaults_to_one() {
+        use crate::idempotency::IdempotencyKey;
+
+        let (state, _n1, _n2) = make_state();
+        let phantom = node_key!("not_in_state");
+        let eid = state.execution_id;
+
+        let key = state.idempotency_key_for_node(eid, phantom.clone());
+        assert_eq!(key, IdempotencyKey::generate(eid, phantom, 1));
     }
 }


### PR DESCRIPTION
## Summary

Closes [#266](https://github.com/vanyastaff/nebula/issues/266).

- Replace two literal `format!("{execution_id}:{node_key}:1")` sites in `engine.rs` (`check_and_apply_idempotency`, `record_idempotency`) with a single `ExecutionState::idempotency_key_for_node` helper that derives attempt from `attempt_count().max(1)` — the same source `save_node_output` already uses — and routes through the existing `IdempotencyKey` seam (canon §11.3).
- Forward-compatible with §11.2's `planned` retry scheduler: once `NodeAttempt`s begin being pushed into `attempts` on dispatch/retry (gated behind `unstable-retry-scheduler`; tracked by [#290](https://github.com/vanyastaff/nebula/issues/290)), keys automatically start differentiating per attempt without any engine-side change.

## Scope note

This PR fixes the format hardcode (§11.6 docs-truth gap — the format claimed per-attempt keying but always collapsed to `:1`). The stale-replay behaviour #266 ultimately describes also depends on §11.2's engine-level retry story landing (NodeAttempt population in production). That remains out of scope here and is tracked by [#290](https://github.com/vanyastaff/nebula/issues/290) / Group E of the engine-lifecycle canon cluster.

## Test plan

- [x] New unit tests in `crates/execution/src/state.rs::tests`:
  - `idempotency_key_for_node_uses_attempt_count` — asserts the helper reads `attempt_count()` and produces the matching `IdempotencyKey`
  - `idempotency_key_for_node_unknown_node_defaults_to_one` — edge case for an unknown node key
- [x] Existing `idempotency_check_prevents_double_execution` updated to reconstruct the key via the helper rather than a hardcoded `:1` suffix (and to deserialize via JSON string to sidestep `#[serde(borrow)]` on domain keys — same workaround `resume_execution` applies)
- [x] `cargo nextest run -p nebula-engine -p nebula-execution` — 235 passed, 0 failed
- [x] `cargo test -p nebula-execution --doc` — 2 passed
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Lefthook pre-push (`shear`, `docs`, `check-all-features`, `check-no-default`, `doctests`, `nextest`) — all passed (3264 tests)

## PR checklist (from PULL_REQUEST_TEMPLATE)

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code
- [x] No silent error suppression
- [x] Execution / engine state transitions go through `transition_node()` (not applicable — this PR does not mutate node state; it only formats idempotency keys)
- [x] Credentials / secrets handling unchanged
- [x] No new `unsafe`

🤖 Generated with [Claude Code](https://claude.com/claude-code)