### PR TITLE
fix(storage): fence mark_completed/mark_failed on processor_id (PR #487 follow-up)

### DIFF
--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -55,13 +55,18 @@ impl nebula_storage::repos::ControlQueueRepo for AlwaysFailControlQueueRepo {
         Ok(vec![])
     }
 
-    async fn mark_completed(&self, _id: &[u8]) -> Result<(), nebula_storage::StorageError> {
+    async fn mark_completed(
+        &self,
+        _id: &[u8],
+        _processor: &[u8],
+    ) -> Result<(), nebula_storage::StorageError> {
         Ok(())
     }
 
     async fn mark_failed(
         &self,
         _id: &[u8],
+        _processor: &[u8],
         _error: &str,
     ) -> Result<(), nebula_storage::StorageError> {
         Ok(())

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -470,7 +470,7 @@ impl ControlConsumer {
         // command. Correctness under redelivery depends entirely on
         // `ControlDispatch` impls being idempotent per `(execution_id, command)`
         // — see the trait-level docs and ADR-0008 §5.
-        if let Err(e) = self.queue.mark_completed(id).await {
+        if let Err(e) = self.queue.mark_completed(id, &self.processor_id).await {
             tracing::error!(
                 id = %hex_display(id),
                 error = %e,
@@ -480,7 +480,7 @@ impl ControlConsumer {
     }
 
     async fn ack_failed(&self, id: &[u8], reason: &str) {
-        if let Err(e) = self.queue.mark_failed(id, reason).await {
+        if let Err(e) = self.queue.mark_failed(id, &self.processor_id, reason).await {
             tracing::error!(
                 id = %hex_display(id),
                 error = %e,

--- a/crates/storage/src/pg/control_queue.rs
+++ b/crates/storage/src/pg/control_queue.rs
@@ -150,35 +150,44 @@ impl ControlQueueRepo for PgControlQueueRepo {
         rows.into_iter().map(tuple_to_entry).collect()
     }
 
-    async fn mark_completed(&self, id: &[u8]) -> Result<(), StorageError> {
-        // Fence on `status = 'Processing'`: a stale worker whose row was
-        // reclaimed (→ Pending, now re-claimed by someone else) or moved
-        // to a terminal state must not be able to overwrite the newer
-        // state. A missed update is an idempotent no-op under the
-        // at-least-once contract of ADR-0008 §5.
+    async fn mark_completed(&self, id: &[u8], processor: &[u8]) -> Result<(), StorageError> {
+        // Fence on `(status = 'Processing', processed_by = $processor)`:
+        // only the runner that owns the current claim can ack it. A stale
+        // worker whose row was reclaimed and re-claimed by a different
+        // runner sees `processed_by != $processor` → zero rows affected,
+        // the newer claim's state is preserved. An idempotent no-op under
+        // the at-least-once contract of ADR-0008 §5.
         sqlx::query(
             "UPDATE execution_control_queue \
              SET status = 'Completed' \
-             WHERE id = $1 AND status = 'Processing'",
+             WHERE id = $1 AND status = 'Processing' AND processed_by = $2",
         )
         .bind(id)
+        .bind(processor)
         .execute(&self.pool)
         .await
         .map_err(|e| map_db_err("control_queue", e))?;
         Ok(())
     }
 
-    async fn mark_failed(&self, id: &[u8], error: &str) -> Result<(), StorageError> {
-        // Same CAS fence as `mark_completed` — a stale worker must not
-        // overwrite an already-terminal or re-claimed row. In particular,
-        // this prevents flipping a `reclaim_exhausted` Failed row back
-        // to a worker-reported Failed with a different error message.
+    async fn mark_failed(
+        &self,
+        id: &[u8],
+        processor: &[u8],
+        error: &str,
+    ) -> Result<(), StorageError> {
+        // Same `(status, processed_by)` fence as `mark_completed`. In
+        // particular, prevents a stale worker from overwriting a
+        // `reclaim_exhausted` Failed message or from terminalising a row
+        // that another runner is still processing after a successful
+        // reclaim round.
         sqlx::query(
             "UPDATE execution_control_queue \
-             SET status = 'Failed', error_message = $2 \
-             WHERE id = $1 AND status = 'Processing'",
+             SET status = 'Failed', error_message = $3 \
+             WHERE id = $1 AND status = 'Processing' AND processed_by = $2",
         )
         .bind(id)
+        .bind(processor)
         .bind(error)
         .execute(&self.pool)
         .await
@@ -608,7 +617,7 @@ mod tests {
         repo.enqueue(&entry).await.unwrap();
         let _ = repo.claim_pending(b"runner-a", 1).await.unwrap();
 
-        repo.mark_completed(&row_id).await.unwrap();
+        repo.mark_completed(&row_id, b"runner-a").await.unwrap();
 
         let status: String =
             sqlx::query_scalar("SELECT status FROM execution_control_queue WHERE id = $1")
@@ -631,7 +640,9 @@ mod tests {
         repo.enqueue(&entry).await.unwrap();
         let _ = repo.claim_pending(b"runner-a", 1).await.unwrap();
 
-        repo.mark_failed(&row_id, "dispatch boom").await.unwrap();
+        repo.mark_failed(&row_id, b"runner-a", "dispatch boom")
+            .await
+            .unwrap();
 
         type Row = (String, Option<String>);
         let row: Row = sqlx::query_as(
@@ -647,11 +658,11 @@ mod tests {
 
     #[tokio::test]
     async fn mark_completed_is_noop_when_row_not_processing() {
-        // Stale-worker safety: an ack arriving after the row has been
-        // reclaimed (→ Pending) or already terminalised must not
-        // overwrite the newer status. The guarded UPDATE returns zero
-        // rows; the repo method still returns Ok under at-least-once
-        // semantics (ADR-0008 §5).
+        // Stale-worker safety (terminal-state side): an ack arriving
+        // after the row has already been terminalised (e.g. by
+        // reclaim-exhaustion → Failed, or never-claimed → Pending) must
+        // not overwrite the newer status. Guarded UPDATE returns zero
+        // rows; the repo method still returns Ok per ADR-0008 §5.
         let Some(pool) = pool().await else { return };
         let _guard = TEST_LOCK.lock().await;
         clean_control_queue(&pool).await;
@@ -662,7 +673,7 @@ mod tests {
         let pending = pending_entry(&exec_id);
         let pending_id = pending.id.clone();
         repo.enqueue(&pending).await.unwrap();
-        repo.mark_completed(&pending_id).await.unwrap();
+        repo.mark_completed(&pending_id, b"runner-a").await.unwrap();
         let status: String =
             sqlx::query_scalar("SELECT status FROM execution_control_queue WHERE id = $1")
                 .bind(&pending_id)
@@ -683,7 +694,7 @@ mod tests {
         );
         let exhausted_id = exhausted.id.clone();
         repo.enqueue(&exhausted).await.unwrap();
-        repo.mark_failed(&exhausted_id, "late worker error")
+        repo.mark_failed(&exhausted_id, b"runner-a", "late worker error")
             .await
             .unwrap();
         type Row = (String, Option<String>);
@@ -702,6 +713,75 @@ mod tests {
             "mark_failed must not overwrite an exhaust message, got: {:?}",
             row.1
         );
+    }
+
+    #[tokio::test]
+    async fn mark_completed_rejects_stale_worker_after_reclaim() {
+        // Regression: the race Copilot flagged on PR #487. Runner A
+        // claims a row, then stalls past `reclaim_after`. The sweep
+        // moves the row back to Pending. Runner B claims the same row,
+        // making its status Processing again — but now owned by B.
+        // Runner A finally wakes up and calls `mark_completed`. Without
+        // a `processed_by = $processor` fence, A's guarded `status =
+        // 'Processing'` check matches and overwrites B's in-progress
+        // state. With the fence it must be a no-op.
+        let Some(pool) = pool().await else { return };
+        let _guard = TEST_LOCK.lock().await;
+        clean_control_queue(&pool).await;
+        let repo = PgControlQueueRepo::new(pool.clone());
+        let exec_id = seed_execution_parent_chain(&pool).await;
+
+        let entry = pending_entry(&exec_id);
+        let row_id = entry.id.clone();
+        repo.enqueue(&entry).await.unwrap();
+
+        // Runner A claims.
+        let _ = repo.claim_pending(b"runner-a", 1).await.unwrap();
+        // Simulate: A's row goes stale, reclaim sweep moves it to
+        // Pending, then B claims. Easiest shortcut: rewrite the row
+        // directly to reflect the post-reclaim-and-reclaim state.
+        sqlx::query(
+            "UPDATE execution_control_queue \
+             SET status = 'Processing', processed_by = $2, \
+                 processed_at = NOW(), reclaim_count = 1 \
+             WHERE id = $1",
+        )
+        .bind(&row_id)
+        .bind(b"runner-b".as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Stale Runner A acks. Must be a no-op under the new fence.
+        repo.mark_completed(&row_id, b"runner-a").await.unwrap();
+        type Row = (String, Option<Vec<u8>>);
+        let row: Row = sqlx::query_as(
+            "SELECT status, processed_by FROM execution_control_queue \
+             WHERE id = $1",
+        )
+        .bind(&row_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            row.0, "Processing",
+            "stale A must not flip B's in-progress row to Completed"
+        );
+        assert_eq!(
+            row.1.as_deref(),
+            Some(b"runner-b".as_slice()),
+            "processed_by must remain the active claimant"
+        );
+
+        // Runner B legitimately acks. Must succeed.
+        repo.mark_completed(&row_id, b"runner-b").await.unwrap();
+        let status: String =
+            sqlx::query_scalar("SELECT status FROM execution_control_queue WHERE id = $1")
+                .bind(&row_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(status, "Completed");
     }
 
     #[tokio::test]

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -122,10 +122,28 @@ pub trait ControlQueueRepo: Send + Sync {
     ) -> Result<Vec<ControlQueueEntry>, StorageError>;
 
     /// Mark a claimed command as successfully processed.
-    async fn mark_completed(&self, id: &[u8]) -> Result<(), StorageError>;
+    ///
+    /// `processor` must match the id currently recorded in the row's
+    /// `processed_by` column — i.e. the runner calling `mark_completed`
+    /// is the one that claimed the row. This prevents a stale worker whose
+    /// row was reclaimed and re-claimed by another runner from overwriting
+    /// the newer claim's state. A mismatch is an idempotent no-op under
+    /// the at-least-once contract of ADR-0008 §5.
+    async fn mark_completed(&self, id: &[u8], processor: &[u8]) -> Result<(), StorageError>;
 
     /// Mark a claimed command as failed (records `error_message`).
-    async fn mark_failed(&self, id: &[u8], error: &str) -> Result<(), StorageError>;
+    ///
+    /// Same `processor` fencing as [`Self::mark_completed`] — only the
+    /// runner that owns the claim may transition the row to `Failed`.
+    /// Prevents a stale worker from overwriting a reclaim-exhausted
+    /// `Failed` message or a newly-claimed `Processing` row from a
+    /// different runner.
+    async fn mark_failed(
+        &self,
+        id: &[u8],
+        processor: &[u8],
+        error: &str,
+    ) -> Result<(), StorageError>;
 
     /// Reclaim rows stuck in `Processing` whose owning runner is presumed
     /// dead (ADR-0017, ADR-0008 B1).
@@ -208,17 +226,28 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
             .collect())
     }
 
-    async fn mark_completed(&self, id: &[u8]) -> Result<(), StorageError> {
+    async fn mark_completed(&self, id: &[u8], processor: &[u8]) -> Result<(), StorageError> {
         let mut entries = self.entries.lock().await;
-        if let Some(row) = entries.iter_mut().find(|e| e.id == id) {
+        if let Some(row) = entries.iter_mut().find(|e| e.id == id)
+            && row.status == "Processing"
+            && row.processed_by.as_deref() == Some(processor)
+        {
             row.status = "Completed".to_string();
         }
         Ok(())
     }
 
-    async fn mark_failed(&self, id: &[u8], error: &str) -> Result<(), StorageError> {
+    async fn mark_failed(
+        &self,
+        id: &[u8],
+        processor: &[u8],
+        error: &str,
+    ) -> Result<(), StorageError> {
         let mut entries = self.entries.lock().await;
-        if let Some(row) = entries.iter_mut().find(|e| e.id == id) {
+        if let Some(row) = entries.iter_mut().find(|e| e.id == id)
+            && row.status == "Processing"
+            && row.processed_by.as_deref() == Some(processor)
+        {
             row.status = "Failed".to_string();
             row.error_message = Some(error.to_string());
         }
@@ -298,6 +327,41 @@ fn hex_encode_bytes(bytes: &[u8]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn mark_completed_rejects_stale_worker_after_reclaim() {
+        // Parity with `pg::PgControlQueueRepo::mark_completed_rejects_stale_worker_after_reclaim`:
+        // after a reclaim+re-claim cycle, the original runner's ack must
+        // be a no-op; only the current claimant can transition to Completed.
+        let repo = InMemoryControlQueueRepo::new();
+        let now = chrono::Utc::now();
+        let entry = ControlQueueEntry {
+            id: vec![9u8; 16],
+            execution_id: b"01JXYZ00000000000000000000".to_vec(),
+            command: ControlCommand::Cancel,
+            issued_by: None,
+            issued_at: now,
+            status: "Processing".to_string(),
+            processed_by: Some(b"runner-b".to_vec()),
+            processed_at: Some(now),
+            error_message: None,
+            reclaim_count: 1,
+        };
+        repo.enqueue(&entry).await.unwrap();
+
+        // Stale Runner A acks — must be a no-op.
+        repo.mark_completed(&[9u8; 16], b"runner-a").await.unwrap();
+        let snap = repo.snapshot().await;
+        let row = snap.iter().find(|r| r.id == vec![9u8; 16]).unwrap();
+        assert_eq!(row.status, "Processing", "stale A must not flip the row");
+        assert_eq!(row.processed_by.as_deref(), Some(b"runner-b".as_slice()));
+
+        // Active Runner B acks — must succeed.
+        repo.mark_completed(&[9u8; 16], b"runner-b").await.unwrap();
+        let snap = repo.snapshot().await;
+        let row = snap.iter().find(|r| r.id == vec![9u8; 16]).unwrap();
+        assert_eq!(row.status, "Completed");
+    }
 
     #[tokio::test]
     async fn claim_pending_stamps_processed_at_and_processed_by() {


### PR DESCRIPTION
## Summary

Closes the race [Copilot flagged on #487](https://github.com/vanyastaff/nebula/pull/487#discussion_r): the `status = 'Processing'` fence in \`mark_completed\` / \`mark_failed\` catches the terminal-state side of stale-worker writes but misses the **re-claim** case.

### The race

1. Runner **A** claims row R (status=Processing, processed_by=A).
2. Runner **A** stalls past \`reclaim_after\`; reclaim sweep (ADR-0017) returns R to Pending with \`reclaim_count=1\`.
3. Runner **B** claims R (status=Processing, processed_by=B).
4. Runner **A** wakes up and calls \`mark_completed(R)\`. The old guard matched because R.status='Processing' again, so A **overwrote B's in-progress work**.

Symmetric case: an early stale \`mark_failed\` locks the row as Failed; the status='Processing' guard then blocks the legitimate runner's later success.

### Fix

Extend the trait to take \`processor: &[u8]\` on both ack methods and fence on \`(status = 'Processing' AND processed_by = \$processor)\`. Only the runner that currently owns the claim can ack it. A mismatch is a 0-row UPDATE → idempotent no-op under ADR-0008 §5 at-least-once semantics.

## Changes

- **\`crates/storage/src/repos/control_queue.rs\`** — trait signature extended; in-memory impl fences on \`(status == \"Processing\" && processed_by == Some(processor))\`. Symmetric parity with Postgres.
- **\`crates/storage/src/pg/control_queue.rs\`** — Postgres impl adds \`AND processed_by = \$2\` to both WHERE clauses.
- **\`crates/engine/src/control_consumer.rs\`** — ack call sites plumb \`&self.processor_id\` through.
- **\`crates/api/tests/knife.rs\`** — \`AlwaysFailControlQueueRepo\` test double signature updated.

### New regression tests (one per impl)

- \`repos::control_queue::tests::mark_completed_rejects_stale_worker_after_reclaim\` (in-memory)
- \`pg::control_queue::tests::mark_completed_rejects_stale_worker_after_reclaim\` (Postgres)

Both prove: (a) stale Runner A's ack is a no-op (row stays Processing under B); (b) active Runner B's ack succeeds (row → Completed).

## Scope

No schema changes, no new migrations. The trait change is a **breaking signature** — but the only production call sites (engine consumer + knife-test double) are updated in the same PR.

## Test plan

- [x] \`cargo nextest run --workspace\` → 3362/3362 passed, 13 skipped.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` → clean.
- [x] \`cargo clippy -p nebula-storage --all-targets --features postgres -- -D warnings\` → clean.
- [x] \`cargo +nightly fmt --all --check\` → no diff.
- [x] \`RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace\` → clean.
- [x] \`lefthook run pre-push\` → 6/6 jobs pass (shear, check-all-features, docs, check-no-default, doctests, nextest).

## Refs

- Parent: [#487](https://github.com/vanyastaff/nebula/pull/487) (and its predecessor [#486](https://github.com/vanyastaff/nebula/pull/486))
- ADR-0008 §5 (at-least-once contract), ADR-0017 (reclaim policy)
- Copilot review thread that surfaced the race

🤖 Generated with [Claude Code](https://claude.com/claude-code)