### PR TITLE
feat(schema): prelude ergonomics and required/active_when docs

### DIFF
--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -137,6 +137,12 @@ macro_rules! define_field {
             }
 
             /// Mark field as always required.
+            ///
+            /// `required` enforces more than presence: an empty string
+            /// (String / Secret / Code / single File), an empty array
+            /// (List, multi-Select, multi-File) and a JSON `null` all count
+            /// as missing. This matches HTML-form `required` semantics —
+            /// callers should not rely on `""` satisfying the constraint.
             #[must_use]
             pub fn required(mut self) -> Self {
                 self.required = RequiredMode::Always;
@@ -144,13 +150,32 @@ macro_rules! define_field {
             }
 
             /// Mark field required when predicate holds.
+            ///
+            /// Emptiness rules mirror [`required`](Self::required): an
+            /// empty collection / empty string / null value is treated as
+            /// absent once the predicate fires.
             #[must_use]
             pub fn required_when(mut self, rule: Rule) -> Self {
                 self.required = RequiredMode::When(rule);
                 self
             }
 
-            /// Mark field visible and required when predicate holds.
+            /// Mark field both visible and required when predicate holds.
+            ///
+            /// Shorthand for calling `visible_when(rule.clone())` +
+            /// `required_when(rule)`. Prefer this over duplicating the rule
+            /// in two setters.
+            ///
+            /// # Example
+            ///
+            /// ```ignore
+            /// // `api_key` only appears and is only required when
+            /// // `auth_type == "api_key"`.
+            /// Field::secret(field_key!("api_key"))
+            ///     .active_when(Rule::predicate(
+            ///         Predicate::eq("auth_type", json!("api_key")).unwrap(),
+            ///     ))
+            /// ```
             #[must_use]
             pub fn active_when(mut self, rule: Rule) -> Self {
                 self.visible = VisibilityMode::When(rule.clone());

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -25,6 +25,38 @@
 //!
 //! assert_eq!(valid.warnings().len(), 0);
 //! ```
+//!
+//! # Conditional fields
+//!
+//! Use `active_when` to express "field X only appears and is only required
+//! when predicate P holds" — the shorthand avoids repeating the same
+//! predicate in `visible_when` and `required_when`.
+//!
+//! ```rust
+//! use nebula_schema::prelude::*;
+//! use serde_json::json;
+//!
+//! let schema = Schema::builder()
+//!     .add(
+//!         Field::select(field_key!("auth_type"))
+//!             .option("api_key", "API key")
+//!             .option("oauth2", "OAuth2")
+//!             .required(),
+//!     )
+//!     .add(
+//!         Field::secret(field_key!("api_key")).active_when(Rule::predicate(
+//!             Predicate::eq("auth_type", json!("api_key")).unwrap(),
+//!         )),
+//!     )
+//!     .add(
+//!         Field::string(field_key!("client_id")).active_when(Rule::predicate(
+//!             Predicate::eq("auth_type", json!("oauth2")).unwrap(),
+//!         )),
+//!     )
+//!     .build()
+//!     .expect("schema is valid");
+//! assert_eq!(schema.fields().len(), 3);
+//! ```
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]

--- a/crates/schema/src/prelude.rs
+++ b/crates/schema/src/prelude.rs
@@ -3,14 +3,21 @@
 //! Bring this into scope with `use nebula_schema::prelude::*;` to get
 //! everything needed to define and validate schemas without spelling out
 //! each import individually.
+//!
+//! Covers:
+//! - All `Field` variants and their builders.
+//! - The closure-style DSL trait (`FieldCollector`) so `.string()/.select()/…` are discoverable on
+//!   `SchemaBuilder` without a separate import.
+//! - The `HasSchema` trait for types produced by `#[derive(Schema)]`.
+//! - `Rule` + `Predicate` for `visible_when` / `required_when` / `active_when`.
 
-pub use nebula_validator::Rule;
+pub use nebula_validator::{Predicate, Rule};
 
 pub use crate::{
     BooleanField, CodeField, ComputedField, DynamicField, Expression, ExpressionContext,
-    ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues, FileField, InputHint,
-    ListField, LoaderContext, LoaderRegistry, ModeField, NumberField, ObjectField, RequiredMode,
-    ResolvedValues, Schema, SchemaBuilder, SecretField, SelectField, SelectOption, Severity,
-    StringField, Transformer, ValidSchema, ValidValues, ValidationError, ValidationReport,
-    VisibilityMode, field_key,
+    ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues, FileField, HasSchema,
+    InputHint, ListField, LoaderContext, LoaderRegistry, ModeField, NumberField, ObjectField,
+    RequiredMode, ResolvedValues, Schema, SchemaBuilder, SecretField, SelectField, SelectOption,
+    Severity, StringField, Transformer, ValidSchema, ValidValues, ValidationError,
+    ValidationReport, VisibilityMode, builder::FieldCollector, field_key,
 };

--- a/crates/schema/src/prelude.rs
+++ b/crates/schema/src/prelude.rs
@@ -5,19 +5,57 @@
 //! each import individually.
 //!
 //! Covers:
-//! - All `Field` variants and their builders.
+//! - All 13 `Field` variants (`StringField`, `SecretField`, `NumberField`, `BooleanField`,
+//!   `SelectField`, `ObjectField`, `ListField`, `ModeField`, `CodeField`, `FileField`,
+//!   `ComputedField`, `DynamicField`, `NoticeField`) and their associated enums (`ComputedReturn`,
+//!   `ModeVariant`, `NoticeSeverity`).
 //! - The closure-style DSL trait (`FieldCollector`) so `.string()/.select()/…` are discoverable on
 //!   `SchemaBuilder` without a separate import.
-//! - The `HasSchema` trait for types produced by `#[derive(Schema)]`.
+//! - The derive family: `HasSchema` / `HasSelectOptions` traits, the `EnumSelect` derive macro, and
+//!   the `field_key!` macro. The `Schema` derive macro lives at `nebula_schema::Schema` — the same
+//!   path as the `Schema` aggregate type (Rust allows a type and a derive macro to share a name);
+//!   it isn't re-exported here because a prelude can't hold both meanings of the same identifier.
 //! - `Rule` + `Predicate` for `visible_when` / `required_when` / `active_when`.
 
+pub use nebula_schema_macros::EnumSelect;
 pub use nebula_validator::{Predicate, Rule};
 
 pub use crate::{
-    BooleanField, CodeField, ComputedField, DynamicField, Expression, ExpressionContext,
-    ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues, FileField, HasSchema,
-    InputHint, ListField, LoaderContext, LoaderRegistry, ModeField, NumberField, ObjectField,
-    RequiredMode, ResolvedValues, Schema, SchemaBuilder, SecretField, SelectField, SelectOption,
-    Severity, StringField, Transformer, ValidSchema, ValidValues, ValidationError,
-    ValidationReport, VisibilityMode, builder::FieldCollector, field_key,
+    BooleanField, CodeField, ComputedField, ComputedReturn, DynamicField, Expression,
+    ExpressionContext, ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues,
+    FileField, HasSchema, HasSelectOptions, InputHint, ListField, LoaderContext, LoaderRegistry,
+    ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField, RequiredMode,
+    ResolvedValues, Schema, SchemaBuilder, SecretField, SelectField, SelectOption, Severity,
+    StringField, Transformer, ValidSchema, ValidValues, ValidationError, ValidationReport,
+    VisibilityMode, builder::FieldCollector, field_key,
 };
+
+#[cfg(test)]
+mod coverage_smoke {
+    //! Fails to compile if an item listed in the prelude doc comment stops
+    //! being re-exported. Add any newly-documented item here.
+
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[allow(dead_code)]
+    fn touch_all_reexports() {
+        // Field variants.
+        fn _f(_: &StringField, _: &SecretField, _: &NumberField, _: &BooleanField) {}
+        fn _g(_: &SelectField, _: &ObjectField, _: &ListField, _: &ModeField) {}
+        fn _h(_: &CodeField, _: &FileField, _: &ComputedField, _: &DynamicField) {}
+        fn _i(_: &NoticeField) {}
+        // Field-variant companions.
+        let _: Option<NoticeSeverity> = None;
+        let _: Option<ComputedReturn> = None;
+        let _: Option<ModeVariant> = None;
+        // Derive family (traits + `EnumSelect` macro is only touched at use sites).
+        fn _j<T: HasSchema>(_: &T) {}
+        fn _k<T: HasSelectOptions>(_: &T) {}
+        // Rule-building.
+        let _: Option<Rule> = None;
+        let _: Option<Predicate> = None;
+        // DSL trait.
+        fn _l<T: FieldCollector>(_: T) {}
+    }
+}


### PR DESCRIPTION
## Summary

DX PR A of 2. `dx-tester` (newcomer-smoke-test agent) ran 6 realistic scenarios (credential schema, conditional fields, nested lists, custom validation, error messages, `#[derive(Schema)]`) and surfaced three BLOCKER-class prelude gaps plus two doc gaps. All compile-time-only changes.

- **Extend `nebula_schema::prelude`** with three re-exports that each block a common newcomer scenario until manually imported:
  - `FieldCollector` — without it `SchemaBuilder::string()`/`select()`/`list()` closure DSL fails with `method not found`.
  - `HasSchema` — without it `MyStruct::schema()` from `#[derive(Schema)]` fails with `function not found`.
  - `Predicate` from `nebula_validator` — needed for every `visible_when` / `required_when` / `active_when`. Cross-crate import was a surprise in schema-only code.
  - Also re-export `EnumSelect` so the derive family travels together with `Schema` / `field_key!`.
  - Prelude doc comment now enumerates what's covered.
- **Document empty-value semantics of `required()` / `required_when()`.** Since #532 tightened enforcement to reject `""` and `[]`, the docstring now states this explicitly so callers don't rely on empty values satisfying the constraint.
- **Document `active_when(rule)` with a worked example in the crate-root doc.** Previously undiscoverable — newcomers duplicated the rule in `visible_when` + `required_when`. New doctest shows the `auth_type` → conditional `api_key` / `client_id` pattern, compiles against the new prelude.

## Test plan

- [x] `cargo +nightly fmt --all` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 3446 passed, 14 skipped
- [x] `cargo test --workspace --doc` — 208 passed (+1 new)
- [x] pre-push lefthook (nextest, doctests, --all-features, --no-default) — clean

## Notes for reviewers

- Follow-up from tech-lead scope sign-off. **PR B (derive-macro enhancements for `visible_when` attrs + `HasSelectOptions` detection)** will follow separately — dx-tester findings #7/#8 synergize in `crates/schema/macros/` and shouldn't be artificially split.
- **Deferred:** phantom `"_item"` key leaking into wire format in `ListBuilder::item_object` (dx-tester #4) → dedicated ADR; `Predicate::eq` returning `Option<Self>` (#9) → issue in `nebula-validator`; `.lint()` compiler suggestion (#10) → rejected (clippy territory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)