### PR TITLE
fix(schema): FieldPath visibility cycles and align docs

### DIFF
--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -27,7 +27,7 @@ Pattern inspiration: DMMF proof-tokens (ch "Modeling with Types") and Rust types
 - `Schema::lint() -> ValidationReport` — structural diagnostics (errors block `build`; warnings are advisory).
 - `SchemaBuilder::build() -> Result<ValidSchema, ValidationReport>` — runs lint passes and returns the `ValidSchema` proof-token.
 - `ValidSchema::validate(&FieldValues) -> Result<ValidValues, ValidationReport>` — schema-time validation; returns the first proof-token.
-- `ValidValues::resolve(&impl ExpressionContext) -> Result<ResolvedValues, ValidationReport>` — runtime resolution; returns the second proof-token.
+- `ValidValues::resolve(self, ctx: &dyn ExpressionContext) -> Result<ResolvedValues, ValidationReport>` — async runtime resolution; consumes the first proof-token and returns the second (use `.await`).
 - `FieldValues`, `ResolvedValues` — value containers.
 
 See `src/lib.rs` rustdoc for the quick-start example.

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -22,11 +22,12 @@ Pattern inspiration: DMMF proof-tokens (ch "Modeling with Types") and Rust types
 ## Public API
 
 - `Field` — unified enum over all field kinds (string, number, bool, enum, nested, …).
-- `Schema` — builder-constructed, lint-checked schema definition.
-- `Schema::builder() -> SchemaBuilder` — entry point.
-- `Schema::lint() -> Result<ValidSchema, LintError>` — structural check.
-- `ValidSchema::validate(&FieldValues) -> Result<ValidValues, ValidationError>` — schema-time validation; returns the first proof-token.
-- `ValidValues::resolve(&impl ExpressionContext) -> Result<ResolvedValues, ResolveError>` — runtime resolution; returns the second proof-token.
+- `Schema` — value type for a field list; use `Schema::builder()` or `Schema::add` for construction.
+- `Schema::builder() -> SchemaBuilder` — primary entry point.
+- `Schema::lint() -> ValidationReport` — structural diagnostics (errors block `build`; warnings are advisory).
+- `SchemaBuilder::build() -> Result<ValidSchema, ValidationReport>` — runs lint passes and returns the `ValidSchema` proof-token.
+- `ValidSchema::validate(&FieldValues) -> Result<ValidValues, ValidationReport>` — schema-time validation; returns the first proof-token.
+- `ValidValues::resolve(&impl ExpressionContext) -> Result<ResolvedValues, ValidationReport>` — runtime resolution; returns the second proof-token.
 - `FieldValues`, `ResolvedValues` — value containers.
 
 See `src/lib.rs` rustdoc for the quick-start example.

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -313,16 +313,24 @@ fn lint_rule_refs_new(
             }
             continue;
         }
+        if let Some(rest) = field_ref.strip_prefix('/') {
+            let rk = rest.split('/').next().unwrap_or_default();
+            if !root_keys.contains(rk) {
+                report.push(
+                    ValidationError::builder("dangling_reference")
+                        .at(path.clone())
+                        .message(format!("rule references unknown root key `{rk}`"))
+                        .build(),
+                );
+            }
+            continue;
+        }
         // Transitional: JSON-pointer form (`/path`) splits only on `/`; legacy
         // dotted form (`a.b.c`) splits on `.`. Dual-splitting would chop a
         // valid JSON-pointer segment like `/user.name` at the dot (RFC 6901
         // allows `.` inside segments). Remove the dotted arm once schema refs
         // fully migrate to JSON Pointer.
-        let lk = if let Some(rest) = field_ref.strip_prefix('/') {
-            rest.split('/').next().unwrap_or_default()
-        } else {
-            field_ref.split('.').next().unwrap_or_default()
-        };
+        let lk = field_ref.split('.').next().unwrap_or_default();
         if !local_keys.contains(lk) {
             report.push(
                 ValidationError::builder("dangling_reference")
@@ -722,6 +730,21 @@ fn append_visibility_edges(
                 for variant in &mode.variants {
                     if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
                         let vpath = path.clone().join(vk.clone());
+                        if let Some(rule) = field_visible_rule(variant.field.as_ref()) {
+                            let mut refs = Vec::new();
+                            rule.field_references(&mut refs);
+                            for field_ref in refs {
+                                if let Some(target) =
+                                    resolve_visibility_dependency(field_ref, &vpath)
+                                {
+                                    let normalized_target =
+                                        normalize_visibility_target_path(&target);
+                                    if defined.contains(&normalized_target) {
+                                        edges.push((vpath.clone(), normalized_target));
+                                    }
+                                }
+                            }
+                        }
                         if let Field::Object(obj) = variant.field.as_ref() {
                             append_visibility_edges(&obj.fields, &vpath, defined, edges);
                         }
@@ -940,6 +963,57 @@ mod tests {
                                 ))
                                 .into_field(),
                         ),
+                )
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "visibility_cycle"),
+            "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn pointer_refs_in_nested_scope_are_checked_against_root_keys() {
+        let fields = vec![
+            Field::object("outer")
+                .add(
+                    Field::string("x")
+                        .visible_when(Rule::predicate(
+                            Predicate::eq("/outer/y", json!(true)).unwrap(),
+                        ))
+                        .into_field(),
+                )
+                .into_field(),
+            Field::string("top").into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            !report.errors().any(|e| e.code == "dangling_reference"),
+            "did not expect dangling_reference, got {:?}",
+            report
+                .errors()
+                .map(|e| (&e.code, e.path.to_string()))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_visibility_cycle_through_mode_variant_payload() {
+        let fields = vec![
+            Field::string("a")
+                .visible_when(Rule::predicate(Predicate::eq("/m/v", json!(true)).unwrap()))
+                .into_field(),
+            Field::mode("m")
+                .variant(
+                    "v",
+                    "Variant",
+                    Field::string("payload")
+                        .visible_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
+                        .into_field(),
                 )
                 .into_field(),
         ];

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -1,8 +1,10 @@
 //! Build-time structural lints.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
-use nebula_validator::{DeferredRule, Logic, Predicate, Rule, ValueRule};
+use nebula_validator::{
+    DeferredRule, Logic, Predicate, Rule, ValueRule, foundation::FieldPath as ValidatorFieldPath,
+};
 
 use crate::{
     Field, FieldPath, ListField, ModeField, RequiredMode, VisibilityMode,
@@ -571,65 +573,209 @@ fn collect_min_max(
     }
 }
 
-fn emit_visibility_cycle(start: &str, prefix: &FieldPath, report: &mut ValidationReport) {
-    let cycle_path = crate::key::FieldKey::new(start)
-        .map_or_else(|_| prefix.clone(), |k| prefix.clone().join(k));
+fn emit_visibility_cycle_on_edge(from: &FieldPath, to: &FieldPath, report: &mut ValidationReport) {
     report.push(
         ValidationError::builder("visibility_cycle")
-            .at(cycle_path)
+            .at(from.clone())
             .message(format!(
-                "visibility rule graph contains cycle involving `{start}`"
+                "visibility rule graph contains a cycle (dependency `{from}` -> `{to}`)"
             ))
             .build(),
     );
 }
 
-fn lint_visibility_cycles_new(fields: &[Field], prefix: &FieldPath, report: &mut ValidationReport) {
-    // TODO(task-26): add full visibility_cycle detection using FieldPath-aware graph
-    // For now, delegate to key-based cycle detection.
-    let mut edges: Vec<(&str, &str)> = Vec::new();
+/// Convert a validator JSON-pointer field path into a schema [`FieldPath`]
+/// (dot/bracket wire form used throughout this crate).
+fn validator_path_to_schema_path(vp: &ValidatorFieldPath) -> Option<FieldPath> {
+    let mut out = FieldPath::root();
+    let mut any = false;
+    for seg in vp.segments() {
+        let s = seg.as_ref();
+        if s.is_empty() {
+            continue;
+        }
+        any = true;
+        let segment = if s.chars().all(|c| c.is_ascii_digit()) {
+            let idx: usize = s.parse().ok()?;
+            PathSegment::Index(idx)
+        } else {
+            PathSegment::Key(crate::key::FieldKey::new(s).ok()?)
+        };
+        out = out.join(segment);
+    }
+    if any { Some(out) } else { None }
+}
+
+fn path_concat_schema(prefix: &FieldPath, suffix: &FieldPath) -> FieldPath {
+    if prefix.is_root() {
+        suffix.clone()
+    } else {
+        let mut out = prefix.clone();
+        for seg in suffix.segments() {
+            out = out.join(seg.clone());
+        }
+        out
+    }
+}
+
+/// Resolve a [`Rule::field_references`] string to an absolute schema [`FieldPath`].
+///
+/// - `$root.` — anchor at schema root (same convention as [`lint_rule_refs_new`]).
+/// - Leading `/` — JSON Pointer from schema root (validator [`ValidatorFieldPath`]).
+/// - Otherwise — legacy path relative to `scope_prefix` (sibling object scope).
+fn resolve_visibility_dependency(field_ref: &str, scope_prefix: &FieldPath) -> Option<FieldPath> {
+    if let Some(rest) = field_ref.strip_prefix("$root.") {
+        let vp = ValidatorFieldPath::parse(rest)?;
+        return validator_path_to_schema_path(&vp);
+    }
+    if field_ref.starts_with('/') {
+        let vp = ValidatorFieldPath::parse(field_ref)?;
+        return validator_path_to_schema_path(&vp);
+    }
+    let suffix = FieldPath::parse(field_ref).ok()?;
+    Some(path_concat_schema(scope_prefix, &suffix))
+}
+
+fn collect_defined_field_paths(
+    fields: &[Field],
+    prefix: &FieldPath,
+    defined: &mut HashSet<FieldPath>,
+) {
     for field in fields {
-        let source = field.key().as_str();
-        if let Some(rule) = field_visible_rule(field) {
-            let mut refs: Vec<&str> = Vec::new();
-            rule.field_references(&mut refs);
-            for target in refs {
-                if target.starts_with("$root.") {
-                    continue;
+        let path = prefix.clone().join(field.key().clone());
+        defined.insert(path.clone());
+
+        match field {
+            Field::List(list) => {
+                if let Some(Field::Object(obj)) = list.item.as_deref() {
+                    collect_defined_field_paths(&obj.fields, &path, defined);
                 }
-                // Transitional: JSON-pointer form (`/path`) splits only on
-                // `/`; legacy dotted form (`a.b.c`) splits on `.`. Dual-split
-                // would mangle a valid pointer segment containing `.` (RFC
-                // 6901 allows it). Remove the dotted arm once schema refs
-                // fully migrate to JSON Pointer.
-                let target = if let Some(rest) = target.strip_prefix('/') {
-                    rest.split('/').next().unwrap_or_default()
-                } else {
-                    target.split('.').next().unwrap_or_default()
-                };
-                edges.push((source, target));
-            }
+            },
+            Field::Object(obj) => {
+                collect_defined_field_paths(&obj.fields, &path, defined);
+            },
+            Field::Mode(mode) => {
+                for variant in &mode.variants {
+                    if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
+                        let vpath = path.clone().join(vk.clone());
+                        defined.insert(vpath.clone());
+                        if let Field::Object(obj) = variant.field.as_ref() {
+                            collect_defined_field_paths(&obj.fields, &vpath, defined);
+                        }
+                    }
+                }
+            },
+            _ => {},
         }
     }
+}
 
-    for (start, _) in &edges {
-        let mut stack = vec![*start];
-        let mut visited = HashSet::new();
-        while let Some(current) = stack.pop() {
-            if !visited.insert(current) {
-                continue;
-            }
-            for (edge_from, edge_to) in &edges {
-                if *edge_from != current {
-                    continue;
+fn append_visibility_edges(
+    fields: &[Field],
+    prefix: &FieldPath,
+    defined: &HashSet<FieldPath>,
+    edges: &mut Vec<(FieldPath, FieldPath)>,
+) {
+    for field in fields {
+        let path = prefix.clone().join(field.key().clone());
+
+        if let Some(rule) = field_visible_rule(field) {
+            let mut refs = Vec::new();
+            rule.field_references(&mut refs);
+            for field_ref in refs {
+                if let Some(target) = resolve_visibility_dependency(field_ref, prefix)
+                    && defined.contains(&target)
+                {
+                    edges.push((path.clone(), target));
                 }
-                if *edge_to == *start {
-                    emit_visibility_cycle(start, prefix, report);
-                    return;
-                }
-                stack.push(edge_to);
             }
         }
+
+        match field {
+            Field::List(list) => {
+                if let Some(Field::Object(obj)) = list.item.as_deref() {
+                    append_visibility_edges(&obj.fields, &path, defined, edges);
+                }
+            },
+            Field::Object(obj) => {
+                append_visibility_edges(&obj.fields, &path, defined, edges);
+            },
+            Field::Mode(mode) => {
+                for variant in &mode.variants {
+                    if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
+                        let vpath = path.clone().join(vk.clone());
+                        if let Field::Object(obj) = variant.field.as_ref() {
+                            append_visibility_edges(&obj.fields, &vpath, defined, edges);
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+fn visibility_adjacency(edges: &[(FieldPath, FieldPath)]) -> HashMap<FieldPath, Vec<FieldPath>> {
+    let mut adj: HashMap<FieldPath, Vec<FieldPath>> = HashMap::new();
+    for (from, to) in edges {
+        adj.entry(from.clone()).or_default().push(to.clone());
+    }
+    adj
+}
+
+fn find_visibility_cycle_edge(
+    adj: &HashMap<FieldPath, Vec<FieldPath>>,
+) -> Option<(FieldPath, FieldPath)> {
+    // 0 = white, 1 = gray, 2 = black
+    let mut color: HashMap<FieldPath, u8> = HashMap::new();
+
+    fn dfs(
+        u: &FieldPath,
+        adj: &HashMap<FieldPath, Vec<FieldPath>>,
+        color: &mut HashMap<FieldPath, u8>,
+    ) -> Option<(FieldPath, FieldPath)> {
+        color.insert(u.clone(), 1);
+        for v in adj.get(u).into_iter().flatten() {
+            match color.get(v).copied().unwrap_or(0) {
+                1 => {
+                    return Some((u.clone(), v.clone()));
+                },
+                0 => {
+                    if let Some(cycle) = dfs(v, adj, color) {
+                        return Some(cycle);
+                    }
+                },
+                _ => {},
+            }
+        }
+        color.insert(u.clone(), 2);
+        None
+    }
+
+    for start in adj.keys() {
+        if color.get(start).copied().unwrap_or(0) == 0
+            && let Some(cycle) = dfs(start, adj, &mut color)
+        {
+            return Some(cycle);
+        }
+    }
+    None
+}
+
+fn lint_visibility_cycles_new(
+    fields: &[Field],
+    _prefix: &FieldPath,
+    report: &mut ValidationReport,
+) {
+    let mut defined: HashSet<FieldPath> = HashSet::new();
+    collect_defined_field_paths(fields, &FieldPath::root(), &mut defined);
+
+    let mut edges: Vec<(FieldPath, FieldPath)> = Vec::new();
+    append_visibility_edges(fields, &FieldPath::root(), &defined, &mut edges);
+
+    let adj = visibility_adjacency(&edges);
+    if let Some((from, to)) = find_visibility_cycle_edge(&adj) {
+        emit_visibility_cycle_on_edge(&from, &to, report);
     }
 }
 
@@ -637,6 +783,9 @@ fn lint_visibility_cycles_new(fields: &[Field], prefix: &FieldPath, report: &mut
 
 #[cfg(test)]
 mod tests {
+    use nebula_validator::{Predicate, Rule};
+    use serde_json::json;
+
     use super::*;
     use crate::{FieldKey, error::ValidationReport, field::Field, path::FieldPath};
 
@@ -694,5 +843,62 @@ mod tests {
         ];
         let report = run(fields);
         assert!(report.errors().any(|e| e.code == "duplicate_variant"));
+    }
+
+    #[test]
+    fn detects_visibility_cycle_between_top_level_fields() {
+        let fields = vec![
+            Field::string(FieldKey::new("a").unwrap())
+                .visible_when(Rule::predicate(Predicate::eq("/b", json!("on")).unwrap()))
+                .into_field(),
+            Field::string(FieldKey::new("b").unwrap())
+                .visible_when(Rule::predicate(Predicate::eq("/a", json!("on")).unwrap()))
+                .into_field(),
+        ];
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "visibility_cycle"),
+            "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_visibility_cycle_inside_nested_object() {
+        let outer = Field::object("outer")
+            .add(
+                Field::string("x")
+                    .visible_when(Rule::predicate(
+                        Predicate::eq("/outer/y", json!(true)).unwrap(),
+                    ))
+                    .into_field(),
+            )
+            .add(
+                Field::string("y")
+                    .visible_when(Rule::predicate(
+                        Predicate::eq("/outer/x", json!(true)).unwrap(),
+                    ))
+                    .into_field(),
+            );
+        let report = run(vec![outer.into()]);
+        assert!(
+            report.errors().any(|e| e.code == "visibility_cycle"),
+            "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn acyclic_visibility_rules_do_not_error() {
+        let fields = vec![
+            Field::string("toggle").into_field(),
+            Field::string("detail")
+                .visible_when(Rule::predicate(
+                    Predicate::eq("/toggle", json!(true)).unwrap(),
+                ))
+                .into_field(),
+        ];
+        let report = run(fields);
+        assert!(!report.errors().any(|e| e.code == "visibility_cycle"));
     }
 }

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -618,6 +618,23 @@ fn path_concat_schema(prefix: &FieldPath, suffix: &FieldPath) -> FieldPath {
     }
 }
 
+/// Normalize dependency paths to the same shape as `collect_defined_field_paths`.
+///
+/// `collect_defined_field_paths` tracks list-item object descendants under the list
+/// key (`items.name`), not indexed instances (`items[0].name`). To make
+/// JSON-pointer refs such as `/items/0/name` comparable against that set, we
+/// drop index segments here.
+fn normalize_visibility_target_path(path: &FieldPath) -> FieldPath {
+    let mut normalized = FieldPath::root();
+    for segment in path.segments() {
+        if matches!(segment, PathSegment::Index(_)) {
+            continue;
+        }
+        normalized = normalized.join(segment.clone());
+    }
+    normalized
+}
+
 /// Resolve a [`Rule::field_references`] string to an absolute schema [`FieldPath`].
 ///
 /// - `$root.` — anchor at schema root (same convention as [`lint_rule_refs_new`]).
@@ -683,10 +700,11 @@ fn append_visibility_edges(
             let mut refs = Vec::new();
             rule.field_references(&mut refs);
             for field_ref in refs {
-                if let Some(target) = resolve_visibility_dependency(field_ref, prefix)
-                    && defined.contains(&target)
-                {
-                    edges.push((path.clone(), target));
+                if let Some(target) = resolve_visibility_dependency(field_ref, prefix) {
+                    let normalized_target = normalize_visibility_target_path(&target);
+                    if defined.contains(&normalized_target) {
+                        edges.push((path.clone(), normalized_target));
+                    }
                 }
             }
         }
@@ -900,5 +918,37 @@ mod tests {
         ];
         let report = run(fields);
         assert!(!report.errors().any(|e| e.code == "visibility_cycle"));
+    }
+
+    #[test]
+    fn detects_visibility_cycle_with_list_index_reference() {
+        let fields = vec![
+            Field::list("items")
+                .item(
+                    Field::object("row")
+                        .add(
+                            Field::string("x")
+                                .visible_when(Rule::predicate(
+                                    Predicate::eq("/items/0/y", json!(true)).unwrap(),
+                                ))
+                                .into_field(),
+                        )
+                        .add(
+                            Field::string("y")
+                                .visible_when(Rule::predicate(
+                                    Predicate::eq("/items/0/x", json!(true)).unwrap(),
+                                ))
+                                .into_field(),
+                        ),
+                )
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "visibility_cycle"),
+            "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
     }
 }

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -294,7 +294,6 @@ impl SchemaBuilder {
     pub fn build(self) -> Result<ValidSchema, ValidationReport> {
         let mut report = ValidationReport::new();
 
-        // Lint passes (Task 19 fills these out fully).
         crate::lint::lint_tree(&self.fields, &FieldPath::root(), &mut report);
 
         if report.has_errors() {

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -52,8 +52,9 @@ pub struct ValidSchemaInner {
 /// Cheap to clone — backed by `Arc`.
 ///
 /// Serde: serializes as the ordered field list (same wire format as `Schema`).
-/// Deserialization rebuilds through `Schema::builder` and panics if lint
-/// fails (only valid schemas may be persisted).
+/// Deserialization rebuilds through `Schema::builder()` /
+/// [`SchemaBuilder`](crate::schema::SchemaBuilder); invalid wire data returns a
+/// [`serde::de::Error`] (lint failures are not panics).
 #[derive(Debug, Clone)]
 pub struct ValidSchema(pub(crate) Arc<ValidSchemaInner>);
 

--- a/crates/schema/tests/lint_and_loader.rs
+++ b/crates/schema/tests/lint_and_loader.rs
@@ -223,13 +223,14 @@ fn lint_schema_detects_visibility_cycles() {
         );
 
     let report = schema.lint();
+    let cycle_paths: Vec<String> = report
+        .errors()
+        .filter(|e| e.code == "visibility_cycle")
+        .map(|e| e.path.to_string())
+        .collect();
     assert!(
-        has_error(&report, "visibility_cycle", "a"),
-        "expected visibility_cycle at a, got: {:?}",
-        report
-            .errors()
-            .map(|e| (&e.code, e.path.to_string()))
-            .collect::<Vec<_>>()
+        cycle_paths.iter().any(|p| p == "a" || p == "b"),
+        "expected visibility_cycle anchored at field `a` or `b`, got {cycle_paths:?}"
     );
 }
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
  type(scope)?: description    — scope is optional
  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
-->

## Summary

Replaces the old key-only `visibility_cycle` lint with a **FieldPath-aware** directed graph: collect all defined schema paths (top-level, nested objects, list item objects, mode variants), resolve `visible_when` predicate refs to absolute `FieldPath`s (JSON Pointer / `$root.` / scope-relative legacy), then DFS for a back-edge. Aligns **README** public API (`lint` vs `build`, proof-token steps) and **ValidSchema** serde rustdoc (deserialize returns `serde::de::Error`, not panic). Stabilizes the visibility-cycle integration test when the reported error path is `a` or `b` depending on graph iteration order.

## Linked issue

<!-- Link the Linear issue and any GitHub issues this PR closes or references. -->

- Closes NEB-
- Refs NEB-

## Type of change

<!-- Tick all that apply. -->

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [x] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

<!-- e.g. nebula-engine, nebula-runtime, nebula-credential, docs/, .github/ -->

- nebula-schema (`crates/schema/`)

## Changes

<!-- Concrete list of what changed. Bullet points, not prose. -->

- `lint.rs`: two-phase path collection + visibility dependency edges + cycle DFS; map validator `FieldPath` segments to schema `FieldPath` (including numeric list indices); new unit tests.
- `README.md`: correct `Schema::lint` / `SchemaBuilder::build` / validate / resolve signatures.
- `validated.rs`: rustdoc for `ValidSchema` serde deserialize behavior.
- `schema.rs`: remove stale Task 19 comment.
- `tests/lint_and_loader.rs`: accept `visibility_cycle` at path `a` or `b`.

## Test plan

<!-- How did you verify this change? Name the tests or scenarios, not just "ran CI". -->

- `cargo +nightly fmt -p nebula-schema`
- `cargo nextest run -p nebula-schema` (205 tests)
- `cargo clippy -p nebula-schema --all-features -- -D warnings`
- Local `git push` ran repo `pre-push` (lefthook) successfully before branch appeared on `origin`.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted (schema crate; fmt required for `validated.rs` line wrap)
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

<!-- If yes: what breaks, who is affected, migration path. Otherwise write "None". -->

None

## Docs checklist

<!--
Required for non-trivial design or execution-lifecycle changes.
See docs/PRODUCT_CANON.md §17 (Definition of Done).
Delete items that do not apply, or delete this section for pure bug fixes and mechanical refactors.
-->

- [x] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [x] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: <!-- path or URL -->)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

`visibility_cycle` diagnostics now anchor at the **source** field of the back-edge (`from` → `to` in the message); callers that asserted a fixed path (`a` only) were updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated public API documentation to reflect redesigned validation and error reporting flow, including updated error types and new build entry points.

* **Bug Fixes**
  * Improved visibility cycle detection to report errors at precise field paths instead of generic locations, providing more accurate diagnostic feedback.

* **Tests**
  * Updated test assertions for visibility cycle detection across multiple field scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->