### PR TITLE
refactor: let-chains sweep (Phase 5, Rust 1.88)

### DIFF
--- a/crates/expression/src/lexer.rs
+++ b/crates/expression/src/lexer.rs
@@ -360,13 +360,11 @@ impl<'a> Lexer<'a> {
                 self.advance();
             } else if ch == '.' && !is_float {
                 // Check if next char is a digit
-                if let Some(next) = self.peek() {
-                    if next.is_ascii_digit() {
-                        is_float = true;
-                        self.advance(); // consume '.'
-                    } else {
-                        break;
-                    }
+                if let Some(next) = self.peek()
+                    && next.is_ascii_digit()
+                {
+                    is_float = true;
+                    self.advance(); // consume '.'
                 } else {
                     break;
                 }

--- a/crates/sdk/macros-support/src/validation_codegen.rs
+++ b/crates/sdk/macros-support/src/validation_codegen.rs
@@ -74,18 +74,18 @@ pub fn generate_len_check(
     if is_option {
         if is_min {
             quote! {
-                if let Some(value) = input.#field_name.as_ref() {
-                    if value.len() < #bound {
-                        errors.add(#error);
-                    }
+                if let Some(value) = input.#field_name.as_ref()
+                    && value.len() < #bound
+                {
+                    errors.add(#error);
                 }
             }
         } else {
             quote! {
-                if let Some(value) = input.#field_name.as_ref() {
-                    if value.len() > #bound {
-                        errors.add(#error);
-                    }
+                if let Some(value) = input.#field_name.as_ref()
+                    && value.len() > #bound
+                {
+                    errors.add(#error);
                 }
             }
         }
@@ -135,18 +135,18 @@ pub fn generate_cmp_check(
     if is_option {
         if is_min {
             quote! {
-                if let Some(value) = input.#field_name.as_ref() {
-                    if value < &#bound {
-                        errors.add(#error);
-                    }
+                if let Some(value) = input.#field_name.as_ref()
+                    && value < &#bound
+                {
+                    errors.add(#error);
                 }
             }
         } else {
             quote! {
-                if let Some(value) = input.#field_name.as_ref() {
-                    if value > &#bound {
-                        errors.add(#error);
-                    }
+                if let Some(value) = input.#field_name.as_ref()
+                    && value > &#bound
+                {
+                    errors.add(#error);
                 }
             }
         }
@@ -186,10 +186,10 @@ pub fn generate_str_validator_check(
 ) -> TokenStream2 {
     if is_option {
         quote! {
-            if let Some(ref value) = input.#field_name {
-                if let Err(e) = ::nebula_validator::foundation::Validate::validate(&#validator_expr, value.as_str()) {
-                    errors.add(e.with_field(#field_key));
-                }
+            if let Some(ref value) = input.#field_name
+                && let Err(e) = ::nebula_validator::foundation::Validate::validate(&#validator_expr, value.as_str())
+            {
+                errors.add(e.with_field(#field_key));
             }
         }
     } else {

--- a/crates/system/src/disk.rs
+++ b/crates/system/src/disk.rs
@@ -291,16 +291,14 @@ pub fn find_by_device(device: &str) -> Option<DiskInfo> {
 
 /// Get recommended I/O block size for a disk
 pub fn optimal_block_size(mount_point: Option<&str>) -> usize {
-    if let Some(mp) = mount_point {
-        if let Some(disk) = get_disk(mp) {
-            match disk.disk_type {
-                DiskType::SSD => 4096,        // 4KB for SSDs
-                DiskType::HDD => 65536,       // 64KB for HDDs
-                DiskType::Network => 131_072, // 128KB for network
-                _ => 8192,                    // 8KB default
-            }
-        } else {
-            8192
+    if let Some(mp) = mount_point
+        && let Some(disk) = get_disk(mp)
+    {
+        match disk.disk_type {
+            DiskType::SSD => 4096,        // 4KB for SSDs
+            DiskType::HDD => 65536,       // 64KB for HDDs
+            DiskType::Network => 131_072, // 128KB for network
+            _ => 8192,                    // 8KB default
         }
     } else {
         8192


### PR DESCRIPTION
## Summary

Phase 5 of [`docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md`](../blob/main/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md) — let-chains chip. Rust 1.88 stabilized `if let Some(x) = a && x.valid() { ... }`; this PR converts **7 sites** across 3 crates where the rubric applies.

**Rubric (from the spec):** convert only when (a) flattening removes ≥ one brace level AND body ≤ 2 statements, OR (b) it eliminates an `else { return … }` mirror. Leave two-level forms where the inner body is complex.

**Conversions (3 commits, one per crate):**

- `crates/system/src/disk.rs:294` — 3-level `if let Some(mp) { if let Some(disk) { match } else { 8192 } } else { 8192 }` → single let-chain with one `else { 8192 }`. Eliminates symmetric else mirror.
- `crates/expression/src/lexer.rs:363` — 3-level `if let Some(next) { if next.is_ascii_digit() { … } else { break } } else { break }` → single let-chain with one `else { break }`.
- `crates/sdk/macros-support/src/validation_codegen.rs` (5 sites at 77, 85, 138, 146, 189) — generated validation code `quote! { if let Some(value) = … { if <cond> { errors.add(…) } } }` → let-chains.

**21 candidates inspected, 14 skipped** with rubric rationale (inner arm >2 statements, outer binding needed after inner check, side-effects that break flattening). See the agent's report in the PR description history for the full skipped list.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 3404/3404 passed, 13 skipped
- [x] `cargo test --workspace --doc` — pass
- [x] `lefthook run pre-push` — all green (shear, docs, check-all-features, check-no-default, doctests, nextest)
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to enhance maintainability with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->