### PR TITLE
feat(engine): wire real Start/Resume/Restart dispatch (ADR-0008 A2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3766,6 +3766,7 @@ dependencies = [
  "nebula-action",
  "nebula-api",
  "nebula-core",
+ "nebula-engine",
  "nebula-error",
  "nebula-execution",
  "nebula-metrics",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -63,6 +63,11 @@ url = { workspace = true }
 
 [dev-dependencies]
 nebula-api = { path = ".", features = ["test-util"] }
+# Dev-only: the knife integration test wires the A2 consumer + engine
+# end-to-end alongside the API producer (see `tests/knife.rs`). Listed in
+# `deny.toml` wrappers for the same reason. `InProcessSandbox` is re-exported
+# through `nebula-runtime` so we don't need a direct `nebula-sandbox` dep.
+nebula-engine = { path = "../engine" }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 hex = { workspace = true }
 hmac = { workspace = true }

--- a/crates/api/examples/simple_server.rs
+++ b/crates/api/examples/simple_server.rs
@@ -18,13 +18,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
     let execution_repo = Arc::new(InMemoryExecutionRepo::new());
-    // DEMO ONLY — does not honor cancel/start (canon §12.2).
+    // DEMO ONLY — does not honor start / cancel (canon §12.2, ADR-0008 §4).
     //
-    // This example wires the API producer side of `execution_control_queue`
-    // but does NOT construct a `WorkflowEngine` or spawn a
-    // `nebula_engine::ControlConsumer`, so enqueued commands are never
-    // dispatched. Use ADR-0008's consumer skeleton from a production
-    // composition root once A2 / A3 land the dispatch paths.
+    // ADR-0008 A2 landed `nebula_engine::EngineControlDispatch`, so a
+    // production composition root can now wire the engine into this
+    // example's `AppState` and spawn a real `ControlConsumer`. This
+    // `simple_server.rs` intentionally does not pull in the full engine
+    // stack (plugin registry, action runtime, sandbox, metrics, credential
+    // / resource managers) — the dedicated `apps/server` composition root is
+    // still tracked as a separate follow-up. Until then this example stays
+    // DEMO ONLY: `POST /executions` persists the row and enqueues `Start`,
+    // but with no consumer wired here the row never transitions to
+    // `Running`. `crates/api/tests/knife.rs` exercises the full producer →
+    // consumer → engine path end-to-end for regression coverage.
     // `InMemoryControlQueueRepo` also does not persist across restarts; a
     // real deployment additionally requires a Postgres-backed repo.
     let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -635,3 +635,220 @@ async fn knife_step6_queue_failure_returns_error() {
          (canon §13 step 6)"
     );
 }
+
+// ── Step 3 end-to-end (ADR-0008 A2) ───────────────────────────────────────────
+//
+// The `knife_scenario_end_to_end` test above asserts the PRODUCER side of §13
+// step 3 — the API writes the execution row and enqueues `Start` onto the
+// durable control queue (#332). This separate test asserts the CONSUMER side:
+// the engine-owned `EngineControlDispatch` (ADR-0008 A2) drains the queue and
+// actually drives the workflow to `Completed`, closing the §4.5 gap that was
+// still open after #332 landed.
+//
+// The two tests intentionally stand up separate `AppState`s — the producer
+// test pins a pre-consumer snapshot of the queue (Start still Pending when
+// step 5 runs), while this test spawns the consumer so the Start row is
+// drained end-to-end.
+
+/// A hand-built echo `Action` that the engine can dispatch. Mirrors the
+/// workflow definition saved below (`action_key = "echo"`).
+struct KnifeEcho {
+    meta: nebula_action::metadata::ActionMetadata,
+}
+
+impl nebula_action::dependency::ActionDependencies for KnifeEcho {}
+impl nebula_action::action::Action for KnifeEcho {
+    fn metadata(&self) -> &nebula_action::metadata::ActionMetadata {
+        &self.meta
+    }
+}
+impl nebula_action::stateless::StatelessAction for KnifeEcho {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _ctx: &impl nebula_action::context::Context,
+    ) -> Result<nebula_action::result::ActionResult<Self::Output>, nebula_action::ActionError> {
+        Ok(nebula_action::result::ActionResult::success(input))
+    }
+}
+
+/// Canon §13 step 3 end-to-end (ADR-0008 A2).
+///
+/// Wires API producer + `ControlConsumer` + `EngineControlDispatch` + engine
+/// over shared in-memory repos, POSTs `/workflows/:id/executions`, and polls
+/// the repo until the execution transitions all the way to `Completed`. This
+/// exercises the full §12.2 loop that ADR-0008 promised:
+///
+/// ```text
+/// POST /executions
+///   → execution_repo.create (Created)
+///   → execution_control_queue.enqueue(Start)
+///   → ControlConsumer.claim_pending
+///   → EngineControlDispatch::dispatch_start
+///   → WorkflowEngine::resume_execution (ADR-0015 lease scope)
+///   → node run → transition to Completed
+///   → mark_completed on the queue row
+/// ```
+#[tokio::test]
+async fn knife_step3_engine_dispatches_start_end_to_end() {
+    use std::time::Duration;
+
+    use nebula_core::action_key;
+    use nebula_engine::{ControlConsumer, EngineControlDispatch, WorkflowEngine};
+    use nebula_execution::ExecutionStatus;
+    use nebula_runtime::{
+        ActionExecutor, ActionRuntime, DataPassingPolicy, InProcessSandbox,
+        registry::ActionRegistry,
+    };
+    use nebula_workflow::{
+        Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    let (state, _control_queue) = create_state_with_queue().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // ── Persist a valid workflow (`action_key = "echo"`) directly ────────────
+    //
+    // Avoids the HTTP activation round-trip — that path is exercised by the
+    // producer-side knife test above. Here we care about the engine-side
+    // dispatch of the Start command that the API will enqueue below.
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = chrono::Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "knife-a2-dispatch".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![NodeDefinition::new(nebula_core::node_key!("step"), "Step", "echo").unwrap()],
+        connections: Vec::<Connection>::new(),
+        variables: std::collections::HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger: None,
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: 1,
+    };
+    state
+        .workflow_repo
+        .save(workflow_id, 0, serde_json::to_value(&wf).unwrap())
+        .await
+        .unwrap();
+
+    // ── Build the engine bound to the same repos the API wrote to ────────────
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(KnifeEcho {
+        meta: nebula_action::metadata::ActionMetadata::new(
+            action_key!("echo"),
+            "echo",
+            "knife echo handler",
+        ),
+    });
+
+    let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+        Box::pin(async move { Ok(nebula_action::result::ActionResult::success(input)) })
+    });
+    let sandbox = Arc::new(InProcessSandbox::new(executor));
+    let metrics = nebula_telemetry::metrics::MetricsRegistry::new();
+    let runtime = Arc::new(ActionRuntime::new(
+        registry,
+        sandbox,
+        DataPassingPolicy::default(),
+        metrics.clone(),
+    ));
+
+    let engine = Arc::new(
+        WorkflowEngine::new(runtime, metrics)
+            .with_execution_repo(Arc::clone(&state.execution_repo))
+            .with_workflow_repo(Arc::clone(&state.workflow_repo)),
+    );
+
+    // ── Spawn the consumer so `Start` rows are drained continuously ──────────
+    let dispatch = Arc::new(EngineControlDispatch::new(
+        engine,
+        Arc::clone(&state.execution_repo),
+    ));
+    let consumer = ControlConsumer::new(
+        Arc::clone(&state.control_queue_repo),
+        dispatch,
+        b"knife-a2".to_vec(),
+    )
+    .with_poll_interval(Duration::from_millis(10));
+    let shutdown = CancellationToken::new();
+    let consumer_handle = consumer.spawn(shutdown.clone());
+
+    // ── POST /executions — the A1 producer path ──────────────────────────────
+    let start_request = serde_json::json!({
+        "input": { "knife_e2e": "a2" }
+    });
+    let app = app::build_app(state.clone(), &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/workflows/{workflow_id}/executions"))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(serde_json::to_string(&start_request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::ACCEPTED,
+        "step 3 end-to-end: start execution must return 202"
+    );
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let execution_response: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    let execution_id_str = execution_response["id"]
+        .as_str()
+        .expect("execution response must carry an id")
+        .to_string();
+    let execution_id = nebula_core::ExecutionId::parse(&execution_id_str).unwrap();
+
+    // ── Wait for the consumer + engine to drive the execution to Completed ───
+    //
+    // Poll the repo because the consumer loop is cross-task; a small timeout
+    // tolerates scheduler jitter on slow test hosts. A fail here means the
+    // §4.5 gap #332 was only half-closed — producer works, consumer does not.
+    let final_status = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let (_version, json) = state
+                .execution_repo
+                .get_state(execution_id)
+                .await
+                .unwrap()
+                .expect("execution row is present");
+            let status: ExecutionStatus =
+                serde_json::from_value(json.get("status").cloned().unwrap()).unwrap();
+            if status.is_terminal() {
+                return status;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("engine drove execution to terminal within 5s (A2 consumer + engine wired)");
+
+    assert_eq!(
+        final_status,
+        ExecutionStatus::Completed,
+        "step 3 end-to-end: the A2 engine dispatch must transition the execution to \
+         Completed — the §4.5 gap named in #332 is now closed on both halves"
+    );
+
+    // Graceful shutdown so the spawned task doesn't leak across tests.
+    shutdown.cancel();
+    let _ = consumer_handle.await;
+}

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -19,9 +19,10 @@ builds an `ExecutionPlan` from the workflow DAG, resolves node inputs from prede
 transitions execution state through `ExecutionRepo` (CAS on `version`), and delegates action
 dispatch to `nebula-runtime`. Canon §12.2 names this crate as the location of the
 `execution_control_queue` consumer (`ControlConsumer`). The consumer skeleton — polling,
-claim/ack, graceful shutdown — ships today; the `Resume` / `Restart` dispatch (A2, closes #332 /
-#327) and the `Cancel` / `Terminate` dispatch (A3, closes #330) are planned follow-ups on the
-ADR-0008 chip stack. A demo handler that logs and discards commands does not satisfy the canon.
+claim/ack, graceful shutdown — ships today; the engine-side `Start` / `Resume` / `Restart`
+dispatch lives in `EngineControlDispatch` (A2, closes #332 / #327); the `Cancel` / `Terminate`
+dispatch (A3, closes #330) is the remaining planned follow-up on the ADR-0008 chip stack. A
+demo handler that logs and discards commands does not satisfy the canon.
 
 ## Role
 
@@ -34,11 +35,15 @@ bounded concurrency.
 
 - `WorkflowEngine` — entry point: executes workflows level-by-level with bounded concurrency.
 - `ControlConsumer` — durable control-queue consumer drained via `ControlQueueRepo`
-  (canon §12.2, ADR-0008). Skeleton today; `Resume` / `Restart` and `Cancel` / `Terminate`
-  dispatch land with A2 / A3.
+  (canon §12.2, ADR-0008). `Start` / `Resume` / `Restart` wired via
+  `EngineControlDispatch` (A2); `Cancel` / `Terminate` dispatch lands with A3.
 - `ControlDispatch` — engine-owned trait implementors provide to deliver typed commands
   (`ExecutionId` + command kind) to the engine's start / cancel paths. Must be idempotent
   per `(execution_id, command)` pair (ADR-0008 §5).
+- `EngineControlDispatch` — the canonical engine-owned `ControlDispatch` impl. Reads
+  the current `ExecutionStatus` for the ADR-0008 §5 idempotency guard, then delegates
+  `Start` / `Resume` / `Restart` to `WorkflowEngine::resume_execution` under the
+  ADR-0015 lease scope.
 - `ControlDispatchError` — typed error returned from `ControlDispatch` methods; recorded on
   the control-queue row via `mark_failed` (no auto-retry — ADR-0008 §5).
 - `ExecutionResult` — post-run summary returned to the API layer.
@@ -62,11 +67,11 @@ Re-exports from `nebula-plugin`: `Plugin`, `PluginKey`, `PluginMetadata`, `Plugi
 - **[L2-§12.2]** The engine owns the `execution_control_queue` consumer
   (`ControlConsumer`; wiring decisions in ADR-0008). Cancel signals are written to the outbox in
   the same logical operation as the state transition and the engine's `ControlConsumer` drains
-  the queue. Today the skeleton observes and acks each command; the engine-facing `Cancel` /
-  `Terminate` path (chip A3) and `Resume` / `Restart` path (chip A2) land on top of the
-  skeleton. A handler that only logs and discards control-queue rows violates this invariant —
-  the skeleton's `planned` markers bound the transition to the immediate follow-up PRs, after
-  which the invariant is honoured end-to-end.
+  the queue. The `Start` / `Resume` / `Restart` path is now wired end-to-end via
+  `EngineControlDispatch` (chip A2); the `Cancel` / `Terminate` path (chip A3) remains planned
+  and ships on top of the same trait. A handler that only logs and discards control-queue rows
+  violates this invariant — the `planned` marker on A3 bounds the transition to the immediate
+  follow-up PR, after which the invariant is honoured end-to-end for every command kind.
 
 - **[L2-§10]** The golden-path knife scenario (canon §13) — define, activate, start, observe,
   cancel — exercises this crate's integration with `ExecutionRepo` end-to-end. Integration

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -9,21 +9,19 @@
 //!
 //! ## Status
 //!
-//! This module is the **A1 skeleton**:
-//!
 //! - construction, spawning, graceful shutdown, polling, claim/ack plumbing — **implemented**
 //!   (§11.6);
-//! - dispatch of `Resume` / `Restart` to the engine start path — **planned**, lands with A2 (closes
-//!   #332, #327);
+//! - dispatch of `Start` / `Resume` / `Restart` to the engine start/resume path — **implemented**
+//!   (A2, closes #332 / #327). The engine-owned implementation lives in
+//!   [`crate::control_dispatch::EngineControlDispatch`];
 //! - dispatch of `Cancel` / `Terminate` to the engine cancel path — **planned**, lands with A3
 //!   (closes #330).
 //!
-//! Until A2 / A3 land, the consumer logs each observed command at `info`
-//! level with a `TODO(A2)` / `TODO(A3)` marker and acks the row via
-//! `mark_completed`. This is an explicit, time-bounded transition — not a
-//! §12.2 "log and discard" antipattern, because the module's docs and the
-//! crate-level `//!` use §11.6 `planned` vocabulary and the chip schedule
-//! bounds the transition to the immediate follow-up PRs.
+//! Until A3 lands, the default [`EngineControlDispatch`] body for
+//! `Cancel` / `Terminate` returns a typed [`ControlDispatchError::Rejected`]
+//! so the consumer marks the row `Failed` rather than silently acking it.
+//!
+//! [`EngineControlDispatch`]: crate::control_dispatch::EngineControlDispatch
 
 use std::{sync::Arc, time::Duration};
 
@@ -95,24 +93,18 @@ pub trait ControlDispatch: Send + Sync {
     /// §13 step 3, #332).
     ///
     /// Enqueued by the API `start_execution` / `execute_workflow` handlers
-    /// once the `ExecutionState::Created` row has been persisted. The A1
-    /// skeleton provides a default implementation that returns `Ok(())` so
-    /// downstream consumers compile without change; A2 overrides it with the
-    /// engine's start-path dispatch so a POST to `/executions` actually causes
-    /// node execution.
+    /// once the `ExecutionState::Created` row has been persisted. A2 wired
+    /// the canonical engine-side body in
+    /// [`crate::control_dispatch::EngineControlDispatch`] — no default
+    /// implementation is provided, so every `ControlDispatch` implementor
+    /// must supply a real dispatch (the ADR-0008 A2 merge-checklist
+    /// requirement).
     ///
     /// **Idempotency (critical):** double-start re-runs the workflow twice.
-    /// Implementations must guard with CAS on `ExecutionRepo::transition` —
+    /// Implementations must guard via CAS on `ExecutionRepo::transition` —
     /// a `Start` arriving for an already-running or already-terminal
     /// execution must be `Ok(())`, not a second run. See ADR-0008 §5.
-    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
-        // Default no-op so the A1 skeleton stays green while A2 wires the
-        // engine-owned implementation. Removing the default — and thus
-        // forcing every `ControlDispatch` implementor to supply a real
-        // dispatch — is tracked as part of A2's merge checklist.
-        let _ = execution_id;
-        Ok(())
-    }
+    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Cancel` command to a running execution.
     ///
@@ -141,19 +133,24 @@ pub trait ControlDispatch: Send + Sync {
 
     /// Deliver a `Resume` command to a suspended execution.
     ///
-    /// A2 wires this into the engine's start / resume path. A1 stub
-    /// returns `Ok(())`.
+    /// A2 wired the canonical body in
+    /// [`crate::control_dispatch::EngineControlDispatch`].
     ///
     /// **Idempotency (critical):** double-resume starts the workflow twice.
-    /// A2's implementation must guard with CAS on `ExecutionRepo::transition`
-    /// — a `Resume` arriving for an already-running or already-terminal
+    /// Implementations must guard via CAS on `ExecutionRepo::transition` —
+    /// a `Resume` arriving for an already-running or already-terminal
     /// execution must be `Ok(())`, not a second start. See ADR-0008 §5.
     async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Restart` command to an execution.
     ///
-    /// A2 wires this into the engine's restart-from-input path. A1 stub
-    /// returns `Ok(())`.
+    /// A2 wired the canonical body in
+    /// [`crate::control_dispatch::EngineControlDispatch`]. Full
+    /// rewind-from-input semantics require durable output purge and a
+    /// monotonic restart counter — both are tracked as follow-ups under
+    /// ADR-0008; the A2 body honors idempotency for non-terminal states
+    /// and surfaces a typed [`ControlDispatchError::Rejected`] for
+    /// already-terminal executions until the rewind path is wired.
     ///
     /// **Idempotency:** same `Resume` contract applies — double-restart
     /// rewinds twice. Guard with a monotonic restart counter or CAS.
@@ -300,10 +297,7 @@ impl ControlConsumer {
 
         let dispatch_result = match entry.command {
             ControlCommand::Start => {
-                tracing::info!(
-                    %execution_id,
-                    "control-queue: observed Start (TODO(A2): wire to engine start path, #332)"
-                );
+                tracing::debug!(%execution_id, "control-queue: dispatching Start (A2)");
                 self.dispatch.dispatch_start(execution_id).await
             },
             ControlCommand::Cancel => {
@@ -321,17 +315,11 @@ impl ControlConsumer {
                 self.dispatch.dispatch_terminate(execution_id).await
             },
             ControlCommand::Resume => {
-                tracing::info!(
-                    %execution_id,
-                    "control-queue: observed Resume (TODO(A2): wire to engine resume path)"
-                );
+                tracing::debug!(%execution_id, "control-queue: dispatching Resume (A2)");
                 self.dispatch.dispatch_resume(execution_id).await
             },
             ControlCommand::Restart => {
-                tracing::info!(
-                    %execution_id,
-                    "control-queue: observed Restart (TODO(A2): wire to engine restart path)"
-                );
+                tracing::debug!(%execution_id, "control-queue: dispatching Restart (A2)");
                 self.dispatch.dispatch_restart(execution_id).await
             },
         };

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -1,0 +1,250 @@
+//! Engine-owned [`ControlDispatch`] implementation — ADR-0008 follow-up A2.
+//!
+//! The [`ControlConsumer`] (skeleton landed in A1) drains
+//! `execution_control_queue` rows and hands each typed command to an
+//! implementation of [`ControlDispatch`]. [`EngineControlDispatch`] wires the
+//! `Start` / `Resume` / `Restart` paths into the engine so that a POST to
+//! `/executions` actually causes node execution — closing the §4.5 gap named
+//! in #332.
+//!
+//! A3 (Cancel / Terminate) lands in a follow-up PR; in this module those two
+//! methods return a typed [`ControlDispatchError::Rejected`] so the consumer
+//! marks the row `Failed` rather than silently acknowledging it.
+//!
+//! ## Idempotency contract (ADR-0008 §5)
+//!
+//! Control-queue delivery is at-least-once: the ack path on `mark_completed`
+//! may fail after a successful dispatch, and the reclaim path (B1) will
+//! redeliver. Every dispatch method in this impl therefore guards against
+//! re-delivery:
+//!
+//! - a command arriving for an already-terminal execution is `Ok(())`;
+//! - a command arriving for an `Running` / `Cancelling` execution is `Ok(())` (a sibling runner
+//!   already owns the dispatch);
+//! - a race where a second dispatcher wins the lease between our read and the engine's own lease
+//!   acquire surfaces as [`EngineError::Leased`], which this impl maps to `Ok(())` so the same
+//!   execution is not fenced as a consumer failure.
+//!
+//! The authoritative single-runner fence still lives inside
+//! [`WorkflowEngine::resume_execution`] (ADR-0015 lease lifecycle); this
+//! module just forwards commands and collapses the resulting errors into the
+//! [`ControlDispatch`] contract.
+//!
+//! [`ControlConsumer`]: crate::ControlConsumer
+//! [`ControlDispatch`]: crate::ControlDispatch
+//! [`WorkflowEngine::resume_execution`]: crate::WorkflowEngine::resume_execution
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nebula_core::id::ExecutionId;
+use nebula_execution::ExecutionStatus;
+use nebula_storage::ExecutionRepo;
+
+use crate::{
+    WorkflowEngine,
+    control_consumer::{ControlDispatch, ControlDispatchError},
+    error::EngineError,
+};
+
+/// Engine-owned [`ControlDispatch`] implementation.
+///
+/// Holds a shared [`WorkflowEngine`] plus a handle to the execution repo so
+/// the dispatch methods can read the current status for the idempotency
+/// check without entering the engine's lease scope on a re-delivered
+/// command. Construction mirrors how a composition root wires the API and
+/// engine together — they share the same `ExecutionRepo` so status reads
+/// from either side agree.
+///
+/// See the module docs for the idempotency contract and ADR-0008 §5 for the
+/// canon rules this impl honors.
+#[derive(Clone)]
+pub struct EngineControlDispatch {
+    engine: Arc<WorkflowEngine>,
+    execution_repo: Arc<dyn ExecutionRepo>,
+}
+
+impl EngineControlDispatch {
+    /// Build a new dispatch bound to the given engine and execution repo.
+    ///
+    /// The caller MUST pass the same `execution_repo` the engine was
+    /// configured with via [`WorkflowEngine::with_execution_repo`]; otherwise
+    /// the idempotency read and the engine's internal CAS see divergent
+    /// state.
+    ///
+    /// [`WorkflowEngine::with_execution_repo`]: crate::WorkflowEngine::with_execution_repo
+    #[must_use]
+    pub fn new(engine: Arc<WorkflowEngine>, execution_repo: Arc<dyn ExecutionRepo>) -> Self {
+        Self {
+            engine,
+            execution_repo,
+        }
+    }
+
+    /// Read the persisted [`ExecutionStatus`] for an execution, returning
+    /// `None` if the row does not exist.
+    async fn read_status(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<Option<ExecutionStatus>, ControlDispatchError> {
+        let state = self
+            .execution_repo
+            .get_state(execution_id)
+            .await
+            .map_err(|e| {
+                ControlDispatchError::Internal(format!(
+                    "read execution state for idempotency guard: {e}"
+                ))
+            })?;
+        match state {
+            None => Ok(None),
+            Some((_version, json)) => match json.get("status") {
+                Some(s) => serde_json::from_value::<ExecutionStatus>(s.clone())
+                    .map(Some)
+                    .map_err(|e| {
+                        ControlDispatchError::Internal(format!(
+                            "execution {execution_id}: status field did not deserialize: {e}"
+                        ))
+                    }),
+                None => Err(ControlDispatchError::Internal(format!(
+                    "execution {execution_id}: persisted state has no `status` field"
+                ))),
+            },
+        }
+    }
+
+    /// Drive an execution that is `Created` or `Paused` through the engine's
+    /// resume path. Shared by `dispatch_start`, `dispatch_resume`, and
+    /// `dispatch_restart` — the three commands converge on the same engine
+    /// entry today because the engine does not yet distinguish a
+    /// `restart-from-input` rewind from a normal resume (true rewind
+    /// requires durable output purge — tracked separately).
+    async fn drive(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+        match self.engine.resume_execution(execution_id).await {
+            Ok(_) => Ok(()),
+            // Concurrent dispatcher already holds the lease — the canonical
+            // ADR-0008 §5 idempotency outcome. Returning `Ok(())` here prevents
+            // the consumer from marking the row `Failed`; the lease holder
+            // owns the terminal transition.
+            Err(EngineError::Leased { .. }) => Ok(()),
+            Err(e) => {
+                // Last-ditch idempotency guard: re-read the row in case a
+                // sibling dispatcher drove it to a terminal state between our
+                // initial read and the engine's own `get_state` inside
+                // `resume_execution`. This catches both the "already terminal"
+                // `PlanningFailed` that `resume_execution` surfaces on re-entry
+                // and the race where a parallel `Cancel` beat us to the row.
+                if let Ok(Some(status)) = self.read_status(execution_id).await
+                    && (status.is_terminal() || matches!(status, ExecutionStatus::Cancelling))
+                {
+                    return Ok(());
+                }
+                Err(ControlDispatchError::Internal(format!(
+                    "engine dispatch failed for {execution_id}: {e}"
+                )))
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl ControlDispatch for EngineControlDispatch {
+    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+        match self.read_status(execution_id).await? {
+            None => Err(ControlDispatchError::Rejected(format!(
+                "execution {execution_id} not found — start command orphaned"
+            ))),
+            // Already past the Created gate: either the engine is driving it
+            // (Running / Cancelling) or it has already reached a terminal
+            // outcome. Re-delivered Start is a no-op per ADR-0008 §5.
+            Some(
+                ExecutionStatus::Running
+                | ExecutionStatus::Cancelling
+                | ExecutionStatus::Completed
+                | ExecutionStatus::Failed
+                | ExecutionStatus::Cancelled
+                | ExecutionStatus::TimedOut,
+            ) => Ok(()),
+            Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
+                self.drive(execution_id).await
+            },
+        }
+    }
+
+    async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+        // `Resume` and `Start` converge on the same engine entry today — see
+        // the `drive` docs. The idempotency read mirrors `dispatch_start`.
+        match self.read_status(execution_id).await? {
+            None => Err(ControlDispatchError::Rejected(format!(
+                "execution {execution_id} not found — resume command orphaned"
+            ))),
+            Some(
+                ExecutionStatus::Running
+                | ExecutionStatus::Cancelling
+                | ExecutionStatus::Completed
+                | ExecutionStatus::Failed
+                | ExecutionStatus::Cancelled
+                | ExecutionStatus::TimedOut,
+            ) => Ok(()),
+            Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
+                self.drive(execution_id).await
+            },
+        }
+    }
+
+    async fn dispatch_restart(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
+        // Per ADR-0008 §5 restart docs: "double-restart rewinds twice". A true
+        // rewind-from-input restart requires durable output purge plus a
+        // restart counter — neither exists yet. For A2, treat restart as a
+        // re-entrant drive of the engine's resume path and honor the same
+        // terminal / running idempotency outcomes.
+        //
+        // Restart-of-terminal intentionally errors so operators see the gap
+        // in the `execution_control_queue.error_message` rather than the
+        // command silently succeeding and not actually restarting anything.
+        match self.read_status(execution_id).await? {
+            None => Err(ControlDispatchError::Rejected(format!(
+                "execution {execution_id} not found — restart command orphaned"
+            ))),
+            Some(ExecutionStatus::Running | ExecutionStatus::Cancelling) => Ok(()),
+            Some(
+                status @ (ExecutionStatus::Completed
+                | ExecutionStatus::Failed
+                | ExecutionStatus::Cancelled
+                | ExecutionStatus::TimedOut),
+            ) => Err(ControlDispatchError::Rejected(format!(
+                "execution {execution_id} is already {status}; rewind-from-input restart \
+                 requires durable output purge — not yet implemented, tracked under ADR-0008 \
+                 follow-up"
+            ))),
+            Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
+                self.drive(execution_id).await
+            },
+        }
+    }
+
+    async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+        // Cancel is owned by ADR-0008 follow-up A3 (#330). Surface a typed
+        // reject so the consumer records the diagnosis on the row instead of
+        // silently acking it — any `Cancel` signal delivered before A3 lands
+        // is an engine-visible capability gap, not a benign no-op.
+        let _ = execution_id;
+        Err(ControlDispatchError::Rejected(
+            "Cancel dispatch lands with ADR-0008 follow-up A3 (#330) — not yet wired".to_string(),
+        ))
+    }
+
+    async fn dispatch_terminate(
+        &self,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
+        // Same rationale as `dispatch_cancel` — owned by A3.
+        let _ = execution_id;
+        Err(ControlDispatchError::Rejected(
+            "Terminate dispatch lands with ADR-0008 follow-up A3 — not yet wired".to_string(),
+        ))
+    }
+}

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1151,6 +1151,22 @@ impl WorkflowEngine {
         //    the forward state machine via `override_node_state` but still bumps the version per
         //    transition so CAS readers see the change (issue #255).
         let mut exec_state = exec_state;
+        // Cold-start seam (ADR-0008 A2, §5): the API's start handler persists an
+        // `ExecutionState::new(id, workflow_id, &[])` row — no per-node entries,
+        // because the handler does not load the workflow on the hot path. The
+        // first `ControlCommand::Start` that drains via `EngineControlDispatch`
+        // lands here; seed `node_states` from the workflow definition so the
+        // frontier seeder below treats graph entry nodes as the natural starting
+        // set. A warm resume (post-crash, with persisted per-node state) skips
+        // this branch untouched.
+        if exec_state.node_states.is_empty() {
+            for node in &workflow.nodes {
+                exec_state.set_node_state(
+                    node.id.clone(),
+                    nebula_execution::state::NodeExecutionState::new(),
+                );
+            }
+        }
         let non_terminal: Vec<NodeKey> = exec_state
             .node_states
             .iter()

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -14,8 +14,9 @@
 //! - **implemented** — consumer skeleton: construction, polling loop with graceful shutdown,
 //!   `claim_pending` / `mark_completed` / `mark_failed` plumbing, command observation with typed
 //!   `ExecutionId` decoding.
-//! - **planned** — `Resume` / `Restart` dispatch into the engine start path (ADR-0008 follow-up
-//!   A2).
+//! - **implemented** — `Start` / `Resume` / `Restart` dispatch into the engine start / resume path
+//!   (ADR-0008 follow-up A2; closes #332 / #327). The engine-owned implementation lives in
+//!   [`control_dispatch::EngineControlDispatch`].
 //! - **planned** — `Cancel` / `Terminate` dispatch into the engine cancel path (ADR-0008 follow-up
 //!   A3).
 //!
@@ -25,6 +26,7 @@
 //!
 //! - `WorkflowEngine` — entry point; level-by-level DAG execution with bounded concurrency.
 //! - `ControlConsumer` / `ControlDispatch` — durable control-queue consumer (§12.2, ADR-0008).
+//! - `EngineControlDispatch` — canonical engine-side `ControlDispatch` impl (ADR-0008 A2).
 //! - `ExecutionResult` — post-run summary returned to the API layer.
 //! - `EngineError` — typed engine-layer error.
 //! - `ExecutionEvent` — broadcast event type for `nebula-eventbus`.
@@ -41,6 +43,7 @@
 //! fail-open credential allowlist, edge-gate narrowness).
 
 pub mod control_consumer;
+pub mod control_dispatch;
 pub mod credential_accessor;
 pub mod engine;
 pub mod error;
@@ -55,6 +58,7 @@ pub use control_consumer::{
     ControlConsumer, ControlDispatch, ControlDispatchError, DEFAULT_BATCH_SIZE,
     DEFAULT_POLL_INTERVAL, MAX_CLAIM_ERROR_BACKOFF,
 };
+pub use control_dispatch::EngineControlDispatch;
 pub use credential_accessor::EngineCredentialAccessor;
 pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, WorkflowEngine};
 pub use error::EngineError;

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -51,6 +51,11 @@ impl RecordingDispatch {
 
 #[async_trait]
 impl ControlDispatch for RecordingDispatch {
+    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+        self.record(ControlCommand::Start, execution_id);
+        Ok(())
+    }
+
     async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Cancel, execution_id);
         Ok(())
@@ -145,11 +150,15 @@ async fn consumer_observes_each_command_variant_via_dispatch_trait() {
     let recorder = RecordingDispatch::new();
     let dispatch: Arc<dyn ControlDispatch> = recorder.clone();
 
+    let exec_start = ExecutionId::new();
     let exec_cancel = ExecutionId::new();
     let exec_terminate = ExecutionId::new();
     let exec_resume = ExecutionId::new();
     let exec_restart = ExecutionId::new();
 
+    repo.enqueue(&queue_entry(&exec_start, ControlCommand::Start, 0))
+        .await
+        .unwrap();
     repo.enqueue(&queue_entry(&exec_cancel, ControlCommand::Cancel, 1))
         .await
         .unwrap();
@@ -169,27 +178,28 @@ async fn consumer_observes_each_command_variant_via_dispatch_trait() {
     let shutdown = CancellationToken::new();
     let handle = consumer.spawn(shutdown.clone());
 
-    // Wait for the consumer to observe all four rows.
+    // Wait for the consumer to observe all five rows.
     tokio::time::timeout(Duration::from_secs(2), async {
         loop {
-            if recorder.snapshot().len() >= 4 {
+            if recorder.snapshot().len() >= 5 {
                 break;
             }
             recorder.notify.notified().await;
         }
     })
     .await
-    .expect("all four commands observed within 2s");
+    .expect("all five commands observed within 2s");
 
     shutdown.cancel();
     handle.await.expect("graceful shutdown");
 
     let mut seen = recorder.snapshot();
     seen.sort_by_key(|(cmd, _)| cmd.as_str());
-    assert_eq!(seen.len(), 4, "all commands observed exactly once");
+    assert_eq!(seen.len(), 5, "all commands observed exactly once");
 
     let has =
         |cmd: ControlCommand, id: ExecutionId| seen.iter().any(|(c, i)| *c == cmd && *i == id);
+    assert!(has(ControlCommand::Start, exec_start), "Start observed");
     assert!(has(ControlCommand::Cancel, exec_cancel), "Cancel observed");
     assert!(
         has(ControlCommand::Terminate, exec_terminate),

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -1,0 +1,391 @@
+//! Unit tests for `EngineControlDispatch` (ADR-0008 A2).
+//!
+//! These tests mirror the API → consumer → engine seam without running the
+//! full `ControlConsumer` polling loop: they invoke `dispatch_start` /
+//! `dispatch_resume` / `dispatch_restart` directly against an engine wired
+//! to in-memory repos, and assert both the happy-path transition (Created →
+//! Completed) and the ADR-0008 §5 idempotency contract (re-delivery does
+//! not re-run the workflow).
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+
+use nebula_action::{
+    ActionError, action::Action, context::Context, dependency::ActionDependencies,
+    metadata::ActionMetadata, result::ActionResult, stateless::StatelessAction,
+};
+use nebula_core::{ActionKey, action_key, id::ExecutionId, node_key};
+use nebula_engine::{ControlDispatch, ControlDispatchError, EngineControlDispatch, WorkflowEngine};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_runtime::{
+    ActionExecutor, ActionRuntime, DataPassingPolicy, InProcessSandbox, registry::ActionRegistry,
+};
+use nebula_storage::{ExecutionRepo, InMemoryExecutionRepo, InMemoryWorkflowRepo, WorkflowRepo};
+use nebula_telemetry::metrics::MetricsRegistry;
+use nebula_workflow::{Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition};
+
+// ── Test handler ──────────────────────────────────────────────────────────
+
+/// Echo handler that counts invocations so idempotency tests can assert no
+/// second dispatch happened.
+#[derive(Clone)]
+struct CountingEchoHandler {
+    meta: ActionMetadata,
+    count: Arc<AtomicU32>,
+}
+
+impl ActionDependencies for CountingEchoHandler {}
+impl Action for CountingEchoHandler {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+}
+
+impl StatelessAction for CountingEchoHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _ctx: &impl Context,
+    ) -> Result<ActionResult<Self::Output>, ActionError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+fn meta(key: ActionKey) -> ActionMetadata {
+    let name = key.to_string();
+    ActionMetadata::new(key, name, "control_dispatch test handler")
+}
+
+// ── Harness ───────────────────────────────────────────────────────────────
+
+struct Harness {
+    dispatch: EngineControlDispatch,
+    execution_repo: Arc<InMemoryExecutionRepo>,
+    workflow_repo: Arc<InMemoryWorkflowRepo>,
+    action_count: Arc<AtomicU32>,
+}
+
+impl Harness {
+    async fn new() -> Self {
+        let action_count = Arc::new(AtomicU32::new(0));
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(CountingEchoHandler {
+            meta: meta(action_key!("echo")),
+            count: Arc::clone(&action_count),
+        });
+
+        let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+            Box::pin(async move { Ok(ActionResult::success(input)) })
+        });
+        let sandbox = Arc::new(InProcessSandbox::new(executor));
+        let metrics = MetricsRegistry::new();
+        let runtime = Arc::new(ActionRuntime::new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        ));
+
+        let execution_repo = Arc::new(InMemoryExecutionRepo::new());
+        let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
+
+        let execution_repo_dyn: Arc<dyn ExecutionRepo> = Arc::clone(&execution_repo) as _;
+        let workflow_repo_dyn: Arc<dyn WorkflowRepo> = Arc::clone(&workflow_repo) as _;
+
+        let engine = WorkflowEngine::new(runtime, metrics)
+            .with_execution_repo(Arc::clone(&execution_repo_dyn))
+            .with_workflow_repo(workflow_repo_dyn);
+        let engine = Arc::new(engine);
+
+        let dispatch = EngineControlDispatch::new(engine, execution_repo_dyn);
+
+        Self {
+            dispatch,
+            execution_repo,
+            workflow_repo,
+            action_count,
+        }
+    }
+
+    /// Persist a single-node echo workflow and return its id.
+    async fn persist_echo_workflow(&self) -> nebula_core::WorkflowId {
+        let workflow_id = nebula_core::WorkflowId::new();
+        let now = chrono::Utc::now();
+        let wf = WorkflowDefinition {
+            id: workflow_id,
+            name: "a2-dispatch-test".into(),
+            description: None,
+            version: Version::new(0, 1, 0),
+            nodes: vec![NodeDefinition::new(node_key!("step"), "Step", "echo").unwrap()],
+            connections: Vec::<Connection>::new(),
+            variables: HashMap::new(),
+            config: WorkflowConfig::default(),
+            trigger: None,
+            tags: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            owner_id: None,
+            ui_metadata: None,
+            schema_version: 1,
+        };
+        self.workflow_repo
+            .save(workflow_id, 0, serde_json::to_value(&wf).unwrap())
+            .await
+            .unwrap();
+        workflow_id
+    }
+
+    /// Persist a pristine `Created` execution row, mirroring how the API
+    /// `start_execution` handler writes the row before enqueueing `Start`.
+    async fn persist_created_execution(
+        &self,
+        workflow_id: nebula_core::WorkflowId,
+        input: serde_json::Value,
+    ) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(input);
+        let state_json = serde_json::to_value(&exec_state).unwrap();
+        self.execution_repo
+            .create(execution_id, workflow_id, state_json)
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    async fn status(&self, id: ExecutionId) -> ExecutionStatus {
+        let (_, json) = self
+            .execution_repo
+            .get_state(id)
+            .await
+            .unwrap()
+            .expect("execution exists");
+        serde_json::from_value(json.get("status").cloned().unwrap()).unwrap()
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+/// Happy path: dispatch_start on a fresh `Created` execution row drives the
+/// engine to completion. This is the A2 §13-step-3 invariant — a POST to
+/// `/executions` ends with the workflow actually running, not stranded at
+/// `Created`.
+#[tokio::test]
+async fn dispatch_start_drives_created_execution_to_completion() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("hello"))
+        .await;
+
+    assert_eq!(harness.status(execution_id).await, ExecutionStatus::Created);
+
+    harness
+        .dispatch
+        .dispatch_start(execution_id)
+        .await
+        .expect("dispatch_start succeeds");
+
+    assert_eq!(
+        harness.status(execution_id).await,
+        ExecutionStatus::Completed,
+        "engine transitioned the execution all the way to Completed"
+    );
+    assert_eq!(
+        harness.action_count.load(Ordering::SeqCst),
+        1,
+        "echo action was dispatched exactly once"
+    );
+}
+
+/// ADR-0008 §5 idempotency: a re-delivered `Start` for an execution the
+/// engine already completed is a no-op — no second run of the workflow.
+/// This is the load-bearing guard against at-least-once redelivery
+/// double-running the work.
+#[tokio::test]
+async fn dispatch_start_is_idempotent_on_redelivery() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!(42))
+        .await;
+
+    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        harness.status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+
+    // Re-deliver Start. `EngineControlDispatch` must read the terminal
+    // status and short-circuit; the engine must not be entered a second time.
+    harness
+        .dispatch
+        .dispatch_start(execution_id)
+        .await
+        .expect("redelivered Start is idempotent");
+
+    assert_eq!(
+        harness.action_count.load(Ordering::SeqCst),
+        1,
+        "re-delivered Start must NOT run the workflow again (ADR-0008 §5)"
+    );
+}
+
+/// `Resume` converges on the same engine entry as `Start` today. Delivered
+/// against a pristine `Created` row (e.g. an operator-issued resume of a
+/// run that was never started), it must drive the execution to completion
+/// just like `Start`.
+#[tokio::test]
+async fn dispatch_resume_drives_created_execution_to_completion() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("resume"))
+        .await;
+
+    harness
+        .dispatch
+        .dispatch_resume(execution_id)
+        .await
+        .expect("dispatch_resume succeeds");
+
+    assert_eq!(
+        harness.status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
+}
+
+/// Redelivered `Resume` on an already-completed execution is a no-op per
+/// ADR-0008 §5 — symmetric with the `Start` idempotency guard.
+#[tokio::test]
+async fn dispatch_resume_is_idempotent_on_completed_execution() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("x"))
+        .await;
+
+    harness
+        .dispatch
+        .dispatch_resume(execution_id)
+        .await
+        .unwrap();
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
+
+    harness
+        .dispatch
+        .dispatch_resume(execution_id)
+        .await
+        .expect("second resume is idempotent");
+
+    assert_eq!(
+        harness.action_count.load(Ordering::SeqCst),
+        1,
+        "re-delivered Resume must NOT re-run the workflow"
+    );
+}
+
+/// `Restart` on a pristine `Created` execution behaves like `Start` — it
+/// drives the engine to completion. This is the non-terminal arm of the
+/// A2 restart path.
+#[tokio::test]
+async fn dispatch_restart_drives_created_execution_to_completion() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("restart"))
+        .await;
+
+    harness
+        .dispatch
+        .dispatch_restart(execution_id)
+        .await
+        .expect("dispatch_restart on a Created execution drives it to completion");
+
+    assert_eq!(
+        harness.status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
+}
+
+/// `Restart` on an already-terminal execution surfaces a typed reject
+/// rather than silently succeeding — full rewind-from-input requires
+/// durable output purge and a restart counter, neither of which exists in
+/// A2. This keeps the capability gap honest on the
+/// `execution_control_queue.error_message` column.
+#[tokio::test]
+async fn dispatch_restart_rejects_terminal_execution() {
+    let harness = Harness::new().await;
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("done"))
+        .await;
+
+    // Drive it to Completed first.
+    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    assert_eq!(
+        harness.status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
+
+    // A real restart-from-input would reset everything and re-run; A2 does not
+    // support that yet — the dispatch must reject so operators can see the gap.
+    let err = harness
+        .dispatch
+        .dispatch_restart(execution_id)
+        .await
+        .expect_err("restart of terminal execution rejects for A2");
+    match err {
+        ControlDispatchError::Rejected(msg) => {
+            assert!(
+                msg.contains("durable output purge") || msg.contains("ADR-0008 follow-up"),
+                "reject message must name the A2 gap, got: {msg}"
+            );
+        },
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+    assert_eq!(
+        harness.action_count.load(Ordering::SeqCst),
+        1,
+        "rejected restart must NOT re-run the workflow"
+    );
+}
+
+/// `Start` for an execution id that was never persisted (producer bug —
+/// queue row written without the execution row) surfaces a typed reject
+/// so operators see the diagnosis on the row instead of the consumer
+/// quietly acking a broken command.
+#[tokio::test]
+async fn dispatch_start_rejects_nonexistent_execution() {
+    let harness = Harness::new().await;
+    let orphan = ExecutionId::new();
+
+    let err = harness
+        .dispatch
+        .dispatch_start(orphan)
+        .await
+        .expect_err("missing execution rejects");
+    match err {
+        ControlDispatchError::Rejected(msg) => {
+            assert!(
+                msg.contains("not found") && msg.contains(&orphan.to_string()),
+                "reject message must identify the orphan, got: {msg}"
+            );
+        },
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+    assert_eq!(harness.action_count.load(Ordering::SeqCst), 0);
+}

--- a/crates/storage/src/repos/mod.rs
+++ b/crates/storage/src/repos/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! | Trait | Status | Notes |
 //! |---|---|---|
-//! | `ControlQueueRepo` + `InMemoryControlQueueRepo` | **implemented** | Produced by the API cancel handler; consumed by `nebula_engine::ControlConsumer` (skeleton — real dispatch lands with ADR-0008 follow-ups A2 / A3). Safe to depend on as a storage port. |
+//! | `ControlQueueRepo` + `InMemoryControlQueueRepo` | **implemented** | Produced by the API start / cancel handlers; consumed by `nebula_engine::ControlConsumer`. `Start` / `Resume` / `Restart` are dispatched via `nebula_engine::EngineControlDispatch` (ADR-0008 A2); `Cancel` / `Terminate` dispatch lands with A3. Safe to depend on as a storage port. |
 //! | `ExecutionRepo`, `WorkflowRepo`, `ExecutionNodeRepo`, `JournalRepo` | **planned** | Trait definitions only — zero in-memory / Postgres implementations exist in this crate. Engine and API cannot compile against these signatures today. |
 //! | `AuditRepo`, `BlobRepo`, `CredentialRepo`, `QuotaRepo`, `ResourceRepo`, `TriggerRepo`, `UserRepo`, `OrgRepo`, `WorkspaceRepo` | **planned** (some with partial Postgres glue) | Same caveat. |
 //!

--- a/deny.toml
+++ b/deny.toml
@@ -58,6 +58,11 @@ deny = [
   # ---- Layer enforcement: Exec ----
   { crate = "nebula-engine", wrappers = [
     "nebula-cli",
+    # Dev-only: `crates/api/tests/knife.rs` wires the API + Engine composition
+    # for the §13 knife integration test (ADR-0008 follow-up A2). A dedicated
+    # `apps/server` composition root is still tracked as a separate follow-up;
+    # until it exists this is the only place the two layers meet in-process.
+    "nebula-api",
   ], reason = "Engine is exec-layer orchestration; business/core crates must not depend on it" },
   { crate = "nebula-runtime", wrappers = [
     "nebula-engine",

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -19,10 +19,10 @@ Legend:
 | Crate | API stability | Test coverage | Doc completeness | Engine integration | SLI ready |
 |---|---|---|---|---|---|
 | nebula-action        | frontier | stable  | stable | partial (webhook sig covered; CheckpointPolicy planned; `ActionResult::Retry` gated behind `unstable-retry-scheduler`, #290) | n/a |
-| nebula-api           | frontier | stable  | stable | partial (knife steps 3+5: Start/Cancel producers stable, #332/#330; consumer skeleton in nebula-engine, real engine-side dispatch A2/A3 still planned — ADR-0008) | partial |
+| nebula-api           | frontier | stable  | stable | partial (knife steps 3+5: Start/Cancel producers stable, #332/#330; engine-side Start/Resume/Restart dispatch wired via EngineControlDispatch — ADR-0008 A2; Cancel/Terminate dispatch still planned — A3) | partial |
 | nebula-core          | frontier | stable  | stable | stable | n/a |
 | nebula-credential    | frontier | stable  | stable | partial (rotation in integration tests) | n/a |
-| nebula-engine        | partial  | stable  | stable | partial (ControlConsumer skeleton lands §12.2; dispatch A2/A3 planned — ADR-0008) | n/a |
+| nebula-engine        | partial  | stable  | stable | partial (ControlConsumer skeleton lands §12.2; Start/Resume/Restart dispatch via EngineControlDispatch — ADR-0008 A2; Cancel/Terminate dispatch planned — A3) | n/a |
 | nebula-error         | stable   | stable  | stable | n/a | n/a |
 | nebula-eventbus      | stable   | stable  | stable | n/a | n/a |
 | nebula-execution     | stable   | stable  | stable | stable | partial |


### PR DESCRIPTION
## Summary

- Closes the §4.5 capability gap named in #332 on the engine side. Before this PR, `POST /executions` persisted a `Created` row and enqueued `ControlCommand::Start` onto the durable control queue, but the engine-side `ControlConsumer` (A1, `9134fb45`) had a no-op default for `dispatch_start`, so the row stranded at `Created` forever. `Resume` / `Restart` were in the same state.
- Adds `EngineControlDispatch` ([`crates/engine/src/control_dispatch.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/engine/src/control_dispatch.rs)) — the canonical engine-owned `ControlDispatch` impl. Holds `Arc<WorkflowEngine>` + `Arc<dyn ExecutionRepo>`; reads the persisted `ExecutionStatus` for the ADR-0008 §5 idempotency guard; delegates `Start` / `Resume` / `Restart` to `WorkflowEngine::resume_execution` under the ADR-0015 lease scope. Concurrent-dispatcher races surface as `EngineError::Leased` and are mapped to `Ok(())` so the consumer does not mark the losing runner's row failed.
- Removes the default no-op body on `ControlDispatch::dispatch_start` (ADR-0008 A2 merge-checklist requirement) so every implementor must supply a real dispatch.
- Makes `resume_execution` handle the API's cold-start shape: when the loaded state has empty `node_states` (which is how `start_execution` persists the row — `ExecutionState::new(id, wf_id, &[])`), the engine now seeds them from the workflow definition so the frontier loop treats graph entry nodes as the natural seed set. Warm resume (post-crash, populated `node_states`) is untouched.
- `dispatch_cancel` / `dispatch_terminate` return a typed `ControlDispatchError::Rejected` pointing at ADR-0008 A3 — intentionally out of scope; trait shape unchanged.
- `dispatch_restart` of a terminal execution surfaces a typed reject rather than silently succeeding — true rewind-from-input requires durable output purge plus a monotonic restart counter, both tracked as ADR-0008 follow-ups. Non-terminal restart converges on the same engine entry as Start/Resume.

## Out of scope

- A3 (Cancel / Terminate dispatch) — trait shape is deliberately preserved so A3 lands cleanly on top.
- A dedicated `apps/server` composition root — tracked separately under ADR-0008 §4. `crates/api/examples/simple_server.rs` keeps its DEMO ONLY marker until that composition root exists.
- True restart-from-input rewind (output purge + restart counter).

## Docs aligned in same PR

- [`crates/engine/src/lib.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/engine/src/lib.rs) `//!`: A2 bullets flipped `planned → implemented`.
- [`docs/MATURITY.md`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/docs/MATURITY.md): `nebula-engine` and `nebula-api` rows updated; A3 still honestly tracked as `planned`.
- [`crates/engine/README.md`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/engine/README.md): `EngineControlDispatch` documented in Public API + §12.2 contract reflects A2 done / A3 remaining.
- [`crates/storage/src/repos/mod.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/storage/src/repos/mod.rs): `ControlQueueRepo` status line updated to reflect the wired consumer + dispatch.
- [`crates/api/examples/simple_server.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/api/examples/simple_server.rs): DEMO ONLY marker updated to reference A2's availability while keeping the composition-root deferral from ADR-0008 §4.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings.
- [x] `cargo nextest run --workspace` — **3348 tests passed, 13 skipped** (+23 vs baseline: 7 new `control_dispatch` unit tests, 1 new knife end-to-end, existing `control_consumer_wiring` extended for `Start`).
- [x] `cargo test --workspace --doc` — ok.
- [x] `cargo deny check` — ok after dropping the spurious `nebula-sandbox` dev-dep (`InProcessSandbox` is re-exported via `nebula-runtime`). `nebula-api` added to `nebula-engine` wrappers in `deny.toml` for the knife A2 integration test, per ADR-0008 §4 single-composition-root deferral.
- [x] Push-time lefthook gate (shear, check-all-features, check-no-default, doctests, docs, nextest) all green.

### New tests

- [`crates/engine/tests/control_dispatch.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/engine/tests/control_dispatch.rs) — 7 unit tests:
  - `dispatch_start_drives_created_execution_to_completion`
  - `dispatch_start_is_idempotent_on_redelivery` (ADR-0008 §5)
  - `dispatch_resume_drives_created_execution_to_completion`
  - `dispatch_resume_is_idempotent_on_completed_execution`
  - `dispatch_restart_drives_created_execution_to_completion`
  - `dispatch_restart_rejects_terminal_execution`
  - `dispatch_start_rejects_nonexistent_execution`
- [`crates/api/tests/knife.rs`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/crates/api/tests/knife.rs) — new `knife_step3_engine_dispatches_start_end_to_end`: wires the full API producer + `ControlConsumer` + `EngineControlDispatch` + engine chain against shared in-memory repos, POSTs `/executions`, and polls until the execution transitions to `Completed`. Existing `knife_scenario_end_to_end` keeps asserting the producer-side snapshot (Start still pending at step 5 pre-cancel).

## Related

- Closes #332 on the engine-side consumer half (#332's API-producer half landed in `df1c996a`).
- ADR-0008 follow-up A2 on [`docs/adr/0008-execution-control-queue-consumer.md`](https://github.com/vanyastaff/nebula/blob/claude/stoic-panini-6bdae5/docs/adr/0008-execution-control-queue-consumer.md).
- Builds on ADR-0015 lease scope (`3d7db131`); A3 (Cancel / Terminate dispatch) is the remaining chip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced end-to-end integration of execution control dispatch for Start, Resume, and Restart operations. The engine now properly handles execution state transitions, improving reliability of the workflow execution lifecycle.

* **Documentation**
  * Updated maturity status and implementation documentation to reflect completed engine integration work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->