### PR TITLE
docs: ADR-0033 integration credentials (Plane B)

### DIFF
--- a/crates/credential/README.md
+++ b/crates/credential/README.md
@@ -17,6 +17,8 @@ In most workflow engines, credentials are blobs of JSON passed directly into nod
 
 **Credential Contract.** Stored-state vs consumer-facing auth-material split, pending-state contract, secret-handling primitives, and credential metadata/types. Each `Credential` type declares three associated types: `Scheme` (the auth protocol), `State` (what is persisted), and `Pending` (interactive flow state, e.g. OAuth2 PKCE). The engine resolves them; action code receives only the projected material.
 
+**Integration credentials (Plane B):** this crate models **workflow integration** secrets (calls to Slack, cloud APIs, databases, …), not operator login to Nebula. The canonical boundary and rules for adding new auth mechanisms are documented in [`docs/adr/0033-integration-credentials-plane-b.md`](../../docs/adr/0033-integration-credentials-plane-b.md).
+
 Pattern: *Typed credential lifecycle* (Release It! ch "Stability Patterns" — secrets must not leak; rotations must not strand in-flight executions). Implementation follows the canonical separation between domain representation (`CredentialRecord`) and persisted row (`nebula_storage::rows::CredentialRow`).
 
 ## Public API

--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -72,7 +72,9 @@ Long-lived managed object: connection pool, SDK client, file handle. Engine owns
 
 **What / why:** unified **Credential** contract — stored state vs projected auth material, refresh/resolve/test paths — so secrets and rotation stay **out of Action code** and logs.
 
-**Where to read:** `crates/credential/README.md`, `crates/credential/src/lib.rs`.
+**Plane B (integration credentials):** workflow-facing secrets for **external** systems (API keys, OAuth to third parties, certificates, …) live in this model. They are **not** the same as authenticating **to Nebula** (browser/API session, future SSO/LDAP to the control plane — see [ADR-0033](adr/0033-integration-credentials-plane-b.md) and a future Plane A / `nebula-auth` crate).
+
+**Where to read:** `crates/credential/README.md`, `crates/credential/src/lib.rs`, [ADR-0033 — Integration credentials (Plane B)](adr/0033-integration-credentials-plane-b.md).
 
 ## `nebula-action`
 

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -51,7 +51,11 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — OAuth2 HTTP transport split: `nebula-credential`
+Last targeted revision: 2026-04-21 — [ADR-0033](docs/adr/0033-integration-credentials-plane-b.md)
+names **Plane B (integration credentials)** vs future Plane A / `nebula-auth`, and
+documents acquisition vs `AuthScheme` vs persistence. Cross-links in
+`docs/INTEGRATION_MODEL.md` and `crates/credential/README.md`.
+Prior: 2026-04-21 — OAuth2 HTTP transport split: `nebula-credential`
 gains Cargo feature `oauth2-http` (default on) with optional `reqwest`;
 authorization URL construction lives in `oauth2/authorize_url.rs` without HTTP.
 CI checks `cargo check -p nebula-credential --no-default-features`. Aligns with

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -51,7 +51,7 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — [ADR-0033](docs/adr/0033-integration-credentials-plane-b.md)
+Last targeted revision: 2026-04-21 — [ADR-0033](adr/0033-integration-credentials-plane-b.md)
 names **Plane B (integration credentials)** vs future Plane A / `nebula-auth`, and
 documents acquisition vs `AuthScheme` vs persistence. Cross-links in
 `docs/INTEGRATION_MODEL.md` and `crates/credential/README.md`.

--- a/docs/adr/0028-cross-crate-credential-invariants.md
+++ b/docs/adr/0028-cross-crate-credential-invariants.md
@@ -13,6 +13,7 @@ related:
   - docs/adr/0030-engine-owns-credential-orchestration.md
   - docs/adr/0031-api-owns-oauth-flow.md
   - docs/adr/0032-credential-store-canonical-home.md
+  - docs/adr/0033-integration-credentials-plane-b.md
   - docs/adr/0021-crate-publication-policy.md
   - docs/adr/0025-sandbox-broker-rpc-surface.md
   - docs/PRODUCT_CANON.md#35-integration-model

--- a/docs/adr/0033-integration-credentials-plane-b.md
+++ b/docs/adr/0033-integration-credentials-plane-b.md
@@ -5,17 +5,7 @@ status: accepted
 date: 2026-04-21
 supersedes: []
 superseded_by: []
-tags:
-  [
-    credential,
-    integration-model,
-    auth-scheme,
-    oauth2,
-    canon-3.5,
-    canon-12.5,
-    canon-13.2,
-    plane-b,
-  ]
+tags: [credential, integration-model, auth-scheme, oauth2, canon-3.5, canon-12.5, canon-13.2, plane-b]
 related:
   - docs/adr/0028-cross-crate-credential-invariants.md
   - docs/adr/0029-storage-owns-credential-persistence.md

--- a/docs/adr/0033-integration-credentials-plane-b.md
+++ b/docs/adr/0033-integration-credentials-plane-b.md
@@ -1,0 +1,178 @@
+---
+id: 0033
+title: integration-credentials-plane-b
+status: accepted
+date: 2026-04-21
+supersedes: []
+superseded_by: []
+tags:
+  [
+    credential,
+    integration-model,
+    auth-scheme,
+    oauth2,
+    canon-3.5,
+    canon-12.5,
+    canon-13.2,
+    plane-b,
+  ]
+related:
+  - docs/adr/0028-cross-crate-credential-invariants.md
+  - docs/adr/0029-storage-owns-credential-persistence.md
+  - docs/adr/0030-engine-owns-credential-orchestration.md
+  - docs/adr/0031-api-owns-oauth-flow.md
+  - docs/adr/0032-credential-store-canonical-home.md
+  - docs/INTEGRATION_MODEL.md
+  - docs/PRODUCT_CANON.md#35-integration-model
+  - docs/PRODUCT_CANON.md#125-secrets-and-auth
+  - docs/PRODUCT_CANON.md#132-rotation-refresh-seam
+  - crates/credential/README.md
+  - crates/credential/src/scheme/auth.rs
+linear: []
+---
+
+# 0033. Integration credentials (Plane B) — canonical model
+
+## Context
+
+Nebula distinguishes **how a workflow authenticates to external systems**
+(integrations: SaaS APIs, databases, webhooks) from **how a human or service
+authenticates to Nebula itself** (platform login, SSO, LDAP bind to the
+control plane). Confusing the two produces the “everything is OAuth” trap
+and duplicates controllers the way monolithic products mix user auth with
+integration secrets.
+
+[Canon §3.5](../PRODUCT_CANON.md#35-integration-model) already states that the
+engine owns the stored-state vs projected auth-material split for
+integrations. [ADR-0028](./0028-cross-crate-credential-invariants.md) through
+[ADR-0032](./0032-credential-store-canonical-home.md) split persistence,
+orchestration, and OAuth HTTP across crates — but they do **not** name the
+**conceptual** boundary this work serves.
+
+This ADR **names and freezes** that boundary as **Plane B — integration
+credentials**, so new protocols and crates (including a future
+**`nebula-auth`** for Plane A) can attach without collapsing layers.
+
+## Decision
+
+### 1. Definition — Plane B (integration credentials)
+
+**Plane B** is the set of **typed integration accounts** that workflows use to
+call **external** systems. Each account is an instance of a type implementing
+[`Credential`](../../crates/credential/src/contract/credential.rs): it has
+encrypted **state**, optional **pending** interactive state, projects to a
+consumer-facing [`AuthScheme`](../../crates/credential/src/scheme/auth.rs),
+and may support refresh, test, or revocation per associated consts.
+
+Plane B is **not** “OAuth only.” OAuth2 is **one** family of integration
+auth; others include static secrets, password pairs, key material, assertions,
+and future plugin-defined schemes — see `AuthPattern` in
+[`scheme/auth.rs`](../../crates/credential/src/scheme/auth.rs).
+
+### 2. Explicit non-scope — Plane A (platform authentication)
+
+**Plane A** — who may call Nebula’s API/UI (sessions, API keys for the host,
+future SSO/SAML/OIDC/LDAP **to Nebula**). A dedicated **`nebula-auth`** (or
+equivalent) crate is **expected** for Plane A; it **must not** implement
+`Credential` for operator login, and **must not** store integration secrets in
+the same conceptual bucket without an explicit, reviewed bridge.
+
+Plane A ADRs are **out of scope** for this document; Plane B ADRs must not
+require Plane A design choices.
+
+### 3. Separation of concerns — acquisition vs material vs persistence
+
+Three orthogonal axes:
+
+| Axis | Question | Lives in |
+| --- | --- | --- |
+| **Acquisition mechanism** | How did the secret first enter the system? (form, OAuth redirect, file upload, pasted token, …) | HTTP/UI adapters in **`nebula-api`** (per protocol family), callers into engine/credential pipeline |
+| **Auth material shape** | What does action code receive? | **`AuthScheme`** + **`AuthPattern`** — classification for resources and tooling |
+| **Persistence** | What is encrypted at rest? | **`CredentialState`** via **`CredentialStore`** in **`nebula-storage`** (per ADR-0029/0032) |
+
+OAuth2 is **one acquisition path** (authorization code, client credentials,
+device code) that produces **`OAuth2Token`** material. API key is **another**
+acquisition path producing **`SecretToken`**. The same `AuthPattern` may be
+filled by different acquisition paths (e.g. manual token vs OAuth) only if the
+team **explicitly** designs two `Credential` types or a single type with
+clear, validated branches — avoid silent ambiguity in `FieldValues`.
+
+### 4. Crate responsibilities for Plane B
+
+Aligned with [ADR-0028](./0028-cross-crate-credential-invariants.md) — this
+table states **intent**; migration debt is tracked in MATURITY and the
+credential cleanup spec.
+
+| Crate | Owns for Plane B |
+| --- | --- |
+| **`nebula-credential`** | `Credential` trait, `State` / `Pending`, `AuthScheme`, `CredentialStore` **trait**, errors, encryption primitives, **pure** helpers (e.g. auth URL construction without HTTP where feasible). **No** dependency on `nebula-engine` or `nebula-api`. |
+| **`nebula-engine`** | Runtime orchestration: resolve/continue/refresh/test dispatch, `CredentialResolver`, `RefreshCoordinator`, execution-time policy. **No** HTTP server. |
+| **`nebula-storage`** | Concrete `CredentialStore` / `PendingStateStore` impls, rows, layers, migrations. **No** business rules for token exchange. |
+| **`nebula-api`** | HTTP **adapters** for integration setup flows that need transport (redirect/callback, future upload endpoints). Delegates to engine/credential; does **not** redefine `Credential` semantics. |
+
+### 5. Adding a new integration auth mechanism
+
+1. **Classify** — map to an existing [`AuthPattern`](../../crates/credential/src/scheme/auth.rs) or extend `AuthScheme` / pattern only after UI/tooling impact is reviewed (`#[non_exhaustive]` on `AuthPattern`).
+2. **Implement `Credential`** — new `struct` + `impl Credential` **or** extend a **family** type (e.g. new OAuth2 grant) if the protocol is truly the same family.
+3. **Set capability consts** — `INTERACTIVE`, `REFRESHABLE`, etc.; default is `false` per trait docs.
+4. **Wire acquisition** — if browser/redirect/file upload is required, add **narrow** routes under `nebula-api` (feature-gated if needed); keep **one** HTTP client strategy per token endpoint family (avoid a fourth copy of the same POST — see ADR-0031 / cleanup spec).
+5. **Persist** — only through `CredentialStore`; split **config** vs **runtime** secrets where git/export could wipe tokens (peer lesson: `docs/research/n8n-credential-pain-points.md`).
+
+### 6. OAuth2 in Plane B (normative)
+
+`OAuth2Credential` is **the** built-in integration type for **OAuth 2.0 client**
+flows to **external** authorization servers. It is **not** a stand-in for
+platform SSO. Multiple grants may live **inside** one `Credential` type when
+they share state shape and token endpoint semantics; otherwise prefer a
+separate type.
+
+HTTP to the token endpoint remains subject to [ADR-0031](./0031-api-owns-oauth-flow.md)
+and the ongoing relocation of transport out of the contract crate (optional
+`oauth2-http` feature in `nebula-credential` is an incremental migration tool,
+not the end state).
+
+## Consequences
+
+### Positive
+
+- Clear vocabulary for reviews: “is this Plane A or B?”
+- Plugin and product authors can add **LDAP/SAML to Nebula** (Plane A) without
+  overloading `Credential` types meant for Slack/AWS (Plane B).
+- Acquisition vs `AuthPattern` vs persistence is explicit — reduces DRY
+  violations in HTTP handlers.
+
+### Negative / accepted
+
+- Requires discipline in **`nebula-api`** module naming (`auth` vs
+  `integration` / `credentials`) so Plane A and B do not share a single
+  `credential` module forever.
+- Existing code may mix concerns until refactors land; this ADR is the **target**
+  shape, not a claim that every file already conforms.
+
+### Follow-up (non-blocking)
+
+- Reference this ADR from `crates/credential/README.md` and
+  `docs/INTEGRATION_MODEL.md` (cross-links).
+- When **`nebula-auth`** is introduced, add a **Plane A** ADR that references
+  this one under “explicit non-overlap.”
+
+## Alternatives considered
+
+1. **Single “AuthService” crate for all protocols** — Rejected: collapses
+   Plane A and B and repeats n8n-scale coupling; violates bounded contexts in
+   `architectural-fit` skill.
+2. **One `Credential` type with stringly `provider` field** — Rejected:
+   breaks typed `project()`, `State`, and schema proofs.
+3. **Put all integration HTTP in `nebula-credential` forever** — Rejected:
+   already superseded by ADR-0029–0031 and optional `oauth2-http` split.
+
+## Seam / verification
+
+- **Trait seam:** `Credential` + `CredentialStore` in `nebula-credential` —
+  integration **meaning** is enforced only here.
+- **Canon:** [§3.5 Integration model](../PRODUCT_CANON.md#35-integration-model),
+  [§12.5 Secrets and auth](../PRODUCT_CANON.md#125-secrets-and-auth),
+  [§13.2 Rotation / refresh](../PRODUCT_CANON.md#132-rotation-refresh-seam).
+- **Tests:** existing credential + engine + API tests for resolve/refresh;
+  new acquisition paths require **at least** unit tests on the `Credential`
+  impl and, when HTTP is involved, contract tests on the adapter boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -40,13 +40,14 @@ changes land as a new ADR that `supersedes` it.
 | [0030](./0030-engine-owns-credential-orchestration.md) | `nebula-engine` owns credential orchestration + token refresh; `RefreshCoordinator` stays concrete-not-trait | accepted | 2026-04-20 |
 | [0031](./0031-api-owns-oauth-flow.md) | `nebula-api` owns OAuth flow HTTP ceremony (PKCE S256, HMAC state, URL allowlist, fail-closed limits) | accepted | 2026-04-20 |
 | [0032](./0032-credential-store-canonical-home.md) | `CredentialStore` trait stays in `nebula-credential`; only impls + layers move to storage (amends 0028 inv 6 and 0029 §1-§2 after dep-graph cycle discovered in P6) | accepted | 2026-04-20 |
+| [0033](./0033-integration-credentials-plane-b.md) | Integration credentials (Plane B) — canonical model; acquisition vs `AuthScheme` vs persistence; explicit non-scope for Plane A / future `nebula-auth` | accepted | 2026-04-21 |
 
 ## Writing a new ADR
 
 1. Copy the frontmatter block from any existing ADR (keep the keys: `id`,
    `title`, `status`, `date`, `supersedes`, `superseded_by`, `tags`,
    `related`, optional `linear`).
-2. Pick the next free number (currently **0032**). Do not reuse.
+2. Pick the next free number (currently **0033**). Do not reuse.
 3. File name: `NNNN-kebab-case-title.md` matching the `title:` field.
 4. Start `status: proposed`. Move to `accepted` only after review and merge.
 5. **Do not substantively edit an accepted ADR.** Open a new one with


### PR DESCRIPTION
## Summary

Adds **ADR-0033** defining **Plane B** (workflow → external systems via \Credential\), explicit **non-scope** for **Plane A** / future \
ebula-auth\, and three axes: acquisition vs \AuthScheme\ vs persistence. Includes crate responsibilities table and rules for new credential mechanisms; OAuth2 as one family in Plane B.

## Changes

- New: \docs/adr/0033-integration-credentials-plane-b.md\ (status **accepted**, 2026-04-21)
- Index: \docs/adr/README.md\ (0033; next free number)
- Related: \docs/adr/0028-cross-crate-credential-invariants.md\ (frontmatter \elated\ + link)
- \docs/INTEGRATION_MODEL.md\ — \
ebula-credential\, Plane B, ADR link
- \docs/MATURITY.md\ — targeted revision line for ADR-0033
- \crates/credential/README.md\ — Plane B paragraph + ADR link

## Checklist

- [x] Typos (pre-commit)
- [x] Pre-push tests (nextest)

Made with [Cursor](https://cursor.com)