### PR TITLE
test(expression): drop debug println in builtins arg-type test (NEB-165)

### DIFF
--- a/crates/expression/src/builtins.rs
+++ b/crates/expression/src/builtins.rs
@@ -463,7 +463,6 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         let msg = err.to_string();
-        println!("Error message: {}", msg);
         assert!(msg.contains("Argument 'text' must be a string"));
         assert!(msg.contains("number"));
     }


### PR DESCRIPTION
## Summary

NEB-165 asks for three things; two were already in place on `main`, the third is the one change here:

1. ✅ `tracing` + `tracing-subscriber` at workspace level — already in `Cargo.toml` (lines 71–72).
2. ✅ Common init helper in `nebula-log` — `auto_init`, `init`, `init_with` exist (`crates/log/src/lib.rs`, documented in the crate header).
3. ✅ No `println!`/`log::` leftovers in runtime crates — removed the sole remaining one: a debug `println!` inside `test_get_string_arg_type_error` in `crates/expression/src/builtins.rs` that duplicated information already checked by the `assert!` calls immediately below it.

Workspace-wide grep for `println!`/`eprintln!` in non-test, non-example, non-doc-comment source is now empty. Direct `log::` use in runtime crates also confirmed absent.

## Acceptance criteria

- [x] `tracing` + `tracing-subscriber` added to workspace Cargo.toml
- [x] Common init helper in `nebula-log` (or wherever)
- [x] Replace any `println!`/`log::` leftovers in runtime crates

## Test plan

- [x] `cargo nextest run -p nebula-expression` — 283 passed, 12 skipped
- [x] `cargo clippy -p nebula-expression --all-targets -- -D warnings` — clean
- [x] `lefthook run pre-push` — green (fmt, clippy, nextest 3333/3333, doctests, shear, check-all-features, check-no-default)

Closes NEB-165