### PR TITLE
docs(sandbox): document stderr drainer lifecycle chain (#270)

### DIFF
--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -501,17 +501,22 @@ impl ProcessSandbox {
         //
         //   cmd.kill_on_drop(true)             (above, ~"kill_on_drop")
         //     → dropping PluginHandle drops Child
-        //     → Child's Drop SIGKILLs the plugin process
+        //     → Child's Drop terminates the plugin process
+        //       (SIGKILL on Unix, TerminateProcess on Windows — both
+        //       close the child's stderr pipe handle as a side effect)
         //     → plugin's stderr pipe closes
         //     → drain_plugin_stderr observes EOF and returns
         //     → detached task completes and is reaped
         //
-        // If a future refactor replaces `kill_on_drop(true)` with an
-        // explicit shutdown path, this chain breaks and the stderr
-        // drainer will leak one task per plugin spawn — tokio's task
-        // slab is bounded, so enough spawns will exhaust it. Either
-        // keep kill_on_drop or replace with an owned JoinHandle + abort
-        // on ProcessSandbox::drop.
+        // If a future refactor removes `kill_on_drop(true)`, make sure
+        // the replacement shutdown path still reliably terminates the
+        // child so stderr closes and the drainer reaches EOF, and/or
+        // keep an owned JoinHandle that can be aborted explicitly on
+        // ProcessSandbox::drop. The leak risk is not "explicit
+        // shutdown" by itself; it is any shutdown path that leaves the
+        // stderr drainer with no guaranteed completion signal — at
+        // that point tokio's task slab grows unbounded per plugin
+        // spawn.
         if let Some(stderr) = child.stderr.take() {
             let plugin_name = self.binary.display().to_string();
             tokio::spawn(drain_plugin_stderr(stderr, plugin_name));

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -493,8 +493,25 @@ impl ProcessSandbox {
         // Spawn a background task that drains the plugin's stderr and logs
         // each line via `tracing`. We do this BEFORE reading the handshake
         // so that any crash diagnostics the plugin writes during startup
-        // are captured. The task ends when the child's stderr closes —
-        // usually on plugin exit.
+        // are captured.
+        //
+        // Fire-and-forget: the returned JoinHandle is intentionally
+        // dropped (#270). The task's lifecycle is bounded implicitly via
+        // the chain:
+        //
+        //   cmd.kill_on_drop(true)             (above, ~"kill_on_drop")
+        //     → dropping PluginHandle drops Child
+        //     → Child's Drop SIGKILLs the plugin process
+        //     → plugin's stderr pipe closes
+        //     → drain_plugin_stderr observes EOF and returns
+        //     → detached task completes and is reaped
+        //
+        // If a future refactor replaces `kill_on_drop(true)` with an
+        // explicit shutdown path, this chain breaks and the stderr
+        // drainer will leak one task per plugin spawn — tokio's task
+        // slab is bounded, so enough spawns will exhaust it. Either
+        // keep kill_on_drop or replace with an owned JoinHandle + abort
+        // on ProcessSandbox::drop.
         if let Some(stderr) = child.stderr.take() {
             let plugin_name = self.binary.display().to_string();
             tokio::spawn(drain_plugin_stderr(stderr, plugin_name));


### PR DESCRIPTION
## Summary

`drain_plugin_stderr` is spawned as a detached task and relies on an implicit chain (`kill_on_drop` → child SIGKILL → stderr pipe closes → drainer observes EOF → task reaped) for bounded lifetime. That chain was correct but unstated at the spawn site — a future edit that removes or replaces `kill_on_drop` would silently leak one task per plugin spawn, exhausting tokio's task slab under churn.

No code change. Just the lifecycle comment at the spawn site so future reviewers see the contract.

## Test plan

- [x] `cargo check -p nebula-sandbox` clean.
- [x] Lefthook pre-commit green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal code documentation to clarify process lifecycle and stderr-draining behavior.

**Note:** No user-visible changes in this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->