### PR TITLE
fix(schema): emit expression.type_mismatch after resolve

### DIFF
--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -1,6 +1,11 @@
 //! Validated schema handles — proof-tokens.
 
-use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    pin::Pin,
+    sync::Arc,
+};
 
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
@@ -305,6 +310,7 @@ impl ValidValues {
 
         let mut report = ValidationReport::new();
         let mut values = self.values;
+        let mut resolved_expression_paths: HashSet<FieldPath> = HashSet::new();
 
         // Walk and resolve every entry in the flat top-level map.
         let keys: Vec<FieldKey> = values.iter().map(|(k, _)| k.clone()).collect();
@@ -313,12 +319,29 @@ impl ValidValues {
                 continue;
             };
             let path = FieldPath::root().join(key.clone());
-            let resolved = resolve_value(value, ctx, &path, &mut report).await;
+            let resolved = resolve_value(
+                value,
+                ctx,
+                &path,
+                &mut report,
+                &mut resolved_expression_paths,
+            )
+            .await;
             values.set(key, resolved);
         }
 
         if report.has_errors() {
             return Err(report);
+        }
+
+        // Re-run schema validation on resolved literals. Any type mismatches at
+        // paths produced by expression evaluation are surfaced as
+        // `expression.type_mismatch`.
+        if let Err(post_resolve_report) = self.schema.validate(&values) {
+            return Err(remap_expression_type_mismatch(
+                post_resolve_report,
+                &resolved_expression_paths,
+            ));
         }
 
         let extra_warnings: Vec<ValidationError> = report
@@ -418,13 +441,17 @@ fn resolve_value<'v>(
     ctx: &'v dyn ExpressionContext,
     path: &'v FieldPath,
     report: &'v mut ValidationReport,
+    resolved_expression_paths: &'v mut HashSet<FieldPath>,
 ) -> Pin<Box<dyn Future<Output = FieldValue> + 'v>> {
     Box::pin(async move {
         match value {
             FieldValue::Expression(ref expr) => {
                 match expr.parse_at(path) {
                     Ok(ast) => match ctx.evaluate(ast).await {
-                        Ok(v) => FieldValue::Literal(v),
+                        Ok(v) => {
+                            resolved_expression_paths.insert(path.clone());
+                            FieldValue::Literal(v)
+                        },
                         Err(mut e) => {
                             // Attach path context and enforce the standard code.
                             if e.code == "expression.runtime" {
@@ -449,7 +476,8 @@ fn resolve_value<'v>(
                 let mut out = IndexMap::with_capacity(map.len());
                 for (k, v) in map {
                     let child_path = path.clone().join(k.clone());
-                    let resolved = resolve_value(v, ctx, &child_path, report).await;
+                    let resolved =
+                        resolve_value(v, ctx, &child_path, report, resolved_expression_paths).await;
                     out.insert(k, resolved);
                 }
                 FieldValue::Object(out)
@@ -458,7 +486,8 @@ fn resolve_value<'v>(
                 let mut out = Vec::with_capacity(items.len());
                 for (i, v) in items.into_iter().enumerate() {
                     let item_path = path.clone().join(i);
-                    let resolved = resolve_value(v, ctx, &item_path, report).await;
+                    let resolved =
+                        resolve_value(v, ctx, &item_path, report, resolved_expression_paths).await;
                     out.push(resolved);
                 }
                 FieldValue::List(out)
@@ -468,7 +497,9 @@ fn resolve_value<'v>(
                     let inner_path = path
                         .clone()
                         .join(FieldKey::new("value").expect("static key"));
-                    let resolved = resolve_value(*inner, ctx, &inner_path, report).await;
+                    let resolved =
+                        resolve_value(*inner, ctx, &inner_path, report, resolved_expression_paths)
+                            .await;
                     Some(Box::new(resolved))
                 } else {
                     None
@@ -482,6 +513,25 @@ fn resolve_value<'v>(
             other => other,
         }
     })
+}
+
+fn remap_expression_type_mismatch(
+    report: ValidationReport,
+    expression_paths: &HashSet<FieldPath>,
+) -> ValidationReport {
+    let remapped = report.into_iter().map(|mut issue| {
+        let from_expression = expression_paths
+            .iter()
+            .any(|expression_path| issue.path.starts_with(expression_path));
+        if issue.code == "type_mismatch" && from_expression {
+            issue.code = "expression.type_mismatch".into();
+        }
+        issue
+    });
+
+    let mut out = ValidationReport::new();
+    out.extend(remapped);
+    out
 }
 
 // ── Schema-time validation helpers ───────────────────────────────────────────

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -337,22 +337,28 @@ impl ValidValues {
         // Re-run schema validation on resolved literals. Any type mismatches at
         // paths produced by expression evaluation are surfaced as
         // `expression.type_mismatch`.
-        if let Err(post_resolve_report) = self.schema.validate(&values) {
-            return Err(remap_expression_type_mismatch(
-                post_resolve_report,
-                &resolved_expression_paths,
-            ));
-        }
-
-        let extra_warnings: Vec<ValidationError> = report
+        let resolve_warnings: Vec<ValidationError> = report
             .iter()
             .filter(|e| e.severity == Severity::Warning)
             .cloned()
             .collect();
+        let post_resolve_warnings: Vec<ValidationError> = match self.schema.validate(&values) {
+            Ok(post_resolve_valid) => post_resolve_valid.warnings().to_vec(),
+            Err(mut post_resolve_report) => {
+                post_resolve_report.extend(self.warnings.iter().cloned());
+                post_resolve_report.extend(resolve_warnings.iter().cloned());
+                return Err(remap_expression_type_mismatch(
+                    post_resolve_report,
+                    &resolved_expression_paths,
+                ));
+            },
+        };
+
         let all_warnings: Arc<[ValidationError]> = self
             .warnings
             .iter()
-            .chain(extra_warnings.iter())
+            .chain(resolve_warnings.iter())
+            .chain(post_resolve_warnings.iter())
             .cloned()
             .collect();
 
@@ -494,9 +500,13 @@ fn resolve_value<'v>(
             },
             FieldValue::Mode { mode, value } => {
                 let resolved_value = if let Some(inner) = value {
-                    let inner_path = path
-                        .clone()
-                        .join(FieldKey::new("value").expect("static key"));
+                    let Ok(payload_key) = FieldKey::new("value") else {
+                        return FieldValue::Mode {
+                            mode,
+                            value: Some(inner),
+                        };
+                    };
+                    let inner_path = path.clone().join(payload_key);
                     let resolved =
                         resolve_value(*inner, ctx, &inner_path, report, resolved_expression_paths)
                             .await;
@@ -940,9 +950,10 @@ fn validate_literal_value(
                 return;
             };
             {
-                let payload_path = path
-                    .clone()
-                    .join(FieldKey::new("value").expect("static key"));
+                let Ok(payload_key) = FieldKey::new("value") else {
+                    return;
+                };
+                let payload_path = path.clone().join(payload_key);
                 validate_field(
                     &variant.field,
                     mode_value.as_deref(),

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -15,12 +15,6 @@
 //! The following STANDARD_CODES entries cannot be emitted without additional
 //! infrastructure that is out of scope for Phase 1:
 //!
-//! - `"expression.runtime"` — requires a real `ExpressionContext` returning an eval error; Phase 4
-//!   scope.
-//!
-//! - `"expression.type_mismatch"` — requires `ExpressionContext` resolving to a wrong type; Phase 4
-//!   scope.
-//!
 //! - `"mode.required"` — unreachable via the public API: `FieldValue::Mode` always carries a
 //!   non-empty `FieldKey` (validated at construction time), so the `mode_key.is_empty()` branch in
 //!   `validated.rs` can never fire.
@@ -40,7 +34,8 @@
 //! - `"loader.missing_config"` — `load_select_options_without_loader_emits_missing_config`.
 
 use nebula_schema::{
-    Field, FieldKey, FieldValue, FieldValues, Schema, ValidationReport, field_key,
+    ExpressionAst, ExpressionContext, Field, FieldKey, FieldValue, FieldValues, Schema,
+    ValidationError, ValidationReport, field_key,
 };
 use serde_json::json;
 
@@ -351,7 +346,57 @@ fn emits_expression_parse() {
     );
 }
 
-// expression.runtime / expression.type_mismatch require Phase 4.
+struct RuntimeFailCtx;
+
+#[async_trait::async_trait]
+impl ExpressionContext for RuntimeFailCtx {
+    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
+        Err(ValidationError::builder("expression.runtime")
+            .message("forced runtime failure")
+            .build())
+    }
+}
+
+struct ConstCtx(serde_json::Value);
+
+#[async_trait::async_trait]
+impl ExpressionContext for ConstCtx {
+    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
+        Ok(self.0.clone())
+    }
+}
+
+#[tokio::test]
+async fn emits_expression_runtime() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("x")))
+        .build()
+        .unwrap();
+    let values = FieldValues::from_json(json!({"x": {"$expr": "{{ $bad }}"}})).unwrap();
+    let validated = schema.validate(&values).unwrap();
+    let report = validated.resolve(&RuntimeFailCtx).await.unwrap_err();
+    assert!(
+        has_code(&report, "expression.runtime"),
+        "expected expression.runtime, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn emits_expression_type_mismatch() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("x")))
+        .build()
+        .unwrap();
+    let values = FieldValues::from_json(json!({"x": {"$expr": "{{ $n }}"}})).unwrap();
+    let validated = schema.validate(&values).unwrap();
+    let report = validated.resolve(&ConstCtx(json!(123))).await.unwrap_err();
+    assert!(
+        has_code(&report, "expression.type_mismatch"),
+        "expected expression.type_mismatch, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
 
 // ── Build-time (lint) codes ──────────────────────────────────────────────
 

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -396,6 +396,11 @@ async fn emits_expression_type_mismatch() {
         "expected expression.type_mismatch, got: {:?}",
         report.errors().map(|e| &e.code).collect::<Vec<_>>()
     );
+    assert!(
+        !report.errors().any(|e| e.code == "type_mismatch"),
+        "raw type_mismatch should have been remapped, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
 }
 
 // ── Build-time (lint) codes ──────────────────────────────────────────────

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -18,6 +18,28 @@ impl ExpressionContext for ConstCtx {
     }
 }
 
+/// Returns values based on expression source fragments.
+struct RoutingCtx;
+
+#[async_trait::async_trait]
+impl ExpressionContext for RoutingCtx {
+    async fn evaluate(&self, ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
+        if ast.source().contains("$bad_str") {
+            return Ok(json!(123));
+        }
+        if ast.source().contains("$ok_str") {
+            return Ok(json!("ok"));
+        }
+        if ast.source().contains("$bad_item") {
+            return Ok(json!(999));
+        }
+        if ast.source().contains("$ok_num") {
+            return Ok(json!(42));
+        }
+        Ok(json!(null))
+    }
+}
+
 /// Always fails with `expression.runtime`.
 struct FailCtx;
 
@@ -128,6 +150,108 @@ async fn expression_type_mismatch_returns_expression_type_mismatch() {
             .errors()
             .any(|e| e.code == "expression.type_mismatch"),
         "expected expression.type_mismatch, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+    assert!(
+        !report.errors().any(|e| e.code == "type_mismatch"),
+        "raw type_mismatch should have been remapped, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn expression_type_mismatch_in_nested_object_is_remapped() {
+    let schema = Schema::builder()
+        .add(Field::object(field_key!("user")).add(Field::string(field_key!("name"))))
+        .build()
+        .unwrap();
+
+    let values =
+        FieldValues::from_json(json!({"user": {"name": {"$expr": "{{ $bad_str }}"}}})).unwrap();
+    let validated = schema.validate(&values).unwrap();
+
+    let report = validated.resolve(&RoutingCtx).await.unwrap_err();
+    assert!(
+        report.errors().any(|e| {
+            e.code == "expression.type_mismatch" && e.path == FieldPath::parse("user.name").unwrap()
+        }),
+        "expected expression.type_mismatch at user.name, got: {:?}",
+        report
+            .errors()
+            .map(|e| (e.code.clone(), e.path.to_string()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !report.errors().any(|e| e.code == "type_mismatch"),
+        "raw type_mismatch should have been remapped, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn expression_type_mismatch_in_list_item_is_remapped() {
+    let schema = Schema::builder()
+        .add(Field::list(field_key!("tags")).item(Field::string(field_key!("_item"))))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "tags": [{"$expr": "{{ $bad_item }}"}]
+    }))
+    .unwrap();
+    let validated = schema.validate(&values).unwrap();
+
+    let report = validated.resolve(&RoutingCtx).await.unwrap_err();
+    assert!(
+        report.errors().any(|e| {
+            e.code == "expression.type_mismatch" && e.path == FieldPath::parse("tags[0]").unwrap()
+        }),
+        "expected expression.type_mismatch at tags[0], got: {:?}",
+        report
+            .errors()
+            .map(|e| (e.code.clone(), e.path.to_string()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !report.errors().any(|e| e.code == "type_mismatch"),
+        "raw type_mismatch should have been remapped, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn expression_type_mismatch_remap_is_scoped_to_failing_sibling() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("a")))
+        .add(Field::number(field_key!("b")))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "a": {"$expr": "{{ $bad_str }}"},
+        "b": {"$expr": "{{ $ok_num }}"}
+    }))
+    .unwrap();
+    let validated = schema.validate(&values).unwrap();
+
+    let report = validated.resolve(&RoutingCtx).await.unwrap_err();
+    let mismatch_paths: Vec<String> = report
+        .errors()
+        .filter(|e| e.code == "expression.type_mismatch")
+        .map(|e| e.path.to_string())
+        .collect();
+    assert_eq!(
+        mismatch_paths,
+        vec!["a".to_string()],
+        "expected remap only for failing sibling, got: {:?}",
+        report
+            .errors()
+            .map(|e| (e.code.clone(), e.path.to_string()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        !report.errors().any(|e| e.code == "type_mismatch"),
+        "raw type_mismatch should have been remapped, got: {:?}",
         report.errors().map(|e| &e.code).collect::<Vec<_>>()
     );
 }

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -112,6 +112,26 @@ async fn expression_evaluation_failure_returns_report() {
     );
 }
 
+#[tokio::test]
+async fn expression_type_mismatch_returns_expression_type_mismatch() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("x")))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"x": {"$expr": "{{ $n }}"}})).unwrap();
+    let validated = schema.validate(&values).unwrap();
+
+    let report = validated.resolve(&ConstCtx(json!(123))).await.unwrap_err();
+    assert!(
+        report
+            .errors()
+            .any(|e| e.code == "expression.type_mismatch"),
+        "expected expression.type_mismatch, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
 // ── Nested object with expressions ────────────────────────────────────────────
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Implement runtime emission of `expression.type_mismatch` by re-validating resolved expression outputs against field constraints and remapping expression-origin type failures from `type_mismatch` to the dedicated expression code. This closes the last major deferred expression error-code gap in the schema proof-token pipeline.

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `nebula-schema`

## Changes

- Track expression-resolved field paths during `ValidValues::resolve`.
- Re-run schema validation against resolved literals and remap expression-origin `type_mismatch` to `expression.type_mismatch`.
- Keep evaluation failures on the existing `expression.runtime` path.
- Add resolve-level test for `expression.type_mismatch`.
- Extend `all_error_codes` flow coverage with async emission tests for `expression.runtime` and `expression.type_mismatch`.
- Remove stale deferred-code note for these two expression codes in test docs.

## Test plan

- `cargo +nightly fmt --all`
- `cargo clippy -p nebula-schema -- -D warnings`
- `cargo nextest run -p nebula-schema`

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: n/a)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

- There is an unrelated local workspace modification in `crates/schema/README.md`; it is not part of this branch commit/PR diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for expression evaluation with distinct codes for runtime errors and type mismatches.
  * Enhanced validation to detect type inconsistencies after expression resolution.

* **Tests**
  * Added integration tests covering expression error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->