### PR TITLE
fix(api): LRU eviction in WebhookRateLimiter (#271)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "jsonwebtoken",
+ "moka",
  "nebula-action",
  "nebula-api",
  "nebula-core",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -57,6 +57,7 @@ rand = { workspace = true }
 
 # Webhook transport
 dashmap = { workspace = true }
+moka = { workspace = true, features = ["future"] }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/api/src/webhook/ratelimit.rs
+++ b/crates/api/src/webhook/ratelimit.rs
@@ -1,39 +1,27 @@
 //! Per-path webhook rate limiting.
 //!
-//! Salvaged from the deleted `crates/webhook/` orphan (verbatim port
-//! of `rate_limit.rs`) and adapted to use a local error type instead
-//! of the old crate's `Error` enum. Wraps
-//! [`nebula_resilience::SlidingWindow`] with per-path tracking:
-//! each unique webhook path gets an independent sliding window
-//! limiter.
+//! Wraps [`nebula_resilience::SlidingWindow`] with per-path tracking: each
+//! unique webhook path gets an independent sliding-window limiter.
 //!
-//! To prevent memory exhaustion from attacker-controlled paths, the
-//! limiter enforces a maximum number of tracked paths (`max_paths`).
-//! Requests for paths beyond this limit pass through without
-//! per-path rate limiting — the soft cap keeps `DashMap` bounded.
+//! To prevent memory exhaustion from attacker-controlled paths, the limiter
+//! caps the number of tracked paths (`max_paths`) using an LRU-style bound
+//! via [`moka::future::Cache`]. When the cap is reached, the **least-recently
+//! used** window is evicted to make room for the new path — so rate-limiting
+//! stays enforced for every path (#271). The previous implementation let
+//! requests for untracked paths fall through without any limit once the cap
+//! was hit, which allowed an attacker who probed enough unique paths to
+//! permanently disable per-path limiting for newly-deployed routes.
 
-use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicUsize, Ordering},
-    },
-    time::Duration,
-};
+use std::{sync::Arc, time::Duration};
 
-use dashmap::DashMap;
+use moka::future::Cache;
 use nebula_resilience::SlidingWindow;
 
 /// Default maximum number of distinct paths to track.
 ///
-/// Paths beyond this limit are allowed without per-path rate limiting
-/// to prevent unbounded `DashMap` growth.
-const DEFAULT_MAX_PATHS: usize = 10_000;
-
-/// Result of a `path_count` slot reservation attempt.
-enum SlotReservation {
-    Reserved,
-    Saturated,
-}
+/// Paths beyond this limit are retained via LRU eviction — the oldest path
+/// is dropped so new arrivals always receive a tracked window.
+const DEFAULT_MAX_PATHS: u64 = 10_000;
 
 /// Error returned when a request exceeds the per-path quota.
 #[derive(Debug, Clone, thiserror::Error)]
@@ -47,116 +35,76 @@ pub struct RateLimitExceeded {
 
 /// Per-path rate limiter backed by [`SlidingWindow`] from nebula-resilience.
 ///
-/// Each unique webhook path gets an independent sliding window that
-/// tracks request timestamps and enforces requests-per-minute limits.
+/// Each unique webhook path gets an independent sliding window that tracks
+/// request timestamps and enforces requests-per-minute limits.
 ///
-/// A `max_paths` cap (default: 10 000) prevents the internal map from
-/// growing without bound when callers supply attacker-controlled paths.
-/// Requests arriving on previously-unseen paths above the cap are allowed
-/// through without per-path rate limiting.
-///
-/// The cap is a **soft limit**: in high concurrency scenarios, the map
-/// may briefly exceed `max_paths` by a small margin before the atomic
-/// counter catches up. This is acceptable for DoS-prevention purposes.
-#[derive(Debug)]
+/// The `max_paths` cap (default: 10 000) bounds memory via **LRU eviction**:
+/// when a new path arrives after the cap is reached, the least-recently used
+/// window is dropped. Every path — attacker-controlled or legitimate — is
+/// rate-limited the same way; the cap does not create a bypass. A window that
+/// has been idle for longer than twice the request window is also eligible
+/// for eviction so paths decommissioned by operators do not linger.
+#[derive(Debug, Clone)]
 pub struct WebhookRateLimiter {
-    /// Per-path sliding windows.
-    windows: DashMap<String, Arc<SlidingWindow>>,
-    /// Maximum requests per window.
+    windows: Cache<String, Arc<SlidingWindow>>,
     max_requests: usize,
-    /// Window duration.
     window: Duration,
-    /// Maximum number of distinct paths to track.
-    max_paths: usize,
-    /// Atomic count of distinct paths currently tracked.
-    path_count: AtomicUsize,
 }
 
 impl WebhookRateLimiter {
     /// Create a rate limiter with the given requests-per-minute limit.
     #[must_use]
     pub fn new(requests_per_minute: u64) -> Self {
-        Self {
-            windows: DashMap::new(),
-            max_requests: requests_per_minute.max(1) as usize,
-            window: Duration::from_secs(60),
-            max_paths: DEFAULT_MAX_PATHS,
-            path_count: AtomicUsize::new(0),
-        }
+        Self::with_config(requests_per_minute, DEFAULT_MAX_PATHS)
     }
 
     /// Override the maximum number of distinct paths to track.
     #[must_use]
-    pub fn with_max_paths(mut self, max_paths: usize) -> Self {
-        self.max_paths = max_paths.max(1);
-        self
+    pub fn with_max_paths(self, max_paths: usize) -> Self {
+        let rpm = self.max_requests as u64;
+        Self::with_config(rpm, (max_paths.max(1)) as u64)
+    }
+
+    fn with_config(requests_per_minute: u64, max_paths: u64) -> Self {
+        let window = Duration::from_secs(60);
+        let max_requests = requests_per_minute.max(1) as usize;
+        let windows = Cache::builder()
+            .max_capacity(max_paths.max(1))
+            .time_to_idle(window.saturating_mul(2))
+            .build();
+        Self {
+            windows,
+            max_requests,
+            window,
+        }
     }
 
     /// Check if a request to the given path is allowed.
     ///
     /// Uses a sliding window per path — more accurate than fixed-window
-    /// counters at window boundaries.
-    ///
-    /// If the path has not been seen before and the number of tracked
-    /// paths has already reached `max_paths`, the request is allowed
-    /// through without per-path rate limiting to prevent memory
-    /// exhaustion.
+    /// counters at window boundaries. If the path is not tracked yet a fresh
+    /// window is inserted, evicting the least-recently used entry when the
+    /// cap is reached.
     ///
     /// # Errors
     ///
     /// Returns [`RateLimitExceeded`] if the path has exceeded its
     /// per-minute request quota.
     pub async fn check(&self, path: &str) -> Result<(), RateLimitExceeded> {
-        // Fast path: path is already tracked — no allocation.
-        if let Some(window) = self.windows.get(path) {
-            return Self::acquire(window.clone(), path, self.window.as_secs()).await;
-        }
+        let window_dur = self.window;
+        let max_requests = self.max_requests;
 
-        // Slow path: get or insert the window atomically via DashMap's
-        // `entry` API. `path_count` is bumped only inside the `Vacant`
-        // arm (via `try_reserve_slot`) so two concurrent first-time
-        // requests for the same path insert exactly one entry and
-        // increment exactly once — the previous pre-CAS-then-entry
-        // ordering could overcount `path_count` and eventually cross
-        // `max_paths` silently, disabling per-path limiting wholesale.
-        use dashmap::mapref::entry::Entry;
-        let window = match self.windows.entry(path.to_string()) {
-            Entry::Occupied(e) => e.get().clone(),
-            Entry::Vacant(v) => match self.try_reserve_slot() {
-                SlotReservation::Reserved => v
-                    .insert(Arc::new(
-                        SlidingWindow::new(self.window, self.max_requests)
-                            .expect("valid config: max_requests >= 1, window > 0"),
-                    ))
-                    .clone(),
-                SlotReservation::Saturated => return Ok(()),
-            },
-        };
+        let window = self
+            .windows
+            .get_with(path.to_string(), async move {
+                Arc::new(
+                    SlidingWindow::new(window_dur, max_requests)
+                        .expect("valid config: max_requests >= 1, window > 0"),
+                )
+            })
+            .await;
 
-        Self::acquire(window, path, self.window.as_secs()).await
-    }
-
-    /// Attempts to reserve a slot in the `path_count` soft cap.
-    ///
-    /// Returns `Reserved` if `path_count` was bumped under the cap;
-    /// `Saturated` if the map has already reached `max_paths` and the
-    /// caller must pass the request through without tracking.
-    fn try_reserve_slot(&self) -> SlotReservation {
-        let mut current = self.path_count.load(Ordering::Relaxed);
-        loop {
-            if current >= self.max_paths {
-                return SlotReservation::Saturated;
-            }
-            match self.path_count.compare_exchange_weak(
-                current,
-                current + 1,
-                Ordering::AcqRel,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => return SlotReservation::Reserved,
-                Err(actual) => current = actual,
-            }
-        }
+        Self::acquire(window, path, window_dur.as_secs()).await
     }
 
     async fn acquire(
@@ -215,15 +163,49 @@ mod tests {
         assert_eq!(err.retry_after_secs, 60);
     }
 
+    /// Regression for #271: a new path that arrives after the capacity cap
+    /// has been reached must still be rate-limited. The previous
+    /// implementation passed every over-cap path through with `Ok(())`,
+    /// giving an attacker who probed `max_paths` unique paths a permanent
+    /// bypass for every subsequent path.
     #[tokio::test]
-    async fn paths_beyond_capacity_are_passed_through() {
+    async fn new_path_beyond_capacity_is_still_rate_limited() {
         let limiter = WebhookRateLimiter::new(1).with_max_paths(2);
+
+        // Saturate the existing paths within their own quotas.
         assert!(limiter.check("/a").await.is_ok());
-        assert!(limiter.check("/b").await.is_ok());
         assert!(limiter.check("/a").await.is_err());
+        assert!(limiter.check("/b").await.is_ok());
         assert!(limiter.check("/b").await.is_err());
-        // /c is a new path but capacity is reached — passes through.
+
+        // A brand-new path pushes capacity over the cap. It must get its
+        // own tracked window (one allowed, then blocked), not a free pass.
         assert!(limiter.check("/c").await.is_ok());
-        assert!(limiter.check("/c").await.is_ok());
+        assert!(
+            limiter.check("/c").await.is_err(),
+            "new over-cap path must be rate-limited, not bypassed",
+        );
+    }
+
+    /// Regression for #271: attacker churn through many unique paths must
+    /// not permanently fill slots. LRU eviction drops the oldest entries so
+    /// legitimate new paths keep getting tracked windows.
+    #[tokio::test]
+    async fn attacker_churn_does_not_exhaust_limiter() {
+        let limiter = WebhookRateLimiter::new(1).with_max_paths(4);
+
+        // Attacker probes far more unique paths than the cap.
+        for i in 0..100 {
+            let path = format!("/attacker-{i}");
+            // First hit for each path is allowed; second would be blocked.
+            assert!(limiter.check(&path).await.is_ok());
+        }
+
+        // A legitimate new path must still receive a tracked window.
+        assert!(limiter.check("/legit").await.is_ok());
+        assert!(
+            limiter.check("/legit").await.is_err(),
+            "legitimate path must be rate-limited after the attacker flood",
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Closes #271. The `max_paths` cap in `WebhookRateLimiter` was a permanent
  DoS bypass: once saturated, every new first-time path returned `Ok(())`
  without per-path limiting until process restart.
- Replace the `DashMap` + `AtomicUsize` cap with `moka::future::Cache`
  bounded by `max_capacity(max_paths)` and `time_to_idle(2 * window)`. New
  paths always get a tracked window; the least-recently-used entry is
  evicted so attacker churn rotates the attacker's own entries out.
- `try_reserve_slot` / `SlotReservation` are gone — moka enforces the cap
  internally.

## Attack this closes

An attacker probing ~10 000 unique bogus paths previously filled every
slot forever (no eviction, no TTL). All subsequent first-time paths —
including legitimate newly-deployed webhook routes — got a free pass.
Under the new implementation, the LRU eviction policy keeps the cap
bounded while never disabling per-path limiting.

## Test plan

- [x] `cargo nextest run -p nebula-api webhook::ratelimit` — 6/6 pass,
      including two new regressions:
      - `new_path_beyond_capacity_is_still_rate_limited`
      - `attacker_churn_does_not_exhaust_limiter`
- [x] `cargo nextest run -p nebula-api webhook` — 12/12 (routing +
      provider + ratelimit + transport) unchanged
- [x] Pre-push lefthook mirror — all green (workspace 3266+ tests)

## Dependency note

Adds `moka = { workspace = true, features = ["future"] }` to
`crates/api/Cargo.toml`. `moka` is already in the workspace depth
(used by `nebula-credential`, `nebula-expression`), no new transitive
is pulled into the tree for a consumer of `nebula-api`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)