### PR TITLE
fix(engine): follow up PR #540 review comments

### DIFF
--- a/crates/engine/src/credential/executor.rs
+++ b/crates/engine/src/credential/executor.rs
@@ -82,7 +82,7 @@ where
 {
     let session_id = ctx.session_id().unwrap_or("default");
     let pending: C::Pending = pending_store
-        .consume(C::KEY, token, &ctx.owner_id, session_id)
+        .get(token)
         .await
         .map_err(ExecutorError::PendingStore)?;
 
@@ -96,7 +96,32 @@ where
     })?
     .map_err(ExecutorError::Credential)?;
 
-    handle_resolve_result::<C, S>(result, ctx, pending_store).await
+    match result {
+        ResolveResult::Complete(state) => {
+            let _consumed: C::Pending = pending_store
+                .consume(C::KEY, token, &ctx.owner_id, session_id)
+                .await
+                .map_err(ExecutorError::PendingStore)?;
+            Ok(ResolveResponse::Complete(state))
+        },
+        ResolveResult::Pending { state, interaction } => {
+            let _consumed: C::Pending = pending_store
+                .consume(C::KEY, token, &ctx.owner_id, session_id)
+                .await
+                .map_err(ExecutorError::PendingStore)?;
+
+            let next_token = pending_store
+                .put(C::KEY, &ctx.owner_id, session_id, state)
+                .await
+                .map_err(ExecutorError::PendingStore)?;
+
+            Ok(ResolveResponse::Pending {
+                token: next_token,
+                interaction,
+            })
+        },
+        ResolveResult::Retry { after } => Ok(ResolveResponse::Retry { after }),
+    }
 }
 
 async fn handle_resolve_result<C, S>(

--- a/crates/engine/src/credential/resolver.rs
+++ b/crates/engine/src/credential/resolver.rs
@@ -245,7 +245,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
                             } else {
                                 tracing::warn!(
                                     credential_id,
-                                    "credential ID is not a valid UUID, refresh event not emitted",
+                                    "credential ID is not a valid `CredentialId` (expected `cred_<ULID>`), refresh event not emitted",
                                 );
                             }
                             let scheme = C::project(&state);

--- a/crates/engine/tests/credential_pending_lifecycle_tests.rs
+++ b/crates/engine/tests/credential_pending_lifecycle_tests.rs
@@ -132,6 +132,76 @@ impl Credential for InteractiveTestCredential {
     }
 }
 
+struct RetryAwareCredential;
+
+impl Credential for RetryAwareCredential {
+    type Input = FieldValues;
+    type Scheme = SecretToken;
+    type State = TestInteractiveState;
+    type Pending = TestPending;
+
+    const KEY: &'static str = "retry_aware";
+    const INTERACTIVE: bool = true;
+
+    fn metadata() -> CredentialMetadata {
+        CredentialMetadata::new(
+            nebula_core::credential_key!("retry_aware"),
+            "Retry Aware",
+            "Test credential for retry-poll pending lifecycle",
+            Self::parameters(),
+            nebula_credential::AuthPattern::SecretToken,
+        )
+    }
+
+    fn project(state: &TestInteractiveState) -> SecretToken {
+        SecretToken::new(SecretString::new(state.token.clone()))
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<TestInteractiveState, TestPending>, CredentialError> {
+        Ok(ResolveResult::Pending {
+            state: TestPending {
+                verification_code: "secret-code-123".into(),
+            },
+            interaction: InteractionRequest::DisplayInfo {
+                title: "Still waiting".into(),
+                message: "Poll once, then provide code".into(),
+                data: DisplayData::Text("waiting for user consent".into()),
+                expires_in: Some(300),
+            },
+        })
+    }
+
+    async fn continue_resolve(
+        pending: &TestPending,
+        input: &UserInput,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<TestInteractiveState, TestPending>, CredentialError> {
+        match input {
+            UserInput::Poll => Ok(ResolveResult::Retry {
+                after: Duration::from_secs(1),
+            }),
+            UserInput::Code { code } if code == &pending.verification_code => {
+                Ok(ResolveResult::Complete(TestInteractiveState {
+                    token: "final-token".into(),
+                }))
+            },
+            _ => Err(CredentialError::InvalidInput(
+                "incorrect verification code".into(),
+            )),
+        }
+    }
+
+    async fn refresh(
+        _state: &mut TestInteractiveState,
+        _ctx: &CredentialContext,
+    ) -> Result<RefreshOutcome, CredentialError> {
+        Ok(RefreshOutcome::NotSupported)
+    }
+}
+
 #[tokio::test]
 async fn pending_lifecycle_resolve_then_continue() {
     let pending_store = InMemoryPendingStore::new();
@@ -248,6 +318,61 @@ async fn continue_with_wrong_code_returns_error() {
     assert!(
         result.is_err(),
         "continue with wrong code should fail: {result:?}"
+    );
+}
+
+#[tokio::test]
+async fn retry_does_not_consume_pending_token() {
+    let pending_store = InMemoryPendingStore::new();
+    let ctx = CredentialContext::new("test-user").with_session_id("sess-1");
+    let values = FieldValues::new();
+
+    let response = nebula_engine::credential::execute_resolve::<RetryAwareCredential, _>(
+        &values,
+        &ctx,
+        &pending_store,
+    )
+    .await
+    .expect("execute_resolve should succeed");
+    let token = match response {
+        nebula_engine::credential::ResolveResponse::Pending { token, .. } => token,
+        other => panic!("expected Pending, got: {other:?}"),
+    };
+
+    let retry = nebula_engine::credential::execute_continue::<RetryAwareCredential, _>(
+        &token,
+        &UserInput::Poll,
+        &ctx,
+        &pending_store,
+    )
+    .await
+    .expect("poll should return Retry");
+    assert!(
+        matches!(
+            retry,
+            nebula_engine::credential::ResolveResponse::Retry { after }
+                if after == Duration::from_secs(1)
+        ),
+        "expected Retry(after=1s), got: {retry:?}"
+    );
+
+    let completed = nebula_engine::credential::execute_continue::<RetryAwareCredential, _>(
+        &token,
+        &UserInput::Code {
+            code: "secret-code-123".into(),
+        },
+        &ctx,
+        &pending_store,
+    )
+    .await
+    .expect("pending token should still be valid after Retry");
+    assert!(
+        matches!(
+            completed,
+            nebula_engine::credential::ResolveResponse::Complete(TestInteractiveState { ref token })
+                if token == "final-token"
+        ),
+        "expected Complete after retry flow, got: {completed:?}"
     );
 }
 

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -1,6 +1,6 @@
 ---
 
-## name: nebula-schema
+name: nebula-schema
 
 role: Typed Configuration Schema with Proof-Token Pipeline (bespoke; informed by Domain Modeling Made Functional "make illegal states unrepresentable")
 status: frontier


### PR DESCRIPTION
## Summary

Follow up PR #540 by fixing review feedback in the migrated engine credential runtime path.

## Linked issue

- Closes NEB-
- Refs #540

## Type of change

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `crates/engine`
- `crates/schema`

## Changes

- Preserve pending state/token across `ResolveResult::Retry` in `execute_continue` by reading via `PendingStateStore::get` and consuming only on terminal transitions.
- Add retry regression coverage in `credential_pending_lifecycle_tests` to prove poll -> retry -> continue works with the same token.
- Fix resolver warning wording to match `CredentialId` format (`cred_<ULID>`), not UUID.
- Restore valid YAML front matter key in `crates/schema/README.md` (`name: nebula-schema`).

## Test plan

- `cargo test -p nebula-engine --test credential_pending_lifecycle_tests`
- `cargo test -p nebula-engine --test credential_executor_tests`

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [ ] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

This PR intentionally scopes to review feedback from #540 only.
