### PR TITLE
docs(adr): ADR index + ADR-0010 Rust 2024 / ADR-0011 serde_json::Value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Satellites loaded on demand:
 - `docs/OBSERVABILITY.md` — SLI / SLO / events / core analysis loop.
 - `docs/GLOSSARY.md` — terms and architectural patterns.
 - `docs/pitfalls.md` — recurring traps (expression builtin re-entry, two-valued skip, OTLP/tonic test reactor, serde MapAccess); read on review of new public types or dispatch surfaces.
-- `docs/adr/` — past decisions; search by filename or frontmatter.
+- [`docs/adr/README.md`](docs/adr/README.md) — ADR index (past decisions, numbering rules, how to write a new one).
 
 ### Decision gate (before proposing an architectural change)
 

--- a/docs/adr/0010-rust-2024-edition.md
+++ b/docs/adr/0010-rust-2024-edition.md
@@ -54,9 +54,11 @@ decision that is de-facto in force.
 3. CI enforces the MSRV on every PR (`rust-toolchain: 1.94` matrix entry plus
    a stable channel entry). The local `lefthook` pre-push mirrors the CI MSRV
    job so divergence is caught before CI.
-4. `cargo-deny` (see `deny.toml`) fails the build if a new dependency
-   advertises a higher MSRV than 1.94 — the build must break loudly, not
-   silently.
+4. A new dependency that effectively raises the compiler floor above 1.94
+   must fail the dedicated 1.94 CI/MSRV job (and the matching local
+   `lefthook` pre-push check) loudly rather than being accepted silently.
+   (`deny.toml` does not currently encode an MSRV gate; if one is added
+   later, it becomes the primary enforcement point.)
 5. **Bumping the MSRV is a breaking change.** Any raise requires:
    - an update to this ADR (supersede, not edit in place);
    - a CHANGELOG entry flagged `breaking`;

--- a/docs/adr/0010-rust-2024-edition.md
+++ b/docs/adr/0010-rust-2024-edition.md
@@ -1,0 +1,107 @@
+---
+id: 0010
+title: rust-2024-edition
+status: accepted
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [toolchain, msrv, edition, workspace]
+related:
+  - Cargo.toml
+  - rust-toolchain.toml
+  - CLAUDE.md
+  - docs/PRODUCT_CANON.md
+linear:
+  - NEB-148
+---
+
+# 0010. Rust 2024 edition + MSRV 1.94
+
+## Context
+
+Nebula is a long-horizon workflow engine aiming for v1.0 by Q2 2027. The
+toolchain choice has to survive two-plus years of active development without
+locking us out of language features we already rely on, while still being
+reachable by users who track stable.
+
+Two decisions are intertwined and therefore recorded together:
+
+1. **Language edition.** Rust 2024 is the current stable edition. It tightens
+   disjoint captures in closures, hardens `unsafe_op_in_unsafe_fn`, and makes
+   several lints warn-by-default that Nebula already enforces. Staying on 2021
+   would require us to suppress these in code we actively want strict.
+2. **MSRV (`rust-version`).** Nebula uses stable language features that landed
+   across 2024 and the 2024 edition itself (stabilized in 1.85). Several
+   crates in the workspace depend on `async fn` in traits, `let ... else`,
+   `gen` blocks (where applicable), and `#[diagnostic::on_unimplemented]` —
+   features with MSRV ≥ 1.75..=1.90. We pick **1.94** (current stable at the
+   time of writing) so all workspace crates share a single floor that is easy
+   to reason about, mirrors what CI runs, and gives first-party plugin authors
+   a predictable baseline.
+
+Contributor tooling (`rust-toolchain.toml`, `rustfmt.toml` with nightly-only
+options) already assumes 2024 and a recent rustc. This ADR documents the
+decision that is de-facto in force.
+
+## Decision
+
+1. Every workspace member uses `edition = "2024"` via
+   `[workspace.package]` in the root `Cargo.toml`. Per-crate overrides are
+   **not allowed** — the workspace is single-edition to keep cross-crate
+   macros and trait impls uniform.
+2. Workspace MSRV is **`rust-version = "1.94"`**, pinned once in
+   `[workspace.package]`.
+3. CI enforces the MSRV on every PR (`rust-toolchain: 1.94` matrix entry plus
+   a stable channel entry). The local `lefthook` pre-push mirrors the CI MSRV
+   job so divergence is caught before CI.
+4. `cargo-deny` (see `deny.toml`) fails the build if a new dependency
+   advertises a higher MSRV than 1.94 — the build must break loudly, not
+   silently.
+5. **Bumping the MSRV is a breaking change.** Any raise requires:
+   - an update to this ADR (supersede, not edit in place);
+   - a CHANGELOG entry flagged `breaking`;
+   - CI matrix update in the same PR.
+
+## Consequences
+
+**Positive**
+
+- One edition, one MSRV, one story. Plugin authors can read a single line in
+  `Cargo.toml` and know what they are targeting.
+- Rust 2024's disjoint closure captures and `unsafe_op_in_unsafe_fn`
+  let us delete a pile of older `#[allow(...)]` workarounds (see
+  `crates/resilience`, `crates/engine`).
+- Keeping MSRV on the current stable lets us use language features as they
+  land instead of waiting a year, which matters on a two-year roadmap.
+
+**Negative**
+
+- Users on long-term distro rustc (e.g. Debian stable) cannot `cargo install
+  nebula` directly — they need `rustup`. Documented in
+  `docs/dev-setup.md`.
+- Any crate that wants to depend on `nebula-sdk` inherits the 1.94 floor;
+  external plugin authors cannot be on older stable.
+
+**Neutral**
+
+- Nightly is still allowed for tooling (`cargo +nightly fmt`) because
+  `rustfmt.toml` uses unstable options. This is tooling-only and does not
+  affect MSRV of the compiled crates.
+
+## Alternatives considered
+
+- **Rust 2021 + MSRV = N-3.** Reject. Too many clippy lints fire under the
+  older edition, and we would keep bumping the floor anyway as we adopt new
+  features.
+- **Pin nightly for the whole workspace.** Reject. Breaks `cargo-deny`
+  version gates, breaks `docs.rs`, breaks our goal of being usable from
+  stable Rust.
+- **Per-crate MSRV.** Reject. Creates a matrix where `cargo-deny` cannot
+  give a single "MSRV clean" answer and where the CI matrix balloons.
+
+## Follow-ups
+
+- `NEB-137` — `ci.yml` update to pin Rust 1.94 across all jobs.
+- `docs/dev-setup.md` — link to this ADR from the toolchain section.
+- Future: when Rust 1.94 leaves stable by ≥ 6 months, open a new ADR raising
+  the floor (never edit this one).

--- a/docs/adr/0011-serde-json-value-interchange.md
+++ b/docs/adr/0011-serde-json-value-interchange.md
@@ -7,7 +7,7 @@ supersedes: []
 superseded_by: []
 tags: [data-model, interchange, schema, engine]
 related:
-  - docs/PRODUCT_CANON.md#125
+  - docs/PRODUCT_CANON.md#124-errors-and-contracts
   - docs/STYLE.md
   - crates/schema/src/lib.rs
   - crates/engine/src/engine.rs
@@ -40,16 +40,20 @@ We need a single in-memory type that:
 
 - Serializes losslessly to/from JSON (the wire format for checkpoints,
   HTTP, persistence);
-- Is cheap to `clone` and `serde`-round-trip;
+- Interoperates naturally with `serde` and JSON tooling; `clone` and
+  `serde`-round-trip costs are proportional to payload size (a deep clone
+  of a large tree is not free — the interchange chooses ergonomics over
+  aliasing);
 - Is tree-shaped so the expression engine (`nebula-expression`) can walk it
   with JSONPath / template lookups;
 - Imposes **zero** static schema on node-to-node data flow.
 
 `serde_json::Value` fits all four. Alternatives considered below.
 
-Product-canon reference: [`§12.5`](../PRODUCT_CANON.md#125) — *"`serde_json::Value`
-is allowed where it is the deliberate interchange type; new stringly protocols
-(magic field names without schema validation) require explicit review."*
+Product-canon reference: [`§12.4`](../PRODUCT_CANON.md#124-errors-and-contracts) —
+*"`serde_json::Value` is allowed where it is the deliberate interchange type;
+new stringly protocols (magic field names without schema validation) require
+explicit review."*
 
 This ADR records the decision already in force and scopes **what it is and
 what it is not**.

--- a/docs/adr/0011-serde-json-value-interchange.md
+++ b/docs/adr/0011-serde-json-value-interchange.md
@@ -1,0 +1,134 @@
+---
+id: 0011
+title: serde-json-value-interchange
+status: accepted
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [data-model, interchange, schema, engine]
+related:
+  - docs/PRODUCT_CANON.md#125
+  - docs/STYLE.md
+  - crates/schema/src/lib.rs
+  - crates/engine/src/engine.rs
+  - docs/adr/0001-schema-consolidation.md
+  - docs/adr/0002-proof-token-pipeline.md
+linear:
+  - NEB-149
+---
+
+# 0011. `serde_json::Value` as the workflow data interchange type
+
+## Context
+
+A workflow engine moves two kinds of data between nodes:
+
+1. **Configuration** — parameters, credentials, resource specs. These are
+   described by explicit schemas and live behind the proof-token pipeline
+   (`ValidSchema` → `ValidValues` → `ResolvedValues`, see
+   [ADR-0002 — proof-token pipeline](./0002-proof-token-pipeline.md)).
+2. **Runtime payloads** — the outputs of one node that become inputs to the
+   next, plus the data coming in from HTTP/webhook triggers and leaving via
+   action responses.
+
+Runtime payloads are **heterogeneous and not statically knowable** at engine
+compile time. A `Telegram.sendMessage` node produces a shape that a downstream
+`HTTP.request` node is free to pick apart, reshape, and forward. This is the
+fundamental n8n-style model Nebula inherits.
+
+We need a single in-memory type that:
+
+- Serializes losslessly to/from JSON (the wire format for checkpoints,
+  HTTP, persistence);
+- Is cheap to `clone` and `serde`-round-trip;
+- Is tree-shaped so the expression engine (`nebula-expression`) can walk it
+  with JSONPath / template lookups;
+- Imposes **zero** static schema on node-to-node data flow.
+
+`serde_json::Value` fits all four. Alternatives considered below.
+
+Product-canon reference: [`§12.5`](../PRODUCT_CANON.md#125) — *"`serde_json::Value`
+is allowed where it is the deliberate interchange type; new stringly protocols
+(magic field names without schema validation) require explicit review."*
+
+This ADR records the decision already in force and scopes **what it is and
+what it is not**.
+
+## Decision
+
+1. **Workflow runtime data is `serde_json::Value`.** Every `ActionResult`
+   payload, every edge data envelope, every checkpoint output column carries
+   `serde_json::Value` (or a newtype over it when the engine needs to attach
+   metadata).
+2. **Configuration is not `Value`.** Parameters, credentials, resource specs
+   go through `nebula-schema`'s proof-token pipeline and arrive at nodes as
+   typed structs. A node that takes a configuration field as raw `Value` is
+   an antipattern unless the field is *explicitly* the generic-JSON escape
+   hatch (e.g. `http.body` when content type is `application/json`).
+3. **Expression context is `Value`.** The expression engine (`{{ $json.x }}`,
+   `{{ $node.<id>.output }}`) walks `serde_json::Value` trees directly. No
+   intermediate "internal value" type.
+4. **Public APIs at layer boundaries** (HTTP, webhook, plugin-sdk protocol):
+   accept and emit JSON. On the wire it is UTF-8 JSON; in process it is
+   `serde_json::Value`.
+5. **New "stringly" contracts require review.** Magic field names like
+   `{"$ref": "...", "$exec": "..."}` invented inside a payload without schema
+   validation are a product-canon `§12.5` violation. If a feature needs such
+   a shape, it must ship a schema — not a convention.
+
+## Consequences
+
+**Positive**
+
+- One interchange type, one mental model. The engine, expression layer,
+  storage layer, and API all speak the same thing.
+- Lossless JSON round-trip for checkpoint/resume and for HTTP I/O.
+- Plugin authors can produce arbitrary JSON from their actions without
+  thinking about `dyn Any` or custom trait objects.
+
+**Negative**
+
+- No compile-time type safety for node-to-node data shape. A downstream
+  node cannot assume `input["foo"]["bar"]` exists; it must defensively
+  check. This is accepted — it is the same trade-off every
+  orchestration engine makes.
+- `serde_json::Value` is not the most memory-efficient representation
+  (string keys, boxed arrays). If a hot path profiles poorly, a newtype
+  with `Arc<str>` keys is a local optimization; the public interchange
+  stays `Value`.
+
+**Neutral**
+
+- `serde_json::Value` *in library public APIs* needs justification: use it
+  only where the value is deliberately open-ended. Typed input is still
+  preferred at function boundaries where the shape is known.
+
+## Alternatives considered
+
+- **Custom `NebulaValue` enum.** Reject. Any custom enum we invent would
+  either (a) be isomorphic to `serde_json::Value` and add zero value, or
+  (b) diverge from JSON and break wire/storage round-trip.
+- **`serde_cbor::Value` / MessagePack.** Reject. Wire format must be
+  human-inspectable for debugging workflows; CBOR loses that. We can still
+  choose CBOR as a *transport* optimization without changing the in-memory
+  type.
+- **`dyn Any` per-node typed outputs.** Reject. Kills serialization,
+  kills the expression engine, kills cross-plugin composition.
+- **`jsonb` (Postgres-native).** Out of scope here — this ADR is about the
+  in-process interchange type, not the storage encoding. Postgres can store
+  `Value` as `jsonb`; SQLite stores it as TEXT; that is orthogonal.
+
+## Scope and non-goals
+
+- This ADR does **not** authorize new "stringly" protocols at config time;
+  those go through `nebula-schema` (see ADR-0001, ADR-0002, ADR-0003).
+- This ADR does **not** mandate `serde_json::Value` inside a crate's
+  internal functions — only at the public interchange layer (node outputs,
+  engine/store/api boundaries).
+
+## Follow-ups
+
+- Any new `serde_json::Value` appearing in a public library function
+  signature must be justified in code review against this ADR.
+- Expression-engine authors: `$json` semantics are documented against
+  `serde_json::Value` shape; do not introduce a parallel value model.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,9 +12,9 @@ changes land as a new ADR that `supersedes` it.
 | [0002](./0002-proof-token-pipeline.md) | Proof-token pipeline — `ValidSchema` / `ValidValues` / `ResolvedValues` | accepted | 2026-04-17 |
 | [0003](./0003-consolidated-field-enum.md) | Consolidated `Field` enum (13 variants; drop `Date`/`DateTime`/`Time`/`Color`/`Hidden`) | accepted | 2026-04-17 |
 | [0004](./0004-credential-metadata-rename.md) | Credential `Metadata` → `Record`, `Description` → `Metadata` rename | accepted | 2026-04-17 |
-| [0005](./0005-trigger-health-trait.md) | `TriggerHealth` — atomic lock-free health state on `TriggerContext` | accepted | 2026-04-17 |
-| [0006](./0006-sandbox-phase1-broker.md) | Sandbox Phase 1 broker — duplex JSON-RPC over UDS / Named Pipe | accepted | 2026-04-17 |
-| [0007](./0007-prefixed-ulid-identifiers.md) | Prefixed ULID identifiers (Stripe-style) | accepted | 2026-04-18 |
+| [0005](./0005-trigger-health-trait.md) | `TriggerHealth` — atomic lock-free health state on `TriggerContext` | accepted | 2026-04-12 |
+| [0006](./0006-sandbox-phase1-broker.md) | Sandbox Phase 1 broker — duplex JSON-RPC over UDS / Named Pipe | proposed | 2026-04-17 |
+| [0007](./0007-prefixed-ulid-identifiers.md) | Prefixed ULID identifiers (Stripe-style) | accepted | 2026-04-17 |
 | [0008](./0008-execution-control-queue-consumer.md) | Execution control-queue consumer | accepted | 2026-04-18 |
 | 0008 ⚠️ [lease-lifecycle](./0008-execution-lease-lifecycle.md) | Execution lease lifecycle | proposed | 2026-04-18 |
 | [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
@@ -35,8 +35,10 @@ changes land as a new ADR that `supersedes` it.
 2. Pick the next free number (currently **0012**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
-5. **Do not edit an accepted ADR.** Open a new one with
-   `supersedes: [NNNN]` and set the old one's `superseded_by`.
+5. **Do not substantively edit an accepted ADR.** Open a new one with
+   `supersedes: [NNNN]`. Frontmatter-only maintenance on the old ADR is
+   allowed to record the supersession link (set `superseded_by`, and flip
+   `status` to `superseded`). The body stays immutable.
 
 ### Frontmatter convention
 
@@ -69,8 +71,8 @@ linear:
 
 ADRs are the **L2 invariant diff log**. When a Product Canon invariant moves,
 the change lands here first — never silently in code. See
-[`docs/PRODUCT_CANON.md §0.2`](../PRODUCT_CANON.md#02) *canon revision
-triggers* for when an ADR is required.
+[`docs/PRODUCT_CANON.md §0.2`](../PRODUCT_CANON.md#02-when-canon-is-wrong-revision-triggers)
+*canon revision triggers* for when an ADR is required.
 
 The session read-order in [`CLAUDE.md`](../../CLAUDE.md) loads this index on
 demand; any non-trivial architectural change should cite or open an ADR

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,77 @@
+# Architecture Decision Records (ADRs)
+
+Short, immutable records of architectural decisions that shape Nebula. One
+ADR = one decision. Once `accepted`, an ADR is **not edited** — subsequent
+changes land as a new ADR that `supersedes` it.
+
+## Index
+
+| #    | Title                                                   | Status   | Date       |
+| :--- | :------------------------------------------------------ | :------- | :--------- |
+| [0001](./0001-schema-consolidation.md) | Schema consolidation — delete `nebula-parameter`, adopt `nebula-schema` | accepted | 2026-04-17 |
+| [0002](./0002-proof-token-pipeline.md) | Proof-token pipeline — `ValidSchema` / `ValidValues` / `ResolvedValues` | accepted | 2026-04-17 |
+| [0003](./0003-consolidated-field-enum.md) | Consolidated `Field` enum (13 variants; drop `Date`/`DateTime`/`Time`/`Color`/`Hidden`) | accepted | 2026-04-17 |
+| [0004](./0004-credential-metadata-rename.md) | Credential `Metadata` → `Record`, `Description` → `Metadata` rename | accepted | 2026-04-17 |
+| [0005](./0005-trigger-health-trait.md) | `TriggerHealth` — atomic lock-free health state on `TriggerContext` | accepted | 2026-04-17 |
+| [0006](./0006-sandbox-phase1-broker.md) | Sandbox Phase 1 broker — duplex JSON-RPC over UDS / Named Pipe | accepted | 2026-04-17 |
+| [0007](./0007-prefixed-ulid-identifiers.md) | Prefixed ULID identifiers (Stripe-style) | accepted | 2026-04-18 |
+| [0008](./0008-execution-control-queue-consumer.md) | Execution control-queue consumer | accepted | 2026-04-18 |
+| 0008 ⚠️ [lease-lifecycle](./0008-execution-lease-lifecycle.md) | Execution lease lifecycle | proposed | 2026-04-18 |
+| [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
+| [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | accepted | 2026-04-19 |
+| [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
+
+> ⚠️ **Number collision on 0008.** Two files share `id: 0008`:
+> `0008-execution-control-queue-consumer` (accepted) and
+> `0008-execution-lease-lifecycle` (proposed). The lease-lifecycle ADR must
+> be renumbered when it moves to `accepted` — tracked separately, out of
+> scope for this index.
+
+## Writing a new ADR
+
+1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
+   `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
+   `related`, optional `linear`).
+2. Pick the next free number (currently **0012**). Do not reuse.
+3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
+4. Start `status: proposed`. Move to `accepted` only after review and merge.
+5. **Do not edit an accepted ADR.** Open a new one with
+   `supersedes: [NNNN]` and set the old one's `superseded_by`.
+
+### Frontmatter convention
+
+```yaml
+---
+id: NNNN
+title: kebab-case-title
+status: proposed | accepted | superseded | rejected
+date: YYYY-MM-DD
+supersedes: []
+superseded_by: []
+tags: [topic, topic]
+related:
+  - path/to/file.rs
+  - docs/PRODUCT_CANON.md#section
+linear:
+  - NEB-XXX
+---
+```
+
+### Body sections (suggested, not mandatory)
+
+- **Context** — why is this decision needed? What forces apply?
+- **Decision** — the explicit choice, in enough detail to implement.
+- **Consequences** — positive / negative / neutral impacts.
+- **Alternatives considered** — paths we rejected and why.
+- **Follow-ups** — tracked issues, future ADRs, supersede hooks.
+
+## How ADRs fit the canon
+
+ADRs are the **L2 invariant diff log**. When a Product Canon invariant moves,
+the change lands here first — never silently in code. See
+[`docs/PRODUCT_CANON.md §0.2`](../PRODUCT_CANON.md#02) *canon revision
+triggers* for when an ADR is required.
+
+The session read-order in [`CLAUDE.md`](../../CLAUDE.md) loads this index on
+demand; any non-trivial architectural change should cite or open an ADR
+before code review.


### PR DESCRIPTION
## Summary

- Adds `docs/adr/README.md` — living index of ADRs 0001..0011 with one-line summaries, numbering rules and a template block for new ADRs.
- Adds `docs/adr/0010-rust-2024-edition.md` — records the already-in-force `edition = "2024"` + `rust-version = "1.94"` workspace decision, plus MSRV bump policy.
- Adds `docs/adr/0011-serde-json-value-interchange.md` — records the "JSON everywhere at runtime, typed schema at configuration" split per PRODUCT_CANON §12.5.
- Updates `CLAUDE.md` satellite list to point at the new ADR index instead of the bare directory.

Closes three **Milestone 0 — Foundations** issues:

- [NEB-148](https://linear.app/nebula-workflow/issue/NEB-148/docsadr0001-rust-2024-editionmd) — ADR for Rust 2024 edition
- [NEB-149](https://linear.app/nebula-workflow/issue/NEB-149/docsadr0002-serde-json-valuemd) — ADR for serde_json::Value interchange
- [NEB-153](https://linear.app/nebula-workflow/issue/NEB-153/docsadrreadmemd-index-of-accepted-adrs) — ADR index

### Note on numbering

Linear titles called these `0001-*` / `0002-*`, but those numbers are already taken by unrelated accepted ADRs (`schema-consolidation`, `proof-token-pipeline`). Shipped as 0010/0011 to avoid a collision. Linear titles retained for traceability. The index also flags the existing `0008` duplicate (control-queue-consumer vs lease-lifecycle) as a follow-up — out of scope for this PR.

## Test plan

- [x] `typos` clean on the new files + CLAUDE.md (hygiene job equivalent)
- [x] `lefthook run pre-push` green (fmt / clippy / nextest / doctests / docs / all-features / no-default-features / shear)
- [ ] CI required jobs green on this PR
- [ ] Copilot review has no blocking comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)