### PR TITLE
docs: ADR-0033 Plane A vs B in crate rustdocs

### DIFF
--- a/crates/api/src/credential/mod.rs
+++ b/crates/api/src/credential/mod.rs
@@ -1,4 +1,9 @@
-//! OAuth credential HTTP ceremony (ADR-0031).
+//! Integration credential HTTP adapters — **Plane B** (ADR-0033) / OAuth ceremony (ADR-0031).
+//!
+//! HTTP endpoints that implement *acquisition* for [`nebula_credential::Credential`] types
+//! (e.g. OAuth2 authorize URL + callback). They delegate to the engine/credential pipeline; they do
+//! **not** define `Credential` semantics and are **not** Nebula operator login (**Plane A** —
+//! see [`crate::middleware::auth`]).
 //!
 //! Feature-gated behind `credential-oauth` during rollout.
 

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -15,6 +15,19 @@
 //! - `config` — `ApiConfig` / `JwtSecret`; startup fails hard on a missing or short secret — no
 //!   `Default` impl (§4.5 operational honesty).
 //!
+//! ## Authentication planes (ADR-0033)
+//!
+//! Keep **Plane A** (who may call this API) separate from **Plane B** (integration credentials
+//! for workflows talking to *external* systems):
+//!
+//! - **`middleware::auth`** — **Plane A**: JWT bearer and `X-API-Key` for the Nebula API itself.
+//! - **`credential`** (feature `credential-oauth`) — **Plane B acquisition**: HTTP adapters that
+//!   run OAuth2 *client* ceremony for integration credentials (authorize redirect + token
+//!   callback). These routes are nested under `/api/v1` and are **protected by Plane A** middleware
+//!   so only authenticated operators can start or complete integration OAuth flows.
+//!
+//! Do not merge these into one conceptual “auth” module — naming stays explicit per ADR-0033.
+//!
 //! ## Canon invariants
 //!
 //! - **§12.4** — All errors are RFC 9457 `application/problem+json`; no new ad-hoc 500s for

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -1,8 +1,11 @@
-//! Authentication Middleware
+//! Authentication middleware — **Plane A** (host / Nebula API).
 //!
 //! Accepts either a JWT Bearer token (`Authorization: Bearer <token>`) or a
 //! static API key (`X-API-Key: nbl_sk_…`). Both paths inject [`AuthenticatedUser`]
 //! into request extensions so downstream handlers are auth-mechanism agnostic.
+//!
+//! This is **not** integration credential OAuth (**Plane B**). Integration OAuth client routes
+//! live in the `credential` module (feature `credential-oauth`); see ADR-0033.
 
 use axum::{
     extract::{Request, State},

--- a/crates/api/src/routes/credential.rs
+++ b/crates/api/src/routes/credential.rs
@@ -1,10 +1,13 @@
-//! OAuth credential routes.
+//! Integration credential routes (**Plane B** — ADR-0033).
+//!
+//! Mounted under `/api/v1` behind [`crate::middleware::auth`] (**Plane A**) so only authenticated
+//! API clients start or complete OAuth flows for external integrations.
 
 use axum::Router;
 
 use crate::state::AppState;
 
-/// OAuth credential endpoints under `/api/v1`.
+/// OAuth integration-credential endpoints under `/api/v1`.
 pub fn router() -> Router<AppState> {
     crate::credential::router()
 }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -26,7 +26,9 @@ pub fn create_routes(state: AppState, _config: &ApiConfig) -> Router {
         .with_state(state)
 }
 
-/// API v1 routes — all protected by JWT auth middleware
+/// API v1 routes — all protected by [`crate::middleware::auth::auth_middleware`]
+/// (**Plane A**). When feature `credential-oauth` is enabled, OAuth integration routes are **Plane
+/// B** acquisition adapters (`routes::credential`).
 fn api_v1_routes(state: AppState) -> Router<AppState> {
     let router = Router::new()
         .merge(workflow::router())

--- a/crates/credential/src/contract/credential.rs
+++ b/crates/credential/src/contract/credential.rs
@@ -26,6 +26,13 @@ use crate::{
 
 /// Unified trait for all credential types.
 ///
+/// # Integration credentials (Plane B)
+///
+/// Implementations of this trait are **integration credentials** — secrets and auth material
+/// for **external** systems (SaaS APIs, webhooks, databases), not for logging into Nebula’s
+/// own API or control plane. That host-facing authentication (**Plane A**) stays out of this
+/// trait; see ADR-0033 (`docs/adr/0033-integration-credentials-plane-b.md`).
+///
 /// One trait replaces six v1 traits. Three associated types pin the
 /// generic parameters at the impl site; five associated consts declare
 /// capabilities at compile time.

--- a/crates/engine/src/credential/mod.rs
+++ b/crates/engine/src/credential/mod.rs
@@ -1,7 +1,10 @@
-//! Engine-owned credential orchestration primitives.
+//! Engine-owned credential orchestration primitives (**Plane B**).
 //!
 //! This module hosts runtime credential resolution and type-erased registry
-//! logic used by the execution engine.
+//! logic used by the execution engine for **integration credentials** — workflow
+//! access to external systems per [`Credential`](nebula_credential::Credential)
+//! and ADR-0033 (`docs/adr/0033-integration-credentials-plane-b.md`). It does
+//! not implement platform/operator authentication (**Plane A**).
 
 pub mod executor;
 pub mod registry;

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -51,7 +51,10 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — `docs/INTEGRATION_MODEL.md` **correctness**: attribute
+Last targeted revision: 2026-04-21 — ADR-0033 **implementation start**: `crate`-level `//!` docs
+for Plane A vs Plane B (`nebula-api` `middleware::auth` vs `credential` / `routes::credential`;
+`nebula-credential` `Credential` trait; `nebula-engine::credential`).
+Prior: 2026-04-21 — `docs/INTEGRATION_MODEL.md` **correctness**: attribute
 `AuthScheme` / `AuthPattern` / `SecretString` / `CredentialEvent` to **`nebula-credential`**
 (not `nebula-core`); trait path `crates/credential/src/scheme/auth.rs`. `MATURITY.md` Plane B
 wording includes **`AuthPattern`** alongside **`AuthScheme`**.


### PR DESCRIPTION
## Summary

Starts **ADR-0033 implementation** as **in-code documentation discipline**: the ADR mostly *names* Plane B (integration credentials) vs future Plane A (platform auth); persistence/orchestration were already split by ADR-0028–0032. This PR encodes the boundary in the crates contributors touch first.

## Changes

- **
ebula_credential::Credential**: trait doc — Plane B scope + ADR-0033 pointer.
- **
ebula_engine::credential**: module doc — Plane B orchestration, not operator auth.
- **
ebula_api**: lib.rs section *Authentication planes*; middleware::auth, credential, outes::credential, outes::mod — Plane A vs B and nesting under /api/v1 + Plane A middleware.
- **docs/MATURITY.md**: targeted revision line.

## Follow-up (not this PR)

- 
ebula-auth crate / Plane A ADR when platform SSO lands.
- Optional: rename outes::credential → integration_credentials if we want stronger naming (ADR-0033 negative consequence).

## Verification

- \cargo check\ (api with/without \credential-oauth\)
- Pre-push: nextest 517 passed, crate-diff-gate api/credential/engine

Made with [Cursor](https://cursor.com)