### PR TITLE
feat(metadata): shared BaseCompatError + complete crate integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,6 +3867,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.2",
  "scopeguard",
+ "semver",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4046,6 +4047,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4127,6 +4129,7 @@ dependencies = [
  "nebula-resource-macros",
  "nebula-schema",
  "nebula-telemetry",
+ "semver",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -67,29 +67,20 @@ pub enum ActionCategory {
     Terminal,
 }
 
-/// Compatibility validation errors for metadata evolution.
+/// Compatibility validation errors for action metadata evolution.
+///
+/// Wraps [`nebula_metadata::BaseCompatError`] (shared catalog-entity rules)
+/// and layers the action-specific port-change rule on top.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum MetadataCompatibilityError {
-    /// Action key changed across versions.
-    #[error("action key changed from `{previous}` to `{current}`")]
-    KeyChanged {
-        /// Previous key.
-        previous: ActionKey,
-        /// Current key.
-        current: ActionKey,
-    },
-    /// Interface version regressed.
-    #[error("interface version regressed from {previous} to {current}")]
-    VersionRegressed {
-        /// Previous version.
-        previous: Version,
-        /// Current version.
-        current: Version,
-    },
-    /// Breaking schema change without a major version bump.
-    #[error("breaking metadata change detected without major version bump")]
-    BreakingChangeWithoutMajorBump,
+    /// A generic catalog-citizen rule fired (key / version / schema).
+    #[error(transparent)]
+    Base(#[from] nebula_metadata::BaseCompatError<ActionKey>),
+
+    /// Input or output ports changed without a major version bump.
+    #[error("action ports changed without a major version bump")]
+    PortsChangeWithoutMajorBump,
 }
 
 /// Static metadata describing an action type.
@@ -323,33 +314,18 @@ impl ActionMetadata {
 
     /// Validate that this metadata update is version-compatible with `previous`.
     ///
-    /// Rules:
-    /// - `key` is immutable across versions.
-    /// - Interface version cannot go backwards (full `semver::Version` ordering).
-    /// - If input/output/parameter schema changed, major must increase.
+    /// Delegates `key immutable / version monotonic / schema-break-requires-
+    /// major` to [`nebula_metadata::validate_base_compat`]; layers the action-
+    /// specific port-change rule on top.
     pub fn validate_compatibility(
         &self,
         previous: &Self,
     ) -> Result<(), MetadataCompatibilityError> {
-        if self.base.key != previous.base.key {
-            return Err(MetadataCompatibilityError::KeyChanged {
-                previous: previous.base.key.clone(),
-                current: self.base.key.clone(),
-            });
-        }
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
 
-        if self.base.version < previous.base.version {
-            return Err(MetadataCompatibilityError::VersionRegressed {
-                previous: previous.base.version.clone(),
-                current: self.base.version.clone(),
-            });
-        }
-
-        let schema_changed = self.inputs != previous.inputs
-            || self.outputs != previous.outputs
-            || self.base.schema != previous.base.schema;
-        if schema_changed && self.base.version.major == previous.base.version.major {
-            return Err(MetadataCompatibilityError::BreakingChangeWithoutMajorBump);
+        let ports_changed = self.inputs != previous.inputs || self.outputs != previous.outputs;
+        if ports_changed && self.base.version.major == previous.base.version.major {
+            return Err(MetadataCompatibilityError::PortsChangeWithoutMajorBump);
         }
 
         Ok(())
@@ -359,6 +335,7 @@ impl ActionMetadata {
 #[cfg(test)]
 mod tests {
     use nebula_core::action_key;
+    use nebula_metadata::BaseCompatError;
 
     use super::*;
 
@@ -560,10 +537,24 @@ mod tests {
             .with_outputs(vec![OutputPort::flow("out"), OutputPort::error("error")]);
 
         let err = next.validate_compatibility(&prev).unwrap_err();
-        assert_eq!(
+        assert_eq!(err, MetadataCompatibilityError::PortsChangeWithoutMajorBump);
+    }
+
+    #[test]
+    fn schema_field_change_requires_major_bump() {
+        use nebula_schema::{FieldCollector, Schema};
+
+        let prev =
+            ActionMetadata::new(action_key!("http.request"), "HTTP", "desc").with_version(1, 0);
+        let next = ActionMetadata::new(action_key!("http.request"), "HTTP", "desc")
+            .with_version(1, 1)
+            .with_schema(Schema::builder().string("added", |s| s).build().unwrap());
+
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert!(matches!(
             err,
-            MetadataCompatibilityError::BreakingChangeWithoutMajorBump
-        );
+            MetadataCompatibilityError::Base(BaseCompatError::SchemaChangeWithoutMajorBump)
+        ));
     }
 
     #[test]
@@ -584,7 +575,10 @@ mod tests {
         let next = ActionMetadata::new(action_key!("a.two"), "A", "desc").with_version(2, 0);
 
         let err = next.validate_compatibility(&prev).unwrap_err();
-        assert!(matches!(err, MetadataCompatibilityError::KeyChanged { .. }));
+        assert!(matches!(
+            err,
+            MetadataCompatibilityError::Base(BaseCompatError::KeyChanged { .. })
+        ));
     }
 
     #[test]
@@ -609,7 +603,7 @@ mod tests {
         let err = next.validate_compatibility(&prev).unwrap_err();
         assert!(matches!(
             err,
-            MetadataCompatibilityError::VersionRegressed { .. }
+            MetadataCompatibilityError::Base(BaseCompatError::VersionRegressed { .. })
         ));
     }
 }

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -317,6 +317,11 @@ impl ActionMetadata {
     /// Delegates `key immutable / version monotonic / schema-break-requires-
     /// major` to [`nebula_metadata::validate_base_compat`]; layers the action-
     /// specific port-change rule on top.
+    ///
+    /// The ports rule lives on this type rather than in `nebula-metadata`
+    /// because no other catalog citizen exposes a typed input/output port
+    /// graph — only actions declare ports that the workflow validator wires
+    /// between nodes, so the rule has no meaningful shared form.
     pub fn validate_compatibility(
         &self,
         previous: &Self,
@@ -528,7 +533,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_change_requires_major_bump() {
+    fn ports_change_requires_major_bump() {
         let prev = ActionMetadata::new(action_key!("http.request"), "HTTP Request", "desc")
             .with_version(1, 0)
             .with_outputs(vec![OutputPort::flow("out")]);
@@ -551,10 +556,10 @@ mod tests {
             .with_schema(Schema::builder().string("added", |s| s).build().unwrap());
 
         let err = next.validate_compatibility(&prev).unwrap_err();
-        assert!(matches!(
+        assert_eq!(
             err,
             MetadataCompatibilityError::Base(BaseCompatError::SchemaChangeWithoutMajorBump)
-        ));
+        );
     }
 
     #[test]

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -70,6 +70,7 @@ scopeguard = "1"
 reqwest = { workspace = true }
 futures = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
+semver = { workspace = true }
 
 [features]
 default = []

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -184,7 +184,7 @@ pub use crate::{
         CredentialError, CryptoError, RefreshErrorKind, ResolutionStage, RetryAdvice,
         ValidationError,
     },
-    metadata::{CredentialMetadata, CredentialMetadataBuilder},
+    metadata::{CredentialMetadata, CredentialMetadataBuilder, MetadataCompatibilityError},
     record::CredentialRecord,
     snapshot::{CredentialSnapshot, SnapshotError},
 };

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -191,3 +191,111 @@ impl CredentialMetadataBuilder {
         })
     }
 }
+
+/// Compatibility validation errors for credential metadata evolution.
+///
+/// Wraps [`nebula_metadata::BaseCompatError`] (shared catalog-entity rules)
+/// and layers the credential-specific auth-pattern rule on top.
+///
+/// The pattern rule lives on this type rather than in `nebula-metadata`
+/// because no other catalog citizen has an auth-pattern classifier —
+/// `AuthPattern` is credential-specific and changing it is semantically
+/// equivalent to replacing the credential, so it requires a major bump.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    /// A generic catalog-citizen rule fired (key / version / schema).
+    #[error(transparent)]
+    Base(#[from] nebula_metadata::BaseCompatError<nebula_core::CredentialKey>),
+
+    /// Auth pattern changed without a major version bump.
+    #[error("credential auth pattern changed without a major version bump")]
+    PatternChangeWithoutMajorBump,
+}
+
+impl CredentialMetadata {
+    /// Validate that this metadata update is version-compatible with `previous`.
+    ///
+    /// Delegates `key immutable / version monotonic / schema-break-requires-
+    /// major` to [`nebula_metadata::validate_base_compat`]; layers the
+    /// credential-specific auth-pattern rule on top.
+    pub fn validate_compatibility(
+        &self,
+        previous: &Self,
+    ) -> Result<(), MetadataCompatibilityError> {
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
+
+        if self.pattern != previous.pattern
+            && self.base.version.major == previous.base.version.major
+        {
+            return Err(MetadataCompatibilityError::PatternChangeWithoutMajorBump);
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod compat_tests {
+    use nebula_core::{AuthPattern, credential_key};
+    use nebula_metadata::BaseCompatError;
+    use nebula_schema::Schema;
+    use semver::Version;
+
+    use super::{CredentialMetadata, MetadataCompatibilityError};
+
+    fn empty_schema() -> nebula_schema::ValidSchema {
+        Schema::builder().build().unwrap()
+    }
+
+    fn cred(pattern: AuthPattern, major: u64, minor: u64) -> CredentialMetadata {
+        let mut m =
+            CredentialMetadata::new(credential_key!("cred"), "C", "d", empty_schema(), pattern);
+        m.base.version = Version::new(major, minor, 0);
+        m
+    }
+
+    #[test]
+    fn pattern_change_requires_major_bump() {
+        let prev = cred(AuthPattern::SecretToken, 1, 0);
+        let next = cred(AuthPattern::OAuth2, 1, 1);
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert_eq!(
+            err,
+            MetadataCompatibilityError::PatternChangeWithoutMajorBump
+        );
+    }
+
+    #[test]
+    fn pattern_change_with_major_accepted() {
+        let prev = cred(AuthPattern::SecretToken, 1, 0);
+        let next = cred(AuthPattern::OAuth2, 2, 0);
+        assert!(next.validate_compatibility(&prev).is_ok());
+    }
+
+    #[test]
+    fn key_change_via_base_rejected() {
+        let prev = CredentialMetadata::new(
+            credential_key!("a"),
+            "A",
+            "d",
+            empty_schema(),
+            AuthPattern::SecretToken,
+        );
+        let next = CredentialMetadata::new(
+            credential_key!("b"),
+            "A",
+            "d",
+            empty_schema(),
+            AuthPattern::SecretToken,
+        );
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert_eq!(
+            err,
+            MetadataCompatibilityError::Base(BaseCompatError::KeyChanged {
+                previous: credential_key!("a"),
+                current: credential_key!("b"),
+            })
+        );
+    }
+}

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -236,7 +236,7 @@ impl CredentialMetadata {
 }
 
 #[cfg(test)]
-mod compat_tests {
+mod tests {
     use nebula_core::{AuthPattern, credential_key};
     use nebula_metadata::BaseCompatError;
     use nebula_schema::Schema;

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -15,6 +15,7 @@ documentation.workspace = true
 nebula-schema = { path = "../schema" }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/metadata/README.md
+++ b/crates/metadata/README.md
@@ -88,8 +88,10 @@ assert_eq!(md.name(), "My Entity");
   `BaseMetadata<CredentialKey>`; adds `pattern`; wraps `BaseCompatError`
   similarly.
 - `nebula-resource::ResourceMetadata` — composes
-  `BaseMetadata<ResourceKey>`; no entity-specific fields today, direct
-  delegation.
+  `BaseMetadata<ResourceKey>`; no entity-specific fields today; wraps
+  `BaseCompatError<ResourceKey>` in a single-variant
+  `MetadataCompatibilityError` for shape parity with the other
+  consumers.
 - `nebula-plugin::PluginMetadata` — **does not** compose `BaseMetadata`
   today. Reshape to `PluginManifest` (bundle descriptor) tracked in
   [ADR-0018](../../docs/adr/0018-plugin-metadata-to-manifest.md);

--- a/crates/metadata/README.md
+++ b/crates/metadata/README.md
@@ -11,14 +11,17 @@ related: [nebula-action, nebula-credential, nebula-resource, nebula-plugin]
 
 ## Purpose
 
-Every catalog citizen in Nebula — an action, a credential, a resource, a
-future plugin — shares the same surface: a typed key, a human-readable
-name and description, a canonical input schema, optional catalog
-ornaments (icon, documentation URL, tags), a declared maturity level,
-and an optional deprecation notice. `nebula-metadata` owns those shared
+Every catalog leaf in Nebula — such as an action, a credential, or a
+resource — shares the same surface: a typed key, a human-readable name
+and description, a canonical input schema, optional catalog ornaments
+(icon, documentation URL, tags), a declared maturity level, and an
+optional deprecation notice. `nebula-metadata` owns those shared
 concerns as concrete types and a small trait, so each business-layer
 crate composes them instead of redeclaring the same prefix with
-incompatible field names.
+incompatible field names. Plugins are described separately as container
+descriptors: they may reuse the small supporting types from this crate,
+but they do not compose `BaseMetadata<K>` and do not carry a canonical
+input schema (see [ADR-0018](../../docs/adr/0018-plugin-metadata-to-manifest.md)).
 
 ## Role
 

--- a/crates/metadata/README.md
+++ b/crates/metadata/README.md
@@ -1,0 +1,103 @@
+---
+name: nebula-metadata
+role: Shared catalog-citizen metadata (BaseMetadata + Metadata trait + Icon / MaturityLevel / DeprecationNotice + compat rules)
+status: frontier
+last-reviewed: 2026-04-19
+canon-invariants: [L2-3.5]
+related: [nebula-action, nebula-credential, nebula-resource, nebula-plugin]
+---
+
+# nebula-metadata
+
+## Purpose
+
+Every catalog citizen in Nebula — an action, a credential, a resource, a
+future plugin — shares the same surface: a typed key, a human-readable
+name and description, a canonical input schema, optional catalog
+ornaments (icon, documentation URL, tags), a declared maturity level,
+and an optional deprecation notice. `nebula-metadata` owns those shared
+concerns as concrete types and a small trait, so each business-layer
+crate composes them instead of redeclaring the same prefix with
+incompatible field names.
+
+## Role
+
+**Core-layer support crate.** Cross-cutting, no upward dependencies.
+Only depends on `nebula-schema` (for `ValidSchema`), `semver`, `serde`,
+and `thiserror`. Every other crate in the business layer
+(`nebula-action`, `nebula-credential`, `nebula-resource`) composes
+`BaseMetadata<K>` via `#[serde(flatten)]` on its own concrete metadata
+struct.
+
+## Public API
+
+- `BaseMetadata<K>` — shared catalog prefix (`key`, `name`, `description`,
+  `schema`, `version`, `icon`, `documentation_url`, `tags`, `maturity`,
+  `deprecation`). Composed on each concrete entity metadata.
+- `Metadata` trait — one-line impl on each concrete metadata
+  (`fn base(&self) -> &BaseMetadata<Self::Key>`); all other accessors
+  default-delegate through it.
+- `Icon` — `None` / `Inline(String)` / `Url { url: String }` enum;
+  replaces the earlier `icon: Option<String>` + `icon_url: Option<String>`
+  pair.
+- `MaturityLevel` — `Experimental` / `Beta` / `Stable` / `Deprecated`.
+- `DeprecationNotice` — `since` / `sunset` / `replacement` / `reason`.
+- `BaseCompatError<K>` + `validate_base_compat` — entity-agnostic compat
+  rules shared by every catalog citizen (`key` immutable, `version`
+  monotonic, schema-break-requires-major-bump). Each consumer layers
+  entity-specific rules on top via a thin wrapper enum.
+
+## Composition
+
+```rust
+use nebula_metadata::{BaseMetadata, Metadata};
+use nebula_schema::{Schema, ValidSchema};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MyKey(&'static str);
+
+pub struct MyEntityMetadata {
+    pub base: BaseMetadata<MyKey>,
+    pub extra_field: u32,
+}
+
+impl Metadata for MyEntityMetadata {
+    type Key = MyKey;
+    fn base(&self) -> &BaseMetadata<Self::Key> {
+        &self.base
+    }
+}
+
+fn empty_schema() -> ValidSchema {
+    Schema::builder().build().unwrap()
+}
+
+let md = MyEntityMetadata {
+    base: BaseMetadata::new(MyKey("k"), "My Entity", "desc", empty_schema()),
+    extra_field: 7,
+};
+assert_eq!(md.name(), "My Entity");
+```
+
+## Consumers
+
+- `nebula-action::ActionMetadata` — composes `BaseMetadata<ActionKey>`;
+  adds `inputs`, `outputs`, `isolation_level`, `category`; wraps
+  `BaseCompatError<ActionKey>` in its own `MetadataCompatibilityError`.
+- `nebula-credential::CredentialMetadata` — composes
+  `BaseMetadata<CredentialKey>`; adds `pattern`; wraps `BaseCompatError`
+  similarly.
+- `nebula-resource::ResourceMetadata` — composes
+  `BaseMetadata<ResourceKey>`; no entity-specific fields today, direct
+  delegation.
+- `nebula-plugin::PluginMetadata` — **does not** compose `BaseMetadata`
+  today. Reshape to `PluginManifest` (bundle descriptor) tracked in
+  [ADR-0018](../../docs/adr/0018-plugin-metadata-to-manifest.md);
+  manifest will reuse `Icon` / `MaturityLevel` / `DeprecationNotice` but
+  not `BaseMetadata<K>` (plugin is a container, not a schematized leaf).
+
+## Canon
+
+- `docs/PRODUCT_CANON.md §3.5` — integration model (one pattern, five concepts).
+- `docs/MATURITY.md` — crate-state dashboard row.
+- `docs/STYLE.md` — idioms, naming, error taxonomy.

--- a/crates/metadata/src/compat.rs
+++ b/crates/metadata/src/compat.rs
@@ -53,7 +53,7 @@ where
 /// Rules:
 /// - `key` must be equal.
 /// - `version` must be `>= previous.version` (full `semver::Version` ordering, including
-///   pre-release + build).
+///   pre-release tags; build metadata is ignored per the SemVer 2.0 spec).
 /// - If `schema` changed, `version.major` must exceed `previous.version.major`.
 ///
 /// Entity-specific rules (ports, auth pattern) are **not** checked here —
@@ -98,10 +98,6 @@ mod tests {
     }
 
     fn schema_with_one_field() -> ValidSchema {
-        // Real API: `SchemaBuilder: FieldCollector` exposes a closure-style
-        // `.string(key, |s| s)` child — see `crates/schema/src/builder/mod.rs:56`.
-        // `FieldCollector` is re-exported at `nebula_schema::FieldCollector`
-        // (see `crates/schema/src/lib.rs:72`).
         Schema::builder()
             .string("extra", |s| s)
             .build()

--- a/crates/metadata/src/compat.rs
+++ b/crates/metadata/src/compat.rs
@@ -1,9 +1,181 @@
-//! Version-compatibility helpers shared across metadata families.
+//! Generic compatibility rules shared by every catalog citizen.
 //!
-//! For v1 the only family that versions its metadata is
-//! [`ActionMetadata`](../../nebula_action/struct.ActionMetadata.html); the
-//! canonical compatibility rules live in `nebula-action` because they
-//! reference action-specific fields (ports, isolation level).
-//!
-//! This module reserves the name and is expected to grow as credentials
-//! and resources gain their own versioned evolution stories.
+//! Entity-specific rules (action ports, credential auth pattern, future
+//! plugin-manifest contents) compose *on top of* the shared checks here.
+//! Keeping the base rules here prevents action/credential/resource from
+//! copy-drifting `key immutable / version monotonic / schema-break-requires-
+//! major-bump` three times with slightly different spellings.
+
+use semver::Version;
+
+use crate::BaseMetadata;
+
+/// Entity-agnostic compatibility errors reported by
+/// [`validate_base_compat`].
+///
+/// `K` is the concrete catalog-entity key type (e.g. `ActionKey`,
+/// `CredentialKey`, `ResourceKey`). It must be `Display` so the error
+/// message can name the keys in each variant and `Debug + Clone + Eq` so
+/// the error composes inside a `thiserror`-derived parent enum.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum BaseCompatError<K>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    /// Typed entity key was replaced across revisions — identity is
+    /// immutable across a version history.
+    #[error("metadata key changed from `{previous}` to `{current}`")]
+    KeyChanged {
+        /// Previous key value.
+        previous: K,
+        /// Current (rejected) key value.
+        current: K,
+    },
+
+    /// Interface version went backwards.
+    #[error("interface version regressed from {previous} to {current}")]
+    VersionRegressed {
+        /// Previous version.
+        previous: Version,
+        /// Current (rejected) version.
+        current: Version,
+    },
+
+    /// Input schema changed shape but the major version was not bumped.
+    #[error("breaking schema change detected without a major version bump")]
+    SchemaChangeWithoutMajorBump,
+}
+
+/// Validate that `current` is a backwards-compatible revision of `previous`
+/// with respect to the shared `BaseMetadata` prefix.
+///
+/// Rules:
+/// - `key` must be equal.
+/// - `version` must be `>= previous.version` (full `semver::Version` ordering, including
+///   pre-release + build).
+/// - If `schema` changed, `version.major` must exceed `previous.version.major`.
+///
+/// Entity-specific rules (ports, auth pattern) are **not** checked here —
+/// each concrete metadata type layers its own rules on top.
+pub fn validate_base_compat<K>(
+    current: &BaseMetadata<K>,
+    previous: &BaseMetadata<K>,
+) -> Result<(), BaseCompatError<K>>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    if current.key != previous.key {
+        return Err(BaseCompatError::KeyChanged {
+            previous: previous.key.clone(),
+            current: current.key.clone(),
+        });
+    }
+    if current.version < previous.version {
+        return Err(BaseCompatError::VersionRegressed {
+            previous: previous.version.clone(),
+            current: current.version.clone(),
+        });
+    }
+    if current.schema != previous.schema && current.version.major == previous.version.major {
+        return Err(BaseCompatError::SchemaChangeWithoutMajorBump);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_schema::{FieldCollector, Schema, ValidSchema};
+    use semver::Version;
+
+    use super::{BaseCompatError, validate_base_compat};
+    use crate::BaseMetadata;
+
+    fn empty_schema() -> ValidSchema {
+        Schema::builder()
+            .build()
+            .expect("empty schema always valid")
+    }
+
+    fn schema_with_one_field() -> ValidSchema {
+        // Real API: `SchemaBuilder: FieldCollector` exposes a closure-style
+        // `.string(key, |s| s)` child — see `crates/schema/src/builder/mod.rs:56`.
+        // `FieldCollector` is re-exported at `nebula_schema::FieldCollector`
+        // (see `crates/schema/src/lib.rs:72`).
+        Schema::builder()
+            .string("extra", |s| s)
+            .build()
+            .expect("single-string schema always valid")
+    }
+
+    // Tests use a tiny newtype key so we don't pull nebula-core here.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestKey(&'static str);
+
+    impl std::fmt::Display for TestKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    fn md(key: &'static str, major: u64, minor: u64) -> BaseMetadata<TestKey> {
+        BaseMetadata::new(TestKey(key), "n", "d", empty_schema())
+            .with_version(Version::new(major, minor, 0))
+    }
+
+    #[test]
+    fn minor_bump_same_schema_ok() {
+        let prev = md("k", 1, 0);
+        let next = md("k", 1, 1);
+        assert!(validate_base_compat(&next, &prev).is_ok());
+    }
+
+    #[test]
+    fn major_bump_same_schema_ok() {
+        let prev = md("k", 1, 0);
+        let next = md("k", 2, 0);
+        assert!(validate_base_compat(&next, &prev).is_ok());
+    }
+
+    #[test]
+    fn key_change_rejected() {
+        let prev = md("old", 1, 0);
+        let next = md("new", 1, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::KeyChanged { .. }));
+    }
+
+    #[test]
+    fn version_regression_rejected() {
+        let prev = md("k", 2, 1);
+        let next = md("k", 2, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::VersionRegressed { .. }));
+    }
+
+    #[test]
+    fn schema_change_without_major_rejected() {
+        let prev = md("k", 1, 0);
+        let next_base = BaseMetadata::new(TestKey("k"), "n", "d", schema_with_one_field())
+            .with_version(Version::new(1, 1, 0));
+        let err = validate_base_compat(&next_base, &prev).unwrap_err();
+        assert_eq!(err, BaseCompatError::SchemaChangeWithoutMajorBump);
+    }
+
+    #[test]
+    fn schema_change_with_major_accepted() {
+        let prev = md("k", 1, 0);
+        let next_base = BaseMetadata::new(TestKey("k"), "n", "d", schema_with_one_field())
+            .with_version(Version::new(2, 0, 0));
+        assert!(validate_base_compat(&next_base, &prev).is_ok());
+    }
+
+    #[test]
+    fn display_includes_keys() {
+        let prev = md("old", 1, 0);
+        let next = md("new", 1, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("old") && msg.contains("new"), "got: {msg}");
+    }
+}

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -1,39 +1,7 @@
-//! `nebula-metadata` — shared metadata shapes for named, schematized entities.
-//!
-//! Every "catalog citizen" in Nebula — an action, a credential, a resource,
-//! a trigger, a future plugin — shares the same surface:
-//!
-//! - a typed [`key`](Metadata::key) that identifies it,
-//! - a human-readable [`name`](Metadata::name) and [`description`](Metadata::description),
-//! - a canonical [`ValidSchema`](nebula_schema::ValidSchema) describing its user-configurable
-//!   inputs,
-//! - optional catalog ornaments — [`icon`](Metadata::icon), documentation URL,
-//!   [`tags`](Metadata::tags),
-//! - a [`MaturityLevel`] and optional [`DeprecationNotice`].
-//!
-//! This crate owns those shared concerns as concrete types and a small trait,
-//! so each business-layer crate (action, credential, resource, …) composes
-//! them instead of redeclaring the same prefix with incompatible field names.
-//!
-//! # Shape
-//!
-//! ```no_run
-//! use nebula_metadata::{BaseMetadata, Icon, MaturityLevel, Metadata};
-//!
-//! pub struct MyKey;
-//!
-//! pub struct MyEntityMetadata {
-//!     pub base: BaseMetadata<MyKey>,
-//!     pub extra_field: u32,
-//! }
-//!
-//! impl Metadata for MyEntityMetadata {
-//!     type Key = MyKey;
-//!     fn base(&self) -> &BaseMetadata<Self::Key> {
-//!         &self.base
-//!     }
-//! }
-//! ```
+//! `nebula-metadata` — shared metadata shapes for catalog-leaf entities
+//! (actions, credentials, resources). See the crate README below for the
+//! full surface, composition example, consumer list, and the
+//! plugin-as-container carve-out (ADR-0018).
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -37,6 +37,7 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+#![doc = include_str!("../README.md")]
 
 /// Core [`BaseMetadata`] struct and [`Metadata`] trait.
 pub mod base;

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -40,7 +40,8 @@
 
 /// Core [`BaseMetadata`] struct and [`Metadata`] trait.
 pub mod base;
-/// Version-compatibility helpers shared across metadata families.
+/// [`BaseCompatError`] + [`validate_base_compat`] — generic compat rules
+/// shared by every catalog citizen.
 pub mod compat;
 /// [`DeprecationNotice`] — standard deprecation payload.
 pub mod deprecation;
@@ -50,6 +51,7 @@ pub mod icon;
 pub mod maturity;
 
 pub use base::{BaseMetadata, Metadata};
+pub use compat::{BaseCompatError, validate_base_compat};
 pub use deprecation::DeprecationNotice;
 pub use icon::Icon;
 pub use maturity::MaturityLevel;

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -38,3 +38,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
+semver = { workspace = true }

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -82,7 +82,9 @@ pub use recovery::{
 };
 pub use registry::{AnyManagedResource, Registry};
 pub use release_queue::ReleaseQueue;
-pub use resource::{AnyResource, Resource, ResourceConfig, ResourceMetadata};
+pub use resource::{
+    AnyResource, MetadataCompatibilityError, Resource, ResourceConfig, ResourceMetadata,
+};
 // Runtime types — needed for `Manager::register()`.
 pub use runtime::TopologyRuntime;
 pub use runtime::{

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -71,6 +71,22 @@ impl nebula_metadata::Metadata for ResourceMetadata {
     }
 }
 
+/// Compatibility validation errors for resource metadata evolution.
+///
+/// Wraps [`nebula_metadata::BaseCompatError`] for parity with the
+/// action- and credential-side error shapes. Resource has no
+/// entity-specific compat rules today, so the enum currently has a
+/// single `Base` variant; new variants will be added here (alongside
+/// `Base`) if `ResourceMetadata` later gains entity-specific fields
+/// whose changes should break version compatibility.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    /// A generic catalog-citizen rule fired (key / version / schema).
+    #[error(transparent)]
+    Base(#[from] nebula_metadata::BaseCompatError<nebula_core::ResourceKey>),
+}
+
 impl ResourceMetadata {
     /// Build resource metadata with explicit catalog-level fields.
     pub fn new(
@@ -116,16 +132,18 @@ impl ResourceMetadata {
 
     /// Validate that this metadata update is version-compatible with `previous`.
     ///
-    /// Resource metadata has no entity-specific fields beyond the shared
-    /// base, so this is a direct delegation to
-    /// [`nebula_metadata::validate_base_compat`]. If a future
-    /// `ResourceMetadata` gains entity-specific fields, wrap the result in
-    /// a `MetadataCompatibilityError` like `nebula-action` does.
+    /// Delegates `key immutable / version monotonic / schema-break-requires-
+    /// major` to [`nebula_metadata::validate_base_compat`]. Resource has no
+    /// entity-specific rules today, so the wrapper enum has only the `Base`
+    /// variant; the wrapper exists for shape parity with `nebula-action` and
+    /// `nebula-credential`, so callers can match the error across all three
+    /// catalog-leaf consumers uniformly.
     pub fn validate_compatibility(
         &self,
         previous: &Self,
-    ) -> Result<(), nebula_metadata::BaseCompatError<nebula_core::ResourceKey>> {
-        nebula_metadata::validate_base_compat(&self.base, &previous.base)
+    ) -> Result<(), MetadataCompatibilityError> {
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
+        Ok(())
     }
 }
 
@@ -225,7 +243,7 @@ mod tests {
     use nebula_schema::Schema;
     use semver::Version;
 
-    use super::ResourceMetadata;
+    use super::{MetadataCompatibilityError, ResourceMetadata};
 
     fn empty_schema() -> nebula_schema::ValidSchema {
         Schema::builder().build().unwrap()
@@ -249,6 +267,9 @@ mod tests {
         let prev = md(2, 1);
         let next = md(2, 0);
         let err = next.validate_compatibility(&prev).unwrap_err();
-        assert!(matches!(err, BaseCompatError::VersionRegressed { .. }));
+        assert!(matches!(
+            err,
+            MetadataCompatibilityError::Base(BaseCompatError::VersionRegressed { .. })
+        ));
     }
 }

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -113,6 +113,20 @@ impl ResourceMetadata {
             nebula_schema::ValidSchema::empty(),
         )
     }
+
+    /// Validate that this metadata update is version-compatible with `previous`.
+    ///
+    /// Resource metadata has no entity-specific fields beyond the shared
+    /// base, so this is a direct delegation to
+    /// [`nebula_metadata::validate_base_compat`]. If a future
+    /// `ResourceMetadata` gains entity-specific fields, wrap the result in
+    /// a `MetadataCompatibilityError` like `nebula-action` does.
+    pub fn validate_compatibility(
+        &self,
+        previous: &Self,
+    ) -> Result<(), nebula_metadata::BaseCompatError<nebula_core::ResourceKey>> {
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)
+    }
 }
 
 /// Core resource trait — 5 associated types + 4 lifecycle methods.
@@ -201,5 +215,40 @@ pub trait Resource: Send + Sync + 'static {
     /// Returns metadata for UI and diagnostics.
     fn metadata() -> ResourceMetadata {
         ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_core::resource_key;
+    use nebula_metadata::BaseCompatError;
+    use nebula_schema::Schema;
+    use semver::Version;
+
+    use super::ResourceMetadata;
+
+    fn empty_schema() -> nebula_schema::ValidSchema {
+        Schema::builder().build().unwrap()
+    }
+
+    fn md(major: u64, minor: u64) -> ResourceMetadata {
+        let mut m = ResourceMetadata::new(resource_key!("postgres"), "pg", "d", empty_schema());
+        m.base.version = Version::new(major, minor, 0);
+        m
+    }
+
+    #[test]
+    fn version_monotonic_accepted() {
+        let prev = md(1, 0);
+        let next = md(1, 1);
+        assert!(next.validate_compatibility(&prev).is_ok());
+    }
+
+    #[test]
+    fn version_regression_rejected() {
+        let prev = md(2, 1);
+        let next = md(2, 0);
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::VersionRegressed { .. }));
     }
 }

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -28,6 +28,7 @@ Legend:
 | nebula-execution     | stable   | stable  | stable | stable | partial |
 | nebula-expression    | stable   | stable  | stable | stable | n/a |
 | nebula-log           | stable   | stable  | stable | n/a | n/a |
+| nebula-metadata      | frontier | stable  | stable | n/a | n/a |
 | nebula-metrics       | stable   | stable  | stable | n/a | n/a |
 | nebula-plugin        | partial  | stable  | stable | partial (registry wired; load path partial) | n/a |
 | nebula-plugin-sdk    | partial  | stable  | stable | n/a | n/a |
@@ -50,4 +51,4 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-19 (ADR-0008 B1 / ADR-0017 follow-up: `pg::PgControlQueueRepo` landed — Postgres now honors the durable control plane via `FOR UPDATE SKIP LOCKED` and a concurrent-safe `reclaim_stuck` CAS; in-memory + Postgres share one behavioral parity test suite). Prior: 2026-04-19 (ADR-0008 A3 landed: engine cancel registry + dispatch_cancel / dispatch_terminate wired end-to-end; ADR-0016 documents the cooperative-cancel contract and the forced-shutdown gap).
+Last targeted revision: 2026-04-19 (nebula-metadata row added; `compat.rs` extracted to BaseCompatError + validate_base_compat; action / credential / resource wired to the shared check). Prior: 2026-04-19 (ADR-0008 B1 / ADR-0017 follow-up: `pg::PgControlQueueRepo` landed — Postgres now honors the durable control plane via `FOR UPDATE SKIP LOCKED` and a concurrent-safe `reclaim_stuck` CAS; in-memory + Postgres share one behavioral parity test suite). Prior: 2026-04-19 (ADR-0008 A3 landed: engine cancel registry + dispatch_cancel / dispatch_terminate wired end-to-end; ADR-0016 documents the cooperative-cancel contract and the forced-shutdown gap).

--- a/docs/adr/0018-plugin-metadata-to-manifest.md
+++ b/docs/adr/0018-plugin-metadata-to-manifest.md
@@ -1,0 +1,138 @@
+---
+id: 0018
+title: plugin-metadata-to-manifest
+status: proposed
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [plugin, metadata, canon-3.5]
+related:
+  - crates/plugin/src/metadata.rs
+  - crates/metadata/src/lib.rs
+  - docs/PRODUCT_CANON.md#35-integration-model-one-pattern-five-concepts
+linear: []
+---
+
+# ADR-0018 — `PluginMetadata` → `PluginManifest`
+
+## Context
+
+`nebula-plugin::PluginMetadata` was introduced before `nebula-metadata`
+existed and still carries the pre-consolidation shape:
+
+- `icon: Option<String>` + `icon_url: Option<String>` — the two-field
+  invalid-combination problem that `nebula_metadata::Icon` was introduced
+  to solve.
+- `version: u32` — conflicts with `semver::Version` used everywhere else
+  in Nebula (and with ADR-0007 identifier conventions spirit).
+- No `maturity`, no `deprecation` — a plugin can never be marked
+  experimental or scheduled for removal.
+- `author`, `license`, `homepage`, `repository`, `nebula_version`,
+  `group`, `color` — all bundle-level / provenance fields that do not
+  apply to leaf entities.
+
+Meanwhile `nebula_metadata::BaseMetadata<K>` is the canonical shape for
+catalog citizens (§3.5). It requires `schema: ValidSchema`, which a
+plugin — being a **container** for actions / credentials / resources —
+does not have: user input lives on the leaves it bundles, not on the
+container itself. Forcing a plugin into `BaseMetadata` would require
+either making `schema` optional (uglifying every leaf consumer's
+accessors) or passing `ValidSchema::empty()` (misleading semantics:
+"empty schema" ≠ "no schema applies").
+
+The right fix is not to bend the leaf shape around a container — it is
+to give the container its own, honest type.
+
+## Decision
+
+1. Rename `nebula-plugin::PluginMetadata` → `nebula-plugin::PluginManifest`
+   (a **bundle descriptor**, not entity metadata).
+
+2. `PluginManifest` **does not compose `BaseMetadata<K>`.** A plugin is
+   not a schematized leaf.
+
+3. `PluginManifest` **reuses the small types** from `nebula-metadata`:
+
+   - `Icon` — replaces `icon: Option<String>` + `icon_url: Option<String>`.
+   - `MaturityLevel` — new for plugins (experimental / beta / stable /
+     deprecated).
+   - `DeprecationNotice` — new for plugins.
+
+4. `PluginManifest::version` adopts `semver::Version` (consistency with
+   `BaseMetadata::version`).
+
+5. Plugin-specific fields stay on the manifest: `author`, `license`,
+   `homepage`, `repository`, `nebula_version`, `group`, `color`,
+   `description`, `name`, `key`, `tags`. Builder + `normalize_key`
+   behavior is preserved.
+
+## Consequences
+
+**Positive.**
+- Manifest stops advertising invalid icon combinations.
+- Plugins can declare `MaturityLevel::Experimental` / mark deprecations.
+- Semver is used uniformly.
+- The conceptual split (container vs. leaf) becomes visible in types.
+
+**Negative.**
+- Wire format breaks for any persisted plugin metadata. Scope is small:
+  no known production deployments, `nebula-plugin` is `frontier` per
+  `docs/MATURITY.md`.
+- `nebula-plugin` gains a direct dep on `nebula-metadata` (for `Icon` /
+  `MaturityLevel` / `DeprecationNotice`).
+
+**Neutral.**
+- `Plugin::metadata() → Plugin::manifest()` rename propagates through
+  `nebula-plugin::macros`, `nebula-engine::lib.rs` re-exports, and every
+  plugin test fixture.
+
+## Alternatives considered
+
+- **(A) Make `BaseMetadata::schema` optional** (`Option<ValidSchema>`).
+  *Rejected:* every leaf consumer — action, credential, resource, and
+  any future leaf — would gain an `Option<ValidSchema>` in its accessor
+  to support a single non-leaf case.
+
+- **(B) Plugin uses `BaseMetadata` with `ValidSchema::empty()`.**
+  *Rejected:* misleading semantics. "Empty schema" implies "this entity
+  has a schema, and it happens to have zero fields", not "this entity
+  has no schema concept".
+
+- **(C) Split `CatalogInfo<K>` (cosmetic prefix: name / description /
+  icon / documentation_url / tags / maturity / deprecation) from
+  `BaseMetadata<K>` (= `CatalogInfo<K>` + schema).** *Rejected* for now:
+  adds a new abstraction layer for a single non-leaf consumer. Revisit
+  only if a second container type (bundle, pack, preset) appears.
+
+- **(D) Leave `PluginMetadata` as-is; extract only the shared small types
+  (`Icon`, `MaturityLevel`, `DeprecationNotice`) and adopt them
+  field-by-field without renaming the struct or touching its accessors.**
+  *Rejected:* the shape problem is not only cosmetic. `version: u32`
+  contradicts semver everywhere else in Nebula, `icon` + `icon_url` as
+  two `Option<String>` fields is exactly the invalid-state bug `Icon`
+  was introduced to fix, and `PluginMetadata` as a *name* now mis-signals
+  that a plugin is a catalog-leaf like `ActionMetadata` /
+  `CredentialMetadata` / `ResourceMetadata` — which it is not. Piecemeal
+  extraction leaves a type whose name lies about its role; the rename to
+  `PluginManifest` is the part that prevents the next contributor from
+  composing `BaseMetadata` into it on reflex. The ADR scope is
+  intentionally wider than "swap the small types".
+
+## Migration plan (executed in a follow-up PR)
+
+1. Introduce `PluginManifest` alongside `PluginMetadata`; mark the old
+   type `#[deprecated]`.
+2. Rename `Plugin::metadata() → Plugin::manifest()` directly — no shim.
+   `nebula-plugin` is `frontier` per `docs/MATURITY.md`; the
+   `CLAUDE.md` quick-win trap catalog explicitly discourages shim-naming.
+3. Update `nebula-plugin::macros` so `#[plugin]` emits
+   `PluginManifest::builder(...)`.
+4. Update `nebula-engine` re-exports (`crates/engine/src/lib.rs:70`) and
+   `crates/engine/README.md:63`.
+5. Delete `PluginMetadata` in the following cycle.
+
+## Follow-ups
+
+- Track migration PR against this ADR (issue created at implementation
+  time).
+- Revisit alternative (C) when a second container-shape entity arrives.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,13 +24,14 @@ changes land as a new ADR that `supersedes` it.
 | [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | accepted | 2026-04-19 |
 | [0015](./0015-execution-lease-lifecycle.md) | Execution lease lifecycle (renumbered from 0008; promoted on #325 implementation) | accepted | 2026-04-19 |
 | [0016](./0016-engine-cancel-registry.md) | Engine cancel registry — cooperative-cancel contract for ADR-0008 A3 | accepted | 2026-04-19 |
+| [0018](./0018-plugin-metadata-to-manifest.md) | `PluginMetadata` → `PluginManifest` (bundle descriptor, reuse small types from `nebula-metadata`) | proposed | 2026-04-19 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0017**). Do not reuse.
+2. Pick the next free number (currently **0019**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/superpowers/plans/2026-04-19-nebula-metadata-completion.md
+++ b/docs/superpowers/plans/2026-04-19-nebula-metadata-completion.md
@@ -1,0 +1,1162 @@
+# nebula-metadata Completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract generic compat rules from `ActionMetadata` into `nebula-metadata::compat`, wire action/credential/resource to the shared checks, and document the crate (README, MATURITY row, ADR-0018 for the future plugin→manifest migration).
+
+**Architecture:** `BaseCompatError<K>` + `validate_base_compat` live in `nebula-metadata`; each consumer wraps the shared error in its own thin enum (or delegates directly when no entity-specific rules exist). `PluginManifest` reshape stays docs-only (ADR-0018).
+
+**Tech Stack:** Rust 2024, `thiserror`, `semver`, `cargo nextest`, workspace clippy gate.
+
+**Spec:** [`docs/superpowers/specs/2026-04-19-nebula-metadata-completion-design.md`](../specs/2026-04-19-nebula-metadata-completion-design.md)
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+|---|---|---|
+| `crates/metadata/Cargo.toml` | Modify | Add `thiserror` workspace dep. |
+| `crates/metadata/src/compat.rs` | Modify | Replace stub with `BaseCompatError<K>` + `validate_base_compat` + tests. |
+| `crates/metadata/src/lib.rs` | Modify | Re-export `BaseCompatError` and `validate_base_compat`. |
+| `crates/action/src/metadata.rs` | Modify | Convert `MetadataCompatibilityError` into wrapper over `BaseCompatError<ActionKey>` + action-specific `PortsChangeWithoutMajorBump`. Update affected tests. |
+| `crates/credential/src/metadata.rs` | Modify | New `MetadataCompatibilityError` (wraps base + `PatternChangeWithoutMajorBump`) + `validate_compatibility`. |
+| `crates/resource/src/resource.rs` | Modify | New `ResourceMetadata::validate_compatibility` (direct delegation). |
+| `crates/metadata/README.md` | Create | Workspace-style crate README (purpose / core types / composition / consumers / crosslinks). |
+| `docs/MATURITY.md` | Modify | Insert `nebula-metadata` row; bump `Last targeted revision`. |
+| `docs/adr/0018-plugin-metadata-to-manifest.md` | Create | ADR capturing the `PluginMetadata` → `PluginManifest` decision (docs-only). |
+| `docs/adr/README.md` | Modify | Add `0018` row to the ADR index. |
+
+---
+
+## Task 1: Compat primitives in `nebula-metadata`
+
+**Files:**
+- Modify: `crates/metadata/Cargo.toml`
+- Modify: `crates/metadata/src/compat.rs` (currently doc-only stub)
+- Modify: `crates/metadata/src/lib.rs`
+- Test: `crates/metadata/src/compat.rs` (inline `#[cfg(test)] mod tests`)
+
+- [ ] **Step 1.1: Add `thiserror` to `crates/metadata/Cargo.toml`**
+
+Edit `crates/metadata/Cargo.toml`. Insert `thiserror = { workspace = true }` into `[dependencies]` so the block reads:
+
+```toml
+[dependencies]
+nebula-schema = { path = "../schema" }
+semver = { workspace = true, features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+thiserror = { workspace = true }
+```
+
+- [ ] **Step 1.2: Write failing tests in `crates/metadata/src/compat.rs`**
+
+Replace the entire contents of `crates/metadata/src/compat.rs` with the tests-first skeleton below. `use super::*;` is not needed yet because the types do not exist — the tests reference them directly from `crate::compat`, giving a compile error we will remove when the implementation lands.
+
+```rust
+//! Generic compatibility rules shared by every catalog citizen.
+//!
+//! Entity-specific rules (action ports, credential auth pattern, future
+//! plugin-manifest contents) compose *on top of* the shared checks here.
+//! Keeping the base rules here prevents action/credential/resource from
+//! copy-drifting `key immutable / version monotonic / schema-break-requires-
+//! major-bump` three times with slightly different spellings.
+
+#[cfg(test)]
+mod tests {
+    use nebula_schema::{FieldCollector, Schema, ValidSchema};
+    use semver::Version;
+
+    use super::{BaseCompatError, validate_base_compat};
+    use crate::BaseMetadata;
+
+    fn empty_schema() -> ValidSchema {
+        Schema::builder()
+            .build()
+            .expect("empty schema always valid")
+    }
+
+    fn schema_with_one_field() -> ValidSchema {
+        // Real API: `SchemaBuilder: FieldCollector` exposes a closure-style
+        // `.string(key, |s| s)` child — see `crates/schema/src/builder/mod.rs:56`.
+        // `FieldCollector` is re-exported at `nebula_schema::FieldCollector`
+        // (see `crates/schema/src/lib.rs:72`).
+        Schema::builder()
+            .string("extra", |s| s)
+            .build()
+            .expect("single-string schema always valid")
+    }
+
+    // Tests use a tiny newtype key so we don't pull nebula-core here.
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestKey(&'static str);
+
+    impl std::fmt::Display for TestKey {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.write_str(self.0)
+        }
+    }
+
+    fn md(key: &'static str, major: u64, minor: u64) -> BaseMetadata<TestKey> {
+        BaseMetadata::new(TestKey(key), "n", "d", empty_schema())
+            .with_version(Version::new(major, minor, 0))
+    }
+
+    #[test]
+    fn minor_bump_same_schema_ok() {
+        let prev = md("k", 1, 0);
+        let next = md("k", 1, 1);
+        assert!(validate_base_compat(&next, &prev).is_ok());
+    }
+
+    #[test]
+    fn major_bump_same_schema_ok() {
+        let prev = md("k", 1, 0);
+        let next = md("k", 2, 0);
+        assert!(validate_base_compat(&next, &prev).is_ok());
+    }
+
+    #[test]
+    fn key_change_rejected() {
+        let prev = md("old", 1, 0);
+        let next = md("new", 1, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::KeyChanged { .. }));
+    }
+
+    #[test]
+    fn version_regression_rejected() {
+        let prev = md("k", 2, 1);
+        let next = md("k", 2, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::VersionRegressed { .. }));
+    }
+
+    #[test]
+    fn schema_change_without_major_rejected() {
+        let prev = md("k", 1, 0);
+        // Same key + minor bump but a *different* schema triggers the rule.
+        let next_base =
+            BaseMetadata::new(TestKey("k"), "n", "d", schema_with_one_field())
+                .with_version(Version::new(1, 1, 0));
+        let err = validate_base_compat(&next_base, &prev).unwrap_err();
+        assert_eq!(err, BaseCompatError::SchemaChangeWithoutMajorBump);
+    }
+
+    #[test]
+    fn schema_change_with_major_accepted() {
+        let prev = md("k", 1, 0);
+        let next_base =
+            BaseMetadata::new(TestKey("k"), "n", "d", schema_with_one_field())
+                .with_version(Version::new(2, 0, 0));
+        assert!(validate_base_compat(&next_base, &prev).is_ok());
+    }
+
+    #[test]
+    fn display_includes_keys() {
+        let prev = md("old", 1, 0);
+        let next = md("new", 1, 0);
+        let err = validate_base_compat(&next, &prev).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("old") && msg.contains("new"), "got: {msg}");
+    }
+}
+```
+
+Builder API reference: `SchemaBuilder: FieldCollector` — see
+`crates/schema/src/builder/mod.rs:36-113` for the trait methods
+(`.string / .number / .boolean / …`) and `crates/schema/src/schema.rs:262`
+for the `impl`. `FieldCollector` is re-exported at
+`nebula_schema::FieldCollector` per `crates/schema/src/lib.rs:72`. The
+closure form is `.string(key, |s| s)` (returns the builder unchanged) —
+any other method from the trait produces a `ValidSchema != empty_schema()`
+and also works. Do **not** invent new method names; if the signatures
+above do not match current source, stop and open an issue before
+continuing.
+
+- [ ] **Step 1.3: Run tests — expect compile failure**
+
+Run: `cargo nextest run -p nebula-metadata`
+Expected: compile error — `BaseCompatError` and `validate_base_compat` unresolved.
+
+- [ ] **Step 1.4: Implement `BaseCompatError<K>` + `validate_base_compat`**
+
+Insert the production code at the top of `crates/metadata/src/compat.rs`, above the `#[cfg(test)] mod tests` block you wrote in Step 1.2. Final file shape:
+
+```rust
+//! Generic compatibility rules shared by every catalog citizen.
+//!
+//! Entity-specific rules (action ports, credential auth pattern, future
+//! plugin-manifest contents) compose *on top of* the shared checks here.
+//! Keeping the base rules here prevents action/credential/resource from
+//! copy-drifting `key immutable / version monotonic / schema-break-requires-
+//! major-bump` three times with slightly different spellings.
+
+use semver::Version;
+
+use crate::BaseMetadata;
+
+/// Entity-agnostic compatibility errors reported by
+/// [`validate_base_compat`].
+///
+/// `K` is the concrete catalog-entity key type (e.g. `ActionKey`,
+/// `CredentialKey`, `ResourceKey`). It must be `Display` so the error
+/// message can name the keys in each variant and `Debug + Clone + Eq` so
+/// the error composes inside a `thiserror`-derived parent enum.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum BaseCompatError<K>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    /// Typed entity key was replaced across revisions — identity is
+    /// immutable across a version history.
+    #[error("metadata key changed from `{previous}` to `{current}`")]
+    KeyChanged {
+        /// Previous key value.
+        previous: K,
+        /// Current (rejected) key value.
+        current: K,
+    },
+
+    /// Interface version went backwards.
+    #[error("interface version regressed from {previous} to {current}")]
+    VersionRegressed {
+        /// Previous version.
+        previous: Version,
+        /// Current (rejected) version.
+        current: Version,
+    },
+
+    /// Input schema changed shape but the major version was not bumped.
+    #[error("breaking schema change detected without a major version bump")]
+    SchemaChangeWithoutMajorBump,
+}
+
+/// Validate that `current` is a backwards-compatible revision of `previous`
+/// with respect to the shared `BaseMetadata` prefix.
+///
+/// Rules:
+/// - `key` must be equal.
+/// - `version` must be `>= previous.version` (full `semver::Version`
+///   ordering, including pre-release + build).
+/// - If `schema` changed, `version.major` must exceed `previous.version.major`.
+///
+/// Entity-specific rules (ports, auth pattern) are **not** checked here —
+/// each concrete metadata type layers its own rules on top.
+pub fn validate_base_compat<K>(
+    current: &BaseMetadata<K>,
+    previous: &BaseMetadata<K>,
+) -> Result<(), BaseCompatError<K>>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    if current.key != previous.key {
+        return Err(BaseCompatError::KeyChanged {
+            previous: previous.key.clone(),
+            current: current.key.clone(),
+        });
+    }
+    if current.version < previous.version {
+        return Err(BaseCompatError::VersionRegressed {
+            previous: previous.version.clone(),
+            current: current.version.clone(),
+        });
+    }
+    if current.schema != previous.schema
+        && current.version.major == previous.version.major
+    {
+        return Err(BaseCompatError::SchemaChangeWithoutMajorBump);
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 1.5: Re-export from `crates/metadata/src/lib.rs`**
+
+Edit `crates/metadata/src/lib.rs`. Update the re-exports block near the bottom of the file so it reads:
+
+```rust
+pub use base::{BaseMetadata, Metadata};
+pub use compat::{BaseCompatError, validate_base_compat};
+pub use deprecation::DeprecationNotice;
+pub use icon::Icon;
+pub use maturity::MaturityLevel;
+```
+
+Also update the module doc comment on `pub mod compat;` above, replacing the current line with:
+
+```rust
+/// [`BaseCompatError`] + [`validate_base_compat`] — generic compat rules
+/// shared by every catalog citizen.
+pub mod compat;
+```
+
+- [ ] **Step 1.6: Run tests — expect green**
+
+Run: `cargo nextest run -p nebula-metadata`
+Expected: all 6 new compat tests pass; existing tests in `base.rs`, `deprecation.rs`, `icon.rs`, `maturity.rs` stay green.
+
+- [ ] **Step 1.7: Run clippy (crate-local)**
+
+Run: `cargo clippy -p nebula-metadata -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 1.8: Commit**
+
+```bash
+git add crates/metadata/Cargo.toml crates/metadata/src/compat.rs crates/metadata/src/lib.rs
+git commit -m "$(cat <<'EOF'
+feat(metadata): extract shared compat rules to BaseCompatError
+
+Generic compat checks (key immutable / version monotonic /
+schema-break-requires-major) now live on BaseMetadata, so action /
+credential / resource can compose them instead of each re-implementing
+the same three rules with slightly different spellings.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate `nebula-action` to the shared error
+
+**Files:**
+- Modify: `crates/action/src/metadata.rs`
+
+- [ ] **Step 2.1: Update existing tests in `crates/action/src/metadata.rs` to the new matcher shape (failing)**
+
+Locate `fn key_change_is_rejected` in the `#[cfg(test)] mod tests` block. Replace its final `assert!(matches!(...))` with:
+
+```rust
+use nebula_metadata::BaseCompatError;
+
+let err = next.validate_compatibility(&prev).unwrap_err();
+assert!(matches!(
+    err,
+    MetadataCompatibilityError::Base(BaseCompatError::KeyChanged { .. })
+));
+```
+
+Locate `fn version_regression_is_rejected`. Replace the matcher similarly:
+
+```rust
+assert!(matches!(
+    err,
+    MetadataCompatibilityError::Base(BaseCompatError::VersionRegressed { .. })
+));
+```
+
+Locate `fn schema_change_requires_major_bump`. Its current body differs the
+`outputs` of the two metadata objects, so after migration it exercises the
+**ports** rule, not the schema rule. Replace the assertion:
+
+```rust
+let err = next.validate_compatibility(&prev).unwrap_err();
+assert_eq!(err, MetadataCompatibilityError::PortsChangeWithoutMajorBump);
+```
+
+Add a new test below it that exercises the schema rule via `BaseCompatError`:
+
+```rust
+#[test]
+fn schema_field_change_requires_major_bump() {
+    use nebula_schema::{FieldCollector, Schema};
+
+    let prev = ActionMetadata::new(action_key!("http.request"), "HTTP", "desc")
+        .with_version(1, 0);
+    let next = ActionMetadata::new(action_key!("http.request"), "HTTP", "desc")
+        .with_version(1, 1)
+        .with_schema(
+            Schema::builder()
+                .string("added", |s| s)
+                .build()
+                .unwrap(),
+        );
+
+    let err = next.validate_compatibility(&prev).unwrap_err();
+    assert!(matches!(
+        err,
+        MetadataCompatibilityError::Base(BaseCompatError::SchemaChangeWithoutMajorBump)
+    ));
+}
+```
+
+`Schema::builder().string(key, |s| s).build()` uses the real
+`FieldCollector::string` method — see the builder API reference in
+Step 1.2. Do not invent a different method name.
+
+Reviewer note: this task intentionally changes the *semantics* of the
+existing `schema_change_requires_major_bump` test (its body differs
+outputs, so under the new rules it exercises ports, not schema) and adds
+a fresh `schema_field_change_requires_major_bump` test for the
+schema-rule path. The commit message in Step 2.7 calls this out in
+plain English.
+
+- [ ] **Step 2.2: Run tests — expect compile failure**
+
+Run: `cargo nextest run -p nebula-action --no-run` (then `run` if you want to see failures directly)
+Expected: compile errors — `MetadataCompatibilityError::Base`, `::PortsChangeWithoutMajorBump`, and the `BaseCompatError` import unresolved.
+
+- [ ] **Step 2.3: Rewrite `MetadataCompatibilityError` in `crates/action/src/metadata.rs`**
+
+Replace the current enum definition (lines 71–93 in the current file) with the wrapper:
+
+```rust
+/// Compatibility validation errors for action metadata evolution.
+///
+/// Wraps [`nebula_metadata::BaseCompatError`] (shared catalog-entity rules)
+/// and layers the action-specific port-change rule on top.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    /// A generic catalog-citizen rule fired (key / version / schema).
+    #[error(transparent)]
+    Base(#[from] nebula_metadata::BaseCompatError<ActionKey>),
+
+    /// Input or output ports changed without a major version bump.
+    #[error("action ports changed without a major version bump")]
+    PortsChangeWithoutMajorBump,
+}
+```
+
+Then replace `ActionMetadata::validate_compatibility` (currently around lines 324–356) with:
+
+```rust
+/// Validate that this metadata update is version-compatible with `previous`.
+///
+/// Delegates `key immutable / version monotonic / schema-break-requires-
+/// major` to [`nebula_metadata::validate_base_compat`]; layers the action-
+/// specific port-change rule on top.
+pub fn validate_compatibility(
+    &self,
+    previous: &Self,
+) -> Result<(), MetadataCompatibilityError> {
+    nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
+
+    let ports_changed =
+        self.inputs != previous.inputs || self.outputs != previous.outputs;
+    if ports_changed && self.base.version.major == previous.base.version.major {
+        return Err(MetadataCompatibilityError::PortsChangeWithoutMajorBump);
+    }
+
+    Ok(())
+}
+```
+
+- [ ] **Step 2.4: Remove the now-orphan imports**
+
+Scroll to the top of `crates/action/src/metadata.rs`. The `use semver::Version;` import stays (used for `with_version_full`). The `thiserror` import is already there via the enum derive attribute — if clippy flags a duplicate, remove the redundant line. No other cleanup is expected.
+
+- [ ] **Step 2.5: Run tests — expect green**
+
+Run: `cargo nextest run -p nebula-action`
+Expected: all action tests pass including the updated matchers and the new `schema_field_change_requires_major_bump`.
+
+- [ ] **Step 2.6: Run workspace clippy over touched crates**
+
+Run: `cargo clippy -p nebula-metadata -p nebula-action -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 2.7: Commit**
+
+```bash
+git add crates/action/src/metadata.rs
+git commit -m "$(cat <<'EOF'
+refactor(action): use BaseCompatError via wrapper in MetadataCompatibilityError
+
+MetadataCompatibilityError now wraps nebula_metadata::BaseCompatError and
+adds a single action-specific variant (PortsChangeWithoutMajorBump).
+Port-change semantics stay identical; schema-change semantics now surface
+as Base(SchemaChangeWithoutMajorBump) so credential and resource can
+reuse the same rule without copy-drift.
+
+Note: the existing `schema_change_requires_major_bump` test in
+crates/action/src/metadata.rs is repurposed — its body differs the
+outputs of the two metadata objects, so post-migration it exercises the
+PortsChangeWithoutMajorBump rule, not the schema rule. A new
+`schema_field_change_requires_major_bump` test added alongside covers
+the schema rule via Base(SchemaChangeWithoutMajorBump). This is a
+test-semantics change, not a pure refactor.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Add compat to `nebula-credential`
+
+**Files:**
+- Modify: `crates/credential/src/metadata.rs`
+
+- [ ] **Step 3.1: Write failing tests at the bottom of `crates/credential/src/metadata.rs`**
+
+Append a `#[cfg(test)] mod tests` block (if one does not already exist — check the file first; if it does, add inside it):
+
+```rust
+#[cfg(test)]
+mod compat_tests {
+    use nebula_core::{AuthPattern, credential_key};
+    use nebula_metadata::BaseCompatError;
+    use nebula_schema::Schema;
+    use semver::Version;
+
+    use super::{CredentialMetadata, MetadataCompatibilityError};
+
+    fn empty_schema() -> nebula_schema::ValidSchema {
+        Schema::builder().build().unwrap()
+    }
+
+    fn cred(pattern: AuthPattern, major: u64, minor: u64) -> CredentialMetadata {
+        let mut m = CredentialMetadata::new(
+            credential_key!("cred"),
+            "C",
+            "d",
+            empty_schema(),
+            pattern,
+        );
+        m.base.version = Version::new(major, minor, 0);
+        m
+    }
+
+    #[test]
+    fn pattern_change_requires_major_bump() {
+        let prev = cred(AuthPattern::OpaqueSecret, 1, 0);
+        let next = cred(AuthPattern::OAuth2, 1, 1);
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert_eq!(err, MetadataCompatibilityError::PatternChangeWithoutMajorBump);
+    }
+
+    #[test]
+    fn pattern_change_with_major_accepted() {
+        let prev = cred(AuthPattern::OpaqueSecret, 1, 0);
+        let next = cred(AuthPattern::OAuth2, 2, 0);
+        assert!(next.validate_compatibility(&prev).is_ok());
+    }
+
+    #[test]
+    fn key_change_via_base_rejected() {
+        let prev = CredentialMetadata::new(
+            credential_key!("a"), "A", "d", empty_schema(), AuthPattern::OpaqueSecret,
+        );
+        let next = CredentialMetadata::new(
+            credential_key!("b"), "A", "d", empty_schema(), AuthPattern::OpaqueSecret,
+        );
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert!(matches!(
+            err,
+            MetadataCompatibilityError::Base(BaseCompatError::KeyChanged { .. })
+        ));
+    }
+}
+```
+
+If `credential_key!` macro isn't available from `nebula_core`, grep `crates/credential/src/` for how tests build a `CredentialKey` (likely `CredentialKey::new("cred").unwrap()`) and substitute.
+
+Both `AuthPattern::OpaqueSecret` and `AuthPattern::OAuth2` are present in
+`crates/core/src/auth.rs` (the `OpaqueSecret` variant is Nebula's name for
+API-key / bearer-token / session-token style credentials; there is no
+`ApiKey` variant).
+
+- [ ] **Step 3.2: Run tests — expect compile failure**
+
+Run: `cargo nextest run -p nebula-credential`
+Expected: compile error — `MetadataCompatibilityError` and `validate_compatibility` undefined.
+
+- [ ] **Step 3.3: Implement `MetadataCompatibilityError` + `validate_compatibility`**
+
+Add below the `CredentialMetadataBuilder` impl block in `crates/credential/src/metadata.rs`:
+
+```rust
+/// Compatibility validation errors for credential metadata evolution.
+///
+/// Wraps [`nebula_metadata::BaseCompatError`] and layers the credential-
+/// specific auth-pattern rule on top.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    /// A generic catalog-citizen rule fired (key / version / schema).
+    #[error(transparent)]
+    Base(#[from] nebula_metadata::BaseCompatError<nebula_core::CredentialKey>),
+
+    /// Auth pattern changed without a major version bump.
+    #[error("credential auth pattern changed without a major version bump")]
+    PatternChangeWithoutMajorBump,
+}
+
+impl CredentialMetadata {
+    /// Validate that this metadata update is version-compatible with `previous`.
+    ///
+    /// Delegates `key immutable / version monotonic / schema-break-requires-
+    /// major` to [`nebula_metadata::validate_base_compat`]; layers the
+    /// credential-specific auth-pattern rule on top.
+    pub fn validate_compatibility(
+        &self,
+        previous: &Self,
+    ) -> Result<(), MetadataCompatibilityError> {
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
+
+        if self.pattern != previous.pattern
+            && self.base.version.major == previous.base.version.major
+        {
+            return Err(MetadataCompatibilityError::PatternChangeWithoutMajorBump);
+        }
+
+        Ok(())
+    }
+}
+```
+
+- [ ] **Step 3.4: Run tests — expect green**
+
+Run: `cargo nextest run -p nebula-credential`
+Expected: all three new compat tests pass; existing tests stay green.
+
+- [ ] **Step 3.5: Run clippy**
+
+Run: `cargo clippy -p nebula-credential -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 3.6: Commit**
+
+```bash
+git add crates/credential/src/metadata.rs
+git commit -m "$(cat <<'EOF'
+feat(credential): add validate_compatibility using shared BaseCompatError
+
+MetadataCompatibilityError wraps nebula_metadata::BaseCompatError and
+adds PatternChangeWithoutMajorBump for the credential-specific auth
+pattern rule. Fills the parity gap vs nebula-action where credential
+metadata previously had no compat validator at all.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Add compat to `nebula-resource`
+
+**Files:**
+- Modify: `crates/resource/src/resource.rs`
+
+- [ ] **Step 4.1: Write failing test in `crates/resource/src/resource.rs`**
+
+Append inside the file's `#[cfg(test)] mod tests` block (if none, add one at the bottom):
+
+```rust
+#[cfg(test)]
+mod compat_tests {
+    use nebula_core::resource_key;
+    use nebula_metadata::BaseCompatError;
+    use nebula_schema::Schema;
+    use semver::Version;
+
+    use super::ResourceMetadata;
+
+    fn empty_schema() -> nebula_schema::ValidSchema {
+        Schema::builder().build().unwrap()
+    }
+
+    fn md(major: u64, minor: u64) -> ResourceMetadata {
+        let mut m = ResourceMetadata::new(
+            resource_key!("postgres"), "pg", "d", empty_schema(),
+        );
+        m.base.version = Version::new(major, minor, 0);
+        m
+    }
+
+    #[test]
+    fn version_monotonic_accepted() {
+        let prev = md(1, 0);
+        let next = md(1, 1);
+        assert!(next.validate_compatibility(&prev).is_ok());
+    }
+
+    #[test]
+    fn version_regression_rejected() {
+        let prev = md(2, 1);
+        let next = md(2, 0);
+        let err = next.validate_compatibility(&prev).unwrap_err();
+        assert!(matches!(err, BaseCompatError::VersionRegressed { .. }));
+    }
+}
+```
+
+If `resource_key!` macro is not exposed, use `ResourceKey::new("postgres").unwrap()` directly.
+
+- [ ] **Step 4.2: Run — expect compile failure**
+
+Run: `cargo nextest run -p nebula-resource`
+Expected: compile error — `validate_compatibility` undefined on `ResourceMetadata`.
+
+- [ ] **Step 4.3: Implement `ResourceMetadata::validate_compatibility`**
+
+Insert inside the existing `impl ResourceMetadata { ... }` block in `crates/resource/src/resource.rs` (currently ending around line 116):
+
+```rust
+    /// Validate that this metadata update is version-compatible with `previous`.
+    ///
+    /// Resource metadata has no entity-specific fields beyond the shared
+    /// base, so this is a direct delegation to
+    /// [`nebula_metadata::validate_base_compat`]. If a future
+    /// `ResourceMetadata` gains entity-specific fields, wrap the result in
+    /// a `MetadataCompatibilityError` like `nebula-action` does.
+    pub fn validate_compatibility(
+        &self,
+        previous: &Self,
+    ) -> Result<(), nebula_metadata::BaseCompatError<nebula_core::ResourceKey>> {
+        nebula_metadata::validate_base_compat(&self.base, &previous.base)
+    }
+```
+
+- [ ] **Step 4.4: Run tests — expect green**
+
+Run: `cargo nextest run -p nebula-resource`
+Expected: both new compat tests pass; existing tests stay green.
+
+- [ ] **Step 4.5: Run clippy**
+
+Run: `cargo clippy -p nebula-resource -- -D warnings`
+Expected: no warnings.
+
+- [ ] **Step 4.6: Commit**
+
+```bash
+git add crates/resource/src/resource.rs
+git commit -m "$(cat <<'EOF'
+feat(resource): add validate_compatibility using shared BaseCompatError
+
+Direct delegation to nebula_metadata::validate_base_compat. Resource has
+no entity-specific rules today, so the consumer signature returns the
+bare BaseCompatError<ResourceKey>; swap to a MetadataCompatibilityError
+wrapper the moment resource-specific rules appear.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `crates/metadata/README.md`
+
+**Files:**
+- Create: `crates/metadata/README.md`
+
+- [ ] **Step 5.1: Write the README**
+
+Create `crates/metadata/README.md` with the exact content:
+
+````markdown
+---
+name: nebula-metadata
+role: Shared catalog-citizen metadata (BaseMetadata + Metadata trait + Icon / MaturityLevel / DeprecationNotice + compat rules)
+status: frontier
+last-reviewed: 2026-04-19
+canon-invariants: [L2-3.5]
+related: [nebula-action, nebula-credential, nebula-resource, nebula-plugin]
+---
+
+# nebula-metadata
+
+## Purpose
+
+Every catalog citizen in Nebula — an action, a credential, a resource, a
+future plugin — shares the same surface: a typed key, a human-readable
+name and description, a canonical input schema, optional catalog
+ornaments (icon, documentation URL, tags), a declared maturity level,
+and an optional deprecation notice. `nebula-metadata` owns those shared
+concerns as concrete types and a small trait, so each business-layer
+crate composes them instead of redeclaring the same prefix with
+incompatible field names.
+
+## Role
+
+**Core-layer support crate.** Cross-cutting, no upward dependencies.
+Only depends on `nebula-schema` (for `ValidSchema`), `semver`, `serde`,
+and `thiserror`. Every other crate in the business layer
+(`nebula-action`, `nebula-credential`, `nebula-resource`) composes
+`BaseMetadata<K>` via `#[serde(flatten)]` on its own concrete metadata
+struct.
+
+## Public API
+
+- `BaseMetadata<K>` — shared catalog prefix (`key`, `name`, `description`,
+  `schema`, `version`, `icon`, `documentation_url`, `tags`, `maturity`,
+  `deprecation`). Composed on each concrete entity metadata.
+- `Metadata` trait — one-line impl on each concrete metadata
+  (`fn base(&self) -> &BaseMetadata<Self::Key>`); all other accessors
+  default-delegate through it.
+- `Icon` — `None` / `Inline(String)` / `Url { url: String }` enum;
+  replaces the earlier `icon: Option<String>` + `icon_url: Option<String>`
+  pair.
+- `MaturityLevel` — `Experimental` / `Beta` / `Stable` / `Deprecated`.
+- `DeprecationNotice` — `since` / `sunset` / `replacement` / `reason`.
+- `BaseCompatError<K>` + `validate_base_compat` — entity-agnostic compat
+  rules shared by every catalog citizen (`key` immutable, `version`
+  monotonic, schema-break-requires-major-bump). Each consumer layers
+  entity-specific rules on top via a thin wrapper enum.
+
+## Composition
+
+```rust
+use nebula_metadata::{BaseMetadata, Metadata};
+use nebula_schema::{Schema, ValidSchema};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MyKey(&'static str);
+
+pub struct MyEntityMetadata {
+    pub base: BaseMetadata<MyKey>,
+    pub extra_field: u32,
+}
+
+impl Metadata for MyEntityMetadata {
+    type Key = MyKey;
+    fn base(&self) -> &BaseMetadata<Self::Key> {
+        &self.base
+    }
+}
+
+fn empty_schema() -> ValidSchema {
+    Schema::builder().build().unwrap()
+}
+
+let md = MyEntityMetadata {
+    base: BaseMetadata::new(MyKey("k"), "My Entity", "desc", empty_schema()),
+    extra_field: 7,
+};
+assert_eq!(md.name(), "My Entity");
+```
+
+## Consumers
+
+- `nebula-action::ActionMetadata` — composes `BaseMetadata<ActionKey>`;
+  adds `inputs`, `outputs`, `isolation_level`, `category`; wraps
+  `BaseCompatError<ActionKey>` in its own `MetadataCompatibilityError`.
+- `nebula-credential::CredentialMetadata` — composes
+  `BaseMetadata<CredentialKey>`; adds `pattern`; wraps `BaseCompatError`
+  similarly.
+- `nebula-resource::ResourceMetadata` — composes
+  `BaseMetadata<ResourceKey>`; no entity-specific fields today, direct
+  delegation.
+- `nebula-plugin::PluginMetadata` — **does not** compose `BaseMetadata`
+  today. Reshape to `PluginManifest` (bundle descriptor) tracked in
+  [ADR-0018](../../docs/adr/0018-plugin-metadata-to-manifest.md);
+  manifest will reuse `Icon` / `MaturityLevel` / `DeprecationNotice` but
+  not `BaseMetadata<K>` (plugin is a container, not a schematized leaf).
+
+## Canon
+
+- `docs/PRODUCT_CANON.md §3.5` — integration model (one pattern, five concepts).
+- `docs/MATURITY.md` — crate-state dashboard row.
+- `docs/STYLE.md` — idioms, naming, error taxonomy.
+````
+
+- [ ] **Step 5.2: Verify doctests compile**
+
+The composition example is a fenced `rust` block (not `no_run`), so it
+runs under `cargo test --doc`.
+
+Run: `cargo test --doc -p nebula-metadata`
+Expected: the composition example compiles and passes. If it fails because
+of a `Schema::builder` API mismatch, adjust the example to whatever form
+`crates/metadata/src/base.rs` tests currently use.
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add crates/metadata/README.md
+git commit -m "$(cat <<'EOF'
+docs(metadata): add crate README
+
+Workspace-standard README with purpose, public API surface, composition
+example (runnable doctest), and consumer crosslinks. References ADR-0018
+for the upcoming PluginMetadata → PluginManifest reshape.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `docs/MATURITY.md` row
+
+**Files:**
+- Modify: `docs/MATURITY.md`
+
+- [ ] **Step 6.1: Insert the `nebula-metadata` row**
+
+Open `docs/MATURITY.md`. Find the existing row for `nebula-log` (currently
+around line 30) and insert directly below it — between `nebula-log` and
+`nebula-metrics` — keeping alphabetical order:
+
+```
+| nebula-metadata      | frontier | stable  | stable | n/a | n/a |
+```
+
+Column-align the pipes so the new row matches the table formatting. Run
+`cargo +nightly fmt --all` will not touch this markdown file — alignment is
+manual.
+
+- [ ] **Step 6.2: Update `Last targeted revision`**
+
+Scroll to the bottom of `docs/MATURITY.md`. Update the line that starts
+with `Last targeted revision:` to include the new entry. Replace the
+current bottom line with:
+
+```
+Last targeted revision: 2026-04-19 (nebula-metadata row added; `compat.rs` extracted to BaseCompatError + validate_base_compat; action / credential / resource wired to the shared check).
+```
+
+(Keep the existing `Last full sweep:` line above it untouched.)
+
+- [ ] **Step 6.3: Commit**
+
+```bash
+git add docs/MATURITY.md
+git commit -m "$(cat <<'EOF'
+docs(maturity): add nebula-metadata row
+
+frontier / stable / stable / n/a / n/a. Frontier because compat.rs
+landed in this cycle and the plugin→manifest ADR may imply further
+nebula-metadata additions. Promote to stable after one release cycle
+without surface changes.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: ADR-0018 — plugin metadata → manifest
+
+**Files:**
+- Create: `docs/adr/0018-plugin-metadata-to-manifest.md`
+- Modify: `docs/adr/README.md` (index row)
+
+- [ ] **Step 7.1: Write the ADR**
+
+Create `docs/adr/0018-plugin-metadata-to-manifest.md` with the exact content:
+
+````markdown
+---
+id: 0018
+title: plugin-metadata-to-manifest
+status: proposed
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [plugin, metadata, canon-3.5]
+related:
+  - crates/plugin/src/metadata.rs
+  - crates/metadata/src/lib.rs
+  - docs/PRODUCT_CANON.md#35-integration-model-one-pattern-five-concepts
+linear: []
+---
+
+# ADR-0018 — `PluginMetadata` → `PluginManifest`
+
+## Context
+
+`nebula-plugin::PluginMetadata` was introduced before `nebula-metadata`
+existed and still carries the pre-consolidation shape:
+
+- `icon: Option<String>` + `icon_url: Option<String>` — the two-field
+  invalid-combination problem that `nebula_metadata::Icon` was introduced
+  to solve.
+- `version: u32` — conflicts with `semver::Version` used everywhere else
+  in Nebula (and with ADR-0007 identifier conventions spirit).
+- No `maturity`, no `deprecation` — a plugin can never be marked
+  experimental or scheduled for removal.
+- `author`, `license`, `homepage`, `repository`, `nebula_version`,
+  `group`, `color` — all bundle-level / provenance fields that do not
+  apply to leaf entities.
+
+Meanwhile `nebula_metadata::BaseMetadata<K>` is the canonical shape for
+catalog citizens (§3.5). It requires `schema: ValidSchema`, which a
+plugin — being a **container** for actions / credentials / resources —
+does not have: user input lives on the leaves it bundles, not on the
+container itself. Forcing a plugin into `BaseMetadata` would require
+either making `schema` optional (uglifying every leaf consumer's
+accessors) or passing `ValidSchema::empty()` (misleading semantics:
+"empty schema" ≠ "no schema applies").
+
+The right fix is not to bend the leaf shape around a container — it is
+to give the container its own, honest type.
+
+## Decision
+
+1. Rename `nebula-plugin::PluginMetadata` → `nebula-plugin::PluginManifest`
+   (a **bundle descriptor**, not entity metadata).
+
+2. `PluginManifest` **does not compose `BaseMetadata<K>`.** A plugin is
+   not a schematized leaf.
+
+3. `PluginManifest` **reuses the small types** from `nebula-metadata`:
+
+   - `Icon` — replaces `icon: Option<String>` + `icon_url: Option<String>`.
+   - `MaturityLevel` — new for plugins (experimental / beta / stable /
+     deprecated).
+   - `DeprecationNotice` — new for plugins.
+
+4. `PluginManifest::version` adopts `semver::Version` (consistency with
+   `BaseMetadata::version`).
+
+5. Plugin-specific fields stay on the manifest: `author`, `license`,
+   `homepage`, `repository`, `nebula_version`, `group`, `color`,
+   `description`, `name`, `key`, `tags`. Builder + `normalize_key`
+   behavior is preserved.
+
+## Consequences
+
+**Positive.**
+- Manifest stops advertising invalid icon combinations.
+- Plugins can declare `MaturityLevel::Experimental` / mark deprecations.
+- Semver is used uniformly.
+- The conceptual split (container vs. leaf) becomes visible in types.
+
+**Negative.**
+- Wire format breaks for any persisted plugin metadata. Scope is small:
+  no known production deployments, `nebula-plugin` is `frontier` per
+  `docs/MATURITY.md`.
+- `nebula-plugin` gains a direct dep on `nebula-metadata` (for `Icon` /
+  `MaturityLevel` / `DeprecationNotice`).
+
+**Neutral.**
+- `Plugin::metadata() → Plugin::manifest()` rename propagates through
+  `nebula-plugin::macros`, `nebula-engine::lib.rs` re-exports, and every
+  plugin test fixture.
+
+## Alternatives considered
+
+- **(A) Make `BaseMetadata::schema` optional** (`Option<ValidSchema>`).
+  *Rejected:* every leaf consumer — action, credential, resource, and
+  any future leaf — would gain an `Option<ValidSchema>` in its accessor
+  to support a single non-leaf case.
+
+- **(B) Plugin uses `BaseMetadata` with `ValidSchema::empty()`.**
+  *Rejected:* misleading semantics. "Empty schema" implies "this entity
+  has a schema, and it happens to have zero fields", not "this entity
+  has no schema concept".
+
+- **(C) Split `CatalogInfo<K>` (cosmetic prefix: name / description /
+  icon / documentation_url / tags / maturity / deprecation) from
+  `BaseMetadata<K>` (= `CatalogInfo<K>` + schema).** *Rejected* for now:
+  adds a new abstraction layer for a single non-leaf consumer. Revisit
+  only if a second container type (bundle, pack, preset) appears.
+
+- **(D) Leave `PluginMetadata` as-is; extract only the shared small types
+  (`Icon`, `MaturityLevel`, `DeprecationNotice`) and adopt them
+  field-by-field without renaming the struct or touching its accessors.**
+  *Rejected:* the shape problem is not only cosmetic. `version: u32`
+  contradicts semver everywhere else in Nebula, `icon` + `icon_url` as
+  two `Option<String>` fields is exactly the invalid-state bug `Icon`
+  was introduced to fix, and `PluginMetadata` as a *name* now mis-signals
+  that a plugin is a catalog-leaf like `ActionMetadata` /
+  `CredentialMetadata` / `ResourceMetadata` — which it is not. Piecemeal
+  extraction leaves a type whose name lies about its role; the rename to
+  `PluginManifest` is the part that prevents the next contributor from
+  composing `BaseMetadata` into it on reflex. The ADR scope is
+  intentionally wider than "swap the small types".
+
+## Migration plan (executed in a follow-up PR)
+
+1. Introduce `PluginManifest` alongside `PluginMetadata`; mark the old
+   type `#[deprecated]`.
+2. Rename `Plugin::metadata() → Plugin::manifest()` directly — no shim.
+   `nebula-plugin` is `frontier` per `docs/MATURITY.md`; the
+   `CLAUDE.md` quick-win trap catalog explicitly discourages shim-naming.
+3. Update `nebula-plugin::macros` so `#[plugin]` emits
+   `PluginManifest::builder(...)`.
+4. Update `nebula-engine` re-exports (`crates/engine/src/lib.rs:70`) and
+   `crates/engine/README.md:63`.
+5. Delete `PluginMetadata` in the following cycle.
+
+## Follow-ups
+
+- Track migration PR against this ADR (issue created at implementation
+  time).
+- Revisit alternative (C) when a second container-shape entity arrives.
+````
+
+- [ ] **Step 7.2: Add row to `docs/adr/README.md` index**
+
+Open `docs/adr/README.md`. In the index table, append a new row after the
+`0017` line:
+
+```
+| [0018](./0018-plugin-metadata-to-manifest.md) | `PluginMetadata` → `PluginManifest` (bundle descriptor, reuse small types from `nebula-metadata`) | proposed | 2026-04-19 |
+```
+
+Update the "Writing a new ADR" section — change "currently **0018**" to
+"currently **0019**".
+
+- [ ] **Step 7.3: Commit**
+
+```bash
+git add docs/adr/0018-plugin-metadata-to-manifest.md docs/adr/README.md
+git commit -m "$(cat <<'EOF'
+docs(adr): file ADR-0018 plugin-metadata → plugin-manifest
+
+Records the decision to rename PluginMetadata → PluginManifest (bundle
+descriptor) and to reuse only the small types from nebula-metadata
+(Icon / MaturityLevel / DeprecationNotice), not BaseMetadata<K>. A
+plugin is a container, not a schematized leaf; forcing it into the
+leaf shape was the original misfit. Implementation lands in a follow-up
+PR per the migration plan in the ADR body.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Final validation
+
+- [ ] **Step F.1: Full local gate**
+
+Run: `cargo +nightly fmt --all && cargo clippy --workspace -- -D warnings && cargo nextest run --workspace && cargo test --workspace --doc`
+Expected: all green. No formatting diffs, no warnings, all tests + doctests pass.
+
+- [ ] **Step F.2: Lefthook mirror (PR pre-flight)**
+
+Run: `lefthook run pre-push`
+Expected: all mirrored CI jobs pass (fmt, clippy, tests, doctests, taplo, MSRV 1.94, `--all-features`, `--no-default-features`).
+
+- [ ] **Step F.3: Push branch, open PR**
+
+Branch: `claude/beautiful-archimedes-34c6aa` (already on it). Push:
+
+```bash
+git push -u origin claude/beautiful-archimedes-34c6aa
+```
+
+Open PR with title `feat(metadata): extract shared compat rules + README + ADR-0018 plugin manifest` and a body linking to the spec and the ADR.
+
+---
+
+## Self-review notes
+
+Plan covers every spec section:
+
+- Artifact 1 (compat.rs) → Tasks 1–4.
+- Artifact 2 (README) → Task 5.
+- Artifact 3 (MATURITY row) → Task 6.
+- Artifact 4 (ADR-0018) → Task 7.
+- Testing strategy → per-task `cargo nextest` + Step F.1 workspace gate.
+- Out-of-scope (plugin reshape code) → stays docs-only per ADR-0018 migration plan.
+
+Type-consistency check done: `BaseCompatError<K>` bounds (`Debug + Display +
+Clone + PartialEq + Eq`) verified against `ActionKey` / `CredentialKey` /
+`ResourceKey` via `domain-key::Key<T>` trait impls. `AuthPattern: PartialEq +
+Eq` confirmed in `crates/core/src/auth.rs`. No placeholder text.

--- a/docs/superpowers/specs/2026-04-19-nebula-metadata-completion-design.md
+++ b/docs/superpowers/specs/2026-04-19-nebula-metadata-completion-design.md
@@ -1,0 +1,359 @@
+---
+title: nebula-metadata completion + plugin-manifest ADR
+status: proposed
+date: 2026-04-19
+related:
+  - crates/metadata/src/lib.rs
+  - crates/metadata/src/compat.rs
+  - crates/action/src/metadata.rs
+  - crates/credential/src/metadata.rs
+  - crates/resource/src/resource.rs
+  - crates/plugin/src/metadata.rs
+  - docs/MATURITY.md
+  - docs/PRODUCT_CANON.md#35-integration-model-one-pattern-five-concepts
+---
+
+# nebula-metadata — completion + plugin-manifest ADR
+
+## Context
+
+`nebula-metadata` owns the shared shape of Nebula's catalog citizens
+(`BaseMetadata<K>`, `Metadata` trait, `Icon`, `MaturityLevel`,
+`DeprecationNotice`). Three consumers compose it today:
+`nebula-action::ActionMetadata`, `nebula-credential::CredentialMetadata`,
+`nebula-resource::ResourceMetadata`.
+
+Three gaps block declaring the crate "complete":
+
+1. **`compat.rs` is a stub.** The module reserves the name but delegates all
+   rules to `ActionMetadata::validate_compatibility`. Key-immutability,
+   version-monotonicity, and breaking-change-requires-major-bump are generic
+   rules that belong on `BaseMetadata`, yet credential and resource today have
+   **no** compat validation at all. The duplication risk is real: whoever adds
+   it next will copy the action implementation and drift.
+
+2. **No `README.md`, no row in `docs/MATURITY.md`.** Canon §17 definition of
+   done requires both for any crate that a consumer depends on. Three
+   consumers already do.
+
+3. **`nebula-plugin::PluginMetadata` does not compose `BaseMetadata`.** It
+   reinvents `key / name / description / icon / icon_url / documentation_url /
+   tags / version / group / color`, invalid combinations included (both
+   `icon` and `icon_url` can be set simultaneously — the exact problem
+   `Icon` enum was introduced to solve). This is not a `nebula-metadata` bug;
+   it is a `nebula-plugin` design issue. The correct resolution is renaming
+   `PluginMetadata` → `PluginManifest` and reshaping it as a **bundle
+   descriptor**, not a schematized-leaf metadata. That decision lands as an
+   ADR; implementation is out of scope for this spec.
+
+## Goals
+
+1. Extract generic compat rules from `ActionMetadata` into
+   `nebula-metadata::compat`; reuse in action / credential / resource.
+2. Add `crates/metadata/README.md` and a row in `docs/MATURITY.md`.
+3. File ADR-0018 capturing the `PluginMetadata` → `PluginManifest` decision,
+   the small-types reuse (`Icon`, `MaturityLevel`, `DeprecationNotice`), and
+   an explicit non-reuse of `BaseMetadata<K>` (with reasoning).
+
+## Non-goals
+
+- Reshaping `nebula-plugin`. The ADR documents the decision; code lands in a
+  later session.
+- Changing the wire format of existing `BaseMetadata<K>` serialization.
+- Adding new optional fields to `BaseMetadata` (author/license/homepage are a
+  plugin-manifest concern, not a leaf-entity concern).
+- Builder helpers beyond what the crate already exposes.
+
+## Artifact 1 — `crates/metadata/src/compat.rs`
+
+### New public types
+
+```rust
+// Error enum generic over the key type.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum BaseCompatError<K>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    #[error("metadata key changed from `{previous}` to `{current}`")]
+    KeyChanged { previous: K, current: K },
+
+    #[error("interface version regressed from {previous} to {current}")]
+    VersionRegressed {
+        previous: semver::Version,
+        current: semver::Version,
+    },
+
+    #[error("breaking schema change detected without a major version bump")]
+    SchemaChangeWithoutMajorBump,
+}
+
+/// Validate the generic, entity-agnostic compatibility rules between two
+/// revisions of the same catalog citizen.
+///
+/// Entity-specific rules (ports, auth pattern, etc.) must be layered on top
+/// by the concrete metadata type's own `validate_compatibility`.
+pub fn validate_base_compat<K>(
+    current: &BaseMetadata<K>,
+    previous: &BaseMetadata<K>,
+) -> Result<(), BaseCompatError<K>>
+where
+    K: std::fmt::Debug + std::fmt::Display + Clone + PartialEq + Eq,
+{
+    if current.key != previous.key {
+        return Err(BaseCompatError::KeyChanged {
+            previous: previous.key.clone(),
+            current: current.key.clone(),
+        });
+    }
+    if current.version < previous.version {
+        return Err(BaseCompatError::VersionRegressed {
+            previous: previous.version.clone(),
+            current: current.version.clone(),
+        });
+    }
+    if current.schema != previous.schema
+        && current.version.major == previous.version.major
+    {
+        return Err(BaseCompatError::SchemaChangeWithoutMajorBump);
+    }
+    Ok(())
+}
+```
+
+Key-type bounds: `ActionKey`, `CredentialKey`, `ResourceKey` all satisfy
+`Debug + Display + Clone + PartialEq + Eq` today — the generic bound does not
+force changes on `nebula-core`.
+
+### Dependency change
+
+Add `thiserror = { workspace = true }` to `crates/metadata/Cargo.toml` —
+already used by every other crate in the workspace.
+
+### `nebula-action` migration
+
+`ActionMetadata::MetadataCompatibilityError` becomes a thin wrapper:
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    #[error(transparent)]
+    Base(#[from] BaseCompatError<ActionKey>),
+
+    #[error("ports changed without a major version bump")]
+    PortsChangeWithoutMajorBump,
+}
+```
+
+`validate_compatibility` delegates then layers port-check:
+
+```rust
+pub fn validate_compatibility(&self, previous: &Self)
+    -> Result<(), MetadataCompatibilityError>
+{
+    nebula_metadata::compat::validate_base_compat(&self.base, &previous.base)?;
+    let ports_changed =
+        self.inputs != previous.inputs || self.outputs != previous.outputs;
+    if ports_changed && self.base.version.major == previous.base.version.major {
+        return Err(MetadataCompatibilityError::PortsChangeWithoutMajorBump);
+    }
+    Ok(())
+}
+```
+
+Note: current `KeyChanged { previous, current }` and
+`VersionRegressed { previous, current }` variants move **inside** the `Base`
+variant. This is a breaking change for any external matcher on the old flat
+enum. `nebula-metadata` has no external consumers yet and the three
+in-workspace consumers (`nebula-action`, `nebula-credential`, `nebula-resource`)
+are updated in this PR, so the rename is acceptable. Existing tests inside
+`crates/action/src/metadata.rs` are updated to match on
+`MetadataCompatibilityError::Base(BaseCompatError::…)`.
+
+### `nebula-credential` addition
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum MetadataCompatibilityError {
+    #[error(transparent)]
+    Base(#[from] BaseCompatError<CredentialKey>),
+
+    #[error("auth pattern changed without a major version bump")]
+    PatternChangeWithoutMajorBump,
+}
+
+impl CredentialMetadata {
+    pub fn validate_compatibility(&self, previous: &Self)
+        -> Result<(), MetadataCompatibilityError>
+    {
+        nebula_metadata::compat::validate_base_compat(&self.base, &previous.base)?;
+        if self.pattern != previous.pattern
+            && self.base.version.major == previous.base.version.major
+        {
+            return Err(MetadataCompatibilityError::PatternChangeWithoutMajorBump);
+        }
+        Ok(())
+    }
+}
+```
+
+Requires `AuthPattern: PartialEq + Eq` (verify during implementation).
+
+### `nebula-resource` addition
+
+```rust
+// No entity-specific fields today; pure delegation.
+impl ResourceMetadata {
+    pub fn validate_compatibility(&self, previous: &Self)
+        -> Result<(), BaseCompatError<ResourceKey>>
+    {
+        nebula_metadata::compat::validate_base_compat(&self.base, &previous.base)
+    }
+}
+```
+
+If and when `ResourceMetadata` grows entity-specific fields, the wrapper
+pattern from action/credential kicks in.
+
+### Tests
+
+Unit tests in `compat.rs`:
+- `key_change_rejected` (uses a test `struct FakeKey(&'static str)` — impls
+  Debug/Display/Clone/PartialEq/Eq).
+- `version_regression_rejected`.
+- `schema_change_without_major_rejected`.
+- `schema_change_with_major_accepted`.
+- `minor_bump_with_same_schema_accepted`.
+- `major_bump_with_same_schema_accepted` (regression guard).
+
+Existing action/credential/resource tests that exercise the new wrapper:
+- Action: port-change rules unchanged — only matcher shapes update.
+- Credential: new `pattern_change_requires_major` test.
+- Resource: new `validate_compatibility_roundtrip` test.
+
+## Artifact 2 — `crates/metadata/README.md`
+
+Standard workspace crate-README template (see `crates/error/README.md`,
+`crates/log/README.md` for shape):
+
+1. **Purpose** — one-paragraph summary (shared catalog prefix + trait).
+2. **Core types** — `BaseMetadata<K>`, `Metadata` trait, `Icon`,
+   `MaturityLevel`, `DeprecationNotice`, new `BaseCompatError<K>` +
+   `validate_base_compat`.
+3. **Composition example** — the `MyEntityMetadata` example from current
+   `lib.rs` module doc, lifted and runnable.
+4. **Consumers** — explicit list: `nebula-action`, `nebula-credential`,
+   `nebula-resource`. Note on `nebula-plugin`: "reshape to `PluginManifest`
+   tracked in ADR-0018".
+5. **Crosslinks** — `docs/PRODUCT_CANON.md §3.5`, `docs/MATURITY.md`.
+
+## Artifact 3 — `docs/MATURITY.md` row
+
+```
+| nebula-metadata      | frontier | stable | stable | n/a | n/a |
+```
+
+Inserted in alphabetical position between `nebula-log` and `nebula-metrics`.
+`frontier` because:
+- `compat.rs` lands in this PR (API surface moves this cycle).
+- The `PluginManifest` ADR may imply future additions to `nebula-metadata`
+  (e.g., shared `BundleManifest` marker trait) — we do not pre-commit.
+
+Bump to `stable` on a follow-up PR after one release cycle without surface
+changes.
+
+Also update the `Last targeted revision` line in `docs/MATURITY.md` per
+current repo convention.
+
+## Artifact 4 — `docs/adr/0018-plugin-metadata-to-manifest.md`
+
+Number `0018` (next free; 0017 is `control-queue-reclaim-policy`). Status
+`proposed`.
+
+### Content outline
+
+- **Context.** `PluginMetadata` was introduced before `BaseMetadata` existed
+  and still carries the pre-consolidation shape: `icon: Option<String>` +
+  `icon_url: Option<String>` (two-field invalid-combination problem),
+  `version: u32` (conflicts with ADR-0007 / semver canon elsewhere),
+  `description: String`, no `maturity`, no `deprecation`, plus bundle-level
+  fields (`author`, `license`, `homepage`, `repository`, `nebula_version`,
+  `group`, `color`) that do not belong on leaf-entity metadata.
+  Meanwhile `nebula-metadata::BaseMetadata<K>` is the canonical shape for
+  catalog citizens and requires a `schema: ValidSchema` — which a plugin as
+  a **container** does not have (user input lives on the actions/credentials
+  /resources it bundles).
+
+- **Decision.**
+  - Rename `PluginMetadata` → `PluginManifest` (bundle descriptor).
+  - `PluginManifest` **does not compose `BaseMetadata<K>`.** A plugin is not
+    a schematized leaf; forcing it into the leaf shape with
+    `ValidSchema::empty()` misleads the engine and UI.
+  - `PluginManifest` **reuses the small types** from `nebula-metadata`:
+    `Icon` (replaces `icon: Option<String>` + `icon_url: Option<String>`),
+    `MaturityLevel` (new for plugins), `DeprecationNotice` (new for plugins).
+  - `PluginManifest::version` adopts `semver::Version` (consistency with
+    `BaseMetadata::version` and ADR-0007 conventions).
+  - Plugin-specific fields stay: `author`, `license`, `homepage`,
+    `repository`, `nebula_version`, `group`, `color`, `description`, `name`,
+    `key`, `tags`.
+  - Builder + normalization behavior preserved (`normalize_key`).
+
+- **Consequences.**
+  - Positive: `PluginManifest` stops advertising invalid icon combinations;
+    plugins can declare `MaturityLevel::Experimental`; semver across the
+    codebase.
+  - Negative: wire format breaks for any persisted plugin metadata. Scope is
+    small (no known production deployments, plugin-registry is frontier).
+  - Neutral: `nebula-plugin` gains a direct dep on `nebula-metadata` for the
+    three small types.
+
+- **Migration plan (to be executed in a follow-up PR).**
+  1. Introduce `PluginManifest` alongside `PluginMetadata`; deprecate the
+     latter with a `#[deprecated]` attribute.
+  2. Rename `Plugin::metadata() → Plugin::manifest()` directly (no shim —
+     `nebula-plugin` is `frontier`-stability per `docs/MATURITY.md`;
+     shim-naming is explicitly discouraged in `CLAUDE.md` quick-win trap
+     catalog).
+  3. Update `nebula-plugin::macros` to emit `PluginManifest::builder(...)`.
+  4. Update `nebula-engine` re-export path (`engine::lib.rs:70`).
+  5. Delete `PluginMetadata` in the cycle after.
+
+- **Alternatives considered.**
+  - **(A)** Make `BaseMetadata::schema` optional (`Option<ValidSchema>`) so
+    plugin can fit. Rejected: every leaf-entity consumer gains an
+    `Option<ValidSchema>` in its accessor for a single non-leaf case.
+  - **(B)** Plugin uses `BaseMetadata` with `ValidSchema::empty()`. Rejected:
+    misleading semantics ("empty schema" ≠ "no schema applies").
+  - **(C)** Split `CatalogInfo<K>` (cosmetic prefix) from
+    `BaseMetadata<K>` (cosmetic + schema). Rejected: adds an abstraction
+    layer for a single non-leaf consumer. Revisit only if a second
+    container-type (bundle, pack) appears.
+
+- **Follow-ups.**
+  - Tracking issue for the migration PR (not filed yet; create during
+    implementation).
+  - Revisit alternative (C) when bundle / pack descriptor arrives.
+
+## Testing strategy
+
+- `cargo nextest run -p nebula-metadata` covers new compat unit tests.
+- `cargo nextest run -p nebula-action -p nebula-credential -p nebula-resource`
+  covers the per-consumer wrapper integration.
+- `cargo test --workspace --doc` covers the updated README examples in
+  `crates/metadata/README.md`.
+- `cargo clippy --workspace -- -D warnings` must stay green.
+- Doc-test the composition example in `crates/metadata/README.md` via a
+  fenced ```rust block, not `no_run`.
+
+## Out of scope / explicit follow-ups
+
+- Implementation of ADR-0018 (plugin → manifest rename).
+- Extending `BaseMetadata` with author/license/homepage (plugin-manifest
+  concern, not a leaf concern; see alternative A above).
+- A generic `Catalog` trait over `M: Metadata` for engine-level listing
+  (separate design — tracked separately).
+- Sharing a builder across consumers (each family has different required
+  fields; a one-size builder loses clarity).


### PR DESCRIPTION
## Summary

- **Extract shared compat rules** into `nebula-metadata::compat` — new `BaseCompatError<K>` + `validate_base_compat` enforce `key immutable / version monotonic / schema-break-requires-major-bump`. Action / credential / resource now compose this primitive instead of each re-implementing it.
- **Wire three consumers uniformly.** `nebula-action::MetadataCompatibilityError` becomes `Base(BaseCompatError<ActionKey>) + PortsChangeWithoutMajorBump`; `nebula-credential::MetadataCompatibilityError` becomes `Base(...) + PatternChangeWithoutMajorBump`; `nebula-resource::MetadataCompatibilityError` is a single-variant `Base(...)` wrapper for forward-compatibility (resource has no entity-specific rules today but the shape stays stable when it gets them).
- **Close the docs gap.** New `crates/metadata/README.md`, new row in `docs/MATURITY.md`, new ADR-0018 (`docs/adr/0018-plugin-metadata-to-manifest.md`) recording the deferred `PluginMetadata` → `PluginManifest` decision — plugin is a bundle container, not a schematized leaf, so it reuses the small types (`Icon` / `MaturityLevel` / `DeprecationNotice`) but **not** `BaseMetadata<K>`.

Spec: [`docs/superpowers/specs/2026-04-19-nebula-metadata-completion-design.md`](docs/superpowers/specs/2026-04-19-nebula-metadata-completion-design.md)
Plan: [`docs/superpowers/plans/2026-04-19-nebula-metadata-completion.md`](docs/superpowers/plans/2026-04-19-nebula-metadata-completion.md)

ADR follow-up (implementation): ADR-0018 migration (`PluginManifest` rename + small-type adoption + semver on plugin version) lands in a separate PR per its own migration plan.

## Test plan

- [x] `cargo +nightly fmt --all --check` — clean
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 3376/3376 pass, 13 skipped
- [x] `cargo test --workspace --doc` — all pass (includes new README composition doctest in `nebula-metadata`)
- [x] `lefthook run pre-push` — all CI-mirror jobs green (shear, check-all-features, docs, doctests, check-no-default, nextest)
- [ ] CI validates on GitHub (expected green)

## Review notes

- `nebula-metadata::compat` is new surface; the crate moves to `frontier` in `docs/MATURITY.md`. Promote to `stable` after one release cycle without surface changes.
- Wire format of `ActionMetadata` / `CredentialMetadata` / `ResourceMetadata` is preserved via existing `#[serde(flatten)]`.
- \`nebula-plugin::PluginMetadata\` is intentionally **not** migrated — see ADR-0018 for the rationale (leaf-vs-container onto­logy) and the four rejected alternatives (A: optional schema, B: empty schema, C: CatalogInfo split, D: piecemeal extraction).
- Pre-existing gap (unrelated): \`docs/adr/0017-control-queue-reclaim-policy.md\` is missing from the ADR index in \`docs/adr/README.md\`. Flagged as a separate follow-up task, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)