### PR TITLE
docs(adr): ADR-0024 defer dynosaur migration (supersedes ADR-0014)

### DIFF
--- a/docs/STYLE.md
+++ b/docs/STYLE.md
@@ -25,7 +25,7 @@ from `CLAUDE.md` read-order.
 - **`#[must_use]`** — on every `Result`, every builder, every function returning a cleanup or cancellation token.
 - **`Cow<'_, T>`** — prefer over premature cloning for read-mostly borrows with occasional mutation.
 - **Sealed traits** for extension points — define via private supertrait when Nebula owns all implementations; opens later if we decide to allow downstream impls.
-- **`dynosaur` for `dyn`-compatible async traits** — author the trait in AFIT form (`async fn` in trait), apply `#[dynosaur::dynosaur(DynFoo)]`, and let the macro generate the `dyn`-compatible sibling. Static signatures name `impl Foo`; dynamic boundaries name `dyn DynFoo`. Never introduce `#[async_trait]` in new code. See [ADR-0014](adr/0014-dynosaur-macro.md).
+- **Async traits — match the seam.** For traits consumed only through generics (no `dyn`), author native AFIT: `fn foo(&self, …) -> impl Future<Output = …> + Send`. For traits stored or passed as `Arc<dyn Foo>` / `Box<dyn Foo>`, use `#[async_trait]` — native AFIT is not `dyn`-compatible on stable Rust today. Do not mix both forms on the same trait. Re-evaluate when `async_fn_in_dyn_trait` stabilizes (see [rust-lang/rust#133119](https://github.com/rust-lang/rust/issues/133119)). See [ADR-0024](adr/0024-defer-dynosaur-migration.md) (supersedes [ADR-0014](adr/0014-dynosaur-macro.md)).
 
 ## 2. Antipatterns we reject
 

--- a/docs/adr/0014-dynosaur-macro.md
+++ b/docs/adr/0014-dynosaur-macro.md
@@ -1,14 +1,15 @@
 ---
 id: 0014
 title: dynosaur-macro
-status: accepted
+status: superseded
 date: 2026-04-19
 supersedes: []
-superseded_by: []
+superseded_by: [0024]
 tags: [traits, async, dyn-compatibility, macros, api-design]
 related:
   - docs/STYLE.md#1-idioms-we-use
   - docs/adr/0010-rust-2024-edition.md
+  - docs/adr/0024-defer-dynosaur-migration.md
 linear:
   - NEB-152
 ---

--- a/docs/adr/0024-defer-dynosaur-migration.md
+++ b/docs/adr/0024-defer-dynosaur-migration.md
@@ -1,0 +1,202 @@
+---
+id: 0024
+title: defer-dynosaur-migration
+status: proposed
+date: 2026-04-20
+supersedes: [0014]
+superseded_by: []
+tags: [traits, async, dyn-compatibility, dependencies, api-design]
+related:
+  - docs/adr/0014-dynosaur-macro.md
+  - docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md
+  - docs/STYLE.md#1-idioms-we-use
+linear: []
+---
+
+# 0024. Defer `dynosaur` migration — keep `#[async_trait]` for `dyn`-consumed traits
+
+## Context
+
+[ADR-0014](./0014-dynosaur-macro.md) approved `dynosaur` as the mechanism
+for `dyn`-compatible async traits across the workspace. Since then, three
+facts changed:
+
+1. **Phase 2 of the 1.75-1.95 feature-adoption plan landed** (PR #507,
+   #508, #509). Every trait with **zero** `dyn Trait` call sites — 20
+   traits across `runtime`, `credential`, `storage/repos/*` — moved to
+   native AFIT (`fn -> impl Future<Output = ...> + Send`). The remaining
+   `#[async_trait]` surface is **14 traits, 100 % of whose call sites
+   are `Arc<dyn …>`** (per the plan's inventory). `dynosaur`'s core
+   selling point — letting generic callers keep the zero-cost path
+   while dyn callers pay the box — **has no call sites to serve** for
+   these 14.
+2. **`async_fn_in_dyn_trait` is still experimental on nightly.** The
+   rust-lang tracking issue ([rust-lang/rust#133119][rfc-133119]) lists
+   RFC as *not yet accepted* and stabilization is not scheduled. An
+   independent project (`assapir/golem` issue #8, 2026-02-18) tested
+   nightly 1.95 and reported the feature is marked **incomplete** and
+   still emits `E0038: trait is not dyn compatible`. Waiting is not a
+   weeks-away bet, but the wait cost for Nebula is **zero**: `async-trait`
+   keeps compiling.
+3. **`dynosaur` adoption stayed narrow.** At the time of this ADR the
+   crate is `v0.3.0`, last released 2025-07-16 (277 days ago, marked
+   "aging" by crate-health metrics), with **13 reverse dependencies** on
+   crates.io — all niche projects. Surveyed peers:
+   - `databend` (query engine, analogous domain) — `async-trait` on
+     every `Arc<dyn Catalog>` / `Arc<dyn Table>` seam.
+   - `apache/opendal` (storage abstraction, closest analog to
+     `storage/repos/*`) — hand-rolls a `Foo` / `FooDyn` pair with
+     manual `BoxedFuture` returns; does **not** depend on `dynosaur`.
+   - `tokio-rs/axum` — native AFIT for extractors/handlers, manual
+     `Pin<Box<dyn Future>>` at the few trait-object sites.
+   - `launchbadge/sqlx` — `BoxFuture` / `BoxStream` in trait
+     signatures plus `async-trait` in lock.
+
+   No major peer adopted `dynosaur`.
+
+Separately, an audit of `dtolnay/async-trait` upstream issues (7 open at
+the time of writing, over a ~5-year history) shows every open report is
+a sophisticated generic-lifetime edge case (elided lifetimes across
+tuples, higher-rank closure bounds, generic tuple-in-Send shapes) —
+none of which match Nebula's trait signatures (simple `async fn foo(&self,
+args: T) -> Result<U, E>` per repo method). Risk of hitting an upstream
+bug with our shapes is negligible.
+
+## Decision
+
+1. **`#[async_trait]` is the approved mechanism for the 14 remaining
+   `dyn`-consumed async traits in Nebula.** The crate stays in
+   `[workspace.dependencies]`. Phase 3 of the feature-adoption plan
+   (`dynosaur` migration) **is not executed** and is dropped from the
+   rollup.
+
+   The 14 traits covered by this decision are the `dyn`-consumed ones
+   inventoried in the plan's §Inventory: `TriggerHandler`,
+   `CredentialAccessor`, `StatelessHandler`, `ControlQueueRepo`, legacy
+   `ExecutionRepo` (`crates/storage/src/execution_repo.rs`), legacy
+   `WorkflowRepo` (`crates/storage/src/workflow_repo.rs`),
+   `ResourceHandler`, `ResourceAccessor`, `ExecutionEmitter`,
+   `StatefulHandler`, `TriggerScheduler`, `AgentHandler`,
+   `StatefulCheckpointSink`, `BlobStorage`, `SandboxRunner`. (Phase 2
+   has already migrated every non-dyn async trait.)
+
+2. **Do not add `dynosaur` to `[workspace.dependencies]`.** A 0.3 crate
+   with 13 reverse-deps does not clear the bar for a load-bearing
+   workspace dependency.
+
+3. **Native AFIT remains the default for new traits that are not
+   `dyn`-consumed.** Phase 2's outcome stands: `fn foo(&self, ...) ->
+   impl Future<Output = ...> + Send` is the house style for traits that
+   live behind generics only. Do not regress to `#[async_trait]` on
+   these.
+
+4. **`#[async_trait]` is not forbidden for new code when the trait is
+   `dyn`-consumed from day one.** The "never introduce `#[async_trait]`"
+   rule in [ADR-0014 §Style guidelines](./0014-dynosaur-macro.md) is
+   rescinded. Match the surrounding seam: if the author introduces a
+   new trait whose concrete consumers will hold it as `Arc<dyn Foo>`,
+   `#[async_trait]` is the correct choice. If the trait has generic
+   consumers only, use native AFIT.
+
+5. **Re-evaluation triggers.** This ADR is revisited — and likely
+   superseded with a follow-up migration — when **any** of the following
+   becomes true:
+
+   - `async_fn_in_dyn_trait` stabilizes on stable Rust and Nebula's
+     MSRV floor reaches that version. At that point the migration is
+     trivial: delete `#[async_trait]` annotations, traits keep
+     compiling as `dyn`-compatible natively. No sibling macro required.
+   - A real hot-path generic consumer appears for one of the 14 traits
+     (e.g. the engine's per-step dispatch loop learns to call a
+     `WorkflowRepo` method directly with a concrete type). In that
+     narrow case, reach for the **opendal hand-rolled pair pattern**
+     (`Foo` native AFIT + `FooDyn` manual `Pin<Box<dyn Future>>`
+     sibling) for **that trait only** — not a workspace-wide macro
+     migration. This is the bounded-scope fallback; a workspace-wide
+     flip back to `dynosaur` remains out of scope.
+   - `async-trait` upstream becomes unmaintained (e.g. no release or
+     issue response for ≥ 12 months while Rust edition moves forward).
+     The low open-issue volume and `dtolnay`'s stewardship make this
+     tail-risk, not a live concern.
+
+## Consequences
+
+**Positive**
+
+- **Zero migration work.** The 14 `dyn`-consumed traits keep compiling
+  as-is. No 5-PR rollup, no ADR-0023 scheduling pressure on
+  `CredentialAccessor`.
+- **One async macro in tree, not two.** `async-trait` is already a
+  transitive dep via tokio-adjacent crates; not adding `dynosaur`
+  keeps the dep graph flatter.
+- **Clean supersession path.** When stdlib stabilizes, the migration is
+  mechanical — delete attributes; no `DynFoo` renaming sweep across
+  consumer crates.
+
+**Negative**
+
+- **Stylistic split.** Phase 2 zero-dyn traits are native AFIT; Phase 3
+  dyn traits remain `#[async_trait]`. Readers navigating between a
+  `repos/*.rs` trait (native) and a `workflow_repo.rs` legacy trait
+  (`#[async_trait]`) see two forms. Canon §11.6 (advertise only what
+  is honored) is not violated — both patterns compile and work — but
+  code-review ergonomics take a hit. Acknowledged; worth it versus the
+  5-PR alternative.
+- **`async-trait` boxes generic call sites too.** If a generic call
+  site appears on one of the 14 traits later, we pay a `Box` we would
+  not pay with `dynosaur`'s static-dispatch path. Re-evaluation
+  trigger (2) above covers this.
+- **No style unification until stdlib stabilizes.** We are explicitly
+  betting on stdlib catching up rather than a third-party macro. If
+  `async_fn_in_dyn_trait` stalls for multiple years, the stylistic
+  split persists.
+
+**Neutral**
+
+- Runtime cost is **identical** to the `dynosaur` route for the 14
+  target traits (every call site is `Arc<dyn>`; both macros box).
+
+## Alternatives considered
+
+- **Execute ADR-0014 as originally written (Phase 3 dynosaur migration).**
+  Reject. Unchanged facts: `dynosaur` 0.3 / aging / 13 reverse-deps /
+  zero major-peer adoption do not justify a new workspace dependency
+  whose core value prop (dual generic + dyn) currently serves zero
+  call sites.
+- **Hand-rolled opendal-style pair workspace-wide.** Reject as a
+  migration; retain as a per-trait fallback under re-evaluation
+  trigger (2). Cost is ≈ 14 traits × 8 methods × 2 signatures = ~224
+  method signatures of boilerplate, for no current-day win over
+  `async-trait`. Opendal made this choice because their trait surface
+  is ~3 trait families that are both heavily generic and heavily dyn;
+  our 14 are dyn-only.
+- **Manual `Pin<Box<dyn Future>>` without the generic sibling.**
+  Reject. Identical runtime cost to `async-trait` with worse
+  ergonomics (lifetime bookkeeping at every method, `Box::pin` wrap
+  in every impl body). No advantage.
+- **`trait-variant`.** Reject. Does not solve `dyn`-compatibility;
+  ADR-0014 already considered and rejected it for that reason. Still
+  true.
+- **Wait for `async_fn_in_dyn_trait` without a formal decision.**
+  Reject. The in-tree status of ADR-0014 would silently rot the
+  spec and block Phase 3 of the adoption plan without an explicit
+  L2-invariant update. This ADR exists precisely to close that gap.
+
+## Follow-ups
+
+- Mark ADR-0014 `superseded` in frontmatter (body immutable per
+  `docs/adr/README.md`).
+- Update [`docs/STYLE.md §1`](../STYLE.md#1-idioms-we-use) to reflect
+  the decision — `#[async_trait]` is permitted for `dyn`-consumed
+  async traits; native AFIT is the default for generic-only async
+  traits.
+- Update the adoption plan
+  ([`docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md`](../superpowers/specs/2026-04-19-rust-feature-adoption-plan.md)):
+  Phase 3 goes to **"cancelled (superseded by ADR-0024)"**. Phase 4
+  (use<> precise-capture) stays — it remains inline work for Phase 2
+  follow-ups. Phase 5 polish items are unaffected.
+- Watch rust-lang/rust#133119 and RFC discussions. When the feature
+  reaches beta on stable, open a follow-up ADR for the
+  `async-trait` → native dyn-AFIT migration.
+
+[rfc-133119]: https://github.com/rust-lang/rust/issues/133119

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -21,7 +21,7 @@ changes land as a new ADR that `supersedes` it.
 | [0011](./0011-serde-json-value-interchange.md) | `serde_json::Value` as the workflow data interchange type | accepted | 2026-04-19 |
 | [0012](./0012-checkpoint-recovery.md) | Checkpoint recovery model (policy-driven, best-effort writes, idempotency over exactly-once) | accepted | 2026-04-19 |
 | [0013](./0013-compile-time-modes.md) | Compile-time deployment modes (`mode-desktop` / `mode-self-hosted` / `mode-cloud` + `build.rs` gate) | accepted | 2026-04-19 |
-| [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | accepted | 2026-04-19 |
+| [0014](./0014-dynosaur-macro.md) | `dynosaur` for `dyn`-compatible async traits (replaces `#[async_trait]`) | superseded | 2026-04-19 |
 | [0015](./0015-execution-lease-lifecycle.md) | Execution lease lifecycle (renumbered from 0008; promoted on #325 implementation) | accepted | 2026-04-19 |
 | [0016](./0016-engine-cancel-registry.md) | Engine cancel registry — cooperative-cancel contract for ADR-0008 A3 | accepted | 2026-04-19 |
 | [0017](./0017-control-queue-reclaim-policy.md) | Control-queue reclaim policy | accepted | 2026-04-19 |
@@ -31,13 +31,14 @@ changes land as a new ADR that `supersedes` it.
 | [0021](./0021-crate-publication-policy.md) | Crate publication policy (`publish = true` requires ≥ 3 external consumers OR dedicated ADR) | proposed | 2026-04-19 |
 | [0022](./0022-webhook-signature-policy.md) | Webhook signature policy (`SignaturePolicy::Required` default at `WebhookAction` trait level) | accepted | 2026-04-19 |
 | [0023](./0023-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source | accepted | 2026-04-19 |
+| [0024](./0024-defer-dynosaur-migration.md) | Defer `dynosaur` migration — keep `#[async_trait]` for `dyn`-consumed traits (supersedes 0014) | proposed | 2026-04-20 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0023**). Do not reuse.
+2. Pick the next free number (currently **0024**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -38,7 +38,7 @@ changes land as a new ADR that `supersedes` it.
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0024**). Do not reuse.
+2. Pick the next free number (currently **0025**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with

--- a/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md
+++ b/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md
@@ -649,6 +649,17 @@ that still need it for Phase 3.
 
 ### Phase 3 — `dynosaur` migration for cross-crate `dyn` traits (5 PRs, ADR-tracked)
 
+> **Cancelled (2026-04-20) — superseded by
+> [ADR-0024](../../adr/0024-defer-dynosaur-migration.md).** The 14
+> `dyn`-consumed traits stay on `#[async_trait]`. Rationale: `dynosaur`
+> adoption is narrow (v0.3.0, 13 reverse-deps, aging), the dual
+> generic+dyn value-prop serves zero current call sites (all 14 are
+> 100 % dyn-consumed), and `async_fn_in_dyn_trait` will eventually make
+> the whole macro class obsolete (tracking
+> [rust-lang/rust#133119](https://github.com/rust-lang/rust/issues/133119)).
+> The section below is retained for historical context and for the
+> re-evaluation trigger defined in ADR-0024 §5.
+
 **Scope.** The 14 traits that *are* consumed as `dyn` somewhere. One
 coordinated PR per family; the ADR gate in Hazards below applies.
 


### PR DESCRIPTION
## Summary

Supersede [ADR-0014](https://github.com/vanyastaff/nebula/blob/main/docs/adr/0014-dynosaur-macro.md) and keep `#[async_trait]` on the 14 remaining `dyn`-consumed async traits. Cancel Phase 3 of the [1.75-1.95 adoption plan](https://github.com/vanyastaff/nebula/blob/main/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md).

**Evidence driving the reversal:**

- **Phase 2 removed the generic-only traits** (PRs #507 / #508 / #509) — the 14 remaining are 100% `Arc<dyn>` call sites, so `dynosaur`'s dual generic+dyn value prop has nothing to serve.
- **Ecosystem survey** — no major Rust project uses `dynosaur`:
  - `databend` (analogous query engine): `async-trait` everywhere
  - `apache/opendal` (closest to `storage/repos/*`): hand-rolled `Foo` / `FooDyn` pair, no `dynosaur` dep
  - `tokio-rs/axum`: native AFIT + manual `Pin<Box<dyn Future>>` at dyn sites
  - `launchbadge/sqlx`: `BoxFuture` / `BoxStream` signatures + `async-trait`
- **`dynosaur` adoption stayed narrow** — v0.3.0, 277 days since release (aging), 13 reverse-deps on crates.io.
- **`async_fn_in_dyn_trait` is still experimental** ([rust-lang/rust#133119](https://github.com/rust-lang/rust/issues/133119)) and marked incomplete on nightly 1.95 per independent verification in [assapir/golem#8](https://github.com/assapir/golem/issues/8).
- **`async-trait` upstream is stable** — 7 open issues across ~5 years, all exotic generic/lifetime edge cases that don't match Nebula's trait shapes.

**Re-evaluation triggers** (ADR §5):
1. `async_fn_in_dyn_trait` stabilizes on stable Rust → migration becomes a mechanical attribute-delete.
2. A real hot-path generic consumer appears for one of the 14 traits → reach for the opendal hand-rolled pair pattern for that trait only, not workspace-wide `dynosaur`.
3. `async-trait` upstream goes unmaintained for ≥ 12 months → revisit.

## Changes

- **New:** `docs/adr/0024-defer-dynosaur-migration.md`
- **Superseded (frontmatter only, body immutable):** `docs/adr/0014-dynosaur-macro.md` — `status: superseded`, `superseded_by: [0024]`
- **Index:** `docs/adr/README.md` — add row 0024, mark 0014 superseded, bump "next free number" to 0025
- **Style:** `docs/STYLE.md §1` — rescind "never introduce `#[async_trait]`", replace with "match the seam" rule
- **Spec:** `docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md` §Phase 3 — add cancelled notice pointing at ADR-0024; body retained for historical context

## Test plan

- [x] `lefthook run pre-push` — all 3404 tests + clippy + fmt + doctests green (docs-only change)
- [x] ADR-0014 frontmatter has only frontmatter edits (body immutable per `docs/adr/README.md`) — verified via diff
- [x] ADR index table updated
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)