### PR TITLE
refactor(storage): drop async_trait for repos/* traits (Phase 2 AFIT)

### DIFF
--- a/crates/storage/src/pg/org.rs
+++ b/crates/storage/src/pg/org.rs
@@ -1,6 +1,5 @@
 //! Postgres implementation of [`OrgRepo`].
 
-use async_trait::async_trait;
 use sqlx::{Pool, Postgres, types::Json};
 
 use crate::{
@@ -55,7 +54,6 @@ fn tuple_to_row(t: OrgTuple) -> OrgRow {
 
 const SELECT_COLS: &str = "id, slug, display_name, created_at, created_by, plan, billing_email, settings, version, deleted_at";
 
-#[async_trait]
 impl OrgRepo for PgOrgRepo {
     async fn create(&self, org: &OrgRow) -> Result<(), StorageError> {
         sqlx::query(

--- a/crates/storage/src/pg/workspace.rs
+++ b/crates/storage/src/pg/workspace.rs
@@ -1,6 +1,5 @@
 //! Postgres implementation of [`WorkspaceRepo`].
 
-use async_trait::async_trait;
 use sqlx::{Pool, Postgres, types::Json};
 
 use crate::{
@@ -56,7 +55,6 @@ fn tuple_to_row(t: WsTuple) -> WorkspaceRow {
 
 const SELECT_COLS: &str = "id, org_id, slug, display_name, description, created_at, created_by, is_default, settings, version, deleted_at";
 
-#[async_trait]
 impl WorkspaceRepo for PgWorkspaceRepo {
     async fn create(&self, ws: &WorkspaceRow) -> Result<(), StorageError> {
         sqlx::query(

--- a/crates/storage/src/repos/audit.rs
+++ b/crates/storage/src/repos/audit.rs
@@ -1,6 +1,6 @@
 //! Audit log and slug-history repositories.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -12,52 +12,54 @@ use crate::{
 /// Spec 16 layer 8 + spec 18. Append-only; retention is plan-configurable
 /// (default 90 days). Separate from `execution_journal` which tracks
 /// per-run step events.
-#[async_trait]
 pub trait AuditRepo: Send + Sync {
     /// Append an audit entry.
-    async fn append(&self, row: &AuditLogRow) -> Result<(), StorageError>;
+    fn append(&self, row: &AuditLogRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List entries for an org, newest first.
-    async fn list_for_org(
+    fn list_for_org(
         &self,
         org_id: &[u8],
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<AuditLogRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<AuditLogRow>, StorageError>> + Send;
 
     /// List entries by actor, newest first.
-    async fn list_for_actor(
+    fn list_for_actor(
         &self,
         actor_kind: &str,
         actor_id: &[u8],
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<AuditLogRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<AuditLogRow>, StorageError>> + Send;
 
     /// List entries filtered by action name (e.g. `'credential.rotated'`).
-    async fn list_by_action(
+    fn list_by_action(
         &self,
         action: &str,
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<AuditLogRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<AuditLogRow>, StorageError>> + Send;
 
     // ── Slug history ────────────────────────────────────────────────────
 
     /// Record a rename so the old slug can still resolve for the grace period.
-    async fn record_rename(&self, row: &SlugHistoryRow) -> Result<(), StorageError>;
+    fn record_rename(
+        &self,
+        row: &SlugHistoryRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Resolve an old slug to its current resource ID.
     ///
     /// Returns `None` when the slug has no history entry or the entry
     /// has expired.
-    async fn resolve_old_slug(
+    fn resolve_old_slug(
         &self,
         kind: &str,
         scope_id: Option<&[u8]>,
         old_slug: &str,
-    ) -> Result<Option<Vec<u8>>, StorageError>;
+    ) -> impl Future<Output = Result<Option<Vec<u8>>, StorageError>> + Send;
 
     /// Delete expired slug-history rows. Returns count deleted.
-    async fn cleanup_expired_slugs(&self) -> Result<u64, StorageError>;
+    fn cleanup_expired_slugs(&self) -> impl Future<Output = Result<u64, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/blob.rs
+++ b/crates/storage/src/repos/blob.rs
@@ -1,6 +1,6 @@
 //! Large binary object storage.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{error::StorageError, rows::BlobRow};
 
@@ -9,22 +9,28 @@ use crate::{error::StorageError, rows::BlobRow};
 /// Blobs are addressed by content-independent IDs (ULID) and referenced
 /// from other tables (e.g. `execution_nodes.state_blob_ref`) when the
 /// inline limit is exceeded.
-#[async_trait]
 pub trait BlobRepo: Send + Sync {
     /// Store a new blob. Returns the generated ID.
-    async fn put(&self, content_type: &str, data: Vec<u8>) -> Result<Vec<u8>, StorageError>;
+    fn put(
+        &self,
+        content_type: &str,
+        data: Vec<u8>,
+    ) -> impl Future<Output = Result<Vec<u8>, StorageError>> + Send;
 
     /// Store a blob with a caller-provided ID (must be unique).
-    async fn put_with_id(&self, blob: &BlobRow) -> Result<(), StorageError>;
+    fn put_with_id(&self, blob: &BlobRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Retrieve a blob by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<BlobRow>, StorageError>;
+    fn get(&self, id: &[u8]) -> impl Future<Output = Result<Option<BlobRow>, StorageError>> + Send;
 
     /// Retrieve only the metadata (size, content_type) without the data.
-    async fn get_metadata(&self, id: &[u8]) -> Result<Option<BlobMetadata>, StorageError>;
+    fn get_metadata(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<BlobMetadata>, StorageError>> + Send;
 
     /// Delete a blob.
-    async fn delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 }
 
 /// Blob metadata without payload (for listing/size checks).

--- a/crates/storage/src/repos/credential.rs
+++ b/crates/storage/src/repos/credential.rs
@@ -3,7 +3,7 @@
 //! Spec 22. Stores encrypted credentials; decryption happens exclusively
 //! in `nebula-credential`. This trait never returns plaintext.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -11,61 +11,79 @@ use crate::{
 };
 
 /// Encrypted credential storage with audit.
-#[async_trait]
 pub trait CredentialRepo: Send + Sync {
     // ── Credentials ─────────────────────────────────────────────────────
 
     /// Insert a new credential.
-    async fn create(&self, cred: &CredentialRow) -> Result<(), StorageError>;
+    fn create(&self, cred: &CredentialRow)
+    -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a credential by ID (skips soft-deleted).
-    async fn get(&self, id: &[u8]) -> Result<Option<CredentialRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<CredentialRow>, StorageError>> + Send;
 
     /// Fetch a credential by (workspace, slug) or (org, slug).
-    async fn get_by_slug(
+    fn get_by_slug(
         &self,
         scope: CredentialScope<'_>,
         slug: &str,
-    ) -> Result<Option<CredentialRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<CredentialRow>, StorageError>> + Send;
 
     /// Update a credential with CAS on `version` (rotates ciphertext).
-    async fn update(&self, cred: &CredentialRow, expected_version: i64)
-    -> Result<(), StorageError>;
+    fn update(
+        &self,
+        cred: &CredentialRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Record a use (`last_used_at`).
-    async fn touch_used(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn touch_used(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a credential.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List credentials visible in a scope.
-    async fn list(&self, scope: CredentialScope<'_>) -> Result<Vec<CredentialRow>, StorageError>;
+    fn list(
+        &self,
+        scope: CredentialScope<'_>,
+    ) -> impl Future<Output = Result<Vec<CredentialRow>, StorageError>> + Send;
 
     // ── Pending (OAuth flow) credentials ────────────────────────────────
 
     /// Stage a pending credential (mid-OAuth flow).
-    async fn create_pending(&self, pending: &PendingCredentialRow) -> Result<(), StorageError>;
+    fn create_pending(
+        &self,
+        pending: &PendingCredentialRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a pending credential (skips expired).
-    async fn get_pending(&self, id: &[u8]) -> Result<Option<PendingCredentialRow>, StorageError>;
+    fn get_pending(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<PendingCredentialRow>, StorageError>> + Send;
 
     /// Delete a pending credential.
-    async fn delete_pending(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn delete_pending(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Clean up expired pending credentials. Returns count deleted.
-    async fn cleanup_expired_pending(&self) -> Result<u64, StorageError>;
+    fn cleanup_expired_pending(&self) -> impl Future<Output = Result<u64, StorageError>> + Send;
 
     // ── Audit ───────────────────────────────────────────────────────────
 
     /// Append an audit row for a credential action.
-    async fn append_audit(&self, row: &CredentialAuditRow) -> Result<(), StorageError>;
+    fn append_audit(
+        &self,
+        row: &CredentialAuditRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List audit rows for a credential (newest first).
-    async fn list_audit(
+    fn list_audit(
         &self,
         credential_id: &[u8],
         limit: u32,
-    ) -> Result<Vec<CredentialAuditRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<CredentialAuditRow>, StorageError>> + Send;
 }
 
 /// Scope of a credential query.

--- a/crates/storage/src/repos/execution.rs
+++ b/crates/storage/src/repos/execution.rs
@@ -3,51 +3,51 @@
 //! Spec 16 layer 4. All state transitions go through [`ExecutionRepo::transition`]
 //! with CAS on `version`. Leases provide multi-process coordination.
 
-use std::time::Duration;
-
-use async_trait::async_trait;
+use std::{future::Future, time::Duration};
 
 use crate::{error::StorageError, rows::ExecutionRow};
 
 /// Execution storage with versioned CAS and leases.
-#[async_trait]
 pub trait ExecutionRepo: Send + Sync {
     /// Insert a new execution.
-    async fn create(&self, exec: &ExecutionRow) -> Result<(), StorageError>;
+    fn create(&self, exec: &ExecutionRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch an execution by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<ExecutionRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<ExecutionRow>, StorageError>> + Send;
 
     /// Apply a state transition with CAS on `version`.
     ///
     /// Returns `Ok(updated_row)` on success, [`StorageError::Conflict`]
     /// on version mismatch, and [`StorageError::NotFound`] if the
     /// execution does not exist.
-    async fn transition(
+    fn transition(
         &self,
         id: &[u8],
         expected_version: i64,
         new_status: &str,
         new_state_patch: Option<serde_json::Value>,
-    ) -> Result<ExecutionRow, StorageError>;
+    ) -> impl Future<Output = Result<ExecutionRow, StorageError>> + Send;
 
     /// Update the `output` column (typically on terminal transition).
-    async fn set_output(
+    fn set_output(
         &self,
         id: &[u8],
         expected_version: i64,
         output: serde_json::Value,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Mark an execution as cancel-requested. Writes `cancel_requested_*`
     /// fields atomically; callers should enqueue a `Cancel` command in
     /// the control queue in the same transaction.
-    async fn request_cancel(
+    fn request_cancel(
         &self,
         id: &[u8],
         requested_by: &[u8],
         reason: Option<&str>,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Lease / claim (multi-process coordination) ──────────────────────
 
@@ -55,52 +55,65 @@ pub trait ExecutionRepo: Send + Sync {
     ///
     /// Returns `true` when acquired, `false` when another holder has
     /// a non-expired lease.
-    async fn acquire_lease(
+    fn acquire_lease(
         &self,
         id: &[u8],
         holder: &[u8],
         ttl: Duration,
-    ) -> Result<bool, StorageError>;
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send;
 
     /// Renew an existing lease. Returns `false` when not held by `holder`
     /// or when the lease has expired.
-    async fn renew_lease(
+    fn renew_lease(
         &self,
         id: &[u8],
         holder: &[u8],
         ttl: Duration,
-    ) -> Result<bool, StorageError>;
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send;
 
     /// Release a lease. Returns `false` when not held by `holder`.
-    async fn release_lease(&self, id: &[u8], holder: &[u8]) -> Result<bool, StorageError>;
+    fn release_lease(
+        &self,
+        id: &[u8],
+        holder: &[u8],
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send;
 
     // ── Dispatcher queries ──────────────────────────────────────────────
 
     /// Claim up to `batch_size` pending/queued executions for a holder
     /// with the given TTL. Uses `FOR UPDATE SKIP LOCKED` on Postgres.
-    async fn claim_pending(
+    fn claim_pending(
         &self,
         holder: &[u8],
         ttl: Duration,
         batch_size: u32,
-    ) -> Result<Vec<ExecutionRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<ExecutionRow>, StorageError>> + Send;
 
     /// List executions with stale leases (eligible for takeover).
-    async fn list_stale_leases(&self, batch_size: u32) -> Result<Vec<ExecutionRow>, StorageError>;
+    fn list_stale_leases(
+        &self,
+        batch_size: u32,
+    ) -> impl Future<Output = Result<Vec<ExecutionRow>, StorageError>> + Send;
 
     /// List executions that have hit their timeout.
-    async fn list_timed_out(&self, batch_size: u32) -> Result<Vec<ExecutionRow>, StorageError>;
+    fn list_timed_out(
+        &self,
+        batch_size: u32,
+    ) -> impl Future<Output = Result<Vec<ExecutionRow>, StorageError>> + Send;
 
     // ── Listing / counts ────────────────────────────────────────────────
 
     /// List executions in a workspace, ordered by `created_at DESC`.
-    async fn list_in_workspace(
+    fn list_in_workspace(
         &self,
         workspace_id: &[u8],
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<ExecutionRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<ExecutionRow>, StorageError>> + Send;
 
     /// Count running executions in an org (for quota enforcement).
-    async fn count_running_in_org(&self, org_id: &[u8]) -> Result<u64, StorageError>;
+    fn count_running_in_org(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<u64, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/execution_node.rs
+++ b/crates/storage/src/repos/execution_node.rs
@@ -1,6 +1,7 @@
 //! Per-attempt node execution storage.
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use chrono::{DateTime, Utc};
 
 use crate::{error::StorageError, rows::ExecutionNodeRow};
@@ -9,97 +10,105 @@ use crate::{error::StorageError, rows::ExecutionNodeRow};
 ///
 /// Spec 16 layer 4. Each retry attempt gets its own row; state column
 /// holds stateful-action state with schema hash for migration detection.
-#[async_trait]
 pub trait ExecutionNodeRepo: Send + Sync {
     /// Insert a new node attempt.
-    async fn create(&self, node: &ExecutionNodeRow) -> Result<(), StorageError>;
+    fn create(
+        &self,
+        node: &ExecutionNodeRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a node attempt by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<ExecutionNodeRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<ExecutionNodeRow>, StorageError>> + Send;
 
     /// Fetch a node attempt by `(execution_id, logical_node_id, attempt)`.
-    async fn get_attempt(
+    fn get_attempt(
         &self,
         execution_id: &[u8],
         logical_node_id: &str,
         attempt: i32,
-    ) -> Result<Option<ExecutionNodeRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<ExecutionNodeRow>, StorageError>> + Send;
 
     /// Update the status of a node attempt with CAS on `version`.
-    async fn transition(
+    fn transition(
         &self,
         id: &[u8],
         expected_version: i64,
         new_status: &str,
         finished_at: Option<DateTime<Utc>>,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Record the final output of a node attempt.
-    async fn set_output(
+    fn set_output(
         &self,
         id: &[u8],
         expected_version: i64,
         output: serde_json::Value,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Record an error on a node attempt.
-    async fn set_error(
+    fn set_error(
         &self,
         id: &[u8],
         expected_version: i64,
         error_kind: &str,
         error_message: &str,
         retry_hint_ms: Option<i64>,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Stateful action checkpoint ──────────────────────────────────────
 
     /// Persist `(iteration_count, state)` for a stateful action.
     /// Atomically updates both columns with CAS on `version`.
-    async fn save_checkpoint(
+    fn save_checkpoint(
         &self,
         id: &[u8],
         expected_version: i64,
         iteration_count: i32,
         state: serde_json::Value,
         state_schema_hash: &[u8],
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Load the current checkpoint state of a node attempt.
-    async fn load_checkpoint(&self, id: &[u8]) -> Result<Option<CheckpointSnapshot>, StorageError>;
+    fn load_checkpoint(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<CheckpointSnapshot>, StorageError>> + Send;
 
     // ── Retry / wake scheduling ─────────────────────────────────────────
 
     /// Schedule the attempt to wake up at `wake_at`.
-    async fn schedule_wake_at(
+    fn schedule_wake_at(
         &self,
         id: &[u8],
         expected_version: i64,
         wake_at: DateTime<Utc>,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Suspend waiting for a named signal.
-    async fn schedule_wake_signal(
+    fn schedule_wake_signal(
         &self,
         id: &[u8],
         expected_version: i64,
         signal_name: &str,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List node attempts ready to wake up by timer.
-    async fn list_wake_ready(
+    fn list_wake_ready(
         &self,
         now: DateTime<Utc>,
         batch_size: u32,
-    ) -> Result<Vec<ExecutionNodeRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<ExecutionNodeRow>, StorageError>> + Send;
 
     // ── Listing ─────────────────────────────────────────────────────────
 
     /// List all node attempts for an execution, ordered by `started_at`.
-    async fn list_for_execution(
+    fn list_for_execution(
         &self,
         execution_id: &[u8],
-    ) -> Result<Vec<ExecutionNodeRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<ExecutionNodeRow>, StorageError>> + Send;
 }
 
 /// Snapshot returned by [`ExecutionNodeRepo::load_checkpoint`].

--- a/crates/storage/src/repos/journal.rs
+++ b/crates/storage/src/repos/journal.rs
@@ -1,6 +1,6 @@
 //! Append-only execution journal.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::error::StorageError;
 
@@ -28,26 +28,29 @@ pub struct JournalEntry {
 /// Spec 16 layer 4. This is the replayable history operators inspect
 /// to answer *what happened*. No UPDATE or DELETE in runtime code —
 /// retention is by cascade on `executions`.
-#[async_trait]
 pub trait JournalRepo: Send + Sync {
     /// Append an entry. Auto-assigns `sequence` as the next value for
     /// the execution.
-    async fn append(&self, entry: &JournalEntry) -> Result<(), StorageError>;
+    fn append(&self, entry: &JournalEntry)
+    -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Batch-append multiple entries atomically.
-    async fn append_batch(&self, entries: &[JournalEntry]) -> Result<(), StorageError>;
+    fn append_batch(
+        &self,
+        entries: &[JournalEntry],
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Read the full journal for an execution, ordered by `sequence`.
-    async fn list_for_execution(
+    fn list_for_execution(
         &self,
         execution_id: &[u8],
-    ) -> Result<Vec<JournalEntry>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<JournalEntry>, StorageError>> + Send;
 
     /// Read entries after a given sequence (for streaming/catch-up).
-    async fn list_after(
+    fn list_after(
         &self,
         execution_id: &[u8],
         after_sequence: i64,
         limit: u32,
-    ) -> Result<Vec<JournalEntry>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<JournalEntry>, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/org.rs
+++ b/crates/storage/src/repos/org.rs
@@ -1,6 +1,6 @@
 //! Organization repository.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -8,51 +8,63 @@ use crate::{
 };
 
 /// Organization storage — top-level tenant.
-#[async_trait]
 pub trait OrgRepo: Send + Sync {
     /// Insert a new organization. Fails on duplicate slug.
-    async fn create(&self, org: &OrgRow) -> Result<(), StorageError>;
+    fn create(&self, org: &OrgRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch an org by ID (skips soft-deleted).
-    async fn get(&self, id: &[u8]) -> Result<Option<OrgRow>, StorageError>;
+    fn get(&self, id: &[u8]) -> impl Future<Output = Result<Option<OrgRow>, StorageError>> + Send;
 
     /// Fetch an org by slug (case-insensitive).
-    async fn get_by_slug(&self, slug: &str) -> Result<Option<OrgRow>, StorageError>;
+    fn get_by_slug(
+        &self,
+        slug: &str,
+    ) -> impl Future<Output = Result<Option<OrgRow>, StorageError>> + Send;
 
     /// Update an org with CAS on `version`.
-    async fn update(&self, org: &OrgRow, expected_version: i64) -> Result<(), StorageError>;
+    fn update(
+        &self,
+        org: &OrgRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete an org.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Members ─────────────────────────────────────────────────────────
 
     /// Add a principal as a member of an org.
-    async fn add_member(&self, member: &OrgMemberRow) -> Result<(), StorageError>;
+    fn add_member(
+        &self,
+        member: &OrgMemberRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Remove a member from an org.
-    async fn remove_member(
+    fn remove_member(
         &self,
         org_id: &[u8],
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Get a principal's role in an org. Returns `None` if not a member.
-    async fn get_member_role(
+    fn get_member_role(
         &self,
         org_id: &[u8],
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<Option<String>, StorageError>;
+    ) -> impl Future<Output = Result<Option<String>, StorageError>> + Send;
 
     /// List all members of an org.
-    async fn list_members(&self, org_id: &[u8]) -> Result<Vec<OrgMemberRow>, StorageError>;
+    fn list_members(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<Vec<OrgMemberRow>, StorageError>> + Send;
 
     /// List all orgs a principal belongs to.
-    async fn list_for_principal(
+    fn list_for_principal(
         &self,
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<Vec<OrgMemberRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<OrgMemberRow>, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/quota.rs
+++ b/crates/storage/src/repos/quota.rs
@@ -1,6 +1,6 @@
 //! Quota enforcement repository (atomic CAS counters).
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -12,42 +12,54 @@ use crate::{
 /// Spec 16 layer 7 + spec 10. Increment/decrement operations are
 /// atomic against the DB — callers must check limits before attempting
 /// to raise a counter.
-#[async_trait]
 pub trait QuotaRepo: Send + Sync {
     // ── Limits ──────────────────────────────────────────────────────────
 
     /// Fetch org quota limits (plan-based).
-    async fn get_org_limits(&self, org_id: &[u8]) -> Result<Option<OrgQuotaRow>, StorageError>;
+    fn get_org_limits(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<Option<OrgQuotaRow>, StorageError>> + Send;
 
     /// Upsert org quota limits (typically on plan change).
-    async fn upsert_org_limits(&self, row: &OrgQuotaRow) -> Result<(), StorageError>;
+    fn upsert_org_limits(
+        &self,
+        row: &OrgQuotaRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Usage counters ──────────────────────────────────────────────────
 
     /// Fetch current org usage.
-    async fn get_org_usage(&self, org_id: &[u8]) -> Result<Option<OrgQuotaUsageRow>, StorageError>;
+    fn get_org_usage(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<Option<OrgQuotaUsageRow>, StorageError>> + Send;
 
     /// Fetch current workspace usage.
-    async fn get_workspace_usage(
+    fn get_workspace_usage(
         &self,
         workspace_id: &[u8],
-    ) -> Result<Option<WorkspaceQuotaUsageRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<WorkspaceQuotaUsageRow>, StorageError>> + Send;
 
     /// Atomically increment a usage counter. Fails with
     /// [`StorageError::Conflict`] if doing so would exceed the limit
     /// when `check_limit = true`.
-    async fn increment(
+    fn increment(
         &self,
         key: QuotaCounter<'_>,
         by: i64,
         check_limit: bool,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Atomically decrement a usage counter (never below zero).
-    async fn decrement(&self, key: QuotaCounter<'_>, by: i64) -> Result<(), StorageError>;
+    fn decrement(
+        &self,
+        key: QuotaCounter<'_>,
+        by: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Reset monthly counters (called by scheduled job at month rollover).
-    async fn reset_monthly(&self) -> Result<(), StorageError>;
+    fn reset_monthly(&self) -> impl Future<Output = Result<(), StorageError>> + Send;
 }
 
 /// Identifies a specific counter to adjust.

--- a/crates/storage/src/repos/resource.rs
+++ b/crates/storage/src/repos/resource.rs
@@ -1,6 +1,6 @@
 //! Resource repository.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::error::StorageError;
 
@@ -9,33 +9,41 @@ use crate::error::StorageError;
 /// Spec 16 layer 6. Resources are long-lived managed objects
 /// (connection pools, SDK clients). The engine owns lifecycle; this
 /// repo only stores definitions.
-#[async_trait]
 pub trait ResourceRepo: Send + Sync {
     /// Insert a new resource definition.
-    async fn create(&self, resource: &ResourceEntry) -> Result<(), StorageError>;
+    fn create(
+        &self,
+        resource: &ResourceEntry,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a resource by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<ResourceEntry>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<ResourceEntry>, StorageError>> + Send;
 
     /// Fetch a resource by (workspace_id, slug).
-    async fn get_by_slug(
+    fn get_by_slug(
         &self,
         workspace_id: &[u8],
         slug: &str,
-    ) -> Result<Option<ResourceEntry>, StorageError>;
+    ) -> impl Future<Output = Result<Option<ResourceEntry>, StorageError>> + Send;
 
     /// Update a resource with CAS on `version`.
-    async fn update(
+    fn update(
         &self,
         resource: &ResourceEntry,
         expected_version: i64,
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a resource.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List all resources in a workspace.
-    async fn list(&self, workspace_id: &[u8]) -> Result<Vec<ResourceEntry>, StorageError>;
+    fn list(
+        &self,
+        workspace_id: &[u8],
+    ) -> impl Future<Output = Result<Vec<ResourceEntry>, StorageError>> + Send;
 }
 
 /// Resource row (in-repo type — the `resources` table is simple enough

--- a/crates/storage/src/repos/trigger.rs
+++ b/crates/storage/src/repos/trigger.rs
@@ -1,6 +1,7 @@
 //! Trigger repository — definitions, events, cron slots.
 
-use async_trait::async_trait;
+use std::future::Future;
+
 use chrono::{DateTime, Utc};
 
 use crate::{
@@ -13,69 +14,92 @@ use crate::{
 /// Spec 16 layer 5. Event inbox uses `UNIQUE (trigger_id, event_id)`
 /// for dedup; cron slots use `PRIMARY KEY (trigger_id, scheduled_for)`
 /// for leaderless firing coordination.
-#[async_trait]
 pub trait TriggerRepo: Send + Sync {
     // ── Trigger definitions ─────────────────────────────────────────────
 
     /// Insert a new trigger.
-    async fn create(&self, trigger: &TriggerRow) -> Result<(), StorageError>;
+    fn create(&self, trigger: &TriggerRow)
+    -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a trigger by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<TriggerRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<TriggerRow>, StorageError>> + Send;
 
     /// Update a trigger with CAS on `version`.
-    async fn update(&self, trigger: &TriggerRow, expected_version: i64)
-    -> Result<(), StorageError>;
+    fn update(
+        &self,
+        trigger: &TriggerRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a trigger.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List all active triggers in a workspace (non-archived, non-deleted).
-    async fn list_active(&self, workspace_id: &[u8]) -> Result<Vec<TriggerRow>, StorageError>;
+    fn list_active(
+        &self,
+        workspace_id: &[u8],
+    ) -> impl Future<Output = Result<Vec<TriggerRow>, StorageError>> + Send;
 
     /// List all active cron triggers across workspaces (for scheduler tick).
-    async fn list_active_cron(&self) -> Result<Vec<TriggerRow>, StorageError>;
+    fn list_active_cron(
+        &self,
+    ) -> impl Future<Output = Result<Vec<TriggerRow>, StorageError>> + Send;
 
     // ── Event inbox ─────────────────────────────────────────────────────
 
     /// Insert a trigger event. Returns `Ok(false)` if the event was a
     /// duplicate (dedup on `UNIQUE(trigger_id, event_id)`), `Ok(true)`
     /// when a new row was inserted.
-    async fn insert_event(&self, event: &TriggerEventRow) -> Result<bool, StorageError>;
+    fn insert_event(
+        &self,
+        event: &TriggerEventRow,
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send;
 
     /// Claim up to `batch_size` pending events for a dispatcher.
-    async fn claim_events(
+    fn claim_events(
         &self,
         claimed_by: &[u8],
         batch_size: u32,
-    ) -> Result<Vec<TriggerEventRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<TriggerEventRow>, StorageError>> + Send;
 
     /// Mark an event as dispatched; links it to the created execution.
-    async fn mark_dispatched(
+    fn mark_dispatched(
         &self,
         event_id: &[u8],
         execution_id: &[u8],
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Mark an event as failed.
-    async fn mark_event_failed(&self, event_id: &[u8], reason: &str) -> Result<(), StorageError>;
+    fn mark_event_failed(
+        &self,
+        event_id: &[u8],
+        reason: &str,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Cron fire slots ─────────────────────────────────────────────────
 
     /// Attempt to claim a cron slot. Returns `true` when this caller
     /// claimed the slot, `false` when another dispatcher got it first
     /// (unique-constraint violation).
-    async fn claim_cron_slot(&self, slot: &CronFireSlotRow) -> Result<bool, StorageError>;
+    fn claim_cron_slot(
+        &self,
+        slot: &CronFireSlotRow,
+    ) -> impl Future<Output = Result<bool, StorageError>> + Send;
 
     /// Link a claimed slot to the created execution.
-    async fn set_cron_slot_execution(
+    fn set_cron_slot_execution(
         &self,
         trigger_id: &[u8],
         scheduled_for: DateTime<Utc>,
         execution_id: &[u8],
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Clean up cron slots older than `retention`. Returns count deleted.
-    async fn cleanup_cron_slots(&self, retention: std::time::Duration)
-    -> Result<u64, StorageError>;
+    fn cleanup_cron_slots(
+        &self,
+        retention: std::time::Duration,
+    ) -> impl Future<Output = Result<u64, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/user.rs
+++ b/crates/storage/src/repos/user.rs
@@ -1,6 +1,6 @@
 //! Identity-layer repositories.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -8,71 +8,88 @@ use crate::{
 };
 
 /// User account storage.
-#[async_trait]
 pub trait UserRepo: Send + Sync {
     /// Insert a new user. Fails if email already exists among active users.
-    async fn create(&self, user: &UserRow) -> Result<(), StorageError>;
+    fn create(&self, user: &UserRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a user by ID. Returns `None` if not found or soft-deleted.
-    async fn get(&self, id: &[u8]) -> Result<Option<UserRow>, StorageError>;
+    fn get(&self, id: &[u8]) -> impl Future<Output = Result<Option<UserRow>, StorageError>> + Send;
 
     /// Fetch a user by email (case-insensitive).
-    async fn get_by_email(&self, email: &str) -> Result<Option<UserRow>, StorageError>;
+    fn get_by_email(
+        &self,
+        email: &str,
+    ) -> impl Future<Output = Result<Option<UserRow>, StorageError>> + Send;
 
     /// Update a user with CAS on `version`.
-    async fn update(&self, user: &UserRow, expected_version: i64) -> Result<(), StorageError>;
+    fn update(
+        &self,
+        user: &UserRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a user (sets `deleted_at`).
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Record a successful login (updates `last_login_at`, resets failed count).
-    async fn record_login_success(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn record_login_success(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Record a failed login attempt. May set `locked_until` after threshold.
-    async fn record_login_failure(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn record_login_failure(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 }
 
 /// Session storage for browser logins.
-#[async_trait]
 pub trait SessionRepo: Send + Sync {
     /// Insert a new session.
-    async fn create(&self, session: &SessionRow) -> Result<(), StorageError>;
+    fn create(&self, session: &SessionRow)
+    -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a session by ID. Returns `None` if not found, revoked, or expired.
-    async fn get(&self, id: &[u8]) -> Result<Option<SessionRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<SessionRow>, StorageError>> + Send;
 
     /// Touch `last_active_at` to now.
-    async fn touch(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn touch(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Mark the session as revoked.
-    async fn revoke(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn revoke(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Delete all expired sessions. Returns the count deleted.
-    async fn cleanup_expired(&self) -> Result<u64, StorageError>;
+    fn cleanup_expired(&self) -> impl Future<Output = Result<u64, StorageError>> + Send;
 }
 
 /// Personal access token storage.
-#[async_trait]
 pub trait PatRepo: Send + Sync {
     /// Insert a new PAT.
-    async fn create(&self, pat: &PersonalAccessTokenRow) -> Result<(), StorageError>;
+    fn create(
+        &self,
+        pat: &PersonalAccessTokenRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Look up a PAT by its SHA-256 hash. Returns `None` if not found or revoked.
-    async fn get_by_hash(
+    fn get_by_hash(
         &self,
         hash: &[u8],
-    ) -> Result<Option<PersonalAccessTokenRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<PersonalAccessTokenRow>, StorageError>> + Send;
 
     /// Touch `last_used_at` after a successful auth.
-    async fn touch(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn touch(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Revoke a PAT (sets `revoked_at`).
-    async fn revoke(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn revoke(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List active PATs for a principal.
-    async fn list_for_principal(
+    fn list_for_principal(
         &self,
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<Vec<PersonalAccessTokenRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<PersonalAccessTokenRow>, StorageError>> + Send;
 }

--- a/crates/storage/src/repos/workflow.rs
+++ b/crates/storage/src/repos/workflow.rs
@@ -1,6 +1,6 @@
 //! Workflow and workflow-version repositories.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -12,77 +12,92 @@ use crate::{
 /// A workflow is a logical container — its executable definition
 /// lives in [`WorkflowVersionRepo`]. `current_version_id` points
 /// at the active published version.
-#[async_trait]
 pub trait WorkflowRepo: Send + Sync {
     /// Insert a new workflow. Fails on duplicate (workspace_id, slug).
-    async fn create(&self, wf: &WorkflowRow) -> Result<(), StorageError>;
+    fn create(&self, wf: &WorkflowRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a workflow by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<WorkflowRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<WorkflowRow>, StorageError>> + Send;
 
     /// Fetch a workflow by (workspace, slug).
-    async fn get_by_slug(
+    fn get_by_slug(
         &self,
         workspace_id: &[u8],
         slug: &str,
-    ) -> Result<Option<WorkflowRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<WorkflowRow>, StorageError>> + Send;
 
     /// Update a workflow with CAS on `version`.
-    async fn update(&self, wf: &WorkflowRow, expected_version: i64) -> Result<(), StorageError>;
+    fn update(
+        &self,
+        wf: &WorkflowRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a workflow.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// List workflows in a workspace, ordered by `created_at DESC`.
-    async fn list(
+    fn list(
         &self,
         workspace_id: &[u8],
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<WorkflowRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<WorkflowRow>, StorageError>> + Send;
 
     /// Count non-deleted workflows in a workspace.
-    async fn count(&self, workspace_id: &[u8]) -> Result<u64, StorageError>;
+    fn count(&self, workspace_id: &[u8]) -> impl Future<Output = Result<u64, StorageError>> + Send;
 }
 
 /// Workflow version storage — immutable published snapshots.
-#[async_trait]
 pub trait WorkflowVersionRepo: Send + Sync {
     /// Insert a new version. The `version_number` must be unique per workflow.
-    async fn create(&self, version: &WorkflowVersionRow) -> Result<(), StorageError>;
+    fn create(
+        &self,
+        version: &WorkflowVersionRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a version by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<WorkflowVersionRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<WorkflowVersionRow>, StorageError>> + Send;
 
     /// Fetch the currently-published version of a workflow.
-    async fn get_published(
+    fn get_published(
         &self,
         workflow_id: &[u8],
-    ) -> Result<Option<WorkflowVersionRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<WorkflowVersionRow>, StorageError>> + Send;
 
     /// Fetch a version by (workflow_id, version_number).
-    async fn get_by_number(
+    fn get_by_number(
         &self,
         workflow_id: &[u8],
         version_number: i32,
-    ) -> Result<Option<WorkflowVersionRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<WorkflowVersionRow>, StorageError>> + Send;
 
     /// List versions for a workflow, ordered by `version_number DESC`.
-    async fn list_for_workflow(
+    fn list_for_workflow(
         &self,
         workflow_id: &[u8],
         offset: u64,
         limit: u64,
-    ) -> Result<Vec<WorkflowVersionRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<WorkflowVersionRow>, StorageError>> + Send;
 
     /// Transition a version from `Draft` to `Published`. Atomically
     /// archives any previously-published version of the same workflow
     /// (the unique index on published state makes this necessary).
-    async fn publish(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn publish(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Transition a version to `Archived`.
-    async fn archive(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn archive(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Pin a version to protect it from retention GC.
-    async fn set_pinned(&self, id: &[u8], pinned: bool) -> Result<(), StorageError>;
+    fn set_pinned(
+        &self,
+        id: &[u8],
+        pinned: bool,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 }

--- a/crates/storage/src/repos/workspace.rs
+++ b/crates/storage/src/repos/workspace.rs
@@ -1,6 +1,6 @@
 //! Workspace repository.
 
-use async_trait::async_trait;
+use std::future::Future;
 
 use crate::{
     error::StorageError,
@@ -8,57 +8,72 @@ use crate::{
 };
 
 /// Workspace storage — second-level tenant under an org.
-#[async_trait]
 pub trait WorkspaceRepo: Send + Sync {
     /// Insert a new workspace. Fails on duplicate (org_id, slug).
-    async fn create(&self, ws: &WorkspaceRow) -> Result<(), StorageError>;
+    fn create(&self, ws: &WorkspaceRow) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Fetch a workspace by ID.
-    async fn get(&self, id: &[u8]) -> Result<Option<WorkspaceRow>, StorageError>;
+    fn get(
+        &self,
+        id: &[u8],
+    ) -> impl Future<Output = Result<Option<WorkspaceRow>, StorageError>> + Send;
 
     /// Fetch a workspace by (org, slug).
-    async fn get_by_slug(
+    fn get_by_slug(
         &self,
         org_id: &[u8],
         slug: &str,
-    ) -> Result<Option<WorkspaceRow>, StorageError>;
+    ) -> impl Future<Output = Result<Option<WorkspaceRow>, StorageError>> + Send;
 
     /// Get the default workspace for an org.
-    async fn get_default(&self, org_id: &[u8]) -> Result<Option<WorkspaceRow>, StorageError>;
+    fn get_default(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<Option<WorkspaceRow>, StorageError>> + Send;
 
     /// List all workspaces under an org.
-    async fn list_for_org(&self, org_id: &[u8]) -> Result<Vec<WorkspaceRow>, StorageError>;
+    fn list_for_org(
+        &self,
+        org_id: &[u8],
+    ) -> impl Future<Output = Result<Vec<WorkspaceRow>, StorageError>> + Send;
 
     /// Update a workspace with CAS on `version`.
-    async fn update(&self, ws: &WorkspaceRow, expected_version: i64) -> Result<(), StorageError>;
+    fn update(
+        &self,
+        ws: &WorkspaceRow,
+        expected_version: i64,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Soft-delete a workspace.
-    async fn soft_delete(&self, id: &[u8]) -> Result<(), StorageError>;
+    fn soft_delete(&self, id: &[u8]) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     // ── Members ─────────────────────────────────────────────────────────
 
     /// Add a principal as a member of a workspace.
-    async fn add_member(&self, member: &WorkspaceMemberRow) -> Result<(), StorageError>;
+    fn add_member(
+        &self,
+        member: &WorkspaceMemberRow,
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Remove a member from a workspace.
-    async fn remove_member(
+    fn remove_member(
         &self,
         workspace_id: &[u8],
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<(), StorageError>;
+    ) -> impl Future<Output = Result<(), StorageError>> + Send;
 
     /// Get a principal's role in a workspace.
-    async fn get_member_role(
+    fn get_member_role(
         &self,
         workspace_id: &[u8],
         principal_kind: &str,
         principal_id: &[u8],
-    ) -> Result<Option<String>, StorageError>;
+    ) -> impl Future<Output = Result<Option<String>, StorageError>> + Send;
 
     /// List members of a workspace.
-    async fn list_members(
+    fn list_members(
         &self,
         workspace_id: &[u8],
-    ) -> Result<Vec<WorkspaceMemberRow>, StorageError>;
+    ) -> impl Future<Output = Result<Vec<WorkspaceMemberRow>, StorageError>> + Send;
 }


### PR DESCRIPTION
## Summary

- Flip 16 zero-`dyn` traits in the new `crates/storage/src/repos/*.rs` layer from `#[async_trait]` to native 1.75 AFIT (`WorkflowRepo`, `WorkflowVersionRepo`, `AuditRepo`, `WorkspaceRepo`, `JournalRepo`, `CredentialRepo`, `ExecutionNodeRepo`, `BlobRepo`, `UserRepo`, `SessionRepo`, `PatRepo`, `OrgRepo`, `ResourceRepo`, `QuotaRepo`, `TriggerRepo`, `ExecutionRepo`).
- ~130 async methods desugared to `fn -> impl Future<Output = ...> + Send`.
- Two real impls touched: `crates/storage/src/pg/org.rs`, `crates/storage/src/pg/workspace.rs`. Rest of `repos/*` has no external impls yet (marked `planned` per canon §11.6).
- Legacy `dyn`-consumed traits **untouched** — `workflow_repo.rs`, `execution_repo.rs`, `control_queue.rs`, `backend/*.rs`, and `repos/control_queue.rs` all carry over to Phase 3 (dynosaur). Duplicate-name pairs (`WorkflowRepo`, `ExecutionRepo`) kept split per ADR-0008.
- `async-trait` dep **preserved** — 9 surviving attrs in Phase 3 files.

Phase 2 of [`docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md`](../blob/main/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md). Biggest of the three Phase 2 PRs; independent of `phase2/afit-runtime` and `phase2/afit-credential`.

**Note on `+ Send` drift.** Spec predicted ~10 touches; actual was ~130. `clippy::async_fn_in_trait` fires per-method on public `Send + Sync` traits. Applied explicit `+ Send` on every method uniformly.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] `cargo clippy -p nebula-storage --all-features -- -D warnings`
- [x] `cargo clippy --workspace -- -D warnings`
- [x] `cargo nextest run -p nebula-storage` → 75/75
- [x] `cargo nextest run -p nebula-api --test knife` → 4/4 (incl. §12.2 control-queue E2E, 30s)
- [x] `cargo check --workspace`
- [x] `cargo test -p nebula-storage --doc`
- [x] Legacy files (`workflow_repo.rs`, `execution_repo.rs`, `control_queue.rs`, `backend/*`, `repos/control_queue.rs`) untouched — verified via `git diff --name-only`
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)