### PR TITLE
chore(claude): guard destructive git/rm commands via ask permissions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -15,6 +15,25 @@
       "Bash(task --list)",
       "Bash(git worktree:*)",
       "Bash(lefthook run:*)"
+    ],
+    "ask": [
+      "Bash(git worktree remove:*)",
+      "Bash(git branch -D:*)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git push --force-with-lease:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git checkout .)",
+      "Bash(git checkout --:*)",
+      "Bash(git restore .)",
+      "Bash(git restore --staged:*)",
+      "Bash(git clean -f:*)",
+      "Bash(git clean -fd:*)",
+      "Bash(git clean -fdx:*)",
+      "Bash(git clean -d:*)",
+      "Bash(rm -rf:*)",
+      "Bash(rm -fr:*)",
+      "Bash(rm -r -f:*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
## Summary

Adds `permissions.ask` rules in `.claude/settings.json` for commands that can silently discard work — `worktree remove`, `branch -D`, force-push family, `hard reset`, `checkout .`, `restore --staged`, `clean -f*`, `rm -rf/-fr/-r -f`.

Motivated by two concrete recent misses:
- NEB-97 session: agent used `worktree remove ... --force` without prompt when the worktree was reusable.
- NEB-99 session: destructive cleanup was attempted implicitly.

`ask` overrides the existing wide `allow "git worktree:*"` so safe operations (add, list, prune) stay auto-approved — only the destructive subset requires a prompt. Works alongside `.claude/hooks/guard-bash.sh`, which already hard-blocks the most dangerous variants (force-push, hard reset, force-clean, force-delete of protected branches); `ask` catches the near-miss cases the hard-block doesn't cover.

## Test plan

- [x] `jq -e '.permissions.ask | length' .claude/settings.json` → 17 rules
- [x] lefthook pre-commit green (typos, convco)
- [x] lefthook pre-push green (fmt, clippy, nextest 3333/3333, doctests, check-all-features, check-no-default, docs, shear)
- [x] Live-tested during this session: `worktree remove` and `branch -D` both correctly triggered the `ask` prompt; safe `git worktree list` / `git fetch --prune` ran without prompt.

## Docs checklist

- [ ] MATURITY.md — N/A (tooling-only)
- [ ] ADR — N/A (no L2 change)
- [ ] Crate README — N/A
- [ ] CLAUDE.md — N/A (operational behavior, not canonical rule)
- [ ] INTEGRATION_MODEL — N/A
- [ ] STYLE — N/A
- [ ] GLOSSARY — N/A

## Breaking changes

None. Purely additive — previously auto-allowed commands under `git worktree:*` may now prompt once when destructive.

## Safety/security impact

Improves safety (new prompts before irreversible ops). No secrets/credentials touched.