### PR TITLE
docs(adr): renumber KeyProvider ADR 0022 → 0023 (resolve clash with #503)

### DIFF
--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -79,5 +79,5 @@ default = []
 rotation = []
 # Expose test-only helpers (e.g. `StaticKeyProvider`) to integration tests and
 # to other crates' dev-dependency paths. Must never be enabled in a production
-# release build — see ADR-0022.
+# release build — see ADR-0023.
 test-util = []

--- a/crates/credential/README.md
+++ b/crates/credential/README.md
@@ -28,7 +28,7 @@ Pattern: *Typed credential lifecycle* (Release It! ch "Stability Patterns" — s
 - 12 built-in scheme types: `SecretToken`, `IdentityPassword`, `OAuth2Token`, `KeyPair`, `Certificate`, `SigningKey`, `FederatedAssertion`, `ChallengeSecret`, `OtpSeed`, `ConnectionUri`, `InstanceBinding`, `SharedKey`.
 - `CredentialStore`, `StoredCredential`, `PutMode`, `StoreError` — storage trait with layered composition.
 - `EncryptionLayer`, `CacheLayer`, `AuditLayer`, `ScopeLayer` — composable store decorators.
-- `KeyProvider`, `ProviderError` — seam between `EncryptionLayer` and the encryption-key source. `Arc<dyn KeyProvider>` replaces `Arc<EncryptionKey>` in `EncryptionLayer::new`; composition roots pick the provider at wiring time. See [ADR-0022](../../docs/adr/0022-keyprovider-trait.md).
+- `KeyProvider`, `ProviderError` — seam between `EncryptionLayer` and the encryption-key source. `Arc<dyn KeyProvider>` replaces `Arc<EncryptionKey>` in `EncryptionLayer::new`; composition roots pick the provider at wiring time. See [ADR-0023](../../docs/adr/0023-keyprovider-trait.md).
 - `EnvKeyProvider` — reads a 32-byte AES-256 key from `NEBULA_CRED_MASTER_KEY` (base64), fail-closed on missing / short / dev-placeholder values.
 - `FileKeyProvider` — reads 32 raw key bytes from a filesystem path, refuses world-readable files on Unix.
 - `StaticKeyProvider` (feature `test-util`) — in-memory key for tests and internal composition; never enabled in production release builds.

--- a/crates/credential/src/layer/encryption.rs
+++ b/crates/credential/src/layer/encryption.rs
@@ -15,7 +15,7 @@
 //! [`Arc<dyn KeyProvider>`](super::KeyProvider), **not** an `Arc<EncryptionKey>`
 //! directly. Composition roots choose the provider (env var, file, KMS, …)
 //! at wiring time — see
-//! [ADR-0022](../../../../docs/adr/0022-keyprovider-trait.md) for the seam
+//! [ADR-0023](../../../../docs/adr/0023-keyprovider-trait.md) for the seam
 //! and ADR-0020 §3 for why this gate exists.
 //!
 //! # Key rotation

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -17,7 +17,7 @@
 //!   stable-version/rotating-key provider would silently mis-decrypt under the new key.
 //!   `EnvKeyProvider` / `FileKeyProvider` derive `version()` from a SHA-256 fingerprint of the key
 //!   material so an in-place rotation (same env var / same file path, new bytes) produces a fresh
-//!   identifier automatically. See ADR-0022 §3 + §6 Rotation procedure.
+//!   identifier automatically. See ADR-0023 §3 + §6 Rotation procedure.
 //! - `current_key()` returns `Arc<EncryptionKey>` — a stable handle over the zeroize-on-drop key
 //!   newtype. Providers do not expose raw key bytes.
 //! - `Debug` / `Display` on providers and on `ProviderError` must not reveal key material (see
@@ -568,7 +568,7 @@ mod tests {
     /// Two different keys must produce different `version()`s so an in-place
     /// env-var rotation flips the envelope `key_id` instead of silently
     /// mis-decrypting under the new key. Regression guard for the rotation
-    /// safety invariant recorded in ADR-0022 §3.
+    /// safety invariant recorded in ADR-0023 §3.
     #[test]
     fn env_provider_version_changes_with_key() {
         let k1 = base64::engine::general_purpose::STANDARD.encode([0x11u8; 32]);

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -4,7 +4,7 @@
 //! `EncryptionLayer` no longer takes `Arc<EncryptionKey>` directly; instead it
 //! accepts `Arc<dyn KeyProvider>`. Composition roots choose the provider — env
 //! var, file, or (in future) a KMS / Vault / cloud-secret-manager impl — at
-//! wiring time. See [ADR-0022](../../../../docs/adr/0022-keyprovider-trait.md)
+//! wiring time. See [ADR-0023](../../../../docs/adr/0023-keyprovider-trait.md)
 //! for the decision and ADR-0020 §3 for why the seam is a pre-condition to any
 //! `apps/server` composition work.
 //!

--- a/docs/adr/0023-keyprovider-trait.md
+++ b/docs/adr/0023-keyprovider-trait.md
@@ -1,7 +1,7 @@
 ---
-id: 0022
+id: 0023
 title: keyprovider-trait
-status: proposed
+status: accepted
 date: 2026-04-19
 supersedes: []
 superseded_by: []

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -29,7 +29,8 @@ changes land as a new ADR that `supersedes` it.
 | [0019](./0019-msrv-1.95.md) | MSRV 1.95 (supersedes 0010) | proposed | 2026-04-19 |
 | [0020](./0020-library-first-gtm.md) | Library-first GTM + `apps/server` as thin composition root | proposed | 2026-04-19 |
 | [0021](./0021-crate-publication-policy.md) | Crate publication policy (`publish = true` requires ≥ 3 external consumers OR dedicated ADR) | proposed | 2026-04-19 |
-| [0022](./0022-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source | proposed | 2026-04-19 |
+| [0022](./0022-webhook-signature-policy.md) | Webhook signature policy (`SignaturePolicy::Required` default at `WebhookAction` trait level) | accepted | 2026-04-19 |
+| [0023](./0023-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source | accepted | 2026-04-19 |
 
 ## Writing a new ADR
 

--- a/docs/audit/2026-04-19-codebase-quality-audit.md
+++ b/docs/audit/2026-04-19-codebase-quality-audit.md
@@ -217,7 +217,7 @@ not a parallel stack with its own auth / key / storage paths. ADR-0008's
 
 | ID | Title | Owner | Trigger |
 |---|---|---|---|
-| [0022](../adr/0022-keyprovider-trait.md) | KeyProvider trait between EncryptionLayer and key material source | security-lead | Before any composition root |
+| [0023](../adr/0023-keyprovider-trait.md) | KeyProvider trait between EncryptionLayer and key material source | security-lead | Before any composition root |
 | [0021](../adr/0021-crate-publication-policy.md) | Crate publication policy (publish=true ≥3 consumers OR ADR) | rust-senior | Before next 1.0 release-train discussion |
 | [0020](../adr/0020-library-first-gtm.md) | Library-first GTM + apps/server as thin composition root | tech-lead | Now (closes the strategic question) |
 | [0022](../adr/0022-webhook-signature-policy.md) | Webhook signature policy (Required default) | security-lead | Before webhook-trigger v1 lock |


### PR DESCRIPTION
## Summary

Two parallel chips ([#502 KeyProvider](https://github.com/vanyastaff/nebula/pull/502) and [#503 webhook signature](https://github.com/vanyastaff/nebula/pull/503)) merged in quick succession and both claimed `ADR-0022` — race condition because each spawned chip independently picked the next free ADR number at design time. Resulted in `docs/adr/0022-keyprovider-trait.md` and `docs/adr/0022-webhook-signature-policy.md` co-existing on `main`.

This PR resolves the clash by moving KeyProvider to `0023`. Webhook signature policy keeps `0022` because it has ~18 inbound refs in code and docs (action README/source, api README/transport, GLOSSARY rows, MATURITY); KeyProvider has only 5.

- `git mv 0022-keyprovider-trait.md → 0023-keyprovider-trait.md`
- ADR frontmatter `id` + `status` corrected (proposed → accepted; impl already landed in #502)
- `docs/adr/README.md` index — added the missing webhook row at 0022 and the KeyProvider row at 0023
- Audit doc "Open ADRs needed" table — KeyProvider link repointed to 0023
- Inbound refs in `crates/credential/{README.md,src/layer/encryption.rs,src/layer/key_provider.rs}` updated

## Test plan

- [x] `rg "ADR-0022"` — only webhook signature refs remain (correct)
- [x] `cargo build -p nebula-credential` — green
- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (lefthook pre-commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)