### PR TITLE
fix(sandbox): stop blind retry of non-idempotent dispatch (#259)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4165,6 +4165,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true, features = ["process", "io-util", "sync", "net"] }
+tokio-util = { workspace = true }
 
 # OS-level sandbox (Linux only)
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/crates/sandbox/src/error.rs
+++ b/crates/sandbox/src/error.rs
@@ -81,4 +81,21 @@ pub enum SandboxError {
     /// to the plugin transport.
     #[error("host failed to serialize outbound envelope")]
     HostMalformedEnvelope(#[source] serde_json::Error),
+
+    /// The plugin's response envelope carried a correlation id that did
+    /// not match the id the host sent in the request (#285). Signals a
+    /// stale response (e.g. a late reply to a cancelled call) or a
+    /// protocol violation. The transport is poisoned after this error
+    /// so the next request respawns the plugin on a fresh connection —
+    /// defense-in-depth against cross-request id confusion.
+    #[error(
+        "plugin response id mismatch: sent {expected}, got {got} — \
+         possible stale response or protocol violation; connection poisoned"
+    )]
+    ResponseIdMismatch {
+        /// The correlation id the host placed in the outgoing request.
+        expected: u64,
+        /// The correlation id the plugin echoed back in its response.
+        got: u64,
+    },
 }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -44,6 +44,7 @@ use tokio::{
     process::{Child, Command},
     sync::Mutex,
 };
+use tokio_util::sync::CancellationToken;
 
 use crate::{
     SandboxRunner,
@@ -291,6 +292,59 @@ where
     Ok(BoundedReadOutcome::Eof)
 }
 
+/// Outcome of a [`race_cancel_timeout`] call.
+#[derive(Debug, PartialEq, Eq)]
+enum RaceOutcome<T> {
+    /// The inner future produced a value within the deadline and before
+    /// the cancellation token fired.
+    Ready(T),
+    /// The wall-clock deadline elapsed first. The inner future was
+    /// dropped mid-flight; callers must assume its side effects are
+    /// partially applied (writes may have reached the peer).
+    Timeout,
+    /// The optional cancellation token fired first. Same partial-side-effect
+    /// caveat as `Timeout` applies — the race only wins a snapshot of
+    /// progress, not a clean rollback.
+    Cancelled,
+}
+
+/// Race `fut` against a wall-clock deadline and (optionally) a
+/// [`CancellationToken`]. Used by [`ProcessSandbox::try_dispatch`] to
+/// honour both the per-call plugin timeout and the engine-wide
+/// cancellation contract — see #257.
+///
+/// When `cancel` is `Some`, the select is `biased` so a token that is
+/// already cancelled on entry is observed on the very first poll, before
+/// the roundtrip future is driven. When `cancel` is `None` (public helpers
+/// like `invoke` / `get_metadata` that run outside an execution context)
+/// the helper degrades to a plain `tokio::time::timeout`.
+async fn race_cancel_timeout<F, T>(
+    fut: F,
+    timeout: std::time::Duration,
+    cancel: Option<&CancellationToken>,
+) -> RaceOutcome<T>
+where
+    F: std::future::Future<Output = T>,
+{
+    let timed = tokio::time::timeout(timeout, fut);
+    match cancel {
+        Some(token) => {
+            tokio::select! {
+                biased;
+                () = token.cancelled() => RaceOutcome::Cancelled,
+                r = timed => match r {
+                    Ok(v) => RaceOutcome::Ready(v),
+                    Err(_) => RaceOutcome::Timeout,
+                },
+            }
+        },
+        None => match timed.await {
+            Ok(v) => RaceOutcome::Ready(v),
+            Err(_) => RaceOutcome::Timeout,
+        },
+    }
+}
+
 impl ProcessSandbox {
     /// Create a new process sandbox for a plugin binary.
     #[must_use]
@@ -318,19 +372,20 @@ impl ProcessSandbox {
         &self,
         action_key: &str,
         input: serde_json::Value,
+        cancel: Option<&CancellationToken>,
     ) -> Result<PluginToHost, ActionError> {
         let request = HostToPlugin::ActionInvoke {
             id: ONE_SHOT_ID,
             action_key: action_key.to_owned(),
             input,
         };
-        self.dispatch_envelope(request).await
+        self.dispatch_envelope(request, cancel).await
     }
 
     /// Query plugin metadata via a `MetadataRequest` envelope.
     pub async fn get_metadata(&self) -> Result<PluginToHost, ActionError> {
         let request = HostToPlugin::MetadataRequest { id: ONE_SHOT_ID };
-        self.dispatch_envelope(request).await
+        self.dispatch_envelope(request, None).await
     }
 
     /// High-level action invocation for host code outside the engine flow
@@ -348,7 +403,7 @@ impl ProcessSandbox {
         action_key: &str,
         input: serde_json::Value,
     ) -> Result<serde_json::Value, ActionError> {
-        let envelope = self.call_action(action_key, input).await?;
+        let envelope = self.call_action(action_key, input, None).await?;
         match envelope {
             PluginToHost::ActionResultOk { output, .. } => Ok(output),
             PluginToHost::ActionResultError {
@@ -374,39 +429,52 @@ impl ProcessSandbox {
     /// Core long-lived dispatch. Reuses the cached [`PluginHandle`] if any,
     /// spawns fresh otherwise. On transport error, clears the handle and
     /// retries once.
-    async fn dispatch_envelope(&self, envelope: HostToPlugin) -> Result<PluginToHost, ActionError> {
-        let first_attempt = self.try_dispatch(envelope.clone()).await;
+    async fn dispatch_envelope(
+        &self,
+        envelope: HostToPlugin,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<PluginToHost, ActionError> {
+        let first_attempt = self.try_dispatch(envelope.clone(), cancel).await;
         if first_attempt.is_ok() {
             return first_attempt;
         }
         // Clear the stale handle and retry once with a fresh spawn.
         *self.handle.lock().await = None;
-        self.try_dispatch(envelope).await
+        self.try_dispatch(envelope, cancel).await
     }
 
-    async fn try_dispatch(&self, envelope: HostToPlugin) -> Result<PluginToHost, ActionError> {
+    async fn try_dispatch(
+        &self,
+        envelope: HostToPlugin,
+        cancel: Option<&CancellationToken>,
+    ) -> Result<PluginToHost, ActionError> {
         let mut guard = self.handle.lock().await;
         if guard.is_none() {
             *guard = Some(self.spawn_and_dial().await?);
         }
         let handle = guard.as_mut().expect("handle set above");
 
-        // Round-trip the envelope with a per-call timeout.
+        // Round-trip the envelope with a per-call timeout AND a race
+        // against the engine's cancellation token. Without the cancel
+        // arm, a cancelled workflow would have to wait out `self.timeout`
+        // on a hung or slow plugin before the engine could reclaim the
+        // slot — see #257.
         let envelope_tag = match &envelope {
             HostToPlugin::ActionInvoke { .. } => "action_invoke",
             HostToPlugin::MetadataRequest { .. } => "metadata_request",
             _ => "other",
         };
 
-        let result = tokio::time::timeout(self.timeout, async {
+        let roundtrip = async {
             handle.send_envelope(&envelope).await?;
             handle.recv_envelope().await
-        })
-        .await;
+        };
 
-        match result {
-            Ok(Ok(response)) => Ok(response),
-            Ok(Err(sandbox_err)) => {
+        let outcome = race_cancel_timeout(roundtrip, self.timeout, cancel).await;
+
+        match outcome {
+            RaceOutcome::Ready(Ok(response)) => Ok(response),
+            RaceOutcome::Ready(Err(sandbox_err)) => {
                 // Transport/protocol error — invalidate the handle so the
                 // next call respawns. Log PluginLineTooLarge at warn so it
                 // shows up in security dashboards.
@@ -426,7 +494,7 @@ impl ProcessSandbox {
                 *guard = None;
                 Err(sandbox_error_to_action_error(sandbox_err))
             },
-            Err(_) => {
+            RaceOutcome::Timeout => {
                 // Timeout — also invalidate; we don't know if the plugin is
                 // still processing and we can't safely reuse the connection.
                 *guard = None;
@@ -435,6 +503,20 @@ impl ProcessSandbox {
                     self.binary.display(),
                     self.timeout
                 )))
+            },
+            RaceOutcome::Cancelled => {
+                // Cancellation observed mid-round-trip. We may have
+                // written part of an envelope to the plugin; the stream
+                // position is undefined, so drop the handle and force a
+                // respawn on the next call. Surface as `ActionError::Cancelled`
+                // so the engine honours the standard cancellation path.
+                *guard = None;
+                tracing::debug!(
+                    plugin = %self.binary.display(),
+                    envelope = %envelope_tag,
+                    "plugin dispatch cancelled via CancellationToken; clearing handle",
+                );
+                Err(ActionError::Cancelled)
             },
         }
     }
@@ -618,7 +700,9 @@ impl SandboxRunner for ProcessSandbox {
             "executing action in process sandbox"
         );
 
-        let envelope = self.call_action(action_key, input).await?;
+        let envelope = self
+            .call_action(action_key, input, Some(context.cancellation()))
+            .await?;
         match envelope {
             PluginToHost::ActionResultOk { output, .. } => Ok(ActionResult::success(output)),
             PluginToHost::ActionResultError {
@@ -1139,5 +1223,81 @@ mod tests {
             .expect_err("fixture must produce serde_json::Error");
         let ae = sandbox_error_to_action_error(SandboxError::HostMalformedEnvelope(parse_err));
         assert!(matches!(ae, ActionError::Fatal { .. }));
+    }
+
+    // ---- race_cancel_timeout (#257 regression guard) -----------------
+
+    #[tokio::test]
+    async fn race_cancel_timeout_returns_ready_when_future_completes_first() {
+        let fut = async { 42u32 };
+        let outcome = race_cancel_timeout(fut, Duration::from_secs(1), None).await;
+        assert_eq!(outcome, RaceOutcome::Ready(42));
+    }
+
+    #[tokio::test]
+    async fn race_cancel_timeout_returns_timeout_without_cancel_arm() {
+        // A future that never completes, no cancel token → must time out
+        // within roughly the configured duration.
+        let fut = std::future::pending::<()>();
+        let outcome = race_cancel_timeout(fut, Duration::from_millis(25), None).await;
+        assert_eq!(outcome, RaceOutcome::Timeout);
+    }
+
+    #[tokio::test]
+    async fn race_cancel_timeout_observes_pre_cancelled_token_promptly() {
+        // If the cancellation token is already cancelled when we enter
+        // the race, the biased select must observe it on first poll
+        // WITHOUT polling the inner future. This is the core fix for
+        // #257: a cancelled workflow does not wait for `timeout`.
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let start = std::time::Instant::now();
+        // `pending` future so the only way out is the cancel arm.
+        let fut = std::future::pending::<()>();
+        let outcome = race_cancel_timeout(fut, Duration::from_secs(30), Some(&token)).await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(outcome, RaceOutcome::Cancelled);
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "pre-cancelled token must resolve promptly, took {elapsed:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn race_cancel_timeout_wins_when_cancel_fires_mid_flight() {
+        // Future that never completes; fire the token shortly after the
+        // race starts. The cancel arm must win, not the timeout.
+        let token = CancellationToken::new();
+        let cancel_clone = token.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            cancel_clone.cancel();
+        });
+
+        let fut = std::future::pending::<()>();
+        // Long enough timeout that the cancel arm is the one that wins.
+        let outcome = race_cancel_timeout(fut, Duration::from_secs(30), Some(&token)).await;
+        assert_eq!(outcome, RaceOutcome::Cancelled);
+    }
+
+    #[tokio::test]
+    async fn race_cancel_timeout_ready_wins_over_never_fired_cancel() {
+        // Token exists but is never cancelled → the inner future's
+        // Ready result wins normally.
+        let token = CancellationToken::new();
+        let fut = async { "ok" };
+        let outcome = race_cancel_timeout(fut, Duration::from_secs(1), Some(&token)).await;
+        assert_eq!(outcome, RaceOutcome::Ready("ok"));
+    }
+
+    #[tokio::test]
+    async fn race_cancel_timeout_timeout_wins_over_never_fired_cancel() {
+        // Token exists but is never cancelled → deadline still applies.
+        let token = CancellationToken::new();
+        let fut = std::future::pending::<()>();
+        let outcome = race_cancel_timeout(fut, Duration::from_millis(25), Some(&token)).await;
+        assert_eq!(outcome, RaceOutcome::Timeout);
     }
 }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -31,7 +31,11 @@
 //! (`poisoned` flag inside `PluginHandle`) and a sandbox-level one
 //! (`*self.handle.lock().await = None`).
 
-use std::{path::PathBuf, time::Duration};
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use nebula_action::{ActionError, ActionMetadata, result::ActionResult};
@@ -79,12 +83,6 @@ const ENVELOPE_LINE_CAP: usize = 1024 * 1024;
 /// newline-starved garbage and starve the host of memory).
 const STDERR_LINE_CAP: usize = 8 * 1024;
 
-/// Correlation id used for the single envelope sent per invocation.
-///
-/// Slice 1c still does one envelope exchange at a time per call. Slice 1d's
-/// concurrent dispatch assigns unique ids across multiple in-flight calls.
-const ONE_SHOT_ID: u64 = 1;
-
 /// Process sandbox: spawns the plugin binary once and keeps the connection
 /// alive for the lifetime of this sandbox instance.
 ///
@@ -105,6 +103,17 @@ pub struct ProcessSandbox {
     /// mutex — slice 1c is sequential per sandbox instance. Slice 1d can
     /// replace this with a lock-free handle once concurrent dispatch lands.
     handle: Mutex<Option<PluginHandle>>,
+    /// Monotonic correlation id source (#285). Each outbound envelope
+    /// gets a fresh id; `try_dispatch` verifies the response echoes it
+    /// back. A stale response (e.g. late reply to a cancelled call)
+    /// therefore can't be silently mis-associated with a fresh request
+    /// — ID mismatch poisons the transport.
+    ///
+    /// Persisted across plugin respawns — the plugin only sees a
+    /// monotone sequence from its own perspective (fresh process,
+    /// fresh socket, fresh id stream), but the host never reuses an
+    /// id across invocations within this sandbox instance's lifetime.
+    next_id: AtomicU64,
 }
 
 /// Live connection to a running plugin process.
@@ -355,7 +364,17 @@ impl ProcessSandbox {
             capabilities,
             linux_rlimits: LinuxRlimits::default(),
             handle: Mutex::new(None),
+            next_id: AtomicU64::new(1),
         }
+    }
+
+    /// Reserve the next monotonic correlation id for an outbound
+    /// envelope (#285). Uses `Relaxed` ordering — id allocation has no
+    /// happens-before requirement against any other memory op; we only
+    /// need uniqueness, which `fetch_add` guarantees regardless of
+    /// ordering.
+    fn next_envelope_id(&self) -> u64 {
+        self.next_id.fetch_add(1, Ordering::Relaxed)
     }
 
     /// Override Linux child-process rlimits for this sandbox instance.
@@ -375,7 +394,7 @@ impl ProcessSandbox {
         cancel: Option<&CancellationToken>,
     ) -> Result<PluginToHost, ActionError> {
         let request = HostToPlugin::ActionInvoke {
-            id: ONE_SHOT_ID,
+            id: self.next_envelope_id(),
             action_key: action_key.to_owned(),
             input,
         };
@@ -384,7 +403,9 @@ impl ProcessSandbox {
 
     /// Query plugin metadata via a `MetadataRequest` envelope.
     pub async fn get_metadata(&self) -> Result<PluginToHost, ActionError> {
-        let request = HostToPlugin::MetadataRequest { id: ONE_SHOT_ID };
+        let request = HostToPlugin::MetadataRequest {
+            id: self.next_envelope_id(),
+        };
         self.dispatch_envelope(request, None).await
     }
 
@@ -464,6 +485,9 @@ impl ProcessSandbox {
             HostToPlugin::MetadataRequest { .. } => "metadata_request",
             _ => "other",
         };
+        // Remember the outbound correlation id so we can validate the
+        // response echoes it back (#285).
+        let expected_id = request_id(&envelope);
 
         let roundtrip = async {
             handle.send_envelope(&envelope).await?;
@@ -473,7 +497,24 @@ impl ProcessSandbox {
         let outcome = race_cancel_timeout(roundtrip, self.timeout, cancel).await;
 
         match outcome {
-            RaceOutcome::Ready(Ok(response)) => Ok(response),
+            RaceOutcome::Ready(Ok(response)) => {
+                if let (Some(expected), Some(got)) = (expected_id, response_id(&response))
+                    && expected != got
+                {
+                    tracing::warn!(
+                        plugin = %self.binary.display(),
+                        envelope = %envelope_tag,
+                        expected,
+                        got,
+                        "plugin response id mismatch — poisoning handle",
+                    );
+                    *guard = None;
+                    return Err(sandbox_error_to_action_error(
+                        SandboxError::ResponseIdMismatch { expected, got },
+                    ));
+                }
+                Ok(response)
+            },
             RaceOutcome::Ready(Err(sandbox_err)) => {
                 // Transport/protocol error — invalidate the handle so the
                 // next call respawns. Log PluginLineTooLarge at warn so it
@@ -675,10 +716,38 @@ fn sandbox_error_to_action_error(err: SandboxError) -> ActionError {
         // Fatal: DoS / protocol-abuse signals. Do not paper over with retry.
         SandboxError::PluginLineTooLarge { .. }
         | SandboxError::HandshakeLineTooLarge { .. }
+        | SandboxError::ResponseIdMismatch { .. }
         | SandboxError::TransportPoisoned
         | SandboxError::Transport(_)
         | SandboxError::MalformedEnvelope(_)
         | SandboxError::HostMalformedEnvelope(_) => ActionError::fatal_from(err),
+    }
+}
+
+/// Correlation id carried by an outbound host→plugin envelope, if any.
+/// `Shutdown` has no id (it's one-way, no response expected); every
+/// other variant carries a `u64`.
+fn request_id(env: &HostToPlugin) -> Option<u64> {
+    match env {
+        HostToPlugin::ActionInvoke { id, .. }
+        | HostToPlugin::MetadataRequest { id }
+        | HostToPlugin::Cancel { id }
+        | HostToPlugin::RpcResponseOk { id, .. }
+        | HostToPlugin::RpcResponseError { id, .. } => Some(*id),
+        HostToPlugin::Shutdown => None,
+    }
+}
+
+/// Correlation id carried by an inbound plugin→host envelope, if any.
+/// `Log` is one-way and carries no correlation id; every other variant
+/// carries a `u64`.
+fn response_id(env: &PluginToHost) -> Option<u64> {
+    match env {
+        PluginToHost::ActionResultOk { id, .. }
+        | PluginToHost::ActionResultError { id, .. }
+        | PluginToHost::RpcCall { id, .. }
+        | PluginToHost::MetadataResponse { id, .. } => Some(*id),
+        PluginToHost::Log { .. } => None,
     }
 }
 
@@ -1299,5 +1368,110 @@ mod tests {
         let fut = std::future::pending::<()>();
         let outcome = race_cancel_timeout(fut, Duration::from_millis(25), Some(&token)).await;
         assert_eq!(outcome, RaceOutcome::Timeout);
+    }
+
+    // ---- #285 monotonic-id + id-matching regression tests ------------
+
+    #[test]
+    fn next_envelope_id_is_monotonic_and_unique() {
+        let sandbox = ProcessSandbox::new(
+            PathBuf::from("/nonexistent"),
+            Duration::from_secs(1),
+            PluginCapabilities::none(),
+        );
+        // Starts at 1 (not 0) so a default-zeroed response id is
+        // visibly stale.
+        let first = sandbox.next_envelope_id();
+        let second = sandbox.next_envelope_id();
+        let third = sandbox.next_envelope_id();
+        assert_eq!(first, 1);
+        assert_eq!(second, 2);
+        assert_eq!(third, 3);
+    }
+
+    #[test]
+    fn request_id_extracts_all_id_bearing_variants() {
+        let action = HostToPlugin::ActionInvoke {
+            id: 7,
+            action_key: String::from("k"),
+            input: serde_json::json!({}),
+        };
+        let meta = HostToPlugin::MetadataRequest { id: 8 };
+        let cancel = HostToPlugin::Cancel { id: 9 };
+        let rpc_ok = HostToPlugin::RpcResponseOk {
+            id: 10,
+            result: serde_json::json!({}),
+        };
+        let rpc_err = HostToPlugin::RpcResponseError {
+            id: 11,
+            code: String::from("c"),
+            message: String::from("m"),
+        };
+        let shutdown = HostToPlugin::Shutdown;
+
+        assert_eq!(request_id(&action), Some(7));
+        assert_eq!(request_id(&meta), Some(8));
+        assert_eq!(request_id(&cancel), Some(9));
+        assert_eq!(request_id(&rpc_ok), Some(10));
+        assert_eq!(request_id(&rpc_err), Some(11));
+        assert_eq!(
+            request_id(&shutdown),
+            None,
+            "Shutdown is one-way and has no correlation id",
+        );
+    }
+
+    #[test]
+    fn response_id_extracts_all_id_bearing_variants() {
+        let ok = PluginToHost::ActionResultOk {
+            id: 42,
+            output: serde_json::json!({}),
+        };
+        let err = PluginToHost::ActionResultError {
+            id: 43,
+            code: String::from("c"),
+            message: String::from("m"),
+            retryable: false,
+        };
+        let rpc = PluginToHost::RpcCall {
+            id: 44,
+            verb: String::from("v"),
+            params: serde_json::json!({}),
+        };
+        let meta = PluginToHost::MetadataResponse {
+            id: 45,
+            protocol_version: 2,
+            plugin_key: String::from("k"),
+            plugin_version: String::from("1.0.0"),
+            actions: Vec::new(),
+        };
+        let log = PluginToHost::Log {
+            level: nebula_plugin_sdk::protocol::LogLevel::Info,
+            message: String::from("hi"),
+            fields: serde_json::json!({}),
+        };
+
+        assert_eq!(response_id(&ok), Some(42));
+        assert_eq!(response_id(&err), Some(43));
+        assert_eq!(response_id(&rpc), Some(44));
+        assert_eq!(response_id(&meta), Some(45));
+        assert_eq!(
+            response_id(&log),
+            None,
+            "Log is one-way and has no correlation id",
+        );
+    }
+
+    #[test]
+    fn response_id_mismatch_converts_to_fatal_action_error() {
+        let err = SandboxError::ResponseIdMismatch {
+            expected: 42,
+            got: 41,
+        };
+        let ae = sandbox_error_to_action_error(err);
+        assert!(
+            matches!(ae, ActionError::Fatal { .. }),
+            "ResponseIdMismatch must classify as Fatal, got {ae:?}",
+        );
     }
 }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -448,19 +448,29 @@ impl ProcessSandbox {
     }
 
     /// Core long-lived dispatch. Reuses the cached [`PluginHandle`] if any,
-    /// spawns fresh otherwise. On transport error, clears the handle and
-    /// retries once.
+    /// spawns fresh otherwise.
+    ///
+    /// # No implicit retry (#259)
+    ///
+    /// This method deliberately does NOT retry on failure. An earlier
+    /// implementation ran `try_dispatch` a second time after clearing
+    /// the cached handle on any error — which silently double-invoked
+    /// non-idempotent `ActionInvoke`s whenever the plugin had already
+    /// performed its side effect (sent a message, charged a card) but
+    /// the response read failed. Blind host-level retry is unsafe
+    /// without an idempotency token in `HostToPlugin::ActionInvoke`;
+    /// the configurable engine-level retry policy is the right layer
+    /// for deciding whether a specific action is safe to retry.
+    ///
+    /// The single-shot shape is still fault-tolerant by design: a
+    /// stale/dead handle clears itself inside `try_dispatch` on error,
+    /// and the next call that reaches `dispatch_envelope` transparently
+    /// respawns the plugin via `spawn_and_dial`.
     async fn dispatch_envelope(
         &self,
         envelope: HostToPlugin,
         cancel: Option<&CancellationToken>,
     ) -> Result<PluginToHost, ActionError> {
-        let first_attempt = self.try_dispatch(envelope.clone(), cancel).await;
-        if first_attempt.is_ok() {
-            return first_attempt;
-        }
-        // Clear the stale handle and retry once with a fresh spawn.
-        *self.handle.lock().await = None;
         self.try_dispatch(envelope, cancel).await
     }
 

--- a/crates/sandbox/src/runner.rs
+++ b/crates/sandbox/src/runner.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use nebula_action::{ActionContext, ActionError, ActionMetadata, result::ActionResult};
+use tokio_util::sync::CancellationToken;
 
 /// Sandboxed execution context wrapping an [`ActionContext`].
 ///
@@ -25,6 +26,13 @@ impl SandboxedContext {
         } else {
             Ok(())
         }
+    }
+
+    /// Borrow the cancellation token for long-running dispatch paths that
+    /// need to `select!` against it (e.g. the process-sandbox plugin
+    /// round-trip).
+    pub fn cancellation(&self) -> &CancellationToken {
+        &self.context.cancellation
     }
 
     /// Access the inner [`ActionContext`].


### PR DESCRIPTION
## Summary

`ProcessSandbox::dispatch_envelope` previously ran `try_dispatch` a second time after clearing the cached handle on any error — silently double-invoking non-idempotent `ActionInvoke`s whenever the plugin had already executed the side effect but the response read had failed (#259).

Drop the implicit retry. A stale/dead handle still clears itself inside `try_dispatch` on error, and the next call that reaches `dispatch_envelope` transparently respawns via `spawn_and_dial` — so fault tolerance is preserved, just pushed one level up to the engine's configurable retry policy (the layer that can reason about whether a specific action is safe to retry).

## Test plan

- [x] `cargo nextest run -p nebula-sandbox` — 41 tests, all green.
- [x] `cargo clippy -p nebula-sandbox --all-targets -- -D warnings` clean.
- [x] Lefthook pre-commit green.

## Stacked on

Base is https://github.com/vanyastaff/nebula/pull/453 (#257 + #285) — GitHub will auto-rebase to `main` once that merges. No new tests needed: the change is a removal, verifiable by inspection; existing handle-invalidation tests cover the remaining contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)