### PR TITLE
refactor: use Atomic::update/try_update where CAS shape matches (Phase 5, Rust 1.95)

### DIFF
--- a/crates/resilience/src/bulkhead.rs
+++ b/crates/resilience/src/bulkhead.rs
@@ -162,16 +162,19 @@ impl Bulkhead {
             return Ok(BulkheadPermit { _permit: permit });
         }
 
-        // Try to enqueue
-        let enqueued =
-            self.waiting_count
-                .fetch_update(Ordering::AcqRel, Ordering::Acquire, |cur| {
-                    if cur < self.config.queue_size {
-                        Some(cur + 1)
-                    } else {
-                        None
-                    }
-                });
+        // Try to enqueue via `try_update` (Rust 1.95).
+        // Signature is `try_update(set_order, fetch_order, f)` — maps from
+        // `fetch_update(success=AcqRel, failure=Acquire, f)` as
+        // `set_order := success = AcqRel`, `fetch_order := failure = Acquire`.
+        let enqueued = self
+            .waiting_count
+            .try_update(Ordering::AcqRel, Ordering::Acquire, |cur| {
+                if cur < self.config.queue_size {
+                    Some(cur + 1)
+                } else {
+                    None
+                }
+            });
 
         if enqueued.is_err() {
             // Queue full — reject

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -617,17 +617,11 @@ impl Resource for SlowCreatePoolResource {
         _ctx: &dyn Ctx,
     ) -> Result<Arc<AtomicU64>, TestError> {
         let now = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
-        // Update peak with a compare-exchange loop.
-        let mut observed = self.peak.load(Ordering::SeqCst);
-        while now > observed {
-            match self
-                .peak
-                .compare_exchange(observed, now, Ordering::SeqCst, Ordering::SeqCst)
-            {
-                Ok(_) => break,
-                Err(cur) => observed = cur,
-            }
-        }
+        // Update peak = max(peak, now) via `AtomicU64::update` (Rust 1.95).
+        // Load and store orderings both SeqCst — match the prior CAS loop.
+        let _ = self
+            .peak
+            .update(Ordering::SeqCst, Ordering::SeqCst, |cur| cur.max(now));
         tokio::time::sleep(std::time::Duration::from_millis(80)).await;
         self.in_flight.fetch_sub(1, Ordering::SeqCst);
         Ok(Arc::new(AtomicU64::new(0)))

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -215,7 +215,7 @@ impl Histogram {
     /// Record an observation.
     ///
     /// Non-finite values (`NaN`, `±∞`) are silently dropped. NaN would
-    /// otherwise permanently poison `sum_bits` via the CAS loop
+    /// otherwise permanently poison `sum_bits` via the atomic update
     /// (`x + NaN = NaN`), breaking every subsequent `sum()` / percentile.
     pub fn observe(&self, value: f64) {
         if !value.is_finite() {
@@ -235,20 +235,13 @@ impl Histogram {
         self.counts[idx].fetch_add(1, Ordering::Relaxed);
         self.total_count.fetch_add(1, Ordering::Relaxed);
 
-        // Atomically add to sum using CAS loop on f64 bits.
-        loop {
-            let old_bits = self.sum_bits.load(Ordering::Relaxed);
-            let old_sum = f64::from_bits(old_bits);
-            let new_sum = old_sum + value;
-            let new_bits = new_sum.to_bits();
-            if self
-                .sum_bits
-                .compare_exchange_weak(old_bits, new_bits, Ordering::Relaxed, Ordering::Relaxed)
-                .is_ok()
-            {
-                break;
-            }
-        }
+        // Atomically add to sum using `AtomicU64::update` on f64 bits (Rust 1.95).
+        // Load and store orderings both Relaxed — match the prior CAS loop.
+        let _ = self
+            .sum_bits
+            .update(Ordering::Relaxed, Ordering::Relaxed, |old_bits| {
+                (f64::from_bits(old_bits) + value).to_bits()
+            });
         self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
     }
 


### PR DESCRIPTION
## Summary

Phase 5 of [`docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md`](../blob/main/docs/superpowers/specs/2026-04-19-rust-feature-adoption-plan.md) — Atomic `update` / `try_update` chip. Rust 1.95 stabilized `AtomicBool::update` / `AtomicPtr::update` / atomic integer `update` + `try_update`. This PR converts **3 sites** across 3 crates where the CAS shape is a clean fit.

**Conversions (3 commits):**

- `crates/telemetry/src/metrics.rs:220-243` — `Histogram::observe` f64-bit sum CAS loop → `self.sum_bits.update(Relaxed, Relaxed, |b| (f64::from_bits(b) + value).to_bits())`. Unconditional closure = `update` fit.
- `crates/resilience/src/bulkhead.rs:167-177` — bounded-queue enqueue `fetch_update(AcqRel, Acquire, |cur| if cur < cap { Some(cur+1) } else { None })` → `try_update(AcqRel, Acquire, ...)`. Conditional = `try_update` fit; the `.is_err()` → queue-full branch is preserved by `try_update`'s `Err(current_value)` on closure-returns-`None`.
- `crates/resource/tests/basic_integration.rs:619-624` — peak-update CAS loop → `self.peak.update(SeqCst, SeqCst, |cur| cur.max(now))`. Drops the outer `while` guard because `update` loops internally.

**2 sites left as-is** (non-fits): `crates/action/src/poll.rs:1299` and `crates/resource/src/manager.rs:1369` — both one-shot test-and-set idempotency guards (`compare_exchange(false, true).is_err()`). These aren't CAS loops; forcing them into `try_update` would reduce readability.

**Ordering verification:** no memory ordering was weakened. Each original `(success, failure)` pair maps to `update(set_order, fetch_order, f)` per the actual std signature at `library/core/src/sync/atomic.rs:3445`.

**Spec erratum (follow-up worth noting):** the spec said Atomic `update` takes `(load_ordering, store_ordering)` — the real signature is `(set_order, fetch_order)` i.e. `(store, load)`. Mapping `set_order := success_ordering`, `fetch_order := failure_ordering` holds. Conversions honour that; the spec could use a clarification in a later pass.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (56.77s)
- [x] `cargo nextest run -p nebula-telemetry -p nebula-resilience` — 203/203 passed
- [x] `cargo nextest run -p nebula-resource` — 220/220 (includes the converted peak-CAS test)
- [x] `cargo nextest run --workspace` — 3404/3404 passed
- [x] `cargo test --workspace --doc` — pass
- [x] `lefthook run pre-push` — all green
- [ ] CI green on required jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)