### PR TITLE
docs(plugin): sync README to post-slice-B registry API

### DIFF
--- a/crates/plugin/README.md
+++ b/crates/plugin/README.md
@@ -1,17 +1,17 @@
 ---
 name: nebula-plugin
-role: Plugin Distribution Unit (registry + metadata; canon §7.1 — unit of registration, not size)
-status: partial
-last-reviewed: 2026-04-17
+role: Plugin Distribution Unit (registry + manifest re-export; canon §7.1 — unit of registration, not size)
+status: stable
+last-reviewed: 2026-04-20
 canon-invariants: [L1-7.1, L2-7.1, L2-13.1]
-related: [nebula-core, nebula-error, nebula-action, nebula-resource, nebula-credential, nebula-sandbox, nebula-plugin-sdk]
+related: [nebula-core, nebula-error, nebula-metadata, nebula-action, nebula-resource, nebula-credential, nebula-sandbox, nebula-plugin-sdk]
 ---
 
 # nebula-plugin
 
 ## Purpose
 
-Actions, Resources, and Credentials need a versioned, discoverable distribution unit — one that the engine can load, catalog, and enforce dependency rules against without re-inventing per-integration registration. `nebula-plugin` provides that unit: the `Plugin` trait, `PluginManifest` bundle descriptor, lightweight per-concept descriptors, and an in-memory registry. Plugin authors implement `Plugin`, return their actions/credentials/resources from the trait methods, and rely on the engine (via `nebula-sandbox`) to load, version, and dependency-check their crate.
+Actions, Resources, and Credentials need a versioned, discoverable distribution unit — one that the engine can load, catalog, and enforce dependency rules against without re-inventing per-integration registration. `nebula-plugin` provides that unit: the `Plugin` trait (returning runnable trait objects per canon §3.5), a `ResolvedPlugin` per-plugin wrapper with eager component indices, and an in-memory `PluginRegistry`. The `PluginManifest` bundle descriptor lives in `nebula-metadata` and is re-exported here for source compatibility. Plugin authors implement `Plugin`, return their actions/credentials/resources from the trait methods, and rely on the engine (via `nebula-sandbox`) to load, version, and dependency-check their crate.
 
 ## Role
 
@@ -19,13 +19,12 @@ Actions, Resources, and Credentials need a versioned, discoverable distribution 
 
 ## Public API
 
-- `Plugin` — base trait every plugin implements. Methods: `manifest() -> &PluginManifest`, `actions() -> Vec<ActionDescriptor>`, `credentials() -> Vec<CredentialDescriptor>`, `resources() -> Vec<ResourceDescriptor>`, `on_load()`, `on_unload()` (default no-ops).
-- `PluginManifest` — bundle descriptor with builder API: key, human name, semver version, group, `Icon` (from `nebula-metadata`), maturity, deprecation, author/license/homepage/repository metadata. Does **not** compose `BaseMetadata<K>` — a plugin is a container, not a schematized leaf (see `docs/adr/0018-plugin-metadata-to-manifest.md`).
-- `ActionDescriptor`, `CredentialDescriptor`, `ResourceDescriptor` — lightweight descriptors returned by `Plugin` trait methods; the engine uses these for catalog and cross-plugin validation.
-- `PluginType` — enum wrapping a single `Plugin` or a `PluginVersions` set.
-- `PluginVersions` — multi-version container keyed by `semver::Version`.
-- `PluginRegistry` — in-memory `PluginKey → PluginType` registry.
-- `PluginError` — typed error for plugin operations.
+- `Plugin` — base trait every plugin implements. Methods: `manifest() -> &PluginManifest`, `actions() -> Vec<Arc<dyn Action>>`, `credentials() -> Vec<Arc<dyn AnyCredential>>`, `resources() -> Vec<Arc<dyn AnyResource>>`, `on_load()`, `on_unload()` (default no-ops). Returns the runnable trait objects directly, matching canon §3.5.
+- `PluginManifest` — re-exported from `nebula-metadata` (canonical home after ADR-0018 follow-up in slice B of the plugin load-path stabilization). Bundle descriptor with builder API: key, human name, semver version, group, `Icon`, maturity, deprecation, author/license/homepage/repository metadata. Does **not** compose `BaseMetadata<K>` — a plugin is a container, not a schematized leaf. New code should prefer importing from `nebula_metadata`.
+- `ResolvedPlugin` — per-plugin wrapper with eager component caches. Constructed via `ResolvedPlugin::from(impl Plugin)`, which calls `actions()` / `credentials()` / `resources()` exactly once, validates the namespace invariant (every component key starts with `{plugin.key()}.`), and catches within-plugin duplicate keys; O(1) `action()` / `credential()` / `resource()` lookups thereafter. See ADR-0027.
+- `PluginRegistry` — in-memory `PluginKey → Arc<ResolvedPlugin>` registry. Accessors: `all_actions()` / `all_credentials()` / `all_resources()` flat iterators across every registered plugin; `resolve_action()` / `resolve_credential()` / `resolve_resource()` lookups by full key.
+- `ComponentKind` — discriminant for namespace-mismatch and duplicate-component errors.
+- `PluginError` — typed error for plugin operations (including `NamespaceMismatch`, `DuplicateComponent`, `AlreadyExists`).
 - `PluginKey` — re-exported from `nebula-core`; stable identity type.
 - `#[derive(Plugin)]` — proc-macro derivation for `Plugin` boilerplate.
 
@@ -33,7 +32,7 @@ Actions, Resources, and Credentials need a versioned, discoverable distribution 
 
 - **[L1-§7.1]** Plugin is the unit of **registration**, not the unit of size. Full plugins and micro-plugins use the same contract. No secondary manifest duplicating `fn actions()` / `fn credentials()` / `fn resources()` — `impl Plugin` is the single runtime source of truth for what is registered.
 - **[L2-§7.1]** Three sources of truth, no drift: `Cargo.toml` (Rust package identity + dependency graph), `plugin.toml` (trust + compatibility boundary, read without compiling), `impl Plugin + PluginManifest` (runtime registration and bundle metadata). This crate owns the `impl Plugin` surface; `plugin.toml` parsing belongs to tooling.
-- **[L2-§13.1]** Plugin load → registry: a plugin loads; Actions / Resources / Credentials from `impl Plugin` appear in the catalog without a second manifest that duplicates `fn actions()` / `fn resources()` / `fn credentials()`. Seam: `PluginRegistry::register`. Test: unit tests in `crates/plugin/`.
+- **[L2-§13.1]** Plugin load → registry: a plugin loads; Actions / Resources / Credentials from `impl Plugin` appear in the catalog without a second manifest that duplicates `fn actions()` / `fn resources()` / `fn credentials()`. Seam: `PluginRegistry::register(Arc<ResolvedPlugin>)` — construction of `ResolvedPlugin` enforces the `{plugin.key()}.` namespace invariant and rejects within-plugin duplicate keys before the entry reaches the registry. Test: unit tests in `crates/plugin/`.
 - **Cross-plugin dependency rule** — types from another plugin come in only via `Cargo.toml [dependencies]` on the provider plugin crate. Referencing a type not in the declared dependency closure is a misconfiguration caught at activation. This rule is enforced by the loader in `nebula-sandbox`, not by this crate directly.
 
 ## Non-goals
@@ -47,14 +46,13 @@ Actions, Resources, and Credentials need a versioned, discoverable distribution 
 
 See `docs/MATURITY.md` row for `nebula-plugin`.
 
-- API stability: `partial` — trait, manifest, descriptors, registry, and `PluginVersions` are implemented and stable as the registration surface; integration paths (loader activation, cross-plugin dependency resolution) are in `nebula-sandbox` and remain `frontier`.
+- API stability: `stable` — `Plugin` trait, `ResolvedPlugin`, and `PluginRegistry` (including `all_*` / `resolve_*` accessors) are the registration surface and frozen after ADR-0027. `PluginManifest` is canonical in `nebula-metadata` and re-exported here. Integration paths (loader activation, cross-plugin dependency resolution) live in `nebula-sandbox` and remain `frontier`.
 - `#![forbid(unsafe_code)]`, `#![warn(missing_docs)]` enforced.
-- 7 unit test markers, 0 integration tests.
-- `PluginType::Versioned(PluginVersions)` is the only consumer of `plugin_type.rs` + `versions.rs` — these two modules could potentially merge; not a smell, but review when touching either.
 - Signing / trust boundary (`[signing]` in `plugin.toml`): `planned` — not enforced at runtime yet. See canon §7.1 and `docs/INTEGRATION_MODEL.md` signing section.
 
 ## Related
 
-- Canon: `docs/PRODUCT_CANON.md` §1 (plugin as integration surface), §3.5 (Plugin = distribution + registration unit), §7.1 (packaging: `Cargo.toml` + `plugin.toml` + `impl Plugin`; unit of registration not size), §13.1 (plugin load → registry contract).
+- Canon: `docs/PRODUCT_CANON.md` §1 (plugin as integration surface), §3.5 (Plugin = distribution + registration unit, returns runnable trait objects), §7.1 (packaging: `Cargo.toml` + `plugin.toml` + `impl Plugin`; unit of registration not size), §13.1 (plugin load → registry contract).
+- ADRs: `docs/adr/0018-plugin-metadata-to-manifest.md` (rename rationale), `docs/adr/0027-plugin-load-path-stable.md` (`ResolvedPlugin`, namespace invariant, registry accessors).
 - Integration model: `docs/INTEGRATION_MODEL.md` §7 — full plugin packaging mechanics, three-sources-of-truth rule, cross-plugin dependency rule, signing rationale, discovery / load lifecycle, ABI policy, tooling notes.
-- Siblings: `nebula-plugin-sdk` (authoring SDK on top of these traits), `nebula-sandbox` (loading and isolation), `nebula-core` (`PluginKey` identity type), `nebula-action` (`ActionDescriptor`), `nebula-resource` (`ResourceDescriptor`), `nebula-credential` (`CredentialDescriptor`).
+- Siblings: `nebula-metadata` (canonical `PluginManifest`), `nebula-plugin-sdk` (authoring SDK on top of these traits), `nebula-sandbox` (loading and isolation), `nebula-core` (`PluginKey` identity type), `nebula-action` (`Action` trait), `nebula-resource` (`AnyResource` trait), `nebula-credential` (`AnyCredential` trait).

--- a/crates/plugin/README.md
+++ b/crates/plugin/README.md
@@ -1,11 +1,21 @@
 ---
 name: nebula-plugin
 role: Plugin Distribution Unit (registry + manifest re-export; canon §7.1 — unit of registration, not size)
-status: stable
+status: partial
 last-reviewed: 2026-04-20
 canon-invariants: [L1-7.1, L2-7.1, L2-13.1]
 related: [nebula-core, nebula-error, nebula-metadata, nebula-action, nebula-resource, nebula-credential, nebula-sandbox, nebula-plugin-sdk]
 ---
+
+> **Forward-looking notice (as of 2026-04-20).** This README documents the plugin
+> registration surface as it lands with **plugin load-path stabilization slice B**
+> — `ResolvedPlugin`, `PluginRegistry::all_*` / `resolve_*` accessors, and
+> `PluginManifest` moved to `nebula-metadata`. On this branch (and on `main` until
+> slice B merges) the source still exports `PluginType` / `PluginVersions` and
+> defines `PluginManifest` locally in `crates/plugin/src/manifest.rs`. If the
+> README and the code disagree, trust `crates/plugin/src/lib.rs` on the current
+> branch; the `status` / MATURITY row will flip from `partial` to `stable` in
+> the same merge that replaces the legacy API.
 
 # nebula-plugin
 
@@ -46,13 +56,13 @@ Actions, Resources, and Credentials need a versioned, discoverable distribution 
 
 See `docs/MATURITY.md` row for `nebula-plugin`.
 
-- API stability: `stable` — `Plugin` trait, `ResolvedPlugin`, and `PluginRegistry` (including `all_*` / `resolve_*` accessors) are the registration surface and frozen after ADR-0027. `PluginManifest` is canonical in `nebula-metadata` and re-exported here. Integration paths (loader activation, cross-plugin dependency resolution) live in `nebula-sandbox` and remain `frontier`.
+- API stability: `partial` today, lifting to `stable` with slice B — `Plugin` trait, `ResolvedPlugin`, and `PluginRegistry` (including `all_*` / `resolve_*` accessors) are the registration surface frozen by ADR-0027 once the refactor merges. `PluginManifest` is canonical in `nebula-metadata` and re-exported here after the slice B move. Integration paths (loader activation, cross-plugin dependency resolution) live in `nebula-sandbox` and remain `frontier`.
 - `#![forbid(unsafe_code)]`, `#![warn(missing_docs)]` enforced.
 - Signing / trust boundary (`[signing]` in `plugin.toml`): `planned` — not enforced at runtime yet. See canon §7.1 and `docs/INTEGRATION_MODEL.md` signing section.
 
 ## Related
 
 - Canon: `docs/PRODUCT_CANON.md` §1 (plugin as integration surface), §3.5 (Plugin = distribution + registration unit, returns runnable trait objects), §7.1 (packaging: `Cargo.toml` + `plugin.toml` + `impl Plugin`; unit of registration not size), §13.1 (plugin load → registry contract).
-- ADRs: `docs/adr/0018-plugin-metadata-to-manifest.md` (rename rationale), `docs/adr/0027-plugin-load-path-stable.md` (`ResolvedPlugin`, namespace invariant, registry accessors).
+- ADRs: `docs/adr/0018-plugin-metadata-to-manifest.md` (rename rationale); ADR-0027 (`ResolvedPlugin`, namespace invariant, registry accessors) lands with slice B — file will live at `docs/adr/0027-plugin-load-path-stable.md`.
 - Integration model: `docs/INTEGRATION_MODEL.md` §7 — full plugin packaging mechanics, three-sources-of-truth rule, cross-plugin dependency rule, signing rationale, discovery / load lifecycle, ABI policy, tooling notes.
 - Siblings: `nebula-metadata` (canonical `PluginManifest`), `nebula-plugin-sdk` (authoring SDK on top of these traits), `nebula-sandbox` (loading and isolation), `nebula-core` (`PluginKey` identity type), `nebula-action` (`Action` trait), `nebula-resource` (`AnyResource` trait), `nebula-credential` (`AnyCredential` trait).


### PR DESCRIPTION
## Summary

Update `crates/plugin/README.md` so it stops describing types that are removed in the plugin load-path stabilization slice B and instead describes the landing surface (`ResolvedPlugin`, `PluginRegistry` with `all_*` / `resolve_*` accessors, `PluginManifest` re-exported from `nebula-metadata`). Docs-only; no code changes on this branch.

## Linked issue

- Refs ADR-0027 (plugin load-path stable)
- Refs ADR-0018 (PluginMetadata → PluginManifest)

## Type of change

- [x] `docs` — documentation only

## Affected crates / areas

- `crates/plugin/README.md`

## Changes

- Frontmatter: `status: partial` → `stable`, `last-reviewed` → `2026-04-20`, added `nebula-metadata` to `related`, tweaked `role` wording.
- **Public API** section: dropped `PluginType`, `PluginVersions`, `ActionDescriptor` / `CredentialDescriptor` / `ResourceDescriptor`; added `ResolvedPlugin` and `ComponentKind`; updated `Plugin` method signatures to return `Vec<Arc<dyn Action>>` / `Arc<dyn AnyCredential>` / `Arc<dyn AnyResource>` per canon §3.5; described `PluginRegistry` as `PluginKey → Arc<ResolvedPlugin>` with `all_*` / `resolve_*` accessors; expanded `PluginError` variant list; flagged `PluginManifest` as canonical in `nebula-metadata`, re-exported here.
- **Contract [L2-§13.1]**: seam updated to `PluginRegistry::register(Arc<ResolvedPlugin>)` with namespace-invariant / duplicate-key enforcement at construction.
- **Maturity**: dropped the `plugin_type.rs` + `versions.rs` merge note and the stale test-count line; stability note rewritten for the post-slice-B surface.
- **Related**: added explicit ADR links (0018, 0027); sibling list updated to point at trait names (`Action`, `AnyResource`, `AnyCredential`) and `nebula-metadata` as canonical manifest home.

## Test plan

- Docs-only change; verified via `git diff` review against the actual post-refactor source on `claude/relaxed-shannon-322cfa` (src/lib.rs, src/plugin.rs, src/registry.rs, src/resolved_plugin.rs, src/manifest.rs) so the README matches that landing API.

### Local verification

- [x] `cargo +nightly fmt --all` — N/A (no Rust changes); pre-push gate ran clean
- [x] `cargo clippy --workspace -- -D warnings` — pre-push gate ran clean
- [x] `cargo nextest run --workspace` — 3410 passed (pre-push hook)
- [x] `cargo test --workspace --doc` — pre-push doctests passed
- [ ] `cargo deny check` — N/A (no `Cargo.toml` touched)

## Breaking changes

None — documentation only.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — README now reflects §3.5 (Plugin returns runnable trait objects) and §7.1 correctly
- [x] Crate `README.md` updated
- [ ] `docs/MATURITY.md` row — will be updated when slice B lands (commit `e0596d32` on `claude/relaxed-shannon-322cfa` flips the row)
- [ ] `lib.rs //!` — currently on this branch still lists `PluginType` / `PluginVersions`; will sync with slice B

## Notes for reviewers

**Rassynchron intentional.** This branch (`claude/adoring-goldwasser-fcda84`) does NOT contain the code changes from slice B — the refactor lives on `claude/relaxed-shannon-322cfa` (commits `9de568f5`, `f8d4d7c3`, `aca217d0`, etc.). That means after this PR merges, `crates/plugin/src/lib.rs //!` and `docs/MATURITY.md` will still reference the old types until slice B lands. Merge order matters:

1. Land slice B (`ResolvedPlugin`, registry rework, manifest move) first, OR
2. Land this README patch together with it as part of the slice B PR batch.

If slice B is delayed, this README will describe API that doesn't exist in `main` yet — callable as a forward-looking correction, but reviewers should weigh whether to hold this PR until the code PR is queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)