### PR TITLE
docs(system): fix stale once_cell reference in DOCS.md

### DIFF
--- a/crates/system/DOCS.md
+++ b/crates/system/DOCS.md
@@ -234,7 +234,7 @@ Use `nebula-system` when you need:
 - All types are `Send + Sync`
 - Internal caching uses `parking_lot::RwLock`
 - Safe to call from multiple threads
-- Initialization is thread-safe (uses `once_cell`)
+- Initialization is thread-safe (uses `std::sync::LazyLock`)
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

`crates/system/DOCS.md` claimed initialization was thread-safe via `once_cell`, but `nebula-system` has never declared `once_cell` as a dependency and the workspace dropped it in `a8de9e73`. The actual primitive used in [crates/system/src/info.rs:144,148](crates/system/src/info.rs:144) is `std::sync::LazyLock` (with `parking_lot::RwLock` guarding the mutable `sysinfo::System` cache — already documented on the line above). Replaced the stale reference with the accurate primitive.

## Linked issue

- N/A (drive-by doc accuracy fix)

## Type of change

- [x] `docs` — documentation only

## Affected crates / areas

- `crates/system/DOCS.md`

## Changes

- Replace `uses \`once_cell\`` with `uses \`std::sync::LazyLock\`` in the Thread Safety section ([crates/system/DOCS.md:237](crates/system/DOCS.md:237))

## Test plan

- `cargo +nightly fmt --all` — no changes
- `cargo clippy -p nebula-system -- -D warnings` — clean
- Pre-push hooks (shear, check-all-features, doctests, docs, check-no-default, nextest: 3404 passed) — all green

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean (ran `-p nebula-system`; full workspace validated by pre-push)
- [x] `cargo nextest run --workspace` — passes (via pre-push mirror)
- [x] `cargo test --workspace --doc` — doctests pass (via pre-push mirror)
- [ ] `cargo deny check` — N/A (no `Cargo.toml` touched)

## Breaking changes

None

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code
- [x] No silent error suppression
- [x] No engine state transitions touched
- [x] No credential / secret paths touched
- [x] No new `unsafe` blocks

## Notes for reviewers

Single-line doc fix. `std::sync::LazyLock` (stable since Rust 1.80) is the actual synchronization primitive at [crates/system/src/info.rs:144](crates/system/src/info.rs:144) and [crates/system/src/info.rs:148](crates/system/src/info.rs:148); `once_cell` was never a dep of this crate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified thread-safety documentation for system initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->