### PR TITLE
docs(adr): ADR-0012 checkpoint recovery / 0013 compile-time modes / 0014 dynosaur

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -25,6 +25,7 @@ from `CLAUDE.md` read-order.
 - **`#[must_use]`** — on every `Result`, every builder, every function returning a cleanup or cancellation token.
 - **`Cow<'_, T>`** — prefer over premature cloning for read-mostly borrows with occasional mutation.
 - **Sealed traits** for extension points — define via private supertrait when Nebula owns all implementations; opens later if we decide to allow downstream impls.
+- **`dynosaur` for `dyn`-compatible async traits** — author the trait in AFIT form (`async fn` in trait), apply `#[dynosaur::dynosaur(DynFoo)]`, and let the macro generate the `dyn`-compatible sibling. Static signatures name `impl Foo`; dynamic boundaries name `dyn DynFoo`. Never introduce `#[async_trait]` in new code. See [ADR-0014](adr/0014-dynosaur-macro.md).
 
 ## 2. Antipatterns we reject
 

--- a/docs/adr/0012-checkpoint-recovery.md
+++ b/docs/adr/0012-checkpoint-recovery.md
@@ -1,0 +1,115 @@
+---
+id: 0012
+title: checkpoint-recovery
+status: accepted
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [engine, execution, storage, checkpoints, resume, persistence]
+related:
+  - docs/PRODUCT_CANON.md#115-persistence--operators
+  - docs/PRODUCT_CANON.md#122-execution-single-semantic-core-durable-control-plane
+  - docs/adr/0009-resume-persistence-schema.md
+  - crates/storage/src/execution_repo.rs
+  - crates/engine/src/engine.rs
+linear:
+  - NEB-150
+---
+
+# 0012. Checkpoint recovery model
+
+## Context
+
+Nebula runs long-horizon workflows — minutes to days (PRODUCT_CANON §1).
+Process restarts happen; networks flap; third-party APIs time out mid-step.
+A workflow engine that re-executes every finished step on resume would be
+useless at the scale we target. A workflow engine that promises
+exactly-once without owning the primitives would be dishonest.
+
+This ADR records the **recovery model** already in force in
+[`§11.5`](../PRODUCT_CANON.md#115-persistence--operators), so future
+design work has a single pointer rather than re-deriving the policy from
+invariants.
+
+[`ADR-0009 — Resume persistence schema`](./0009-resume-persistence-schema.md)
+is the *mechanism* ADR (what rows and columns store what). This one is
+the *policy* ADR (what contract resume carries).
+
+## Decision
+
+1. **Checkpointing is policy-driven, not "fsync every step."** The engine
+   writes a checkpoint at declared boundaries (workflow- or action-level
+   policy) and on workflow completion. Between checkpoints, progress is
+   in-memory and may be lost on crash. Authors place boundaries before
+   side effects that are **irreversible or expensive to re-run**.
+2. **Recovery falls back to the last successful checkpoint.** On resume,
+   the engine reconstructs state from the durable surface (`executions` +
+   `execution_journal` + `stateful_checkpoints`). Work performed *after*
+   the last successful checkpoint may be replayed. Authors treat such
+   replay as the expected case for any step that lacks an idempotency
+   key.
+3. **Checkpoint-write failure is best-effort.** A failed checkpoint write
+   is **logged** but does **not** abort the live execution. The engine
+   keeps running; the failed write surfaces as stale durable state and
+   an alert, not as a crash. Resume picks up from whatever checkpoint
+   last made it to durable storage.
+4. **Idempotency keys, not "exactly once."** The
+   checkpoint-vs-side-effect race (side effect commits externally, then
+   the checkpoint write fails) is a real failure mode and is handled by
+   design through idempotency keys (PRODUCT_CANON §11.3 / §11.6). Docs
+   and APIs **do not advertise exactly-once**; they advertise
+   **at-least-once with idempotency**.
+5. **The durable surface is authoritative.** In-process `mpsc` channels
+   and ephemeral state are **never** treated as recovery inputs. Any
+   control signal — cancel, restart, resume — lives in
+   `execution_control_queue` (§12.2) and is driven by the engine's
+   single consumer wiring per deployment mode.
+
+## Consequences
+
+**Positive**
+
+- Operators have one checkpoint story to audit; no hidden second
+  durability layer.
+- Recovery cost is bounded by "time since last checkpoint" — authors
+  tune that by placing boundaries where replay hurts.
+- The engine stays live across transient storage hiccups; one failed
+  checkpoint write does not take down a long-running run.
+
+**Negative**
+
+- Work between checkpoints is at risk. A run that places *no* checkpoints
+  and crashes loses everything it did that session. The engine trades
+  per-step strictness for long-run survivability; authors must
+  understand the trade.
+- Replay requires either idempotency or an author-side compensation
+  story. Nebula does not mask this with false promises.
+
+**Neutral**
+
+- Checkpoint frequency is a knob, not a constant. Tuning happens per
+  workflow / action, not globally.
+
+## Alternatives considered
+
+- **Checkpoint every step (synchronous fsync).** Reject. Dominates run
+  wall-time for any non-trivial workflow; degrades operator experience
+  more than it protects work.
+- **Pretend exactly-once.** Reject. Not achievable without owning the
+  two-phase-commit path with every external system we call; lying about
+  it in docs violates §11.6 (documentation truth).
+- **Discard the journal, keep only latest checkpoint.** Reject. Loses
+  the replayable history that drives observability, debugging, and
+  forensic analysis of failed runs.
+
+## Follow-ups
+
+- Keep `crates/storage/src/execution_repo.rs` and
+  `crates/engine/src/engine.rs` in sync with this policy; any change to
+  checkpoint placement, write semantics, or replay contract lands as a
+  new ADR that supersedes this one.
+- `docs/OBSERVABILITY.md` should keep a narrative of "what operators see
+  when checkpoint writes fail" — this ADR pins the policy it describes.
+- `nebula-resilience` wiring around retries (M2 exit criterion) must
+  interact with checkpoint boundaries explicitly — its ADR will cite
+  this one.

--- a/docs/adr/0013-compile-time-modes.md
+++ b/docs/adr/0013-compile-time-modes.md
@@ -64,22 +64,30 @@ starts coding against the choice.
      multi-tenant middleware, Redis required.
 
 2. **Exactly one mode feature must be active.** A `build.rs` in each
-   binary crate asserts mutual exclusivity:
+   binary crate asserts mutual exclusivity. Build scripts must inspect
+   the parent crate's features via the `CARGO_FEATURE_<NAME>`
+   environment variables (`cfg!(feature = "...")` inside `build.rs`
+   would check the *build script's* own features, not the crate being
+   built — a subtle footgun we have to call out here so this pattern is
+   copied correctly):
 
    ```rust
    // apps/<binary>/build.rs
    fn main() {
-       let modes = [
-           cfg!(feature = "mode-desktop"),
-           cfg!(feature = "mode-self-hosted"),
-           cfg!(feature = "mode-cloud"),
-       ];
-       let active = modes.iter().filter(|x| **x).count();
+       let desktop     = std::env::var_os("CARGO_FEATURE_MODE_DESKTOP").is_some();
+       let self_hosted = std::env::var_os("CARGO_FEATURE_MODE_SELF_HOSTED").is_some();
+       let cloud       = std::env::var_os("CARGO_FEATURE_MODE_CLOUD").is_some();
+
+       let active = [desktop, self_hosted, cloud].iter().filter(|x| **x).count();
        assert!(
            active == 1,
            "exactly one of mode-desktop/mode-self-hosted/mode-cloud \
             must be selected (got {active})"
        );
+
+       println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MODE_DESKTOP");
+       println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MODE_SELF_HOSTED");
+       println!("cargo:rerun-if-env-changed=CARGO_FEATURE_MODE_CLOUD");
    }
    ```
 

--- a/docs/adr/0013-compile-time-modes.md
+++ b/docs/adr/0013-compile-time-modes.md
@@ -1,0 +1,157 @@
+---
+id: 0013
+title: compile-time-modes
+status: accepted
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [build, cargo-features, deployment, workspace, packaging]
+related:
+  - deploy/STACKS.md
+  - Cargo.toml
+  - docs/PRODUCT_CANON.md#123-local-path
+linear:
+  - NEB-151
+---
+
+# 0013. Compile-time deployment modes
+
+## Context
+
+Nebula ships **one codebase, three deployment shapes** (per `deploy/STACKS.md`):
+
+- **Local / desktop** — single process, SQLite by default, no external brokers.
+- **Self-hosted** — `nebula-api` + embedded worker loop, Postgres + optional
+  Redis via Docker compose.
+- **Cloud / SaaS** — multi-tenant, Postgres, Redis, long-lived workers.
+
+Each mode has different assumptions about storage, brokers, background
+workers, and tenant boundaries. Some choices (e.g. SQLite vs Postgres
+driver, in-process dispatch vs `LISTEN/NOTIFY`, tenancy middleware) must
+be resolved **at build time** because:
+
+1. Pulling SQLite into a cloud binary is dead code.
+2. Pulling Postgres into a desktop binary blocks the "no Docker required"
+   local path (§12.3).
+3. A runtime `DeploymentMode` enum forces every call site to handle three
+   branches forever; the canon (§0 — Non-goals) rules it out.
+
+Three existing constraints make this decision urgent enough to record:
+
+- **§12.3 Local path** mandates that the default developer experience runs
+  without Docker or external brokers — the desktop shape must not transitively
+  depend on `tokio-postgres`/`deadpool-postgres`.
+- **§12.2 Durable control plane** requires **one** consumer wiring per
+  deployment mode, documented in code. That wiring cannot be chosen
+  "dynamically at startup" without proliferating branches across crates.
+- **Non-goal** (project scope): `DeploymentMode` as a runtime enum.
+
+This ADR records the decision to select mode at compile time via cargo
+features, with a `build.rs` mutual-exclusivity gate, before any crate
+starts coding against the choice.
+
+## Decision
+
+1. **Deployment mode is a build-time selection, exposed as cargo features
+   on the top-level binary crates** (`apps/cli`, `apps/desktop`,
+   `crates/api`):
+   - `mode-desktop` — SQLite storage, in-process control-queue consumer,
+     single-tenant, no Redis.
+   - `mode-self-hosted` — Postgres storage, `LISTEN/NOTIFY` consumer,
+     single-tenant, optional Redis.
+   - `mode-cloud` — Postgres storage, `LISTEN/NOTIFY` consumer,
+     multi-tenant middleware, Redis required.
+
+2. **Exactly one mode feature must be active.** A `build.rs` in each
+   binary crate asserts mutual exclusivity:
+
+   ```rust
+   // apps/<binary>/build.rs
+   fn main() {
+       let modes = [
+           cfg!(feature = "mode-desktop"),
+           cfg!(feature = "mode-self-hosted"),
+           cfg!(feature = "mode-cloud"),
+       ];
+       let active = modes.iter().filter(|x| **x).count();
+       assert!(
+           active == 1,
+           "exactly one of mode-desktop/mode-self-hosted/mode-cloud \
+            must be selected (got {active})"
+       );
+   }
+   ```
+
+   A zero-mode or two-mode build fails **at compile time**, not at runtime.
+
+3. **Library crates do not carry mode features.** Crates below the binary
+   layer (`core`, `engine`, `storage`, `credential`, …) expose capability
+   features (`postgres`, `sqlite`, `redis`, `multi-tenant`) and let the
+   binary compose them. A library that depends on "which mode am I in"
+   is an architectural smell — it should depend on the capability instead.
+
+4. **No runtime `DeploymentMode` enum.** The decision is encoded in the
+   dependency graph and in `#[cfg(feature = "...")]` gates. Call sites
+   do not match on a mode at runtime; they either have a Postgres pool
+   in scope or they have a SQLite one.
+
+5. **`deploy/STACKS.md` is the human-facing description of the three
+   shapes** (what they include, how to run them). This ADR is the
+   normative build-system contract. The two must stay in sync; any
+   change to the list of modes lands as a new ADR.
+
+## Consequences
+
+**Positive**
+
+- Unused drivers and middleware never reach the final binary — desktop
+  builds stay slim, cloud builds do not carry SQLite.
+- Call-site complexity does not balloon over time; there is no
+  `if mode == Desktop` pattern to sprawl across crates.
+- Mode-specific behavior lives at the dependency boundary and is
+  greppable by feature name.
+
+**Negative**
+
+- CI must build all three modes to catch feature-gating bugs. Add a
+  `build-modes` matrix job (desktop × self-hosted × cloud × OS).
+  See "Follow-ups".
+- Cross-mode code sharing still requires careful feature composition;
+  rushed `#[cfg(feature = ...)]` without a capability abstraction can
+  produce "Frankenstein" builds that compile only under specific
+  combinations.
+
+**Neutral**
+
+- `deploy/STACKS.md` continues to describe runtime deployment (how to
+  start a stack); this ADR covers how the binary is *built*.
+
+## Alternatives considered
+
+- **Single universal binary with runtime `DeploymentMode` enum.**
+  Reject. Forces every dependency into every build, violates §12.3
+  (local path stays lean), and spreads branch logic across crates
+  indefinitely.
+- **Separate git repos per mode.** Reject. Defeats the
+  "one codebase, three shapes" positioning and doubles the maintenance
+  cost of shared crates.
+- **`default-run = "..."`-style switch without feature gates.** Reject.
+  Doesn't stop the wrong drivers from being compiled in; not a build-time
+  decision in any meaningful sense.
+- **One binary per mode with fully duplicated `main.rs`.** Reject.
+  Deduplication of glue code produces reusable modules that end up
+  needing the same feature gates — this decision just records them.
+
+## Follow-ups
+
+- Add `build.rs` with the assertion above to `apps/cli`, `apps/desktop/src-tauri`,
+  and `crates/api` (binary targets only).
+- Extend the CI test matrix in `.github/workflows/test-matrix.yml` with
+  a `build-modes` dimension (`mode-desktop | mode-self-hosted | mode-cloud`)
+  so feature-gating regressions are caught before merge.
+- When the first cross-cutting code path needs to vary per mode, open a
+  follow-up ADR (or capability sub-ADR) that specifies *the boundary
+  type* — do not scatter `#[cfg(feature = ...)]` in high-traffic
+  functions without design review.
+- `deploy/STACKS.md` link note: each mode section should name the cargo
+  feature it expects.

--- a/docs/adr/0013-compile-time-modes.md
+++ b/docs/adr/0013-compile-time-modes.md
@@ -53,8 +53,9 @@ starts coding against the choice.
 ## Decision
 
 1. **Deployment mode is a build-time selection, exposed as cargo features
-   on the top-level binary crates** (`apps/cli`, `apps/desktop`,
-   `crates/api`):
+   on the top-level binary crates** (`apps/cli`, `apps/desktop/src-tauri`,
+   and any server binary introduced later — `crates/api` stays a library
+   and is composed from those binaries):
    - `mode-desktop` — SQLite storage, in-process control-queue consumer,
      single-tenant, no Redis.
    - `mode-self-hosted` — Postgres storage, `LISTEN/NOTIFY` consumer,
@@ -144,8 +145,11 @@ starts coding against the choice.
 
 ## Follow-ups
 
-- Add `build.rs` with the assertion above to `apps/cli`, `apps/desktop/src-tauri`,
-  and `crates/api` (binary targets only).
+- Add `build.rs` with the assertion above to `apps/cli` and
+  `apps/desktop/src-tauri` (binary targets only). If a server binary
+  package is introduced later, that binary — **not** the current
+  `crates/api` library crate — owns the mutually-exclusive `mode-*`
+  feature gate and `build.rs`.
 - Extend the CI test matrix in `.github/workflows/test-matrix.yml` with
   a `build-modes` dimension (`mode-desktop | mode-self-hosted | mode-cloud`)
   so feature-gating regressions are caught before merge.

--- a/docs/adr/0014-dynosaur-macro.md
+++ b/docs/adr/0014-dynosaur-macro.md
@@ -1,0 +1,146 @@
+---
+id: 0014
+title: dynosaur-macro
+status: accepted
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [traits, async, dyn-compatibility, macros, api-design]
+related:
+  - docs/STYLE.md#1-idioms-we-use
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/adr/0010-rust-2024-edition.md
+linear:
+  - NEB-152
+---
+
+# 0014. `dynosaur` for `dyn`-compatible async traits
+
+## Context
+
+Many Nebula trait seams need **both** static dispatch (for the hot path in
+the engine / storage layer) **and** `dyn Trait` objects (for the integration
+surface — stored handlers, plugin broker boundaries, CLI command dispatch).
+Async methods in traits make this awkward:
+
+- **`async fn` in trait** (AFIT) is stable since Rust 1.75 and is the
+  ergonomic form we want authors to read and write. It is the static-dispatch
+  path.
+- AFIT traits are **not** directly `dyn`-compatible. Naïve
+  `dyn MyTrait` fails to compile because the compiler cannot pick a concrete
+  `impl Future` return type.
+- The historical fix — `#[async_trait]` — rewrites every `async fn` to
+  return `Pin<Box<dyn Future + Send>>`, which boxes the future **even at
+  call sites that never needed `dyn`**, and fights against stable AFIT.
+
+The `dynosaur` macro solves this cleanly: author the trait in idiomatic
+AFIT form, apply `#[dynosaur::dynosaur(DynMyTrait)]`, and the macro
+generates a second `dyn`-compatible trait whose methods return
+`Pin<Box<dyn Future + 'a>>` (or similar). Static callers keep the
+zero-cost AFIT path; dynamic callers name the generated `DynMyTrait`.
+
+With MSRV 1.94 (see [ADR-0010](./0010-rust-2024-edition.md)) stable AFIT
+is available workspace-wide and this pattern becomes our default.
+
+## Decision
+
+1. **`dynosaur` is the approved mechanism for `dyn`-compatible async
+   traits** across the workspace. It replaces `#[async_trait]` in new
+   code.
+2. **Author the trait in AFIT form.** No `async fn` rewrite, no
+   `impl Future` return types unless there is a specific reason (GATs on
+   the future, cancellation tokens, etc.). Example:
+
+   ```rust
+   #[dynosaur::dynosaur(DynExecutionRepo)]
+   pub trait ExecutionRepo: Send + Sync {
+       async fn load(&self, id: ExecutionId) -> Result<ExecutionRow, RepoError>;
+       async fn transition(&self, row: ExecutionRow) -> Result<(), RepoError>;
+   }
+   ```
+
+   `&dyn ExecutionRepo` is not valid — the engine uses
+   `&dyn DynExecutionRepo` where `dyn` dispatch is needed (e.g. repo
+   registries, swappable storage backends), and `impl ExecutionRepo` for
+   static call sites (hot path, per-run dispatch).
+
+3. **Static dispatch is the default.** Name `impl TraitName` (or a
+   concrete type) in signatures. Use `dyn DynTraitName` only at a
+   boundary that stores the trait object (registry, broker, cross-plugin
+   boundary).
+
+4. **Do not reintroduce `#[async_trait]`.** Existing call sites that still
+   use it are tech debt and should be migrated as they are touched — not
+   in a mass refactor.
+
+5. **Keep `Send + Sync` bounds explicit on the trait.** `dynosaur`
+   generates the `Dyn*` version preserving these bounds; consumers get
+   a compile error if they try to cross thread boundaries with a trait
+   missing `Send`. Do not rely on macro defaults.
+
+6. **MSRV gate.** `dynosaur` requires stable AFIT (≥ 1.75); we are on
+   1.94 (ADR-0010) so the floor is not an issue. If the workspace MSRV
+   ever drops below AFIT support, this ADR must be superseded, not edited.
+
+## Consequences
+
+**Positive**
+
+- Zero-cost static dispatch is preserved at hot-path call sites. The
+  engine's per-run dispatch loop does not pay `Box<dyn Future>` tax on
+  every step.
+- Trait authors write idiomatic AFIT — new contributors do not need to
+  learn the `#[async_trait]` desugaring to read core traits.
+- `Dyn*` naming keeps the cognitive boundary explicit: a function
+  signature that says `DynExecutionRepo` is a deliberate choice to pay
+  for dynamic dispatch.
+
+**Negative**
+
+- Consumers see two names per trait (`ExecutionRepo` + `DynExecutionRepo`).
+  The `Dyn` prefix is conventional but adds a lookup step when navigating
+  code.
+- `dynosaur` is a young crate. API breakage would touch every seam using
+  it; pinning exact versions in `Cargo.toml` workspace deps is a
+  prerequisite (see "Follow-ups").
+
+**Neutral**
+
+- Runtime cost of `dyn DynTraitName` is the usual indirect-call + `Box`
+  allocation per async call. It is the same cost `#[async_trait]` forced
+  on every call site; with `dynosaur` it is opt-in.
+
+## Alternatives considered
+
+- **Stay on `#[async_trait]`.** Reject. Mandates `Box<dyn Future>` at
+  every call site regardless of dispatch kind; fights stable AFIT.
+- **Hand-write parallel `DynFoo` wrappers.** Reject. Drift between the
+  static and dynamic forms is inevitable; macro-generation removes the
+  class of bug.
+- **Avoid `dyn` trait objects entirely (pure generics).** Reject.
+  Plugin registries, repo swaps, and cross-crate dispatch need stored
+  trait objects; forcing everything monomorphic balloons compile time
+  and binary size without a real ergonomic win.
+- **`trait-variant`.** Similar goal, but as of 2026 its feature set is
+  narrower and it pre-dates some stabilized patterns `dynosaur` targets.
+  Re-evaluate when / if it grows to cover our cases.
+
+## Style guidelines (summary)
+
+Full rule lives in [`docs/STYLE.md §1 — Idioms we use`](../STYLE.md#1-idioms-we-use):
+
+- Trait is authored in AFIT form; `#[dynosaur::dynosaur(DynFoo)]` generates
+  the `dyn`-compatible sibling.
+- Static signatures: `impl Foo`. Dynamic boundary: `dyn DynFoo`.
+- Never add `#[async_trait]` in new code.
+
+## Follow-ups
+
+- `Cargo.toml` workspace deps: pin `dynosaur = "<exact>"` once adopted
+  so a semver bump is an intentional PR, not an accidental `cargo update`.
+- Migrate existing `#[async_trait]` trait definitions opportunistically;
+  track as low-priority cleanup, not a blocking refactor.
+- When `dynosaur` (or an upstream RFC) no longer requires the `Dyn`
+  sibling pattern — because the compiler natively supports `dyn Trait`
+  on AFIT — open a follow-up ADR and migrate the trait names back to
+  the single form.

--- a/docs/adr/0014-dynosaur-macro.md
+++ b/docs/adr/0014-dynosaur-macro.md
@@ -8,7 +8,6 @@ superseded_by: []
 tags: [traits, async, dyn-compatibility, macros, api-design]
 related:
   - docs/STYLE.md#1-idioms-we-use
-  - docs/PRODUCT_CANON.md#125-secrets-and-auth
   - docs/adr/0010-rust-2024-edition.md
 linear:
   - NEB-152

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,9 @@ changes land as a new ADR that `supersedes` it.
 | [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
 | [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | accepted | 2026-04-19 |
 | [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
+| [0012](./0012-checkpoint-recovery.md) | Checkpoint recovery model (policy-driven, best-effort writes, idempotency over exactly-once) | accepted | 2026-04-19 |
+| [0013](./0013-compile-time-modes.md) | Compile-time deployment modes (`mode-desktop` / `mode-self-hosted` / `mode-cloud` + `build.rs` gate) | accepted | 2026-04-19 |
+| [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | accepted | 2026-04-19 |
 
 > ⚠️ **Number collision on 0008.** Two files share `id: 0008`:
 > `0008-execution-control-queue-consumer` (accepted) and
@@ -32,7 +35,7 @@ changes land as a new ADR that `supersedes` it.
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0012**). Do not reuse.
+2. Pick the next free number (currently **0015**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with


### PR DESCRIPTION
## Summary

Second batch of M0 foundational ADRs. Documents three decisions already in force (or imminently-so) across the workspace:

- **ADR-0012 — Checkpoint recovery model.** Records the §11.5 policy: checkpoint at declared boundaries, best-effort writes (log, do not abort), resume from the last successful checkpoint, idempotency instead of exactly-once. Policy sibling to [ADR-0009](docs/adr/0009-resume-persistence-schema.md) (schema).
- **ADR-0013 — Compile-time deployment modes.** "One codebase, three shapes" realized as cargo features (`mode-desktop`, `mode-self-hosted`, `mode-cloud`) on binary crates with a `build.rs` mutual-exclusivity gate; library crates stay capability-gated only. No runtime `DeploymentMode` enum.
- **ADR-0014 — `dynosaur` macro.** Commits to `dynosaur` for `dyn`-compatible async traits, replacing `#[async_trait]` going forward. AFIT stays the static-dispatch default; `dyn DynFoo` is the explicit dynamic boundary.

Also:
- `docs/STYLE.md §1` — adds the `dynosaur` idiom bullet cross-linking ADR-0014.
- `docs/adr/README.md` — index extended to 0014; next-free-number bumped to 0015.

Closes:
- [NEB-150](https://linear.app/nebula-workflow/issue/NEB-150) — ADR checkpoint recovery
- [NEB-151](https://linear.app/nebula-workflow/issue/NEB-151) — ADR compile-time modes
- [NEB-152](https://linear.app/nebula-workflow/issue/NEB-152) — ADR dynosaur

### Note on numbering

Linear titles were `0003-*` / `0004-*` / `0005-*`; those numbers are already taken by unrelated accepted ADRs (consolidated-field-enum, credential-metadata-rename, trigger-health-trait). Shipped as 0012/0013/0014 per the numbering rule added in [PR #473](https://github.com/vanyastaff/nebula/pull/473). Linear titles retained for traceability.

## Test plan

- [x] `typos` clean
- [x] `lefthook run pre-push` green (fmt / clippy / nextest / doctests / docs / all-features / no-default-features / shear)
- [ ] CI required jobs green on this PR
- [ ] Copilot review has no blocking comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added new style guide conventions and best practices for implementing and using async traits throughout the codebase.
* Introduced three new architecture decision records covering checkpoint recovery and failure handling behavior, compile-time deployment mode configuration strategies, and async trait design and compatibility patterns.
* Updated the architecture decision record index with newly added entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->