### PR TITLE
docs: address Copilot review feedback on #494 (MSRV 1.95)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,10 +38,11 @@ updates:
     commit-message:
       prefix: "chore(ci)"
     ignore:
-      # MSRV pin in ci.yml uses @1.95 intentionally. Dependabot can't tell
-      # that's a deliberate version pin (not a stale dep) and tries to bump
-      # to whatever Rust version is current (1.96, 1.97, ..., 1.100, ...).
-      # @stable / @nightly references in other jobs don't need version bumps.
+      # `dtolnay/rust-toolchain` is SHA-pinned with a `# v1` comment in
+      # ci.yml; the MSRV (currently 1.95) is passed via the `toolchain:`
+      # input, not the action ref. Dependabot would otherwise open weekly
+      # PRs bumping the action's SHA — we prefer to review and roll that
+      # action by hand since it installs the compiler for every CI job.
       - dependency-name: "dtolnay/rust-toolchain"
     groups:
       # Group all action updates into one PR

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,7 @@ Notes:
 - `cargo +nightly fmt` is required (unstable rustfmt options are enabled).
 - Doctests are run separately with `cargo test --doc`.
 - `lefthook run pre-push` is the local mirror of CI required jobs (fmt, clippy, tests, doctests, taplo, MSRV 1.95, `--all-features`, `--no-default-features`). When adding or removing a CI required job, update `lefthook.yml` in the same PR.
-- Commit messages use conventional commits (`feat:`, `fix(scope):`, `chore:` …); `pr-validation.yml` enforces this via commitlint.
+- Commit messages use conventional commits (`feat:`, `fix(scope):`, `chore:` …); `pr-validation.yml` enforces this via `convco`.
 - Releases are manual: `cargo release -p <crate> <patch|minor|major> --execute` (see `docs/dev-setup.md`).
 
 ## Architecture Boundaries

--- a/docs/adr/0019-msrv-1.95.md
+++ b/docs/adr/0019-msrv-1.95.md
@@ -42,9 +42,10 @@ cheap and the delta is small:
    just to pick up language features we can use today is make-work.
 
 Rust 1.96 is scheduled for **2026-05-28** (currently beta) and adds nothing
-workspace-relevant; pinning to an unreleased channel would also break
-`dtolnay/rust-toolchain@1.95` lookups in CI. We explicitly do **not** jump
-to 1.96.
+workspace-relevant. CI pins `dtolnay/rust-toolchain` by SHA (`# v1`) and
+selects the compiler via the `toolchain:` input, so the concrete blocker
+for jumping early is that `rustup` cannot install a stable `1.96`
+toolchain before it ships. We explicitly do **not** jump to 1.96.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

Fixes three doc/comment inaccuracies flagged by Copilot on [#494](https://github.com/vanyastaff/nebula/pull/494) after it was merged. All three are pre-existing or mine; all three are pure docs.

- **[CLAUDE.md:89](CLAUDE.md#L89)** — `pr-validation.yml` enforces conventional commits via `convco`, not `commitlint`. (The repo still has an orphaned `commitlint.config.mjs` from the old setup — separate follow-up task, not in this PR.)
- **[docs/adr/0019-msrv-1.95.md §Context](docs/adr/0019-msrv-1.95.md)** — rewrote the "why not 1.96" paragraph. The real failure mode is `rustup` refusing to install an unreleased stable; `dtolnay/rust-toolchain` is SHA-pinned and takes the Rust version as a `toolchain:` input, not as an action ref. ADR-0019 is still `proposed`, so the body edit is within the review window (not an accepted-ADR edit).
- **[.github/dependabot.yml](.github/dependabot.yml)** — rewrote the ignore comment. The ignore blocks SHA bumps of the action ref (what Dependabot actually touches), not Rust-version bumps (Dependabot doesn't see `toolchain:` input). Kept the ignore itself: we want to review SHA changes on this action by hand since it installs the compiler for every CI job.

## Test plan

- [x] `lefthook run pre-push` → green (nextest 3376/3376, doctests, --all-features, --no-default-features, docs, shear)
- [ ] CI green on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)