### PR TITLE
docs(engine): retire fail-open credential allowlist debt (canon §12.5)

### DIFF
--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -98,8 +98,6 @@ See `docs/MATURITY.md` row for `nebula-engine`.
 - API stability: `partial` — `WorkflowEngine` and `ExecutionResult` are in active use;
   known open debts (see Appendix) affect correctness boundaries.
 - `ExecutionBudget` is ephemeral (not persisted on resume) — §11.5 debt.
-- Per-node credential `allowed_keys` is not populated from declared dependencies — the
-  credential allowlist is currently fail-open (§12.5 debt; see Appendix).
 - Downstream-edge gate only blocks local edges, not the full graph (§10 narrower than
   advertised for multi-hop conditional flows).
 
@@ -120,18 +118,18 @@ See `docs/MATURITY.md` row for `nebula-engine`.
 |---|---|---|
 | `ExecutionBudget` not persisted in `ExecutionState` — budget is lost on resume | `src/engine.rs:796` | §11.5 durability matrix: budget is **ephemeral** |
 | Original workflow input not persisted — resume cannot replay from input | `src/engine.rs:809` | §11.5 + §11.2 retry/resume story narrower than optimal |
-| Per-node `allowed_keys` not populated from declared credential dependencies | `src/engine.rs:1312, :1601` | §12.5 credential boundary **fail-open** until fixed |
 | Downstream-edge gate blocks only **local** edges, not the full graph | `src/engine.rs:1808` | §10 conditional-flow gate is narrower than advertised |
 | `ExecutionBudget` moved to `nebula-execution` — import cleanup pending | `src/engine.rs:20` | documentation / import hygiene |
 
 ### Architecture notes
 
-- **Fail-open credential allowlist** (`credential_accessor.rs`): an empty allowlist means all
-  credentials are permitted ("open / passthrough mode"). Canon §12.5 implies fail-closed; the
-  default is the opposite until the `TODO: populate allowed_keys` is implemented. Until then,
-  per-node credential-dependency enforcement is a `false capability` (§4.5).
+- **Deny-by-default credential allowlist** (`credential_accessor.rs`): an empty allowlist denies
+  every request (canon §12.5, §4.5). Per-action allowlists are populated via
+  `WorkflowEngine::with_action_credentials`; an action whose credentials were never declared to
+  the engine falls through to the deny baseline. There is no "fail-open" escape hatch.
 - **No resource allowlist** (`resource_accessor.rs`): unlike credentials, there is no allowlist
-  for resources — any registered key may be acquired by any action.
+  for resources — any registered key may be acquired by any action. Resource scoping is
+  intentionally owned by the topology layer (e.g. pool scope, daemon scope), not the engine.
 - **Cross-layer bridges**: `credential_accessor.rs` and `resource_accessor.rs` bridge business-
   layer traits into engine concrete types. Architecturally these belong to `nebula-credential`
   / `nebula-resource` as extension points; the move is a candidate refactor when the gaps above

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -43,7 +43,7 @@
 //! - §12.2 durable control plane; engine owns the `execution_control_queue` consumer.
 //!
 //! See `crates/engine/README.md` for known open debts (budget ephemerality,
-//! fail-open credential allowlist, edge-gate narrowness).
+//! edge-gate narrowness).
 
 pub mod control_consumer;
 pub mod control_dispatch;

--- a/docs/superpowers/specs/2026-04-16-workspace-health-audit.md
+++ b/docs/superpowers/specs/2026-04-16-workspace-health-audit.md
@@ -57,7 +57,7 @@ Legend: **S** = stable, **H** = half-done, **B** = broken, **O** = orphan (no re
 
 | Crate | SLOC | Health | Top issues | Pri | Recommendation |
 |---|---|---|---|---|---|
-| `nebula-engine` | ~4 400 | H | `engine.rs` ~4 000 lines god file; **fail-open credential allowlist** (§4.5); no resource allowlist; 4 undocumented panic sites | P0 | fix allowlists; split orchestrator; replace panics |
+| `nebula-engine` | ~4 400 | H | `engine.rs` ~4 000 lines god file; ~~**fail-open credential allowlist** (§4.5)~~ resolved via `7b811372` (deny-by-default); no resource allowlist (intentional per Q4=B); 4 undocumented panic sites | P0 | split orchestrator; replace panics |
 | `nebula-runtime` | ~2 700 | H | **`src/sandbox.rs` is a self-documented dead compat shim (§14)**; 4 panic sites | P0 | **delete `sandbox.rs`**; typed errors for panics |
 | `nebula-storage` | ~2 000 | H | **§12.2 two-truths**: old `execution_repo.rs`/`workflow_repo.rs` + new `repos/` coexist; new control queue only in new layer | P0 | finish migration; delete old trait files; verify engine calls new API |
 | `nebula-sandbox` | ~1 600 | S | no e2e test of in-process + process paths together | P3 | keep; add integration test |
@@ -161,7 +161,7 @@ These block §13 knife or violate §14 "implement end-to-end or delete." Every i
 
 ---
 
-### 2.4 Engine credential allowlist is fail-open — §4.5 + §12.5
+### 2.4 Engine credential allowlist was fail-open — RESOLVED (§4.5 + §12.5)
 
 **Status:** **RESOLVED** — landed via commit `7b811372 fix(engine): credential access denies by default without declaration`. `EngineCredentialAccessor` now denies every request when the allowlist is empty; per-action allowlists are populated via `WorkflowEngine::with_action_credentials` and merge on repeated declarations. TDD coverage: `credential_accessor::tests::{get_denies_every_key_when_allowlist_is_empty, has_returns_false_for_empty_allowlist, denied_request_never_invokes_resolver}` plus five engine-level integration tests (`credential_access_denied_without_declaration`, `credential_access_allowed_with_declaration`, `credential_access_denied_for_mismatched_key`, `credential_declaration_is_per_action_key`, `action_credentials_merge_across_builder_calls`).
 

--- a/docs/superpowers/specs/2026-04-16-workspace-health-audit.md
+++ b/docs/superpowers/specs/2026-04-16-workspace-health-audit.md
@@ -163,13 +163,15 @@ These block §13 knife or violate §14 "implement end-to-end or delete." Every i
 
 ### 2.4 Engine credential allowlist is fail-open — §4.5 + §12.5
 
-**Location:** `crates/engine/src/engine.rs::EngineCredentialAccessor` (around line 1312).
+**Status:** **RESOLVED** — landed via commit `7b811372 fix(engine): credential access denies by default without declaration`. `EngineCredentialAccessor` now denies every request when the allowlist is empty; per-action allowlists are populated via `WorkflowEngine::with_action_credentials` and merge on repeated declarations. TDD coverage: `credential_accessor::tests::{get_denies_every_key_when_allowlist_is_empty, has_returns_false_for_empty_allowlist, denied_request_never_invokes_resolver}` plus five engine-level integration tests (`credential_access_denied_without_declaration`, `credential_access_allowed_with_declaration`, `credential_access_denied_for_mismatched_key`, `credential_declaration_is_per_action_key`, `action_credentials_merge_across_builder_calls`).
 
-**Current behavior:** empty allowlist = "allow all." Docs say enforcement will come when per-node declarations are wired from action dependency metadata — **unimplemented today**.
+**Location (historical):** `crates/engine/src/engine.rs::EngineCredentialAccessor` (around line 1312).
+
+**Prior behavior:** empty allowlist = "allow all." Docs said enforcement would come when per-node declarations are wired from action dependency metadata — unimplemented at audit time.
 
 **Canon:** §4.5 "operational honesty — no false capabilities" + §12.5 "secrets and auth."
 
-**Fix:** wire per-node allowlist from `ActionMetadata` / `ActionDependencies` (already declared in `nebula-action`). Deny by default; explicit allow via declaration. Add test: action without credential declaration fails to acquire; action with declaration succeeds.
+**Fix (landed):** `EngineCredentialAccessor::is_allowed` now checks membership unconditionally — no "empty means all" escape hatch. Per-action allowlists are populated via `WorkflowEngine::with_action_credentials(ActionKey, [credential_ids])`; nodes whose action was never declared to the engine fall through to the deny baseline.
 
 **Resource access scoping — decision Q4 (resolved):** engine does **not** grow a resource allowlist. Resource scoping lives at the **topology** layer (e.g. pool scope, daemon scope) per user direction. The current engine-side `resource_accessor.rs` stays "allow all" intentionally; document this in its module docs so it's not read as a false-capability stub. Remove any dead allowlist-shaped code that implies enforcement.
 


### PR DESCRIPTION
## Summary

- Code fix already landed in `7b811372` ("fix(engine): credential access denies by default without declaration"): `EngineCredentialAccessor` now denies every request when the allowlist is empty, and per-action allowlists populate via `WorkflowEngine::with_action_credentials` with merge-on-repeat semantics. TDD coverage: 3 unit tests in `credential_accessor::tests` + 5 engine-level integration tests.
- This PR is pure docs-sync: the engine crate README, `lib.rs //!` known-debts pointer, and workspace health audit §2.4 still claimed the allowlist was fail-open. Canon §17 DoD requires docs to match code.
- Retires the §4.5 false-capability for per-node credential-dependency enforcement. No L2 invariant moved — "empty = deny" is §12.5 implementation, not a new canon rule, so no ADR is warranted. MATURITY.md `nebula-engine` row was already clean.

## Changes

- `crates/engine/README.md` — drop fail-open row from Appendix debt table; rewrite "Fail-open credential allowlist" architecture note as "Deny-by-default credential allowlist" with canon refs; drop debt line from Maturity paragraph.
- `crates/engine/src/lib.rs` — drop "fail-open credential allowlist" from the crate-level `//!` known-debts list.
- `docs/superpowers/specs/2026-04-16-workspace-health-audit.md` §2.4 — mark **RESOLVED** with commit reference + test list. Q4 resource-scoping decision preserved (out of scope, topology-owned).

## credential-security-review checklist

- [x] No raw credential ids or secret strings in new tracing calls (no new tracing calls — docs-only).
- [x] STYLE.md §6 secret-handling patterns untouched (no new credential-code paths).
- [x] §12.5 deny-by-default invariant now truthfully documented — code enforces it, docs say so.
- [x] No log-redaction helper regression — `crates/credential/tests/redaction.rs` unchanged.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — 0 warnings
- [x] `cargo nextest run --workspace` — 3361 passed, 13 skipped
- [x] `cargo test --workspace --doc` — 39 passed
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean
- [x] `cargo deny check` — advisories/bans/licenses/sources ok
- [x] `lefthook run pre-push` — shear, doctests, docs, check-all-features, check-no-default, nextest all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)