### PR TITLE
docs(idea): restructure IDEA.md with TOC and canon cross-links

### DIFF
--- a/IDEA.md
+++ b/IDEA.md
@@ -129,7 +129,7 @@ Nebula бьёт в обе дыры одним движением: **делает
 
 Моя проекция, не обязательство. Актуальный статус крейтов — [`docs/MATURITY.md`](docs/MATURITY.md).
 
-- **Сейчас (alpha):** стабилизация execution core, честные invariants (см. свежие фиксы `ExecutionBudget`, leases, CAS), SDK façade оформлен.
+- **Сейчас (alpha):** стабилизация execution core, честные invariants (lease-управление, CAS на переходах состояний, восстановление `ExecutionBudget` на resume), SDK façade оформлен.
 - **Следующий горизонт:** Agent actions как полноценная integration family, health trait унификация (когда появится второй consumer), distributed execution с multi-node leases.
 - **За горизонтом:** UI, marketplace интеграций, managed hosting — но только когда ядро станет скучным и надёжным.
 

--- a/IDEA.md
+++ b/IDEA.md
@@ -1,18 +1,41 @@
 # IDEA.md — Как я вижу Nebula
 
-Это не спецификация и не роадмап. Это попытка отойти от реализации и описать **что за вещь ты строишь и зачем** — как её видит человек со стороны, читающий канон, COMPETITIVE и код.
+Это не спецификация и не роадмап. Это попытка отойти от реализации и описать **что за вещь ты строишь и зачем** — личная рамка поверх кода и канона.
 
-Канон (`docs/PRODUCT_CANON.md`) — что можно делать. Этот файл — **почему стоит**.
+Три жанра доков, чтобы не путать:
+
+- [`docs/PRODUCT_CANON.md`](docs/PRODUCT_CANON.md) — что можно делать (нормативно).
+- [`docs/COMPETITIVE.md`](docs/COMPETITIVE.md) — как мы сравниваемся с рынком (убеждающе).
+- `IDEA.md` (этот файл) — зачем это вообще стоит строить (личная рамка).
 
 ---
 
-## Одна фраза
+## Содержание
+
+1. [В одной фразе](#1-в-одной-фразе)
+2. [Почему существует](#2-почему-существует)
+3. [Главная ставка](#3-главная-ставка)
+4. [Для кого](#4-для-кого)
+5. [Форма продукта](#5-форма-продукта)
+6. [Философия](#6-философия)
+7. [Чем выигрывает](#7-чем-выигрывает)
+8. [Чем не пытается быть](#8-чем-не-пытается-быть)
+9. [Куда идёт](#9-куда-идёт)
+10. [Финал](#10-финал)
+
+---
+
+## 1. В одной фразе
 
 Nebula — это **серьёзный оркестратор рабочих процессов, где автор интеграции — первоклассный гражданин**, а не досадное приложение к UI.
 
+Если нужно ещё короче — для инвестора или в лифте:
+
+> "Мы делаем Temporal, но с n8n-уровнем DX для интеграций — на Rust, с честной моделью durability и без UI-first налога."
+
 ---
 
-## Почему существует
+## 2. Почему существует
 
 В мире workflow-движков есть две устойчивые дыры:
 
@@ -23,71 +46,74 @@ Nebula бьёт в обе дыры одним движением: **делает
 
 ---
 
-## Главная ставка
+## 3. Главная ставка
 
 > **Меньше честных гарантий лучше, чем много привлекательных, но мягких.**
 
-Это и есть продуктовый нерв. Nebula не хочет быть универсальным low-code или самым гибким graph-editor. Она хочет:
+Это и есть продуктовый нерв. Коротко:
 
-- Типы на границах — потому что неправильный integration contract ломается в 3 утра
-- Durable state как дефолт — потому что "положил в память" — это не orchestration
-- Integration model с пятью ортогональными концепциями (Resource, Credential, Action, Plugin, Schema) — потому что путать auth rotation и connection lifecycle — чужая боль, которую мы не хотим наследовать
-- Честный SDK — потому что integration authors должны иметь стабильный фасад, а не копаться в 30 внутренних крейтах
+- Типы на границах — неправильный integration contract ломается в 3 утра.
+- Durable state как дефолт — "положил в память" это не orchestration.
+- Пять ортогональных концепций (Resource, Credential, Action, Plugin, Schema) — путать auth rotation и connection lifecycle мы не хотим.
+- Честный SDK — один стабильный фасад, а не 30 внутренних крейтов.
+
+Эти ставки кодифицированы в [`PRODUCT_CANON.md` §2 "Position"](docs/PRODUCT_CANON.md#2-position) и [§3 "The problem & core thesis"](docs/PRODUCT_CANON.md#3-the-problem--core-thesis).
 
 ---
 
-## Для кого
+## 4. Для кого
 
 **Primary:** разработчик, пишущий интеграцию. Он хочет `use nebula_sdk::prelude::*;`, написать `StatefulAction`, получить типизированные параметры, вернуть `Result`, и чтобы движок сам разобрался с ретраями, credential rotation, resource pooling и durability.
 
 **Secondary:** команда, встраивающая Nebula в свою платформу. Ей нужен стабильный API-слой, понятная модель расширения, и уверенность, что engine не протечёт в её бизнес-код.
 
-**Tertiary:** оператор, запускающий workflow. Он не главный, но его не забывают — observability первого класса (`docs/OBSERVABILITY.md`), credential safety, предсказуемая lifecycle.
+**Tertiary:** оператор, запускающий workflow. Он не главный, но его не забывают — observability первого класса ([`docs/OBSERVABILITY.md`](docs/OBSERVABILITY.md)), credential safety, предсказуемая lifecycle.
 
 Явно **не** primary: юзер low-code UI, ETL-инженер на петабайтах данных, ML-пайплайн автор. Это другие рынки с другими ставками.
 
 ---
 
-## Философия
+## 5. Форма продукта
+
+Если убрать реализацию и смотреть с высоты, продукт держится на четырёх опорах:
+
+- **Golden path** — автор описывает Action → регистрирует в registry → движок планирует исполнение → state durable → observability снаружи. Канонично: [`PRODUCT_CANON §10 "Golden path"`](docs/PRODUCT_CANON.md#10-golden-path-product).
+- **Integration surface** — маленькая (5 концепций), ортогональная, расширяется через ADR. Полная модель: [`docs/INTEGRATION_MODEL.md`](docs/INTEGRATION_MODEL.md).
+- **Plugin isolation** — out-of-process через `plugin-sdk`, чтобы чужой код не ронял движок. Детали: [`docs/PLUGIN_MODEL.md`](docs/PLUGIN_MODEL.md).
+- **Две параллельные поверхности API** — `nebula-api` для runtime caller'ов и `nebula-sdk` для integration author'ов. Параллельны, не вложены.
+
+Что **намеренно отсутствует** — это явные запреты канона, а не забывчивость:
+
+- Implicit in-memory backbone → [`§12.2`](docs/PRODUCT_CANON.md#122-execution-single-semantic-core-durable-control-plane).
+- Public surface, которую движок не honorит end-to-end → [`§4.5`](docs/PRODUCT_CANON.md#45-operational-honesty--no-false-capabilities).
+- Capability, обещанная в доках без реализации в коде → [`§11.6`](docs/PRODUCT_CANON.md#116-documentation-truth).
+
+---
+
+## 6. Философия
 
 Несколько вещей, которые я считываю из кода, канона и твоих реакций на ревью:
 
 - **Clean design > backward compatibility.** Сломать чистый API лучше, чем нарастить на него адаптерный слой. "Shim" — ругательство.
 - **Root cause > symptom.** Починить место, где баг возник, а не замазать там, где всплыл.
 - **DX — это фича, а не документация.** Плохой API — это bug, даже если он "работает".
-- **Security — не-переговариваемый инвариант.** Credential encryption, zeroization, redacted logs — не опция, а вход в игру.
-- **Канон — не тюрьма.** Если правило блокирует правильное улучшение — ADR, а не workaround. Правило может быть stale.
-
-Эти принципы не декларации из README — они видны в том, как отказано от `release-plz`, как `nebula-sdk` изолирован в `deny.toml`, как `pitfalls.md` родился из session memory.
+- **Security — не-переговариваемый инвариант.** Credential encryption, zeroization, redacted logs — не опция, а вход в игру. Формально: [`PRODUCT_CANON §4.2 "Safety"`](docs/PRODUCT_CANON.md#42-safety).
+- **Канон — не тюрьма.** Если правило блокирует правильное улучшение — ADR, а не workaround. Условия пересмотра: [`§0.2 "When canon is wrong"`](docs/PRODUCT_CANON.md#02-when-canon-is-wrong-revision-triggers).
 
 ---
 
-## Форма вещи
+## 7. Чем выигрывает
 
-Если убрать реализацию и смотреть с высоты:
+Разбор ceiling'ов и наших bet'ов против каждого peer'а — в [`docs/COMPETITIVE.md` "Competitive bets"](docs/COMPETITIVE.md#competitive-bets). Здесь — только личная рамка: чего именно у них не хватает, что я хочу видеть в Nebula.
 
-**Golden path:** автор описывает Action → регистрирует в registry → движок планирует исполнение → state durable → observability снаружи.
-
-**Границы:**
-- Integration surface — маленькая (5 концепций), ортогональная, расширяется через ADR.
-- Execution core — durable, CAS-версионированный, с честной concurrency-моделью (leases, budgets, outbox).
-- Plugin isolation — out-of-process через `plugin-sdk`, чтобы чужой код не ронял движок.
-- Public API — две поверхности: `nebula-api` для runtime caller'ов (HTTP, webhook) и `nebula-sdk` для integration author'ов. Они **параллельны**, не вложены.
-
-**Что намеренно отсутствует:** implicit in-memory backbone, hidden lifecycles, undocumented capabilities. Это явные запреты канона (§12.2, §4.5, §11.6).
+- У **n8n** — типобезопасности в месте, где в 3 утра ломается именно интеграция, а не UI.
+- У **Temporal** — чтобы автор шага думал про шаг, а не про durable primitive.
+- У **Airflow** — другого рынка: Nebula про события и интеграции, не про scheduled DAG'и.
+- У **Windmill** — фокуса: не пытаться быть и IDE, и runtime, и low-code одновременно.
 
 ---
 
-## Чем Nebula выигрывает
-
-- У **n8n** — типобезопасностью и серьёзной моделью durability. n8n прекрасен для citizen integrator, но серьёзный production — не его рынок.
-- У **Temporal** — DX для integration authors. Temporal заставляет думать в рамках его SDK; Nebula даёт integration author сфокусироваться на шаге, а не на durable primitive.
-- У **Airflow** — это вообще другой рынок (batch ETL), но: Nebula про события и интеграции, не про scheduled DAG'и.
-- У **Windmill** — фокусом. Windmill хочет быть и IDE, и runtime, и low-code. Nebula узкая: orchestration + integrations, остальное — за границей.
-
----
-
-## Чем Nebula **не** пытается быть
+## 8. Чем не пытается быть
 
 Это не менее важно, чем то, чем пытается:
 
@@ -99,20 +125,16 @@ Nebula бьёт в обе дыры одним движением: **делает
 
 ---
 
-## Куда это идёт (моя проекция, не обязательство)
+## 9. Куда идёт
+
+Моя проекция, не обязательство. Актуальный статус крейтов — [`docs/MATURITY.md`](docs/MATURITY.md).
 
 - **Сейчас (alpha):** стабилизация execution core, честные invariants (см. свежие фиксы `ExecutionBudget`, leases, CAS), SDK façade оформлен.
-- **Следующий горизонт:** Agent actions как полноценная integration family, health trait унификация (когда появится второй consumer — см. `project_health_trait.md`), distributed execution с multi-node leases.
+- **Следующий горизонт:** Agent actions как полноценная integration family, health trait унификация (когда появится второй consumer), distributed execution с multi-node leases.
 - **За горизонтом:** UI, marketplace интеграций, managed hosting — но только когда ядро станет скучным и надёжным.
 
 ---
 
-## Самая важная мысль
+## 10. Финал
 
 Продукт не побеждает тем, что делает больше. Он побеждает тем, что делает **меньше, но честно**. Каждое "да" в канон — это обещание оператору в 3 утра. Nebula выбирает мало обещаний и много доставленного — и это, пожалуй, её самая сильная ставка.
-
-Если бы мне нужно было объяснить Nebula инвестору одним предложением:
-
-> "Мы делаем Temporal, но с n8n-уровнем DX для интеграций — на Rust, с честной моделью durability и без UI-first налога."
-
-Этого достаточно, чтобы отличить её от конкурентов и от искушения стать "ещё одним универсальным framework".


### PR DESCRIPTION
## Summary

`IDEA.md` was recently added (commit 9459406) as a third doc genre — not normative (`docs/PRODUCT_CANON.md`), not persuasive (`docs/COMPETITIVE.md`), but *why this product is worth building*. Useful intent, but as written it rambled, duplicated canon prose, and offered no cross-links back to the normative sources. A reader had no way to trace claims.

This PR restructures the file in place (Russian prose preserved, file stays at repo root per author preference):

- **Header names all three doc genres** (canon / competitive / idea) with inline links, so the file's place in the doc stack is explicit.
- **Table of contents** added — 10 anchor links.
- **Sections renumbered 1–10**; §5 (shape) and §6 (philosophy) swapped so "what the product looks like" precedes "why I think this way about it". Investor one-liner moved up from the old closing section into §1 so both elevator pitches sit together.
- **Cross-links added** into `PRODUCT_CANON.md` (§0.2, §2, §3, §4.2, §4.5, §10, §11.6, §12.2), `COMPETITIVE.md#competitive-bets`, `INTEGRATION_MODEL.md`, `PLUGIN_MODEL.md`, `MATURITY.md`.
- **Trimmed paraphrase of canon** in §3 (main bet), §5 (product shape — "implicit in-memory backbone", "end-to-end honoring", "docs-vs-code"), §6 (dropped the rot-prone "visible in `release-plz` / `deny.toml` / `pitfalls.md`" trivia line), §7 (collapsed the peer-by-peer matrix and deferred to `COMPETITIVE.md` for the detailed bets).

Net diff: +68/-46. The file grew modestly despite trimming because the TOC and the cross-link bullets are additive; the trade is intentional — structure and traceability matter more here than raw line count.

## Test plan

Docs-only change; no code paths touched.

- [x] `wc -l IDEA.md` — 140 lines (was 118; growth is TOC + cross-links).
- [x] Every TOC anchor matches its heading (`#1-в-одной-фразе` through `#10-финал`).
- [x] Every canon cross-reference points at a section that exists:
  - `PRODUCT_CANON.md` — `## 0.2`, `## 2.`, `## 3.`, `### 4.2`, `### 4.5`, `## 10.`, `### 11.6`, `### 12.2` all verified present.
  - `COMPETITIVE.md#competitive-bets` verified.
  - `INTEGRATION_MODEL.md`, `PLUGIN_MODEL.md`, `MATURITY.md`, `OBSERVABILITY.md` verified present.
- [ ] Render check on GitHub (reviewer: confirm TOC anchors resolve in Cyrillic).

https://claude.ai/code/session_01Ux9YW91oF8T7h8Tn5HMm78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Restructured product concept documentation with improved organization, table of contents, and cross-references to canonical resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->