### PR TITLE
docs(adr): add missing ADR-0017 row to index

### DIFF
--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -31,7 +31,7 @@ changes land as a new ADR that `supersedes` it.
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0017**). Do not reuse.
+2. Pick the next free number (currently **0018**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ changes land as a new ADR that `supersedes` it.
 | [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | accepted | 2026-04-19 |
 | [0015](./0015-execution-lease-lifecycle.md) | Execution lease lifecycle (renumbered from 0008; promoted on #325 implementation) | accepted | 2026-04-19 |
 | [0016](./0016-engine-cancel-registry.md) | Engine cancel registry — cooperative-cancel contract for ADR-0008 A3 | accepted | 2026-04-19 |
+| [0017](./0017-control-queue-reclaim-policy.md) | Control-queue reclaim policy | accepted | 2026-04-19 |
 
 ## Writing a new ADR
 


### PR DESCRIPTION
## Summary

- `docs/adr/0017-control-queue-reclaim-policy.md` exists on disk but was never listed in the ADR index table in `docs/adr/README.md` — squash-merge miss on the original ADR-0017 PR.
- Inserts the row after 0016 with title/status/date pulled from the ADR's frontmatter, matching the format of the neighboring rows.

## Heads-up for reviewer

A parallel branch (`claude/beautiful-archimedes-34c6aa`, commit `c503a214`) files **ADR-0018** and also appends to this same table. Both PRs touch the tail of the table, so whichever lands second will hit a trivial merge conflict — resolution is just ordering the rows `0016 → 0017 → 0018`. The `currently **0019**` line that PR already wrote is correct once both land.

## Test plan

- [x] `docs/adr/README.md` renders with 0017 row in the index table
- [x] Row format matches neighboring rows (same column widths, same link style)
- [x] Pre-commit hooks green (typos, convco)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new architectural decision record for control-queue reclaim policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->