### PR TITLE
chore(infra): add issue templates for bug/feature/security/rfc (NEB-99)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,116 @@
+name: Bug Report
+description: Report something that's broken or not working as expected
+title: "bug: <short description>"
+labels: ["type:bug", "status:needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug. Please fill in as much detail as possible so we can reproduce and fix it quickly.
+
+        > **Security vulnerability?** Do not open a public issue. See [SECURITY.md](https://github.com/vanyastaff/nebula/blob/main/SECURITY.md) or [report a private advisory](https://github.com/vanyastaff/nebula/security/advisories/new).
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal, complete steps to trigger the bug.
+      placeholder: |
+        1. Define a workflow with ...
+        2. Execute via `cargo nextest run -p nebula-engine -- test_name`
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What should happen?
+      placeholder: "The workflow should complete successfully and return ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happens instead?
+      placeholder: "The engine panics / returns an error / silently skips ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Tracing Output
+      description: |
+        Paste relevant log output, stack traces, or `RUST_BACKTRACE=1` output.
+        **Redact any secrets, tokens, credentials, or PII before posting.**
+      placeholder: |
+        ```
+        thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: ...'
+        note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+        ```
+      render: shell
+
+  - type: dropdown
+    id: affected-crate
+    attributes:
+      label: Affected Crate(s)
+      description: Which crate(s) are affected? Select all that apply.
+      multiple: true
+      options:
+        - nebula-action
+        - nebula-engine
+        - nebula-runtime
+        - nebula-storage
+        - nebula-credential
+        - nebula-resource
+        - nebula-api
+        - nebula-workflow
+        - nebula-execution
+        - nebula-expression
+        - nebula-plugin
+        - nebula-resilience
+        - nebula-schema
+        - Other (describe in additional context)
+    validations:
+      required: true
+
+  - type: input
+    id: rust-version
+    attributes:
+      label: Rust Version
+      description: Output of `rustc --version`
+      placeholder: "rustc 1.94.0 (2025-...)"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      description: Linux, macOS, Windows, Docker, etc.
+      placeholder: "Ubuntu 24.04 / macOS 15.0 / Windows 11"
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Related issues, workarounds you've tried, or anything else relevant.
+      placeholder: "This regressed in #456 / workaround: ..."
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched for existing issues and this is not a duplicate.
+          required: true
+        - label: This is NOT a security vulnerability (see SECURITY.md for private disclosure).
+          required: true
+        - label: I have redacted all secrets, credentials, and PII from logs above.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,15 @@
 blank_issues_enabled: false
 contact_links:
-  - name: 💬 GitHub Discussions
+  - name: Security vulnerability
+    url: https://github.com/vanyastaff/nebula/security/advisories/new
+    about: Please report security vulnerabilities privately, not as public issues.
+  - name: GitHub Discussions
     url: https://github.com/vanyastaff/nebula/discussions
     about: Ask questions and discuss ideas with the community
-  - name: 📖 Documentation
+  - name: Documentation
     url: https://github.com/vanyastaff/nebula/blob/main/README.md
     about: Read the project documentation and guides
-  - name: 🏗️ Architecture
+  - name: Architecture
     url: https://github.com/vanyastaff/nebula/tree/main/docs
     about: Learn about the system architecture and design
 

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,108 @@
+name: Feature Request
+description: Propose a new capability or improvement to Nebula
+title: "feat: <short description>"
+labels: ["type:feature", "status:needs-discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping shape Nebula. A strong feature request includes a clear problem statement, a concrete proposal, and consideration of alternatives.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        What limitation, gap, or pain point are you encountering?
+        Frame this as a user need, not a solution.
+      placeholder: |
+        When building high-throughput order workflows, there is no way to bound
+        concurrency at the tenant level. This causes downstream APIs to receive
+        burst traffic they cannot handle.
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: How would you solve this? Include API sketches, type signatures, or config examples where helpful.
+      placeholder: |
+        Add a `max_concurrent_executions` field to `TenantConfig`:
+
+        ```rust
+        TenantConfig {
+            max_concurrent_executions: Some(10),
+            // ...
+        }
+        ```
+
+        The engine's dispatcher would acquire a semaphore permit per tenant before
+        scheduling a new execution.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you evaluate, and why did you rule them out?
+      placeholder: |
+        - Rate-limiting at the API gateway: shifts the problem upstream, doesn't help
+          internal worker dispatch.
+        - Per-workflow limits: too granular, creates N configuration points.
+
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: How would you verify this feature is complete and correct?
+      placeholder: |
+        - [ ] `TenantConfig::max_concurrent_executions` is respected by the engine dispatcher.
+        - [ ] Excess executions are queued (not rejected) and drained in FIFO order.
+        - [ ] Integration test: 20 concurrent starts with limit=5 — at most 5 run simultaneously.
+        - [ ] Telemetry: `execution.queue_depth` metric is emitted per tenant.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Primary Area
+      description: Which layer or crate does this affect most?
+      options:
+        - engine / runtime (execution lifecycle)
+        - action (action primitives)
+        - resource / credential (integration layer)
+        - storage (persistence)
+        - api (HTTP / webhook surface)
+        - plugin / sandbox (out-of-process plugins)
+        - workflow / execution (definition model)
+        - expression / schema (data model)
+        - resilience (retry / circuit-breaker)
+        - telemetry / metrics / observability
+        - cli / tooling
+        - docs
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Related Issues or Discussions
+      description: Link to related items, prior art, or canon sections that apply.
+      placeholder: |
+        Related: #789 (load-shedding RFC)
+        Canon: PRODUCT_CANON.md §12 (execution lifecycle invariants)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have searched for existing feature requests and this is not a duplicate.
+          required: true
+        - label: I have described the problem, not just the solution.
+          required: true
+        - label: I have considered at least one alternative approach.

--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -1,0 +1,121 @@
+name: RFC (Request for Comments)
+description: Propose a significant design change, new abstraction, or architecture revision
+title: "rfc: <short description>"
+labels: ["type:rfc", "status:needs-discussion"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        An RFC is for changes that affect architecture, public contracts, or product canon — not for routine feature requests or bug fixes.
+
+        Before submitting, review:
+        - [`docs/PRODUCT_CANON.md §0.2`](https://github.com/vanyastaff/nebula/blob/main/docs/PRODUCT_CANON.md) — canon revision triggers
+        - [`docs/adr/`](https://github.com/vanyastaff/nebula/tree/main/docs/adr) — prior decisions this might interact with
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: |
+        Why is this change needed? What problem does the status quo create?
+        Be specific about which canon invariant, layer boundary, or user-facing contract is at stake.
+      placeholder: |
+        The current `ExecutionContext` type leaks runtime-layer detail into the Core layer
+        (PRODUCT_CANON §4 — layer invariants). This makes unit-testing Core-layer logic
+        impossible without wiring a full engine.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: |
+        Describe the change in enough detail that a reviewer can assess correctness and impact.
+        Include type signatures, trait definitions, or API sketches where relevant.
+      placeholder: |
+        Extract `ContextView` (a read-only, Core-layer trait) from `ExecutionContext`.
+        The engine implements `ContextView`; Core-layer consumers accept `&dyn ContextView`.
+
+        ```rust
+        // nebula-core
+        pub trait ContextView: Send + Sync {
+            fn workflow_id(&self) -> &WorkflowId;
+            fn node_id(&self) -> &NodeId;
+        }
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: What other approaches did you evaluate? Why did you reject them?
+      placeholder: |
+        - Pass individual fields instead of a trait: rejected — combinatorial explosion as
+          nodes gain more context needs.
+        - Keep status quo, add re-export: rejected — does not fix the layering violation.
+
+  - type: textarea
+    id: canon-impact
+    attributes:
+      label: Impact on Product Canon
+      description: |
+        Does this change, extend, or contradict any invariant in `docs/PRODUCT_CANON.md`?
+        Reference specific sections (e.g., §4.3, §12.2). If a canon revision is needed,
+        state that explicitly — see §0.2 for revision triggers.
+      placeholder: |
+        Affects §4 (layer invariants) — this change *fixes* a violation rather than
+        introducing one. No canon revision needed; the proposal aligns with §4.3.
+    validations:
+      required: true
+
+  - type: textarea
+    id: migration
+    attributes:
+      label: Migration Plan
+      description: |
+        How are existing callers, tests, and integrations migrated?
+        What is the rollout order? Are there deprecation periods?
+      placeholder: |
+        1. Add `ContextView` trait in `nebula-core` (non-breaking).
+        2. Implement `ContextView` on `ExecutionContext` in `nebula-engine` (non-breaking).
+        3. Migrate Core-layer consumers to `&dyn ContextView` in one PR.
+        4. Remove `ExecutionContext` re-export from `nebula-core` (breaking — minor bump).
+
+        No external API surface affected at alpha stage.
+    validations:
+      required: true
+
+  - type: textarea
+    id: open-questions
+    attributes:
+      label: Open Questions
+      description: What is still uncertain? What do you want reviewers to focus on?
+      placeholder: |
+        - Should `ContextView` expose `span_context()` for tracing, or keep that runtime-only?
+        - Do we need a `ContextViewMut` for write access, or is that always runtime-scoped?
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Related Issues, ADRs, or Canon Sections
+      description: Link to anything that provides relevant prior context.
+      placeholder: |
+        ADR: docs/adr/0012-execution-context-design.md
+        Related: #234 (original `ExecutionContext` PR), #456 (Core-layer test pain)
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I have read PRODUCT_CANON.md §0.2 (canon revision triggers) before filing.
+          required: true
+        - label: I have checked docs/adr/ for prior decisions that apply.
+          required: true
+        - label: This RFC proposes a design, not a bug fix or routine feature (use the other templates for those).
+          required: true
+        - label: I have described the canon impact explicitly, even if it is "none."
+          required: true

--- a/.github/ISSUE_TEMPLATE/security.yml
+++ b/.github/ISSUE_TEMPLATE/security.yml
@@ -1,0 +1,36 @@
+name: Security Vulnerability Report
+description: DO NOT USE — report security vulnerabilities privately, not here.
+labels: ["type:security"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Stop — do not open a public issue for security vulnerabilities
+
+        Reporting a security vulnerability publicly puts all Nebula users at risk before a fix is available.
+
+        **Please report privately using one of these channels:**
+
+        - **GitHub Security Advisories (preferred):**
+          [Open a private advisory](https://github.com/vanyastaff/nebula/security/advisories/new) — only maintainers can see it.
+
+        - **Email:**
+          [vanya.john.stafford@gmail.com](mailto:vanya.john.stafford@gmail.com) — include "SECURITY" in the subject line.
+
+        See [SECURITY.md](https://github.com/vanyastaff/nebula/blob/main/SECURITY.md) for the full disclosure policy, response SLAs, and scope.
+
+        ---
+
+        **If you have already filed this issue publicly and it contains sensitive details, please:**
+        1. Edit the issue body to remove the sensitive content.
+        2. Open a private advisory at the link above.
+        3. Ping a maintainer to close this issue.
+
+  - type: checkboxes
+    id: redirect-confirm
+    attributes:
+      label: Acknowledgment
+      description: Please confirm before submitting this form.
+      options:
+        - label: I understand this public form is NOT for security vulnerabilities. I will use the private advisory channel linked above.
+          required: true


### PR DESCRIPTION
## Summary

Adds four GitHub issue form templates and updates `config.yml` to satisfy NEB-99 acceptance criteria.

## What changed

| File | Purpose |
|------|---------|
| `.github/ISSUE_TEMPLATE/bug.yml` | Steps to reproduce, expected vs actual, environment (OS + Rust version), log/tracing field with redaction reminder |
| `.github/ISSUE_TEMPLATE/feature.yml` | Problem statement, proposed solution, alternatives considered, acceptance criteria |
| `.github/ISSUE_TEMPLATE/security.yml` | Hard redirect to private advisory — no public form body; routes to GitHub Security Advisories + email |
| `.github/ISSUE_TEMPLATE/rfc.yml` | Motivation, proposal, alternatives, canon impact (§0.2 triggers), migration plan |
| `.github/ISSUE_TEMPLATE/config.yml` | Security advisory `contact_links` entry added as first item; `blank_issues_enabled: false` retained |

## Security template design

The `security.yml` template does **not** collect vulnerability details in a public form. It displays a hard stop with links to:
- GitHub Security Advisories: `https://github.com/vanyastaff/nebula/security/advisories/new`
- Email: `vanya.john.stafford@gmail.com`

This is consistent with the existing `SECURITY.md` policy.

## Notes / follow-up

- `SECURITY.md` already exists at the repo root — no action needed there (out of scope for this PR per NEB-99 spec).
- The existing numbered templates (`01-bug-report.yml`, `02-feature-request.yml`, etc.) are unchanged; the new canonical names (`bug.yml`, `feature.yml`, `security.yml`, `rfc.yml`) are additive.
- Labels used (`type:bug`, `type:feature`, `type:security`, `type:rfc`) follow the `type:*` convention established by the existing templates.

## Verification

- `cargo check --workspace` — clean (no Rust source touched)
- `lefthook run pre-push` — all hooks green (shear, doctests, docs, check-all-features, check-no-default, nextest)
- Only `.github/ISSUE_TEMPLATE/` files modified

Closes NEB-99 — https://linear.app/nebula-workflow/issue/NEB-99/issue-templates-bug-feature-security-rfc