### PR TITLE
docs(adr): 0028-0031 credential cross-crate invariants; 0023 superseded in location

### DIFF
--- a/docs/adr/0023-keyprovider-trait.md
+++ b/docs/adr/0023-keyprovider-trait.md
@@ -14,7 +14,7 @@ related:
   - docs/adr/0029-storage-owns-credential-persistence.md
   - docs/audit/2026-04-19-codebase-quality-audit.md
   - crates/credential/src/layer/encryption.rs
-  - crates/credential/src/crypto.rs
+  - crates/credential/src/secrets/crypto.rs
 linear: []
 ---
 

--- a/docs/adr/0023-keyprovider-trait.md
+++ b/docs/adr/0023-keyprovider-trait.md
@@ -4,13 +4,14 @@ title: keyprovider-trait
 status: accepted
 date: 2026-04-19
 supersedes: []
-superseded_by: []
+superseded_by: [0029]
 tags: [credential, security, encryption, key-custody, composition-root, canon-12.5]
 related:
   - docs/PRODUCT_CANON.md#125-secrets-and-auth
   - docs/STYLE.md#6-secret-handling
   - docs/adr/0020-library-first-gtm.md
   - docs/adr/0021-crate-publication-policy.md
+  - docs/adr/0029-storage-owns-credential-persistence.md
   - docs/audit/2026-04-19-codebase-quality-audit.md
   - crates/credential/src/layer/encryption.rs
   - crates/credential/src/crypto.rs

--- a/docs/adr/0028-cross-crate-credential-invariants.md
+++ b/docs/adr/0028-cross-crate-credential-invariants.md
@@ -1,0 +1,361 @@
+---
+id: 0028
+title: cross-crate-credential-invariants
+status: accepted
+date: 2026-04-20
+supersedes: []
+superseded_by: []
+tags: [credential, storage, engine, api, security, canon-12.5, canon-13.2, canon-3.5, canon-14, canon-4.5]
+related:
+  - docs/adr/0023-keyprovider-trait.md
+  - docs/adr/0029-storage-owns-credential-persistence.md
+  - docs/adr/0030-engine-owns-credential-orchestration.md
+  - docs/adr/0031-api-owns-oauth-flow.md
+  - docs/adr/0021-crate-publication-policy.md
+  - docs/adr/0025-sandbox-broker-rpc-surface.md
+  - docs/PRODUCT_CANON.md#35-integration-model
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/PRODUCT_CANON.md#132-rotation-refresh-seam
+  - docs/PRODUCT_CANON.md#14-anti-patterns
+  - docs/PRODUCT_CANON.md#45-operational-honesty--no-false-capabilities
+  - docs/STYLE.md#6-secret-handling
+  - docs/MATURITY.md
+  - docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md
+linear: []
+---
+
+# 0028. Cross-crate credential invariants (umbrella)
+
+## Context
+
+`nebula-credential` today is a ~34-module monolith that mixes several
+responsibilities: credential contract (what a `Credential` is), storage work
+(`CredentialStore` + layers), runtime orchestration (rotation scheduler,
+resolver executor), and HTTP flow (OAuth2 reqwest client). This violates SRP
+and breaks symmetry with sibling crates `nebula-action` (thin, contract-only)
+and `nebula-resource` (holds orchestration internally, also irregular —
+addressed by a parallel follow-up spec).
+
+The [`docs/MATURITY.md`](../MATURITY.md) row
+(`frontier / stable / stable / partial / n/a`) reflects this:
+`Engine integration: partial (rotation in integration tests)` — because
+rotation orchestration currently lives in `nebula-credential` instead of
+`nebula-engine`. The crate also pulls unnecessary base deps: `reqwest` (for
+OAuth HTTP), `nebula-metrics` + `nebula-telemetry` (observability),
+`moka` + `lru` (two caches).
+
+The design spec
+[`docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md`](../superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md)
+describes redistribution of responsibilities across four existing crates
+(`credential` → `credential` / `storage` / `engine` / `api`) without creating
+new crates, domain-first submodule grouping in target crates, and a phased
+landing sequence.
+
+Three follow-up ADRs codify the specific moves:
+
+- [ADR-0029](./0029-storage-owns-credential-persistence.md) — storage owns
+  credential persistence (supersedes ADR-0023 in the location of
+  `KeyProvider`).
+- [ADR-0030](./0030-engine-owns-credential-orchestration.md) — engine owns
+  credential orchestration and token refresh.
+- [ADR-0031](./0031-api-owns-oauth-flow.md) — api owns OAuth flow HTTP
+  ceremony.
+
+This ADR is the **umbrella**: a single normative anchor that the three
+migration ADRs cite as the source of invariants. Without it, each migration
+could in isolation drift from canon §12.5 (secrets and auth), §13.2
+(rotation/refresh seam), §3.5 (stored-state vs auth-material split), §14
+(anti-patterns), or §4.5 (operational honesty). The invariants below are
+cross-cutting — they bind all four home crates simultaneously, and no single
+migration ADR can restate them without drift.
+
+## Decision
+
+This ADR fixes eight cross-crate invariants that apply to every PR in the
+credential cleanup series and to every future change that touches credential
+material, persistence, orchestration, or transport.
+
+### 1. §12.5 preservation (encryption at rest)
+
+AES-256-GCM + Argon2id + AAD credential-id binding are preserved
+**bit-for-bit** across the migration. Primitives (`encrypt`/`decrypt`
+functions, `EncryptionKey`, `EncryptedData`) stay in
+`nebula-credential/src/secrets/crypto.rs`. The impl (`EncryptionLayer`)
+moves to `nebula-storage/src/credential/layer/encryption.rs`; the layer
+calls the primitives. **AAD binding code does not change.** Any PR in the
+cleanup series that modifies the AAD wiring without a superseding ADR is
+canon-level wrong.
+
+### 2. §13.2 seam integrity (non-stranding refresh)
+
+`RefreshCoordinator` (the thundering-herd prevention primitive) stays in
+`nebula-credential/src/refresh.rs`. Orchestration concerns — when to
+refresh, grace-period windows, transactional state flip — live in
+`nebula-engine/src/credential/rotation/`. The seam is **defined** in
+credential; the invariant **enforcer** is engine. A PR that moves
+`RefreshCoordinator` to engine without a superseding ADR breaks the seam
+contract.
+
+See [ADR-0030 §RefreshCoordinator design note](./0030-engine-owns-credential-orchestration.md)
+for why the coordinator is kept concrete (not a trait).
+
+### 3. §3.5 stored-state vs auth-material split (preserved)
+
+`Credential::project()` and the `State` / `Pending` associated types stay
+in `nebula-credential`. They are not part of the migration. Auth material
+derivation is a credential-contract concern, not a persistence or
+orchestration concern; moving `project()` would conflate the two
+responsibilities that canon §3.5 deliberately separates.
+
+### 4. §14 no discard-and-log (audit durability)
+
+Audit is **in-line durable** — the audit write happens before the
+credential operation returns. If the audit sink fails, the whole operation
+fails (fail-closed, per spec §8). The fire-and-forget eventbus path
+(`CredentialEvent` on `nebula-eventbus`) is **only** for metrics /
+dashboards / alerts fanout; it does not replace the audit write and does
+not carry security-critical data.
+
+A PR that log-and-discards an audit failure — "log when audit fails,
+continue anyway" — is the exact §14 anti-pattern and is rejected
+categorically. See
+[`CLAUDE.md §"Quick Win trap catalog"`](../../CLAUDE.md) entry
+"Log-and-discard on an outbox consumer."
+
+### 5. §4.5 operational honesty (MATURITY gated on landing)
+
+The `Engine integration` column for `nebula-credential` flips from
+`partial` to `stable` only after all phases land and the engine actually
+drives rotation orchestration end-to-end. The PR series **does not permit**
+flipping the MATURITY row before the corresponding code migration (P6
+onwards) lands. For `nebula-api`, OAuth flow is feature-gated behind
+`credential-oauth` until the `e2e_oauth2_flow` integration test (spec
+§13) is green; `credential-oauth` is not a default feature until then.
+
+Advertising a capability in docs that the code does not deliver is a §11.6
+false capability and violates §4.5.
+
+### 6. Cross-crate compat invariants
+
+- **`CredentialStore` re-export is permanent, not transitional.** The
+  trait moves to `nebula-storage/src/credential/store.rs`, but
+  `nebula-credential::lib.rs` keeps `pub use nebula_storage::CredentialStore;`
+  (or equivalent) as a stable DX alias. Consumers depending on
+  `nebula_credential::CredentialStore` do not need to rewrite imports
+  every three months.
+- **Re-exports do not leak storage-internal types.** Cache impl details,
+  backend-specific hints, and repo internals stay behind the storage
+  crate. The credential re-export surface is **only trait + error + DTO
+  shapes** — impl detail is hidden.
+- **ADR-0023 `KeyProvider` public API moves to storage.** ADR-0029
+  supersedes ADR-0023 in the **location** of the trait. Trait shape,
+  invariants, and impl contracts from ADR-0023 are preserved bit-for-bit
+  — only the crate that owns them changes.
+- **`CredentialRecord`, `CredentialMetadata`, `CredentialKey`,
+  `CredentialEvent` stay in `nebula-credential`.** They are contract
+  types reachable from storage / engine / api via sibling dependencies.
+
+### 7. Zeroize-on-drop at crate boundaries
+
+Any plaintext secret crossing a crate boundary **must** be wrapped in
+`SecretString`, `Zeroizing<T>`, or `CredentialGuard`. The following are
+rejected at review:
+
+- `credential → storage` handoff of a raw `String` containing a token.
+- `storage → engine` handoff of a `Vec<u8>` of plaintext.
+- `engine → api` handoff of a bare `&str` containing a refresh token.
+
+The invariant applies **on all four home crates** (credential, storage,
+engine, api). The redaction fuzz test (spec §13, §8 CI gates) enforces it:
+a crate boundary without a zeroize container that passes a secret-bearing
+field is a CI failure.
+
+See [STYLE.md §6](../STYLE.md#6-secret-handling) for the mandatory
+patterns, anti-patterns, and log-redaction test helper.
+
+### 8. Versioning discipline during alpha
+
+During the migration, all four home crates use **workspace path-deps**
+and do not bump SemVer. `nebula-credential` is named in
+[ADR-0021 §3](./0021-crate-publication-policy.md) as part of the initial
+publish set, but the acceptance of that commitment was for the post-
+migration shape; mid-migration publishes would require every downstream
+consumer to chase pre-release versions per phase. Post-migration, the
+publishing decision is taken in a separate ADR against the settled shape.
+
+## Consequences
+
+**Positive.**
+
+- Every invariant above is citable from the code that upholds it:
+  §12.5 from `secrets/crypto.rs` + `credential/layer/encryption.rs`,
+  §13.2 from `refresh.rs` + `credential/rotation/`, §14 from
+  `AuditLayer` + `AuditSink`, §4.5 from `docs/MATURITY.md` + feature
+  gates. Auditing "is this invariant alive?" is a grep, not an
+  archaeology session.
+- Each migration ADR (0029 / 0030 / 0031) can cite this umbrella without
+  restating the invariants; drift between the three migration ADRs is
+  caught by a review gate against this file.
+- Consumers of `nebula-credential` see a stable DX surface through the
+  migration: `CredentialStore` remains reachable at
+  `nebula_credential::CredentialStore`; zeroize wrappers remain the
+  canonical secret-bearing types; §12.5 primitives remain in credential.
+- Operators do not see silent capability claims: MATURITY and feature
+  gates are tied to actual implementation landing per §4.5.
+
+**Negative / accepted costs.**
+
+- Four ADRs land together as a hard go/no-go checkpoint (plan P5) before
+  any physical crate move. If even one migration ADR is blocked, the
+  entire P6+ sequence stops. This is the intended posture — better a
+  clean intermediate state (P1-P5 cleanup landed, cross-crate moves not
+  yet started) than a half-migrated workspace with drift.
+- The permanent re-export policy (invariant 6) means two canonical
+  import paths exist for `CredentialStore` (`nebula_credential::…` and
+  `nebula_storage::…`). Documented in `nebula-credential::lib.rs` doc;
+  rustdoc rendering links both, consumers pick either. The alternative
+  — forcing a global import rewrite every migration — is worse.
+- Zeroize-at-crate-boundaries invariant (7) adds redaction-test rows per
+  new cross-crate seam. One test per verb/operation per boundary. Spec
+  §8 CI gates quantify the ongoing cost (order of 10 tests total across
+  the four home crates after migration completes).
+
+**Neutral.**
+
+- The invariants are cross-cutting, not new. §12.5 was already canon;
+  §13.2 was already a seam; §14 was already an anti-pattern. This ADR
+  makes each enforceable across four crates simultaneously. Nothing
+  about canon changes; what changes is the enforcement surface area.
+- The umbrella defers specifics to 0029 / 0030 / 0031. Each satellite
+  ADR is shorter because it cites this one instead of restating the
+  invariants.
+- Does not change `KeyProvider`'s shape or semantics from ADR-0023 —
+  only its location (handled in ADR-0029).
+
+## Alternatives considered
+
+### A. Model A — status quo
+
+**Rejected.** `nebula-credential` stays a 34-module monolith. Observable
+costs: violates SRP, breaks symmetry with `nebula-action` and (the future
+symmetric) `nebula-resource`, blocks `Engine integration` MATURITY
+improvement, keeps unnecessary base deps (`reqwest`, `nebula-metrics`,
+`nebula-telemetry`, redundant caches). The crate would remain the place
+where new credential-adjacent concerns land by default, compounding the
+problem.
+
+### B. Model B+ — sister crate for rotation orchestration
+
+**Rejected.** A fifth crate (`nebula-credential-rotation`) would own
+rotation orchestration. Observable costs: adds workspace-member count
+without reducing responsibility sprawl (we would still have credential +
+storage + engine + api layers all touching credentials, plus a fifth crate
+that only owns rotation). Engine already owns execution orchestration;
+rotation is a lifecycle concern of execution, not an independent domain.
+Putting rotation adjacent to `engine/control_consumer.rs` (where cancel
+and resume orchestration already live) is the right adjacency.
+
+### C. Full n8n-parity immediate
+
+**Rejected.** A one-shot rewrite matching n8n's credential subsystem
+(five controllers, one helper, one refresh service, three repos) in a
+single PR. Observable costs: blast radius too large to review; every
+canon invariant would have to be re-verified against a ~2000-LOC diff
+instead of a ~200-LOC diff per phase. The n8n-parity layout is the
+**target**; the phased landing is the **path**. This ADR governs the
+path; the spec §12 phases define the sequencing.
+
+### D. No ADR, handle invariants in each migration ADR
+
+**Rejected.** Three migration ADRs each restating the same eight
+invariants would drift within weeks — one ADR would tighten a condition
+while another would loosen it, and no single canonical statement of the
+cross-cutting contract would exist. The umbrella pattern (one ADR names
+the invariants, three migration ADRs cite them) is the standard resolution
+for cross-cutting constraints.
+
+### E. Inline invariants in PRODUCT_CANON.md directly
+
+**Rejected.** The canon sections cited above (§12.5, §13.2, §3.5, §14,
+§4.5) already express the invariants at the level of principle. This
+ADR translates those principles into the specific cross-crate shape the
+four home crates take after migration. Canon should say "secrets are
+encrypted at rest"; ADRs should say "the primitive lives here, the impl
+lives there, the AAD binding is bit-for-bit preserved, a PR that touches
+the AAD wiring opens a superseding ADR." The division of labor between
+canon and ADRs is correct as-is.
+
+## Seam / verification
+
+Files that will carry the invariants (post-migration shape, see spec §2):
+
+- `crates/credential/src/secrets/crypto.rs` — §12.5 primitives
+  (`encrypt`, `decrypt`, `EncryptionKey`, `EncryptedData`). Invariant 1.
+- `crates/storage/src/credential/layer/encryption.rs` — `EncryptionLayer`
+  impl; AAD binding preserved bit-for-bit. Invariant 1.
+- `crates/credential/src/refresh.rs` — `RefreshCoordinator` primitive.
+  Invariant 2.
+- `crates/engine/src/credential/rotation/` — orchestration
+  (`scheduler.rs`, `grace_period.rs`, `blue_green.rs`, `transaction.rs`,
+  `token_refresh.rs`). Invariant 2, 5.
+- `crates/credential/src/contract/` — `Credential` trait + `State` /
+  `Pending` associated types. Invariant 3.
+- `crates/storage/src/credential/layer/audit.rs` — `AuditSink` trait +
+  `AuditLayer` (in-line durable). Invariant 4.
+- `crates/credential/src/event.rs` — `CredentialEvent` for eventbus
+  fanout (metrics only). Invariant 4.
+- `crates/storage/src/credential/pending.rs` — encrypted-at-rest pending
+  store. Invariant 7 (zeroize at boundary); see ADR-0029.
+- `crates/engine/src/credential/rotation/token_refresh.rs` — reqwest
+  client + redaction filter. Invariant 7; see ADR-0030.
+- `crates/api/src/credential/` — OAuth controller + flow + state.
+  Invariant 7; see ADR-0031.
+- `docs/MATURITY.md` — credential row, api row. Invariant 5.
+
+Test coverage:
+
+- `crates/storage/tests/credential_encryption_invariants.rs` — AAD
+  round-trip, rotation, CAS-on-rotate, legacy alias (migrated from
+  `crates/credential/tests/units/encryption_tests.rs`). Invariant 1.
+- `crates/storage/tests/credential_audit_durable.rs` — mock audit sink
+  fails → operation returns `StoreError`. Invariant 4.
+- `crates/storage/tests/credential_eventbus_fanout.rs` — subscriber
+  crash → credential op continues unblocked. Invariant 4.
+- `crates/credential/tests/redaction.rs` — extended fuzz: one case per
+  credential operation (put / get / rotate / refresh / resolve /
+  oauth_exchange). Invariant 7.
+- `crates/api/tests/e2e_oauth2_flow.rs` — end-to-end cycle across all
+  four crates. Invariant 5 (gate on MATURITY flip).
+
+CI signals that catch regressions:
+
+- **Layer direction** (`deny.toml`): credential does not depend on
+  storage / engine / api; storage may depend on credential; engine /
+  api may depend on credential + storage. Updates land with the
+  corresponding P6 / P8 / P10 PRs, not after — policy-layer audit
+  blocked until `deny.toml` reflects the new edge.
+- **Feature matrix**: CI runs `--all-features` and `--no-default-features`
+  legs for `nebula-api` from P10 onwards; without this `credential-oauth`
+  silently bitrots between releases.
+- **Redaction fuzz**: every new credential verb / cross-crate boundary
+  adds a row to the fuzz test that greps all outputs (audit rows,
+  eventbus emissions, tracing spans) for secret substrings.
+
+## Follow-ups
+
+- [ADR-0029](./0029-storage-owns-credential-persistence.md) — storage
+  owns credential persistence (supersedes ADR-0023 §KeyProvider
+  location). Downstream.
+- [ADR-0030](./0030-engine-owns-credential-orchestration.md) — engine
+  owns credential orchestration + token refresh. Downstream.
+- [ADR-0031](./0031-api-owns-oauth-flow.md) — api owns OAuth flow HTTP
+  ceremony. Downstream.
+- **Phase P6-P11 implementation PRs** per spec §12. Each PR cites this
+  ADR + the relevant migration ADR. MATURITY row flip is P11 only.
+- **`nebula-resource` symmetric rework** — follow-up spec restores
+  symmetry between `nebula-credential` (post-migration) and
+  `nebula-resource`. Out of scope for this ADR set.
+- **Post-migration publishing decision** — ADR-0021 §3 named
+  `nebula-credential` in the initial publish set; the publishing
+  decision is revisited against the settled post-migration shape in
+  a dedicated ADR.

--- a/docs/adr/0029-storage-owns-credential-persistence.md
+++ b/docs/adr/0029-storage-owns-credential-persistence.md
@@ -279,10 +279,12 @@ wholesale to `crates/storage/tests/` and pin invariants 1-6 above.
 - AAD binding at the former `encryption.rs:146-211` — credential-id is
   AAD, AAD-less records rejected, record-swapping rejected — ports
   without modification.
-- `nebula-credential::secrets::crypto` (primitives) is called by
-  `nebula-storage::credential::layer::encryption` via sibling
-  dependency. Crypto primitives stay in credential; impl stays in
-  storage. Clean layer direction.
+- Crypto primitives at `crates/credential/src/secrets/crypto.rs`
+  (public re-exports on `nebula_credential::secrets` and the crate
+  root — `encrypt`/`decrypt`/`EncryptedData`/`EncryptionKey`) are
+  called by `nebula-storage::credential::layer::encryption` via sibling
+  dependency. Primitives stay in credential; `EncryptionLayer` impl
+  stays in storage. Clean layer direction.
 
 ## Alternatives considered
 

--- a/docs/adr/0029-storage-owns-credential-persistence.md
+++ b/docs/adr/0029-storage-owns-credential-persistence.md
@@ -1,0 +1,400 @@
+---
+id: 0029
+title: storage-owns-credential-persistence
+status: accepted
+date: 2026-04-20
+supersedes: [0023]
+superseded_by: []
+tags: [credential, storage, security, canon-12.5, persistence, key-custody]
+related:
+  - docs/adr/0023-keyprovider-trait.md
+  - docs/adr/0028-cross-crate-credential-invariants.md
+  - docs/adr/0030-engine-owns-credential-orchestration.md
+  - docs/adr/0031-api-owns-oauth-flow.md
+  - docs/adr/0021-crate-publication-policy.md
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/STYLE.md#6-secret-handling
+  - docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md
+linear: []
+---
+
+# 0029. `nebula-storage` owns credential persistence
+
+## Context
+
+[ADR-0028](./0028-cross-crate-credential-invariants.md) establishes the
+umbrella of cross-crate credential invariants for the architecture
+cleanup. This ADR codifies the first of three migrations: **all
+persistence-related credential types move from `nebula-credential` to
+`nebula-storage/src/credential/`**. The credential crate becomes a pure
+contract crate (trait + DTOs + §12.5 primitives); the storage crate
+owns the persistence impl.
+
+The concrete motivation is §1 of the design spec
+([`docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md`](../superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md)):
+`nebula-credential` currently owns
+`CredentialStore` trait + `InMemoryStore` impl + `EncryptionLayer` +
+`CacheLayer` + `AuditLayer` + `ScopeLayer` + `KeyProvider` + pending
+store + backup store. Every one of those is persistence work. That SRP
+violation breaks symmetry with the sibling `nebula-storage` crate
+(which already hosts `repos/` for non-credential stores) and leaves
+`nebula-credential` with a conflated responsibility set.
+
+[ADR-0023](./0023-keyprovider-trait.md) named `KeyProvider` as a
+public contract in `nebula-credential`. That ADR's trait shape,
+invariants, rotation semantics, and three impl contracts (`Env`,
+`File`, `Static`) remain correct; only the crate that owns them
+changes. This ADR supersedes ADR-0023 in the **location** of
+`KeyProvider` and `EncryptionLayer`, not in their design.
+
+The canon context that binds this migration:
+
+- [§12.5 — Secrets and auth](../PRODUCT_CANON.md#125-secrets-and-auth)
+  — AES-256-GCM authenticated encryption at rest, Argon2id KDF, AAD
+  binding. Invariant 1 of ADR-0028.
+- [§14 — Anti-patterns](../PRODUCT_CANON.md#14-anti-patterns) —
+  no discard-and-log on audit. Invariant 4 of ADR-0028.
+- [STYLE.md §6 — Secret handling](../STYLE.md#6-secret-handling) —
+  `Zeroize` / `ZeroizeOnDrop`, `Zeroizing<T>` intermediates, no
+  plaintext in error strings, log-redaction test helper.
+
+## Decision
+
+### 1. Supersede relationship with ADR-0023
+
+**This ADR supersedes ADR-0023 in the _location_ of the `KeyProvider`
+trait. The trait shape, `ProviderError` variants, rotation-safety
+fingerprint scheme, three in-tree impls (`EnvKeyProvider`,
+`FileKeyProvider`, `StaticKeyProvider`), and every other contract
+from ADR-0023 are preserved bit-for-bit — only the crate that owns
+them changes.**
+
+- Trait definition moves from
+  `crates/credential/src/layer/key_provider.rs` to
+  `crates/storage/src/credential/key_provider.rs`.
+- `EncryptionLayer` moves from
+  `crates/credential/src/layer/encryption.rs` to
+  `crates/storage/src/credential/layer/encryption.rs`.
+- AAD binding at the existing `encryption.rs:146-211` (credential id is
+  AAD; record-swapping is rejected; AAD-less records are rejected) is
+  ported without modification. ADR-0028 invariant 1 applies.
+- `with_legacy_keys` rotation path and the `""` → `"default"` migration
+  story land verbatim in the new location.
+- SHA-256-prefix `version()` scheme (`env:<fp>`, `file:<name>:<fp>`)
+  remains observable SemVer surface of the storage crate, inheriting
+  from ADR-0023 §5.
+
+### 2. Canonical file paths in `nebula-storage`
+
+The target shape under `crates/storage/src/credential/` (see spec §3):
+
+```
+crates/storage/src/credential/
+├── mod.rs
+├── store.rs              # CredentialStore trait + StoredCredential + PutMode + StoreError
+├── memory.rs             # InMemoryStore (feature: credential-in-memory)
+├── key_provider.rs       # KeyProvider + EnvKeyProvider + FileKeyProvider + StaticKeyProvider
+├── pending.rs            # pending state repo (encrypted at rest; see §4)
+├── backup.rs             # rotation backup repo
+└── layer/
+    ├── mod.rs
+    ├── encryption.rs     # EncryptionLayer (§12.5 AAD preserved)
+    ├── cache.rs          # CacheLayer (moka)
+    ├── audit.rs          # AuditSink trait + in-line durable default impl
+    └── scope.rs          # ScopeLayer
+```
+
+The following types move from `nebula-credential` to `nebula-storage`
+at the listed destinations:
+
+| From `nebula-credential/src/` | To `nebula-storage/src/credential/` |
+|---|---|
+| `store.rs` (`CredentialStore`, `StoredCredential`, `PutMode`, `StoreError`) | `store.rs` |
+| `store_memory.rs` (`InMemoryStore`) | `memory.rs` |
+| `layer/encryption.rs` (`EncryptionLayer`) | `layer/encryption.rs` |
+| `layer/key_provider.rs` (`KeyProvider` + impls) | `key_provider.rs` |
+| `layer/cache.rs` (`CacheLayer`, `moka`-backed) | `layer/cache.rs` |
+| `layer/audit.rs` (`AuditSink`, `AuditLayer`) | `layer/audit.rs` |
+| `layer/scope.rs` (`ScopeLayer`) | `layer/scope.rs` |
+| `pending_store.rs`, `pending_store_memory.rs` | `pending.rs` |
+| `rotation/backup.rs` | `backup.rs` |
+
+### 3. `nebula-credential` reexports
+
+`nebula-credential::lib.rs` keeps a stable re-export for `CredentialStore`:
+
+```rust
+pub use nebula_storage::credential::CredentialStore;
+```
+
+This re-export is **permanent**, not transitional. Consumers importing
+`nebula_credential::CredentialStore` do not need to chase the path
+change. ADR-0028 invariant 6 applies: re-exports may expose trait +
+error + DTO shapes, but not storage impl details (no `InMemoryStore`,
+no `CacheLayer`, no backend-specific hints).
+
+### 4. Pending store invariants
+
+The pending store (`crates/storage/src/credential/pending.rs`) holds
+interactive-flow state (OAuth2 PKCE `code_verifier`, `state` token,
+CSRF binding) between the authorization-request step and the callback
+step. Because `code_verifier` is a secret, the pending store carries
+security invariants equivalent to the encrypted credential store, with
+additional TTL and single-use semantics.
+
+The following invariants are **non-negotiable** and enforced by CI:
+
+1. **Encrypted at rest.** `code_verifier` and any adjacent secret
+   fields are wrapped by `EncryptionLayer` on write; the pending repo
+   never persists plaintext. AAD binding applies (credential id +
+   pending token as AAD per the canonical AAD scheme).
+2. **TTL ≤ 10 minutes.** Pending entries auto-expire 10 minutes after
+   creation. An entry past its TTL is treated as absent
+   (`PendingError::Expired`); no error-message side channel
+   distinguishes "never existed" from "expired."
+3. **Single-use.** The callback consume step issues a transactional
+   `get_then_delete` against the repo; there is no read-without-delete
+   API exposed to the OAuth controller. A replay attempt returns
+   `PendingError::NotFound` (indistinguishable from expiry).
+4. **Request-session binding.** Each pending entry carries the
+   originating API request session id; the callback consume step
+   rejects (`PendingError::SessionMismatch`) if the callback session
+   differs. Defense against cross-session CSRF is in ADR-0031; this
+   store's job is to surface a safe error if the binding is violated.
+5. **API returns `SecretString`, not `String`.** Read path returns
+   `PendingRecord { code_verifier: SecretString, state: SecretString, … }`.
+   Raw `String` is not part of the public API of the pending repo.
+   ADR-0028 invariant 7 applies.
+6. **Zeroize-on-drop on read.** `PendingRecord` derives
+   `ZeroizeOnDrop`; the read path's intermediate buffers use
+   `Zeroizing<Vec<u8>>`. Scope exit scrubs the decrypted bytes per
+   STYLE.md §6.
+
+### 5. Audit sink — in-line durable
+
+`AuditSink` trait + default impl (`storage/src/repos/audit.rs` — already
+exists) backs `AuditLayer`. The invariant is **fail-closed**: if the
+audit write errors, the credential operation errors. No "log and
+continue" path. ADR-0028 invariant 4 is the normative source; this
+section declares the storage-side enforcement point.
+
+`AuditEvent` fields (redaction-safe by construction, per STYLE.md §6
+and spec §8):
+
+```
+AuditEvent {
+    verb:         "put" | "get" | "delete" | "rotate" | "refresh",
+    credential_id,
+    outcome:      Ok | Denied | Error,
+    started_at,
+    latency_ms,
+}
+```
+
+**No plaintext value, no ciphertext, no key_id hash.** `AuditEvent`
+`Debug` / `Display` are hand-written (not auto-derived) and fmt only
+the whitelisted fields above. Future field additions must be
+hand-added to `Debug` — auto-derive would silently leak new fields
+through `{:?}`.
+
+### 6. SemVer surface of `nebula-storage`
+
+From the day this ADR's implementation lands, the following become
+part of `nebula-storage` public SemVer surface (per ADR-0021):
+
+- `CredentialStore` trait + `StoredCredential` / `PutMode` / `StoreError`.
+- `KeyProvider` trait + `ProviderError` (`#[non_exhaustive]`) + three
+  in-tree impls. Inherits the SemVer commitments from ADR-0023 §5,
+  including the fingerprint scheme on `version()`.
+- `EncryptionLayer` constructor signatures (`new`, `with_legacy_keys`).
+- `PendingStore` trait + `PendingRecord` + `PendingError`.
+- `AuditSink` trait + `AuditEvent` (the redacted shape; new fields are
+  additive only).
+
+Breaking any of the above requires a superseding ADR.
+
+### 7. Test coverage migration
+
+The existing `crates/credential/src/layer/encryption.rs` mod tests
+(round-trip, AAD enforcement, multi-key lazy rotation, CAS-on-rotate
+for issue #282, `""` → `"default"` legacy alias for issue #281) move
+to a single file at
+`crates/storage/tests/credential_encryption_invariants.rs`.
+
+ADR-0028 invariant 1 declares §12.5 tests are **single source of
+truth** — not scattered across crates. If a future change requires a
+credential-side invariant test, it lives with the contract; if it
+requires a storage-side impl test, it lives with the impl. No
+duplication.
+
+Pending-store lifecycle tests
+(`crates/credential/tests/units/pending_lifecycle_tests.rs`) move
+wholesale to `crates/storage/tests/` and pin invariants 1-6 above.
+
+## Consequences
+
+**Positive.**
+
+- `nebula-credential` becomes a pure contract crate. SRP satisfied.
+- `nebula-storage` gains a symmetric `credential/` module next to its
+  existing repos; credential persistence is discoverable where persistence
+  code lives.
+- Operators and library embedders see the composition root more
+  clearly: `nebula-storage::credential::CredentialStore` is the impl
+  trait, and `KeyProvider` implementations (KMS, Vault, env, file) plug
+  into the storage crate alongside backend choice. The "where does
+  credential key material come from" question has a single answer.
+- `EncryptionLayer` wraps any `CredentialStore` impl (in-memory,
+  SQLite-backed future, Postgres-backed future) — the §12.5 guarantee
+  is decoupled from the backend.
+- Pending-store invariants §4 make the OAuth2 PKCE flow's security
+  posture explicit and CI-enforced.
+- `KeyProvider`'s next impls (`KmsKeyProvider`, `VaultKeyProvider` —
+  see ADR-0023 follow-ups) land next to the trait in `nebula-storage`
+  instead of reaching back into `nebula-credential`.
+
+**Negative / accepted costs.**
+
+- Import-path churn for callers constructing `EncryptionLayer`,
+  `InMemoryStore`, or a `KeyProvider` impl directly. The call site
+  stays the same; only the `use` line changes. Workspace has zero
+  external publish consumers today (ADR-0021 §Context), so the cost
+  is absorbed before `nebula-credential` has an external audience.
+- `nebula-storage` takes on a credential-adjacent dependency surface:
+  `moka` for caching, `aes-gcm` + `argon2` via `nebula-credential`'s
+  `secrets::crypto` primitives. The alternative — duplicating
+  primitives in storage — is worse (two implementations of AAD
+  binding drift within weeks).
+- Two canonical paths for `CredentialStore` (`nebula_credential::…`
+  and `nebula_storage::credential::…`). Documented; ADR-0028 invariant
+  6 makes the re-export permanent.
+- Test file rename changes blame attribution. Acceptable; the tests
+  were always co-invariant with the impl.
+
+**Neutral.**
+
+- ADR-0023's design decisions (sync `current_key()`, two-constructor
+  surface, `ProviderError` typed variants, `StaticKeyProvider` behind
+  `test-util`) are **unchanged**. Only the crate location moves.
+- AAD binding at the former `encryption.rs:146-211` — credential-id is
+  AAD, AAD-less records rejected, record-swapping rejected — ports
+  without modification.
+- `nebula-credential::secrets::crypto` (primitives) is called by
+  `nebula-storage::credential::layer::encryption` via sibling
+  dependency. Crypto primitives stay in credential; impl stays in
+  storage. Clean layer direction.
+
+## Alternatives considered
+
+### A. Keep `CredentialStore` in `nebula-credential`, move only `EncryptionLayer` to storage
+
+**Rejected.** Partial move creates a worse taxonomy: the trait lives in
+credential, but implementations (encryption wrap, cache wrap, audit wrap)
+live in storage. Consumers constructing the composition root would
+import from both crates to build a layered store. The alternative
+preserves `nebula-credential`'s monolith profile without eliminating
+it. Full move is the simpler result.
+
+### B. Create a new `nebula-credential-store` crate
+
+**Rejected.** A new workspace member for credential persistence would
+duplicate the `nebula-storage` crate's purpose. `nebula-storage`
+already exists for the same reason (consolidated persistence), and
+credential persistence is not categorically different from execution
+persistence, control-queue persistence, or trigger-lock persistence.
+Model B+ from the design spec §4 alternatives.
+
+### C. Keep `KeyProvider` in `nebula-credential`, move only the encryption layer
+
+**Rejected.** The composition root lives next to the impl. Putting
+`EncryptionLayer` in storage but `KeyProvider` in credential forces
+every storage-side impl site to depend on credential for key material
+and on storage for the layer. The trait binds to the layer's
+construction — they belong together.
+
+### D. Single `crates/storage/src/credential.rs` file, no submodule
+
+**Rejected.** After the move, the credential module has store + memory
++ three layer impls + key_provider + pending + backup + tests. One
+file would push into thousands of lines. Submodule organization (§2)
+follows the existing pattern of `crates/storage/src/repos/` — each
+repo gets a module, credential is no exception.
+
+### E. Move `secrets::crypto` primitives to storage alongside the impl
+
+**Rejected. Would break ADR-0028 invariant 1.** `EncryptionLayer`
+calls crypto primitives, but the primitives are the canon §12.5
+surface that every credential-aware crate may reference (including
+api for OAuth PKCE — `crypto::pkce_challenge`). Keeping them in
+`nebula-credential` (pure Core-layer sibling) means storage, engine,
+and api all import primitives from credential without cycle; moving
+primitives to storage would force api and engine to depend on storage
+for pure arithmetic. Wrong layer.
+
+## Seam / verification
+
+Files that carry the invariants after the migration (spec §3):
+
+- `crates/storage/src/credential/store.rs` — `CredentialStore` trait,
+  `StoredCredential`, `PutMode`, `StoreError`.
+- `crates/storage/src/credential/memory.rs` — `InMemoryStore` behind
+  `credential-in-memory` feature.
+- `crates/storage/src/credential/key_provider.rs` — `KeyProvider`
+  trait + `EnvKeyProvider` + `FileKeyProvider` + `StaticKeyProvider`
+  (inherits ADR-0023 §3 invariants).
+- `crates/storage/src/credential/layer/encryption.rs` —
+  `EncryptionLayer`; AAD binding preserved.
+- `crates/storage/src/credential/layer/cache.rs` — `CacheLayer` on
+  `moka`.
+- `crates/storage/src/credential/layer/audit.rs` — `AuditSink` trait,
+  `AuditLayer` in-line durable default impl, `AuditEvent` redacted
+  shape.
+- `crates/storage/src/credential/layer/scope.rs` — `ScopeLayer`.
+- `crates/storage/src/credential/pending.rs` — `PendingStore` +
+  `PendingRecord` + `PendingError`; invariants 1-6 §4.
+- `crates/storage/src/credential/backup.rs` — rotation backup repo.
+- `crates/credential/src/lib.rs` — permanent `pub use
+  nebula_storage::credential::CredentialStore` (ADR-0028 invariant 6).
+
+Test coverage:
+
+- `crates/storage/tests/credential_encryption_invariants.rs` — AAD
+  round-trip, multi-key rotation, CAS-on-rotate, legacy alias (migrated
+  from `crates/credential/tests/units/encryption_tests.rs`).
+- `crates/storage/tests/credential_audit_durable.rs` — mock
+  `AuditSink` failure → `put()` returns `StoreError` (not silent
+  success). ADR-0028 invariant 4.
+- `crates/storage/tests/credential_pending_lifecycle.rs` — TTL expiry,
+  single-use delete, session-binding mismatch, zeroize-on-read.
+  Invariants §4.1-§4.6.
+- `crates/credential/tests/redaction.rs` (remains — shared helper) —
+  adds rows for pending-store operations. ADR-0028 invariant 7.
+
+CI signals:
+
+- **Layer direction in `deny.toml`**: `nebula-storage` may depend on
+  `nebula-credential`; reverse direction forbidden. Rule lands in the
+  same PR as the move (P6), not follow-up.
+- **MSRV 1.95**: all new files respect MSRV per
+  [ADR-0019](./0019-msrv-1.95.md).
+
+## Follow-ups
+
+- **Phase P6 implementation PR** (spec §12) — physical move of
+  `store.rs`, `store_memory.rs`, `layer/`, `key_provider.rs` into
+  `nebula-storage/src/credential/`. Re-export in `nebula-credential`
+  lands in the same PR.
+- **Phase P7 implementation PR** — physical move of `pending_store*.rs`
+  and `rotation/backup.rs` into `nebula-storage/src/credential/`.
+- **[ADR-0030](./0030-engine-owns-credential-orchestration.md)** —
+  downstream sibling; engine consumes `CredentialStore` from
+  `nebula-storage` for resolver and rotation orchestration.
+- **[ADR-0031](./0031-api-owns-oauth-flow.md)** — downstream sibling;
+  api consumes `CredentialStore` and the pending store for OAuth
+  callback flow.
+- **`KmsKeyProvider` ADR** (was ADR-0023 follow-up) — lands against
+  `nebula-storage::credential::KeyProvider` instead of
+  `nebula-credential::KeyProvider`. No other change.
+- **`VaultKeyProvider` ADR** — same.
+- **Key-rotation runbook** under `docs/` (already a follow-up from
+  ADR-0023) — updated path references are the only change.

--- a/docs/adr/0030-engine-owns-credential-orchestration.md
+++ b/docs/adr/0030-engine-owns-credential-orchestration.md
@@ -49,8 +49,9 @@ elsewhere:
    `credential_accessor.rs` and `resolver.rs`; the credential-side
    files are redundant wrappers.
 3. **Token refresh HTTP.** The refresh fragment inside
-   `credentials/oauth2_flow.rs` performs an HTTP round-trip to an
-   OAuth2 token endpoint when a projected access token nears expiry.
+   `credentials/oauth2/flow.rs` (nested under `oauth2/` since P2)
+   performs an HTTP round-trip to an OAuth2 token endpoint when a
+   projected access token nears expiry.
    The call happens during resolve, on the engine's hot path — it is
    engine work, not contract work.
 
@@ -85,7 +86,7 @@ The following types move from `nebula-credential/src/` to
 | `rotation/transaction.rs` | `rotation/transaction.rs` |
 | `resolver.rs` + `executor.rs` | `resolver.rs` (merged with existing `credential_accessor.rs` and `engine/resolver.rs`) |
 | `registry.rs` | `registry.rs` |
-| `credentials/oauth2_flow.rs` refresh fragment | `rotation/token_refresh.rs` (new file, reqwest client — see §4) |
+| `credentials/oauth2/flow.rs` refresh fragment | `rotation/token_refresh.rs` (new file, reqwest client — see §4) |
 
 The target shape under `crates/engine/src/credential/` (spec §3):
 
@@ -406,7 +407,7 @@ CI signals:
   `rotation/*`, `resolver.rs`, `executor.rs`, `registry.rs` into
   `engine/src/credential/`.
 - **Phase P9 implementation PR** — physical move of token-refresh
-  fragment from `credentials/oauth2_flow.rs` into
+  fragment from `credentials/oauth2/flow.rs` into
   `engine/src/credential/rotation/token_refresh.rs`. `reqwest`
   becomes engine base dep in this PR.
 - **[ADR-0031](./0031-api-owns-oauth-flow.md)** — downstream sibling;

--- a/docs/adr/0030-engine-owns-credential-orchestration.md
+++ b/docs/adr/0030-engine-owns-credential-orchestration.md
@@ -1,0 +1,421 @@
+---
+id: 0030
+title: engine-owns-credential-orchestration
+status: accepted
+date: 2026-04-20
+supersedes: []
+superseded_by: []
+tags: [credential, engine, rotation, refresh, canon-13.2, orchestration, reqwest]
+related:
+  - docs/adr/0028-cross-crate-credential-invariants.md
+  - docs/adr/0029-storage-owns-credential-persistence.md
+  - docs/adr/0031-api-owns-oauth-flow.md
+  - docs/adr/0016-engine-cancel-registry.md
+  - docs/adr/0017-control-queue-reclaim-policy.md
+  - docs/adr/0023-keyprovider-trait.md
+  - docs/adr/0025-sandbox-broker-rpc-surface.md
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/PRODUCT_CANON.md#132-rotation-refresh-seam
+  - docs/STYLE.md#6-secret-handling
+  - docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md
+linear: []
+---
+
+# 0030. `nebula-engine` owns credential orchestration
+
+## Context
+
+[ADR-0028](./0028-cross-crate-credential-invariants.md) establishes the
+umbrella of cross-crate credential invariants. [ADR-0029](./0029-storage-owns-credential-persistence.md)
+hands persistence to `nebula-storage`. This ADR codifies the second
+migration: **runtime orchestration moves from `nebula-credential` to
+`nebula-engine/src/credential/`**.
+
+Today `nebula-credential` owns four kinds of orchestration that belong
+elsewhere:
+
+1. **Rotation orchestration.** `rotation/scheduler.rs`,
+   `grace_period.rs`, `blue_green.rs`, `transaction.rs` — when to rotate,
+   how long the grace window is, how to flip state transactionally. These
+   are execution-lifecycle concerns; they belong adjacent to
+   `engine/control_consumer.rs` (which already owns cancel / resume /
+   restart orchestration per
+   [ADR-0008](./0008-execution-control-queue-consumer.md) /
+   [ADR-0016](./0016-engine-cancel-registry.md) /
+   [ADR-0017](./0017-control-queue-reclaim-policy.md)).
+2. **Resolver + executor + registry.** `resolver.rs`, `executor.rs`,
+   `registry.rs` — type-erased dispatch and the hot-path credential
+   resolve during workflow execution. Engine already has
+   `credential_accessor.rs` and `resolver.rs`; the credential-side
+   files are redundant wrappers.
+3. **Token refresh HTTP.** The refresh fragment inside
+   `credentials/oauth2_flow.rs` performs an HTTP round-trip to an
+   OAuth2 token endpoint when a projected access token nears expiry.
+   The call happens during resolve, on the engine's hot path — it is
+   engine work, not contract work.
+
+The seam that must **not** move is `RefreshCoordinator`
+(`crates/credential/src/refresh.rs`). It is a thundering-herd
+prevention primitive (like `tokio::sync::Semaphore`), not a pluggable
+policy — see §3 below.
+
+The canon context that binds this migration:
+
+- [§13.2 — Rotation / refresh seam](../PRODUCT_CANON.md#132-rotation-refresh-seam)
+  — the seam is defined in credential; the invariant enforcer is
+  engine. ADR-0028 invariant 2.
+- [§12.5 — Secrets and auth](../PRODUCT_CANON.md#125-secrets-and-auth)
+  — engine never materialises plaintext in a hot loop outside a
+  zeroize container. ADR-0028 invariants 1 and 7.
+- [STYLE.md §6 — Secret handling](../STYLE.md#6-secret-handling) —
+  log-redaction helper. Non-negotiable for token refresh (see §4).
+
+## Decision
+
+### 1. Runtime orchestration moves to `nebula-engine`
+
+The following types move from `nebula-credential/src/` to
+`nebula-engine/src/credential/`:
+
+| From `nebula-credential/src/` | To `nebula-engine/src/credential/` |
+|---|---|
+| `rotation/scheduler.rs` | `rotation/scheduler.rs` |
+| `rotation/grace_period.rs` | `rotation/grace_period.rs` |
+| `rotation/blue_green.rs` | `rotation/blue_green.rs` |
+| `rotation/transaction.rs` | `rotation/transaction.rs` |
+| `resolver.rs` + `executor.rs` | `resolver.rs` (merged with existing `credential_accessor.rs` and `engine/resolver.rs`) |
+| `registry.rs` | `registry.rs` |
+| `credentials/oauth2_flow.rs` refresh fragment | `rotation/token_refresh.rs` (new file, reqwest client — see §4) |
+
+The target shape under `crates/engine/src/credential/` (spec §3):
+
+```
+crates/engine/src/credential/
+├── mod.rs
+├── resolver.rs           # merged: existing credential_accessor + credential/executor + credential/resolver
+├── registry.rs           # type-erased dispatch
+└── rotation/
+    ├── mod.rs
+    ├── scheduler.rs
+    ├── grace_period.rs
+    ├── blue_green.rs
+    ├── transaction.rs
+    └── token_refresh.rs  # HTTP token refresh (reqwest) during resolve
+```
+
+Contract types **stay** in `nebula-credential/src/rotation/`:
+`policy.rs`, `state.rs`, `validation.rs`, `error.rs`, `events.rs`
+(data types). Engine consumes these via sibling dep.
+
+### 2. Resolver + executor + registry merge
+
+The four existing resolver-shaped files across two crates
+(`credential::resolver.rs`, `credential::executor.rs`,
+`credential::registry.rs`, `engine::credential_accessor.rs`,
+`engine::resolver.rs`) collapse into **two files** in
+`engine/src/credential/`:
+
+- `resolver.rs` — hot-path credential resolve, consuming the
+  `CredentialStore` from `nebula-storage` (per ADR-0029). Merges
+  `credential::resolver`, `credential::executor`, and the existing
+  `engine::credential_accessor.rs`. The pre-migration split of
+  "resolver" vs "executor" vs "accessor" was three names for the same
+  role; post-migration one type does the work.
+- `registry.rs` — type-erased dispatch against `Arc<dyn AnyCredential>`.
+  Symmetric with the Y-model for actions (plugin registry dispatches
+  actions; engine credential registry dispatches credentials).
+
+The merge is **lossless**: every public call site against the old
+shape maps 1:1 to a call against the new shape.
+
+### 3. `RefreshCoordinator` design note — concrete, not trait
+
+**`RefreshCoordinator` stays in `nebula-credential/src/refresh.rs` as
+a concrete primitive (not a trait).** Engine uses it via its concrete
+API surface. This ADR explicitly declares **no extension seam desired**
+for `RefreshCoordinator`.
+
+Rationale:
+
+- Thundering-herd prevention is a property of the data structure, not
+  a pluggable policy. The analogous primitive is
+  `tokio::sync::Semaphore` — not a trait, not because "semaphore is
+  simple," but because a swappable semaphore impl would invite broken
+  impls that violate the contract (a semaphore that drops permits is
+  not a semaphore).
+- `RefreshCoordinator` uses a `parking_lot::Mutex<LruCache<String,
+  Arc<CircuitBreaker>>>` at `refresh.rs:51` to bound memory under
+  adversarial input (credential-id fanout) and coordinate per-key
+  refresh coalescing. A trait-ified version would accept any impl,
+  including ones that skip the LRU bound or the per-key coalescing.
+  Both failures are silent (no type error) and severe (memory DoS or
+  thundering herd on the upstream token endpoint).
+- No production consumer has asked for an alternative coordination
+  strategy. The one-good-impl-only posture matches the existing
+  `nebula-resilience` retry primitives, `tokio`'s sync primitives,
+  and the design spec §4 principle that "a seam you cannot honestly
+  enforce is a §11.6 false capability."
+
+If a future need arises for an alternative coordination strategy
+(e.g., distributed refresh coalescing across multiple nebula-engine
+replicas via a storage-backed lock), a new ADR opens. That ADR does
+not relax `RefreshCoordinator`; it **supersedes** this §3 decision and
+introduces a new primitive.
+
+### 4. Token refresh logging — redaction mandatory
+
+`crates/engine/src/credential/rotation/token_refresh.rs` performs an
+HTTP POST to the OAuth2 token endpoint with the refresh grant and
+receives a new access token (and optionally a new refresh token).
+The file **MUST NOT** log access tokens, refresh tokens, bearer
+values, or response body — **ever, at any tracing level, including
+DEBUG and TRACE.**
+
+Specific rules:
+
+- All HTTP responses pass through a redaction filter before any
+  `tracing::` call touches them. The redaction filter is the same
+  helper used by STYLE.md §6 log-redaction tests.
+- Tracing spans carry only metadata: duration, HTTP status code,
+  credential_id, and the token-endpoint host (not full URL with
+  query). Never the request body. Never the response body. Never
+  request or response headers except `Content-Type` and
+  `Content-Length`.
+- `reqwest::Error` values and any intermediate response buffers are
+  wrapped in `Zeroizing<>` (or scrubbed manually in a `Drop` impl)
+  so that a panic mid-call does not leave plaintext in an error
+  chain printed by the async runtime.
+- Partial / truncated responses → fail-closed with zeroization of all
+  buffers. Same posture as ADR-0031 §4.
+
+CI gate: **one redaction test per token_refresh code path** in
+`crates/engine/tests/credential_refresh_redaction.rs`. Each test
+injects a secret-bearing response, invokes the code path, and greps
+all emitted tracing spans / audit events / metrics labels / error
+strings for substring. Any hit = CI fail. A new code path (e.g., an
+additional retry-on-server-error path, a forked token-request shape
+for a new IdP flavor) adds a row to the test.
+
+### 5. `reqwest` becomes a base dep of `nebula-engine`
+
+`reqwest` is already in the workspace `[workspace.dependencies]`
+table (used today by `nebula-credential` for OAuth flow, scheduled to
+move; potentially by `nebula-sandbox` for network broker verb). Adding
+it to `nebula-engine/Cargo.toml` as a base dep is a layer-consistent
+move: engine is the execution layer and already performs outbound
+work (the control-queue consumer dispatches to actions that reach out,
+but the engine itself was not the outbound HTTP owner until now).
+
+This is consistent with the [ADR-0025](./0025-sandbox-broker-rpc-surface.md)
+broker pattern — engine is the host-side owner for out-of-process
+verbs. Token refresh is exactly that shape: engine mediates the
+outbound call on behalf of the credential resolve.
+
+`reqwest` configuration inherits from ADR-0031 §4 where applicable
+(TLS only, bounded timeout, bounded response size). Token-refresh
+specific tuning is declared in `token_refresh.rs` mod docs.
+
+### 6. Canon §12.5 interaction on the hot path
+
+Engine never materialises plaintext credential material in the hot
+loop outside a zeroize container. Concrete rules:
+
+- All reads go through `CredentialStore` (from `nebula-storage` per
+  ADR-0029); the returned `StoredCredential` is already encrypted-
+  at-rest semantics.
+- Projected auth material (the output of `Credential::project()`)
+  lives in a zeroize container for the lifetime of the action
+  invocation. Scope exit scrubs it per STYLE.md §6.
+- Token refresh writes the new state back through the store; the
+  encrypt-at-rest path goes through `EncryptionLayer` per ADR-0029.
+- The resolver does not log projected material, even on `ERROR` path.
+  Errors reference the credential id and operation verb, never the
+  decrypted bytes.
+
+### 7. Rotation orchestration semantics
+
+Rotation orchestration (scheduler, grace period, blue/green,
+transaction) moves as-is from credential to engine. **No semantic
+change** in this ADR — the move is physical. If the scheduler's
+backoff, the grace period duration, or the blue/green swap invariants
+require tuning, a separate ADR opens against the post-migration
+location.
+
+Adjacency: rotation orchestration lives in `engine/src/credential/
+rotation/`; execution control-queue lives in
+`engine/src/control_consumer.rs`. The two interact via the same
+engine-internal error taxonomy (`engine::Error`) and the same
+storage-backed durability
+([ADR-0008 §5](./0008-execution-control-queue-consumer.md)). A future
+ADR may unify rotation dispatch with control-queue dispatch if the
+patterns converge; out of scope here.
+
+## Consequences
+
+**Positive.**
+
+- `nebula-credential` becomes a pure contract crate (trait + DTOs +
+  §12.5 primitives + contract-level rotation data types + refresh
+  primitive). `Engine integration` MATURITY column flips from
+  `partial` to `stable` (per ADR-0028 invariant 5, after P11 lands).
+- Rotation orchestration lives next to execution orchestration. A
+  reviewer tracing a `Cancel` through `control_consumer.rs` follows
+  the same shape as tracing a `Rotate` through `rotation/scheduler.rs`.
+- Token refresh is on the engine's hot path, which is where the
+  redaction gate belongs. No surprise tracing leak from a credential-
+  side fragment that escapes the engine's span context.
+- Deleting `credential::executor.rs` + `credential::resolver.rs` +
+  `engine::credential_accessor.rs` + `engine::resolver.rs` and merging
+  to two files is a net-simpler engine surface.
+- `RefreshCoordinator` stays concrete and close to the data
+  structures — the seam per §13.2 is `Credential::refresh()` (the
+  trait method), not a trait over the coordinator. This matches the
+  canon seam shape.
+
+**Negative / accepted costs.**
+
+- `reqwest` becomes an engine base dep. Increases engine's compile-
+  time cost and binary size (reqwest + rustls + tokio-util). Accepted:
+  engine is the outbound HTTP host-side owner, consistent with ADR-
+  0025. Duplicating reqwest usage across three crates (credential
+  today, engine for refresh, api for OAuth exchange) was the cost we
+  wanted to eliminate.
+- Engine takes on a larger surface post-merge (resolver.rs and
+  registry.rs pull in behavior that lived in credential). Accepted:
+  the merge reduces **total** code (four files → two files) and
+  eliminates a layer of thin wrapping.
+- Rotation orchestration tests that lived in `credential/tests/units/`
+  move to `engine/tests/`. Same invariants, different location.
+- The `token_refresh.rs` redaction CI gate is an ongoing test-
+  maintenance cost. One redaction test per code path is the quantified
+  ongoing load. Accepted — this is the §4 non-negotiable.
+
+**Neutral.**
+
+- Contract-level rotation types (`policy.rs`, `state.rs`,
+  `validation.rs`, `error.rs`, `events.rs`) stay in credential and
+  are consumed by engine via sibling dep. No behavioral change to
+  those files in this phase.
+- `RefreshCoordinator` stays in credential (§3). Engine uses its
+  concrete API; no trait.
+- The scheduler's existing `tokio_util::sync::CancellationToken`
+  dependency moves with the file — `tokio-util` becomes an engine dep
+  and leaves credential's base deps (spec §9).
+
+## Alternatives considered
+
+### A. Leave rotation orchestration in `nebula-credential`
+
+**Rejected.** Preserves the existing SRP violation. The crate's
+MATURITY `partial / Engine integration` row captures this — rotation
+orchestration in credential is already the load-bearing complaint.
+Also misaligned with `nebula-action` (thin contract) and the planned
+`nebula-resource` symmetric rework.
+
+### B. New `nebula-credential-rotation` crate
+
+**Rejected** for the same reason as Model B+ in ADR-0028 §A: adds a
+fifth workspace member for a single orchestration concern when
+`nebula-engine` already owns execution-lifecycle orchestration. The
+adjacency argument (rotation next to control-queue) is load-bearing —
+a separate crate loses that adjacency.
+
+### C. Trait-ify `RefreshCoordinator`
+
+**Rejected.** See §3 rationale above. Trait-ification invites broken
+impls, and the use case for swapping the coordinator does not exist
+in any production workflow. The §13.2 seam is the `Credential::refresh()`
+method (trait-level), not the coordinator (primitive-level).
+
+### D. Put `token_refresh.rs` in `nebula-credential` behind a feature
+
+**Rejected.** Feature-gating the HTTP fragment keeps the dep on
+`reqwest` in credential, preserving today's problem. The refresh-
+during-resolve path is engine hot-path work; moving it cleanly to
+engine removes reqwest from credential entirely (the goal per spec
+§9) and eliminates the feature-flag bitrot risk.
+
+### E. Merge resolver / executor / registry into a single `orchestration.rs` file
+
+**Rejected.** Two files (resolver + registry) is the natural split:
+`resolver.rs` owns the resolve-for-this-action path (hot path);
+`registry.rs` owns type-erased dispatch setup (construction-time).
+A single-file merge conflates two lifetimes (hot path vs construction)
+and loses the documentation locality that's useful for new contributors.
+
+### F. Put token refresh in `nebula-api` alongside OAuth callback exchange
+
+**Rejected.** Token refresh happens during **workflow execution**
+(engine hot path), not during **API request handling** (api hot
+path). A credential whose access token expires mid-execution must be
+refreshed before the action's next outbound call; the refresh is
+not user-initiated. n8n makes this exact split
+(`packages/core/execution-engine/utils` for refresh vs
+`packages/cli/oauth/` for callback); we follow the same reasoning.
+
+## Seam / verification
+
+Files that carry the invariants after the migration (spec §3):
+
+- `crates/engine/src/credential/mod.rs` — module root.
+- `crates/engine/src/credential/resolver.rs` — merged resolver +
+  executor + credential_accessor. §6 redaction on error paths.
+- `crates/engine/src/credential/registry.rs` — type-erased dispatch
+  registry.
+- `crates/engine/src/credential/rotation/mod.rs` — rotation module
+  root.
+- `crates/engine/src/credential/rotation/scheduler.rs` — rotation
+  scheduler.
+- `crates/engine/src/credential/rotation/grace_period.rs` — grace
+  window semantics.
+- `crates/engine/src/credential/rotation/blue_green.rs` — state
+  swap.
+- `crates/engine/src/credential/rotation/transaction.rs` —
+  transactional flip.
+- `crates/engine/src/credential/rotation/token_refresh.rs` — reqwest
+  client; §4 redaction rules apply.
+- `crates/credential/src/refresh.rs` — `RefreshCoordinator` stays
+  here (§3). Consumed by engine via concrete API.
+
+Test coverage:
+
+- `crates/engine/tests/credential_refresh_redaction.rs` — §4 CI gate.
+  Row per token-refresh code path. ADR-0028 invariants 1 and 7.
+- `crates/engine/tests/credential_rotation_scheduler.rs` — scheduler
+  trigger + grace-period + blue/green flow migrated from
+  `crates/credential/tests/units/rotation_*`.
+- `crates/credential/tests/units/thundering_herd_tests.rs` — stays
+  in credential (tests the coordinator primitive directly). §3
+  guarantees that the primitive is not trait-ified; this test pins
+  the bound LRU + per-key coalescing invariants.
+- `crates/credential/tests/units/resolve_snapshot_tests.rs` — moves
+  to engine alongside the resolver merge.
+
+CI signals:
+
+- **Layer direction in `deny.toml`**: `nebula-engine` may depend on
+  `nebula-storage` + `nebula-credential`; reverse direction forbidden.
+  Rule lands in P8 (same PR as the move).
+- **MSRV 1.95**: all new files respect MSRV per
+  [ADR-0019](./0019-msrv-1.95.md).
+- **Redaction CI**: as §4 defines. No token substring in any output.
+
+## Follow-ups
+
+- **Phase P8 implementation PR** (spec §12) — physical move of
+  `rotation/*`, `resolver.rs`, `executor.rs`, `registry.rs` into
+  `engine/src/credential/`.
+- **Phase P9 implementation PR** — physical move of token-refresh
+  fragment from `credentials/oauth2_flow.rs` into
+  `engine/src/credential/rotation/token_refresh.rs`. `reqwest`
+  becomes engine base dep in this PR.
+- **[ADR-0031](./0031-api-owns-oauth-flow.md)** — downstream sibling;
+  api owns OAuth callback exchange (separate from engine-side refresh
+  per §F).
+- **Distributed refresh coalescing ADR** — if a future requirement
+  needs cross-replica coordination, opens against §3.
+- **Rotation dispatch unification with control-queue ADR** — if the
+  two orchestration shapes converge, opens against §7.
+- **MATURITY flip** — `nebula-credential` `Engine integration`
+  `partial` → `stable` lands in P11 (after this and ADR-0031's impl
+  lands). ADR-0028 invariant 5.

--- a/docs/adr/0031-api-owns-oauth-flow.md
+++ b/docs/adr/0031-api-owns-oauth-flow.md
@@ -1,0 +1,477 @@
+---
+id: 0031
+title: api-owns-oauth-flow
+status: accepted
+date: 2026-04-20
+supersedes: []
+superseded_by: []
+tags: [credential, api, oauth2, security, csrf, pkce, ssrf, canon-12.5, canon-4.5]
+related:
+  - docs/adr/0028-cross-crate-credential-invariants.md
+  - docs/adr/0029-storage-owns-credential-persistence.md
+  - docs/adr/0030-engine-owns-credential-orchestration.md
+  - docs/adr/0022-webhook-signature-policy.md
+  - docs/adr/0023-keyprovider-trait.md
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/PRODUCT_CANON.md#45-operational-honesty--no-false-capabilities
+  - docs/STYLE.md#6-secret-handling
+  - docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md
+linear: []
+---
+
+# 0031. `nebula-api` owns OAuth flow HTTP ceremony
+
+## Context
+
+[ADR-0028](./0028-cross-crate-credential-invariants.md) establishes the
+umbrella of cross-crate credential invariants. [ADR-0029](./0029-storage-owns-credential-persistence.md)
+hands persistence to `nebula-storage`. [ADR-0030](./0030-engine-owns-credential-orchestration.md)
+hands runtime orchestration (including token refresh) to `nebula-engine`.
+This ADR codifies the third migration: **user-facing OAuth2 HTTP
+ceremony moves from `nebula-credential::credentials::oauth2_flow`
+into `nebula-api/src/credential/`**.
+
+Today, `nebula-credential::credentials::oauth2_flow.rs` mixes four
+distinct concerns:
+
+1. Authorization URI construction with PKCE challenge + CSRF token.
+2. Callback handling — receive authorization code, validate state,
+   exchange code for tokens via HTTP POST.
+3. Token refresh during workflow execution (out of scope here;
+   migrated to engine per ADR-0030 §4).
+4. PKCE primitives (code_verifier / code_challenge generation, SHA-256
+   hashing) — pure primitives, no HTTP.
+
+Only (1) + (2) are user-facing HTTP ceremony. They belong in the HTTP
+API surface, adjacent to `nebula-api`'s existing auth and webhook
+handlers. (3) moved to engine per ADR-0030. (4) stays in
+`nebula-credential::secrets::crypto` — pure arithmetic, reachable by
+api and engine via sibling dep.
+
+The canon context that binds this migration:
+
+- [§12.5 — Secrets and auth](../PRODUCT_CANON.md#125-secrets-and-auth)
+  — all credential state reads pass through `CredentialStore`
+  (encrypted at rest per ADR-0029). Plaintext token material lives
+  only on in-memory request paths, wrapped in zeroize containers.
+- [§4.5 — Operational honesty / no false capabilities](../PRODUCT_CANON.md#45-operational-honesty--no-false-capabilities)
+  — OAuth endpoints appear in `nebula-api`'s MATURITY row only after
+  this migration lands; until then, `credential-oauth` is a non-
+  default feature (ADR-0028 invariant 5).
+- [STYLE.md §6 — Secret handling](../STYLE.md#6-secret-handling) —
+  mandatory patterns for token material on request paths.
+- [ADR-0022](./0022-webhook-signature-policy.md) — prior precedent for
+  `nebula-api` adopting strict-by-default security posture on HTTP
+  surfaces.
+
+## Decision
+
+### 1. Scope — what moves
+
+The following file is split and moved from
+`crates/credential/src/credentials/oauth2/flow.rs` into two
+destinations:
+
+| From | To |
+|---|---|
+| Authorization URI construction | `crates/api/src/credential/flow.rs` |
+| Callback code → token exchange (HTTP POST to token endpoint) | `crates/api/src/credential/flow.rs` |
+| Token refresh during execution | `crates/engine/src/credential/rotation/token_refresh.rs` (ADR-0030) |
+| PKCE primitives | `crates/credential/src/secrets/crypto.rs` (stays) |
+
+Additionally, new files in `nebula-api`:
+
+```
+crates/api/src/credential/
+├── mod.rs
+├── oauth_controller.rs   # GET /credentials/:id/oauth2/auth
+│                         # GET/POST /credentials/:id/oauth2/callback
+├── flow.rs               # HTTP client (reqwest) + token exchange
+└── state.rs              # CSRF token generation + pending-state correlation
+```
+
+### 2. n8n parity
+
+Pattern parity with n8n's existing production separation (spec §7):
+
+| Step | n8n location | Nebula analog |
+|---|---|---|
+| Auth URI construct | `packages/cli/src/oauth/oauth.service.ts` | `nebula-api` (`api/credential/flow.rs`) |
+| Callback endpoint | `packages/cli/src/controllers/oauth/oauth2-credential.controller.ts` | `nebula-api` (`api/credential/oauth_controller.rs`) |
+| Token exchange | `packages/cli/src/oauth/oauth.service.ts` + `@n8n/client-oauth2` | `nebula-api` (`api/credential/flow.rs`) |
+| Token refresh | `packages/core/execution-engine/utils/request-helper-functions.ts` (`refreshOrFetchToken`) | `nebula-engine` (`engine/credential/rotation/token_refresh.rs`, per ADR-0030) |
+| Credential type def | `packages/nodes-base/credentials/*.credentials.ts` | `nebula-credential` (`credential/credentials/oauth2/`, stays) |
+
+The ceremony / refresh split is n8n's operational shape, validated
+across three major versions and thousands of plugin authors. We adopt
+it deliberately rather than collapsing ceremony + refresh into a single
+crate.
+
+### 3. Endpoints
+
+Three HTTP endpoints on `nebula-api`:
+
+- **`GET /credentials/:id/oauth2/auth`** — construct authorization URI
+  (client_id, redirect_uri, scope, state, PKCE challenge), persist a
+  pending entry (via the storage pending store per ADR-0029 §4), and
+  return either a `302 Location` redirect or a `200 application/json`
+  body with `{authorize_url}` for UIs that handle the redirect
+  client-side.
+- **`GET /credentials/:id/oauth2/callback`** — receive authorization
+  code + state. Verify state (§4.3). Consume pending entry (single-use,
+  per ADR-0029 §4.3). Exchange code for tokens via HTTP POST. Encrypt
+  token state via `CredentialStore` (`EncryptionLayer` per ADR-0029).
+- **`POST /credentials/:id/oauth2/callback`** — identical to GET but
+  for IdPs that use `response_mode=form_post` (SAML-OIDC, some
+  Okta flows). Same invariants.
+
+### 4. Security invariants (non-negotiable, CI-enforced)
+
+The following invariants are enforced by CI tests and are canon-level
+for any PR in the OAuth2 area. Violating any of them → CI fail.
+
+#### 4.1. PKCE mandatory S256 (fail-closed on plain)
+
+Authorization URI construction **must** include a PKCE challenge with
+`code_challenge_method=S256`. `plain` is not accepted — an IdP
+configured for `plain` (or no PKCE) returns
+`OAuthError::PkceRequired` without attempting the request. No
+fallback.
+
+Rationale: PKCE S256 is the modern OAuth2 baseline (RFC 7636); `plain`
+is a historical compromise that modern IdPs universally support
+upgrading out of. A fallback path would invite silent downgrade to
+`plain` on misconfiguration, which is the exact class of drift §4.5
+rejects.
+
+#### 4.2. CSRF token ≤ 10 minutes TTL, single-use, constant-time compare
+
+The `state` parameter carries (among other things) a CSRF token
+generated at authorization-URI construction time:
+
+- TTL ≤ 10 minutes from generation. Enforced by pending-store (ADR-
+  0029 §4.2).
+- Single-use — consumed transactionally at callback via
+  `get_then_delete` on the pending store (ADR-0029 §4.3).
+- Compared against the callback-provided value with
+  `subtle::ConstantTimeEq` (not `==`). Mismatch or expired →
+  `OAuthError::CsrfFailure` with HTTP 401. The error message does
+  not include the token value (to prevent leak via error log /
+  response body).
+
+#### 4.3. State parameter crypto-bound (HMAC, not random)
+
+The `state` parameter is **not** a plain random hex string. It is
+`base64url(hmac_sha256(server_secret, csrf_token || credential_id ||
+expires_at) || csrf_token || credential_id || expires_at)`.
+
+- HMAC secret lives in the api composition root (config injected).
+- Callback recomputes HMAC and verifies constant-time **before**
+  consuming the pending record. An attacker who forges a state with
+  the right shape but wrong HMAC is rejected without pending-store
+  lookup.
+- Rejection error is indistinguishable between "HMAC failed",
+  "expired", "unknown credential_id" — no side channel.
+
+Rationale: a plain random state is vulnerable to replay if an
+attacker intercepts a valid state during flight. HMAC binding ties
+the state to the credential and the expiry; interception without
+the HMAC secret is useless.
+
+#### 4.4. reqwest client shape — fail-closed limits
+
+The `reqwest::Client` used for token exchange is configured once at
+api startup with:
+
+- **TLS only** — rustls backend, no `--insecure` escape hatch.
+- **Redirect cap 5** — `redirect::Policy::limited(5)`. Each redirect
+  target is re-validated against the token endpoint URL allowlist
+  (§4.5). A redirect to a non-allowlisted URL → hard fail.
+- **Timeout 30 s** per call — `Client::builder().timeout(Duration::from_secs(30))`.
+- **Response body cap 1 MiB** — streaming reader capped. Overage →
+  `OAuthError::ResponseTooLarge`. Token endpoints universally
+  return <100 KiB; 1 MiB is a belt-and-braces bound against a
+  malicious / misconfigured endpoint trying to exhaust memory.
+
+These match the ADR-0025 broker network verb posture — consistent
+"fail-closed limits on outbound HTTP" across nebula-api and the
+sandbox broker.
+
+#### 4.5. Token endpoint URL allowlist (per-credential, workflow-config)
+
+Each credential config declares `allowed_token_endpoints: Vec<Url>`
+at registration time. At runtime, the api verifies the IdP's
+token-endpoint URL (from the credential config, not from the IdP's
+redirect response) is in the allowlist. **Literal URL match** — no
+DNS-resolve-then-compare (defeats allowlist under DNS rebind
+attacks).
+
+Redirect chains (up to 5 per §4.4) re-validate each hop against the
+allowlist. A redirect target not in the allowlist fails the request.
+
+Rationale: without the allowlist, a misconfigured credential pointing
+at `http://169.254.169.254/token` (cloud metadata endpoint) would
+exfiltrate the authorization code to the metadata service on behalf
+of the workflow. The allowlist defaults to empty — a credential with
+no `allowed_token_endpoints` fails to activate the OAuth flow. Same
+SSRF-prevent-not-detect posture as ADR-0025 §3.
+
+#### 4.6. Zeroize on partial reqwest failure
+
+Timeout, connection reset, partial response, or any early-return
+error path leaves zero plaintext in memory:
+
+- Request body (contains client_secret and authorization code) is a
+  `Zeroizing<Vec<u8>>`. Dropped on scope exit regardless of success
+  or error.
+- Partial response body (if any bytes arrived before a timeout) is
+  zeroized via the streaming reader's on-error `Drop`. No `.to_vec()`
+  capture of the partial bytes.
+- Any `OAuthError` variant that wraps a reqwest error chain filters
+  the error chain through a redaction helper (same helper as
+  ADR-0030 §4) before formatting.
+
+CI test: mock reqwest failure mid-response, assert that process
+memory (queried via a dedicated test helper that scans an
+allocated-then-deallocated region) contains no token substring.
+
+### 5. `reqwest` becomes a base dep of `nebula-api`
+
+`reqwest` is already in the workspace `[workspace.dependencies]`.
+Adding it to `crates/api/Cargo.toml` as a base dep (not optional) is
+consistent with the migration scope. `url` accompanies it for the
+typed URL handling required by §4.5 (allowlist is `Vec<Url>`, not
+`Vec<String>`).
+
+Removing `reqwest` from `nebula-credential` (per spec §9) is a
+consequence of moving both refresh (to engine, ADR-0030) and
+ceremony (to api, this ADR). After P10 lands, credential has no
+HTTP surface.
+
+### 6. Feature gate during rollout
+
+`crates/api/src/credential/` is feature-gated behind
+`credential-oauth` until the `e2e_oauth2_flow` integration test
+(spec §13) is green. The feature is **not** default during rollout:
+
+```toml
+[features]
+default = []
+credential-oauth = ["dep:reqwest", "dep:url"]
+```
+
+Once the E2E test passes on CI, a separate PR flips the feature into
+default (and adjusts MATURITY). Until then, operators building
+`nebula-api` without `--features credential-oauth` do not get the
+OAuth controller — the api MATURITY row reflects "OAuth ceremony
+available, requires --features credential-oauth" honestly, not as a
+silent capability claim.
+
+ADR-0028 invariant 5 (operational honesty) applies. The feature
+gate is **not** a permanent toggle — it exists only for the rollout
+window.
+
+### 7. CI gates for feature matrix
+
+From P10 onwards, CI runs both `--all-features` and
+`--no-default-features` matrix legs for `nebula-api`. Without both
+legs, `credential-oauth` silently bitrots between releases (compiles
+on default path but breaks under `--features credential-oauth`, or
+vice versa). The matrix is a required job in `lefthook pre-push` and
+the mirror `pr-validation.yml` workflow per CLAUDE.md.
+
+### 8. Canon interaction — §12.5 on request path
+
+Plaintext token material on the api request path lives only in
+zeroize containers:
+
+- Request body for token exchange → `Zeroizing<Vec<u8>>`.
+- Response body (during parse) → `Zeroizing<String>` then parsed into
+  `Zeroizing<OAuth2Tokens>`.
+- Writes to `CredentialStore` pass through `EncryptionLayer` per
+  ADR-0029 §1. Encrypted at rest immediately.
+
+The api crate does not log tokens — same redaction rules as
+ADR-0030 §4 apply. Tracing spans on callback carry credential_id,
+status_code, latency_ms, token-endpoint host (without query). Never
+the body. Never headers except `Content-Type` / `Content-Length`.
+
+## Consequences
+
+**Positive.**
+
+- OAuth2 HTTP ceremony lives in the crate whose layer is HTTP.
+  Operators tracing a callback from access-log to code path hit
+  `api/credential/` on the first grep.
+- `nebula-credential` becomes a pure contract crate post-P10 (spec
+  §2): no HTTP, no reqwest, no url. Base-dep diet complete.
+- n8n parity on the ceremony / refresh split means plugin authors
+  familiar with n8n's architecture find analogous code in the same
+  pattern.
+- Security invariants §4.1-§4.6 are CI-enforced, not prose-enforced.
+  A PR that weakens any invariant fails CI.
+- Feature gate during rollout per §6 means the MATURITY row for
+  `nebula-api` stays honest — OAuth is "available under
+  `credential-oauth`" until the E2E integration test is green,
+  then "stable."
+- `reqwest` configuration (§4.4 + ADR-0030 §5 + ADR-0025 §3) is
+  consistent across nebula-api, nebula-engine, and nebula-sandbox:
+  TLS, bounded timeout, bounded body, allowlist-enforced
+  destinations. One mental model for outbound HTTP.
+
+**Negative / accepted costs.**
+
+- `nebula-api` takes on reqwest + url base deps (P10). Increases
+  compile time and binary size. Accepted: api is the HTTP layer; it
+  is the right place for outbound HTTP ceremony.
+- Security invariants §4 require explicit allowlist configuration
+  per credential. Operators moving from the prior (permissive)
+  posture must declare `allowed_token_endpoints` for every OAuth2
+  credential. Migration note in `docs/UPGRADE_COMPAT.md` (follow-up).
+- Feature gate §6 is an ongoing CI matrix cost (two extra legs
+  per api test). Accepted — without both legs `credential-oauth`
+  bitrots. This is a permanent cost during the rollout window; once
+  `credential-oauth` flips to default, the cost reduces to the
+  `--no-default-features` leg only.
+- The state-parameter HMAC (§4.3) requires a server secret in the
+  composition root, in addition to the encryption key (ADR-0023) and
+  the JWT secret (per `api/src/config.rs`). Three secrets to manage.
+  Accepted — each has distinct lifecycle (encryption rotates with
+  credential key rotation; JWT rotates with session policy; OAuth
+  state HMAC rotates with a longer cadence). Conflating them would
+  be a regression.
+
+**Neutral.**
+
+- n8n's `@n8n/client-oauth2` is a reqwest-analog with a small
+  feature set; we do not adopt the crate itself (adds a
+  dependency hop) but adopt its shape.
+- PKCE primitives stay in `nebula-credential::secrets::crypto` —
+  pure arithmetic, reachable by api via sibling dep. Not moved.
+- `CredentialStore` is consumed from `nebula-storage` per ADR-0029.
+  The api crate's composition root already depends on
+  `nebula-storage` for session storage and similar; no new dep
+  edge.
+
+## Alternatives considered
+
+### A. Leave OAuth ceremony in `nebula-credential::credentials::oauth2_flow`
+
+**Rejected.** Preserves today's layering violation: credential crate
+contains HTTP ceremony. Reqwest stays as a credential base dep.
+MATURITY `partial / Engine integration` for credential does not
+improve. Failure to act on the spec's §2 target shape.
+
+### B. Put ceremony in `nebula-engine` alongside refresh
+
+**Rejected.** Engine is the execution layer; ceremony is HTTP
+request/response work initiated by a user. Canonical split — see
+n8n's layering (§2). A user-initiated authorization request is not
+a workflow execution event.
+
+### C. New `nebula-oauth` crate
+
+**Rejected.** Adds a seventh workspace member for one concern that
+fits cleanly into `nebula-api`. `nebula-api` already owns HTTP
+routing, auth handling, webhook reception — OAuth2 endpoints are the
+same kind of work.
+
+### D. Accept plain-state instead of HMAC-state (§4.3)
+
+**Rejected.** Plain random state is vulnerable to interception +
+replay. The HMAC shape is standard OAuth2 threat-model hardening;
+accepting plain is a §11.6 false-capability claim ("CSRF defense" that
+does not defend against interception).
+
+### E. Drop the token endpoint URL allowlist (§4.5), rely on workflow-
+config trust
+
+**Rejected.** Workflow-config is edited by humans; misconfigurations
+happen. The allowlist is a second layer of defense, not a replacement
+for config review. Same SSRF-prevent posture as ADR-0025 §3 for
+broker network verbs.
+
+### F. Allow PKCE `plain` as fallback for legacy IdPs (§4.1)
+
+**Rejected.** Every major IdP in production (Google, Microsoft,
+GitHub, GitLab, Okta, Auth0) supports `S256`. A `plain` fallback
+would land us in the "legacy IdP support" bitrot class, where tests
+never exercise the fallback path and it silently breaks. Fail-closed
+is honest.
+
+### G. Log response body at DEBUG for troubleshooting
+
+**Rejected.** Access tokens in DEBUG logs is a §12.5 violation and
+a common exfiltration vector. Debug-time introspection uses a
+redacted dump helper (same one the redaction test helper drives)
+that can be toggled per-call with strict filtering; general DEBUG
+logs do not contain bodies.
+
+## Seam / verification
+
+Files that carry the invariants after the migration (spec §3):
+
+- `crates/api/src/credential/mod.rs` — module root.
+- `crates/api/src/credential/oauth_controller.rs` — three HTTP
+  endpoints (§3). Feature-gated under `credential-oauth` during
+  rollout (§6).
+- `crates/api/src/credential/flow.rs` — auth URI construction, token
+  exchange HTTP client. Reqwest configuration per §4.4.
+- `crates/api/src/credential/state.rs` — CSRF + pending-state
+  correlation, HMAC-state generation/verification (§4.3).
+- `crates/storage/src/credential/pending.rs` — pending store
+  (created by ADR-0029); api consumes.
+- `crates/credential/src/secrets/crypto.rs` — PKCE primitives stay;
+  api consumes.
+
+Test coverage:
+
+- `crates/api/tests/e2e_oauth2_flow.rs` — end-to-end OAuth2 cycle
+  (register, authorize, mock callback, resolve, refresh, rotate,
+  revoke). Spec §13 integration test. Gate for MATURITY flip.
+- `crates/api/tests/oauth_pkce_enforcement.rs` — §4.1: plain rejected,
+  S256 accepted. Mock IdP returns plain → api refuses.
+- `crates/api/tests/oauth_csrf_invariants.rs` — §4.2: TTL expiry,
+  single-use replay rejection, constant-time compare (timing-attack
+  regression test).
+- `crates/api/tests/oauth_state_hmac.rs` — §4.3: forged state
+  rejected; HMAC tamper rejected; error-message side-channel absent.
+- `crates/api/tests/oauth_reqwest_limits.rs` — §4.4: 31 s timeout
+  fires; 2 MiB response fails; 6th redirect rejected; TLS-only
+  (plain http://... refused).
+- `crates/api/tests/oauth_endpoint_allowlist.rs` — §4.5: literal
+  match required; DNS-rebind defeated (URL match not IP match);
+  redirect to non-allowlisted → fail.
+- `crates/api/tests/oauth_memory_zeroize.rs` — §4.6: post-request
+  memory scan shows no token substring.
+
+CI signals:
+
+- **Layer direction in `deny.toml`**: `nebula-api` may depend on
+  `nebula-storage` + `nebula-credential` + `nebula-engine`; reverse
+  direction forbidden. Rule lands in P10 (same PR as the move).
+- **Feature matrix** (§7): `--all-features` and
+  `--no-default-features` legs required for `nebula-api` from P10.
+- **Redaction CI**: per §8, token substring absent from all outputs.
+  Row in `crates/api/tests/oauth_redaction.rs`.
+- **MSRV 1.95**: all new files respect MSRV per
+  [ADR-0019](./0019-msrv-1.95.md).
+
+## Follow-ups
+
+- **Phase P10 implementation PR** (spec §12) — physical creation of
+  `crates/api/src/credential/` with `oauth_controller.rs`, `flow.rs`,
+  `state.rs`. `reqwest` and `url` become api base deps (behind
+  `credential-oauth` feature).
+- **E2E integration test green** → flip `credential-oauth` to
+  default, update MATURITY for `nebula-api` accordingly. Separate
+  post-P11 PR.
+- **Operator migration doc** — `docs/UPGRADE_COMPAT.md` entry for
+  `allowed_token_endpoints` (§4.5) per-credential config field.
+- **Refresh token revocation endpoint** — post-migration enhancement;
+  new ADR.
+- **OIDC support** — post-migration; mostly additive, but ID token
+  validation has its own invariant set. New ADR.
+- **[ADR-0030](./0030-engine-owns-credential-orchestration.md)
+  token_refresh CI gate** — adjacent redaction gate lives in engine;
+  ceremony's gate lives in api. Both cite ADR-0028 invariant 7.

--- a/docs/adr/0031-api-owns-oauth-flow.md
+++ b/docs/adr/0031-api-owns-oauth-flow.md
@@ -28,11 +28,12 @@ umbrella of cross-crate credential invariants. [ADR-0029](./0029-storage-owns-cr
 hands persistence to `nebula-storage`. [ADR-0030](./0030-engine-owns-credential-orchestration.md)
 hands runtime orchestration (including token refresh) to `nebula-engine`.
 This ADR codifies the third migration: **user-facing OAuth2 HTTP
-ceremony moves from `nebula-credential::credentials::oauth2_flow`
-into `nebula-api/src/credential/`**.
+ceremony moves from `crates/credential/src/credentials/oauth2/flow.rs`
+into `crates/api/src/credential/`**.
 
-Today, `nebula-credential::credentials::oauth2_flow.rs` mixes four
-distinct concerns:
+Today, `crates/credential/src/credentials/oauth2/flow.rs` (nested
+under the `credentials::oauth2` module since P2) mixes four distinct
+concerns:
 
 1. Authorization URI construction with PKCE challenge + CSRF token.
 2. Callback handling — receive authorization code, validate state,
@@ -45,8 +46,9 @@ distinct concerns:
 Only (1) + (2) are user-facing HTTP ceremony. They belong in the HTTP
 API surface, adjacent to `nebula-api`'s existing auth and webhook
 handlers. (3) moved to engine per ADR-0030. (4) stays in
-`nebula-credential::secrets::crypto` — pure arithmetic, reachable by
-api and engine via sibling dep.
+`crates/credential/src/secrets/crypto.rs` (public re-exports on
+`nebula_credential::secrets` and the crate root) — pure arithmetic,
+reachable by api and engine via sibling dep.
 
 The canon context that binds this migration:
 
@@ -346,8 +348,9 @@ the body. Never headers except `Content-Type` / `Content-Length`.
 - n8n's `@n8n/client-oauth2` is a reqwest-analog with a small
   feature set; we do not adopt the crate itself (adds a
   dependency hop) but adopt its shape.
-- PKCE primitives stay in `nebula-credential::secrets::crypto` —
-  pure arithmetic, reachable by api via sibling dep. Not moved.
+- PKCE primitives stay at `crates/credential/src/secrets/crypto.rs`
+  (public re-exports on `nebula_credential::secrets` and the crate
+  root) — pure arithmetic, reachable by api via sibling dep. Not moved.
 - `CredentialStore` is consumed from `nebula-storage` per ADR-0029.
   The api crate's composition root already depends on
   `nebula-storage` for session storage and similar; no new dep
@@ -355,7 +358,7 @@ the body. Never headers except `Content-Type` / `Content-Length`.
 
 ## Alternatives considered
 
-### A. Leave OAuth ceremony in `nebula-credential::credentials::oauth2_flow`
+### A. Leave OAuth ceremony in `crates/credential/src/credentials/oauth2/flow.rs`
 
 **Rejected.** Preserves today's layering violation: credential crate
 contains HTTP ceremony. Reqwest stays as a credential base dep.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -30,18 +30,22 @@ changes land as a new ADR that `supersedes` it.
 | [0020](./0020-library-first-gtm.md) | Library-first GTM + `apps/server` as thin composition root | accepted | 2026-04-19 |
 | [0021](./0021-crate-publication-policy.md) | Crate publication policy (`publish = true` requires ≥ 3 external consumers OR dedicated ADR) | accepted | 2026-04-19 |
 | [0022](./0022-webhook-signature-policy.md) | Webhook signature policy (`SignaturePolicy::Required` default at `WebhookAction` trait level) | accepted | 2026-04-19 |
-| [0023](./0023-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source | accepted | 2026-04-19 |
+| [0023](./0023-keyprovider-trait.md) | `KeyProvider` trait between `EncryptionLayer` and key material source (superseded by 0029 in location) | accepted | 2026-04-19 |
 | [0024](./0024-defer-dynosaur-migration.md) | Defer `dynosaur` migration — keep `#[async_trait]` for `dyn`-consumed traits (supersedes 0014) | accepted | 2026-04-20 |
 | [0025](./0025-sandbox-broker-rpc-surface.md) | Sandbox Phase 1 broker — RPC surface and audit posture (sibling to 0006) | accepted | 2026-04-20 |
 | [0026](./0026-nebula-sdk-dependency-closure.md) | `nebula-sdk` dependency closure for crates.io publication (follow-up to 0021) | proposed | 2026-04-20 |
 | [0027](./0027-plugin-load-path-stable.md) | Plugin load-path stable — `Plugin` trait canonical; `ResolvedPlugin` per plugin; `PluginManifest` in `nebula-metadata`; multi-version runtime dropped | accepted | 2026-04-20 |
+| [0028](./0028-cross-crate-credential-invariants.md) | Cross-crate credential invariants (umbrella for 0029/0030/0031; §12.5 / §13.2 / §3.5 / §14 / §4.5 anchors) | accepted | 2026-04-20 |
+| [0029](./0029-storage-owns-credential-persistence.md) | `nebula-storage` owns credential persistence (supersedes 0023 in location of `KeyProvider` / `EncryptionLayer`) | accepted | 2026-04-20 |
+| [0030](./0030-engine-owns-credential-orchestration.md) | `nebula-engine` owns credential orchestration + token refresh; `RefreshCoordinator` stays concrete-not-trait | accepted | 2026-04-20 |
+| [0031](./0031-api-owns-oauth-flow.md) | `nebula-api` owns OAuth flow HTTP ceremony (PKCE S256, HMAC state, URL allowlist, fail-closed limits) | accepted | 2026-04-20 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0027**). Do not reuse.
+2. Pick the next free number (currently **0031**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with


### PR DESCRIPTION
## Summary

Phase P5 of credential architecture cleanup ([spec](docs/superpowers/specs/2026-04-20-credential-architecture-cleanup-design.md) §4-§7 / [plan](docs/superpowers/plans/2026-04-20-credential-cleanup-p1-p5.md)). **Docs-only** — four ADRs that codify cross-crate credential invariants. **This PR is the hard go/no-go checkpoint before P6+ physical crate moves.**

Single commit: `703addb3`.

## ADRs

| ADR | Title | Lines | Role |
|---|---|---|---|
| **0028** | [cross-crate credential invariants](docs/adr/0028-cross-crate-credential-invariants.md) | 361 | **Umbrella** — 8 numbered invariants (§12.5 preservation, §13.2 seam integrity, §3.5 split, §14 no-discard-and-log, §4.5 operational honesty, cross-crate compat, zeroize-at-boundaries, versioning in alpha) |
| **0029** | [storage owns credential persistence](docs/adr/0029-storage-owns-credential-persistence.md) | 400 | **Supersedes ADR-0023 in location only** — trait shape, `ProviderError`, fingerprint scheme, three impls preserved bit-for-bit. CredentialStore + impls + EncryptionLayer + KeyProvider + cache + audit + scope + pending repo + backup repo live in storage/credential/. Pending store invariants: code_verifier encrypted + TTL ≤ 10min + single-use + session-bound + SecretString return + zeroize-on-read |
| **0030** | [engine owns credential orchestration](docs/adr/0030-engine-owns-credential-orchestration.md) | 421 | Rotation (scheduler + grace + blue_green + transaction) + resolver + registry + token_refresh in engine. **RefreshCoordinator stays concrete-not-trait** (thundering-herd primitive, not pluggable policy — trait-ification invites broken impls). Token refresh **MUST NOT** log tokens — CI redaction gate |
| **0031** | [api owns OAuth flow ceremony](docs/adr/0031-api-owns-oauth-flow.md) | 477 | n8n-parity split (ceremony in api, refresh in engine, type def in credential). **6 CI-enforced security invariants**: PKCE S256 mandatory (plain rejected), CSRF ≤10min + constant-time compare, HMAC-bound state param, reqwest TLS-only + redirect/timeout/body caps, token endpoint URL allowlist, zeroize on partial failure |

Plus:
- `docs/adr/0023-keyprovider-trait.md` — frontmatter-only update (`superseded_by: [0029]` + `related:` entry); body untouched per ADR convention
- `docs/adr/README.md` — 4 new index entries + note on 0023 row

## Design anchor

The umbrella-satellite pattern prevents invariant drift: 0029/0030/0031 cite 0028 invariants by number rather than restating. ADR-0028's own Alternatives D rejects "handle invariants in each migration ADR" and articulates why (drift within weeks).

## Review results

- **Spec review** (agent): ✅ — All 4 ADRs have required frontmatter keys, body sections, cross-refs complete, zero placeholders, content matches spec §4-§7 paraphrased into ADR register.
- **Code-quality review** (agent): **Accept** — supersede hygiene clean (0023 body untouched, 0029 scopes supersede to location only), normative force consistent (MUST/MUST NOT where warranted), seam/verification sections point at concrete post-P6 paths, follow-ups reference P6-P11 by phase rather than hand-waving.

Minor findings (non-blockers):
- ADR-0023 body line 21 shows `# 0022.` (pre-existing typo, body immutable — leave for future touch-up)
- ADR-0030 §5 reqwest/broker-pattern analogy slightly stretched (ADR-0025 is sandbox-specific) — acceptable framing
- ADR-0031 §4.3 HMAC serialization detail — implementation-time concern

## Test plan (docs-only)

- [x] `cargo check -p nebula-credential` — clean (no code changes, sanity check)
- [x] Markdown well-formed (headings nested, code fences closed, lists terminated)
- [x] `grep -i "TBD\|TODO\|placeholder\|FIXME\|XXX"` on all 4 new ADRs → zero hits
- [x] Cross-refs validated across `related:` frontmatter + README index
- [x] Commit via lefthook (typos, convco) — passed

## Go/No-Go checkpoint

**After merge, P6+ (physical crate moves) is unblocked.** If any ADR content has blockers or unresolved questions, reject this PR and revise the spec — don't start P6 until all four ADRs land accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)