### PR TITLE
fix(desktop): try OAuth callback port range (#293)

### DIFF
--- a/apps/desktop/src-tauri/src/auth/server.rs
+++ b/apps/desktop/src-tauri/src/auth/server.rs
@@ -1,8 +1,10 @@
 use std::time::Duration;
 
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::TcpListener;
-use tokio::time::timeout;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+    time::timeout,
+};
 
 /// Result of a successful OAuth callback capture.
 #[derive(Debug)]
@@ -44,7 +46,8 @@ pub const CALLBACK_PATH: &str = "/auth/github/callback";
 /// and returns the first one that succeeds; fails only when every port in the
 /// range is already in use. Returns the chosen port alongside a future that
 /// resolves to the callback result (#293).
-pub async fn start_callback_server() -> Result<(u16, tokio::task::JoinHandle<Result<CallbackResult, String>>), String> {
+pub async fn start_callback_server(
+) -> Result<(u16, tokio::task::JoinHandle<Result<CallbackResult, String>>), String> {
     let (listener, port) = bind_in_range(CALLBACK_PORT_MIN, CALLBACK_PORT_MAX).await?;
 
     let handle = tokio::spawn(async move {
@@ -59,11 +62,23 @@ pub async fn start_callback_server() -> Result<(u16, tokio::task::JoinHandle<Res
 }
 
 async fn bind_in_range(min: u16, max: u16) -> Result<(TcpListener, u16), String> {
+    if min > max {
+        return Err(format!(
+            "invalid OAuth callback port range: min ({min}) must be <= max ({max})"
+        ));
+    }
     let mut last_err: Option<String> = None;
     for port in min..=max {
         match TcpListener::bind(("127.0.0.1", port)).await {
             Ok(listener) => return Ok((listener, port)),
-            Err(e) => last_err = Some(e.to_string()),
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                last_err = Some(e.to_string());
+            },
+            Err(e) => {
+                return Err(format!(
+                    "failed to bind OAuth callback server on port {port}: {e}"
+                ));
+            },
         }
     }
     Err(format!(
@@ -114,10 +129,7 @@ fn parse_callback_params(request: &str) -> Result<CallbackResult, String> {
         .and_then(|line| line.split_whitespace().nth(1))
         .ok_or("invalid HTTP request")?;
 
-    let query = path
-        .split_once('?')
-        .map(|(_, q)| q)
-        .unwrap_or("");
+    let query = path.split_once('?').map(|(_, q)| q).unwrap_or("");
 
     let params: Vec<(String, String)> = url::form_urlencoded::parse(query.as_bytes())
         .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -144,7 +156,8 @@ mod tests {
 
     #[test]
     fn parse_valid_callback() {
-        let req = "GET /auth/github/callback?code=abc123&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n";
+        let req =
+            "GET /auth/github/callback?code=abc123&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n";
         let result = parse_callback_params(req).unwrap();
         assert_eq!(result.code, "abc123");
         assert_eq!(result.state, "xyz");
@@ -167,20 +180,21 @@ mod tests {
     /// of returning `AddrInUse`.
     #[tokio::test]
     async fn bind_in_range_falls_through_to_next_free_port() {
-        // Hold the first port in the range so the first bind attempt fails.
-        let _blocker = TcpListener::bind(("127.0.0.1", CALLBACK_PORT_MIN))
+        // Use an ephemeral base port to avoid colliding with whatever is bound
+        // at the fixed CALLBACK_PORT_MIN on the host running the test.
+        let blocker = TcpListener::bind(("127.0.0.1", 0))
             .await
-            .expect("first port should be bindable in a fresh test env");
+            .expect("ephemeral bind works");
+        let base = blocker.local_addr().unwrap().port();
+        // Small runtime-selected range starting at the blocked port.
+        let max = base.saturating_add(4);
 
-        let (_listener, port) = bind_in_range(CALLBACK_PORT_MIN, CALLBACK_PORT_MAX)
+        let (_listener, port) = bind_in_range(base, max)
             .await
-            .expect("second port in range should be free");
+            .expect("a free port above the blocker should be available");
         assert!(
-            port > CALLBACK_PORT_MIN && port <= CALLBACK_PORT_MAX,
-            "expected port in range ({}, {}], got {}",
-            CALLBACK_PORT_MIN,
-            CALLBACK_PORT_MAX,
-            port,
+            port > base && port <= max,
+            "expected port in range ({base}, {max}], got {port}",
         );
     }
 
@@ -189,22 +203,14 @@ mod tests {
     /// in use" message for a range bind.
     #[tokio::test]
     async fn bind_in_range_reports_when_fully_saturated() {
-        // Grab a single narrow two-port range and occupy both ports.
-        let a = TcpListener::bind(("127.0.0.1", 0))
+        // Two ephemeral ports from the OS are rarely contiguous, so hold a
+        // single ephemeral port and ask the helper for a one-port range.
+        let held = TcpListener::bind(("127.0.0.1", 0))
             .await
             .expect("ephemeral bind works");
-        let b = TcpListener::bind(("127.0.0.1", 0))
-            .await
-            .expect("ephemeral bind works");
-        let port_a = a.local_addr().unwrap().port();
-        let port_b = b.local_addr().unwrap().port();
-        let (lo, hi) = if port_a <= port_b {
-            (port_a, port_b)
-        } else {
-            (port_b, port_a)
-        };
+        let port = held.local_addr().unwrap().port();
 
-        let err = bind_in_range(lo, hi)
+        let err = bind_in_range(port, port)
             .await
             .expect_err("range fully occupied must error");
         assert!(

--- a/apps/desktop/src-tauri/src/auth/server.rs
+++ b/apps/desktop/src-tauri/src/auth/server.rs
@@ -27,23 +27,25 @@ const ERROR_HTML: &str = r#"<!DOCTYPE html>
 <p>Missing required parameters. Please try again.</p>
 </body></html>"#;
 
-/// Fixed port for the OAuth localhost callback server.
-pub const CALLBACK_PORT: u16 = 5678;
+/// Inclusive lower bound of the OAuth callback port range.
+///
+/// Every value in `CALLBACK_PORT_MIN..=CALLBACK_PORT_MAX` must be registered
+/// as an allowed redirect URI in the GitHub / Google OAuth application, since
+/// providers do not honor wildcards. Keep the range small.
+pub const CALLBACK_PORT_MIN: u16 = 5678;
+/// Inclusive upper bound of the OAuth callback port range.
+pub const CALLBACK_PORT_MAX: u16 = 5685;
 /// Fixed path for the OAuth callback endpoint.
 pub const CALLBACK_PATH: &str = "/auth/github/callback";
 
 /// Starts a temporary localhost HTTP server that waits for one OAuth callback.
 ///
-/// Binds to `127.0.0.1:5678`, accepts a single connection,
-/// parses the `code` and `state` query parameters, and shuts down.
-///
-/// Returns the port and a future that resolves to the callback result.
+/// Tries to bind each port in `CALLBACK_PORT_MIN..=CALLBACK_PORT_MAX` in order
+/// and returns the first one that succeeds; fails only when every port in the
+/// range is already in use. Returns the chosen port alongside a future that
+/// resolves to the callback result (#293).
 pub async fn start_callback_server() -> Result<(u16, tokio::task::JoinHandle<Result<CallbackResult, String>>), String> {
-    let listener = TcpListener::bind(("127.0.0.1", CALLBACK_PORT))
-        .await
-        .map_err(|e| format!("failed to bind callback server on port {CALLBACK_PORT}: {e}"))?;
-
-    let port = CALLBACK_PORT;
+    let (listener, port) = bind_in_range(CALLBACK_PORT_MIN, CALLBACK_PORT_MAX).await?;
 
     let handle = tokio::spawn(async move {
         let result = timeout(CALLBACK_TIMEOUT, accept_callback(&listener)).await;
@@ -54,6 +56,21 @@ pub async fn start_callback_server() -> Result<(u16, tokio::task::JoinHandle<Res
     });
 
     Ok((port, handle))
+}
+
+async fn bind_in_range(min: u16, max: u16) -> Result<(TcpListener, u16), String> {
+    let mut last_err: Option<String> = None;
+    for port in min..=max {
+        match TcpListener::bind(("127.0.0.1", port)).await {
+            Ok(listener) => return Ok((listener, port)),
+            Err(e) => last_err = Some(e.to_string()),
+        }
+    }
+    Err(format!(
+        "failed to bind OAuth callback server: every port in {min}..={max} is in use \
+         (close a duplicate Nebula instance or conflicting process); last error: {}",
+        last_err.unwrap_or_else(|| "none".to_string())
+    ))
 }
 
 async fn accept_callback(listener: &TcpListener) -> Result<CallbackResult, String> {
@@ -143,5 +160,56 @@ mod tests {
     fn parse_missing_state() {
         let req = "GET /callback?code=abc HTTP/1.1\r\nHost: localhost\r\n\r\n";
         assert!(parse_callback_params(req).is_err());
+    }
+
+    /// Regression for #293: when the first port in the range is already in
+    /// use, `bind_in_range` must fall through to the next free port instead
+    /// of returning `AddrInUse`.
+    #[tokio::test]
+    async fn bind_in_range_falls_through_to_next_free_port() {
+        // Hold the first port in the range so the first bind attempt fails.
+        let _blocker = TcpListener::bind(("127.0.0.1", CALLBACK_PORT_MIN))
+            .await
+            .expect("first port should be bindable in a fresh test env");
+
+        let (_listener, port) = bind_in_range(CALLBACK_PORT_MIN, CALLBACK_PORT_MAX)
+            .await
+            .expect("second port in range should be free");
+        assert!(
+            port > CALLBACK_PORT_MIN && port <= CALLBACK_PORT_MAX,
+            "expected port in range ({}, {}], got {}",
+            CALLBACK_PORT_MIN,
+            CALLBACK_PORT_MAX,
+            port,
+        );
+    }
+
+    /// Regression for #293: when every port in the range is occupied, the
+    /// helper must return an actionable error, not a misleading "port 5678
+    /// in use" message for a range bind.
+    #[tokio::test]
+    async fn bind_in_range_reports_when_fully_saturated() {
+        // Grab a single narrow two-port range and occupy both ports.
+        let a = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("ephemeral bind works");
+        let b = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("ephemeral bind works");
+        let port_a = a.local_addr().unwrap().port();
+        let port_b = b.local_addr().unwrap().port();
+        let (lo, hi) = if port_a <= port_b {
+            (port_a, port_b)
+        } else {
+            (port_b, port_a)
+        };
+
+        let err = bind_in_range(lo, hi)
+            .await
+            .expect_err("range fully occupied must error");
+        assert!(
+            err.contains("every port"),
+            "error must explain that the whole range was tried, got: {err}",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Closes #293. `start_callback_server` now iterates
  `CALLBACK_PORT_MIN..=CALLBACK_PORT_MAX` (5678..=5685, 8 ports) instead of
  hardcoding 5678, so a second Nebula instance or a conflicting process on
  the default port no longer blocks OAuth login.
- A new `bind_in_range` helper returns the first free port alongside the
  listener; the caller in `auth/mod.rs` already builds `redirect_uri` from
  the returned port, so the OAuth flow adapts without further changes.
- When the whole range is occupied the error names the cause — "close a
  duplicate Nebula instance or conflicting process" — rather than a bare
  "port 5678 in use".

## Operator note

GitHub / Google OAuth applications do not honor wildcards, so every URI
in the range must be registered as an allowed redirect URI in the OAuth
app configuration. The doc comment on `CALLBACK_PORT_MIN` records this.

## Test plan

- [x] `cargo test -p nebula-desktop --lib auth::server` — 5/5 pass,
      including two new regressions:
      - `bind_in_range_falls_through_to_next_free_port`
      - `bind_in_range_reports_when_fully_saturated`
- [x] `cargo +nightly fmt --check`, `cargo clippy -p nebula-api -- -D warnings`
- [x] Pre-push lefthook (shear, check-all-features, check-no-default, docs,
      doctests, nextest 3266 tests) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)