### PR TITLE
test: add workspace test deps, baseline dev-deps, and docs/TESTING.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ Normative core and satellites are listed in the **§15** table — load `PRODUCT
 - **Pinned toolchain:** `channel = "1.95.0"` — `rust-toolchain.toml` lines 16–18.
 - **Formatting (CI):** `cargo +nightly fmt --all -- --check` — `.github/workflows/ci.yml` lines 60–66 (`fmt` job uses nightly rustfmt per comment lines 56–59).
 - **Clippy (CI):** `cargo clippy --workspace -- -D warnings` — `.github/workflows/ci.yml` lines 87–88.
-- **Tests (matrix):** `cargo nextest run -p … --profile ci --no-tests=pass` — `.github/workflows/test-matrix.yml` lines 160–164.
+- **Tests (matrix):** `cargo nextest run -p … --profile ci --no-tests=pass` — `.github/workflows/test-matrix.yml` lines 160–164. Test *libraries* (insta, wiremock, mockall, …) — `docs/TESTING.md`.
 
 For a local gate similar to historical dev practice, run fmt (nightly) + clippy + nextest; align changed crates with `lefthook.yml` / CI when touching those paths.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -304,7 +304,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -347,6 +347,46 @@ dependencies = [
  "blake2",
  "cpufeatures 0.2.17",
  "password-hash",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
+name = "assert_fs"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a652f6cb1f516886fcfee5e7a5c078b9ade62cfcb889524efe5a64d682dd27a9"
+dependencies = [
+ "anstyle",
+ "doc-comment",
+ "globwalk",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "tempfile",
 ]
 
 [[package]]
@@ -1090,6 +1130,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1377,7 +1428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1435,6 +1486,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1797,6 +1859,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,6 +1987,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1957,7 +2049,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1980,6 +2072,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
 
 [[package]]
 name = "document-features"
@@ -2010,6 +2108,12 @@ name = "dotenvy"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
+name = "downcast"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "dunce"
@@ -2124,6 +2228,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2165,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2323,6 +2433,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2492,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fragile"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
 ]
 
 [[package]]
@@ -2583,6 +2711,30 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "globwalk"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
+dependencies = [
+ "bitflags 2.11.1",
+ "ignore",
+ "walkdir",
+]
 
 [[package]]
 name = "governor"
@@ -3093,6 +3245,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "impl-more"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3155,6 +3323,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "instability"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,7 +3374,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3605,6 +3788,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockall"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
+dependencies = [
+ "cfg-if",
+ "downcast",
+ "fragile",
+ "mockall_derive",
+ "predicates",
+ "predicates-tree",
+]
+
+[[package]]
+name = "mockall_derive"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "moka"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,6 +3862,7 @@ dependencies = [
  "hex",
  "hmac 0.13.0",
  "http 1.4.0",
+ "insta",
  "nebula-action-macros",
  "nebula-core",
  "nebula-credential",
@@ -3661,6 +3871,8 @@ dependencies = [
  "nebula-resource",
  "nebula-schema",
  "parking_lot",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -3698,7 +3910,9 @@ dependencies = [
  "governor",
  "hex",
  "hmac 0.13.0",
+ "insta",
  "jsonwebtoken",
+ "mockall",
  "moka",
  "nebula-action",
  "nebula-api",
@@ -3715,8 +3929,10 @@ dependencies = [
  "nebula-telemetry",
  "nebula-validator",
  "nebula-workflow",
+ "pretty_assertions",
  "rand 0.10.1",
  "reqwest 0.13.2",
+ "rstest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -3729,6 +3945,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 
@@ -3737,6 +3954,7 @@ name = "nebula-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "chrono",
  "clap",
  "clap_complete",
@@ -3754,6 +3972,7 @@ dependencies = [
  "nebula-telemetry",
  "nebula-workflow",
  "notify",
+ "predicates",
  "ratatui",
  "serde",
  "serde_json",
@@ -3773,7 +3992,10 @@ dependencies = [
  "chrono",
  "codspeed-criterion-compat",
  "domain-key",
+ "insta",
  "nebula-error",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3794,7 +4016,9 @@ dependencies = [
  "domain-key",
  "futures",
  "humantime-serde",
+ "insta",
  "lru",
+ "mockall",
  "nebula-core",
  "nebula-credential-macros",
  "nebula-error",
@@ -3803,8 +4027,10 @@ dependencies = [
  "nebula-resilience",
  "nebula-schema",
  "parking_lot",
+ "pretty_assertions",
  "rand 0.10.1",
  "reqwest 0.13.2",
+ "rstest",
  "scopeguard",
  "semver",
  "serde",
@@ -3817,6 +4043,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
  "zeroize",
 ]
 
@@ -3838,6 +4065,7 @@ dependencies = [
  "chrono",
  "dashmap",
  "futures",
+ "insta",
  "nebula-action",
  "nebula-core",
  "nebula-credential",
@@ -3854,8 +4082,10 @@ dependencies = [
  "nebula-storage",
  "nebula-telemetry",
  "nebula-workflow",
+ "pretty_assertions",
  "rand 0.10.1",
  "reqwest 0.13.2",
+ "rstest",
  "scopeguard",
  "semver",
  "serde",
@@ -3864,6 +4094,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
+ "wiremock",
  "zeroize",
 ]
 
@@ -3871,7 +4102,10 @@ dependencies = [
 name = "nebula-error"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "nebula-error-macros",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3892,7 +4126,10 @@ version = "0.1.0"
 dependencies = [
  "codspeed-criterion-compat",
  "futures-core",
+ "insta",
  "parking_lot",
+ "pretty_assertions",
+ "rstest",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -3919,9 +4156,12 @@ name = "nebula-execution"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "insta",
  "nebula-core",
  "nebula-error",
  "nebula-workflow",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3933,11 +4173,14 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "codspeed-criterion-compat",
+ "insta",
  "moka",
  "nebula-error",
  "nebula-log",
  "parking_lot",
+ "pretty_assertions",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -3952,12 +4195,15 @@ dependencies = [
  "arc-swap",
  "codspeed-criterion-compat",
  "flate2",
+ "insta",
  "nebula-error",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
  "parking_lot",
  "pin-project",
+ "pretty_assertions",
+ "rstest",
  "sentry",
  "sentry-tracing",
  "serde",
@@ -3988,9 +4234,12 @@ dependencies = [
 name = "nebula-metadata"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "nebula-core",
  "nebula-error",
  "nebula-schema",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4001,8 +4250,11 @@ dependencies = [
 name = "nebula-metrics"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "nebula-eventbus",
  "nebula-telemetry",
+ "pretty_assertions",
+ "rstest",
  "tracing",
 ]
 
@@ -4010,6 +4262,7 @@ dependencies = [
 name = "nebula-plugin"
 version = "0.1.0"
 dependencies = [
+ "insta",
  "nebula-action",
  "nebula-core",
  "nebula-credential",
@@ -4018,6 +4271,8 @@ dependencies = [
  "nebula-plugin-macros",
  "nebula-resource",
  "nebula-schema",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "thiserror 2.0.18",
 ]
@@ -4038,8 +4293,11 @@ name = "nebula-plugin-sdk"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "insta",
  "nebula-metadata",
  "nebula-schema",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4058,9 +4316,12 @@ dependencies = [
  "futures",
  "governor",
  "humantime-serde",
+ "insta",
  "loom",
  "nebula-error",
  "parking_lot",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "smallvec",
  "thiserror 2.0.18",
@@ -4075,6 +4336,7 @@ version = "0.1.0"
 dependencies = [
  "arc-swap",
  "dashmap",
+ "insta",
  "nebula-core",
  "nebula-credential",
  "nebula-error",
@@ -4084,6 +4346,8 @@ dependencies = [
  "nebula-resource-macros",
  "nebula-schema",
  "nebula-telemetry",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "smallvec",
  "thiserror 2.0.18",
@@ -4110,12 +4374,15 @@ dependencies = [
  "async-trait",
  "codspeed-criterion-compat",
  "dashmap",
+ "insta",
  "nebula-action",
  "nebula-core",
  "nebula-error",
  "nebula-metrics",
  "nebula-sandbox",
  "nebula-telemetry",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4131,6 +4398,7 @@ name = "nebula-sandbox"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "insta",
  "landlock",
  "nebula-action",
  "nebula-core",
@@ -4141,6 +4409,8 @@ dependencies = [
  "nebula-resource",
  "nebula-schema",
  "nix 0.31.2",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4162,11 +4432,14 @@ dependencies = [
  "codspeed-criterion-compat",
  "hex",
  "indexmap",
+ "insta",
  "nebula-expression",
  "nebula-schema-macros",
  "nebula-validator",
+ "pretty_assertions",
  "proptest",
  "regex",
+ "rstest",
  "schemars",
  "serde",
  "serde_json",
@@ -4194,6 +4467,7 @@ name = "nebula-sdk"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "insta",
  "nebula-action",
  "nebula-core",
  "nebula-credential",
@@ -4202,6 +4476,8 @@ dependencies = [
  "nebula-schema",
  "nebula-validator",
  "nebula-workflow",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4213,17 +4489,21 @@ dependencies = [
 name = "nebula-storage"
 version = "0.1.0"
 dependencies = [
+ "assert_fs",
  "async-trait",
  "aws-config",
  "aws-sdk-s3",
  "base64",
  "chrono",
  "hex",
+ "insta",
  "moka",
  "nebula-core",
  "nebula-credential",
+ "pretty_assertions",
  "redis",
  "rmp-serde",
+ "rstest",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4240,9 +4520,12 @@ name = "nebula-system"
 version = "0.1.0"
 dependencies = [
  "codspeed-criterion-compat",
+ "insta",
  "libc",
  "nebula-error",
  "parking_lot",
+ "pretty_assertions",
+ "rstest",
  "serde",
  "serde_json",
  "sysinfo",
@@ -4254,8 +4537,11 @@ name = "nebula-telemetry"
 version = "0.1.0"
 dependencies = [
  "dashmap",
+ "insta",
  "lasso",
  "nebula-error",
+ "pretty_assertions",
+ "rstest",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -4265,10 +4551,13 @@ name = "nebula-validator"
 version = "0.1.0"
 dependencies = [
  "codspeed-criterion-compat",
+ "insta",
  "nebula-error",
  "nebula-validator-macros",
+ "pretty_assertions",
  "proptest",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "smallvec",
@@ -4292,9 +4581,12 @@ name = "nebula-workflow"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "insta",
  "nebula-core",
  "nebula-error",
  "petgraph",
+ "pretty_assertions",
+ "rstest",
  "semver",
  "serde",
  "serde_json",
@@ -4361,6 +4653,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "notify"
 version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,7 +4700,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4476,6 +4774,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5231,6 +5539,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5739,6 +6087,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5905,6 +6259,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e905296805ab93e13c1ec3a03f4b6c4f35e9498a3d5fa96dc626d22c03cd89"
+dependencies = [
+ "futures-timer",
+ "futures-util",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn 2.0.117",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5935,7 +6319,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5992,7 +6376,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6506,6 +6890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6567,7 +6957,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6955,7 +7345,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6974,7 +7364,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6997,6 +7387,12 @@ checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "termwiz"
@@ -8069,7 +8465,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8492,6 +8888,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,16 @@ tempfile = "3.27.0"
 proptest = "1.11"
 criterion = { package = "codspeed-criterion-compat", version = "4" }
 
+# Test helpers — crates opt in via [dev-dependencies] (see `docs/TESTING.md`)
+assert_cmd = "2.0.17"
+assert_fs = "1.1.2"
+insta = { version = "1.47.2", features = ["json", "redactions"] }
+mockall = "0.13.1"
+predicates = "3.1.3"
+pretty_assertions = "1.4.1"
+rstest = "0.24.0"
+wiremock = "0.6"
+
 # Semantic versioning
 semver = { version = "1", features = ["serde"] }
 

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -66,6 +66,8 @@ nebula-telemetry = { path = "../../crates/telemetry" }
 nebula-action = { path = "../../crates/action" }
 
 [dev-dependencies]
+assert_cmd = { workspace = true }
+predicates = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["rt"] }
 

--- a/apps/cli/tests/cli_smoke.rs
+++ b/apps/cli/tests/cli_smoke.rs
@@ -1,0 +1,15 @@
+//! CLI integration checks: binary exists, help exits zero, output mentions the product.
+//! Uses [`assert_cmd`] + [`predicates`]; see `docs/TESTING.md`.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn nebula_help_succeeds() {
+    Command::cargo_bin("nebula")
+        .expect("cargo_bin finds nebula from this package")
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Nebula").or(predicate::str::contains("nebula")));
+}

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -59,6 +59,9 @@ subtle = { workspace = true }
 nebula-core = { path = "../core" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }
 hex = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -86,6 +86,14 @@ sha2 = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 tokio-util = { workspace = true }
 async-trait = { workspace = true }
+insta = { workspace = true }
+mockall = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+wiremock = { workspace = true }
+# Dev-only: `tests/wiremock_smoke.rs` — HTTP client + mock server (no full `App` required).
+reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }
+serde_json = { workspace = true }
 
 [features]
 default = []

--- a/crates/api/tests/mockall_smoke.rs
+++ b/crates/api/tests/mockall_smoke.rs
@@ -1,0 +1,22 @@
+//! Example: [`mockall`] for local test doubles — use for traits you own in a test module,
+//! not for large external surfaces (prefer `wiremock` for HTTP).
+
+use mockall::automock;
+use pretty_assertions::assert_eq;
+
+/// Tiny clock seam — shows `expect_*` + `returning` without pulling production code.
+#[automock]
+pub trait TestClock {
+    /// Milliseconds since an arbitrary epoch.
+    fn now_ms(&self) -> u64;
+}
+
+#[test]
+fn mockall_clock_returns_configured_value() {
+    let mut mock = MockTestClock::new();
+    mock.expect_now_ms()
+        .times(1)
+        .returning(|| 1_700_000_000_000);
+
+    assert_eq!(mock.now_ms(), 1_700_000_000_000);
+}

--- a/crates/api/tests/rest_body_limit.rs
+++ b/crates/api/tests/rest_body_limit.rs
@@ -22,6 +22,7 @@ use nebula_api::{ApiConfig, AppState, app};
 use nebula_storage::{
     InMemoryExecutionRepo, InMemoryWorkflowRepo, repos::InMemoryControlQueueRepo,
 };
+use pretty_assertions::assert_eq;
 use tower::ServiceExt;
 
 async fn create_test_state() -> AppState {

--- a/crates/api/tests/wiremock_smoke.rs
+++ b/crates/api/tests/wiremock_smoke.rs
@@ -1,0 +1,34 @@
+//! [`wiremock`] for tests that exercise HTTP **clients** (webhooks, callbacks) without the real
+//! network. The full router tests live in `webhook_transport_integration.rs`; this is a minimal
+//! harness check.
+
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+#[tokio::test]
+async fn wiremock_returns_json_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/ping"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({ "ok": true, "crate": "nebula-api" })),
+        )
+        .mount(&server)
+        .await;
+
+    let client = reqwest::Client::new();
+    let value: serde_json::Value = client
+        .get(format!("{}/ping", server.uri()))
+        .send()
+        .await
+        .expect("request")
+        .json()
+        .await
+        .expect("json body");
+
+    assert_eq!(value["ok"], true);
+    assert_eq!(value["crate"], "nebula-api");
+}

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,6 +23,9 @@ tokio-util = { workspace = true, features = ["rt"] }
 
 [dev-dependencies]
 criterion = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "id_parse_serialize"

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -86,6 +86,11 @@ base64 = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 semver = { workspace = true }
+insta = { workspace = true }
+mockall = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+wiremock = { workspace = true }
 
 [features]
 default = ["oauth2-http"]

--- a/crates/credential/tests/mockall_smoke.rs
+++ b/crates/credential/tests/mockall_smoke.rs
@@ -1,0 +1,21 @@
+//! [`mockall`] example for this crate — use for **traits under test**, not for `reqwest` (use
+//! `wiremock`).
+
+use mockall::automock;
+use pretty_assertions::assert_eq;
+
+/// Test-only seam (real code uses concrete types; this shows the pattern).
+#[automock]
+pub trait TestSecretVersion {
+    fn version_label(&self) -> String;
+}
+
+#[test]
+fn mockall_returns_configured_version() {
+    let mut mock = MockTestSecretVersion::new();
+    mock.expect_version_label()
+        .times(1)
+        .returning(|| "v-test".to_owned());
+
+    assert_eq!(mock.version_label(), "v-test");
+}

--- a/crates/credential/tests/wiremock_token_http.rs
+++ b/crates/credential/tests/wiremock_token_http.rs
@@ -1,0 +1,37 @@
+//! OAuth2 token JSON over HTTP: [`wiremock`] stands in for a real authorization server.
+//! Complements the raw `TcpListener` unit tests in `token_http.rs` (same ADR-0031 policy).
+
+use nebula_credential::credentials::oauth2::token_http::{
+    OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES, oauth_token_http_client, read_token_response_limited,
+};
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+#[tokio::test]
+async fn read_token_response_via_wiremock() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "wiremock-token",
+            "token_type": "Bearer",
+        })))
+        .mount(&server)
+        .await;
+
+    let client = oauth_token_http_client();
+    let response = client
+        .get(format!("{}/token", server.uri()))
+        .send()
+        .await
+        .expect("request to mock token endpoint");
+
+    let value = read_token_response_limited(response, OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES)
+        .await
+        .expect("bounded read + JSON parse");
+
+    assert_eq!(value["access_token"], "wiremock-token");
+    assert_eq!(value["token_type"], "Bearer");
+}

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -60,6 +60,10 @@ futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 # `token_refresh` tests use a loopback `TcpListener` to mock the token endpoint.
 tokio = { workspace = true, features = ["io-util", "net", "rt", "macros"] }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+wiremock = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/error/Cargo.toml
+++ b/crates/error/Cargo.toml
@@ -30,6 +30,9 @@ derive = ["dep:nebula-error-macros"]
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 nebula-error-macros = { path = "macros" }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/eventbus/Cargo.toml
+++ b/crates/eventbus/Cargo.toml
@@ -22,6 +22,9 @@ tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
 criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt", "ansi"] }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "emit"

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -20,5 +20,10 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 
+[dev-dependencies]
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/expression/Cargo.toml
+++ b/crates/expression/Cargo.toml
@@ -30,6 +30,9 @@ parking_lot = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "baseline"

--- a/crates/log/Cargo.toml
+++ b/crates/log/Cargo.toml
@@ -72,6 +72,9 @@ criterion = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }
 uuid = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[example]]
 name = "sentry_test"

--- a/crates/metadata/Cargo.toml
+++ b/crates/metadata/Cargo.toml
@@ -21,6 +21,9 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -17,6 +17,9 @@ nebula-telemetry = { path = "../telemetry" }
 
 [dev-dependencies]
 tracing = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/plugin-sdk/Cargo.toml
+++ b/crates/plugin-sdk/Cargo.toml
@@ -34,6 +34,9 @@ tokio = { workspace = true, features = [
   "io-util",
   "sync",
 ] }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[bin]]
 name = "nebula-echo-fixture"

--- a/crates/plugin/Cargo.toml
+++ b/crates/plugin/Cargo.toml
@@ -28,6 +28,9 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 nebula-schema = { path = "../schema" }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/resilience/Cargo.toml
+++ b/crates/resilience/Cargo.toml
@@ -49,6 +49,9 @@ criterion = { workspace = true, features = ["async_tokio", "html_reports"] }
 futures = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -40,6 +40,9 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 semver = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/runtime/Cargo.toml
+++ b/crates/runtime/Cargo.toml
@@ -34,6 +34,9 @@ nebula-core = { path = "../core" }
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time", "test-util"] }
 tokio-util = { workspace = true }
 criterion = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/sandbox/Cargo.toml
+++ b/crates/sandbox/Cargo.toml
@@ -39,5 +39,10 @@ uuid = { workspace = true }
 landlock = "0.4"
 nix = { version = "0.31", features = ["resource"] }
 
+[dev-dependencies]
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -39,6 +39,9 @@ serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 trybuild = "1"
 proptest = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[test]]
 name = "flow_all_error_codes"

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -38,6 +38,9 @@ chrono = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full"] }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [features]
 default = ["derive", "testing"]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -78,6 +78,10 @@ msgpack-storage = ["dep:rmp-serde"]
 tokio = { workspace = true, features = ["full", "test-util"] }
 # Used by FileKeyProvider tests (key_provider.rs).
 tempfile = { workspace = true }
+assert_fs = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [lib]
 doctest = false

--- a/crates/storage/tests/credential_encryption_invariants.rs
+++ b/crates/storage/tests/credential_encryption_invariants.rs
@@ -8,6 +8,9 @@ use std::time::Instant;
 use nebula_credential::{
     CryptoError, EncryptedData, EncryptionKey, SecretString, decrypt, encrypt,
 };
+use pretty_assertions::assert_eq;
+use rstest::rstest;
+use serde_json::json;
 
 /// Test: Encrypt secret → decrypt → verify match (roundtrip)
 ///
@@ -40,6 +43,38 @@ fn test_encrypt_decrypt_roundtrip() {
         String::from_utf8(decrypted.to_vec()).unwrap(),
         "my-api-key-12345"
     );
+}
+
+/// Structural snapshot for `EncryptedData`: field sizes and version — no key material.
+#[test]
+fn encrypted_data_shape_snapshot() {
+    let salt = [7u8; 16];
+    let key = EncryptionKey::derive_from_password("snapshot-test", &salt)
+        .expect("key derivation should succeed");
+    let plaintext = b"snap";
+    let encrypted = encrypt(&key, plaintext).expect("encryption should succeed");
+
+    insta::assert_json_snapshot!(json!({
+        "version": encrypted.version,
+        "nonce_len": encrypted.nonce.len(),
+        "tag_len": encrypted.tag.len(),
+        "ciphertext_len": encrypted.ciphertext.len(),
+        "key_id_empty": encrypted.key_id.is_empty(),
+    }));
+}
+
+/// Table-driven KDF + encrypt roundtrip (rstest parametric style).
+#[rstest]
+#[case("a")]
+#[case("long-password-with-unicode-кириллица")]
+fn kdf_roundtrip_parametrized(#[case] password: &str) {
+    let salt = [9u8; 16];
+    let key = EncryptionKey::derive_from_password(password, &salt)
+        .expect("key derivation should succeed");
+    let plaintext = b"payload-bytes";
+    let encrypted = encrypt(&key, plaintext).expect("encryption should succeed");
+    let decrypted = decrypt(&key, &encrypted).expect("decryption should succeed");
+    assert_eq!(decrypted.as_slice(), plaintext);
 }
 
 /// Test: Same password + salt → same key twice (deterministic)

--- a/crates/storage/tests/file_key_assert_fs.rs
+++ b/crates/storage/tests/file_key_assert_fs.rs
@@ -1,0 +1,29 @@
+//! [`assert_fs`] fixtures for paths read by [`nebula_storage::credential::FileKeyProvider`].
+//! Complements `tempfile` in unit tests — same behaviour, slightly clearer child-file API.
+
+use assert_fs::{TempDir, prelude::*};
+use nebula_storage::credential::{FileKeyProvider, KeyProvider};
+
+#[test]
+fn file_key_loads_from_assert_fs_child_path() {
+    let temp = TempDir::new().expect("tempdir");
+    let keyfile = temp.child("nebula.key");
+    keyfile
+        .write_binary(&[0x42u8; 32])
+        .expect("write 32-byte raw key");
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(keyfile.path(), std::fs::Permissions::from_mode(0o600))
+            .expect("restrict key file perms");
+    }
+
+    let provider = FileKeyProvider::from_path(keyfile.path()).expect("load from assert_fs path");
+    assert!(
+        provider.version().starts_with("file:nebula.key:"),
+        "expected file-scoped version prefix, got {}",
+        provider.version()
+    );
+    provider.current_key().expect("key material");
+}

--- a/crates/storage/tests/snapshots/credential_encryption_invariants__encrypted_data_shape_snapshot.snap
+++ b/crates/storage/tests/snapshots/credential_encryption_invariants__encrypted_data_shape_snapshot.snap
@@ -1,0 +1,11 @@
+---
+source: crates/storage/tests/credential_encryption_invariants.rs
+expression: "json!({\n    \"version\": encrypted.version, \"nonce_len\": encrypted.nonce.len(),\n    \"tag_len\": encrypted.tag.len(), \"ciphertext_len\":\n    encrypted.ciphertext.len(), \"key_id_empty\": encrypted.key_id.is_empty(),\n})"
+---
+{
+  "ciphertext_len": 4,
+  "key_id_empty": true,
+  "nonce_len": 12,
+  "tag_len": 16,
+  "version": 1
+}

--- a/crates/system/Cargo.toml
+++ b/crates/system/Cargo.toml
@@ -51,6 +51,9 @@ libc = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 [[bench]]
 name = "system_load"

--- a/crates/telemetry/Cargo.toml
+++ b/crates/telemetry/Cargo.toml
@@ -18,5 +18,10 @@ tracing = { workspace = true }
 dashmap = { workspace = true }
 lasso = { workspace = true }
 
+[dev-dependencies]
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+
 [lints]
 workspace = true

--- a/crates/validator/Cargo.toml
+++ b/crates/validator/Cargo.toml
@@ -44,6 +44,9 @@ serde_json = { workspace = true }
 [dev-dependencies]
 proptest = "1"
 trybuild = "1"
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
 
 # Benchmarking
 criterion = { workspace = true }

--- a/crates/workflow/Cargo.toml
+++ b/crates/workflow/Cargo.toml
@@ -21,6 +21,11 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 
+[dev-dependencies]
+insta = { workspace = true }
+pretty_assertions = { workspace = true }
+rstest = { workspace = true }
+
 [lib]
 doctest = false
 

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -2,7 +2,7 @@
 name: Nebula crate maturity dashboard
 description: Manual per-crate state dashboard. Edited in PRs that change a crate's API stability, test coverage, doc state, engine integration, or SLI-readiness.
 status: accepted
-last-reviewed: 2026-04-20
+last-reviewed: 2026-04-22
 related: [PRODUCT_CANON.md, STYLE.md]
 ---
 
@@ -52,7 +52,11 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-04-21 — **P6–P11 credential cleanup:** add
+Last targeted revision: 2026-04-22 — **Test stack:** workspace `dev-dependencies` for
+`insta`, `pretty_assertions`, `rstest`, `wiremock`, `mockall`, `assert_cmd`, `predicates`,
+`assert_fs`; `docs/TESTING.md` + cross-links from `QUALITY_GATES` / `PRODUCT_CANON` §15;
+example tests in `nebula-api`, `nebula-credential`, `nebula-storage`, `nebula-cli`.
+Prior: 2026-04-21 — **P6–P11 credential cleanup:** add
 `docs/superpowers/plans/2026-04-20-credential-cleanup-p6-p11.md` (ADR-0032 pointer, spec §12
 rolled-up status: storage/engine/API phases landed); P1–P5 plan links to it; `credential/Cargo.toml`
 tokio comment corrected (resolver/executor in engine).

--- a/docs/PRODUCT_CANON.md
+++ b/docs/PRODUCT_CANON.md
@@ -457,6 +457,7 @@ This is the **minimum bar** for “we did not break the product direction.” Ex
 | `docs/STYLE.md` | Idioms / antipatterns / naming / error taxonomy / type-design bets. |
 | `docs/GLOSSARY.md` | Terms and architectural patterns (Outbox, WAL, Idempotent Receiver, Bulkhead, Circuit Breaker, OCC). |
 | `docs/MATURITY.md` | Per-crate state dashboard (API stability, test coverage, doc completeness, engine integration, SLI-ready). |
+| `docs/TESTING.md` | Test *tooling* — nextest profiles, insta / wiremock / mockall / assert_cmd / rstest, security notes for snapshots near credentials. |
 | `docs/dev-setup.md` | Local dev environment setup. |
 | `docs/ENGINE_GUARANTEES.md` | Operator-facing guarantees narrative (satellite of §11). |
 | `docs/UPGRADE_COMPAT.md` | Engine upgrade and workflow compatibility rules (satellite of §7.2). |

--- a/docs/QUALITY_GATES.md
+++ b/docs/QUALITY_GATES.md
@@ -66,6 +66,8 @@ Do **not** duplicate those knobs elsewhere — extend them in place and update t
 | `cargo quality` | `fmt --check` + `clippy -D warnings` + all `xtask` checks. |
 | `cargo precommit` | `cargo quality` + `cargo nextest run --workspace --profile ci --no-tests=pass` (full — use CI or narrow locally when iterating). |
 
+**Test libraries and nextest profiles** (not a mechanical gate) are described in `docs/TESTING.md`.
+
 **Pre-commit / push:** `lefthook.yml` runs fast gates; full `cargo quality` is mirrored in **`.github/workflows/quality.yml`** on PRs.
 
 ## How to add a new gate

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,57 @@
+# Testing stack (Nebula)
+
+Normative **commands** for fmt / clippy / `cargo deny` live in `docs/QUALITY_GATES.md` and `CLAUDE.md`. This document describes **libraries and runners** we standardize on for unit and integration tests.
+
+## Runner: `cargo-nextest`
+
+- **Config:** [`.config/nextest.toml`](../.config/nextest.toml) — profiles `default`, `ci` (retries, JUnit to `target/nextest/ci/junit.xml`), and `agent`.
+- **CI:** [`.github/workflows/test-matrix.yml`](../.github/workflows/test-matrix.yml) uses `taiki-e/install-action@cargo-nextest` and `cargo nextest run -p … --profile ci`.
+- **Local:** `cargo nextest run --workspace --profile ci` (or `-p <crate>` while iterating). Prefer nextest over plain `cargo test` for large workspaces (parallelism, flakiness metadata, JUnit).
+
+## Crates (by use case)
+
+| Crate | Role | Typical crates |
+|--------|------|----------------|
+| **insta** + **`cargo insta review`** | Snapshot (JSON, strings) — run review after changing expected output; **never** snapshot secrets or raw ciphertext. | `nebula-storage` credential crypto shape tests, future API error bodies |
+| **pretty_assertions** | Readable `assert_eq!` / `assert_ne!` diffs. | Any test with non-trivial equality |
+| **rstest** | Parametric / table tests (`#[rstest]`, `#[case]`). | Crypto, validation matrices |
+| **wiremock** | In-process HTTP mock server (async) for `reqwest` and Axum-style clients. | `nebula-credential` (OAuth token JSON), `nebula-api` (outbound HTTP in tests) |
+| **mockall** | `#[automock]` trait doubles in **unit** or small integration tests. | Boundaries you own (not third-party `reqwest`); pair with `wiremock` for HTTP |
+| **assert_cmd** + **predicates** | Spawn CLI binaries, assert exit code and stdout/stderr. | `nebula-cli` (`tests/cli_smoke.rs`) |
+| **assert_fs** | Temp dirs / fixture files with a clear child-file API. | `nebula-storage` (`FileKeyProvider`, filesystem layers) |
+| **proptest** | Property-based tests (workspace dependency). | See existing engine / core usages |
+
+## Per-crate baseline (library crates)
+
+Every crate that ships **library** tests under `src/…` and/or `tests/*.rs` and participates in CI (`test-matrix.yml` or obvious siblings) declares a **shared baseline** in `[dev-dependencies]`:
+
+`insta`, `pretty_assertions`, `rstest` — `{ workspace = true }` from the root [Cargo.toml](../Cargo.toml).
+
+**Extra** (only where the shape of tests needs it):
+
+| Addition | Crates (today) |
+|----------|----------------|
+| `wiremock` | `nebula-api`, `nebula-credential`, **`nebula-engine`** (token / HTTP client tests) |
+| `mockall` | `nebula-api`, `nebula-credential` (trait doubles in `tests/*_smoke.rs`) |
+| `assert_fs` | `nebula-storage` |
+| `assert_cmd`, `predicates` | `nebula-cli` (binary smoke) |
+
+**Baseline only** (no extra test-only HTTP/CLI/fs row): `nebula-action`, `nebula-core`, `nebula-error`, `nebula-eventbus`, `nebula-execution`, `nebula-expression`, `nebula-log`, `nebula-metrics`, `nebula-metadata`, `nebula-plugin`, `nebula-plugin-sdk`, `nebula-resilience`, `nebula-resource`, `nebula-runtime`, `nebula-sandbox`, `nebula-schema`, `nebula-sdk`, `nebula-system`, `nebula-validator`, `nebula-workflow`, `nebula-telemetry`.
+
+**Baseline + extras:** `nebula-api`, `nebula-credential`, `nebula-storage` (see table); `nebula-engine` adds `wiremock`; `nebula-cli` uses `assert_cmd` / `predicates` (binary), not the three-crate baseline.
+
+## Workspace wiring
+
+- Versions live in the **root** [Cargo.toml](../Cargo.toml) under `[workspace.dependencies]`. Individual crates add only `[dev-dependencies]` with `{ workspace = true }`.
+- Prefer **using** the baseline in new tests (`use pretty_assertions::assert_eq;`, `#[rstest]`, `insta::assert_*_snapshot!`) rather than growing bespoke helpers.
+
+## Security
+
+- **Credential / encryption tests:** use **insta** only on *structural* or *redacted* values (lengths, version numbers). Do not commit snapshots of base64 keys, tokens, or plaintext secrets.
+- **Mock HTTP:** use **wiremock** for TLS-capable `reqwest` against `http://` mock URLs in tests, not `mockall` for the HTTP stack itself.
+
+## See also
+
+- [awesome-rust-testing](https://github.com/hoodie/awesome-rust-testing) (curated ecosystem list)
+- [nextest book](https://nexte.st/docs/installation/) — installation
+- [insta](https://github.com/mitsuhiko/insta) — redactions and JSON snapshots


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
  type(scope)?: description    — scope is optional
  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
-->

## Summary

Centralizes common Rust testing crates in the workspace `Cargo.toml` and opts library crates into a shared **baseline** (`insta`, `pretty_assertions`, `rstest`) via `[dev-dependencies]`. Adds targeted extras where integration tests need them (`wiremock`, `mockall`, `assert_fs`, `assert_cmd` / `predicates`), small smoke tests for API / credential / storage / CLI, and documents the stack in `docs/TESTING.md` with links from `QUALITY_GATES`, `PRODUCT_CANON` §15, `MATURITY`, and `CLAUDE.md`.

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [ ] `feat` — new capability
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [x] `test` — tests only
- [x] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

Root `Cargo.toml`, `Cargo.lock`, `CLAUDE.md`, `docs/` (`TESTING.md`, `QUALITY_GATES.md`, `PRODUCT_CANON.md`, `MATURITY.md`), `apps/cli/`, and dev-dependencies / tests across: `nebula-action`, `nebula-api`, `nebula-core`, `nebula-credential`, `nebula-engine`, `nebula-error`, `nebula-eventbus`, `nebula-execution`, `nebula-expression`, `nebula-log`, `nebula-metadata`, `nebula-metrics`, `nebula-plugin`, `nebula-plugin-sdk`, `nebula-resilience`, `nebula-resource`, `nebula-runtime`, `nebula-sandbox`, `nebula-schema`, `nebula-sdk`, `nebula-storage`, `nebula-system`, `nebula-telemetry`, `nebula-validator`, `nebula-workflow`.

## Changes

- Workspace `[workspace.dependencies]`: `insta`, `pretty_assertions`, `rstest`, `wiremock`, `mockall`, `assert_cmd`, `predicates`, `assert_fs` (versions pinned).
- Per-crate `[dev-dependencies]` baseline on library crates with tests; extras on `nebula-api`, `nebula-credential`, `nebula-storage`, `nebula-engine` (`wiremock`), `nebula-cli` (`assert_cmd` / `predicates`).
- New / updated integration tests: CLI `--help` smoke; API `mockall` / `wiremock` / `pretty_assertions` on REST limit test; credential `wiremock` + `mockall`; storage `insta` snapshot (non-secret shape), `rstest` param case, `assert_fs` file key test.
- Docs: new `docs/TESTING.md`; cross-links and `MATURITY` revision note.

## Test plan

- `cargo +nightly fmt --all`
- `cargo clippy` on touched crates (e.g. `nebula-api`, `nebula-credential`, `nebula-storage`, `nebula-cli`) with `-D warnings`
- `cargo test` for new smoke / snapshot targets
- `cargo deny check`
- Pre-push hook ran full workspace nextest successfully before the last push of this branch.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean (via targeted / pre-commit runs)
- [x] `cargo nextest run --workspace` — passes (pre-push)
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [x] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Docs checklist

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [x] `docs/MATURITY.md` row updated if crate maturity changed
- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: <!-- path or URL -->)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths (`insta` snapshots use structural fields only for crypto tests)
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

Draft PR: mechanical test-tooling and docs only; no production API or runtime behavior change. `Cargo.lock` updated for new dev dependency graph.
