### PR TITLE
fix(sandbox): path_under symlink bypass + forged handshake (#284, #260)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,6 +4167,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/plugin-sdk/src/transport.rs
+++ b/crates/plugin-sdk/src/transport.rs
@@ -42,17 +42,125 @@ pub const HANDSHAKE_VERSION: u32 = DUPLEX_PROTOCOL_VERSION;
 #[cfg(unix)]
 const MAX_UNIX_SOCKET_PATH_BYTES: usize = 100;
 
+/// Environment variable the host uses to tell the plugin exactly which
+/// socket address to bind (#260). When set, the plugin MUST bind this
+/// address and announce it in the handshake — no plugin-chosen path.
+///
+/// The corresponding [`ENV_SOCKET_KIND`] indicates `"unix"` or `"pipe"`.
+pub const ENV_SOCKET_ADDR: &str = "NEBULA_PLUGIN_SOCKET_ADDR";
+
+/// Environment variable that pairs with [`ENV_SOCKET_ADDR`] and names the
+/// transport kind (`"unix"` for Unix domain sockets, `"pipe"` for Windows
+/// named pipes). Required when [`ENV_SOCKET_ADDR`] is set.
+pub const ENV_SOCKET_KIND: &str = "NEBULA_PLUGIN_SOCKET_KIND";
+
 /// Bind a transport listener, return it paired with the handshake line the
 /// plugin should print on stdout before calling [`PluginListener::accept`].
+///
+/// # Host-controlled address (#260)
+///
+/// If the host sets [`ENV_SOCKET_ADDR`] + [`ENV_SOCKET_KIND`] (which the
+/// Nebula `ProcessSandbox` always does), the plugin MUST bind exactly that
+/// address. A compromised plugin that tries to print a different address
+/// in its handshake is rejected by the host-side validator in
+/// `nebula-sandbox`, preventing the "forged handshake → hijack sibling
+/// plugin socket" attack.
+///
+/// When the env vars are not set (standalone plugin development, ad-hoc
+/// tests) the plugin falls back to self-allocating a per-plugin directory
+/// — the pre-#260 behaviour, kept for DX.
 pub fn bind_listener() -> io::Result<(PluginListener, String)> {
-    #[cfg(unix)]
-    {
-        bind_unix()
+    match (
+        std::env::var(ENV_SOCKET_ADDR),
+        std::env::var(ENV_SOCKET_KIND),
+    ) {
+        (Ok(addr), Ok(kind)) => bind_listener_at(&addr, &kind),
+        _ => {
+            #[cfg(unix)]
+            {
+                bind_unix()
+            }
+            #[cfg(windows)]
+            {
+                bind_named_pipe()
+            }
+        },
     }
-    #[cfg(windows)]
-    {
-        bind_named_pipe()
+}
+
+fn bind_listener_at(addr: &str, kind: &str) -> io::Result<(PluginListener, String)> {
+    match kind {
+        "unix" => {
+            #[cfg(unix)]
+            {
+                bind_unix_at(addr)
+            }
+            #[cfg(not(unix))]
+            {
+                let _ = addr;
+                Err(io::Error::other(format!(
+                    "{ENV_SOCKET_KIND}=unix requested but this platform is not Unix"
+                )))
+            }
+        },
+        "pipe" => {
+            #[cfg(windows)]
+            {
+                bind_pipe_at(addr)
+            }
+            #[cfg(not(windows))]
+            {
+                let _ = addr;
+                Err(io::Error::other(format!(
+                    "{ENV_SOCKET_KIND}=pipe requested but this platform is not Windows"
+                )))
+            }
+        },
+        other => Err(io::Error::other(format!(
+            "unknown value for {ENV_SOCKET_KIND}: `{other}` (expected `unix` or `pipe`)"
+        ))),
     }
+}
+
+#[cfg(unix)]
+fn bind_unix_at(addr: &str) -> io::Result<(PluginListener, String)> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let socket_path = PathBuf::from(addr);
+    // Host is responsible for creating the parent directory with 0700
+    // before spawn. Plugin binds the socket file itself and sets 0600.
+    let listener = tokio::net::UnixListener::bind(&socket_path)?;
+    std::fs::set_permissions(&socket_path, std::fs::Permissions::from_mode(0o600))?;
+
+    let line = format!(
+        "NEBULA-PROTO-{HANDSHAKE_VERSION}|unix|{}",
+        socket_path.display()
+    );
+    Ok((
+        PluginListener::Unix {
+            listener,
+            // Cleanup is the host's responsibility — we didn't create
+            // the directory, so we don't remove it.
+            cleanup: CleanupGuard { dir: None },
+        },
+        line,
+    ))
+}
+
+#[cfg(windows)]
+fn bind_pipe_at(addr: &str) -> io::Result<(PluginListener, String)> {
+    use tokio::net::windows::named_pipe::ServerOptions;
+
+    let server = ServerOptions::new()
+        .first_pipe_instance(true)
+        .create(addr)?;
+    let line = format!("NEBULA-PROTO-{HANDSHAKE_VERSION}|pipe|{addr}");
+    Ok((
+        PluginListener::NamedPipe {
+            server: Some(server),
+        },
+        line,
+    ))
 }
 
 #[cfg(unix)]

--- a/crates/plugin-sdk/src/transport.rs
+++ b/crates/plugin-sdk/src/transport.rs
@@ -39,8 +39,16 @@ use crate::protocol::DUPLEX_PROTOCOL_VERSION;
 /// [`DUPLEX_PROTOCOL_VERSION`].
 pub const HANDSHAKE_VERSION: u32 = DUPLEX_PROTOCOL_VERSION;
 
+/// Upper bound on the byte length of a Unix-domain-socket path the plugin
+/// transport is willing to bind. `sun_path` in `sockaddr_un` is only
+/// 108 bytes on Linux / 104 on macOS; leaving headroom for the trailing
+/// NUL and for platforms with tighter limits keeps `UnixListener::bind()`
+/// from surprising callers with `ENAMETOOLONG`.
+///
+/// Exposed so host-side callers (nebula-sandbox) that allocate the socket
+/// path themselves can enforce the same cap before spawning the plugin.
 #[cfg(unix)]
-const MAX_UNIX_SOCKET_PATH_BYTES: usize = 100;
+pub const MAX_UNIX_SOCKET_PATH_BYTES: usize = 100;
 
 /// Environment variable the host uses to tell the plugin exactly which
 /// socket address to bind (#260). When set, the plugin MUST bind this
@@ -70,12 +78,12 @@ pub const ENV_SOCKET_KIND: &str = "NEBULA_PLUGIN_SOCKET_KIND";
 /// tests) the plugin falls back to self-allocating a per-plugin directory
 /// — the pre-#260 behaviour, kept for DX.
 pub fn bind_listener() -> io::Result<(PluginListener, String)> {
-    match (
-        std::env::var(ENV_SOCKET_ADDR),
-        std::env::var(ENV_SOCKET_KIND),
+    match classify_env(
+        std::env::var(ENV_SOCKET_ADDR).ok(),
+        std::env::var(ENV_SOCKET_KIND).ok(),
     ) {
-        (Ok(addr), Ok(kind)) => bind_listener_at(&addr, &kind),
-        _ => {
+        EnvBindMode::HostProvided { addr, kind } => bind_listener_at(&addr, &kind),
+        EnvBindMode::SelfAllocate => {
             #[cfg(unix)]
             {
                 bind_unix()
@@ -85,6 +93,46 @@ pub fn bind_listener() -> io::Result<(PluginListener, String)> {
                 bind_named_pipe()
             }
         },
+        EnvBindMode::PartialError(err) => Err(err),
+    }
+}
+
+/// Decision the plugin transport makes from the `(ADDR, KIND)` env pair.
+enum EnvBindMode {
+    /// Both env vars set — bind at the host-provided address.
+    HostProvided { addr: String, kind: String },
+    /// Neither set — self-allocate a per-plugin directory (ad-hoc/dev).
+    SelfAllocate,
+    /// Exactly one set — misconfiguration, fail fast.
+    PartialError(io::Error),
+}
+
+/// Pure classifier split out of [`bind_listener`] so the decision logic
+/// can be exercised without mutating process-global env state.
+///
+/// Partial configuration is a host bug (or tampering): one env var alone
+/// cannot express the host's chosen transport. Silently falling through
+/// to self-allocation would hide the misconfigured spawn and defeat the
+/// #260 handshake-forgery mitigation whenever the sandbox expected to
+/// enforce a host-chosen address.
+fn classify_env(addr: Option<String>, kind: Option<String>) -> EnvBindMode {
+    match (addr, kind) {
+        (Some(addr), Some(kind)) => EnvBindMode::HostProvided { addr, kind },
+        (Some(_), None) => EnvBindMode::PartialError(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{ENV_SOCKET_ADDR} is set but {ENV_SOCKET_KIND} is missing; \
+                 both must be set together"
+            ),
+        )),
+        (None, Some(_)) => EnvBindMode::PartialError(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!(
+                "{ENV_SOCKET_KIND} is set but {ENV_SOCKET_ADDR} is missing; \
+                 both must be set together"
+            ),
+        )),
+        (None, None) => EnvBindMode::SelfAllocate,
     }
 }
 
@@ -464,5 +512,66 @@ impl Drop for CleanupGuard {
         if let Some(dir) = self.dir.take() {
             let _ = std::fs::remove_dir_all(&dir);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_partial_env_error(mode: EnvBindMode) {
+        match mode {
+            EnvBindMode::PartialError(err) => {
+                assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+                let msg = err.to_string();
+                assert!(
+                    msg.contains(ENV_SOCKET_ADDR) && msg.contains(ENV_SOCKET_KIND),
+                    "error must name both env vars; got: {msg}",
+                );
+            },
+            EnvBindMode::HostProvided { .. } => {
+                panic!("partial env must not be classified as host-provided")
+            },
+            EnvBindMode::SelfAllocate => panic!(
+                "partial env must not fall through to self-allocation \
+                 (would defeat #260 handshake mitigation)"
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_env_rejects_addr_without_kind() {
+        assert_partial_env_error(classify_env(Some("/tmp/should-not-be-used".into()), None));
+    }
+
+    #[test]
+    fn classify_env_rejects_kind_without_addr() {
+        assert_partial_env_error(classify_env(None, Some("unix".into())));
+    }
+
+    #[test]
+    fn classify_env_both_set_is_host_provided() {
+        match classify_env(Some("/tmp/ok".into()), Some("unix".into())) {
+            EnvBindMode::HostProvided { addr, kind } => {
+                assert_eq!(addr, "/tmp/ok");
+                assert_eq!(kind, "unix");
+            },
+            other => panic!(
+                "both env vars set must classify as HostProvided, got other variant: {}",
+                match other {
+                    EnvBindMode::PartialError(e) => format!("PartialError({e})"),
+                    EnvBindMode::SelfAllocate => "SelfAllocate".into(),
+                    EnvBindMode::HostProvided { .. } => unreachable!(),
+                },
+            ),
+        }
+    }
+
+    #[test]
+    fn classify_env_neither_set_is_self_allocate() {
+        assert!(matches!(
+            classify_env(None, None),
+            EnvBindMode::SelfAllocate
+        ));
     }
 }

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -21,14 +21,13 @@ async-trait = { workspace = true }
 semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "sync", "net"] }
+uuid = { workspace = true }
 
 # OS-level sandbox (Linux only)
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"
 nix = { version = "0.31", features = ["resource"] }
-
-[dev-dependencies]
-tempfile = { workspace = true }

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -29,3 +29,6 @@ tokio = { workspace = true, features = ["process", "io-util", "sync", "net"] }
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"
 nix = { version = "0.31", features = ["resource"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/sandbox/src/capabilities.rs
+++ b/crates/sandbox/src/capabilities.rs
@@ -212,12 +212,54 @@ impl PluginCapabilities {
 ///
 /// On-disk ancestor walk-up treats only `ErrorKind::NotFound` as
 /// "keep climbing". Every other error kind is a trust violation and
-/// returns `false`.
+/// returns `false`. A `NotFound` from `canonicalize` is further cross-checked
+/// against `symlink_metadata`: if the component itself exists on disk (i.e.
+/// it IS a symlink, but its target is broken or outside the base), the walk
+/// stops and we fail closed. Otherwise the component really is absent and
+/// we continue climbing to find the deepest existing ancestor. This closes
+/// the #284 bypass where a symlink pointing at a not-yet-created outside
+/// target would slip past the walk and let the parent base match.
 fn path_under(path: &str, base: &str) -> bool {
     use std::{
         io::ErrorKind,
         path::{Component, Path, PathBuf},
     };
+
+    /// `canonicalize(a)` returning `NotFound` is ambiguous:
+    /// - the component does not exist at all → safe to climb to parent;
+    /// - the component IS a symlink whose target is broken or absent → NOT safe to climb, because
+    ///   once the target materialises the kernel will follow it wherever it points.
+    ///
+    /// Differentiate via `symlink_metadata`, which inspects the link itself
+    /// (no traversal). Any success = the component exists on disk, so a
+    /// `canonicalize NotFound` must be a broken symlink → fail closed.
+    fn ancestor_is_broken_symlink(a: &Path) -> bool {
+        std::fs::symlink_metadata(a).is_ok()
+    }
+
+    /// Walk up from `start`'s parent until an ancestor canonicalises,
+    /// then return whether it sits under `canon_base`. A `NotFound`
+    /// whose subject is a broken symlink (see `ancestor_is_broken_symlink`)
+    /// fails closed rather than climbing further — this is the #284
+    /// bypass fix.
+    fn canonical_ancestor_is_under(start: &Path, canon_base: &Path) -> bool {
+        let mut ancestor = start.parent();
+        while let Some(a) = ancestor {
+            match a.canonicalize() {
+                Ok(canon_a) => return canon_a.starts_with(canon_base),
+                Err(e) if e.kind() == ErrorKind::NotFound => {
+                    if ancestor_is_broken_symlink(a) {
+                        return false;
+                    }
+                    ancestor = a.parent();
+                },
+                // EACCES, ELOOP, ENOTDIR, etc. — the path references a
+                // filesystem object we can't verify. Fail closed per #284.
+                Err(_) => return false,
+            }
+        }
+        false
+    }
 
     fn normalize_lex(p: &Path) -> PathBuf {
         let mut out = PathBuf::new();
@@ -262,20 +304,15 @@ fn path_under(path: &str, base: &str) -> bool {
             match path.canonicalize() {
                 Ok(canon_path) => canon_path.starts_with(&canon_base),
                 Err(e) if e.kind() == ErrorKind::NotFound => {
-                    let mut ancestor = path.parent();
-                    while let Some(a) = ancestor {
-                        match a.canonicalize() {
-                            Ok(canon_a) => return canon_a.starts_with(&canon_base),
-                            Err(e) if e.kind() == ErrorKind::NotFound => {
-                                ancestor = a.parent();
-                            },
-                            // EACCES, ELOOP, ENOTDIR, etc. — the path
-                            // references a filesystem object we can't
-                            // verify. Fail closed per #284.
-                            Err(_) => return false,
-                        }
+                    // Leaf might legitimately not exist yet (common:
+                    // write to a new file under a granted dir). But if
+                    // the leaf itself IS a broken symlink on disk, fail
+                    // closed — otherwise the #284 bypass resurfaces when
+                    // the target appears later.
+                    if ancestor_is_broken_symlink(path) {
+                        return false;
                     }
-                    false
+                    canonical_ancestor_is_under(path, &canon_base)
                 },
                 // Same "fail closed on unknown error" policy for the
                 // top-level canonicalize (e.g., EACCES on a symlink's
@@ -489,6 +526,52 @@ mod tests {
             !path_under(requested_str, base_str),
             "symlink to nonexistent target outside base must be rejected, \
              base={base:?} requested={requested:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_rejects_broken_symlink_mid_path() {
+        // Defense-in-depth for the #284 regression the previous commit
+        // left open: the symlink is in the MIDDLE of the requested
+        // path (`base/escape/passwd`), its target is a not-yet-existing
+        // file outside the base. canonicalize(base/escape/passwd)
+        // returns NotFound, and canonicalize(base/escape) ALSO returns
+        // NotFound because the symlink target is broken — but
+        // symlink_metadata succeeds, so we must NOT climb to `base`.
+        let base = tempfile::tempdir().expect("base tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_target = outside.path().join("not-yet");
+        let escape = base.path().join("escape");
+        std::os::unix::fs::symlink(&outside_target, &escape).expect("create symlink");
+
+        let requested = escape.join("passwd");
+        let base_str = base.path().to_str().expect("utf8 base");
+        let requested_str = requested.to_str().expect("utf8 requested");
+        assert!(
+            !path_under(requested_str, base_str),
+            "broken symlink in the middle of the path must fail closed, \
+             base={base:?} requested={requested:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_rejects_broken_symlink_as_leaf() {
+        // Complementary case: the symlink IS the leaf, target missing,
+        // target outside base. Without the symlink_metadata check the
+        // walk would climb to `base` and accept.
+        let base = tempfile::tempdir().expect("base tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_target = outside.path().join("not-yet");
+        let escape = base.path().join("escape");
+        std::os::unix::fs::symlink(&outside_target, &escape).expect("create symlink");
+
+        let base_str = base.path().to_str().expect("utf8 base");
+        let escape_str = escape.to_str().expect("utf8 escape");
+        assert!(
+            !path_under(escape_str, base_str),
+            "broken symlink as leaf must fail closed, base={base:?} escape={escape:?}",
         );
     }
 

--- a/crates/sandbox/src/capabilities.rs
+++ b/crates/sandbox/src/capabilities.rs
@@ -182,26 +182,42 @@ impl PluginCapabilities {
 /// "/tmp/foo" is under "/tmp", but "/tmp_evil" is NOT under "/tmp" —
 /// comparison is component-wise via [`Path::starts_with`], not substring.
 ///
-/// # Security
+/// # Security (#284)
 ///
-/// Traversal attacks like `/tmp/../etc/passwd` are defused in two layers:
+/// The pre-#284 implementation fell back to a purely lexical prefix check
+/// whenever `canonicalize` failed on either side. That fallback was
+/// exploitable: an attacker with write access to a granted directory
+/// could drop a symlink (`/allowed/tmp/escape → /etc`) and then request
+/// `/allowed/tmp/escape/passwd`. `canonicalize` would fail (target not
+/// accessible or not yet a valid path), the lexical fallback would keep
+/// the path unchanged, the prefix check against `/allowed/tmp` would
+/// succeed, and the subsequent `open()` call in the kernel would follow
+/// the symlink and read `/etc/passwd`.
 ///
-/// 1. **Preferred path** — if both `path` and `base` canonicalize successfully (both exist on
-///    disk), the canonical forms are used, so `..` is resolved by the OS before comparison.
-/// 2. **Fallback** — if either path does not exist, both are run through a lexical normalisation
-///    pass that drops `.` components and resolves `..` by popping the previous component. This
-///    keeps the function usable in tests and sandboxed environments where paths are abstract,
-///    without opening a traversal hole.
+/// The current rule defuses that by being strict about the base and
+/// only falling back to lexical when the filesystem clearly isn't in
+/// play:
 ///
-/// The fallback is component-wise: `"/tmp/file.txt".starts_with("/tmp")`
-/// returns `true`, `"/tmp_evil".starts_with("/tmp")` returns `false`.
-/// This is sep-agnostic — works the same on POSIX and Windows paths.
+/// 1. `..` components are banned in either argument. A capability declaration should never contain
+///    parent-traversal, and a requested path with `..` can't be resolved safely without a canonical
+///    form.
+/// 2. Degenerate bases (`""`, `"."` that normalises empty) never match.
+/// 3. If the base canonicalizes, the path must either canonicalize under it, or have its **deepest
+///    existing ancestor** canonicalize under it. Any other error on `canonicalize` (EACCES, ELOOP,
+///    ENOTDIR) fails closed — a path that references something we cannot verify is treated as
+///    denied.
+/// 4. If the base does **not** canonicalize (abstract test fixtures or a capability pointing at a
+///    path that doesn't exist yet), a lexical prefix check is used. There is no real filesystem at
+///    the base, so there is no symlink attack surface — and `..` has already been banned in (1).
 ///
-/// A **degenerate base** (`""`, `"."`, or any path that lexically normalises to an empty
-/// relative path) never matches: otherwise `Path::starts_with` would treat the empty prefix as
-/// matching every path, which would bypass filesystem capability checks.
+/// On-disk ancestor walk-up treats only `ErrorKind::NotFound` as
+/// "keep climbing". Every other error kind is a trust violation and
+/// returns `false`.
 fn path_under(path: &str, base: &str) -> bool {
-    use std::path::{Component, Path, PathBuf};
+    use std::{
+        io::ErrorKind,
+        path::{Component, Path, PathBuf},
+    };
 
     fn normalize_lex(p: &Path) -> PathBuf {
         let mut out = PathBuf::new();
@@ -221,43 +237,65 @@ fn path_under(path: &str, base: &str) -> bool {
         normalize_lex(base_path).as_os_str().is_empty()
     }
 
+    fn contains_parent_dir(p: &Path) -> bool {
+        p.components().any(|c| matches!(c, Component::ParentDir))
+    }
+
     let path = Path::new(path);
     let base_path = Path::new(base);
 
-    match (path.canonicalize(), base_path.canonicalize()) {
-        (Ok(p), Ok(b)) => {
-            if b.as_os_str().is_empty() {
-                return false;
+    // (1) Reject parent-traversal in either argument.
+    if contains_parent_dir(path) || contains_parent_dir(base_path) {
+        return false;
+    }
+
+    // (2) Degenerate base never matches.
+    if base_lex_is_degenerate(base_path) {
+        return false;
+    }
+
+    match base_path.canonicalize() {
+        Ok(canon_base) if !canon_base.as_os_str().is_empty() => {
+            // (3) Filesystem-grounded check. Prefer full-path canonicalisation; otherwise walk up
+            //     through `NotFound` ancestors until one canonicalises, and check that resolved
+            //     point against the canonical base. Every other error kind fails closed.
+            match path.canonicalize() {
+                Ok(canon_path) => canon_path.starts_with(&canon_base),
+                Err(e) if e.kind() == ErrorKind::NotFound => {
+                    let mut ancestor = path.parent();
+                    while let Some(a) = ancestor {
+                        match a.canonicalize() {
+                            Ok(canon_a) => return canon_a.starts_with(&canon_base),
+                            Err(e) if e.kind() == ErrorKind::NotFound => {
+                                ancestor = a.parent();
+                            },
+                            // EACCES, ELOOP, ENOTDIR, etc. — the path
+                            // references a filesystem object we can't
+                            // verify. Fail closed per #284.
+                            Err(_) => return false,
+                        }
+                    }
+                    false
+                },
+                // Same "fail closed on unknown error" policy for the
+                // top-level canonicalize (e.g., EACCES on a symlink's
+                // parent): we can't reason about where the symlink
+                // actually points, so deny.
+                Err(_) => false,
             }
-            p.starts_with(&b)
         },
-        // Path missing on disk but base resolved — use lexical prefix when the base is not
-        // degenerate; otherwise compare against the canonical base (for example `"."` → cwd).
-        (Err(_), Ok(b)) => {
-            if b.as_os_str().is_empty() {
-                return false;
-            }
-            let path_lex = normalize_lex(path);
+        // (4) Base is abstract — lexical comparison only. `..` is already banned, so this is safe
+        //     against traversal. Symlink attacks are not in scope here because there is no real
+        //     filesystem at the base.
+        _ => {
             let base_lex = normalize_lex(base_path);
             if base_lex.as_os_str().is_empty() {
-                path_lex.starts_with(&b)
-            } else {
-                path_lex.starts_with(&base_lex)
-            }
-        },
-        (Ok(p), Err(_)) => {
-            if base_lex_is_degenerate(base_path) {
                 return false;
             }
-            let base_lex = normalize_lex(base_path);
-            p.starts_with(&base_lex)
-        },
-        (Err(_), Err(_)) => {
-            if base_lex_is_degenerate(base_path) {
-                return false;
+            match path.canonicalize() {
+                Ok(canon_path) => canon_path.starts_with(&base_lex),
+                Err(_) => normalize_lex(path).starts_with(&base_lex),
             }
-            let base_lex = normalize_lex(base_path);
-            normalize_lex(path).starts_with(&base_lex)
         },
     }
 }
@@ -389,5 +427,107 @@ mod tests {
             paths: vec!["".into()],
         }]);
         assert!(!caps.check_fs_read("/tmp/file.txt"));
+    }
+
+    // ---- #284 symlink-bypass regression tests ------------------------
+
+    #[test]
+    fn path_under_rejects_parent_dir_in_path() {
+        // Lexical escape via `..` must be rejected even when the base
+        // doesn't canonicalize (the attack surface the pre-#284 lexical
+        // fallback otherwise kept open).
+        assert!(!path_under("/allowed/../etc/passwd", "/allowed"));
+        assert!(!path_under("/allowed/nested/../../etc/passwd", "/allowed"));
+    }
+
+    #[test]
+    fn path_under_rejects_parent_dir_in_base() {
+        assert!(!path_under("/etc/passwd", "/allowed/.."));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_rejects_symlink_escape_to_existing_target() {
+        // Classic symlink escape: the symlink resolves to a real path
+        // OUTSIDE the granted base. canonicalize sees this, starts_with
+        // against the base fails, request is rejected.
+        let base = tempfile::tempdir().expect("base tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        let outside_file = outside.path().join("secret");
+        std::fs::write(&outside_file, b"secret").expect("write secret");
+        let escape = base.path().join("escape");
+        std::os::unix::fs::symlink(&outside_file, &escape).expect("create symlink");
+
+        let base_str = base.path().to_str().expect("utf8 tempdir path");
+        let escape_str = escape.to_str().expect("utf8 symlink path");
+        assert!(
+            !path_under(escape_str, base_str),
+            "symlink escape to {outside_file:?} must be rejected under base {base:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_rejects_symlink_to_nonexistent_target_outside_base() {
+        // Core #284 bypass: symlink's target does not exist yet, so
+        // canonicalize fails — the old lexical fallback happily
+        // accepted the path as being under the granted base. With the
+        // new rule, the deepest existing ancestor (the symlink itself)
+        // canonicalizes to the target's PARENT outside the base and is
+        // rejected by starts_with.
+        let base = tempfile::tempdir().expect("base tempdir");
+        let outside = tempfile::tempdir().expect("outside tempdir");
+        // Note: the target does NOT exist — only `outside` exists.
+        let outside_target = outside.path().join("not-yet");
+        let escape = base.path().join("escape");
+        std::os::unix::fs::symlink(&outside_target, &escape).expect("create symlink");
+
+        let requested = escape.join("passwd");
+        let base_str = base.path().to_str().expect("utf8 base");
+        let requested_str = requested.to_str().expect("utf8 requested");
+        assert!(
+            !path_under(requested_str, base_str),
+            "symlink to nonexistent target outside base must be rejected, \
+             base={base:?} requested={requested:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_accepts_symlink_resolving_inside_base() {
+        // Sanity: if the symlink resolves to a location INSIDE the
+        // granted base, the request IS legitimate (`real/` lives under
+        // the same tempdir as the symlink).
+        let base = tempfile::tempdir().expect("base tempdir");
+        let real_dir = base.path().join("real");
+        std::fs::create_dir(&real_dir).expect("create real dir");
+        let real_file = real_dir.join("data");
+        std::fs::write(&real_file, b"data").expect("write data");
+        let link = base.path().join("alias");
+        std::os::unix::fs::symlink(&real_file, &link).expect("create symlink");
+
+        let base_str = base.path().to_str().expect("utf8 base");
+        let link_str = link.to_str().expect("utf8 link");
+        assert!(
+            path_under(link_str, base_str),
+            "symlink resolving inside base must be accepted, base={base:?} link={link:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn path_under_accepts_nonexistent_leaf_under_real_base() {
+        // Common legitimate case: the base exists, the caller wants to
+        // write to a not-yet-existing file inside it. Walking up from
+        // the requested path finds the base itself as the deepest
+        // canonicalizable ancestor, and the prefix check passes.
+        let base = tempfile::tempdir().expect("base tempdir");
+        let requested = base.path().join("does-not-exist-yet.txt");
+        let base_str = base.path().to_str().expect("utf8 base");
+        let requested_str = requested.to_str().expect("utf8 requested");
+        assert!(
+            path_under(requested_str, base_str),
+            "nonexistent leaf under a real base must be accepted",
+        );
     }
 }

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -81,4 +81,20 @@ pub enum SandboxError {
     /// to the plugin transport.
     #[error("host failed to serialize outbound envelope")]
     HostMalformedEnvelope(#[source] serde_json::Error),
+
+    /// The plugin announced a handshake address that does not match the
+    /// host-allocated one. Protects against the "forged handshake →
+    /// hijack sibling plugin socket" attack (#260).
+    #[error(
+        "plugin announced handshake address `{got}` but host expected `{expected}` — \
+         refusing to dial; a compromised plugin may be attempting to redirect \
+         to another process's socket"
+    )]
+    HandshakeAddrMismatch {
+        /// The address the host set via the `NEBULA_PLUGIN_SOCKET_ADDR`
+        /// env var before spawn.
+        expected: String,
+        /// The address announced by the plugin in its handshake line.
+        got: String,
+    },
 }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -622,6 +622,13 @@ impl ProcessSandbox {
 /// [`PluginHandle`] so the directory persists for as long as the socket
 /// is in use and is cleaned up on drop.
 ///
+/// Prefers `/tmp` when available over the platform temp dir (macOS
+/// defaults to `/var/folders/...` paths that can exceed
+/// [`transport::MAX_UNIX_SOCKET_PATH_BYTES`]). Falls back to the platform
+/// temp dir, and skips any candidate whose resulting socket path would
+/// overflow `sun_path`. This mirrors the plugin-side self-allocation
+/// policy so the host and plugin cannot disagree on what's bindable.
+///
 /// On Windows: generates an unpredictable named-pipe path under
 /// `\\.\pipe\LOCAL\` (session-scoped namespace). The pipe is bound by
 /// the plugin and released when the plugin process exits; no
@@ -630,18 +637,60 @@ fn allocate_host_socket_addr()
 -> Result<(String, &'static str, Option<tempfile::TempDir>), ActionError> {
     #[cfg(unix)]
     {
-        let dir = tempfile::Builder::new()
-            .prefix("nebula-plugin-host-")
-            .tempdir()
-            .map_err(|e| {
-                ActionError::fatal(format!("failed to allocate plugin socket tempdir: {e}"))
-            })?;
-        let socket_path = dir.path().join("sock");
-        let addr = socket_path
-            .to_str()
-            .ok_or_else(|| ActionError::fatal("plugin socket tempdir path is not valid UTF-8"))?
-            .to_owned();
-        Ok((addr, "unix", Some(dir)))
+        use std::{os::unix::ffi::OsStrExt, path::PathBuf};
+
+        // Candidate roots in preference order: short `/tmp` first (macOS
+        // `/var/folders/…` often exceeds the `sun_path` cap), then the
+        // platform temp dir. Deduplicate so `/tmp`-is-temp_dir callers
+        // don't try the same root twice.
+        let mut candidate_roots: Vec<PathBuf> = Vec::new();
+        let short_tmp = PathBuf::from("/tmp");
+        if short_tmp.is_dir() {
+            candidate_roots.push(short_tmp);
+        }
+        let platform_tmp = std::env::temp_dir();
+        if !candidate_roots.iter().any(|root| root == &platform_tmp) {
+            candidate_roots.push(platform_tmp);
+        }
+
+        let mut last_alloc_error: Option<(PathBuf, std::io::Error)> = None;
+        for root in candidate_roots {
+            let dir = match tempfile::Builder::new()
+                .prefix("nebula-plugin-host-")
+                .tempdir_in(&root)
+            {
+                Ok(dir) => dir,
+                Err(e) => {
+                    last_alloc_error = Some((root, e));
+                    continue;
+                },
+            };
+
+            let socket_path = dir.path().join("sock");
+            let socket_path_len = socket_path.as_os_str().as_bytes().len();
+            if socket_path_len > transport::MAX_UNIX_SOCKET_PATH_BYTES {
+                // Drop the oversized tempdir (Drop cleans up) and try
+                // the next candidate root.
+                continue;
+            }
+
+            let addr = socket_path
+                .to_str()
+                .ok_or_else(|| ActionError::fatal("plugin socket tempdir path is not valid UTF-8"))?
+                .to_owned();
+            return Ok((addr, "unix", Some(dir)));
+        }
+
+        if let Some((root, e)) = last_alloc_error {
+            return Err(ActionError::fatal(format!(
+                "failed to allocate plugin socket tempdir in {}: {e}",
+                root.display()
+            )));
+        }
+        Err(ActionError::fatal(format!(
+            "failed to allocate a Unix socket path within {} bytes",
+            transport::MAX_UNIX_SOCKET_PATH_BYTES
+        )))
     }
     #[cfg(windows)]
     {

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -37,7 +37,7 @@ use async_trait::async_trait;
 use nebula_action::{ActionError, ActionMetadata, result::ActionResult};
 use nebula_plugin_sdk::{
     protocol::{HostToPlugin, PluginToHost},
-    transport::{self, PluginStream},
+    transport::{self, ENV_SOCKET_ADDR, ENV_SOCKET_KIND, PluginStream},
 };
 use tokio::{
     io::{AsyncBufRead, AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
@@ -118,6 +118,13 @@ struct PluginHandle {
     /// child. Read nowhere; the underscore prefix silences dead-code
     /// warnings.
     _child: Child,
+    /// Host-allocated temp directory holding the UDS socket on Unix.
+    /// Kept alive for the lifetime of the handle so the directory (and
+    /// its 0700 perms) survive as long as the plugin process. Dropping
+    /// the `TempDir` removes the directory tree. `None` on Windows —
+    /// named pipes aren't in a filesystem directory. Dead code at
+    /// read-time; the `_` prefix silences warnings.
+    _socket_dir: Option<tempfile::TempDir>,
     /// Buffered reader over the stream's read half. Crucial for
     /// throughput — byte-at-a-time reads hit ~4 MB/s, BufReader reaches
     /// hundreds of MB/s on local sockets/pipes.
@@ -141,10 +148,11 @@ struct PluginHandle {
 }
 
 impl PluginHandle {
-    fn new(child: Child, stream: PluginStream) -> Self {
+    fn new(child: Child, stream: PluginStream, socket_dir: Option<tempfile::TempDir>) -> Self {
         let (read_half, write_half) = tokio::io::split(stream);
         Self {
             _child: child,
+            _socket_dir: socket_dir,
             reader: BufReader::new(read_half),
             writer: write_half,
             line_buf: Vec::with_capacity(512),
@@ -455,13 +463,25 @@ impl ProcessSandbox {
             .filter_map(|key| std::env::var(&key).ok().map(|val| (key, val)))
             .collect();
 
+        // #260: host allocates the plugin's socket address up-front and
+        // passes it via env so the child cannot forge a handshake that
+        // redirects the host at a sibling plugin's socket. `socket_dir`
+        // is `Some` on Unix (TempDir that owns the 0700 parent) and
+        // `None` on Windows (named pipes aren't in a filesystem dir).
+        let (expected_addr, kind, socket_dir) = allocate_host_socket_addr()?;
+
         let mut cmd = Command::new(&self.binary);
         cmd.stdin(std::process::Stdio::null())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true)
             .env_clear()
-            .envs(allowed_env);
+            .envs(allowed_env)
+            // Host-controlled transport env: always set, regardless of
+            // the plugin's declared capability set. `env()` applied
+            // after `envs()` adds on top of the capability allowlist.
+            .env(ENV_SOCKET_ADDR, &expected_addr)
+            .env(ENV_SOCKET_KIND, kind);
 
         // Apply OS-level sandbox in child process before exec (Linux only).
         #[cfg(target_os = "linux")]
@@ -572,13 +592,96 @@ impl ProcessSandbox {
             "plugin handshake received"
         );
 
+        // #260: validate the announced address against what we pre-allocated
+        // before dialling. A compromised plugin that prints a sibling
+        // plugin's socket path here is rejected, not connected to.
+        if let Err(err) = validate_handshake_addr(handshake_line, &expected_addr, kind) {
+            tracing::warn!(
+                plugin = %self.binary.display(),
+                expected = %expected_addr,
+                error = %err,
+                "plugin handshake address mismatch — refusing to dial",
+            );
+            return Err(sandbox_error_to_action_error(err));
+        }
+
         // Dial the announced transport.
         let stream = transport::dial(handshake_line)
             .await
             .map_err(|e| ActionError::fatal(format!("plugin transport dial failed: {e}")))?;
 
-        Ok(PluginHandle::new(child, stream))
+        Ok(PluginHandle::new(child, stream, socket_dir))
     }
+}
+
+/// Allocate a host-controlled socket address for the plugin to bind (#260).
+///
+/// On Unix: creates a tempdir with `0700` permissions (via `tempfile`) and
+/// returns a socket path inside it. Keeping the `TempDir` alive is the
+/// caller's responsibility — it must be stored on the resulting
+/// [`PluginHandle`] so the directory persists for as long as the socket
+/// is in use and is cleaned up on drop.
+///
+/// On Windows: generates an unpredictable named-pipe path under
+/// `\\.\pipe\LOCAL\` (session-scoped namespace). The pipe is bound by
+/// the plugin and released when the plugin process exits; no
+/// directory-level cleanup is needed.
+fn allocate_host_socket_addr()
+-> Result<(String, &'static str, Option<tempfile::TempDir>), ActionError> {
+    #[cfg(unix)]
+    {
+        let dir = tempfile::Builder::new()
+            .prefix("nebula-plugin-host-")
+            .tempdir()
+            .map_err(|e| {
+                ActionError::fatal(format!("failed to allocate plugin socket tempdir: {e}"))
+            })?;
+        let socket_path = dir.path().join("sock");
+        let addr = socket_path
+            .to_str()
+            .ok_or_else(|| ActionError::fatal("plugin socket tempdir path is not valid UTF-8"))?
+            .to_owned();
+        Ok((addr, "unix", Some(dir)))
+    }
+    #[cfg(windows)]
+    {
+        let nonce = uuid::Uuid::new_v4().simple().to_string();
+        let pipe = format!(r"\\.\pipe\LOCAL\nebula-plugin-host-{nonce}");
+        Ok((pipe, "pipe", None))
+    }
+}
+
+/// Verify that the handshake line's `kind|addr` pair matches the
+/// host-allocated values from [`allocate_host_socket_addr`]. Returns
+/// [`SandboxError::HandshakeAddrMismatch`] on any deviation.
+///
+/// Exact string comparison is used — the plugin is expected to echo the
+/// address we passed via `NEBULA_PLUGIN_SOCKET_ADDR` verbatim. An
+/// attacker-controlled plugin that prints a different address (to
+/// redirect the host at a sibling plugin's UDS or pipe) fails this check
+/// and never reaches `transport::dial`.
+fn validate_handshake_addr(
+    handshake_line: &str,
+    expected_addr: &str,
+    expected_kind: &'static str,
+) -> Result<(), SandboxError> {
+    let line = handshake_line.trim();
+    let mut parts = line.splitn(3, '|');
+    let _version = parts.next(); // already checked by the caller's length cap and UTF-8 decode
+    let announced_kind = parts.next().unwrap_or("");
+    let announced_addr = parts.next().unwrap_or("");
+    if announced_kind != expected_kind || announced_addr != expected_addr {
+        let got = if announced_kind.is_empty() && announced_addr.is_empty() {
+            String::from("<malformed handshake>")
+        } else {
+            format!("{announced_kind}|{announced_addr}")
+        };
+        return Err(SandboxError::HandshakeAddrMismatch {
+            expected: format!("{expected_kind}|{expected_addr}"),
+            got,
+        });
+    }
+    Ok(())
 }
 
 /// Convert an internal [`SandboxError`] into the public `ActionError` the
@@ -593,6 +696,7 @@ fn sandbox_error_to_action_error(err: SandboxError) -> ActionError {
         // Fatal: DoS / protocol-abuse signals. Do not paper over with retry.
         SandboxError::PluginLineTooLarge { .. }
         | SandboxError::HandshakeLineTooLarge { .. }
+        | SandboxError::HandshakeAddrMismatch { .. }
         | SandboxError::TransportPoisoned
         | SandboxError::Transport(_)
         | SandboxError::MalformedEnvelope(_)
@@ -1139,5 +1243,115 @@ mod tests {
             .expect_err("fixture must produce serde_json::Error");
         let ae = sandbox_error_to_action_error(SandboxError::HostMalformedEnvelope(parse_err));
         assert!(matches!(ae, ActionError::Fatal { .. }));
+    }
+
+    // ---- #260 forged-handshake regression guard ----------------------
+
+    #[test]
+    fn validate_handshake_addr_accepts_matching_pair() {
+        let line = "NEBULA-PROTO-2|unix|/tmp/nebula-plugin-host-abc/sock\n";
+        let result = validate_handshake_addr(line, "/tmp/nebula-plugin-host-abc/sock", "unix");
+        assert!(result.is_ok(), "matching addr+kind must be accepted");
+    }
+
+    #[test]
+    fn validate_handshake_addr_rejects_forged_sibling_socket() {
+        // The exact #260 scenario: a compromised plugin prints a path
+        // that belongs to a DIFFERENT plugin's socket tree. The host
+        // allocated `/tmp/nebula-plugin-host-ours/sock`, but the plugin
+        // announces `/tmp/nebula-plugin-host-other/sock`. Must fail
+        // BEFORE `dial` so the host never connects to the sibling.
+        let line = "NEBULA-PROTO-2|unix|/tmp/nebula-plugin-host-other/sock\n";
+        let err = validate_handshake_addr(line, "/tmp/nebula-plugin-host-ours/sock", "unix")
+            .expect_err("forged sibling path must be rejected");
+        match err {
+            SandboxError::HandshakeAddrMismatch { expected, got } => {
+                assert!(
+                    expected.contains("/tmp/nebula-plugin-host-ours/sock"),
+                    "expected field should contain the host-allocated addr, got {expected:?}",
+                );
+                assert!(
+                    got.contains("/tmp/nebula-plugin-host-other/sock"),
+                    "got field should contain the announced addr, got {got:?}",
+                );
+            },
+            other => panic!("expected HandshakeAddrMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_handshake_addr_rejects_mismatched_kind() {
+        // Plugin tries to smuggle a pipe address on a Unix host (or
+        // vice versa). Kind mismatch is a protocol violation and must
+        // be rejected with the same error type.
+        let line = "NEBULA-PROTO-2|pipe|some-pipe-name\n";
+        let err = validate_handshake_addr(line, "/tmp/nebula/sock", "unix")
+            .expect_err("kind mismatch must be rejected");
+        assert!(matches!(err, SandboxError::HandshakeAddrMismatch { .. }));
+    }
+
+    #[test]
+    fn validate_handshake_addr_rejects_malformed_handshake() {
+        // Missing kind/addr entirely → mismatch error (with a clear
+        // "<malformed handshake>" marker on the got side).
+        let line = "NEBULA-PROTO-2\n";
+        let err = validate_handshake_addr(line, "/tmp/nebula/sock", "unix")
+            .expect_err("malformed handshake must be rejected");
+        match err {
+            SandboxError::HandshakeAddrMismatch { got, .. } => {
+                assert!(
+                    got.contains("malformed"),
+                    "got should flag the malformed handshake, was {got:?}",
+                );
+            },
+            other => panic!("expected HandshakeAddrMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn handshake_addr_mismatch_converts_to_fatal_action_error() {
+        let err = SandboxError::HandshakeAddrMismatch {
+            expected: String::from("unix|/tmp/ok"),
+            got: String::from("unix|/tmp/evil"),
+        };
+        let ae = sandbox_error_to_action_error(err);
+        assert!(
+            matches!(ae, ActionError::Fatal { .. }),
+            "HandshakeAddrMismatch must classify as Fatal (no retry on forged handshake), got {ae:?}",
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn allocate_host_socket_addr_gives_distinct_tempdirs() {
+        // Two successive allocations must produce distinct addresses and
+        // distinct tempdirs — otherwise two concurrent plugin spawns
+        // would race on the same socket path.
+        let (a, kind_a, dir_a) = allocate_host_socket_addr().expect("alloc a");
+        let (b, kind_b, dir_b) = allocate_host_socket_addr().expect("alloc b");
+        assert_eq!(kind_a, "unix");
+        assert_eq!(kind_b, "unix");
+        assert_ne!(a, b, "two allocations must produce distinct socket paths");
+        assert_ne!(
+            dir_a.as_ref().map(|d| d.path().to_path_buf()),
+            dir_b.as_ref().map(|d| d.path().to_path_buf()),
+            "two allocations must produce distinct tempdirs",
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn allocate_host_socket_addr_gives_distinct_pipe_names() {
+        let (a, kind_a, dir_a) = allocate_host_socket_addr().expect("alloc a");
+        let (b, kind_b, dir_b) = allocate_host_socket_addr().expect("alloc b");
+        assert_eq!(kind_a, "pipe");
+        assert_eq!(kind_b, "pipe");
+        assert!(dir_a.is_none(), "no tempdir on windows");
+        assert!(dir_b.is_none(), "no tempdir on windows");
+        assert_ne!(a, b, "two allocations must produce distinct pipe names");
+        assert!(
+            a.starts_with(r"\\.\pipe\LOCAL\nebula-plugin-host-"),
+            "pipe name must carry the host-plugin prefix, was {a:?}",
+        );
     }
 }


### PR DESCRIPTION
## Summary

Security hardening for `nebula-sandbox`. Two independent findings, bundled because both touch the trust boundary code reviewed together (security-lead scope).

- **#284** — `path_under` lexical fallback let an attacker with write access to a granted directory drop a symlink and bypass the filesystem capability check. Now strict: base must canonicalize, path's deepest existing ancestor must canonicalize under it, `..` banned in either argument, `EACCES`/`ELOOP`/`ENOTDIR` fails closed.
- **#260** — `transport::dial` trusted whatever address the plugin printed in its handshake. Now the host allocates the socket path (tempdir with `0700` on Unix, nonce-based pipe name on Windows), passes it via `NEBULA_PLUGIN_SOCKET_ADDR`/`NEBULA_PLUGIN_SOCKET_KIND`, and verifies the announced `kind|addr` matches exactly before dialling.

Both add typed regression tests (`SandboxError::HandshakeAddrMismatch` variant is new; `#[non_exhaustive]` → no semver break).

## Test plan

- [x] `cargo nextest run -p nebula-sandbox -p nebula-plugin-sdk` — 63 tests, all green (including 6 `cfg(unix)` symlink regression tests and the `broker_smoke` integration tests that exercise the new env-var plugin binding path).
- [x] `cargo clippy -p nebula-sandbox -p nebula-plugin-sdk --all-targets -- -D warnings` clean.
- [x] Lefthook pre-commit (typos, taplo, fmt-check, cargo-deny, clippy) green.
- [ ] Security-lead review of trust-boundary rules (`credential-security-review` skill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)