### PR TITLE
chore(toolchain): bump MSRV to 1.95 (ADR-0019)

### DIFF
--- a/.claude/agents/devops.md
+++ b/.claude/agents/devops.md
@@ -97,7 +97,7 @@ Downloads: {monthly — is it established?}
 Last release: {date — is it maintained?}
 Transitive deps: {count — is the tree reasonable?}
 Unsafe code: {any? justified?}
-MSRV: {compatible with 1.94?}
+MSRV: {compatible with 1.95?}
 Verdict: approve / reject / conditional
 ```
 

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -83,7 +83,7 @@ body:
     attributes:
       label: Rust Version
       description: Output of `rustc --version`
-      placeholder: "rustc 1.94.0 (2025-...)"
+      placeholder: "rustc 1.95.0 (2026-...)"
     validations:
       required: true
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,7 +1,7 @@
 # Copilot Instructions for Nebula
 
 ## Project Context
-Modular type-safe Rust workflow engine. Edition 2024, MSRV 1.94, alpha stage.
+Modular type-safe Rust workflow engine. Edition 2024, MSRV 1.95, alpha stage.
 Architecture: Core → Business → Exec → API (one-way deps, no upward).
 Universal data type: serde_json::Value.
 Error handling: thiserror in libs, anyhow in binaries.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,9 +38,9 @@ updates:
     commit-message:
       prefix: "chore(ci)"
     ignore:
-      # MSRV pin in ci.yml uses @1.94 intentionally. Dependabot can't tell
+      # MSRV pin in ci.yml uses @1.95 intentionally. Dependabot can't tell
       # that's a deliberate version pin (not a stale dep) and tries to bump
-      # to whatever Rust version is current (1.95, 1.96, ..., 1.100, ...).
+      # to whatever Rust version is current (1.96, 1.97, ..., 1.100, ...).
       # @stable / @nightly references in other jobs don't need version bumps.
       - dependency-name: "dtolnay/rust-toolchain"
     groups:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
           components: clippy
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
@@ -98,7 +98,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -129,7 +129,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -142,7 +142,7 @@ jobs:
   # ── MSRV ───────────────────────────────────────────────────────────────────
   # Tier 2: skipped on draft PRs.
   msrv:
-    name: MSRV (1.94)
+    name: MSRV (1.95)
     needs: [check]
     if: >-
       github.event_name != 'pull_request' ||
@@ -152,10 +152,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Rust 1.94
+      - name: Install Rust 1.95
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -183,7 +183,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -205,7 +205,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
@@ -230,7 +230,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: "1.94"
+          toolchain: "1.95"
       - name: Install cargo-deny
         uses: taiki-e/install-action@cargo-deny
       - name: Run cargo deny

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **BREAKING — workspace**: MSRV raised from **1.94 → 1.95** (see
+  [ADR-0019](docs/adr/0019-msrv-1.95.md); supersedes ADR-0010).
+  `workspace.package.rust-version`, `clippy.toml` `msrv`, all
+  `.github/workflows/ci.yml` toolchain pins, CLI templates, and docs moved
+  together. Contributors must `rustup install 1.95`. Unlocks `if let` guards,
+  `cfg_select!`, atomic `update` / `try_update`, and `core::range` for
+  follow-up refactors (tracked in ADR-0019 §Follow-ups).
 - **nebula-validator**: **Breaking** — replaced flat 30-variant `Rule` enum
   with a typed sum-of-sums: `Rule::{Value(ValueRule), Predicate(Predicate),
   Logic(Box<Logic>), Deferred(DeferredRule), Described(Box<Rule>, String)}`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,7 @@ Nebula is a modular, type-safe workflow automation engine in Rust (alpha stage).
 The workspace contains core libraries, execution/runtime layers, API, CLI, and examples.
 
 - Rust edition: `2024`
-- Rust version: `1.94`
+- Rust version: `1.95`
 - Primary test runner: `cargo nextest`
 - Formatting: nightly `rustfmt` (required by `rustfmt.toml`)
 
@@ -85,7 +85,7 @@ Notes:
 
 - `cargo +nightly fmt` is required (unstable rustfmt options are enabled).
 - Doctests are run separately with `cargo test --doc`.
-- `lefthook run pre-push` is the local mirror of CI required jobs (fmt, clippy, tests, doctests, taplo, MSRV 1.94, `--all-features`, `--no-default-features`). When adding or removing a CI required job, update `lefthook.yml` in the same PR.
+- `lefthook run pre-push` is the local mirror of CI required jobs (fmt, clippy, tests, doctests, taplo, MSRV 1.95, `--all-features`, `--no-default-features`). When adding or removing a CI required job, update `lefthook.yml` in the same PR.
 - Commit messages use conventional commits (`feat:`, `fix(scope):`, `chore:` …); `pr-validation.yml` enforces this via commitlint.
 - Releases are manual: `cargo release -p <crate> <patch|minor|major> --execute` (see `docs/dev-setup.md`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ tuning, worktree tips), see [docs/dev-setup.md](docs/dev-setup.md).
 
 ## Prerequisites
 
-- **Rust 1.94+** (MSRV, pinned via `workspace.package.rust-version`)
+- **Rust 1.95+** (MSRV, pinned via `workspace.package.rust-version`)
 - **[cargo-nextest](https://nexte.st/)** — test runner
 - **Nightly `rustfmt`** — `rustup toolchain install nightly --component rustfmt`
 - **[task](https://taskfile.dev/)** (recommended) — `task --list` for the catalog
@@ -58,7 +58,7 @@ lefthook install
 - `commit-msg`: conventional-commit validation via `convco`
 - `pre-push` (≤90s): nextest, doctests, `--all-features`,
   `--no-default-features`, docs (`RUSTDOCFLAGS=-D warnings`), cargo-shear.
-  The MSRV-1.94 check runs in CI only (see the note in `lefthook.yml`).
+  The MSRV-1.95 check runs in CI only (see the note in `lefthook.yml`).
 
 See [docs/dev-setup.md](docs/dev-setup.md) for lefthook troubleshooting and
 agent-profile notes.
@@ -123,7 +123,7 @@ messages) and a regex check on the PR title — see
    fill in Summary, Changes, Testing, and the Safety checklist.
 3. PR title must also follow Conventional Commits.
 4. Required CI jobs must be green: `fmt`, `clippy -D warnings`, `nextest`,
-   `doctests`, `MSRV 1.94`, `--all-features`, `--no-default-features`,
+   `doctests`, `MSRV 1.95`, `--all-features`, `--no-default-features`,
    `cargo deny`. A green `lefthook pre-push` catches most of these locally,
    but some jobs (notably the MSRV check) run only in CI.
 5. **Squash-merge only** — keep `main` history linear.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "3"
 [workspace.package]
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 keywords = ["workflow", "integrations", "no-code", "low-code", "automation"]
 authors = ["Vanya Stafford <vanya.john.stafford@gmail.com>"]
 description = "Workflow automation toolkit"

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ cargo build
 cargo nextest run --workspace
 ```
 
-Requires **Rust 1.94+** (edition 2024). Uses [cargo-nextest](https://nexte.st/) for test runs.
+Requires **Rust 1.95+** (edition 2024). Uses [cargo-nextest](https://nexte.st/) for test runs.
 
 ### Local Infrastructure
 

--- a/apps/cli/src/commands/dev/action.rs
+++ b/apps/cli/src/commands/dev/action.rs
@@ -73,7 +73,7 @@ fn cargo_toml(crate_name: &str, name: &str) -> String {
 name = "{crate_name}"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "Nebula action: {name}"
 license = "MIT OR Apache-2.0"
 

--- a/apps/cli/src/commands/plugin_new.rs
+++ b/apps/cli/src/commands/plugin_new.rs
@@ -107,7 +107,7 @@ fn cargo_toml(crate_name: &str, name: &str) -> String {
 name = "{crate_name}"
 version = "0.1.0"
 edition = "2024"
-rust-version = "1.94"
+rust-version = "1.95"
 description = "Nebula plugin: {name}"
 license = "MIT OR Apache-2.0"
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,5 +1,5 @@
 # Keep lint interpretation aligned with workspace toolchain.
-msrv = "1.94"
+msrv = "1.95"
 
 # Complexity limits (balanced for a heavily generic Rust workspace).
 cognitive-complexity-threshold = 25

--- a/docs/adr/0010-rust-2024-edition.md
+++ b/docs/adr/0010-rust-2024-edition.md
@@ -1,10 +1,10 @@
 ---
 id: 0010
 title: rust-2024-edition
-status: accepted
+status: superseded
 date: 2026-04-19
 supersedes: []
-superseded_by: []
+superseded_by: [0019]
 tags: [toolchain, msrv, edition, workspace]
 related:
   - Cargo.toml

--- a/docs/adr/0019-msrv-1.95.md
+++ b/docs/adr/0019-msrv-1.95.md
@@ -1,0 +1,119 @@
+---
+id: 0019
+title: msrv-1.95
+status: proposed
+date: 2026-04-19
+supersedes: [0010]
+superseded_by: []
+tags: [toolchain, msrv, workspace]
+related:
+  - Cargo.toml
+  - clippy.toml
+  - .github/workflows/ci.yml
+  - CLAUDE.md
+  - docs/adr/0010-rust-2024-edition.md
+---
+
+# 0019. MSRV 1.95
+
+## Context
+
+[ADR-0010](./0010-rust-2024-edition.md) pinned the workspace MSRV at
+**1.94**. Rust **1.95.0** shipped on **2026-04-16** (three days before this
+ADR). ADR-0010 §Follow-ups mentions that the floor should move "when 1.94
+leaves stable by ≥ 6 months"; we are raising it sooner because the bump is
+cheap and the delta is small:
+
+1. Nebula is pre-1.0 (alpha). No external downstream crate publishes against
+   `nebula-sdk` yet, so the "breaking change" blast radius of the floor move
+   is zero outside the workspace.
+2. Several 1.95 stabilizations map directly onto code patterns we already
+   write or are about to write:
+   - **`if let` guards** on match arms — several `engine` / `workflow`
+     match blocks currently split into nested `match` + manual bindings.
+   - **`cfg_select!`** — replaces ad-hoc `cfg_if!` nests in platform code.
+   - **Atomic `update` / `try_update`** on `AtomicPtr`, `AtomicBool`,
+     atomic integers — removes CAS loops in metrics counters.
+   - **`core::range`** stabilization — usable where we currently fall back
+     to manual bounds helpers.
+3. The six-month cooldown in ADR-0010 was written pessimistically for a
+   hypothetical post-1.0 world where the floor is an API promise. While we
+   are still alpha the cost/benefit tilts the other way: waiting a quarter
+   just to pick up language features we can use today is make-work.
+
+Rust 1.96 is scheduled for **2026-05-28** (currently beta) and adds nothing
+workspace-relevant; pinning to an unreleased channel would also break
+`dtolnay/rust-toolchain@1.95` lookups in CI. We explicitly do **not** jump
+to 1.96.
+
+## Decision
+
+1. Workspace MSRV becomes **`rust-version = "1.95"`** in `[workspace.package]`.
+2. `clippy.toml` `msrv` mirrors the same value so Clippy's MSRV-aware
+   lints align with the floor.
+3. The dedicated CI MSRV job (`.github/workflows/ci.yml` job `msrv`) is
+   pinned to `toolchain: "1.95"`. All other `dtolnay/rust-toolchain` pins in
+   the same file (clippy, check, doctests, doc, bench, deny) move in the same
+   PR — the workspace is single-floor.
+4. The dependabot ignore comment for `dtolnay/rust-toolchain` is updated to
+   reflect the new pin.
+5. Per ADR-0010 §Decision rule 5, this bump is a breaking change. It ships
+   as a single squash-merge PR that updates toolchain pins, docs
+   (`CLAUDE.md`, `CONTRIBUTING.md`, `README.md`, `docs/dev-setup.md`,
+   `.github/copilot-instructions.md`, `.github/ISSUE_TEMPLATE/bug.yml`),
+   CLI templates (`apps/cli/src/commands/dev/action.rs`,
+   `apps/cli/src/commands/plugin_new.rs`), and the ADR index.
+6. ADR-0010's frontmatter is updated in the same PR:
+   `status: superseded`, `superseded_by: [0019]`. Its body remains
+   immutable per the ADR workflow.
+
+## Consequences
+
+**Positive**
+
+- New match-arm `if let` guards and `cfg_select!` replace ad-hoc helpers —
+  we stop writing workarounds for stable-since-yesterday syntax.
+- Clippy's MSRV-sensitive lints (`manual_let_else`, `use_self`,
+  `uninlined_format_args`, etc.) now fire for 1.95-era suggestions rather
+  than being silenced as "too new".
+- Keeps the floor close to current stable, matching the alpha-stage
+  posture in ADR-0010 (one edition, one MSRV, one story).
+
+**Negative**
+
+- Contributors on a pinned 1.94 toolchain must run `rustup install 1.95`.
+  Documented in `docs/dev-setup.md`.
+- Any external consumer that had started tracking `nebula-sdk` against
+  1.94 (we are not aware of any) loses compatibility. Alpha-stage risk
+  accepted.
+
+**Neutral**
+
+- Nightly `rustfmt` tooling is unaffected — `rustfmt.toml` options remain
+  the same.
+- `deny.toml` does not currently encode an MSRV gate, so no policy file
+  needs updating.
+
+## Alternatives considered
+
+- **Stay on 1.94 until the 6-month ADR-0010 cooldown elapses.** Reject.
+  The cooldown was written for a post-1.0 world; applying it literally in
+  alpha just delays features we can use now at zero downstream cost.
+- **Jump straight to 1.96.** Reject. 1.96 is beta (releases 2026-05-28);
+  CI `dtolnay/rust-toolchain@1.96` would not resolve today, and the
+  delta over 1.95 contains nothing workspace-relevant. Re-evaluate after
+  the 1.96 release.
+- **Raise only Clippy's `msrv` without moving `rust-version`.** Reject.
+  Creates a split where CI's MSRV job is the source of truth but Clippy
+  lints above it — confusing and easy to drift.
+
+## Follow-ups
+
+- When Rust 1.96 ships (2026-05-28), evaluate whether the stabilized
+  `Range` / `RangeToInclusive` types or any other 1.96 additions are worth
+  a follow-up ADR. Default answer is "no, wait for a reason".
+- Opportunistic refactors in `engine` / `workflow` / metrics crates to use
+  `if let` guards, `cfg_select!`, and atomic `update` / `try_update` — not
+  required for the bump, but unlocked by it.
+- This ADR itself is subject to the same immutability rule: any future
+  raise of the floor opens a new ADR that supersedes 0019.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,7 +17,7 @@ changes land as a new ADR that `supersedes` it.
 | [0007](./0007-prefixed-ulid-identifiers.md) | Prefixed ULID identifiers (Stripe-style) | accepted | 2026-04-17 |
 | [0008](./0008-execution-control-queue-consumer.md) | Execution control-queue consumer | accepted | 2026-04-18 |
 | [0009](./0009-resume-persistence-schema.md) | Resume persistence schema (persist full `ActionResult` per node) | accepted | 2026-04-18 |
-| [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | accepted | 2026-04-19 |
+| [0010](./0010-rust-2024-edition.md) | Rust 2024 edition + MSRV 1.94 | superseded | 2026-04-19 |
 | [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
 | [0012](./0012-checkpoint-recovery.md) | Checkpoint recovery model (policy-driven, best-effort writes, idempotency over exactly-once) | accepted | 2026-04-19 |
 | [0013](./0013-compile-time-modes.md) | Compile-time deployment modes (`mode-desktop` / `mode-self-hosted` / `mode-cloud` + `build.rs` gate) | accepted | 2026-04-19 |
@@ -26,13 +26,14 @@ changes land as a new ADR that `supersedes` it.
 | [0016](./0016-engine-cancel-registry.md) | Engine cancel registry — cooperative-cancel contract for ADR-0008 A3 | accepted | 2026-04-19 |
 | [0017](./0017-control-queue-reclaim-policy.md) | Control-queue reclaim policy | accepted | 2026-04-19 |
 | [0018](./0018-plugin-metadata-to-manifest.md) | `PluginMetadata` → `PluginManifest` (bundle descriptor, reuse small types from `nebula-metadata`) | proposed | 2026-04-19 |
+| [0019](./0019-msrv-1.95.md) | MSRV 1.95 (supersedes 0010) | proposed | 2026-04-19 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0019**). Do not reuse.
+2. Pick the next free number (currently **0020**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -6,9 +6,9 @@ and CI mirror.
 ## Quick start
 
 1. Install [rustup](https://rustup.rs/) and pick a toolchain:
-   `rustup default stable`. The workspace MSRV is **1.94** (pinned via
+   `rustup default stable`. The workspace MSRV is **1.95** (pinned via
    `workspace.package.rust-version` in `Cargo.toml`); CI also runs an
-   explicit MSRV-1.94 check.
+   explicit MSRV-1.95 check.
 2. Install workspace dev tools:
    ```bash
    bash scripts/install-tools.sh
@@ -187,9 +187,9 @@ from `Cargo.toml` — bump there and run with `--workspace`.
 **"convco: command not found" in commit-msg hook.** Re-run
 `bash scripts/install-tools.sh`, or manually: `cargo install convco`.
 
-**"cargo +1.94: toolchain not installed" in pre-push.** The MSRV check
-skips gracefully if 1.94 is missing. To enable it locally:
-`rustup install 1.94`.
+**"cargo +1.95: toolchain not installed" in pre-push.** The MSRV check
+skips gracefully if 1.95 is missing. To enable it locally:
+`rustup install 1.95`.
 
 **Pre-push too slow.** Expected ~60-90s on warm cache (sccache + workspace
 cache). On cold cache the first run is several minutes. If consistently

--- a/scripts/install-tools.sh
+++ b/scripts/install-tools.sh
@@ -4,7 +4,7 @@
 # is available for the host platform.
 #
 # Prerequisites: rustup (any toolchain — Cargo.toml `workspace.package.rust-version`
-# pins MSRV at 1.94, CI mirrors that). Run `rustup default stable` once.
+# pins MSRV at 1.95, CI mirrors that). Run `rustup default stable` once.
 #
 # Usage: bash scripts/install-tools.sh
 #


### PR DESCRIPTION
## Summary

- Raises workspace MSRV from **1.94 → 1.95** via new [ADR-0019](docs/adr/0019-msrv-1.95.md) that supersedes ADR-0010.
- Single atomic change per ADR-0010 §Decision rule 5: `Cargo.toml` + `clippy.toml` + all `ci.yml` toolchain pins + CLI templates + docs.
- Rust 1.95.0 shipped 2026-04-16 (3 days ago); rationale for bumping inside the 6-month cooldown documented in ADR-0019 §Context (alpha stage, zero downstream blast radius, concrete 1.95 features we want).

## Why now, not 1.96?

- 1.96 is beta (releases 2026-05-28). `dtolnay/rust-toolchain@1.96` would not resolve today.
- 1.96 delta over 1.95 is nothing workspace-relevant (see ADR-0019 §Alternatives).
- Re-evaluate when 1.96 ships.

## What this unlocks (follow-up PRs, **not** this one)

Per ADR-0019 §Follow-ups — intentionally split out of this PR so the bump stays mechanical:

- `if let` guards on match arms (engine / workflow)
- `cfg_select!` replacing nested `cfg_if!` in platform code
- Atomic `update` / `try_update` in metrics counters
- `core::range` where manual bounds helpers exist

## Test plan

- [x] `cargo +stable check --workspace --all-targets` on stable-1.95.0 → green (47s)
- [x] `cargo +stable clippy --workspace -- -D warnings` → green (11s); MSRV-sensitive lints raised no new issues
- [x] `lefthook run pre-push` → green (nextest 3376/3376, doctests, --all-features, --no-default-features, docs, shear)
- [ ] CI: `fmt`, `clippy`, `check`, `doctests`, `MSRV (1.95)`, `doc`, `deny` all green on GitHub

## Notes for reviewers

- `docs/adr/0010-rust-2024-edition.md` body is **unchanged** — only frontmatter updated (`status: superseded`, `superseded_by: [0019]`) per the ADR immutability rule in `docs/adr/README.md`.
- CHANGELOG entry under `[Unreleased] > Changed` flagged BREAKING.
- Remaining `1.94` grep hits are all in historical/archived content: ADR-0010 (immutable), ADR-0014 (references 0010 historically), generated rustdoc snapshot under `docs/superpowers/specs/nebula_schema_phase0_api_snapshot/`, and archived plans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)