### PR TITLE
fix(api): bound OAuth token HTTP (reqwest + max body)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5807,12 +5807,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -7907,6 +7909,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -60,6 +60,7 @@ reqwest = { workspace = true, default-features = false, features = [
   "json",
   "rustls",
   "form",
+  "stream",
 ], optional = true }
 hmac = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }

--- a/crates/api/src/credential/flow.rs
+++ b/crates/api/src/credential/flow.rs
@@ -278,4 +278,46 @@ mod tests {
             "expected size gate error, got: {err}"
         );
     }
+
+    /// `Content-Length` missing: `bytes_stream()` must still cap the body (e.g. chunked).
+    #[tokio::test]
+    async fn token_exchange_rejects_oversized_streaming_body_without_content_length() {
+        let max = OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES;
+        let one_chunk = max + 1;
+        // Single chunk, HTTP/1.1 chunked, no `Content-Length`.
+        // Body bytes are never parsed as successful JSON: size gate fails first.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            const HEAD: &[u8] = b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
+            if stream.write_all(HEAD).await.is_err() {
+                return;
+            }
+            let size_line = format!("{one_chunk:x}\r\n");
+            if stream.write_all(size_line.as_bytes()).await.is_err() {
+                return;
+            }
+            if stream.write_all(&vec![b'x'; one_chunk]).await.is_err() {
+                return;
+            }
+            if stream.write_all(b"\r\n0\r\n\r\n").await.is_err() {
+                return;
+            }
+        });
+
+        let mut req = sample_exchange();
+        req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = exchange_code(&req)
+            .await
+            .expect_err("streaming body over max should fail");
+        let lower = err.to_lowercase();
+        assert!(
+            lower.contains("exceeded"),
+            "expected streaming cap (exceeded) error, got: {err}"
+        );
+    }
 }

--- a/crates/api/src/credential/flow.rs
+++ b/crates/api/src/credential/flow.rs
@@ -1,8 +1,64 @@
 //! OAuth HTTP flow helpers for the API layer.
 
+use std::time::Duration;
+
+use futures::StreamExt;
 use nebula_credential::credentials::oauth2::AuthStyle;
 use serde::Deserialize;
 use url::Url;
+
+// ─── ADR-0031: bounded HTTP client for OAuth2 token exchange ─────────────────
+//
+// Policy names (timeouts, redirect cap, max body) and shared builder live here so
+// token exchange and future refresh work share the same `reqwest` shape. Pointers:
+// - Product canon: integration credential / OAuth and ADR-0031
+
+/// Upper bound in bytes for the token endpoint **response body** before JSON parse.
+/// OAuth token JSON is small; rejecting larger payloads bounds memory and avoids
+/// misinterpreting a huge response as a valid token document.
+pub const OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+const OAUTH_TOKEN_HTTP_MAX_REDIRECTS: usize = 5;
+const OAUTH_TOKEN_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+const OAUTH_TOKEN_HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Builds a [`reqwest::Client`] with ADR-0031 policy for the OAuth2 **token** endpoint
+/// (authorization code exchange, and refresh when wired through the same stack).
+/// Callers should not layer extra permissive policy on this client.
+pub fn oauth_token_http_client() -> Result<reqwest::Client, String> {
+    reqwest::Client::builder()
+        .connect_timeout(OAUTH_TOKEN_HTTP_CONNECT_TIMEOUT)
+        .timeout(OAUTH_TOKEN_HTTP_TIMEOUT)
+        .redirect(reqwest::redirect::Policy::limited(
+            OAUTH_TOKEN_HTTP_MAX_REDIRECTS,
+        ))
+        .build()
+        .map_err(|e| format!("oauth client build failed: {e}"))
+}
+
+async fn read_token_response_limited(
+    response: reqwest::Response,
+    max_bytes: usize,
+) -> Result<serde_json::Value, String> {
+    if let Some(claimed) = response.content_length()
+        && claimed > u64::try_from(max_bytes).unwrap_or(u64::MAX)
+    {
+        return Err(format!(
+            "token response too large: Content-Length {claimed} (max {max_bytes} bytes)"
+        ));
+    }
+
+    let mut buf = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("read token response body: {e}"))?;
+        if buf.len().saturating_add(chunk.len()) > max_bytes {
+            return Err(format!("token response body exceeded {max_bytes} bytes"));
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    serde_json::from_slice(&buf).map_err(|e| format!("token response parse failed: {e}"))
+}
 
 /// Request parameters for authorization URI construction.
 #[derive(Debug, Clone, Deserialize)]
@@ -69,11 +125,7 @@ pub struct TokenExchangeRequest {
 
 /// Exchange authorization code for tokens.
 pub async fn exchange_code(req: &TokenExchangeRequest) -> Result<serde_json::Value, String> {
-    let client = reqwest::Client::builder()
-        .redirect(reqwest::redirect::Policy::limited(5))
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| format!("oauth client build failed: {e}"))?;
+    let client = oauth_token_http_client()?;
 
     let mut form: Vec<(&str, &str)> = vec![
         ("grant_type", "authorization_code"),
@@ -103,14 +155,17 @@ pub async fn exchange_code(req: &TokenExchangeRequest) -> Result<serde_json::Val
     if !status.is_success() {
         return Err(format!("token endpoint returned {status}"));
     }
-    response
-        .json::<serde_json::Value>()
-        .await
-        .map_err(|e| format!("token response parse failed: {e}"))
+    read_token_response_limited(response, OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES).await
 }
 
 #[cfg(test)]
 mod tests {
+    use nebula_credential::credentials::oauth2::AuthStyle;
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
     use super::*;
 
     #[test]
@@ -131,5 +186,96 @@ mod tests {
         assert!(text.contains("code_challenge_method=S256"));
         assert!(text.contains("code_challenge=code_challenge_123"));
         assert!(text.contains("state=signed_state"));
+    }
+
+    /// Drain a single HTTP/1.1 request until the header block ends; enough for a POST with small
+    /// form body.
+    async fn drain_incoming_request(stream: &mut tokio::net::TcpStream) {
+        let mut acc = Vec::new();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream
+                .read(&mut buf)
+                .await
+                .expect("read request from client");
+            if n == 0 {
+                break;
+            }
+            acc.extend_from_slice(&buf[..n]);
+            if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+            if acc.len() > 64 * 1024 {
+                return;
+            }
+        }
+    }
+
+    fn sample_exchange() -> TokenExchangeRequest {
+        TokenExchangeRequest {
+            token_url: String::new(), // set per test
+            client_id: "client-id".to_owned(),
+            client_secret: "client-secret".to_owned(),
+            code: "auth-code".to_owned(),
+            redirect_uri: "https://app.example.com/cb".to_owned(),
+            code_verifier: "pkce-verifier".to_owned(),
+            auth_style: AuthStyle::Header,
+        }
+    }
+
+    #[tokio::test]
+    async fn token_exchange_succeeds_for_small_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let body = br#"{"access_token":"t","token_type":"Bearer"}"#;
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            stream.write_all(head.as_bytes()).await.expect("write head");
+            stream.write_all(body).await.expect("write body");
+        });
+
+        let mut req = sample_exchange();
+        req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let val = exchange_code(&req)
+            .await
+            .expect("small token body should parse");
+        assert_eq!(val["access_token"], "t");
+    }
+
+    #[tokio::test]
+    async fn token_exchange_rejects_oversized_content_length() {
+        let max = OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES;
+        let body_len = max + 1;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            // Body is never read: the client must fail closed on `Content-Length` alone.
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body_len
+            );
+            let _ = stream.write_all(head.as_bytes()).await;
+        });
+
+        let mut req = sample_exchange();
+        req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = exchange_code(&req)
+            .await
+            .expect_err("oversized Content-Length should fail");
+        assert!(
+            err.to_lowercase().contains("too large")
+                || err.to_lowercase().contains("exceeded")
+                || err.to_lowercase().contains("exceeds"),
+            "expected size gate error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Implements ADR-0031-aligned bounds for the OAuth2 token HTTP path in `nebula-api` (`credential-oauth`): shared `reqwest` client policy (connect timeout, overall timeout, limited redirects), a hard cap on token response body size, and safe body reads via `bytes_stream`. Closes [GitHub #547](https://github.com/vanyastaff/nebula/issues/547).

## Linked issue

- Closes #547
- Refs NEB- (none)

## Type of change

- [ ] `feat` — new capability
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [x] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `crates/api` (`nebula-api`, feature `credential-oauth`)
- `Cargo.lock` (request `stream` + transitive deps)

## Changes

- Add `oauth_token_http_client()` with connect 10s, request timeout 30s, HTTP redirects capped at 5; document ADR-0031 pointer in-module.
- Enforce `OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES` (256 KiB): fail fast on oversized `Content-Length`; stream body with a hard cap so missing or untrusted `Content-Length` cannot allocate unbounded memory.
- Enable `reqwest` `stream` feature; parse JSON with `serde_json::from_slice` on the bounded buffer.
- Add Tokio `TcpListener` unit tests: small success JSON, oversized `Content-Length` path fails closed (no full body sent).

## Test plan

- `cargo test -p nebula-api --features credential-oauth credential::flow::tests` — 3 unit tests in `flow.rs` (including the two new async tests).
- Pre-commit: `cargo clippy -p nebula-api --features credential-oauth -- -D warnings` — clean.
- Pre-push hook: `cargo nextest run` (workspace tests relevant to changed crate gate) — passed in this worktree when pushing the branch.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — not run for full workspace this session; `clippy` on `nebula-api` with `credential-oauth` clean (pre-commit)
- [ ] `cargo nextest run --workspace` — user / CI
- [ ] `cargo test --workspace --doc` — not required (no public doc change)
- [x] `cargo deny check` — clean (pre-commit; `Cargo.lock` / `api` touched)

## Breaking changes

None. Behavior is stricter on token responses: oversized bodies are rejected. Feature `credential-oauth` is unchanged at the public route level.

## Docs checklist

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: n/a)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO) — one intentional `let _ =` in test for fire-and-forget write is not used; test path only
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — N/A, API credential-OAuth only
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification — none added

## Notes for reviewers

- Refresh flows that add a second token HTTP call should reuse `oauth_token_http_client()` and `OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES` (or a shared private helper) so policy stays in one place.
- Follow-up: #546 (allowlist `token_url`) is not in this PR.
