### PR TITLE
docs(schema): sync PR-3 docs with shipped C1 status

### DIFF
--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -37,6 +37,32 @@ Pattern inspiration: DMMF proof-tokens (ch "Modeling with Types") and Rust types
 
 See `src/lib.rs` rustdoc for the quick-start example.
 
+## JSON Schema export (`schemars` feature)
+
+Enable the optional `schemars` feature to export a validated Nebula schema as
+JSON Schema Draft 2020-12:
+
+```bash
+cargo test -p nebula-schema --features schemars
+```
+
+```rust
+use nebula_schema::{Field, FieldKey, Schema};
+
+let schema = Schema::builder()
+    .add(Field::string(FieldKey::new("name").unwrap()).required())
+    .build()
+    .unwrap();
+
+let exported = schema.json_schema().unwrap();
+let json = exported.to_value();
+assert_eq!(json["$schema"], "https://json-schema.org/draft/2020-12/schema");
+```
+
+The export includes `x-nebula-*` extension keys for semantics that plain JSON
+Schema cannot fully represent (expression mode, required/visibility modes,
+root-rule metadata, and UI/runtime hints).
+
 ## Contract
 
 - **[L1-3.5]** Schema is the typed-configuration surface for all integration concepts. See `docs/INTEGRATION_MODEL.md`.

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -42,6 +42,19 @@ See `src/lib.rs` rustdoc for the quick-start example.
 Enable the optional `schemars` feature to export a validated Nebula schema as
 JSON Schema Draft 2020-12:
 
+```toml
+[dependencies]
+nebula-schema = { version = "*", features = ["schemars"] }
+```
+
+or:
+
+```bash
+cargo add nebula-schema --features schemars
+```
+
+then:
+
 ```bash
 cargo test -p nebula-schema --features schemars
 ```

--- a/docs/plans/nebula-schema-pr3-phase4-json-schema-plus-docs.md
+++ b/docs/plans/nebula-schema-pr3-phase4-json-schema-plus-docs.md
@@ -37,7 +37,8 @@ roadmap: nebula-schema-roadmap.md
 
 ## Execution status (2026-04-22)
 
-- **Done on branch:** C1 (`schemars` JSON Schema export + mapper + tests), P3-D1 (`CHANGELOG.md`), P3-D3 (roadmap refresh in progress), P3-D4 (`crates/schema/README.md` feature usage section).
+- **Done on branch:** C1 (`schemars` JSON Schema export + mapper + tests), P3-D1 (`CHANGELOG.md`), P3-D4 (`crates/schema/README.md` feature usage section).
+- **In progress on branch:** P3-D3 (roadmap refresh).
 - **No maturity level change:** P3-D2 is satisfied with `nebula-schema` remaining `frontier` in `docs/MATURITY.md`.
 - **Remaining:** issue handoff for deferred C2–C6 follow-ups.
 

--- a/docs/plans/nebula-schema-pr3-phase4-json-schema-plus-docs.md
+++ b/docs/plans/nebula-schema-pr3-phase4-json-schema-plus-docs.md
@@ -1,6 +1,6 @@
 ---
 title: nebula-schema — PR-3 (scoped Phase 4 + docs)
-status: draft
+status: active
 created: 2026-04-22
 depends_on: [nebula-schema-pr2-phase3-security.md]
 blocks: []
@@ -34,6 +34,12 @@ roadmap: nebula-schema-roadmap.md
 | P3-D2 | `docs/MATURITY.md` row for `nebula-schema` if stability/integration moved | `docs/MATURITY.md` |
 | P3-D3 | Refresh `docs/plans/nebula-schema-roadmap.md` (`last-reviewed`, checkboxes) | `docs/plans/` |
 | P3-D4 | `crates/schema/README.md` if public surface / features changed | `crates/schema/README.md` |
+
+## Execution status (2026-04-22)
+
+- **Done on branch:** C1 (`schemars` JSON Schema export + mapper + tests), P3-D1 (`CHANGELOG.md`), P3-D3 (roadmap refresh in progress), P3-D4 (`crates/schema/README.md` feature usage section).
+- **No maturity level change:** P3-D2 is satisfied with `nebula-schema` remaining `frontier` in `docs/MATURITY.md`.
+- **Remaining:** issue handoff for deferred C2–C6 follow-ups.
 
 ## Merge gate (PR-3)
 

--- a/docs/plans/nebula-schema-roadmap.md
+++ b/docs/plans/nebula-schema-roadmap.md
@@ -37,7 +37,7 @@ This file is the **single place** for *what to do next* for `nebula-schema` (`cr
 | **Phase 1 — Foundation** | **Shipped** in tree | Proof tokens, `nebula-parameter` removed, callers migrated. See design spec acceptance; bench partiality documented in `crates/schema/benches/RESULTS.md` if present. |
 | **Phase 2 — DX** | **Mostly shipped** | `HasSchema` / `HasSelectOptions`, typed `Schema::builder()` DSL, `#[derive(Schema)]`, `#[derive(EnumSelect)]`, `field_key!`, trybuild suite, `#[param(enum_select)]` for enum-backed `SelectField`, `SelectField::extend_options`. |
 | **Phase 3 — Security** | **Complete on branch** (PR-2; merge + security review) | `SecretValue`, `KdfParams` (Argon2id), `FieldValue::SecretLiteral`, `get_secret`, `LoaderContext::with_secrets_redacted`, ADR-0034 + configuration pipeline diagram (ADR + `INTEGRATION_MODEL.md`). Credential wiring for `SecretWire` at call sites remains follow-up per ADR-0034. |
-| **Phase 4 — Advanced** | **In progress** (PR-3 C1 implemented on branch) | JSON Schema export (`schemars`) shipped in-tree with tests; C2–C6 remain intentionally deferred follow-ups per PR-3 scope cut. |
+| **Phase 4 — Advanced** | **In progress** (PR-3 C1 implemented on branch) | JSON Schema export (`schemars`) is implemented on this branch with tests; C2–C6 remain intentionally deferred follow-ups per PR-3 scope cut. |
 
 ## Remaining work — Phase 2 (close the gap)
 

--- a/docs/plans/nebula-schema-roadmap.md
+++ b/docs/plans/nebula-schema-roadmap.md
@@ -37,7 +37,7 @@ This file is the **single place** for *what to do next* for `nebula-schema` (`cr
 | **Phase 1 — Foundation** | **Shipped** in tree | Proof tokens, `nebula-parameter` removed, callers migrated. See design spec acceptance; bench partiality documented in `crates/schema/benches/RESULTS.md` if present. |
 | **Phase 2 — DX** | **Mostly shipped** | `HasSchema` / `HasSelectOptions`, typed `Schema::builder()` DSL, `#[derive(Schema)]`, `#[derive(EnumSelect)]`, `field_key!`, trybuild suite, `#[param(enum_select)]` for enum-backed `SelectField`, `SelectField::extend_options`. |
 | **Phase 3 — Security** | **Complete on branch** (PR-2; merge + security review) | `SecretValue`, `KdfParams` (Argon2id), `FieldValue::SecretLiteral`, `get_secret`, `LoaderContext::with_secrets_redacted`, ADR-0034 + configuration pipeline diagram (ADR + `INTEGRATION_MODEL.md`). Credential wiring for `SecretWire` at call sites remains follow-up per ADR-0034. |
-| **Phase 4 — Advanced** | **Not started** (skeleton) | JSON Schema export, expression inference, diff, i18n — follow phase 4 design spec. |
+| **Phase 4 — Advanced** | **In progress** (PR-3 C1 implemented on branch) | JSON Schema export (`schemars`) shipped in-tree with tests; C2–C6 remain intentionally deferred follow-ups per PR-3 scope cut. |
 
 ## Remaining work — Phase 2 (close the gap)
 
@@ -48,7 +48,7 @@ Use the phase 2 **design** spec for semantics; this list is the execution queue.
 - [x] **Integration roundtrip** — `crates/schema/tests/flow/derive_roundtrip.rs`: derive + `validate` (+ serde-default example).  
 - [x] **`Vec<Enum>` + select** — derive still rejects `Vec<...>` with `enum_select`; `docs/GLOSSARY.md` + trybuild `derive_schema_enum_select_vec` document the manual list path.  
 - [x] **Doctest / lib.rs** — crate-level doctest for `Schema::builder` + `root_rule` (predicate).  
-- [ ] **CHANGELOG** — one entry when the above close enough for a release note.
+- [x] **CHANGELOG** — one entry when the above close enough for a release note.
 
 **Verification (when touching schema):** `cargo test -p nebula-schema`, `cargo clippy -p nebula-schema -p nebula-schema-macros -- -D warnings`, and if compile-fail changes: `cargo test -p nebula-schema --test compile_fail` with `TRYBUILD=overwrite` only when updating `.stderr` intentionally.
 
@@ -59,6 +59,19 @@ See `docs/superpowers/specs/2026-04-16-nebula-schema-phase3-security-design.md` 
 ## Backlog — Phase 4 (Advanced)
 
 See `docs/superpowers/specs/2026-04-16-nebula-schema-phase4-advanced-design.md` and archived `...-phase4-advanced.md` in the same archive folder.
+
+## Active queue — PR-3 (Phase 4 C1 + docs)
+
+Execution source: `docs/plans/nebula-schema-pr3-phase4-json-schema-plus-docs.md`.
+
+- [x] **C1.1 `schemars` feature wiring** — add optional JSON Schema export path in `nebula-schema` behind the existing `schemars` feature.
+- [x] **C1.2 Type mapping pass** — cover field/value variants touched in this PR with deterministic JSON Schema output; keep unsupported cases explicit.
+- [x] **C1.3 Test matrix** — verify `cargo test -p nebula-schema` and `cargo test -p nebula-schema --features schemars`; add targeted tests for exported schema shape.
+- [x] **P3-D1 CHANGELOG** — add release-note entry for the PR stack closeout (including the remaining Phase 2 checkbox in this file).
+- [x] **P3-D2 MATURITY** — no maturity row change required; `nebula-schema` remains `frontier` with stable integration semantics.
+- [x] **P3-D3 Roadmap refresh** — after merge, update this roadmap (`status`, Phase 4 row, remaining checkboxes, `last-reviewed`).
+- [x] **P3-D4 Schema README** — update `crates/schema/README.md` with feature flag and JSON Schema usage examples if public API changed.
+- [ ] **Follow-up issue handoff (C2-C6)** — create owner-tagged issues for deferred Phase 4 scope (expression AST coupling, inference, diff, i18n crate, async validation).
 
 ## Agent instructions
 


### PR DESCRIPTION
## Summary
- sync `docs/plans/nebula-schema-roadmap.md` with the actual PR-3 state so Phase 4 C1 is marked in progress/completed where appropriate
- mark the PR-3 plan as active and add a compact execution status section
- document `schemars` JSON Schema export usage in `crates/schema/README.md`

## Test plan
- [x] `cargo +nightly fmt --all --check`
- [x] `cargo test -p nebula-schema`
- [x] `cargo test -p nebula-schema --features schemars`
- [x] `cargo clippy -p nebula-schema --all-targets --all-features -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test --workspace --doc`
- [x] `cargo deny check`

Made with [Cursor](https://cursor.com)