### PR TITLE
fix(engine): fence cancel registry against overlapping resume race (PR #482 follow-up)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -178,11 +178,19 @@ pub struct WorkflowEngine {
     lease_heartbeat_interval: Duration,
     /// Volatile index of in-flight executions this runner owns.
     ///
-    /// Populated on entry to [`execute_workflow`] / [`resume_execution`] right
-    /// after the per-run [`CancellationToken`] is minted, and removed via an
-    /// RAII guard on exit. [`cancel_execution`] looks up the token here and
-    /// cancels it, closing the ADR-0008 A3 control-queue `Cancel` path into
-    /// the cooperative-cancel signal the frontier loop already observes.
+    /// Published **after** `acquire_and_heartbeat_lease` succeeds — the lease
+    /// is the authoritative single-runner fence (ADR-0015), so publishing
+    /// after the lease prevents an overlapping attempt for the same
+    /// [`ExecutionId`] from overwriting the live token. Each entry is
+    /// tagged with a monotonically-increasing [`RunningRegistrationId`]
+    /// nonce, and the [`RunningRegistration`] guard's `Drop` uses
+    /// [`DashMap::remove_if`] to remove only entries that still carry its
+    /// own nonce — a defensive guard against an out-of-order drop from a
+    /// losing attempt clobbering the winner's registration.
+    ///
+    /// [`cancel_execution`] looks up the token here and cancels it,
+    /// closing the ADR-0008 A3 control-queue `Cancel` path into the
+    /// cooperative-cancel signal the frontier loop already observes.
     ///
     /// **Not durable.** This map lives only as long as the `WorkflowEngine`
     /// instance. On process crash the entries vanish with the runner; the
@@ -192,21 +200,49 @@ pub struct WorkflowEngine {
     /// [`execute_workflow`]: Self::execute_workflow
     /// [`resume_execution`]: Self::resume_execution
     /// [`cancel_execution`]: Self::cancel_execution
-    running: Arc<DashMap<ExecutionId, CancellationToken>>,
+    running: Arc<DashMap<ExecutionId, RunningEntry>>,
+}
+
+/// Monotonic per-registration identifier used to fence out-of-order drops
+/// from concurrent attempts on the same [`ExecutionId`] (ADR-0016 / #482
+/// Copilot review). A `u64` is fine — we'd need billions of registrations
+/// per runner lifetime to wrap, and the counter resets on process restart
+/// anyway.
+type RunningRegistrationId = u64;
+
+/// Process-wide monotonic counter for registration nonces.
+static NEXT_REGISTRATION_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+
+/// Value stored in [`WorkflowEngine::running`]. Pairs the live
+/// [`CancellationToken`] with the [`RunningRegistrationId`] nonce so the
+/// drop guard can use [`DashMap::remove_if`] instead of unconditional
+/// `remove`.
+struct RunningEntry {
+    registration_id: RunningRegistrationId,
+    token: CancellationToken,
 }
 
 /// RAII guard that removes an execution from the [`WorkflowEngine::running`]
-/// registry when dropped. Covers the normal exit path and every early-return
-/// branch (e.g. the heartbeat-lost `EngineError::Leased`) without manually
-/// threading a `remove` call through each site.
+/// registry when dropped **only if the entry still carries its own
+/// [`RunningRegistrationId`]**. Covers the normal exit path and every
+/// early-return branch (e.g. heartbeat-lost `EngineError::Leased`) without
+/// manually threading a `remove` call through each site. The nonce check
+/// prevents a losing attempt from removing the winning attempt's token —
+/// see [`WorkflowEngine::running`] doc for the hazard.
 struct RunningRegistration {
-    running: Arc<DashMap<ExecutionId, CancellationToken>>,
+    running: Arc<DashMap<ExecutionId, RunningEntry>>,
     execution_id: ExecutionId,
+    registration_id: RunningRegistrationId,
 }
 
 impl Drop for RunningRegistration {
     fn drop(&mut self) {
-        self.running.remove(&self.execution_id);
+        // `remove_if` only removes when the predicate matches; if a winner
+        // has already published a newer `RunningEntry` we leave theirs
+        // intact (fence against the hazard Copilot flagged on #482).
+        self.running.remove_if(&self.execution_id, |_k, entry| {
+            entry.registration_id == self.registration_id
+        });
     }
 }
 
@@ -260,8 +296,8 @@ impl WorkflowEngine {
     /// `Cancel` command reaches the consumer (canon §12.2, §13 step 5).
     pub fn cancel_execution(&self, execution_id: ExecutionId) -> bool {
         match self.running.get(&execution_id) {
-            Some(token) => {
-                token.cancel();
+            Some(entry) => {
+                entry.value().token.cancel();
                 true
             },
             None => false,
@@ -961,18 +997,7 @@ impl WorkflowEngine {
         // 5. Create cancellation token
         let cancel_token = CancellationToken::new();
 
-        // 5a. Register this run's cancel token so a durable `Cancel`
-        // control command can reach the live frontier loop (ADR-0008 A3,
-        // canon §12.2). The guard's `Drop` removes the entry on every exit
-        // path — normal completion, heartbeat-lost `Leased`, final-persist
-        // errors — so the registry cannot leak stale tokens across runs.
-        self.running.insert(execution_id, cancel_token.clone());
-        let _cancel_registration = RunningRegistration {
-            running: Arc::clone(&self.running),
-            execution_id,
-        };
-
-        // 5b. Acquire the execution lease before dispatching nodes (ADR
+        // 5a. Acquire the execution lease before dispatching nodes (ADR
         // 0008, #325). Second runners that race in after the
         // `create` above but before lease acquire will observe a held
         // lease and get `EngineError::Leased`; we do not sleep-retry.
@@ -986,6 +1011,31 @@ impl WorkflowEngine {
         let lease = self
             .acquire_and_heartbeat_lease(execution_id, cancel_token.clone())
             .await?;
+
+        // 5b. Publish the cancel token into the running registry ONLY
+        // after the lease is ours. The lease is the authoritative
+        // single-runner fence (ADR-0015); publishing after it prevents
+        // an overlapping attempt for the same `ExecutionId` from
+        // overwriting the live token (#482 Copilot review). The guard's
+        // nonce-scoped `Drop` (`RunningRegistration::drop`) removes the
+        // entry on every exit path — normal completion, heartbeat-lost
+        // `Leased`, final-persist errors — and is defensive against
+        // clobbering a winner's registration if a losing attempt ever
+        // slips through.
+        let registration_id =
+            NEXT_REGISTRATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.running.insert(
+            execution_id,
+            RunningEntry {
+                registration_id,
+                token: cancel_token.clone(),
+            },
+        );
+        let _cancel_registration = RunningRegistration {
+            running: Arc::clone(&self.running),
+            execution_id,
+            registration_id,
+        };
 
         // 6. Record start metric
         self.metrics
@@ -1379,16 +1429,6 @@ impl WorkflowEngine {
         let cancel_token = CancellationToken::new();
         let mut repo_version = repo_version_loaded;
 
-        // Register this run's cancel token so an ADR-0008 A3 `Cancel`
-        // control command can reach the live resume frontier (canon §12.2).
-        // Guard's Drop removes the entry on every exit path, including the
-        // heartbeat-lost `Leased` early-return below.
-        self.running.insert(execution_id, cancel_token.clone());
-        let _cancel_registration = RunningRegistration {
-            running: Arc::clone(&self.running),
-            execution_id,
-        };
-
         // Acquire the execution lease before running the frontier (ADR
         // 0008, #325). Resume is explicitly a second entry point for an
         // existing execution — if another runner is already driving it
@@ -1399,6 +1439,25 @@ impl WorkflowEngine {
         let lease = self
             .acquire_and_heartbeat_lease(execution_id, cancel_token.clone())
             .await?;
+
+        // Publish the cancel token into the running registry ONLY after
+        // the lease is ours (ADR-0015 single-runner fence). Symmetric to
+        // `execute_workflow` — see its comment for the full rationale
+        // and the #482 Copilot review context.
+        let registration_id =
+            NEXT_REGISTRATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.running.insert(
+            execution_id,
+            RunningEntry {
+                registration_id,
+                token: cancel_token.clone(),
+            },
+        );
+        let _cancel_registration = RunningRegistration {
+            running: Arc::clone(&self.running),
+            execution_id,
+            registration_id,
+        };
 
         self.metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
@@ -7669,6 +7728,100 @@ mod tests {
              got status={:?}",
             successes[0].status
         );
+    }
+
+    /// Registry race regression (ADR-0016 / #482 Copilot review).
+    ///
+    /// Two `resume_execution` calls overlap on the **same engine** for the
+    /// **same execution_id**. The winner acquires the lease and publishes
+    /// its token into `running`; the loser hits `EngineError::Leased`
+    /// before it ever inserts — so no drop guard can clobber the winner's
+    /// entry. This asserts the observable contract: while the winner's
+    /// frontier loop is live, `engine.cancel_execution(id)` still finds a
+    /// registered token even after the loser has returned.
+    #[tokio::test]
+    async fn overlapping_resume_losers_do_not_clobber_winners_registry_entry() {
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless(SlowHandler {
+            meta: ActionMetadata::new(action_key!("slow"), "Slow", "slow echoes"),
+            delay: Duration::from_millis(500),
+        });
+
+        let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+        let n = node_key!("n");
+        let wf = make_workflow(
+            vec![NodeDefinition::new(n.clone(), "Slow", "slow").unwrap()],
+            vec![],
+        );
+        let workflow_repo = save_workflow_to_repo(&wf).await;
+
+        let execution_id = ExecutionId::new();
+        let node_ids = vec![n.clone()];
+        let exec_state = ExecutionState::new(execution_id, wf.id, &node_ids);
+        exec_repo
+            .create(
+                execution_id,
+                wf.id,
+                serde_json::to_value(&exec_state).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Single engine, so both calls share the same `running` registry —
+        // this is the path the Copilot review flagged. Wrap in `Arc` so we
+        // can drive the second call from a background task and still
+        // observe the registry from the test thread.
+        let (engine, _) = make_engine(registry);
+        let engine = Arc::new(
+            engine
+                .with_execution_repo(exec_repo.clone())
+                .with_workflow_repo(workflow_repo),
+        );
+
+        // Winner: drive the workflow in the background. Its frontier loop
+        // will be live (500ms sleep) long enough for the loser to race.
+        let winner_engine = Arc::clone(&engine);
+        let winner =
+            tokio::spawn(async move { winner_engine.resume_execution(execution_id).await });
+
+        // Poll the registry until the winner has published its token.
+        // This synchronises on the exact moment the race window opens.
+        let t_wait = std::time::Instant::now();
+        loop {
+            if engine.running.contains_key(&execution_id) {
+                break;
+            }
+            assert!(
+                t_wait.elapsed() < Duration::from_secs(2),
+                "winner failed to register its token within 2s"
+            );
+            tokio::task::yield_now().await;
+        }
+
+        // Loser: a second resume call on the same engine for the same id.
+        // Must fail fast with `Leased` — and crucially must NOT clobber
+        // the registry entry the winner just published.
+        let loser = engine.resume_execution(execution_id).await;
+        assert!(
+            matches!(loser, Err(EngineError::Leased { .. })),
+            "overlapping resume must be fenced by the lease; got {loser:?}"
+        );
+
+        // The winner is still running — its token must still be live.
+        // This is the property that would have failed without the
+        // vacant-only insert + nonce-scoped remove_if (Copilot hazard).
+        assert!(
+            engine.cancel_execution(execution_id),
+            "winner's registry entry must survive the loser's failed attempt \
+             (if this fails, the loser's Drop clobbered the winner's token)"
+        );
+
+        // Signalling cancel aborts the winner quickly.
+        let winner_result = tokio::time::timeout(Duration::from_secs(5), winner)
+            .await
+            .expect("winner returns within 5s of cancel")
+            .expect("join ok");
+        let _ = winner_result; // Ok(Cancelled) or Ok(Failed) — both acceptable terminal outcomes.
     }
 
     /// After the first runner releases the lease on terminal completion,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -7816,12 +7816,28 @@ mod tests {
              (if this fails, the loser's Drop clobbered the winner's token)"
         );
 
-        // Signalling cancel aborts the winner quickly.
+        // Signalling cancel aborts the winner quickly. Assert the outcome
+        // explicitly — `Err(EngineError::Leased)` or any non-terminal status
+        // would indicate a real regression (e.g. the heartbeat unexpectedly
+        // stole the lease during the 500ms slow handler); silently dropping
+        // the `Result` would mask that.
         let winner_result = tokio::time::timeout(Duration::from_secs(5), winner)
             .await
             .expect("winner returns within 5s of cancel")
-            .expect("join ok");
-        let _ = winner_result; // Ok(Cancelled) or Ok(Failed) — both acceptable terminal outcomes.
+            .expect("join ok")
+            .expect("winner returns Ok(ExecutionResult) after cancel");
+        // Both labels are acceptable: the abort-select arm ends in `Cancelled`;
+        // the node-error arm (handler returned `ActionError::Cancelled`, processed
+        // as node failure) ends in `Failed`. The scheduler race between the two is
+        // pre-existing behaviour covered by `integration::cancellation_via_sibling_failure`.
+        assert!(
+            matches!(
+                winner_result.status,
+                ExecutionStatus::Cancelled | ExecutionStatus::Failed
+            ),
+            "winner must reach a terminal non-success status after cancel; got {:?}",
+            winner_result.status
+        );
     }
 
     /// After the first runner releases the lease on terminal completion,

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -547,15 +547,23 @@ async fn dispatch_cancel_aborts_running_execution() {
     );
 }
 
-/// ADR-0008 §5 idempotency: a `Cancel` re-delivered for an already-terminal
-/// execution is a no-op. Crucially, `cancel_execution` must NOT be invoked a
-/// second time (the in-flight run has long since dropped its token and
-/// cleared the registry, so a second `cancel_execution` lookup would return
-/// `false` — but more importantly, the dispatch must short-circuit before
-/// reaching the engine so observers cannot mistake a re-delivery for a
-/// fresh cancel signal). Also covers the case where the Cancel loses the
-/// race and arrives after the engine already drove the run to a natural
-/// terminal state.
+/// ADR-0008 §5 idempotency on terminal: a `Cancel` re-delivered for an
+/// already-terminal execution must be `Ok(())` without disturbing state or
+/// triggering a second dispatch of the workflow.
+///
+/// The A3 contract (ADR-0016) makes this property hold through **two
+/// layers**, not a status short-circuit:
+///
+///   1. `dispatch_cancel` signals the engine on every non-orphan delivery, including terminal.
+///      `engine.cancel_execution(id)` looks up the registry — by the time the run is terminal, its
+///      `RunningRegistration` guard has already removed the entry, so the lookup returns `false`
+///      and the call is a no-op.
+///   2. The underlying `CancellationToken::cancel` is idempotent per token, so even a racy delivery
+///      where the registry entry is still live cannot re-run the workflow (the frontier loop
+///      already observed the original cancel or completed naturally).
+///
+/// This test asserts the observable effect: no second dispatch of the
+/// echo handler, terminal row untouched.
 #[tokio::test]
 async fn dispatch_cancel_is_idempotent_on_terminal() {
     let harness = Harness::new().await;
@@ -572,8 +580,10 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
     );
     assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
 
-    // Re-deliver Cancel. Dispatch must short-circuit on the terminal status
-    // read and return `Ok(())` — no engine re-entry, no second signal.
+    // Re-deliver Cancel. The A3 body signals `engine.cancel_execution`
+    // unconditionally — but the registry entry was removed when the run
+    // finished, so the lookup is a no-op and the workflow is not
+    // re-dispatched. The return value is `Ok(())`.
     harness
         .dispatch
         .dispatch_cancel(execution_id)
@@ -588,10 +598,11 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
     assert_eq!(
         harness.action_count.load(Ordering::SeqCst),
         1,
-        "no second dispatch happened"
+        "no second dispatch happened — registry entry was already cleared \
+         when the run finished, so the engine signal was a no-op"
     );
-    // The engine's registry entry was removed when the run finished —
-    // calling cancel_execution now must report false (no live runner).
+    // Confirm the registry is indeed empty for this id — the observable
+    // truth behind point (1) above.
     assert!(
         !harness.engine.cancel_execution(execution_id),
         "registry entry was removed on run completion"


### PR DESCRIPTION
## Summary

Addresses [PR #482](https://github.com/vanyastaff/nebula/pull/482) Copilot review: overlapping `resume_execution` / `execute_workflow` calls for the same `ExecutionId` on the **same engine** could have the losing (lease-fenced) attempt overwrite and then `Drop`-remove the winner's cancel token, leaving `Cancel` dispatch unable to signal the live frontier loop. The hazard was flagged on three separate comments on `engine.rs:210`, `engine.rs:973`, `engine.rs:1390` — same root cause, all three sites addressed here.

## What changed

**Two-layer fence** for the `running: DashMap<ExecutionId, _>` registry:

1. **Publish after lease acquire.** The insert into `running` moves to AFTER `acquire_and_heartbeat_lease` succeeds, so a loser that hits `EngineError::Leased` never creates a registration. The lease is the authoritative single-runner fence (ADR-0015); publishing after it structurally prevents overwrites.

2. **Nonce-scoped removal.** Each registration now carries a process-wide monotonic `RunningRegistrationId` (u64 atomic counter). The `RunningRegistration::Drop` uses `DashMap::remove_if` to remove only entries whose nonce still matches its own — defensive redundancy against any future path that could overlap. Map value type bumps from `CancellationToken` to `RunningEntry { registration_id, token }`.

**Regression test**: `overlapping_resume_losers_do_not_clobber_winners_registry_entry` in `crates/engine/src/engine.rs` tests — spawns the winner in the background, polls the registry until the winner has published, issues a second `resume_execution` on the same engine for the same id, asserts it fails with `EngineError::Leased`, and then asserts `engine.cancel_execution(id)` still finds the winner's token. Without the fence, the loser's `Drop` would clobber the winner's entry and the assertion would fail.

**Test comment fix**: `dispatch_cancel_is_idempotent_on_terminal` had a comment claiming "dispatch must short-circuit on the terminal status read" — that was wrong against the actual A3 contract. The A3 dispatch signals the engine on every non-orphan delivery; idempotency comes from the `CancellationToken::cancel` being token-idempotent plus the registry's missing-entry no-op on terminal runs (the `RunningRegistration` guard has already removed the entry by then). Comment updated to reflect the two-layer property.

## Why this is the right shape

Copilot suggested "vacant-only insert + conditional removal (e.g., nonce/token in the guard and `remove_if`), or publish the token only after lease acquisition succeeds." Doing **both** is the belt-and-braces fix:

- Layer 1 (publish after lease) is the structural fence — the normal path can't trip the hazard.
- Layer 2 (nonce + `remove_if`) is the defense-in-depth — if a future path ever concurrently writes the map (e.g. a new engine entry point that forgot to go through the lease), the Drop still can't silently remove someone else's entry.

## Out of scope

- Splitting the `RunningEntry` nonce out into its own ADR — the rationale fits comfortably under ADR-0016 (which is already accepted and covers the registry design). If a future reviewer wants an explicit invariant record, a frontmatter-only ADR-0016 supersession would be the path; not done here because the invariant didn't change.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` — 3361 passed, 13 skipped (new regression test included)
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps`
- [x] Lefthook pre-push (shear + docs + check-all-features + check-no-default + doctests + nextest) — all green
- [x] New regression test `overlapping_resume_losers_do_not_clobber_winners_registry_entry` — stable in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential execution registry corruption when concurrent execution attempts occur on the same workflow
  * Enhanced cancellation token reliability in overlapping execution scenarios to prevent state interference
  * Improved overall execution state consistency under concurrent load

<!-- end of auto-generated comment: release notes by coderabbit.ai -->