### PR TITLE
refactor(credential): drop async_trait for rotation traits (Phase 2 AFIT)

### DIFF
--- a/crates/credential/src/rotation/events.rs
+++ b/crates/credential/src/rotation/events.rs
@@ -2,7 +2,8 @@
 //!
 //! Provides event types and notification abstraction for rotation lifecycle events.
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use chrono::{DateTime, Utc};
 use nebula_core::CredentialId;
 use serde::{Deserialize, Serialize};
@@ -284,7 +285,6 @@ impl NotificationEvent {
 ///     webhook_url: String,
 /// }
 ///
-/// #[async_trait]
 /// impl NotificationSender for SlackNotifier {
 ///     async fn send(&self, event: &NotificationEvent) -> RotationResult<()> {
 ///         let payload = json!({
@@ -302,7 +302,6 @@ impl NotificationEvent {
 ///     }
 /// }
 /// ```
-#[async_trait]
 pub trait NotificationSender: Send + Sync {
     /// Send a notification event
     ///
@@ -313,7 +312,7 @@ pub trait NotificationSender: Send + Sync {
     /// # Returns
     ///
     /// * `RotationResult<()>` - Success or error
-    async fn send(&self, event: &NotificationEvent) -> RotationResult<()>;
+    fn send(&self, event: &NotificationEvent) -> impl Future<Output = RotationResult<()>> + Send;
 }
 
 /// Send notification with retry logic
@@ -686,7 +685,6 @@ mod tests {
         should_fail: bool,
     }
 
-    #[async_trait]
     impl NotificationSender for MockSender {
         async fn send(&self, _event: &NotificationEvent) -> RotationResult<()> {
             if self.should_fail {

--- a/crates/credential/src/rotation/mod.rs
+++ b/crates/credential/src/rotation/mod.rs
@@ -169,8 +169,8 @@
 //! ```rust,ignore
 //! use nebula_credential::rotation::{
 //!     RotationPolicy, PeriodicConfig, TestResult, RotationResult,
+//!     RotatableCredential, TestableCredential,
 //! };
-//! use nebula_credential::traits::{RotatableCredential, TestableCredential};
 //! use std::time::Duration;
 //!
 //! // Your credential type

--- a/crates/credential/src/rotation/mod.rs
+++ b/crates/credential/src/rotation/mod.rs
@@ -171,7 +171,6 @@
 //!     RotationPolicy, PeriodicConfig, TestResult, RotationResult,
 //! };
 //! use nebula_credential::traits::{RotatableCredential, TestableCredential};
-//! use async_trait::async_trait;
 //! use std::time::Duration;
 //!
 //! // Your credential type
@@ -182,7 +181,6 @@
 //!     database: String,
 //! }
 //!
-//! #[async_trait]
 //! impl TestableCredential for PostgresCredential {
 //!     async fn test(&self) -> RotationResult<TestResult> {
 //!         // Test database connection
@@ -191,7 +189,6 @@
 //!     }
 //! }
 //!
-//! #[async_trait]
 //! impl RotatableCredential for PostgresCredential {
 //!     async fn rotate(&self) -> RotationResult<Self> {
 //!         // Generate new password

--- a/crates/credential/src/rotation/validation.rs
+++ b/crates/credential/src/rotation/validation.rs
@@ -11,9 +11,8 @@
 //! This allows each credential type (MySQL, PostgreSQL, OAuth2, etc.) to implement
 //! their own validation logic using their specific client libraries.
 
-use std::time::Duration;
+use std::{future::Future, time::Duration};
 
-use async_trait::async_trait;
 use nebula_core::CredentialId;
 use serde::{Deserialize, Serialize};
 use tokio::time::timeout;
@@ -30,12 +29,11 @@ use crate::record::CredentialRecord;
 /// - **OAuth2**: Call userinfo endpoint with token
 /// - **API Key**: Call account/status endpoint
 /// - **Certificate**: Perform TLS handshake
-#[async_trait]
 pub trait TestableCredential: Send + Sync {
     /// Test the credential by performing an actual operation.
     ///
     /// Returns `TestResult` with success/failure details.
-    async fn test(&self) -> RotationResult<TestResult>;
+    fn test(&self) -> impl Future<Output = RotationResult<TestResult>> + Send;
 
     /// Get test timeout (default: 30 seconds).
     fn test_timeout(&self) -> Duration {
@@ -47,7 +45,6 @@ pub trait TestableCredential: Send + Sync {
 ///
 /// Credentials implementing this trait can generate new versions and
 /// cleanup old ones.
-#[async_trait]
 pub trait RotatableCredential: TestableCredential {
     /// Generate a new version of this credential.
     ///
@@ -55,7 +52,7 @@ pub trait RotatableCredential: TestableCredential {
     /// - Different secrets (password, token, key)
     /// - Same permissions and access levels
     /// - Same connection details (host, port, database)
-    async fn rotate(&self) -> RotationResult<Self>
+    fn rotate(&self) -> impl Future<Output = RotationResult<Self>> + Send
     where
         Self: Sized;
 
@@ -63,8 +60,8 @@ pub trait RotatableCredential: TestableCredential {
     ///
     /// Optional: implement if cleanup is needed (e.g., delete old database user).
     /// Called after grace period expires.
-    async fn cleanup_old(&self) -> RotationResult<()> {
-        Ok(())
+    fn cleanup_old(&self) -> impl Future<Output = RotationResult<()>> + Send {
+        async { Ok(()) }
     }
 }
 
@@ -434,7 +431,6 @@ mod tests {
         should_pass: bool,
     }
 
-    #[async_trait]
     impl TestableCredential for MockCredential {
         async fn test(&self) -> RotationResult<TestResult> {
             let start = std::time::Instant::now();
@@ -456,7 +452,6 @@ mod tests {
         }
     }
 
-    #[async_trait]
     impl RotatableCredential for MockCredential {
         async fn rotate(&self) -> RotationResult<Self> {
             Ok(MockCredential {


### PR DESCRIPTION
## Summary

- Flip three zero-`dyn` rotation traits (`NotificationSender`, `TestableCredential`, `RotatableCredential`) from `#[async_trait]` to native 1.75 AFIT.
- All methods desugared to `fn -> impl Future<Output = ...> + Send`.
- `CredentialAccessor` **untouched** (16 `dyn` sites — Phase 3, ADR-0023-gated).
- `async-trait` dep **preserved** — accessor still needs it.
- Doc examples in `rotation/{mod.rs, events.rs}` updated in lockstep so integration-author docs don't drift.

Phase 2 of [`docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md`](../blob/main/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md). Independent of the other two Phase 2 PRs.

**Secret-handling audit:** CLEAN — zero touches to `Zeroize`, `Secret`, `KeyProvider`, `EncryptionLayer`, or redaction helpers. Attribute removal + signature desugaring only.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run -p nebula-credential` → 358/358
- [x] `cargo check --workspace`
- [x] `cargo test -p nebula-credential --doc` (25 passed, 24 ignored)
- [x] `rg '#\[async_trait\]' crates/credential/src/` = 4 (all on `CredentialAccessor` — expected)
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated credential rotation trait method signatures for async operations. Implementations of `NotificationSender`, `TestableCredential`, and `RotatableCredential` traits may require adjustments to align with new signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->