### PR TITLE
docs: n8n credential taxonomy vs Nebula Plane B axes

### DIFF
--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -2,8 +2,8 @@
 name: Nebula integration model
 description: Authoritative integration-model mechanics — Resource / Credential / Action / Schema / Plugin contract, plugin packaging, cross-plugin dependency rules. Canon §3.5 states invariants; this document carries the mechanics.
 status: accepted
-last-reviewed: 2026-04-17
-related: [PRODUCT_CANON.md, GLOSSARY.md, STYLE.md]
+last-reviewed: 2026-04-21
+related: [PRODUCT_CANON.md, GLOSSARY.md, STYLE.md, adr/0033-integration-credentials-plane-b.md]
 ---
 
 # Nebula integration model
@@ -75,6 +75,26 @@ Long-lived managed object: connection pool, SDK client, file handle. Engine owns
 **Plane B (integration credentials):** workflow-facing secrets for **external** systems (API keys, OAuth to third parties, certificates, …) live in this model. They are **not** the same as authenticating **to Nebula** (browser/API session, future SSO/LDAP to the control plane — see [ADR-0033](adr/0033-integration-credentials-plane-b.md) and a future Plane A / `nebula-auth` crate).
 
 **Where to read:** `crates/credential/README.md`, `crates/credential/src/lib.rs`, [ADR-0033 — Integration credentials (Plane B)](adr/0033-integration-credentials-plane-b.md).
+
+### Industry reference — n8n credential taxonomy vs Nebula axes
+
+Popular integration tools ship **many** credential types: one public codebase ([n8n](https://github.com/n8n-io/n8n)) exposes on the order of **hundreds** of distinct credential definitions (roughly **428** files in a recent classification). Those definitions are **product-facing labels** — what the UI stores and how nodes authenticate — not Nebula’s internal split.
+
+The table below is an **external, illustrative** bucketing (by auth *shape* / transport), **not** a Nebula API. It shows how real-world volume concentrates before any Nebula-specific design.
+
+| Bucket (illustrative) | Typical meaning | Count (example) |
+| --- | --- | ---: |
+| API key / Bearer | Static secret, header or query | 252 |
+| OAuth 2.0 | Authorization-code / client flows to third-party IdPs | 108 |
+| Basic | Username + password (often HTTP Basic) | 25 |
+| Custom | Multi-step, signed requests, LDAP, vendor-specific | 12 |
+| Database | Host, port, user, password, SSL / SSH tunnel | 10 |
+| Message queue | AMQP, MQTT, Kafka | 4 |
+| AWS keys / AssumeRole | Access keys vs STS role chain | 2 + 1 |
+| FTP / SFTP; SMTP / IMAP; OAuth 1.0a; SSH | Protocol-specific connection + auth | 2 each |
+| Other | mTLS, digest, JWT, service-account JWT, … | 1 each |
+
+**How this maps to Nebula (Plane B):** n8n’s buckets mix **transport** (DB, queue, mail), **protocol family** (OAuth2 vs API key), and **acquisition UX** (custom wizards) in one flat namespace. Nebula keeps those concerns **orthogonal** — see [ADR-0033](adr/0033-integration-credentials-plane-b.md): **acquisition** (how the secret first entered the system), **`AuthScheme` / `AuthPattern`** (what material actions receive), and **persistence** (encrypted stored state vs projected auth). High counts for **API key** and **OAuth2** align with treating them as major **auth families**, not as 360 unrelated one-off schemes. **Database**, **queue**, and **SSH**-shaped credentials often pair **connection topology** (Resource or schema fields) with **auth material** (Credential); collapsing both into a single “credential type” is exactly the ad hoc pattern Nebula avoids.
 
 ## `nebula-action`
 

--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -78,9 +78,9 @@ Long-lived managed object: connection pool, SDK client, file handle. Engine owns
 
 ### Industry reference — n8n credential taxonomy vs Nebula axes
 
-Popular integration tools ship **many** credential types: one public codebase ([n8n](https://github.com/n8n-io/n8n)) exposes on the order of **hundreds** of distinct credential definitions (roughly **428** files in a recent classification). Those definitions are **product-facing labels** — what the UI stores and how nodes authenticate — not Nebula’s internal split.
+Popular integration tools ship **many** credential types: in [n8n](https://github.com/n8n-io/n8n), credential definitions are TypeScript modules under [`packages/nodes-base/credentials/`](https://github.com/n8n-io/n8n/tree/master/packages/nodes-base/credentials) (glob `*.credentials.ts`). Raw file counts are **on the order of 400** on recent upstream snapshots and **drift by release** — re-check that directory when refreshing this example. Those modules are **product-facing labels** — what the UI stores and how nodes authenticate — not Nebula’s internal split.
 
-The table below is an **external, illustrative** bucketing (by auth *shape* / transport), **not** a Nebula API. It shows how real-world volume concentrates before any Nebula-specific design.
+The table below is an **external, illustrative** bucketing (by auth *shape* / transport), **not** a Nebula API. Counts come from **one manual classification** of the catalog into these buckets (totalling **428** definitions in that exercise); they are **not** guaranteed to sum to a fresh clone’s file count, which varies by n8n revision.
 
 | Bucket (illustrative) | Typical meaning | Count (example) |
 | --- | --- | ---: |
@@ -90,11 +90,19 @@ The table below is an **external, illustrative** bucketing (by auth *shape* / tr
 | Custom | Multi-step, signed requests, LDAP, vendor-specific | 12 |
 | Database | Host, port, user, password, SSL / SSH tunnel | 10 |
 | Message queue | AMQP, MQTT, Kafka | 4 |
-| AWS keys / AssumeRole | Access keys vs STS role chain | 2 + 1 |
-| FTP / SFTP; SMTP / IMAP; OAuth 1.0a; SSH | Protocol-specific connection + auth | 2 each |
-| Other | mTLS, digest, JWT, service-account JWT, … | 1 each |
+| AWS access keys | Static AWS key style | 2 |
+| AWS AssumeRole | STS role chain | 1 |
+| FTP / SFTP | Protocol-specific connection + auth | 2 |
+| SMTP / IMAP | Mail server | 2 |
+| OAuth 1.0a | OAuth 1 | 2 |
+| SSH | Password or private key | 2 |
+| Unclassified | Vendor bucket not mapped elsewhere | 2 |
+| mTLS | Client certificate | 1 |
+| Digest | HTTP Digest | 1 |
+| JWT | JWT auth | 1 |
+| Service-account JWT | e.g. RS256 bearer to Google APIs | 1 |
 
-**How this maps to Nebula (Plane B):** n8n’s buckets mix **transport** (DB, queue, mail), **protocol family** (OAuth2 vs API key), and **acquisition UX** (custom wizards) in one flat namespace. Nebula keeps those concerns **orthogonal** — see [ADR-0033](adr/0033-integration-credentials-plane-b.md): **acquisition** (how the secret first entered the system), **`AuthScheme` / `AuthPattern`** (what material actions receive), and **persistence** (encrypted stored state vs projected auth). High counts for **API key** and **OAuth2** align with treating them as major **auth families**, not as 360 unrelated one-off schemes. **Database**, **queue**, and **SSH**-shaped credentials often pair **connection topology** (Resource or schema fields) with **auth material** (Credential); collapsing both into a single “credential type” is exactly the ad hoc pattern Nebula avoids.
+**How this maps to Nebula (Plane B):** n8n’s buckets mix **transport** (DB, queue, mail), **protocol family** (OAuth2 vs API key), and **acquisition UX** (custom wizards) in one flat namespace. Nebula keeps those concerns **orthogonal** — see [ADR-0033](adr/0033-integration-credentials-plane-b.md): **acquisition** (how the secret first entered the system), **`AuthScheme` / `AuthPattern`** (what material actions receive), and **persistence** (encrypted stored state vs projected auth). High counts for **API key** and **OAuth2** align with treating them as major **auth families**, not as hundreds of unrelated one-off schemes. **Database**, **queue**, and **SSH**-shaped credentials often pair **connection topology** (Resource or schema fields) with **auth material** (Credential); collapsing both into a single “credential type” is the same ad hoc pattern Nebula avoids.
 
 ## `nebula-action`
 

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -51,7 +51,11 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — [ADR-0033](adr/0033-integration-credentials-plane-b.md)
+Last targeted revision: 2026-04-21 — `docs/INTEGRATION_MODEL.md` adds an **industry reference**
+subsection (n8n credential taxonomy vs Nebula Plane B axes: acquisition /
+`AuthScheme` / persistence). Illustrative bucket counts from a public codebase;
+not a Nebula API surface.
+Prior: 2026-04-21 — [ADR-0033](adr/0033-integration-credentials-plane-b.md)
 names **Plane B (integration credentials)** vs future Plane A / `nebula-auth`, and
 documents acquisition vs `AuthScheme` vs persistence. Cross-links in
 `docs/INTEGRATION_MODEL.md` and `crates/credential/README.md`.


### PR DESCRIPTION
## Summary

Adds an **industry reference** subsection under \## nebula-credential\ in \docs/INTEGRATION_MODEL.md\: illustrative bucket counts from the n8n integration catalog (~428 credential definitions), framed as **third-party UX labels**, and mapped to Nebula’s orthogonal axes from [ADR-0033](docs/adr/0033-integration-credentials-plane-b.md) (acquisition / \AuthScheme\ / persistence).

Updates \docs/MATURITY.md\ targeted revision line and \INTEGRATION_MODEL\ frontmatter (\last-reviewed\, \elated\).

## Why not edit ADR-0033

ADR-0033 is **accepted**; per repo ADR policy we do not append substantive comparative content to accepted ADRs. The comparison lives next to the integration model narrative instead.

## Verification

- \	ypos\ on touched files (pre-commit)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated integration documentation with industry-standard credential taxonomy reference materials
  * Added comparison and mapping of external credential standards to the platform's credential acquisition, authentication schemes, and persistence models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->