### PR TITLE
docs(adr): ADR-0012 checkpoint-based recovery (not event sourcing) (NEB-150)

### DIFF
--- a/docs/PRODUCT_CANON.md
+++ b/docs/PRODUCT_CANON.md
@@ -354,6 +354,7 @@ Seams: `crates/storage/src/execution_repo.rs` — `ExecutionRepo::save_stateful_
 - **[L2]** **A demo handler that logs the command and discards it does not satisfy this invariant.** Examples and `simple_server.rs` must either wire a **real** engine consumer or be marked `// DEMO ONLY — does not honor cancel` so nothing mistakes them for the contract.
 - **[L2]** **Batching outbox writes for throughput is valid only if per-transition atomicity is preserved.** Never batch as a workaround that breaks “state transition + control signal” integrity.
 - **[L2]** Any second control channel (HTTP webhook, in-memory event) is **forbidden** unless this canon is updated with a **reconciliation** story.
+- **Recovery model:** checkpoint snapshots, not event sourcing. See [ADR-0012](./adr/0012-checkpoint-recovery.md) for the rationale and the contract with §11.5.
 
 ### 12.3 Local path
 

--- a/docs/PRODUCT_CANON.md
+++ b/docs/PRODUCT_CANON.md
@@ -354,7 +354,7 @@ Seams: `crates/storage/src/execution_repo.rs` — `ExecutionRepo::save_stateful_
 - **[L2]** **A demo handler that logs the command and discards it does not satisfy this invariant.** Examples and `simple_server.rs` must either wire a **real** engine consumer or be marked `// DEMO ONLY — does not honor cancel` so nothing mistakes them for the contract.
 - **[L2]** **Batching outbox writes for throughput is valid only if per-transition atomicity is preserved.** Never batch as a workaround that breaks “state transition + control signal” integrity.
 - **[L2]** Any second control channel (HTTP webhook, in-memory event) is **forbidden** unless this canon is updated with a **reconciliation** story.
-- **Recovery model:** checkpoint snapshots, not event sourcing. See [ADR-0012](./adr/0012-checkpoint-recovery.md) for the rationale and the contract with §11.5.
+- **[L2]** **Recovery model:** checkpoint snapshots, not event sourcing. See [ADR-0012](./adr/0012-checkpoint-recovery.md) for the rationale and the contract with §11.5.
 
 ### 12.3 Local path
 

--- a/docs/adr/0012-checkpoint-recovery.md
+++ b/docs/adr/0012-checkpoint-recovery.md
@@ -1,0 +1,97 @@
+---
+id: 0012
+title: checkpoint-recovery
+status: proposed
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [execution, durability, recovery, storage]
+related:
+  - docs/PRODUCT_CANON.md#122-execution-single-semantic-core-durable-control-plane
+  - docs/PRODUCT_CANON.md#115-persistence--operators
+  - crates/execution
+  - crates/storage
+  - crates/eventbus
+linear:
+  - NEB-150
+---
+
+# 0012. Checkpoint-based recovery (not event sourcing)
+
+## Context
+
+A durable workflow engine must recover from crashes mid-run. Two canonical
+models:
+
+1. **Event sourcing.** Log every state change, replay to rebuild. Temporal's
+   model.
+2. **Checkpoint snapshots.** Periodically write frontier + node outputs;
+   recovery = load the latest checkpoint. Airflow's model.
+
+Trade-offs:
+
+- Event sourcing is replay-correct and deterministic, but forces workflows
+  into a deterministic execution model (no wall-clock, no random, no
+  arbitrary I/O without sandboxing the effects). Unbounded log growth also
+  requires compaction engineering.
+- Checkpointing is simpler, makes non-deterministic workflows feasible, but
+  loses fine-grained audit unless supplemented. Recovery resumes from the
+  last known good state — some re-execution is possible.
+
+## Decision
+
+Use **checkpoint-based recovery** as the authoritative durability model.
+
+- The engine writes a `FrontierState` + per-node outputs at checkpoint
+  boundaries.
+- Checkpoints are written via `nebula-storage` (SQLite or Postgres).
+- Recovery loads the latest valid checkpoint and resumes from the frontier.
+- For nodes that are **non-idempotent**, the runtime marks them with an
+  explicit flag and the engine may re-ask the user / skip / require manual
+  intervention on recovery.
+- An audit log is still emitted through `nebula-eventbus` for observability
+  — but the event log is **not** the authoritative state.
+
+## Consequences
+
+**Positive**
+
+- Workflows can use wall-clock, randomness, and arbitrary I/O without a
+  sandbox.
+- Recovery is O(1) from the latest checkpoint.
+- No log-compaction engineering.
+
+**Negative**
+
+- Non-idempotent side effects may execute twice on crash-recovery; mitigated
+  by explicit idempotency markers (`PRODUCT_CANON` §11.3) and at-least-once
+  semantics in the contract.
+- Audit granularity is coarser than event-sourced — we rely on the eventbus
+  stream for fine detail.
+
+## Alternatives considered
+
+- **Event sourcing (Temporal-style).** Rejected because forcing workflow
+  authors into a deterministic execution model conflicts with Nebula's goal
+  of letting authors write straightforward Rust, including wall-clock, I/O,
+  and ecosystem crates. Also rejected on engineering cost: log growth,
+  compaction, and sandboxing effects are a large surface area for a model
+  whose benefits (fine-grained replay audit) can be approximated by the
+  eventbus stream without owning authoritative state.
+
+## Follow-ups
+
+- `PRODUCT_CANON` §12.2 and §11.5 govern the boundary between checkpoint
+  writes, the durable control queue, and best-effort semantics. This ADR is
+  the decision record those sections refer back to.
+- Non-idempotent node markers and the recovery UX (re-ask / skip / manual)
+  are tracked as separate work under the checkpoint-recovery milestone.
+
+## References
+
+- `PRODUCT_CANON` §12.2 — Execution: single semantic core, durable control
+  plane (`docs/PRODUCT_CANON.md`).
+- `PRODUCT_CANON` §11.5 — Persistence & operators (checkpoint boundaries,
+  best-effort framing).
+- Airflow's checkpointing model (reference).
+- Temporal's event-sourced workflow model (reference, rejected).

--- a/docs/adr/0012-checkpoint-recovery.md
+++ b/docs/adr/0012-checkpoint-recovery.md
@@ -42,7 +42,7 @@ Trade-offs:
 
 Use **checkpoint-based recovery** as the authoritative durability model.
 
-- The engine writes a `FrontierState` + per-node outputs at checkpoint
+- The engine writes a frontier snapshot plus per-node outputs at checkpoint
   boundaries.
 - Checkpoints are written via `nebula-storage` (SQLite or Postgres).
 - Recovery loads the latest valid checkpoint and resumes from the frontier.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ changes land as a new ADR that `supersedes` it.
 | [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
 | [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | accepted | 2026-04-19 |
 | [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
+| [0012](./0012-checkpoint-recovery.md) | Checkpoint-based recovery (not event sourcing) | proposed | 2026-04-19 |
 
 > ⚠️ **Number collision on 0008.** Two files share `id: 0008`:
 > `0008-execution-control-queue-consumer` (accepted) and
@@ -32,7 +33,7 @@ changes land as a new ADR that `supersedes` it.
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0012**). Do not reuse.
+2. Pick the next free number (currently **0013**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with


### PR DESCRIPTION
## Summary

Mirrors the Linear **ADR-0003** draft (checkpoint snapshots as the
authoritative durability model, rejecting event sourcing) into the repo's
ADR log. Filed under `0012` because numbers `0001`–`0011` were already
taken by earlier ADRs (see the README's number collision note on 0008).

Also adds:

- A one-line back-link from `PRODUCT_CANON` §12.2 so the recovery model is
  discoverable from the canon section that already references §11.5's
  checkpoint semantics.
- Bumps the \"next free number\" hint in `docs/adr/README.md` to **0013**.

Status is `proposed` per the README's \"new ADRs land proposed, flipped to
accepted after review\" rule.

## Acceptance criteria

- [x] File at `docs/adr/0012-checkpoint-recovery.md` (numbered `0003` in the
      Linear issue title; `0012` in-repo because of the pre-existing series)
- [x] Mirrors Linear ADR-0003 doc content
- [x] Cross-referenced from §12.2 PRODUCT_CANON

## Test plan

- [x] No Rust changes — `cargo` hooks skipped by lefthook's pre-commit.
- [x] Markdown index entry and file path match.

Closes NEB-150