### PR TITLE
docs(runtime): clarify TaskQueue AFIT spawn caveat (PR #507 follow-up)

### DIFF
--- a/crates/runtime/src/queue.rs
+++ b/crates/runtime/src/queue.rs
@@ -47,9 +47,11 @@ impl QueueError {
 ///
 /// At-least-once semantics: enqueue → dequeue → ack (or nack to requeue).
 ///
-/// Methods are desugared from `async fn` to `fn -> impl Future + Send` so
-/// callers can `tokio::spawn` trait method futures without needing a
-/// `Pin<Box<dyn Future>>` wrapper (ADR-0014 direction; Phase 2 AFIT).
+/// Methods are desugared from `async fn` to `fn -> impl Future + Send` to
+/// avoid a `Pin<Box<dyn Future>>` wrapper and preserve `Send` on the returned
+/// futures (ADR-0014 direction; Phase 2 AFIT). Callers that use
+/// `tokio::spawn` may still need an owning `async move { ... }` wrapper and
+/// owned/cloned inputs to satisfy the spawned future's `'static` requirement.
 pub trait TaskQueue: Send + Sync {
     /// Enqueue a task. Returns a task ID.
     fn enqueue(


### PR DESCRIPTION
## Summary

Follow-up to merged #507 — applies the Copilot review suggestion that landed after the PR was merged.

The prior doc comment on `TaskQueue` claimed callers can `tokio::spawn` trait method futures without a wrapper. That's wrong: `tokio::spawn` still requires `'static`, and methods taking `&self` / `&str` return futures that borrow, so an owning `async move { ... }` wrapper with owned/cloned inputs is still needed. Reword to say the AFIT shape avoids boxing and preserves `Send`, but does not eliminate the `'static` requirement for spawn.

## Test plan

- [x] `cargo +nightly fmt --all`
- [x] Docs-only change — no behavior change
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)