### PR TITLE
chore(credential): P3 audit tokio features; document justification inline

### DIFF
--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -11,6 +11,13 @@ repository.workspace = true
 [dependencies]
 # Async
 async-trait = { workspace = true }
+# Tokio features (audited 2026-04-20, phase P3.1):
+#   `time`   — tokio::time::{timeout, sleep, sleep_until, Instant} in executor,
+#              resolver, refresh, pending_store_memory, rotation/{scheduler,validation}
+#   `sync`   — tokio::sync::{RwLock, Mutex, oneshot, Semaphore} in
+#              refresh (RefreshCoordinator), resolver, store_memory, pending_store_memory
+#   `macros` — #[tokio::test] (100+ sites) and tokio::select! in rotation/scheduler
+#   `rt`     — required by #[tokio::test] expansion and tokio::spawn in tests
 tokio = { workspace = true, features = ["time", "sync", "macros", "rt"] }
 tokio-util = { workspace = true }
 

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -12,11 +12,15 @@ repository.workspace = true
 # Async
 async-trait = { workspace = true }
 # Tokio features (audited 2026-04-20, phase P3.1):
-#   `time`   — tokio::time::{timeout, sleep, sleep_until, Instant} in executor,
-#              resolver, refresh, pending_store_memory, rotation/{scheduler,validation}
-#   `sync`   — tokio::sync::{RwLock, Mutex, oneshot, Semaphore} in
-#              refresh (RefreshCoordinator), resolver, store_memory, pending_store_memory
-#   `macros` — #[tokio::test] (100+ sites) and tokio::select! in rotation/scheduler
+#   `time`   — tokio::time items used across the crate:
+#              `timeout` in executor, resolver, refresh, rotation/validation;
+#              `sleep` in pending_store_memory;
+#              `Instant` + `sleep_until` in rotation/scheduler
+#   `sync`   — tokio::sync items used across the crate:
+#              `RwLock` in store_memory, pending_store_memory;
+#              `Mutex` in resolver;
+#              `oneshot` + `Semaphore` in refresh (RefreshCoordinator)
+#   `macros` — #[tokio::test] (133 sites) and tokio::select! in rotation/scheduler
 #   `rt`     — required by #[tokio::test] expansion and tokio::spawn in tests
 tokio = { workspace = true, features = ["time", "sync", "macros", "rt"] }
 tokio-util = { workspace = true }


### PR DESCRIPTION
## Summary

Phase P3 of credential architecture cleanup ([spec](docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md) §9 / [plan](docs/superpowers/plans/2026-04-20-credential-cleanup-p1-p5.md)). **Single commit, documentation only** — audit tokio feature flags in `crates/credential/Cargo.toml`.

`750f8d15` — audit findings: all 4 current features (`time`, `sync`, `macros`, `rt`) are actively used. Nothing trimmed. Inline justification comments added to document each feature's usage site so future readers + refactors have an audit trail.

## Audit findings

| Feature | Decision | Justification |
|---|---|---|
| `sync` | KEPT | `RwLock`/`Mutex`/`oneshot`/`Semaphore` in refresh/resolver/store_memory/pending_store_memory |
| `time` | KEPT | `timeout`/`sleep`/`Instant` in executor/resolver/refresh/rotation |
| `macros` | KEPT | 133× `#[tokio::test]` + `tokio::select!` in rotation/scheduler |
| `rt` | KEPT | Required by `#[tokio::test]` expansion + explicit `tokio::spawn` in tests |

Grep evidence documented per feature in commit body.

## Scope note

Phase P3 is a **partial** base-dep diet. Larger dep removals (`reqwest`, `url`, tokio-util) are deferred:

- `reqwest` / `url` — stay until P10 (OAuth flow relocates to `nebula-api` / `nebula-engine`)
- `tokio-util` — stays until P8 (`rotation/scheduler.rs` uses `CancellationToken`; moves to engine in P8)
- `nebula-metrics` / `nebula-telemetry` — already removed in P1.4 (orphan deps after `rotation/metrics.rs` deletion)

## Test plan

- [x] `cargo +nightly fmt --all --check` — clean
- [x] `cargo clippy -p nebula-credential -- -D warnings` — clean
- [x] `cargo nextest run -p nebula-credential` — 361/361
- [x] `cargo check --workspace` — clean

Documentation-only change; no behavioral tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)