### PR TITLE
fix(schema): lint required_when dependency cycles

### DIFF
--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -300,6 +300,7 @@ pub const STANDARD_CODES: &[&str] = &[
     "dangling_reference",
     "self_dependency",
     "visibility_cycle",
+    "required_cycle",
     "rule.contradictory",
     "missing_item_schema",
     "invalid_default_variant",

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -628,7 +628,7 @@ fn validator_path_to_schema_path(vp: &ValidatorFieldPath) -> Option<FieldPath> {
 /// key (`items.name`), not indexed instances (`items[0].name`). To make
 /// JSON-pointer refs such as `/items/0/name` comparable against that set, we
 /// drop index segments here.
-fn normalize_visibility_target_path(path: &FieldPath) -> FieldPath {
+fn normalize_rule_target_path(path: &FieldPath) -> FieldPath {
     let mut normalized = FieldPath::root();
     for segment in path.segments() {
         if matches!(segment, PathSegment::Index(_)) {
@@ -644,7 +644,7 @@ fn normalize_visibility_target_path(path: &FieldPath) -> FieldPath {
 /// - `$root.` — anchor at schema root (same convention as [`lint_rule_refs_new`]).
 /// - Leading `/` — JSON Pointer from schema root (validator [`ValidatorFieldPath`]).
 /// - Any other form is ignored (schema lint accepts JSON-pointer forms only).
-fn resolve_visibility_dependency(field_ref: &str, _scope_prefix: &FieldPath) -> Option<FieldPath> {
+fn resolve_rule_dependency(field_ref: &str, _scope_prefix: &FieldPath) -> Option<FieldPath> {
     if let Some(rest) = field_ref.strip_prefix("$root.") {
         let vp = ValidatorFieldPath::parse(rest)?;
         return validator_path_to_schema_path(&vp);
@@ -690,21 +690,22 @@ fn collect_defined_field_paths(
     }
 }
 
-fn append_visibility_edges(
+fn append_rule_edges(
     fields: &[Field],
     prefix: &FieldPath,
     defined: &HashSet<FieldPath>,
     edges: &mut Vec<(FieldPath, FieldPath)>,
+    rule_for: fn(&Field) -> Option<&Rule>,
 ) {
     for field in fields {
         let path = prefix.clone().join(field.key().clone());
 
-        if let Some(rule) = field_visible_rule(field) {
+        if let Some(rule) = rule_for(field) {
             let mut refs = Vec::new();
             rule.field_references(&mut refs);
             for field_ref in refs {
-                if let Some(target) = resolve_visibility_dependency(field_ref, prefix) {
-                    let normalized_target = normalize_visibility_target_path(&target);
+                if let Some(target) = resolve_rule_dependency(field_ref, prefix) {
+                    let normalized_target = normalize_rule_target_path(&target);
                     if defined.contains(&normalized_target) {
                         edges.push((path.clone(), normalized_target));
                     }
@@ -715,25 +716,22 @@ fn append_visibility_edges(
         match field {
             Field::List(list) => {
                 if let Some(Field::Object(obj)) = list.item.as_deref() {
-                    append_visibility_edges(&obj.fields, &path, defined, edges);
+                    append_rule_edges(&obj.fields, &path, defined, edges, rule_for);
                 }
             },
             Field::Object(obj) => {
-                append_visibility_edges(&obj.fields, &path, defined, edges);
+                append_rule_edges(&obj.fields, &path, defined, edges, rule_for);
             },
             Field::Mode(mode) => {
                 for variant in &mode.variants {
                     if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
                         let vpath = path.clone().join(vk.clone());
-                        if let Some(rule) = field_visible_rule(variant.field.as_ref()) {
+                        if let Some(rule) = rule_for(variant.field.as_ref()) {
                             let mut refs = Vec::new();
                             rule.field_references(&mut refs);
                             for field_ref in refs {
-                                if let Some(target) =
-                                    resolve_visibility_dependency(field_ref, &vpath)
-                                {
-                                    let normalized_target =
-                                        normalize_visibility_target_path(&target);
+                                if let Some(target) = resolve_rule_dependency(field_ref, &vpath) {
+                                    let normalized_target = normalize_rule_target_path(&target);
                                     if defined.contains(&normalized_target) {
                                         edges.push((vpath.clone(), normalized_target));
                                     }
@@ -741,7 +739,7 @@ fn append_visibility_edges(
                             }
                         }
                         if let Field::Object(obj) = variant.field.as_ref() {
-                            append_visibility_edges(&obj.fields, &vpath, defined, edges);
+                            append_rule_edges(&obj.fields, &vpath, defined, edges, rule_for);
                         }
                     }
                 }
@@ -751,68 +749,7 @@ fn append_visibility_edges(
     }
 }
 
-fn append_required_edges(
-    fields: &[Field],
-    prefix: &FieldPath,
-    defined: &HashSet<FieldPath>,
-    edges: &mut Vec<(FieldPath, FieldPath)>,
-) {
-    for field in fields {
-        let path = prefix.clone().join(field.key().clone());
-
-        if let Some(rule) = field_required_rule(field) {
-            let mut refs = Vec::new();
-            rule.field_references(&mut refs);
-            for field_ref in refs {
-                if let Some(target) = resolve_visibility_dependency(field_ref, prefix) {
-                    let normalized_target = normalize_visibility_target_path(&target);
-                    if defined.contains(&normalized_target) {
-                        edges.push((path.clone(), normalized_target));
-                    }
-                }
-            }
-        }
-
-        match field {
-            Field::List(list) => {
-                if let Some(Field::Object(obj)) = list.item.as_deref() {
-                    append_required_edges(&obj.fields, &path, defined, edges);
-                }
-            },
-            Field::Object(obj) => {
-                append_required_edges(&obj.fields, &path, defined, edges);
-            },
-            Field::Mode(mode) => {
-                for variant in &mode.variants {
-                    if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
-                        let vpath = path.clone().join(vk.clone());
-                        if let Some(rule) = field_required_rule(variant.field.as_ref()) {
-                            let mut refs = Vec::new();
-                            rule.field_references(&mut refs);
-                            for field_ref in refs {
-                                if let Some(target) =
-                                    resolve_visibility_dependency(field_ref, &vpath)
-                                {
-                                    let normalized_target =
-                                        normalize_visibility_target_path(&target);
-                                    if defined.contains(&normalized_target) {
-                                        edges.push((vpath.clone(), normalized_target));
-                                    }
-                                }
-                            }
-                        }
-                        if let Field::Object(obj) = variant.field.as_ref() {
-                            append_required_edges(&obj.fields, &vpath, defined, edges);
-                        }
-                    }
-                }
-            },
-            _ => {},
-        }
-    }
-}
-
-fn visibility_adjacency(edges: &[(FieldPath, FieldPath)]) -> HashMap<FieldPath, Vec<FieldPath>> {
+fn rule_adjacency(edges: &[(FieldPath, FieldPath)]) -> HashMap<FieldPath, Vec<FieldPath>> {
     let mut adj: HashMap<FieldPath, Vec<FieldPath>> = HashMap::new();
     for (from, to) in edges {
         adj.entry(from.clone()).or_default().push(to.clone());
@@ -820,9 +757,7 @@ fn visibility_adjacency(edges: &[(FieldPath, FieldPath)]) -> HashMap<FieldPath, 
     adj
 }
 
-fn find_visibility_cycle_edge(
-    adj: &HashMap<FieldPath, Vec<FieldPath>>,
-) -> Option<(FieldPath, FieldPath)> {
+fn find_cycle_edge(adj: &HashMap<FieldPath, Vec<FieldPath>>) -> Option<(FieldPath, FieldPath)> {
     // 0 = white, 1 = gray, 2 = black
     let mut color: HashMap<FieldPath, u8> = HashMap::new();
 
@@ -868,10 +803,16 @@ fn lint_visibility_cycles_new(
     collect_defined_field_paths(fields, &FieldPath::root(), &mut defined);
 
     let mut edges: Vec<(FieldPath, FieldPath)> = Vec::new();
-    append_visibility_edges(fields, &FieldPath::root(), &defined, &mut edges);
+    append_rule_edges(
+        fields,
+        &FieldPath::root(),
+        &defined,
+        &mut edges,
+        field_visible_rule,
+    );
 
-    let adj = visibility_adjacency(&edges);
-    if let Some((from, to)) = find_visibility_cycle_edge(&adj) {
+    let adj = rule_adjacency(&edges);
+    if let Some((from, to)) = find_cycle_edge(&adj) {
         emit_visibility_cycle_on_edge(&from, &to, report);
     }
 }
@@ -881,10 +822,16 @@ fn lint_required_cycles_new(fields: &[Field], _prefix: &FieldPath, report: &mut 
     collect_defined_field_paths(fields, &FieldPath::root(), &mut defined);
 
     let mut edges: Vec<(FieldPath, FieldPath)> = Vec::new();
-    append_required_edges(fields, &FieldPath::root(), &defined, &mut edges);
+    append_rule_edges(
+        fields,
+        &FieldPath::root(),
+        &defined,
+        &mut edges,
+        field_required_rule,
+    );
 
-    let adj = visibility_adjacency(&edges);
-    if let Some((from, to)) = find_visibility_cycle_edge(&adj) {
+    let adj = rule_adjacency(&edges);
+    if let Some((from, to)) = find_cycle_edge(&adj) {
         emit_required_cycle_on_edge(&from, &to, report);
     }
 }
@@ -1190,6 +1137,32 @@ mod tests {
         ];
 
         let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "required_cycle"),
+            "expected required_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_visibility_and_required_cycles_independently() {
+        let fields = vec![
+            Field::string("a")
+                .visible_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
+                .required_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
+                .into_field(),
+            Field::string("b")
+                .visible_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
+                .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "visibility_cycle"),
+            "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
         assert!(
             report.errors().any(|e| e.code == "required_cycle"),
             "expected required_cycle, got {:?}",

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -21,6 +21,7 @@ pub(crate) fn lint_tree(fields: &[Field], prefix: &FieldPath, report: &mut Valid
     let root_keys: HashSet<&str> = fields.iter().map(|f| f.key().as_str()).collect();
     lint_fields_new(fields, prefix, &root_keys, report);
     lint_visibility_cycles_new(fields, prefix, report);
+    lint_required_cycles_new(fields, prefix, report);
 }
 
 fn lint_fields_new(
@@ -588,6 +589,17 @@ fn emit_visibility_cycle_on_edge(from: &FieldPath, to: &FieldPath, report: &mut 
     );
 }
 
+fn emit_required_cycle_on_edge(from: &FieldPath, to: &FieldPath, report: &mut ValidationReport) {
+    report.push(
+        ValidationError::builder("required_cycle")
+            .at(from.clone())
+            .message(format!(
+                "required rule graph contains a cycle (dependency `{from}` -> `{to}`)"
+            ))
+            .build(),
+    );
+}
+
 /// Convert a validator JSON-pointer field path into a schema [`FieldPath`]
 /// (dot/bracket wire form used throughout this crate).
 fn validator_path_to_schema_path(vp: &ValidatorFieldPath) -> Option<FieldPath> {
@@ -739,6 +751,67 @@ fn append_visibility_edges(
     }
 }
 
+fn append_required_edges(
+    fields: &[Field],
+    prefix: &FieldPath,
+    defined: &HashSet<FieldPath>,
+    edges: &mut Vec<(FieldPath, FieldPath)>,
+) {
+    for field in fields {
+        let path = prefix.clone().join(field.key().clone());
+
+        if let Some(rule) = field_required_rule(field) {
+            let mut refs = Vec::new();
+            rule.field_references(&mut refs);
+            for field_ref in refs {
+                if let Some(target) = resolve_visibility_dependency(field_ref, prefix) {
+                    let normalized_target = normalize_visibility_target_path(&target);
+                    if defined.contains(&normalized_target) {
+                        edges.push((path.clone(), normalized_target));
+                    }
+                }
+            }
+        }
+
+        match field {
+            Field::List(list) => {
+                if let Some(Field::Object(obj)) = list.item.as_deref() {
+                    append_required_edges(&obj.fields, &path, defined, edges);
+                }
+            },
+            Field::Object(obj) => {
+                append_required_edges(&obj.fields, &path, defined, edges);
+            },
+            Field::Mode(mode) => {
+                for variant in &mode.variants {
+                    if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
+                        let vpath = path.clone().join(vk.clone());
+                        if let Some(rule) = field_required_rule(variant.field.as_ref()) {
+                            let mut refs = Vec::new();
+                            rule.field_references(&mut refs);
+                            for field_ref in refs {
+                                if let Some(target) =
+                                    resolve_visibility_dependency(field_ref, &vpath)
+                                {
+                                    let normalized_target =
+                                        normalize_visibility_target_path(&target);
+                                    if defined.contains(&normalized_target) {
+                                        edges.push((vpath.clone(), normalized_target));
+                                    }
+                                }
+                            }
+                        }
+                        if let Field::Object(obj) = variant.field.as_ref() {
+                            append_required_edges(&obj.fields, &vpath, defined, edges);
+                        }
+                    }
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
 fn visibility_adjacency(edges: &[(FieldPath, FieldPath)]) -> HashMap<FieldPath, Vec<FieldPath>> {
     let mut adj: HashMap<FieldPath, Vec<FieldPath>> = HashMap::new();
     for (from, to) in edges {
@@ -800,6 +873,19 @@ fn lint_visibility_cycles_new(
     let adj = visibility_adjacency(&edges);
     if let Some((from, to)) = find_visibility_cycle_edge(&adj) {
         emit_visibility_cycle_on_edge(&from, &to, report);
+    }
+}
+
+fn lint_required_cycles_new(fields: &[Field], _prefix: &FieldPath, report: &mut ValidationReport) {
+    let mut defined: HashSet<FieldPath> = HashSet::new();
+    collect_defined_field_paths(fields, &FieldPath::root(), &mut defined);
+
+    let mut edges: Vec<(FieldPath, FieldPath)> = Vec::new();
+    append_required_edges(fields, &FieldPath::root(), &defined, &mut edges);
+
+    let adj = visibility_adjacency(&edges);
+    if let Some((from, to)) = find_visibility_cycle_edge(&adj) {
+        emit_required_cycle_on_edge(&from, &to, report);
     }
 }
 
@@ -1005,6 +1091,108 @@ mod tests {
         assert!(
             report.errors().any(|e| e.code == "visibility_cycle"),
             "expected visibility_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_required_cycle_between_top_level_fields() {
+        let fields = vec![
+            Field::string("a")
+                .required_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
+                .into_field(),
+            Field::string("b")
+                .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "required_cycle"),
+            "expected required_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_required_cycle_inside_nested_object() {
+        let outer = Field::object("outer")
+            .add(
+                Field::string("x")
+                    .required_when(Rule::predicate(
+                        Predicate::eq("/outer/y", json!(true)).unwrap(),
+                    ))
+                    .into_field(),
+            )
+            .add(
+                Field::string("y")
+                    .required_when(Rule::predicate(
+                        Predicate::eq("/outer/x", json!(true)).unwrap(),
+                    ))
+                    .into_field(),
+            );
+
+        let report = run(vec![outer.into()]);
+        assert!(
+            report.errors().any(|e| e.code == "required_cycle"),
+            "expected required_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_required_cycle_with_list_index_reference() {
+        let fields = vec![
+            Field::list("items")
+                .item(
+                    Field::object("row")
+                        .add(
+                            Field::string("x")
+                                .required_when(Rule::predicate(
+                                    Predicate::eq("/items/0/y", json!(true)).unwrap(),
+                                ))
+                                .into_field(),
+                        )
+                        .add(
+                            Field::string("y")
+                                .required_when(Rule::predicate(
+                                    Predicate::eq("/items/0/x", json!(true)).unwrap(),
+                                ))
+                                .into_field(),
+                        ),
+                )
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "required_cycle"),
+            "expected required_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn detects_required_cycle_through_mode_variant_payload() {
+        let fields = vec![
+            Field::string("a")
+                .required_when(Rule::predicate(Predicate::eq("/m/v", json!(true)).unwrap()))
+                .into_field(),
+            Field::mode("m")
+                .variant(
+                    "v",
+                    "Variant",
+                    Field::string("payload")
+                        .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
+                        .into_field(),
+                )
+                .into_field(),
+        ];
+
+        let report = run(fields);
+        assert!(
+            report.errors().any(|e| e.code == "required_cycle"),
+            "expected required_cycle, got {:?}",
             report.errors().map(|e| &e.code).collect::<Vec<_>>()
         );
     }

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -470,6 +470,26 @@ fn emits_visibility_cycle() {
 }
 
 #[test]
+fn emits_required_cycle() {
+    // A's required predicate references B, B's required predicate references A.
+    use nebula_validator::{Predicate, Rule, foundation::FieldPath};
+
+    let rule_a_references_b = Rule::predicate(Predicate::IsTrue(FieldPath::parse("b").unwrap()));
+    let rule_b_references_a = Rule::predicate(Predicate::IsTrue(FieldPath::parse("a").unwrap()));
+
+    let schema = Schema::new()
+        .add(Field::string(fk("a")).required_when(rule_a_references_b))
+        .add(Field::string(fk("b")).required_when(rule_b_references_a));
+
+    let lint = schema.lint();
+    assert!(
+        lint.errors().any(|d| d.code == "required_cycle"),
+        "expected required_cycle, got: {:?}",
+        lint.errors().map(|d| &d.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn emits_dangling_reference() {
     // A rule referencing an unknown field key → dangling_reference.
     use nebula_validator::{Predicate, Rule, foundation::FieldPath};


### PR DESCRIPTION
## Summary

Add a structural lint pass that detects dependency cycles formed by `required_when` rules, mirroring existing `visibility_cycle` behavior, so cyclic required constraints fail at schema build/lint time with explicit diagnostics.

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `nebula-schema`

## Changes

- Add `lint_required_cycles_new` to `lint_tree` and emit `required_cycle` diagnostics on cycle edges.
- Add required-cycle graph edge collection across top-level fields, nested objects, list item objects, and mode variant payloads.
- Add `required_cycle` to `STANDARD_CODES`.
- Add targeted lint/unit/integration coverage, including `all_error_codes` emission for `required_cycle`.

## Test plan

- `cargo +nightly fmt --all`
- `cargo clippy -p nebula-schema -- -D warnings`
- `cargo nextest run -p nebula-schema`

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: n/a)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

- Existing cycle-detection helper is reused intentionally to keep visibility/required behavior symmetric.
- Working tree has an unrelated local edit in `crates/schema/README.md` that is not part of this PR.