### PR TITLE
feat(schema): document mode wire format, variant_empty, and int number helpers

### DIFF
--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -56,6 +56,16 @@ path = "tests/proptest/path_roundtrip.rs"
 name = "proptest_serde_preserves"
 path = "tests/proptest/serde_preserves.rs"
 
+[[test]]
+name = "json_schema_smoke"
+path = "tests/json_schema_smoke.rs"
+required-features = ["schemars"]
+
+[[example]]
+name = "json_schema_export"
+path = "examples/json_schema_export.rs"
+required-features = ["schemars"]
+
 [[bench]]
 name = "bench_build"
 harness = false

--- a/crates/schema/examples/async_resolve.rs
+++ b/crates/schema/examples/async_resolve.rs
@@ -1,0 +1,43 @@
+//! Full proof-token pipeline: `ValidSchema` → `ValidValues` → `ResolvedValues` using a
+//! tiny [`ExpressionContext`](nebula_schema::ExpressionContext) stub.
+//!
+//! Run:
+//! `cargo run -p nebula-schema --example async_resolve`
+
+use nebula_schema::{
+    ExpressionAst, ExpressionContext, Field, FieldValues, Schema, ValidationError, field_key,
+};
+use serde_json::json;
+
+/// Returns the same JSON for every expression — enough to resolve `{{ $x }}` shapes in tests.
+struct ConstJson(serde_json::Value);
+
+#[async_trait::async_trait]
+impl ExpressionContext for ConstJson {
+    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
+        Ok(self.0.clone())
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let schema = Schema::builder()
+        .add(Field::boolean(field_key!("enabled")))
+        .add(Field::number(field_key!("n")))
+        .build()
+        .expect("lint");
+
+    // Literal + expression wire for `n`.
+    let values = FieldValues::from_json(json!({
+        "enabled": true,
+        "n": {"$expr": "{{ cost }}"},
+    }))
+    .expect("strict keys");
+
+    let valid = schema.validate(&values).expect("validate");
+    let ctx = ConstJson(json!(42.0));
+    let resolved = valid.resolve(&ctx).await.expect("resolve");
+
+    assert_eq!(resolved.get(&field_key!("n")), Some(&json!(42.0)));
+    eprintln!("OK: resolved numeric field via expression context");
+}

--- a/crates/schema/examples/builder_validate.rs
+++ b/crates/schema/examples/builder_validate.rs
@@ -1,0 +1,30 @@
+//! Build a schema with the builder API, parse `FieldValues` from JSON, and run
+//! `ValidSchema::validate` to obtain a `ValidValues` proof token.
+//!
+//! Run:
+//! `cargo run -p nebula-schema --example builder_validate`
+
+use nebula_schema::{Field, FieldValues, Schema, field_key};
+use serde_json::json;
+
+fn main() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("name")).required())
+        .add(
+            Field::number(field_key!("retries"))
+                .default(json!(3))
+                .label("Retries"),
+        )
+        .build()
+        .expect("structural lint should pass");
+
+    let values = FieldValues::from_json(json!({"name": "demo", "retries": 1}))
+        .expect("strict key validation should accept this object");
+
+    let valid = schema
+        .validate(&values)
+        .expect("field values should satisfy the schema");
+
+    assert!(valid.warnings().is_empty());
+    eprintln!("OK: validated {} top-level field(s)", schema.fields().len());
+}

--- a/crates/schema/examples/conditional_fields.rs
+++ b/crates/schema/examples/conditional_fields.rs
@@ -1,0 +1,55 @@
+//! Conditional fields with `active_when`: a secret is only visible and required
+//! when the user picks a matching select option.
+//!
+//! Run:
+//! `cargo run -p nebula-schema --example conditional_fields`
+
+use nebula_schema::prelude::*;
+use serde_json::json;
+
+fn main() {
+    let schema = Schema::builder()
+        .add(
+            Field::select(field_key!("auth_type"))
+                .option("api_key", "API key")
+                .option("oauth2", "OAuth2")
+                .required(),
+        )
+        .add(
+            Field::secret(field_key!("api_key")).active_when(Rule::predicate(
+                Predicate::eq("auth_type", json!("api_key")).expect("predicate"),
+            )),
+        )
+        .add(
+            Field::string(field_key!("client_id")).active_when(Rule::predicate(
+                Predicate::eq("auth_type", json!("oauth2")).expect("predicate"),
+            )),
+        )
+        .build()
+        .expect("schema should lint");
+
+    // API key path: secret must be present when active.
+    let wire = json!({
+        "auth_type": "api_key",
+        "api_key": "s3cr3t",
+    });
+    let values = FieldValues::from_json(wire).expect("wire");
+    schema
+        .validate(&values)
+        .expect("values should validate for api_key flow");
+
+    // OAuth path: client_id required when branch is active.
+    let wire = json!({
+        "auth_type": "oauth2",
+        "client_id": "my-app",
+    });
+    let values = FieldValues::from_json(wire).expect("wire");
+    schema
+        .validate(&values)
+        .expect("values should validate for oauth2 flow");
+
+    eprintln!(
+        "OK: conditional schema has {} field(s)",
+        schema.fields().len()
+    );
+}

--- a/crates/schema/examples/derive_config.rs
+++ b/crates/schema/examples/derive_config.rs
@@ -1,0 +1,33 @@
+//! Use `#[derive(Schema)]` so the Rust type and the Nebula field list stay in sync.
+//! `HasSchema::schema()` returns the same `ValidSchema` the engine would load from wire.
+//!
+//! Run:
+//! `cargo run -p nebula-schema --example derive_config`
+
+use nebula_schema::{FieldValues, HasSchema, Schema};
+use serde::Deserialize;
+use serde_json::json;
+
+#[derive(Schema, Deserialize, Debug)]
+struct DemoConfig {
+    /// Shown in generated schema metadata.
+    #[param(label = "Display title")]
+    title: String,
+}
+
+fn main() {
+    let schema = DemoConfig::schema();
+    assert_eq!(
+        schema.fields().len(),
+        1,
+        "one struct field → one top-level field"
+    );
+
+    let sample = json!({"title": "hello"});
+    let values = FieldValues::from_json(sample.clone()).expect("json");
+    schema
+        .validate(&values)
+        .expect("valid against derived schema");
+    let cfg: DemoConfig = serde_json::from_value(sample).expect("round-trip");
+    eprintln!("OK: derived schema validates title={}", cfg.title);
+}

--- a/crates/schema/examples/json_schema_export.rs
+++ b/crates/schema/examples/json_schema_export.rs
@@ -1,0 +1,25 @@
+//! Export a validated schema to JSON Schema Draft 2020-12 (requires the `schemars` feature).
+//!
+//! Run:
+//! `cargo run -p nebula-schema --example json_schema_export --features schemars`
+
+use nebula_schema::{Field, FieldKey, Schema};
+use serde_json::Value;
+
+fn main() {
+    let key = FieldKey::new("name").expect("valid key");
+    let schema = Schema::builder()
+        .add(Field::string(key).required().label("Name").no_expression())
+        .build()
+        .expect("lint");
+
+    let exported = schema.json_schema().expect("export to JSON Schema");
+    let json: Value = serde_json::to_value(&exported).expect("schemars::Schema serializes");
+
+    assert_eq!(
+        json["$schema"],
+        Value::String("https://json-schema.org/draft/2020-12/schema".to_owned())
+    );
+    assert_eq!(json["type"], "object");
+    eprintln!("OK: JSON Schema export: {}", json["$schema"]);
+}

--- a/crates/schema/examples/outbound_http_connector.rs
+++ b/crates/schema/examples/outbound_http_connector.rs
@@ -27,7 +27,7 @@ fn main() {
         "headers": [
             { "name": "X-Correlation-Id", "value": "ulid-here" }
         ],
-        "body": { "mode": "json", "value": { "json_body": "{\n  \"hello\": \"world\"\n}" } },
+        "body": { "mode": "json", "value": "{\n  \"hello\": \"world\"\n}" },
         "query": { "params": [ { "name": "debug", "value": "0" } ] },
         "timeout_ms": 15000,
         "retry": { "max_attempts": 5, "initial_backoff_ms": 200 },

--- a/crates/schema/examples/outbound_http_connector.rs
+++ b/crates/schema/examples/outbound_http_connector.rs
@@ -1,0 +1,59 @@
+//! A dense **outbound HTTP connector** example: auth and body as `mode` branches, header/query
+//! lists, retry object, optional HMAC signing, and a string list filter — useful to stress-test
+//! UI generation and validation without a real third-party spec.
+//!
+//! Run: `cargo run -p nebula-schema --example outbound_http_connector`
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples_include/outbound_http_connector_shared.rs"
+));
+
+use nebula_schema::FieldValues;
+use serde_json::json;
+
+fn main() {
+    let schema = build_outbound_http_connector_schema();
+    eprintln!("Schema: {} top-level field(s)", schema.fields().len());
+
+    let full = json!({
+        "base_url": "https://hooks.partner.example",
+        "http_method": "POST",
+        "path": "/v2/events/ingest",
+        "auth": { "mode": "api_key_header", "value": {
+            "header_name": "X-Api-Key",
+            "api_key_value": "supersecretkeyatleast8chars"
+        }},
+        "headers": [
+            { "name": "X-Correlation-Id", "value": "ulid-here" }
+        ],
+        "body": { "mode": "json", "value": { "json_body": "{\n  \"hello\": \"world\"\n}" } },
+        "query": { "params": [ { "name": "debug", "value": "0" } ] },
+        "timeout_ms": 15000,
+        "retry": { "max_attempts": 5, "initial_backoff_ms": 200 },
+        "request_signing": { "mode": "hmac_sha256", "value": {
+            "secret": "signingkeymustbeeightplus",
+            "header_name": "X-Signature"
+        }},
+        "include_event_types": [ "order.paid", "user.created" ]
+    });
+
+    let v = FieldValues::from_json(full).expect("ingest");
+    schema
+        .validate(&v)
+        .expect("full connector payload should validate");
+
+    let minimal = json!({
+        "base_url": "https://api.example.com",
+        "http_method": "GET",
+        "path": "/health",
+        "auth": { "mode": "none" },
+        "body": { "mode": "none" },
+        "query": { "params": [] },
+        "request_signing": { "mode": "none" },
+    });
+    let v = FieldValues::from_json(minimal).expect("ingest");
+    schema.validate(&v).expect("minimal GET without lists");
+
+    eprintln!("OK: outbound HTTP connector example payloads validated");
+}

--- a/crates/schema/examples/telegram_send_message.rs
+++ b/crates/schema/examples/telegram_send_message.rs
@@ -1,0 +1,70 @@
+//! One integration surface: **Telegram sendMessage** (token, chat, text, optional parse mode and
+//! toggles, optional nested `reply_markup` → `inline_keyboard` with callback / url / web_app).
+//!
+//! There is no `resource` / `operation` indirection: configuring this action *is* sending a
+//! message.
+//!
+//! Run: `cargo run -p nebula-schema --example telegram_send_message`
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples_include/telegram_send_message_shared.rs"
+));
+
+use nebula_schema::FieldValues;
+use serde_json::json;
+
+fn main() {
+    let schema = build_telegram_send_message_schema();
+    eprintln!("Schema: {} top-level field(s)", schema.fields().len());
+
+    let with_keyboard = json!({
+        "api_key": "1234567890:AAHevabcdefghijklmnopqrstuvwxyz12",
+        "chat_id": "-1001234567890",
+        "text": "Hello from Nebula — pick an action:",
+        "parse_mode": "HTML",
+        "append_attribution": true,
+        "disable_web_page_preview": false,
+        "disable_notification": false,
+        "reply_markup": {
+            "inline_keyboard": [
+                [
+                    {
+                        "text": "✅ OK",
+                        "action": { "mode": "callback", "value": "ok" }
+                    },
+                    {
+                        "text": "Docs",
+                        "action": { "mode": "url", "value": "https://n8n.io" }
+                    }
+                ],
+                [
+                    {
+                        "text": "WebApp",
+                        "action": {
+                            "mode": "web_app",
+                            "value": { "url": "https://example.com/app" }
+                        }
+                    }
+                ]
+            ]
+        }
+    });
+
+    let values = FieldValues::from_json(with_keyboard).expect("ingest");
+    schema
+        .validate(&values)
+        .expect("message + inline keyboard should validate");
+
+    let minimal = json!({
+        "api_key": "1234567890:AAHevabcdefghijklmnopqrstuvwxyz12",
+        "chat_id": "@channelusername",
+        "text": "Plain text only",
+    });
+    let values = FieldValues::from_json(minimal).expect("ingest");
+    schema
+        .validate(&values)
+        .expect("minimal message without options");
+
+    eprintln!("OK: Telegram send_message payloads validated");
+}

--- a/crates/schema/examples_include/outbound_http_connector_shared.rs
+++ b/crates/schema/examples_include/outbound_http_connector_shared.rs
@@ -170,7 +170,6 @@ pub fn build_outbound_http_connector_schema() -> ValidSchema {
         .add(
             Field::number(field_key!("timeout_ms"))
                 .label("Request timeout (ms)")
-                .integer()
                 .min_int(100)
                 .default_int(30_000),
         )
@@ -180,7 +179,6 @@ pub fn build_outbound_http_connector_schema() -> ValidSchema {
                 .add(
                     Field::number(field_key!("max_attempts"))
                         .label("Max attempts")
-                        .integer()
                         .min_int(1)
                         .max_int(8)
                         .default_int(3),
@@ -188,7 +186,6 @@ pub fn build_outbound_http_connector_schema() -> ValidSchema {
                 .add(
                     Field::number(field_key!("initial_backoff_ms"))
                         .label("First backoff (ms)")
-                        .integer()
                         .min_int(100)
                         .default_int(500),
                 ),

--- a/crates/schema/examples_include/outbound_http_connector_shared.rs
+++ b/crates/schema/examples_include/outbound_http_connector_shared.rs
@@ -1,0 +1,209 @@
+// Fictional “outbound HTTP connector” integration: URL, method, auth modes, custom headers,
+// body modes (JSON / form), HMAC signing, retry policy, and a filter list — for exercising
+// object/list/mode composition without tying to a specific vendor.
+//
+// Included from `examples/outbound_http_connector.rs` and `tests/outbound_http_connector.rs`.
+
+use nebula_schema::{Field, Schema, ValidSchema, field_key};
+
+fn auth_mode() -> Field {
+    Field::mode(field_key!("auth"))
+        .label("How to authenticate the outbound request")
+        .variant_empty("none", "No auth")
+        .variant(
+            "bearer",
+            "Authorization: Bearer …",
+            Field::secret(field_key!("token"))
+                .required()
+                .min_length(4)
+                .label("Access token"),
+        )
+        .variant(
+            "api_key_header",
+            "API key in a header",
+            Field::object(field_key!("api_key_in_header"))
+                .add(
+                    Field::string(field_key!("header_name"))
+                        .label("Header name")
+                        .default(serde_json::json!("X-API-Key"))
+                        .required(),
+                )
+                .add(
+                    Field::secret(field_key!("api_key_value"))
+                        .label("Key value")
+                        .required(),
+                ),
+        )
+        .variant(
+            "basic",
+            "HTTP Basic",
+            Field::object(field_key!("basic_auth"))
+                .add(Field::string(field_key!("username")).required().label("Username"))
+                .add(
+                    Field::secret(field_key!("password"))
+                        .required()
+                        .min_length(1)
+                        .label("Password"),
+                ),
+        )
+        .default_variant("none")
+        .into()
+}
+
+fn body_mode() -> Field {
+    Field::mode(field_key!("body"))
+        .label("Entity body")
+        .variant_empty("none", "Empty")
+        .variant(
+            "json",
+            "JSON (code editor)",
+            Field::code(field_key!("json_body"))
+                .label("JSON")
+                .language("json")
+                .description("Serialized as the raw request body (UTF-8)"),
+        )
+        .variant(
+            "form_urlencoded",
+            "Form (application/x-www-form-urlencoded)",
+            // As the sole `mode` payload, wire is a **JSON array** of objects (not `{form_fields: …}`).
+            Field::list(field_key!("form_fields"))
+                .label("Fields")
+                .item(
+                    Field::object(field_key!("field"))
+                        .add(
+                            Field::string(field_key!("name"))
+                                .required()
+                                .max_length(256),
+                        )
+                        .add(Field::string(field_key!("value")).max_length(4096)),
+                )
+                .min_items(1)
+                .max_items(64),
+        )
+        .default_variant("none")
+        .into()
+}
+
+fn signing_mode() -> Field {
+    Field::mode(field_key!("request_signing"))
+        .label("Request signing (optional, e.g. webhooks HMAC)")
+        .variant_empty("none", "None")
+        .variant(
+            "hmac_sha256",
+            "HMAC-SHA256 header",
+            Field::object(field_key!("hmac_sha256"))
+                .add(
+                    Field::secret(field_key!("secret"))
+                        .required()
+                        .min_length(8)
+                        .label("Shared secret"),
+                )
+                .add(
+                    Field::string(field_key!("header_name"))
+                        .label("Header to set")
+                        .default(serde_json::json!("X-Integration-Signature"))
+                        .max_length(128),
+                )
+                .description("Signature = hex(HMAC-SHA256(secret, raw_body_bytes)) — policy is illustrative"),
+        )
+        .default_variant("none")
+        .into()
+}
+
+/// A heavier integration shape: many branches, optional subtrees, nested lists.
+pub fn build_outbound_http_connector_schema() -> ValidSchema {
+    Schema::builder()
+        .add(
+            Field::string(field_key!("base_url"))
+                .label("Base URL")
+                .description("e.g. https://api.partner.example; path is appended (no trailing slash required)")
+                .required()
+                .url(),
+        )
+        .add(
+            Field::select(field_key!("http_method"))
+                .label("Method")
+                .option("GET", "GET")
+                .option("POST", "POST")
+                .option("PUT", "PUT")
+                .option("PATCH", "PATCH")
+                .option("DELETE", "DELETE")
+                .required(),
+        )
+        .add(
+            Field::string(field_key!("path"))
+                .label("Path")
+                .description("Appended to base_url; may contain `{template}` segments")
+                .required()
+                .max_length(512),
+        )
+        .add(auth_mode())
+        .add(
+            Field::list(field_key!("headers"))
+                .label("Extra headers")
+                .item(
+                    Field::object(field_key!("header"))
+                        .add(
+                            Field::string(field_key!("name"))
+                                .required()
+                                .max_length(128)
+                                .description("Header name (ASCII)"),
+                        )
+                        .add(Field::string(field_key!("value")).max_length(4096)),
+                )
+                .max_items(32),
+        )
+        .add(body_mode())
+        .add(
+            Field::object(field_key!("query"))
+                .label("Query string parameters")
+                .add(
+                    Field::list(field_key!("params"))
+                        .item(
+                            Field::object(field_key!("param"))
+                                .add(Field::string(field_key!("name")).required().max_length(128))
+                                .add(Field::string(field_key!("value"))),
+                        )
+                        .max_items(40),
+                ),
+        )
+        .add(
+            Field::number(field_key!("timeout_ms"))
+                .label("Request timeout (ms)")
+                .integer()
+                .min_int(100)
+                .default_int(30_000),
+        )
+        .add(
+            Field::object(field_key!("retry"))
+                .label("Retry on transport errors")
+                .add(
+                    Field::number(field_key!("max_attempts"))
+                        .label("Max attempts")
+                        .integer()
+                        .min_int(1)
+                        .max_int(8)
+                        .default_int(3),
+                )
+                .add(
+                    Field::number(field_key!("initial_backoff_ms"))
+                        .label("First backoff (ms)")
+                        .integer()
+                        .min_int(100)
+                        .default_int(500),
+                ),
+        )
+        .add(signing_mode())
+        .add(
+            Field::list(field_key!("include_event_types"))
+                .label("Send only for these event types (empty = all)")
+                .item(
+                    Field::string(field_key!("_item"))
+                        .min_length(1)
+                        .max_length(64),
+                )
+                .max_items(50),
+        )
+        .build()
+        .expect("outbound HTTP connector example schema lints")
+}

--- a/crates/schema/examples_include/telegram_send_message_shared.rs
+++ b/crates/schema/examples_include/telegram_send_message_shared.rs
@@ -1,0 +1,126 @@
+// Telegram `sendMessage`-shaped config (single integration surface): token, target chat, text,
+// optional mode/toggles, optional `reply_markup.inline_keyboard` (rows × buttons with mode actions).
+// No resource/operation routing — the action is the integration itself.
+//
+// Included from `examples/telegram_send_message.rs` and `tests/telegram_send_message.rs`.
+
+use nebula_schema::{Field, Schema, ValidSchema, field_key};
+
+/// One inline button: label + `action` (callback / url / web_app) in Nebula mode wire.
+fn inline_button_field() -> Field {
+    Field::object(field_key!("button"))
+        .label("Inline button")
+        .add(
+            Field::string(field_key!("text"))
+                .required()
+                .max_length(256)
+                .description("Button label (Telegram `text`)"),
+        )
+        .add(
+            Field::mode(field_key!("action"))
+                .label("Button action")
+                .variant(
+                    "callback",
+                    "Callback",
+                    Field::string(field_key!("callback_data"))
+                        .required()
+                        .max_length(64)
+                        .description("`callback_data` (1–64 bytes in API)"),
+                )
+                .variant(
+                    "url",
+                    "Open URL",
+                    Field::string(field_key!("url"))
+                        .required()
+                        .url()
+                        .description("HTTPS link opened when the user taps the button"),
+                )
+                .variant(
+                    "web_app",
+                    "Web App",
+                    Field::object(field_key!("web_app"))
+                        .description("Same shape as Telegram `web_app: { url }` on InlineKeyboardButton")
+                        .add(
+                            Field::string(field_key!("url"))
+                                .required()
+                                .url()
+                                .label("Web App URL"),
+                        ),
+                )
+                .default_variant("callback"),
+        )
+        .into()
+}
+
+fn inline_keyboard_list() -> Field {
+    let row = Field::list(field_key!("row"))
+        .label("Row of buttons")
+        .min_items(1)
+        .max_items(8)
+        .item(inline_button_field());
+
+    Field::list(field_key!("inline_keyboard"))
+        .label("Inline keyboard (rows × buttons)")
+        .description("Maps to `reply_markup.inline_keyboard` in sendMessage")
+        .min_items(1)
+        .max_items(20)
+        .item(row)
+        .into()
+}
+
+/// Schema for a Telegram “send message + optional inline keyboard” action only.
+pub fn build_telegram_send_message_schema() -> ValidSchema {
+    Schema::builder()
+        .add(
+            Field::secret(field_key!("api_key"))
+                .label("Bot API token")
+                .description("From BotFather; never log or echo")
+                .required()
+                .min_length(20)
+                .reveal_last(4),
+        )
+        .add(
+            Field::string(field_key!("chat_id"))
+                .label("Chat ID")
+                .description("Target chat, thread id, or @username")
+                .required(),
+        )
+        .add(
+            Field::string(field_key!("text"))
+                .label("Text")
+                .description("Message body (max 4096, Telegram API)")
+                .min_length(1)
+                .max_length(4096)
+                .required(),
+        )
+        .add(
+            Field::select(field_key!("parse_mode"))
+                .label("Parse mode")
+                .option("none", "None (plain text)")
+                .option("HTML", "HTML")
+                .option("MarkdownV2", "MarkdownV2")
+                .option("Markdown", "Markdown (legacy)"),
+        )
+        .add(
+            Field::boolean(field_key!("append_attribution"))
+                .label("Append “sent via automation” line")
+                .description("Product choice: append a short footer to `text`"),
+        )
+        .add(
+            Field::boolean(field_key!("disable_web_page_preview"))
+                .label("Disable link previews"),
+        )
+        .add(
+            Field::boolean(field_key!("disable_notification"))
+                .label("Send silently")
+                .description("If true, the message is sent without sound"),
+        )
+        .add(
+            Field::object(field_key!("reply_markup"))
+                .label("Reply markup (inline keyboard)")
+                .description("Optional. Omit entirely if you do not need a keyboard")
+                .add(inline_keyboard_list()),
+        )
+        .build()
+        .expect("telegram send_message example schema lints")
+}

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -34,7 +34,9 @@ pub(crate) fn crate_path() -> TokenStream2 {
     }
 }
 
-/// Build a `FieldKey` from a string literal, validated at compile time.
+/// Build a `FieldKey` (from `nebula-schema`) from a string literal, using the same rules as
+/// `FieldKey::new` at **compile time** (non-empty, max 64 chars, ASCII identifier: leading letter
+/// or `_`, then letters, digits, or `_`).
 ///
 /// ```ignore
 /// let k = field_key!("alpha");   // OK

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -362,11 +362,11 @@ impl NumberField {
         self
     }
 
-    /// Shorthand for [`min`](Self::min) on integer fields: lower bound as `i64` (becomes
-    /// `serde_json::Number` in rules).
+    /// Shorthand for integer ranges: sets [`integer`](Self::integer), then [`min`](Self::min) with
+    /// an `i64` bound (stored as `serde_json::Number` in rules).
     #[must_use]
     pub fn min_int(self, min: i64) -> Self {
-        self.min(Number::from(min))
+        self.integer().min(Number::from(min))
     }
 
     /// Add maximum numeric rule.
@@ -376,16 +376,16 @@ impl NumberField {
         self
     }
 
-    /// Shorthand for [`max`](Self::max) with an `i64` upper bound.
+    /// Like [`min_int`](Self::min_int): sets [`integer`](Self::integer), then [`max`](Self::max).
     #[must_use]
     pub fn max_int(self, max: i64) -> Self {
-        self.max(Number::from(max))
+        self.integer().max(Number::from(max))
     }
 
-    /// Set default to a whole number without spelling `serde_json::Value` for the common case.
+    /// Default whole number: sets [`integer`](Self::integer), then [`default`](Self::default).
     #[must_use]
     pub fn default_int(self, n: i64) -> Self {
-        self.default(Value::Number(Number::from(n)))
+        self.integer().default(Value::Number(Number::from(n)))
     }
 
     /// Set increment step.
@@ -395,10 +395,10 @@ impl NumberField {
         self
     }
 
-    /// Shorthand for [`step`](Self::step) with an `i64` step.
+    /// Integer step: sets [`integer`](Self::integer), then [`step`](Self::step).
     #[must_use]
     pub fn step_int(self, s: i64) -> Self {
-        self.step(Number::from(s))
+        self.integer().step(Number::from(s))
     }
 }
 
@@ -626,12 +626,10 @@ impl ModeField {
             key: key.into(),
             label: label.into(),
             field: Box::new(
-                Field::string(
-                    FieldKey::new(Self::EMPTY_PLACEHOLDER_KEY)
-                        .expect("EMPTY_PLACEHOLDER_KEY must be a valid FieldKey"),
-                )
-                .visible(VisibilityMode::Never)
-                .into(),
+                Field::string(Self::EMPTY_PLACEHOLDER_KEY)
+                    .visible(VisibilityMode::Never)
+                    .no_expression()
+                    .into(),
             ),
         });
         self

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -362,6 +362,13 @@ impl NumberField {
         self
     }
 
+    /// Shorthand for [`min`](Self::min) on integer fields: lower bound as `i64` (becomes
+    /// `serde_json::Number` in rules).
+    #[must_use]
+    pub fn min_int(self, min: i64) -> Self {
+        self.min(Number::from(min))
+    }
+
     /// Add maximum numeric rule.
     #[must_use]
     pub fn max(mut self, max: impl Into<Number>) -> Self {
@@ -369,11 +376,29 @@ impl NumberField {
         self
     }
 
+    /// Shorthand for [`max`](Self::max) with an `i64` upper bound.
+    #[must_use]
+    pub fn max_int(self, max: i64) -> Self {
+        self.max(Number::from(max))
+    }
+
+    /// Set default to a whole number without spelling `serde_json::Value` for the common case.
+    #[must_use]
+    pub fn default_int(self, n: i64) -> Self {
+        self.default(Value::Number(Number::from(n)))
+    }
+
     /// Set increment step.
     #[must_use]
     pub fn step(mut self, s: impl Into<Number>) -> Self {
         self.step = Some(s.into());
         self
+    }
+
+    /// Shorthand for [`step`](Self::step) with an `i64` step.
+    #[must_use]
+    pub fn step_int(self, s: i64) -> Self {
+        self.step(Number::from(s))
     }
 }
 
@@ -567,7 +592,13 @@ pub struct ModeVariant {
 }
 
 impl ModeField {
-    /// Append variant.
+    /// Key used in the child payload of [`ModeField::variant_empty`] (hidden, never shown).
+    pub const EMPTY_PLACEHOLDER_KEY: &'static str = "_nebula_mode_empty";
+
+    /// Append a variant: `key` discriminates, `field` is the `value` payload for that key.
+    ///
+    /// The JSON under `value` is described in the [`ModeField`] doc (object vs list vs scalar,
+    /// and the `mode`/`value` envelope).
     #[must_use]
     pub fn variant(
         mut self,
@@ -579,6 +610,29 @@ impl ModeField {
             key: key.into(),
             label: label.into(),
             field: Box::new(field.into()),
+        });
+        self
+    }
+
+    /// A variant with no user-facing payload, for example `"none"` authentication.
+    ///
+    /// The schema still needs a child field; this uses a hidden `String` field with key
+    /// [`EMPTY_PLACEHOLDER_KEY`](Self::EMPTY_PLACEHOLDER_KEY) so authors do not hand-copy the
+    /// `field_key!("_skip")` + `VisibilityMode::Never` pattern. Omitted `value` in wire data is
+    /// still accepted for such variants when validators skip hidden absent fields.
+    #[must_use]
+    pub fn variant_empty(mut self, key: impl Into<String>, label: impl Into<String>) -> Self {
+        self.variants.push(ModeVariant {
+            key: key.into(),
+            label: label.into(),
+            field: Box::new(
+                Field::string(
+                    FieldKey::new(Self::EMPTY_PLACEHOLDER_KEY)
+                        .expect("EMPTY_PLACEHOLDER_KEY must be a valid FieldKey"),
+                )
+                .visible(VisibilityMode::Never)
+                .into(),
+            ),
         });
         self
     }
@@ -947,13 +1001,14 @@ impl Field {
         Ok(ListField::with_key(key))
     }
 
-    /// Create `ModeField`.
+    /// Create a mode field. See [`ModeField`] for the `{ "mode", "value" }` wire contract and
+    /// list payload rules, and [`ModeField::variant_empty`] for no-payload branches.
     #[must_use]
     pub fn mode(key: impl AsRef<str>) -> ModeField {
         ModeField::new(key)
     }
 
-    /// Fallible variant of [`Field::mode`] for runtime-provided keys.
+    /// Fallible variant of [`Field::mode`].
     ///
     /// # Errors
     ///

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -180,8 +180,10 @@ pub use expression::{Expression, ExpressionAst, ExpressionContext};
 ///   outer wrapper key around the list: each array element is validated with the `item`
 ///   schema, and that schema’s outer `Field` key (if the item is an `ObjectField`) is not
 ///   re-emitted as an extra wrapper in the wire.
-/// - For other leaf families ([`StringField`], [`SecretField`], [`CodeField`]), `value` is the
-///   scalar the field type expects.
+/// - For scalar leaf families, `value` is the JSON the field type expects, for example
+///   [`StringField`], [`SecretField`], [`CodeField`], [`NumberField`], [`BooleanField`],
+///   [`SelectField`], and [`FileField`] (per-field options, such as `multiple`, apply as
+///   usual).
 ///
 /// Integrators and UI authors should treat a JSON object with `"mode"` and optional `"value"`
 /// keys as the standard envelope, with the `value` kind determined by the selected variant’s

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -162,10 +162,42 @@ pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };
 pub use expression::{Expression, ExpressionAst, ExpressionContext};
+/// Discriminated field: one of several payload shapes (auth scheme, body kind, etc.).
+///
+/// # JSON wire format
+///
+/// A mode value is a JSON object with:
+///
+/// - **`mode`**: the variant’s string key.
+/// - **`value`** (optional): the payload for that variant.
+///
+/// When `value` is present, it matches the `field` you pass to [`ModeField::variant`]. The
+/// shape depends on that child field:
+///
+/// - If the child is an [`ObjectField`], `value` is a JSON object whose keys are the nested
+///   fields (each key must be a valid [`FieldKey`] string).
+/// - If the child is a [`ListField`], `value` is a **JSON array** of list items. There is no
+///   outer wrapper key around the list: each array element is validated with the `item`
+///   schema, and that schema’s outer `Field` key (if the item is an `ObjectField`) is not
+///   re-emitted as an extra wrapper in the wire.
+/// - For other leaf families ([`StringField`], [`SecretField`], [`CodeField`]), `value` is the
+///   scalar the field type expects.
+///
+/// Integrators and UI authors should treat a JSON object with `"mode"` and optional `"value"`
+/// keys as the standard envelope, with the `value` kind determined by the selected variant’s
+/// payload field type.
+///
+/// # Empty / no-payload variants
+///
+/// Variants with no user-facing data can use [`ModeField::variant_empty`], which stores a
+/// hidden string placeholder under a stable key ([`ModeField::EMPTY_PLACEHOLDER_KEY`]). When
+/// `value` is omitted, validators still accept the input if the only payload fields are hidden
+/// and non-required.
+pub use field::ModeField;
 pub use field::{
     BooleanField, CodeField, ComputedField, ComputedReturn, DynamicField, Field, FileField,
-    ListField, ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField,
-    SecretField, SelectField, StringField,
+    ListField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField, SecretField,
+    SelectField, StringField,
 };
 pub use has_schema::{HasSchema, HasSelectOptions};
 pub use input_hint::InputHint;

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -28,8 +28,8 @@ pub enum FieldValue {
     Object(IndexMap<FieldKey, Self>),
     /// Ordered sequence of values.
     List(Vec<Self>),
-    /// Discriminated mode payload. JSON object `{"mode": "...", "value": ...}` — see [`ModeField`]
-    /// for how `value` is shaped (object, array, or scalar).
+    /// Discriminated mode payload. JSON object `{"mode": "...", "value": ...}` — see
+    /// [`crate::ModeField`] for how `value` is shaped (object, array, or scalar).
     Mode {
         /// Chosen mode key.
         mode: FieldKey,

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -28,7 +28,8 @@ pub enum FieldValue {
     Object(IndexMap<FieldKey, Self>),
     /// Ordered sequence of values.
     List(Vec<Self>),
-    /// Discriminated mode payload.
+    /// Discriminated mode payload. JSON object `{"mode": "...", "value": ...}` — see [`ModeField`]
+    /// for how `value` is shaped (object, array, or scalar).
     Mode {
         /// Chosen mode key.
         mode: FieldKey,

--- a/crates/schema/tests/json_schema_smoke.rs
+++ b/crates/schema/tests/json_schema_smoke.rs
@@ -1,0 +1,31 @@
+//! JSON Schema export smoke test (`schemars` feature). Run with:
+//! `cargo test -p nebula-schema --features schemars json_schema_smoke`
+
+use nebula_schema::{Field, FieldKey, Schema};
+use serde_json::Value;
+
+#[test]
+fn valid_schema_json_schema_includes_draft_2020_12_and_typed_property() {
+    let key = FieldKey::new("name").expect("key");
+    let schema = Schema::builder()
+        // Literal-only string so the export keeps a top-level `type: string` (not `anyOf` for
+        // expression wrappers).
+        .add(Field::string(key).required().no_expression())
+        .build()
+        .expect("build");
+
+    let exported = schema.json_schema().expect("export");
+    let value: Value = serde_json::to_value(&exported).expect("serialize");
+
+    assert_eq!(
+        value.get("$schema").and_then(|v| v.as_str()),
+        Some("https://json-schema.org/draft/2020-12/schema")
+    );
+    assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("object"));
+    assert!(
+        value
+            .pointer("/properties/name")
+            .is_some_and(|n| n.get("type") == Some(&Value::String("string".to_owned())))
+    );
+    assert_eq!(value.get("additionalProperties"), Some(&Value::Bool(false)));
+}

--- a/crates/schema/tests/outbound_http_connector.rs
+++ b/crates/schema/tests/outbound_http_connector.rs
@@ -36,8 +36,8 @@ fn post_with_bearer_and_json_body_validates() {
         "base_url": "https://partner.example",
         "http_method": "POST",
         "path": "/in",
-        "auth": { "mode": "bearer", "value": { "token": "bearersecrettokenthing" } },
-        "body": { "mode": "json", "value": { "json_body": "{}" } },
+        "auth": { "mode": "bearer", "value": "bearersecrettokenthing" },
+        "body": { "mode": "json", "value": "{}" },
         "query": { "params": [] },
         "request_signing": { "mode": "none" },
     });

--- a/crates/schema/tests/outbound_http_connector.rs
+++ b/crates/schema/tests/outbound_http_connector.rs
@@ -1,0 +1,63 @@
+//! See `examples_include/outbound_http_connector_shared.rs`.
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples_include/outbound_http_connector_shared.rs"
+));
+
+use nebula_schema::FieldValues;
+use serde_json::json;
+
+#[test]
+fn outbound_schema_builds() {
+    let s = build_outbound_http_connector_schema();
+    assert!(s.fields().len() >= 10);
+}
+
+#[test]
+fn minimal_get_validates() {
+    let s = build_outbound_http_connector_schema();
+    let v = json!({
+        "base_url": "https://api.example.com",
+        "http_method": "GET",
+        "path": "/v1/ok",
+        "auth": { "mode": "none" },
+        "body": { "mode": "none" },
+        "query": { "params": [] },
+        "request_signing": { "mode": "none" },
+    });
+    assert!(s.validate(&FieldValues::from_json(v).unwrap()).is_ok());
+}
+
+#[test]
+fn post_with_bearer_and_json_body_validates() {
+    let s = build_outbound_http_connector_schema();
+    let v = json!({
+        "base_url": "https://partner.example",
+        "http_method": "POST",
+        "path": "/in",
+        "auth": { "mode": "bearer", "value": { "token": "bearersecrettokenthing" } },
+        "body": { "mode": "json", "value": { "json_body": "{}" } },
+        "query": { "params": [] },
+        "request_signing": { "mode": "none" },
+    });
+    assert!(s.validate(&FieldValues::from_json(v).unwrap()).is_ok());
+}
+
+#[test]
+fn form_body_validates() {
+    let s = build_outbound_http_connector_schema();
+    let v = json!({
+        "base_url": "https://form.example",
+        "http_method": "POST",
+        "path": "/form",
+        "auth": { "mode": "none" },
+        "body": { "mode": "form_urlencoded", "value": [
+            { "name": "a", "value": "1" }
+        ] },
+        "query": { "params": [] },
+        "request_signing": { "mode": "none" },
+    });
+    let values = FieldValues::from_json(v).expect("ingest");
+    assert!(s.validate(&values).is_ok());
+}

--- a/crates/schema/tests/pipeline_e2e.rs
+++ b/crates/schema/tests/pipeline_e2e.rs
@@ -1,0 +1,53 @@
+//! End-to-end integration: build a schema, ingest `FieldValues`, validate, then resolve
+//! with a stub [`nebula_schema::ExpressionContext`].
+//!
+//! This mirrors the `examples/async_resolve` flow but is CI-friendly and uses structured
+//! assertions instead of `main`.
+
+use nebula_schema::{
+    ExpressionAst, ExpressionContext, Field, FieldValues, Schema, ValidationError, field_key,
+};
+use serde_json::json;
+
+struct Ctx(serde_json::Value);
+
+#[async_trait::async_trait]
+impl ExpressionContext for Ctx {
+    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
+        Ok(self.0.clone())
+    }
+}
+
+#[tokio::test]
+async fn e2e_happy_path_validate_then_resolve() {
+    let schema = Schema::builder()
+        .add(Field::string(field_key!("name")).required())
+        .add(Field::number(field_key!("count")))
+        .build()
+        .expect("schema lints");
+
+    let values = FieldValues::from_json(json!({
+        "name": "e2e",
+        "count": { "$expr": "{{ x }}" },
+    }))
+    .expect("ingest");
+
+    let valid = schema.validate(&values).expect("valid values");
+    let resolved = valid.resolve(&Ctx(json!(7.0))).await.expect("resolve");
+    assert_eq!(resolved.get(&field_key!("count")), Some(&json!(7.0)));
+}
+
+#[tokio::test]
+async fn e2e_fast_path_no_expressions_uses_booleans() {
+    let schema = Schema::builder()
+        .add(Field::boolean(field_key!("flag")))
+        .build()
+        .expect("build");
+
+    assert!(!schema.flags().uses_expressions);
+
+    let values = FieldValues::from_json(json!({ "flag": true })).expect("ingest");
+    let valid = schema.validate(&values).expect("valid");
+    let resolved = valid.resolve(&Ctx(json!(null))).await.expect("resolve");
+    assert_eq!(resolved.get(&field_key!("flag")), Some(&json!(true)));
+}

--- a/crates/schema/tests/telegram_send_message.rs
+++ b/crates/schema/tests/telegram_send_message.rs
@@ -1,0 +1,46 @@
+//! See `examples_include/telegram_send_message_shared.rs`.
+
+include!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/examples_include/telegram_send_message_shared.rs"
+));
+
+use nebula_schema::FieldValues;
+use serde_json::json;
+
+#[test]
+fn telegram_send_message_schema_builds() {
+    let s = build_telegram_send_message_schema();
+    assert_eq!(s.fields().len(), 8);
+}
+
+#[test]
+fn message_with_inline_keyboard_validates() {
+    let schema = build_telegram_send_message_schema();
+    let v = json!({
+        "api_key": "1234567890:AAHevabcdefghijklmnopqrstuvwxyz12",
+        "chat_id": "12345",
+        "text": "Keyboard demo",
+        "parse_mode": "none",
+        "append_attribution": false,
+        "disable_web_page_preview": true,
+        "disable_notification": true,
+        "reply_markup": {
+            "inline_keyboard": [
+                [ { "text": "Ping", "action": { "mode": "callback", "value": "p" } } ]
+            ]
+        }
+    });
+    assert!(schema.validate(&FieldValues::from_json(v).unwrap()).is_ok());
+}
+
+#[test]
+fn text_only_message_validates() {
+    let schema = build_telegram_send_message_schema();
+    let v = json!({
+        "api_key": "1234567890:AAHevabcdefghijklmnopqrstuvwxyz12",
+        "chat_id": "x",
+        "text": "ok",
+    });
+    assert!(schema.validate(&FieldValues::from_json(v).unwrap()).is_ok());
+}

--- a/crates/schema/tests/validate_schema.rs
+++ b/crates/schema/tests/validate_schema.rs
@@ -116,6 +116,28 @@ fn expression_in_explicit_forbidden_string_emits_error() {
 }
 
 #[test]
+fn mode_variant_empty_rejects_expression_in_placeholder() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("m"))
+                .variant_empty("none", "None")
+                .default_variant("none"),
+        )
+        .build()
+        .unwrap();
+    let values = FieldValues::from_json(json!({
+        "m": { "mode": "none", "value": "{{ $x }}" }
+    }))
+    .unwrap();
+    let report = schema.validate(&values).unwrap_err();
+    assert!(
+        report.errors().any(|e| e.code == "expression.forbidden"),
+        "expected expression.forbidden, got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn computed_field_literal_emits_expression_required() {
     let schema = Schema::builder()
         .add(Field::computed(fk("derived")))

--- a/docs/guidelines/research/README.md
+++ b/docs/guidelines/research/README.md
@@ -11,8 +11,8 @@ Dense notes mined from official docs, Nomicon, RFC clusters, Tokio/async books, 
 ## Files (reading hints)
 
 
-| File                                                                                               | Focus                                                                       |
-| -------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| File                                                                                             | Focus                                                                       |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
 | [cluster-01-book-examples-std.md](cluster-01-book-examples-std.md)                               | Book, RBE, std, style, edition, error codes — dense bullets + `[source: …]` |
 | [cluster-02-nomicon-unsafe-rfcs.md](cluster-02-nomicon-unsafe-rfcs.md)                           | Nomicon, unsafe guidelines, RFC/dev-guide excerpts, modern RFCs             |
 | [cluster-03-cargo-rustc.md](cluster-03-cargo-rustc.md)                                           | Cargo, rustc, profiles, features                                            |
@@ -31,4 +31,3 @@ Dense notes mined from official docs, Nomicon, RFC clusters, Tokio/async books, 
 - Prefer the **numbered guide** (`../README.md`) for **actionable rule IDs** and PR checklist; use **research/** when you need **extra citations**, error-code patterns (E0xxx), or ecosystem specifics.
 - Do not treat blog excerpts as normative — verify against official docs when behavior matters.
 - For local environment/bootstrap commands, treat `docs/dev-setup.md` as the source of truth; research cluster snippets are supplementary.
-


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
  type(scope)?: description    — scope is optional
  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
-->

## Summary

Improves `nebula-schema` developer experience: documents the `mode` / `value` JSON wire contract for `ModeField`, adds `ModeField::variant_empty` (and `EMPTY_PLACEHOLDER_KEY`) to replace hand-rolled hidden `_skip` string fields, and adds `NumberField` shorthands (`min_int` / `max_int` / `default_int` / `step_int`). Expands `field_key!` proc-macro documentation. Adds rich examples (Telegram `sendMessage`-shaped config, fictional outbound HTTP connector) with shared `examples_include` modules and integration tests; minor research README and `Cargo.toml` example wiring.

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [x] `feat` — new capability
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `crates/schema` (nebula-schema, nebula-schema-macros)
- `docs/guidelines/research/README.md`

## Changes

- Document `ModeField` wire format on crate re-export; cross-links from `Field::mode` and `FieldValue::Mode`.
- Add `ModeField::variant_empty`, `ModeField::EMPTY_PLACEHOLDER_KEY` (`_nebula_mode_empty`).
- Add `NumberField::{min_int,max_int,default_int,step_int}`.
- Expand `field_key!` doc in `nebula-schema-macros`.
- Examples: `telegram_send_message`, `outbound_http_connector` (+ shared `examples_include`); other registered examples as in branch.
- Tests: `telegram_send_message`, `outbound_http_connector`, `pipeline_e2e`, `json_schema_smoke` (feature-gated where applicable).
- `crates/schema/Cargo.toml` example / test entries; research guidelines README update.

## Test plan

- `cargo test -p nebula-schema` and pre-push `nextest` for schema crate (as run by lefthook on push).
- Validate example schemas build and sample JSON payloads in integration tests.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean (pre-commit)
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None. New public API is additive. Wire using previous ad-hoc placeholder keys may differ from `_nebula_mode_empty` for `variant_empty` only if callers serialized that hidden key explicitly.

## Docs checklist

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [x] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: <!-- path or URL -->)

## Safety / security impact

- [ ] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted) — `ModeField::variant_empty` uses `expect` on a static `FieldKey` (same pattern as `Field::new` paths)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

<!-- Anything reviewers should focus on, known follow-ups, or out-of-scope items. Optional. -->
Focus: rustdoc on `ModeField` re-export length; whether `EMPTY_PLACEHOLDER_KEY` name is acceptable long-term. Examples are illustrative (Telegram / fictional HTTP connector), not product integrations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added integer-specific builder methods for numeric fields: `min_int()`, `max_int()`, `default_int()`, and `step_int()`.
  * Added `variant_empty()` helper for creating mode variants with no payload.

* **Documentation**
  * Enhanced documentation for `ModeField` with detailed JSON envelope specifications.
  * Improved field-key macro documentation for clarity.
  * Expanded `FieldValue::Mode` documentation with JSON representation guidance.

* **Tests**
  * Added comprehensive integration tests covering validation, expression resolution, and schema workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->