### PR TITLE
docs: sync engine-lifecycle cluster closure

### DIFF
--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -19,7 +19,7 @@ Legend:
 | Crate | API stability | Test coverage | Doc completeness | Engine integration | SLI ready |
 |---|---|---|---|---|---|
 | nebula-action        | frontier | stable  | stable | partial (webhook sig covered; CheckpointPolicy planned; `ActionResult::Retry` gated behind `unstable-retry-scheduler`, #290) | n/a |
-| nebula-api           | frontier | stable  | stable | partial (step 5 cancel: producer side stable; consumer skeleton in nebula-engine, dispatch A2/A3 planned — ADR-0008) | partial |
+| nebula-api           | frontier | stable  | stable | partial (knife steps 3+5: Start/Cancel producers stable, #332/#330; consumer skeleton in nebula-engine, real engine-side dispatch A2/A3 still planned — ADR-0008) | partial |
 | nebula-core          | frontier | stable  | stable | stable | n/a |
 | nebula-credential    | frontier | stable  | stable | partial (rotation in integration tests) | n/a |
 | nebula-engine        | partial  | stable  | stable | partial (ControlConsumer skeleton lands §12.2; dispatch A2/A3 planned — ADR-0008) | n/a |
@@ -50,4 +50,4 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-18 (ADR-0008, chip A1 — ControlConsumer skeleton).
+Last targeted revision: 2026-04-19 (Engine lifecycle cluster doc-sync: all 15 P1 issues landed; ADR-0015 lease-lifecycle promoted from proposed-0008 to accepted).

--- a/docs/adr/0015-execution-lease-lifecycle.md
+++ b/docs/adr/0015-execution-lease-lifecycle.md
@@ -1,15 +1,17 @@
 ---
-id: 0008
+id: 0015
 title: execution-lease-lifecycle
-status: proposed
-date: 2026-04-18
+status: accepted
+date: 2026-04-19
 supersedes: []
 superseded_by: []
 tags: [engine, execution, storage, concurrency, multi-runner]
 related: [crates/engine/src/engine.rs, crates/storage/src/execution_repo.rs, docs/PRODUCT_CANON.md]
+linear:
+  - NEB-325
 ---
 
-# 0008. Execution lease lifecycle
+# 0015. Execution lease lifecycle
 
 ## Context
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,26 +16,20 @@ changes land as a new ADR that `supersedes` it.
 | [0006](./0006-sandbox-phase1-broker.md) | Sandbox Phase 1 broker — duplex JSON-RPC over UDS / Named Pipe | proposed | 2026-04-17 |
 | [0007](./0007-prefixed-ulid-identifiers.md) | Prefixed ULID identifiers (Stripe-style) | accepted | 2026-04-17 |
 | [0008](./0008-execution-control-queue-consumer.md) | Execution control-queue consumer | accepted | 2026-04-18 |
-| 0008 ⚠️ [lease-lifecycle](./0008-execution-lease-lifecycle.md) | Execution lease lifecycle | proposed | 2026-04-18 |
 | [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
 | [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | accepted | 2026-04-19 |
 | [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
 | [0012](./0012-checkpoint-recovery.md) | Checkpoint recovery model (policy-driven, best-effort writes, idempotency over exactly-once) | accepted | 2026-04-19 |
 | [0013](./0013-compile-time-modes.md) | Compile-time deployment modes (`mode-desktop` / `mode-self-hosted` / `mode-cloud` + `build.rs` gate) | accepted | 2026-04-19 |
 | [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | accepted | 2026-04-19 |
-
-> ⚠️ **Number collision on 0008.** Two files share `id: 0008`:
-> `0008-execution-control-queue-consumer` (accepted) and
-> `0008-execution-lease-lifecycle` (proposed). The lease-lifecycle ADR must
-> be renumbered when it moves to `accepted` — tracked separately, out of
-> scope for this index.
+| [0015](./0015-execution-lease-lifecycle.md) | Execution lease lifecycle (renumbered from 0008; promoted on #325 implementation) | accepted | 2026-04-19 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0015**). Do not reuse.
+2. Pick the next free number (currently **0016**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/plans/archive/engine-lifecycle-canon-cluster-2026-04.md
+++ b/docs/plans/archive/engine-lifecycle-canon-cluster-2026-04.md
@@ -1,6 +1,27 @@
 # Engine Lifecycle Canon Cluster — Planning Document
 
-> **Status:** PLANNING — group / sequence / handoff document, **not** an implementation plan.
+> **Status:** COMPLETED (archived 2026-04-19). All 15 P1 issues from §0 closed in `main`; cross-reference below.
+>
+> | # | Fix commit |
+> |---|---|
+> | 290 | batch landed via `b2b0c6fc` (`ActionResult::Retry` gated behind `unstable-retry-scheduler`) |
+> | 297 | `15092823` (persist OnError payload) + `54d416b5` (persist before edge routing) |
+> | 298 | batch 1 `a130ea93` (run_frontier fixes) |
+> | 299 | batch 2 `646d11e6` (execution-state correctness) |
+> | 308 | `54d416b5` (persist before edge routing) |
+> | 311 | batch 2 `646d11e6` + `7dd3d00d` (ExecutionBudget restore) |
+> | 321 | batch 2 `646d11e6` + `58740664` (setup-failure checkpoint symmetry) |
+> | 324 | `54d416b5` (persist before edge routing) |
+> | 325 | `3d7db131` (acquire and renew execution lease) — ADR-0015 (ex-0008 lease-lifecycle) promoted to accepted |
+> | 327 | `926a2d5f` (persist canonical state on start) |
+> | 330 | `9134fb45` (control-queue consumer skeleton, ADR-0008) |
+> | 332 | `df1c996a` (dispatch execution to engine on start) |
+> | 333 | `d51f9c5c` (surface CAS conflicts) |
+> | 336 | `54d416b5` (persist before edge routing) |
+> | 341 | `8c47623f` (gate Completed on all_nodes_terminal invariant) |
+>
+> Residual follow-ups flagged during closure: engine-side **real** dispatch for Start/Resume/Restart (ADR-0008 A2) and Cancel/Terminate (ADR-0008 A3) remain `planned` — producer side is done, engine consumer is currently a skeleton with no-op dispatch defaults. Out of scope for this cluster; lives as ongoing work under ADR-0008.
+>
 > **Date:** 2026-04-18
 > **Scope:** 15 P1 issues against `vanyastaff/nebula` clustered around execution lifecycle (canon §11–§12). Output: grouping, root-cause hypothesis per group, canon impact, ADR-needed flag, recommended PR sequencing.
 > **Authority:** Subordinate to [`docs/PRODUCT_CANON.md`](../PRODUCT_CANON.md). All groups below are framed against §11 (core contracts) and §12 (non-negotiable invariants).


### PR DESCRIPTION
## Summary

All 15 P1 issues from `docs/plans/engine-lifecycle-canon-cluster-2026-04.md` are closed on `main`, but three canonical truth sites were lagging. This PR brings the docs back in line with the code: promotes the lease-lifecycle ADR (proposed → accepted, renumbered off the 0008 collision), archives the completed plan with a per-issue fix-commit table, and corrects the `nebula-api` maturity row now that the `Start` producer landed via #332.

## Linked issue

- Refs the full cluster (all closed in `main`): #290, #297, #298, #299, #308, #311, #321, #324, #325, #327, #330, #332, #333, #336, #341

## Type of change

- [x] `docs` — documentation only

## Affected crates / areas

- `docs/adr/` — ADR renumber + promotion
- `docs/plans/` — plan archival
- `docs/MATURITY.md` — nebula-api row truthfulness

## Changes

- `docs/adr/0008-execution-lease-lifecycle.md` → `docs/adr/0015-execution-lease-lifecycle.md`: renumbered off the collision with `0008-execution-control-queue-consumer`; flipped `status: proposed` → `accepted` now that #325 shipped in `3d7db131`; `date` bumped to 2026-04-19; `linear: [NEB-325]` added.
- `docs/adr/README.md`: +0015 row; dropped the ⚠️ collision warning block; next-free number 0015 → 0016.
- `docs/MATURITY.md`: `nebula-api` row now says `knife steps 3+5: Start/Cancel producers stable, #332/#330` (previously only `step 5 cancel`); last-revised bumped to 2026-04-19 with a one-line cluster-closure note.
- `docs/plans/engine-lifecycle-canon-cluster-2026-04.md` → `docs/plans/archive/`: adds a COMPLETED header with a 15-row fix-commit table so the plan stays navigable as a historical record; residual follow-ups (engine-side **real** dispatch for Start/Resume/Restart and Cancel/Terminate, still scoped to ADR-0008 A2/A3) are called out explicitly.

## Test plan

- Docs-only change; no code paths touched. Pre-push `lefthook` ran the full CI-mirror gate on this branch: `fmt-check`, `clippy`, `cargo-deny`, `taplo`, `shear`, `docs`, `check-all-features`, `check-no-default`, `doctests`, and `nextest` (3340 tests, 13 skipped, 0 failures).
- Verified no stale link references to the old `0008-execution-lease-lifecycle` path or the old plan location (`grep -r`).
- Verified ADR frontmatter YAML parses and the body heading was renumbered from `# 0008.` → `# 0015.`.

### Local verification

- [x] `cargo +nightly fmt --all` — no matching staged files (docs only)
- [x] `cargo clippy --workspace -- -D warnings` — no matching staged files
- [x] `cargo nextest run --workspace` — 3340 passed / 13 skipped via lefthook pre-push
- [x] `cargo test --workspace --doc` — passed via lefthook
- [x] `cargo deny check` — not applicable, no `Cargo.toml` touched

## Breaking changes

None.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` §17 — this PR is the §17 DoD follow-through for the already-landed cluster; no new lifecycle introduced
- [x] Layer direction preserved (docs-only)
- [x] `docs/MATURITY.md` row updated
- [x] Plan that motivated this change archived: `docs/plans/archive/engine-lifecycle-canon-cluster-2026-04.md`
- [x] ADR maintenance: `0008-execution-lease-lifecycle` → `0015-execution-lease-lifecycle`; frontmatter-only promotion + renumber per `docs/adr/README.md` renumbering rule

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` — docs only
- [x] No silent error suppression — docs only
- [x] Engine state transitions — docs only
- [x] Credentials / secrets — docs only
- [x] `unsafe` — docs only

## Notes for reviewers

Only the ADR content-edits to focus on are the frontmatter block (id/status/date/linear) and the H1 `# 0015. Execution lease lifecycle`. Body is unchanged from the pre-rename file. The `Follow-up work this enables` section and seam/verification block already describe the shipped #325 implementation, so no body revisions were needed.

The residual engine-side **real** Start/Resume/Restart + Cancel/Terminate dispatch (ADR-0008 A2/A3) remains honestly tracked as `planned` in the `nebula-engine` `lib.rs //!` docs — that work is out of scope here and continues under the existing ADR-0008 consumer contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)