### PR TITLE
fix(credential): stop OAuth2 flows materialising plaintext secrets (#265)

### DIFF
--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -511,22 +511,20 @@ impl Credential for OAuth2Credential {
                     .as_deref()
                     .ok_or_else(|| CredentialError::InvalidInput(FAILED.into()))?;
 
-                // TODO(BL-C7-13, issue #265): these materialise plaintext
-                // `String`s that live until the HTTP round-trip drops them
-                // without zeroization. Wrap in `Zeroizing<String>` when
-                // that issue lands so the heap is scrubbed on drop. The
-                // window is narrow — `PendingStoreMemory::consume` wipes
-                // the pending row in the same call — but narrow is not
-                // zero.
-                let client_secret = pending.client_secret.expose_secret(|s| s.to_owned());
-                let code_verifier = verifier_secret.expose_secret(|s| s.to_owned());
+                // Zeroizing<String> scrubs the intermediate plaintext on drop.
+                // Downstream oauth2_flow::exchange_authorization_code builds the
+                // form body from &str borrows (GitHub issue #265).
+                let client_secret: zeroize::Zeroizing<String> =
+                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(|s| s.to_owned()));
+                let code_verifier: zeroize::Zeroizing<String> =
+                    zeroize::Zeroizing::new(verifier_secret.expose_secret(|s| s.to_owned()));
 
                 let state = oauth2_flow::exchange_authorization_code(
                     &pending.config,
                     &pending.client_id,
-                    &client_secret,
+                    client_secret.as_str(),
                     code,
-                    &code_verifier,
+                    code_verifier.as_str(),
                     redirect_uri,
                 )
                 .await?;
@@ -542,12 +540,15 @@ impl Credential for OAuth2Credential {
                     CredentialError::InvalidInput("pending state missing device_code".into())
                 })?;
                 let interval = pending.interval.unwrap_or(5);
-                let client_secret = pending.client_secret.expose_secret(|s| s.to_owned());
+                // Zeroizing<String>: intermediate plaintext scrubs on drop;
+                // poll_device_code builds its form from &str borrows (#265).
+                let client_secret: zeroize::Zeroizing<String> =
+                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(|s| s.to_owned()));
 
                 match oauth2_flow::poll_device_code(
                     &pending.config,
                     &pending.client_id,
-                    &client_secret,
+                    client_secret.as_str(),
                     device_code,
                     interval,
                 )

--- a/crates/credential/src/credentials/oauth2_flow.rs
+++ b/crates/credential/src/credentials/oauth2_flow.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use chrono::Utc;
 use serde_json::Value;
+use zeroize::Zeroizing;
 
 use super::{
     oauth2::OAuth2State,
@@ -81,6 +82,13 @@ pub(crate) fn build_auth_url(
 }
 
 /// Exchange client credentials for an access token (Client Credentials grant).
+///
+/// `client_secret` must be borrowed from a zeroizing buffer (typically
+/// `Zeroizing<String>` materialised from a `SecretString` at the caller).
+/// This function never owns a plaintext `String` copy of the secret — the
+/// form body is built from `&str` borrows so our intermediate heap is bounded
+/// by the caller's zeroize discipline. `reqwest` still maintains its own
+/// URL-encoded body buffer which we cannot zeroize.
 pub(crate) async fn exchange_client_credentials(
     config: &OAuth2Config,
     client_id: &str,
@@ -88,24 +96,30 @@ pub(crate) async fn exchange_client_credentials(
 ) -> Result<OAuth2State, CredentialError> {
     let client = http_client();
 
-    let mut form: Vec<(&str, String)> = vec![("grant_type", "client_credentials".into())];
+    let scope_joined = config.scopes.join(" ");
+    let mut form: Vec<(&str, &str)> = vec![("grant_type", "client_credentials")];
 
     if !config.scopes.is_empty() {
-        form.push(("scope", config.scopes.join(" ")));
+        form.push(("scope", &scope_joined));
     }
 
     let mut req = client.post(&config.token_url);
 
     match config.auth_style {
         AuthStyle::Header => {
-            let credentials = BASE64.encode(format!("{client_id}:{client_secret}"));
+            // Wrap the colon-joined plaintext so the intermediate scrubs on drop;
+            // the BASE64 output is still fed to reqwest unzeroized (out of our hands).
+            let basic_plaintext: Zeroizing<String> =
+                Zeroizing::new(format!("{client_id}:{client_secret}"));
+            let credentials: Zeroizing<String> =
+                Zeroizing::new(BASE64.encode(basic_plaintext.as_bytes()));
             req = req
-                .header("Authorization", format!("Basic {credentials}"))
+                .header("Authorization", format!("Basic {}", credentials.as_str()))
                 .form(&form);
         },
         AuthStyle::PostBody => {
-            form.push(("client_id", client_id.to_owned()));
-            form.push(("client_secret", client_secret.to_owned()));
+            form.push(("client_id", client_id));
+            form.push(("client_secret", client_secret));
             req = req.form(&form);
         },
     }
@@ -131,6 +145,10 @@ pub(crate) async fn exchange_client_credentials(
 /// `code_verifier` must be the same value whose SHA256 was sent as
 /// `code_challenge` in [`build_auth_url`]. `redirect_uri` must byte-match
 /// the one on the original auth request (RFC 6749 §4.1.3).
+///
+/// `code_verifier` and `client_secret` should be borrowed from zeroizing
+/// buffers at the caller — this function builds the form body from `&str`
+/// references so no plaintext `String` copy is produced on our heap.
 pub(crate) async fn exchange_authorization_code(
     config: &OAuth2Config,
     client_id: &str,
@@ -154,9 +172,12 @@ pub(crate) async fn exchange_authorization_code(
 
     match config.auth_style {
         AuthStyle::Header => {
-            let credentials = BASE64.encode(format!("{client_id}:{client_secret}"));
+            let basic_plaintext: Zeroizing<String> =
+                Zeroizing::new(format!("{client_id}:{client_secret}"));
+            let credentials: Zeroizing<String> =
+                Zeroizing::new(BASE64.encode(basic_plaintext.as_bytes()));
             req = req
-                .header("Authorization", format!("Basic {credentials}"))
+                .header("Authorization", format!("Basic {}", credentials.as_str()))
                 .form(&form);
         },
         AuthStyle::PostBody => {
@@ -191,23 +212,27 @@ pub(crate) async fn exchange_authorization_code(
 /// `redirect_uri`. When [`AuthStyle::PostBody`] is used, `client_id` and
 /// `client_secret` are appended; otherwise they are carried in the
 /// `Authorization: Basic` header by the caller.
-pub(crate) fn compose_auth_code_form(
-    code: &str,
-    code_verifier: &str,
-    redirect_uri: &str,
-    client_id: &str,
-    client_secret: &str,
+///
+/// Returns borrowed `&str` slices rather than owned `String`s so the
+/// caller's zeroizing buffers are not duplicated onto an extra heap copy
+/// (GitHub issue #265).
+pub(crate) fn compose_auth_code_form<'a>(
+    code: &'a str,
+    code_verifier: &'a str,
+    redirect_uri: &'a str,
+    client_id: &'a str,
+    client_secret: &'a str,
     auth_style: AuthStyle,
-) -> Vec<(&'static str, String)> {
-    let mut form: Vec<(&'static str, String)> = vec![
-        ("grant_type", "authorization_code".into()),
-        ("code", code.to_owned()),
-        ("code_verifier", code_verifier.to_owned()),
-        ("redirect_uri", redirect_uri.to_owned()),
+) -> Vec<(&'static str, &'a str)> {
+    let mut form: Vec<(&'static str, &'a str)> = vec![
+        ("grant_type", "authorization_code"),
+        ("code", code),
+        ("code_verifier", code_verifier),
+        ("redirect_uri", redirect_uri),
     ];
     if matches!(auth_style, AuthStyle::PostBody) {
-        form.push(("client_id", client_id.to_owned()));
-        form.push(("client_secret", client_secret.to_owned()));
+        form.push(("client_id", client_id));
+        form.push(("client_secret", client_secret));
     }
     form
 }
@@ -233,9 +258,10 @@ pub(crate) async fn request_device_code(
 ) -> Result<DeviceCodeResponse, CredentialError> {
     let client = http_client();
 
-    let mut form = vec![("client_id", client_id.to_owned())];
+    let scope_joined = config.scopes.join(" ");
+    let mut form: Vec<(&str, &str)> = vec![("client_id", client_id)];
     if !config.scopes.is_empty() {
-        form.push(("scope", config.scopes.join(" ")));
+        form.push(("scope", &scope_joined));
     }
 
     let resp = client
@@ -308,26 +334,26 @@ pub(crate) async fn poll_device_code(
 
     let client = http_client();
 
-    let mut form: Vec<(&str, String)> = vec![
-        (
-            "grant_type",
-            "urn:ietf:params:oauth:grant-type:device_code".into(),
-        ),
-        ("device_code", device_code.to_owned()),
+    let mut form: Vec<(&str, &str)> = vec![
+        ("grant_type", "urn:ietf:params:oauth:grant-type:device_code"),
+        ("device_code", device_code),
     ];
 
     let mut req = client.post(&config.token_url);
 
     match config.auth_style {
         AuthStyle::Header => {
-            let credentials = BASE64.encode(format!("{client_id}:{client_secret}"));
+            let basic_plaintext: Zeroizing<String> =
+                Zeroizing::new(format!("{client_id}:{client_secret}"));
+            let credentials: Zeroizing<String> =
+                Zeroizing::new(BASE64.encode(basic_plaintext.as_bytes()));
             req = req
-                .header("Authorization", format!("Basic {credentials}"))
+                .header("Authorization", format!("Basic {}", credentials.as_str()))
                 .form(&form);
         },
         AuthStyle::PostBody => {
-            form.push(("client_id", client_id.to_owned()));
-            form.push(("client_secret", client_secret.to_owned()));
+            form.push(("client_id", client_id));
+            form.push(("client_secret", client_secret));
             req = req.form(&form);
         },
     }
@@ -372,6 +398,15 @@ pub(crate) async fn poll_device_code(
 /// Mutates `state` in place: updates `access_token`, `expires_at`, and
 /// optionally `refresh_token` and `token_type` from the response.
 ///
+/// # Secret materialization (GitHub issue #265)
+///
+/// `refresh_token`, `client_id`, and `client_secret` are materialised into
+/// `Zeroizing<String>` buffers that scrub on drop. The form body is built
+/// from `&str` borrows into these buffers — we do not give `reqwest`
+/// ownership of our plaintext copies. `reqwest` still maintains an internal
+/// URL-encoded body buffer (and TLS write buffer) that we cannot zeroize;
+/// that residency is bounded by the HTTP round-trip.
+///
 /// # Errors
 ///
 /// Returns `CredentialError::Provider` if no `refresh_token` is available
@@ -380,22 +415,25 @@ pub(crate) async fn refresh_token(
     state: &mut OAuth2State,
     config: &OAuth2Config,
 ) -> Result<(), CredentialError> {
-    let refresh_tok = state
-        .refresh_token
-        .as_ref()
-        .ok_or_else(|| provider_error("no refresh_token available for token refresh".into()))?
-        .expose_secret(|s| s.to_owned());
+    let refresh_tok: Zeroizing<String> = Zeroizing::new(
+        state
+            .refresh_token
+            .as_ref()
+            .ok_or_else(|| provider_error("no refresh_token available for token refresh".into()))?
+            .expose_secret(|s| s.to_owned()),
+    );
+    let client_id: Zeroizing<String> =
+        Zeroizing::new(state.client_id.expose_secret(|s| s.to_owned()));
+    let client_secret: Zeroizing<String> =
+        Zeroizing::new(state.client_secret.expose_secret(|s| s.to_owned()));
 
-    let client_id = state.client_id.expose_secret(|s| s.to_owned());
-    let client_secret_str = state.client_secret.expose_secret(|s| s.to_owned());
-
-    let mut form: Vec<(&str, String)> = vec![
-        ("grant_type", "refresh_token".into()),
-        ("refresh_token", refresh_tok),
+    let scope_joined = config.scopes.join(" ");
+    let mut form: Vec<(&str, &str)> = vec![
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_tok.as_str()),
     ];
-
     if !config.scopes.is_empty() {
-        form.push(("scope", config.scopes.join(" ")));
+        form.push(("scope", &scope_joined));
     }
 
     let client = http_client();
@@ -403,14 +441,17 @@ pub(crate) async fn refresh_token(
 
     match config.auth_style {
         AuthStyle::Header => {
-            let credentials = BASE64.encode(format!("{client_id}:{client_secret_str}"));
+            let basic_plaintext: Zeroizing<String> =
+                Zeroizing::new(format!("{}:{}", client_id.as_str(), client_secret.as_str()));
+            let credentials: Zeroizing<String> =
+                Zeroizing::new(BASE64.encode(basic_plaintext.as_bytes()));
             req = req
-                .header("Authorization", format!("Basic {credentials}"))
+                .header("Authorization", format!("Basic {}", credentials.as_str()))
                 .form(&form);
         },
         AuthStyle::PostBody => {
-            form.push(("client_id", client_id));
-            form.push(("client_secret", client_secret_str));
+            form.push(("client_id", client_id.as_str()));
+            form.push(("client_secret", client_secret.as_str()));
             req = req.form(&form);
         },
     }
@@ -648,10 +689,10 @@ mod tests {
         assert_eq!(
             form,
             vec![
-                ("grant_type", "authorization_code".into()),
-                ("code", "the_code".into()),
-                ("code_verifier", "the_verifier".into()),
-                ("redirect_uri", "https://cb.example/path".into()),
+                ("grant_type", "authorization_code"),
+                ("code", "the_code"),
+                ("code_verifier", "the_verifier"),
+                ("redirect_uri", "https://cb.example/path"),
             ]
         );
     }
@@ -662,12 +703,12 @@ mod tests {
         assert_eq!(
             form,
             vec![
-                ("grant_type", "authorization_code".into()),
-                ("code", "c".into()),
-                ("code_verifier", "v".into()),
-                ("redirect_uri", "r".into()),
-                ("client_id", "cid".into()),
-                ("client_secret", "csecret".into()),
+                ("grant_type", "authorization_code"),
+                ("code", "c"),
+                ("code_verifier", "v"),
+                ("redirect_uri", "r"),
+                ("client_id", "cid"),
+                ("client_secret", "csecret"),
             ]
         );
     }


### PR DESCRIPTION
## Summary

Closes [#265](https://github.com/vanyastaff/nebula/issues/265).

OAuth2 refresh and exchange paths materialised `refresh_token`, `client_id`, and `client_secret` via `expose_secret(|s| s.to_owned())` into plain `String` copies that lived on the heap for the full HTTP round-trip without zeroization — defeating the `SecretString` contract exactly where it's touched most (heap-scraping / core-dump exposure per refresh).

Fix covers the whole class, not only the site named in the issue:

- **`oauth2_flow::refresh_token`** — intermediates wrapped in `Zeroizing<String>`; form body built from `&str` borrows; BASE64 plaintext input also zeroized.
- **`oauth2_flow::exchange_client_credentials` / `exchange_authorization_code` / `request_device_code` / `poll_device_code`** — forms changed from `Vec<(&str, String)>` → `Vec<(&str, &str)>` so no owned `String` clone lives on our heap; BASE64 `Basic` inputs wrapped in `Zeroizing<String>`.
- **`compose_auth_code_form`** — signature now returns `Vec<(&'static str, &'a str)>` with a lifetime tied to inputs; callers keep ownership and scrub on drop.
- **`oauth2::continue_resolve`** (AuthCode + DeviceCode callback paths) — materialised `client_secret` / `code_verifier` wrapped in `Zeroizing<String>`; the TODO block referencing #265 is removed.

### Known limitation

`reqwest` still owns its internal URL-encoded body buffer and the TLS write buffer. Those are out of our control and documented inline. This residency is bounded by the HTTP round-trip.

### Canon alignment

- PRODUCT_CANON §4.2 (credentials behind abstractions; rotation engine-owned) ✓
- PRODUCT_CANON §12.5 (secrets and auth: `Zeroize`/`ZeroizeOnDrop` on key material) ✓

## Test plan

- [x] `cargo nextest run -p nebula-credential` — 324/324 passed
- [x] `cargo test -p nebula-credential --doc` — 25/25 passed
- [x] `cargo clippy -p nebula-credential -- -D warnings` — clean
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] Pre-push hook (mirrors CI): shear, docs, check-all-features, check-no-default, doctests, nextest 3266/3266 — all green
- [x] `compose_auth_code_form` unit tests updated for new `&str` signature; shape assertions preserved

## Follow-ups

Sibling open credential issues not covered here: [#268](https://github.com/vanyastaff/nebula/issues/268), [#281](https://github.com/vanyastaff/nebula/issues/281), [#282](https://github.com/vanyastaff/nebula/issues/282).

🤖 Generated with [Claude Code](https://claude.com/claude-code)