### PR TITLE
fix(api): persist canonical execution state on start (#327)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3767,6 +3767,7 @@ dependencies = [
  "nebula-api",
  "nebula-core",
  "nebula-error",
+ "nebula-execution",
  "nebula-metrics",
  "nebula-plugin",
  "nebula-resilience",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -15,6 +15,7 @@ documentation.workspace = true
 nebula-error = { workspace = true, features = ["derive"] }
 nebula-storage = { path = "../storage" }
 nebula-core = { path = "../core" }
+nebula-execution = { path = "../execution" }
 nebula-validator = { path = "../validator" }
 nebula-metrics = { path = "../metrics" }
 nebula-telemetry = { path = "../telemetry" }

--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -6,6 +6,7 @@ use axum::{
     http::StatusCode,
 };
 use nebula_core::{ExecutionId, WorkflowId};
+use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_storage::repos::{ControlCommand, ControlQueueEntry};
 use uuid::Uuid;
 
@@ -175,14 +176,24 @@ pub async fn get_execution(
         .unwrap_or("unknown")
         .to_string();
 
-    let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
+    // Canonical `ExecutionState` exposes `started_at` (engine run start,
+    // `None` until transitioned to `Running`) and `created_at` (always set
+    // at construction). Fall back to `created_at` so the API response
+    // retains a meaningful timestamp for executions that have not yet been
+    // dispatched (#327).
+    let started_at = extract_timestamp(&execution_state, "started_at")
+        .or_else(|| extract_timestamp(&execution_state, "created_at"))
+        .unwrap_or(0);
     // Canonical engine state uses `completed_at` (see `ExecutionState` in
-    // `crates/execution/src/state.rs`); the legacy API write path uses
-    // `finished_at`. Accept either, prefer canonical.
+    // `crates/execution/src/state.rs`); legacy rows used `finished_at`.
     let finished_at = extract_timestamp(&execution_state, "completed_at")
         .or_else(|| extract_timestamp(&execution_state, "finished_at"));
 
-    let input = execution_state.get("input").cloned();
+    // Canonical field is `workflow_input`; legacy rows used `input`.
+    let input = execution_state
+        .get("workflow_input")
+        .or_else(|| execution_state.get("input"))
+        .cloned();
 
     let output = execution_state.get("output").cloned();
 
@@ -219,16 +230,27 @@ pub async fn start_execution(
     // Generate new execution ID
     let execution_id = ExecutionId::new();
 
-    // Current timestamp via chrono — does not panic on misconfigured clocks.
-    let now = chrono::Utc::now().timestamp();
+    // Build the canonical execution state directly from the typed enum so
+    // that the persisted row matches the schema the engine's
+    // `resume_execution` reads (canon §4.5: public surface must be honored
+    // end-to-end). The legacy hand-rolled JSON with `status: "pending"` was
+    // a false capability — `ExecutionStatus` has no `Pending` variant, and
+    // neither `list_running` (storage filter) nor `ExecutionState::deserialize`
+    // (engine resume path) would accept it (#327).
+    //
+    // `ExecutionState::new` seeds with `ExecutionStatus::Created` — the only
+    // correct initial state per the transition table. The node map is empty
+    // at API-start time: the dispatcher will populate per-node rows once the
+    // workflow is loaded and a plan is built. The workflow input (trigger
+    // payload) is attached so resume can feed entry nodes the same value
+    // (#311).
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id_parsed, &[]);
+    if let Some(input) = payload.input.clone() {
+        exec_state.set_workflow_input(input);
+    }
 
-    // Create initial execution state
-    let execution_state = serde_json::json!({
-        "workflow_id": workflow_id,
-        "status": "pending",
-        "started_at": now,
-        "input": payload.input,
-    });
+    let state_json = serde_json::to_value(&exec_state)
+        .map_err(|e| ApiError::Internal(format!("serialize execution state: {}", e)))?;
 
     // Create execution record. We must call `create` here — the previous
     // implementation called `transition(id, expected_version = 0, ...)`,
@@ -237,16 +259,30 @@ pub async fn start_execution(
     // surfaced an Internal error unconditionally.
     state
         .execution_repo
-        .create(execution_id, workflow_id_parsed, execution_state.clone())
+        .create(execution_id, workflow_id_parsed, state_json)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to create execution: {}", e)))?;
 
-    // Build response
+    // Build response. `started_at` is omitted on a Created execution —
+    // canon §13 step 3 forbids synthetic timestamps for fields the engine
+    // has not actually populated yet. `ExecutionState::started_at` is
+    // `None` until the engine transitions the status to `Running`, and the
+    // API response must reflect that.
+    //
+    // The legacy response returned `chrono::Utc::now().timestamp()` as a
+    // placeholder, which conflated "row was created" with "engine started
+    // the run" — two different events under canon §11.1. Downstream tools
+    // that graphed `started_at` therefore measured API-enqueue latency, not
+    // engine dispatch latency. The DTO field stays `i64` (wire-compatible),
+    // but we now return `created_at` as the observable timestamp so clients
+    // still get a real time for "when did this execution exist?" — which
+    // is what `started_at` was used for in practice pre-fix.
+    let created_at = exec_state.created_at.timestamp();
     let response = ExecutionResponse {
         id: execution_id.to_string(),
         workflow_id,
-        status: "pending".to_string(),
-        started_at: now,
+        status: exec_state.status.to_string(),
+        started_at: created_at,
         finished_at: None,
         input: payload.input,
         output: None,
@@ -294,14 +330,32 @@ pub async fn cancel_execution(
         )));
     }
 
-    // Update state to cancelled
+    // Update state to cancelled. Write the status as the canonical
+    // snake-case string that `ExecutionStatus::Cancelled` serializes to,
+    // so that engine-side reads via `ExecutionStatus::deserialize` round-
+    // trip cleanly (#327, canon §4.5). Persist `completed_at` (not the
+    // legacy `finished_at`) because that is the field `ExecutionState`
+    // actually declares — see `crates/execution/src/state.rs`.
     if let Some(state_obj) = execution_state.as_object_mut() {
-        state_obj.insert("status".to_string(), serde_json::json!("cancelled"));
+        state_obj.insert(
+            "status".to_string(),
+            serde_json::json!(ExecutionStatus::Cancelled.to_string()),
+        );
 
-        // Set finished_at timestamp if not already set
-        if !state_obj.contains_key("finished_at") {
-            let now = chrono::Utc::now().timestamp();
-            state_obj.insert("finished_at".to_string(), serde_json::json!(now));
+        // Set completed_at timestamp. The canonical `ExecutionState`
+        // serializes `Option::None` as `null`, not as an absent field —
+        // so `contains_key` alone is not enough; we must also overwrite
+        // explicit nulls. RFC 3339 string matches what `DateTime<Utc>`
+        // serializes to via serde.
+        let needs_write = state_obj
+            .get("completed_at")
+            .is_none_or(serde_json::Value::is_null);
+        if needs_write {
+            let now = chrono::Utc::now();
+            state_obj.insert(
+                "completed_at".to_string(),
+                serde_json::json!(now.to_rfc3339()),
+            );
         }
     }
 
@@ -388,13 +442,23 @@ pub async fn cancel_execution(
         .unwrap_or("cancelled")
         .to_string();
 
-    let started_at = extract_timestamp(&execution_state, "started_at").unwrap_or(0);
-    // This handler just wrote `finished_at` above; prefer that, then fall
-    // back to canonical `completed_at` if the engine had already set it.
-    let finished_at = extract_timestamp(&execution_state, "finished_at")
-        .or_else(|| extract_timestamp(&execution_state, "completed_at"));
+    // Canonical `ExecutionState` exposes `started_at` (engine run start,
+    // `None` until the engine transitions to `Running`) and `created_at`
+    // (always set at construction). Fall back to `created_at` so the API
+    // response retains a meaningful timestamp for executions that have
+    // not yet been dispatched (#327).
+    let started_at = extract_timestamp(&execution_state, "started_at")
+        .or_else(|| extract_timestamp(&execution_state, "created_at"))
+        .unwrap_or(0);
+    // Canonical field is `completed_at`; legacy rows used `finished_at`.
+    let finished_at = extract_timestamp(&execution_state, "completed_at")
+        .or_else(|| extract_timestamp(&execution_state, "finished_at"));
 
-    let input = execution_state.get("input").cloned();
+    // Canonical field is `workflow_input`; legacy rows used `input`.
+    let input = execution_state
+        .get("workflow_input")
+        .or_else(|| execution_state.get("input"))
+        .cloned();
 
     let output = execution_state.get("output").cloned();
 

--- a/crates/api/src/handlers/workflow.rs
+++ b/crates/api/src/handlers/workflow.rs
@@ -7,6 +7,7 @@ use axum::{
 };
 use chrono::Utc;
 use nebula_core::{ExecutionId, WorkflowId};
+use nebula_execution::ExecutionState;
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -520,34 +521,39 @@ pub async fn execute_workflow(
     // Generate new execution ID
     let execution_id = ExecutionId::new();
 
-    // Current timestamp — `chrono::Utc::now()` is monotonic through time
-    // shifts and does not panic on clocks set before 1970, unlike
-    // `SystemTime::duration_since(UNIX_EPOCH).unwrap()`.
-    let now = Utc::now().timestamp();
+    // Build the canonical execution state — same rationale as
+    // `start_execution` in `handlers/execution.rs` (#327, canon §4.5): the
+    // persisted row must match `ExecutionState` so the engine's
+    // `resume_execution` can deserialize it, and the status must be the
+    // canonical `Created`, not the non-existent `"pending"` that the
+    // storage `list_running` filter would also drop.
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    if let Some(input) = payload.input.clone() {
+        exec_state.set_workflow_input(input);
+    }
 
-    // Create initial execution state
-    let execution_state = serde_json::json!({
-        "workflow_id": id,
-        "status": "pending",
-        "started_at": now,
-        "input": payload.input,
-    });
+    let state_json = serde_json::to_value(&exec_state)
+        .map_err(|e| ApiError::Internal(format!("serialize execution state: {}", e)))?;
 
     // Create execution record via `create` — `transition` is a CAS UPDATE
     // and was hitting zero rows for every brand-new ID, so every call to
     // this handler previously returned a 500.
     state
         .execution_repo
-        .create(execution_id, workflow_id, execution_state.clone())
+        .create(execution_id, workflow_id, state_json)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to create execution: {}", e)))?;
 
-    // Build response
+    // Report `created_at` as the observable timestamp — the engine has not
+    // transitioned `started_at` yet (that happens at dispatch time). See
+    // the parallel comment in `handlers::execution::start_execution` for
+    // the full rationale.
+    let created_at = exec_state.created_at.timestamp();
     let response = ExecutionResponse {
         id: execution_id.to_string(),
         workflow_id: id,
-        status: "pending".to_string(),
-        started_at: now,
+        status: exec_state.status.to_string(),
+        started_at: created_at,
         finished_at: None,
         input: payload.input,
         output: None,

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -851,7 +851,7 @@ async fn test_execute_workflow() {
         execution_response["workflow_id"].as_str().unwrap(),
         workflow_id
     );
-    assert_eq!(execution_response["status"].as_str().unwrap(), "pending");
+    assert_eq!(execution_response["status"].as_str().unwrap(), "created");
 }
 
 #[tokio::test]
@@ -1167,7 +1167,7 @@ async fn test_execution_start() {
         .unwrap();
     let execution_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
     assert!(execution_response["id"].is_string());
-    assert_eq!(execution_response["status"].as_str().unwrap(), "pending");
+    assert_eq!(execution_response["status"].as_str().unwrap(), "created");
 }
 
 #[tokio::test]
@@ -2246,5 +2246,180 @@ async fn cancel_timed_out_execution_rejected() {
     assert!(
         control_queue.snapshot().await.is_empty(),
         "control queue must be empty after rejected cancel of timed_out execution"
+    );
+}
+
+// ── Issue #327 regression ─────────────────────────────────────────────────────
+//
+// Canon §4.5: a public surface exists iff the engine honors it end-to-end.
+// The API's `start_execution` previously persisted a hand-rolled JSON with
+// `status: "pending"` — a string that is not in `ExecutionStatus` and that
+// neither `list_running` (storage filter) nor `ExecutionState::deserialize`
+// (engine resume path) would accept. Starting an execution therefore produced
+// a row the engine could never read back: split-brain schema.
+//
+// This test pins the fix by asserting the exact contract that failed:
+//
+//   1. `POST /workflows/:id/executions` → 202.
+//   2. The persisted `execution_repo.get_state(id)` row round-trips through
+//      `serde_json::from_value::<ExecutionState>` without error — the same operation the engine's
+//      `resume_execution` performs.
+//   3. The deserialized `ExecutionStatus` is the canonical `Created`, not a synthetic "pending"
+//      variant.
+//   4. The `list_running` storage query — which filters on canonical status names — actually
+//      returns the newly-created execution ID (it did not before, because `"pending"` is not in the
+//      filter).
+#[tokio::test]
+async fn test_issue_327_start_execution_persists_canonical_execution_state() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use nebula_core::ExecutionId;
+    use nebula_execution::{ExecutionState, ExecutionStatus};
+    use tower::ServiceExt;
+
+    let (state, _control_queue) = create_state_with_queue().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // Seed a workflow via POST /workflows — the same path a real client uses.
+    let create_request = serde_json::json!({
+        "name": "Issue 327 Workflow",
+        "description": "Contract test: API-created execution must round-trip through ExecutionState",
+        "definition": { "nodes": [], "edges": [] }
+    });
+    let app = app::build_app(state.clone(), &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/workflows")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(serde_json::to_string(&create_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::CREATED,
+        "#327: seed workflow must return 201"
+    );
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let created_workflow: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let workflow_id_str = created_workflow["id"].as_str().unwrap().to_string();
+    let workflow_id = nebula_core::WorkflowId::parse(&workflow_id_str).unwrap();
+
+    // POST /api/v1/workflows/:id/executions with a real input.
+    let input = serde_json::json!({ "knife_key": "knife_value" });
+    let app = app::build_app(state.clone(), &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/workflows/{workflow_id_str}/executions"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(
+                    serde_json::to_string(&serde_json::json!({ "input": input })).unwrap(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::ACCEPTED,
+        "#327: POST must return 202"
+    );
+
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let execution_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let execution_id_str = execution_response["id"]
+        .as_str()
+        .expect("id field")
+        .to_string();
+    let execution_id = ExecutionId::parse(&execution_id_str).expect("parse id");
+
+    // Response status must be canonical.
+    assert_eq!(
+        execution_response["status"].as_str(),
+        Some("created"),
+        "#327: API response status must be canonical 'created', not 'pending'"
+    );
+
+    // Load the persisted row directly through the repo — same path the engine
+    // uses in `resume_execution`.
+    let (_version, state_json) = state
+        .execution_repo
+        .get_state(execution_id)
+        .await
+        .expect("get_state must not error")
+        .expect("row must exist after start_execution");
+
+    // The exact contract `resume_execution` performs at
+    // `crates/engine/src/engine.rs` lines 778-781: serialize the stored
+    // Value to a string and deserialize back into `ExecutionState`. If this
+    // fails, the engine cannot resume the execution — the exact bug #327.
+    let state_str = serde_json::to_string(&state_json).expect("state must serialize");
+    let exec_state: ExecutionState = serde_json::from_str(&state_str).unwrap_or_else(|e| {
+        panic!(
+            "#327: persisted row must deserialize into canonical ExecutionState \
+             (engine resume_execution contract); got error: {e}; row was: {state_json}"
+        )
+    });
+
+    // Canonical status — not the deprecated "pending".
+    assert_eq!(
+        exec_state.status,
+        ExecutionStatus::Created,
+        "#327: persisted status must be canonical Created, not a drifted variant"
+    );
+    assert_eq!(
+        exec_state.execution_id, execution_id,
+        "#327: persisted execution_id must round-trip"
+    );
+    assert_eq!(
+        exec_state.workflow_id, workflow_id,
+        "#327: persisted workflow_id must round-trip"
+    );
+    // `started_at` is None for a Created execution — the engine has not
+    // transitioned to Running yet.
+    assert!(
+        exec_state.started_at.is_none(),
+        "#327: started_at must be None until the engine transitions to Running \
+         (canon §11.1: authority over lifecycle transitions lives in the engine)"
+    );
+    assert!(
+        exec_state.completed_at.is_none(),
+        "#327: completed_at must be None on a non-terminal execution"
+    );
+    // Workflow input (#311) round-trips.
+    assert_eq!(
+        exec_state.workflow_input,
+        Some(input),
+        "#327 (and #311): workflow_input must be persisted so resume can replay entry nodes"
+    );
+
+    // The list_running storage filter — which only accepts canonical statuses —
+    // must actually see the newly-created execution. Before the fix this list
+    // was empty because "pending" is not in the accepted set
+    // (created|running|paused|cancelling).
+    let running = state
+        .execution_repo
+        .list_running()
+        .await
+        .expect("list_running must not error");
+    assert!(
+        running.contains(&execution_id),
+        "#327: list_running must include the newly-created execution \
+         (split-brain check — status is canonical and the filter matches)"
     );
 }

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -15,7 +15,7 @@
 //! | 1 | `POST /workflows` round-trips through `GET /workflows/:id` | `knife_scenario_end_to_end` |
 //! | 2a | `POST /workflows/:id/activate` valid → 200 | `knife_scenario_end_to_end` |
 //! | 2b | `POST /workflows/:id/activate` cyclic → 422 RFC 9457 | `knife_scenario_end_to_end` |
-//! | 3 | `POST /workflows/:id/executions` → 202, `status=pending`, `started_at > 0`, `finished_at` absent | `knife_scenario_end_to_end` |
+//! | 3 | `POST /workflows/:id/executions` → 202, `status=created`, `started_at > 0`, `finished_at` absent | `knife_scenario_end_to_end` |
 //! | 4 | `GET /executions/:id` → `finished_at` is null/absent, `status` = latest persisted value | `knife_scenario_end_to_end` |
 //! | 5 | `POST /executions/:id/cancel` → DB row = `cancelled`, control queue has exactly one `Cancel` entry | `knife_scenario_end_to_end` |
 //! | 6 | Enqueue failure → 503 (orchestration absent; canon §13 step 6) | `knife_step6_queue_failure_returns_error` |
@@ -334,7 +334,8 @@ async fn knife_scenario_end_to_end() {
     // `started_at` must be > 0 (real chrono timestamp).
     // `finished_at` must be absent from the JSON (Option::None, skipped by
     // serde).
-    // `status` must be "pending".
+    // `status` must be the canonical `"created"` (the only valid
+    // `ExecutionStatus` for a freshly-enqueued row; #327).
     //
     // Note: `ExecutionResponse` does not expose a `version` field — the repo
     // stores a version but the DTO omits it. The "monotonic version" invariant
@@ -376,8 +377,8 @@ async fn knife_scenario_end_to_end() {
 
     assert_eq!(
         execution_response["status"].as_str(),
-        Some("pending"),
-        "step 3: initial status must be 'pending'"
+        Some("created"),
+        "step 3: initial status must be canonical 'created' (#327)"
     );
 
     let started_at = execution_response["started_at"]
@@ -392,7 +393,7 @@ async fn knife_scenario_end_to_end() {
     assert!(
         execution_response.get("finished_at").is_none()
             || execution_response["finished_at"].is_null(),
-        "step 3: finished_at must be absent (None) on a pending execution, got: {:?}",
+        "step 3: finished_at must be absent (None) on a newly-created execution, got: {:?}",
         execution_response.get("finished_at")
     );
 
@@ -432,8 +433,8 @@ async fn knife_scenario_end_to_end() {
     );
     assert_eq!(
         observed["status"].as_str(),
-        Some("pending"),
-        "step 4: status must reflect the latest persisted value (pending)"
+        Some("created"),
+        "step 4: status must reflect the latest persisted value (canonical 'created')"
     );
 
     // finished_at must be absent (not "0") — canon explicitly forbids synthetic zero.
@@ -446,7 +447,7 @@ async fn knife_scenario_end_to_end() {
         !finished_at_is_zero,
         "step 4: finished_at must NOT be synthetic 0 — must be absent or a real timestamp"
     );
-    // Also verify it is either absent or null — not a number for a pending execution.
+    // Also verify it is either absent or null — not a number for a non-terminal execution.
     let is_absent_or_null = finished_at_value.is_none() || finished_at_value.unwrap().is_null();
     assert!(
         is_absent_or_null,


### PR DESCRIPTION
## Summary

- Replaces the legacy hand-rolled JSON (`status: "pending"`, flat `input`) in `start_execution` with `ExecutionState::new` + `set_workflow_input`
- The persisted row now matches the schema the engine's `resume_execution` reads (canon §4.5: public surface honored end-to-end)
- `ExecutionStatus::Pending` never existed — old value was rejected by `list_running` and `ExecutionState::deserialize`. Canonical initial status is `Created`
- `get_execution` read path falls back to legacy field names (`started_at`→`created_at`, `input`→`workflow_input`) so in-flight legacy rows keep rendering

## Test plan

- [x] 88/88 `nebula-api` nextest pass
- [x] Lefthook pre-push full chain green (fmt-check, clippy, cargo-deny, shear, doctests, check-all-features, check-no-default, nextest 233s, docs)

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)