### PR TITLE
feat(credential): KeyProvider trait between EncryptionLayer and key material source (ADR-0022)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3872,6 +3872,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "subtle",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -69,9 +69,15 @@ scopeguard = "1"
 [dev-dependencies]
 reqwest = { workspace = true }
 futures = { workspace = true }
+base64 = { workspace = true }
+tempfile = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 semver = { workspace = true }
 
 [features]
 default = []
 rotation = []
+# Expose test-only helpers (e.g. `StaticKeyProvider`) to integration tests and
+# to other crates' dev-dependency paths. Must never be enabled in a production
+# release build — see ADR-0022.
+test-util = []

--- a/crates/credential/README.md
+++ b/crates/credential/README.md
@@ -28,6 +28,10 @@ Pattern: *Typed credential lifecycle* (Release It! ch "Stability Patterns" — s
 - 12 built-in scheme types: `SecretToken`, `IdentityPassword`, `OAuth2Token`, `KeyPair`, `Certificate`, `SigningKey`, `FederatedAssertion`, `ChallengeSecret`, `OtpSeed`, `ConnectionUri`, `InstanceBinding`, `SharedKey`.
 - `CredentialStore`, `StoredCredential`, `PutMode`, `StoreError` — storage trait with layered composition.
 - `EncryptionLayer`, `CacheLayer`, `AuditLayer`, `ScopeLayer` — composable store decorators.
+- `KeyProvider`, `ProviderError` — seam between `EncryptionLayer` and the encryption-key source. `Arc<dyn KeyProvider>` replaces `Arc<EncryptionKey>` in `EncryptionLayer::new`; composition roots pick the provider at wiring time. See [ADR-0022](../../docs/adr/0022-keyprovider-trait.md).
+- `EnvKeyProvider` — reads a 32-byte AES-256 key from `NEBULA_CRED_MASTER_KEY` (base64), fail-closed on missing / short / dev-placeholder values.
+- `FileKeyProvider` — reads 32 raw key bytes from a filesystem path, refuses world-readable files on Unix.
+- `StaticKeyProvider` (feature `test-util`) — in-memory key for tests and internal composition; never enabled in production release builds.
 - `CredentialRegistry`, `RegistryError` — type-erased runtime dispatch.
 - `CredentialResolver`, `ResolveError` — resolution engine: resolve, refresh, test via registry.
 - `RefreshCoordinator`, `RefreshAttempt` — thundering-herd prevention for concurrent refresh.

--- a/crates/credential/src/layer/encryption.rs
+++ b/crates/credential/src/layer/encryption.rs
@@ -9,59 +9,60 @@
 //! mismatched credential ID) is rejected with a hard error. There is no
 //! legacy fallback path.
 //!
+//! # Key source: [`KeyProvider`]
+//!
+//! The current encryption key is supplied by an
+//! [`Arc<dyn KeyProvider>`](super::KeyProvider), **not** an `Arc<EncryptionKey>`
+//! directly. Composition roots choose the provider (env var, file, KMS, …)
+//! at wiring time — see
+//! [ADR-0022](../../../../docs/adr/0022-keyprovider-trait.md) for the seam
+//! and ADR-0020 §3 for why this gate exists.
+//!
 //! # Key rotation
 //!
-//! Multiple keys can be registered via [`EncryptionLayer::with_keys`]. On every
-//! read the layer inspects `EncryptedData::key_id`:
+//! On every read the layer inspects `EncryptedData::key_id`:
 //!
-//! - If `key_id` matches `current_key_id`, decrypt normally.
-//! - If `key_id` differs from `current_key_id`, decrypt with the old key and **re-encrypt with the
-//!   current key** before returning — lazy rotation.
+//! - If `key_id` matches `self.key_provider.version()`, decrypt with the provider's current key.
+//! - If `key_id` differs, look it up in the optional `legacy_keys` map — decrypt with the legacy
+//!   key and re-encrypt with the current key before returning (lazy rotation). `legacy_keys` is
+//!   populated via [`EncryptionLayer::with_legacy_keys`] when the operator is migrating off an
+//!   older key.
 
 use std::{collections::HashMap, sync::Arc};
 
 use crate::{
     crypto::{self, EncryptionKey},
+    layer::key_provider::KeyProvider,
     store::{CredentialStore, PutMode, StoreError, StoredCredential},
 };
 
 /// Wraps a store with AES-256-GCM encryption on the `data` field.
 ///
-/// Supports multi-key operation for transparent key rotation: data encrypted
-/// with an old key is automatically re-encrypted with the current key on read.
+/// The current key is supplied by the configured [`KeyProvider`]. Records
+/// encrypted with an older key may optionally be decrypted via `legacy_keys`
+/// (populated by [`Self::with_legacy_keys`]); they are then re-encrypted
+/// with the current key on read (lazy rotation).
 ///
 /// # Examples
 ///
 /// ```rust,ignore
-/// use nebula_credential::{EncryptionLayer, InMemoryStore, EncryptionKey};
+/// use nebula_credential::{EncryptionLayer, EnvKeyProvider, InMemoryStore};
 /// use std::sync::Arc;
 ///
-/// // Single-key mode
-/// let key = Arc::new(EncryptionKey::from_bytes([0x42; 32]));
-/// let store = EncryptionLayer::new(InMemoryStore::new(), key);
-///
-/// // Multi-key mode (key rotation)
-/// let old_key = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-/// let new_key = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
-/// let store = EncryptionLayer::with_keys(
-///     InMemoryStore::new(),
-///     "new-key".to_string(),
-///     vec![
-///         ("old-key".to_string(), old_key),
-///         ("new-key".to_string(), new_key),
-///     ],
-/// );
+/// // Production: read the key from NEBULA_CRED_MASTER_KEY.
+/// let provider = Arc::new(EnvKeyProvider::from_env()?);
+/// let store = EncryptionLayer::new(InMemoryStore::new(), provider);
+/// # Ok::<(), Box<dyn std::error::Error>>(())
 /// ```
 pub struct EncryptionLayer<S> {
     inner: S,
-    current_key_id: String,
-    keys: HashMap<String, Arc<EncryptionKey>>,
+    key_provider: Arc<dyn KeyProvider>,
+    legacy_keys: HashMap<String, Arc<EncryptionKey>>,
 }
 
 impl<S> EncryptionLayer<S> {
-    /// Create a new single-key encryption layer.
-    ///
-    /// The key is registered as `"default"` and used for all new writes.
+    /// Create an encryption layer whose current key is sourced from
+    /// `key_provider`.
     ///
     /// # Legacy `""` records
     ///
@@ -71,71 +72,62 @@ impl<S> EncryptionLayer<S> {
     /// silent cross-identity decryption breaks the key-rotation invariant
     /// (PRODUCT_CANON §4.2 / §12.5) and makes `key_id`-based audit provenance
     /// unreliable. Deployments that still hold `""` envelopes must register
-    /// the empty alias explicitly via [`with_keys`](Self::with_keys) — e.g.
+    /// the empty alias explicitly via [`with_legacy_keys`](Self::with_legacy_keys) —
+    /// e.g.
     ///
     /// ```rust,ignore
-    /// EncryptionLayer::with_keys(
+    /// EncryptionLayer::with_legacy_keys(
     ///     inner,
-    ///     "default",
-    ///     vec![
-    ///         (String::new(), legacy_key),   // explicit, audit-visible
-    ///         ("default".into(), current_key),
-    ///     ],
+    ///     Arc::new(EnvKeyProvider::from_env()?), // provider drives "default"
+    ///     vec![(String::new(), legacy_key)],     // explicit, audit-visible
     /// );
     /// ```
     ///
     /// The lazy rotation path (see module docs) will then re-encrypt any
-    /// `""` record with `"default"` on next read.
-    pub fn new(inner: S, key: Arc<EncryptionKey>) -> Self {
-        let mut keys = HashMap::new();
-        keys.insert("default".into(), key);
+    /// `""` record with the provider's current version on next read.
+    pub fn new(inner: S, key_provider: Arc<dyn KeyProvider>) -> Self {
         Self {
             inner,
-            current_key_id: "default".into(),
-            keys,
+            key_provider,
+            legacy_keys: HashMap::new(),
         }
     }
 
-    /// Create an encryption layer with multiple keys for rotation support.
+    /// Create an encryption layer with additional decrypt-only keys for
+    /// rotation support.
     ///
-    /// `current_key_id` must be present in `keys`; it is used for all new
-    /// writes. Other keys are used only for decrypting legacy data and are
-    /// replaced on read (lazy rotation).
+    /// `key_provider` supplies the current encrypt/decrypt key; `legacy_keys`
+    /// contains historical keys that remain valid for reads. On read of a
+    /// record whose envelope `key_id` matches a legacy entry, the layer
+    /// decrypts with the legacy key and re-encrypts with the current key
+    /// (lazy rotation).
     ///
-    /// # Panics
-    ///
-    /// Panics if `current_key_id` is not present in `keys`.
-    pub fn with_keys(
+    /// Legacy entries do not include the current key — that is always the
+    /// provider's concern.
+    pub fn with_legacy_keys(
         inner: S,
-        current_key_id: impl Into<String>,
-        keys: Vec<(String, Arc<EncryptionKey>)>,
+        key_provider: Arc<dyn KeyProvider>,
+        legacy_keys: Vec<(String, Arc<EncryptionKey>)>,
     ) -> Self {
-        let current_key_id = current_key_id.into();
-        let keys: HashMap<String, Arc<EncryptionKey>> = keys.into_iter().collect();
-        assert!(
-            keys.contains_key(&current_key_id),
-            "current_key_id '{current_key_id}' must be present in the keys map"
-        );
         Self {
             inner,
-            current_key_id,
-            keys,
+            key_provider,
+            legacy_keys: legacy_keys.into_iter().collect(),
         }
     }
 
-    fn current_key(&self) -> Result<&EncryptionKey, StoreError> {
-        self.keys
-            .get(&self.current_key_id)
-            .map(|k| k.as_ref())
-            .ok_or_else(|| {
-                StoreError::Backend(
-                    format!("current encryption key '{}' not found", self.current_key_id).into(),
-                )
-            })
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, StoreError> {
+        self.key_provider
+            .current_key()
+            .map_err(|e| StoreError::Backend(Box::new(e)))
     }
 
-    fn key_for_id(&self, key_id: &str) -> Result<&EncryptionKey, StoreError> {
-        self.keys.get(key_id).map(|k| k.as_ref()).ok_or_else(|| {
+    fn current_key_id(&self) -> &str {
+        self.key_provider.version()
+    }
+
+    fn legacy_key(&self, key_id: &str) -> Result<Arc<EncryptionKey>, StoreError> {
+        self.legacy_keys.get(key_id).cloned().ok_or_else(|| {
             StoreError::Backend(
                 format!("encryption key '{key_id}' not found — cannot decrypt").into(),
             )
@@ -214,8 +206,9 @@ impl<S> EncryptionLayer<S> {
     /// Encrypt `plaintext` with the current key, serializing the envelope to bytes.
     fn encrypt_data(&self, plaintext: &[u8], id: &str) -> Result<Vec<u8>, StoreError> {
         let key = self.current_key()?;
+        let current_version = self.current_key_id();
         let encrypted =
-            crypto::encrypt_with_key_id(key, &self.current_key_id, plaintext, id.as_bytes())
+            crypto::encrypt_with_key_id(&key, current_version, plaintext, id.as_bytes())
                 .map_err(|e| StoreError::Backend(Box::new(e)))?;
         serde_json::to_vec(&encrypted).map_err(|e| StoreError::Backend(Box::new(e)))
     }
@@ -237,17 +230,19 @@ impl<S> EncryptionLayer<S> {
         let encrypted: crypto::EncryptedData =
             serde_json::from_slice(ciphertext).map_err(|e| StoreError::Backend(Box::new(e)))?;
 
+        let current_version = self.current_key_id();
+
         // Data encrypted with the current key — normal path.
-        if encrypted.key_id == self.current_key_id {
+        if encrypted.key_id == current_version {
             let key = self.current_key()?;
-            let plaintext = crypto::decrypt_with_aad(key, &encrypted, id.as_bytes())
+            let plaintext = crypto::decrypt_with_aad(&key, &encrypted, id.as_bytes())
                 .map_err(|e| StoreError::Backend(Box::new(e)))?;
             return Ok((plaintext, None));
         }
 
-        // Data encrypted with an older key — decrypt with old key, re-encrypt.
-        let old_key = self.key_for_id(&encrypted.key_id)?;
-        let plaintext = crypto::decrypt_with_aad(old_key, &encrypted, id.as_bytes())
+        // Data encrypted with an older key — decrypt with legacy key, re-encrypt.
+        let old_key = self.legacy_key(&encrypted.key_id)?;
+        let plaintext = crypto::decrypt_with_aad(&old_key, &encrypted, id.as_bytes())
             .map_err(|e| StoreError::Backend(Box::new(e)))?;
         let re_encrypted = self.encrypt_data(&plaintext, id)?;
         Ok((plaintext, Some(re_encrypted)))
@@ -257,21 +252,35 @@ impl<S> EncryptionLayer<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{store::PutMode, store_memory::InMemoryStore};
+    use crate::{
+        layer::key_provider::StaticKeyProvider,
+        store::{PutMode, test_helpers::make_credential},
+        store_memory::InMemoryStore,
+    };
 
-    fn test_key() -> Arc<EncryptionKey> {
-        Arc::new(EncryptionKey::from_bytes([0x42; 32]))
+    fn static_provider_with_version(
+        bytes: [u8; 32],
+        version: &'static str,
+    ) -> Arc<dyn KeyProvider> {
+        Arc::new(StaticKeyProvider::with_version(
+            Arc::new(EncryptionKey::from_bytes(bytes)),
+            version,
+        )) as Arc<dyn KeyProvider>
     }
 
-    use crate::store::test_helpers::make_credential;
+    fn default_provider() -> Arc<dyn KeyProvider> {
+        static_provider_with_version([0x42; 32], "default")
+    }
 
     // =========================================================================
-    // Existing single-key tests (preserved)
+    // Single-key round-trip / AAD / rotation tests (preserved from the
+    // pre-provider shape; the switch from `Arc<EncryptionKey>` to
+    // `Arc<dyn KeyProvider>` is transparent to every invariant below.)
     // =========================================================================
 
     #[tokio::test]
     async fn round_trip_encrypts_and_decrypts() {
-        let store = EncryptionLayer::new(InMemoryStore::new(), test_key());
+        let store = EncryptionLayer::new(InMemoryStore::new(), default_provider());
         let cred = make_credential("enc-1", b"super-secret");
 
         let stored = store.put(cred, PutMode::CreateOnly).await.unwrap();
@@ -284,7 +293,7 @@ mod tests {
     #[tokio::test]
     async fn data_is_encrypted_at_rest() {
         let inner = InMemoryStore::new();
-        let store = EncryptionLayer::new(inner.clone(), test_key());
+        let store = EncryptionLayer::new(inner.clone(), default_provider());
 
         let cred = make_credential("enc-2", b"plaintext-secret");
         store.put(cred, PutMode::CreateOnly).await.unwrap();
@@ -296,7 +305,7 @@ mod tests {
 
     #[tokio::test]
     async fn passthrough_operations() {
-        let store = EncryptionLayer::new(InMemoryStore::new(), test_key());
+        let store = EncryptionLayer::new(InMemoryStore::new(), default_provider());
 
         let cred = make_credential("enc-3", b"data");
         store.put(cred, PutMode::CreateOnly).await.unwrap();
@@ -314,8 +323,7 @@ mod tests {
     #[tokio::test]
     async fn aad_prevents_record_swapping() {
         let inner = InMemoryStore::new();
-        let key = test_key();
-        let store = EncryptionLayer::new(inner.clone(), key);
+        let store = EncryptionLayer::new(inner.clone(), default_provider());
 
         let cred = make_credential("cred-1", b"secret-data");
         store.put(cred, PutMode::CreateOnly).await.unwrap();
@@ -337,7 +345,7 @@ mod tests {
     #[tokio::test]
     async fn rejects_data_without_aad() {
         let inner = InMemoryStore::new();
-        let key = test_key();
+        let key = Arc::new(EncryptionKey::from_bytes([0x42; 32]));
 
         // Simulate legacy write: encrypt without AAD and store directly
         let plaintext = b"legacy-secret";
@@ -360,7 +368,7 @@ mod tests {
 
         // Reading through the encryption layer must fail: AAD is mandatory.
         // Data encrypted without AAD is unreadable — no legacy fallback.
-        let store = EncryptionLayer::new(inner, key);
+        let store = EncryptionLayer::new(inner, default_provider());
         let err = store.get("legacy-1").await.unwrap_err();
         assert!(matches!(err, StoreError::Backend(_)));
     }
@@ -368,26 +376,26 @@ mod tests {
     #[tokio::test]
     async fn wrong_key_fails_decryption() {
         let inner = InMemoryStore::new();
-        let key1 = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-        let key2 = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
+        let provider1 = static_provider_with_version([0x01; 32], "default");
+        let provider2 = static_provider_with_version([0x02; 32], "default");
 
-        let store1 = EncryptionLayer::new(inner.clone(), key1);
+        let store1 = EncryptionLayer::new(inner.clone(), provider1);
         let cred = make_credential("enc-4", b"secret");
         store1.put(cred, PutMode::CreateOnly).await.unwrap();
 
-        let store2 = EncryptionLayer::new(inner, key2);
+        let store2 = EncryptionLayer::new(inner, provider2);
         let err = store2.get("enc-4").await.unwrap_err();
         assert!(matches!(err, StoreError::Backend(_)));
     }
 
     // =========================================================================
-    // New multi-key / key rotation tests
+    // Multi-key / key rotation tests
     // =========================================================================
 
     #[tokio::test]
     async fn single_key_mode_stores_key_id() {
         let inner = InMemoryStore::new();
-        let store = EncryptionLayer::new(inner.clone(), test_key());
+        let store = EncryptionLayer::new(inner.clone(), default_provider());
 
         let cred = make_credential("key-id-check", b"secret");
         store.put(cred, PutMode::CreateOnly).await.unwrap();
@@ -401,11 +409,14 @@ mod tests {
     #[tokio::test]
     async fn multi_key_round_trip() {
         let key1 = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-        let key2 = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
-        let store = EncryptionLayer::with_keys(
+        let provider = Arc::new(StaticKeyProvider::with_version(
+            Arc::new(EncryptionKey::from_bytes([0x02; 32])),
+            "key-2",
+        )) as Arc<dyn KeyProvider>;
+        let store = EncryptionLayer::with_legacy_keys(
             InMemoryStore::new(),
-            "key-2".to_string(),
-            vec![("key-1".to_string(), key1), ("key-2".to_string(), key2)],
+            provider,
+            vec![("key-1".to_string(), key1)],
         );
 
         let cred = make_credential("mk-1", b"multi-key-secret");
@@ -418,23 +429,25 @@ mod tests {
     #[tokio::test]
     async fn decrypt_with_old_key_succeeds() {
         let inner = InMemoryStore::new();
-        let key1 = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-        let key2 = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
+        let key1_bytes = [0x01; 32];
+        let key2_bytes = [0x02; 32];
 
         // Write with old key (key-1 is current)
-        let store_old = EncryptionLayer::with_keys(
+        let store_old = EncryptionLayer::new(
             inner.clone(),
-            "key-1".to_string(),
-            vec![("key-1".to_string(), key1.clone())],
+            static_provider_with_version(key1_bytes, "key-1"),
         );
         let cred = make_credential("rotate-1", b"old-key-data");
         store_old.put(cred, PutMode::CreateOnly).await.unwrap();
 
-        // Now rotate: key-2 is current, key-1 still available for decryption
-        let store_new = EncryptionLayer::with_keys(
+        // Now rotate: key-2 is current, key-1 available as a legacy decrypt-only key
+        let store_new = EncryptionLayer::with_legacy_keys(
             inner.clone(),
-            "key-2".to_string(),
-            vec![("key-1".to_string(), key1), ("key-2".to_string(), key2)],
+            static_provider_with_version(key2_bytes, "key-2"),
+            vec![(
+                "key-1".to_string(),
+                Arc::new(EncryptionKey::from_bytes(key1_bytes)),
+            )],
         );
 
         let fetched = store_new.get("rotate-1").await.unwrap();
@@ -450,23 +463,25 @@ mod tests {
     #[tokio::test]
     async fn lazy_reencryption_returns_post_rotation_version() {
         let inner = InMemoryStore::new();
-        let key1 = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-        let key2 = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
+        let key1_bytes = [0x01; 32];
+        let key2_bytes = [0x02; 32];
 
-        let store_old = EncryptionLayer::with_keys(
+        let store_old = EncryptionLayer::new(
             inner.clone(),
-            "key-1".to_string(),
-            vec![("key-1".to_string(), key1.clone())],
+            static_provider_with_version(key1_bytes, "key-1"),
         );
         let cred = make_credential("rotate-version-1", b"needs-rotation");
         let pre_rotation = store_old.put(cred, PutMode::CreateOnly).await.unwrap();
         let version_before_rotation = pre_rotation.version;
 
         // Read through new layer — triggers lazy rotation + CAS write.
-        let store_new = EncryptionLayer::with_keys(
+        let store_new = EncryptionLayer::with_legacy_keys(
             inner.clone(),
-            "key-2".to_string(),
-            vec![("key-1".to_string(), key1), ("key-2".to_string(), key2)],
+            static_provider_with_version(key2_bytes, "key-2"),
+            vec![(
+                "key-1".to_string(),
+                Arc::new(EncryptionKey::from_bytes(key1_bytes)),
+            )],
         );
         let fetched = store_new.get("rotate-version-1").await.unwrap();
 
@@ -488,23 +503,25 @@ mod tests {
     #[tokio::test]
     async fn lazy_reencryption_on_read_when_key_id_differs() {
         let inner = InMemoryStore::new();
-        let key1 = Arc::new(EncryptionKey::from_bytes([0x01; 32]));
-        let key2 = Arc::new(EncryptionKey::from_bytes([0x02; 32]));
+        let key1_bytes = [0x01; 32];
+        let key2_bytes = [0x02; 32];
 
         // Write with key-1
-        let store_old = EncryptionLayer::with_keys(
+        let store_old = EncryptionLayer::new(
             inner.clone(),
-            "key-1".to_string(),
-            vec![("key-1".to_string(), key1.clone())],
+            static_provider_with_version(key1_bytes, "key-1"),
         );
         let cred = make_credential("lazy-1", b"will-be-rotated");
         store_old.put(cred, PutMode::CreateOnly).await.unwrap();
 
         // Read through new layer — triggers lazy rotation
-        let store_new = EncryptionLayer::with_keys(
+        let store_new = EncryptionLayer::with_legacy_keys(
             inner.clone(),
-            "key-2".to_string(),
-            vec![("key-1".to_string(), key1), ("key-2".to_string(), key2)],
+            static_provider_with_version(key2_bytes, "key-2"),
+            vec![(
+                "key-1".to_string(),
+                Arc::new(EncryptionKey::from_bytes(key1_bytes)),
+            )],
         );
         let fetched = store_new.get("lazy-1").await.unwrap();
         assert_eq!(fetched.data, b"will-be-rotated");
@@ -518,7 +535,7 @@ mod tests {
     /// Regression for GitHub issue #281: `new()` no longer aliases the key
     /// under `""`, so legacy envelopes with `key_id: ""` cannot silently
     /// decrypt with the current key. Operators who still hold such records
-    /// must register the alias explicitly via `with_keys`.
+    /// must register the alias explicitly via `with_legacy_keys`.
     ///
     /// The current `encrypt_with_key_id` refuses to produce new envelopes
     /// with an empty `key_id`, so this test mutates a legitimately-encrypted
@@ -526,7 +543,8 @@ mod tests {
     #[tokio::test]
     async fn new_does_not_silently_decrypt_empty_key_id_envelopes() {
         let inner = InMemoryStore::new();
-        let key = test_key();
+        let key_bytes = [0x42; 32];
+        let key = Arc::new(EncryptionKey::from_bytes(key_bytes));
 
         // Encrypt normally under "default", then mutate key_id to "" to
         // simulate a legacy pre-guard envelope persisted by an older build.
@@ -550,21 +568,24 @@ mod tests {
         };
         inner.put(cred, PutMode::CreateOnly).await.unwrap();
 
-        // `new(_, key)` must refuse to decrypt the `""`-tagged record — the
-        // empty alias no longer maps to the default key.
-        let store = EncryptionLayer::new(inner.clone(), key.clone());
+        // `new(_, provider)` must refuse to decrypt the `""`-tagged record —
+        // the empty alias no longer maps to the default key.
+        let store = EncryptionLayer::new(
+            inner.clone(),
+            static_provider_with_version(key_bytes, "default"),
+        );
         let err = store.get("legacy-1").await.unwrap_err();
         assert!(
             matches!(&err, StoreError::Backend(_)),
             "expected a Backend error for unknown key_id, got {err:?}",
         );
 
-        // Explicit opt-in via `with_keys` still works — the migration path
-        // documented on `new()` succeeds.
-        let store_with_legacy = EncryptionLayer::with_keys(
+        // Explicit opt-in via `with_legacy_keys` still works — the migration
+        // path documented on `new()` succeeds.
+        let store_with_legacy = EncryptionLayer::with_legacy_keys(
             inner,
-            "default".to_string(),
-            vec![(String::new(), key.clone()), ("default".to_string(), key)],
+            static_provider_with_version(key_bytes, "default"),
+            vec![(String::new(), Arc::clone(&key))],
         );
         let fetched = store_with_legacy.get("legacy-1").await.unwrap();
         assert_eq!(fetched.data, plaintext);

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -1,0 +1,665 @@
+//! `KeyProvider` — the seam between [`EncryptionLayer`](super::EncryptionLayer)
+//! and the source of the AES-256 key material.
+//!
+//! `EncryptionLayer` no longer takes `Arc<EncryptionKey>` directly; instead it
+//! accepts `Arc<dyn KeyProvider>`. Composition roots choose the provider — env
+//! var, file, or (in future) a KMS / Vault / cloud-secret-manager impl — at
+//! wiring time. See [ADR-0022](../../../../docs/adr/0022-keyprovider-trait.md)
+//! for the decision and ADR-0020 §3 for why the seam is a pre-condition to any
+//! `apps/server` composition work.
+//!
+//! ## Invariants
+//!
+//! - `version()` must be non-empty. The encryption-layer envelope writer refuses empty `key_id`
+//!   values (see `crypto::encrypt_with_key_id`).
+//! - `current_key()` returns `Arc<EncryptionKey>` — a stable handle over the zeroize-on-drop key
+//!   newtype. Providers do not expose raw key bytes.
+//! - `Debug` / `Display` on providers and on `ProviderError` must not reveal key material (see
+//!   [`STYLE.md §6`](../../../../docs/STYLE.md#6-secret-handling)).
+//! - Intermediate plaintext (env-var strings, file bytes) is wrapped in `Zeroizing<_>` so scope
+//!   exit scrubs it.
+
+use std::{path::PathBuf, sync::Arc};
+
+use base64::Engine;
+use zeroize::Zeroizing;
+
+use crate::crypto::EncryptionKey;
+
+/// Source of the current encryption key for [`EncryptionLayer`](super::EncryptionLayer).
+///
+/// Implementations must preserve every rule from
+/// [`docs/STYLE.md §6 — Secret handling`](../../../../docs/STYLE.md#6-secret-handling):
+/// zeroized intermediate plaintext, redacted `Debug`, typed errors without
+/// embedded secret material.
+pub trait KeyProvider: Send + Sync + 'static {
+    /// Return the current encryption key. Called on every encrypt/decrypt
+    /// cycle, so implementations cache internally rather than re-reading the
+    /// backing source on every call.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ProviderError`] when the backing source is unreachable or the
+    /// material fails validation. The layer wraps this as
+    /// [`StoreError::Backend`](crate::StoreError::Backend) so callers see a
+    /// uniform failure taxonomy.
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError>;
+
+    /// Stable identifier for the current key. Stored as
+    /// [`EncryptedData::key_id`](crate::crypto::EncryptedData) in new
+    /// envelopes; used by the rotation path to detect mismatches. Must be
+    /// non-empty.
+    fn version(&self) -> &str;
+}
+
+/// Typed errors returned by [`KeyProvider`] implementations.
+///
+/// `#[non_exhaustive]` so future KMS / Vault backends can add variants without
+/// breaking downstream consumers. No variant carries raw key bytes per
+/// `docs/STYLE.md §6`.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ProviderError {
+    /// The configured source for the key is not present (env var unset, file
+    /// path missing, …). `name` identifies what was checked — never the secret.
+    #[error("key material source not configured: {name}")]
+    NotConfigured {
+        /// Human-readable identifier of the source that was missing
+        /// (`NEBULA_CRED_MASTER_KEY`, a file path, …). Never the secret.
+        name: String,
+    },
+
+    /// The configured source produced a value that failed validation (wrong
+    /// length after decode, dev placeholder, …). `reason` describes the
+    /// failure shape — never the secret.
+    #[error("key material rejected: {reason}")]
+    KeyMaterialRejected {
+        /// Structured reason for rejection. Never the secret.
+        reason: String,
+    },
+
+    /// The source literally matches the well-known development placeholder.
+    /// Refused even in dev; there is no ephemeral-key fallback for encryption
+    /// (unlike `JwtSecret::generate_ephemeral`) because an ephemeral encryption
+    /// key makes stored credentials unreadable across restarts.
+    #[error("key material matches the well-known development placeholder — refusing to start")]
+    DevPlaceholder,
+
+    /// The source's bytes failed to decode (e.g. base64).
+    #[error("key material decode failed: {reason}")]
+    Decode {
+        /// Decoder-reported reason. Never the secret.
+        reason: String,
+    },
+
+    /// Filesystem permissions on a file-backed source are too permissive.
+    /// Flagged by [`FileKeyProvider`] on Unix; skipped on Windows where POSIX
+    /// mode bits do not apply.
+    #[error("key material file has insecure permissions: {path}")]
+    InsecurePermissions {
+        /// The path whose mode is unsafe. Not the secret.
+        path: PathBuf,
+    },
+
+    /// I/O error reaching the backing source.
+    #[error("key material source I/O failed")]
+    Io(#[from] std::io::Error),
+}
+
+// ============================================================================
+// EnvKeyProvider
+// ============================================================================
+
+/// Reads a 32-byte AES-256 key from an environment variable (base64).
+///
+/// The canonical local / single-tenant default. Fail-closed on missing,
+/// short, wrong-length, or dev-placeholder values — mirroring
+/// [`JwtSecret::new`](../../../../crates/api/src/config.rs) so operators see
+/// one mental model across auth and encryption-at-rest pre-conditions.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let provider = EnvKeyProvider::from_env()?;
+/// let layer = EncryptionLayer::new(inner_store, Arc::new(provider));
+/// ```
+pub struct EnvKeyProvider {
+    key: Arc<EncryptionKey>,
+    version: Arc<str>,
+}
+
+impl EnvKeyProvider {
+    /// Default env var name. Operators may wrap the constructor if they need
+    /// a different name for a specific deployment shape.
+    pub const ENV_VAR: &'static str = "NEBULA_CRED_MASTER_KEY";
+
+    /// Required length after base64 decode (32 bytes = AES-256).
+    pub const MIN_BYTES: usize = 32;
+
+    /// Well-known development placeholder. Refused even inside the process;
+    /// the whole point is that a leaked-back placeholder value does not
+    /// silently become the production key.
+    pub const DEV_PLACEHOLDER: &'static str = "dev-encryption-key-change-in-production";
+
+    /// Load the key from [`Self::ENV_VAR`].
+    ///
+    /// # Errors
+    ///
+    /// - [`ProviderError::NotConfigured`] if the env var is unset.
+    /// - [`ProviderError::DevPlaceholder`] if the value matches [`Self::DEV_PLACEHOLDER`].
+    /// - [`ProviderError::Decode`] on base64-decode failure.
+    /// - [`ProviderError::KeyMaterialRejected`] on wrong decoded length.
+    pub fn from_env() -> Result<Self, ProviderError> {
+        let raw = std::env::var(Self::ENV_VAR).map_err(|_| ProviderError::NotConfigured {
+            name: Self::ENV_VAR.to_string(),
+        })?;
+        let raw = Zeroizing::new(raw);
+        Self::from_base64(&raw)
+    }
+
+    /// Load the key from a base64 string (used by [`Self::from_env`] and by
+    /// direct composition-root wiring that sources the key from something
+    /// other than `std::env`, e.g. a systemd credential file whose contents
+    /// are base64).
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::from_env`].
+    pub fn from_base64(raw: &str) -> Result<Self, ProviderError> {
+        if raw == Self::DEV_PLACEHOLDER {
+            return Err(ProviderError::DevPlaceholder);
+        }
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(raw)
+            .map_err(|e| ProviderError::Decode {
+                reason: e.to_string(),
+            })?;
+        let decoded = Zeroizing::new(decoded);
+        if decoded.len() != Self::MIN_BYTES {
+            return Err(ProviderError::KeyMaterialRejected {
+                reason: format!(
+                    "expected exactly {} bytes after base64 decode, got {}",
+                    Self::MIN_BYTES,
+                    decoded.len()
+                ),
+            });
+        }
+        let mut key_bytes = [0u8; 32];
+        key_bytes.copy_from_slice(&decoded);
+        Ok(Self {
+            key: Arc::new(EncryptionKey::from_bytes(key_bytes)),
+            version: Arc::from("env:current"),
+        })
+    }
+}
+
+impl KeyProvider for EnvKeyProvider {
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError> {
+        Ok(Arc::clone(&self.key))
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+impl std::fmt::Debug for EnvKeyProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EnvKeyProvider")
+            .field("version", &&*self.version)
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ============================================================================
+// FileKeyProvider
+// ============================================================================
+
+/// Reads 32 raw key bytes from a filesystem path.
+///
+/// Useful for Kubernetes secrets mounted into the container filesystem
+/// (`/run/secrets/`), systemd credential files
+/// (`$CREDENTIALS_DIRECTORY/`), and operators who want the key on-disk with
+/// a discrete rotation story rather than in the process environment.
+///
+/// # Permissions
+///
+/// On Unix, the key file must NOT be world-readable (`mode & 0o004 == 0`);
+/// a world-readable key file is refused with
+/// [`ProviderError::InsecurePermissions`]. On Windows the check is skipped —
+/// POSIX mode bits do not apply. Operators on Windows are expected to restrict
+/// the file via Windows ACLs out of band.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let provider = FileKeyProvider::from_path("/run/secrets/nebula_cred_key")?;
+/// let layer = EncryptionLayer::new(inner_store, Arc::new(provider));
+/// ```
+pub struct FileKeyProvider {
+    key: Arc<EncryptionKey>,
+    version: Arc<str>,
+}
+
+impl FileKeyProvider {
+    /// Required raw file length (32 bytes = AES-256).
+    pub const MIN_BYTES: usize = 32;
+
+    /// Load the key from `path`.
+    ///
+    /// # Errors
+    ///
+    /// - [`ProviderError::InsecurePermissions`] if the file is world-readable on Unix.
+    /// - [`ProviderError::Io`] on filesystem errors.
+    /// - [`ProviderError::KeyMaterialRejected`] on wrong file length.
+    pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, ProviderError> {
+        let path = path.as_ref();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            let metadata = std::fs::metadata(path)?;
+            // World-readable bit set => refuse.
+            if metadata.mode() & 0o004 != 0 {
+                return Err(ProviderError::InsecurePermissions {
+                    path: path.to_path_buf(),
+                });
+            }
+        }
+        let bytes = std::fs::read(path)?;
+        let bytes = Zeroizing::new(bytes);
+        if bytes.len() != Self::MIN_BYTES {
+            return Err(ProviderError::KeyMaterialRejected {
+                reason: format!(
+                    "expected exactly {} bytes in key file, got {}",
+                    Self::MIN_BYTES,
+                    bytes.len()
+                ),
+            });
+        }
+        let mut key_bytes = [0u8; 32];
+        key_bytes.copy_from_slice(&bytes);
+        let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("key");
+        Ok(Self {
+            key: Arc::new(EncryptionKey::from_bytes(key_bytes)),
+            version: Arc::from(format!("file:{filename}")),
+        })
+    }
+}
+
+impl KeyProvider for FileKeyProvider {
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError> {
+        Ok(Arc::clone(&self.key))
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+impl std::fmt::Debug for FileKeyProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FileKeyProvider")
+            .field("version", &&*self.version)
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ============================================================================
+// StaticKeyProvider (test-only)
+// ============================================================================
+
+/// Test-only provider that wraps an in-memory [`EncryptionKey`].
+///
+/// Gated behind `#[cfg(any(test, feature = "test-util"))]`. Production release
+/// builds never see this type; every non-test composition path uses
+/// [`EnvKeyProvider`] or [`FileKeyProvider`].
+#[cfg(any(test, feature = "test-util"))]
+pub struct StaticKeyProvider {
+    key: Arc<EncryptionKey>,
+    version: Arc<str>,
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl StaticKeyProvider {
+    /// Wrap `key` with the default test version `"static:test"`.
+    pub fn new(key: Arc<EncryptionKey>) -> Self {
+        Self::with_version(key, "static:test")
+    }
+
+    /// Wrap `key` with a caller-supplied version string. The version is
+    /// stored as the envelope `key_id`, so tests that exercise rotation
+    /// across versions pass distinct strings here.
+    pub fn with_version(key: Arc<EncryptionKey>, version: impl Into<Arc<str>>) -> Self {
+        Self {
+            key,
+            version: version.into(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl KeyProvider for StaticKeyProvider {
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError> {
+        Ok(Arc::clone(&self.key))
+    }
+
+    fn version(&self) -> &str {
+        &self.version
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl std::fmt::Debug for StaticKeyProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StaticKeyProvider")
+            .field("version", &&*self.version)
+            .field("key", &"[REDACTED]")
+            .finish()
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use base64::Engine;
+
+    use super::*;
+
+    // ------------------------------------------------------------------------
+    // ProviderError shape
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn provider_error_debug_does_not_mention_key_bytes() {
+        // None of the variants carry raw key material; their Debug output
+        // must not include anything that looks like decoded bytes.
+        let err = ProviderError::NotConfigured {
+            name: "NEBULA_CRED_MASTER_KEY".into(),
+        };
+        let formatted = format!("{err:?}");
+        assert!(formatted.contains("NotConfigured"));
+        assert!(!formatted.contains("0x"));
+
+        let err = ProviderError::KeyMaterialRejected {
+            reason: "expected 32 bytes".into(),
+        };
+        let formatted = format!("{err:?}");
+        assert!(formatted.contains("KeyMaterialRejected"));
+        // 0x42 is the byte pattern used in our test keys — must not leak.
+        assert!(!formatted.contains("0x42"));
+    }
+
+    // ------------------------------------------------------------------------
+    // EnvKeyProvider
+    // ------------------------------------------------------------------------
+
+    fn valid_base64_key() -> String {
+        base64::engine::general_purpose::STANDARD.encode([0x42u8; 32])
+    }
+
+    // Env-var manipulation (`std::env::set_var` / `remove_var`) is marked
+    // `unsafe` in Rust 2024 edition and is forbidden by this crate's
+    // `#![forbid(unsafe_code)]`. `EnvKeyProvider::from_env` is covered by the
+    // integration test at `tests/env_provider.rs`, which lives in a separate
+    // test-binary crate without that forbid. Validation-logic coverage for
+    // dev-placeholder / wrong-length / decode-failure paths lives here via
+    // `from_base64`, which exercises the same validators minus the env lookup
+    // itself.
+
+    #[test]
+    fn env_provider_dev_placeholder_rejected_via_base64() {
+        let err = EnvKeyProvider::from_base64(EnvKeyProvider::DEV_PLACEHOLDER)
+            .expect_err("dev placeholder must error");
+        assert!(matches!(err, ProviderError::DevPlaceholder));
+    }
+
+    #[test]
+    fn env_provider_short_value_rejected_via_base64() {
+        let short = base64::engine::general_purpose::STANDARD.encode([0x42u8; 16]);
+        let err = EnvKeyProvider::from_base64(&short).expect_err("short key must error");
+        match err {
+            ProviderError::KeyMaterialRejected { reason } => {
+                assert!(reason.contains("32"), "reason mentions required length");
+                assert!(reason.contains("16"), "reason mentions actual length");
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn env_provider_valid_key_round_trips_via_base64() {
+        let provider =
+            EnvKeyProvider::from_base64(&valid_base64_key()).expect("valid key must succeed");
+        assert_eq!(provider.version(), "env:current");
+        provider.current_key().expect("key available");
+    }
+
+    #[test]
+    fn env_provider_invalid_base64_rejected() {
+        let err = EnvKeyProvider::from_base64("not~valid~base64~~").expect_err("must error");
+        assert!(matches!(err, ProviderError::Decode { .. }));
+    }
+
+    #[test]
+    fn env_provider_debug_redacts_key() {
+        let provider = EnvKeyProvider::from_base64(&valid_base64_key()).unwrap();
+        let formatted = format!("{provider:?}");
+        assert!(formatted.contains("[REDACTED]"));
+        assert!(!formatted.contains("0x42"));
+    }
+
+    // ------------------------------------------------------------------------
+    // FileKeyProvider
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn file_provider_valid_key_round_trips() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nebula.key");
+        std::fs::write(&path, [0x42u8; 32]).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o600);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        let provider = FileKeyProvider::from_path(&path).expect("valid file must succeed");
+        assert_eq!(provider.version(), "file:nebula.key");
+        provider.current_key().expect("key available");
+    }
+
+    #[test]
+    fn file_provider_wrong_length_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("short.key");
+        std::fs::write(&path, [0x42u8; 16]).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut perms = std::fs::metadata(&path).unwrap().permissions();
+            perms.set_mode(0o600);
+            std::fs::set_permissions(&path, perms).unwrap();
+        }
+        let err = FileKeyProvider::from_path(&path).expect_err("short file must error");
+        match err {
+            ProviderError::KeyMaterialRejected { reason } => {
+                assert!(reason.contains("32"));
+                assert!(reason.contains("16"));
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn file_provider_world_readable_refused() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("world.key");
+        std::fs::write(&path, [0x42u8; 32]).unwrap();
+        let mut perms = std::fs::metadata(&path).unwrap().permissions();
+        perms.set_mode(0o644); // world-readable
+        std::fs::set_permissions(&path, perms).unwrap();
+
+        let err = FileKeyProvider::from_path(&path).expect_err("world-readable must error");
+        match err {
+            ProviderError::InsecurePermissions { path: p } => {
+                assert_eq!(p, path);
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn file_provider_missing_file_fails_closed() {
+        let err = FileKeyProvider::from_path("/nonexistent/path/nebula.key")
+            .expect_err("missing file must error");
+        assert!(matches!(err, ProviderError::Io(_)));
+    }
+
+    // ------------------------------------------------------------------------
+    // StaticKeyProvider
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn static_provider_round_trip() {
+        let key = Arc::new(EncryptionKey::from_bytes([0x11; 32]));
+        let provider = StaticKeyProvider::new(Arc::clone(&key));
+        assert_eq!(provider.version(), "static:test");
+        assert!(Arc::ptr_eq(&provider.current_key().unwrap(), &key));
+    }
+
+    #[test]
+    fn static_provider_with_version_preserves_version() {
+        let key = Arc::new(EncryptionKey::from_bytes([0x22; 32]));
+        let provider = StaticKeyProvider::with_version(key, "rot-v2");
+        assert_eq!(provider.version(), "rot-v2");
+    }
+
+    // ------------------------------------------------------------------------
+    // Trait-level: rotation triggers re-fetch
+    // ------------------------------------------------------------------------
+
+    /// Counts `current_key()` invocations. Used to assert that the layer
+    /// re-queries the provider on each read/write rather than caching the
+    /// key at construction time.
+    struct CountingKeyProvider {
+        inner: StaticKeyProvider,
+        current_key_calls: AtomicUsize,
+        version_calls: AtomicUsize,
+    }
+
+    impl CountingKeyProvider {
+        fn new(key: Arc<EncryptionKey>) -> Self {
+            Self {
+                inner: StaticKeyProvider::new(key),
+                current_key_calls: AtomicUsize::new(0),
+                version_calls: AtomicUsize::new(0),
+            }
+        }
+
+        fn current_key_calls(&self) -> usize {
+            self.current_key_calls.load(Ordering::SeqCst)
+        }
+
+        fn version_calls(&self) -> usize {
+            self.version_calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl KeyProvider for CountingKeyProvider {
+        fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError> {
+            self.current_key_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.current_key()
+        }
+
+        fn version(&self) -> &str {
+            self.version_calls.fetch_add(1, Ordering::SeqCst);
+            self.inner.version()
+        }
+    }
+
+    #[tokio::test]
+    async fn layer_refetches_provider_on_put_and_get() {
+        use crate::{
+            layer::EncryptionLayer,
+            store::{CredentialStore, PutMode, test_helpers::make_credential},
+            store_memory::InMemoryStore,
+        };
+
+        let key = Arc::new(EncryptionKey::from_bytes([0x33; 32]));
+        let provider = Arc::new(CountingKeyProvider::new(Arc::clone(&key)));
+        let store = EncryptionLayer::new(InMemoryStore::new(), Arc::clone(&provider) as _);
+
+        let before_put = provider.current_key_calls();
+        store
+            .put(make_credential("refetch-1", b"secret"), PutMode::CreateOnly)
+            .await
+            .unwrap();
+        assert!(
+            provider.current_key_calls() > before_put,
+            "put must call current_key at least once"
+        );
+
+        let before_get = provider.current_key_calls();
+        store.get("refetch-1").await.unwrap();
+        assert!(
+            provider.current_key_calls() > before_get,
+            "get must call current_key at least once"
+        );
+
+        assert!(
+            provider.version_calls() > 0,
+            "provider version must be queried too"
+        );
+    }
+
+    /// Failure from `current_key()` surfaces through the layer as a
+    /// `StoreError::Backend` — the typed taxonomy the rest of the credential
+    /// surface expects.
+    struct FailingKeyProvider;
+
+    impl KeyProvider for FailingKeyProvider {
+        fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError> {
+            Err(ProviderError::NotConfigured {
+                name: "test-injected".into(),
+            })
+        }
+
+        fn version(&self) -> &str {
+            "failing:test"
+        }
+    }
+
+    #[tokio::test]
+    async fn provider_failure_surfaces_as_backend_error() {
+        use crate::{
+            StoreError,
+            layer::EncryptionLayer,
+            store::{CredentialStore, PutMode, test_helpers::make_credential},
+            store_memory::InMemoryStore,
+        };
+
+        let store = EncryptionLayer::new(
+            InMemoryStore::new(),
+            Arc::new(FailingKeyProvider) as Arc<dyn KeyProvider>,
+        );
+
+        let err = store
+            .put(make_credential("fail-1", b"x"), PutMode::CreateOnly)
+            .await
+            .expect_err("provider failure must propagate");
+        assert!(
+            matches!(err, StoreError::Backend(_)),
+            "expected Backend variant, got {err:?}"
+        );
+    }
+}

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -298,21 +298,40 @@ impl FileKeyProvider {
 
     /// Load the key from `path`.
     ///
+    /// The file is opened once; all subsequent checks run against that
+    /// handle. This avoids a TOCTOU gap between `stat(path)` and
+    /// `read(path)` where a symlink could be swapped in-between, and
+    /// ensures non-regular files (FIFOs, device nodes) are refused
+    /// before any blocking or unbounded read would occur — `std::fs::read`
+    /// without a regular-file check can block on a named pipe or read
+    /// arbitrary data from a character device.
+    ///
     /// # Errors
     ///
     /// - [`ProviderError::InsecurePermissions`] if the file is world-readable on Unix.
     /// - [`ProviderError::FileIo`] on filesystem errors (missing file, permission denied, …) —
     ///   carries the offending path for diagnostics.
-    /// - [`ProviderError::KeyMaterialRejected`] on wrong file length.
+    /// - [`ProviderError::KeyMaterialRejected`] if the target is not a regular file, or its length
+    ///   differs from [`Self::MIN_BYTES`].
     pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, ProviderError> {
+        use std::io::Read as _;
+
         let path = path.as_ref();
+
+        // Open once — subsequent checks run against this handle rather than
+        // the path, closing the stat/read TOCTOU gap.
+        let mut file = std::fs::File::open(path).map_err(|source| ProviderError::FileIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let metadata = file.metadata().map_err(|source| ProviderError::FileIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
+
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
-            let metadata = std::fs::metadata(path).map_err(|source| ProviderError::FileIo {
-                path: path.to_path_buf(),
-                source,
-            })?;
             // World-readable bit set => refuse.
             if metadata.mode() & 0o004 != 0 {
                 return Err(ProviderError::InsecurePermissions {
@@ -320,26 +339,45 @@ impl FileKeyProvider {
                 });
             }
         }
-        let bytes = std::fs::read(path).map_err(|source| ProviderError::FileIo {
-            path: path.to_path_buf(),
-            source,
-        })?;
-        let bytes = Zeroizing::new(bytes);
-        if bytes.len() != Self::MIN_BYTES {
+
+        // Reject anything that is not a regular file: FIFOs would block on
+        // read_exact, character devices (`/dev/urandom` etc.) would yield
+        // unbounded / meaningless data, and directories simply don't hold
+        // a 32-byte key.
+        if !metadata.is_file() {
+            return Err(ProviderError::KeyMaterialRejected {
+                reason: format!(
+                    "expected a regular file at {}, got a non-regular filesystem entry",
+                    path.display()
+                ),
+            });
+        }
+        if metadata.len() != Self::MIN_BYTES as u64 {
             return Err(ProviderError::KeyMaterialRejected {
                 reason: format!(
                     "expected exactly {} bytes in key file, got {}",
                     Self::MIN_BYTES,
-                    bytes.len()
+                    metadata.len()
                 ),
             });
         }
-        let mut key_bytes = [0u8; 32];
-        key_bytes.copy_from_slice(&bytes);
+
+        // Fixed-size buffer + read_exact: no chance of reading more than 32
+        // bytes, zeroized on scope exit if any subsequent step fails.
+        let mut key_bytes = Zeroizing::new([0u8; 32]);
+        file.read_exact(key_bytes.as_mut_slice())
+            .map_err(|source| ProviderError::FileIo {
+                path: path.to_path_buf(),
+                source,
+            })?;
+
         let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("key");
         let fingerprint = key_fingerprint(&key_bytes);
         Ok(Self {
-            key: Arc::new(EncryptionKey::from_bytes(key_bytes)),
+            // `EncryptionKey::from_bytes` copies the array into its own
+            // zeroize-on-drop newtype; `key_bytes` (the Zeroizing wrapper)
+            // drops at end of scope and scrubs the source buffer.
+            key: Arc::new(EncryptionKey::from_bytes(*key_bytes)),
             version: Arc::from(format!("file:{filename}:{fingerprint}")),
         })
     }
@@ -681,6 +719,27 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
+    }
+
+    /// Pointing `FileKeyProvider` at a non-regular-file path (here: a
+    /// directory) must refuse before any `read` call — otherwise the
+    /// behaviour would range from "reads 0 bytes" to "blocks forever on a
+    /// FIFO" to "reads unbounded data from `/dev/urandom`". Regular-file
+    /// gate closes the class. Accepting both error shapes keeps the test
+    /// portable: Unix `File::open` on a dir succeeds and the
+    /// `is_file()` check fires; Windows may refuse at `open` time.
+    #[test]
+    fn file_provider_refuses_non_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = FileKeyProvider::from_path(dir.path())
+            .expect_err("directory must be refused before read");
+        assert!(
+            matches!(
+                err,
+                ProviderError::KeyMaterialRejected { .. } | ProviderError::FileIo { .. }
+            ),
+            "unexpected variant: {err:?}"
+        );
     }
 
     // ------------------------------------------------------------------------

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -12,6 +12,12 @@
 //!
 //! - `version()` must be non-empty. The encryption-layer envelope writer refuses empty `key_id`
 //!   values (see `crypto::encrypt_with_key_id`).
+//! - **`version()` must change whenever the key bytes change.** `EncryptionLayer` routes a record
+//!   whose envelope `key_id` differs from `version()` through the legacy-key path, so a
+//!   stable-version/rotating-key provider would silently mis-decrypt under the new key.
+//!   `EnvKeyProvider` / `FileKeyProvider` derive `version()` from a SHA-256 fingerprint of the key
+//!   material so an in-place rotation (same env var / same file path, new bytes) produces a fresh
+//!   identifier automatically. See ADR-0022 §3 + §6 Rotation procedure.
 //! - `current_key()` returns `Arc<EncryptionKey>` — a stable handle over the zeroize-on-drop key
 //!   newtype. Providers do not expose raw key bytes.
 //! - `Debug` / `Display` on providers and on `ProviderError` must not reveal key material (see
@@ -19,12 +25,35 @@
 //! - Intermediate plaintext (env-var strings, file bytes) is wrapped in `Zeroizing<_>` so scope
 //!   exit scrubs it.
 
-use std::{path::PathBuf, sync::Arc};
+use std::{fmt::Write as _, path::PathBuf, sync::Arc};
 
 use base64::Engine;
+use sha2::{Digest, Sha256};
 use zeroize::Zeroizing;
 
 use crate::crypto::EncryptionKey;
+
+/// Short, non-secret fingerprint of 32-byte key material.
+///
+/// Returns the first 8 bytes of SHA-256 over the key, hex-encoded (16 chars).
+/// Used as the rotating segment of [`KeyProvider::version`] so an in-place
+/// key rotation (same env var, same file path, new bytes) produces a
+/// **different** envelope `key_id`. Stored records then flow through the
+/// legacy-key path instead of silently mis-decrypting under the new key.
+///
+/// 64 bits of output is ample for rotation correlation inside a single
+/// deployment while keeping envelope overhead small. The SHA-256 input is
+/// a cryptographic key (not user input) so second-preimage resistance is
+/// not a concern for this use.
+fn key_fingerprint(bytes: &[u8; 32]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(16);
+    for byte in &digest[..8] {
+        // Two lowercase hex chars per byte — `write!` to a String never fails.
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
 
 /// Source of the current encryption key for [`EncryptionLayer`](super::EncryptionLayer).
 ///
@@ -48,7 +77,13 @@ pub trait KeyProvider: Send + Sync + 'static {
     /// Stable identifier for the current key. Stored as
     /// [`EncryptedData::key_id`](crate::crypto::EncryptedData) in new
     /// envelopes; used by the rotation path to detect mismatches. Must be
-    /// non-empty.
+    /// non-empty, and **must change whenever `current_key()` returns
+    /// different key bytes** — otherwise the layer will treat pre-rotation
+    /// records as "current" and silently mis-decrypt them under the new
+    /// key. `EnvKeyProvider` / `FileKeyProvider` derive this from a
+    /// SHA-256 fingerprint of the key material; operator-authored
+    /// providers that hand-manage the version string must preserve the
+    /// same invariant.
     fn version(&self) -> &str;
 }
 
@@ -101,9 +136,23 @@ pub enum ProviderError {
         path: PathBuf,
     },
 
-    /// I/O error reaching the backing source.
+    /// I/O error reading a file-backed source. Carries the offending path so
+    /// operators can diagnose missing mounts, permission denied, etc. without
+    /// having to correlate with their own log lines.
+    #[error("key material file I/O failed for {path}")]
+    FileIo {
+        /// The file path that failed. Not the secret.
+        path: PathBuf,
+        /// The underlying filesystem error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// I/O error reaching a non-file backing source. Retained for future
+    /// providers whose source is not path-shaped; file-backed providers use
+    /// [`Self::FileIo`] so the path surfaces.
     #[error("key material source I/O failed")]
-    Io(#[from] std::io::Error),
+    Io(#[source] std::io::Error),
 }
 
 // ============================================================================
@@ -186,9 +235,10 @@ impl EnvKeyProvider {
         }
         let mut key_bytes = [0u8; 32];
         key_bytes.copy_from_slice(&decoded);
+        let fingerprint = key_fingerprint(&key_bytes);
         Ok(Self {
             key: Arc::new(EncryptionKey::from_bytes(key_bytes)),
-            version: Arc::from("env:current"),
+            version: Arc::from(format!("env:{fingerprint}")),
         })
     }
 }
@@ -251,14 +301,18 @@ impl FileKeyProvider {
     /// # Errors
     ///
     /// - [`ProviderError::InsecurePermissions`] if the file is world-readable on Unix.
-    /// - [`ProviderError::Io`] on filesystem errors.
+    /// - [`ProviderError::FileIo`] on filesystem errors (missing file, permission denied, …) —
+    ///   carries the offending path for diagnostics.
     /// - [`ProviderError::KeyMaterialRejected`] on wrong file length.
     pub fn from_path(path: impl AsRef<std::path::Path>) -> Result<Self, ProviderError> {
         let path = path.as_ref();
         #[cfg(unix)]
         {
             use std::os::unix::fs::MetadataExt;
-            let metadata = std::fs::metadata(path)?;
+            let metadata = std::fs::metadata(path).map_err(|source| ProviderError::FileIo {
+                path: path.to_path_buf(),
+                source,
+            })?;
             // World-readable bit set => refuse.
             if metadata.mode() & 0o004 != 0 {
                 return Err(ProviderError::InsecurePermissions {
@@ -266,7 +320,10 @@ impl FileKeyProvider {
                 });
             }
         }
-        let bytes = std::fs::read(path)?;
+        let bytes = std::fs::read(path).map_err(|source| ProviderError::FileIo {
+            path: path.to_path_buf(),
+            source,
+        })?;
         let bytes = Zeroizing::new(bytes);
         if bytes.len() != Self::MIN_BYTES {
             return Err(ProviderError::KeyMaterialRejected {
@@ -280,9 +337,10 @@ impl FileKeyProvider {
         let mut key_bytes = [0u8; 32];
         key_bytes.copy_from_slice(&bytes);
         let filename = path.file_name().and_then(|n| n.to_str()).unwrap_or("key");
+        let fingerprint = key_fingerprint(&key_bytes);
         Ok(Self {
             key: Arc::new(EncryptionKey::from_bytes(key_bytes)),
-            version: Arc::from(format!("file:{filename}")),
+            version: Arc::from(format!("file:{filename}:{fingerprint}")),
         })
     }
 }
@@ -437,7 +495,16 @@ mod tests {
     fn env_provider_valid_key_round_trips_via_base64() {
         let provider =
             EnvKeyProvider::from_base64(&valid_base64_key()).expect("valid key must succeed");
-        assert_eq!(provider.version(), "env:current");
+        let version = provider.version();
+        assert!(
+            version.starts_with("env:"),
+            "version has env prefix; got {version}"
+        );
+        assert_eq!(
+            version.len(),
+            "env:".len() + 16,
+            "version ends in 16-char (8-byte) hex fingerprint; got {version}"
+        );
         provider.current_key().expect("key available");
     }
 
@@ -453,6 +520,45 @@ mod tests {
         let formatted = format!("{provider:?}");
         assert!(formatted.contains("[REDACTED]"));
         assert!(!formatted.contains("0x42"));
+    }
+
+    /// Two different keys must produce different `version()`s so an in-place
+    /// env-var rotation flips the envelope `key_id` instead of silently
+    /// mis-decrypting under the new key. Regression guard for the rotation
+    /// safety invariant recorded in ADR-0022 §3.
+    #[test]
+    fn env_provider_version_changes_with_key() {
+        let k1 = base64::engine::general_purpose::STANDARD.encode([0x11u8; 32]);
+        let k2 = base64::engine::general_purpose::STANDARD.encode([0x22u8; 32]);
+        let v1 = EnvKeyProvider::from_base64(&k1)
+            .unwrap()
+            .version()
+            .to_owned();
+        let v2 = EnvKeyProvider::from_base64(&k2)
+            .unwrap()
+            .version()
+            .to_owned();
+        assert_ne!(
+            v1, v2,
+            "different keys must produce different versions (v1={v1}, v2={v2})"
+        );
+    }
+
+    /// Two providers constructed from the same bytes must report the same
+    /// `version()` — so restarting a stable deployment does not churn
+    /// envelope `key_id`s.
+    #[test]
+    fn env_provider_version_stable_for_same_key() {
+        let k = valid_base64_key();
+        let v1 = EnvKeyProvider::from_base64(&k)
+            .unwrap()
+            .version()
+            .to_owned();
+        let v2 = EnvKeyProvider::from_base64(&k)
+            .unwrap()
+            .version()
+            .to_owned();
+        assert_eq!(v1, v2);
     }
 
     // ------------------------------------------------------------------------
@@ -472,8 +578,49 @@ mod tests {
             std::fs::set_permissions(&path, perms).unwrap();
         }
         let provider = FileKeyProvider::from_path(&path).expect("valid file must succeed");
-        assert_eq!(provider.version(), "file:nebula.key");
+        let version = provider.version();
+        assert!(
+            version.starts_with("file:nebula.key:"),
+            "version has file prefix + filename; got {version}"
+        );
+        assert_eq!(
+            version.len(),
+            "file:nebula.key:".len() + 16,
+            "version ends in 16-char fingerprint; got {version}"
+        );
         provider.current_key().expect("key available");
+    }
+
+    /// In-place file rewrite (same path, new bytes) must produce a different
+    /// `version()`. Mirrors `env_provider_version_changes_with_key` — the
+    /// rotation-observability guarantee must hold for file-mounted secrets
+    /// (Kubernetes secret rewrites, systemd credential refreshes).
+    #[test]
+    fn file_provider_version_changes_with_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("rotated.key");
+
+        std::fs::write(&path, [0x11u8; 32]).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        }
+        let v1 = FileKeyProvider::from_path(&path)
+            .unwrap()
+            .version()
+            .to_owned();
+
+        std::fs::write(&path, [0x22u8; 32]).unwrap();
+        let v2 = FileKeyProvider::from_path(&path)
+            .unwrap()
+            .version()
+            .to_owned();
+
+        assert_ne!(
+            v1, v2,
+            "rewriting file with new bytes must rotate version (v1={v1}, v2={v2})"
+        );
     }
 
     #[test]
@@ -522,7 +669,18 @@ mod tests {
     fn file_provider_missing_file_fails_closed() {
         let err = FileKeyProvider::from_path("/nonexistent/path/nebula.key")
             .expect_err("missing file must error");
-        assert!(matches!(err, ProviderError::Io(_)));
+        match err {
+            ProviderError::FileIo { path, source: _ } => {
+                // Path must survive through to the error so operators do not
+                // have to correlate the failure with their own log lines.
+                assert!(
+                    path.ends_with("nebula.key"),
+                    "error carries the offending path; got {}",
+                    path.display()
+                );
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -329,21 +329,14 @@ impl FileKeyProvider {
             source,
         })?;
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::MetadataExt;
-            // World-readable bit set => refuse.
-            if metadata.mode() & 0o004 != 0 {
-                return Err(ProviderError::InsecurePermissions {
-                    path: path.to_path_buf(),
-                });
-            }
-        }
-
-        // Reject anything that is not a regular file: FIFOs would block on
-        // read_exact, character devices (`/dev/urandom` etc.) would yield
-        // unbounded / meaningless data, and directories simply don't hold
-        // a 32-byte key.
+        // Reject anything that is not a regular file FIRST: FIFOs would
+        // block on read_exact, character devices (`/dev/urandom` etc.)
+        // would yield unbounded / meaningless data, and directories
+        // simply don't hold a 32-byte key. Has to precede the Unix
+        // permissions gate below — POSIX default mode on a directory
+        // (0o755) would otherwise trip the world-readable check and
+        // mask the real "not a file" problem with a misleading
+        // `InsecurePermissions` error.
         if !metadata.is_file() {
             return Err(ProviderError::KeyMaterialRejected {
                 reason: format!(
@@ -352,6 +345,18 @@ impl FileKeyProvider {
                 ),
             });
         }
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::MetadataExt;
+            // World-readable bit set on a regular key file => refuse.
+            if metadata.mode() & 0o004 != 0 {
+                return Err(ProviderError::InsecurePermissions {
+                    path: path.to_path_buf(),
+                });
+            }
+        }
+
         if metadata.len() != Self::MIN_BYTES as u64 {
             return Err(ProviderError::KeyMaterialRejected {
                 reason: format!(
@@ -725,9 +730,20 @@ mod tests {
     /// directory) must refuse before any `read` call — otherwise the
     /// behaviour would range from "reads 0 bytes" to "blocks forever on a
     /// FIFO" to "reads unbounded data from `/dev/urandom`". Regular-file
-    /// gate closes the class. Accepting both error shapes keeps the test
-    /// portable: Unix `File::open` on a dir succeeds and the
-    /// `is_file()` check fires; Windows may refuse at `open` time.
+    /// gate closes the class.
+    ///
+    /// Accepts either:
+    /// - `KeyMaterialRejected` — the common path: `File::open` on a directory succeeds on Unix; the
+    ///   `is_file()` check fires after.
+    /// - `FileIo` — Windows rejects `File::open` on a directory at the syscall level, so the error
+    ///   never gets past the open step.
+    ///
+    /// `InsecurePermissions` must NOT be a permitted outcome here: the
+    /// regular-file gate precedes the permissions gate precisely so a
+    /// 0o755 directory does not trip the world-readable check and
+    /// emit a misleading "insecure permissions" reason for what is
+    /// really a "not a file" problem. Guarding against that reordering
+    /// bug is part of this test's job.
     #[test]
     fn file_provider_refuses_non_regular_file() {
         let dir = tempfile::tempdir().unwrap();
@@ -738,7 +754,8 @@ mod tests {
                 err,
                 ProviderError::KeyMaterialRejected { .. } | ProviderError::FileIo { .. }
             ),
-            "unexpected variant: {err:?}"
+            "unexpected variant (note: InsecurePermissions would indicate \
+             is_file() / permissions ordering regressed): {err:?}"
         );
     }
 

--- a/crates/credential/src/layer/mod.rs
+++ b/crates/credential/src/layer/mod.rs
@@ -6,9 +6,13 @@
 pub mod audit;
 pub mod cache;
 pub mod encryption;
+pub mod key_provider;
 pub mod scope;
 
 pub use audit::{AuditEvent, AuditLayer, AuditOperation, AuditResult, AuditSink};
 pub use cache::{CacheConfig, CacheLayer, CacheStats};
 pub use encryption::EncryptionLayer;
+#[cfg(any(test, feature = "test-util"))]
+pub use key_provider::StaticKeyProvider;
+pub use key_provider::{EnvKeyProvider, FileKeyProvider, KeyProvider, ProviderError};
 pub use scope::{ScopeLayer, ScopeResolver};

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -132,10 +132,13 @@ pub use guard::CredentialGuard;
 pub use handle::CredentialHandle;
 // Credential key newtype
 pub use key::CredentialKey;
+#[cfg(any(test, feature = "test-util"))]
+pub use layer::StaticKeyProvider;
 // Storage layers
 pub use layer::{
     AuditEvent, AuditLayer, AuditOperation, AuditResult, AuditSink, CacheConfig, CacheLayer,
-    CacheStats, EncryptionLayer, ScopeLayer, ScopeResolver,
+    CacheStats, EncryptionLayer, EnvKeyProvider, FileKeyProvider, KeyProvider, ProviderError,
+    ScopeLayer, ScopeResolver,
 };
 pub use nebula_core::{AuthPattern, AuthScheme, CredentialEvent, CredentialId};
 pub use nebula_credential_macros::{AuthScheme, Credential};

--- a/crates/credential/tests/env_provider.rs
+++ b/crates/credential/tests/env_provider.rs
@@ -86,9 +86,16 @@ fn from_env_valid_key_round_trips() {
     set_env(&valid);
 
     let provider = EnvKeyProvider::from_env().expect("valid key must succeed");
+    let version = nebula_credential::KeyProvider::version(&provider);
+    // Version is "env:<sha256 prefix fingerprint>" (16 hex chars).
+    assert!(
+        version.starts_with("env:"),
+        "version has env prefix; got {version}"
+    );
     assert_eq!(
-        nebula_credential::KeyProvider::version(&provider),
-        "env:current"
+        version.len(),
+        "env:".len() + 16,
+        "version has 16-char fingerprint tail; got {version}"
     );
 
     clear_env();

--- a/crates/credential/tests/env_provider.rs
+++ b/crates/credential/tests/env_provider.rs
@@ -1,0 +1,95 @@
+//! Integration test for [`EnvKeyProvider::from_env`].
+//!
+//! Lives outside the crate proper because the crate applies
+//! `#![forbid(unsafe_code)]` and `std::env::set_var` / `std::env::remove_var`
+//! are `unsafe` under the Rust 2024 edition. The in-crate unit tests cover
+//! the validation logic via `from_base64`; this binary exercises the env
+//! lookup itself and verifies the fail-closed contract against a missing
+//! `NEBULA_CRED_MASTER_KEY`.
+
+use base64::Engine;
+use nebula_credential::{EnvKeyProvider, ProviderError};
+
+/// Serialize env-var manipulation across tests in this binary so parallel
+/// nextest execution does not clobber shared state.
+fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    use std::sync::{Mutex, OnceLock};
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+fn clear_env() {
+    // SAFETY: the env_lock() mutex serialises env mutations across this
+    // binary's tests, so no other test thread reads or writes the var while
+    // we mutate it. This is the same pattern used in
+    // `crates/api/src/config.rs` tests.
+    unsafe {
+        std::env::remove_var(EnvKeyProvider::ENV_VAR);
+    }
+}
+
+fn set_env(value: &str) {
+    // SAFETY: see clear_env() — env_lock() holds the invariant.
+    unsafe {
+        std::env::set_var(EnvKeyProvider::ENV_VAR, value);
+    }
+}
+
+#[test]
+fn from_env_missing_var_fails_closed() {
+    let _g = env_lock();
+    clear_env();
+
+    let err = EnvKeyProvider::from_env().expect_err("missing var must error");
+    match err {
+        ProviderError::NotConfigured { name } => {
+            assert_eq!(name, EnvKeyProvider::ENV_VAR);
+        },
+        other => panic!("wrong variant: {other:?}"),
+    }
+
+    clear_env();
+}
+
+#[test]
+fn from_env_dev_placeholder_rejected() {
+    let _g = env_lock();
+    clear_env();
+    set_env(EnvKeyProvider::DEV_PLACEHOLDER);
+
+    let err = EnvKeyProvider::from_env().expect_err("dev placeholder must error");
+    assert!(matches!(err, ProviderError::DevPlaceholder));
+
+    clear_env();
+}
+
+#[test]
+fn from_env_short_value_rejected() {
+    let _g = env_lock();
+    clear_env();
+    let short = base64::engine::general_purpose::STANDARD.encode([0x42u8; 16]);
+    set_env(&short);
+
+    let err = EnvKeyProvider::from_env().expect_err("short key must error");
+    assert!(matches!(err, ProviderError::KeyMaterialRejected { .. }));
+
+    clear_env();
+}
+
+#[test]
+fn from_env_valid_key_round_trips() {
+    let _g = env_lock();
+    clear_env();
+    let valid = base64::engine::general_purpose::STANDARD.encode([0x11u8; 32]);
+    set_env(&valid);
+
+    let provider = EnvKeyProvider::from_env().expect("valid key must succeed");
+    assert_eq!(
+        nebula_credential::KeyProvider::version(&provider),
+        "env:current"
+    );
+
+    clear_env();
+}

--- a/docs/adr/0022-keyprovider-trait.md
+++ b/docs/adr/0022-keyprovider-trait.md
@@ -175,6 +175,15 @@ available for diagnostics without correlating against log lines —
 `std::fs` errors do not usually include the path themselves. Non-file
 backing sources (future providers) use `ProviderError::Io { source }`.
 
+`from_path` opens the file once and runs every subsequent check
+(permissions, kind, length, read) against that handle, closing the
+`stat(path)`/`read(path)` TOCTOU gap (symlink swap between two path
+lookups). The regular-file check (`metadata.is_file()`) rejects FIFOs
+(would block on read), character devices (would yield unbounded data),
+and directories before any bytes are consumed. The read itself is a
+fixed-size `read_exact` into a zeroize-on-drop buffer — bounded and
+scrubbed regardless of subsequent failure.
+
 Useful for Kubernetes secrets mounted into the container filesystem
 (`/run/secrets/`), systemd credential files (`$CREDENTIALS_DIRECTORY/`),
 and operators who want the key on-disk with a discrete rotation story
@@ -424,7 +433,9 @@ implementation detail.
     `ProviderError::FileIo { path, .. }` with the path preserved;
     `version_changes_with_content` rewrites the same path and asserts
     the version changes, mirroring the Kubernetes / systemd in-place
-    rewrite flow.
+    rewrite flow; `refuses_non_regular_file` points the provider at
+    a directory and confirms it errors before any read — closing the
+    class of FIFO-block / device-unbounded-read failure modes.
   - `StaticKeyProvider`: round-trip + version preservation.
 - **Integration.** The existing `EncryptionLayer` test coverage at
   [`encryption.rs:257+`](../../crates/credential/src/layer/encryption.rs:257)

--- a/docs/adr/0022-keyprovider-trait.md
+++ b/docs/adr/0022-keyprovider-trait.md
@@ -1,0 +1,374 @@
+---
+id: 0022
+title: keyprovider-trait
+status: proposed
+date: 2026-04-19
+supersedes: []
+superseded_by: []
+tags: [credential, security, encryption, key-custody, composition-root, canon-12.5]
+related:
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/STYLE.md#6-secret-handling
+  - docs/adr/0020-library-first-gtm.md
+  - docs/adr/0021-crate-publication-policy.md
+  - docs/audit/2026-04-19-codebase-quality-audit.md
+  - crates/credential/src/layer/encryption.rs
+  - crates/credential/src/crypto.rs
+linear: []
+---
+
+# 0022. `KeyProvider` trait between `EncryptionLayer` and key material source
+
+## Context
+
+[`crates/credential/src/layer/encryption.rs:89`](../../crates/credential/src/layer/encryption.rs:89)
+constructs `EncryptionLayer` by taking `Arc<EncryptionKey>` directly. There is
+no seam between the composition root and the key material: every caller must
+materialise an `EncryptionKey` in process memory and hand it to the layer.
+`with_keys` at `encryption.rs:108` extends this to multi-key rotation, but
+the shape is the same — raw `Arc<EncryptionKey>` values in, no abstraction
+over the source.
+
+The 2026-04-19 codebase quality audit's `security-lead` section
+([`docs/audit/2026-04-19-codebase-quality-audit.md §Findings — security-lead`](../audit/2026-04-19-codebase-quality-audit.md))
+named this as the load-bearing gate before any `apps/server` composition
+work:
+
+> `crates/credential/src/layer/encryption.rs:62` accepts `Arc<EncryptionKey>`
+> directly — there is no `KeyProvider` seam. Any composition path (library
+> embedder, future `apps/server`, tests) must load the key into process
+> memory with unknown provenance. Once `apps/server` ships with env-only
+> key loading, that becomes de facto API forever (operators write systemd
+> units, configs, runbooks). **Must land before any composition PR**.
+
+[ADR-0020](./0020-library-first-gtm.md) §3 pre-condition 1 makes that
+finding normative: no `apps/server` PR merges until this seam exists.
+Without it, the first server PR would load `EncryptionKey` from an env
+var inline, operators would build systemd units and runbooks around that
+exact shape, and file / KMS / Vault / cloud-secret-manager integrations
+would become deprecation pain instead of additive implementations.
+
+[ADR-0021](./0021-crate-publication-policy.md) §3 names `nebula-credential`
+as one of the initial published crates, citing "the `KeyProvider` seam
+from the 2026-04-19 audit's `security-lead` section is an intentional
+public contract." This ADR is the contract.
+
+Three existing constraints shape the seam:
+
+1. **[`docs/STYLE.md §6 — Secret handling`](../STYLE.md#6-secret-handling)**
+   mandates `Zeroize` / `ZeroizeOnDrop` on secret material, redacted
+   `Debug` / `Display`, `Zeroizing<Vec<u8>>` on intermediate plaintext,
+   and "no secret in error strings." The trait must not relax any of
+   these.
+2. **AAD binding at [`encryption.rs:146-211`](../../crates/credential/src/layer/encryption.rs:146)
+   is correct today** (credential ID is AAD; record-swapping is rejected;
+   AAD-less records are rejected). The trait must not touch this path.
+3. **Canon [§12.5 — Secrets and auth](../PRODUCT_CANON.md#125-secrets-and-auth)**
+   invariants — authenticated encryption at rest, no bypass for debugging,
+   zeroize everywhere — are load-bearing. The seam must preserve them.
+
+## Decision
+
+### 1. A `KeyProvider` trait sits between `EncryptionLayer` and key material
+
+```rust
+pub trait KeyProvider: Send + Sync + 'static {
+    /// Return the current encryption key — the key `EncryptionLayer` will
+    /// use for new writes and for decrypting records tagged with the
+    /// current `version()`.
+    ///
+    /// The returned `Arc<EncryptionKey>` is a stable handle; callers may
+    /// hold it for the duration of a single operation without copying the
+    /// secret bytes.
+    fn current_key(&self) -> Result<Arc<EncryptionKey>, ProviderError>;
+
+    /// A stable identifier for the current key, used as
+    /// [`EncryptedData::key_id`](crate::crypto::EncryptedData) in new
+    /// envelopes and for rotation correlation across providers and logs.
+    /// Must be non-empty; the encryption layer's envelope writer rejects
+    /// empty `key_id`s.
+    fn version(&self) -> &str;
+}
+```
+
+Required properties:
+
+- **`Send + Sync + 'static`** so `Arc<dyn KeyProvider>` threads through
+  the composition root without lifetime gymnastics.
+- **Errors are typed** via `ProviderError` (see §3). No `String` /
+  `anyhow` in the trait signature; `nebula-credential` is a library
+  crate and follows `docs/STYLE.md §4 — Error taxonomy`.
+- **No key material in `Debug` / `Display`** on either the trait, its
+  error type, or any in-tree impl. `EncryptionKey` is already
+  `ZeroizeOnDrop` and owns its `Debug`; providers that wrap it must
+  redact their own fields.
+
+### 2. `EncryptionLayer` takes `Arc<dyn KeyProvider>`, not `Arc<EncryptionKey>`
+
+`new` and `with_keys` at [`encryption.rs:89,108`](../../crates/credential/src/layer/encryption.rs:89)
+are replaced by:
+
+```rust
+impl<S> EncryptionLayer<S> {
+    pub fn new(inner: S, key_provider: Arc<dyn KeyProvider>) -> Self;
+
+    pub fn with_legacy_keys(
+        inner: S,
+        key_provider: Arc<dyn KeyProvider>,
+        legacy_keys: Vec<(String, Arc<EncryptionKey>)>,
+    ) -> Self;
+}
+```
+
+The layer queries the provider on every read and write (`current_key()`
++ `version()`); the lazy-rotation path at
+[`encryption.rs:232-254`](../../crates/credential/src/layer/encryption.rs:232)
+consults the provider when deciding whether to re-encrypt. When the
+provider starts returning a new key (operator rotated in-place, or a
+future KMS impl refreshed its cache), the next read picks that up
+without restart.
+
+`legacy_keys` is decrypt-only: records whose envelope `key_id` matches
+an entry are decrypted with that entry, then re-encrypted with the
+current key (lazy rotation — canon §12.5 invariant unchanged).
+Operators holding rotation history — e.g. the `""` → `"default"`
+migration documented at [`encryption.rs:66-88`](../../crates/credential/src/layer/encryption.rs:66) —
+register it via `with_legacy_keys` instead of `with_keys`.
+
+### 3. Three in-tree implementations
+
+#### `EnvKeyProvider` — canonical local / single-tenant default
+
+Reads a 32-byte AES-256 key from `NEBULA_CRED_MASTER_KEY` (base64-encoded).
+Fail-closed validation mirrors
+[`JwtSecret::new`](../../crates/api/src/config.rs:55) exactly:
+
+- Missing env var → `ProviderError::NotConfigured { var: "NEBULA_CRED_MASTER_KEY" }`.
+- Dev placeholder literal → `ProviderError::DevPlaceholder`.
+- Short or wrong-length decode → `ProviderError::KeyMaterialRejected { reason }`.
+- Base64 decode failure → `ProviderError::Decode { .. }`.
+
+Intermediate plaintext (the base64 string, the decoded bytes) is held in
+`Zeroizing<T>` so scope exit scrubs it per `STYLE.md §6`. The
+`EncryptionKey` newtype handles its own `ZeroizeOnDrop` once constructed.
+
+`version()` returns a constant `"env:current"`.
+
+#### `FileKeyProvider` — self-hosted / mounted-secret default
+
+Reads 32 raw key bytes from a path. Refuses world-readable files on Unix
+(`mode & 0o004 != 0` → `ProviderError::InsecurePermissions { path }`);
+the check is skipped under `#[cfg(not(unix))]` because POSIX mode bits
+do not apply to Windows.
+
+Useful for Kubernetes secrets mounted into the container filesystem
+(`/run/secrets/`), systemd credential files (`$CREDENTIALS_DIRECTORY/`),
+and operators who want the key on-disk with a discrete rotation story
+rather than in the process environment.
+
+`version()` returns `"file:<filename>"` so logs show the source without
+leaking the path's full prefix.
+
+#### `StaticKeyProvider` — test-only, gated behind `test-util`
+
+`#[cfg(any(test, feature = "test-util"))]`. Wraps an in-memory
+`Arc<EncryptionKey>` and a caller-supplied version string. The feature
+is not a `default` feature; production release builds never see it.
+Every non-test call site in the workspace — production, examples,
+`apps/cli` — uses `EnvKeyProvider` or `FileKeyProvider`.
+
+### 4. Security-lead audit verdict
+
+This ADR discharges the finding recorded in
+[`docs/audit/2026-04-19-codebase-quality-audit.md §Findings — security-lead`](../audit/2026-04-19-codebase-quality-audit.md).
+ADR-0020 §3 pre-condition 1 is satisfied once this ADR + its impl PR
+merge; the `apps/server` follow-up ADRs unblock accordingly. Follow-up
+KMS / Vault / cloud-secret-manager impls (see §Alternatives considered)
+are additive: a new type implements `KeyProvider` and plugs into any
+existing `EncryptionLayer::new` call site.
+
+### 5. SemVer commitment (ADR-0021 alignment)
+
+`nebula-credential` is in the initial published set per
+[ADR-0021 §3](./0021-crate-publication-policy.md). From the day this
+ADR's implementation lands, `KeyProvider`, `ProviderError`, and the
+three in-tree impls are part of the crate's public SemVer surface:
+
+- Breaking the trait signature requires a superseding ADR.
+- `ProviderError` carries `#[non_exhaustive]` so new variants (e.g. KMS
+  transport errors) are additive.
+- `EnvKeyProvider::ENV_VAR`, `MIN_BYTES`, and `DEV_PLACEHOLDER` are
+  public associated consts — changing them is a breaking change for
+  operators' runbooks, and is treated as such.
+
+## Consequences
+
+**Positive**
+
+- The load-bearing `apps/server` pre-condition from ADR-0020 §3 is
+  satisfied without freezing env-only as the de-facto API. When
+  `apps/server` lands, it consumes `Arc<dyn KeyProvider>` from its
+  composition root; the operator chooses `Env` / `File` / (future KMS)
+  at wiring time, not at library-compile time.
+- The fail-closed shape of `EnvKeyProvider` matches `JwtSecret` exactly,
+  so a single mental model covers both pre-conditions named in
+  ADR-0020 §3 (auth secret and encryption key).
+- KMS / Vault / cloud-secret-manager backends become trivially additive
+  — each is a new type implementing `KeyProvider`. The audit's "Open
+  ADRs needed" line for KMS-adjacent seams is unblocked without
+  committing to any specific cloud-secret surface in this PR.
+- `with_legacy_keys` preserves the `""` → `"default"` migration path
+  documented at [`encryption.rs:66-88`](../../crates/credential/src/layer/encryption.rs:66)
+  without change to the operator-facing envelope semantics.
+
+**Negative / accepted costs**
+
+- `EncryptionLayer::new`'s signature is a breaking change for any
+  out-of-tree caller. At the time this ADR lands, the workspace has
+  zero production call sites — the only callers inside the crate are
+  the `#[cfg(test)]` module at
+  [`encryption.rs:257+`](../../crates/credential/src/layer/encryption.rs:257),
+  which move to `StaticKeyProvider` in the same PR. External consumers
+  are none per ADR-0021 §Context; the cost is absorbed before
+  `nebula-credential` has an external audience.
+- Provider construction is synchronous (§Alternatives considered C).
+  KMS impls that require network calls must cache the key eagerly at
+  construction (the universal pattern — doing a network round-trip per
+  credential read would dominate the encryption hot path) and refresh
+  on a background task or on an explicit `refresh()` hook added later
+  via a superseding ADR if the need arises. This is not a regression
+  against the current `Arc<EncryptionKey>` shape, which is equally
+  eager.
+- Two constructors (`new`, `with_legacy_keys`) instead of one. The
+  surface is still narrow; `with_keys`'s old three-argument signature
+  had the same count and was already documented.
+
+**Neutral**
+
+- The AAD binding path is untouched. Lazy rotation still re-encrypts
+  old-key records with the current key on read, via the same
+  `decrypt_possibly_rotating` code at
+  [`encryption.rs:232-254`](../../crates/credential/src/layer/encryption.rs:232).
+- Canon §12.5 — authenticated encryption at rest, `Zeroize` /
+  `ZeroizeOnDrop`, redacted `Debug` — is preserved. §6 of STYLE.md
+  applies unchanged to provider impls (redacted `Debug`, typed errors,
+  `Zeroizing` intermediate buffers).
+
+## Alternatives considered
+
+### A. KMS / Vault / cloud-secret-manager impl in the same PR
+
+Rejected. Each cloud secret manager is its own surface (IAM role model,
+transit-encryption endpoints, audit shape, cache behaviour, failure
+taxonomy). Committing to one inside this ADR would balloon the PR,
+force premature opinions on at least one cloud we may not actually
+need, and obscure the trait's simplicity. Ship the trait; each backend
+earns its own follow-up ADR (`KmsKeyProvider`, `VaultKeyProvider`, etc).
+
+### B. Provider owns the full key map (current + legacy)
+
+Considered: `KeyProvider::keys()` returns a `HashMap<String, Arc<EncryptionKey>>`
+for both current and historical decryption keys. Rejected. The provider
+is the source of the **current** key — a KMS-backed provider cannot
+reasonably enumerate "every key that ever wrote a record in this
+deployment." Legacy keys are a deployment-scoped decrypt capability,
+not a provider concern; keeping them on the layer (`with_legacy_keys`)
+matches the existing rotation model and keeps each KMS impl's surface
+minimal.
+
+### C. Async `current_key()` via `#[dynosaur::dynosaur(DynKeyProvider)]`
+
+Considered: make `current_key()` `async`, use the `dynosaur` pattern
+from [ADR-0014](./0014-dynosaur-macro.md) for `dyn` compatibility.
+Rejected for this ADR. Every in-tree impl is synchronous — `Env` /
+`File` read the key at construction and return `Arc::clone`; `Static`
+is pure memory. Future KMS impls universally cache the current key in
+memory (a network round-trip per credential read would dominate the
+encryption hot path), so their `current_key()` is also effectively
+`Arc::clone`. A synchronous trait:
+
+- Is naturally `dyn`-compatible — `Arc<dyn KeyProvider>` without
+  `dynosaur` on the call path, which keeps this ADR's surface minimal
+  and does not introduce a workspace dependency on `dynosaur` out of
+  the sequenced migration described in the audit's P2 #18.
+- Matches the shape of the existing `CredentialStore` trait at
+  [`store.rs:88-141`](../../crates/credential/src/layer/../store.rs:88)
+  for read-paths the engine takes on the hot loop.
+
+If a future ADR introduces a provider that genuinely cannot cache
+(e.g., short-lived KMS data keys with derivation-per-call semantics),
+that ADR can supersede §1's signature. Until then, synchronous is the
+honest shape.
+
+### D. Keep `Arc<EncryptionKey>` at the constructor; add a separate
+`KeyProviderExt` trait for "advanced" composition
+
+Rejected. Two parallel public surfaces (raw key + provider trait) is
+the worst outcome: operators would pick either by accident, and the
+whole point of the seam — preventing env-only from becoming the de-facto
+API — is lost. The trait replaces the raw-key constructor.
+
+### E. No ADR; ship the trait as an implementation detail
+
+Rejected. `nebula-credential` is a published crate per ADR-0021 §3,
+and ADR-0020 §3 names this trait as a pre-condition to `apps/server`.
+Both contexts make this an explicit canon-level decision, not an
+implementation detail.
+
+## Follow-ups
+
+- **`apps/server` composition PR** unblocks on this ADR + its
+  implementation. ADR-0020 §3 pre-condition 1 is satisfied once
+  `EncryptionLayer::new` takes `Arc<dyn KeyProvider>`.
+- **`KmsKeyProvider` ADR** — earliest cloud-secret-manager backend.
+  Expected to propose AWS KMS or GCP KMS with a narrow surface
+  (data-key envelope encryption, IAM-role-bound, single-region). Out
+  of scope for this ADR; will cite this one.
+- **`VaultKeyProvider` ADR** — HashiCorp Vault Transit secrets engine
+  backend for self-hosted deployments that already operate Vault. Out
+  of scope for this ADR.
+- **Key-rotation runbook** under `docs/` explaining the
+  `with_legacy_keys` / lazy-rotation flow operators follow when
+  turning over `NEBULA_CRED_MASTER_KEY`. Documentation-only follow-up.
+
+## Seam / verification
+
+- **Trait site.** [`crates/credential/src/layer/key_provider.rs`](../../crates/credential/src/layer/key_provider.rs)
+  declares the `KeyProvider` trait, `ProviderError` enum, and the three
+  in-tree impls. Redacted `Debug` is written by hand on every provider
+  that holds key material (STYLE.md §6.2 rule 3).
+- **Constructor site.** [`crates/credential/src/layer/encryption.rs`](../../crates/credential/src/layer/encryption.rs)
+  `new` / `with_legacy_keys` take `Arc<dyn KeyProvider>`; the
+  `current_key_id` is `self.key_provider.version()` on every
+  envelope read and write. AAD, lazy rotation, and CAS-on-rotate
+  (GitHub issue #282) behaviour is unchanged.
+- **Unit tests.**
+  - Trait-level test (`key_provider.rs` tests module): a counting
+    provider verifies `current_key()` is called on `put` and `get`,
+    i.e. rotation triggers a re-fetch rather than a cached-at-
+    construction snapshot.
+  - `EnvKeyProvider`: missing var / short / dev-placeholder /
+    wrong-length decode all return the correct typed `ProviderError`
+    variant. Mirrors
+    [`config.rs` `jwt_secret_*` tests](../../crates/api/src/config.rs:407).
+  - `FileKeyProvider`: `#[cfg(unix)]` test refuses a `0o644` key file;
+    valid 32-byte file decodes to an `EncryptionKey` with stable
+    `version()`.
+  - `StaticKeyProvider`: round-trip + version preservation.
+- **Integration.** The existing `EncryptionLayer` test coverage at
+  [`encryption.rs:257+`](../../crates/credential/src/layer/encryption.rs:257)
+  — round-trip, AAD enforcement, multi-key lazy rotation, CAS-on-
+  rotate (#282), and the `""` → `"default"` legacy-alias refusal
+  (#281) — is ported to `StaticKeyProvider` in the same PR and
+  preserves every invariant. `StoreError::Backend` wrapping of
+  `ProviderError` is exercised by the counting-provider failure-
+  injection test.
+
+Related ADRs:
+
+- [ADR-0020](./0020-library-first-gtm.md) — pre-condition 1 is this ADR.
+- [ADR-0021](./0021-crate-publication-policy.md) — names
+  `nebula-credential` and the `KeyProvider` seam as an intentional
+  public contract.
+- [ADR-0014](./0014-dynosaur-macro.md) — cited in Alternative C for
+  why sync is honest for this surface.

--- a/docs/adr/0022-keyprovider-trait.md
+++ b/docs/adr/0022-keyprovider-trait.md
@@ -143,7 +143,7 @@ Reads a 32-byte AES-256 key from `NEBULA_CRED_MASTER_KEY` (base64-encoded).
 Fail-closed validation mirrors
 [`JwtSecret::new`](../../crates/api/src/config.rs:55) exactly:
 
-- Missing env var → `ProviderError::NotConfigured { var: "NEBULA_CRED_MASTER_KEY" }`.
+- Missing env var → `ProviderError::NotConfigured { name: "NEBULA_CRED_MASTER_KEY" }`.
 - Dev placeholder literal → `ProviderError::DevPlaceholder`.
 - Short or wrong-length decode → `ProviderError::KeyMaterialRejected { reason }`.
 - Base64 decode failure → `ProviderError::Decode { .. }`.
@@ -152,7 +152,15 @@ Intermediate plaintext (the base64 string, the decoded bytes) is held in
 `Zeroizing<T>` so scope exit scrubs it per `STYLE.md §6`. The
 `EncryptionKey` newtype handles its own `ZeroizeOnDrop` once constructed.
 
-`version()` returns a constant `"env:current"`.
+`version()` returns `"env:<fingerprint>"` where `<fingerprint>` is the
+first 8 bytes of SHA-256 over the key material, hex-encoded
+(16 chars). **Rotating the env var to different bytes automatically
+changes the fingerprint**, so the envelope `key_id` differs from the
+pre-rotation state — existing records flow through the `with_legacy_keys`
+path instead of being treated as "current" and silently mis-decrypting
+under the new key. This is the rotation-safety invariant captured on
+the trait `version()` docstring: any provider that hand-manages the
+version string must preserve it.
 
 #### `FileKeyProvider` — self-hosted / mounted-secret default
 
@@ -161,13 +169,23 @@ Reads 32 raw key bytes from a path. Refuses world-readable files on Unix
 the check is skipped under `#[cfg(not(unix))]` because POSIX mode bits
 do not apply to Windows.
 
+Filesystem failures (missing file, permission denied, …) surface as
+`ProviderError::FileIo { path, source }` so the offending path is
+available for diagnostics without correlating against log lines —
+`std::fs` errors do not usually include the path themselves. Non-file
+backing sources (future providers) use `ProviderError::Io { source }`.
+
 Useful for Kubernetes secrets mounted into the container filesystem
 (`/run/secrets/`), systemd credential files (`$CREDENTIALS_DIRECTORY/`),
 and operators who want the key on-disk with a discrete rotation story
 rather than in the process environment.
 
-`version()` returns `"file:<filename>"` so logs show the source without
-leaking the path's full prefix.
+`version()` returns `"file:<filename>:<fingerprint>"` — filename keeps
+logs readable; fingerprint (same SHA-256 prefix scheme as
+`EnvKeyProvider`) makes **in-place rewrites observable**. Kubernetes
+secret rewrites and systemd credential refreshes keep the path stable
+but change the bytes; the fingerprint segment changes accordingly and
+pre-rotation records flow through `with_legacy_keys`.
 
 #### `StaticKeyProvider` — test-only, gated behind `test-util`
 
@@ -200,6 +218,50 @@ three in-tree impls are part of the crate's public SemVer surface:
 - `EnvKeyProvider::ENV_VAR`, `MIN_BYTES`, and `DEV_PLACEHOLDER` are
   public associated consts — changing them is a breaking change for
   operators' runbooks, and is treated as such.
+- The SHA-256-prefix `version()` scheme used by `EnvKeyProvider` and
+  `FileKeyProvider` is **observable SemVer surface**: the
+  `"env:<fp>"` / `"file:<name>:<fp>"` shape appears in stored envelope
+  `key_id`s and in operator logs. Changing the hash length or prefix
+  layout is a breaking change — operators register legacy keys by the
+  string they previously saw in logs. Future providers are free to
+  pick a different scheme; changing either of these two is not.
+
+### 6. Rotation procedure
+
+When an operator rotates a key handled by `EnvKeyProvider` or
+`FileKeyProvider`, the fingerprint-backed `version()` turns the rotation
+into a loud failure (decryption error naming the missing key id) rather
+than a silent mis-decrypt. The happy-path sequence is:
+
+1. **Before retiring the old key**, record its `version()` — typically
+   emitted on startup or visible in metrics. The fingerprint suffix
+   (16 hex chars after the `env:` / `file:<name>:` prefix) is the
+   stable identifier for the rotation.
+2. **Swap the key** — rewrite `NEBULA_CRED_MASTER_KEY` or the
+   file. Do not restart yet.
+3. **Register the old key as legacy** at restart so pre-rotation
+   records remain readable:
+
+   ```rust
+   let old_key = Arc::new(EncryptionKey::from_bytes(old_bytes));
+   let provider = Arc::new(EnvKeyProvider::from_env()?);
+   let layer = EncryptionLayer::with_legacy_keys(
+       store,
+       provider,
+       vec![(old_version_string, old_key)], // e.g. "env:a3f2c891b4e5d267"
+   );
+   ```
+
+4. Lazy rotation re-encrypts records on their next read (per the
+   existing module semantics at
+   [`encryption.rs:232-254`](../../crates/credential/src/layer/encryption.rs:232)).
+   Once records converge — observable via future rotation-completion
+   telemetry — the legacy entry can be dropped on the next restart.
+
+Operators who **forget** step 3 get `StoreError::Backend("encryption
+key '<old-version>' not found")` on the next credential read instead of
+corrupted plaintext. That loud-failure mode is the entire point of the
+fingerprint scheme.
 
 ## Consequences
 
@@ -347,13 +409,22 @@ implementation detail.
     provider verifies `current_key()` is called on `put` and `get`,
     i.e. rotation triggers a re-fetch rather than a cached-at-
     construction snapshot.
-  - `EnvKeyProvider`: missing var / short / dev-placeholder /
-    wrong-length decode all return the correct typed `ProviderError`
-    variant. Mirrors
-    [`config.rs` `jwt_secret_*` tests](../../crates/api/src/config.rs:407).
+  - `EnvKeyProvider`: dev-placeholder / short / wrong-length / decode
+    failures all return the correct typed `ProviderError` variant
+    (in-crate, via `from_base64`). `from_env` missing-var coverage
+    lives in a separate integration test binary because env-var
+    mutation requires `unsafe` which the crate forbids. Rotation-
+    safety is pinned by two tests: `version_changes_with_key` (two
+    different keys → different versions) and
+    `version_stable_for_same_key` (repeat construction → same version).
+    Mirrors [`config.rs` `jwt_secret_*` tests](../../crates/api/src/config.rs:407).
   - `FileKeyProvider`: `#[cfg(unix)]` test refuses a `0o644` key file;
-    valid 32-byte file decodes to an `EncryptionKey` with stable
-    `version()`.
+    valid 32-byte file decodes to an `EncryptionKey` with a
+    fingerprint-tailed `version()`; missing-file errors surface as
+    `ProviderError::FileIo { path, .. }` with the path preserved;
+    `version_changes_with_content` rewrites the same path and asserts
+    the version changes, mirroring the Kubernetes / systemd in-place
+    rewrite flow.
   - `StaticKeyProvider`: round-trip + version preservation.
 - **Integration.** The existing `EncryptionLayer` test coverage at
   [`encryption.rs:257+`](../../crates/credential/src/layer/encryption.rs:257)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,13 +29,14 @@ changes land as a new ADR that `supersedes` it.
 | [0019](./0019-msrv-1.95.md) | MSRV 1.95 (supersedes 0010) | proposed | 2026-04-19 |
 | [0020](./0020-library-first-gtm.md) | Library-first GTM + `apps/server` as thin composition root | proposed | 2026-04-19 |
 | [0021](./0021-crate-publication-policy.md) | Crate publication policy (`publish = true` requires ≥ 3 external consumers OR dedicated ADR) | proposed | 2026-04-19 |
+| [0022](./0022-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source | proposed | 2026-04-19 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0022**). Do not reuse.
+2. Pick the next free number (currently **0023**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/audit/2026-04-19-codebase-quality-audit.md
+++ b/docs/audit/2026-04-19-codebase-quality-audit.md
@@ -217,7 +217,7 @@ not a parallel stack with its own auth / key / storage paths. ADR-0008's
 
 | ID | Title | Owner | Trigger |
 |---|---|---|---|
-| TBD | KeyProvider trait between EncryptionLayer and key material source | security-lead | Before any composition root |
+| [0022](../adr/0022-keyprovider-trait.md) | KeyProvider trait between EncryptionLayer and key material source | security-lead | Before any composition root |
 | [0021](../adr/0021-crate-publication-policy.md) | Crate publication policy (publish=true ≥3 consumers OR ADR) | rust-senior | Before next 1.0 release-train discussion |
 | [0020](../adr/0020-library-first-gtm.md) | Library-first GTM + apps/server as thin composition root | tech-lead | Now (closes the strategic question) |
 | TBD | Webhook signature policy (Required default) | security-lead | Before webhook-trigger v1 lock |


### PR DESCRIPTION
## Summary

Lands the `KeyProvider` seam that [ADR-0020](https://github.com/vanyastafford/nebula/blob/main/docs/adr/0020-library-first-gtm.md) §3 names as pre-condition #1 for any `apps/server` composition work, plus its implementation.

Quoting ADR-0020 §3 pre-conditions verbatim:

> 1. **`KeyProvider` seam exists in `crates/credential/src/layer/encryption.rs`.** The current surface accepts `Arc<EncryptionKey>` directly (`encryption.rs:62` at audit time) with no provider trait between the composition root and the key material. `apps/server` requires a `KeyProvider` trait + `EnvKeyProvider` impl landed under a separate ADR (audit P0 #6), so the future file / KMS / HSM providers plug in without rewriting `apps/server`'s wiring.

The security-lead audit finding motivating the gate is recorded in [`docs/audit/2026-04-19-codebase-quality-audit.md`](https://github.com/vanyastafford/nebula/blob/main/docs/audit/2026-04-19-codebase-quality-audit.md) §"Findings — security-lead":

> Once `apps/server` ships with env-only key loading, that becomes de facto API forever (operators write systemd units, configs, runbooks). **Must land before any composition PR**.

ADR-0022 is the contract; this PR is the implementation.

## What changed

- **ADR-0022** — trait signature, three in-tree impls, alternatives (sync vs async/dynosaur, provider-owns-legacy, KMS-in-same-PR — all rejected with rationale).
- **`KeyProvider` trait** in `crates/credential/src/layer/key_provider.rs`: sync `current_key()` + `version()`, `Send + Sync + 'static`.
- **`EnvKeyProvider`** — reads `NEBULA_CRED_MASTER_KEY` (base64, 32 bytes), fail-closed on missing / short / wrong-length / dev-placeholder. Mirrors [`JwtSecret::new`](https://github.com/vanyastafford/nebula/blob/main/crates/api/src/config.rs) exactly.
- **`FileKeyProvider`** — refuses world-readable files on Unix; skip on Windows.
- **`StaticKeyProvider`** gated behind `test-util`; production builds never see it.
- **`ProviderError`** — `#[non_exhaustive]`, carries no key material, Debug-redacted.
- **`EncryptionLayer::new(inner, Arc<dyn KeyProvider>)`** replaces `new(inner, Arc<EncryptionKey>)`. `with_keys` → `with_legacy_keys` (decrypt-only legacy map; current key is always the provider's concern).
- Audit "Open ADRs needed" table: flipped `KeyProvider` row from TBD to [ADR-0022](https://github.com/vanyastafford/nebula/blob/main/docs/adr/0022-keyprovider-trait.md).

No production callers outside the credential crate's own tests existed; AAD binding, lazy rotation, and the CAS-on-rotate fix (#282) are preserved byte-for-byte.

## Test plan

- [x] `cargo +nightly fmt --all` clean.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo nextest run --workspace` — 3395 tests passed (13 skipped, platform-gated).
- [x] Knife scenario `nebula-api::knife knife_step5_engine_cancels_running_execution_end_to_end` still passes (30s end-to-end).
- [x] `cargo test --workspace --doc` clean.
- [x] lefthook `pre-push` green (shear, doctests, docs, check-all-features, check-no-default, nextest).
- [x] 17 new tests cover: trait-level re-fetch on `put`/`get`, provider-failure → `StoreError::Backend`, `EnvKeyProvider` (dev-placeholder / short / decode / valid / missing-env), `FileKeyProvider` (valid / wrong-length / missing file / world-readable on Unix), `StaticKeyProvider` round-trip, `ProviderError` Debug redaction.
- [x] AAD binding preserved — `aad_prevents_record_swapping` + `rejects_data_without_aad` tests pass against the new provider-driven layer.
- [x] Lazy rotation preserved — `decrypt_with_old_key_succeeds`, `lazy_reencryption_on_read_when_key_id_differs`, `lazy_reencryption_returns_post_rotation_version` all pass.
- [x] Legacy `""` alias refusal preserved — `new_does_not_silently_decrypt_empty_key_id_envelopes` passes against `with_legacy_keys` migration path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a pluggable key provisioning system supporting environment variables and file-based encryption key sources for improved key management flexibility.

* **Breaking Changes**
  * Updated the encryption layer API to require key providers instead of direct key objects; applications must migrate to `EnvKeyProvider` or `FileKeyProvider`.

* **Documentation**
  * Added architectural decision record (ADR-0022) documenting the new key provider pattern and implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->