### PR TITLE
fix(schema): KdfError sources + loader secret redaction tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,6 +4172,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "subtle",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "trybuild",

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -29,6 +29,7 @@ schemars = { version = "1.0", optional = true }
 zeroize = { workspace = true }
 hex = { workspace = true }
 argon2 = { workspace = true }
+thiserror = { workspace = true }
 tracing = { workspace = true }
 subtle = { workspace = true }
 

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -345,9 +345,17 @@ impl LoaderRegistry {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use serde_json::{Value as Json, json};
 
     use super::*;
+    use crate::{
+        Field, FieldValues, Schema, expression::Expression, key::FieldKey, secret::SECRET_REDACTED,
+        value::FieldValue,
+    };
+
+    fn k(name: &str) -> FieldKey {
+        FieldKey::new(name).expect("test key")
+    }
 
     #[tokio::test]
     async fn load_options_unregistered_returns_not_registered() {
@@ -438,5 +446,122 @@ mod tests {
 
         let t = p.with_total(100);
         assert_eq!(t.total, Some(100));
+    }
+
+    fn redacted_literal() -> FieldValue {
+        FieldValue::Literal(Json::String(SECRET_REDACTED.to_owned()))
+    }
+
+    #[test]
+    fn with_secrets_redacted_object_nested_and_non_secret_unchanged() {
+        let schema = Schema::builder()
+            .add(
+                Field::object("config")
+                    .add(Field::secret("api_key"))
+                    .add(Field::string("label")),
+            )
+            .build()
+            .expect("valid schema");
+        let values = FieldValues::from_json(json!({
+            "config": {
+                "api_key": "hunter2",
+                "label": "visible"
+            }
+        }))
+        .expect("values");
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let config = ctx.values.get_by_str("config").expect("config");
+        let FieldValue::Object(map) = config else {
+            panic!("expected object, got {config:?}");
+        };
+        assert_eq!(map.get(&k("api_key")), Some(&redacted_literal()));
+        let label = map.get(&k("label")).expect("label");
+        let FieldValue::Literal(Json::String(s)) = label else {
+            panic!("expected string literal, got {label:?}");
+        };
+        assert_eq!(s, "visible");
+    }
+
+    #[test]
+    fn with_secrets_redacted_list_of_secrets() {
+        let schema = Schema::builder()
+            .add(Field::list("tokens").item(Field::secret("t")))
+            .build()
+            .expect("valid schema");
+        let values = FieldValues::from_json(json!({ "tokens": ["a", "b"] })).expect("values");
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let list = ctx.values.get_by_str("tokens").expect("tokens");
+        let FieldValue::List(items) = list else {
+            panic!("expected list, got {list:?}");
+        };
+        assert_eq!(items.as_slice(), &[redacted_literal(), redacted_literal()]);
+    }
+
+    /// Mode variant payload is an `Object` with a secret leaf and a non-secret sibling
+    /// (exercises the `Field::Mode` + nested `Object` path, not a bare `Field::Secret`
+    /// that replaces the entire mode `value` tree with one redacted literal).
+    #[test]
+    fn with_secrets_redacted_mode_variant_object_with_nested_secret() {
+        let schema = Schema::builder()
+            .add(
+                Field::mode("auth")
+                    .variant(
+                        "oauth",
+                        "OAuth",
+                        Field::object("creds")
+                            .add(Field::secret("client_secret"))
+                            .add(Field::string("client_id")),
+                    )
+                    .variant("plain", "Plain", Field::string("name")),
+            )
+            .build()
+            .expect("valid schema");
+        // The mode `value` is the unwrapped object payload: same shape as a top-level
+        // `Object` field's value (child keys), not `{"creds": { ... }}` — see `redact` +
+        // `Field::Object` matching in `redact_secrets_in_value_for_loader`.
+        let values = FieldValues::from_json(json!({
+            "auth": {
+                "mode": "oauth",
+                "value": {
+                    "client_secret": "top",
+                    "client_id": "visible"
+                }
+            }
+        }))
+        .expect("values");
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let auth = ctx.values.get_by_str("auth").expect("auth");
+        let FieldValue::Mode { mode, value } = auth else {
+            panic!("expected mode, got {auth:?}");
+        };
+        assert_eq!(mode.as_str(), "oauth");
+        let Some(inner) = value else {
+            panic!("expected mode payload, got {auth:?}");
+        };
+        let FieldValue::Object(m) = inner.as_ref() else {
+            panic!("expected object in mode value, got {inner:?}");
+        };
+        assert_eq!(m.get(&k("client_secret")), Some(&redacted_literal()));
+        let id = m.get(&k("client_id")).expect("id");
+        let FieldValue::Literal(Json::String(s)) = id else {
+            panic!("expected client_id literal, got {id:?}");
+        };
+        assert_eq!(s, "visible");
+    }
+
+    #[test]
+    fn with_secrets_redacted_expression_on_secret_is_literal_token() {
+        let schema = Schema::builder()
+            .add(Field::secret("api_key"))
+            .build()
+            .expect("valid schema");
+        let mut values = FieldValues::new();
+        values.set(
+            k("api_key"),
+            FieldValue::Expression(Expression::new("would.leak()")),
+        );
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let v = ctx.values.get_by_str("api_key").expect("api_key");
+        assert_eq!(*v, redacted_literal());
     }
 }

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -25,8 +25,8 @@ pub const SECRET_REDACTED: &str = "<redacted>";
 /// Failure while hashing a secret at resolve time.
 #[derive(Debug, Error)]
 pub enum KdfError {
-    /// User-facing misconfiguration in `KdfParams` (including salt length/parity
-    /// rules that are not a [`hex::FromHexError`].
+    /// User-facing misconfiguration in `KdfParams` (including invalid salt
+    /// length/parity) when the failure is not a [`hex::FromHexError`].
     #[error("invalid KDF parameters: {0}")]
     InvalidParams(String),
     /// Invalid hex in `salt_hex` (chained from [`hex::FromHexError`]).
@@ -36,7 +36,7 @@ pub enum KdfError {
     /// underlying CSPRNG parameters).
     #[error("invalid KDF parameters: {0}")]
     Argon2Params(#[source] argon2::Error),
-    /// Argon2 hashing failed (password can be `hash_password_into`).
+    /// Argon2 hashing failed (e.g. from `Argon2::hash_password_into`).
     #[error("KDF operation failed: {0}")]
     KdfHash(#[source] argon2::Error),
 }

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -14,6 +14,7 @@ use std::{fmt, ops::DerefMut};
 
 use argon2::{Argon2, Params};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use thiserror::Error;
 use zeroize::{Zeroize, Zeroizing};
 
 /// String returned by JSON helpers when a secret must not be leaked on the wire.
@@ -22,24 +23,23 @@ pub const SECRET_REDACTED: &str = "<redacted>";
 // ── KDF error + salt ---------------------------------------------------------
 
 /// Failure while hashing a secret at resolve time.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Error)]
 pub enum KdfError {
-    /// User-facing misconfiguration in `KdfParams` or salt encoding.
+    /// User-facing misconfiguration in `KdfParams` (including salt length/parity
+    /// rules that are not a [`hex::FromHexError`].
+    #[error("invalid KDF parameters: {0}")]
     InvalidParams(String),
-    /// Underlying Argon2 failure.
-    KdfFailed(String),
+    /// Invalid hex in `salt_hex` (chained from [`hex::FromHexError`]).
+    #[error("invalid KDF parameters: {0}")]
+    InvalidSaltHex(#[from] hex::FromHexError),
+    /// Argon2 `Params` construction failed (e.g. cost tuple out of range for the
+    /// underlying CSPRNG parameters).
+    #[error("invalid KDF parameters: {0}")]
+    Argon2Params(#[source] argon2::Error),
+    /// Argon2 hashing failed (password can be `hash_password_into`).
+    #[error("KDF operation failed: {0}")]
+    KdfHash(#[source] argon2::Error),
 }
-
-impl fmt::Display for KdfError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::InvalidParams(m) => write!(f, "invalid KDF parameters: {m}"),
-            Self::KdfFailed(m) => write!(f, "KDF operation failed: {m}"),
-        }
-    }
-}
-
-impl std::error::Error for KdfError {}
 
 fn decode_salt(salt_hex: &str) -> Result<Vec<u8>, KdfError> {
     let s = salt_hex.trim().trim_start_matches("0x");
@@ -48,7 +48,7 @@ fn decode_salt(salt_hex: &str) -> Result<Vec<u8>, KdfError> {
             "KDF salt_hex must be even-length".into(),
         ));
     }
-    let bytes = hex::decode(s).map_err(|e| KdfError::InvalidParams(e.to_string()))?;
+    let bytes = hex::decode(s).map_err(KdfError::InvalidSaltHex)?;
     if !(8..=64).contains(&bytes.len()) {
         return Err(KdfError::InvalidParams(
             "KDF salt must decode to 8–64 bytes after hex decode".into(),
@@ -341,13 +341,13 @@ impl KdfParams {
                     u32::from(*parallelism),
                     Some(out_len),
                 )
-                .map_err(|e| KdfError::InvalidParams(e.to_string()))?;
+                .map_err(KdfError::Argon2Params)?;
                 let argon2 =
                     Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
                 let mut out = vec![0u8; out_len];
                 argon2
                     .hash_password_into(password, &salt, &mut out)
-                    .map_err(|e| KdfError::KdfFailed(e.to_string()))?;
+                    .map_err(KdfError::KdfHash)?;
                 Ok(SecretValue::Bytes(SecretBytes::from_vec_unchecked(out)))
             },
         }
@@ -388,6 +388,24 @@ mod tests {
         let v = SecretValue::Bytes(b);
         let ser = serde_json::to_value(SecretWire(&v)).expect("json");
         assert_eq!(ser, serde_json::Value::String("616263".into()));
+    }
+
+    #[test]
+    fn kdf_invalid_salt_hex_chains_from_hex_error() {
+        let kdf = KdfParams::Argon2id {
+            // Even length but non-hex characters → `hex::FromHexError`.
+            salt_hex: "gggggggggggggggg".to_owned(),
+            memory_kib: 4096,
+            time_cost: 1,
+            parallelism: 1,
+        };
+        let err = kdf.hash_password(b"pw").expect_err("invalid hex");
+        let KdfError::InvalidSaltHex(_) = &err else {
+            panic!("expected InvalidSaltHex, got {err:?}");
+        };
+        assert!(std::error::Error::source(&err).is_some());
+        let msg = err.to_string();
+        assert!(msg.contains("invalid KDF parameters"), "msg was: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Refactors `KdfError` in `nebula-schema` to use `thiserror` while preserving typed error sources for hex decode and Argon2 (`Params` / `hash_password_into`). Adds focused unit tests for `LoaderContext::with_secrets_redacted` (nested `Object`, `List` of secrets, `Mode` payload with object + non-secret sibling, and `Expression` on a `Secret` field). Closes the follow-up items from the prior schema security work (#565 review).

## Linked issue

- Closes #566
- Closes #567

## Type of change

- [x] `fix` — bug fix
- [x] `test` — tests only

## Affected crates / areas

- nebula-schema

## Changes

- Add `thiserror` to `nebula-schema` (workspace dep).
- `KdfError`: `InvalidParams(String)` unchanged for pure validation; `InvalidSaltHex(#[from] hex::FromHexError)`; `Argon2Params` / `KdfHash` with `#[source] argon2::Error` (replaces `KdfFailed` string).
- `secret`: test `kdf_invalid_salt_hex_chains_from_hex_error` (source chain + message prefix).
- `loader` tests: `k()` helper; redaction cases for object, list, mode+object, expression; comment on unwrapped `mode` `value` JSON shape vs `redact`/`Object` matching.
- `KdfError` no longer derives `Clone` / `PartialEq` / `Eq` (see breaking note).

## Test plan

- `cargo test -p nebula-schema` — 117 lib + integration tests, doctests OK.
- Lefthook on commit: `fmt-check`, `clippy` (nebula-schema).
- Lefthook on push: `nextest` crate-diff gate for `schema` — 279 tests passed.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted (fmt-check in lefthook)
- [x] `cargo clippy --workspace -- -D warnings` — pre-commit clippy passed
- [x] `cargo nextest run --workspace` — not full workspace; push hook ran nextest for changed crate range (schema) — 279 passed
- [x] `cargo test --workspace --doc` — not re-run; `nebula-schema` doctests passed as part of `cargo test -p nebula-schema`
- [x] `cargo deny check` — pre-commit `cargo-deny` passed (`Cargo.lock` / manifest touched)

## Breaking changes

**API (minor):** `KdfError` no longer implements `Clone`, `PartialEq`, or `Eq` (incompatible with storing `argon2::Error` in sources with those derives). Call sites that only matched or formatted errors are unaffected; code that equated or cloned `KdfError` will need a small update.

**None** for wire/runtime behavior of KDF or loader redaction.

## Docs checklist

- [ ] N/A — mechanical error typing + tests; no canon/ADR change required for this PR (delete or ignore section for merge if policy allows)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [n/a] Execution / engine state transitions — N/A
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [n/a] New `unsafe` blocks — none

## Notes for reviewers

- `field_key!` is not used in these unit tests inside `loader.rs` because the macro expands to `::nebula_schema::…`, which does not resolve in the same crate’s lib tests; `FieldKey::new` + string `Field::…` helpers are used instead.
- Mode test JSON uses an unwrapped object for `value` (child keys only), consistent with how top-level `Object` field values are stored, so `redact` + `Field::Object` can find children.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for secret field redaction across multiple data handling scenarios
  * Added error handling validation tests

* **Chores**
  * Updated external dependencies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->