### PR TITLE
test(oauth): expand coverage, SDK P11 docs, and CI matrix

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -160,8 +160,21 @@ jobs:
       - name: Install cargo-nextest
         uses: taiki-e/install-action@cargo-nextest
 
+      # - `nebula-engine`: OAuth2 `refresh_oauth2_state` + tests live behind `rotation`.
+      # - `nebula-api`: `credential::flow` + OAuth e2e are behind `credential-oauth`.
+      # - `nebula-storage`: `EncryptionLayer` + `KeyProvider` unit tests (incl. OAuth at-rest) need `test-util`.
       - name: Run tests for ${{ matrix.package }}
-        run: cargo nextest run -p ${{ matrix.package }} --profile ci --no-tests=pass
+        run: |
+          set -euo pipefail
+          if [[ "${{ matrix.package }}" == "nebula-engine" ]]; then
+            cargo nextest run -p nebula-engine --all-features --profile ci --no-tests=pass
+          elif [[ "${{ matrix.package }}" == "nebula-api" ]]; then
+            cargo nextest run -p nebula-api --features credential-oauth --profile ci --no-tests=pass
+          elif [[ "${{ matrix.package }}" == "nebula-storage" ]]; then
+            cargo nextest run -p nebula-storage --features "test-util,credential-in-memory" --profile ci --no-tests=pass
+          else
+            cargo nextest run -p "${{ matrix.package }}" --profile ci --no-tests=pass
+          fi
 
       - name: Test summary
         if: always()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Documentation
+
+- **nebula-sdk** (P11): Credential/OAuth re-export audit — described how the façade exposes `nebula_credential` (full crate + prelude picks), what is intentionally not part of the SDK, and how integrators should migrate when credential types change. See `crates/sdk/README.md` §*Credential, OAuth, and the SDK*.
+
 ### Fixed
 
 - **nebula-schema** (PR review): `SecretString` now uses `Zeroizing<String>` so `expose()` stays infallible under `#![forbid(unsafe_code)]`; secret promotion uses `mem::take` + `password.zeroize()` on the KDF path (restore password on KDF error); incompatible secret shapes report a static label (no `Debug` of values); mode payload key construction reports `ValidationError` instead of `expect`. **docs:** correct relative ADR link from `GLOSSARY.md`.

--- a/crates/api/src/credential/flow.rs
+++ b/crates/api/src/credential/flow.rs
@@ -272,4 +272,63 @@ Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
             "expected streaming cap (exceeded) error, got: {err}"
         );
     }
+
+    #[tokio::test]
+    async fn token_exchange_fails_on_non_success_status() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            const BODY: &[u8] = b"{\"error\":\"invalid_client\",\"error_description\":\"bad\"}";
+            let n = BODY.len();
+            let head = format!(
+                "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {n}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(head.as_bytes()).await.is_err() {
+                return;
+            }
+            let _ = stream.write_all(BODY).await;
+        });
+
+        let mut req = sample_exchange();
+        req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = exchange_code(&req)
+            .await
+            .expect_err("401 from token endpoint should map to error");
+        assert!(
+            err.contains("401") || err.to_lowercase().contains("unauthorized"),
+            "expected non-success status in error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn token_exchange_fails_on_invalid_json_body_for_200() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let body: &[u8] = b"this is not json {";
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            let n = body.len();
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {n}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(head.as_bytes()).await.is_err() {
+                return;
+            }
+            let _ = stream.write_all(body).await;
+        });
+
+        let mut req = sample_exchange();
+        req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = exchange_code(&req)
+            .await
+            .expect_err("invalid json on 2xx should fail");
+        let lower = err.to_lowercase();
+        assert!(
+            lower.contains("parse") || lower.contains("json") || lower.contains("token response"),
+            "expected JSON parse / token response error, got: {err}"
+        );
+    }
 }

--- a/crates/api/tests/e2e_oauth2_flow.rs
+++ b/crates/api/tests/e2e_oauth2_flow.rs
@@ -153,6 +153,7 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
         .get(credential_id)
         .await
         .expect("stored oauth credential");
+    assert_eq!(stored.version, 1, "first persisted row should be version 1");
     assert_eq!(stored.credential_key, OAuth2Credential::KEY);
     assert_eq!(stored.state_kind, OAuth2State::KIND);
 
@@ -182,24 +183,40 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
     let mut stale_record = stored.clone();
     stale_record.data = serde_json::to_vec(&persisted_state).expect("serialize stale oauth state");
     stale_record.expires_at = persisted_state.expires_at();
-    state
+    let stale_put = state
         .oauth_credential_store
         .put(stale_record, PutMode::Overwrite)
         .await
         .expect("persist stale oauth state");
+    assert_eq!(
+        stale_put.version, 2,
+        "manual overwrite of stale state should bump StoredCredential::version (CAS basis)"
+    );
 
     let resolver = CredentialResolver::new(state.oauth_credential_store.clone());
     let ctx = CredentialContext::new("test-user");
-    resolver
+    let handle = resolver
         .resolve_with_refresh::<OAuth2Credential>(credential_id, &ctx)
         .await
         .expect("resolve with refresh should succeed");
+    assert_eq!(handle.credential_id(), credential_id);
+    let token = handle.snapshot();
+    assert_eq!(token.token_type, "Bearer");
+    assert_eq!(token.scopes, vec!["repo".to_owned(), "workflow".to_owned()]);
+    assert_eq!(
+        token.access_token().expose_secret(|s| s.to_owned()),
+        "e2e-access-token-refreshed"
+    );
 
     let refreshed = state
         .oauth_credential_store
         .get(credential_id)
         .await
         .expect("refreshed oauth credential in store");
+    assert_eq!(
+        refreshed.version, 3,
+        "engine refresh should persist via CAS and increment version"
+    );
     let refreshed_state: OAuth2State =
         serde_json::from_slice(&refreshed.data).expect("deserialize refreshed oauth state");
     assert_eq!(

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -58,6 +58,8 @@ nebula-metrics = { path = "../metrics" }
 chrono = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+# `token_refresh` tests use a loopback `TcpListener` to mock the token endpoint.
+tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
 
 [lib]
 doctest = false

--- a/crates/engine/src/credential/rotation/scheduler.rs
+++ b/crates/engine/src/credential/rotation/scheduler.rs
@@ -61,7 +61,7 @@ impl PeriodicScheduler {
         loop {
             let next = self.calculate_next_rotation_time();
             tokio::select! {
-                _ = sleep_until(next) => {
+                () = sleep_until(next) => {
                     if let Err(error) = rotation_fn(credential_id).await {
                         tracing::error!(
                             credential_id = %credential_id,
@@ -70,7 +70,7 @@ impl PeriodicScheduler {
                         );
                     }
                 }
-                _ = shutdown.cancelled() => {
+                () = shutdown.cancelled() => {
                     tracing::info!(
                         credential_id = %credential_id,
                         "Rotation loop shut down"

--- a/crates/engine/src/credential/rotation/token_refresh.rs
+++ b/crates/engine/src/credential/rotation/token_refresh.rs
@@ -215,4 +215,89 @@ mod tests {
             .expose_secret(|v| assert_eq!(v, "refresh-2"));
         assert!(state.expires_at.is_some());
     }
+
+    use tokio::{
+        io::{AsyncReadExt, AsyncWriteExt},
+        net::TcpListener,
+    };
+
+    /// Drain a single HTTP/1.1 request until the header block ends.
+    async fn drain_incoming_request(stream: &mut tokio::net::TcpStream) {
+        let mut acc = Vec::new();
+        let mut buf = [0u8; 1024];
+        loop {
+            let n = stream
+                .read(&mut buf)
+                .await
+                .expect("read request from client");
+            if n == 0 {
+                break;
+            }
+            acc.extend_from_slice(&buf[..n]);
+            if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                break;
+            }
+            if acc.len() > 64 * 1024 {
+                return;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn refresh_oauth2_state_maps_401_to_token_endpoint_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        const BODY: &[u8] = b"{\"error\":\"invalid_client\"}";
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            let n = BODY.len();
+            let head = format!(
+                "HTTP/1.1 401 Unauthorized\r\nContent-Type: application/json\r\nContent-Length: {n}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(head.as_bytes()).await.is_err() {
+                return;
+            }
+            let _ = stream.write_all(BODY).await;
+        });
+
+        let mut state = sample_state();
+        state.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = refresh_oauth2_state(&mut state)
+            .await
+            .expect_err("401 from token");
+        assert!(
+            matches!(err, TokenRefreshError::TokenEndpoint { .. }),
+            "expected TokenEndpoint, got: {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn refresh_oauth2_state_maps_invalid_json_to_parse_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local addr");
+        let body: &[u8] = b"not json {";
+        tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept");
+            drain_incoming_request(&mut stream).await;
+            let n = body.len();
+            let head = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {n}\r\nConnection: close\r\n\r\n"
+            );
+            if stream.write_all(head.as_bytes()).await.is_err() {
+                return;
+            }
+            let _ = stream.write_all(body).await;
+        });
+
+        let mut state = sample_state();
+        state.token_url = format!("http://127.0.0.1:{}/token", addr.port());
+        let err = refresh_oauth2_state(&mut state)
+            .await
+            .expect_err("invalid json body");
+        assert!(
+            matches!(err, TokenRefreshError::Parse(_)),
+            "expected Parse, got: {err:?}"
+        );
+    }
 }

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -2,7 +2,7 @@
 name: nebula-sdk
 role: Integration Author SDK (Re-export Façade)
 status: partial
-last-reviewed: 2026-04-17
+last-reviewed: 2026-04-22
 canon-invariants: [L1-3.5, L1-4.4, L1-7]
 related: [nebula-action, nebula-credential, nebula-resource, nebula-schema, nebula-workflow, nebula-plugin, nebula-validator, nebula-core]
 ---
@@ -39,6 +39,19 @@ Top-level re-exports (full crates):
 - `nebula_plugin` — `Plugin` trait, `PluginManifest`, `PluginRegistry`.
 - `nebula_validator` — validation traits.
 - `nebula_core` — core ID types (`ExecutionId`, `NodeKey`, `WorkflowId`).
+
+### Credential, OAuth, and the SDK (P11 re-export audit)
+
+The SDK does not introduce a second OAuth façade on top of `nebula-credential`. Integration authors get credentials in two ways:
+
+| Surface | What you use |
+|--------|----------------|
+| **Full crate** | `nebula_sdk::nebula_credential` (same as depending on `nebula-credential` directly). All OAuth2 resolver/engine types, errors, and helpers live here. |
+| **Prelude** | `nebula_sdk::prelude::*` re-exports the common credential and OAuth2 types used in actions (`Credential`, `OAuth2Credential`, `OAuth2Token`, `CredentialContext`, `CredentialSnapshot`, …) — see `prelude.rs`. |
+
+**Not in the SDK:** HTTP token exchange/refresh against a provider, storage encryption, and engine `CredentialResolver` — those are product/runtime crates (`nebula-api`, `nebula-engine`, `nebula-storage`). If you outgrow the prelude list, import from `nebula_sdk::nebula_credential` without adding another workspace dependency.
+
+**Migration:** When credential/OAuth types move or rename, follow `nebula-credential` release notes and this README; the SDK version tracks workspace `nebula-credential` and does not add its own parallel OAuth type aliases.
 
 Modules provided by this crate:
 

--- a/crates/storage/src/credential/layer/encryption.rs
+++ b/crates/storage/src/credential/layer/encryption.rs
@@ -256,7 +256,12 @@ impl<S> EncryptionLayer<S> {
 // `StaticKeyProvider`. Storage's own `test-util` feature forwards that.
 #[cfg(all(test, feature = "test-util"))]
 mod tests {
-    use nebula_credential::{PutMode, encrypt, store::test_helpers::make_credential};
+    use nebula_credential::{
+        PutMode, SecretString,
+        credentials::oauth2::{AuthStyle, OAuth2State},
+        encrypt,
+        store::test_helpers::make_credential,
+    };
 
     use super::{
         super::super::{key_provider::StaticKeyProvider, memory::InMemoryStore},
@@ -306,6 +311,39 @@ mod tests {
         // Read directly from inner store — data should NOT be plaintext
         let raw = inner.get("enc-2").await.unwrap();
         assert_ne!(raw.data, b"plaintext-secret");
+    }
+
+    /// Integration-style check: an OAuth2 credential blob must not be stored as raw JSON
+    /// strings in the backend row (regression for ADR-0029 / at-rest expectations).
+    #[tokio::test]
+    async fn oauth2_state_secrets_not_plaintext_in_inner_store() {
+        const PLAINTEXT_ACCESS: &str = "nebula-integration-plaintext-access-token-zz";
+        const PLAINTEXT_REFRESH: &str = "nebula-integration-plaintext-refresh-zz";
+
+        let inner = InMemoryStore::new();
+        let store = EncryptionLayer::new(inner.clone(), default_provider());
+
+        let state = OAuth2State {
+            access_token: SecretString::new(PLAINTEXT_ACCESS),
+            token_type: "Bearer".to_owned(),
+            refresh_token: Some(SecretString::new(PLAINTEXT_REFRESH)),
+            expires_at: None,
+            scopes: vec!["s1".to_owned()],
+            client_id: SecretString::new("c"),
+            client_secret: SecretString::new("s"),
+            token_url: "https://example.invalid/token".to_owned(),
+            auth_style: AuthStyle::Header,
+        };
+        let data = serde_json::to_vec(&state).expect("serialize OAuth2 state");
+        let cred = make_credential("enc-oauth2-state", &data);
+        store.put(cred, PutMode::CreateOnly).await.unwrap();
+
+        let raw = inner.get("enc-oauth2-state").await.unwrap();
+        let lossy = String::from_utf8_lossy(&raw.data);
+        assert!(
+            !lossy.contains(PLAINTEXT_ACCESS) && !lossy.contains(PLAINTEXT_REFRESH),
+            "inner row must not contain discoverable credential secrets, got: {lossy}"
+        );
     }
 
     #[tokio::test]

--- a/crates/storage/src/credential/layer/encryption.rs
+++ b/crates/storage/src/credential/layer/encryption.rs
@@ -340,9 +340,10 @@ mod tests {
 
         let raw = inner.get("enc-oauth2-state").await.unwrap();
         let lossy = String::from_utf8_lossy(&raw.data);
+        let stored_len = raw.data.len();
         assert!(
             !lossy.contains(PLAINTEXT_ACCESS) && !lossy.contains(PLAINTEXT_REFRESH),
-            "inner row must not contain discoverable credential secrets, got: {lossy}"
+            "inner row must not contain discoverable credential secrets (stored bytes: {stored_len})"
         );
     }
 


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
  type(scope)?: description    — scope is optional
  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
-->

## Summary

Expands OAuth2 and credential test coverage across API token exchange, engine `refresh_oauth2_state`, e2e store versioning and resolver projection, and encrypted storage. Documents the nebula-sdk credential/OAuth re-export story (P11) in `crates/sdk/README.md` and `CHANGELOG.md`. Updates the test matrix so CI actually runs OAuth- and rotation-gated code paths (`credential-oauth`, `--all-features` for engine, `test-util` for storage). Closes the related GitHub issues below.

## Linked issue

- Closes #545
- Closes #548
- Closes #549
- Closes #550
- Closes #551
- Closes #552
- Closes #553
- Refs NEB-

## Type of change

<!-- Tick all that apply. -->

- [ ] `feat` — new capability
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [x] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [x] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

nebula-api, nebula-engine, nebula-storage, nebula-sdk, `CHANGELOG.md`, `.github/workflows/test-matrix.yml`

## Changes

- `crates/api/src/credential/flow.rs`: negative tests for token exchange (401, invalid JSON on 2xx).
- `crates/api/tests/e2e_oauth2_flow.rs`: `StoredCredential` version assertions (1→2→3), `CredentialHandle` / `OAuth2Token` projection after refresh.
- `crates/engine`: loopback token server tests for `refresh_oauth2_state`; `tokio` dev-dep with `net`/`io-util`; `scheduler.rs` clippy (`()` in `select!`).
- `crates/storage/.../encryption.rs`: OAuth2 state not stored as plaintext in inner store behind `EncryptionLayer` (behind `test-util`).
- `crates/sdk/README.md` + `CHANGELOG.md`: P11 credential/OAuth re-export audit and migration note.
- `.github/workflows/test-matrix.yml`: `nebula-engine` uses `--all-features`; `nebula-api` uses `credential-oauth`; `nebula-storage` uses `test-util,credential-in-memory`.

## Test plan

- `cargo test -p nebula-api --features credential-oauth --lib` — pass (includes `flow` and OAuth controller unit tests).
- `cargo test -p nebula-api --features credential-oauth --test e2e_oauth2_flow` — pass.
- `cargo test -p nebula-engine --all-features` — pass (includes `rotation` / `token_refresh`).
- `cargo nextest run -p nebula-storage --features "test-util,credential-in-memory"` — pass (170 tests).
- `cargo clippy -p nebula-api --features credential-oauth -p nebula-engine --all-features -- -D warnings` — clean.
- Pre-push `nextest` on changed crates (lefthook) — pass.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted (pre-commit)
- [x] `cargo clippy` — targeted crates with required features (pre-commit)
- [x] `cargo nextest` — changed-crate gate + manual runs above
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Docs checklist

<!--
Required for non-trivial design or execution-lifecycle changes.
See docs/PRODUCT_CANON.md §17 (Definition of Done).
Delete items that do not apply, or delete this section for pure bug fixes and mechanical refactors.
-->

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [x] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: <!-- path or URL -->)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

Draft PR. Two commits on branch: SDK P11 docs + OAuth test/CI work. Unstaged local change in `docs/guidelines/research/README.md` is intentionally not included.
