### PR TITLE
feat(credential): optional reqwest via oauth2-http; split authorize URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           cargo check -p nebula-expression --no-default-features
           cargo check -p nebula-api --no-default-features
           cargo check -p nebula-api --no-default-features --features credential-oauth
+          cargo check -p nebula-credential --no-default-features
 
   # ── Doctests (workspace-wide, off the critical path) ──────────────────────
   # Tier 2: skipped on draft PRs — re-runs on `ready_for_review`.

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -52,8 +52,12 @@ nebula-resilience = { path = "../resilience" }
 nebula-error = { workspace = true }
 thiserror = { workspace = true }
 
-# HTTP client (for flows)
-reqwest = { workspace = true, default-features = false, features = ["json", "rustls", "form"] }
+# HTTP client (OAuth2 token exchange / device poll / refresh) — optional; see feature `oauth2-http`.
+reqwest = { workspace = true, default-features = false, features = [
+  "json",
+  "rustls",
+  "form",
+], optional = true }
 url = { workspace = true }
 
 # Serialization
@@ -82,7 +86,10 @@ tracing-subscriber = { workspace = true, features = ["fmt"] }
 semver = { workspace = true }
 
 [features]
-default = []
+default = ["oauth2-http"]
+# Token exchange, device-code polling, and refresh over HTTP (`reqwest`). When disabled, the crate
+# has no HTTP client dependency; flows that need network I/O return `CredentialError::Provider`.
+oauth2-http = ["dep:reqwest"]
 rotation = []
 # Expose test-only helpers (e.g. `StaticKeyProvider`) to integration tests and
 # to other crates' dev-dependency paths. Must never be enabled in a production

--- a/crates/credential/src/credentials/oauth2/authorize_url.rs
+++ b/crates/credential/src/credentials/oauth2/authorize_url.rs
@@ -1,0 +1,144 @@
+//! Authorization URL construction for the OAuth2 Authorization Code grant.
+//!
+//! This module is intentionally **HTTP-client-free**: it only builds the
+//! browser redirect URL (RFC 6749 §4.1.1 + RFC 7636 PKCE query parameters).
+//! Token exchange and refresh live in [`super::flow`] behind the
+//! `oauth2-http` feature (ADR-0031 incremental split).
+
+use super::config::OAuth2Config;
+use crate::error::CredentialError;
+
+/// Build the authorization URL for the Authorization Code grant.
+///
+/// Appends every query parameter required by RFC 6749 §4.1.1 plus the
+/// RFC 7636 PKCE extension and the anti-CSRF `state` parameter. The
+/// config MUST come from the `AuthCodeBuilder` in `config`, which
+/// guarantees that `config.pkce` and `config.redirect_uri` are both
+/// `Some(_)` — callers cannot hand us a misconfigured [`OAuth2Config`]
+/// without a compile error. The runtime `ok_or_else` branches are there
+/// only to defend against struct-literal construction and malformed
+/// deserialized records.
+///
+/// Uses [`url::Url`] query encoding so special characters in
+/// `client_id`, `redirect_uri`, and scope values are properly
+/// percent-encoded.
+pub(crate) fn build_auth_url(
+    config: &OAuth2Config,
+    client_id: &str,
+    code_challenge: &str,
+    state: &str,
+) -> Result<String, CredentialError> {
+    let redirect_uri = config
+        .redirect_uri
+        .as_deref()
+        .ok_or_else(|| provider_error("authorization_code config missing redirect_uri".into()))?;
+    let pkce_method = config
+        .pkce
+        .ok_or_else(|| provider_error("authorization_code config missing pkce method".into()))?;
+
+    let mut url = url::Url::parse(&config.auth_url)
+        .map_err(|e| provider_error(format!("invalid auth_url: {e}")))?;
+
+    {
+        let mut q = url.query_pairs_mut();
+        q.append_pair("response_type", "code");
+        q.append_pair("client_id", client_id);
+        q.append_pair("redirect_uri", redirect_uri);
+
+        if !config.scopes.is_empty() {
+            q.append_pair("scope", &config.scopes.join(" "));
+        }
+
+        q.append_pair("state", state);
+        q.append_pair("code_challenge", code_challenge);
+        q.append_pair("code_challenge_method", pkce_method.as_str());
+    }
+
+    Ok(url.to_string())
+}
+
+fn provider_error(message: String) -> CredentialError {
+    CredentialError::Provider(message)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::config::OAuth2Config, *};
+
+    const CALLBACK: &str = "https://app.example.com/cb";
+
+    /// RFC 7636 appendix B vector (section 4.2).
+    const RFC7636_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const RFC7636_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+
+    #[test]
+    fn build_auth_url_includes_code_challenge_s256() {
+        let config = OAuth2Config::authorization_code(CALLBACK)
+            .auth_url("https://example.com/auth")
+            .token_url("https://example.com/token")
+            .build();
+
+        let url = build_auth_url(&config, "cid", RFC7636_CHALLENGE, "state_abc").unwrap();
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains(&format!("code_challenge={RFC7636_CHALLENGE}")));
+    }
+
+    #[test]
+    fn build_auth_url_includes_state_and_redirect_uri() {
+        let config = OAuth2Config::authorization_code(CALLBACK)
+            .auth_url("https://example.com/auth")
+            .token_url("https://example.com/token")
+            .build();
+
+        let url = build_auth_url(&config, "cid", "chal", "state_abc").unwrap();
+        assert!(url.contains("state=state_abc"));
+        // `CALLBACK` contains `://` which percent-encodes as `%3A%2F%2F`.
+        assert!(
+            url.contains("redirect_uri=https%3A%2F%2Fapp.example.com%2Fcb"),
+            "redirect_uri not percent-encoded in URL: {url}"
+        );
+    }
+
+    #[test]
+    fn build_auth_url_verifier_hashes_to_challenge() {
+        // Guard against a future refactor breaking the PKCE helper chain.
+        let challenge = crate::generate_code_challenge(RFC7636_VERIFIER);
+        assert_eq!(challenge, RFC7636_CHALLENGE);
+    }
+
+    #[test]
+    fn build_auth_url_without_scopes() {
+        let config = OAuth2Config::authorization_code(CALLBACK)
+            .auth_url("https://example.com/auth")
+            .token_url("https://example.com/token")
+            .build();
+
+        let url = build_auth_url(&config, "cid", "chal", "st").unwrap();
+        assert!(!url.contains("scope="));
+        assert!(url.contains("response_type=code"));
+        assert!(url.contains("client_id=cid"));
+    }
+
+    #[test]
+    fn build_auth_url_with_scopes() {
+        let config = OAuth2Config::authorization_code(CALLBACK)
+            .auth_url("https://example.com/auth")
+            .token_url("https://example.com/token")
+            .scopes(["read", "write"])
+            .build();
+
+        let url = build_auth_url(&config, "cid", "chal", "st").unwrap();
+        assert!(url.contains("scope=read+write"));
+    }
+
+    #[test]
+    fn invalid_auth_url_returns_error() {
+        let config = OAuth2Config::authorization_code(CALLBACK)
+            .auth_url("not a url")
+            .token_url("https://t.com/token")
+            .build();
+
+        let result = build_auth_url(&config, "cid", "chal", "st");
+        assert!(result.is_err());
+    }
+}

--- a/crates/credential/src/credentials/oauth2/credential.rs
+++ b/crates/credential/src/credentials/oauth2/credential.rs
@@ -16,15 +16,19 @@ use serde::{Deserialize, Serialize};
 use subtle::ConstantTimeEq;
 use zeroize::Zeroize;
 
+#[cfg(feature = "oauth2-http")]
+use super::flow;
 use super::{
+    authorize_url,
     config::{AuthStyle, GrantType, OAuth2Config},
-    flow,
 };
+#[cfg(feature = "oauth2-http")]
+use crate::resolve::DisplayData;
 use crate::{
     Credential, CredentialContext, CredentialState, PendingState, SecretString,
     error::CredentialError,
     metadata::CredentialMetadata,
-    resolve::{DisplayData, InteractionRequest, RefreshOutcome, ResolveResult, UserInput},
+    resolve::{InteractionRequest, RefreshOutcome, ResolveResult, UserInput},
     scheme::OAuth2Token,
 };
 
@@ -383,7 +387,8 @@ impl Credential for OAuth2Credential {
                 let challenge = crate::generate_code_challenge(&verifier);
                 let state_token = crate::generate_random_state();
 
-                let url = flow::build_auth_url(&config, client_id, &challenge, &state_token)?;
+                let url =
+                    authorize_url::build_auth_url(&config, client_id, &challenge, &state_token)?;
 
                 // `build_config` rejects missing `redirect_uri` for this
                 // grant type, so this `clone()` unwraps a value that was
@@ -411,40 +416,55 @@ impl Credential for OAuth2Credential {
                 })
             },
             GrantType::ClientCredentials => {
-                let state =
-                    flow::exchange_client_credentials(&config, client_id, client_secret).await?;
-                Ok(ResolveResult::Complete(state))
+                #[cfg(feature = "oauth2-http")]
+                {
+                    let state =
+                        flow::exchange_client_credentials(&config, client_id, client_secret)
+                            .await?;
+                    Ok(ResolveResult::Complete(state))
+                }
+                #[cfg(not(feature = "oauth2-http"))]
+                {
+                    Err(oauth2_http_transport_disabled())
+                }
             },
             GrantType::DeviceCode => {
-                let device_resp = flow::request_device_code(&config, client_id).await?;
-                let pending = OAuth2Pending {
-                    client_id: client_id.to_owned(),
-                    client_secret: SecretString::new(client_secret),
-                    grant_type: GrantType::DeviceCode,
-                    auth_style: config.auth_style,
-                    device_code: Some(device_resp.device_code),
-                    interval: Some(device_resp.interval),
-                    pkce_verifier: None,
-                    state: None,
-                    redirect_uri: None,
-                    config,
-                };
-                Ok(ResolveResult::Pending {
-                    state: pending,
-                    interaction: InteractionRequest::DisplayInfo {
-                        title: "Device Authorization".to_owned(),
-                        message: format!(
-                            "Enter code {} at the verification URL to authorize this device.",
-                            device_resp.user_code,
-                        ),
-                        data: DisplayData::UserCode {
-                            code: device_resp.user_code,
-                            verification_uri: device_resp.verification_url,
-                            verification_uri_complete: None,
+                #[cfg(feature = "oauth2-http")]
+                {
+                    let device_resp = flow::request_device_code(&config, client_id).await?;
+                    let pending = OAuth2Pending {
+                        client_id: client_id.to_owned(),
+                        client_secret: SecretString::new(client_secret),
+                        grant_type: GrantType::DeviceCode,
+                        auth_style: config.auth_style,
+                        device_code: Some(device_resp.device_code),
+                        interval: Some(device_resp.interval),
+                        pkce_verifier: None,
+                        state: None,
+                        redirect_uri: None,
+                        config,
+                    };
+                    Ok(ResolveResult::Pending {
+                        state: pending,
+                        interaction: InteractionRequest::DisplayInfo {
+                            title: "Device Authorization".to_owned(),
+                            message: format!(
+                                "Enter code {} at the verification URL to authorize this device.",
+                                device_resp.user_code,
+                            ),
+                            data: DisplayData::UserCode {
+                                code: device_resp.user_code,
+                                verification_uri: device_resp.verification_url,
+                                verification_uri_complete: None,
+                            },
+                            expires_in: device_resp.expires_in,
                         },
-                        expires_in: device_resp.expires_in,
-                    },
-                })
+                    })
+                }
+                #[cfg(not(feature = "oauth2-http"))]
+                {
+                    Err(oauth2_http_transport_disabled())
+                }
             },
         }
     }
@@ -505,24 +525,33 @@ impl Credential for OAuth2Credential {
                     .as_deref()
                     .ok_or_else(|| CredentialError::InvalidInput(FAILED.into()))?;
 
-                // Zeroizing<String> scrubs the intermediate plaintext on drop.
-                // Downstream flow::exchange_authorization_code builds the
-                // form body from &str borrows (GitHub issue #265).
-                let client_secret: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(ToOwned::to_owned));
-                let code_verifier: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(verifier_secret.expose_secret(ToOwned::to_owned));
+                #[cfg(feature = "oauth2-http")]
+                {
+                    // Zeroizing<String> scrubs the intermediate plaintext on drop.
+                    // Downstream flow::exchange_authorization_code builds the
+                    // form body from &str borrows (GitHub issue #265).
+                    let client_secret: zeroize::Zeroizing<String> = zeroize::Zeroizing::new(
+                        pending.client_secret.expose_secret(ToOwned::to_owned),
+                    );
+                    let code_verifier: zeroize::Zeroizing<String> =
+                        zeroize::Zeroizing::new(verifier_secret.expose_secret(ToOwned::to_owned));
 
-                let state = flow::exchange_authorization_code(
-                    &pending.config,
-                    &pending.client_id,
-                    client_secret.as_str(),
-                    code,
-                    code_verifier.as_str(),
-                    redirect_uri,
-                )
-                .await?;
-                Ok(ResolveResult::Complete(state))
+                    let state = flow::exchange_authorization_code(
+                        &pending.config,
+                        &pending.client_id,
+                        client_secret.as_str(),
+                        code,
+                        code_verifier.as_str(),
+                        redirect_uri,
+                    )
+                    .await?;
+                    Ok(ResolveResult::Complete(state))
+                }
+                #[cfg(not(feature = "oauth2-http"))]
+                {
+                    let _ = (verifier_secret, redirect_uri, code);
+                    Err(oauth2_http_transport_disabled())
+                }
             },
             GrantType::DeviceCode => {
                 if !matches!(input, UserInput::Poll) {
@@ -530,33 +559,41 @@ impl Credential for OAuth2Credential {
                         "device_code flow expects UserInput::Poll".into(),
                     ));
                 }
-                let device_code = pending.device_code.as_deref().ok_or_else(|| {
-                    CredentialError::InvalidInput("pending state missing device_code".into())
-                })?;
-                let interval = pending.interval.unwrap_or(5);
-                // Zeroizing<String>: intermediate plaintext scrubs on drop;
-                // poll_device_code builds its form from &str borrows (#265).
-                let client_secret: zeroize::Zeroizing<String> =
-                    zeroize::Zeroizing::new(pending.client_secret.expose_secret(ToOwned::to_owned));
-
-                match flow::poll_device_code(
-                    &pending.config,
-                    &pending.client_id,
-                    client_secret.as_str(),
-                    device_code,
-                    interval,
-                )
-                .await?
+                #[cfg(feature = "oauth2-http")]
                 {
-                    flow::DevicePollStatus::Ready(state) => Ok(ResolveResult::Complete(state)),
-                    flow::DevicePollStatus::Pending | flow::DevicePollStatus::SlowDown => {
-                        Ok(ResolveResult::Retry {
-                            after: Duration::from_secs(interval),
-                        })
-                    },
-                    flow::DevicePollStatus::Expired => {
-                        Err(CredentialError::Provider("device code expired".into()))
-                    },
+                    let device_code = pending.device_code.as_deref().ok_or_else(|| {
+                        CredentialError::InvalidInput("pending state missing device_code".into())
+                    })?;
+                    let interval = pending.interval.unwrap_or(5);
+                    // Zeroizing<String>: intermediate plaintext scrubs on drop;
+                    // poll_device_code builds its form from &str borrows (#265).
+                    let client_secret: zeroize::Zeroizing<String> = zeroize::Zeroizing::new(
+                        pending.client_secret.expose_secret(ToOwned::to_owned),
+                    );
+
+                    match flow::poll_device_code(
+                        &pending.config,
+                        &pending.client_id,
+                        client_secret.as_str(),
+                        device_code,
+                        interval,
+                    )
+                    .await?
+                    {
+                        flow::DevicePollStatus::Ready(state) => Ok(ResolveResult::Complete(state)),
+                        flow::DevicePollStatus::Pending | flow::DevicePollStatus::SlowDown => {
+                            Ok(ResolveResult::Retry {
+                                after: Duration::from_secs(interval),
+                            })
+                        },
+                        flow::DevicePollStatus::Expired => {
+                            Err(CredentialError::Provider("device code expired".into()))
+                        },
+                    }
+                }
+                #[cfg(not(feature = "oauth2-http"))]
+                {
+                    Err(oauth2_http_transport_disabled())
                 }
             },
             GrantType::ClientCredentials => Err(CredentialError::InvalidInput(
@@ -573,19 +610,34 @@ impl Credential for OAuth2Credential {
             return Ok(RefreshOutcome::ReauthRequired);
         }
 
-        // Reconstruct minimal config for the refresh call, preserving auth style.
-        let config = OAuth2Config::client_credentials()
-            .token_url(&state.token_url)
-            .auth_style(state.auth_style)
-            .scopes(state.scopes.clone())
-            .build();
+        #[cfg(feature = "oauth2-http")]
+        {
+            // Reconstruct minimal config for the refresh call, preserving auth style.
+            let config = OAuth2Config::client_credentials()
+                .token_url(&state.token_url)
+                .auth_style(state.auth_style)
+                .scopes(state.scopes.clone())
+                .build();
 
-        flow::refresh_token(state, &config).await?;
-        Ok(RefreshOutcome::Refreshed)
+            flow::refresh_token(state, &config).await?;
+            Ok(RefreshOutcome::Refreshed)
+        }
+        #[cfg(not(feature = "oauth2-http"))]
+        {
+            Err(oauth2_http_transport_disabled())
+        }
     }
 }
 
 // ── Private helpers ────────────────────────────────────────────────────
+
+#[cfg(not(feature = "oauth2-http"))]
+fn oauth2_http_transport_disabled() -> CredentialError {
+    CredentialError::Provider(
+        "OAuth2 HTTP transport is disabled: enable the `oauth2-http` feature on the `nebula-credential` crate"
+            .into(),
+    )
+}
 
 /// Extract a required string parameter, returning an error if missing.
 fn extract_required<'a>(values: &'a FieldValues, key: &str) -> Result<&'a str, CredentialError> {

--- a/crates/credential/src/credentials/oauth2/flow.rs
+++ b/crates/credential/src/credentials/oauth2/flow.rs
@@ -3,9 +3,9 @@
 //! Extracted from the v1 `FlowProtocol` implementation. All functions use
 //! v2 error types and operate on the v2 OAuth2State.
 
-// TODO(P10/ADR-0031): relocate reqwest HTTP flow to nebula-api (auth URI
-// construct + /oauth/callback endpoint + token exchange) and nebula-engine
-// (token refresh during resolve). PKCE primitives stay here.
+// TODO(P10/ADR-0031): relocate reqwest HTTP flow to nebula-api (token exchange
+// on /oauth/callback) and nebula-engine (token refresh during resolve).
+// Authorization URL construction is split to `authorize_url` (no reqwest).
 
 use std::time::Duration;
 
@@ -34,55 +34,6 @@ fn http_client() -> &'static reqwest::Client {
             .build()
             .expect("failed to build HTTP client")
     })
-}
-
-/// Build the authorization URL for the Authorization Code grant.
-///
-/// Appends every query parameter required by RFC 6749 §4.1.1 plus the
-/// RFC 7636 PKCE extension and the anti-CSRF `state` parameter. The
-/// config MUST come from the `AuthCodeBuilder` in `config`, which
-/// guarantees that `config.pkce` and `config.redirect_uri` are both
-/// `Some(_)` — callers cannot hand us a misconfigured [`OAuth2Config`]
-/// without a compile error. The runtime `ok_or_else` branches are there
-/// only to defend against struct-literal construction and malformed
-/// deserialized records.
-///
-/// Uses [`url::Url`] query encoding so special characters in
-/// `client_id`, `redirect_uri`, and scope values are properly
-/// percent-encoded.
-pub(crate) fn build_auth_url(
-    config: &OAuth2Config,
-    client_id: &str,
-    code_challenge: &str,
-    state: &str,
-) -> Result<String, CredentialError> {
-    let redirect_uri = config
-        .redirect_uri
-        .as_deref()
-        .ok_or_else(|| provider_error("authorization_code config missing redirect_uri".into()))?;
-    let pkce_method = config
-        .pkce
-        .ok_or_else(|| provider_error("authorization_code config missing pkce method".into()))?;
-
-    let mut url = url::Url::parse(&config.auth_url)
-        .map_err(|e| provider_error(format!("invalid auth_url: {e}")))?;
-
-    {
-        let mut q = url.query_pairs_mut();
-        q.append_pair("response_type", "code");
-        q.append_pair("client_id", client_id);
-        q.append_pair("redirect_uri", redirect_uri);
-
-        if !config.scopes.is_empty() {
-            q.append_pair("scope", &config.scopes.join(" "));
-        }
-
-        q.append_pair("state", state);
-        q.append_pair("code_challenge", code_challenge);
-        q.append_pair("code_challenge_method", pkce_method.as_str());
-    }
-
-    Ok(url.to_string())
 }
 
 /// Exchange client credentials for an access token (Client Credentials grant).
@@ -153,7 +104,7 @@ pub(crate) async fn exchange_client_credentials(
 /// Exchange authorization code for access token (Authorization Code grant).
 ///
 /// `code_verifier` must be the same value whose SHA256 was sent as
-/// `code_challenge` in [`build_auth_url`]. `redirect_uri` must byte-match
+/// `code_challenge` in [`super::authorize_url::build_auth_url`]. `redirect_uri` must byte-match
 /// the one on the original auth request (RFC 6749 §4.1.3).
 ///
 /// `code_verifier` and `client_secret` should be borrowed from zeroizing
@@ -625,72 +576,6 @@ fn provider_error(message: String) -> CredentialError {
 mod tests {
     use super::*;
 
-    const CALLBACK: &str = "https://app.example.com/cb";
-
-    /// RFC 7636 appendix B vector (section 4.2).
-    const RFC7636_VERIFIER: &str = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
-    const RFC7636_CHALLENGE: &str = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
-
-    #[test]
-    fn build_auth_url_includes_code_challenge_s256() {
-        let config = OAuth2Config::authorization_code(CALLBACK)
-            .auth_url("https://example.com/auth")
-            .token_url("https://example.com/token")
-            .build();
-
-        let url = build_auth_url(&config, "cid", RFC7636_CHALLENGE, "state_abc").unwrap();
-        assert!(url.contains("code_challenge_method=S256"));
-        assert!(url.contains(&format!("code_challenge={RFC7636_CHALLENGE}")));
-    }
-
-    #[test]
-    fn build_auth_url_includes_state_and_redirect_uri() {
-        let config = OAuth2Config::authorization_code(CALLBACK)
-            .auth_url("https://example.com/auth")
-            .token_url("https://example.com/token")
-            .build();
-
-        let url = build_auth_url(&config, "cid", "chal", "state_abc").unwrap();
-        assert!(url.contains("state=state_abc"));
-        // `CALLBACK` contains `://` which percent-encodes as `%3A%2F%2F`.
-        assert!(
-            url.contains("redirect_uri=https%3A%2F%2Fapp.example.com%2Fcb"),
-            "redirect_uri not percent-encoded in URL: {url}"
-        );
-    }
-
-    #[test]
-    fn build_auth_url_verifier_hashes_to_challenge() {
-        // Guard against a future refactor breaking the PKCE helper chain.
-        let challenge = crate::generate_code_challenge(RFC7636_VERIFIER);
-        assert_eq!(challenge, RFC7636_CHALLENGE);
-    }
-
-    #[test]
-    fn build_auth_url_without_scopes() {
-        let config = OAuth2Config::authorization_code(CALLBACK)
-            .auth_url("https://example.com/auth")
-            .token_url("https://example.com/token")
-            .build();
-
-        let url = build_auth_url(&config, "cid", "chal", "st").unwrap();
-        assert!(!url.contains("scope="));
-        assert!(url.contains("response_type=code"));
-        assert!(url.contains("client_id=cid"));
-    }
-
-    #[test]
-    fn build_auth_url_with_scopes() {
-        let config = OAuth2Config::authorization_code(CALLBACK)
-            .auth_url("https://example.com/auth")
-            .token_url("https://example.com/token")
-            .scopes(["read", "write"])
-            .build();
-
-        let url = build_auth_url(&config, "cid", "chal", "st").unwrap();
-        assert!(url.contains("scope=read+write"));
-    }
-
     #[test]
     fn compose_auth_code_form_header_style_has_exact_shape() {
         let form = compose_auth_code_form(
@@ -883,16 +768,5 @@ mod tests {
         let err = update_state_from_token_response(&mut state, &body).unwrap_err();
         assert!(matches!(err, CredentialError::Provider(_)));
         state.access_token.expose_secret(|s| assert_eq!(s, "stale"));
-    }
-
-    #[test]
-    fn invalid_auth_url_returns_error() {
-        let config = OAuth2Config::authorization_code(CALLBACK)
-            .auth_url("not a url")
-            .token_url("https://t.com/token")
-            .build();
-
-        let result = build_auth_url(&config, "cid", "chal", "st");
-        assert!(result.is_err());
     }
 }

--- a/crates/credential/src/credentials/oauth2/mod.rs
+++ b/crates/credential/src/credentials/oauth2/mod.rs
@@ -2,14 +2,15 @@
 //!
 //! The [`Credential`](crate::Credential) trait implementation and the
 //! `State` / `Pending` shapes live in `credential`; provider URL and
-//! scope configuration in `config`; and reqwest-based HTTP flow helpers
-//! (auth URL construction, token exchange, device code polling, refresh)
-//! in `flow`.
+//! scope configuration in `config`; **authorization URL construction**
+//! (no HTTP client) in [`authorize_url`]; and reqwest-based token
+//! exchange, device code polling, and refresh in `flow` when the
+//! **`oauth2-http`** feature is enabled (default).
 //!
-//! The `flow` submodule will relocate to `nebula-api` / `nebula-engine`
-//! in phase P10 (see the credential architecture cleanup spec §7 and
-//! ADR-0031). Until then, reqwest stays as a direct credential
-//! dependency.
+//! Disabling `oauth2-http` removes the `reqwest` dependency so the crate
+//! can type-check in slim dependency graphs; interactive flows that need
+//! token exchange return [`CredentialError::Provider`] with a message
+//! pointing at the feature flag (ADR-0031 incremental split).
 //!
 //! # Canonical import paths
 //!
@@ -20,8 +21,10 @@
 //! GrantType, …}`) — they are part of the OAuth2 surface but not hot
 //! enough to deserve a crate-root alias.
 
+mod authorize_url;
 mod config;
 mod credential;
+#[cfg(feature = "oauth2-http")]
 mod flow;
 
 pub use config::{

--- a/crates/credential/src/credentials/oauth2/mod.rs
+++ b/crates/credential/src/credentials/oauth2/mod.rs
@@ -3,13 +3,13 @@
 //! The [`Credential`](crate::Credential) trait implementation and the
 //! `State` / `Pending` shapes live in `credential`; provider URL and
 //! scope configuration in `config`; **authorization URL construction**
-//! (no HTTP client) in [`authorize_url`]; and reqwest-based token
+//! (no HTTP client) in the internal `authorize_url` submodule; and reqwest-based token
 //! exchange, device code polling, and refresh in `flow` when the
 //! **`oauth2-http`** feature is enabled (default).
 //!
 //! Disabling `oauth2-http` removes the `reqwest` dependency so the crate
 //! can type-check in slim dependency graphs; interactive flows that need
-//! token exchange return [`CredentialError::Provider`] with a message
+//! token exchange return [`crate::error::CredentialError::Provider`] with a message
 //! pointing at the feature flag (ADR-0031 incremental split).
 //!
 //! # Canonical import paths

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -51,7 +51,12 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — P10 slice of credential cleanup completed:
+Last targeted revision: 2026-04-21 — OAuth2 HTTP transport split: `nebula-credential`
+gains Cargo feature `oauth2-http` (default on) with optional `reqwest`;
+authorization URL construction lives in `oauth2/authorize_url.rs` without HTTP.
+CI checks `cargo check -p nebula-credential --no-default-features`. Aligns with
+ADR-0031 incremental relocation of token exchange out of the contract crate.
+Prior: 2026-04-21 — P10 slice of credential cleanup completed:
 feature-gated API OAuth controller landed (`/credentials/:id/oauth2/auth`,
 GET/POST callback), callback path now persists exchanged OAuth2 state into
 `oauth_credential_store`, and callback tests cover both create and overwrite


### PR DESCRIPTION
## Summary

Incremental **ADR-0031** step: separate **authorization URL construction** (no HTTP client) from **token exchange / device poll / refresh** (reqwest).

### Changes
- New \oauth2/authorize_url.rs\ with \uild_auth_url\ — moved from \low.rs\.
- Cargo feature \oauth2-http\ (**default: on**) pulls in optional \eqwest\. With \--no-default-features\, the crate builds **without** reqwest; OAuth2 paths that need HTTP return \CredentialError::Provider\ with a clear message.
- \low.rs\ remains the reqwest implementation; compiled only when \oauth2-http\ is enabled.
- CI: \cargo check -p nebula-credential --no-default-features\.

### Verification
- \cargo test -p nebula-credential\ (default features): 223 tests
- \cargo test -p nebula-credential --no-default-features\: 215 tests (flow unit tests skipped without HTTP)
- \cargo clippy -p nebula-credential -- -D warnings\

### Follow-up
Full removal of HTTP from the contract crate (ports, engine-only resolve) remains for later P10 slices.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved OAuth2 module modularity by separating authorization URL construction from HTTP transport logic.
  * Added `oauth2-http` Cargo feature for granular dependency control (enabled by default; default behavior unchanged).
  * Extended CI feature configuration coverage with additional build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->