### PR TITLE
fix(engine+storage): address PR #483 review feedback (ADR-0008 B1 follow-up)

### DIFF
--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -302,7 +302,16 @@ impl ControlConsumer {
         reclaim_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
         let _ = reclaim_ticker.tick().await;
 
+        // Deadline at which the next `claim_pending` is allowed to fire. Held
+        // in scope across the `tokio::select!` below so that a reclaim
+        // interruption does not reset the backoff / poll_interval clock —
+        // see the review finding for PR #483 and ADR-0008 §5.
+        let mut claim_deadline = tokio::time::Instant::now();
+
         loop {
+            let claim_sleep = tokio::time::sleep_until(claim_deadline);
+            tokio::pin!(claim_sleep);
+
             tokio::select! {
                 biased;
                 () = shutdown.cancelled() => {
@@ -314,8 +323,14 @@ impl ControlConsumer {
                 }
                 _ = reclaim_ticker.tick() => {
                     self.sweep_reclaim().await;
+                    // `claim_deadline` is preserved — reclaim does not
+                    // short-circuit the backoff or the idle poll delay.
                 }
-                () = self.tick(&mut consecutive_errors) => {}
+                () = &mut claim_sleep => {
+                    let next_delay = self.tick(&mut consecutive_errors).await;
+                    claim_deadline = tokio::time::Instant::now()
+                        + next_delay.unwrap_or(std::time::Duration::ZERO);
+                }
             }
         }
     }
@@ -355,7 +370,14 @@ impl ControlConsumer {
         }
     }
 
-    async fn tick(&self, consecutive_errors: &mut u32) {
+    /// Drain a single batch. Returns the duration the caller should wait
+    /// before the next claim attempt (backoff on error, poll interval on
+    /// empty queue) or `None` if a batch was just processed and the loop
+    /// should claim again immediately.
+    ///
+    /// The outer loop persists this delay as a deadline so that a reclaim
+    /// interruption does not cancel the backoff — see `run`.
+    async fn tick(&self, consecutive_errors: &mut u32) -> Option<Duration> {
         let claimed = match self
             .queue
             .claim_pending(&self.processor_id, self.batch_size)
@@ -374,19 +396,18 @@ impl ControlConsumer {
                     backoff_ms = backoff.as_millis() as u64,
                     "control-queue claim_pending failed; backing off"
                 );
-                tokio::time::sleep(backoff).await;
-                return;
+                return Some(backoff);
             },
         };
 
         if claimed.is_empty() {
-            tokio::time::sleep(self.poll_interval).await;
-            return;
+            return Some(self.poll_interval);
         }
 
         for entry in claimed {
             self.handle_entry(entry).await;
         }
+        None
     }
 
     async fn handle_entry(&self, entry: ControlQueueEntry) {

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -74,7 +74,13 @@ pub struct ControlQueueEntry {
     pub status: String,
     /// Node/instance that processed the command.
     pub processed_by: Option<Vec<u8>>,
-    /// When processing finished.
+    /// When this row was claimed for processing (stamped by `claim_pending`).
+    ///
+    /// Used by [`ControlQueueRepo::reclaim_stuck`] as the staleness signal
+    /// for crashed-runner recovery — rows whose `processed_at` is older
+    /// than the `reclaim_after` window are redelivered. Cleared on a
+    /// successful reclaim so the next `claim_pending` resets the clock.
+    /// See ADR-0017 / ADR-0008 B1.
     pub processed_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Error message if processing failed.
     pub error_message: Option<String>,
@@ -89,13 +95,13 @@ pub struct ControlQueueEntry {
 ///
 /// `reclaimed` counts rows moved `Processing → Pending` for a fresh dispatch
 /// attempt; `exhausted` counts rows moved `Processing → Failed` because
-/// their `reclaim_count` exceeded `max_reclaim_count`. Both are per-sweep
-/// counters — callers aggregate across ticks for observability.
+/// their `reclaim_count` reached or exceeded `max_reclaim_count`. Both are
+/// per-sweep counters — callers aggregate across ticks for observability.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReclaimOutcome {
     /// Rows transitioned back to `Pending` for redelivery.
     pub reclaimed: u64,
-    /// Rows transitioned to `Failed` because `reclaim_count` > `max_reclaim_count`.
+    /// Rows transitioned to `Failed` because `reclaim_count` >= `max_reclaim_count`.
     pub exhausted: u64,
 }
 

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -231,8 +231,13 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
         max_reclaim_count: u32,
     ) -> Result<ReclaimOutcome, StorageError> {
         let mut entries = self.entries.lock().await;
-        let cutoff = chrono::Utc::now()
-            - chrono::Duration::from_std(reclaim_after).unwrap_or(chrono::Duration::zero());
+        // If `reclaim_after` overflows `chrono::Duration` (i64 milliseconds),
+        // clamp to the maximum representable value rather than falling back
+        // to zero — a zero fallback would make `cutoff == now`, which would
+        // reclaim EVERY `Processing` row regardless of age.
+        let reclaim_chrono =
+            chrono::Duration::from_std(reclaim_after).unwrap_or(chrono::Duration::MAX);
+        let cutoff = chrono::Utc::now() - reclaim_chrono;
         let mut outcome = ReclaimOutcome::default();
 
         for row in entries.iter_mut() {
@@ -250,7 +255,7 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
                 let processor = row
                     .processed_by
                     .as_deref()
-                    .map(|b| String::from_utf8_lossy(b).into_owned())
+                    .map(hex_encode_bytes)
                     .unwrap_or_else(|| "<unknown>".to_string());
                 row.status = "Failed".to_string();
                 row.error_message = Some(format!(
@@ -274,6 +279,19 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
         // In-memory entries have no real timestamps for age-based pruning; no-op.
         Ok(0)
     }
+}
+
+/// Render opaque byte fields as lowercase hex for inclusion in user-visible
+/// strings (error messages, diagnostics). Keeps correlation with structured
+/// logs sane — the engine consumer logs `processor_id` via the same encoding
+/// in `tracing` fields.
+fn hex_encode_bytes(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
 }
 
 #[cfg(test)]
@@ -425,12 +443,19 @@ mod tests {
         assert_eq!(row.status, "Failed");
         let msg = row.error_message.as_deref().expect("error_message set");
         assert!(
-            msg.starts_with("reclaim exhausted: "),
+            msg.starts_with("reclaim exhausted: processor "),
             "canonical prefix, got: {msg}"
         );
         assert!(
-            msg.contains("dead-runner"),
-            "includes processor_id, got: {msg}"
+            msg.contains("presumed dead after 3 reclaims"),
+            "includes reclaim count, got: {msg}"
+        );
+        // processor_id is hex-encoded ("dead-runner" -> 22 hex chars) so the
+        // correlation with structured `processor=...` log fields is lossless.
+        let hex_expected = "646561642d72756e6e6572";
+        assert!(
+            msg.contains(hex_expected),
+            "includes hex-encoded processor_id, got: {msg}"
         );
     }
 }

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -286,10 +286,11 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
 /// logs sane — the engine consumer logs `processor_id` via the same encoding
 /// in `tracing` fields.
 fn hex_encode_bytes(bytes: &[u8]) -> String {
-    use std::fmt::Write;
+    const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut s = String::with_capacity(bytes.len() * 2);
-    for b in bytes {
-        let _ = write!(s, "{b:02x}");
+    for &b in bytes {
+        s.push(HEX[(b >> 4) as usize] as char);
+        s.push(HEX[(b & 0x0f) as usize] as char);
     }
     s
 }


### PR DESCRIPTION
## Summary

Addresses all 5 review findings from [copilot-pull-request-reviewer on #483](https://github.com/vanyastaff/nebula/pull/483). No semantic change — the ADR-0017 policy stands as written; this is code-level hygiene + one correctness fix.

Split into three commits by concern:

| SHA | Subject | Findings |
|---|---|---|
| `7934e2c8` | `docs(storage): fix processed_at + ReclaimOutcome doc drift` | F1 (processed_at meaning changed), F2 (`>` vs `>=` boundary) |
| `2171df82` | `fix(storage): clamp reclaim_after overflow + hex-encode processor_id` | F3 (silent zero fallback → reclaim-everything footgun), F4 (`String::from_utf8_lossy` → hex so error messages correlate with structured log fields) |
| `cc769b15` | `fix(engine): preserve claim backoff across reclaim interruptions` | F5 (`tokio::select!` was cancelling the `poll_interval`/backoff sleep when reclaim fired — fix hoists the deadline out of the cancellation scope via `tokio::time::sleep_until(claim_deadline)`) |

## Finding details

### F1 — `ControlQueueEntry::processed_at` doc drift
Field is stamped in `claim_pending` (claim time) and used by `reclaim_stuck` as the staleness signal. Old doc said \"When processing finished\". Updated to describe the actual meaning + reclaim clock semantics.

### F2 — `ReclaimOutcome` doc vs impl boundary
Impl used `reclaim_count >= max_reclaim_count` (correct — after 3 successful reclaims the row is exhausted on the 4th sweep), doc said `>`. Aligned both.

### F3 — Overflow clamp
`chrono::Duration::from_std(reclaim_after).unwrap_or(chrono::Duration::zero())` was a silent footgun: if a caller passes a `Duration` beyond `chrono::Duration`'s i64-ms limit, cutoff would be `now`, reclaiming **every** `Processing` row on every sweep. Changed to clamp to `chrono::Duration::MAX` — the opposite failure mode (nothing reclaims) is obviously broken and gets noticed.

### F4 — Hex-encode `processor_id`
`processor_id` is explicitly opaque bytes (docs on `ControlQueueEntry::processed_by`). The engine consumer already logs it via `tracing` as lowercase hex. The exhaust-error message was using `String::from_utf8_lossy`, which would emit replacement characters for non-UTF-8 processor identifiers and break grep/join against log fields. Added `hex_encode_bytes` private helper (mirrors `hex_display` in `control_consumer.rs`) and switched the format. Test updated to assert the structural contract instead of raw bytes.

### F5 — Preserve backoff across reclaim
Previously `run()` had `tokio::select!` between `reclaim_ticker.tick()` and `self.tick(...)`, where `tick()` internally did `tokio::time::sleep(backoff)` on errors and `tokio::time::sleep(poll_interval)` on idle. When reclaim fired mid-sleep, the `tick()` future (and its sleep) was dropped; next iteration re-entered `tick()` fresh, bypassing the backoff. Fixed by:
- `tick()` now returns `Option<Duration>` (the desired sleep) instead of sleeping internally.
- `run()` holds `claim_deadline: tokio::time::Instant` outside the select. Each iteration does `sleep_until(claim_deadline)` as the claim arm. Reclaim interruption is OK — `claim_deadline` is preserved, so the next iteration resumes waiting for the remaining time.
- End-to-end test unchanged and still passes — Consumer #2's `claim_deadline = Instant::now()` at startup means the first `sleep_until` completes immediately, preserving the \"immediate first claim\" semantic.

## Test plan

- [x] `cargo nextest run -p nebula-storage` — 74/74 pass (hex-encoding assertion updated in `reclaim_stuck_exhausts_after_max_count`)
- [x] `cargo nextest run -p nebula-engine` — 143/143 pass, including `reclaim_sweep_recovers_orphaned_processing_row_end_to_end`
- [x] `cargo nextest run --workspace` — 3360/3360 pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo +nightly fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `lefthook run pre-push` — 48s, all jobs clean (shear/doctests/docs/check-all-features/check-no-default/nextest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)