### PR TITLE
chore(workspace): adopt strict clippy/fmt gate on Rust 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,134 @@ nebula-error = { path = "crates/error" }
 nebula-error-macros = { path = "crates/error/macros" }
 
 
+# ─── Workspace-wide lint policy ──────────────────────────────────────────────
+#
+# Every crate opts in with `[lints] workspace = true` in its own Cargo.toml.
+# Groups use `priority = -1` so specific lint overrides below them win.
+#
+# The allow-list exists for two reasons:
+#   (1) pedantic/nursery lints that are stylistic noise in a heavily generic
+#       codebase (e.g. `module_name_repetitions`, `similar_names`);
+#   (2) lints that conflict with load-bearing patterns we use on purpose
+#       (e.g. `cast_*` around byte-level encoding, `option_if_let_else`
+#       where `match` reads better than `.map_or`).
+#
+# If you find yourself wanting to `#[allow(...)]` the same pedantic lint in
+# three or more files, consider promoting the allow here instead.
+[workspace.lints.rust]
+unsafe_code = "warn"           # sandbox / plugin-sdk opt out via crate-level `#![allow(unsafe_code)]`
+unused_lifetimes = "warn"
+unused_qualifications = "warn"
+trivial_numeric_casts = "warn"
+redundant_lifetimes = "warn"
+# Deliberately NOT enabled workspace-wide (revisit once the core stabilises):
+# - `missing_docs` — too noisy on internal modules; will land crate-by-crate.
+# - `missing_debug_implementations` — same.
+# - `unreachable_pub` — conflicts with re-export chains in the sdk façade.
+# - `let_underscore_drop` — `let _ = tokio::spawn(...)` / `let _ = tx.send(_)`
+#   is the standard idiom for fire-and-forget; forcing `drop(x)` hurts clarity.
+#
+# `cfg(loom)` is set by nebula-resilience's loom harness; keep the check-cfg
+# entry at workspace level so every crate can switch `workspace = true` on
+# without re-declaring it locally.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+
+[workspace.lints.clippy]
+# Opt into the big batteries. `priority = -1` lets individual `allow = ...`
+# entries below this section override the group default.
+pedantic = { level = "warn", priority = -1 }
+nursery = { level = "warn", priority = -1 }
+cargo = { level = "warn", priority = -1 }
+
+# ── pedantic: stylistic noise on a generic workspace ───────────────────────
+module_name_repetitions = "allow"   # `credential::CredentialManager` reads fine
+similar_names = "allow"             # `req` / `res`, `tx` / `rx` etc.
+too_many_lines = "allow"            # threshold lives in clippy.toml
+must_use_candidate = "allow"        # builder / fluent APIs are ubiquitous
+return_self_not_must_use = "allow"
+missing_errors_doc = "allow"        # error docs live on the error enum itself
+missing_panics_doc = "allow"
+needless_pass_by_value = "allow"    # conflicts with ergonomic builder API
+struct_excessive_bools = "allow"    # threshold lives in clippy.toml
+fn_params_excessive_bools = "allow"
+
+# ── casts that are load-bearing at IO / codec / hashing boundaries ─────────
+cast_precision_loss = "allow"
+cast_possible_truncation = "allow"
+cast_possible_wrap = "allow"
+cast_sign_loss = "allow"
+cast_lossless = "allow"
+
+# ── nursery: known-noisy experimental lints ────────────────────────────────
+option_if_let_else = "allow"            # `match` often reads cleaner than .map_or
+missing_const_for_fn = "allow"          # churns with every generic bound change
+use_self = "allow"                      # fires inside macro expansions
+redundant_pub_crate = "allow"           # conflicts with the sdk re-export façade
+significant_drop_tightening = "allow"   # too many false positives
+significant_drop_in_scrutinee = "allow"
+branches_sharing_code = "allow"         # often makes branches less readable
+cognitive_complexity = "allow"          # threshold lives in clippy.toml
+future_not_send = "allow"               # `Send` bound on futures is runtime's call
+ignore_without_reason = "allow"         # gated by clippy-cargo, too strict for tests
+
+# ── pedantic stylistic noise that is not worth churning code over ─────────
+items_after_statements = "allow"             # late-initialised helpers inside fn bodies
+manual_let_else = "allow"                    # not every match → let-else is a win
+match_same_arms = "allow"                    # different comment / semantics per arm
+default_trait_access = "allow"               # `T::default()` ≡ `Default::default()`
+ref_option = "allow"                         # `&Option<T>` is sometimes required by API shape
+too_long_first_doc_paragraph = "allow"
+missing_fields_in_debug = "allow"            # manual Debug impls drop cred / secret fields on purpose
+match_wildcard_for_single_variants = "allow"
+needless_continue = "allow"
+format_push_string = "allow"                 # `push_str(&format!(...))` is idiomatic enough
+unused_async = "allow"                       # bench helpers (criterion.to_async) + public API forward-compat
+unused_self = "allow"                        # pedantic noise on trait impls where `self` is required by signature
+unnecessary_wraps = "allow"                  # API-consistency `Result` on builtin tables, `fn main() -> Result<…>`
+
+# ── long-tail pedantic / nursery noise (<10 hits each, not worth churning) ──
+# These fire a handful of times across the workspace, each one is a matter of
+# taste or a micro-optimisation that would mean an API break. Revisit when a
+# refactor naturally touches the site.
+wildcard_imports = "allow"                    # kept noisy but shelved: prelude / re-export patterns
+or_fun_call = "allow"                         # `unwrap_or(T::default())` is clearer than unwrap_or_else
+trivially_copy_pass_by_ref = "allow"
+needless_pass_by_ref_mut = "allow"
+needless_collect = "allow"
+map_unwrap_or = "allow"
+excessive_nesting = "allow"                   # threshold lives in clippy.toml
+useless_let_if_seq = "allow"
+assigning_clones = "allow"                    # micro-perf on `a = b.clone()`
+unused_peekable = "allow"
+type_repetition_in_bounds = "allow"
+trivial_regex = "allow"
+struct_field_names = "allow"                  # threshold lives in clippy.toml
+literal_string_with_formatting_args = "allow"
+into_iter_without_iter = "allow"
+inline_always = "allow"                       # `#[inline(always)]` on cold happy paths is intentional
+implicit_hasher = "allow"
+doc_link_with_quotes = "allow"
+iter_on_single_items = "allow"
+from_iter_instead_of_collect = "allow"
+enum_glob_use = "allow"
+
+# ── cargo: expected noise in a multi-crate workspace ───────────────────────
+multiple_crate_versions = "allow" # transitive dep version skew is unavoidable
+cargo_common_metadata = "allow"   # re-enable per-crate once public metadata stabilises
+
+# ── doc_markdown: too many domain identifiers to chase via doc-valid-idents ─
+doc_markdown = "allow"
+
+# ── macro-expansion false positives (not our code) ─────────────────────────
+# `assert_eq!`/`proptest!` expand to `==` comparisons on floats — clippy
+# attributes the lint to the macro call site, which is useless noise.
+float_cmp = "allow"
+# Bindings like `_fixture` from rstest / proptest are internal to the macro.
+used_underscore_binding = "allow"
+
+# ── correctness / soundness escalated from default ─────────────────────────
+mem_forget = "deny"
+
 [profile.dev]
 # Standard dev mode
 opt-level = 0

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -71,3 +71,6 @@ tokio = { workspace = true, features = ["rt"] }
 [features]
 default = ["tui"]
 tui = ["dep:ratatui", "dep:crossterm"]
+
+[lints]
+workspace = true

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -20,7 +20,7 @@ fn parse_concurrency_at_least_one(s: &str) -> Result<usize, String> {
 /// Run, validate, and manage workflows from the terminal.
 #[derive(Parser)]
 #[command(name = "nebula", version, about, propagate_version = true)]
-pub struct Cli {
+pub(crate) struct Cli {
     /// Enable verbose logging (debug level).
     #[arg(short, long, global = true)]
     pub verbose: bool,
@@ -34,7 +34,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
-pub enum Command {
+pub(crate) enum Command {
     /// Execute a workflow from a YAML or JSON file.
     Run(RunArgs),
 
@@ -78,7 +78,7 @@ pub enum Command {
 // ── Config ───────────────────────────────────────────────────────────────
 
 #[derive(Subcommand)]
-pub enum ConfigCommand {
+pub(crate) enum ConfigCommand {
     /// Show the resolved configuration.
     Show,
     /// Generate a default config file.
@@ -86,7 +86,7 @@ pub enum ConfigCommand {
 }
 
 #[derive(Parser)]
-pub struct ConfigInitArgs {
+pub(crate) struct ConfigInitArgs {
     /// Create global config at ~/.nebula/config.toml instead of ./nebula.toml.
     #[arg(long)]
     pub global: bool,
@@ -95,7 +95,7 @@ pub struct ConfigInitArgs {
 // ── Actions ──────────────────────────────────────────────────────────────
 
 #[derive(Subcommand)]
-pub enum ActionsCommand {
+pub(crate) enum ActionsCommand {
     /// List all registered actions.
     List(ActionsListArgs),
     /// Show detailed info about an action.
@@ -105,7 +105,7 @@ pub enum ActionsCommand {
 }
 
 #[derive(Parser)]
-pub struct ActionsTestArgs {
+pub(crate) struct ActionsTestArgs {
     /// Action key to test (e.g. "echo", "http.get").
     pub key: String,
 
@@ -119,14 +119,14 @@ pub struct ActionsTestArgs {
 }
 
 #[derive(Parser)]
-pub struct ActionsListArgs {
+pub(crate) struct ActionsListArgs {
     /// Output format (auto-detects: text for terminal, json for pipes).
     #[arg(long)]
     pub format: Option<OutputFormat>,
 }
 
 #[derive(Parser)]
-pub struct ActionsInfoArgs {
+pub(crate) struct ActionsInfoArgs {
     /// Action key (e.g. "echo", "delay").
     pub key: String,
 
@@ -138,7 +138,7 @@ pub struct ActionsInfoArgs {
 // ── Plugin ────────────────────────────────────────────────────────────────
 
 #[derive(Subcommand)]
-pub enum PluginCommand {
+pub(crate) enum PluginCommand {
     /// List loaded plugins (built-in + external from plugins/ dir).
     List,
     /// Create a new plugin project.
@@ -147,7 +147,7 @@ pub enum PluginCommand {
 
 /// Arguments for the `plugin new` command.
 #[derive(Parser)]
-pub struct PluginNewArgs {
+pub(crate) struct PluginNewArgs {
     /// Plugin name (e.g. "telegram", "slack", "csv-parser").
     pub name: String,
 
@@ -163,7 +163,7 @@ pub struct PluginNewArgs {
 // ── Dev ──────────────────────────────────────────────────────────────────
 
 #[derive(Subcommand)]
-pub enum DevCommand {
+pub(crate) enum DevCommand {
     /// Initialize a new Nebula project in the current directory.
     Init(DevInitArgs),
     /// Scaffold a new action crate.
@@ -174,14 +174,14 @@ pub enum DevCommand {
 }
 
 #[derive(Subcommand)]
-pub enum DevActionCommand {
+pub(crate) enum DevActionCommand {
     /// Create a new action project.
     New(DevActionNewArgs),
 }
 
 /// Arguments for the `dev init` command.
 #[derive(Parser)]
-pub struct DevInitArgs {
+pub(crate) struct DevInitArgs {
     /// Project name (defaults to directory name).
     #[arg(short, long)]
     pub name: Option<String>,
@@ -193,7 +193,7 @@ pub struct DevInitArgs {
 
 /// Arguments for the `dev action new` command.
 #[derive(Parser)]
-pub struct DevActionNewArgs {
+pub(crate) struct DevActionNewArgs {
     /// Action name (e.g. "http-request", "slack-send").
     pub name: String,
 
@@ -205,7 +205,7 @@ pub struct DevActionNewArgs {
 // ── Completion ───────────────────────────────────────────────────────────
 
 #[derive(Parser)]
-pub struct CompletionArgs {
+pub(crate) struct CompletionArgs {
     /// Shell to generate completions for.
     pub shell: clap_complete::Shell,
 }
@@ -214,7 +214,7 @@ pub struct CompletionArgs {
 
 /// Arguments for the `run` command.
 #[derive(Parser)]
-pub struct RunArgs {
+pub(crate) struct RunArgs {
     /// Path to the workflow file (YAML or JSON).
     pub workflow: PathBuf,
 
@@ -259,7 +259,7 @@ pub struct RunArgs {
 
 /// Arguments for the `watch` command.
 #[derive(Parser)]
-pub struct WatchArgs {
+pub(crate) struct WatchArgs {
     /// Path to the workflow file (YAML or JSON).
     pub workflow: PathBuf,
 
@@ -278,7 +278,7 @@ pub struct WatchArgs {
 
 /// Arguments for the `replay` command.
 #[derive(Parser)]
-pub struct ReplayArgs {
+pub(crate) struct ReplayArgs {
     /// Path to the workflow file (YAML or JSON).
     pub workflow: PathBuf,
 
@@ -301,7 +301,7 @@ pub struct ReplayArgs {
 
 /// Arguments for the `validate` command.
 #[derive(Parser)]
-pub struct ValidateArgs {
+pub(crate) struct ValidateArgs {
     /// Path to the workflow file (YAML or JSON).
     pub workflow: PathBuf,
 
@@ -312,7 +312,7 @@ pub struct ValidateArgs {
 
 /// Supported output formats.
 #[derive(Clone, Debug, clap::ValueEnum)]
-pub enum OutputFormat {
+pub(crate) enum OutputFormat {
     /// JSON output (machine-readable).
     Json,
     /// Human-readable table/text output.
@@ -321,7 +321,7 @@ pub enum OutputFormat {
 
 /// Resolve output format: explicit flag > TTY detection.
 /// Terminal → text, pipe → json.
-pub fn resolve_format(explicit: Option<OutputFormat>) -> OutputFormat {
+pub(crate) fn resolve_format(explicit: Option<OutputFormat>) -> OutputFormat {
     explicit.unwrap_or_else(|| {
         if std::io::stdout().is_terminal() {
             OutputFormat::Text

--- a/apps/cli/src/commands/actions.rs
+++ b/apps/cli/src/commands/actions.rs
@@ -23,7 +23,7 @@ fn build_registry() -> Arc<ActionRegistry> {
 }
 
 /// Execute the `actions list` command.
-pub fn list(args: ActionsListArgs) {
+pub(crate) fn list(args: ActionsListArgs) {
     let registry = build_registry();
     let mut keys = registry.keys();
     keys.sort();
@@ -66,12 +66,12 @@ pub fn list(args: ActionsListArgs) {
 }
 
 /// Execute the `actions info` command.
-pub fn info(args: ActionsInfoArgs) {
+pub(crate) fn info(args: ActionsInfoArgs) {
     let registry = build_registry();
     let format = resolve_format(args.format);
 
-    match registry.get_by_str(&args.key) {
-        Some((meta, _)) => match format {
+    if let Some((meta, _)) = registry.get_by_str(&args.key) {
+        match format {
             OutputFormat::Json => {
                 let json = serde_json::json!({
                     "key": meta.base.key.as_str(),
@@ -97,18 +97,17 @@ pub fn info(args: ActionsInfoArgs) {
                     }
                 );
             },
-        },
-        None => {
-            eprintln!("error: action '{}' not found", args.key);
-            eprintln!();
-            eprintln!("Available actions:");
-            let mut keys = registry.keys();
-            keys.sort();
-            for key in &keys {
-                eprintln!("  {key}");
-            }
-            std::process::exit(1);
-        },
+        }
+    } else {
+        eprintln!("error: action '{}' not found", args.key);
+        eprintln!();
+        eprintln!("Available actions:");
+        let mut keys = registry.keys();
+        keys.sort();
+        for key in &keys {
+            eprintln!("  {key}");
+        }
+        std::process::exit(1);
     }
 }
 
@@ -119,20 +118,19 @@ pub fn info(args: ActionsInfoArgs) {
 /// - `Stateless` → one execute call
 /// - `Stateful` → iterative loop (init_state → execute until `Break` or cap)
 /// - other variants → not yet supported
-pub async fn test(args: ActionsTestArgs) {
+pub(crate) async fn test(args: ActionsTestArgs) {
     let registry = build_registry();
     let format = resolve_format(args.format);
 
-    let (meta, handler) = match registry.get_by_str(&args.key) {
-        Some(entry) => entry,
-        None => {
-            eprintln!("error: action '{}' not found", args.key);
-            let mut keys = registry.keys();
-            keys.sort();
-            let names: Vec<String> = keys.iter().map(|k| k.as_str().to_owned()).collect();
-            eprintln!("Available: {}", names.join(", "));
-            std::process::exit(1);
-        },
+    let (meta, handler) = if let Some(entry) = registry.get_by_str(&args.key) {
+        entry
+    } else {
+        eprintln!("error: action '{}' not found", args.key);
+        let mut keys = registry.keys();
+        keys.sort();
+        let names: Vec<String> = keys.iter().map(|k| k.as_str().to_owned()).collect();
+        eprintln!("Available: {}", names.join(", "));
+        std::process::exit(1);
     };
 
     let input: serde_json::Value = match serde_json::from_str(&args.input) {
@@ -220,9 +218,8 @@ async fn run_stateful(
 
         match &result {
             ActionResult::Continue { progress, .. } => {
-                let pct = progress
-                    .map(|p| format!("{:>5.1}%", p * 100.0))
-                    .unwrap_or_else(|| "  ?  ".to_owned());
+                let pct =
+                    progress.map_or_else(|| "  ?  ".to_owned(), |p| format!("{:>5.1}%", p * 100.0));
                 eprintln!(
                     "  iter {iterations:>3}: Continue ({pct})  partial={}",
                     truncate(&compact_json(&last_output), 160)
@@ -371,7 +368,7 @@ fn truncate(s: &str, max: usize) -> String {
     out
 }
 
-fn print_report(report: &TestReport, elapsed: std::time::Duration, format: OutputFormat) {
+fn print_report(report: &TestReport, elapsed: Duration, format: OutputFormat) {
     match format {
         OutputFormat::Json => {
             let json = serde_json::json!({

--- a/apps/cli/src/commands/completion.rs
+++ b/apps/cli/src/commands/completion.rs
@@ -4,7 +4,7 @@ use clap_complete::generate;
 use crate::cli::{Cli, CompletionArgs};
 
 /// Execute the `completion` command.
-pub fn execute(args: CompletionArgs) {
+pub(crate) fn execute(args: CompletionArgs) {
     let mut cmd = Cli::command();
     let name = cmd.get_name().to_owned();
     generate(args.shell, &mut cmd, name, &mut std::io::stdout());

--- a/apps/cli/src/commands/config.rs
+++ b/apps/cli/src/commands/config.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, bail};
 use crate::config::{self, CliConfig};
 
 /// Execute the `config show` command.
-pub async fn show() -> anyhow::Result<()> {
+pub(crate) async fn show() -> anyhow::Result<()> {
     let config = CliConfig::load().await?;
     let toml = toml::to_string_pretty(&config).expect("config serialization");
     println!("{toml}");
@@ -19,7 +19,7 @@ pub async fn show() -> anyhow::Result<()> {
 }
 
 /// Execute the `config init` command.
-pub fn init(global: bool) -> anyhow::Result<()> {
+pub(crate) fn init(global: bool) -> anyhow::Result<()> {
     let path = if global {
         let dir = config::global_config_dir().context("could not determine home directory")?;
         if !dir.exists() {

--- a/apps/cli/src/commands/dev/action.rs
+++ b/apps/cli/src/commands/dev/action.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, bail};
 use crate::cli::DevActionNewArgs;
 
 /// Execute the `dev action new` command.
-pub fn execute(args: DevActionNewArgs) -> anyhow::Result<()> {
+pub(crate) fn execute(args: DevActionNewArgs) -> anyhow::Result<()> {
     let name = &args.name;
     let dir = args.path.unwrap_or_else(|| name.into());
 

--- a/apps/cli/src/commands/dev/init.rs
+++ b/apps/cli/src/commands/dev/init.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, bail};
 use crate::cli::DevInitArgs;
 
 /// Execute the `dev init` command.
-pub fn execute(args: DevInitArgs) -> anyhow::Result<()> {
+pub(crate) fn execute(args: DevInitArgs) -> anyhow::Result<()> {
     let dir = &args.path;
 
     let name = args.name.unwrap_or_else(|| {

--- a/apps/cli/src/commands/dev/mod.rs
+++ b/apps/cli/src/commands/dev/mod.rs
@@ -1,2 +1,2 @@
-pub mod action;
-pub mod init;
+pub(crate) mod action;
+pub(crate) mod init;

--- a/apps/cli/src/commands/mod.rs
+++ b/apps/cli/src/commands/mod.rs
@@ -1,20 +1,20 @@
-pub mod actions;
-pub mod completion;
-pub mod config;
-pub mod dev;
-pub mod plugin;
-pub mod plugin_new;
-pub mod replay;
-pub mod run;
-pub mod validate;
-pub mod watch;
+pub(crate) mod actions;
+pub(crate) mod completion;
+pub(crate) mod config;
+pub(crate) mod dev;
+pub(crate) mod plugin;
+pub(crate) mod plugin_new;
+pub(crate) mod replay;
+pub(crate) mod run;
+pub(crate) mod validate;
+pub(crate) mod watch;
 
 /// Shared exit code constants.
-pub mod exit_codes {
+pub(crate) mod exit_codes {
     /// Workflow executed but finished with non-success status.
-    pub const WORKFLOW_FAILED: u8 = 2;
+    pub(crate) const WORKFLOW_FAILED: u8 = 2;
     /// Workflow validation found errors.
-    pub const VALIDATION_FAILED: u8 = 3;
+    pub(crate) const VALIDATION_FAILED: u8 = 3;
     /// Execution timed out.
-    pub const TIMEOUT: u8 = 4;
+    pub(crate) const TIMEOUT: u8 = 4;
 }

--- a/apps/cli/src/commands/plugin.rs
+++ b/apps/cli/src/commands/plugin.rs
@@ -5,7 +5,7 @@ use nebula_sandbox::{capabilities::PluginCapabilities, discovery};
 use crate::plugins;
 
 /// Execute the `plugin list` command.
-pub async fn list() {
+pub(crate) async fn list() {
     let dirs = plugins::plugin_directories();
     let dir_str = if dirs.is_empty() {
         "(no plugin directories found)".to_owned()

--- a/apps/cli/src/commands/plugin_new.rs
+++ b/apps/cli/src/commands/plugin_new.rs
@@ -6,7 +6,7 @@ use nebula_core::{ActionKey, PluginKey};
 use crate::cli::PluginNewArgs;
 
 /// Execute the `plugin new` command.
-pub fn execute(args: PluginNewArgs) -> anyhow::Result<()> {
+pub(crate) fn execute(args: PluginNewArgs) -> anyhow::Result<()> {
     let name = &args.name;
 
     // Validate plugin name as a valid PluginKey.
@@ -220,9 +220,6 @@ echo '{{"action_key":"__metadata__","input":{{}}}}' | cargo run
 echo '{{"action_key":"{plugin_key}.{first_action}","input":{{"key":"value"}}}}' | cargo run
 ```
 "#,
-        first_action = action_names
-            .first()
-            .map(|s| s.as_str())
-            .unwrap_or("execute"),
+        first_action = action_names.first().map_or("execute", String::as_str),
     )
 }

--- a/apps/cli/src/commands/replay.rs
+++ b/apps/cli/src/commands/replay.rs
@@ -11,7 +11,7 @@ use nebula_telemetry::metrics::MetricsRegistry;
 use crate::cli::{OutputFormat, ReplayArgs, resolve_format};
 
 /// Execute the `replay` command.
-pub async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> {
+pub(crate) async fn execute(args: ReplayArgs, quiet: bool) -> anyhow::Result<ExitCode> {
     // 1. Parse workflow.
     let content = std::fs::read_to_string(&args.workflow)
         .with_context(|| format!("failed to read {}", args.workflow.display()))?;

--- a/apps/cli/src/commands/run.rs
+++ b/apps/cli/src/commands/run.rs
@@ -11,7 +11,7 @@ use nebula_telemetry::metrics::MetricsRegistry;
 use crate::cli::{OutputFormat, RunArgs, resolve_format};
 
 /// Execute the `run` command.
-pub async fn execute(args: RunArgs, quiet: bool) -> anyhow::Result<ExitCode> {
+pub(crate) async fn execute(args: RunArgs, quiet: bool) -> anyhow::Result<ExitCode> {
     // 1. Load and parse workflow.
     let content = std::fs::read_to_string(&args.workflow)
         .with_context(|| format!("failed to read {}", args.workflow.display()))?;
@@ -224,7 +224,7 @@ fn print_text_result(result: &nebula_engine::ExecutionResult) {
 ///
 /// Format: `<node_name>.params.<key>=<value>`
 /// Example: `fetch.params.url=https://staging.api.com`
-pub fn apply_overrides(
+pub(crate) fn apply_overrides(
     workflow: &mut nebula_workflow::WorkflowDefinition,
     overrides: &[String],
 ) -> anyhow::Result<()> {
@@ -249,18 +249,17 @@ pub fn apply_overrides(
             .iter_mut()
             .find(|n| n.name.eq_ignore_ascii_case(node_name));
 
-        let node = match node {
-            Some(n) => n,
-            None => {
-                let suggestion = find_closest(&node_names, node_name);
-                let hint = suggestion
-                    .map(|s| format!(" Did you mean \"{s}\"?"))
-                    .unwrap_or_default();
-                anyhow::bail!(
-                    "unknown node \"{node_name}\" in --set.{hint}\nAvailable: {}",
-                    node_names.join(", ")
-                );
-            },
+        let node = if let Some(n) = node {
+            n
+        } else {
+            let suggestion = find_closest(&node_names, node_name);
+            let hint = suggestion
+                .map(|s| format!(" Did you mean \"{s}\"?"))
+                .unwrap_or_default();
+            anyhow::bail!(
+                "unknown node \"{node_name}\" in --set.{hint}\nAvailable: {}",
+                node_names.join(", ")
+            );
         };
 
         // Parse value as JSON, fall back to string.
@@ -299,7 +298,7 @@ fn find_closest<'a>(options: &'a [String], target: &str) -> Option<&'a str> {
             }
             o_lower.len().abs_diff(target_lower.len()) + 2
         })
-        .map(|s| s.as_str())
+        .map(String::as_str)
 }
 
 /// --dry-run: show execution plan without running.
@@ -357,8 +356,10 @@ fn dry_run(
                         .nodes
                         .iter()
                         .find(|n| n.id == *node_key)
-                        .map(|n| format!("{} ({})", n.name, n.action_key))
-                        .unwrap_or_else(|| node_key.to_string());
+                        .map_or_else(
+                            || node_key.to_string(),
+                            |n| format!("{} ({})", n.name, n.action_key),
+                        );
                     println!("    {node_key}  {name}");
                 }
             }
@@ -383,7 +384,7 @@ fn print_stream_event(event: &nebula_engine::ExecutionEvent) {
         ExecutionEvent::NodeFailed {
             node_key, error, ..
         } => {
-            eprintln!("  ✗ {node_key} failed: {error}")
+            eprintln!("  ✗ {node_key} failed: {error}");
         },
         ExecutionEvent::NodeSkipped { node_key, .. } => {
             eprintln!("  ⊘ {node_key} skipped");

--- a/apps/cli/src/commands/validate.rs
+++ b/apps/cli/src/commands/validate.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 /// Execute the `validate` command.
-pub fn execute(args: ValidateArgs, quiet: bool) -> anyhow::Result<ExitCode> {
+pub(crate) fn execute(args: ValidateArgs, quiet: bool) -> anyhow::Result<ExitCode> {
     let content = std::fs::read_to_string(&args.workflow)
         .with_context(|| format!("failed to read {}", args.workflow.display()))?;
 
@@ -30,7 +30,7 @@ pub fn execute(args: ValidateArgs, quiet: bool) -> anyhow::Result<ExitCode> {
 }
 
 /// Parse a workflow definition strictly (all fields required).
-pub fn parse_workflow(
+pub(crate) fn parse_workflow(
     content: &str,
     path: &std::path::Path,
 ) -> anyhow::Result<nebula_workflow::WorkflowDefinition> {
@@ -51,7 +51,7 @@ pub fn parse_workflow(
 ///
 /// Fills missing: `id`, `owner_id`, `created_at`, `updated_at`, `version`, `schema_version`.
 /// Uses JSON string roundtrip to satisfy `#[serde(borrow)]` on ActionKey.
-pub fn parse_workflow_lenient(
+pub(crate) fn parse_workflow_lenient(
     content: &str,
     path: &std::path::Path,
 ) -> anyhow::Result<nebula_workflow::WorkflowDefinition> {

--- a/apps/cli/src/commands/watch.rs
+++ b/apps/cli/src/commands/watch.rs
@@ -19,7 +19,7 @@ use tokio::sync::mpsc;
 use crate::cli::WatchArgs;
 
 /// Execute the `watch` command.
-pub async fn execute(args: WatchArgs) -> anyhow::Result<ExitCode> {
+pub(crate) async fn execute(args: WatchArgs) -> anyhow::Result<ExitCode> {
     let workflow_path = args
         .workflow
         .canonicalize()
@@ -58,7 +58,7 @@ pub async fn execute(args: WatchArgs) -> anyhow::Result<ExitCode> {
             Some(()) = rx.recv() => {
                 last_change = Instant::now();
             }
-            _ = tokio::time::sleep(Duration::from_millis(200)) => {
+            () = tokio::time::sleep(Duration::from_millis(200)) => {
                 if last_change.elapsed() < Duration::from_millis(300)
                     && last_change.elapsed() >= Duration::from_millis(200)
                 {

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -44,12 +44,12 @@ use serde::{Deserialize, Serialize};
 /// certainly a misconfigured path (pointing at a log file, `/dev/urandom`, or
 /// a symlink-swapped victim). Reading it uncapped would OOM the process
 /// before logging is initialized, leaving no usable diagnostic.
-pub const MAX_CONFIG_BYTES: u64 = 10 * 1024 * 1024;
+pub(crate) const MAX_CONFIG_BYTES: u64 = 10 * 1024 * 1024;
 
 /// CLI configuration.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(default)]
-pub struct CliConfig {
+pub(crate) struct CliConfig {
     /// Execution defaults.
     pub run: RunConfig,
     /// Remote server settings (for future API client mode).
@@ -60,7 +60,7 @@ pub struct CliConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct RunConfig {
+pub(crate) struct RunConfig {
     /// Default max concurrent nodes.
     pub concurrency: usize,
     /// Default execution timeout in seconds. `None` = unlimited.
@@ -70,7 +70,7 @@ pub struct RunConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct RemoteConfig {
+pub(crate) struct RemoteConfig {
     /// Server URL.
     pub url: String,
     /// API key for authentication.
@@ -79,7 +79,7 @@ pub struct RemoteConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
-pub struct LogConfig {
+pub(crate) struct LogConfig {
     /// Default log level.
     pub level: String,
 }
@@ -167,7 +167,7 @@ impl CliConfig {
     ///
     /// Returns an error if a config file exists but contains invalid TOML.
     /// Missing config files are silently skipped (they are optional).
-    pub async fn load() -> anyhow::Result<Self> {
+    pub(crate) async fn load() -> anyhow::Result<Self> {
         let mut fig = Figment::from(Serialized::defaults(CliConfig::default()));
 
         if let Some(global_path) = global_config_path()
@@ -190,7 +190,7 @@ impl CliConfig {
     }
 
     /// Generate the default config file content as TOML.
-    pub fn default_toml() -> String {
+    pub(crate) fn default_toml() -> String {
         r#"# Nebula CLI configuration
 # Global: ~/.config/nebula/config.toml (Linux), ~/Library/Application Support/nebula/config.toml (macOS)
 # Project: ./nebula.toml
@@ -220,17 +220,17 @@ level = "error"
 /// - Linux:   `~/.config/nebula/config.toml`
 /// - macOS:   `~/Library/Application Support/nebula/config.toml`
 /// - Windows: `C:\Users\<user>\AppData\Roaming\nebula\config.toml`
-pub fn global_config_path() -> Option<PathBuf> {
+pub(crate) fn global_config_path() -> Option<PathBuf> {
     dirs::config_dir().map(|c| c.join("nebula").join("config.toml"))
 }
 
 /// Path to the global config directory.
-pub fn global_config_dir() -> Option<PathBuf> {
+pub(crate) fn global_config_dir() -> Option<PathBuf> {
     dirs::config_dir().map(|c| c.join("nebula"))
 }
 
 /// Check if a config file exists at the standard locations.
-pub fn find_config_file() -> Option<PathBuf> {
+pub(crate) fn find_config_file() -> Option<PathBuf> {
     let local = PathBuf::from("nebula.toml");
     if local.exists() {
         return Some(local);
@@ -245,6 +245,10 @@ pub fn find_config_file() -> Option<PathBuf> {
 // ── Tests ────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
+#[allow(
+    unsafe_code,
+    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
+)]
 mod tests {
     use super::*;
 

--- a/apps/cli/src/output.rs
+++ b/apps/cli/src/output.rs
@@ -1,13 +1,13 @@
 use crate::cli::OutputFormat;
 
 /// Print a serializable value in the requested format.
-pub fn print_json<T: serde::Serialize>(value: &T) {
+pub(crate) fn print_json<T: serde::Serialize>(value: &T) {
     let json = serde_json::to_string_pretty(value).expect("failed to serialize output");
     println!("{json}");
 }
 
 /// Print a validation result summary.
-pub fn print_validation(errors: &[String], format: &OutputFormat) {
+pub(crate) fn print_validation(errors: &[String], format: &OutputFormat) {
     match format {
         OutputFormat::Json => {
             let result = serde_json::json!({

--- a/apps/cli/src/plugins.rs
+++ b/apps/cli/src/plugins.rs
@@ -22,7 +22,7 @@ const DEFAULT_PLUGIN_TIMEOUT: Duration = Duration::from_secs(30);
 /// Discover and register community plugins from standard directories.
 ///
 /// Returns the number of actions registered.
-pub async fn discover_and_register(registry: &ActionRegistry) -> usize {
+pub(crate) async fn discover_and_register(registry: &ActionRegistry) -> usize {
     let dirs = plugin_directories();
     let mut total = 0;
 
@@ -58,7 +58,7 @@ pub async fn discover_and_register(registry: &ActionRegistry) -> usize {
 }
 
 /// List the directories that would be scanned for plugins.
-pub fn plugin_directories() -> Vec<PathBuf> {
+pub(crate) fn plugin_directories() -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     let local = PathBuf::from("plugins");

--- a/apps/cli/src/suggestions.rs
+++ b/apps/cli/src/suggestions.rs
@@ -6,7 +6,7 @@
 use nebula_engine::ExecutionResult;
 
 /// A recovery suggestion for a failed node.
-pub struct Suggestion {
+pub(crate) struct Suggestion {
     /// Node key that failed.
     pub node_key: String,
     /// What went wrong (short).
@@ -18,7 +18,7 @@ pub struct Suggestion {
 }
 
 /// Analyze execution result and generate recovery suggestions.
-pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
+pub(crate) fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
     let mut suggestions = Vec::new();
 
     for (node_key, error) in &result.node_errors {
@@ -74,8 +74,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
             let key = error
                 .split("action not found:")
                 .nth(1)
-                .map(|s| s.trim())
-                .unwrap_or("unknown");
+                .map_or("unknown", str::trim);
 
             suggestions.push(Suggestion {
                 node_key: nid.clone(),
@@ -159,7 +158,7 @@ pub fn suggest(result: &ExecutionResult) -> Vec<Suggestion> {
 }
 
 /// Print suggestions to stderr.
-pub fn print_suggestions(suggestions: &[Suggestion]) {
+pub(crate) fn print_suggestions(suggestions: &[Suggestion]) {
     if suggestions.is_empty() {
         return;
     }

--- a/apps/cli/src/tui/app.rs
+++ b/apps/cli/src/tui/app.rs
@@ -17,7 +17,7 @@ use super::{
 
 /// Status of a single node in the TUI.
 #[derive(Clone)]
-pub struct NodeInfo {
+pub(crate) struct NodeInfo {
     pub name: String,
     pub action_key: String,
     pub status: NodeStatus,
@@ -26,8 +26,8 @@ pub struct NodeInfo {
     pub error: Option<String>,
 }
 
-#[derive(Clone, PartialEq)]
-pub enum NodeStatus {
+#[derive(Clone, PartialEq, Eq)]
+pub(crate) enum NodeStatus {
     Pending,
     Running,
     Completed,
@@ -38,14 +38,14 @@ pub enum NodeStatus {
 
 /// A log entry displayed in the bottom panel.
 #[derive(Clone)]
-pub struct LogEntry {
+pub(crate) struct LogEntry {
     pub offset: Duration,
     pub level: LogLevel,
     pub message: String,
 }
 
 /// The TUI application state.
-pub struct App {
+pub(crate) struct App {
     pub workflow_name: String,
     pub execution_id: String,
     pub started_at: Instant,
@@ -61,7 +61,7 @@ pub struct App {
 }
 
 impl App {
-    pub fn new(
+    pub(crate) fn new(
         workflow_name: String,
         execution_id: String,
         node_order: Vec<(NodeKey, String, String)>,
@@ -99,30 +99,30 @@ impl App {
         }
     }
 
-    pub fn total_elapsed(&self) -> Duration {
+    pub(crate) fn total_elapsed(&self) -> Duration {
         self.started_at.elapsed()
     }
 
-    pub fn completed_count(&self) -> usize {
+    pub(crate) fn completed_count(&self) -> usize {
         self.nodes
             .iter()
             .filter(|(_, n)| n.status == NodeStatus::Completed)
             .count()
     }
 
-    pub fn failed_count(&self) -> usize {
+    pub(crate) fn failed_count(&self) -> usize {
         self.nodes
             .iter()
             .filter(|(_, n)| n.status == NodeStatus::Failed)
             .count()
     }
 
-    pub fn selected_info(&self) -> Option<&NodeInfo> {
+    pub(crate) fn selected_info(&self) -> Option<&NodeInfo> {
         self.nodes.get(self.selected_node).map(|(_, info)| info)
     }
 
     /// Apply a TUI event to update app state.
-    pub fn apply_event(&mut self, evt: TuiEvent) {
+    pub(crate) fn apply_event(&mut self, evt: TuiEvent) {
         match evt {
             TuiEvent::Key(key) => {
                 if key.kind == KeyEventKind::Press {
@@ -212,7 +212,10 @@ impl App {
 ///
 /// Takes an `mpsc::UnboundedReceiver<TuiEvent>` that receives engine events
 /// and terminal events are polled via crossterm.
-pub async fn run_tui(mut rx: mpsc::UnboundedReceiver<TuiEvent>, mut app: App) -> io::Result<()> {
+pub(crate) async fn run_tui(
+    mut rx: mpsc::UnboundedReceiver<TuiEvent>,
+    mut app: App,
+) -> io::Result<()> {
     let mut terminal = ratatui::init();
     terminal.clear()?;
 

--- a/apps/cli/src/tui/event.rs
+++ b/apps/cli/src/tui/event.rs
@@ -9,7 +9,7 @@ use nebula_core::NodeKey;
     dead_code,
     reason = "Variants used when real-time engine events are wired"
 )]
-pub enum TuiEvent {
+pub(crate) enum TuiEvent {
     /// Terminal key press.
     Key(crossterm::event::KeyEvent),
     /// Terminal resize.
@@ -48,7 +48,7 @@ pub enum TuiEvent {
     dead_code,
     reason = "Variants used when real-time engine events are wired"
 )]
-pub enum LogLevel {
+pub(crate) enum LogLevel {
     Info,
     Warn,
     Error,

--- a/apps/cli/src/tui/mod.rs
+++ b/apps/cli/src/tui/mod.rs
@@ -4,11 +4,11 @@
 //! current node detail, error panel, and execution log.
 
 #[cfg(feature = "tui")]
-pub mod app;
+pub(crate) mod app;
 #[cfg(feature = "tui")]
-pub mod event;
+pub(crate) mod event;
 #[cfg(feature = "tui")]
-pub mod render;
+pub(crate) mod render;
 
 #[cfg(feature = "tui")]
-pub use app::run_tui;
+pub(crate) use app::run_tui;

--- a/apps/cli/src/tui/render.rs
+++ b/apps/cli/src/tui/render.rs
@@ -25,7 +25,7 @@ use super::{
     event::LogLevel,
 };
 
-pub fn draw(frame: &mut Frame, app: &App) {
+pub(crate) fn draw(frame: &mut Frame, app: &App) {
     let outer = Layout::vertical([
         Constraint::Length(2), // header
         Constraint::Min(8),    // main area
@@ -113,10 +113,7 @@ fn draw_node_graph(frame: &mut Frame, area: Rect, app: &App) {
         .map(|(i, (_, info))| {
             let is_selected = i == app.selected_node;
             let status_cell = status_cell(&info.status);
-            let duration = info
-                .elapsed
-                .map(format_duration)
-                .unwrap_or_else(|| "—".to_owned());
+            let duration = info.elapsed.map_or_else(|| "—".to_owned(), format_duration);
 
             let name_style = if is_selected {
                 Style::default()
@@ -179,10 +176,7 @@ fn draw_detail_panel(frame: &mut Frame, area: Rect, app: &App) {
         .border_style(Style::default().fg(Color::DarkGray));
 
     let status_str = status_text(&info.status).to_owned();
-    let duration_str = info
-        .elapsed
-        .map(format_duration)
-        .unwrap_or_else(|| "—".to_owned());
+    let duration_str = info.elapsed.map_or_else(|| "—".to_owned(), format_duration);
 
     let info_lines = vec![
         info_line("action", &info.action_key, Color::White),
@@ -330,10 +324,7 @@ fn status_color(status: &NodeStatus) -> Color {
 
 fn info_line<'a>(label: &'a str, value: &'a str, color: Color) -> Line<'a> {
     Line::from(vec![
-        Span::styled(
-            format!("{:<12}", label),
-            Style::default().fg(Color::DarkGray),
-        ),
+        Span::styled(format!("{label:<12}"), Style::default().fg(Color::DarkGray)),
         Span::styled(value, Style::default().fg(color)),
     ])
 }
@@ -348,7 +339,7 @@ fn format_log_line(entry: &LogEntry) -> Line<'static> {
     };
 
     Line::from(vec![
-        Span::styled(format!("{:<8}", ts), Style::default().fg(Color::DarkGray)),
+        Span::styled(format!("{ts:<8}"), Style::default().fg(Color::DarkGray)),
         Span::styled(level_str, Style::default().fg(level_color)),
         Span::raw(" "),
         Span::styled(entry.message.clone(), Style::default().fg(Color::White)),

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,24 +1,98 @@
 # Keep lint interpretation aligned with workspace toolchain.
 msrv = "1.95"
 
-# Complexity limits (balanced for a heavily generic Rust workspace).
+# ── Complexity thresholds (balanced for a heavily generic Rust workspace) ──
 cognitive-complexity-threshold = 25
 excessive-nesting-threshold = 5
 type-complexity-threshold = 250
 too-many-arguments-threshold = 7
 too-many-lines-threshold = 100
+verbose-bit-mask-threshold = 1
 
-# Hygiene and test ergonomics.
-warn-on-all-wildcard-imports = true
+# ── Identifier / naming heuristics ─────────────────────────────────────────
+# `clippy::min_ident_chars` flags single/double-letter bindings. Keep the
+# threshold at 3 but whitelist domain abbreviations and classic iteration
+# names that are idiomatic to Rust.
+min-ident-chars-threshold = 3
+single-char-binding-names-threshold = 4
+allowed-idents-below-min-chars = [
+  "..",
+  "_",
+  "a",
+  "b",
+  "c",
+  "x",
+  "y",
+  "z",
+  "i",
+  "j",
+  "k",
+  "n",
+  "m",
+  "id",
+  "db",
+  "tx",
+  "rx",
+  "fs",
+  "io",
+  "to",
+  "up",
+  "ok",
+  "fn",
+]
+# Prefixes that do not count against `struct_field_names` / `enum_variant_names`.
+allowed-prefixes = ["to", "from", "as", "into", "is", "has", "with"]
+# Do not warn on fields / variants sharing a prefix of fewer than 3 chars.
+struct-field-name-threshold = 3
+enum-variant-name-threshold = 3
+# `HTTP`, `URL`, `OAuth` are everywhere in integration code.
+upper-case-acronyms-aggressive = false
+
+# ── Test ergonomics ────────────────────────────────────────────────────────
+# Tests may panic / unwrap / dbg / print liberally — production code may not.
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true
+allow-panic-in-tests = true
 allow-dbg-in-tests = true
 allow-print-in-tests = true
+allow-indexing-slicing-in-tests = true
+allow-useless-vec-in-tests = true
+# Enforce MSRV checks in test code as well (no `1.96` APIs sneaking in).
+check-incompatible-msrv-in-tests = true
 
-# Domain docs use these identifiers frequently; avoid false positives.
-doc-valid-idents = ["GitHub", "OpenTelemetry", "OAuth2", "PostgreSQL", "WebSocket"]
+# ── Const-context ergonomics ───────────────────────────────────────────────
+allow-expect-in-consts = true
+allow-unwrap-in-consts = true
 
-# Data-shape / memory-footprint heuristics.
+# ── Wildcard / glob imports ────────────────────────────────────────────────
+warn-on-all-wildcard-imports = true
+
+# ── Doc policy in library crates ───────────────────────────────────────────
+# Check public items, skip private ones, and do not require docs on
+# `#[allow(unused)]` stubs.
+missing-docs-in-crate-items = true
+missing-docs-allow-unused = true
+check-private-items = false
+# Domain docs use these identifiers frequently; avoid false positives from
+# `clippy::doc_markdown`.
+doc-valid-idents = [
+  "GitHub",
+  "OpenTelemetry",
+  "OAuth2",
+  "PostgreSQL",
+  "WebSocket",
+  "gRPC",
+  "GraphQL",
+  "JSON",
+  "YAML",
+  "TOML",
+  "UUID",
+  "ULID",
+  "OTLP",
+  "OpenID",
+]
+
+# ── Data-shape / memory-footprint heuristics ───────────────────────────────
 enum-variant-size-threshold = 200
 array-size-threshold = 512000
 vec-box-size-threshold = 4096
@@ -30,6 +104,19 @@ pass-by-value-size-limit = 256
 too-large-for-stack = 200
 future-size-threshold = 16384
 
-# Docs policy in library crates.
-missing-docs-in-crate-items = true
-check-private-items = false
+# ── `undocumented_unsafe_blocks` ergonomics ────────────────────────────────
+# Accept SAFETY comments placed above the statement / above attributes,
+# not only inline on the same line.
+accept-comment-above-statement = true
+accept-comment-above-attributes = true
+
+# ── Misc strictness ────────────────────────────────────────────────────────
+# `clippy::semicolon_if_nothing_returned` friendlier on one-liners / trailing.
+semicolon-inside-block-ignore-singleline = true
+semicolon-outside-block-ignore-multiline = true
+# Warn when private macros capture unsafe in metavars (soundness footgun).
+warn-unsafe-macro-metavars-in-private-macros = true
+# Push toward `let … else` over unwrap-chains where the pattern is well-known.
+matches-for-let-else = "WellKnownTypes"
+# Encourage re-borrow in `for x in &mut iter` style loops.
+enforce-iter-loop-reborrow = true

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -59,3 +59,6 @@ subtle = { workspace = true }
 nebula-core = { path = "../core" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }
 hex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/action/macros/Cargo.toml
+++ b/crates/action/macros/Cargo.toml
@@ -22,3 +22,6 @@ semver = { workspace = true }
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/action/macros/src/action.rs
+++ b/crates/action/macros/src/action.rs
@@ -7,7 +7,7 @@ use syn::{Data, DeriveInput, parse_macro_input};
 
 use crate::action_attrs::ActionAttrs;
 
-pub fn derive(input: TokenStream) -> TokenStream {
+pub(crate) fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match expand(input) {

--- a/crates/action/macros/src/action_attrs.rs
+++ b/crates/action/macros/src/action_attrs.rs
@@ -7,7 +7,7 @@ use syn::{Ident, Result, Type};
 
 /// Parsed action container attributes.
 #[derive(Debug, Clone)]
-pub struct ActionAttrs {
+pub(crate) struct ActionAttrs {
     /// Unique key (e.g. `"http.request"`).
     pub key: String,
     /// Human-readable name.
@@ -34,7 +34,7 @@ pub struct ActionAttrs {
 
 impl ActionAttrs {
     /// Parse from `#[action(...)]` attribute args.
-    pub fn parse(
+    pub(crate) fn parse(
         attr_args: &attrs::AttrArgs,
         struct_name: &Ident,
         description_fallback: Option<String>,
@@ -118,7 +118,7 @@ impl ActionAttrs {
     }
 
     /// Generate `ActionMetadata` initialization expression.
-    pub fn metadata_init_expr(&self) -> TokenStream2 {
+    pub(crate) fn metadata_init_expr(&self) -> TokenStream2 {
         let key = &self.key;
         let name = &self.name;
         let description = &self.description;
@@ -145,7 +145,7 @@ impl ActionAttrs {
     }
 
     /// Generate `ActionDependencies` impl expression.
-    pub fn dependencies_impl_expr(
+    pub(crate) fn dependencies_impl_expr(
         &self,
         struct_name: &Ident,
         impl_generics: &syn::ImplGenerics<'_>,

--- a/crates/action/src/context.rs
+++ b/crates/action/src/context.rs
@@ -310,7 +310,7 @@ pub trait CredentialContextExt {
     fn credential_by_id(
         &self,
         id: &str,
-    ) -> impl std::future::Future<Output = Result<CredentialSnapshot, ActionError>> + Send
+    ) -> impl Future<Output = Result<CredentialSnapshot, ActionError>> + Send
     where
         Self: Sync,
     {
@@ -338,7 +338,7 @@ pub trait CredentialContextExt {
     fn credential_typed<S: AuthScheme>(
         &self,
         id: &str,
-    ) -> impl std::future::Future<Output = Result<S, ActionError>> + Send
+    ) -> impl Future<Output = Result<S, ActionError>> + Send
     where
         Self: Sync,
     {
@@ -364,9 +364,7 @@ pub trait CredentialContextExt {
     ///
     /// - [`ActionError::Fatal`] if no credential of type `S` is configured
     /// - [`ActionError::Fatal`] if the stored scheme does not match `S`
-    fn credential<S>(
-        &self,
-    ) -> impl std::future::Future<Output = Result<CredentialGuard<S>, ActionError>> + Send
+    fn credential<S>(&self) -> impl Future<Output = Result<CredentialGuard<S>, ActionError>> + Send
     where
         S: AuthScheme + zeroize::Zeroize,
         Self: Sync,
@@ -387,7 +385,7 @@ pub trait CredentialContextExt {
     }
 
     /// Check whether a credential exists by id.
-    fn has_credential_id(&self, id: &str) -> impl std::future::Future<Output = bool> + Send
+    fn has_credential_id(&self, id: &str) -> impl Future<Output = bool> + Send
     where
         Self: Sync,
     {
@@ -619,7 +617,7 @@ mod tests {
         value: String,
     }
 
-    impl nebula_core::AuthScheme for ZeroizableToken {
+    impl AuthScheme for ZeroizableToken {
         fn pattern() -> nebula_core::AuthPattern {
             nebula_core::AuthPattern::SecretToken
         }

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -934,7 +934,7 @@ mod tests {
     fn adapter_preserves_original_outputs_after_stamp() {
         // The adapter only rewrites `category`; it must not touch `outputs`
         // or any other metadata field.
-        let original_outputs = TestIf::new().metadata.outputs.clone();
+        let original_outputs = TestIf::new().metadata.outputs;
         let adapter = ControlActionAdapter::new(TestIf::new());
         assert_eq!(adapter.metadata().outputs, original_outputs);
     }

--- a/crates/action/src/output.rs
+++ b/crates/action/src/output.rs
@@ -258,7 +258,7 @@ pub enum DeltaFormat {
 }
 
 /// Current state of a stream.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum StreamState {
     /// Created but not started.
@@ -280,7 +280,7 @@ pub enum StreamState {
 }
 
 /// Backpressure configuration for streams.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BufferConfig {
     /// Maximum number of buffered items.
     pub capacity: usize,
@@ -289,7 +289,7 @@ pub struct BufferConfig {
 }
 
 /// Overflow strategy when a stream buffer is full.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum Overflow {
     /// Block the producer until space is available.
     Block,
@@ -436,7 +436,7 @@ pub struct TokenUsage {
 }
 
 /// Caching information for an output.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub enum CacheInfo {
     /// Output is not cacheable.
@@ -621,7 +621,7 @@ impl<T> ActionOutput<T> {
     pub fn needs_resolution(&self) -> bool {
         match self {
             Self::Deferred(_) | Self::Streaming(_) => true,
-            Self::Collection(items) => items.iter().any(|o| o.needs_resolution()),
+            Self::Collection(items) => items.iter().any(ActionOutput::needs_resolution),
             _ => false,
         }
     }
@@ -653,7 +653,7 @@ impl<T> ActionOutput<T> {
                 max_interval: Some(Duration::from_secs(30)),
                 non_retryable_errors: vec!["content_policy_violation".into()],
             }),
-            timeout: Some(Duration::from_secs(120)),
+            timeout: Some(Duration::from_mins(2)),
         }))
     }
 
@@ -680,7 +680,7 @@ impl<T> ActionOutput<T> {
                 version: None,
             },
             retry: None,
-            timeout: Some(Duration::from_secs(300)),
+            timeout: Some(Duration::from_mins(5)),
         }))
     }
 
@@ -805,7 +805,7 @@ pub enum BinaryStorage {
 }
 
 /// A reference to data stored externally (not fetched yet).
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct DataReference {
     /// Backend identifier (e.g. `"s3"`, `"local"`, `"database"`).
     pub storage_type: String,
@@ -838,7 +838,7 @@ mod tests {
     fn action_output_binary() {
         let out: ActionOutput<i32> = ActionOutput::Binary(BinaryData {
             content_type: "image/png".into(),
-            data: BinaryStorage::Inline(vec![0x89, 0x50, 0x4E, 0x47]),
+            data: BinaryStorage::Inline(vec![0x89, 0x50, 0x4e, 0x47]),
             size: 4,
             metadata: None,
         });
@@ -873,7 +873,7 @@ mod tests {
                 version: None,
             },
             retry: None,
-            timeout: Some(Duration::from_secs(60)),
+            timeout: Some(Duration::from_mins(1)),
         }));
         assert!(out.is_deferred());
         assert!(!out.is_value());
@@ -1098,7 +1098,7 @@ mod tests {
                 assert_eq!(d.handle_id, "doc-456");
                 assert_eq!(d.producer.kind, ProducerKind::LocalCompute);
                 assert!(d.progress.is_some());
-                assert_eq!(d.timeout, Some(Duration::from_secs(300)));
+                assert_eq!(d.timeout, Some(Duration::from_mins(5)));
             },
             _ => panic!("expected Deferred"),
         }
@@ -1111,14 +1111,14 @@ mod tests {
             "https://hooks.example.com/callback",
             "tok-abc",
             ExpectedOutput::Value { schema: None },
-            Some(Duration::from_secs(3600)),
+            Some(Duration::from_hours(1)),
         );
         match &out {
             ActionOutput::Deferred(d) => {
                 assert_eq!(d.handle_id, "cb-789");
                 assert!(matches!(d.resolution, Resolution::Callback { .. }));
                 assert_eq!(d.producer.kind, ProducerKind::ExternalApi);
-                assert_eq!(d.timeout, Some(Duration::from_secs(3600)));
+                assert_eq!(d.timeout, Some(Duration::from_hours(1)));
             },
             _ => panic!("expected Deferred"),
         }
@@ -1197,7 +1197,7 @@ mod tests {
                 },
                 interval: Duration::from_secs(5),
                 backoff: 2.0,
-                max_interval: Some(Duration::from_secs(60)),
+                max_interval: Some(Duration::from_mins(1)),
             },
             expected: ExpectedOutput::Binary {
                 content_type: "image/png".into(),
@@ -1213,7 +1213,7 @@ mod tests {
                 version: Some("v1".into()),
             },
             retry: None,
-            timeout: Some(Duration::from_secs(120)),
+            timeout: Some(Duration::from_mins(2)),
         };
 
         let json = serde_json::to_string(&deferred).unwrap();
@@ -1400,7 +1400,7 @@ mod tests {
         assert_ne!(a, c);
 
         let mut set: HashSet<TokenUsage> = HashSet::new();
-        set.insert(a.clone());
+        set.insert(a);
         assert!(set.contains(&b));
         assert!(!set.contains(&c));
     }
@@ -1430,7 +1430,7 @@ mod tests {
         assert_ne!(a, c);
 
         let mut set: HashSet<Timing> = HashSet::new();
-        set.insert(a.clone());
+        set.insert(a);
         assert!(set.contains(&b));
         assert!(!set.contains(&c));
     }

--- a/crates/action/src/poll.rs
+++ b/crates/action/src/poll.rs
@@ -103,8 +103,8 @@ pub struct PollConfig {
 impl Default for PollConfig {
     fn default() -> Self {
         Self {
-            base_interval: Duration::from_secs(60),
-            max_interval: Duration::from_secs(3600),
+            base_interval: Duration::from_mins(1),
+            max_interval: Duration::from_hours(1),
             backoff_factor: 1.0,
             jitter: 0.0,
             poll_timeout: Duration::from_secs(30),
@@ -1394,10 +1394,10 @@ where
             // computed AFTER the poll so override_next (e.g.
             // Retry-After from upstream) from the cycle we just
             // ran takes effect.
-            let interval = override_next
-                .take()
-                .map(|d| d.clamp(POLL_INTERVAL_FLOOR, effective_max_interval))
-                .unwrap_or_else(|| compute_interval(&config, consecutive_empty, identity_seed));
+            let interval = override_next.take().map_or_else(
+                || compute_interval(&config, consecutive_empty, identity_seed),
+                |d| d.clamp(POLL_INTERVAL_FLOOR, effective_max_interval),
+            );
 
             tokio::select! {
                 () = ctx.cancellation.cancelled() => return Ok(()),

--- a/crates/action/src/result.rs
+++ b/crates/action/src/result.rs
@@ -390,11 +390,11 @@ mod duration_ms {
         u64::try_from(d.as_millis()).unwrap_or(u64::MAX)
     }
 
-    pub fn serialize<S: Serializer>(duration: &Duration, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(duration: &Duration, s: S) -> Result<S::Ok, S::Error> {
         millis_saturating(duration).serialize(s)
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, D::Error> {
         let millis = u64::deserialize(d)?;
         Ok(Duration::from_millis(millis))
     }
@@ -405,7 +405,10 @@ mod duration_opt_ms {
 
     use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-    pub fn serialize<S: Serializer>(duration: &Option<Duration>, s: S) -> Result<S::Ok, S::Error> {
+    pub(super) fn serialize<S: Serializer>(
+        duration: &Option<Duration>,
+        s: S,
+    ) -> Result<S::Ok, S::Error> {
         match duration {
             Some(d) => u64::try_from(d.as_millis())
                 .unwrap_or(u64::MAX)
@@ -414,7 +417,9 @@ mod duration_opt_ms {
         }
     }
 
-    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Duration>, D::Error> {
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<Duration>, D::Error> {
         let opt: Option<u64> = Option::deserialize(d)?;
         Ok(opt.map(Duration::from_millis))
     }
@@ -929,9 +934,9 @@ mod tests {
     fn wait_result() {
         let result: ActionResult<()> = ActionResult::Wait {
             condition: WaitCondition::Duration {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_mins(1),
             },
-            timeout: Some(Duration::from_secs(300)),
+            timeout: Some(Duration::from_mins(5)),
             partial_output: None,
         };
         assert!(result.is_waiting());
@@ -966,7 +971,7 @@ mod tests {
         match mapped {
             ActionResult::Skip { reason, output } => {
                 assert_eq!(reason, "skip");
-                assert_eq!(output.unwrap().as_value().map(|s| s.as_str()), Some("3"));
+                assert_eq!(output.unwrap().as_value().map(String::as_str), Some("3"));
             },
             _ => panic!("expected Skip"),
         }
@@ -1013,7 +1018,7 @@ mod tests {
         let mapped = r.map_output(|n| format!("result:{n}"));
         match mapped {
             ActionResult::Break { output, reason } => {
-                assert_eq!(output.as_value().map(|s| s.as_str()), Some("result:42"));
+                assert_eq!(output.as_value().map(String::as_str), Some("result:42"));
                 assert_eq!(reason, BreakReason::Completed);
             },
             _ => panic!("expected Break"),
@@ -1087,9 +1092,9 @@ mod tests {
     fn map_output_wait() {
         let r: ActionResult<String> = ActionResult::Wait {
             condition: WaitCondition::Duration {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_mins(1),
             },
-            timeout: Some(Duration::from_secs(300)),
+            timeout: Some(Duration::from_mins(5)),
             partial_output: Some(ActionOutput::Value("partial".into())),
         };
         let mapped = r.map_output(|s| s.len());
@@ -1100,7 +1105,7 @@ mod tests {
                 ..
             } => {
                 assert_eq!(partial_output.unwrap().into_value(), Some(7));
-                assert_eq!(timeout, Some(Duration::from_secs(300)));
+                assert_eq!(timeout, Some(Duration::from_mins(5)));
             },
             _ => panic!("expected Wait"),
         }
@@ -1164,7 +1169,7 @@ mod tests {
         match mapped.unwrap() {
             ActionResult::Skip { reason, output } => {
                 assert_eq!(reason, "filtered");
-                assert_eq!(output.unwrap().as_value().map(|s| s.as_str()), Some("3"));
+                assert_eq!(output.unwrap().as_value().map(String::as_str), Some("3"));
             },
             _ => panic!("expected Skip"),
         }
@@ -1280,7 +1285,7 @@ mod tests {
     fn into_primary_output_wait_none() {
         let r: ActionResult<i32> = ActionResult::Wait {
             condition: WaitCondition::Duration {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_mins(1),
             },
             timeout: None,
             partial_output: None,
@@ -1292,7 +1297,7 @@ mod tests {
     fn into_primary_output_wait_some() {
         let r: ActionResult<i32> = ActionResult::Wait {
             condition: WaitCondition::Duration {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_mins(1),
             },
             timeout: None,
             partial_output: Some(ActionOutput::Value(33)),
@@ -1510,7 +1515,7 @@ mod tests {
         assert!(!result.is_continue());
         match result {
             ActionResult::Break { output, reason } => {
-                assert_eq!(output.as_value().map(|s| s.as_str()), Some("done"));
+                assert_eq!(output.as_value().map(String::as_str), Some("done"));
                 assert_eq!(reason, BreakReason::Completed);
             },
             _ => panic!("expected Break"),

--- a/crates/action/src/stateful.rs
+++ b/crates/action/src/stateful.rs
@@ -58,7 +58,7 @@ pub trait StatefulAction: Action {
     /// [`Self::State`]. Return `Some(migrated)` to continue execution with
     /// the migrated state, or `None` to propagate the original
     /// deserialization error as [`ActionError::Validation`].
-    fn migrate_state(&self, _old: serde_json::Value) -> Option<Self::State> {
+    fn migrate_state(&self, _old: Value) -> Option<Self::State> {
         None
     }
 
@@ -495,9 +495,9 @@ impl<A> StatefulActionAdapter<A> {
 impl<A> StatefulHandler for StatefulActionAdapter<A>
 where
     A: StatefulAction + Send + Sync + 'static,
-    A::Input: serde::de::DeserializeOwned + Send + Sync,
-    A::Output: serde::Serialize + Send + Sync,
-    A::State: serde::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
+    A::Input: DeserializeOwned + Send + Sync,
+    A::Output: Serialize + Send + Sync,
+    A::State: Serialize + DeserializeOwned + Clone + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
         self.action.metadata()

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -161,8 +161,8 @@ pub fn stateless_fn<F, Input, Output>(
     FnStatelessAction::new(metadata, func)
 }
 
-impl<F, Input, Output> std::fmt::Debug for FnStatelessAction<F, Input, Output> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<F, Input, Output> fmt::Debug for FnStatelessAction<F, Input, Output> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("FnStatelessAction")
             .field("action", &self.metadata.base.key)
             .finish_non_exhaustive()
@@ -433,7 +433,7 @@ mod tests {
 
     #[tokio::test]
     async fn fn_stateless_action_executes_with_low_boilerplate() {
-        let action = stateless_fn::<_, serde_json::Value, serde_json::Value>(
+        let action = stateless_fn::<_, Value, Value>(
             ActionMetadata::new(
                 nebula_core::action_key!("example.fn"),
                 "Fn",
@@ -466,7 +466,7 @@ mod tests {
 
     #[tokio::test]
     async fn fn_stateless_ctx_action_receives_context() {
-        let action = stateless_ctx_fn::<_, serde_json::Value, serde_json::Value>(
+        let action = stateless_ctx_fn::<_, Value, Value>(
             ActionMetadata::new(
                 nebula_core::action_key!("example.ctx_fn"),
                 "CtxFn",

--- a/crates/action/src/testing.rs
+++ b/crates/action/src/testing.rs
@@ -933,7 +933,7 @@ mod tests {
     fn assert_wait_macro_ok() {
         let result: Result<ActionResult<i32>, ActionError> = Ok(ActionResult::Wait {
             condition: crate::result::WaitCondition::Duration {
-                duration: Duration::from_secs(60),
+                duration: Duration::from_mins(1),
             },
             timeout: None,
             partial_output: None,
@@ -1014,8 +1014,7 @@ mod tests {
             _input: Self::Input,
             state: &mut Self::State,
             _ctx: &impl Context,
-        ) -> impl std::future::Future<Output = Result<ActionResult<Self::Output>, ActionError>> + Send
-        {
+        ) -> impl Future<Output = Result<ActionResult<Self::Output>, ActionError>> + Send {
             state.count += 1;
             let count = state.count;
             let max = self.max;
@@ -1097,12 +1096,12 @@ mod tests {
         fn start(
             &self,
             ctx: &TriggerContext,
-        ) -> impl std::future::Future<Output = Result<(), ActionError>> + Send {
+        ) -> impl Future<Output = Result<(), ActionError>> + Send {
             let emitter = Arc::clone(&ctx.emitter);
             let scheduler = Arc::clone(&ctx.scheduler);
             async move {
                 emitter.emit(serde_json::json!({"tick": 1})).await?;
-                scheduler.schedule_after(Duration::from_secs(60)).await?;
+                scheduler.schedule_after(Duration::from_mins(1)).await?;
                 Ok(())
             }
         }
@@ -1124,7 +1123,7 @@ mod tests {
         assert_eq!(harness.emit_count(), 1);
         assert_eq!(harness.emitted()[0], serde_json::json!({"tick": 1}));
         assert_eq!(harness.schedule_count(), 1);
-        assert_eq!(harness.scheduled()[0], Duration::from_secs(60));
+        assert_eq!(harness.scheduled()[0], Duration::from_mins(1));
 
         harness.stop().await.unwrap();
     }

--- a/crates/action/src/validation.rs
+++ b/crates/action/src/validation.rs
@@ -170,15 +170,15 @@ mod tests {
         let meta = ActionMetadata::new(action_key!("test.action"), "Test", "desc")
             .with_inputs(vec![InputPort::Support(SupportPort {
                 key: "tools".into(),
-                name: "".into(),
-                description: "".into(),
+                name: String::new(),
+                description: String::new(),
                 required: false,
                 multi: true,
                 filter: Default::default(),
             })])
             .with_outputs(vec![OutputPort::Dynamic(DynamicPort {
                 key: "rule".into(),
-                source_field: "".into(),
+                source_field: String::new(),
                 label_field: None,
                 include_fallback: false,
             })]);

--- a/crates/action/src/webhook.rs
+++ b/crates/action/src/webhook.rs
@@ -1213,25 +1213,24 @@ where
         // Clone Arc under read lock; the guard drops at end of statement BEFORE
         // the await on handle_request. Holding a parking_lot guard across .await
         // would be unsound (non-Send) and risk re-entry panic with start/stop.
-        let state = match self.state.read().as_ref().cloned() {
-            Some(s) => s,
-            None => {
-                // State could be None in two situations: (1) genuine
-                // "before start" programmer error, or (2) a race with
-                // stop() that already took the state. Both should not
-                // hang the transport — send a 500 so the caller gets
-                // a real HTTP response instead of `RecvError`.
-                if let Some(tx) = response_tx {
-                    let _ = tx.send(WebhookHttpResponse::new(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        Bytes::new(),
-                    ));
-                }
-                ctx.health.record_error();
-                return Err(ActionError::fatal(
-                    "handle_event called before start or after stop — no state available",
+        let state = if let Some(s) = self.state.read().as_ref().cloned() {
+            s
+        } else {
+            // State could be None in two situations: (1) genuine
+            // "before start" programmer error, or (2) a race with
+            // stop() that already took the state. Both should not
+            // hang the transport — send a 500 so the caller gets
+            // a real HTTP response instead of `RecvError`.
+            if let Some(tx) = response_tx {
+                let _ = tx.send(WebhookHttpResponse::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Bytes::new(),
                 ));
-            },
+            }
+            ctx.health.record_error();
+            return Err(ActionError::fatal(
+                "handle_event called before start or after stop — no state available",
+            ));
         };
 
         // H6 — cancellation-safe dispatch. If the trigger is being

--- a/crates/action/tests/contracts.rs
+++ b/crates/action/tests/contracts.rs
@@ -41,8 +41,7 @@ fn flow_kind_serialization_contract() {
         let json = serde_json::to_string(&value).unwrap();
         assert_eq!(
             json, expected,
-            "FlowKind serialization changed for {:?}",
-            value
+            "FlowKind serialization changed for {value:?}"
         );
     }
 }
@@ -151,7 +150,7 @@ fn action_result_serialization_contract_all_variants_roundtrip() {
         condition: WaitCondition::Duration {
             duration: Duration::from_millis(1500),
         },
-        timeout: Some(Duration::from_millis(30000)),
+        timeout: Some(Duration::from_secs(30)),
         partial_output: Some(ActionOutput::Value(serde_json::json!({"partial": true}))),
     });
 
@@ -168,7 +167,7 @@ fn action_result_duration_millis_wire_format_contract() {
         condition: WaitCondition::Duration {
             duration: Duration::from_millis(250),
         },
-        timeout: Some(Duration::from_millis(5000)),
+        timeout: Some(Duration::from_secs(5)),
         partial_output: None,
     };
     let json = serde_json::to_string(&wait).unwrap();
@@ -199,7 +198,7 @@ fn wait_condition_serialization_contract() {
             datetime: Utc::now(),
         },
         WaitCondition::Duration {
-            duration: Duration::from_millis(2000),
+            duration: Duration::from_secs(2),
         },
         WaitCondition::Approval {
             approver: "ops".to_string(),

--- a/crates/action/tests/deferred_recovery.rs
+++ b/crates/action/tests/deferred_recovery.rs
@@ -39,7 +39,7 @@ fn sample_deferred(handle_id: &str) -> DeferredOutput {
             max_interval: Some(Duration::from_secs(30)),
             non_retryable_errors: vec!["validation_error".to_string()],
         }),
-        timeout: Some(Duration::from_secs(120)),
+        timeout: Some(Duration::from_mins(2)),
     }
 }
 
@@ -65,7 +65,7 @@ fn deferred_success_roundtrip_survives_persist_and_resume() {
                     Resolution::AwaitOrPoll { .. }
                 ));
                 assert!(deferred.retry.is_some());
-                assert_eq!(deferred.timeout, Some(Duration::from_secs(120)));
+                assert_eq!(deferred.timeout, Some(Duration::from_mins(2)));
             },
             other => panic!("expected Deferred output, got {other:?}"),
         },
@@ -79,7 +79,7 @@ fn wait_with_partial_deferred_roundtrip_survives_resume() {
         condition: WaitCondition::Execution {
             execution_id: nebula_core::id::ExecutionId::new(),
         },
-        timeout: Some(Duration::from_secs(300)),
+        timeout: Some(Duration::from_mins(5)),
         partial_output: Some(ActionOutput::Deferred(Box::new(sample_deferred("job-99")))),
     };
 
@@ -93,7 +93,7 @@ fn wait_with_partial_deferred_roundtrip_survives_resume() {
             timeout,
             ..
         } => {
-            assert_eq!(timeout, Some(Duration::from_secs(300)));
+            assert_eq!(timeout, Some(Duration::from_mins(5)));
             match partial_output {
                 Some(ActionOutput::Deferred(deferred)) => {
                     assert_eq!(deferred.handle_id, "job-99");

--- a/crates/action/tests/dx_batch.rs
+++ b/crates/action/tests/dx_batch.rs
@@ -31,7 +31,9 @@ impl nebula_schema::HasSchema for NumberList {
     fn schema() -> nebula_schema::ValidSchema {
         use nebula_schema::{FieldCollector, Schema};
         Schema::builder()
-            .list("numbers", |l| l.item_number("n", |n| n.integer()))
+            .list("numbers", |l| {
+                l.item_number("n", nebula_schema::NumberBuilder::integer)
+            })
             .build()
             .expect("NumberList schema is valid")
     }

--- a/crates/action/tests/dx_poll.rs
+++ b/crates/action/tests/dx_poll.rs
@@ -97,7 +97,7 @@ async fn poll_adapter_emits_events() {
 async fn poll_adapter_stop_is_noop() {
     let (poller, _) = make_poller();
     let adapter = PollTriggerAdapter::new(poller);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     assert!(adapter.stop(&ctx).await.is_ok());
 }
@@ -112,7 +112,7 @@ async fn poll_adapter_does_not_accept_events() {
 #[tokio::test]
 async fn poll_action_cursor_advances_through_poll_cursor() {
     let (poller, _) = make_poller();
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     let mut cursor = PollCursor::new(0u32);
 
     let result = poller.poll(&mut cursor, &ctx).await.unwrap();
@@ -130,7 +130,7 @@ async fn poll_action_cursor_advances_through_poll_cursor() {
 async fn poll_adapter_rejects_concurrent_start() {
     let (poller, _) = make_poller();
     let adapter = Arc::new(PollTriggerAdapter::new(poller));
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let cancel = ctx.cancellation.clone();
     let adapter1 = Arc::clone(&adapter);
@@ -197,7 +197,7 @@ async fn poll_adapter_clamps_zero_interval_to_floor() {
         poll_count: poll_count.clone(),
     };
     let adapter = Arc::new(PollTriggerAdapter::new(poller));
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let cancel = ctx.cancellation.clone();
     let adapter1 = Arc::clone(&adapter);
@@ -247,7 +247,7 @@ async fn poll_adapter_start_after_cancellation_succeeds() {
     let (poller2, _) = make_poller();
     let adapter1 = PollTriggerAdapter::new(poller1);
     let adapter2 = PollTriggerAdapter::new(poller2);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let cancel = ctx.cancellation.clone();
     let ctx_clone = ctx.clone();
@@ -258,7 +258,7 @@ async fn poll_adapter_start_after_cancellation_succeeds() {
     cancel.cancel();
     handle.await.unwrap().unwrap();
 
-    let (ctx2, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx2, ..) = TestContextBuilder::minimal().build_trigger();
     let cancel2 = ctx2.cancellation.clone();
     let handle2 = tokio::spawn(async move { adapter2.start(&ctx2).await });
     for _ in 0..5 {
@@ -281,9 +281,9 @@ fn poll_config_fixed_sets_equal_intervals() {
 
 #[test]
 fn poll_config_with_backoff_includes_jitter() {
-    let config = PollConfig::with_backoff(Duration::from_secs(10), Duration::from_secs(600), 2.0);
+    let config = PollConfig::with_backoff(Duration::from_secs(10), Duration::from_mins(10), 2.0);
     assert_eq!(config.base_interval, Duration::from_secs(10));
-    assert_eq!(config.max_interval, Duration::from_secs(600));
+    assert_eq!(config.max_interval, Duration::from_mins(10));
     assert_eq!(config.backoff_factor, 2.0);
     assert!(config.jitter > 0.0);
 }
@@ -299,7 +299,7 @@ fn poll_config_jitter_clamped() {
 
 #[test]
 fn poll_config_backoff_factor_clamped_to_one() {
-    let config = PollConfig::with_backoff(Duration::from_secs(1), Duration::from_secs(60), 0.5);
+    let config = PollConfig::with_backoff(Duration::from_secs(1), Duration::from_mins(1), 0.5);
     assert_eq!(config.backoff_factor, 1.0);
 }
 
@@ -322,8 +322,8 @@ fn poll_result_from_non_empty_vec_is_ready() {
 #[test]
 fn poll_result_with_override() {
     let result: PollResult<i32> =
-        PollResult::from(vec![1]).with_override_next(Duration::from_secs(60));
-    assert_eq!(result.override_next, Some(Duration::from_secs(60)));
+        PollResult::from(vec![1]).with_override_next(Duration::from_mins(1));
+    assert_eq!(result.override_next, Some(Duration::from_mins(1)));
 }
 
 #[test]
@@ -455,7 +455,7 @@ impl PollAction for FailingValidator {
     type Event = serde_json::Value;
 
     fn poll_config(&self) -> PollConfig {
-        PollConfig::fixed(Duration::from_secs(60))
+        PollConfig::fixed(Duration::from_mins(1))
     }
 
     async fn validate(&self, _ctx: &TriggerContext) -> Result<(), ActionError> {
@@ -481,7 +481,7 @@ async fn poll_adapter_validate_failure_prevents_start() {
         ),
     };
     let adapter = PollTriggerAdapter::new(validator);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let err = adapter.start(&ctx).await.expect_err("start must fail");
     assert!(err.is_fatal());
@@ -606,7 +606,7 @@ impl PollAction for ReadyPoller {
     type Event = serde_json::Value;
 
     fn poll_config(&self) -> PollConfig {
-        PollConfig::with_backoff(Duration::from_millis(100), Duration::from_secs(60), 2.0)
+        PollConfig::with_backoff(Duration::from_millis(100), Duration::from_mins(1), 2.0)
             .with_emit_failure(EmitFailurePolicy::RetryBatch)
     }
 
@@ -635,7 +635,7 @@ async fn retry_batch_dispatch_failure_records_error_and_backs_off() {
     let adapter = PollTriggerAdapter::new(poller);
 
     let failing = Arc::new(FailingEmitter::new());
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     let ctx = ctx.with_emitter(Arc::clone(&failing) as Arc<dyn ExecutionEmitter>);
 
     let cancel = ctx.cancellation.clone();
@@ -745,7 +745,7 @@ async fn drop_and_continue_total_loss_records_error() {
     let adapter = PollTriggerAdapter::new(poller);
 
     let emitter = Arc::new(DropCountingFailingEmitter::new());
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     let ctx = ctx.with_emitter(Arc::clone(&emitter) as Arc<dyn ExecutionEmitter>);
 
     let cancel = ctx.cancellation.clone();
@@ -824,7 +824,7 @@ impl PollAction for HugeOverridePoller {
     ) -> Result<PollResult<serde_json::Value>, ActionError> {
         self.poll_count.fetch_add(1, Ordering::Relaxed);
         Ok(PollResult::from(vec![serde_json::json!({})])
-            .with_override_next(Duration::from_secs(3600)))
+            .with_override_next(Duration::from_hours(1)))
     }
 }
 
@@ -840,7 +840,7 @@ async fn override_next_clamped_by_max_interval() {
         poll_count: poll_count.clone(),
     };
     let adapter = PollTriggerAdapter::new(poller);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let cancel = ctx.cancellation.clone();
     let ctx_clone = ctx.clone();
@@ -922,7 +922,7 @@ async fn partial_with_empty_events_retryable_records_error() {
         called: called.clone(),
     };
     let adapter = PollTriggerAdapter::new(poller);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let cancel = ctx.cancellation.clone();
     let ctx_clone = ctx.clone();
@@ -972,7 +972,7 @@ async fn first_poll_runs_immediately_after_start() {
         type Cursor = u32;
         type Event = serde_json::Value;
         fn poll_config(&self) -> PollConfig {
-            PollConfig::fixed(Duration::from_secs(600))
+            PollConfig::fixed(Duration::from_mins(10))
         }
         async fn poll(
             &self,
@@ -1030,7 +1030,7 @@ async fn stop_cancels_cancellation_token() {
     // no-op and the test had to cancel the token manually.
     let (poller, _) = make_poller();
     let adapter = Arc::new(PollTriggerAdapter::new(poller));
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let adapter1 = Arc::clone(&adapter);
     let ctx1 = ctx.clone();
@@ -1136,9 +1136,9 @@ async fn poll_config_max_interval_below_base_is_clamped_and_warned() {
     // must raise max to base and log a warn.
     let builder = TestContextBuilder::new();
     let logger = builder.spy_logger();
-    let (ctx, _, _) = builder.build_trigger();
+    let (ctx, ..) = builder.build_trigger();
 
-    let mut config = PollConfig::fixed(Duration::from_secs(60));
+    let mut config = PollConfig::fixed(Duration::from_mins(1));
     config.max_interval = Duration::from_secs(10); // deliberately below base
 
     let poller = WildConfigPoller {
@@ -1174,7 +1174,7 @@ async fn poll_config_backoff_factor_clamped_to_ceiling() {
     // backoff_factor = 1e9 is clamped to 60.0 with a warn.
     let builder = TestContextBuilder::new();
     let logger = builder.spy_logger();
-    let (ctx, _, _) = builder.build_trigger();
+    let (ctx, ..) = builder.build_trigger();
 
     let mut config = PollConfig::fixed(Duration::from_secs(1));
     config.backoff_factor = 1.0e9;
@@ -1211,7 +1211,7 @@ async fn poll_config_backoff_factor_clamped_to_ceiling() {
 async fn poll_config_zero_timeout_is_reset_with_warn() {
     let builder = TestContextBuilder::new();
     let logger = builder.spy_logger();
-    let (ctx, _, _) = builder.build_trigger();
+    let (ctx, ..) = builder.build_trigger();
 
     let mut config = PollConfig::fixed(Duration::from_secs(1));
     config.poll_timeout = Duration::ZERO;

--- a/crates/action/tests/dx_webhook.rs
+++ b/crates/action/tests/dx_webhook.rs
@@ -98,7 +98,7 @@ fn wrap_event(req: WebhookRequest) -> TriggerEvent {
 async fn webhook_adapter_start_stores_state() {
     let (webhook, activated, _) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
     assert!(activated.load(Ordering::Relaxed));
@@ -108,7 +108,7 @@ async fn webhook_adapter_start_stores_state() {
 async fn webhook_adapter_stop_passes_stored_state() {
     let (webhook, _, deactivated) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
     adapter.stop(&ctx).await.unwrap();
@@ -117,9 +117,9 @@ async fn webhook_adapter_stop_passes_stored_state() {
 
 #[tokio::test]
 async fn webhook_adapter_handle_event_emits_on_valid_secret() {
-    let (webhook, _, _) = make_webhook();
+    let (webhook, ..) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
 
@@ -131,9 +131,9 @@ async fn webhook_adapter_handle_event_emits_on_valid_secret() {
 
 #[tokio::test]
 async fn webhook_adapter_handle_event_skips_on_bad_secret() {
-    let (webhook, _, _) = make_webhook();
+    let (webhook, ..) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
 
@@ -144,16 +144,16 @@ async fn webhook_adapter_handle_event_skips_on_bad_secret() {
 
 #[tokio::test]
 async fn webhook_adapter_accepts_events() {
-    let (webhook, _, _) = make_webhook();
+    let (webhook, ..) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
     assert!(adapter.accepts_events());
 }
 
 #[tokio::test]
 async fn webhook_adapter_handle_event_before_start_fails() {
-    let (webhook, _, _) = make_webhook();
+    let (webhook, ..) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     let req =
         webhook_request_for_test(br#"{"action":"push"}"#, &[("X-Secret", "mysecret")]).unwrap();
@@ -228,7 +228,7 @@ fn make_counting() -> (CountingWebhook, Arc<AtomicUsize>, Arc<AtomicUsize>) {
 async fn webhook_adapter_rejects_double_start() {
     let (webhook, activate, deactivate) = make_counting();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
     assert_eq!(activate.load(Ordering::Relaxed), 1);
@@ -250,7 +250,7 @@ async fn webhook_adapter_rejects_double_start() {
 async fn webhook_adapter_start_stop_start_succeeds() {
     let (webhook, activate, deactivate) = make_counting();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
 
     adapter.start(&ctx).await.unwrap();
     adapter.stop(&ctx).await.unwrap();
@@ -303,7 +303,7 @@ async fn handle_request_error_sends_500_via_oneshot() {
             "handle_request always returns Err",
         ),
     });
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     adapter.start(&ctx).await.unwrap();
 
     let req = webhook_request_for_test(b"{}", &[]).unwrap();
@@ -372,7 +372,7 @@ async fn handle_request_cancelled_mid_flight_returns_cleanly() {
         ),
         entered: entered.clone(),
     }));
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     adapter.start(&ctx).await.unwrap();
 
     let req = webhook_request_for_test(b"{}", &[]).unwrap();
@@ -414,9 +414,9 @@ async fn handle_request_cancelled_mid_flight_returns_cleanly() {
 
 #[tokio::test]
 async fn webhook_adapter_records_health_success_on_emit() {
-    let (webhook, _, _) = make_webhook();
+    let (webhook, ..) = make_webhook();
     let adapter = WebhookTriggerAdapter::new(webhook);
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     adapter.start(&ctx).await.unwrap();
 
     let req = webhook_request_for_test(br#"{"ok":true}"#, &[("X-Secret", "mysecret")]).unwrap();
@@ -441,7 +441,7 @@ async fn webhook_adapter_records_health_error_on_handler_failure() {
             "error path health check",
         ),
     });
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     adapter.start(&ctx).await.unwrap();
 
     let req = webhook_request_for_test(b"{}", &[]).unwrap();
@@ -502,7 +502,7 @@ async fn in_flight_notify_wakes_stop() {
         ),
         finish: finish.clone(),
     }));
-    let (ctx, _, _) = TestContextBuilder::minimal().build_trigger();
+    let (ctx, ..) = TestContextBuilder::minimal().build_trigger();
     adapter.start(&ctx).await.unwrap();
 
     let req = webhook_request_for_test(b"{}", &[]).unwrap();

--- a/crates/action/tests/execution_integration.rs
+++ b/crates/action/tests/execution_integration.rs
@@ -61,7 +61,7 @@ async fn stateless_action_execute_returns_success() {
             let v = output.as_value().expect("value");
             assert_eq!(v, &input);
         },
-        _ => panic!("expected Success, got {:?}", result),
+        _ => panic!("expected Success, got {result:?}"),
     }
 }
 
@@ -129,7 +129,7 @@ async fn stateful_action_continue_then_break() {
         ActionResult::Continue { output, .. } => {
             assert_eq!(output.as_value(), Some(&0));
         },
-        _ => panic!("expected Continue, got {:?}", r0),
+        _ => panic!("expected Continue, got {r0:?}"),
     }
     assert_eq!(state, 1);
 
@@ -138,7 +138,7 @@ async fn stateful_action_continue_then_break() {
         ActionResult::Continue { output, .. } => {
             assert_eq!(output.as_value(), Some(&1));
         },
-        _ => panic!("expected Continue, got {:?}", r1),
+        _ => panic!("expected Continue, got {r1:?}"),
     }
     assert_eq!(state, 2);
 
@@ -148,7 +148,7 @@ async fn stateful_action_continue_then_break() {
             assert_eq!(output.as_value(), Some(&2));
             assert_eq!(*reason, BreakReason::Completed);
         },
-        _ => panic!("expected Break, got {:?}", r2),
+        _ => panic!("expected Break, got {r2:?}"),
     }
     assert_eq!(state, 3);
 }

--- a/crates/action/tests/type_sizes.rs
+++ b/crates/action/tests/type_sizes.rs
@@ -152,6 +152,6 @@ fn print_type_size_baseline() {
     ];
     println!();
     for (name, size) in rows {
-        println!("{name:40} size={size:>6}  lines={}", size.div_ceil(64),);
+        println!("{name:40} size={size:>6}  lines={}", size.div_ceil(64));
     }
 }

--- a/crates/action/tests/webhook_request_limits.rs
+++ b/crates/action/tests/webhook_request_limits.rs
@@ -66,7 +66,7 @@ fn try_new_accepts_max_header_count() {
 
 #[test]
 fn try_new_rejects_too_many_headers() {
-    let headers_owned: Vec<(String, String)> = (0..(MAX_HEADER_COUNT + 1))
+    let headers_owned: Vec<(String, String)> = (0..=MAX_HEADER_COUNT)
         .map(|i| (format!("x-h{i}"), "v".to_string()))
         .collect();
     let headers: Vec<(&str, &str)> = headers_owned
@@ -125,7 +125,7 @@ fn default_limits_match_documented_constants() {
 #[test]
 fn body_json_bounded_accepts_reasonable_nesting() {
     let body = br#"{"a":{"b":{"c":{"d":1}}}}"#;
-    let req = nebula_action::webhook::webhook_request_for_test(body, &[]).unwrap();
+    let req = webhook_request_for_test(body, &[]).unwrap();
     let v: serde_json::Value = req.body_json_bounded(64).expect("depth 4 fits under 64");
     assert_eq!(v["a"]["b"]["c"]["d"], 1);
 }
@@ -141,7 +141,7 @@ fn body_json_bounded_rejects_deep_nesting() {
     for _ in 0..100 {
         body.push('}');
     }
-    let req = nebula_action::webhook::webhook_request_for_test(body.as_bytes(), &[]).unwrap();
+    let req = webhook_request_for_test(body.as_bytes(), &[]).unwrap();
     let err = req
         .body_json_bounded::<serde_json::Value>(64)
         .expect_err("100 levels must exceed max_depth=64");
@@ -155,7 +155,7 @@ fn body_json_bounded_rejects_deep_nesting() {
 fn body_json_bounded_handles_arrays() {
     // Nested arrays should count toward depth the same as objects.
     let body = b"[[[[[[[[1]]]]]]]]";
-    let req = nebula_action::webhook::webhook_request_for_test(body, &[]).unwrap();
+    let req = webhook_request_for_test(body, &[]).unwrap();
     assert!(req.body_json_bounded::<serde_json::Value>(10).is_ok());
     assert!(req.body_json_bounded::<serde_json::Value>(5).is_err());
 }
@@ -164,7 +164,7 @@ fn body_json_bounded_handles_arrays() {
 fn body_json_bounded_ignores_braces_in_strings() {
     // A brace inside a string literal should NOT count toward depth.
     let body = br#"{"comment":"this has {{{ braces }}} inside"}"#;
-    let req = nebula_action::webhook::webhook_request_for_test(body, &[]).unwrap();
+    let req = webhook_request_for_test(body, &[]).unwrap();
     let v: serde_json::Value = req
         .body_json_bounded(2)
         .expect("string-bracketed braces must not inflate depth");
@@ -177,7 +177,7 @@ fn body_json_bounded_handles_escaped_quotes() {
     // prematurely — otherwise a { inside what looks like a string
     // would count as real depth.
     let body = br#"{"quote":"she said \"hello\"","next":1}"#;
-    let req = nebula_action::webhook::webhook_request_for_test(body, &[]).unwrap();
+    let req = webhook_request_for_test(body, &[]).unwrap();
     let v: serde_json::Value = req.body_json_bounded(8).unwrap();
     assert_eq!(v["quote"], "she said \"hello\"");
     assert_eq!(v["next"], 1);

--- a/crates/action/tests/webhook_signature.rs
+++ b/crates/action/tests/webhook_signature.rs
@@ -234,7 +234,7 @@ fn verify_hmac_sha256_with_timestamp_stripe_scheme() {
         secret,
         "Stripe-Signature",
         "Stripe-Ts",
-        Duration::from_secs(300),
+        Duration::from_mins(5),
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();
@@ -245,7 +245,7 @@ fn verify_hmac_sha256_with_timestamp_stripe_scheme() {
 fn verify_hmac_sha256_with_timestamp_slack_scheme() {
     let secret = b"slack_signing_secret";
     let ts = 1_700_000_000u64;
-    let body = br#"payload=%7B%22type%22%3A%22event%22%7D"#;
+    let body = br"payload=%7B%22type%22%3A%22event%22%7D";
     // Slack canonical form: "v0:{ts}:{body}"
     let canonical = format!("v0:{ts}:{}", std::str::from_utf8(body).unwrap());
     let sig = hex::encode(hmac_sha256_compute(secret, canonical.as_bytes()));
@@ -264,7 +264,7 @@ fn verify_hmac_sha256_with_timestamp_slack_scheme() {
         secret,
         "X-Slack-Signature",
         "X-Slack-Request-Timestamp",
-        Duration::from_secs(300),
+        Duration::from_mins(5),
         |t, b| format!("v0:{t}:{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();
@@ -288,7 +288,7 @@ fn verify_hmac_sha256_with_timestamp_rejects_old_timestamp() {
         secret,
         "Sig",
         "Ts",
-        Duration::from_secs(300), // 5 min tolerance
+        Duration::from_mins(5), // 5 min tolerance
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();
@@ -314,7 +314,7 @@ fn verify_hmac_sha256_with_timestamp_rejects_future_timestamp() {
         secret,
         "Sig",
         "Ts",
-        Duration::from_secs(3600), // huge tolerance for past; forward is capped
+        Duration::from_hours(1), // huge tolerance for past; forward is capped
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();
@@ -337,7 +337,7 @@ fn verify_hmac_sha256_with_timestamp_rejects_non_numeric_ts() {
         b"k",
         "Sig",
         "Ts",
-        Duration::from_secs(300),
+        Duration::from_mins(5),
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();
@@ -356,7 +356,7 @@ fn verify_hmac_sha256_with_timestamp_empty_secret_is_error() {
         b"",
         "Sig",
         "Ts",
-        Duration::from_secs(300),
+        Duration::from_mins(5),
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap_err();
@@ -379,7 +379,7 @@ fn verify_hmac_sha256_with_timestamp_rejects_multi_valued_ts() {
         b"k",
         "Sig",
         "Ts",
-        Duration::from_secs(300),
+        Duration::from_mins(5),
         |t, b| format!("{t}.{}", std::str::from_utf8(b).unwrap()).into_bytes(),
     )
     .unwrap();

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -82,3 +82,6 @@ default = []
 # enable this in production builds — it exposes a constructor that
 # bypasses the JwtSecret validation gate.
 test-util = []
+
+[lints]
+workspace = true

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -24,7 +24,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // so external providers only hit one port. `Router::merge`
     // works because the webhook router carries its own state type
     // (`WebhookTransport`) that does not collide with `AppState`.
-    let routes = match state.webhook_transport.clone() {
+    let routes = match state.webhook_transport {
         Some(transport) => routes.merge(transport.router()),
         None => routes,
     };
@@ -63,7 +63,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
 /// Request ID middleware
 async fn request_id_middleware(
     mut request: axum::extract::Request,
-    next: axum::middleware::Next,
+    next: middleware::Next,
 ) -> Response {
     use uuid::Uuid;
 
@@ -73,8 +73,7 @@ async fn request_id_middleware(
         .headers()
         .get(X_REQUEST_ID)
         .and_then(|h| h.to_str().ok())
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| Uuid::new_v4().to_string());
+        .map_or_else(|| Uuid::new_v4().to_string(), ToString::to_string);
 
     request
         .extensions_mut()
@@ -131,7 +130,7 @@ fn build_cors_layer(config: &ApiConfig) -> CorsLayer {
         crate::middleware::auth::X_API_KEY.clone(),
     ])
     .expose_headers([header::HeaderName::from_static(X_REQUEST_ID)])
-    .max_age(Duration::from_secs(3600))
+    .max_age(Duration::from_hours(1))
 }
 
 /// Build router with graceful shutdown signal
@@ -174,8 +173,8 @@ async fn shutdown_signal() {
     let terminate = std::future::pending::<()>();
 
     tokio::select! {
-        _ = ctrl_c => {},
-        _ = terminate => {},
+        () = ctrl_c => {},
+        () = terminate => {},
     }
 
     tracing::info!("Shutdown signal received, starting graceful shutdown");

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -368,6 +368,10 @@ impl ApiConfig {
 }
 
 #[cfg(test)]
+#[allow(
+    unsafe_code,
+    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
+)]
 mod tests {
     use super::*;
 

--- a/crates/api/src/errors.rs
+++ b/crates/api/src/errors.rs
@@ -259,7 +259,7 @@ fn flatten_validation_error(
 ) {
     let pointer = err
         .field_pointer()
-        .map(|p| p.into_owned())
+        .map(std::borrow::Cow::into_owned)
         .or_else(|| inherited_pointer.map(str::to_owned))
         .unwrap_or_else(|| "/".to_owned());
 
@@ -563,10 +563,7 @@ mod tests {
         let to = node_key!("b");
         let api_error = ApiError::InvalidWorkflowDefinition {
             detail: "1 error(s)".to_string(),
-            errors: vec![WorkflowError::DuplicateConnection {
-                from: from.clone(),
-                to: to.clone(),
-            }],
+            errors: vec![WorkflowError::DuplicateConnection { from, to }],
         };
         let (status, problem) = api_error.to_problem_details();
 

--- a/crates/api/src/extractors/json_extractor.rs
+++ b/crates/api/src/extractors/json_extractor.rs
@@ -24,7 +24,7 @@ where
     async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
         let Json(value) = Json::<T>::from_request(req, state)
             .await
-            .map_err(|err| ApiError::validation_message(format!("Invalid JSON: {}", err)))?;
+            .map_err(|err| ApiError::validation_message(format!("Invalid JSON: {err}")))?;
 
         NebulaValidate::validate(&value, &value).map_err(ApiError::from)?;
 

--- a/crates/api/src/handlers/catalog.rs
+++ b/crates/api/src/handlers/catalog.rs
@@ -34,13 +34,14 @@ pub async fn list_actions(State(state): State<AppState>) -> ApiResult<Json<ListA
         .into_iter()
         .map(|key| {
             let entry = registry.get(&key);
-            let name = entry
-                .as_ref()
-                .map(|(meta, _)| meta.base.name.clone())
-                .unwrap_or_else(|| key.as_str().to_string());
-            let version = entry
-                .map(|(meta, _)| meta.base.version.to_string())
-                .unwrap_or_else(|| "1.0.0".to_string());
+            let name = entry.as_ref().map_or_else(
+                || key.as_str().to_string(),
+                |(meta, _)| meta.base.name.clone(),
+            );
+            let version = entry.map_or_else(
+                || "1.0.0".to_string(),
+                |(meta, _)| meta.base.version.to_string(),
+            );
             ActionSummary {
                 key: key.as_str().to_string(),
                 name,
@@ -71,11 +72,11 @@ pub async fn get_action(
         .ok_or_else(|| ApiError::ServiceUnavailable("Action registry not configured".into()))?;
 
     let action_key = nebula_core::ActionKey::new(&key)
-        .map_err(|e| ApiError::validation_message(format!("Invalid action key: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid action key: {e}")))?;
 
     let (meta, _handler) = registry
         .get(&action_key)
-        .ok_or_else(|| ApiError::NotFound(format!("Action '{}' not found", key)))?;
+        .ok_or_else(|| ApiError::NotFound(format!("Action '{key}' not found")))?;
 
     Ok(Json(ActionDetailResponse {
         key: meta.base.key.as_str().to_string(),
@@ -112,10 +113,10 @@ pub async fn list_plugins(State(state): State<AppState>) -> ApiResult<Json<ListP
                 ApiError::Internal(format!("Failed to get plugin '{}': {}", key.as_str(), e))
             })?;
             let plugin = pt.latest().ok();
-            let (name, version) = plugin
-                .as_ref()
-                .map(|p| (p.name().to_string(), p.version()))
-                .unwrap_or_else(|| (key.as_str().to_string(), 1));
+            let (name, version) = plugin.as_ref().map_or_else(
+                || (key.as_str().to_string(), 1),
+                |p| (p.name().to_string(), p.version()),
+            );
             Ok(PluginSummary {
                 key: key.as_str().to_string(),
                 name,
@@ -147,18 +148,18 @@ pub async fn get_plugin(
 
     let plugin_key: nebula_core::PluginKey = key
         .parse()
-        .map_err(|e| ApiError::validation_message(format!("Invalid plugin key: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid plugin key: {e}")))?;
 
     let registry = registry_lock.read().await;
 
     let plugin_type = registry
         .get(&plugin_key)
-        .map_err(|_| ApiError::NotFound(format!("Plugin '{}' not found", key)))?;
+        .map_err(|_| ApiError::NotFound(format!("Plugin '{key}' not found")))?;
 
     let versions = plugin_type.version_numbers();
     let latest = plugin_type
         .latest()
-        .map_err(|e| ApiError::Internal(format!("Failed to get plugin: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get plugin: {e}")))?;
 
     let meta = latest.metadata();
 

--- a/crates/api/src/handlers/execution.rs
+++ b/crates/api/src/handlers/execution.rs
@@ -33,7 +33,7 @@ pub async fn list_all_executions(
         .execution_repo
         .list_running()
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to list executions: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to list executions: {e}")))?;
 
     let total = running_ids.len();
 
@@ -66,7 +66,7 @@ pub async fn list_executions(
     Query(params): Query<PaginationParams>,
 ) -> ApiResult<Json<ListExecutionsResponse>> {
     let workflow_id_parsed = WorkflowId::parse(&workflow_id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Scope the list to the requested workflow (#286, #288, #328). Using the
     // global `list_running()` here would leak execution IDs from every other
@@ -77,7 +77,7 @@ pub async fn list_executions(
         .execution_repo
         .list_running_for_workflow(workflow_id_parsed)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to list executions: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to list executions: {e}")))?;
 
     let total = running_ids.len();
     let offset = params.offset();
@@ -112,21 +112,21 @@ pub async fn get_execution_outputs(
     Path(id): Path<String>,
 ) -> ApiResult<Json<ExecutionOutputsResponse>> {
     let execution_id = ExecutionId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {e}")))?;
 
     // Verify the execution exists before loading outputs.
     state
         .execution_repo
         .get_state(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to check execution: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Execution {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to check execution: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Execution {id} not found")))?;
 
     let outputs = state
         .execution_repo
         .load_all_outputs(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to load outputs: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to load outputs: {e}")))?;
 
     // Convert NodeKey keys to strings for JSON serialisation.
     let string_outputs: std::collections::HashMap<String, serde_json::Value> = outputs
@@ -150,18 +150,18 @@ pub async fn get_execution(
 
     // Parse execution ID
     let execution_id = ExecutionId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {e}")))?;
 
     // Fetch execution state from repository
     let state_result = state
         .execution_repo
         .get_state(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get execution: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get execution: {e}")))?;
 
     // Check if execution exists (get_state returns Option<(version, state)>)
     let (_version, execution_state) =
-        state_result.ok_or_else(|| ApiError::NotFound(format!("Execution {} not found", id)))?;
+        state_result.ok_or_else(|| ApiError::NotFound(format!("Execution {id} not found")))?;
 
     // Extract fields from execution state JSON
     let workflow_id = execution_state
@@ -217,15 +217,15 @@ pub async fn start_execution(
 ) -> ApiResult<(StatusCode, Json<ExecutionResponse>)> {
     // Parse workflow ID
     let workflow_id_parsed = WorkflowId::parse(&workflow_id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Verify workflow exists
     state
         .workflow_repo
         .get(workflow_id_parsed)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", workflow_id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workflow {workflow_id} not found")))?;
 
     // Generate new execution ID
     let execution_id = ExecutionId::new();
@@ -250,7 +250,7 @@ pub async fn start_execution(
     }
 
     let state_json = serde_json::to_value(&exec_state)
-        .map_err(|e| ApiError::Internal(format!("serialize execution state: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("serialize execution state: {e}")))?;
 
     // Create execution record. We must call `create` here — the previous
     // implementation called `transition(id, expected_version = 0, ...)`,
@@ -261,7 +261,7 @@ pub async fn start_execution(
         .execution_repo
         .create(execution_id, workflow_id_parsed, state_json)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to create execution: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to create execution: {e}")))?;
 
     // Enqueue the Start signal onto the durable control queue (canon §12.2,
     // §13 step 3, #332). Before this PR the API persisted the row but never
@@ -336,16 +336,14 @@ pub(crate) async fn enqueue_start(state: &AppState, execution_id: ExecutionId) -
         match &e {
             StorageError::Internal(_) | StorageError::Connection(_) => {
                 ApiError::ServiceUnavailable(format!(
-                    "Execution {} persisted but control-queue backend is \
+                    "Execution {execution_id} persisted but control-queue backend is \
                      unavailable — engine will not see Start signal \
-                     (canon §13 step 6, §12.2 orphan): {}",
-                    execution_id, e
+                     (canon §13 step 6, §12.2 orphan): {e}"
                 ))
             },
             _ => ApiError::Internal(format!(
-                "Execution {} persisted but failed to enqueue Start signal \
-                 (canon §12.2 orphan — caller should retry): {}",
-                execution_id, e
+                "Execution {execution_id} persisted but failed to enqueue Start signal \
+                 (canon §12.2 orphan — caller should retry): {e}"
             )),
         }
     })
@@ -361,18 +359,18 @@ pub async fn cancel_execution(
 
     // Parse execution ID
     let execution_id = ExecutionId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {e}")))?;
 
     // Fetch current execution state from repository
     let state_result = state
         .execution_repo
         .get_state(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get execution: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get execution: {e}")))?;
 
     // Check if execution exists
     let (version, mut execution_state) =
-        state_result.ok_or_else(|| ApiError::NotFound(format!("Execution {} not found", id)))?;
+        state_result.ok_or_else(|| ApiError::NotFound(format!("Execution {id} not found")))?;
 
     // Check if execution is already in a terminal state
     let current_status = execution_state
@@ -385,8 +383,7 @@ pub async fn cancel_execution(
         "completed" | "failed" | "cancelled" | "timed_out"
     ) {
         return Err(ApiError::validation_message(format!(
-            "Cannot cancel execution in '{}' state",
-            current_status
+            "Cannot cancel execution in '{current_status}' state"
         )));
     }
 
@@ -431,7 +428,7 @@ pub async fn cancel_execution(
         .execution_repo
         .transition(execution_id, version, execution_state.clone())
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to cancel execution: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to cancel execution: {e}")))?;
 
     if !transition_result {
         return Err(ApiError::Conflict(
@@ -476,16 +473,14 @@ pub async fn cancel_execution(
             match &e {
                 StorageError::Internal(_) | StorageError::Connection(_) => {
                     ApiError::ServiceUnavailable(format!(
-                        "Execution {} cancelled in DB but control-queue backend is \
+                        "Execution {execution_id} cancelled in DB but control-queue backend is \
                          unavailable — orchestration absent (canon §13 step 6, §12.2 \
-                         orphan): {}",
-                        execution_id, e
+                         orphan): {e}"
                     ))
                 },
                 _ => ApiError::Internal(format!(
-                    "Execution {} cancelled in DB but failed to enqueue Cancel signal \
-                     (canon §12.2 orphan — caller should retry): {}",
-                    execution_id, e
+                    "Execution {execution_id} cancelled in DB but failed to enqueue Cancel signal \
+                     (canon §12.2 orphan — caller should retry): {e}"
                 )),
             }
         })?;
@@ -549,21 +544,21 @@ pub async fn get_execution_logs(
     Path(id): Path<String>,
 ) -> ApiResult<Json<ExecutionLogsResponse>> {
     let execution_id = ExecutionId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid execution ID: {e}")))?;
 
     // Verify the execution exists before loading the journal.
     state
         .execution_repo
         .get_state(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to check execution: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Execution {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to check execution: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Execution {id} not found")))?;
 
     let logs = state
         .execution_repo
         .get_journal(execution_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to load execution logs: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to load execution logs: {e}")))?;
 
     Ok(Json(ExecutionLogsResponse {
         execution_id: id,

--- a/crates/api/src/handlers/health.rs
+++ b/crates/api/src/handlers/health.rs
@@ -183,7 +183,7 @@ mod tests {
             // runtime auto-advances to whichever timer fires first — that's
             // the timeout, so this sleep gets cancelled and never elapses
             // in wall-clock time.
-            tokio::time::sleep(Duration::from_secs(60)).await;
+            tokio::time::sleep(Duration::from_mins(1)).await;
             Ok(0)
         }
     }
@@ -193,12 +193,7 @@ mod tests {
         let control_queue_repo: Arc<dyn nebula_storage::repos::ControlQueueRepo> =
             Arc::new(nebula_storage::repos::InMemoryControlQueueRepo::new());
         let config = ApiConfig::for_test();
-        AppState::new(
-            repo,
-            execution_repo,
-            control_queue_repo,
-            config.jwt_secret.clone(),
-        )
+        AppState::new(repo, execution_repo, control_queue_repo, config.jwt_secret)
     }
 
     #[tokio::test]

--- a/crates/api/src/handlers/mod.rs
+++ b/crates/api/src/handlers/mod.rs
@@ -8,7 +8,13 @@ pub mod execution;
 pub mod health;
 pub mod workflow;
 
-pub use catalog::*;
-pub use execution::*;
-pub use health::*;
-pub use workflow::*;
+pub use catalog::{get_action, get_plugin, list_actions, list_plugins};
+pub use execution::{
+    cancel_execution, get_execution, get_execution_logs, get_execution_outputs,
+    list_all_executions, list_executions, start_execution,
+};
+pub use health::{health_check, readiness_check};
+pub use workflow::{
+    activate_workflow, create_workflow, delete_workflow, execute_workflow, get_workflow,
+    list_workflows, update_workflow, validate_workflow_handler,
+};

--- a/crates/api/src/handlers/workflow.rs
+++ b/crates/api/src/handlers/workflow.rs
@@ -109,13 +109,13 @@ pub async fn list_workflows(
         .workflow_repo
         .list(offset, limit)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to list workflows: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to list workflows: {e}")))?;
 
     let total = state
         .workflow_repo
         .count()
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to count workflows: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to count workflows: {e}")))?;
 
     // Map to response DTOs
     let workflow_responses: Vec<WorkflowResponse> = workflows
@@ -131,7 +131,7 @@ pub async fn list_workflows(
             let description = definition
                 .get("description")
                 .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
+                .map(ToString::to_string);
 
             let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
             let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
@@ -162,18 +162,18 @@ pub async fn get_workflow(
 ) -> ApiResult<Json<WorkflowResponse>> {
     // Parse workflow ID
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Fetch workflow from repository
     let definition = state
         .workflow_repo
         .get(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?;
 
     // Check if workflow exists
     let definition =
-        definition.ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", id)))?;
+        definition.ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
     // Extract fields from workflow definition JSON
     let name = definition
@@ -185,7 +185,7 @@ pub async fn get_workflow(
     let description = definition
         .get("description")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(ToString::to_string);
 
     let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
     let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
@@ -245,7 +245,7 @@ pub async fn create_workflow(
         .workflow_repo
         .save(workflow_id, 0, definition.clone())
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to create workflow: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to create workflow: {e}")))?;
 
     // Build response
     let response = WorkflowResponse {
@@ -268,15 +268,15 @@ pub async fn update_workflow(
 ) -> ApiResult<Json<WorkflowResponse>> {
     // Parse workflow ID
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Get current workflow with version
     let (version, mut definition) = state
         .workflow_repo
         .get_with_version(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
     // Current timestamp — `chrono::Utc::now()` is monotonic through time
     // shifts and does not panic on clocks set before 1970, unlike
@@ -341,7 +341,7 @@ pub async fn update_workflow(
                 WorkflowRepoError::Conflict { .. } => {
                     ApiError::Conflict("Workflow was modified by another request".to_string())
                 },
-                _ => ApiError::Internal(format!("Failed to update workflow: {}", e)),
+                _ => ApiError::Internal(format!("Failed to update workflow: {e}")),
             }
         })?;
 
@@ -355,7 +355,7 @@ pub async fn update_workflow(
     let description = definition
         .get("description")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(ToString::to_string);
 
     let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
     let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
@@ -377,20 +377,20 @@ pub async fn delete_workflow(
 ) -> ApiResult<StatusCode> {
     // Parse workflow ID
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Delete workflow from repository
     let existed = state
         .workflow_repo
         .delete(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to delete workflow: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to delete workflow: {e}")))?;
 
     // Return 404 if workflow didn't exist, 204 No Content if it was deleted
     if existed {
         Ok(StatusCode::NO_CONTENT)
     } else {
-        Err(ApiError::NotFound(format!("Workflow {} not found", id)))
+        Err(ApiError::NotFound(format!("Workflow {id} not found")))
     }
 }
 
@@ -402,15 +402,15 @@ pub async fn activate_workflow(
 ) -> ApiResult<Json<WorkflowResponse>> {
     // Parse workflow ID
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Get current workflow with version for optimistic concurrency
     let (version, mut definition) = state
         .workflow_repo
         .get_with_version(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
     // Canon §10 step 2: validate the workflow definition before flipping the
     // active flag.  Invalid definitions are rejected with RFC 9457 422
@@ -423,14 +423,12 @@ pub async fn activate_workflow(
     // through a JSON string (`to_string` → `from_str`) gives a proper streaming
     // deserializer that does support `visit_borrowed_str`, so all key types
     // parse correctly.
-    let raw_json = serde_json::to_string(&definition).map_err(|e| {
-        ApiError::Internal(format!("Failed to serialize workflow definition: {}", e))
-    })?;
+    let raw_json = serde_json::to_string(&definition)
+        .map_err(|e| ApiError::Internal(format!("Failed to serialize workflow definition: {e}")))?;
     let workflow_def: nebula_workflow::WorkflowDefinition = serde_json::from_str(&raw_json)
         .map_err(|e| {
             ApiError::validation_message(format!(
-                "Workflow definition cannot be parsed as WorkflowDefinition: {}",
-                e
+                "Workflow definition cannot be parsed as WorkflowDefinition: {e}"
             ))
         })?;
 
@@ -472,7 +470,7 @@ pub async fn activate_workflow(
                 WorkflowRepoError::Conflict { .. } => {
                     ApiError::Conflict("Workflow was modified by another request".to_string())
                 },
-                _ => ApiError::Internal(format!("Failed to activate workflow: {}", e)),
+                _ => ApiError::Internal(format!("Failed to activate workflow: {e}")),
             }
         })?;
 
@@ -486,7 +484,7 @@ pub async fn activate_workflow(
     let description = definition
         .get("description")
         .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
+        .map(ToString::to_string);
 
     let created_at = extract_timestamp(&definition, "created_at").unwrap_or(0);
     let updated_at = extract_timestamp(&definition, "updated_at").unwrap_or(0);
@@ -509,15 +507,15 @@ pub async fn execute_workflow(
 ) -> ApiResult<(StatusCode, Json<ExecutionResponse>)> {
     // Parse workflow ID
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     // Verify workflow exists
     state
         .workflow_repo
         .get(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
     // Generate new execution ID
     let execution_id = ExecutionId::new();
@@ -534,7 +532,7 @@ pub async fn execute_workflow(
     }
 
     let state_json = serde_json::to_value(&exec_state)
-        .map_err(|e| ApiError::Internal(format!("serialize execution state: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("serialize execution state: {e}")))?;
 
     // Create execution record via `create` — `transition` is a CAS UPDATE
     // and was hitting zero rows for every brand-new ID, so every call to
@@ -543,7 +541,7 @@ pub async fn execute_workflow(
         .execution_repo
         .create(execution_id, workflow_id, state_json)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to create execution: {}", e)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to create execution: {e}")))?;
 
     // Enqueue the Start signal on the durable control queue — closes the
     // §4.5 gap where the API advertised dispatch but never reached the
@@ -594,21 +592,20 @@ pub async fn validate_workflow_handler(
     Path(id): Path<String>,
 ) -> ApiResult<Json<WorkflowValidateResponse>> {
     let workflow_id = WorkflowId::parse(&id)
-        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {}", e)))?;
+        .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
     let definition = state
         .workflow_repo
         .get(workflow_id)
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {}", e)))?
-        .ok_or_else(|| ApiError::NotFound(format!("Workflow {} not found", id)))?;
+        .map_err(|e| ApiError::Internal(format!("Failed to get workflow: {e}")))?
+        .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
     // Deserialise the stored JSON into a WorkflowDefinition.
     let workflow_def: nebula_workflow::WorkflowDefinition = serde_json::from_value(definition)
         .map_err(|e| {
             ApiError::validation_message(format!(
-                "Workflow definition cannot be parsed as WorkflowDefinition: {}",
-                e
+                "Workflow definition cannot be parsed as WorkflowDefinition: {e}"
             ))
         })?;
 
@@ -619,7 +616,7 @@ pub async fn validate_workflow_handler(
             errors: vec![],
         }))
     } else {
-        let error_messages: Vec<String> = errors.iter().map(|e| e.to_string()).collect();
+        let error_messages: Vec<String> = errors.iter().map(ToString::to_string).collect();
         Ok(Json(WorkflowValidateResponse {
             valid: false,
             errors: error_messages,

--- a/crates/api/src/middleware/rate_limit.rs
+++ b/crates/api/src/middleware/rate_limit.rs
@@ -93,15 +93,14 @@ impl RateLimitState {
 
         let ip = extract_client_ip(&request);
 
-        match self.limiter.check_key(&ip) {
-            Ok(_) => next.run(request).await,
-            Err(_) => {
-                let mut response = StatusCode::TOO_MANY_REQUESTS.into_response();
-                response
-                    .headers_mut()
-                    .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
-                response
-            },
+        if self.limiter.check_key(&ip) == Ok(()) {
+            next.run(request).await
+        } else {
+            let mut response = StatusCode::TOO_MANY_REQUESTS.into_response();
+            response
+                .headers_mut()
+                .insert(header::RETRY_AFTER, HeaderValue::from_static("1"));
+            response
         }
     }
 }

--- a/crates/api/src/middleware/request_id.rs
+++ b/crates/api/src/middleware/request_id.rs
@@ -54,8 +54,7 @@ where
             .headers()
             .get(X_REQUEST_ID)
             .and_then(|h| h.to_str().ok())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| Uuid::new_v4().to_string());
+            .map_or_else(|| Uuid::new_v4().to_string(), ToString::to_string);
 
         // Insert into extensions for handlers
         request

--- a/crates/api/src/models/mod.rs
+++ b/crates/api/src/models/mod.rs
@@ -7,7 +7,16 @@ pub mod execution;
 pub mod health;
 pub mod workflow;
 
-pub use catalog::*;
-pub use execution::*;
-pub use health::*;
-pub use workflow::*;
+pub use catalog::{
+    ActionDetailResponse, ActionSummary, ListActionsResponse, ListPluginsResponse,
+    PluginDetailResponse, PluginSummary,
+};
+pub use execution::{
+    ExecutionLogsResponse, ExecutionOutputsResponse, ExecutionResponse, ListExecutionsResponse,
+    RunningExecutionSummary, StartExecutionRequest,
+};
+pub use health::{DependenciesStatus, HealthResponse, ReadinessResponse};
+pub use workflow::{
+    CreateWorkflowRequest, ListWorkflowsResponse, UpdateWorkflowRequest, WorkflowResponse,
+    WorkflowValidateResponse,
+};

--- a/crates/api/src/webhook/ratelimit.rs
+++ b/crates/api/src/webhook/ratelimit.rs
@@ -66,7 +66,7 @@ impl WebhookRateLimiter {
     }
 
     fn with_config(requests_per_minute: u64, max_paths: u64) -> Self {
-        let window = Duration::from_secs(60);
+        let window = Duration::from_mins(1);
         let max_requests = requests_per_minute.max(1) as usize;
         let windows = Cache::builder()
             .max_capacity(max_paths.max(1))

--- a/crates/api/src/webhook/transport.rs
+++ b/crates/api/src/webhook/transport.rs
@@ -336,12 +336,11 @@ async fn webhook_handler(
     }
 
     // 4. Route lookup.
-    let entry = match transport.inner.routing.lookup(&trigger_uuid, &nonce) {
-        Some(e) => e,
-        None => {
-            debug!(uuid = %trigger_uuid, "no webhook registered for path");
-            return (StatusCode::NOT_FOUND, "").into_response();
-        },
+    let entry = if let Some(e) = transport.inner.routing.lookup(&trigger_uuid, &nonce) {
+        e
+    } else {
+        debug!(uuid = %trigger_uuid, "no webhook registered for path");
+        return (StatusCode::NOT_FOUND, "").into_response();
     };
 
     // 5. Construct WebhookRequest. Limits are already enforced by
@@ -400,12 +399,11 @@ async fn webhook_handler(
             // been used by the adapter to record health. The HTTP
             // response comes through the oneshot the adapter sent to
             // right before returning Ok.
-            match rx.await {
-                Ok(http) => http_response_to_axum(http),
-                Err(_) => {
-                    warn!("webhook handler returned Ok but oneshot sender was dropped");
-                    (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
-                },
+            if let Ok(http) = rx.await {
+                http_response_to_axum(http)
+            } else {
+                warn!("webhook handler returned Ok but oneshot sender was dropped");
+                (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
             }
         },
         Ok(Err(e)) => {

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -15,13 +15,15 @@ use nebula_storage::{
 
 // ── Shared constant ───────────────────────────────────────────────────────────
 
-pub const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests-0123456789";
+pub(crate) const TEST_JWT_SECRET: &str = "test-secret-for-integration-tests-0123456789";
 
 // ── Workflow definition builders ──────────────────────────────────────────────
 
 /// Build a minimal, structurally valid `WorkflowDefinition` JSON that passes
 /// `nebula_workflow::validate_workflow` (single node, no cycles, schema_version=1).
-pub fn make_valid_workflow_definition(workflow_id: &nebula_core::WorkflowId) -> serde_json::Value {
+pub(crate) fn make_valid_workflow_definition(
+    workflow_id: &nebula_core::WorkflowId,
+) -> serde_json::Value {
     serde_json::json!({
         "id": workflow_id.to_string(),
         "name": "Valid Workflow",
@@ -39,7 +41,9 @@ pub fn make_valid_workflow_definition(workflow_id: &nebula_core::WorkflowId) -> 
 /// Build a `WorkflowDefinition` JSON that parses correctly but fails
 /// `validate_workflow` due to a cycle (A → B, B → A) and therefore also
 /// fails entry-node detection.
-pub fn make_cyclic_workflow_definition(workflow_id: &nebula_core::WorkflowId) -> serde_json::Value {
+pub(crate) fn make_cyclic_workflow_definition(
+    workflow_id: &nebula_core::WorkflowId,
+) -> serde_json::Value {
     serde_json::json!({
         "id": workflow_id.to_string(),
         "name": "Cyclic Workflow",
@@ -61,7 +65,7 @@ pub fn make_cyclic_workflow_definition(workflow_id: &nebula_core::WorkflowId) ->
 // ── JWT helper ────────────────────────────────────────────────────────────────
 
 /// Build a valid JWT token signed with [`TEST_JWT_SECRET`].
-pub fn create_test_jwt() -> String {
+pub(crate) fn create_test_jwt() -> String {
     use jsonwebtoken::{EncodingKey, Header, encode};
     use serde::{Deserialize, Serialize};
 
@@ -93,7 +97,7 @@ pub fn create_test_jwt() -> String {
 
 /// Create an `AppState` with fully functional in-memory repos; return both the
 /// state and a typed reference to the control queue so tests can inspect it.
-pub async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
+pub(crate) async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
     let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
     let execution_repo = Arc::new(InMemoryExecutionRepo::new());
     let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());
@@ -106,7 +110,7 @@ pub async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRep
         workflow_repo,
         execution_repo,
         control_queue_dyn,
-        api_config.jwt_secret.clone(),
+        api_config.jwt_secret,
     );
 
     (state, control_queue_repo)
@@ -114,6 +118,6 @@ pub async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRep
 
 /// Alias for [`create_state_with_queue`], preserving the name used by
 /// `integration_tests.rs` callers so no test body needs to change.
-pub async fn create_test_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
+pub(crate) async fn create_test_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
     create_state_with_queue().await
 }

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -19,7 +19,7 @@ async fn create_test_state() -> AppState {
         workflow_repo,
         execution_repo,
         control_queue_repo,
-        api_config.jwt_secret.clone(),
+        api_config.jwt_secret,
     )
 }
 
@@ -58,7 +58,7 @@ async fn test_workflow_list_empty() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/workflows")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -94,11 +94,8 @@ async fn test_error_format_rfc9457() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!(
-                    "/api/v1/workflows/{}",
-                    nebula_core::WorkflowId::new()
-                ))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{}", WorkflowId::new()))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -135,7 +132,7 @@ async fn test_error_format_rfc9457() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/workflows/invalid-uuid")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -191,8 +188,8 @@ async fn test_error_format_rfc9457() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -267,7 +264,7 @@ async fn create_workflow() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -318,7 +315,7 @@ async fn test_workflow_list_with_data() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -334,7 +331,7 @@ async fn test_workflow_list_with_data() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/workflows")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -378,7 +375,7 @@ async fn test_workflow_list_total_matches_full_dataset_across_pages() {
                     .method("POST")
                     .uri("/api/v1/workflows")
                     .header("content-type", "application/json")
-                    .header("authorization", format!("Bearer {}", token))
+                    .header("authorization", format!("Bearer {token}"))
                     .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                     .unwrap(),
             )
@@ -397,7 +394,7 @@ async fn test_workflow_list_total_matches_full_dataset_across_pages() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/workflows?page=1&page_size=2")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -417,7 +414,7 @@ async fn test_workflow_list_total_matches_full_dataset_across_pages() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/workflows?page=2&page_size=2")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -461,7 +458,7 @@ async fn test_get_workflow_by_id() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -482,8 +479,8 @@ async fn test_get_workflow_by_id() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/workflows/{}", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -522,8 +519,8 @@ async fn test_get_workflow_not_found() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/workflows/{}", nonexistent_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{nonexistent_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -562,7 +559,7 @@ async fn test_update_workflow() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -592,9 +589,9 @@ async fn test_update_workflow() {
         .oneshot(
             Request::builder()
                 .method("PUT")
-                .uri(format!("/api/v1/workflows/{}", workflow_id))
+                .uri(format!("/api/v1/workflows/{workflow_id}"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&update_request).unwrap()))
                 .unwrap(),
         )
@@ -646,7 +643,7 @@ async fn test_delete_workflow() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -667,8 +664,8 @@ async fn test_delete_workflow() {
         .oneshot(
             Request::builder()
                 .method("DELETE")
-                .uri(format!("/api/v1/workflows/{}", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -683,8 +680,8 @@ async fn test_delete_workflow() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/workflows/{}", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -721,8 +718,8 @@ async fn test_activate_workflow() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/activate", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}/activate"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -762,8 +759,8 @@ async fn test_activate_workflow_not_found() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/activate", nonexistent_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{nonexistent_id}/activate"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -802,7 +799,7 @@ async fn test_execute_workflow() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -829,9 +826,9 @@ async fn test_execute_workflow() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/execute", workflow_id))
+                .uri(format!("/api/v1/workflows/{workflow_id}/execute"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&execute_request).unwrap()))
                 .unwrap(),
         )
@@ -878,9 +875,9 @@ async fn test_execute_workflow_not_found() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/execute", nonexistent_id))
+                .uri(format!("/api/v1/workflows/{nonexistent_id}/execute"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&execute_request).unwrap()))
                 .unwrap(),
         )
@@ -911,7 +908,7 @@ async fn test_execution_list_all_empty() {
             Request::builder()
                 .method("GET")
                 .uri("/api/v1/executions")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -960,7 +957,7 @@ async fn test_execution_list_for_workflow_empty() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -981,8 +978,8 @@ async fn test_execution_list_for_workflow_empty() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/workflows/{}/executions", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}/executions"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1040,8 +1037,8 @@ async fn test_execution_get_by_id() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/executions/{}", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1082,8 +1079,8 @@ async fn test_execution_get_not_found() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/executions/{}", nonexistent_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{nonexistent_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1122,7 +1119,7 @@ async fn test_execution_start() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -1149,9 +1146,9 @@ async fn test_execution_start() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/executions", workflow_id))
+                .uri(format!("/api/v1/workflows/{workflow_id}/executions"))
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&start_request).unwrap()))
                 .unwrap(),
         )
@@ -1210,8 +1207,8 @@ async fn test_execution_cancel() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1235,8 +1232,8 @@ async fn test_execution_cancel() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/executions/{}", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1273,8 +1270,8 @@ async fn test_execution_cancel_not_found() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", nonexistent_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{nonexistent_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1326,8 +1323,8 @@ async fn test_execution_cancel_already_completed() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1371,8 +1368,8 @@ async fn test_execution_get_invalid_id() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/executions/{}", invalid_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{invalid_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1705,7 +1702,7 @@ async fn update_workflow_rejects_immutable_identity_fields() {
                 .method("POST")
                 .uri("/api/v1/workflows")
                 .header("content-type", "application/json")
-                .header("authorization", format!("Bearer {}", token))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::from(serde_json::to_string(&create_request).unwrap()))
                 .unwrap(),
         )
@@ -1737,7 +1734,7 @@ async fn update_workflow_rejects_immutable_identity_fields() {
                     .method("PUT")
                     .uri(format!("/api/v1/workflows/{workflow_id}"))
                     .header("content-type", "application/json")
-                    .header("authorization", format!("Bearer {}", token))
+                    .header("authorization", format!("Bearer {token}"))
                     .body(Body::from(serde_json::to_string(&update_request).unwrap()))
                     .unwrap(),
             )
@@ -1788,8 +1785,8 @@ async fn get_workflow_parses_rfc3339_timestamps() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/workflows/{}", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1831,8 +1828,8 @@ async fn activate_valid_returns_200() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/activate", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}/activate"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1882,8 +1879,8 @@ async fn activate_invalid_returns_422() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/workflows/{}/activate", workflow_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/workflows/{workflow_id}/activate"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -1933,8 +1930,7 @@ async fn activate_invalid_returns_422() {
         assert!(
             err["pointer"]
                 .as_str()
-                .map(|p| p.is_empty() || p.starts_with('/'))
-                .unwrap_or(false),
+                .is_some_and(|p| p.is_empty() || p.starts_with('/')),
             "pointer must be a valid RFC 6901 JSON Pointer (empty string or starts with /)"
         );
     }
@@ -1999,8 +1995,8 @@ async fn cancel_enqueues_durable_control_signal() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -2101,8 +2097,8 @@ async fn cancel_terminal_execution_does_not_enqueue() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -2167,8 +2163,8 @@ async fn get_execution_parses_rfc3339_timestamps() {
         .oneshot(
             Request::builder()
                 .method("GET")
-                .uri(format!("/api/v1/executions/{}", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )
@@ -2228,8 +2224,8 @@ async fn cancel_timed_out_execution_rejected() {
         .oneshot(
             Request::builder()
                 .method("POST")
-                .uri(format!("/api/v1/executions/{}/cancel", execution_id))
-                .header("authorization", format!("Bearer {}", token))
+                .uri(format!("/api/v1/executions/{execution_id}/cancel"))
+                .header("authorization", format!("Bearer {token}"))
                 .body(Body::empty())
                 .unwrap(),
         )

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -101,7 +101,7 @@ async fn create_state_with_failing_queue() -> AppState {
         workflow_repo,
         execution_repo,
         control_queue_repo,
-        api_config.jwt_secret.clone(),
+        api_config.jwt_secret,
     )
 }
 
@@ -453,9 +453,8 @@ async fn knife_scenario_end_to_end() {
     // finished_at must be absent (not "0") — canon explicitly forbids synthetic zero.
     let finished_at_value = observed.get("finished_at");
     let finished_at_is_zero = finished_at_value
-        .and_then(|v| v.as_i64())
-        .map(|v| v == 0)
-        .unwrap_or(false);
+        .and_then(serde_json::Value::as_i64)
+        .is_some_and(|v| v == 0);
     assert!(
         !finished_at_is_zero,
         "step 4: finished_at must NOT be synthetic 0 — must be absent or a real timestamp"
@@ -484,8 +483,7 @@ async fn knife_scenario_end_to_end() {
     assert_eq!(
         pre_cancel_entries.len(),
         1,
-        "step 5 pre-condition (#332): queue must hold the Start entry written by step 3, got {:?}",
-        pre_cancel_entries
+        "step 5 pre-condition (#332): queue must hold the Start entry written by step 3, got {pre_cancel_entries:?}"
     );
     assert_eq!(
         pre_cancel_entries[0].command,

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,3 +27,6 @@ criterion = { workspace = true }
 [[bench]]
 name = "id_parse_serialize"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/core/src/scope.rs
+++ b/crates/core/src/scope.rs
@@ -178,10 +178,10 @@ impl fmt::Display for ScopeLevel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ScopeLevel::Global => write!(f, "global"),
-            ScopeLevel::Organization(id) => write!(f, "organization:{}", id),
-            ScopeLevel::Workspace(id) => write!(f, "workspace:{}", id),
-            ScopeLevel::Workflow(id) => write!(f, "workflow:{}", id),
-            ScopeLevel::Execution(id) => write!(f, "execution:{}", id),
+            ScopeLevel::Organization(id) => write!(f, "organization:{id}"),
+            ScopeLevel::Workspace(id) => write!(f, "workspace:{id}"),
+            ScopeLevel::Workflow(id) => write!(f, "workflow:{id}"),
+            ScopeLevel::Execution(id) => write!(f, "execution:{id}"),
         }
     }
 }

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -81,3 +81,6 @@ rotation = []
 # to other crates' dev-dependency paths. Must never be enabled in a production
 # release build — see ADR-0023.
 test-util = []
+
+[lints]
+workspace = true

--- a/crates/credential/macros/Cargo.toml
+++ b/crates/credential/macros/Cargo.toml
@@ -21,3 +21,6 @@ nebula-macro-support = { path = "../../sdk/macros-support" }
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/credential/macros/src/auth_scheme.rs
+++ b/crates/credential/macros/src/auth_scheme.rs
@@ -6,7 +6,7 @@ use quote::quote;
 use syn::{DeriveInput, parse_macro_input};
 
 /// Entry point for `#[derive(AuthScheme)]`.
-pub fn derive(input: TokenStream) -> TokenStream {
+pub(crate) fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match expand(input) {

--- a/crates/credential/macros/src/credential.rs
+++ b/crates/credential/macros/src/credential.rs
@@ -6,7 +6,7 @@ use quote::quote;
 use syn::{Data, DeriveInput, Fields, parse_macro_input};
 
 /// Entry point for `#[derive(Credential)]`.
-pub fn derive(input: TokenStream) -> TokenStream {
+pub(crate) fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match expand(input) {
@@ -88,13 +88,15 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let scheme = &attrs.scheme;
     let protocol = &attrs.protocol;
 
-    let icon_expr = match &attrs.icon {
-        Some(icon) => quote! { ::std::option::Option::Some(#icon.to_owned()) },
-        None => quote! { ::std::option::Option::None },
+    let icon_expr = if let Some(icon) = &attrs.icon {
+        quote! { ::std::option::Option::Some(#icon.to_owned()) }
+    } else {
+        quote! { ::std::option::Option::None }
     };
-    let doc_url_expr = match &attrs.doc_url {
-        Some(url) => quote! { ::std::option::Option::Some(#url.to_owned()) },
-        None => quote! { ::std::option::Option::None },
+    let doc_url_expr = if let Some(url) = &attrs.doc_url {
+        quote! { ::std::option::Option::Some(#url.to_owned()) }
+    } else {
+        quote! { ::std::option::Option::None }
     };
 
     let expanded = quote! {

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -114,8 +114,8 @@ mod tests {
     fn project_returns_clone_of_state() {
         let token = SecretToken::new(SecretString::new("test-token"));
         let projected = ApiKeyCredential::project(&token);
-        let original = token.token().expose_secret(|s| s.to_owned());
-        let cloned = projected.token().expose_secret(|s| s.to_owned());
+        let original = token.token().expose_secret(ToOwned::to_owned);
+        let cloned = projected.token().expose_secret(ToOwned::to_owned);
         assert_eq!(original, cloned);
     }
 
@@ -127,7 +127,7 @@ mod tests {
         let result = ApiKeyCredential::resolve(&values, &ctx).await.unwrap();
         match result {
             StaticResolveResult::Complete(token) => {
-                let exposed = token.token().expose_secret(|s| s.to_owned());
+                let exposed = token.token().expose_secret(ToOwned::to_owned);
                 assert_eq!(exposed, "sk-secret-123");
             },
             _ => panic!("expected Complete variant"),

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -105,8 +105,8 @@ mod tests {
         let auth = IdentityPassword::new("admin", SecretString::new("s3cret"));
         let projected = BasicAuthCredential::project(&auth);
         assert_eq!(projected.identity(), "admin");
-        let original = auth.password().expose_secret(|s| s.to_owned());
-        let cloned = projected.password().expose_secret(|s| s.to_owned());
+        let original = auth.password().expose_secret(ToOwned::to_owned);
+        let cloned = projected.password().expose_secret(ToOwned::to_owned);
         assert_eq!(original, cloned);
     }
 
@@ -120,7 +120,7 @@ mod tests {
         match result {
             StaticResolveResult::Complete(auth) => {
                 assert_eq!(auth.identity(), "alice");
-                let pw = auth.password().expose_secret(|s| s.to_owned());
+                let pw = auth.password().expose_secret(ToOwned::to_owned);
                 assert_eq!(pw, "p@ssw0rd");
             },
             _ => panic!("expected Complete variant"),

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -176,8 +176,8 @@ pub struct OAuth2Pending {
 // the `device_code` (device-flow bearer), the `pkce_verifier` (one-shot
 // auth-code verifier), or the `state` (callback CSRF token). The
 // `redirect_uri` is not secret and is shown verbatim.
-impl std::fmt::Debug for OAuth2Pending {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for OAuth2Pending {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.debug_struct("OAuth2Pending")
             .field("config", &self.config)
             .field("client_id", &"[REDACTED]")
@@ -237,7 +237,7 @@ impl PendingState for OAuth2Pending {
     const KIND: &'static str = "oauth2_pending";
 
     fn expires_in(&self) -> Duration {
-        Duration::from_secs(600) // 10 minutes for interactive flows
+        Duration::from_mins(10) // 10 minutes for interactive flows
     }
 }
 
@@ -515,9 +515,9 @@ impl Credential for OAuth2Credential {
                 // Downstream oauth2_flow::exchange_authorization_code builds the
                 // form body from &str borrows (GitHub issue #265).
                 let client_secret: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(|s| s.to_owned()));
+                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(ToOwned::to_owned));
                 let code_verifier: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(verifier_secret.expose_secret(|s| s.to_owned()));
+                    zeroize::Zeroizing::new(verifier_secret.expose_secret(ToOwned::to_owned));
 
                 let state = oauth2_flow::exchange_authorization_code(
                     &pending.config,
@@ -543,7 +543,7 @@ impl Credential for OAuth2Credential {
                 // Zeroizing<String>: intermediate plaintext scrubs on drop;
                 // poll_device_code builds its form from &str borrows (#265).
                 let client_secret: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(|s| s.to_owned()));
+                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(ToOwned::to_owned));
 
                 match oauth2_flow::poll_device_code(
                     &pending.config,
@@ -978,7 +978,7 @@ mod tests {
             auth_style: AuthStyle::default(),
         };
         // Expires in 30s, margin is 60s => expired
-        assert!(state.is_expired(Duration::from_secs(60)));
+        assert!(state.is_expired(Duration::from_mins(1)));
         // Margin is 0 => not expired
         assert!(!state.is_expired(Duration::from_secs(0)));
     }
@@ -1075,7 +1075,7 @@ mod tests {
             redirect_uri: None,
         };
 
-        assert_eq!(pending.expires_in(), Duration::from_secs(600));
+        assert_eq!(pending.expires_in(), Duration::from_mins(10));
     }
 
     #[test]

--- a/crates/credential/src/credentials/oauth2_flow.rs
+++ b/crates/credential/src/credentials/oauth2_flow.rs
@@ -430,12 +430,12 @@ pub(crate) async fn refresh_token(
             .refresh_token
             .as_ref()
             .ok_or_else(|| provider_error("no refresh_token available for token refresh".into()))?
-            .expose_secret(|s| s.to_owned()),
+            .expose_secret(ToOwned::to_owned),
     );
     let client_id: Zeroizing<String> =
-        Zeroizing::new(state.client_id.expose_secret(|s| s.to_owned()));
+        Zeroizing::new(state.client_id.expose_secret(ToOwned::to_owned));
     let client_secret: Zeroizing<String> =
-        Zeroizing::new(state.client_secret.expose_secret(|s| s.to_owned()));
+        Zeroizing::new(state.client_secret.expose_secret(ToOwned::to_owned));
 
     let scope_joined: Option<String> = (!config.scopes.is_empty()).then(|| config.scopes.join(" "));
     let mut form: Vec<(&str, &str)> = vec![
@@ -561,11 +561,10 @@ fn state_from_token_response(
         .and_then(Value::as_u64)
         .map(|secs| Utc::now() + chrono::Duration::seconds(secs as i64));
 
-    let scopes = body
-        .get("scope")
-        .and_then(Value::as_str)
-        .map(|s| s.split_whitespace().map(str::to_owned).collect())
-        .unwrap_or_else(|| default_scopes.to_vec());
+    let scopes = body.get("scope").and_then(Value::as_str).map_or_else(
+        || default_scopes.to_vec(),
+        |s| s.split_whitespace().map(str::to_owned).collect(),
+    );
 
     Ok(OAuth2State {
         access_token: SecretString::new(access_token),
@@ -851,7 +850,7 @@ mod tests {
     #[test]
     fn oauth_token_error_summary_omits_raw_body_and_echoed_secrets() {
         let body = r#"{"error":"invalid_client","client_secret":"hunter2"}"#;
-        let summary = super::oauth_token_error_summary(body);
+        let summary = oauth_token_error_summary(body);
         assert!(
             !summary.contains("hunter2"),
             "secret echoed by provider must not appear: {summary}"

--- a/crates/credential/src/crypto.rs
+++ b/crates/credential/src/crypto.rs
@@ -471,7 +471,7 @@ mod tests {
         let encrypted = EncryptedData::new("", [0u8; 12], vec![], [0u8; 16]);
         assert!(encrypted.is_supported_version());
 
-        let mut unsupported = encrypted.clone();
+        let mut unsupported = encrypted;
         unsupported.version = 99;
         assert!(!unsupported.is_supported_version());
     }

--- a/crates/credential/src/handle.rs
+++ b/crates/credential/src/handle.rs
@@ -90,7 +90,7 @@ mod tests {
         let handle = CredentialHandle::new(token, "cred-1");
 
         let snapshot = handle.snapshot();
-        let value = snapshot.token().expose_secret(|s| s.to_owned());
+        let value = snapshot.token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "abc");
     }
 
@@ -112,8 +112,8 @@ mod tests {
 
         // Replacing on one does not affect the other (independent ArcSwap)
         handle.replace(SecretToken::new(SecretString::new("updated")));
-        let orig_val = handle.snapshot().token().expose_secret(|s| s.to_owned());
-        let clone_val = cloned.snapshot().token().expose_secret(|s| s.to_owned());
+        let orig_val = handle.snapshot().token().expose_secret(ToOwned::to_owned);
+        let clone_val = cloned.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(orig_val, "updated");
         assert_eq!(clone_val, "shared");
     }
@@ -124,15 +124,15 @@ mod tests {
         let handle = CredentialHandle::new(token, "cred-1");
 
         let snap1 = handle.snapshot();
-        assert_eq!(snap1.token().expose_secret(|s| s.to_owned()), "original");
+        assert_eq!(snap1.token().expose_secret(ToOwned::to_owned), "original");
 
         handle.replace(SecretToken::new(SecretString::new("refreshed")));
 
         let snap2 = handle.snapshot();
-        assert_eq!(snap2.token().expose_secret(|s| s.to_owned()), "refreshed");
+        assert_eq!(snap2.token().expose_secret(ToOwned::to_owned), "refreshed");
 
         // Old snapshot still valid
-        assert_eq!(snap1.token().expose_secret(|s| s.to_owned()), "original");
+        assert_eq!(snap1.token().expose_secret(ToOwned::to_owned), "original");
     }
 
     #[test]

--- a/crates/credential/src/layer/cache.rs
+++ b/crates/credential/src/layer/cache.rs
@@ -41,8 +41,8 @@ impl Default for CacheConfig {
     fn default() -> Self {
         Self {
             max_entries: 10_000,
-            ttl: Duration::from_secs(300),
-            tti: Duration::from_secs(120),
+            ttl: Duration::from_mins(5),
+            tti: Duration::from_mins(2),
         }
     }
 }

--- a/crates/credential/src/layer/encryption.rs
+++ b/crates/credential/src/layer/encryption.rs
@@ -352,7 +352,7 @@ mod tests {
 
         // Simulate legacy write: encrypt without AAD and store directly
         let plaintext = b"legacy-secret";
-        let encrypted = crate::crypto::encrypt(&key, plaintext).unwrap();
+        let encrypted = crypto::encrypt(&key, plaintext).unwrap();
         let encrypted_bytes = serde_json::to_vec(&encrypted).unwrap();
 
         let cred = StoredCredential {
@@ -405,7 +405,7 @@ mod tests {
 
         // Inspect the raw bytes stored — should contain "default" as key_id
         let raw = inner.get("key-id-check").await.unwrap();
-        let envelope: crate::crypto::EncryptedData = serde_json::from_slice(&raw.data).unwrap();
+        let envelope: crypto::EncryptedData = serde_json::from_slice(&raw.data).unwrap();
         assert_eq!(envelope.key_id, "default");
     }
 
@@ -531,7 +531,7 @@ mod tests {
 
         // Verify the data was re-encrypted with key-2 in the backing store
         let raw = inner.get("lazy-1").await.unwrap();
-        let envelope: crate::crypto::EncryptedData = serde_json::from_slice(&raw.data).unwrap();
+        let envelope: crypto::EncryptedData = serde_json::from_slice(&raw.data).unwrap();
         assert_eq!(envelope.key_id, "key-2");
     }
 
@@ -553,7 +553,7 @@ mod tests {
         // simulate a legacy pre-guard envelope persisted by an older build.
         let plaintext = b"legacy-record";
         let mut legacy_envelope =
-            crate::crypto::encrypt_with_key_id(&key, "default", plaintext, b"legacy-1").unwrap();
+            crypto::encrypt_with_key_id(&key, "default", plaintext, b"legacy-1").unwrap();
         legacy_envelope.key_id = String::new();
         let envelope_bytes = serde_json::to_vec(&legacy_envelope).unwrap();
 

--- a/crates/credential/src/layer/key_provider.rs
+++ b/crates/credential/src/layer/key_provider.rs
@@ -868,7 +868,7 @@ mod tests {
             })
         }
 
-        fn version(&self) -> &str {
+        fn version(&self) -> &'static str {
             "failing:test"
         }
     }

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -206,7 +206,7 @@ impl CredentialMetadataBuilder {
 pub enum MetadataCompatibilityError {
     /// A generic catalog-citizen rule fired (key / version / schema).
     #[error(transparent)]
-    Base(#[from] nebula_metadata::BaseCompatError<nebula_core::CredentialKey>),
+    Base(#[from] nebula_metadata::BaseCompatError<CredentialKey>),
 
     /// Auth pattern changed without a major version bump.
     #[error("credential auth pattern changed without a major version bump")]

--- a/crates/credential/src/pending_store_memory.rs
+++ b/crates/credential/src/pending_store_memory.rs
@@ -187,7 +187,7 @@ mod tests {
         const KIND: &'static str = "test_pending";
 
         fn expires_in(&self) -> Duration {
-            Duration::from_secs(300)
+            Duration::from_mins(5)
         }
     }
 

--- a/crates/credential/src/record.rs
+++ b/crates/credential/src/record.rs
@@ -162,9 +162,7 @@ impl CredentialRecord {
     /// assert!(!record.is_expired());
     /// ```
     pub fn is_expired(&self) -> bool {
-        self.expires_at
-            .map(|exp| exp <= Utc::now())
-            .unwrap_or(false)
+        self.expires_at.is_some_and(|exp| exp <= Utc::now())
     }
 
     /// Update last accessed timestamp

--- a/crates/credential/src/refresh.rs
+++ b/crates/credential/src/refresh.rs
@@ -245,7 +245,7 @@ impl RefreshCoordinator {
         }
         let config = CircuitBreakerConfig {
             failure_threshold: 5,
-            reset_timeout: Duration::from_secs(300),
+            reset_timeout: Duration::from_mins(5),
             min_operations: 1,
             ..Default::default()
         };
@@ -642,10 +642,7 @@ mod tests {
     #[tokio::test]
     async fn default_coordinator_has_default_permits() {
         let coord = RefreshCoordinator::new();
-        assert_eq!(
-            coord.available_permits(),
-            super::DEFAULT_MAX_CONCURRENT_REFRESHES
-        );
+        assert_eq!(coord.available_permits(), DEFAULT_MAX_CONCURRENT_REFRESHES);
     }
 
     /// #314: `with_max_concurrent(0)` must not construct a deadlocking

--- a/crates/credential/src/registry.rs
+++ b/crates/credential/src/registry.rs
@@ -164,7 +164,7 @@ mod tests {
 
         let any = registry.project("secret_token", &data).unwrap();
         let projected = any.downcast::<SecretToken>().unwrap();
-        let value = projected.token().expose_secret(|s| s.to_owned());
+        let value = projected.token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "test-key");
     }
 

--- a/crates/credential/src/resolve.rs
+++ b/crates/credential/src/resolve.rs
@@ -197,7 +197,7 @@ pub struct RefreshPolicy {
 impl RefreshPolicy {
     /// Sensible defaults for most credential types.
     pub const DEFAULT: Self = Self {
-        early_refresh: Duration::from_secs(300),
+        early_refresh: Duration::from_mins(5),
         min_retry_backoff: Duration::from_secs(5),
         jitter: Duration::from_secs(30),
     };

--- a/crates/credential/src/resolver.rs
+++ b/crates/credential/src/resolver.rs
@@ -209,7 +209,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
                 // from Drop.
                 let credential_id_for_guard = credential_id.to_string();
                 let coordinator = &self.refresh_coordinator;
-                let _guard = scopeguard::guard((), |_| {
+                let _guard = scopeguard::guard((), |()| {
                     coordinator.complete(&credential_id_for_guard);
                 });
                 let result = self
@@ -362,12 +362,13 @@ impl<S: CredentialStore> CredentialResolver<S> {
                         .await
                     {
                         Ok(_) => {
-                            match CredentialId::parse(credential_id) {
-                                Ok(id) => self.emit_refreshed(id),
-                                Err(_) => tracing::warn!(
+                            if let Ok(id) = CredentialId::parse(credential_id) {
+                                self.emit_refreshed(id);
+                            } else {
+                                tracing::warn!(
                                     credential_id,
                                     "credential ID is not a valid UUID, refresh event not emitted",
-                                ),
+                                );
                             }
                             let scheme = C::project(&state);
                             return Ok(CredentialHandle::new(scheme, credential_id));
@@ -497,7 +498,7 @@ mod tests {
         const KEY: &'static str = "refreshable_test";
         const REFRESHABLE: bool = true;
         const REFRESH_POLICY: RefreshPolicy = RefreshPolicy {
-            early_refresh: std::time::Duration::from_secs(300), // 5 minutes
+            early_refresh: std::time::Duration::from_mins(5), // 5 minutes
             ..RefreshPolicy::DEFAULT
         };
 
@@ -546,7 +547,7 @@ mod tests {
         const KEY: &'static str = "tiny_jitter_refreshable_test";
         const REFRESHABLE: bool = true;
         const REFRESH_POLICY: RefreshPolicy = RefreshPolicy {
-            early_refresh: std::time::Duration::from_secs(300),
+            early_refresh: std::time::Duration::from_mins(5),
             jitter: std::time::Duration::from_micros(500),
             ..RefreshPolicy::DEFAULT
         };
@@ -611,7 +612,7 @@ mod tests {
             .unwrap();
 
         let snapshot = handle.snapshot();
-        let value = snapshot.token().expose_secret(|s| s.to_owned());
+        let value = snapshot.token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "test-api-key");
         assert_eq!(handle.credential_id(), "my-api-key");
     }
@@ -782,7 +783,7 @@ mod tests {
             .resolve::<ApiKeyCredential>("non-expiring")
             .await
             .expect("non-expiring credential should resolve under any circuit state");
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "forever");
     }
 
@@ -827,7 +828,7 @@ mod tests {
             .resolve_with_refresh::<RefreshableTestCredential>("closed-circuit-expired", &ctx)
             .await
             .expect("closed-circuit + expired = normal refresh path");
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "refreshed-token");
     }
 
@@ -880,7 +881,7 @@ mod tests {
             .resolve_with_refresh::<RefreshableTestCredential>("soon-expiring", &ctx)
             .await
             .expect("stale-but-valid token must still resolve while circuit is open");
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "still-valid");
     }
 
@@ -919,7 +920,7 @@ mod tests {
             .unwrap();
 
         // The refresh should have fired because 4 min < 5 min early_refresh
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "refreshed-token");
     }
 
@@ -957,7 +958,7 @@ mod tests {
             .await
             .unwrap();
 
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "tiny-jitter-refreshed-token");
     }
 
@@ -1045,7 +1046,7 @@ mod tests {
         const KEY: &'static str = "cas_retry_test";
         const REFRESHABLE: bool = true;
         const REFRESH_POLICY: RefreshPolicy = RefreshPolicy {
-            early_refresh: std::time::Duration::from_secs(300),
+            early_refresh: std::time::Duration::from_mins(5),
             jitter: std::time::Duration::ZERO,
             ..RefreshPolicy::DEFAULT
         };
@@ -1120,7 +1121,7 @@ mod tests {
             .unwrap();
 
         // Token should be the refreshed value despite CAS conflict
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "refreshed-token");
 
         // Critical: refresh() must be called exactly once — the retry
@@ -1216,7 +1217,7 @@ mod tests {
             .unwrap();
 
         // Should NOT have refreshed -- token still valid outside the window
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "still-valid-token");
     }
 
@@ -1260,7 +1261,7 @@ mod tests {
             .unwrap();
 
         // Refresh should have fired
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "refreshed-token");
 
         // Subscriber should have received a Refreshed event
@@ -1315,7 +1316,7 @@ mod tests {
             .unwrap();
 
         // Should NOT have refreshed
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "still-valid");
 
         // No event should be pending -- recv should time out

--- a/crates/credential/src/scheme/federated_assertion.rs
+++ b/crates/credential/src/scheme/federated_assertion.rs
@@ -111,7 +111,7 @@ mod tests {
 
     #[test]
     fn expires_at_propagates_to_auth_scheme() {
-        let expiry = chrono::Utc::now() + chrono::Duration::hours(1);
+        let expiry = Utc::now() + chrono::Duration::hours(1);
         let a = FederatedAssertion::new(SecretString::new("tok"), "issuer").with_expires_at(expiry);
         assert_eq!(AuthScheme::expires_at(&a), Some(expiry));
     }

--- a/crates/credential/src/snapshot.rs
+++ b/crates/credential/src/snapshot.rs
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn clone_preserves_projected_value() {
         let snap = token_snapshot();
-        let cloned = snap.clone();
+        let cloned = snap;
         let token = cloned.project::<SecretToken>().unwrap();
         token.token().expose_secret(|t| assert_eq!(t, "test-token"));
         assert_eq!(cloned.kind(), "api_key");

--- a/crates/credential/src/static_protocol.rs
+++ b/crates/credential/src/static_protocol.rs
@@ -142,7 +142,7 @@ mod tests {
         let mut values = FieldValues::new();
         values.set_raw("token", serde_json::json!("test-token"));
         let token = TestProtocol::build(&values).unwrap();
-        let value = token.token().expose_secret(|s| s.to_owned());
+        let value = token.token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "test-token");
     }
 

--- a/crates/credential/src/store.rs
+++ b/crates/credential/src/store.rs
@@ -146,7 +146,7 @@ pub(crate) mod test_helpers {
     use super::StoredCredential;
 
     /// Build a minimal [`StoredCredential`] for testing.
-    pub fn make_credential(id: &str, data: &[u8]) -> StoredCredential {
+    pub(crate) fn make_credential(id: &str, data: &[u8]) -> StoredCredential {
         StoredCredential {
             id: id.into(),
             credential_key: "test_credential".into(),

--- a/crates/credential/tests/env_provider.rs
+++ b/crates/credential/tests/env_provider.rs
@@ -1,3 +1,8 @@
+#![allow(
+    unsafe_code,
+    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
+)]
+
 //! Integration test for [`EnvKeyProvider::from_env`].
 //!
 //! Lives outside the crate proper because the crate applies

--- a/crates/credential/tests/units/encryption_tests.rs
+++ b/crates/credential/tests/units/encryption_tests.rs
@@ -123,8 +123,7 @@ fn test_nonce_uniqueness() {
         for j in (i + 1)..nonces.len() {
             assert_ne!(
                 nonces[i], nonces[j],
-                "Nonce collision detected at indices {} and {}",
-                i, j
+                "Nonce collision detected at indices {i} and {j}"
             );
         }
     }
@@ -159,7 +158,7 @@ fn test_decryption_with_wrong_key() {
         Err(CryptoError::DecryptionFailed) => {
             // Expected error
         },
-        other => panic!("Expected DecryptionFailed, got {:?}", other),
+        other => panic!("Expected DecryptionFailed, got {other:?}"),
     }
 }
 
@@ -185,18 +184,15 @@ fn test_key_derivation_timing() {
     // Release builds should complete in ~100-200ms on modern hardware.
     let upper_ms: u128 = if cfg!(debug_assertions) { 2000 } else { 500 };
     let millis = duration.as_millis();
-    println!("Key derivation took {}ms", millis);
+    println!("Key derivation took {millis}ms");
 
     assert!(
         millis >= 50,
-        "Key derivation too fast ({}ms), may be vulnerable to brute force",
-        millis
+        "Key derivation too fast ({millis}ms), may be vulnerable to brute force"
     );
     assert!(
         millis <= upper_ms,
-        "Key derivation too slow ({}ms > {}ms), may impact usability",
-        millis,
-        upper_ms
+        "Key derivation too slow ({millis}ms > {upper_ms}ms), may impact usability"
     );
 }
 

--- a/crates/credential/tests/units/pending_lifecycle_tests.rs
+++ b/crates/credential/tests/units/pending_lifecycle_tests.rs
@@ -36,7 +36,7 @@ impl PendingState for TestPending {
     const KIND: &'static str = "test_interactive_pending";
 
     fn expires_in(&self) -> Duration {
-        Duration::from_secs(300)
+        Duration::from_mins(5)
     }
 }
 

--- a/crates/credential/tests/units/thundering_herd_tests.rs
+++ b/crates/credential/tests/units/thundering_herd_tests.rs
@@ -54,7 +54,7 @@ impl Credential for ThunderingHerdCredential {
     const KEY: &'static str = "thundering_herd_test";
     const REFRESHABLE: bool = true;
     const REFRESH_POLICY: RefreshPolicy = RefreshPolicy {
-        early_refresh: std::time::Duration::from_secs(300),
+        early_refresh: std::time::Duration::from_mins(5),
         jitter: std::time::Duration::ZERO, // no jitter for deterministic test
         ..RefreshPolicy::DEFAULT
     };
@@ -148,7 +148,7 @@ async fn only_one_refresh_under_concurrent_access() {
     // Verify all callers got the refreshed token
     for result in &results {
         let handle = result.as_ref().unwrap().as_ref().unwrap();
-        let value = handle.snapshot().token().expose_secret(|s| s.to_owned());
+        let value = handle.snapshot().token().expose_secret(ToOwned::to_owned);
         assert_eq!(value, "refreshed-token");
     }
 

--- a/crates/credential/tests/units/validation_tests.rs
+++ b/crates/credential/tests/units/validation_tests.rs
@@ -51,7 +51,7 @@ fn test_credential_id_rejects_wrong_prefix() {
 #[test]
 fn test_credential_id_display() {
     let id = CredentialId::new();
-    let display = format!("{}", id);
+    let display = format!("{id}");
     assert!(
         display.starts_with("cred_"),
         "expected cred_ prefix, got: {display}"
@@ -62,10 +62,10 @@ fn test_credential_id_display() {
 fn test_secret_string_redacted() {
     let secret = SecretString::new("my-super-secret-password-12345");
 
-    let debug_str = format!("{:?}", secret);
+    let debug_str = format!("{secret:?}");
     assert_eq!(debug_str, "[REDACTED]");
 
-    let display_str = format!("{}", secret);
+    let display_str = format!("{secret}");
     assert_eq!(display_str, "[REDACTED]");
 
     assert!(!debug_str.contains("my-super-secret"));
@@ -76,10 +76,10 @@ fn test_secret_string_redacted() {
 fn test_secret_string_expose_secret() {
     let secret = SecretString::new("test-secret-value");
 
-    let length = secret.expose_secret(|s| s.len());
+    let length = secret.expose_secret(str::len);
     assert_eq!(length, 17);
 
-    let uppercase = secret.expose_secret(|s| s.to_uppercase());
+    let uppercase = secret.expose_secret(str::to_uppercase);
     assert_eq!(uppercase, "TEST-SECRET-VALUE");
 
     let contains_test = secret.expose_secret(|s| s.contains("test"));

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -51,3 +51,6 @@ chrono = { workspace = true }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -356,7 +356,7 @@ impl ControlConsumer {
                 () = &mut claim_sleep => {
                     let next_delay = self.tick(&mut consecutive_errors).await;
                     claim_deadline = tokio::time::Instant::now()
-                        + next_delay.unwrap_or(std::time::Duration::ZERO);
+                        + next_delay.unwrap_or(Duration::ZERO);
                 }
             }
         }

--- a/crates/engine/src/credential_accessor.rs
+++ b/crates/engine/src/credential_accessor.rs
@@ -231,7 +231,7 @@ mod tests {
     #[tokio::test]
     async fn allows_declared_key_and_delegates_to_resolver() {
         let allowed_keys: HashSet<String> =
-            ["my_credential"].iter().map(|s| s.to_string()).collect();
+            ["my_credential"].iter().map(ToString::to_string).collect();
 
         let accessor = EngineCredentialAccessor::new(
             allowed_keys,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -88,12 +88,7 @@ pub const DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL: Duration = Duration::from_
 /// credentials, passing the credential ID. The callee is responsible for refreshing
 /// the credential (e.g., rotating short-lived tokens) before the action resolves it.
 type CredentialRefreshFn = Arc<
-    dyn Fn(
-            &str,
-        )
-            -> Pin<Box<dyn Future<Output = Result<(), nebula_action::error::ActionError>> + Send>>
-        + Send
-        + Sync,
+    dyn Fn(&str) -> Pin<Box<dyn Future<Output = Result<(), ActionError>> + Send>> + Send + Sync,
 >;
 
 /// Type alias for the boxed async credential-resolution function stored on the engine.
@@ -214,7 +209,7 @@ pub struct WorkflowEngine {
 type RunningRegistrationId = u64;
 
 /// Process-wide monotonic counter for registration nonces.
-static NEXT_REGISTRATION_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(1);
+static NEXT_REGISTRATION_ID: AtomicU64 = AtomicU64::new(1);
 
 /// Value stored in [`WorkflowEngine::running`]. Pairs the live
 /// [`CancellationToken`] with the [`RunningRegistrationId`] nonce so the
@@ -436,13 +431,11 @@ impl WorkflowEngine {
     pub fn with_credential_refresh<F, Fut>(mut self, refresh_fn: F) -> Self
     where
         F: Fn(&str) -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = Result<(), nebula_action::error::ActionError>> + Send + 'static,
+        Fut: Future<Output = Result<(), ActionError>> + Send + 'static,
     {
         self.credential_refresh = Some(Arc::new(move |id: &str| {
             Box::pin(refresh_fn(id))
-                as Pin<
-                    Box<dyn Future<Output = Result<(), nebula_action::error::ActionError>> + Send>,
-                >
+                as Pin<Box<dyn Future<Output = Result<(), ActionError>> + Send>>
         }));
         self
     }
@@ -681,8 +674,7 @@ impl WorkflowEngine {
             .filter(|n| {
                 predecessors
                     .get(*n)
-                    .map(|preds| preds.iter().all(|p| pinned.contains(p)))
-                    .unwrap_or(true) // no predecessors = entry node
+                    .is_none_or(|preds| preds.iter().all(|p| pinned.contains(p))) // no predecessors = entry node
             })
             .cloned()
             .collect();
@@ -856,7 +848,7 @@ impl WorkflowEngine {
             ticker.tick().await;
             loop {
                 tokio::select! {
-                    _ = heartbeat_shutdown_cloned.cancelled() => {
+                    () = heartbeat_shutdown_cloned.cancelled() => {
                         // Normal shutdown from the caller after frontier exits.
                         break;
                     }
@@ -1025,8 +1017,7 @@ impl WorkflowEngine {
         // `Leased`, final-persist errors — and is defensive against
         // clobbering a winner's registration if a losing attempt ever
         // slips through.
-        let registration_id =
-            NEXT_REGISTRATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
         self.running.insert(
             execution_id,
             RunningEntry {
@@ -1400,7 +1391,7 @@ impl WorkflowEngine {
             }
             let incoming = graph.incoming_connections(node_key.clone());
             let required = incoming.len();
-            let resolved = resolved_edges.get(node_key).cloned().unwrap_or(0);
+            let resolved = resolved_edges.get(node_key).copied().unwrap_or(0);
 
             if required == 0 || resolved == required {
                 seed_nodes.push(node_key.clone());
@@ -1415,18 +1406,17 @@ impl WorkflowEngine {
         // `ExecutionBudget::default()` with a warning so the degraded
         // limits are visible in logs instead of silently swapping
         // operator-configured limits for default ones.
-        let budget = match exec_state.budget.clone() {
-            Some(b) => b,
-            None => {
-                tracing::warn!(
-                    %execution_id,
-                    "resume: persisted execution state is missing budget; \
-                     falling back to ExecutionBudget::default() — \
-                     concurrency, retry, and timeout limits from the \
-                     original run are not being honoured (issue #289)"
-                );
-                ExecutionBudget::default()
-            },
+        let budget = if let Some(b) = exec_state.budget.clone() {
+            b
+        } else {
+            tracing::warn!(
+                %execution_id,
+                "resume: persisted execution state is missing budget; \
+                 falling back to ExecutionBudget::default() — \
+                 concurrency, retry, and timeout limits from the \
+                 original run are not being honoured (issue #289)"
+            );
+            ExecutionBudget::default()
         };
         let semaphore = Arc::new(Semaphore::new(budget.max_concurrent_nodes));
         let cancel_token = CancellationToken::new();
@@ -1447,8 +1437,7 @@ impl WorkflowEngine {
         // the lease is ours (ADR-0015 single-runner fence). Symmetric to
         // `execute_workflow` — see its comment for the full rationale
         // and the #482 Copilot review context.
-        let registration_id =
-            NEXT_REGISTRATION_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
         self.running.insert(
             execution_id,
             RunningEntry {
@@ -1471,17 +1460,16 @@ impl WorkflowEngine {
         // execution state. Legacy states that predate #311 deserialize
         // the field as `None` — fall back to `Null` with a warning so
         // the regression is visible in logs.
-        let workflow_input = match exec_state.workflow_input.clone() {
-            Some(v) => v,
-            None => {
-                tracing::warn!(
-                    %execution_id,
-                    "resume: persisted execution state is missing workflow_input; \
-                     falling back to Null — entry nodes that did not complete \
-                     on the original run will receive Null input"
-                );
-                serde_json::Value::Null
-            },
+        let workflow_input = if let Some(v) = exec_state.workflow_input.clone() {
+            v
+        } else {
+            tracing::warn!(
+                %execution_id,
+                "resume: persisted execution state is missing workflow_input; \
+                 falling back to Null — entry nodes that did not complete \
+                 on the original run will receive Null input"
+            );
+            serde_json::Value::Null
         };
         let failed_node = self
             .run_frontier(
@@ -1864,9 +1852,9 @@ impl WorkflowEngine {
                 .map(|max_dur| max_dur.saturating_sub(started.elapsed()));
             let sleep_fut = async {
                 if let Some(d) = wall_clock_remaining {
-                    tokio::time::sleep(d).await
+                    tokio::time::sleep(d).await;
                 } else {
-                    std::future::pending::<()>().await
+                    std::future::pending::<()>().await;
                 }
             };
             tokio::pin!(sleep_fut);
@@ -1912,9 +1900,7 @@ impl WorkflowEngine {
                     task_nodes.remove(&task_id);
                     total_retries.fetch_add(1, Ordering::Relaxed);
                     let err = EngineError::Runtime(nebula_runtime::RuntimeError::ActionError(
-                        nebula_action::error::ActionError::retryable(
-                            "Action retry is not supported by the engine",
-                        ),
+                        ActionError::retryable("Action retry is not supported by the engine"),
                     ));
                     mark_node_failed(exec_state, node_key.clone(), &err);
                     let err_str = err.to_string();
@@ -1979,9 +1965,8 @@ impl WorkflowEngine {
 
                     // Track output size for budget enforcement
                     if let Some(output) = outputs.get(&node_key) {
-                        let bytes = serde_json::to_string(output.value())
-                            .map(|s| s.len() as u64)
-                            .unwrap_or(0);
+                        let bytes =
+                            serde_json::to_string(output.value()).map_or(0, |s| s.len() as u64);
                         total_output_bytes.fetch_add(bytes, Ordering::Relaxed);
                     }
 
@@ -2014,8 +1999,7 @@ impl WorkflowEngine {
                     let attempt = exec_state
                         .node_states
                         .get(&node_key)
-                        .map(|ns| ns.attempt_count().max(1) as u32)
-                        .unwrap_or(1);
+                        .map_or(1, |ns| ns.attempt_count().max(1) as u32);
                     self.record_node_result(
                         execution_id,
                         node_key.clone(),
@@ -2604,8 +2588,7 @@ impl WorkflowEngine {
             let attempt = exec_state
                 .node_states
                 .get(&node_key)
-                .map(|ns| ns.attempt_count().max(1) as u32)
-                .unwrap_or(1);
+                .map_or(1, |ns| ns.attempt_count().max(1) as u32);
             if let Err(e) = repo
                 .save_node_output(
                     execution_id,
@@ -2854,7 +2837,7 @@ impl WorkflowEngine {
         &self,
         _execution_id: ExecutionId,
         status: ExecutionStatus,
-        elapsed: std::time::Duration,
+        elapsed: Duration,
         _failed_node: &Option<(NodeKey, String)>,
     ) {
         match status {
@@ -2960,7 +2943,7 @@ impl NodeTask {
                 Ok(()) => {},
                 Err(source) => {
                     let action_err =
-                        ActionError::credential_refresh_failed(self.action_key.to_string(), source);
+                        ActionError::credential_refresh_failed(self.action_key.clone(), source);
                     return (self.node_key, Err(EngineError::Action(action_err)));
                 },
             }
@@ -2986,7 +2969,7 @@ impl NodeTask {
                     error = ?e,
                     "rate limit exceeded; failing node"
                 );
-                let action_err = nebula_action::error::ActionError::retryable_with_hint(
+                let action_err = ActionError::retryable_with_hint(
                     format!("rate limit exceeded: {e:?}"),
                     nebula_action::error::RetryHintCode::RateLimited,
                 );
@@ -3067,9 +3050,9 @@ fn process_outgoing_edges(
         }
 
         // Check if target is now fully resolved
-        let resolved = resolved_edges.get(&target).cloned().unwrap_or(0);
-        let required = required_count.get(&target).cloned().unwrap_or(0);
-        let activated = activated_edges.get(&target).map_or(0, |s| s.len());
+        let resolved = resolved_edges.get(&target).copied().unwrap_or(0);
+        let required = required_count.get(&target).copied().unwrap_or(0);
+        let activated = activated_edges.get(&target).map_or(0, HashSet::len);
 
         if resolved == required {
             if activated > 0 {
@@ -3255,9 +3238,9 @@ fn propagate_skip(
         // the same skipped source to the same target are each counted.
         *resolved_edges.entry(target.clone()).or_insert(0) += 1;
 
-        let resolved = resolved_edges.get(&target).cloned().unwrap_or(0);
-        let required = required_count.get(&target).cloned().unwrap_or(0);
-        let activated = activated_edges.get(&target).map_or(0, |s| s.len());
+        let resolved = resolved_edges.get(&target).copied().unwrap_or(0);
+        let required = required_count.get(&target).copied().unwrap_or(0);
+        let activated = activated_edges.get(&target).map_or(0, HashSet::len);
 
         if resolved == required {
             if activated > 0 {
@@ -3465,12 +3448,12 @@ fn route_failure_edges(
 /// Uses the versioned transition API (issue #255) so CAS readers see
 /// the parent version move.
 fn mark_node_skipped(exec_state: &mut ExecutionState, node_key: NodeKey) {
-    let _ = exec_state.transition_node(node_key.clone(), NodeState::Skipped);
+    let _ = exec_state.transition_node(node_key, NodeState::Skipped);
 }
 
 /// Mark a node as completed in the execution state.
 fn mark_node_completed(exec_state: &mut ExecutionState, node_key: NodeKey) {
-    let _ = exec_state.transition_node(node_key.clone(), NodeState::Completed);
+    let _ = exec_state.transition_node(node_key, NodeState::Completed);
 }
 
 /// Mark a node as failed in the execution state.
@@ -3744,8 +3727,7 @@ fn resolve_node_input_with_support(
     } else if flow_predecessors.len() == 1 {
         outputs
             .get(&flow_predecessors[0])
-            .map(|v| v.value().clone())
-            .unwrap_or(serde_json::Value::Null)
+            .map_or(serde_json::Value::Null, |v| v.value().clone())
     } else {
         let mut merged = serde_json::Map::new();
         for pred_id in &flow_predecessors {
@@ -4195,7 +4177,7 @@ mod tests {
         let ctx = TriggerContext::new(
             WorkflowId::new(),
             node_key!("test"),
-            tokio_util::sync::CancellationToken::new(),
+            CancellationToken::new(),
         );
         assert!(!ctx.has_credential_id("missing").await);
         assert!(
@@ -4260,7 +4242,7 @@ mod tests {
             Ok(ActionResult::Branch {
                 selected: self.selected.clone(),
                 output: nebula_action::output::ActionOutput::Value(input),
-                alternatives: std::collections::HashMap::new(),
+                alternatives: HashMap::new(),
             })
         }
     }
@@ -5219,7 +5201,7 @@ mod tests {
     struct FailAtTransitionN {
         inner: Arc<nebula_storage::InMemoryExecutionRepo>,
         fail_on: u32,
-        calls: std::sync::atomic::AtomicU32,
+        calls: AtomicU32,
     }
 
     impl FailAtTransitionN {
@@ -5227,13 +5209,13 @@ mod tests {
             Self {
                 inner,
                 fail_on,
-                calls: std::sync::atomic::AtomicU32::new(0),
+                calls: AtomicU32::new(0),
             }
         }
     }
 
     #[async_trait::async_trait]
-    impl nebula_storage::ExecutionRepo for FailAtTransitionN {
+    impl ExecutionRepo for FailAtTransitionN {
         async fn get_state(
             &self,
             id: ExecutionId,
@@ -5247,7 +5229,7 @@ mod tests {
             expected_version: u64,
             new_state: serde_json::Value,
         ) -> Result<bool, nebula_storage::ExecutionRepoError> {
-            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
             if n == self.fail_on {
                 return Err(nebula_storage::ExecutionRepoError::Connection(format!(
                     "injected transition failure at call #{n}"
@@ -5462,7 +5444,7 @@ mod tests {
         let failing_repo = Arc::new(FailAtTransitionN::new(base, 1));
 
         let (engine, _) = make_engine(registry);
-        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+        let (event_tx, mut event_rx) = mpsc::channel(64);
         let engine = engine
             .with_execution_repo(failing_repo)
             .with_workflow_repo(workflow_repo)
@@ -5621,7 +5603,7 @@ mod tests {
         let failing_repo = Arc::new(FailAtTransitionN::new(base, 1));
 
         let (engine, _) = make_engine(registry);
-        let (event_tx, mut event_rx) = tokio::sync::mpsc::channel(64);
+        let (event_tx, mut event_rx) = mpsc::channel(64);
         let engine = engine
             .with_execution_repo(failing_repo)
             .with_workflow_repo(workflow_repo)
@@ -5814,7 +5796,7 @@ mod tests {
             .unwrap()
             .expect("execution state must be persisted after first run");
         let state_str = serde_json::to_string(&state_json).unwrap();
-        let exec_state: nebula_execution::state::ExecutionState =
+        let exec_state: ExecutionState =
             serde_json::from_str(&state_str).expect("deserialize persisted execution state");
         let idem_key = exec_state.idempotency_key_for_node(n.clone());
 
@@ -6374,7 +6356,7 @@ mod tests {
         async fn execute(
             &self,
             input: serde_json::Value,
-            ctx: &nebula_action::ActionContext,
+            ctx: &ActionContext,
         ) -> Result<ActionResult<serde_json::Value>, ActionError> {
             let id = input
                 .get("credential_id")
@@ -6401,7 +6383,7 @@ mod tests {
     /// Build a workflow with a single `CredProbeHandler` node that probes `cred_id`.
     fn probe_workflow(action: &str, cred_id: &str) -> WorkflowDefinition {
         let n1 = node_key!("probe");
-        let node = NodeDefinition::new(n1.clone(), "probe", action)
+        let node = NodeDefinition::new(n1, "probe", action)
             .unwrap()
             .with_parameter(
                 "credential_id",
@@ -7043,8 +7025,7 @@ mod tests {
             .expect("load_node_result should return the persisted ActionResult after #299");
         assert_eq!(
             persisted_record.kind, "Branch",
-            "persisted ActionResult for A should be the Branch variant, got: {:?}",
-            persisted_record
+            "persisted ActionResult for A should be the Branch variant, got: {persisted_record:?}"
         );
         assert_eq!(
             persisted_record
@@ -7070,7 +7051,7 @@ mod tests {
         inner: Arc<nebula_storage::InMemoryExecutionRepo>,
         mutate_before: u32,
         new_status: Option<String>,
-        calls: std::sync::atomic::AtomicU32,
+        calls: AtomicU32,
         injected: std::sync::atomic::AtomicBool,
     }
 
@@ -7084,14 +7065,14 @@ mod tests {
                 inner,
                 mutate_before,
                 new_status: new_status.map(ToOwned::to_owned),
-                calls: std::sync::atomic::AtomicU32::new(0),
+                calls: AtomicU32::new(0),
                 injected: std::sync::atomic::AtomicBool::new(false),
             }
         }
     }
 
     #[async_trait::async_trait]
-    impl nebula_storage::ExecutionRepo for ExternalMutateBeforeN {
+    impl ExecutionRepo for ExternalMutateBeforeN {
         async fn get_state(
             &self,
             id: ExecutionId,
@@ -7105,11 +7086,9 @@ mod tests {
             expected_version: u64,
             new_state: serde_json::Value,
         ) -> Result<bool, nebula_storage::ExecutionRepoError> {
-            let n = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
+            let n = self.calls.fetch_add(1, Ordering::SeqCst) + 1;
             if n == self.mutate_before
-                && !self
-                    .injected
-                    .swap(true, std::sync::atomic::Ordering::SeqCst)
+                && !self.injected.swap(true, Ordering::SeqCst)
                 && let Ok(Some((current_version, mut current_state))) =
                     self.inner.get_state(id).await
             {
@@ -7500,7 +7479,7 @@ mod tests {
             .transition_status(ExecutionStatus::Completed)
             .unwrap();
 
-        let repo: Arc<dyn nebula_storage::ExecutionRepo> = inner.clone();
+        let repo: Arc<dyn ExecutionRepo> = inner.clone();
         let outcome = engine
             .persist_final_state(
                 &repo,
@@ -7594,7 +7573,7 @@ mod tests {
             .transition_status(ExecutionStatus::Completed)
             .unwrap();
 
-        let repo: Arc<dyn nebula_storage::ExecutionRepo> = inner.clone();
+        let repo: Arc<dyn ExecutionRepo> = inner.clone();
         let outcome = engine
             .persist_final_state(
                 &repo,
@@ -7789,7 +7768,7 @@ mod tests {
 
         // Poll the registry until the winner has published its token.
         // This synchronises on the exact moment the race window opens.
-        let t_wait = std::time::Instant::now();
+        let t_wait = Instant::now();
         loop {
             if engine.running.contains_key(&execution_id) {
                 break;

--- a/crates/engine/src/resolver.rs
+++ b/crates/engine/src/resolver.rs
@@ -46,7 +46,7 @@ impl ParamResolver {
         ctx.set_input(predecessor_input.clone());
 
         // Populate $node with all available outputs
-        for entry in outputs.iter() {
+        for entry in outputs {
             ctx.set_node_data(entry.key(), entry.value().clone());
         }
 
@@ -112,7 +112,7 @@ impl ParamResolver {
                         .ok_or_else(|| EngineError::ParameterResolution {
                             node_key: node_key.clone(),
                             param_key: key.to_owned(),
-                            error: format!("referenced node {} has no output", ref_node),
+                            error: format!("referenced node {ref_node} has no output"),
                         })?;
                 let value = navigate_path(output.value(), output_path);
                 Ok(value)

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -472,8 +472,7 @@ async fn reclaim_sweep_recovers_orphaned_processing_row_end_to_end() {
     assert_eq!(
         cancels_for_exec.len(),
         1,
-        "exactly one successful dispatch recorded (first stalled), got {:?}",
-        observed
+        "exactly one successful dispatch recorded (first stalled), got {observed:?}"
     );
 }
 

--- a/crates/error/Cargo.toml
+++ b/crates/error/Cargo.toml
@@ -30,3 +30,6 @@ derive = ["dep:nebula-error-macros"]
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 nebula-error-macros = { path = "macros" }
+
+[lints]
+workspace = true

--- a/crates/error/macros/Cargo.toml
+++ b/crates/error/macros/Cargo.toml
@@ -20,3 +20,6 @@ doctest = false
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/error/src/collection.rs
+++ b/crates/error/src/collection.rs
@@ -121,7 +121,7 @@ impl<E: Classify> ErrorCollection<E> {
     /// ```
     #[must_use]
     pub fn any_retryable(&self) -> bool {
-        self.errors.iter().any(|e| e.is_retryable())
+        self.errors.iter().any(NebulaError::is_retryable)
     }
 
     /// Returns the highest severity among all errors.
@@ -152,7 +152,7 @@ impl<E: Classify> ErrorCollection<E> {
     pub fn max_severity(&self) -> ErrorSeverity {
         self.errors
             .iter()
-            .map(|e| e.severity())
+            .map(NebulaError::severity)
             .max()
             .unwrap_or(ErrorSeverity::Info)
     }
@@ -266,7 +266,7 @@ impl<E: Classify> FromIterator<NebulaError<E>> for ErrorCollection<E> {
 ///
 /// assert!(validate().is_err());
 /// ```
-pub type BatchResult<T, E> = std::result::Result<T, ErrorCollection<E>>;
+pub type BatchResult<T, E> = Result<T, ErrorCollection<E>>;
 
 #[cfg(test)]
 mod tests {
@@ -292,7 +292,7 @@ mod tests {
             self.cat
         }
         fn code(&self) -> crate::ErrorCode {
-            codes::INTERNAL.clone()
+            codes::INTERNAL
         }
         fn severity(&self) -> ErrorSeverity {
             self.sev
@@ -332,7 +332,7 @@ mod tests {
         assert_eq!(coll.len(), 2);
         assert!(!coll.is_empty());
 
-        let categories: Vec<_> = coll.iter().map(|e| e.category()).collect();
+        let categories: Vec<_> = coll.iter().map(NebulaError::category).collect();
         assert_eq!(
             categories,
             vec![ErrorCategory::Validation, ErrorCategory::Validation]

--- a/crates/error/src/error.rs
+++ b/crates/error/src/error.rs
@@ -375,7 +375,7 @@ mod tests {
             self.cat
         }
         fn code(&self) -> ErrorCode {
-            codes::INTERNAL.clone()
+            codes::INTERNAL
         }
         fn severity(&self) -> ErrorSeverity {
             self.sev
@@ -488,7 +488,7 @@ mod tests {
                 self.0
             }
             fn code(&self) -> ErrorCode {
-                codes::EXTERNAL.clone()
+                codes::EXTERNAL
             }
         }
 

--- a/crates/error/src/retry.rs
+++ b/crates/error/src/retry.rs
@@ -90,7 +90,7 @@ impl fmt::Display for RetryHint {
         match (self.after, self.max_attempts) {
             (Some(d), Some(n)) => write!(f, "retry after {}ms (max {} attempts)", d.as_millis(), n),
             (Some(d), None) => write!(f, "retry after {}ms", d.as_millis()),
-            (None, Some(n)) => write!(f, "retry (max {} attempts)", n),
+            (None, Some(n)) => write!(f, "retry (max {n} attempts)"),
             (None, None) => write!(f, "retry"),
         }
     }

--- a/crates/error/src/traits.rs
+++ b/crates/error/src/traits.rs
@@ -155,7 +155,7 @@ mod tests {
             self.cat
         }
         fn code(&self) -> ErrorCode {
-            codes::INTERNAL.clone()
+            codes::INTERNAL
         }
     }
 
@@ -167,7 +167,7 @@ mod tests {
             ErrorCategory::RateLimit
         }
         fn code(&self) -> ErrorCode {
-            codes::RATE_LIMIT.clone()
+            codes::RATE_LIMIT
         }
         fn severity(&self) -> ErrorSeverity {
             ErrorSeverity::Warning

--- a/crates/error/tests/derive.rs
+++ b/crates/error/tests/derive.rs
@@ -70,7 +70,7 @@ fn full_retryable_override() {
 #[test]
 fn full_retry_hint() {
     let hint = FullError::RateLimited.retry_hint().unwrap();
-    assert_eq!(hint.after, Some(Duration::from_secs(60)));
+    assert_eq!(hint.after, Some(Duration::from_mins(1)));
     assert!(FullError::Timeout.retry_hint().is_none());
 }
 

--- a/crates/eventbus/Cargo.toml
+++ b/crates/eventbus/Cargo.toml
@@ -30,3 +30,6 @@ harness = false
 [[bench]]
 name = "throughput"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/eventbus/examples/subscriber_patterns.rs
+++ b/crates/eventbus/examples/subscriber_patterns.rs
@@ -48,7 +48,7 @@ async fn basic_subscribe_loop() {
                 status: "started".to_string(),
             };
             let outcome = bus_clone.emit(event);
-            println!("  Emitted event {}: {:?}", i, outcome);
+            println!("  Emitted event {i}: {outcome:?}");
         }
     });
 
@@ -97,7 +97,7 @@ async fn filtered_subscription() {
         );
         count += 1;
     }
-    println!("  ✓ Received {} filtered events", count);
+    println!("  ✓ Received {count} filtered events");
 }
 
 /// Pattern 3: Lag monitoring
@@ -127,7 +127,7 @@ async fn lag_monitoring() {
             received += 1;
             let lagged = sub.lagged_count();
             if lagged > 0 {
-                println!("  Received event #{}, lagged_count={}", received, lagged);
+                println!("  Received event #{received}, lagged_count={lagged}");
             }
         }
         tokio::time::sleep(tokio::time::Duration::from_millis(1)).await;

--- a/crates/eventbus/tests/helpers.rs
+++ b/crates/eventbus/tests/helpers.rs
@@ -1,10 +1,16 @@
 //! Test helpers and utilities for eventbus integration tests.
+//!
+//! Integration-test binaries are compiled independently, so Rust cannot see
+//! that `integration.rs` uses these items via `mod helpers`. Silence the
+//! resulting `dead_code` false positive here.
 
-pub fn init_log() {
+#![allow(dead_code, reason = "consumed by sibling integration-test binaries")]
+
+pub(crate) fn init_log() {
     let _ = tracing_subscriber::fmt().with_test_writer().try_init();
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct TestEvent {
+pub(crate) struct TestEvent {
     pub id: u64,
 }

--- a/crates/eventbus/tests/integration.rs
+++ b/crates/eventbus/tests/integration.rs
@@ -47,7 +47,10 @@ async fn test_registry_get_or_create_returns_same_arc_on_concurrent_access() {
     // All 8 handles should point to the same Arc
     for i in 1..buses.len() {
         assert!(
-            ptr::eq(buses[0].as_ref() as *const _, buses[i].as_ref() as *const _),
+            ptr::eq(
+                ptr::from_ref(buses[0].as_ref()),
+                ptr::from_ref(buses[i].as_ref())
+            ),
             "all threads must get the same Arc<EventBus>"
         );
     }
@@ -171,8 +174,8 @@ async fn test_concurrent_producers_and_subscribers() {
             // Keep receiving for up to 5 seconds or until bus closes
             let timeout = tokio::time::sleep(tokio::time::Duration::from_secs(5));
             tokio::select! {
-                _ = timeout => {},
-                _ = async {
+                () = timeout => {},
+                () = async {
                     while let Some(_event) = sub.recv().await {
                         count += 1;
                     }
@@ -444,8 +447,7 @@ async fn test_drop_oldest_ring_buffer_behavior() {
         // With DropOldest and a subscriber, emit should always succeed (returns Sent)
         assert!(
             outcome.is_sent(),
-            "DropOldest should send when subscriber exists (event {})",
-            i
+            "DropOldest should send when subscriber exists (event {i})"
         );
     }
 

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -19,3 +19,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
+
+[lints]
+workspace = true

--- a/crates/execution/src/context.rs
+++ b/crates/execution/src/context.rs
@@ -164,12 +164,12 @@ mod tests {
     fn builder_sets_all_fields() {
         let budget = ExecutionBudget::default()
             .with_max_concurrent_nodes(4)
-            .with_max_duration(Duration::from_secs(300))
+            .with_max_duration(Duration::from_mins(5))
             .with_max_output_bytes(1024 * 1024)
             .with_max_total_retries(50);
 
         assert_eq!(budget.max_concurrent_nodes, 4);
-        assert_eq!(budget.max_duration, Some(Duration::from_secs(300)));
+        assert_eq!(budget.max_duration, Some(Duration::from_mins(5)));
         assert_eq!(budget.max_output_bytes, Some(1024 * 1024));
         assert_eq!(budget.max_total_retries, Some(50));
     }
@@ -177,7 +177,7 @@ mod tests {
     #[test]
     fn serde_roundtrip_full() {
         let budget = ExecutionBudget::default()
-            .with_max_duration(Duration::from_millis(5000))
+            .with_max_duration(Duration::from_secs(5))
             .with_max_output_bytes(999)
             .with_max_total_retries(3);
 

--- a/crates/execution/src/idempotency.rs
+++ b/crates/execution/src/idempotency.rs
@@ -45,7 +45,7 @@ mod tests {
         let exec_id = ExecutionId::new();
         let node_key = node_key!("test_node");
         let key1 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
-        let key2 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
+        let key2 = IdempotencyKey::generate(exec_id, node_key, 0);
         assert_eq!(key1, key2);
     }
 
@@ -54,7 +54,7 @@ mod tests {
         let exec_id = ExecutionId::new();
         let node_key = node_key!("test_node");
         let key0 = IdempotencyKey::generate(exec_id, node_key.clone(), 0);
-        let key1 = IdempotencyKey::generate(exec_id, node_key.clone(), 1);
+        let key1 = IdempotencyKey::generate(exec_id, node_key, 1);
         assert_ne!(key0, key1);
     }
 

--- a/crates/execution/src/result.rs
+++ b/crates/execution/src/result.rs
@@ -253,7 +253,7 @@ mod tests {
         // Legacy payloads serialized before termination_reason existed
         // must deserialize with termination_reason == None.
         let id = ExecutionId::new();
-        let json = format!(r#"{{"execution_id":"{}","status":"completed"}}"#, id);
+        let json = format!(r#"{{"execution_id":"{id}","status":"completed"}}"#);
         let result: ExecutionResult = serde_json::from_str(&json).unwrap();
         assert!(result.termination_reason.is_none());
     }
@@ -261,7 +261,7 @@ mod tests {
     #[test]
     fn deserialize_minimal_json() {
         let id = ExecutionId::new();
-        let json = format!(r#"{{"execution_id":"{}","status":"completed"}}"#, id);
+        let json = format!(r#"{{"execution_id":"{id}","status":"completed"}}"#);
         let result: ExecutionResult = serde_json::from_str(&json).unwrap();
 
         assert_eq!(result.execution_id, id);

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -253,8 +253,7 @@ impl ExecutionState {
         let attempt = self
             .node_states
             .get(&node_key)
-            .map(|ns| ns.attempt_count().max(1) as u32)
-            .unwrap_or(1);
+            .map_or(1, |ns| ns.attempt_count().max(1) as u32);
         IdempotencyKey::generate(self.execution_id, node_key, attempt)
     }
 
@@ -714,7 +713,7 @@ mod tests {
 
         let budget = ExecutionBudget::default()
             .with_max_concurrent_nodes(4)
-            .with_max_duration(Duration::from_secs(120))
+            .with_max_duration(Duration::from_mins(2))
             .with_max_output_bytes(4 * 1024 * 1024)
             .with_max_total_retries(7);
         state.set_budget(budget.clone());
@@ -735,8 +734,8 @@ mod tests {
             "status": "created",
             "node_states": {},
             "version": 0,
-            "created_at": chrono::Utc::now(),
-            "updated_at": chrono::Utc::now(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
             "total_retries": 0,
             "total_output_bytes": 0,
         });
@@ -754,8 +753,8 @@ mod tests {
             "status": "created",
             "node_states": {},
             "version": 0,
-            "created_at": chrono::Utc::now(),
-            "updated_at": chrono::Utc::now(),
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
             "total_retries": 0,
             "total_output_bytes": 0,
         });

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -14,21 +14,26 @@ use crate::{error::ExecutionError, status::ExecutionStatus};
 pub fn can_transition_execution(from: ExecutionStatus, to: ExecutionStatus) -> bool {
     matches!(
         (from, to),
-        (ExecutionStatus::Created, ExecutionStatus::Running)
-            | (ExecutionStatus::Created, ExecutionStatus::Cancelled)
-            | (ExecutionStatus::Running, ExecutionStatus::Paused)
-            | (ExecutionStatus::Running, ExecutionStatus::Cancelling)
-            | (ExecutionStatus::Running, ExecutionStatus::Completed)
-            | (ExecutionStatus::Running, ExecutionStatus::Failed)
-            | (ExecutionStatus::Running, ExecutionStatus::TimedOut)
-            | (ExecutionStatus::Paused, ExecutionStatus::Running)
-            | (ExecutionStatus::Paused, ExecutionStatus::Cancelling)
-            | (ExecutionStatus::Paused, ExecutionStatus::Failed)
-            | (ExecutionStatus::Paused, ExecutionStatus::TimedOut)
-            | (ExecutionStatus::Cancelling, ExecutionStatus::Cancelled)
-            | (ExecutionStatus::Cancelling, ExecutionStatus::Failed)
-            | (ExecutionStatus::Cancelling, ExecutionStatus::Completed)
-            | (ExecutionStatus::Cancelling, ExecutionStatus::TimedOut)
+        (
+            ExecutionStatus::Created | ExecutionStatus::Paused,
+            ExecutionStatus::Running
+        ) | (
+            ExecutionStatus::Created | ExecutionStatus::Cancelling,
+            ExecutionStatus::Cancelled
+        ) | (
+            ExecutionStatus::Running,
+            ExecutionStatus::Paused
+                | ExecutionStatus::Cancelling
+                | ExecutionStatus::Completed
+                | ExecutionStatus::Failed
+                | ExecutionStatus::TimedOut
+        ) | (
+            ExecutionStatus::Paused,
+            ExecutionStatus::Cancelling | ExecutionStatus::Failed | ExecutionStatus::TimedOut
+        ) | (
+            ExecutionStatus::Cancelling,
+            ExecutionStatus::Failed | ExecutionStatus::Completed | ExecutionStatus::TimedOut
+        )
     )
 }
 
@@ -49,20 +54,23 @@ pub fn validate_execution_transition(
 pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
     matches!(
         (from, to),
-        (NodeState::Pending, NodeState::Ready)
-            | (NodeState::Pending, NodeState::Skipped)
-            | (NodeState::Pending, NodeState::Cancelled)
-            | (NodeState::Ready, NodeState::Running)
-            | (NodeState::Ready, NodeState::Skipped)
-            | (NodeState::Ready, NodeState::Cancelled)
-            | (NodeState::Running, NodeState::Completed)
-            | (NodeState::Running, NodeState::Failed)
-            | (NodeState::Running, NodeState::Cancelled)
-            | (NodeState::Failed, NodeState::Retrying)
-            | (NodeState::Failed, NodeState::Cancelled)
-            | (NodeState::Retrying, NodeState::Running)
-            | (NodeState::Retrying, NodeState::Failed)
-            | (NodeState::Retrying, NodeState::Cancelled)
+        (
+            NodeState::Pending,
+            NodeState::Ready | NodeState::Skipped | NodeState::Cancelled
+        ) | (NodeState::Ready | NodeState::Retrying, NodeState::Running)
+            | (NodeState::Ready, NodeState::Skipped | NodeState::Cancelled)
+            | (
+                NodeState::Running,
+                NodeState::Completed | NodeState::Failed | NodeState::Cancelled
+            )
+            | (
+                NodeState::Failed,
+                NodeState::Retrying | NodeState::Cancelled
+            )
+            | (
+                NodeState::Retrying,
+                NodeState::Failed | NodeState::Cancelled
+            )
     )
 }
 

--- a/crates/expression/Cargo.toml
+++ b/crates/expression/Cargo.toml
@@ -43,3 +43,6 @@ datetime = []
 uuid = ["dep:uuid"]
 # Full feature set
 full = ["cache", "regex", "datetime", "uuid"]
+
+[lints]
+workspace = true

--- a/crates/expression/benches/baseline.rs
+++ b/crates/expression/benches/baseline.rs
@@ -16,17 +16,17 @@ fn benchmark_template_parse(c: &mut Criterion) {
 
     // Simple template
     group.bench_function("simple", |b| {
-        b.iter(|| Template::new(black_box("Hello {{ $input }}!")))
+        b.iter(|| Template::new(black_box("Hello {{ $input }}!")));
     });
 
     // Multiple expressions
     group.bench_function("multiple_expressions", |b| {
-        b.iter(|| Template::new(black_box("{{ $a }} + {{ $b }} = {{ $a + $b }}")))
+        b.iter(|| Template::new(black_box("{{ $a }} + {{ $b }} = {{ $a + $b }}")));
     });
 
     // Complex template
     group.bench_function("complex", |b| {
-        let template = r#"
+        let template = r"
             <html>
                 <title>{{ $workflow.name }}</title>
                 <body>
@@ -35,8 +35,8 @@ fn benchmark_template_parse(c: &mut Criterion) {
                     <span>{{ $node.data.count * 2 }}</span>
                 </body>
             </html>
-        "#;
-        b.iter(|| Template::new(black_box(template)))
+        ";
+        b.iter(|| Template::new(black_box(template)));
     });
 
     group.finish();
@@ -51,21 +51,21 @@ fn benchmark_template_render(c: &mut Criterion) {
 
     let simple = Template::new("Hello {{ $input }}!").unwrap();
     let complex = Template::new(
-        r#"
+        r"
         <html>
             <title>{{ $input | uppercase() }}</title>
             <p>Length: {{ length($input) }}</p>
         </html>
-    "#,
+    ",
     )
     .unwrap();
 
     group.bench_function("simple", |b| {
-        b.iter(|| simple.render(black_box(&engine), black_box(&context)))
+        b.iter(|| simple.render(black_box(&engine), black_box(&context)));
     });
 
     group.bench_function("complex", |b| {
-        b.iter(|| complex.render(black_box(&engine), black_box(&context)))
+        b.iter(|| complex.render(black_box(&engine), black_box(&context)));
     });
 
     group.finish();
@@ -99,7 +99,7 @@ fn benchmark_evaluate_no_cache(c: &mut Criterion) {
 
     for (name, expr) in test_cases {
         group.bench_with_input(BenchmarkId::from_parameter(name), expr, |b, expr| {
-            b.iter(|| engine.evaluate(black_box(expr), black_box(&context)))
+            b.iter(|| engine.evaluate(black_box(expr), black_box(&context)));
         });
     }
 
@@ -118,7 +118,7 @@ fn benchmark_evaluate_with_cache(c: &mut Criterion) {
     let _ = engine.evaluate(expr, &context);
 
     group.bench_function("cache_hit", |b| {
-        b.iter(|| engine.evaluate(black_box(expr), black_box(&context)))
+        b.iter(|| engine.evaluate(black_box(expr), black_box(&context)));
     });
 
     // Cache miss
@@ -128,7 +128,7 @@ fn benchmark_evaluate_with_cache(c: &mut Criterion) {
             counter += 1;
             let expr = format!("{} + {}", counter, counter + 1);
             engine.evaluate(black_box(&expr), black_box(&context))
-        })
+        });
     });
 
     group.finish();
@@ -144,7 +144,7 @@ fn benchmark_context_operations(c: &mut Criterion) {
     // Create context with many variables
     let mut context = EvaluationContext::new();
     for i in 0..100 {
-        context.set_execution_var(format!("var_{}", i), Value::Number((i as i64).into()));
+        context.set_execution_var(format!("var_{i}"), Value::Number((i as i64).into()));
     }
 
     // Clone benchmark
@@ -152,7 +152,7 @@ fn benchmark_context_operations(c: &mut Criterion) {
 
     // Lookup benchmark
     group.bench_function("lookup", |b| {
-        b.iter(|| context.get_execution_var(black_box("var_50")))
+        b.iter(|| context.get_execution_var(black_box("var_50")));
     });
 
     group.finish();
@@ -182,12 +182,12 @@ fn benchmark_concurrent_access(c: &mut Criterion) {
     // Single thread baseline
     group.bench_function("1_thread", |b| {
         let context = EvaluationContext::new();
-        b.iter(|| engine.evaluate(black_box(expr), black_box(&context)))
+        b.iter(|| engine.evaluate(black_box(expr), black_box(&context)));
     });
 
     // Multi-threaded
     for num_threads in [2, 4, 8] {
-        group.bench_function(format!("{}_threads", num_threads), |b| {
+        group.bench_function(format!("{num_threads}_threads"), |b| {
             b.iter(|| {
                 let handles: Vec<_> = (0..num_threads)
                     .map(|_| {
@@ -204,7 +204,7 @@ fn benchmark_concurrent_access(c: &mut Criterion) {
                 for handle in handles {
                     handle.join().unwrap();
                 }
-            })
+            });
         });
     }
 
@@ -219,7 +219,7 @@ fn benchmark_throughput(c: &mut Criterion) {
     let context = EvaluationContext::new();
 
     group.bench_function("ops_per_sec", |b| {
-        b.iter(|| engine.evaluate(black_box("2 + 2"), black_box(&context)))
+        b.iter(|| engine.evaluate(black_box("2 + 2"), black_box(&context)));
     });
 
     group.finish();
@@ -251,7 +251,7 @@ fn benchmark_builtins(c: &mut Criterion) {
 
     for (name, expr) in test_cases {
         group.bench_with_input(BenchmarkId::from_parameter(name), expr, |b, expr| {
-            b.iter(|| engine.evaluate(black_box(expr), black_box(&context)))
+            b.iter(|| engine.evaluate(black_box(expr), black_box(&context)));
         });
     }
 

--- a/crates/expression/examples/error_messages.rs
+++ b/crates/expression/examples/error_messages.rs
@@ -12,23 +12,23 @@ fn main() {
     context.set_input(Value::String("Alice".to_string()));
 
     println!("=== Example 1: Undefined Variable ===\n");
-    let template = r#"<html>
+    let template = r"<html>
   <head>
     <title>{{ $execution.title }}</title>
   </head>
   <body>
     <h1>Hello {{ $undefined_variable }}!</h1>
   </body>
-</html>"#;
+</html>";
 
     match Template::new(template) {
         Ok(tmpl) => match tmpl.render(&engine, &context) {
             Ok(_) => println!("Success!"),
             Err(e) => {
-                println!("{}\n", e);
+                println!("{e}\n");
             },
         },
-        Err(e) => println!("Parse error: {}\n", e),
+        Err(e) => println!("Parse error: {e}\n"),
     }
 
     println!("=== Example 2: Invalid Function ===\n");
@@ -42,45 +42,45 @@ fn main() {
         Ok(tmpl) => match tmpl.render(&engine, &context) {
             Ok(_) => println!("Success!"),
             Err(e) => {
-                println!("{}\n", e);
+                println!("{e}\n");
             },
         },
-        Err(e) => println!("Parse error: {}\n", e),
+        Err(e) => println!("Parse error: {e}\n"),
     }
 
     println!("=== Example 3: Unclosed Expression ===\n");
-    let template3 = r#"Line 1
+    let template3 = r"Line 1
 Line 2
 Line 3 has {{ unclosed expression
 Line 4
-Line 5"#;
+Line 5";
 
     match Template::new(template3) {
         Ok(_) => println!("Parsed successfully"),
         Err(e) => {
-            println!("{}\n", e);
+            println!("{e}\n");
         },
     }
 
     println!("=== Example 4: Type Error ===\n");
     context.set_execution_var("count", Value::String("not a number".to_string()));
 
-    let template4 = r#"<div>
+    let template4 = r"<div>
     <p>Total items: {{ $execution.count * 2 }}</p>
-</div>"#;
+</div>";
 
     match Template::new(template4) {
         Ok(tmpl) => match tmpl.render(&engine, &context) {
             Ok(_) => println!("Success!"),
             Err(e) => {
-                println!("{}\n", e);
+                println!("{e}\n");
             },
         },
-        Err(e) => println!("Parse error: {}\n", e),
+        Err(e) => println!("Parse error: {e}\n"),
     }
 
     println!("=== Example 5: Multiline with Good Error ===\n");
-    let template5 = r#"<!DOCTYPE html>
+    let template5 = r"<!DOCTYPE html>
 <html>
 <head>
     <title>My Page</title>
@@ -93,15 +93,15 @@ Line 5"#;
         <p>Content goes here</p>
     </main>
 </body>
-</html>"#;
+</html>";
 
     match Template::new(template5) {
         Ok(tmpl) => match tmpl.render(&engine, &context) {
             Ok(_) => println!("Success!"),
             Err(e) => {
-                println!("{}\n", e);
+                println!("{e}\n");
             },
         },
-        Err(e) => println!("Parse error: {}\n", e),
+        Err(e) => println!("Parse error: {e}\n"),
     }
 }

--- a/crates/expression/examples/maybe_vs_template.rs
+++ b/crates/expression/examples/maybe_vs_template.rs
@@ -87,10 +87,10 @@ fn main() {
     let debug = config.debug.resolve_as_bool(&engine, &context).unwrap();
 
     println!("Resolved values:");
-    println!("  timeout: {}", timeout);
-    println!("  retry_count: {}", retry_count);
-    println!("  base_url: {}", base_url);
-    println!("  debug: {}\n", debug);
+    println!("  timeout: {timeout}");
+    println!("  retry_count: {retry_count}");
+    println!("  base_url: {base_url}");
+    println!("  debug: {debug}\n");
 
     // Dynamic configuration with expressions
     let dynamic_config = r#"{
@@ -123,10 +123,10 @@ fn main() {
     let debug = config.debug.resolve_as_bool(&engine, &context).unwrap();
 
     println!("Resolved values:");
-    println!("  timeout: {} (computed from $input * 1000)", timeout);
-    println!("  retry_count: {} (from $input)", retry_count);
-    println!("  base_url: {} (computed from env)", base_url);
-    println!("  debug: {} (env is production, not development)\n", debug);
+    println!("  timeout: {timeout} (computed from $input * 1000)");
+    println!("  retry_count: {retry_count} (from $input)");
+    println!("  base_url: {base_url} (computed from env)");
+    println!("  debug: {debug} (env is production, not development)\n");
 
     // Example 2: MaybeTemplate for text templates
     println!("=== Example 2: MaybeTemplate for Text Templates ===\n");
@@ -150,9 +150,9 @@ fn main() {
     let from = email.from.resolve_as_string(&engine, &context).unwrap();
 
     println!("Rendered email:");
-    println!("  From: {}", from);
-    println!("  Subject: {}", subject);
-    println!("  Body: {}\n", body);
+    println!("  From: {from}");
+    println!("  Subject: {subject}");
+    println!("  Body: {body}\n");
 
     // Dynamic email template with multiple expressions
     let dynamic_email = r#"{
@@ -173,14 +173,14 @@ fn main() {
     let from = email.from.resolve_as_string(&engine, &context).unwrap();
 
     println!("Rendered email:");
-    println!("  From: {}", from);
-    println!("  Subject: {}", subject);
-    println!("  Body:\n{}\n", body);
+    println!("  From: {from}");
+    println!("  Subject: {subject}");
+    println!("  Body:\n{body}\n");
 
     // Example 3: Using Template directly for advanced features
     println!("=== Example 3: Template for Advanced Features ===\n");
 
-    let template_str = r#"<!DOCTYPE html>
+    let template_str = r"<!DOCTYPE html>
 <html>
 <head>
     <title>Order #{{ $execution.order_id }}</title>
@@ -190,7 +190,7 @@ fn main() {
     <p>Your order total is: ${{ $execution.total }}</p>
     <p>Environment: {{ $execution.env }}</p>
 </body>
-</html>"#;
+</html>";
 
     let template = Template::new(template_str).unwrap();
 
@@ -204,7 +204,7 @@ fn main() {
     println!();
 
     let result = template.render(&engine, &context).unwrap();
-    println!("Rendered HTML:\n{}\n", result);
+    println!("Rendered HTML:\n{result}\n");
 
     // Example 4: Combining both in a real-world scenario
     println!("=== Example 4: Real-World Scenario - HTTP Request ===\n");
@@ -245,10 +245,10 @@ fn main() {
     let body = request.body.resolve(&engine, &context).unwrap();
 
     println!("Resolved HTTP Request:");
-    println!("  URL: {}", url);
-    println!("  Method: {}", method);
-    println!("  Timeout: {} ms", timeout);
-    println!("  Body: {}\n", body);
+    println!("  URL: {url}");
+    println!("  Method: {method}");
+    println!("  Timeout: {timeout} ms");
+    println!("  Body: {body}\n");
 
     // Example 5: When to use which
     println!("=== Example 5: Decision Guide ===\n");

--- a/crates/expression/examples/template_advanced.rs
+++ b/crates/expression/examples/template_advanced.rs
@@ -28,7 +28,7 @@ fn main() {
     context.set_execution_var("count", serde_json::json!(5));
 
     let result = template.render(&engine, &context).unwrap();
-    println!("Result: {}\n", result);
+    println!("Result: {result}\n");
 
     // Example 2: Template part inspection
     println!("=== Example 2: Inspecting Template Parts ===");
@@ -37,7 +37,7 @@ fn main() {
     for (i, part) in template.parts().iter().enumerate() {
         match part {
             TemplatePart::Static { content, position } => {
-                println!("Part {}: Static at {} = {:?}", i, position, content);
+                println!("Part {i}: Static at {position} = {content:?}");
             },
             TemplatePart::Expression {
                 content,
@@ -47,8 +47,7 @@ fn main() {
                 strip_right,
             } => {
                 println!(
-                    "Part {}: Expression at {} (length: {}, strip_left: {}, strip_right: {}) = {:?}",
-                    i, position, length, strip_left, strip_right, content
+                    "Part {i}: Expression at {position} (length: {length}, strip_left: {strip_left}, strip_right: {strip_right}) = {content:?}"
                 );
             },
         }
@@ -58,15 +57,15 @@ fn main() {
     // Example 3: Error handling with position information
     println!("=== Example 3: Error with Position Information ===");
     let template = Template::new(
-        r#"Line 1
+        r"Line 1
 Line 2 with {{ invalid_function() }}
-Line 3"#,
+Line 3",
     )
     .unwrap();
 
     match template.render(&engine, &context) {
-        Ok(result) => println!("Result: {}", result),
-        Err(e) => println!("Error: {}\n", e),
+        Ok(result) => println!("Result: {result}"),
+        Err(e) => println!("Error: {e}\n"),
     }
 
     // Example 4: MaybeTemplate auto-detection
@@ -83,8 +82,8 @@ Line 3"#,
     let result1 = dynamic.resolve(&engine, &context).unwrap();
     let result2 = static_text.resolve(&engine, &context).unwrap();
 
-    println!("Dynamic result: {}", result1);
-    println!("Static result: {}\n", result2);
+    println!("Dynamic result: {result1}");
+    println!("Static result: {result2}\n");
 
     // Example 5: Multiline template with position tracking
     println!("=== Example 5: Multiline Template ===");
@@ -106,10 +105,10 @@ Line 3"#,
     context.set_input(Value::String("charlie".to_string()));
     context.set_execution_var("title", Value::String("Dashboard".to_string()));
     context.set_execution_var("message_count", serde_json::json!(42));
-    context.set_execution_var("last_login", serde_json::json!(1704067200)); // 2024-01-01
+    context.set_execution_var("last_login", serde_json::json!(1_704_067_200)); // 2024-01-01
 
     let result = html.render(&engine, &context).unwrap();
-    println!("{}\n", result);
+    println!("{result}\n");
 
     // Example 6: Template reusability
     println!("=== Example 6: Template Reusability ===");
@@ -124,7 +123,7 @@ Line 3"#,
         context.set_execution_var("score", serde_json::json!(score));
 
         let result = greeting_template.render(&engine, &context).unwrap();
-        println!("{}", result);
+        println!("{result}");
     }
     println!();
 
@@ -132,7 +131,7 @@ Line 3"#,
     println!("=== Example 7: Parse Error with Position ===");
     match Template::new("Hello {{ $input") {
         Ok(_) => println!("Parsed successfully"),
-        Err(e) => println!("Parse error: {}", e),
+        Err(e) => println!("Parse error: {e}"),
     }
     println!();
 
@@ -164,5 +163,5 @@ Line 3"#,
     context.set_execution_var("active", serde_json::json!(true));
 
     let result = json_template.render(&engine, &context).unwrap();
-    println!("{}", result);
+    println!("{result}");
 }

--- a/crates/expression/examples/template_rendering.rs
+++ b/crates/expression/examples/template_rendering.rs
@@ -20,7 +20,7 @@ fn main() {
     )
     .unwrap();
     let result = template.render(&engine, &context).unwrap();
-    println!("{}", result);
+    println!("{result}");
 
     // Example 2: HTML Email Template
     println!("\n=== Example 2: HTML Email Template ===");
@@ -49,7 +49,7 @@ fn main() {
         .unwrap()
         .render(&engine, &context)
         .unwrap();
-    println!("{}", result);
+    println!("{result}");
 
     // Example 3: JSON Template
     println!("\n=== Example 3: JSON Template ===");
@@ -74,14 +74,14 @@ fn main() {
         .unwrap()
         .render(&engine, &context)
         .unwrap();
-    println!("{}", result);
+    println!("{result}");
 
     // Example 4: Markdown Document
     println!("\n=== Example 4: Markdown Document ===");
     context.set_execution_var("product", Value::String("Premium Widget".to_string()));
     context.set_execution_var("price", serde_json::json!(29.99));
 
-    let markdown_template = r#"
+    let markdown_template = r"
 # Order Summary
 
 **Customer:** {{ $input }}
@@ -96,17 +96,17 @@ fn main() {
 ---
 
 *Generated on {{ now_iso() }}*
-"#;
+";
 
     let result = Template::new(markdown_template)
         .unwrap()
         .render(&engine, &context)
         .unwrap();
-    println!("{}", result);
+    println!("{result}");
 
     // Example 5: Complex expressions with functions
     println!("\n=== Example 5: Complex Expressions ===");
-    context.set_input(serde_json::json!(1704067200)); // 2024-01-01 00:00:00 UTC
+    context.set_input(serde_json::json!(1_704_067_200)); // 2024-01-01 00:00:00 UTC
 
     let template = r#"
 Report for {{ $execution.username }}:
@@ -122,14 +122,14 @@ Report for {{ $execution.username }}:
         .unwrap()
         .render(&engine, &context)
         .unwrap();
-    println!("{}", result);
+    println!("{result}");
 
     // Example 6: Conditional content (using pipeline)
     println!("\n=== Example 6: With Calculations ===");
     context.set_execution_var("quantity", serde_json::json!(5));
     context.set_execution_var("unit_price", serde_json::json!(19.99));
 
-    let template = r#"
+    let template = r"
 Invoice:
 --------
 Quantity: {{ $execution.quantity }}
@@ -137,11 +137,11 @@ Unit Price: ${{ $execution.unit_price }}
 Subtotal: ${{ $execution.quantity * $execution.unit_price }}
 Tax (10%): ${{ $execution.quantity * $execution.unit_price * 0.1 | round(2) }}
 Total: ${{ $execution.quantity * $execution.unit_price * 1.1 | round(2) }}
-"#;
+";
 
     let result = Template::new(template)
         .unwrap()
         .render(&engine, &context)
         .unwrap();
-    println!("{}", result);
+    println!("{result}");
 }

--- a/crates/expression/src/builtins.rs
+++ b/crates/expression/src/builtins.rs
@@ -196,13 +196,13 @@ pub(crate) fn check_arg_count(
     args: &[Value],
     expected: usize,
 ) -> ExpressionResult<()> {
-    if args.len() != expected {
+    if args.len() == expected {
+        Ok(())
+    } else {
         Err(ExpressionError::expression_invalid_argument(
             func_name,
             format!("Expected {} arguments, got {}", expected, args.len()),
         ))
-    } else {
-        Ok(())
     }
 }
 
@@ -245,7 +245,7 @@ pub(crate) fn get_string_arg<'a>(
         .ok_or_else(|| {
             ExpressionError::expression_invalid_argument(
                 func_name,
-                format!("Missing argument '{}' at position {}", arg_name, index),
+                format!("Missing argument '{arg_name}' at position {index}"),
             )
         })?
         .as_str()
@@ -271,7 +271,7 @@ pub(crate) fn get_int_arg(
     let val = args.get(index).ok_or_else(|| {
         ExpressionError::expression_invalid_argument(
             func_name,
-            format!("Missing argument '{}' at position {}", arg_name, index),
+            format!("Missing argument '{arg_name}' at position {index}"),
         )
     })?;
 
@@ -299,7 +299,7 @@ pub(crate) fn get_int_arg_with_policy(
     let val = args.get(index).ok_or_else(|| {
         ExpressionError::expression_invalid_argument(
             func_name,
-            format!("Missing argument '{}' at position {}", arg_name, index),
+            format!("Missing argument '{arg_name}' at position {index}"),
         )
     })?;
 
@@ -339,7 +339,7 @@ pub(crate) fn get_number_arg(
     let val = args.get(index).ok_or_else(|| {
         ExpressionError::expression_invalid_argument(
             func_name,
-            format!("Missing argument '{}' at position {}", arg_name, index),
+            format!("Missing argument '{arg_name}' at position {index}"),
         )
     })?;
 
@@ -367,7 +367,7 @@ pub(crate) fn get_number_arg_with_policy(
     let val = args.get(index).ok_or_else(|| {
         ExpressionError::expression_invalid_argument(
             func_name,
-            format!("Missing argument '{}' at position {}", arg_name, index),
+            format!("Missing argument '{arg_name}' at position {index}"),
         )
     })?;
 
@@ -408,7 +408,7 @@ pub(crate) fn get_array_arg<'a>(
         .ok_or_else(|| {
             ExpressionError::expression_invalid_argument(
                 func_name,
-                format!("Missing argument '{}' at position {}", arg_name, index),
+                format!("Missing argument '{arg_name}' at position {index}"),
             )
         })?
         .as_array()
@@ -435,7 +435,7 @@ pub(crate) fn get_object_arg<'a>(
         .ok_or_else(|| {
             ExpressionError::expression_invalid_argument(
                 func_name,
-                format!("Missing argument '{}' at position {}", arg_name, index),
+                format!("Missing argument '{arg_name}' at position {index}"),
             )
         })?
         .as_object()

--- a/crates/expression/src/builtins/array.rs
+++ b/crates/expression/src/builtins/array.rs
@@ -96,7 +96,7 @@ pub fn sort(
     check_arg_count("sort", args, 1)?;
     let arr = get_array_arg("sort", args, 0, "array")?;
 
-    let mut elements: Vec<Value> = arr.to_vec();
+    let mut elements: Vec<Value> = arr.clone();
 
     // Sort the values
     elements.sort_by(|a, b| match (a, b) {
@@ -123,7 +123,7 @@ pub fn reverse(
     check_arg_count("reverse", args, 1)?;
     let arr = get_array_arg("reverse", args, 0, "array")?;
 
-    let mut elements: Vec<Value> = arr.to_vec();
+    let mut elements: Vec<Value> = arr.clone();
     elements.reverse();
 
     Ok(Value::Array(elements))
@@ -199,7 +199,7 @@ pub fn concat(
     // Calculate total size to pre-allocate
     let total_size: usize = args
         .iter()
-        .filter_map(|arg| arg.as_array().map(|arr| arr.len()))
+        .filter_map(|arg| arg.as_array().map(Vec::len))
         .sum();
 
     let mut result = Vec::with_capacity(total_size);
@@ -251,7 +251,7 @@ pub fn flatten(
         .iter()
         .flat_map(|elem| {
             if let Some(inner_arr) = elem.as_array() {
-                inner_arr.to_vec()
+                inner_arr.clone()
             } else {
                 vec![elem.clone()]
             }

--- a/crates/expression/src/builtins/conversion.rs
+++ b/crates/expression/src/builtins/conversion.rs
@@ -36,7 +36,7 @@ pub fn to_string(
         Value::Bool(b) => b.to_string(),
         Value::Null => "null".to_string(),
         Value::Array(_) | Value::Object(_) => serde_json::to_string(&args[0]).map_err(|e| {
-            ExpressionError::expression_eval_error(format!("Failed to convert to string: {}", e))
+            ExpressionError::expression_eval_error(format!("Failed to convert to string: {e}"))
         })?,
     };
     Ok(Value::String(string_val))
@@ -95,7 +95,7 @@ pub fn to_json(
     check_arg_count("to_json", args, 1)?;
 
     let json_string = serde_json::to_string(&args[0]).map_err(|e| {
-        ExpressionError::expression_eval_error(format!("Failed to serialize to JSON: {}", e))
+        ExpressionError::expression_eval_error(format!("Failed to serialize to JSON: {e}"))
     })?;
 
     Ok(Value::String(json_string))
@@ -128,8 +128,8 @@ pub fn parse_json(
         )));
     }
 
-    let json: serde_json::Value = serde_json::from_str(json_str).map_err(|e| {
-        ExpressionError::expression_eval_error(format!("Failed to parse JSON: {}", e))
+    let json: Value = serde_json::from_str(json_str).map_err(|e| {
+        ExpressionError::expression_eval_error(format!("Failed to parse JSON: {e}"))
     })?;
 
     if eval.strict_conversions_enabled(ctx) && !matches!(json, Value::Object(_) | Value::Array(_)) {

--- a/crates/expression/src/builtins/datetime.rs
+++ b/crates/expression/src/builtins/datetime.rs
@@ -97,7 +97,7 @@ pub fn date_add(
         _ => {
             return Err(ExpressionError::expression_invalid_argument(
                 "date_add",
-                format!("Invalid unit: {}", unit),
+                format!("Invalid unit: {unit}"),
             ));
         },
     };
@@ -133,7 +133,7 @@ pub fn date_subtract(
         _ => {
             return Err(ExpressionError::expression_invalid_argument(
                 "date_subtract",
-                format!("Invalid unit: {}", unit),
+                format!("Invalid unit: {unit}"),
             ));
         },
     };
@@ -169,7 +169,7 @@ pub fn date_diff(
         _ => {
             return Err(ExpressionError::expression_invalid_argument(
                 "date_diff",
-                format!("Invalid unit: {}", unit),
+                format!("Invalid unit: {unit}"),
             ));
         },
     };
@@ -299,8 +299,7 @@ fn parse_datetime(value: &Value) -> ExpressionResult<DateTime<Utc>> {
             }
 
             Err(ExpressionError::expression_eval_error(format!(
-                "Cannot parse date: {}",
-                s
+                "Cannot parse date: {s}"
             )))
         },
         _ => Err(ExpressionError::expression_type_error(
@@ -344,7 +343,7 @@ fn format_datetime(dt: &DateTime<Utc>, format: &str) -> ExpressionResult<String>
     // Replace in order from longest to shortest to avoid partial replacements
     if result.contains("YYYY") {
         buf.clear();
-        let _ = write!(buf, "{:04}", year);
+        let _ = write!(buf, "{year:04}");
         result = Cow::Owned(result.replace("YYYY", &buf));
     }
     if result.contains("YY") {
@@ -354,27 +353,27 @@ fn format_datetime(dt: &DateTime<Utc>, format: &str) -> ExpressionResult<String>
     }
     if result.contains("MM") {
         buf.clear();
-        let _ = write!(buf, "{:02}", month);
+        let _ = write!(buf, "{month:02}");
         result = Cow::Owned(result.replace("MM", &buf));
     }
     if result.contains("DD") {
         buf.clear();
-        let _ = write!(buf, "{:02}", day);
+        let _ = write!(buf, "{day:02}");
         result = Cow::Owned(result.replace("DD", &buf));
     }
     if result.contains("HH") {
         buf.clear();
-        let _ = write!(buf, "{:02}", hour);
+        let _ = write!(buf, "{hour:02}");
         result = Cow::Owned(result.replace("HH", &buf));
     }
     if result.contains("mm") {
         buf.clear();
-        let _ = write!(buf, "{:02}", minute);
+        let _ = write!(buf, "{minute:02}");
         result = Cow::Owned(result.replace("mm", &buf));
     }
     if result.contains("ss") {
         buf.clear();
-        let _ = write!(buf, "{:02}", second);
+        let _ = write!(buf, "{second:02}");
         result = Cow::Owned(result.replace("ss", &buf));
     }
 
@@ -382,27 +381,27 @@ fn format_datetime(dt: &DateTime<Utc>, format: &str) -> ExpressionResult<String>
     // These use itoa-style formatting for efficiency
     if result.contains('M') {
         buf.clear();
-        let _ = write!(buf, "{}", month);
+        let _ = write!(buf, "{month}");
         result = Cow::Owned(result.replace('M', &buf));
     }
     if result.contains('D') {
         buf.clear();
-        let _ = write!(buf, "{}", day);
+        let _ = write!(buf, "{day}");
         result = Cow::Owned(result.replace('D', &buf));
     }
     if result.contains('H') {
         buf.clear();
-        let _ = write!(buf, "{}", hour);
+        let _ = write!(buf, "{hour}");
         result = Cow::Owned(result.replace('H', &buf));
     }
     if result.contains('m') {
         buf.clear();
-        let _ = write!(buf, "{}", minute);
+        let _ = write!(buf, "{minute}");
         result = Cow::Owned(result.replace('m', &buf));
     }
     if result.contains('s') {
         buf.clear();
-        let _ = write!(buf, "{}", second);
+        let _ = write!(buf, "{second}");
         result = Cow::Owned(result.replace('s', &buf));
     }
 

--- a/crates/expression/src/builtins/object.rs
+++ b/crates/expression/src/builtins/object.rs
@@ -20,7 +20,7 @@ pub fn keys(
     let obj = get_object_arg("keys", args, 0, "object")?;
 
     // Pre-allocate with known size to avoid reallocations
-    let keys: Vec<_> = obj.keys().map(|k| Value::String(k.to_string())).collect();
+    let keys: Vec<_> = obj.keys().map(|k| Value::String(k.clone())).collect();
 
     Ok(Value::Array(keys))
 }

--- a/crates/expression/src/builtins/string.rs
+++ b/crates/expression/src/builtins/string.rs
@@ -329,8 +329,7 @@ pub fn repeat(
     let result_len = s.len().saturating_mul(count);
     if result_len > MAX_RESULT_LEN {
         return Err(ExpressionError::expression_eval_error(format!(
-            "repeat would produce a string of {} bytes, exceeding limit of {MAX_RESULT_LEN}",
-            result_len
+            "repeat would produce a string of {result_len} bytes, exceeding limit of {MAX_RESULT_LEN}"
         )));
     }
 

--- a/crates/expression/src/engine.rs
+++ b/crates/expression/src/engine.rs
@@ -27,7 +27,7 @@ pub struct CacheStats {
 }
 
 /// Lightweight cache observability snapshot for `ExpressionEngine`.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CacheOverview {
     /// Whether expression parsing cache is enabled.
     pub expr_cache_enabled: bool,
@@ -71,15 +71,12 @@ impl<K: std::hash::Hash + Eq + Send + Sync + 'static, V: Clone + Send + Sync + '
     }
 
     fn get(&self, key: &K) -> Option<V> {
-        match self.inner.get(key) {
-            Some(v) => {
-                self.hits.fetch_add(1, Ordering::Relaxed);
-                Some(v)
-            },
-            None => {
-                self.misses.fetch_add(1, Ordering::Relaxed);
-                None
-            },
+        if let Some(v) = self.inner.get(key) {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            Some(v)
+        } else {
+            self.misses.fetch_add(1, Ordering::Relaxed);
+            None
         }
     }
 
@@ -360,7 +357,7 @@ impl ExpressionEngine {
     pub fn expr_cache_size(&self) -> Option<usize> {
         #[cfg(feature = "cache")]
         {
-            self.expr_cache.as_ref().map(|cache| cache.len())
+            self.expr_cache.as_ref().map(TrackedCache::len)
         }
         #[cfg(not(feature = "cache"))]
         {
@@ -372,7 +369,7 @@ impl ExpressionEngine {
     pub fn template_cache_size(&self) -> Option<usize> {
         #[cfg(feature = "cache")]
         {
-            self.template_cache.as_ref().map(|cache| cache.len())
+            self.template_cache.as_ref().map(TrackedCache::len)
         }
         #[cfg(not(feature = "cache"))]
         {
@@ -384,14 +381,14 @@ impl ExpressionEngine {
     pub fn cache_overview(&self) -> CacheOverview {
         #[cfg(feature = "cache")]
         {
-            let expr_stats = self.expr_cache.as_ref().map(|c| c.stats());
-            let tmpl_stats = self.template_cache.as_ref().map(|c| c.stats());
+            let expr_stats = self.expr_cache.as_ref().map(TrackedCache::stats);
+            let tmpl_stats = self.template_cache.as_ref().map(TrackedCache::stats);
 
             CacheOverview {
                 expr_cache_enabled: self.expr_cache.is_some(),
                 template_cache_enabled: self.template_cache.is_some(),
-                expr_entries: self.expr_cache.as_ref().map_or(0, |c| c.len()),
-                template_entries: self.template_cache.as_ref().map_or(0, |c| c.len()),
+                expr_entries: self.expr_cache.as_ref().map_or(0, TrackedCache::len),
+                template_entries: self.template_cache.as_ref().map_or(0, TrackedCache::len),
                 expr_hits: expr_stats.as_ref().map_or(0, |s| s.hits),
                 expr_misses: expr_stats.as_ref().map_or(0, |s| s.misses),
                 template_hits: tmpl_stats.as_ref().map_or(0, |s| s.hits),
@@ -419,7 +416,7 @@ impl ExpressionEngine {
     pub fn expr_cache_stats(&self) -> Option<CacheStats> {
         #[cfg(feature = "cache")]
         {
-            self.expr_cache.as_ref().map(|c| c.stats())
+            self.expr_cache.as_ref().map(TrackedCache::stats)
         }
         #[cfg(not(feature = "cache"))]
         {
@@ -433,7 +430,7 @@ impl ExpressionEngine {
     pub fn template_cache_stats(&self) -> Option<CacheStats> {
         #[cfg(feature = "cache")]
         {
-            self.template_cache.as_ref().map(|c| c.stats())
+            self.template_cache.as_ref().map(TrackedCache::stats)
         }
         #[cfg(not(feature = "cache"))]
         {
@@ -455,7 +452,7 @@ mod tests {
 
     fn constant_one(
         _args: &[Value],
-        _evaluator: &crate::eval::Evaluator,
+        _evaluator: &Evaluator,
         _context: &EvaluationContext,
     ) -> ExpressionResult<Value> {
         Ok(Value::from(1))
@@ -549,11 +546,11 @@ mod tests {
         context.set_input(Value::Number(42.into()));
         context.set_execution_var("name", Value::String("Alice".to_string()));
 
-        let html = r#"<html>
+        let html = r"<html>
   <h1>Welcome {{ $execution.name }}</h1>
   <p>Your score: {{ $input * 2 }}</p>
   <span>Total: {{ $input + 8 }}</span>
-</html>"#;
+</html>";
 
         let template = engine.parse_template(html).unwrap();
         let result = engine.render_template(&template, &context).unwrap();

--- a/crates/expression/src/error_formatter.rs
+++ b/crates/expression/src/error_formatter.rs
@@ -80,7 +80,7 @@ impl<'a> ErrorFormatter<'a> {
             // Add highlighting under the error position
             let padding = " ".repeat(line_num_width + 3); // " N | "
             let column_padding = " ".repeat(self.position.column.saturating_sub(1));
-            output.push_str(&format!("{}{}^\n", padding, column_padding));
+            output.push_str(&format!("{padding}{column_padding}^\n"));
         }
 
         // Show context after error
@@ -140,7 +140,7 @@ impl<'a> ErrorFormatter<'a> {
             let padding = " ".repeat(line_num_width + 3);
             let column_padding = " ".repeat(self.position.column.saturating_sub(1));
             let highlight = "^".repeat(length.max(1));
-            output.push_str(&format!("{}{}{}\n", padding, column_padding, highlight));
+            output.push_str(&format!("{padding}{column_padding}{highlight}\n"));
         }
 
         // Context after
@@ -176,7 +176,7 @@ pub fn format_template_error(
     };
 
     if let Some(expr) = expression {
-        format!("{}\nExpression: {}", formatted, expr)
+        format!("{formatted}\nExpression: {expr}")
     } else {
         formatted
     }
@@ -196,7 +196,7 @@ mod tests {
         assert!(output.contains("Error at line 2, column 8"));
         assert!(output.contains("Variable not found"));
         assert!(output.contains("Line 2 with error"));
-        assert!(output.contains("^"));
+        assert!(output.contains('^'));
     }
 
     #[test]

--- a/crates/expression/src/eval.rs
+++ b/crates/expression/src/eval.rs
@@ -896,8 +896,7 @@ impl Evaluator {
             Value::Object(o) => {
                 let json_val = o.get(property).ok_or_else(|| {
                     ExpressionError::expression_eval_error(format!(
-                        "Property '{}' not found",
-                        property
+                        "Property '{property}' not found"
                     ))
                 })?;
                 Ok(json_val.clone())
@@ -945,7 +944,7 @@ impl Evaluator {
                     )
                 })?;
                 let json_val = o.get(key).ok_or_else(|| {
-                    ExpressionError::expression_eval_error(format!("Key '{}' not found", key))
+                    ExpressionError::expression_eval_error(format!("Key '{key}' not found"))
                 })?;
                 Ok(json_val.clone())
             },
@@ -1039,8 +1038,7 @@ impl Evaluator {
             let denied = policy.denied_functions();
             if denied.contains(name) || denied.contains(canonical) {
                 return Err(ExpressionError::expression_eval_error(format!(
-                    "Function '{}' is denied by policy",
-                    name
+                    "Function '{name}' is denied by policy"
                 )));
             }
         }
@@ -1050,8 +1048,7 @@ impl Evaluator {
                 continue;
             }
             return Err(ExpressionError::expression_eval_error(format!(
-                "Function '{}' is not allowed by policy",
-                name
+                "Function '{name}' is not allowed by policy"
             )));
         }
 
@@ -1177,7 +1174,7 @@ impl Evaluator {
 
         // Filter the array
         let mut result = Vec::with_capacity(array.len());
-        for item in array.iter() {
+        for item in array {
             let predicate_result = self.eval_lambda(param, body, item, context, frame)?;
             if self.coerce_boolean(&predicate_result, context)? {
                 result.push(item.clone());
@@ -1226,7 +1223,7 @@ impl Evaluator {
 
         // Map the array
         let mut result = Vec::with_capacity(array.len());
-        for item in array.iter() {
+        for item in array {
             let transformed = self.eval_lambda(param, body, item, context, frame)?;
             result.push(transformed);
         }
@@ -1282,7 +1279,7 @@ impl Evaluator {
         // previous `self.eval(body, ...)` pattern reset the counter on
         // every element and was the CO-C1-01 DoS bypass.
         let mut accumulator = initial;
-        for item in array.iter() {
+        for item in array {
             // Create context with both accumulator and current item
             let mut reduce_context = context.clone();
             reduce_context.set_lambda_var("$acc", accumulator.clone());
@@ -1328,7 +1325,7 @@ impl Evaluator {
             },
         };
 
-        for item in array.iter() {
+        for item in array {
             let predicate_result = self.eval_lambda(param, body, item, context, frame)?;
             if self.coerce_boolean(&predicate_result, context)? {
                 return Ok(item.clone());
@@ -1373,7 +1370,7 @@ impl Evaluator {
             },
         };
 
-        for item in array.iter() {
+        for item in array {
             let predicate_result = self.eval_lambda(param, body, item, context, frame)?;
             if !self.coerce_boolean(&predicate_result, context)? {
                 return Ok(Value::Bool(false));
@@ -1418,7 +1415,7 @@ impl Evaluator {
             },
         };
 
-        for item in array.iter() {
+        for item in array {
             let predicate_result = self.eval_lambda(param, body, item, context, frame)?;
             if self.coerce_boolean(&predicate_result, context)? {
                 return Ok(Value::Bool(true));
@@ -1510,7 +1507,7 @@ impl Evaluator {
         };
 
         let mut groups = serde_json::Map::new();
-        for item in array.iter() {
+        for item in array {
             let key_val = self.eval_lambda(param, body, item, context, frame)?;
             let key = match &key_val {
                 Value::String(s) => s.clone(),
@@ -1577,7 +1574,7 @@ impl Evaluator {
         };
 
         let mut result = Vec::new();
-        for item in array.iter() {
+        for item in array {
             let transformed = self.eval_lambda(param, body, item, context, frame)?;
             match transformed {
                 Value::Array(inner) => result.extend(inner),
@@ -1874,7 +1871,7 @@ mod tests {
 
         // Fill the cache with many patterns
         for i in 0..MAX_REGEX_CACHE_SIZE + 10 {
-            let pattern = format!("pattern_{}", i);
+            let pattern = format!("pattern_{i}");
             let expr = Expr::Binary {
                 left: Box::new(Expr::Literal(Value::String("test".to_string()))),
                 op: BinaryOp::RegexMatch,
@@ -1887,9 +1884,7 @@ mod tests {
         let cache_size = evaluator.regex_cache.lock().len();
         assert!(
             cache_size <= MAX_REGEX_CACHE_SIZE,
-            "Cache size {} exceeds limit {}",
-            cache_size,
-            MAX_REGEX_CACHE_SIZE
+            "Cache size {cache_size} exceeds limit {MAX_REGEX_CACHE_SIZE}"
         );
     }
 
@@ -2473,8 +2468,8 @@ mod tests {
         let result = evaluator.eval(&expr, &context).unwrap();
         let arr = result.as_array().expect("map returns an array");
         assert_eq!(arr.len(), 100);
-        assert_eq!(arr.first().and_then(|v| v.as_i64()), Some(1));
-        assert_eq!(arr.last().and_then(|v| v.as_i64()), Some(100));
+        assert_eq!(arr.first().and_then(Value::as_i64), Some(1));
+        assert_eq!(arr.last().and_then(Value::as_i64), Some(100));
     }
 
     #[test]

--- a/crates/expression/src/interner.rs
+++ b/crates/expression/src/interner.rs
@@ -120,7 +120,7 @@ mod tests {
         assert_eq!(interner.len(), 0);
 
         for i in 0..10 {
-            interner.intern(&format!("str{}", i));
+            interner.intern(&format!("str{i}"));
         }
 
         assert_eq!(interner.len(), 10);

--- a/crates/expression/src/maybe.rs
+++ b/crates/expression/src/maybe.rs
@@ -321,7 +321,7 @@ where
         D: Deserializer<'de>,
     {
         // First try to deserialize as a string to check if it's an expression
-        let value = serde_json::Value::deserialize(deserializer)?;
+        let value = Value::deserialize(deserializer)?;
 
         if let Some(s) = value.as_str() {
             // If it's a string, check if it looks like an expression

--- a/crates/expression/src/parser.rs
+++ b/crates/expression/src/parser.rs
@@ -57,8 +57,7 @@ impl<'a> Parser<'a> {
     fn parse_expression_with_depth(&mut self, depth: usize) -> ExpressionResult<Expr> {
         if depth > MAX_PARSER_DEPTH {
             return Err(ExpressionError::expression_parse_error(format!(
-                "Maximum parser recursion depth ({}) exceeded",
-                MAX_PARSER_DEPTH
+                "Maximum parser recursion depth ({MAX_PARSER_DEPTH}) exceeded"
             )));
         }
         self.parse_conditional_with_depth(depth)
@@ -130,8 +129,7 @@ impl<'a> Parser<'a> {
         // guard is not enough. Enforce the cap here too.
         if depth > MAX_PARSER_DEPTH {
             return Err(ExpressionError::expression_parse_error(format!(
-                "Maximum parser recursion depth ({}) exceeded",
-                MAX_PARSER_DEPTH
+                "Maximum parser recursion depth ({MAX_PARSER_DEPTH}) exceeded"
             )));
         }
         let mut left = self.parse_unary_with_depth(depth + 1)?;
@@ -196,8 +194,7 @@ impl<'a> Parser<'a> {
         // stop a stack overflow on hostile input, so enforce the cap here.
         if depth > MAX_PARSER_DEPTH {
             return Err(ExpressionError::expression_parse_error(format!(
-                "Maximum parser recursion depth ({}) exceeded",
-                MAX_PARSER_DEPTH
+                "Maximum parser recursion depth ({MAX_PARSER_DEPTH}) exceeded"
             )));
         }
         match &self.current_token().kind {
@@ -557,7 +554,7 @@ mod tests {
         // So 40 parentheses = ~240 depth, which is safely under MAX_PARSER_DEPTH of 256
         let mut expr = String::from("1");
         for _ in 0..40 {
-            expr = format!("({})", expr);
+            expr = format!("({expr})");
         }
 
         let result = parse(&expr);
@@ -567,7 +564,7 @@ mod tests {
             result
                 .as_ref()
                 .err()
-                .map(|e| format!("{:?}", e))
+                .map(|e| format!("{e:?}"))
                 .unwrap_or_default()
         );
     }

--- a/crates/expression/src/template.rs
+++ b/crates/expression/src/template.rs
@@ -21,7 +21,7 @@ use crate::{
 const MAX_TEMPLATE_EXPRESSIONS: usize = 1000;
 
 /// A template part - either static text or an expression to evaluate
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TemplatePart {
     /// Static text that doesn't need evaluation
     Static {
@@ -276,8 +276,7 @@ impl Template {
                         .count();
                     if expr_count > MAX_TEMPLATE_EXPRESSIONS {
                         return Err(ExpressionError::expression_parse_error(format!(
-                            "Template contains too many expressions: {} (max {})",
-                            expr_count, MAX_TEMPLATE_EXPRESSIONS
+                            "Template contains too many expressions: {expr_count} (max {MAX_TEMPLATE_EXPRESSIONS})"
                         )));
                     }
 
@@ -495,9 +494,9 @@ mod tests {
         context.set_input(Value::String("Alice".to_string()));
 
         let template = Template::new(
-            r#"Line 1: {{ $input }}
+            r"Line 1: {{ $input }}
 Line 2: {{ $input | uppercase() }}
-Line 3: Done"#,
+Line 3: Done",
         )
         .unwrap();
 

--- a/crates/expression/src/token.rs
+++ b/crates/expression/src/token.rs
@@ -130,7 +130,7 @@ pub enum TokenKind<'a> {
     Eof,
 }
 
-impl<'a> TokenKind<'a> {
+impl TokenKind<'_> {
     /// Check if this token is a literal value
     pub fn is_literal(&self) -> bool {
         matches!(
@@ -215,22 +215,22 @@ impl<'a> TokenKind<'a> {
     }
 }
 
-impl<'a> std::fmt::Display for Token<'a> {
+impl std::fmt::Display for Token<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.kind)
     }
 }
 
-impl<'a> std::fmt::Display for TokenKind<'a> {
+impl std::fmt::Display for TokenKind<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            TokenKind::Integer(n) => write!(f, "{}", n),
-            TokenKind::Float(n) => write!(f, "{}", n),
-            TokenKind::String(s) => write!(f, "\"{}\"", s),
-            TokenKind::Boolean(b) => write!(f, "{}", b),
+            TokenKind::Integer(n) => write!(f, "{n}"),
+            TokenKind::Float(n) => write!(f, "{n}"),
+            TokenKind::String(s) => write!(f, "\"{s}\""),
+            TokenKind::Boolean(b) => write!(f, "{b}"),
             TokenKind::Null => write!(f, "null"),
-            TokenKind::Identifier(s) => write!(f, "{}", s),
-            TokenKind::Variable(s) => write!(f, "${}", s),
+            TokenKind::Identifier(s) => write!(f, "{s}"),
+            TokenKind::Variable(s) => write!(f, "${s}"),
             TokenKind::Plus => write!(f, "+"),
             TokenKind::Minus => write!(f, "-"),
             TokenKind::Star => write!(f, "*"),

--- a/crates/expression/src/value_utils.rs
+++ b/crates/expression/src/value_utils.rs
@@ -74,7 +74,7 @@ pub fn to_integer(value: &Value) -> Result<i64, &'static str> {
     match value {
         Value::Number(n) => number_as_i64(n).ok_or("number is not an integer"),
         Value::String(s) => s.parse().map_err(|_| "string is not a valid integer"),
-        Value::Bool(b) => Ok(if *b { 1 } else { 0 }),
+        Value::Bool(b) => Ok(i64::from(*b)),
         _ => Err("value cannot be converted to integer"),
     }
 }

--- a/crates/expression/tests/benchmarks.rs
+++ b/crates/expression/tests/benchmarks.rs
@@ -27,7 +27,7 @@ where
     let duration = start.elapsed();
 
     let avg = duration / ITERATIONS as u32;
-    println!("{:45} {:>12.2?}", name, avg);
+    println!("{name:45} {avg:>12.2?}");
 
     duration
 }
@@ -62,7 +62,7 @@ fn template_benchmarks() {
     });
 
     // Parse complex
-    let complex_template = r#"
+    let complex_template = r"
         <html>
             <title>{{ $workflow.name }}</title>
             <body>
@@ -70,7 +70,7 @@ fn template_benchmarks() {
                 <p>Result: {{ $input | uppercase() }}</p>
             </body>
         </html>
-    "#;
+    ";
     benchmark("template/parse/complex", || {
         let _ = Template::new(complex_template);
     });
@@ -141,7 +141,7 @@ fn context_benchmarks() {
     // Create context with many variables
     let mut context = EvaluationContext::new();
     for i in 0..100 {
-        context.set_execution_var(format!("var_{}", i), serde_json::json!(i as i64));
+        context.set_execution_var(format!("var_{i}"), serde_json::json!(i as i64));
     }
 
     benchmark("context/clone_100_vars", || {

--- a/crates/expression/tests/builtin_functions.rs
+++ b/crates/expression/tests/builtin_functions.rs
@@ -265,7 +265,7 @@ fn entries_converts_to_pairs() {
 
 #[test]
 fn entries_empty_object() {
-    assert_eq!(eval(r#"entries({})"#), json!([]));
+    assert_eq!(eval(r"entries({})"), json!([]));
 }
 
 // ──────────────────────────────────────────────

--- a/crates/expression/tests/manual_benchmarks.rs
+++ b/crates/expression/tests/manual_benchmarks.rs
@@ -44,7 +44,7 @@ fn benchmark_baseline() {
     });
     println!("{:40} {:>15.2?}", "template/parse/multiple", time);
 
-    let complex = r#"
+    let complex = r"
         <html>
             <title>{{ $workflow.name }}</title>
             <body>
@@ -52,7 +52,7 @@ fn benchmark_baseline() {
                 <p>Result: {{ $input | uppercase() }}</p>
             </body>
         </html>
-    "#;
+    ";
     let time = avg_time(|| {
         let _ = Template::new(complex);
     });
@@ -122,7 +122,7 @@ fn benchmark_baseline() {
 
     let mut big_ctx = EvaluationContext::new();
     for i in 0..100 {
-        big_ctx.set_execution_var(format!("var_{}", i), serde_json::json!(i as i64));
+        big_ctx.set_execution_var(format!("var_{i}"), serde_json::json!(i as i64));
     }
 
     let time = avg_time(|| {

--- a/crates/log/Cargo.toml
+++ b/crates/log/Cargo.toml
@@ -101,3 +101,6 @@ harness = false
 #   - tracing-log: activated through tracing-subscriber's `tracing-log`
 #     feature; the `log-compat` feature re-exposes it for downstream.
 ignored = ["flate2", "tracing-log"]
+
+[lints]
+workspace = true

--- a/crates/log/benches/log_hot_path.rs
+++ b/crates/log/benches/log_hot_path.rs
@@ -45,7 +45,7 @@ impl BenchEvent {
 }
 
 impl ObservabilityEvent for BenchEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "bench.operation"
     }
 

--- a/crates/log/examples/async_timing.rs
+++ b/crates/log/examples/async_timing.rs
@@ -1,9 +1,13 @@
 use anyhow::Result;
-use nebula_log::{async_timed, measure, prelude::*, with_context};
+use nebula_log::{
+    async_timed, measure,
+    prelude::{auto_init, info},
+    with_context,
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    nebula_log::auto_init()?;
+    auto_init()?;
 
     // Build context, then scope it over our async work
     let ctx = with_context!(request_id = "req-123", user_id = "user-456");

--- a/crates/log/examples/context_propagation.rs
+++ b/crates/log/examples/context_propagation.rs
@@ -4,15 +4,18 @@
 //! points in multi-thread Tokio runtimes via `tokio::task_local!`.
 
 use anyhow::Result;
-use nebula_log::{Context, prelude::*};
+use nebula_log::{
+    Context,
+    prelude::{auto_init, debug, info},
+};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    nebula_log::auto_init()?;
+    auto_init()?;
 
     // Simulate handling multiple requests concurrently
     let handles: Vec<_> = (0..3)
-        .map(|i| tokio::spawn(handle_user_request(format!("user-{}", i))))
+        .map(|i| tokio::spawn(handle_user_request(format!("user-{i}"))))
         .collect();
 
     for handle in handles {

--- a/crates/log/examples/custom_observability.rs
+++ b/crates/log/examples/custom_observability.rs
@@ -113,7 +113,7 @@ struct UserActionEvent {
 }
 
 impl ObservabilityEvent for UserActionEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "user_action"
     }
 
@@ -147,7 +147,7 @@ struct SystemHealthEvent {
 }
 
 impl ObservabilityEvent for SystemHealthEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "system_health"
     }
 
@@ -178,7 +178,7 @@ struct BusinessMetricEvent {
 }
 
 impl ObservabilityEvent for BusinessMetricEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "business_metric"
     }
 
@@ -213,7 +213,7 @@ struct ErrorEvent {
 }
 
 impl ObservabilityEvent for ErrorEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "error_event"
     }
 

--- a/crates/log/examples/log_basic.rs
+++ b/crates/log/examples/log_basic.rs
@@ -1,8 +1,8 @@
-use nebula_log::prelude::*;
+use nebula_log::prelude::{auto_init, debug, error, info, warn};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Auto-detect best configuration
-    nebula_log::auto_init()?;
+    auto_init()?;
 
     // Note: fields come BEFORE the message
     info!(port = 8080, "Server starting");

--- a/crates/log/examples/multi_crate_observability.rs
+++ b/crates/log/examples/multi_crate_observability.rs
@@ -73,7 +73,7 @@ fn simulate_memory_crate_events() {
         let event = CrateEvent {
             crate_name: "nebula-memory".to_string(),
             event_type: "cache_operation".to_string(),
-            operation: format!("lookup_{}", i),
+            operation: format!("lookup_{i}"),
             success: i % 2 == 0,
         };
         emit_event(&event);
@@ -87,7 +87,7 @@ fn simulate_validator_crate_events() {
         let event = CrateEvent {
             crate_name: "nebula-validator".to_string(),
             event_type: "validation".to_string(),
-            operation: format!("validate_{}", i),
+            operation: format!("validate_{i}"),
             success: true,
         };
         emit_event(&event);
@@ -131,8 +131,8 @@ impl UnifiedMetricsCollector {
     fn display_metrics(&self) {
         let metrics = self.metrics.lock().unwrap();
 
-        for (crate_name, crate_metrics) in metrics.iter() {
-            println!("\n{}", crate_name);
+        for (crate_name, crate_metrics) in &*metrics {
+            println!("\n{crate_name}");
             println!("  Total events:   {}", crate_metrics.total_events);
             println!("  Successful:     {}", crate_metrics.success_count);
             println!("  Failed:         {}", crate_metrics.failure_count);
@@ -149,7 +149,8 @@ impl ObservabilityHook for UnifiedMetricsCollector {
         if let Some(data) = event_data_json(event)
             && let (Some(crate_name), Some(success)) = (
                 data.get("crate_name").and_then(|v| v.as_str()),
-                data.get("success").and_then(|v| v.as_bool()),
+                data.get("success")
+                    .and_then(serde_json::value::Value::as_bool),
             )
         {
             let mut metrics = self.metrics.lock().unwrap();
@@ -177,7 +178,7 @@ struct CrateEvent {
 }
 
 impl ObservabilityEvent for CrateEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "crate_event"
     }
 

--- a/crates/log/examples/observability_hooks.rs
+++ b/crates/log/examples/observability_hooks.rs
@@ -32,7 +32,7 @@ struct ValidationEvent {
 }
 
 impl ObservabilityEvent for ValidationEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "validation"
     }
 
@@ -50,7 +50,7 @@ struct AllocationEvent {
 }
 
 impl ObservabilityEvent for AllocationEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "allocation"
     }
 
@@ -107,7 +107,7 @@ impl ObservabilityHook for FilteringHook {
         if event.name().contains(&self.filter) {
             println!("  [FilteringHook] Matched event: {}", event.name());
             if let Some(data) = event_data_json(event) {
-                println!("    Data: {}", data);
+                println!("    Data: {data}");
             }
         }
     }

--- a/crates/log/examples/resource_based_observability.rs
+++ b/crates/log/examples/resource_based_observability.rs
@@ -10,7 +10,12 @@
 
 use std::sync::Arc;
 
-use nebula_log::observability::*;
+use nebula_log::observability::{
+    EventFilter, ExecutionContext, GlobalContext, LogLevel, LoggerResource, LoggingHook,
+    NodeContext, ObservabilityEvent, ObservabilityFieldValue, ObservabilityFieldVisitor,
+    ObservabilityHook, ResourceAwareAdapter, ResourceAwareHook, emit_event, register_hook,
+    shutdown_hooks,
+};
 use tracing::Level;
 
 /// Custom event for workflow operations
@@ -169,9 +174,7 @@ fn main() {
     struct PanickingHook;
     impl ObservabilityHook for PanickingHook {
         fn on_event(&self, event: &dyn ObservabilityEvent) {
-            if event.name() == "test.panic" {
-                panic!("Intentional panic");
-            }
+            assert!(event.name() != "test.panic", "Intentional panic");
         }
     }
 

--- a/crates/log/examples/span_like_resources.rs
+++ b/crates/log/examples/span_like_resources.rs
@@ -3,7 +3,11 @@
 //! Demonstrates how resources automatically merge from parent contexts,
 //! similar to how `tracing` spans inherit attributes.
 
-use nebula_log::observability::*;
+use nebula_log::observability::{
+    ExecutionContext, LogLevel, LoggerResource, NodeContext, ObservabilityEvent,
+    ResourceAwareAdapter, ResourceAwareHook, emit_event, get_current_logger_resource,
+    register_hook, shutdown_hooks,
+};
 use tracing::Level;
 
 fn main() {

--- a/crates/log/src/builder/reload.rs
+++ b/crates/log/src/builder/reload.rs
@@ -30,8 +30,8 @@ impl ReloadHandle {
     /// dropped.
     pub fn reload(&self, filter: &str) -> LogResult<()> {
         use crate::core::LogError;
-        let new_filter = EnvFilter::try_new(filter)
-            .map_err(|e| LogError::Filter(format!("{}: {}", filter, e)))?;
+        let new_filter =
+            EnvFilter::try_new(filter).map_err(|e| LogError::Filter(format!("{filter}: {e}")))?;
         self.filter
             .reload(new_filter)
             .map_err(|e| LogError::Config(format!("Failed to reload filter: {e}")))?;

--- a/crates/log/src/builder/watcher.rs
+++ b/crates/log/src/builder/watcher.rs
@@ -70,7 +70,7 @@ async fn watcher_task(
 
     loop {
         tokio::select! {
-            _ = tokio::time::sleep(interval) => {}
+            () = tokio::time::sleep(interval) => {}
             _ = cancel.changed() => {
                 tracing::debug!(path = %path.display(), "config watcher stopped");
                 return;

--- a/crates/log/src/layer/context.rs
+++ b/crates/log/src/layer/context.rs
@@ -29,7 +29,7 @@ mod storage {
 
     #[inline]
     pub fn current() -> Arc<Context> {
-        CTX.try_with(|c| c.clone())
+        CTX.try_with(Clone::clone)
             .unwrap_or_else(|_| Arc::new(Context::default()))
     }
 
@@ -151,7 +151,7 @@ impl Context {
     /// The context survives across `.await` points, even in multi-thread
     /// Tokio runtimes with work-stealing.
     #[cfg(feature = "async")]
-    pub async fn scope<F: std::future::Future>(self, f: F) -> F::Output {
+    pub async fn scope<F: Future>(self, f: F) -> F::Output {
         storage::with_ctx(Arc::new(self), f).await
     }
 }

--- a/crates/log/src/lib.rs
+++ b/crates/log/src/lib.rs
@@ -225,7 +225,7 @@ pub fn auto_init() -> LogResult<LoggerGuard> {
             info!(source = ?source, "logging initialized");
             Ok(guard)
         },
-        Err(crate::core::LogError::AlreadyInitialized) => Ok(LoggerGuard::noop()),
+        Err(LogError::AlreadyInitialized) => Ok(LoggerGuard::noop()),
         Err(e) => Err(e),
     }
 }

--- a/crates/log/src/observability/context.rs
+++ b/crates/log/src/observability/context.rs
@@ -168,12 +168,12 @@ mod storage {
 
     #[inline]
     pub fn current_execution() -> Option<Arc<ExecutionContext>> {
-        EXECUTION_CTX.try_with(|ctx| ctx.clone()).ok()
+        EXECUTION_CTX.try_with(Clone::clone).ok()
     }
 
     #[inline]
     pub fn current_node() -> Option<Arc<NodeContext>> {
-        NODE_CTX.try_with(|ctx| ctx.clone()).ok()
+        NODE_CTX.try_with(Clone::clone).ok()
     }
 
     pub async fn with_execution<F: Future>(ctx: Arc<ExecutionContext>, f: F) -> F::Output {
@@ -317,7 +317,7 @@ impl ExecutionContext {
     ///
     /// Nesting is supported — inner scopes shadow outer ones and restore on completion.
     #[cfg(feature = "async")]
-    pub async fn scope<F: std::future::Future>(self, f: F) -> F::Output {
+    pub async fn scope<F: Future>(self, f: F) -> F::Output {
         storage::with_execution(Arc::new(self), f).await
     }
 }
@@ -398,7 +398,7 @@ impl NodeContext {
     ///
     /// Nesting is supported — inner scopes shadow outer ones and restore on completion.
     #[cfg(feature = "async")]
-    pub async fn scope<F: std::future::Future>(self, f: F) -> F::Output {
+    pub async fn scope<F: Future>(self, f: F) -> F::Output {
         storage::with_node(Arc::new(self), f).await
     }
 }

--- a/crates/log/src/observability/hooks.rs
+++ b/crates/log/src/observability/hooks.rs
@@ -112,8 +112,7 @@ pub fn event_data_json(event: &dyn ObservabilityEvent) -> Option<serde_json::Val
                 ObservabilityFieldValue::I64(v) => serde_json::Value::Number(v.into()),
                 ObservabilityFieldValue::U64(v) => serde_json::Value::Number(v.into()),
                 ObservabilityFieldValue::F64(v) => serde_json::Number::from_f64(v)
-                    .map(serde_json::Value::Number)
-                    .unwrap_or(serde_json::Value::Null),
+                    .map_or(serde_json::Value::Null, serde_json::Value::Number),
             };
             // Only allocate key string if necessary; most keys are short patterns
             self.fields.insert(key.to_string(), value);

--- a/crates/log/src/observability/registry.rs
+++ b/crates/log/src/observability/registry.rs
@@ -32,7 +32,7 @@ type HookList = Vec<Arc<dyn ObservabilityHook>>;
 /// one panicked hook doesn't poison others.
 #[inline]
 fn emit_to_hooks_inline(hooks: &HookList, event: &dyn ObservabilityEvent) {
-    for hook in hooks.iter() {
+    for hook in hooks {
         let result = panic::catch_unwind(AssertUnwindSafe(|| {
             hook.on_event(event);
         }));
@@ -56,7 +56,7 @@ fn emit_to_hooks_inline(hooks: &HookList, event: &dyn ObservabilityEvent) {
 fn emit_to_hooks_bounded(hooks: &HookList, event: &dyn ObservabilityEvent, timeout_ms: u64) {
     let started = Instant::now();
 
-    for hook in hooks.iter() {
+    for hook in hooks {
         if started.elapsed().as_millis() as u64 > timeout_ms {
             tracing::warn!(
                 event_name = event.name(),
@@ -433,7 +433,7 @@ mod tests {
             .map(|i| {
                 thread::spawn(move || {
                     let event = TestEvent {
-                        name: format!("thread_{}", i),
+                        name: format!("thread_{i}"),
                     };
                     emit_event(&event);
                 })
@@ -460,9 +460,10 @@ mod tests {
 
     impl ObservabilityHook for PanickingHook {
         fn on_event(&self, event: &dyn ObservabilityEvent) {
-            if event.name() == self.panic_on {
-                panic!("Intentional panic for testing");
-            }
+            assert!(
+                event.name() != self.panic_on,
+                "Intentional panic for testing"
+            );
         }
     }
 

--- a/crates/log/src/observability/resources.rs
+++ b/crates/log/src/observability/resources.rs
@@ -310,7 +310,7 @@ mod tests {
     fn debug_output_redacts_sentry_dsn() {
         let resource = LoggerResource::new().with_sentry_dsn("https://secret-key@sentry.io/12345");
 
-        let debug_output = format!("{:?}", resource);
+        let debug_output = format!("{resource:?}");
 
         assert!(!debug_output.contains("secret-key"));
         assert!(!debug_output.contains("sentry.io/12345"));
@@ -322,7 +322,7 @@ mod tests {
         let resource = LoggerResource::new()
             .with_webhook("https://hooks.slack.com/services/T00/B00/SECRET123");
 
-        let debug_output = format!("{:?}", resource);
+        let debug_output = format!("{resource:?}");
 
         assert!(!debug_output.contains("SECRET123"));
         assert!(!debug_output.contains("hooks.slack.com"));
@@ -340,7 +340,7 @@ mod tests {
             ..Default::default()
         };
 
-        let debug_output = format!("{:?}", prefs);
+        let debug_output = format!("{prefs:?}");
 
         assert!(!debug_output.contains("admin@example.com"));
         assert!(!debug_output.contains("security@internal.net"));
@@ -351,7 +351,7 @@ mod tests {
     fn debug_output_shows_none_when_no_secrets() {
         let resource = LoggerResource::new();
 
-        let debug_output = format!("{:?}", resource);
+        let debug_output = format!("{resource:?}");
 
         assert!(debug_output.contains("sentry_dsn: None"));
         assert!(debug_output.contains("webhook_url: None"));

--- a/crates/log/src/writer.rs
+++ b/crates/log/src/writer.rs
@@ -83,7 +83,7 @@ impl<'a> MakeWriter<'a> for FanoutMakeWriter {
     type Writer = FanoutWriter<'a>;
 
     fn make_writer(&'a self) -> Self::Writer {
-        let writers: FanoutVec<'a> = self.writers.iter().map(|w| w.make_writer()).collect();
+        let writers: FanoutVec<'a> = self.writers.iter().map(MakeWriter::make_writer).collect();
         FanoutWriter {
             policy: self.policy,
             writers,
@@ -120,7 +120,7 @@ fn write_fail_fast(writers: &mut FanoutVec<'_>, buf: &[u8]) -> io::Result<usize>
             "at least one writer is required",
         ));
     }
-    for writer in writers.iter_mut() {
+    for writer in &mut *writers {
         writer.write_all(buf)?;
     }
     Ok(buf.len())
@@ -129,7 +129,7 @@ fn write_fail_fast(writers: &mut FanoutVec<'_>, buf: &[u8]) -> io::Result<usize>
 fn write_best_effort(writers: &mut FanoutVec<'_>, buf: &[u8]) -> io::Result<usize> {
     let mut first_err = None;
     let mut success = false;
-    for writer in writers.iter_mut() {
+    for writer in &mut *writers {
         match writer.write_all(buf) {
             Ok(()) => success = true,
             Err(err) if first_err.is_none() => first_err = Some(err),
@@ -161,7 +161,7 @@ fn write_primary_with_fallback(writers: &mut FanoutVec<'_>, buf: &[u8]) -> io::R
         return Ok(buf.len());
     }
 
-    for writer in fallback.iter_mut() {
+    for writer in &mut *fallback {
         if writer.write_all(buf).is_ok() {
             return Ok(buf.len());
         }
@@ -179,7 +179,7 @@ fn flush_fail_fast(writers: &mut FanoutVec<'_>) -> io::Result<()> {
             "at least one writer is required",
         ));
     }
-    for writer in writers.iter_mut() {
+    for writer in &mut *writers {
         writer.flush()?;
     }
     Ok(())
@@ -188,7 +188,7 @@ fn flush_fail_fast(writers: &mut FanoutVec<'_>) -> io::Result<()> {
 fn flush_best_effort(writers: &mut FanoutVec<'_>) -> io::Result<()> {
     let mut first_err = None;
     let mut success = false;
-    for writer in writers.iter_mut() {
+    for writer in &mut *writers {
         match writer.flush() {
             Ok(()) => success = true,
             Err(err) if first_err.is_none() => first_err = Some(err),
@@ -219,7 +219,7 @@ fn flush_primary_with_fallback(writers: &mut FanoutVec<'_>) -> io::Result<()> {
         return Ok(());
     }
 
-    for writer in fallback.iter_mut() {
+    for writer in &mut *fallback {
         if writer.flush().is_ok() {
             return Ok(());
         }

--- a/crates/log/tests/api_contract.rs
+++ b/crates/log/tests/api_contract.rs
@@ -1,3 +1,10 @@
+//! API contract test — exercises every public type by constructing it.
+
+#![allow(
+    clippy::no_effect_underscore_binding,
+    reason = "bindings exist solely to pin down the public API shape"
+)]
+
 use nebula_log::{DestinationFailurePolicy, Rolling, WriterConfig, observability::HookPolicy};
 
 #[test]

--- a/crates/log/tests/config_precedence.rs
+++ b/crates/log/tests/config_precedence.rs
@@ -1,3 +1,8 @@
+#![allow(
+    unsafe_code,
+    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
+)]
+
 use std::sync::{LazyLock, Mutex};
 
 use nebula_log::{Config, LogError, LoggerBuilder};

--- a/crates/log/tests/hook_policy.rs
+++ b/crates/log/tests/hook_policy.rs
@@ -16,7 +16,7 @@ static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 struct SlowEvent;
 
 impl ObservabilityEvent for SlowEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         "slow_event"
     }
 }

--- a/crates/log/tests/integration_tests.rs
+++ b/crates/log/tests/integration_tests.rs
@@ -203,7 +203,7 @@ fn test_high_frequency_events() {
     // Emit 1000 events rapidly
     for i in 0..1000 {
         let event = TestEvent {
-            name: format!("event_{}", i),
+            name: format!("event_{i}"),
         };
         emit_event(&event);
     }
@@ -272,7 +272,7 @@ impl ObservabilityEvent for TestEvent {
 struct EmptyEvent;
 
 impl ObservabilityEvent for EmptyEvent {
-    fn name(&self) -> &str {
+    fn name(&self) -> &'static str {
         ""
     }
 }

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -19,3 +19,6 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/metadata/src/base.rs
+++ b/crates/metadata/src/base.rs
@@ -135,14 +135,14 @@ impl<K> BaseMetadata<K> {
     /// Set an inline-identifier icon (e.g. `"github"`, `"🔑"`).
     #[must_use]
     pub fn with_inline_icon(mut self, name: impl Into<String>) -> Self {
-        self.icon = crate::icon::Icon::inline(name);
+        self.icon = Icon::inline(name);
         self
     }
 
     /// Set a URL-backed icon.
     #[must_use]
     pub fn with_url_icon(mut self, url: impl Into<String>) -> Self {
-        self.icon = crate::icon::Icon::url(url);
+        self.icon = Icon::url(url);
         self
     }
 
@@ -171,7 +171,7 @@ impl<K> BaseMetadata<K> {
     /// records the version the entity was deprecated in. For a richer
     /// notice use [`Self::with_deprecation`].
     #[must_use]
-    pub fn deprecate(self, since: semver::Version) -> Self {
+    pub fn deprecate(self, since: Version) -> Self {
         self.with_deprecation(DeprecationNotice::new(since))
     }
 
@@ -317,7 +317,7 @@ mod tests {
     #[test]
     fn deprecation_forces_maturity() {
         let base = BaseMetadata::new(DummyKey("k"), "n", "d", empty_schema())
-            .with_deprecation(DeprecationNotice::new(semver::Version::new(1, 0, 0)));
+            .with_deprecation(DeprecationNotice::new(Version::new(1, 0, 0)));
         assert_eq!(base.maturity, MaturityLevel::Deprecated);
     }
 }

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -17,3 +17,6 @@ nebula-telemetry = { path = "../telemetry" }
 
 [dev-dependencies]
 tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/metrics/examples/cardinality_guard.rs
+++ b/crates/metrics/examples/cardinality_guard.rs
@@ -92,7 +92,7 @@ fn main() {
     reg3.counter_labeled("nebula_actions_total", &labels).inc(); // keep-alive touch
 
     // With a generous window (5 min) fresh series survive.
-    reg3.retain_recent(Duration::from_secs(300));
+    reg3.retain_recent(Duration::from_mins(5));
     println!(
         "\nActive series preserved by retain_recent: {}",
         reg3.metric_count()

--- a/crates/metrics/src/export/prometheus.rs
+++ b/crates/metrics/src/export/prometheus.rs
@@ -593,11 +593,11 @@ mod tests {
             "first label key should use the sanitized base name:\n{out}"
         );
         assert!(
-            out.contains("__") && out.contains(r#"a_b__"#),
+            out.contains("__") && out.contains(r"a_b__"),
             "second colliding key should be suffixed with a stable hash:\n{out}"
         );
         assert!(
-            out.contains(r#"a_b__"#) && out.contains(r#"="space""#),
+            out.contains(r"a_b__") && out.contains(r#"="space""#),
             "both values should be present with distinct keys:\n{out}"
         );
     }

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -39,3 +39,6 @@ path = "src/bin/echo_fixture.rs"
 [[bin]]
 name = "nebula-counter-fixture"
 path = "src/bin/counter_fixture.rs"
+
+[lints]
+workspace = true

--- a/crates/plugin-sdk/src/bin/counter_fixture.rs
+++ b/crates/plugin-sdk/src/bin/counter_fixture.rs
@@ -55,7 +55,7 @@ impl PluginHandler for CounterPlugin {
     ) -> Result<Value, PluginError> {
         match action_key {
             "increment" => {
-                let amount = input.get("amount").and_then(|v| v.as_i64()).unwrap_or(1);
+                let amount = input.get("amount").and_then(Value::as_i64).unwrap_or(1);
                 let previous = self.total.fetch_add(amount, Ordering::Relaxed);
                 let new_total = previous + amount;
                 Ok(json!({
@@ -80,12 +80,12 @@ impl PluginHandler for CounterPlugin {
                 panic!("boom from counter plugin (probe)");
             },
             "slow" => {
-                let millis = input.get("millis").and_then(|v| v.as_u64()).unwrap_or(2000);
+                let millis = input.get("millis").and_then(Value::as_u64).unwrap_or(2000);
                 tokio::time::sleep(Duration::from_millis(millis)).await;
                 Ok(json!({ "slept_ms": millis }))
             },
             "big" => {
-                let kb = input.get("kb").and_then(|v| v.as_u64()).unwrap_or(100);
+                let kb = input.get("kb").and_then(Value::as_u64).unwrap_or(100);
                 let len = (kb as usize) * 1024;
                 let data: String = "x".repeat(len);
                 Ok(json!({

--- a/crates/plugin-sdk/src/lib.rs
+++ b/crates/plugin-sdk/src/lib.rs
@@ -285,7 +285,7 @@ async fn run_event_loop<H: PluginHandler>(
                 return Ok(());
             },
         };
-        if line_buf.iter().all(|b| b.is_ascii_whitespace()) {
+        if line_buf.iter().all(u8::is_ascii_whitespace) {
             continue;
         }
 

--- a/crates/plugin-sdk/src/protocol.rs
+++ b/crates/plugin-sdk/src/protocol.rs
@@ -35,7 +35,7 @@ pub const DUPLEX_PROTOCOL_VERSION: u32 = 2;
 /// Tagged by `kind`. Correlation IDs (`id`) are host-assigned `u64` values that
 /// the plugin echoes back in the corresponding response message. IDs are
 /// unique within a single plugin process lifetime.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum HostToPlugin {
     /// Invoke an action.
@@ -82,7 +82,7 @@ pub enum HostToPlugin {
 /// Tagged by `kind`. Plugins send these as responses to host requests
 /// (`ActionResult*`, `MetadataResponse`) or as plugin-initiated events
 /// (`RpcCall`, `Log`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum PluginToHost {
     /// Successful action result.

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -23,3 +23,6 @@ semver = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/plugin/macros/Cargo.toml
+++ b/crates/plugin/macros/Cargo.toml
@@ -21,3 +21,6 @@ nebula-macro-support = { path = "../../sdk/macros-support" }
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/plugin/macros/src/plugin.rs
+++ b/crates/plugin/macros/src/plugin.rs
@@ -7,7 +7,7 @@ use syn::{Data, DeriveInput, parse_macro_input};
 
 use crate::plugin_attrs::PluginAttrs;
 
-pub fn derive(input: TokenStream) -> TokenStream {
+pub(crate) fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match expand(input) {

--- a/crates/plugin/macros/src/plugin_attrs.rs
+++ b/crates/plugin/macros/src/plugin_attrs.rs
@@ -7,7 +7,7 @@ use syn::{Ident, Result};
 
 /// Parsed plugin container attributes.
 #[derive(Debug, Clone)]
-pub struct PluginAttrs {
+pub(crate) struct PluginAttrs {
     /// Unique key (e.g. `"http"`).
     pub key: String,
     /// Human-readable name.
@@ -22,7 +22,7 @@ pub struct PluginAttrs {
 
 impl PluginAttrs {
     /// Parse from `#[plugin(...)]` attribute args.
-    pub fn parse(
+    pub(crate) fn parse(
         attr_args: &attrs::AttrArgs,
         struct_name: &Ident,
         description_fallback: Option<String>,
@@ -49,7 +49,7 @@ impl PluginAttrs {
     }
 
     /// Generate `PluginMetadata` builder expression.
-    pub fn metadata_builder_expr(&self) -> TokenStream2 {
+    pub(crate) fn metadata_builder_expr(&self) -> TokenStream2 {
         let key = &self.key;
         let name = &self.name;
         let description = &self.description;

--- a/crates/plugin/src/error.rs
+++ b/crates/plugin/src/error.rs
@@ -66,7 +66,7 @@ pub enum PluginError {
     /// Plugin key validation failed.
     #[classify(category = "validation", code = "PLUGIN:INVALID_KEY")]
     #[error("invalid plugin key: {0}")]
-    InvalidKey(<nebula_core::PluginKey as std::str::FromStr>::Err),
+    InvalidKey(<PluginKey as std::str::FromStr>::Err),
 }
 
 impl PartialEq for PluginError {

--- a/crates/plugin/src/plugin_type.rs
+++ b/crates/plugin/src/plugin_type.rs
@@ -169,7 +169,7 @@ mod tests {
         pt.add_version(stub("a", 5)).unwrap();
 
         let mut nums = pt.version_numbers();
-        nums.sort();
+        nums.sort_unstable();
         assert_eq!(nums, vec![1, 3, 5]);
     }
 

--- a/crates/resilience/Cargo.toml
+++ b/crates/resilience/Cargo.toml
@@ -50,8 +50,8 @@ futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+[lints]
+workspace = true
 
 [[bench]]
 name = "compose"

--- a/crates/resilience/benches/circuit_breaker.rs
+++ b/crates/resilience/benches/circuit_breaker.rs
@@ -14,7 +14,7 @@ use nebula_resilience::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig, O
 fn closed_config() -> CircuitBreakerConfig {
     CircuitBreakerConfig {
         failure_threshold: 1000,
-        reset_timeout: Duration::from_secs(60),
+        reset_timeout: Duration::from_mins(1),
         min_operations: 1000,
         ..Default::default()
     }

--- a/crates/resilience/benches/sliding_window_cb.rs
+++ b/crates/resilience/benches/sliding_window_cb.rs
@@ -96,7 +96,7 @@ fn bench_record_outcome_failure_rate(c: &mut Criterion) {
                     failure_rate_threshold: Some(0.8),
                     min_operations: 1,
                     failure_threshold: n * 2,
-                    reset_timeout: Duration::from_secs(3600),
+                    reset_timeout: Duration::from_hours(1),
                     ..Default::default()
                 })
                 .unwrap();
@@ -131,7 +131,7 @@ fn bench_record_outcome_slow_rate(c: &mut Criterion) {
                     failure_rate_threshold: Some(0.95),
                     min_operations: 1,
                     failure_threshold: n * 2,
-                    reset_timeout: Duration::from_secs(3600),
+                    reset_timeout: Duration::from_hours(1),
                     ..Default::default()
                 })
                 .unwrap();

--- a/crates/resilience/src/circuit_breaker.rs
+++ b/crates/resilience/src/circuit_breaker.rs
@@ -546,7 +546,7 @@ impl CircuitBreaker {
     /// or `Err(CallError::Operation)` if the operation itself fails.
     pub async fn call<T, E, Fut>(&self, f: impl FnOnce() -> Fut) -> Result<T, CallError<E>>
     where
-        Fut: std::future::Future<Output = Result<T, E>> + Send,
+        Fut: Future<Output = Result<T, E>> + Send,
     {
         self.try_acquire()?;
         let mut guard = ProbeGuard::new(self);
@@ -581,7 +581,7 @@ impl CircuitBreaker {
         f: impl FnOnce() -> Fut,
     ) -> Result<T, CallError<E>>
     where
-        Fut: std::future::Future<Output = Result<T, E>> + Send,
+        Fut: Future<Output = Result<T, E>> + Send,
     {
         self.try_acquire()?;
         let mut guard = ProbeGuard::new(self);
@@ -1140,7 +1140,7 @@ mod tests {
             failure_rate_threshold: None,
         })
         .unwrap()
-        .with_clock(Arc::clone(&clock) as Arc<dyn crate::clock::Clock>);
+        .with_clock(Arc::clone(&clock) as Arc<dyn Clock>);
 
         // First trip
         cb.record_outcome(Outcome::Failure);

--- a/crates/resilience/src/error.rs
+++ b/crates/resilience/src/error.rs
@@ -270,7 +270,7 @@ pub struct ConfigError {
     pub field: &'static str,
     /// Human-readable description of the validation error.
     /// `Cow` avoids heap allocation for static messages (95%+ of call sites).
-    pub message: std::borrow::Cow<'static, str>,
+    pub message: Cow<'static, str>,
 }
 
 impl nebula_error::Classify for ConfigError {
@@ -286,7 +286,7 @@ impl nebula_error::Classify for ConfigError {
 impl ConfigError {
     /// Create a new configuration error.
     #[must_use]
-    pub fn new(field: &'static str, message: impl Into<std::borrow::Cow<'static, str>>) -> Self {
+    pub fn new(field: &'static str, message: impl Into<Cow<'static, str>>) -> Self {
         Self {
             field,
             message: message.into(),
@@ -362,7 +362,7 @@ mod tests {
 
     #[test]
     fn timeout_is_retryable() {
-        let e: CallError<MyErr> = CallError::Timeout(std::time::Duration::from_secs(1));
+        let e: CallError<MyErr> = CallError::Timeout(Duration::from_secs(1));
         assert!(e.is_retryable());
     }
 

--- a/crates/resilience/src/gate.rs
+++ b/crates/resilience/src/gate.rs
@@ -116,8 +116,8 @@ pub struct Gate {
     inner: Arc<GateInner>,
 }
 
-impl std::fmt::Debug for Gate {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Gate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let closing = self.inner.closing.load(Ordering::Relaxed);
         f.debug_struct("Gate")
             .field("closing", &closing)
@@ -283,12 +283,12 @@ mod tests {
         // Spawn a task that drops the guard after a short delay.
         let gate2 = gate.clone();
         tokio::spawn(async move {
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            tokio::time::sleep(Duration::from_millis(20)).await;
             drop(guard);
         });
 
         // close() should complete after the guard is dropped.
-        tokio::time::timeout(std::time::Duration::from_secs(2), gate2.close())
+        tokio::time::timeout(Duration::from_secs(2), gate2.close())
             .await
             .expect("close() should complete quickly");
 
@@ -315,12 +315,12 @@ mod tests {
             gate2.close().await;
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
         drop(g1);
         drop(g2);
         drop(g3);
 
-        tokio::time::timeout(std::time::Duration::from_secs(2), close_task)
+        tokio::time::timeout(Duration::from_secs(2), close_task)
             .await
             .expect("timeout")
             .expect("task panicked");

--- a/crates/resilience/src/hedge.rs
+++ b/crates/resilience/src/hedge.rs
@@ -440,7 +440,7 @@ mod tests {
         let _ = executor
             .call(|| {
                 Box::pin(async {
-                    tokio::time::sleep(Duration::from_millis(100)).await;
+                    sleep(Duration::from_millis(100)).await;
                     Ok::<_, &str>("late")
                 })
             })

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -665,7 +665,7 @@ mod tests {
     #[tokio::test]
     async fn pipeline_bulkhead_takes_single_permit() {
         let bh = Arc::new(
-            crate::Bulkhead::new(crate::BulkheadConfig {
+            Bulkhead::new(crate::BulkheadConfig {
                 max_concurrency: 2,
                 queue_size: 1,
                 timeout: None,

--- a/crates/resilience/src/rate_limiter.rs
+++ b/crates/resilience/src/rate_limiter.rs
@@ -485,7 +485,7 @@ impl fmt::Debug for AdaptiveRateLimiter {
             .field("max_rate", &self.max_rate)
             .field(
                 "current_rate",
-                &f64::from_bits(self.atomic_rate.load(std::sync::atomic::Ordering::Relaxed)),
+                &f64::from_bits(self.atomic_rate.load(Ordering::Relaxed)),
             )
             .finish_non_exhaustive()
     }
@@ -846,17 +846,17 @@ mod tests {
 
     #[test]
     fn sliding_window_rejects_zero_requests() {
-        assert!(SlidingWindow::new(std::time::Duration::from_secs(1), 0).is_err());
+        assert!(SlidingWindow::new(Duration::from_secs(1), 0).is_err());
     }
 
     #[test]
     fn sliding_window_rejects_zero_duration() {
-        assert!(SlidingWindow::new(std::time::Duration::ZERO, 10).is_err());
+        assert!(SlidingWindow::new(Duration::ZERO, 10).is_err());
     }
 
     #[test]
     fn sliding_window_accepts_valid_config() {
-        assert!(SlidingWindow::new(std::time::Duration::from_secs(1), 10).is_ok());
+        assert!(SlidingWindow::new(Duration::from_secs(1), 10).is_ok());
     }
 
     // ── B2: AdaptiveRateLimiter rejects initial_rate outside bounds ──────

--- a/crates/resilience/src/retry.rs
+++ b/crates/resilience/src/retry.rs
@@ -501,8 +501,8 @@ mod tests {
     /// Test error type implementing Classify. Always retryable.
     #[derive(Debug, Clone, PartialEq)]
     struct TransientErr(&'static str);
-    impl std::fmt::Display for TransientErr {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl fmt::Display for TransientErr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str(self.0)
         }
     }
@@ -522,8 +522,8 @@ mod tests {
         AuthFailed,
         RateLimited(Duration),
     }
-    impl std::fmt::Display for TestApiErr {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    impl fmt::Display for TestApiErr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             write!(f, "{self:?}")
         }
     }

--- a/crates/resilience/tests/cancel_safety.rs
+++ b/crates/resilience/tests/cancel_safety.rs
@@ -42,7 +42,7 @@ async fn cb_probe_slot_released_when_pipeline_cancelled() {
             tokio::time::sleep(Duration::from_secs(10)).await;
             Ok::<u32, &str>(42)
         })) => unreachable!("operation should not complete"),
-        _ = tokio::time::sleep(Duration::from_millis(5)) => {
+        () = tokio::time::sleep(Duration::from_millis(5)) => {
             // Future dropped — ProbeGuard should release the probe slot
         }
     }
@@ -81,7 +81,7 @@ async fn bulkhead_permit_released_when_pipeline_cancelled() {
             tokio::time::sleep(Duration::from_secs(10)).await;
             Ok::<u32, &str>(42)
         })) => unreachable!("operation should not complete"),
-        _ = tokio::time::sleep(Duration::from_millis(5)) => {
+        () = tokio::time::sleep(Duration::from_millis(5)) => {
             // Future dropped — permit should be released
         }
     }
@@ -141,7 +141,7 @@ async fn combined_cb_and_bulkhead_released_on_cancel() {
             tokio::time::sleep(Duration::from_secs(10)).await;
             Ok::<u32, &str>(42)
         })) => unreachable!(),
-        _ = tokio::time::sleep(Duration::from_millis(5)) => {}
+        () = tokio::time::sleep(Duration::from_millis(5)) => {}
     }
 
     tokio::task::yield_now().await;

--- a/crates/resilience/tests/pipeline.rs
+++ b/crates/resilience/tests/pipeline.rs
@@ -143,7 +143,7 @@ async fn full_stack_cb_trips_after_threshold() {
         CircuitBreaker::new(CircuitBreakerConfig {
             failure_threshold: 3,
             min_operations: 1,
-            reset_timeout: Duration::from_secs(60),
+            reset_timeout: Duration::from_mins(1),
             ..Default::default()
         })
         .unwrap(),

--- a/crates/resilience/tests/rate_limiter.rs
+++ b/crates/resilience/tests/rate_limiter.rs
@@ -100,13 +100,8 @@ async fn test_concurrent_rate_limiting() {
     // Should have limited some requests
     assert!(
         successes <= 15,
-        "Expected burst limit, got {} successes",
-        successes
+        "Expected burst limit, got {successes} successes"
     );
-    assert!(
-        rejects >= 85,
-        "Expected rejections, got {} rejects",
-        rejects
-    );
+    assert!(rejects >= 85, "Expected rejections, got {rejects} rejects");
     assert_eq!(successes + rejects, 100);
 }

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -39,3 +39,6 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 semver = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/resource/macros/Cargo.toml
+++ b/crates/resource/macros/Cargo.toml
@@ -21,3 +21,6 @@ nebula-macro-support = { path = "../../sdk/macros-support" }
 syn = { version = "2.0", features = ["full", "extra-traits"] }
 quote = "1.0"
 proc-macro2 = "1.0"
+
+[lints]
+workspace = true

--- a/crates/resource/macros/src/resource.rs
+++ b/crates/resource/macros/src/resource.rs
@@ -5,7 +5,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, parse_macro_input};
 
-pub fn derive(input: TokenStream) -> TokenStream {
+pub(crate) fn derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     match expand(input) {
@@ -37,7 +37,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 "Resource derive can only be used on structs",
             ));
         },
-    };
+    }
 
     let expanded = quote! {
         impl #impl_generics ::nebula_resource::Resource for #struct_name #ty_generics #where_clause {

--- a/crates/resource/src/ctx.rs
+++ b/crates/resource/src/ctx.rs
@@ -91,7 +91,7 @@ impl Extensions {
 
     /// Returns the raw `dyn Any` for a given `TypeId`.
     pub fn get_raw(&self, type_id: TypeId) -> Option<&(dyn Any + Send + Sync)> {
-        self.map.get(&type_id).map(|b| b.as_ref())
+        self.map.get(&type_id).map(AsRef::as_ref)
     }
 }
 
@@ -219,8 +219,8 @@ mod tests {
         extensions.insert(99_i64);
 
         let ctx = BasicCtx::new(ExecutionId::new()).with_extensions(extensions);
-        assert_eq!(super::ctx_ext::<i64>(&ctx), Some(&99));
-        assert_eq!(super::ctx_ext::<bool>(&ctx), None);
+        assert_eq!(ctx_ext::<i64>(&ctx), Some(&99));
+        assert_eq!(ctx_ext::<bool>(&ctx), None);
     }
 
     #[test]

--- a/crates/resource/src/handle.rs
+++ b/crates/resource/src/handle.rs
@@ -351,7 +351,7 @@ mod tests {
         }
     }
 
-    impl crate::resource::Resource for DummyResource {
+    impl Resource for DummyResource {
         type Config = ();
         type Runtime = ();
         type Lease = u32;
@@ -455,7 +455,7 @@ mod tests {
     #[test]
     fn detach_guarded_returns_lease_and_skips_callback() {
         let released = Arc::new(AtomicBool::new(false));
-        let released_clone = released.clone();
+        let released_clone = released;
 
         let handle = ResourceHandle::<DummyResource>::guarded(
             10,

--- a/crates/resource/src/integration/resilience.rs
+++ b/crates/resource/src/integration/resilience.rs
@@ -72,7 +72,7 @@ impl AcquireResilience {
     /// Tolerant: 60 s timeout, 5 retries.
     pub fn slow() -> Self {
         Self {
-            timeout: Some(Duration::from_secs(60)),
+            timeout: Some(Duration::from_mins(1)),
             retry: Some(AcquireRetryConfig {
                 max_attempts: 5,
                 initial_backoff: Duration::from_millis(500),

--- a/crates/resource/src/manager.rs
+++ b/crates/resource/src/manager.rs
@@ -52,7 +52,7 @@ pub struct ResourceHealthSnapshot {
     /// Current lifecycle phase.
     pub phase: crate::state::ResourcePhase,
     /// Recovery gate state (if a gate is attached).
-    pub gate_state: Option<crate::recovery::gate::GateState>,
+    pub gate_state: Option<GateState>,
     /// Aggregate operation counters (present when a metrics registry is configured).
     pub metrics: Option<ResourceOpsSnapshot>,
     /// Config generation counter.
@@ -331,7 +331,7 @@ impl Manager {
             config: arc_swap::ArcSwap::from_pointee(config),
             topology,
             release_queue: Arc::clone(&self.release_queue),
-            generation: std::sync::atomic::AtomicU64::new(0),
+            generation: AtomicU64::new(0),
             status: arc_swap::ArcSwap::from_pointee(crate::state::ResourceStatus::new()),
             resilience,
             recovery_gate,
@@ -1582,7 +1582,7 @@ impl Manager {
             key: R::key(),
             phase: managed.status().phase,
             gate_state: managed.recovery_gate.as_ref().map(|g| g.state()),
-            metrics: self.metrics.as_ref().map(|m| m.snapshot()),
+            metrics: self.metrics.as_ref().map(ResourceOpsMetrics::snapshot),
             generation: managed.generation(),
         })
     }
@@ -1712,7 +1712,7 @@ fn settle_gate_admission<T>(admission: GateAdmission, result: &Result<T, Error>)
                 ticket.fail_transient(e.to_string());
             }
         },
-        (GateAdmission::OpenGated(_), _) | (GateAdmission::Open, _) => {},
+        (GateAdmission::OpenGated(_) | GateAdmission::Open, _) => {},
     }
 }
 
@@ -1728,7 +1728,7 @@ async fn execute_with_resilience<F, Fut, T>(
 ) -> Result<T, Error>
 where
     F: FnMut() -> Fut,
-    Fut: std::future::Future<Output = Result<T, Error>> + Send,
+    Fut: Future<Output = Result<T, Error>> + Send,
 {
     let Some(config) = resilience else {
         return operation().await;
@@ -1825,7 +1825,7 @@ mod gate_admission_tests {
                     drop(ticket);
                     (1, 0)
                 },
-                Ok(GateAdmission::Open) | Ok(GateAdmission::OpenGated(_)) => (0, 1),
+                Ok(GateAdmission::Open | GateAdmission::OpenGated(_)) => (0, 1),
                 Err(_) => (0, 1),
             }
         }

--- a/crates/resource/src/options.rs
+++ b/crates/resource/src/options.rs
@@ -141,10 +141,9 @@ mod tests {
 
     #[test]
     fn remaining_returns_some_when_deadline_set() {
-        let opts =
-            AcquireOptions::default().with_deadline(Instant::now() + Duration::from_secs(60));
+        let opts = AcquireOptions::default().with_deadline(Instant::now() + Duration::from_mins(1));
         let remaining = opts.remaining().unwrap();
-        assert!(remaining <= Duration::from_secs(60));
+        assert!(remaining <= Duration::from_mins(1));
         assert!(remaining > Duration::from_secs(50));
     }
 
@@ -157,11 +156,11 @@ mod tests {
     #[test]
     fn streaming_intent_carries_duration() {
         let intent = AcquireIntent::Streaming {
-            expected: Duration::from_secs(300),
+            expected: Duration::from_mins(5),
         };
         match intent {
             AcquireIntent::Streaming { expected } => {
-                assert_eq!(expected, Duration::from_secs(300));
+                assert_eq!(expected, Duration::from_mins(5));
             },
             _ => panic!("wrong variant"),
         }

--- a/crates/resource/src/recovery/gate.rs
+++ b/crates/resource/src/recovery/gate.rs
@@ -24,7 +24,7 @@ use arc_swap::ArcSwap;
 use tokio::sync::Notify;
 
 /// Maximum backoff cap (5 minutes).
-const MAX_BACKOFF: Duration = Duration::from_secs(300);
+const MAX_BACKOFF: Duration = Duration::from_mins(5);
 
 /// Current state of a [`RecoveryGate`].
 #[non_exhaustive]
@@ -461,7 +461,7 @@ mod tests {
 
     #[test]
     fn backoff_caps_at_five_minutes() {
-        let base = Duration::from_secs(60);
+        let base = Duration::from_mins(1);
         // 60 * 2^4 = 960s > 300s cap
         assert_eq!(compute_backoff(base, 5), MAX_BACKOFF);
     }

--- a/crates/resource/src/recovery/watchdog.rs
+++ b/crates/resource/src/recovery/watchdog.rs
@@ -94,7 +94,7 @@ impl WatchdogHandle {
     ) -> Self
     where
         F: Fn() -> Fut + Send + Sync + 'static,
-        Fut: std::future::Future<Output = Result<(), crate::Error>> + Send,
+        Fut: Future<Output = Result<(), crate::Error>> + Send,
     {
         let cancel = parent_cancel.child_token();
         let token = cancel.clone();

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -197,8 +197,8 @@ impl Registry {
     /// shutdown, #387) without needing typed access to each entry.
     pub(crate) fn all_managed(&self) -> Vec<Arc<dyn AnyManagedResource>> {
         let mut out = Vec::new();
-        for row in self.entries.iter() {
-            for entry in row.value().iter() {
+        for row in &self.entries {
+            for entry in row.value() {
                 out.push(Arc::clone(&entry.managed));
             }
         }
@@ -306,7 +306,7 @@ mod tests {
         // Replace only the Global entry with FakeB. Workflow still
         // holds FakeA, so the TypeA row in type_index must survive.
         reg.register(
-            key.clone(),
+            key,
             TypeId::of::<FakeB>(),
             ScopeLevel::Global,
             Arc::new(FakeB),
@@ -334,12 +334,7 @@ mod tests {
         assert!(reg.type_index.contains_key(&TypeId::of::<FakeA>()));
 
         // Replace at the same key+scope with a different concrete type.
-        reg.register(
-            key.clone(),
-            TypeId::of::<FakeB>(),
-            scope.clone(),
-            Arc::new(FakeB),
-        );
+        reg.register(key, TypeId::of::<FakeB>(), scope, Arc::new(FakeB));
 
         // The stale TypeId row for FakeA must be gone (#382).
         assert!(

--- a/crates/resource/src/release_queue.rs
+++ b/crates/resource/src/release_queue.rs
@@ -253,7 +253,7 @@ impl ReleaseQueue {
         tokio::spawn(async move {
             tokio::select! {
                 biased;
-                _ = cancel.cancelled() => {
+                () = cancel.cancelled() => {
                     // Shutdown signalled while we were waiting for capacity.
                     // The drain loop in worker_loop will not see us — record
                     // the drop and exit.
@@ -333,7 +333,7 @@ impl ReleaseQueue {
                         None => break, // channel closed
                     }
                 }
-                _ = cancel.cancelled() => {
+                () = cancel.cancelled() => {
                     // Drain remaining buffered tasks, then exit.
                     rx.close();
                     while let Some(factory) = rx.recv().await {
@@ -593,7 +593,7 @@ mod tests {
         queue.submit(move || {
             Box::pin(async move {
                 // Sleep longer than TASK_EXECUTION_TIMEOUT (30s).
-                tokio::time::sleep(Duration::from_secs(60)).await;
+                tokio::time::sleep(Duration::from_mins(1)).await;
                 c.store(true, Ordering::Relaxed);
             })
         });

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -84,7 +84,7 @@ impl nebula_metadata::Metadata for ResourceMetadata {
 pub enum MetadataCompatibilityError {
     /// A generic catalog-citizen rule fired (key / version / schema).
     #[error(transparent)]
-    Base(#[from] nebula_metadata::BaseCompatError<nebula_core::ResourceKey>),
+    Base(#[from] nebula_metadata::BaseCompatError<ResourceKey>),
 }
 
 impl ResourceMetadata {

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -841,7 +841,7 @@ async fn release_entry<R>(
     entry: PoolEntry<R>,
     tainted: bool,
     current_fp: u64,
-    max_lifetime: Option<std::time::Duration>,
+    max_lifetime: Option<Duration>,
     idle: Arc<Mutex<VecDeque<PoolEntry<R>>>>,
 ) where
     R: Pooled + Send + Sync + 'static,
@@ -1019,7 +1019,7 @@ mod tests {
             _config: &PoolTestConfig,
             _auth: &(),
             _ctx: &dyn Ctx,
-        ) -> impl std::future::Future<Output = Result<u32, MockError>> + Send {
+        ) -> impl Future<Output = Result<u32, MockError>> + Send {
             let fail = self.fail_create.load(Ordering::Relaxed);
             async move {
                 if fail {
@@ -1030,10 +1030,7 @@ mod tests {
             }
         }
 
-        fn check(
-            &self,
-            _runtime: &u32,
-        ) -> impl std::future::Future<Output = Result<(), MockError>> + Send {
+        fn check(&self, _runtime: &u32) -> impl Future<Output = Result<(), MockError>> + Send {
             let fail = self.fail_check.load(Ordering::Relaxed);
             async move {
                 if fail {
@@ -1098,7 +1095,7 @@ mod tests {
 
         drop(handle);
         // Give release queue time to process.
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Instance should be recycled back to idle.
         assert_eq!(pool.idle_count().await, 1);
@@ -1134,7 +1131,7 @@ mod tests {
             .await
             .unwrap();
         drop(handle);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(pool.idle_count().await, 1);
 
         // Second acquire should reuse the idle instance.
@@ -1153,7 +1150,7 @@ mod tests {
         assert!(handle2.is_ok());
 
         drop(handle2);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         drop(rq);
         ReleaseQueue::shutdown(rq_handle).await;
@@ -1188,7 +1185,7 @@ mod tests {
             .await
             .unwrap();
         drop(handle);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(pool.idle_count().await, 1);
 
         // Now mark broken — next acquire should destroy the idle instance
@@ -1210,7 +1207,7 @@ mod tests {
         assert!(handle2.is_ok());
 
         drop(handle2);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // The broken instance should have been destroyed, not returned to idle.
         assert_eq!(pool.idle_count().await, 0);
@@ -1246,7 +1243,7 @@ mod tests {
             .unwrap();
         handle.taint();
         drop(handle);
-        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Tainted — should not be in idle.
         assert_eq!(pool.idle_count().await, 0);
@@ -1291,8 +1288,7 @@ mod tests {
     async fn semaphore_timeout_sanity() {
         // Minimal test: semaphore with 0 permits should timeout.
         let sem = Arc::new(Semaphore::new(0));
-        let result =
-            tokio::time::timeout(std::time::Duration::from_millis(100), sem.acquire_owned()).await;
+        let result = tokio::time::timeout(Duration::from_millis(100), sem.acquire_owned()).await;
         assert!(result.is_err(), "should have timed out");
     }
 
@@ -1306,7 +1302,7 @@ mod tests {
         let resource = MockPool::new();
         let config = Config {
             max_size: 1,
-            create_timeout: std::time::Duration::from_millis(200),
+            create_timeout: Duration::from_millis(200),
             ..Config::default()
         };
         let pool = PoolRuntime::<MockPool>::new(config, 1);
@@ -1365,7 +1361,7 @@ mod tests {
         let resource = MockPool::new();
         let config = Config {
             max_size: 5,
-            idle_timeout: Some(std::time::Duration::from_millis(50)),
+            idle_timeout: Some(Duration::from_millis(50)),
             max_lifetime: None,
             ..Config::default()
         };
@@ -1373,7 +1369,9 @@ mod tests {
 
         // Push two entries: one returned long ago (should be evicted),
         // one returned just now (should be kept).
-        let long_ago = Instant::now() - std::time::Duration::from_millis(200);
+        let long_ago = Instant::now()
+            .checked_sub(Duration::from_millis(200))
+            .unwrap();
         push_idle_entry(&pool, Instant::now(), Some(long_ago), 1).await;
         push_idle_entry(&pool, Instant::now(), Some(Instant::now()), 1).await;
 
@@ -1389,13 +1387,15 @@ mod tests {
         let config = Config {
             max_size: 5,
             idle_timeout: None,
-            max_lifetime: Some(std::time::Duration::from_millis(50)),
+            max_lifetime: Some(Duration::from_millis(50)),
             ..Config::default()
         };
         let pool = PoolRuntime::<MockPool>::new(config, 1);
 
         // One old entry (should be evicted), one fresh (should be kept).
-        let old_creation = Instant::now() - std::time::Duration::from_millis(200);
+        let old_creation = Instant::now()
+            .checked_sub(Duration::from_millis(200))
+            .unwrap();
         push_idle_entry(&pool, old_creation, Some(Instant::now()), 1).await;
         push_idle_entry(&pool, Instant::now(), Some(Instant::now()), 1).await;
 
@@ -1433,8 +1433,8 @@ mod tests {
         let resource = MockPool::new();
         let config = Config {
             max_size: 5,
-            idle_timeout: Some(std::time::Duration::from_secs(300)),
-            max_lifetime: Some(std::time::Duration::from_secs(1800)),
+            idle_timeout: Some(Duration::from_mins(5)),
+            max_lifetime: Some(Duration::from_mins(30)),
             ..Config::default()
         };
         let pool = PoolRuntime::<MockPool>::new(config, 1);

--- a/crates/resource/src/runtime/resident.rs
+++ b/crates/resource/src/runtime/resident.rs
@@ -225,7 +225,7 @@ mod tests {
             _config: &bool,
             _auth: &(),
             _ctx: &dyn Ctx,
-        ) -> impl std::future::Future<Output = Result<u32, MockError>> + Send {
+        ) -> impl Future<Output = Result<u32, MockError>> + Send {
             let count = self.create_count.fetch_add(1, Ordering::Relaxed);
             async move {
                 // Yield to increase the chance of concurrent interleaving.
@@ -380,7 +380,7 @@ mod tests {
             _auth: &(),
             _ctx: &dyn Ctx,
         ) -> Result<u32, MockError> {
-            tokio::time::sleep(Duration::from_secs(3600)).await;
+            tokio::time::sleep(Duration::from_hours(1)).await;
             Ok(0)
         }
 

--- a/crates/resource/src/runtime/service.rs
+++ b/crates/resource/src/runtime/service.rs
@@ -182,7 +182,7 @@ mod tests {
             &self,
             runtime: &String,
             _ctx: &dyn Ctx,
-        ) -> impl std::future::Future<Output = Result<String, SvcError>> + Send {
+        ) -> impl Future<Output = Result<String, SvcError>> + Send {
             let token = format!("{runtime}-token");
             async move { Ok(token) }
         }
@@ -227,7 +227,7 @@ mod tests {
             &self,
             runtime: &String,
             _ctx: &dyn Ctx,
-        ) -> impl std::future::Future<Output = Result<String, SvcError>> + Send {
+        ) -> impl Future<Output = Result<String, SvcError>> + Send {
             let token = format!("{runtime}-tracked-token");
             async move { Ok(token) }
         }
@@ -236,7 +236,7 @@ mod tests {
             &self,
             _runtime: &String,
             _token: String,
-        ) -> impl std::future::Future<Output = Result<(), SvcError>> + Send {
+        ) -> impl Future<Output = Result<(), SvcError>> + Send {
             let released = self.released.clone();
             async move {
                 released.store(true, Ordering::Relaxed);

--- a/crates/resource/src/topology/daemon.rs
+++ b/crates/resource/src/topology/daemon.rs
@@ -43,7 +43,7 @@ pub trait Daemon: Resource {
 
 /// Configuration types for daemon topology.
 pub mod config {
-    use super::*;
+    use super::{Duration, RestartPolicy};
 
     /// Daemon configuration.
     #[derive(Debug, Clone)]

--- a/crates/resource/src/topology/pooled.rs
+++ b/crates/resource/src/topology/pooled.rs
@@ -172,8 +172,8 @@ pub mod config {
             Self {
                 min_size: 1,
                 max_size: 10,
-                idle_timeout: Some(Duration::from_secs(300)),
-                max_lifetime: Some(Duration::from_secs(1800)),
+                idle_timeout: Some(Duration::from_mins(5)),
+                max_lifetime: Some(Duration::from_mins(30)),
                 create_timeout: Duration::from_secs(30),
                 strategy: PoolStrategy::default(),
                 warmup: WarmupStrategy::default(),

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -111,7 +111,7 @@ impl Resource for PoolTestResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             let id = counter.fetch_add(1, Ordering::Relaxed);
@@ -185,7 +185,7 @@ impl Resource for ResidentTestResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             let id = counter.fetch_add(1, Ordering::Relaxed);
@@ -1227,7 +1227,7 @@ async fn manager_scope_mismatch_not_found() {
 
 #[tokio::test]
 async fn metrics_track_acquire_release_create_destroy() {
-    let registry = std::sync::Arc::new(nebula_telemetry::metrics::MetricsRegistry::new());
+    let registry = Arc::new(nebula_telemetry::metrics::MetricsRegistry::new());
     let manager = Manager::with_config(nebula_resource::ManagerConfig {
         release_queue_workers: 2,
         metrics_registry: Some(registry.clone()),
@@ -1509,7 +1509,7 @@ impl Resource for ServiceTestResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<ServiceInner>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<ServiceInner>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             counter.fetch_add(1, Ordering::Relaxed);
@@ -1535,7 +1535,7 @@ impl Service for ServiceTestResource {
         &self,
         runtime: &Arc<ServiceInner>,
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<ServiceToken, TestError>> + Send {
+    ) -> impl Future<Output = Result<ServiceToken, TestError>> + Send {
         let token_id = self.token_counter.fetch_add(1, Ordering::Relaxed);
         let data = format!("{}-token-{token_id}", runtime.data);
         async move { Ok(ServiceToken { data }) }
@@ -1593,7 +1593,7 @@ impl Resource for TransportTestResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<TransportInner>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<TransportInner>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             counter.fetch_add(1, Ordering::Relaxed);
@@ -1617,7 +1617,7 @@ impl Transport for TransportTestResource {
         &self,
         _transport: &Arc<TransportInner>,
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<SessionHandle, TestError>> + Send {
+    ) -> impl Future<Output = Result<SessionHandle, TestError>> + Send {
         let id = self.session_counter.fetch_add(1, Ordering::Relaxed);
         async move { Ok(SessionHandle { id }) }
     }
@@ -1627,7 +1627,7 @@ impl Transport for TransportTestResource {
         _transport: &Arc<TransportInner>,
         _session: SessionHandle,
         _healthy: bool,
-    ) -> impl std::future::Future<Output = Result<(), TestError>> + Send {
+    ) -> impl Future<Output = Result<(), TestError>> + Send {
         let close_counter = self.close_counter.clone();
         async move {
             close_counter.fetch_add(1, Ordering::Relaxed);
@@ -1671,7 +1671,7 @@ impl Resource for ExclusiveTestResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             let id = counter.fetch_add(1, Ordering::Relaxed);
@@ -1692,7 +1692,7 @@ impl Exclusive for ExclusiveTestResource {
     fn reset(
         &self,
         _runtime: &Arc<AtomicU64>,
-    ) -> impl std::future::Future<Output = Result<(), TestError>> + Send {
+    ) -> impl Future<Output = Result<(), TestError>> + Send {
         self.reset_counter.fetch_add(1, Ordering::Relaxed);
         async { Ok(()) }
     }
@@ -2102,8 +2102,8 @@ async fn exclusive_acquire_timeout_when_locked() {
 
 #[derive(Clone)]
 struct SlowResetExclusive {
-    in_progress: Arc<std::sync::atomic::AtomicBool>,
-    overlap_observed: Arc<std::sync::atomic::AtomicBool>,
+    in_progress: Arc<AtomicBool>,
+    overlap_observed: Arc<AtomicBool>,
 }
 
 impl Resource for SlowResetExclusive {
@@ -2139,7 +2139,7 @@ impl Exclusive for SlowResetExclusive {
     fn reset(
         &self,
         _runtime: &Arc<AtomicU64>,
-    ) -> impl std::future::Future<Output = Result<(), TestError>> + Send {
+    ) -> impl Future<Output = Result<(), TestError>> + Send {
         let in_progress = self.in_progress.clone();
         async move {
             in_progress.store(true, Ordering::SeqCst);
@@ -2157,8 +2157,8 @@ async fn exclusive_next_acquire_waits_until_reset_completes() {
     // resource's reset() holds `in_progress = true` for ~150ms, so under
     // the fix the next acquire must block for at least that long.
     let resource = SlowResetExclusive {
-        in_progress: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        overlap_observed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        in_progress: Arc::new(AtomicBool::new(false)),
+        overlap_observed: Arc::new(AtomicBool::new(false)),
     };
     let runtime = Arc::new(AtomicU64::new(0));
     let rt =
@@ -2269,7 +2269,7 @@ async fn pool_permit_not_leaked_after_release() {
 
 #[tokio::test]
 async fn registry_backed_metrics_record_operations() {
-    let registry = std::sync::Arc::new(nebula_telemetry::metrics::MetricsRegistry::new());
+    let registry = Arc::new(nebula_telemetry::metrics::MetricsRegistry::new());
     let manager = Manager::with_config(nebula_resource::ManagerConfig {
         release_queue_workers: 1,
         metrics_registry: Some(registry.clone()),
@@ -2435,7 +2435,7 @@ async fn graceful_shutdown_clears_registry() {
 
 #[tokio::test]
 async fn graceful_shutdown_default_config() {
-    let config = nebula_resource::ShutdownConfig::default();
+    let config = ShutdownConfig::default();
     assert_eq!(config.drain_timeout, std::time::Duration::from_secs(30));
 }
 
@@ -2479,7 +2479,7 @@ impl Resource for FailingResidentResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let count = self.create_count.fetch_add(1, Ordering::Relaxed);
         let threshold = self.failures_before_success;
         async move {
@@ -2554,7 +2554,7 @@ impl Resource for PermanentFailResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, PermanentTestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, PermanentTestError>> + Send {
         self.create_count.fetch_add(1, Ordering::Relaxed);
         async { Err(PermanentTestError("permanent failure".into())) }
     }
@@ -2697,7 +2697,7 @@ async fn acquire_timeout_fires() {
     let resource = FailingResidentResource::new(100);
     let resident_rt = ResidentRuntime::<FailingResidentResource>::new(resident::config::Config {
         // Set create_timeout long so the resilience timeout fires first.
-        create_timeout: std::time::Duration::from_secs(60),
+        create_timeout: std::time::Duration::from_mins(1),
         ..Default::default()
     });
 
@@ -2884,7 +2884,7 @@ async fn acquire_failure_passively_triggers_recovery_gate() {
     let resource = FailingResidentResource::new(100);
     let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig {
         max_attempts: 5,
-        base_backoff: std::time::Duration::from_secs(300),
+        base_backoff: std::time::Duration::from_mins(5),
     }));
     let resident_rt =
         ResidentRuntime::<FailingResidentResource>::new(resident::config::Config::default());
@@ -3146,7 +3146,7 @@ impl Resource for DropOnRecycleResource {
         _config: &TestConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             let id = counter.fetch_add(1, Ordering::Relaxed);
@@ -3621,7 +3621,7 @@ impl Resource for ReloadPoolResource {
         _config: &ReloadConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, TestError>> + Send {
         let counter = self.create_counter.clone();
         async move {
             let id = counter.fetch_add(1, Ordering::Relaxed);

--- a/crates/resource/tests/classify_error.rs
+++ b/crates/resource/tests/classify_error.rs
@@ -128,13 +128,13 @@ enum DurationError {
 #[test]
 fn duration_minutes() {
     let err: Error = DurationError::FiveMinutes.into();
-    assert_eq!(err.retry_after(), Some(Duration::from_secs(300)));
+    assert_eq!(err.retry_after(), Some(Duration::from_mins(5)));
 }
 
 #[test]
 fn duration_hours() {
     let err: Error = DurationError::OneHour.into();
-    assert_eq!(err.retry_after(), Some(Duration::from_secs(3600)));
+    assert_eq!(err.retry_after(), Some(Duration::from_hours(1)));
 }
 
 #[test]

--- a/crates/resource/tests/dx_audit.rs
+++ b/crates/resource/tests/dx_audit.rs
@@ -138,7 +138,7 @@ impl Resource for HttpClientResource {
         _config: &HttpClientConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<FakeHttpClient, DxTestError>> + Send {
+    ) -> impl Future<Output = Result<FakeHttpClient, DxTestError>> + Send {
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         async move { Ok(FakeHttpClient { connection_id: id }) }
     }
@@ -304,7 +304,7 @@ impl Resource for ConfigStoreResource {
         config: &ConfigStoreConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<ConfigStore, DxTestError>> + Send {
+    ) -> impl Future<Output = Result<ConfigStore, DxTestError>> + Send {
         let path = config.path.clone();
         async move {
             // Simulate loading from file
@@ -447,7 +447,7 @@ impl Resource for DbResource {
         _config: &DbConfig,
         _auth: &(),
         _ctx: &dyn Ctx,
-    ) -> impl std::future::Future<Output = Result<FakeDbConnection, DxTestError>> + Send {
+    ) -> impl Future<Output = Result<FakeDbConnection, DxTestError>> + Send {
         let count = self.create_count.clone();
         let fail = self.fail_create.clone();
         async move {

--- a/crates/resource/tests/dx_evaluation.rs
+++ b/crates/resource/tests/dx_evaluation.rs
@@ -281,7 +281,7 @@ async fn use_case_2_resident_config_store() {
     // The first acquire triggers lazy creation — handle contains ConfigStore
     assert_eq!(handle.env, "production");
     assert_eq!(
-        handle.values.get("log_level").map(|s| s.as_str()),
+        handle.values.get("log_level").map(String::as_str),
         Some("info")
     );
 

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -41,3 +41,6 @@ doctest = false
 [[bench]]
 name = "queue_bench"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/runtime/src/data_policy.rs
+++ b/crates/runtime/src/data_policy.rs
@@ -32,9 +32,7 @@ impl DataPassingPolicy {
     ///
     /// Returns `Ok(size)` if within limits, or `Err((limit, actual))` if exceeded.
     pub fn check_output_size(&self, output: &serde_json::Value) -> Result<u64, (u64, u64)> {
-        let size = serde_json::to_vec(output)
-            .map(|v| v.len() as u64)
-            .unwrap_or(0);
+        let size = serde_json::to_vec(output).map_or(0, |v| v.len() as u64);
         if size > self.max_node_output_bytes {
             Err((self.max_node_output_bytes, size))
         } else {

--- a/crates/runtime/src/queue.rs
+++ b/crates/runtime/src/queue.rs
@@ -92,7 +92,7 @@ pub trait TaskQueue: Send + Sync {
 }
 
 /// Outcome of a dequeue attempt.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DequeueResult {
     /// A task was successfully leased to a worker.
     Item {

--- a/crates/runtime/src/runtime.rs
+++ b/crates/runtime/src/runtime.rs
@@ -630,7 +630,7 @@ impl ActionRuntime {
         action_key: &str,
         execution_id: ExecutionId,
         action_result: &mut ActionResult<serde_json::Value>,
-        error_counter: &nebula_telemetry::metrics::Counter,
+        error_counter: &Counter,
     ) -> Result<(), RuntimeError> {
         let limit = self.data_policy.max_node_output_bytes;
         let total_limit = self.data_policy.max_total_execution_bytes;
@@ -780,11 +780,11 @@ impl ActionRuntime {
 /// per-node enforcement (including nested collections).
 fn estimated_action_output_payload_bytes(slot: &ActionOutput<serde_json::Value>) -> u64 {
     match slot {
-        ActionOutput::Value(v) => serde_json::to_vec(v).map(|b| b.len() as u64).unwrap_or(0),
+        ActionOutput::Value(v) => serde_json::to_vec(v).map_or(0, |b| b.len() as u64),
         ActionOutput::Binary(b) => b.effective_size(),
         ActionOutput::Reference(r) => r
             .size
-            .unwrap_or_else(|| serde_json::to_vec(r).map(|b| b.len() as u64).unwrap_or(0)),
+            .unwrap_or_else(|| serde_json::to_vec(r).map_or(0, |b| b.len() as u64)),
         ActionOutput::Deferred(_) => 0,
         ActionOutput::Streaming(_) => 0,
         ActionOutput::Collection(items) => items
@@ -814,7 +814,7 @@ fn collect_output_slots_mut<'a>(
     ) {
         match slot {
             ActionOutput::Collection(items) => {
-                for item in items.iter_mut() {
+                for item in &mut *items {
                     collect_slot(item, out);
                 }
             },
@@ -1899,21 +1899,20 @@ mod tests {
             state: &mut JsonValue,
             _ctx: &ActionContext,
         ) -> Result<ActionResult<JsonValue>, ActionError> {
-            let count = state.get("count").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            let count = state
+                .get("count")
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or(0) as u32;
             let next = count + 1;
             *state = serde_json::json!({ "count": next });
             if next >= self.target {
                 Ok(ActionResult::Break {
-                    output: nebula_action::output::ActionOutput::Value(
-                        serde_json::json!({ "final": next }),
-                    ),
+                    output: ActionOutput::Value(serde_json::json!({ "final": next })),
                     reason: nebula_action::result::BreakReason::Completed,
                 })
             } else {
                 Ok(ActionResult::Continue {
-                    output: nebula_action::output::ActionOutput::Value(
-                        serde_json::json!({ "step": next }),
-                    ),
+                    output: ActionOutput::Value(serde_json::json!({ "step": next })),
                     progress: None,
                     delay: None,
                 })
@@ -1941,9 +1940,9 @@ mod tests {
             _state: &mut JsonValue,
             _ctx: &ActionContext,
         ) -> Result<ActionResult<JsonValue>, ActionError> {
-            tokio::time::sleep(std::time::Duration::from_secs(3600)).await;
+            tokio::time::sleep(std::time::Duration::from_hours(1)).await;
             Ok(ActionResult::Break {
-                output: nebula_action::output::ActionOutput::Value(serde_json::json!(null)),
+                output: ActionOutput::Value(serde_json::json!(null)),
                 reason: nebula_action::result::BreakReason::Completed,
             })
         }
@@ -2004,7 +2003,7 @@ mod tests {
         let meta = ActionMetadata::new(action_key!("test.sleepy"), "Sleepy", "hangs in execute");
         registry.register(
             meta.clone(),
-            nebula_action::handler::ActionHandler::Stateful(Arc::new(SleepyHandler { meta })),
+            ActionHandler::Stateful(Arc::new(SleepyHandler { meta })),
         );
         let rt = Arc::new(make_runtime(registry));
 
@@ -2047,10 +2046,7 @@ mod tests {
         let meta = ActionMetadata::new(action_key!("test.count"), "Count", "counts");
         registry.register(
             meta.clone(),
-            nebula_action::handler::ActionHandler::Stateful(Arc::new(CountingHandler {
-                meta,
-                target: 3,
-            })),
+            ActionHandler::Stateful(Arc::new(CountingHandler { meta, target: 3 })),
         );
         let rt = make_runtime(registry);
 
@@ -2097,10 +2093,7 @@ mod tests {
         let meta = ActionMetadata::new(action_key!("test.resume"), "Resume", "resumes");
         registry.register(
             meta.clone(),
-            nebula_action::handler::ActionHandler::Stateful(Arc::new(CountingHandler {
-                meta,
-                target: 5,
-            })),
+            ActionHandler::Stateful(Arc::new(CountingHandler { meta, target: 5 })),
         );
         let rt = make_runtime(registry);
 
@@ -2144,10 +2137,7 @@ mod tests {
         let meta = ActionMetadata::new(action_key!("test.load_fail"), "LoadFail", "load fails");
         registry.register(
             meta.clone(),
-            nebula_action::handler::ActionHandler::Stateful(Arc::new(CountingHandler {
-                meta,
-                target: 2,
-            })),
+            ActionHandler::Stateful(Arc::new(CountingHandler { meta, target: 2 })),
         );
         let rt = make_runtime(registry);
 

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -32,3 +32,6 @@ uuid = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = "0.4"
 nix = { version = "0.31", features = ["resource"] }
+
+[lints]
+workspace = true

--- a/crates/sandbox/examples/sandbox_demo.rs
+++ b/crates/sandbox/examples/sandbox_demo.rs
@@ -42,18 +42,17 @@ fn locate_counter_binary() -> Option<PathBuf> {
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let binary = match locate_counter_binary() {
-        Some(p) => p,
-        None => {
-            eprintln!("error: nebula-counter-fixture binary not found next to this example");
-            eprintln!();
-            eprintln!("build the fixture first:");
-            eprintln!("  cargo build -p nebula-plugin-sdk --bin nebula-counter-fixture");
-            eprintln!();
-            eprintln!("then run the demo again:");
-            eprintln!("  cargo run -p nebula-sandbox --example sandbox_demo");
-            std::process::exit(1);
-        },
+    let binary = if let Some(p) = locate_counter_binary() {
+        p
+    } else {
+        eprintln!("error: nebula-counter-fixture binary not found next to this example");
+        eprintln!();
+        eprintln!("build the fixture first:");
+        eprintln!("  cargo build -p nebula-plugin-sdk --bin nebula-counter-fixture");
+        eprintln!();
+        eprintln!("then run the demo again:");
+        eprintln!("  cargo run -p nebula-sandbox --example sandbox_demo");
+        std::process::exit(1);
     };
 
     println!("=== nebula-sandbox slice-1c demo ===");
@@ -84,7 +83,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .invoke("increment", json!({ "amount": amount }))
             .await?;
         running += amount;
-        let reported = result.get("total").and_then(|v| v.as_i64()).unwrap_or(-1);
+        let reported = result
+            .get("total")
+            .and_then(serde_json::Value::as_i64)
+            .unwrap_or(-1);
         println!(
             "call {} — increment({:>3}) → total={:>4} (expected {:>4}) {}",
             i + 1,
@@ -163,7 +165,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let t0 = Instant::now();
         match sandbox.invoke("big", json!({ "kb": kb })).await {
             Ok(v) => {
-                let size = v.get("size_bytes").and_then(|x| x.as_u64()).unwrap_or(0);
+                let size = v
+                    .get("size_bytes")
+                    .and_then(serde_json::Value::as_u64)
+                    .unwrap_or(0);
                 let elapsed = t0.elapsed();
                 let throughput_kbps = (size as f64) / 1024.0 / elapsed.as_secs_f64();
                 println!(

--- a/crates/sandbox/src/capabilities.rs
+++ b/crates/sandbox/src/capabilities.rs
@@ -8,7 +8,7 @@
 use serde::{Deserialize, Serialize};
 
 /// A single capability that a plugin can request.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum Capability {
     // ── OS level (CLI + Desktop) ─────────────────────────────────────
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn filesystem_empty_path_entry_does_not_grant_all_paths() {
         let caps = PluginCapabilities::new(vec![Capability::FilesystemRead {
-            paths: vec!["".into()],
+            paths: vec![String::new()],
         }]);
         assert!(!caps.check_fs_read("/tmp/file.txt"));
     }

--- a/crates/sandbox/src/process.rs
+++ b/crates/sandbox/src/process.rs
@@ -399,11 +399,11 @@ enum RaceOutcome<T> {
 /// the helper degrades to a plain `tokio::time::timeout`.
 async fn race_cancel_timeout<F, T>(
     fut: F,
-    timeout: std::time::Duration,
+    timeout: Duration,
     cancel: Option<&CancellationToken>,
 ) -> RaceOutcome<T>
 where
-    F: std::future::Future<Output = T>,
+    F: Future<Output = T>,
 {
     let timed = tokio::time::timeout(timeout, fut);
     match cancel {
@@ -1154,7 +1154,7 @@ async fn drain_plugin_stderr(stderr: tokio::process::ChildStderr, plugin_name: S
 /// `STDERR_LINE_CAP`.
 async fn drop_until_newline<R>(reader: &mut R) -> bool
 where
-    R: tokio::io::AsyncBufRead + Unpin,
+    R: AsyncBufRead + Unpin,
 {
     loop {
         let chunk = match reader.fill_buf().await {

--- a/crates/sandbox/src/runner.rs
+++ b/crates/sandbox/src/runner.rs
@@ -63,10 +63,7 @@ pub trait SandboxRunner: Send + Sync {
 
 /// Boxed future returned by the action executor.
 pub type ActionExecutorFuture = std::pin::Pin<
-    Box<
-        dyn std::future::Future<Output = Result<ActionResult<serde_json::Value>, ActionError>>
-            + Send,
-    >,
+    Box<dyn Future<Output = Result<ActionResult<serde_json::Value>, ActionError>> + Send>,
 >;
 
 /// Callback type for executing an action (registry lookup + invoke).

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -74,3 +74,6 @@ harness = false
 # `#[cfg_attr(feature = "schemars", derive(JsonSchema))]` attributes on
 # schema types; cargo-shear doesn't follow derive-macro call paths.
 ignored = ["schemars"]
+
+[lints]
+workspace = true

--- a/crates/schema/benches/bench_build.rs
+++ b/crates/schema/benches/bench_build.rs
@@ -15,7 +15,7 @@ fn bench_schema_build(c: &mut Criterion) {
     let mut group = c.benchmark_group("schema_build");
     for size in [10_usize, 50, 100, 500] {
         group.bench_function(format!("build_{size}"), |b| {
-            b.iter(|| build_sample_schema(black_box(size)))
+            b.iter(|| build_sample_schema(black_box(size)));
         });
     }
     group.finish();

--- a/crates/schema/benches/bench_memory.rs
+++ b/crates/schema/benches/bench_memory.rs
@@ -17,7 +17,7 @@ fn bench_schema_clone_memory(c: &mut Criterion) {
         b.iter(|| {
             let cloned = black_box(&schema).clone();
             black_box(cloned.len());
-        })
+        });
     });
 }
 

--- a/crates/schema/benches/bench_serde.rs
+++ b/crates/schema/benches/bench_serde.rs
@@ -22,7 +22,7 @@ fn bench_schema_serde(c: &mut Criterion) {
             let encoded = serde_json::to_vec(black_box(&schema)).expect("serialize schema");
             let decoded: Schema = serde_json::from_slice(&encoded).expect("deserialize schema");
             black_box(decoded);
-        })
+        });
     });
 }
 

--- a/crates/schema/benches/bench_validate.rs
+++ b/crates/schema/benches/bench_validate.rs
@@ -36,7 +36,7 @@ fn bench_validate_static(c: &mut Criterion) {
         b.iter(|| {
             let result = schema.validate(black_box(&values));
             let _ = black_box(result);
-        })
+        });
     });
 }
 
@@ -80,7 +80,7 @@ fn bench_validate_nested(c: &mut Criterion) {
         b.iter(|| {
             let result = schema.validate(black_box(&values));
             let _ = black_box(result);
-        })
+        });
     });
 }
 

--- a/crates/schema/macros/Cargo.toml
+++ b/crates/schema/macros/Cargo.toml
@@ -18,3 +18,6 @@ syn = { version = "2", features = ["full"] }
 quote = "1"
 proc-macro2 = "1"
 proc-macro-crate = "3"
+
+[lints]
+workspace = true

--- a/crates/schema/macros/src/attrs.rs
+++ b/crates/schema/macros/src/attrs.rs
@@ -61,7 +61,7 @@ pub(crate) struct ValidateAttrs {
 }
 
 impl ParamAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         let mut out = Self::default();
         for attr in attrs.iter().filter(|a| a.path().is_ident("param")) {
             let entries: Punctuated<ParamEntry, Token![,]> =
@@ -75,7 +75,7 @@ impl ParamAttrs {
 }
 
 impl ValidateAttrs {
-    pub fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
+    pub(crate) fn from_attrs(attrs: &[Attribute]) -> syn::Result<Self> {
         let mut out = Self::default();
         for attr in attrs.iter().filter(|a| a.path().is_ident("validate")) {
             let entries: Punctuated<ValidateEntry, Token![,]> =

--- a/crates/schema/macros/src/type_infer.rs
+++ b/crates/schema/macros/src/type_infer.rs
@@ -40,11 +40,11 @@ pub(crate) enum FieldKind {
 }
 
 impl FieldKind {
-    pub fn is_optional(&self) -> bool {
+    pub(crate) fn is_optional(&self) -> bool {
         matches!(self, FieldKind::Optional(_))
     }
 
-    pub fn inner(&self) -> &FieldKind {
+    pub(crate) fn inner(&self) -> &FieldKind {
         match self {
             FieldKind::Optional(inner) => inner,
             other => other,

--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -101,8 +101,8 @@ mod tests {
     #[test]
     fn lazy_parse_is_cached() {
         let e = Expression::new("{{ $x }}");
-        let a1 = e.parse().unwrap() as *const _;
-        let a2 = e.parse().unwrap() as *const _;
+        let a1 = std::ptr::from_ref(e.parse().unwrap());
+        let a2 = std::ptr::from_ref(e.parse().unwrap());
         assert_eq!(a1, a2, "parse should cache the same AST instance");
     }
 

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -497,19 +497,19 @@ fn rule_name(rule: &Rule) -> &'static str {
             _ => "unknown_rule",
         },
         Rule::Predicate(p) => match p {
-            Predicate::Eq(_, _) => "eq",
-            Predicate::Ne(_, _) => "ne",
-            Predicate::Gt(_, _) => "gt",
-            Predicate::Gte(_, _) => "gte",
-            Predicate::Lt(_, _) => "lt",
-            Predicate::Lte(_, _) => "lte",
+            Predicate::Eq(..) => "eq",
+            Predicate::Ne(..) => "ne",
+            Predicate::Gt(..) => "gt",
+            Predicate::Gte(..) => "gte",
+            Predicate::Lt(..) => "lt",
+            Predicate::Lte(..) => "lte",
             Predicate::IsTrue(_) => "is_true",
             Predicate::IsFalse(_) => "is_false",
             Predicate::Set(_) => "set",
             Predicate::Empty(_) => "empty",
-            Predicate::Contains(_, _) => "contains",
-            Predicate::Matches(_, _) => "matches",
-            Predicate::In(_, _) => "in",
+            Predicate::Contains(..) => "contains",
+            Predicate::Matches(..) => "matches",
+            Predicate::In(..) => "in",
             _ => "unknown_rule",
         },
         Rule::Logic(l) => match l.as_ref() {
@@ -573,8 +573,7 @@ fn collect_min_max(
 
 fn emit_visibility_cycle(start: &str, prefix: &FieldPath, report: &mut ValidationReport) {
     let cycle_path = crate::key::FieldKey::new(start)
-        .map(|k| prefix.clone().join(k))
-        .unwrap_or_else(|_| prefix.clone());
+        .map_or_else(|_| prefix.clone(), |k| prefix.clone().join(k));
     report.push(
         ValidationError::builder("visibility_cycle")
             .at(cycle_path)

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -116,7 +116,7 @@ impl<T: Send + 'static> std::fmt::Debug for Loader<T> {
 }
 
 /// Paginated result returned from runtime loaders.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoaderResult<T> {
     /// Page of resolved items.
     pub items: Vec<T>,
@@ -169,9 +169,10 @@ pub type RecordLoader = Loader<Value>;
 /// Build a single-key `FieldPath` from a `LoaderContext::field_key` string.
 /// Falls back to root if the key is not a valid `FieldKey`.
 fn field_path_from_key(key: &str) -> FieldPath {
-    FieldKey::new(key)
-        .map(|fk| FieldPath::root().join(PathSegment::Key(fk)))
-        .unwrap_or_else(|_| FieldPath::root())
+    FieldKey::new(key).map_or_else(
+        |_| FieldPath::root(),
+        |fk| FieldPath::root().join(PathSegment::Key(fk)),
+    )
 }
 
 /// Use the path from a loader-returned error if it's non-root, otherwise build
@@ -238,14 +239,14 @@ impl LoaderRegistry {
             return Err(ValidationError::builder("loader.not_registered")
                 .at(field_path)
                 .message(format!("option loader `{key}` is not registered"))
-                .param("loader", serde_json::Value::String(key.to_owned()))
+                .param("loader", Value::String(key.to_owned()))
                 .build());
         };
         loader.call(context).await.map_err(|e| {
             ValidationError::builder("loader.failed")
                 .at(field_path_from_err_or(key, &e))
                 .message(format!("option loader `{key}` failed: {e}"))
-                .param("loader", serde_json::Value::String(key.to_owned()))
+                .param("loader", Value::String(key.to_owned()))
                 .source(e)
                 .build()
         })
@@ -268,14 +269,14 @@ impl LoaderRegistry {
             return Err(ValidationError::builder("loader.not_registered")
                 .at(field_path)
                 .message(format!("record loader `{key}` is not registered"))
-                .param("loader", serde_json::Value::String(key.to_owned()))
+                .param("loader", Value::String(key.to_owned()))
                 .build());
         };
         loader.call(context).await.map_err(|e| {
             ValidationError::builder("loader.failed")
                 .at(field_path_from_err_or(key, &e))
                 .message(format!("record loader `{key}` failed: {e}"))
-                .param("loader", serde_json::Value::String(key.to_owned()))
+                .param("loader", Value::String(key.to_owned()))
                 .source(e)
                 .build()
         })

--- a/crates/schema/src/path.rs
+++ b/crates/schema/src/path.rs
@@ -225,11 +225,9 @@ mod tests {
     #[test]
     fn join_appends_segment() {
         let a = FieldPath::parse("user").unwrap();
-        let b = a
-            .clone()
-            .join(PathSegment::Key(FieldKey::new("email").unwrap()));
+        let b = a.join(PathSegment::Key(FieldKey::new("email").unwrap()));
         assert_eq!(b.to_string(), "user.email");
-        let c = b.clone().join(PathSegment::Index(0));
+        let c = b.join(PathSegment::Index(0));
         assert_eq!(c.to_string(), "user.email[0]");
     }
 

--- a/crates/schema/src/transformer.rs
+++ b/crates/schema/src/transformer.rs
@@ -39,7 +39,7 @@ pub enum Transformer {
 
 impl PartialEq for Transformer {
     fn eq(&self, other: &Self) -> bool {
-        use Transformer::*;
+        use Transformer::{Lowercase, Regex, Replace, Trim, Uppercase};
         match (self, other) {
             (Trim, Trim) | (Lowercase, Lowercase) | (Uppercase, Uppercase) => true,
             (Replace { from: a1, to: a2 }, Replace { from: b1, to: b2 }) => a1 == b1 && a2 == b2,
@@ -78,8 +78,7 @@ impl Transformer {
                 });
                 re.captures(t)
                     .and_then(|c| c.get(*group))
-                    .map(|m| m.as_str().to_owned())
-                    .unwrap_or_else(|| t.to_owned())
+                    .map_or_else(|| t.to_owned(), |m| m.as_str().to_owned())
             }),
         }
     }

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -86,7 +86,10 @@ impl<'de> Deserialize<'de> for ValidSchema {
         let repr = ValidSchemaRepr::deserialize(deserializer)?;
         repr.fields
             .into_iter()
-            .fold(crate::schema::SchemaBuilder::default(), |b, f| b.add(f))
+            .fold(
+                crate::schema::SchemaBuilder::default(),
+                super::schema::SchemaBuilder::add,
+            )
             .build()
             .map_err(|report| serde::de::Error::custom(format!("invalid schema: {report:?}")))
     }
@@ -419,13 +422,13 @@ fn resolve_value<'v>(
                         Ok(v) => FieldValue::Literal(v),
                         Err(mut e) => {
                             // Attach path context and enforce the standard code.
-                            if e.code != "expression.runtime" {
+                            if e.code == "expression.runtime" {
+                                e.path = path.clone();
+                            } else {
                                 e = ValidationError::builder("expression.runtime")
                                     .at(path.clone())
                                     .message(e.message.clone())
                                     .build();
-                            } else {
-                                e.path = path.clone();
                             }
                             report.push(e);
                             FieldValue::Literal(serde_json::Value::Null)
@@ -439,7 +442,7 @@ fn resolve_value<'v>(
                 }
             },
             FieldValue::Object(map) => {
-                let mut out = indexmap::IndexMap::with_capacity(map.len());
+                let mut out = IndexMap::with_capacity(map.len());
                 for (k, v) in map {
                     let child_path = path.clone().join(k.clone());
                     let resolved = resolve_value(v, ctx, &child_path, report).await;

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -383,7 +383,7 @@ mod tests {
         let key = FieldKey::new("user").unwrap();
         let email = FieldKey::new("email").unwrap();
         vs.set(
-            key.clone(),
+            key,
             FieldValue::Object(indexmap::indexmap! { email => FieldValue::Literal(json!("a@b")) }),
         );
         let p = FieldPath::parse("user.email").unwrap();

--- a/crates/schema/tests/builder_dsl.rs
+++ b/crates/schema/tests/builder_dsl.rs
@@ -77,7 +77,7 @@ fn closure_nested_object_holds_children() {
     let schema = Schema::builder()
         .object("user", |o| {
             o.label("User")
-                .string("name", |s| s.required())
+                .string("name", nebula_schema::StringBuilder::required)
                 .number("age", |n| n.integer().min(0_i64))
         })
         .build()
@@ -130,7 +130,7 @@ fn builder_full_example_from_spec() {
         .integer("timeout", |n| {
             n.label("Timeout (s)").min(1_i64).max(300_i64)
         })
-        .boolean("verbose", |b| b.no_expression())
+        .boolean("verbose", nebula_schema::BooleanBuilder::no_expression)
         .build()
         .unwrap();
 
@@ -145,7 +145,7 @@ fn builder_full_example_from_spec() {
 fn group_propagates_visible_when_to_children() {
     let rule = eq_rule("method", "POST");
     let schema = Schema::builder()
-        .string("method", |s| s.required())
+        .string("method", nebula_schema::StringBuilder::required)
         .group("body_section", |g| {
             g.visible_when(rule.clone())
                 .string("body", |s| s.widget(StringWidget::Multiline))
@@ -245,7 +245,7 @@ fn group_required_when_composes_with_always_and_never_children() {
         // `Always` branch).
         .group("details", |g| {
             g.required_when(rule.clone())
-                .string("always_required", |s| s.required())
+                .string("always_required", nebula_schema::StringBuilder::required)
                 .string("optional_by_default", |s| s)
         })
         .build()

--- a/crates/schema/tests/field_schema.rs
+++ b/crates/schema/tests/field_schema.rs
@@ -215,7 +215,7 @@ fn serde_roundtrip_supports_all_field_variants() {
         .add(Field::string("color_field").hint(InputHint::Color))
         .add(Field::file("file"))
         // Hidden → visible(Never) on any field
-        .add(Field::string("hidden_field").visible(nebula_schema::VisibilityMode::Never))
+        .add(Field::string("hidden_field").visible(VisibilityMode::Never))
         .add(Field::computed("computed"))
         .add(Field::dynamic("dynamic"))
         .add(Field::notice("notice"));

--- a/crates/schema/tests/proptest/serde_preserves.rs
+++ b/crates/schema/tests/proptest/serde_preserves.rs
@@ -31,13 +31,10 @@ proptest! {
     ) {
         let v = json!({ key1: val1 });
         let fvs = FieldValues::from_json(v.clone());
-        match fvs {
-            Ok(fvs2) => {
-                prop_assert_eq!(fvs2.to_json(), v);
-            },
-            Err(_) => {
-                // key1 might be invalid as FieldKey (e.g. starts with digit) — ok.
-            },
+        if let Ok(fvs2) = fvs {
+            prop_assert_eq!(fvs2.to_json(), v);
+        } else {
+            // key1 might be invalid as FieldKey (e.g. starts with digit) — ok.
         }
     }
 }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -47,3 +47,6 @@ testing = []
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[lints]
+workspace = true

--- a/crates/sdk/macros-support/Cargo.toml
+++ b/crates/sdk/macros-support/Cargo.toml
@@ -18,3 +18,6 @@ proc-macro2 = "1.0"
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/sdk/macros-support/src/attrs.rs
+++ b/crates/sdk/macros-support/src/attrs.rs
@@ -118,7 +118,7 @@ impl AttrArgs {
     /// Get an ident value as a string (e.g. `auth_style = PostBody` -> `"PostBody"`).
     #[allow(dead_code)] // Reason: reserved for OAuth2/LDAP credential derive macros
     pub fn get_ident_str(&self, key: &str) -> Option<String> {
-        self.get_ident(key).map(|i| i.to_string())
+        self.get_ident(key).map(ToString::to_string)
     }
 
     /// Get a boolean value by key (e.g. `pkce = true`).

--- a/crates/sdk/src/action.rs
+++ b/crates/sdk/src/action.rs
@@ -81,7 +81,7 @@ pub mod helpers {
             if let Some(field) = req.as_str()
                 && input.get(field).is_none()
             {
-                return Err(format!("Missing required field: {}", field));
+                return Err(format!("Missing required field: {field}"));
             }
         }
         Ok(())

--- a/crates/sdk/src/runtime.rs
+++ b/crates/sdk/src/runtime.rs
@@ -294,7 +294,7 @@ impl TestRuntime {
             kind: "trigger:webhook",
             output: serde_json::json!({
                 "outcome": format!("{outcome:?}"),
-                "emitted": emitted.clone(),
+                "emitted": emitted,
             }),
             iterations: 1,
             duration: start.elapsed(),

--- a/crates/sdk/src/workflow.rs
+++ b/crates/sdk/src/workflow.rs
@@ -68,7 +68,7 @@ impl WorkflowBuilder {
     pub fn new(id: impl Into<String>) -> Self {
         let id_str = id.into();
         Self {
-            name: id_str.clone(),
+            name: id_str,
             id: WorkflowId::new(),
             description: None,
             nodes: Vec::new(),
@@ -189,14 +189,12 @@ impl WorkflowBuilder {
         for (from, to) in &self.connections {
             if !node_id_by_name.contains_key(from) {
                 return Err(crate::Error::workflow(format!(
-                    "Connection references unknown source node: {}",
-                    from
+                    "Connection references unknown source node: {from}"
                 )));
             }
             if !node_id_by_name.contains_key(to) {
                 return Err(crate::Error::workflow(format!(
-                    "Connection references unknown target node: {}",
-                    to
+                    "Connection references unknown target node: {to}"
                 )));
             }
         }
@@ -238,10 +236,10 @@ impl WorkflowBuilder {
             .into_iter()
             .map(|(from, to)| -> crate::Result<Connection> {
                 let from_node = node_id_by_name.get(&from).cloned().ok_or_else(|| {
-                    crate::Error::workflow(format!("Unknown source node in connection: {}", from))
+                    crate::Error::workflow(format!("Unknown source node in connection: {from}"))
                 })?;
                 let to_node = node_id_by_name.get(&to).cloned().ok_or_else(|| {
-                    crate::Error::workflow(format!("Unknown target node in connection: {}", to))
+                    crate::Error::workflow(format!("Unknown target node in connection: {to}"))
                 })?;
 
                 Ok(Connection {

--- a/crates/sdk/tests/simple_action_macro.rs
+++ b/crates/sdk/tests/simple_action_macro.rs
@@ -10,8 +10,8 @@ use nebula_sdk::{prelude::*, simple_action};
 simple_action! {
     name: EchoAction,
     key: "test.echo",
-    input: serde_json::Value,
-    output: serde_json::Value,
+    input: Value,
+    output: Value,
     async fn execute(&self, input, _ctx) {
         Ok(ActionResult::success(input))
     }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -54,3 +54,6 @@ doctest = false
 # declared so the backend surface is stable even while implementation
 # is landing incrementally.
 ignored = ["aws-config", "aws-sdk-s3", "redis"]
+
+[lints]
+workspace = true

--- a/crates/storage/src/execution_repo.rs
+++ b/crates/storage/src/execution_repo.rs
@@ -695,7 +695,7 @@ impl ExecutionRepo for InMemoryExecutionRepo {
     ) -> Result<HashMap<NodeKey, serde_json::Value>, ExecutionRepoError> {
         let outputs = self.node_outputs.read().await;
         let mut best: HashMap<NodeKey, (u32, serde_json::Value)> = HashMap::new();
-        for ((eid, nid, attempt), val) in outputs.iter() {
+        for ((eid, nid, attempt), val) in &*outputs {
             if *eid != execution_id {
                 continue;
             }
@@ -856,7 +856,7 @@ impl ExecutionRepo for InMemoryExecutionRepo {
         // so that an older (non-latest) attempt with a future version does
         // not block a load whose latest attempt is well-formed.
         let mut best: HashMap<NodeKey, (u32, NodeResultRecord)> = HashMap::new();
-        for ((eid, nid, attempt), record) in results.iter() {
+        for ((eid, nid, attempt), record) in &*results {
             if *eid != execution_id {
                 continue;
             }
@@ -1447,7 +1447,7 @@ mod tests {
                         "type": "Duration",
                         "duration": 60000,
                     },
-                    "timeout": 300000,
+                    "timeout": 300_000,
                     "partial_output": null,
                 }),
             ),

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -284,8 +284,7 @@ impl ControlQueueRepo for InMemoryControlQueueRepo {
                 let processor = row
                     .processed_by
                     .as_deref()
-                    .map(hex_encode_bytes)
-                    .unwrap_or_else(|| "<unknown>".to_string());
+                    .map_or_else(|| "<unknown>".to_string(), hex_encode_bytes);
                 row.status = "Failed".to_string();
                 row.error_message = Some(format!(
                     "reclaim exhausted: processor {processor} presumed dead after {} reclaims",

--- a/crates/system/Cargo.toml
+++ b/crates/system/Cargo.toml
@@ -91,3 +91,6 @@ required-features = ["disk"]
 # "serde_json"]`) for JSON output of system snapshots; cargo-shear does
 # not always trace feature-composed optional deps.
 ignored = ["serde_json"]
+
+[lints]
+workspace = true

--- a/crates/system/src/cpu.rs
+++ b/crates/system/src/cpu.rs
@@ -428,7 +428,7 @@ pub mod affinity {
                 CPU_SET(cpu, &mut set);
             }
 
-            if sched_setaffinity(0, mem::size_of::<cpu_set_t>(), &set) != 0 {
+            if sched_setaffinity(0, size_of::<cpu_set_t>(), &raw const set) != 0 {
                 return Err(SystemError::platform_error(format!(
                     "Failed to set CPU affinity: {}",
                     std::io::Error::last_os_error()

--- a/crates/system/src/utils.rs
+++ b/crates/system/src/utils.rs
@@ -56,8 +56,8 @@ mod tests {
         assert_eq!(format_bytes(512), "512 B");
         assert_eq!(format_bytes(1024), "1.00 KB");
         assert_eq!(format_bytes(1536), "1.50 KB");
-        assert_eq!(format_bytes(1048576), "1.00 MB");
-        assert_eq!(format_bytes(1073741824), "1.00 GB");
+        assert_eq!(format_bytes(1_048_576), "1.00 MB");
+        assert_eq!(format_bytes(1_073_741_824), "1.00 GB");
     }
 
     #[test]
@@ -167,7 +167,7 @@ impl PlatformInfo {
         Self {
             page_size: crate::info::SystemInfo::get().memory.page_size,
             cache_line_size: cache_line_size(),
-            pointer_width: std::mem::size_of::<usize>() * 8,
+            pointer_width: usize::BITS as usize,
         }
     }
 }

--- a/crates/system/tests/integration.rs
+++ b/crates/system/tests/integration.rs
@@ -515,8 +515,7 @@ mod tests {
             let h = load.headroom();
             assert!(
                 (0.0..=1.0).contains(&h),
-                "headroom {} must be in [0.0, 1.0]",
-                h
+                "headroom {h} must be in [0.0, 1.0]"
             );
         }
 

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -17,3 +17,6 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 dashmap = { workspace = true }
 lasso = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -342,7 +342,7 @@ impl Histogram {
                 // Linear interpolation within the bucket.
                 let prev_cumulative = cumulative - bucket_count;
                 let fraction = (target - prev_cumulative as f64) / bucket_count as f64;
-                return prev_bound + (upper - prev_bound) * fraction;
+                return (upper - prev_bound).mul_add(fraction, prev_bound);
             }
 
             if i < self.boundaries.len() {
@@ -630,15 +630,15 @@ impl MetricsRegistry {
         };
 
         let new_counters: DashMap<MetricKey, Counter> = DashMap::new();
-        for entry in self.counters.iter() {
+        for entry in &*self.counters {
             new_counters.insert(remap_key(entry.key()), entry.value().clone());
         }
         let new_gauges: DashMap<MetricKey, Gauge> = DashMap::new();
-        for entry in self.gauges.iter() {
+        for entry in &*self.gauges {
             new_gauges.insert(remap_key(entry.key()), entry.value().clone());
         }
         let new_histograms: DashMap<MetricKey, Histogram> = DashMap::new();
-        for entry in self.histograms.iter() {
+        for entry in &*self.histograms {
             new_histograms.insert(remap_key(entry.key()), entry.value().clone());
         }
 
@@ -959,7 +959,7 @@ mod tests {
         reg.gauge("also_fresh").set(1);
 
         // Everything was just written — a 1-hour window should keep all.
-        reg.retain_recent(Duration::from_secs(3600));
+        reg.retain_recent(Duration::from_hours(1));
         assert_eq!(reg.metric_count(), 2);
     }
 
@@ -975,7 +975,7 @@ mod tests {
         reg.counter("a").inc();
         reg.gauge("b").set(1);
         reg.histogram("c").observe(0.5);
-        reg.retain_recent(Duration::from_secs(3600));
+        reg.retain_recent(Duration::from_hours(1));
         assert_eq!(
             reg.metric_count(),
             3,

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -78,3 +78,6 @@ harness = false
 [[bench]]
 name = "derive_large_struct"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/validator/benches/combinators.rs
+++ b/crates/validator/benches/combinators.rs
@@ -10,7 +10,10 @@ use std::hint::black_box;
 use criterion::{Criterion, criterion_group, criterion_main};
 use nebula_validator::{
     foundation::{Validate, ValidateExt},
-    validators::*,
+    validators::{
+        alphabetic, alphanumeric, contains, email, ends_with, exact_length, max_length, min_length,
+        not_empty, starts_with,
+    },
 };
 
 // ============================================================================
@@ -23,21 +26,21 @@ fn bench_and_combinator(c: &mut Criterion) {
     // Two validators
     let validator = min_length(5).and(max_length(20));
     group.bench_function("two_validators_success", |b| {
-        b.iter(|| validator.validate(black_box("hello")))
+        b.iter(|| validator.validate(black_box("hello")));
     });
 
     group.bench_function("two_validators_fail_first", |b| {
-        b.iter(|| validator.validate(black_box("hi")))
+        b.iter(|| validator.validate(black_box("hi")));
     });
 
     group.bench_function("two_validators_fail_second", |b| {
-        b.iter(|| validator.validate(black_box("verylongstringthatexceedslimit")))
+        b.iter(|| validator.validate(black_box("verylongstringthatexceedslimit")));
     });
 
     // Three validators
     let validator3 = min_length(5).and(max_length(20)).and(alphanumeric());
     group.bench_function("three_validators_success", |b| {
-        b.iter(|| validator3.validate(black_box("hello123")))
+        b.iter(|| validator3.validate(black_box("hello123")));
     });
 
     // Five validators
@@ -47,7 +50,7 @@ fn bench_and_combinator(c: &mut Criterion) {
         .and(starts_with("h"))
         .and(ends_with("o"));
     group.bench_function("five_validators_success", |b| {
-        b.iter(|| validator5.validate(black_box("hello")))
+        b.iter(|| validator5.validate(black_box("hello")));
     });
 
     group.finish();
@@ -59,15 +62,15 @@ fn bench_or_combinator(c: &mut Criterion) {
     let validator = exact_length(5).or(exact_length(10));
 
     group.bench_function("success_first", |b| {
-        b.iter(|| validator.validate(black_box("hello"))) // 5 chars
+        b.iter(|| validator.validate(black_box("hello"))); // 5 chars
     });
 
     group.bench_function("success_second", |b| {
-        b.iter(|| validator.validate(black_box("helloworld"))) // 10 chars
+        b.iter(|| validator.validate(black_box("helloworld"))); // 10 chars
     });
 
     group.bench_function("both_fail", |b| {
-        b.iter(|| validator.validate(black_box("hi"))) // 2 chars
+        b.iter(|| validator.validate(black_box("hi"))); // 2 chars
     });
 
     // Multiple options
@@ -77,15 +80,15 @@ fn bench_or_combinator(c: &mut Criterion) {
         .or(exact_length(20));
 
     group.bench_function("four_options_success_first", |b| {
-        b.iter(|| validator_multi.validate(black_box("hello")))
+        b.iter(|| validator_multi.validate(black_box("hello")));
     });
 
     group.bench_function("four_options_success_last", |b| {
-        b.iter(|| validator_multi.validate(black_box(&*"a".repeat(20))))
+        b.iter(|| validator_multi.validate(black_box(&*"a".repeat(20))));
     });
 
     group.bench_function("four_options_all_fail", |b| {
-        b.iter(|| validator_multi.validate(black_box("hi")))
+        b.iter(|| validator_multi.validate(black_box("hi")));
     });
 
     group.finish();
@@ -97,11 +100,11 @@ fn bench_not_combinator(c: &mut Criterion) {
     let validator = contains("admin").not();
 
     group.bench_function("success_no_match", |b| {
-        b.iter(|| validator.validate(black_box("hello world")))
+        b.iter(|| validator.validate(black_box("hello world")));
     });
 
     group.bench_function("fail_matches", |b| {
-        b.iter(|| validator.validate(black_box("admin user")))
+        b.iter(|| validator.validate(black_box("admin user")));
     });
 
     group.finish();
@@ -117,15 +120,15 @@ fn bench_when_combinator(c: &mut Criterion) {
     let validator = min_length(10).when(|s: &str| s.starts_with("long"));
 
     group.bench_function("condition_true_valid", |b| {
-        b.iter(|| validator.validate(black_box("longstring123")))
+        b.iter(|| validator.validate(black_box("longstring123")));
     });
 
     group.bench_function("condition_true_invalid", |b| {
-        b.iter(|| validator.validate(black_box("longstr")))
+        b.iter(|| validator.validate(black_box("longstr")));
     });
 
     group.bench_function("condition_false_skipped", |b| {
-        b.iter(|| validator.validate(black_box("short")))
+        b.iter(|| validator.validate(black_box("short")));
     });
 
     group.finish();
@@ -141,13 +144,13 @@ fn bench_composition_depth(c: &mut Criterion) {
     // Depth 1
     let depth1 = min_length(5);
     group.bench_function("depth_1", |b| {
-        b.iter(|| depth1.validate(black_box("hello")))
+        b.iter(|| depth1.validate(black_box("hello")));
     });
 
     // Depth 2
     let depth2 = min_length(5).and(max_length(20));
     group.bench_function("depth_2", |b| {
-        b.iter(|| depth2.validate(black_box("hello")))
+        b.iter(|| depth2.validate(black_box("hello")));
     });
 
     // Depth 5
@@ -157,7 +160,7 @@ fn bench_composition_depth(c: &mut Criterion) {
         .and(starts_with("h"))
         .and(ends_with("o"));
     group.bench_function("depth_5", |b| {
-        b.iter(|| depth5.validate(black_box("hello")))
+        b.iter(|| depth5.validate(black_box("hello")));
     });
 
     // Depth 10
@@ -172,7 +175,7 @@ fn bench_composition_depth(c: &mut Criterion) {
         .and(min_length(4))
         .and(max_length(25));
     group.bench_function("depth_10", |b| {
-        b.iter(|| depth10.validate(black_box("hello")))
+        b.iter(|| depth10.validate(black_box("hello")));
     });
 
     group.finish();
@@ -188,11 +191,11 @@ fn bench_mixed_combinators(c: &mut Criterion) {
     // AND + OR
     let and_or = min_length(5).and(max_length(20)).or(exact_length(3));
     group.bench_function("and_or_success_left", |b| {
-        b.iter(|| and_or.validate(black_box("hello")))
+        b.iter(|| and_or.validate(black_box("hello")));
     });
 
     group.bench_function("and_or_success_right", |b| {
-        b.iter(|| and_or.validate(black_box("abc")))
+        b.iter(|| and_or.validate(black_box("abc")));
     });
 
     // Complex: (A AND B) OR (C AND D)
@@ -200,15 +203,15 @@ fn bench_mixed_combinators(c: &mut Criterion) {
         .and(alphanumeric())
         .or(exact_length(3).and(alphabetic()));
     group.bench_function("complex_success_left", |b| {
-        b.iter(|| complex.validate(black_box("hello123")))
+        b.iter(|| complex.validate(black_box("hello123")));
     });
 
     group.bench_function("complex_success_right", |b| {
-        b.iter(|| complex.validate(black_box("abc")))
+        b.iter(|| complex.validate(black_box("abc")));
     });
 
     group.bench_function("complex_fail", |b| {
-        b.iter(|| complex.validate(black_box("ab")))
+        b.iter(|| complex.validate(black_box("ab")));
     });
 
     group.finish();
@@ -225,17 +228,17 @@ fn bench_error_paths(c: &mut Criterion) {
 
     // Success path (no errors)
     group.bench_function("success_no_error", |b| {
-        b.iter(|| validator.validate(black_box("hello123")))
+        b.iter(|| validator.validate(black_box("hello123")));
     });
 
     // Fail fast (first validator fails)
     group.bench_function("fail_fast", |b| {
-        b.iter(|| validator.validate(black_box("hi")))
+        b.iter(|| validator.validate(black_box("hi")));
     });
 
     // Fail late (last validator fails)
     group.bench_function("fail_late", |b| {
-        b.iter(|| validator.validate(black_box("hello!")))
+        b.iter(|| validator.validate(black_box("hello!")));
     });
 
     group.finish();
@@ -258,15 +261,15 @@ fn bench_form_validation(c: &mut Criterion) {
     let password = min_length(8).and(max_length(128));
 
     group.bench_function("username_valid", |b| {
-        b.iter(|| username.validate(black_box("alice123")))
+        b.iter(|| username.validate(black_box("alice123")));
     });
 
     group.bench_function("email_valid", |b| {
-        b.iter(|| email_val.validate(black_box("alice@example.com")))
+        b.iter(|| email_val.validate(black_box("alice@example.com")));
     });
 
     group.bench_function("password_valid", |b| {
-        b.iter(|| password.validate(black_box("SecurePass123!")))
+        b.iter(|| password.validate(black_box("SecurePass123!")));
     });
 
     // Simulate full form validation
@@ -276,7 +279,7 @@ fn bench_form_validation(c: &mut Criterion) {
             let e = email_val.validate(black_box("alice@example.com"));
             let p = password.validate(black_box("SecurePass123!"));
             (u.is_ok(), e.is_ok(), p.is_ok())
-        })
+        });
     });
 
     group.bench_function("full_form_one_invalid", |b| {
@@ -285,7 +288,7 @@ fn bench_form_validation(c: &mut Criterion) {
             let e = email_val.validate(black_box("alice@example.com"));
             let p = password.validate(black_box("SecurePass123!"));
             (u.is_ok(), e.is_ok(), p.is_ok())
-        })
+        });
     });
 
     group.finish();

--- a/crates/validator/benches/derive_large_struct.rs
+++ b/crates/validator/benches/derive_large_struct.rs
@@ -100,7 +100,7 @@ fn sample_valid() -> WideRecord {
 fn sample_invalid() -> WideRecord {
     WideRecord {
         id: "!".into(),
-        name: "".into(),
+        name: String::new(),
         email: "not-an-email".into(),
         homepage: "not a url".into(),
         external_id: "not-a-uuid".into(),
@@ -127,11 +127,11 @@ fn bench_wide_struct_valid(c: &mut Criterion) {
     let subject = sample_valid();
 
     group.bench_function("validate_success", |b| {
-        b.iter(|| subject.validate(black_box(&subject)))
+        b.iter(|| subject.validate(black_box(&subject)));
     });
 
     group.bench_function("validate_fields_success", |b| {
-        b.iter(|| black_box(&subject).validate_fields())
+        b.iter(|| black_box(&subject).validate_fields());
     });
 
     group.finish();
@@ -142,7 +142,7 @@ fn bench_wide_struct_invalid(c: &mut Criterion) {
     let subject = sample_invalid();
 
     group.bench_function("validate_collect_all", |b| {
-        b.iter(|| black_box(&subject).validate_fields())
+        b.iter(|| black_box(&subject).validate_fields());
     });
 
     group.finish();

--- a/crates/validator/benches/derive_regex.rs
+++ b/crates/validator/benches/derive_regex.rs
@@ -52,11 +52,11 @@ fn bench_derive_regex_hot(c: &mut Criterion) {
     };
 
     group.bench_function("derive_precompiled", |b| {
-        b.iter(|| subject.validate(black_box(&subject)))
+        b.iter(|| subject.validate(black_box(&subject)));
     });
 
     group.bench_function("naive_recompile", |b| {
-        b.iter(|| naive.validate(black_box("alice_42")))
+        b.iter(|| naive.validate(black_box("alice_42")));
     });
 
     group.finish();
@@ -72,11 +72,11 @@ fn bench_derive_regex_failure(c: &mut Criterion) {
     };
 
     group.bench_function("derive_precompiled", |b| {
-        b.iter(|| subject.validate(black_box(&subject)))
+        b.iter(|| subject.validate(black_box(&subject)));
     });
 
     group.bench_function("naive_recompile", |b| {
-        b.iter(|| naive.validate(black_box("BAD!name")))
+        b.iter(|| naive.validate(black_box("BAD!name")));
     });
 
     group.finish();

--- a/crates/validator/benches/error_construction.rs
+++ b/crates/validator/benches/error_construction.rs
@@ -20,7 +20,7 @@ fn bench_error_new(c: &mut Criterion) {
     group.bench_function("static_strings", |b| {
         b.iter(|| {
             black_box(ValidationError::new("min_length", "String is too short"));
-        })
+        });
     });
 
     // Dynamic message (Cow::Owned — allocates)
@@ -30,21 +30,21 @@ fn bench_error_new(c: &mut Criterion) {
                 "min_length",
                 format!("Must be at least {} characters", black_box(5)),
             ));
-        })
+        });
     });
 
     // With field path (dot-notation → JSON Pointer conversion)
     group.bench_function("with_field_dot", |b| {
         b.iter(|| {
             black_box(ValidationError::new("min_length", "too short").with_field("user.name"));
-        })
+        });
     });
 
     // With field path (already JSON Pointer — no conversion)
     group.bench_function("with_field_pointer", |b| {
         b.iter(|| {
             black_box(ValidationError::new("min_length", "too short").with_pointer("/user/name"));
-        })
+        });
     });
 
     group.finish();
@@ -61,7 +61,7 @@ fn bench_error_params(c: &mut Criterion) {
     group.bench_function("one_param", |b| {
         b.iter(|| {
             black_box(ValidationError::new("min_length", "too short").with_param("min", "5"));
-        })
+        });
     });
 
     // 2 params — still inline in SmallVec<[_;2]>
@@ -72,7 +72,7 @@ fn bench_error_params(c: &mut Criterion) {
                     .with_param("min", "5")
                     .with_param("actual", "3"),
             );
-        })
+        });
     });
 
     // 3 params — spills to heap (beyond SmallVec<[_;2]> capacity)
@@ -84,7 +84,7 @@ fn bench_error_params(c: &mut Criterion) {
                     .with_param("max", "100")
                     .with_param("actual", "150"),
             );
-        })
+        });
     });
 
     group.finish();
@@ -98,27 +98,27 @@ fn bench_convenience_constructors(c: &mut Criterion) {
     let mut group = c.benchmark_group("constructors");
 
     group.bench_function("required", |b| {
-        b.iter(|| black_box(ValidationError::required("email")))
+        b.iter(|| black_box(ValidationError::required("email")));
     });
 
     group.bench_function("min_length", |b| {
-        b.iter(|| black_box(ValidationError::min_length("name", 3, 1)))
+        b.iter(|| black_box(ValidationError::min_length("name", 3, 1)));
     });
 
     group.bench_function("max_length", |b| {
-        b.iter(|| black_box(ValidationError::max_length("name", 100, 150)))
+        b.iter(|| black_box(ValidationError::max_length("name", 100, 150)));
     });
 
     group.bench_function("invalid_format", |b| {
-        b.iter(|| black_box(ValidationError::invalid_format("email", "email")))
+        b.iter(|| black_box(ValidationError::invalid_format("email", "email")));
     });
 
     group.bench_function("out_of_range", |b| {
-        b.iter(|| black_box(ValidationError::out_of_range("age", 0, 120, 150)))
+        b.iter(|| black_box(ValidationError::out_of_range("age", 0, 120, 150)));
     });
 
     group.bench_function("custom", |b| {
-        b.iter(|| black_box(ValidationError::custom("Something went wrong")))
+        b.iter(|| black_box(ValidationError::custom("Something went wrong")));
     });
 
     group.finish();
@@ -138,7 +138,7 @@ fn bench_nested_errors(c: &mut Criterion) {
                 ValidationError::new("or_failed", "no alternative succeeded")
                     .with_nested_error(ValidationError::new("min_length", "too short")),
             );
-        })
+        });
     });
 
     // Three nested children
@@ -151,7 +151,7 @@ fn bench_nested_errors(c: &mut Criterion) {
                     ValidationError::new("alphanumeric", "not alphanumeric"),
                 ]),
             );
-        })
+        });
     });
 
     // With severity + help (full extras)
@@ -165,7 +165,7 @@ fn bench_nested_errors(c: &mut Criterion) {
                     .with_severity(ErrorSeverity::Error)
                     .with_help("usernames must be at least 3 characters"),
             );
-        })
+        });
     });
 
     group.finish();
@@ -180,7 +180,7 @@ fn bench_to_json(c: &mut Criterion) {
 
     let simple = ValidationError::new("min_length", "too short");
     group.bench_function("simple_error", |b| {
-        b.iter(|| black_box(simple.to_json_value()))
+        b.iter(|| black_box(simple.to_json_value()));
     });
 
     let with_params = ValidationError::new("min_length", "too short")
@@ -188,7 +188,7 @@ fn bench_to_json(c: &mut Criterion) {
         .with_param("min", "3")
         .with_param("actual", "1");
     group.bench_function("with_params", |b| {
-        b.iter(|| black_box(with_params.to_json_value()))
+        b.iter(|| black_box(with_params.to_json_value()));
     });
 
     let nested = ValidationError::new("or_failed", "no alternative succeeded").with_nested(vec![
@@ -196,7 +196,7 @@ fn bench_to_json(c: &mut Criterion) {
         ValidationError::new("alphanumeric", "not alphanumeric"),
     ]);
     group.bench_function("with_nested", |b| {
-        b.iter(|| black_box(nested.to_json_value()))
+        b.iter(|| black_box(nested.to_json_value()));
     });
 
     group.finish();
@@ -214,7 +214,7 @@ fn bench_memory_layout(c: &mut Criterion) {
         b.iter(|| {
             let err = ValidationError::new("min_length", "too short");
             drop(black_box(err));
-        })
+        });
     });
 
     group.bench_function("drop_with_extras", |b| {
@@ -223,19 +223,19 @@ fn bench_memory_layout(c: &mut Criterion) {
                 .with_param("min", "3")
                 .with_param("actual", "1");
             drop(black_box(err));
-        })
+        });
     });
 
     group.bench_function("clone_simple", |b| {
         let err = ValidationError::new("min_length", "too short");
-        b.iter(|| black_box(err.clone()))
+        b.iter(|| black_box(err.clone()));
     });
 
     group.bench_function("clone_with_extras", |b| {
         let err = ValidationError::new("min_length", "too short")
             .with_param("min", "3")
             .with_param("actual", "1");
-        b.iter(|| black_box(err.clone()))
+        b.iter(|| black_box(err.clone()));
     });
 
     group.finish();

--- a/crates/validator/benches/rule_engine.rs
+++ b/crates/validator/benches/rule_engine.rs
@@ -50,11 +50,11 @@ fn bench_value_rules(c: &mut Criterion) {
                 black_box(&rules),
                 ExecutionMode::StaticOnly,
             )
-        })
+        });
     });
 
     group.bench_function("full_mode", |b| {
-        b.iter(|| validate_rules(black_box(&value), black_box(&rules), ExecutionMode::Full))
+        b.iter(|| validate_rules(black_box(&value), black_box(&rules), ExecutionMode::Full));
     });
 
     group.finish();
@@ -72,7 +72,7 @@ fn bench_mixed_rules(c: &mut Criterion) {
     ] {
         let label = format!("{mode:?}");
         group.bench_function(label, |b| {
-            b.iter(|| validate_rules(black_box(&value), black_box(&rules), mode))
+            b.iter(|| validate_rules(black_box(&value), black_box(&rules), mode));
         });
     }
 
@@ -85,12 +85,12 @@ fn bench_combinator_rules(c: &mut Criterion) {
 
     group.bench_function("depth_3_passes", |b| {
         let v = json!("abcdefghij");
-        b.iter(|| validate_rules(black_box(&v), black_box(&rules), ExecutionMode::StaticOnly))
+        b.iter(|| validate_rules(black_box(&v), black_box(&rules), ExecutionMode::StaticOnly));
     });
 
     group.bench_function("depth_3_fails", |b| {
         let v = json!("hello5");
-        b.iter(|| validate_rules(black_box(&v), black_box(&rules), ExecutionMode::StaticOnly))
+        b.iter(|| validate_rules(black_box(&v), black_box(&rules), ExecutionMode::StaticOnly));
     });
 
     group.finish();
@@ -109,7 +109,7 @@ fn bench_large_ruleset(c: &mut Criterion) {
                     black_box(&rules),
                     ExecutionMode::StaticOnly,
                 )
-            })
+            });
         });
     }
 

--- a/crates/validator/benches/string_validators.rs
+++ b/crates/validator/benches/string_validators.rs
@@ -9,7 +9,13 @@
 use std::hint::black_box;
 
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use nebula_validator::{foundation::Validate, validators::*};
+use nebula_validator::{
+    foundation::Validate,
+    validators::{
+        alphabetic, alphanumeric, contains, email, ends_with, exact_length, length_range,
+        max_length, min_length, not_empty, starts_with, url,
+    },
+};
 
 // ============================================================================
 // LENGTH VALIDATORS
@@ -21,17 +27,17 @@ fn bench_min_length(c: &mut Criterion) {
 
     // Valid input (fast path)
     group.bench_function("valid_short", |b| {
-        b.iter(|| validator.validate(black_box("hello world")))
+        b.iter(|| validator.validate(black_box("hello world")));
     });
 
     // Invalid input (error path)
     group.bench_function("invalid", |b| {
-        b.iter(|| validator.validate(black_box("hi")))
+        b.iter(|| validator.validate(black_box("hi")));
     });
 
     // Edge case: exactly minimum
     group.bench_function("exact_minimum", |b| {
-        b.iter(|| validator.validate(black_box("hello")))
+        b.iter(|| validator.validate(black_box("hello")));
     });
 
     group.finish();
@@ -41,12 +47,12 @@ fn bench_min_length_scaling(c: &mut Criterion) {
     let mut group = c.benchmark_group("min_length_scaling");
     let validator = min_length(5);
 
-    for size in [10, 100, 1_000, 10_000, 100_000].iter() {
+    for size in &[10, 100, 1_000, 10_000, 100_000] {
         let input: String = "a".repeat(*size);
         group.throughput(Throughput::Bytes(*size as u64));
 
         group.bench_with_input(BenchmarkId::from_parameter(size), size, |b, _| {
-            b.iter(|| validator.validate(black_box(&input)))
+            b.iter(|| validator.validate(black_box(&input)));
         });
     }
 
@@ -58,17 +64,17 @@ fn bench_max_length(c: &mut Criterion) {
     let validator = max_length(100);
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("hello world")))
+        b.iter(|| validator.validate(black_box("hello world")));
     });
 
     group.bench_function("invalid", |b| {
         let long_string = "a".repeat(150);
-        b.iter(|| validator.validate(black_box(&long_string)))
+        b.iter(|| validator.validate(black_box(&long_string)));
     });
 
     group.bench_function("exact_maximum", |b| {
         let exact = "a".repeat(100);
-        b.iter(|| validator.validate(black_box(&exact)))
+        b.iter(|| validator.validate(black_box(&exact)));
     });
 
     group.finish();
@@ -79,15 +85,15 @@ fn bench_exact_length(c: &mut Criterion) {
     let validator = exact_length(10);
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("helloworld")))
+        b.iter(|| validator.validate(black_box("helloworld")));
     });
 
     group.bench_function("too_short", |b| {
-        b.iter(|| validator.validate(black_box("hello")))
+        b.iter(|| validator.validate(black_box("hello")));
     });
 
     group.bench_function("too_long", |b| {
-        b.iter(|| validator.validate(black_box("hello world is long")))
+        b.iter(|| validator.validate(black_box("hello world is long")));
     });
 
     group.finish();
@@ -98,25 +104,25 @@ fn bench_length_range(c: &mut Criterion) {
     let validator = length_range(5, 20).unwrap();
 
     group.bench_function("valid_middle", |b| {
-        b.iter(|| validator.validate(black_box("hello world")))
+        b.iter(|| validator.validate(black_box("hello world")));
     });
 
     group.bench_function("valid_min", |b| {
-        b.iter(|| validator.validate(black_box("hello")))
+        b.iter(|| validator.validate(black_box("hello")));
     });
 
     group.bench_function("valid_max", |b| {
         let s = "a".repeat(20);
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.bench_function("invalid_too_short", |b| {
-        b.iter(|| validator.validate(black_box("hi")))
+        b.iter(|| validator.validate(black_box("hi")));
     });
 
     group.bench_function("invalid_too_long", |b| {
         let s = "a".repeat(50);
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.finish();
@@ -127,11 +133,11 @@ fn bench_not_empty(c: &mut Criterion) {
     let validator = not_empty();
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("hello")))
+        b.iter(|| validator.validate(black_box("hello")));
     });
 
     group.bench_function("invalid_empty", |b| {
-        b.iter(|| validator.validate(black_box("")))
+        b.iter(|| validator.validate(black_box("")));
     });
 
     group.finish();
@@ -146,21 +152,21 @@ fn bench_contains(c: &mut Criterion) {
     let validator = contains("@");
 
     group.bench_function("found_early", |b| {
-        b.iter(|| validator.validate(black_box("@hello")))
+        b.iter(|| validator.validate(black_box("@hello")));
     });
 
     group.bench_function("found_middle", |b| {
-        b.iter(|| validator.validate(black_box("hello@world")))
+        b.iter(|| validator.validate(black_box("hello@world")));
     });
 
     group.bench_function("found_late", |b| {
         let s = "a".repeat(100) + "@";
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.bench_function("not_found", |b| {
         let s = "a".repeat(100);
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.finish();
@@ -171,11 +177,11 @@ fn bench_starts_with(c: &mut Criterion) {
     let validator = starts_with("http");
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("https://example.com")))
+        b.iter(|| validator.validate(black_box("https://example.com")));
     });
 
     group.bench_function("invalid", |b| {
-        b.iter(|| validator.validate(black_box("ftp://example.com")))
+        b.iter(|| validator.validate(black_box("ftp://example.com")));
     });
 
     group.finish();
@@ -186,11 +192,11 @@ fn bench_ends_with(c: &mut Criterion) {
     let validator = ends_with(".com");
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("example.com")))
+        b.iter(|| validator.validate(black_box("example.com")));
     });
 
     group.bench_function("invalid", |b| {
-        b.iter(|| validator.validate(black_box("example.org")))
+        b.iter(|| validator.validate(black_box("example.org")));
     });
 
     group.finish();
@@ -201,21 +207,21 @@ fn bench_alphanumeric(c: &mut Criterion) {
     let validator = alphanumeric();
 
     group.bench_function("valid_short", |b| {
-        b.iter(|| validator.validate(black_box("abc123")))
+        b.iter(|| validator.validate(black_box("abc123")));
     });
 
     group.bench_function("valid_long", |b| {
         let s = "a".repeat(1000);
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.bench_function("invalid_early", |b| {
-        b.iter(|| validator.validate(black_box("!abc123")))
+        b.iter(|| validator.validate(black_box("!abc123")));
     });
 
     group.bench_function("invalid_late", |b| {
         let s = "a".repeat(100) + "!";
-        b.iter(|| validator.validate(black_box(&s)))
+        b.iter(|| validator.validate(black_box(&s)));
     });
 
     group.finish();
@@ -226,11 +232,11 @@ fn bench_alphabetic(c: &mut Criterion) {
     let validator = alphabetic();
 
     group.bench_function("valid", |b| {
-        b.iter(|| validator.validate(black_box("HelloWorld")))
+        b.iter(|| validator.validate(black_box("HelloWorld")));
     });
 
     group.bench_function("invalid_with_digits", |b| {
-        b.iter(|| validator.validate(black_box("Hello123")))
+        b.iter(|| validator.validate(black_box("Hello123")));
     });
 
     group.finish();
@@ -245,23 +251,23 @@ fn bench_email(c: &mut Criterion) {
     let validator = email();
 
     group.bench_function("valid_simple", |b| {
-        b.iter(|| validator.validate(black_box("user@example.com")))
+        b.iter(|| validator.validate(black_box("user@example.com")));
     });
 
     group.bench_function("valid_complex", |b| {
-        b.iter(|| validator.validate(black_box("user.name+tag@sub.example.co.uk")))
+        b.iter(|| validator.validate(black_box("user.name+tag@sub.example.co.uk")));
     });
 
     group.bench_function("invalid_no_at", |b| {
-        b.iter(|| validator.validate(black_box("userexample.com")))
+        b.iter(|| validator.validate(black_box("userexample.com")));
     });
 
     group.bench_function("invalid_no_domain", |b| {
-        b.iter(|| validator.validate(black_box("user@")))
+        b.iter(|| validator.validate(black_box("user@")));
     });
 
     group.bench_function("invalid_format", |b| {
-        b.iter(|| validator.validate(black_box("not an email")))
+        b.iter(|| validator.validate(black_box("not an email")));
     });
 
     group.finish();
@@ -272,19 +278,19 @@ fn bench_url(c: &mut Criterion) {
     let validator = url();
 
     group.bench_function("valid_http", |b| {
-        b.iter(|| validator.validate(black_box("http://example.com")))
+        b.iter(|| validator.validate(black_box("http://example.com")));
     });
 
     group.bench_function("valid_https", |b| {
-        b.iter(|| validator.validate(black_box("https://example.com/path?query=value")))
+        b.iter(|| validator.validate(black_box("https://example.com/path?query=value")));
     });
 
     group.bench_function("invalid_no_scheme", |b| {
-        b.iter(|| validator.validate(black_box("example.com")))
+        b.iter(|| validator.validate(black_box("example.com")));
     });
 
     group.bench_function("invalid_format", |b| {
-        b.iter(|| validator.validate(black_box("not a url")))
+        b.iter(|| validator.validate(black_box("not a url")));
     });
 
     group.finish();
@@ -300,32 +306,32 @@ fn bench_unicode_handling(c: &mut Criterion) {
 
     // ASCII only
     group.bench_function("ascii", |b| {
-        b.iter(|| validator.validate(black_box("hello world")))
+        b.iter(|| validator.validate(black_box("hello world")));
     });
 
     // Latin extended
     group.bench_function("latin_extended", |b| {
-        b.iter(|| validator.validate(black_box("héllo wörld")))
+        b.iter(|| validator.validate(black_box("héllo wörld")));
     });
 
     // Cyrillic
     group.bench_function("cyrillic", |b| {
-        b.iter(|| validator.validate(black_box("привет мир")))
+        b.iter(|| validator.validate(black_box("привет мир")));
     });
 
     // Chinese
     group.bench_function("chinese", |b| {
-        b.iter(|| validator.validate(black_box("你好世界")))
+        b.iter(|| validator.validate(black_box("你好世界")));
     });
 
     // Emoji
     group.bench_function("emoji", |b| {
-        b.iter(|| validator.validate(black_box("👋🌍🚀💻🎉")))
+        b.iter(|| validator.validate(black_box("👋🌍🚀💻🎉")));
     });
 
     // Mixed
     group.bench_function("mixed", |b| {
-        b.iter(|| validator.validate(black_box("Hello мир 世界 🌍")))
+        b.iter(|| validator.validate(black_box("Hello мир 世界 🌍")));
     });
 
     group.finish();
@@ -343,19 +349,19 @@ fn bench_composition(c: &mut Criterion) {
     // Single validator
     let single = min_length(5);
     group.bench_function("single_validator", |b| {
-        b.iter(|| single.validate(black_box("hello")))
+        b.iter(|| single.validate(black_box("hello")));
     });
 
     // Two validators
     let double = min_length(5).and(max_length(20));
     group.bench_function("two_validators", |b| {
-        b.iter(|| double.validate(black_box("hello")))
+        b.iter(|| double.validate(black_box("hello")));
     });
 
     // Three validators
     let triple = min_length(5).and(max_length(20)).and(alphanumeric());
     group.bench_function("three_validators", |b| {
-        b.iter(|| triple.validate(black_box("hello")))
+        b.iter(|| triple.validate(black_box("hello")));
     });
 
     // Five validators (complex composition)
@@ -365,7 +371,7 @@ fn bench_composition(c: &mut Criterion) {
         .and(starts_with("h"))
         .and(ends_with("o"));
     group.bench_function("five_validators", |b| {
-        b.iter(|| complex.validate(black_box("hello")))
+        b.iter(|| complex.validate(black_box("hello")));
     });
 
     group.finish();
@@ -384,22 +390,22 @@ fn bench_early_termination(c: &mut Criterion) {
 
     // Fail on first validator
     group.bench_function("fail_first", |b| {
-        b.iter(|| validator.validate(black_box("hi"))) // Too short
+        b.iter(|| validator.validate(black_box("hi"))); // Too short
     });
 
     // Fail on second validator
     group.bench_function("fail_second", |b| {
-        b.iter(|| validator.validate(black_box(&*"a".repeat(30)))) // Too long
+        b.iter(|| validator.validate(black_box(&*"a".repeat(30)))); // Too long
     });
 
     // Fail on third validator
     group.bench_function("fail_third", |b| {
-        b.iter(|| validator.validate(black_box("hello!"))) // Not alphanumeric
+        b.iter(|| validator.validate(black_box("hello!"))); // Not alphanumeric
     });
 
     // Success (all validators pass)
     group.bench_function("success_all", |b| {
-        b.iter(|| validator.validate(black_box("hello123")))
+        b.iter(|| validator.validate(black_box("hello123")));
     });
 
     group.finish();
@@ -420,19 +426,19 @@ fn bench_username_validation(c: &mut Criterion) {
         .and(starts_with("a")); // Must start with letter (simplified)
 
     group.bench_function("valid_short", |b| {
-        b.iter(|| validator.validate(black_box("alice")))
+        b.iter(|| validator.validate(black_box("alice")));
     });
 
     group.bench_function("valid_long", |b| {
-        b.iter(|| validator.validate(black_box("alicewonderland123")))
+        b.iter(|| validator.validate(black_box("alicewonderland123")));
     });
 
     group.bench_function("invalid_too_short", |b| {
-        b.iter(|| validator.validate(black_box("al")))
+        b.iter(|| validator.validate(black_box("al")));
     });
 
     group.bench_function("invalid_special_char", |b| {
-        b.iter(|| validator.validate(black_box("alice@123")))
+        b.iter(|| validator.validate(black_box("alice@123")));
     });
 
     group.finish();

--- a/crates/validator/examples/combinators.rs
+++ b/crates/validator/examples/combinators.rs
@@ -1,6 +1,6 @@
 //! Combinators example for nebula-validator
 
-use nebula_validator::prelude::*;
+use nebula_validator::prelude::{Validate, and, max_length, min_length};
 
 fn main() {
     // Combine validators with AND
@@ -10,21 +10,21 @@ fn main() {
 
     // Valid username
     match username_validator.validate("alice") {
-        Ok(_) => println!("✓ 'alice' is valid"),
-        Err(e) => println!("✗ Error: {}", e),
+        Ok(()) => println!("✓ 'alice' is valid"),
+        Err(e) => println!("✗ Error: {e}"),
     }
 
     // Too short
     match username_validator.validate("ab") {
-        Ok(_) => println!("✓ 'ab' is valid"),
-        Err(e) => println!("✗ 'ab' is too short: {}", e),
+        Ok(()) => println!("✓ 'ab' is valid"),
+        Err(e) => println!("✗ 'ab' is too short: {e}"),
     }
 
     // Too long
     let long_name = "verylongusernamethatexceedslimit";
     match username_validator.validate(long_name) {
-        Ok(_) => println!("✓ '{}' is valid", long_name),
-        Err(e) => println!("✗ '{}' is too long: {}", long_name, e),
+        Ok(()) => println!("✓ '{long_name}' is valid"),
+        Err(e) => println!("✗ '{long_name}' is too long: {e}"),
     }
 
     println!("\nCombinators are working correctly!");

--- a/crates/validator/examples/json_validation.rs
+++ b/crates/validator/examples/json_validation.rs
@@ -116,7 +116,7 @@ fn composed_validators() {
 
     // WHEN: validate email only when notify is true
     let v = when(json_field("/email", email()), |v: &Value| {
-        v.get("notify").and_then(|n| n.as_bool()).unwrap_or(false)
+        v.get("notify").and_then(Value::as_bool).unwrap_or(false)
     });
 
     let data = json!({"notify": false, "email": "bad"});
@@ -200,10 +200,10 @@ fn error_reporting() {
         println!("Error code:    {}", e.code);
         println!("Error message: {}", e.message);
         if let Some(field) = &e.field {
-            println!("Error field:   {}", field);
+            println!("Error field:   {field}");
         }
         for (k, v) in e.params() {
-            println!("  param {}: {}", k, v);
+            println!("  param {k}: {v}");
         }
     }
 

--- a/crates/validator/examples/validator_basic_usage.rs
+++ b/crates/validator/examples/validator_basic_usage.rs
@@ -1,6 +1,10 @@
 //! Basic usage example for nebula-validator
 
-use nebula_validator::prelude::*;
+use nebula_validator::prelude::{
+    AnyValidator, Validatable, Validate, ValidateExt, ValidationError, ValidationMode, all_of,
+    alphanumeric, email, exact_length, hostname, in_range, ip_addr, json_field,
+    json_field_optional, matches_regex, max_length, min_length, size_range, url,
+};
 use serde_json::json;
 
 fn main() {
@@ -25,13 +29,13 @@ fn basic_string_validation() {
     let validator = min_length(5);
 
     match validator.validate("hello") {
-        Ok(_) => println!("✓ 'hello' is valid (length >= 5)"),
-        Err(e) => println!("✗ Error: {}", e),
+        Ok(()) => println!("✓ 'hello' is valid (length >= 5)"),
+        Err(e) => println!("✗ Error: {e}"),
     }
 
     match validator.validate("hi") {
-        Ok(_) => println!("✓ 'hi' is valid"),
-        Err(e) => println!("✗ 'hi' is invalid: {}", e),
+        Ok(()) => println!("✓ 'hi' is valid"),
+        Err(e) => println!("✗ 'hi' is invalid: {e}"),
     }
 }
 
@@ -43,8 +47,8 @@ fn composed_string_validation() {
 
     for sample in ["alice123", "ab", "john_doe"] {
         match username.validate(sample) {
-            Ok(_) => println!("✓ '{sample}' passed username rules"),
-            Err(e) => println!("✗ '{sample}' failed: {}", e),
+            Ok(()) => println!("✓ '{sample}' passed username rules"),
+            Err(e) => println!("✗ '{sample}' failed: {e}"),
         }
     }
 

--- a/crates/validator/macros/Cargo.toml
+++ b/crates/validator/macros/Cargo.toml
@@ -24,3 +24,6 @@ proc-macro2 = "1.0"
 # Used to validate `#[validate(regex = "...")]` patterns at macro-time so
 # compile errors surface before runtime.
 regex = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/validator/macros/src/emit/mod.rs
+++ b/crates/validator/macros/src/emit/mod.rs
@@ -23,7 +23,7 @@ use rules::emit_field_rule;
 
 /// Generate the full `Validate`, `SelfValidating`, and `validate_fields()`
 /// implementations from the parsed IR.
-pub fn emit(input: &ValidatorInput) -> TokenStream2 {
+pub(crate) fn emit(input: &ValidatorInput) -> TokenStream2 {
     let struct_name = &input.ident;
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let root_message = &input.container.message;

--- a/crates/validator/macros/src/model.rs
+++ b/crates/validator/macros/src/model.rs
@@ -14,7 +14,7 @@ use syn::{Generics, Ident, Type};
 /// Contains all parsed information needed to generate the `Validate`,
 /// `SelfValidating`, and `validate_fields()` implementations.
 #[derive(Debug)]
-pub struct ValidatorInput {
+pub(crate) struct ValidatorInput {
     /// The struct identifier.
     pub ident: Ident,
     /// Generic parameters from the struct definition.
@@ -27,7 +27,7 @@ pub struct ValidatorInput {
 
 /// Container-level attributes parsed from `#[validator(...)]`.
 #[derive(Debug)]
-pub struct ContainerAttrs {
+pub(crate) struct ContainerAttrs {
     /// Root error message used when converting `ValidationErrors` to a
     /// single `ValidationError`. Defaults to `"validation failed"`.
     pub message: String,
@@ -43,7 +43,7 @@ impl Default for ContainerAttrs {
 
 /// A single field definition with its validation rules.
 #[derive(Debug)]
-pub struct FieldDef {
+pub(crate) struct FieldDef {
     /// The field identifier.
     pub ident: Ident,
     /// The original type as written in the struct (may be `Option<T>`).
@@ -62,7 +62,7 @@ pub struct FieldDef {
 
 /// A single validation rule extracted from `#[validate(...)]` attributes.
 #[derive(Debug)]
-pub enum Rule {
+pub(crate) enum Rule {
     /// Field is required (must be `Some` for `Option` fields).
     Required,
 
@@ -139,7 +139,7 @@ pub enum Rule {
 
 /// Element-level validation rules for `Vec<T>` fields via `each(...)`.
 #[derive(Debug)]
-pub struct EachRules {
+pub(crate) struct EachRules {
     /// Element type for `Vec<T>` (or inner element for `Vec<Option<T>>`).
     pub element_ty: Type,
     /// Validation rules applied to each element.
@@ -148,7 +148,7 @@ pub struct EachRules {
 
 /// Built-in string format validators (zero-argument factories).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StringFormat {
+pub(crate) enum StringFormat {
     /// String must not be empty.
     NotEmpty,
     /// String must be alphanumeric.
@@ -185,7 +185,7 @@ pub enum StringFormat {
 
 /// Built-in string factory validators (one-argument factories).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum StringFactoryKind {
+pub(crate) enum StringFactoryKind {
     /// String must contain the given substring.
     Contains,
     /// String must start with the given prefix.

--- a/crates/validator/macros/src/parse/mod.rs
+++ b/crates/validator/macros/src/parse/mod.rs
@@ -50,7 +50,7 @@ pub(super) fn validate_regex_pattern<T: quote::ToTokens>(
 /// Returns a `syn::Error` when attributes are malformed, types are
 /// incompatible with the requested rule, or required sub-attributes are
 /// missing.
-pub fn parse(input: &DeriveInput) -> syn::Result<ValidatorInput> {
+pub(crate) fn parse(input: &DeriveInput) -> syn::Result<ValidatorInput> {
     let fields = match &input.data {
         syn::Data::Struct(data) => match &data.fields {
             syn::Fields::Named(fields) => &fields.named,

--- a/crates/validator/src/combinators/field.rs
+++ b/crates/validator/src/combinators/field.rs
@@ -440,7 +440,7 @@ mod tests {
             ValidationError::new("invalid", "Invalid value"),
         );
 
-        let display = format!("{}", error);
+        let display = format!("{error}");
         assert!(display.contains("age"));
         assert!(display.contains("Invalid value"));
     }
@@ -536,7 +536,7 @@ mod tests {
     fn test_field_debug() {
         let validator: Field<TestUser, u32, MinValue, _> =
             named_field("age", MinValue { min: 18 }, get_age);
-        let debug_str = format!("{:?}", validator);
+        let debug_str = format!("{validator:?}");
         assert!(debug_str.contains("Field"));
         assert!(debug_str.contains("age"));
     }

--- a/crates/validator/src/combinators/nested.rs
+++ b/crates/validator/src/combinators/nested.rs
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_nested_validator_invalid_name() {
         let user = TestUser {
-            name: "".to_string(),
+            name: String::new(),
             age: 25,
         };
         let validator = nested_validator::<TestUser>();
@@ -423,7 +423,7 @@ mod tests {
     #[test]
     fn test_optional_nested_some_invalid() {
         let user = Some(TestUser {
-            name: "".to_string(),
+            name: String::new(),
             age: 25,
         });
         let validator = optional_nested::<TestUser>();
@@ -461,7 +461,7 @@ mod tests {
                 age: 25,
             },
             TestUser {
-                name: "".to_string(), // Invalid
+                name: String::new(), // Invalid
                 age: 30,
             },
         ];

--- a/crates/validator/src/foundation/any.rs
+++ b/crates/validator/src/foundation/any.rs
@@ -182,7 +182,7 @@ mod tests {
     #[test]
     fn test_any_validator_debug() {
         let validator: AnyValidator<str> = AnyValidator::new(min_length(3));
-        let debug = format!("{:?}", validator);
+        let debug = format!("{validator:?}");
         assert!(debug.contains("AnyValidator"));
     }
 

--- a/crates/validator/src/foundation/error/mod.rs
+++ b/crates/validator/src/foundation/error/mod.rs
@@ -38,7 +38,7 @@ mod tests {
     #[test]
     fn test_validation_error_size() {
         // Ensure our optimized struct is <= 80 bytes
-        let size = std::mem::size_of::<ValidationError>();
+        let size = size_of::<ValidationError>();
         assert!(
             size <= 80,
             "ValidationError size is {size} bytes, expected <= 80"

--- a/crates/validator/src/foundation/error/validation_error.rs
+++ b/crates/validator/src/foundation/error/validation_error.rs
@@ -279,8 +279,7 @@ impl ValidationError {
     pub fn severity(&self) -> ErrorSeverity {
         self.extras
             .as_ref()
-            .map(|e| e.severity)
-            .unwrap_or(ErrorSeverity::Error)
+            .map_or(ErrorSeverity::Error, |e| e.severity)
     }
 
     /// Returns help text if available.
@@ -338,7 +337,7 @@ impl ValidationError {
             "params": params,
             "severity": format!("{:?}", self.severity()),
             "help": self.help(),
-            "nested": self.nested().iter().map(|e| e.to_json_value()).collect::<Vec<_>>(),
+            "nested": self.nested().iter().map(ValidationError::to_json_value).collect::<Vec<_>>(),
         })
     }
 
@@ -392,13 +391,12 @@ pub(crate) fn render_template<'a>(
                 out.push_str(&name);
                 continue;
             }
-            match params.iter().find(|(k, _)| k.as_ref() == name) {
-                Some((_, v)) => out.push_str(v.as_ref()),
-                None => {
-                    out.push('{');
-                    out.push_str(&name);
-                    out.push('}');
-                },
+            if let Some((_, v)) = params.iter().find(|(k, _)| k.as_ref() == name) {
+                out.push_str(v.as_ref());
+            } else {
+                out.push('{');
+                out.push_str(&name);
+                out.push('}');
             }
         } else if c == '}' {
             if matches!(chars.peek(), Some((_, '}'))) {

--- a/crates/validator/src/foundation/field_path.rs
+++ b/crates/validator/src/foundation/field_path.rs
@@ -266,7 +266,7 @@ impl serde::Serialize for FieldPath {
 
 impl<'de> serde::Deserialize<'de> for FieldPath {
     fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
-        let raw = <std::borrow::Cow<'de, str> as serde::Deserialize>::deserialize(d)?;
+        let raw = <Cow<'de, str> as serde::Deserialize>::deserialize(d)?;
         FieldPath::parse(raw.as_ref())
             .ok_or_else(|| serde::de::Error::custom(format!("invalid field path: {raw:?}")))
     }

--- a/crates/validator/src/foundation/validatable.rs
+++ b/crates/validator/src/foundation/validatable.rs
@@ -472,7 +472,7 @@ mod tests {
         // 2^53 is exactly representable
         let n: i64 = 1 << 53;
         let result: f64 = AsValidatable::<f64>::as_validatable(&n).unwrap();
-        assert_eq!(result, 9007199254740992.0);
+        assert_eq!(result, 9_007_199_254_740_992.0);
     }
 
     #[test]

--- a/crates/validator/src/proof.rs
+++ b/crates/validator/src/proof.rs
@@ -220,14 +220,8 @@ mod tests {
 
     #[test]
     fn zero_cost_size() {
-        assert_eq!(
-            std::mem::size_of::<Validated<u64>>(),
-            std::mem::size_of::<u64>()
-        );
-        assert_eq!(
-            std::mem::size_of::<Validated<String>>(),
-            std::mem::size_of::<String>()
-        );
+        assert_eq!(size_of::<Validated<u64>>(), size_of::<u64>());
+        assert_eq!(size_of::<Validated<String>>(), size_of::<String>());
     }
 
     #[test]

--- a/crates/validator/src/rule/deserialize.rs
+++ b/crates/validator/src/rule/deserialize.rs
@@ -112,11 +112,11 @@ impl<'de> Visitor<'de> for RuleVisitor {
             // Bare-string form `"email"` / `"url"` is the canonical wire shape;
             // map form is accepted leniently for robustness across formats.
             "email" => {
-                let _: serde::de::IgnoredAny = m.next_value()?;
+                let _: de::IgnoredAny = m.next_value()?;
                 Rule::Value(ValueRule::Email)
             },
             "url" => {
-                let _: serde::de::IgnoredAny = m.next_value()?;
+                let _: de::IgnoredAny = m.next_value()?;
                 Rule::Value(ValueRule::Url)
             },
 

--- a/crates/validator/src/rule/mod.rs
+++ b/crates/validator/src/rule/mod.rs
@@ -241,10 +241,10 @@ fn evaluate_predicate_via_rule_context(p: &Predicate, ctx: &dyn RuleContext) -> 
     match p {
         Predicate::Eq(_, v) => ctx.get(key).is_some_and(|x| x == v),
         Predicate::Ne(_, v) => ctx.get(key).is_none_or(|x| x != v),
-        Predicate::Gt(_, rhs) => number_cmp(ctx.get(key), rhs, |o| o.is_gt()),
-        Predicate::Gte(_, rhs) => number_cmp(ctx.get(key), rhs, |o| o.is_ge()),
-        Predicate::Lt(_, rhs) => number_cmp(ctx.get(key), rhs, |o| o.is_lt()),
-        Predicate::Lte(_, rhs) => number_cmp(ctx.get(key), rhs, |o| o.is_le()),
+        Predicate::Gt(_, rhs) => number_cmp(ctx.get(key), rhs, std::cmp::Ordering::is_gt),
+        Predicate::Gte(_, rhs) => number_cmp(ctx.get(key), rhs, std::cmp::Ordering::is_ge),
+        Predicate::Lt(_, rhs) => number_cmp(ctx.get(key), rhs, std::cmp::Ordering::is_lt),
+        Predicate::Lte(_, rhs) => number_cmp(ctx.get(key), rhs, std::cmp::Ordering::is_le),
         Predicate::IsTrue(_) => ctx.get(key).and_then(serde_json::Value::as_bool) == Some(true),
         Predicate::IsFalse(_) => ctx.get(key).and_then(serde_json::Value::as_bool) == Some(false),
         Predicate::Set(_) => ctx.get(key).is_some_and(|v| {
@@ -292,19 +292,19 @@ pub enum RuleKind {
 
 fn predicate_code(p: &Predicate) -> &'static str {
     match p {
-        Predicate::Eq(_, _) => "eq_failed",
-        Predicate::Ne(_, _) => "ne_failed",
-        Predicate::Gt(_, _) => "gt_failed",
-        Predicate::Gte(_, _) => "gte_failed",
-        Predicate::Lt(_, _) => "lt_failed",
-        Predicate::Lte(_, _) => "lte_failed",
+        Predicate::Eq(..) => "eq_failed",
+        Predicate::Ne(..) => "ne_failed",
+        Predicate::Gt(..) => "gt_failed",
+        Predicate::Gte(..) => "gte_failed",
+        Predicate::Lt(..) => "lt_failed",
+        Predicate::Lte(..) => "lte_failed",
         Predicate::IsTrue(_) => "is_true_failed",
         Predicate::IsFalse(_) => "is_false_failed",
         Predicate::Set(_) => "set_failed",
         Predicate::Empty(_) => "empty_failed",
-        Predicate::Contains(_, _) => "contains_failed",
-        Predicate::Matches(_, _) => "matches_failed",
-        Predicate::In(_, _) => "in_failed",
+        Predicate::Contains(..) => "contains_failed",
+        Predicate::Matches(..) => "matches_failed",
+        Predicate::In(..) => "in_failed",
     }
 }
 
@@ -335,7 +335,7 @@ fn predicate_error(p: &Predicate) -> ValidationError {
         | Predicate::IsFalse(_)
         | Predicate::Set(_)
         | Predicate::Empty(_)
-        | Predicate::Matches(_, _) => err,
+        | Predicate::Matches(..) => err,
     }
 }
 

--- a/crates/validator/src/rule/predicate.rs
+++ b/crates/validator/src/rule/predicate.rs
@@ -72,10 +72,10 @@ impl Predicate {
         match self {
             Self::Eq(f, v) => ctx.get(f).is_some_and(|x| x == v),
             Self::Ne(f, v) => ctx.get(f).is_none_or(|x| x != v),
-            Self::Gt(f, v) => cmp_number_predicate(ctx.get(f), v, |o| o.is_gt()),
-            Self::Gte(f, v) => cmp_number_predicate(ctx.get(f), v, |o| o.is_ge()),
-            Self::Lt(f, v) => cmp_number_predicate(ctx.get(f), v, |o| o.is_lt()),
-            Self::Lte(f, v) => cmp_number_predicate(ctx.get(f), v, |o| o.is_le()),
+            Self::Gt(f, v) => cmp_number_predicate(ctx.get(f), v, std::cmp::Ordering::is_gt),
+            Self::Gte(f, v) => cmp_number_predicate(ctx.get(f), v, std::cmp::Ordering::is_ge),
+            Self::Lt(f, v) => cmp_number_predicate(ctx.get(f), v, std::cmp::Ordering::is_lt),
+            Self::Lte(f, v) => cmp_number_predicate(ctx.get(f), v, std::cmp::Ordering::is_le),
             Self::IsTrue(f) => ctx.get(f).and_then(serde_json::Value::as_bool) == Some(true),
             Self::IsFalse(f) => ctx.get(f).and_then(serde_json::Value::as_bool) == Some(false),
             Self::Set(f) => ctx.get(f).is_some_and(|v| {

--- a/crates/validator/src/validators/range.rs
+++ b/crates/validator/src/validators/range.rs
@@ -153,7 +153,7 @@ pub fn try_in_range<T: PartialOrd + Display + Copy>(
     min: T,
     max: T,
 ) -> Result<InRange<T>, ValidationError> {
-    if min.partial_cmp(&max).is_none_or(|o| o.is_gt()) {
+    if min.partial_cmp(&max).is_none_or(std::cmp::Ordering::is_gt) {
         return Err(ValidationError::new(
             "invalid_range",
             format!("in_range requires min <= max (got min={min}, max={max})"),
@@ -185,7 +185,7 @@ pub fn try_exclusive_range<T: PartialOrd + Display + Copy>(
     min: T,
     max: T,
 ) -> Result<ExclusiveRange<T>, ValidationError> {
-    if !min.partial_cmp(&max).is_some_and(|o| o.is_lt()) {
+    if !min.partial_cmp(&max).is_some_and(std::cmp::Ordering::is_lt) {
         return Err(ValidationError::new(
             "invalid_range",
             format!("exclusive_range requires min < max (got min={min}, max={max})"),

--- a/crates/validator/src/validators/temporal.rs
+++ b/crates/validator/src/validators/temporal.rs
@@ -206,7 +206,7 @@ impl Validate<str> for DateTime {
 
         // Separator T/t/space
         let sep = input.as_bytes().get(10).copied();
-        if !matches!(sep, Some(b'T') | Some(b't') | Some(b' ')) {
+        if !matches!(sep, Some(b'T' | b't' | b' ')) {
             return Err(err());
         }
 
@@ -215,7 +215,7 @@ impl Validate<str> for DateTime {
         let rest = parse_time_parts(time_str).map_err(|_| err())?;
 
         // Timezone: Z, +HH:MM, -HH:MM
-        validate_timezone_suffix(rest).map_err(|_| err())?;
+        validate_timezone_suffix(rest).map_err(|()| err())?;
 
         Ok(())
     }

--- a/crates/validator/tests/contract/benchmark_budget_test.rs
+++ b/crates/validator/tests/contract/benchmark_budget_test.rs
@@ -221,7 +221,7 @@ fn validation_error_size_matches_budget() {
         .as_u64()
         .unwrap() as usize;
 
-    let actual = std::mem::size_of::<nebula_validator::foundation::ValidationError>();
+    let actual = size_of::<nebula_validator::foundation::ValidationError>();
     assert_eq!(
         actual, expected,
         "ValidationError size changed: expected {expected} bytes, got {actual} bytes. \
@@ -237,7 +237,7 @@ fn error_extras_pointer_fits_budget() {
         .unwrap() as usize;
 
     // Option<Box<T>> is pointer-sized
-    let actual = std::mem::size_of::<Option<Box<u8>>>();
+    let actual = size_of::<Option<Box<u8>>>();
     assert_eq!(
         actual, expected,
         "Option<Box<ErrorExtras>> size changed: expected {expected} bytes, got {actual} bytes"

--- a/crates/validator/tests/contract/governance_policy_test.rs
+++ b/crates/validator/tests/contract/governance_policy_test.rs
@@ -197,8 +197,7 @@ fn registry_version_follows_semver() {
     for part in &parts {
         assert!(
             part.parse::<u32>().is_ok(),
-            "registry version segment '{}' is not a valid number",
-            part
+            "registry version segment '{part}' is not a valid number"
         );
     }
 }

--- a/crates/validator/tests/contract/helpers.rs
+++ b/crates/validator/tests/contract/helpers.rs
@@ -3,7 +3,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 #[derive(Debug, Deserialize)]
-pub struct FixtureCase {
+pub(super) struct FixtureCase {
     pub id: String,
     pub scenario: String,
     pub input: Value,
@@ -11,18 +11,18 @@ pub struct FixtureCase {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct FixtureExpectation {
+pub(super) struct FixtureExpectation {
     pub pass: bool,
     pub error_code: Option<String>,
     pub field_path: Option<String>,
 }
 
-pub fn load_contract_fixture() -> Vec<FixtureCase> {
+pub(super) fn load_contract_fixture() -> Vec<FixtureCase> {
     let raw = include_str!("../fixtures/compat/minor_contract_v1.json");
     serde_json::from_str(raw).expect("compat fixture JSON must be valid")
 }
 
-pub fn load_named_fixture(name: &str) -> Vec<FixtureCase> {
+pub(super) fn load_named_fixture(name: &str) -> Vec<FixtureCase> {
     let raw = match name {
         "boolean" => include_str!("../fixtures/compat/boolean_contract_v1.json"),
         "pattern" => include_str!("../fixtures/compat/pattern_contract_v1.json"),
@@ -35,7 +35,7 @@ pub fn load_named_fixture(name: &str) -> Vec<FixtureCase> {
     serde_json::from_str(raw).unwrap_or_else(|e| panic!("{name} fixture JSON invalid: {e}"))
 }
 
-pub fn assert_error_contract(
+pub(super) fn assert_error_contract(
     error: &ValidationError,
     expected_code: Option<&str>,
     expected_field: Option<&str>,
@@ -48,7 +48,7 @@ pub fn assert_error_contract(
     }
 }
 
-pub fn assert_no_secrets(text: &str) {
+pub(super) fn assert_no_secrets(text: &str) {
     let forbidden = [
         "super-secret",
         "p@ssw0rd",

--- a/crates/validator/tests/derive_tests.rs
+++ b/crates/validator/tests/derive_tests.rs
@@ -27,8 +27,7 @@ fn first_message(result: &Result<(), ValidationErrors>) -> &str {
         .as_ref()
         .err()
         .and_then(|e| e.errors().first())
-        .map(|e| e.message.as_ref())
-        .unwrap_or("")
+        .map_or("", |e| e.message.as_ref())
 }
 
 // ============================================================================
@@ -707,8 +706,8 @@ fn each_rejects_invalid_elements() {
         .iter()
         .filter_map(|e| e.field.as_deref())
         .collect();
-    assert!(fields.iter().any(|f| f.contains("1")));
-    assert!(fields.iter().any(|f| f.contains("2")));
+    assert!(fields.iter().any(|f| f.contains('1')));
+    assert!(fields.iter().any(|f| f.contains('2')));
 }
 
 #[derive(Validator)]

--- a/crates/validator/tests/integration/common.rs
+++ b/crates/validator/tests/integration/common.rs
@@ -8,7 +8,9 @@
 use nebula_validator::foundation::{ValidationError, ValidationErrors};
 
 /// Asserts the result is `Err` and returns the collected errors.
-pub fn expect_errors<T: std::fmt::Debug>(result: Result<T, ValidationErrors>) -> ValidationErrors {
+pub(crate) fn expect_errors<T: std::fmt::Debug>(
+    result: Result<T, ValidationErrors>,
+) -> ValidationErrors {
     match result {
         Ok(ok) => panic!("expected validation to fail, got Ok({ok:?})"),
         Err(errors) => errors,
@@ -18,7 +20,7 @@ pub fn expect_errors<T: std::fmt::Debug>(result: Result<T, ValidationErrors>) ->
 /// Asserts that the given error code is present somewhere in the error
 /// list. Useful when multiple errors accumulate and the test only cares
 /// about a specific one.
-pub fn assert_has_code(errors: &ValidationErrors, code: &str) {
+pub(crate) fn assert_has_code(errors: &ValidationErrors, code: &str) {
     let found = errors.errors().iter().any(|e| e.code.as_ref() == code);
     assert!(
         found,
@@ -29,7 +31,7 @@ pub fn assert_has_code(errors: &ValidationErrors, code: &str) {
 
 /// Asserts the error set covers exactly the given codes (order-independent,
 /// duplicates allowed in either side).
-pub fn assert_codes_exactly(errors: &ValidationErrors, expected: &[&str]) {
+pub(crate) fn assert_codes_exactly(errors: &ValidationErrors, expected: &[&str]) {
     let mut actual: Vec<&str> = errors.errors().iter().map(|e| e.code.as_ref()).collect();
     let mut expected: Vec<&str> = expected.to_vec();
     actual.sort_unstable();
@@ -43,7 +45,7 @@ pub fn assert_codes_exactly(errors: &ValidationErrors, expected: &[&str]) {
 }
 
 /// Returns a comma-separated list of error codes — handy for panic messages.
-pub fn error_code_list(errors: &ValidationErrors) -> String {
+pub(crate) fn error_code_list(errors: &ValidationErrors) -> String {
     errors
         .errors()
         .iter()
@@ -53,7 +55,10 @@ pub fn error_code_list(errors: &ValidationErrors) -> String {
 }
 
 /// Returns the first error whose field pointer matches `field`, if any.
-pub fn find_by_field<'a>(errors: &'a ValidationErrors, field: &str) -> Option<&'a ValidationError> {
+pub(crate) fn find_by_field<'a>(
+    errors: &'a ValidationErrors,
+    field: &str,
+) -> Option<&'a ValidationError> {
     errors
         .errors()
         .iter()

--- a/crates/validator/tests/integration/derive_form.rs
+++ b/crates/validator/tests/integration/derive_form.rs
@@ -106,7 +106,7 @@ fn every_field_reports_its_own_error() {
 fn nested_address_errors_carry_path() {
     let form = RegistrationForm {
         address: Some(Address {
-            line1: "".into(),
+            line1: String::new(),
             city: "X".into(),
             country: "usa".into(), // lower + wrong length
         }),

--- a/crates/validator/tests/integration/error_semantics.rs
+++ b/crates/validator/tests/integration/error_semantics.rs
@@ -20,8 +20,8 @@ struct Credentials {
 #[test]
 fn field_pointers_are_rfc6901_normalized() {
     let creds = Credentials {
-        username: "".into(),
-        password: "".into(),
+        username: String::new(),
+        password: String::new(),
     };
     let errors = expect_errors(creds.validate_fields());
     // Field pointers normalise to `/field`, not `field` or `.field`.
@@ -75,8 +75,8 @@ fn flatten_walks_entire_tree_depth_first() {
 #[test]
 fn validate_fields_returns_collection_validate_returns_single() {
     let creds = Credentials {
-        username: "".into(),
-        password: "".into(),
+        username: String::new(),
+        password: String::new(),
     };
 
     // Raw collection keeps each field failure independent.

--- a/crates/validator/tests/integration/proof_tokens.rs
+++ b/crates/validator/tests/integration/proof_tokens.rs
@@ -22,14 +22,8 @@ fn greet(name: Validated<String>) -> String {
 fn validated_has_zero_memory_overhead() {
     // The type system guarantee is carried in a zero-sized marker, so the
     // runtime footprint matches the wrapped type exactly.
-    assert_eq!(
-        std::mem::size_of::<Validated<String>>(),
-        std::mem::size_of::<String>()
-    );
-    assert_eq!(
-        std::mem::size_of::<Validated<u64>>(),
-        std::mem::size_of::<u64>()
-    );
+    assert_eq!(size_of::<Validated<String>>(), size_of::<String>());
+    assert_eq!(size_of::<Validated<u64>>(), size_of::<u64>());
 }
 
 #[test]

--- a/crates/validator/tests/integration_test.rs
+++ b/crates/validator/tests/integration_test.rs
@@ -44,8 +44,8 @@ fn test_error_messages() {
     match validator.validate("hi") {
         Err(e) => {
             assert_eq!(e.code, "min_length");
-            assert!(e.message.contains("5"));
+            assert!(e.message.contains('5'));
         },
-        Ok(_) => panic!("Expected error"),
+        Ok(()) => panic!("Expected error"),
     }
 }

--- a/crates/validator/tests/json_integration.rs
+++ b/crates/validator/tests/json_integration.rs
@@ -316,7 +316,7 @@ fn when_combinator_json() {
 
     // Validate email only when notify=true
     let v = when(json_field("/email", email()), |v: &Value| {
-        v.get("notify").and_then(|n| n.as_bool()).unwrap_or(false)
+        v.get("notify").and_then(Value::as_bool).unwrap_or(false)
     });
 
     // notify=true, invalid email → fail
@@ -428,7 +428,7 @@ fn multiple_field_errors() {
     });
 
     // Validate each field independently and collect errors
-    let validators: Vec<Box<dyn Validate<serde_json::Value>>> = vec![
+    let validators: Vec<Box<dyn Validate<Value>>> = vec![
         Box::new(json_field("/name", min_length(1))),
         Box::new(json_field("/email", email())),
     ];

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -23,3 +23,6 @@ chrono = { workspace = true, features = ["serde"] }
 
 [lib]
 doctest = false
+
+[lints]
+workspace = true

--- a/crates/workflow/src/builder.rs
+++ b/crates/workflow/src/builder.rs
@@ -336,7 +336,7 @@ mod tests {
             .variable("env", serde_json::json!("production"))
             .tag("test")
             .tag("v1")
-            .timeout(Duration::from_secs(60))
+            .timeout(Duration::from_mins(1))
             .max_parallel(4)
             .build()
             .unwrap();
@@ -348,7 +348,7 @@ mod tests {
             Some(&serde_json::json!("production"))
         );
         assert_eq!(def.tags, vec!["test", "v1"]);
-        assert_eq!(def.config.timeout, Some(Duration::from_secs(60)));
+        assert_eq!(def.config.timeout, Some(Duration::from_mins(1)));
         assert_eq!(def.config.max_parallel_nodes, 4);
     }
 

--- a/crates/workflow/src/connection.rs
+++ b/crates/workflow/src/connection.rs
@@ -198,6 +198,10 @@ mod tests {
     }
 
     #[test]
+    #[allow(
+        clippy::no_effect_underscore_binding,
+        reason = "API contract test — constructs each variant"
+    )]
     fn edge_condition_variants() {
         let _always = EdgeCondition::Always;
         let _expr = EdgeCondition::Expression {

--- a/crates/workflow/src/definition.rs
+++ b/crates/workflow/src/definition.rs
@@ -143,7 +143,7 @@ impl Default for WorkflowConfig {
 }
 
 /// Settings that control how often execution progress is persisted.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CheckpointingConfig {
     /// Whether checkpointing is enabled at all.
     #[serde(default = "default_true")]
@@ -332,24 +332,21 @@ mod tests {
     #[test]
     fn workflow_config_serde_roundtrip() {
         let cfg = WorkflowConfig {
-            timeout: Some(Duration::from_millis(30_000)),
+            timeout: Some(Duration::from_secs(30)),
             max_parallel_nodes: 5,
             checkpointing: CheckpointingConfig {
                 enabled: false,
-                interval: Some(Duration::from_millis(1_000)),
+                interval: Some(Duration::from_secs(1)),
             },
             retry_policy: Some(RetryConfig::fixed(3, 500)),
             error_strategy: ErrorStrategy::ContinueOnError,
         };
         let json = serde_json::to_string(&cfg).unwrap();
         let back: WorkflowConfig = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.timeout, Some(Duration::from_millis(30_000)));
+        assert_eq!(back.timeout, Some(Duration::from_secs(30)));
         assert_eq!(back.max_parallel_nodes, 5);
         assert!(!back.checkpointing.enabled);
-        assert_eq!(
-            back.checkpointing.interval,
-            Some(Duration::from_millis(1_000))
-        );
+        assert_eq!(back.checkpointing.interval, Some(Duration::from_secs(1)));
         assert!(back.retry_policy.is_some());
     }
 

--- a/crates/workflow/src/graph.rs
+++ b/crates/workflow/src/graph.rs
@@ -56,7 +56,7 @@ impl DependencyGraph {
     /// Returns `true` if the graph contains at least one cycle.
     #[must_use]
     pub fn has_cycle(&self) -> bool {
-        petgraph::algo::is_cyclic_directed(&self.graph)
+        algo::is_cyclic_directed(&self.graph)
     }
 
     /// Topological sort of the graph. Returns an error if a cycle exists.

--- a/crates/workflow/src/node.rs
+++ b/crates/workflow/src/node.rs
@@ -58,7 +58,7 @@ pub struct NodeDefinition {
 ///   max_requests: 60
 ///   window_secs: 60
 /// ```
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RateLimit {
     /// Maximum requests allowed within the window.
     pub max_requests: u32,
@@ -278,7 +278,7 @@ mod tests {
         let pv = ParamValue::expression("{{ nodes.a.output.count + 1 }}");
         match pv {
             ParamValue::Expression { expr } => {
-                assert_eq!(expr, "{{ nodes.a.output.count + 1 }}")
+                assert_eq!(expr, "{{ nodes.a.output.count + 1 }}");
             },
             _ => panic!("expected Expression"),
         }

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -56,7 +56,7 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
     // `Connection` cannot derive `Hash` (because `serde_json::Value` doesn't implement it),
     // so we serialize each connection to a canonical JSON string and use a HashSet<String>
     // for O(n) average-case detection.
-    let mut seen_connections: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut seen_connections: HashSet<String> = HashSet::new();
     for conn in &definition.connections {
         let key = serde_json::to_string(conn).unwrap_or_default();
         if !seen_connections.insert(key) {
@@ -282,7 +282,7 @@ mod tests {
     fn trigger_validation_rejects_invalid_webhook_path() {
         let a = node_key!("a");
         let mut def = make_definition("webhook-test", vec![node(a)], vec![]);
-        def.trigger = Some(crate::definition::TriggerDefinition::Webhook {
+        def.trigger = Some(TriggerDefinition::Webhook {
             method: "POST".into(),
             path: "no-leading-slash".into(),
         });
@@ -299,7 +299,7 @@ mod tests {
     fn trigger_validation_rejects_empty_cron_expression() {
         let a = node_key!("a");
         let mut def = make_definition("cron-test", vec![node(a)], vec![]);
-        def.trigger = Some(crate::definition::TriggerDefinition::Cron {
+        def.trigger = Some(TriggerDefinition::Cron {
             expression: String::new(),
         });
         let errors = validate_workflow(&def);
@@ -315,7 +315,7 @@ mod tests {
     fn trigger_validation_accepts_valid_webhook() {
         let a = node_key!("a");
         let mut def = make_definition("webhook-ok", vec![node(a)], vec![]);
-        def.trigger = Some(crate::definition::TriggerDefinition::Webhook {
+        def.trigger = Some(TriggerDefinition::Webhook {
             method: "POST".into(),
             path: "/hooks/incoming".into(),
         });
@@ -332,7 +332,7 @@ mod tests {
     fn trigger_validation_accepts_valid_cron() {
         let a = node_key!("a");
         let mut def = make_definition("cron-ok", vec![node(a)], vec![]);
-        def.trigger = Some(crate::definition::TriggerDefinition::Cron {
+        def.trigger = Some(TriggerDefinition::Cron {
             expression: "0 */5 * * *".into(),
         });
         let errors = validate_workflow(&def);

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -51,3 +51,6 @@ path = "validator_derive.rs"
 [[bin]]
 name = "validator_macro"
 path = "validator_macro.rs"
+
+[lints]
+workspace = true

--- a/examples/batch_products.rs
+++ b/examples/batch_products.rs
@@ -10,7 +10,11 @@
 //! `BatchItemResult::Failed` without aborting the rest of the batch.
 //! The default `batch_size = 5` chunks the 13 items into 3 iterations.
 
-use nebula_sdk::prelude::*;
+use nebula_sdk::prelude::{
+    Action, ActionContext, ActionDependencies, ActionError, ActionMetadata, BatchAction,
+    BatchItemResult, Deserialize, TestContextBuilder, TestRuntime, Value, action_key,
+    impl_batch_action, json,
+};
 
 // ── Action definition ──────────────────────────────────────────────────────
 
@@ -56,15 +60,14 @@ impl BatchAction for DummyJsonProductsBatchAction {
     }
 
     fn extract_items(&self, input: &Self::Input) -> Vec<u32> {
-        input
-            .get("ids")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
+        input.get("ids").and_then(|v| v.as_array()).map_or_else(
+            || vec![1, 2, 3, 4, 5, 6, 7, 8, 9999, 9, 10, 11, 12],
+            |arr| {
                 arr.iter()
                     .filter_map(|v| v.as_u64().map(|n| n as u32))
                     .collect()
-            })
-            .unwrap_or_else(|| vec![1, 2, 3, 4, 5, 6, 7, 8, 9999, 9, 10, 11, 12])
+            },
+        )
     }
 
     async fn process_item(

--- a/examples/hello_action.rs
+++ b/examples/hello_action.rs
@@ -27,7 +27,12 @@
 //! a custom struct, mirror the `AddAction` test in
 //! `crates/action/src/stateless.rs`.
 
-use nebula_sdk::{nebula_action::stateless_fn, prelude::*};
+use nebula_sdk::{
+    nebula_action::stateless_fn,
+    prelude::{
+        ActionError, ActionMetadata, TestContextBuilder, TestRuntime, Value, action_key, json,
+    },
+};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/examples/paginated_users.rs
+++ b/examples/paginated_users.rs
@@ -11,7 +11,11 @@
 //! it through [`TestRuntime::run_stateful`] — one line for context, one for
 //! the run, no adapter wiring.
 
-use nebula_sdk::prelude::*;
+use nebula_sdk::prelude::{
+    Action, ActionContext, ActionDependencies, ActionError, ActionMetadata, Deserialize,
+    PageResult, PaginatedAction, Serialize, TestContextBuilder, TestRuntime, Value, action_key,
+    impl_paginated_action, json,
+};
 
 // ── Action definition ──────────────────────────────────────────────────────
 

--- a/examples/poll_habr.rs
+++ b/examples/poll_habr.rs
@@ -24,7 +24,11 @@
 
 use std::time::Duration;
 
-use nebula_sdk::prelude::*;
+use nebula_sdk::prelude::{
+    Action, ActionDependencies, ActionError, ActionMetadata, DeduplicatingCursor, PollAction,
+    PollConfig, PollCursor, PollResult, Serialize, TestContextBuilder, TestRuntime, TriggerContext,
+    action_key,
+};
 
 // ── Action definition ──────────────────────────────────────────────────────
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,19 @@
+# Pin the project's default toolchain.
+#
+# This locks `rustc`, `cargo`, `clippy` and `rustfmt` that `cargo <cmd>` invokes
+# without an explicit override to the workspace's declared `rust-version`.
+#
+# Notes:
+# - `cargo +nightly fmt --all` still works: rustup installs nightly on demand
+#   when the `+toolchain` override is used. Nightly rustfmt is required by
+#   `rustfmt.toml` (`unstable_features = true`).
+# - `rust-src` and `rust-analyzer` are included so IDE / std-expansion features
+#   work out of the box after `rustup show active-toolchain` in a fresh clone.
+# - Legacy `rust-toolchain` (without the `.toml` extension) is still accepted
+#   by rustup for backwards compatibility, but the TOML form is the
+#   recommended format per the rustup book.
+
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy", "rust-src", "rust-analyzer"]
+profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,28 +6,50 @@
 #     cargo +nightly fmt --all
 #
 # CI formatting check is pinned to nightly in `.github/workflows/ci.yml`.
-# `cargo build`/`clippy`/`test` stay on stable `rust-version` from the
-# workspace Cargo.toml — only `cargo fmt` is nightly-only.
+# `cargo build`/`clippy`/`test` stay on stable `rust-version` (1.95) from the
+# workspace Cargo.toml (pinned in `rust-toolchain.toml`) — only `cargo fmt`
+# is nightly-only.
 
+# ── Parser / Style Guide editions ──────────────────────────────────────────
 edition = "2024"
+style_edition = "2024"
+
+# ── Width / layout knobs ───────────────────────────────────────────────────
 max_width = 100
 hard_tabs = false
 newline_style = "Unix"
-reorder_imports = true
-use_field_init_shorthand = true
-use_try_shorthand = true
 match_block_trailing_comma = true
 
-# ── Unstable features (require nightly rustfmt) ─────────────────────────
+# ── Misc stable niceties ───────────────────────────────────────────────────
+reorder_imports = true
+reorder_modules = true
+use_field_init_shorthand = true
+use_try_shorthand = true
+merge_derives = true
+
+# ── Unstable features (require nightly rustfmt) ────────────────────────────
 unstable_features = true
 
-# Group imports: std → external crates → crate::
+# Imports: group std → external crates → crate::, then collapse same-crate
+# `use` lines into a single `use { … }` block. Massively reduces churn.
 group_imports = "StdExternalCrate"
-# Collapse multiple `use` lines from the same crate into a single `use {..}`
 imports_granularity = "Crate"
 
-# Comments: wrap long lines and format code fences inside doc comments.
+# Comments: wrap long lines, format code fences inside doc comments, and
+# collapse `#[doc = "…"]` to `///` form.
 wrap_comments = true
 comment_width = 100
 format_code_in_doc_comments = true
 normalize_comments = true
+normalize_doc_attributes = true
+
+# Format the matchers and bodies of `macro_rules!` declarations. `rustfmt`
+# only touches macros it can parse, so this is safe for the token-soup cases.
+format_macro_matchers = true
+format_macro_bodies = true
+
+# Unify hex literal casing to lowercase (`0xFF` → `0xff`).
+hex_literal_case = "Lower"
+
+# Collapse trailing wildcard tuple / struct patterns: `(_, _, _)` → `(..)`.
+condense_wildcard_suffixes = true


### PR DESCRIPTION
## Summary

Pin the toolchain, refresh formatter/linter configs, and wire a workspace-wide Clippy lint policy so that `cargo clippy --workspace -- -D warnings` becomes a real gate. Until now only default lints were enforced; `pedantic`/`nursery`/`cargo` groups were invisible and there was no single place to turn stylistic knobs on/off.

## Linked issue

- Refs NEB-

## Type of change

- [x] `chore` — tooling, maintenance, dependencies
- [x] `ci` — CI configuration or workflow changes *(indirect: the clippy job now has bite)*

## Affected crates / areas

- workspace root (`Cargo.toml`, `clippy.toml`, `rustfmt.toml`, new `rust-toolchain.toml`)
- every workspace member (`crates/*/Cargo.toml`, `apps/cli/Cargo.toml`, `examples/Cargo.toml`) — adds `[lints] workspace = true`
- small source-level fallout fixes across many crates (see below)

## Changes

- **`rust-toolchain.toml`** — pin stable `1.95.0` + `clippy` / `rustfmt` / `rust-src` / `rust-analyzer`. Legacy `rust-toolchain` (no extension) is still accepted but the TOML form is the [recommended format per the rustup book](https://rust-lang.github.io/rustup/overrides.html).
- **`clippy.toml`** — layered onto the existing config with 1.95 options:
  - naming: `min-ident-chars-threshold`, `allowed-idents-below-min-chars`, `allowed-prefixes`, `struct-field-name-threshold`, `enum-variant-name-threshold`, `upper-case-acronyms-aggressive = false`.
  - const-context ergonomics: `allow-expect-in-consts`, `allow-unwrap-in-consts`.
  - `undocumented_unsafe_blocks` SAFETY-comment placement: `accept-comment-above-statement`, `accept-comment-above-attributes`.
  - misc: `matches-for-let-else = "WellKnownTypes"`, `enforce-iter-loop-reborrow`, `warn-unsafe-macro-metavars-in-private-macros`, expanded `doc-valid-idents`.
- **`rustfmt.toml`** — `style_edition = "2024"`, `normalize_doc_attributes`, `format_macro_matchers` / `format_macro_bodies`, `hex_literal_case = "Lower"`, `condense_wildcard_suffixes`, explicit `reorder_modules` / `merge_derives`. Invasive options (`reorder_impl_items`, `overflow_delimited_expr`) were tried, diffed, and rejected — they reshuffle code without clear win.
- **`[workspace.lints]`** — strict-by-default: `clippy::pedantic`, `nursery`, `cargo` as `warn` with `priority = -1`; explicit, commented `allow` list for documented-noisy lints (`module_name_repetitions`, `similar_names`, `cast_*` at IO/codec boundaries, `option_if_let_else`, …); `clippy::mem_forget = "deny"`.
- Moved `cfg(loom)` `unexpected_cfgs` check-cfg from `nebula-resilience` up to the workspace so every crate can switch on `workspace = true` uniformly.
- **`[lints] workspace = true`** added to every workspace member.
- **Fallout fixes** so `-D warnings` actually passes:
  - `#![allow(unsafe_code)]` (with `reason = ...`) on the four files that call `std::env::set_var` / `remove_var` — those are `unsafe fn` under edition 2024.
  - `#![allow(dead_code)]` on `crates/eventbus/tests/helpers.rs` (consumed by a sibling integration-test binary — Rust cannot see the cross-binary usage).
  - Dropped unused imports, underscore-separator formatting on long literal constants, trailing-semicolon fixes in `validator` and `credential`, API-contract `#[allow]` on two tests that construct every enum variant.
  - Several hundred mechanical suggestions applied via `cargo clippy --fix` (uninlined format args, redundant closures, `semicolon_if_nothing_returned`, etc.).

## Test plan

- `cargo +nightly fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-targets --no-deps -- -D warnings` — **0 warnings** (down from 2971 on the first run).
- `cargo nextest run --workspace` — **3404 tests pass**, 13 skipped.
- `cargo test --workspace --doc` — all doctests pass.
- `taplo fmt --check` — clean.
- `lefthook run pre-push` — green (typos, cargo-deny, fmt-check, clippy, taplo, doctests, check-no-default, nextest).

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — passes
- [x] `cargo test --workspace --doc` — doctests pass
- [x] `cargo deny check` — no new advisories

## Breaking changes

None. This is tooling / lint configuration only; no public API or runtime behavior changes.

## Notes for reviewers

- The `allow` list in `[workspace.lints.clippy]` is deliberately **documented** — each entry either cites a structural reason (macro expansion noise, re-export façade) or identifies a load-bearing idiom (`cast_*` at hashing boundaries, `let _ = tokio::spawn(...)` as fire-and-forget). Worth scanning to confirm none of those allows hide something you'd rather see flagged.
- `let_underscore_drop`, `missing_docs`, `missing_debug_implementations`, `unreachable_pub` are intentionally **not** enabled workspace-wide yet — rationale is inlined in `Cargo.toml`. These are candidates for a follow-up PR once the core stabilises.
- Only the four files doing `std::env::set_var` got crate/module-scoped `allow(unsafe_code)`; everywhere else `unsafe_code = "warn"` is live, so future `unsafe` blocks will light up in review.
- `rust-toolchain.toml` changes what `cargo <cmd>` without `+channel` resolves to locally. `cargo +nightly fmt` still works because rustup installs nightly on demand when the `+toolchain` override is used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)