### PR TITLE
fix(schema): harden loader paths and secret boundaries

### DIFF
--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -576,7 +576,6 @@ impl ListField {
 define_field!(ModeField {
     variants: Vec<ModeVariant> = Vec::new(),
     default_variant: Option<String> = None,
-    allow_dynamic_mode: bool = false,
 } expr: ExpressionMode::Allowed);
 
 /// Variant definition for mode fields.
@@ -639,13 +638,6 @@ impl ModeField {
     #[must_use]
     pub fn default_variant(mut self, key: impl Into<String>) -> Self {
         self.default_variant = Some(key.into());
-        self
-    }
-
-    /// Allow the mode to be selected dynamically at runtime.
-    #[must_use]
-    pub const fn allow_dynamic_mode(mut self) -> Self {
-        self.allow_dynamic_mode = true;
         self
     }
 }

--- a/crates/schema/src/json_schema.rs
+++ b/crates/schema/src/json_schema.rs
@@ -492,10 +492,6 @@ fn apply_contract_keywords(field: &Field, schema: &mut Map<String, Value>) {
         );
     }
     if let Field::Mode(f) = field {
-        schema.insert(
-            "x-nebula-mode-allow-dynamic".to_owned(),
-            Value::Bool(f.allow_dynamic_mode),
-        );
         if let Some(default_variant) = &f.default_variant {
             schema.insert(
                 "x-nebula-mode-default-variant".to_owned(),
@@ -597,6 +593,32 @@ mod tests {
             .find(|v| v["properties"]["mode"]["const"] == Value::String("token".to_owned()))
             .expect("token branch exists");
         assert_eq!(token["required"], json!(["mode", "value"]));
+    }
+
+    #[test]
+    fn mode_json_schema_does_not_export_removed_dynamic_flag() {
+        let schema = Schema::builder()
+            .add(
+                Field::mode(FieldKey::new("auth").expect("static key"))
+                    .variant(
+                        "token",
+                        "Token",
+                        Field::secret(FieldKey::new("token").expect("static key")),
+                    )
+                    .default_variant("token"),
+            )
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+        assert_eq!(
+            json["properties"]["auth"]["x-nebula-mode-default-variant"],
+            json!("token")
+        );
+        assert!(
+            json["properties"]["auth"]["x-nebula-mode-allow-dynamic"].is_null(),
+            "removed compatibility flag should not be exported"
+        );
     }
 
     #[test]

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -255,6 +255,22 @@ fn lint_mode_new(
 
     let mut seen: HashSet<&str> = HashSet::new();
     for variant in &mode.variants {
+        let variant_key = match crate::key::FieldKey::new(variant.key.as_str()) {
+            Ok(vk) => Some(vk),
+            Err(e) => {
+                report.push(
+                    ValidationError::builder("invalid_key")
+                        .at(path.clone())
+                        .message(format!(
+                            "mode variant key `{}` cannot participate in schema paths: {}",
+                            variant.key, e.message
+                        ))
+                        .param("key", variant.key.clone())
+                        .build(),
+                );
+                None
+            },
+        };
         if !seen.insert(variant.key.as_str()) {
             report.push(
                 ValidationError::builder("duplicate_variant")
@@ -265,7 +281,7 @@ fn lint_mode_new(
         }
         if variant.label.trim().is_empty() {
             // Build variant path for precise location.
-            if let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str()) {
+            if let Some(vk) = variant_key.clone() {
                 let vpath = path.clone().join(vk);
                 report.push(
                     ValidationError::builder("missing_variant_label")
@@ -278,7 +294,7 @@ fn lint_mode_new(
         }
         // Recurse into variant payload.
         if let Field::Object(obj) = variant.field.as_ref()
-            && let Ok(vk) = crate::key::FieldKey::new(variant.key.as_str())
+            && let Some(vk) = variant_key
         {
             let vpath = path.clone().join(vk);
             lint_fields_new(&obj.fields, &vpath, root_keys, report);
@@ -964,6 +980,21 @@ mod tests {
         ];
         let report = run(&fields);
         assert!(report.errors().any(|e| e.code == "duplicate_variant"));
+    }
+
+    #[test]
+    fn detects_invalid_mode_variant_key() {
+        let fields = vec![
+            Field::mode(FieldKey::new("m").unwrap())
+                .variant(
+                    "oauth-token",
+                    "OAuth",
+                    Field::string(FieldKey::new("x").unwrap()),
+                )
+                .into_field(),
+        ];
+        let report = run(&fields);
+        assert!(report.errors().any(|e| e.code == "invalid_key"));
     }
 
     #[test]

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -133,14 +133,21 @@ fn redact_secrets_in_value_for_loader(field: &Field, value: &mut FieldValue) {
             let Ok(payload_key) = FieldKey::new("value") else {
                 return;
             };
-            let Some(FieldValue::Literal(Json::String(mode_key))) = map.get(&mode_selector_key)
-            else {
-                return;
-            };
-            let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
-                return;
+            let resolved_key = match map.get(&mode_selector_key) {
+                Some(FieldValue::Literal(Json::String(mode_key))) => Some(mode_key.clone()),
+                Some(_) => None,
+                None => mode.default_variant.clone(),
             };
             let Some(mv) = map.get_mut(&payload_key) else {
+                return;
+            };
+            let Some(var) = resolved_key
+                .as_deref()
+                .and_then(|mode_key| mode.variants.iter().find(|v| v.key == mode_key))
+            else {
+                // If the active variant cannot be determined, over-redact the payload rather
+                // than risk exposing nested secret material to loader implementations.
+                *mv = FieldValue::Literal(Json::String(SECRET_REDACTED.to_owned()));
                 return;
             };
             redact_secrets_in_value_for_loader(&var.field, mv);
@@ -561,6 +568,49 @@ mod tests {
             panic!("expected mode literal, got {mode:?}");
         };
         assert_eq!(mode_key, "oauth");
+        let payload = map.get(&k("value")).expect("payload");
+        let FieldValue::Object(m) = payload else {
+            panic!("expected object payload, got {payload:?}");
+        };
+        assert_eq!(m.get(&k("client_secret")), Some(&redacted_literal()));
+        let id = m.get(&k("client_id")).expect("id");
+        let FieldValue::Literal(Json::String(s)) = id else {
+            panic!("expected client_id literal, got {id:?}");
+        };
+        assert_eq!(s, "visible");
+    }
+
+    #[test]
+    fn with_secrets_redacted_mode_object_without_mode_uses_default_variant() {
+        let schema = Schema::builder()
+            .add(
+                Field::mode("auth")
+                    .variant(
+                        "oauth",
+                        "OAuth",
+                        Field::object("creds")
+                            .add(Field::secret("client_secret"))
+                            .add(Field::string("client_id")),
+                    )
+                    .default_variant("oauth"),
+            )
+            .build()
+            .expect("valid schema");
+        let values = FieldValues::from_json(json!({
+            "auth": {
+                "value": {
+                    "client_secret": "top",
+                    "client_id": "visible"
+                }
+            }
+        }))
+        .expect("values");
+
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let auth = ctx.values.get_by_str("auth").expect("auth");
+        let FieldValue::Object(map) = auth else {
+            panic!("expected object envelope, got {auth:?}");
+        };
         let payload = map.get(&k("value")).expect("payload");
         let FieldValue::Object(m) = payload else {
             panic!("expected object payload, got {payload:?}");

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -33,7 +33,7 @@ pub type LoaderFuture<T> =
 /// Context passed to runtime loaders.
 #[derive(Debug, Clone)]
 pub struct LoaderContext {
-    /// Key of the field currently requesting dynamic data.
+    /// Key or schema path of the field currently requesting dynamic data.
     pub field_key: String,
     /// Current runtime values at call time.
     pub values: FieldValues,
@@ -125,6 +125,25 @@ fn redact_secrets_in_value_for_loader(field: &Field, value: &mut FieldValue) {
                 return;
             };
             redact_secrets_in_value_for_loader(&var.field, mv.as_mut());
+        },
+        (Field::Mode(mode), FieldValue::Object(map)) => {
+            let Ok(mode_selector_key) = FieldKey::new("mode") else {
+                return;
+            };
+            let Ok(payload_key) = FieldKey::new("value") else {
+                return;
+            };
+            let Some(FieldValue::Literal(Json::String(mode_key))) = map.get(&mode_selector_key)
+            else {
+                return;
+            };
+            let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
+                return;
+            };
+            let Some(mv) = map.get_mut(&payload_key) else {
+                return;
+            };
+            redact_secrets_in_value_for_loader(&var.field, mv);
         },
         _ => {},
     }
@@ -225,13 +244,16 @@ pub type OptionLoader = Loader<SelectOption>;
 /// Loader returning dynamic record payloads.
 pub type RecordLoader = Loader<Value>;
 
-/// Build a single-key `FieldPath` from a `LoaderContext::field_key` string.
-/// Falls back to root if the key is not a valid `FieldKey`.
+/// Build a `FieldPath` from a `LoaderContext::field_key` string.
+///
+/// Falls back to root if the string is not a valid schema path.
 fn field_path_from_key(key: &str) -> FieldPath {
-    FieldKey::new(key).map_or_else(
-        |_| FieldPath::root(),
-        |fk| FieldPath::root().join(PathSegment::Key(fk)),
-    )
+    FieldPath::parse(key).unwrap_or_else(|_| {
+        FieldKey::new(key).map_or_else(
+            |_| FieldPath::root(),
+            |fk| FieldPath::root().join(PathSegment::Key(fk)),
+        )
+    })
 }
 
 /// Use the path from a loader-returned error if it's non-root, otherwise fall
@@ -531,15 +553,17 @@ mod tests {
         .expect("values");
         let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
         let auth = ctx.values.get_by_str("auth").expect("auth");
-        let FieldValue::Mode { mode, value } = auth else {
-            panic!("expected mode, got {auth:?}");
+        let FieldValue::Object(map) = auth else {
+            panic!("expected object envelope, got {auth:?}");
         };
-        assert_eq!(mode.as_str(), "oauth");
-        let Some(inner) = value else {
-            panic!("expected mode payload, got {auth:?}");
+        let mode = map.get(&k("mode")).expect("mode");
+        let FieldValue::Literal(Json::String(mode_key)) = mode else {
+            panic!("expected mode literal, got {mode:?}");
         };
-        let FieldValue::Object(m) = inner.as_ref() else {
-            panic!("expected object in mode value, got {inner:?}");
+        assert_eq!(mode_key, "oauth");
+        let payload = map.get(&k("value")).expect("payload");
+        let FieldValue::Object(m) = payload else {
+            panic!("expected object payload, got {payload:?}");
         };
         assert_eq!(m.get(&k("client_secret")), Some(&redacted_literal()));
         let id = m.get(&k("client_id")).expect("id");

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -13,7 +13,7 @@ use smallvec::SmallVec;
 use crate::{
     Field, LoaderContext, LoaderRegistry, LoaderResult, SelectOption,
     error::{ValidationError, ValidationReport},
-    path::FieldPath,
+    path::{FieldPath, PathSegment},
     validated::{FieldHandle, SchemaFlags, ValidSchema, ValidSchemaInner},
 };
 
@@ -146,7 +146,35 @@ impl Schema {
         registry: &LoaderRegistry,
         context: LoaderContext,
     ) -> Result<LoaderResult<SelectOption>, ValidationError> {
-        let loader_key = resolve_select_loader_key(self.fields(), key)?;
+        let path = FieldPath::root().join(parse_top_level_key(key)?);
+        self.load_select_options_at(&path, registry, context).await
+    }
+
+    /// Resolve dynamic options for a select field at a nested schema path.
+    ///
+    /// This path addresses the schema tree, not a concrete runtime instance.
+    /// For example:
+    ///
+    /// - nested object child: `config.workspace`
+    /// - list item child: `rows[0].workspace` or `rows.workspace`
+    /// - mode variant child: `auth.oauth.workspace`
+    ///
+    /// # Errors
+    ///
+    /// - `field.not_found` — schema has no field at this path.
+    /// - `field.type_mismatch` — field exists but isn't a `Select`. Carries `expected` and `actual`
+    ///   params.
+    /// - `loader.missing_config` — field is a select but has no loader configured (static options
+    ///   only).
+    /// - `loader.not_registered` / `loader.failed` — propagated from
+    ///   [`LoaderRegistry::load_options`].
+    pub async fn load_select_options_at(
+        &self,
+        path: &FieldPath,
+        registry: &LoaderRegistry,
+        context: LoaderContext,
+    ) -> Result<LoaderResult<SelectOption>, ValidationError> {
+        let loader_key = resolve_select_loader_path(self.fields(), path)?;
         registry.load_options(&loader_key, context).await
     }
 
@@ -163,7 +191,26 @@ impl Schema {
         registry: &LoaderRegistry,
         context: LoaderContext,
     ) -> Result<LoaderResult<Value>, ValidationError> {
-        let loader_key = resolve_dynamic_loader_key(self.fields(), key)?;
+        let path = FieldPath::root().join(parse_top_level_key(key)?);
+        self.load_dynamic_records_at(&path, registry, context).await
+    }
+
+    /// Resolve dynamic record payloads for a field at a nested schema path.
+    ///
+    /// Uses the same schema-path addressing rules as [`Schema::load_select_options_at`].
+    ///
+    /// # Errors
+    ///
+    /// Same taxonomy as [`Schema::load_select_options_at`] — `field.not_found`,
+    /// `field.type_mismatch`, `loader.missing_config`, or the registry's
+    /// `loader.not_registered` / `loader.failed`.
+    pub async fn load_dynamic_records_at(
+        &self,
+        path: &FieldPath,
+        registry: &LoaderRegistry,
+        context: LoaderContext,
+    ) -> Result<LoaderResult<Value>, ValidationError> {
+        let loader_key = resolve_dynamic_loader_path(self.fields(), path)?;
         registry.load_records(&loader_key, context).await
     }
 }
@@ -197,42 +244,23 @@ pub(crate) fn resolve_select_loader_key(
     fields: &[Field],
     key: &str,
 ) -> Result<String, ValidationError> {
-    let parsed_key = parse_top_level_key(key)?;
-    let path = FieldPath::root().join(parsed_key);
-    let field = fields
-        .iter()
-        .find(|field| field.key().as_str() == key)
-        .ok_or_else(|| {
-            ValidationError::builder("field.not_found")
-                .at(path.clone())
-                .param("key", Value::String(key.to_owned()))
-                .message(format!("field `{key}` not found in schema"))
-                .build()
-        })?;
+    let path = FieldPath::root().join(parse_top_level_key(key)?);
+    resolve_select_loader_path(fields, &path)
+}
+
+#[allow(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+pub(crate) fn resolve_select_loader_path(
+    fields: &[Field],
+    path: &FieldPath,
+) -> Result<String, ValidationError> {
+    let field = find_field_by_schema_path(fields, path)?;
     let Field::Select(select) = field else {
-        return Err(ValidationError::builder("field.type_mismatch")
-            .at(path.clone())
-            .param("key", Value::String(key.to_owned()))
-            .param("expected", Value::String("select".to_owned()))
-            .param("actual", Value::String(field.type_name().to_owned()))
-            .message(format!(
-                "field `{key}` is not a select field (got {})",
-                field.type_name()
-            ))
-            .build());
+        return Err(loader_type_mismatch(path, "select", field.type_name()));
     };
-    select
-        .loader
-        .as_deref()
-        .filter(|loader| !loader.trim().is_empty())
-        .map(str::to_owned)
-        .ok_or_else(|| {
-            ValidationError::builder("loader.missing_config")
-                .at(path)
-                .param("key", Value::String(key.to_owned()))
-                .message(format!("field `{key}` has no loader configured"))
-                .build()
-        })
+    loader_key_or_error(select.loader.as_deref(), path)
 }
 
 #[allow(
@@ -243,42 +271,180 @@ pub(crate) fn resolve_dynamic_loader_key(
     fields: &[Field],
     key: &str,
 ) -> Result<String, ValidationError> {
-    let parsed_key = parse_top_level_key(key)?;
-    let path = FieldPath::root().join(parsed_key);
-    let field = fields
-        .iter()
-        .find(|field| field.key().as_str() == key)
-        .ok_or_else(|| {
-            ValidationError::builder("field.not_found")
-                .at(path.clone())
-                .param("key", Value::String(key.to_owned()))
-                .message(format!("field `{key}` not found in schema"))
-                .build()
-        })?;
+    let path = FieldPath::root().join(parse_top_level_key(key)?);
+    resolve_dynamic_loader_path(fields, &path)
+}
+
+#[allow(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+pub(crate) fn resolve_dynamic_loader_path(
+    fields: &[Field],
+    path: &FieldPath,
+) -> Result<String, ValidationError> {
+    let field = find_field_by_schema_path(fields, path)?;
     let Field::Dynamic(dynamic) = field else {
-        return Err(ValidationError::builder("field.type_mismatch")
-            .at(path.clone())
-            .param("key", Value::String(key.to_owned()))
-            .param("expected", Value::String("dynamic".to_owned()))
-            .param("actual", Value::String(field.type_name().to_owned()))
-            .message(format!(
-                "field `{key}` is not a dynamic field (got {})",
-                field.type_name()
-            ))
-            .build());
+        return Err(loader_type_mismatch(path, "dynamic", field.type_name()));
     };
-    dynamic
-        .loader
-        .as_deref()
+    loader_key_or_error(dynamic.loader.as_deref(), path)
+}
+
+#[allow(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+fn loader_key_or_error(loader: Option<&str>, path: &FieldPath) -> Result<String, ValidationError> {
+    loader
         .filter(|loader| !loader.trim().is_empty())
         .map(str::to_owned)
         .ok_or_else(|| {
             ValidationError::builder("loader.missing_config")
-                .at(path)
-                .param("key", Value::String(key.to_owned()))
-                .message(format!("field `{key}` has no loader configured"))
+                .at(path.clone())
+                .param("key", Value::String(path.to_string()))
+                .message(format!("field `{path}` has no loader configured"))
                 .build()
         })
+}
+
+fn loader_type_mismatch(path: &FieldPath, expected: &str, actual: &str) -> ValidationError {
+    ValidationError::builder("field.type_mismatch")
+        .at(path.clone())
+        .param("key", Value::String(path.to_string()))
+        .param("expected", Value::String(expected.to_owned()))
+        .param("actual", Value::String(actual.to_owned()))
+        .message(format!(
+            "field `{path}` is not a {expected} field (got {actual})"
+        ))
+        .build()
+}
+
+#[allow(
+    clippy::result_large_err,
+    reason = "ValidationError is intentionally large; callers are on the validation path"
+)]
+fn find_field_by_schema_path<'a>(
+    fields: &'a [Field],
+    path: &FieldPath,
+) -> Result<&'a Field, ValidationError> {
+    let mut segments = path.segments().iter();
+    let Some(PathSegment::Key(first_key)) = segments.next() else {
+        return Err(ValidationError::builder("field.not_found")
+            .at(path.clone())
+            .param("key", Value::String(path.to_string()))
+            .message(format!("field `{path}` not found in schema"))
+            .build());
+    };
+
+    let mut current_path = FieldPath::root().join(first_key.clone());
+    let mut current = fields
+        .iter()
+        .find(|field| field.key() == first_key)
+        .ok_or_else(|| {
+            ValidationError::builder("field.not_found")
+                .at(current_path.clone())
+                .param("key", Value::String(current_path.to_string()))
+                .message(format!("field `{current_path}` not found in schema"))
+                .build()
+        })?;
+
+    for segment in segments {
+        match segment {
+            PathSegment::Key(key) => match current {
+                Field::Object(object) => {
+                    current_path = current_path.join(key.clone());
+                    current = object
+                        .fields
+                        .iter()
+                        .find(|field| field.key() == key)
+                        .ok_or_else(|| {
+                            ValidationError::builder("field.not_found")
+                                .at(current_path.clone())
+                                .param("key", Value::String(current_path.to_string()))
+                                .message(format!("field `{current_path}` not found in schema"))
+                                .build()
+                        })?;
+                },
+                Field::List(list) => {
+                    let Some(item) = list.item.as_deref() else {
+                        current_path = current_path.join(key.clone());
+                        return Err(ValidationError::builder("field.not_found")
+                            .at(current_path.clone())
+                            .param("key", Value::String(current_path.to_string()))
+                            .message(format!("field `{current_path}` not found in schema"))
+                            .build());
+                    };
+                    if let Field::Object(object) = item {
+                        current_path = current_path.join(key.clone());
+                        current = object
+                            .fields
+                            .iter()
+                            .find(|field| field.key() == key)
+                            .ok_or_else(|| {
+                                ValidationError::builder("field.not_found")
+                                    .at(current_path.clone())
+                                    .param("key", Value::String(current_path.to_string()))
+                                    .message(format!("field `{current_path}` not found in schema"))
+                                    .build()
+                            })?;
+                    } else {
+                        current_path = current_path.join(key.clone());
+                        return Err(ValidationError::builder("field.not_found")
+                            .at(current_path.clone())
+                            .param("key", Value::String(current_path.to_string()))
+                            .message(format!("field `{current_path}` not found in schema"))
+                            .build());
+                    }
+                },
+                Field::Mode(mode) => {
+                    current_path = current_path.join(key.clone());
+                    current = mode
+                        .variants
+                        .iter()
+                        .find(|variant| variant.key == key.as_str())
+                        .map(|variant| variant.field.as_ref())
+                        .ok_or_else(|| {
+                            ValidationError::builder("field.not_found")
+                                .at(current_path.clone())
+                                .param("key", Value::String(current_path.to_string()))
+                                .message(format!("field `{current_path}` not found in schema"))
+                                .build()
+                        })?;
+                },
+                _ => {
+                    current_path = current_path.join(key.clone());
+                    return Err(ValidationError::builder("field.not_found")
+                        .at(current_path.clone())
+                        .param("key", Value::String(current_path.to_string()))
+                        .message(format!("field `{current_path}` not found in schema"))
+                        .build());
+                },
+            },
+            PathSegment::Index(index) => {
+                current_path = current_path.join(*index);
+                match current {
+                    Field::List(list) => {
+                        current = list.item.as_deref().ok_or_else(|| {
+                            ValidationError::builder("field.not_found")
+                                .at(current_path.clone())
+                                .param("key", Value::String(current_path.to_string()))
+                                .message(format!("field `{current_path}` not found in schema"))
+                                .build()
+                        })?;
+                    },
+                    _ => {
+                        return Err(ValidationError::builder("field.not_found")
+                            .at(current_path.clone())
+                            .param("key", Value::String(current_path.to_string()))
+                            .message(format!("field `{current_path}` not found in schema"))
+                            .build());
+                    },
+                }
+            },
+        }
+    }
+
+    Ok(current)
 }
 
 // ── SchemaBuilder ─────────────────────────────────────────────────────────────

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -21,7 +21,10 @@ use crate::{
     mode::{ExpressionMode, RequiredMode, VisibilityMode},
     option::SelectOption,
     path::FieldPath,
-    schema::{resolve_dynamic_loader_key, resolve_select_loader_key},
+    schema::{
+        resolve_dynamic_loader_key, resolve_dynamic_loader_path, resolve_select_loader_key,
+        resolve_select_loader_path,
+    },
     secret::SecretValue,
     value::{FieldValue, FieldValues},
 };
@@ -216,6 +219,25 @@ impl ValidSchema {
         registry.load_options(&loader_key, context).await
     }
 
+    /// Resolve dynamic options for a select field at a nested schema path.
+    ///
+    /// Uses the same schema-path addressing rules as
+    /// [`crate::Schema::load_select_options_at`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `field.not_found`, `field.type_mismatch`, `loader.missing_config`,
+    /// `loader.not_registered`, or `loader.failed`.
+    pub async fn load_select_options_at(
+        &self,
+        path: &FieldPath,
+        registry: &LoaderRegistry,
+        context: LoaderContext,
+    ) -> Result<LoaderResult<SelectOption>, ValidationError> {
+        let loader_key = resolve_select_loader_path(self.fields(), path)?;
+        registry.load_options(&loader_key, context).await
+    }
+
     /// Resolve dynamic record payloads for a dynamic field through registry.
     ///
     /// Same error taxonomy as [`crate::Schema::load_dynamic_records`], but this
@@ -231,6 +253,25 @@ impl ValidSchema {
         context: LoaderContext,
     ) -> Result<LoaderResult<serde_json::Value>, ValidationError> {
         let loader_key = resolve_dynamic_loader_key(self.fields(), key)?;
+        registry.load_records(&loader_key, context).await
+    }
+
+    /// Resolve dynamic record payloads for a field at a nested schema path.
+    ///
+    /// Uses the same schema-path addressing rules as
+    /// [`crate::Schema::load_dynamic_records_at`].
+    ///
+    /// # Errors
+    ///
+    /// Returns `field.not_found`, `field.type_mismatch`, `loader.missing_config`,
+    /// `loader.not_registered`, or `loader.failed`.
+    pub async fn load_dynamic_records_at(
+        &self,
+        path: &FieldPath,
+        registry: &LoaderRegistry,
+        context: LoaderContext,
+    ) -> Result<LoaderResult<serde_json::Value>, ValidationError> {
+        let loader_key = resolve_dynamic_loader_path(self.fields(), path)?;
         registry.load_records(&loader_key, context).await
     }
 
@@ -554,8 +595,23 @@ impl ResolvedValues {
     ///
     /// # Errors
     ///
-    /// Returns `type_mismatch` when deserialization fails.
+    /// Returns `type_mismatch` when deserialization fails or when the resolved
+    /// value tree still contains secret material. Secret-bearing schemas must
+    /// cross an explicit boundary via [`Self::get_secret`] / `SecretWire`,
+    /// rather than generic typed extraction.
     pub fn into_typed<T: serde::de::DeserializeOwned>(self) -> Result<T, Box<ValidationError>> {
+        if let Some(path) = first_secret_path_in_values(&self.values) {
+            return Err(Box::new(
+                ValidationError::builder("type_mismatch")
+                    .at(path)
+                    .message(
+                        "typed extraction refused because resolved values contain secret material; use get_secret() / SecretWire across an explicit boundary instead"
+                            .to_owned(),
+                    )
+                    .build(),
+            ));
+        }
+
         serde_json::from_value(self.into_json()).map_err(|e| {
             Box::new(
                 ValidationError::builder("type_mismatch")
@@ -563,6 +619,52 @@ impl ResolvedValues {
                     .build(),
             )
         })
+    }
+}
+
+fn first_secret_path_in_values(values: &FieldValues) -> Option<FieldPath> {
+    for (key, value) in values.iter() {
+        let path = FieldPath::root().join(key.clone());
+        if let Some(secret_path) = first_secret_path_in_field_value(value, &path) {
+            return Some(secret_path);
+        }
+    }
+    None
+}
+
+fn first_secret_path_in_field_value(value: &FieldValue, path: &FieldPath) -> Option<FieldPath> {
+    match value {
+        FieldValue::SecretLiteral(_) => Some(path.clone()),
+        FieldValue::Object(map) => {
+            for (key, child) in map {
+                let child_path = path.clone().join(key.clone());
+                if let Some(secret_path) = first_secret_path_in_field_value(child, &child_path) {
+                    return Some(secret_path);
+                }
+            }
+            None
+        },
+        FieldValue::List(items) => {
+            for (index, child) in items.iter().enumerate() {
+                let child_path = path.clone().join(index);
+                if let Some(secret_path) = first_secret_path_in_field_value(child, &child_path) {
+                    return Some(secret_path);
+                }
+            }
+            None
+        },
+        FieldValue::Mode {
+            value: Some(payload),
+            ..
+        } => {
+            let payload_key =
+                FieldKey::new("value").expect("static mode payload key must be valid");
+            let payload_path = path.clone().join(payload_key);
+            first_secret_path_in_field_value(payload, &payload_path)
+        },
+        FieldValue::Literal(_)
+        | FieldValue::Expression(_)
+        | FieldValue::Mode { value: None, .. } => None,
     }
 }
 
@@ -640,6 +742,27 @@ fn promote_secrets_in_value(
             };
             let p = path.clone().join(k);
             promote_secrets_in_value(&var.field, mv.as_mut(), &p, report);
+        },
+        (Field::Mode(mode), FieldValue::Object(map)) => {
+            let Ok(mode_selector_key) = FieldKey::new("mode") else {
+                return;
+            };
+            let Ok(payload_key) = FieldKey::new("value") else {
+                return;
+            };
+            let Some(FieldValue::Literal(serde_json::Value::String(mode_key))) =
+                map.get(&mode_selector_key)
+            else {
+                return;
+            };
+            let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
+                return;
+            };
+            let Some(mv) = map.get_mut(&payload_key) else {
+                return;
+            };
+            let p = path.clone().join(payload_key);
+            promote_secrets_in_value(&var.field, mv, &p, report);
         },
         _ => {},
     }
@@ -1247,23 +1370,65 @@ fn validate_literal_value(
             rules,
             ..
         }) => {
-            let FieldValue::Mode {
-                mode: mode_key,
-                value: mode_value,
-            } = value
-            else {
-                report.push(
-                    ValidationError::builder("type_mismatch")
-                        .at(path.clone())
-                        .message(format!(
-                            "field `{path}` expects a mode value ({{\"mode\": \"...\", ...}})"
-                        ))
-                        .build(),
-                );
-                return;
+            let mode_selector_key =
+                FieldKey::new("mode").expect("static mode selector key must remain valid");
+            let payload_key =
+                FieldKey::new("value").expect("static mode payload key must remain valid");
+
+            let (resolved_key, mode_value) = match value {
+                FieldValue::Mode {
+                    mode: mode_key,
+                    value: mode_value,
+                } => (Some(mode_key.as_str()), mode_value.as_deref()),
+                FieldValue::Object(map) => {
+                    if map
+                        .keys()
+                        .any(|key| key.as_str() != "mode" && key.as_str() != "value")
+                    {
+                        report.push(
+                            ValidationError::builder("type_mismatch")
+                                .at(path.clone())
+                                .message(format!(
+                                    "field `{path}` expects a mode value ({{\"mode\": \"...\", ...}})"
+                                ))
+                                .build(),
+                        );
+                        return;
+                    }
+
+                    match map.get(&mode_selector_key) {
+                        Some(FieldValue::Literal(serde_json::Value::String(mode))) => {
+                            (Some(mode.as_str()), map.get(&payload_key))
+                        },
+                        Some(other) => {
+                            report.push(
+                                ValidationError::builder("type_mismatch")
+                                    .at(path.clone().join(mode_selector_key.clone()))
+                                    .message(format!(
+                                        "field `{path}.mode` expects a string value, got {}",
+                                        field_value_shape_for_errors(other)
+                                    ))
+                                    .build(),
+                            );
+                            return;
+                        },
+                        None => (None, map.get(&payload_key)),
+                    }
+                },
+                _ => {
+                    report.push(
+                        ValidationError::builder("type_mismatch")
+                            .at(path.clone())
+                            .message(format!(
+                                "field `{path}` expects a mode value ({{\"mode\": \"...\", ...}})"
+                            ))
+                            .build(),
+                    );
+                    return;
+                },
             };
             run_rules(rules, &value.to_json(), path, report);
-            let resolved_key = Some(mode_key.as_str()).or(default_variant.as_deref());
+            let resolved_key = resolved_key.or(default_variant.as_deref());
             let Some(resolved_key) = resolved_key else {
                 report.push(
                     ValidationError::builder("mode.required")
@@ -1286,17 +1451,8 @@ fn validate_literal_value(
                 return;
             };
             {
-                let Ok(payload_key) = FieldKey::new("value") else {
-                    return;
-                };
                 let payload_path = path.clone().join(payload_key);
-                validate_field(
-                    &variant.field,
-                    mode_value.as_deref(),
-                    ctx,
-                    &payload_path,
-                    report,
-                );
+                validate_field(&variant.field, mode_value, ctx, &payload_path, report);
             }
         },
         // File, Computed, Dynamic, Notice — no type-check rule at schema time.

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -750,12 +750,17 @@ fn promote_secrets_in_value(
             let Ok(payload_key) = FieldKey::new("value") else {
                 return;
             };
-            let Some(FieldValue::Literal(serde_json::Value::String(mode_key))) =
-                map.get(&mode_selector_key)
-            else {
-                return;
+            let resolved_key = match map.get(&mode_selector_key) {
+                Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => {
+                    Some(mode_key.clone())
+                },
+                Some(_) => None,
+                None => mode.default_variant.clone(),
             };
-            let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
+            let Some(var) = resolved_key
+                .as_deref()
+                .and_then(|mode_key| mode.variants.iter().find(|v| v.key == mode_key))
+            else {
                 return;
             };
             let Some(mv) = map.get_mut(&payload_key) else {

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -53,21 +53,6 @@ impl FieldValue {
                 {
                     return Self::Expression(Expression::new(expr));
                 }
-                let only_mode_keys = map.keys().all(|k| k == "mode" || k == "value");
-                if only_mode_keys
-                    && map.contains_key("mode")
-                    && let Some(mode_str) = map.get("mode").and_then(Value::as_str)
-                    && let Ok(mode_key) = FieldKey::new(mode_str)
-                {
-                    let v = map
-                        .get("value")
-                        .cloned()
-                        .map(|inner| Box::new(Self::from_json(inner)));
-                    return Self::Mode {
-                        mode: mode_key,
-                        value: v,
-                    };
-                }
 
                 // Parse keys first so conversion remains panic-free.
                 let Some(parsed_keys): Option<Vec<FieldKey>> = map
@@ -426,20 +411,6 @@ fn validate_json_keys(
                 return Ok(());
             }
 
-            let only_mode_keys = map.keys().all(|k| k == "mode" || k == "value");
-            let valid_mode_key = map
-                .get("mode")
-                .and_then(Value::as_str)
-                .is_some_and(|mode| FieldKey::new(mode).is_ok());
-            if only_mode_keys && valid_mode_key {
-                if let Some(inner) = map.get("value") {
-                    let payload_key = FieldKey::new("value").expect("value is a valid field key");
-                    let payload_path = path.clone().join(payload_key);
-                    validate_json_keys(inner, &payload_path)?;
-                }
-                return Ok(());
-            }
-
             for (raw_key, child) in map {
                 let key = FieldKey::new(raw_key).map_err(|e| {
                     crate::error::ValidationError::builder("invalid_key")
@@ -502,9 +473,9 @@ mod tests {
     }
 
     #[test]
-    fn detects_mode_wrapper() {
+    fn mode_like_object_stays_object() {
         let v = FieldValue::from_json(json!({"mode": "oauth2", "value": {"scope":"r"}}));
-        assert!(matches!(v, FieldValue::Mode { .. }));
+        assert!(matches!(v, FieldValue::Object(_)));
     }
 
     #[test]

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -445,6 +445,19 @@ fn emits_invalid_key() {
 }
 
 #[test]
+fn emits_invalid_key_for_mode_variant_path_segment() {
+    let report = Schema::builder()
+        .add(Field::mode(field_key!("auth")).variant(
+            "oauth-token",
+            "OAuth",
+            Field::string(fk("token")),
+        ))
+        .build()
+        .unwrap_err();
+    assert!(has_code(&report, "invalid_key"));
+}
+
+#[test]
 fn emits_duplicate_key() {
     let report = Schema::builder()
         .add(Field::string(fk("x")))

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -10,15 +10,6 @@
 //! `translate_validator_code` before being stored in `ValidationReport`.
 //! So `"min_length"` → `"length.min"`, `"max_length"` → `"length.max"`, etc.
 //!
-//! # Deferred codes (Phase 4)
-//!
-//! The following `STANDARD_CODES` entries cannot be emitted without additional
-//! infrastructure that is out of scope for Phase 1:
-//!
-//! - `"mode.required"` — unreachable via the public API: `FieldValue::Mode` always carries a
-//!   non-empty `FieldKey` (validated at construction time), so the `mode_key.is_empty()` branch in
-//!   `validated.rs` can never fire.
-//!
 //! # Loader-family codes
 //!
 //! The following `STANDARD_CODES` entries are loader-registry-scoped. They
@@ -320,7 +311,25 @@ fn emits_mode_invalid() {
     );
 }
 
-// mode.required is unreachable via the public API — see deferred note at top of file.
+#[test]
+fn emits_mode_required() {
+    let schema = Schema::builder()
+        .add(Field::mode(field_key!("m")).variant("a", "A", Field::string(fk("val"))))
+        .build()
+        .unwrap();
+    let vs = FieldValues::from_json(json!({
+        "m": {
+            "value": "missing mode selector"
+        }
+    }))
+    .unwrap();
+    let err = schema.validate(&vs).unwrap_err();
+    assert!(
+        has_code(&err, "mode.required"),
+        "codes: {:?}",
+        err.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
 
 // ── Expression codes ──────────────────────────────────────────────────────
 

--- a/crates/schema/tests/lint_and_loader.rs
+++ b/crates/schema/tests/lint_and_loader.rs
@@ -167,6 +167,186 @@ async fn valid_schema_loader_apis_resolve_loaders() {
 }
 
 #[tokio::test]
+async fn nested_schema_loader_apis_resolve_object_paths() {
+    let schema = raw_schema(vec![
+        Field::object("config")
+            .add(
+                Field::select("workspace")
+                    .dynamic()
+                    .loader("workspace_loader"),
+            )
+            .add(Field::dynamic("resource").loader("resource_loader"))
+            .into(),
+    ]);
+
+    let registry = LoaderRegistry::new()
+        .register_option("workspace_loader", |ctx| async move {
+            assert_eq!(ctx.field_key, "config.workspace");
+            Ok(LoaderResult::done(vec![nebula_schema::SelectOption::new(
+                json!("ws_nested"),
+                "Nested Workspace",
+            )]))
+        })
+        .register_record("resource_loader", |ctx| async move {
+            assert_eq!(ctx.field_key, "config.resource");
+            Ok(LoaderResult::done(vec![json!({"id": "res_nested"})]))
+        });
+
+    let workspace_path = FieldPath::parse("config.workspace").unwrap();
+    let resource_path = FieldPath::parse("config.resource").unwrap();
+
+    let options = schema
+        .load_select_options_at(
+            &workspace_path,
+            &registry,
+            LoaderContext::new("config.workspace", FieldValues::new()),
+        )
+        .await
+        .expect("nested workspace options should load");
+    assert_eq!(options.items.len(), 1);
+    assert_eq!(options.items[0].label, "Nested Workspace");
+
+    let records = schema
+        .load_dynamic_records_at(
+            &resource_path,
+            &registry,
+            LoaderContext::new("config.resource", FieldValues::new()),
+        )
+        .await
+        .expect("nested resource records should load");
+    assert_eq!(records.items.len(), 1);
+    assert_eq!(records.items[0]["id"], json!("res_nested"));
+}
+
+#[tokio::test]
+async fn nested_schema_loader_apis_resolve_list_item_paths() {
+    let schema = raw_schema(vec![
+        Field::list("rows")
+            .item(
+                Field::object("row").add(
+                    Field::select("workspace")
+                        .dynamic()
+                        .loader("workspace_loader"),
+                ),
+            )
+            .into(),
+    ]);
+
+    let registry = LoaderRegistry::new().register_option("workspace_loader", |ctx| async move {
+        Ok(LoaderResult::done(vec![nebula_schema::SelectOption::new(
+            json!(ctx.field_key),
+            "Workspace from list",
+        )]))
+    });
+
+    let indexed_path = FieldPath::parse("rows[0].workspace").unwrap();
+    let indexed = schema
+        .load_select_options_at(
+            &indexed_path,
+            &registry,
+            LoaderContext::new("rows[0].workspace", FieldValues::new()),
+        )
+        .await
+        .expect("indexed list path should resolve");
+    assert_eq!(indexed.items.len(), 1);
+    assert_eq!(indexed.items[0].value, json!("rows[0].workspace"));
+
+    let schema_path = FieldPath::parse("rows.workspace").unwrap();
+    let schema_level = schema
+        .load_select_options_at(
+            &schema_path,
+            &registry,
+            LoaderContext::new("rows.workspace", FieldValues::new()),
+        )
+        .await
+        .expect("schema-level list path should resolve");
+    assert_eq!(schema_level.items.len(), 1);
+    assert_eq!(schema_level.items[0].value, json!("rows.workspace"));
+}
+
+#[tokio::test]
+async fn nested_valid_schema_loader_api_resolves_mode_variant_paths() {
+    let schema = Schema::builder()
+        .add(Field::mode("auth").variant(
+            "oauth",
+            "OAuth",
+            Field::object("creds").add(Field::dynamic("resource").loader("resource_loader")),
+        ))
+        .build()
+        .expect("schema should build");
+
+    let registry = LoaderRegistry::new().register_record("resource_loader", |ctx| async move {
+        assert_eq!(ctx.field_key, "auth.oauth.resource");
+        Ok(LoaderResult::done(vec![json!({"id": "oauth_resource"})]))
+    });
+
+    let path = FieldPath::parse("auth.oauth.resource").unwrap();
+    let records = schema
+        .load_dynamic_records_at(
+            &path,
+            &registry,
+            LoaderContext::new("auth.oauth.resource", FieldValues::new()),
+        )
+        .await
+        .expect("mode-variant resource records should load");
+
+    assert_eq!(records.items.len(), 1);
+    assert_eq!(records.items[0]["id"], json!("oauth_resource"));
+}
+
+#[tokio::test]
+async fn nested_loader_errors_anchor_to_nested_path() {
+    let schema = raw_schema(vec![
+        Field::object("config")
+            .add(
+                Field::select("workspace")
+                    .dynamic()
+                    .loader("missing_workspace_loader"),
+            )
+            .into(),
+    ]);
+    let registry = LoaderRegistry::new();
+    let path = FieldPath::parse("config.workspace").unwrap();
+
+    let error = schema
+        .load_select_options_at(
+            &path,
+            &registry,
+            LoaderContext::new("config.workspace", FieldValues::new()),
+        )
+        .await
+        .expect_err("missing nested loader must fail");
+
+    assert_eq!(error.code, "loader.not_registered");
+    assert_eq!(error.path.to_string(), "config.workspace");
+}
+
+#[tokio::test]
+async fn top_level_loader_string_api_rejects_nested_paths() {
+    let schema = raw_schema(vec![
+        Field::object("config")
+            .add(
+                Field::select("workspace")
+                    .dynamic()
+                    .loader("workspace_loader"),
+            )
+            .into(),
+    ]);
+    let registry = LoaderRegistry::new();
+    let error = schema
+        .load_select_options(
+            "config.workspace",
+            &registry,
+            LoaderContext::new("config.workspace", FieldValues::new()),
+        )
+        .await
+        .expect_err("top-level string API should reject nested paths");
+
+    assert_eq!(error.code, "invalid_key");
+    assert_eq!(error.path.to_string(), "");
+}
+
+#[tokio::test]
 async fn loader_registry_reports_missing_loader_registration() {
     let schema = raw_schema(vec![
         Field::select("region")

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -11,6 +11,20 @@ struct Person {
     name: String,
 }
 
+#[derive(Debug, PartialEq)]
+struct SecretWrapper(String);
+
+impl<'de> serde::Deserialize<'de> for SecretWrapper {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        String::deserialize(deserializer).map(Self)
+    }
+}
+
+#[derive(Debug, serde::Deserialize, PartialEq)]
+struct ApiCredential {
+    api_key: SecretWrapper,
+}
+
 // ── Stub ExpressionContext ────────────────────────────────────────────────────
 
 /// Returns a constant value for every expression.
@@ -436,4 +450,25 @@ async fn secret_field_promotes_and_resolved_get_sanitizes_json() {
     let wire = resolved.values().to_json();
     let obj = wire.as_object().expect("object");
     assert_eq!(obj.get("api_key"), Some(&json!("<redacted>")));
+}
+
+#[tokio::test]
+async fn into_typed_rejects_secret_material_by_default() {
+    let schema = Schema::builder()
+        .add(Field::secret(field_key!("api_key")).required())
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({"api_key": "sekrit"})).unwrap();
+    let valid = schema.validate(&values).unwrap();
+    let resolved = valid.resolve(&ConstCtx(json!(null))).await.unwrap();
+
+    let err = resolved.into_typed::<ApiCredential>().unwrap_err();
+    assert_eq!(err.code, "type_mismatch");
+    assert_eq!(err.path.to_string(), "api_key");
+    assert!(
+        err.message.contains("get_secret() / SecretWire"),
+        "expected explicit opt-in guidance, got: {}",
+        err.message
+    );
 }

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -472,3 +472,47 @@ async fn into_typed_rejects_secret_material_by_default() {
         err.message
     );
 }
+
+#[tokio::test]
+async fn resolve_promotes_mode_object_envelope_secrets_via_default_variant() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(field_key!("auth"))
+                .variant(
+                    "token",
+                    "Token",
+                    Field::object(field_key!("payload")).add(Field::secret(field_key!("api_key"))),
+                )
+                .default_variant("token")
+                .required(),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "auth": {
+            "value": {
+                "api_key": "sekrit"
+            }
+        }
+    }))
+    .unwrap();
+    let valid = schema.validate(&values).unwrap();
+    let resolved = valid.resolve(&ConstCtx(json!(null))).await.unwrap();
+
+    let secret_path = FieldPath::parse("auth.value.api_key").unwrap();
+    let secret = resolved
+        .values()
+        .get_path(&secret_path)
+        .expect("secret path");
+    assert!(
+        matches!(secret, FieldValue::SecretLiteral(_)),
+        "expected promoted secret literal, got {secret:?}"
+    );
+
+    let wire = resolved.values().to_json();
+    assert_eq!(
+        wire.pointer("/auth/value/api_key"),
+        Some(&json!("<redacted>"))
+    );
+}

--- a/crates/schema/tests/validate_schema.rs
+++ b/crates/schema/tests/validate_schema.rs
@@ -138,6 +138,59 @@ fn mode_variant_empty_rejects_expression_in_placeholder() {
 }
 
 #[test]
+fn mode_field_accepts_object_wire_envelope() {
+    let schema = Schema::builder()
+        .add(Field::mode(fk("auth")).variant("token", "Token", Field::secret(fk("token"))))
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "auth": { "mode": "token", "value": "shh" }
+    }))
+    .unwrap();
+
+    assert!(schema.validate(&values).is_ok());
+}
+
+#[test]
+fn mode_field_uses_default_variant_for_object_wire_envelope_without_mode() {
+    let schema = Schema::builder()
+        .add(
+            Field::mode(fk("auth"))
+                .variant("token", "Token", Field::secret(fk("token")))
+                .default_variant("token"),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "auth": { "value": "shh" }
+    }))
+    .unwrap();
+
+    assert!(schema.validate(&values).is_ok());
+}
+
+#[test]
+fn object_field_can_use_mode_and_value_keys_without_mode_coercion() {
+    let schema = Schema::builder()
+        .add(
+            Field::object(fk("config"))
+                .add(Field::string(fk("mode")).required())
+                .add(Field::string(fk("value")).required()),
+        )
+        .build()
+        .unwrap();
+
+    let values = FieldValues::from_json(json!({
+        "config": { "mode": "manual", "value": "literal" }
+    }))
+    .unwrap();
+
+    assert!(schema.validate(&values).is_ok());
+}
+
+#[test]
 fn computed_field_literal_emits_expression_required() {
     let schema = Schema::builder()
         .add(Field::computed(fk("derived")))


### PR DESCRIPTION
## Summary
- add nested loader path APIs and regression coverage for object, list, and mode paths
- remove implicit `{mode,value}` coercion from raw parsing and validate mode envelopes explicitly at schema runtime
- delete the unsupported `allow_dynamic_mode()` surface and stop exporting its JSON Schema flag
- keep `ResolvedValues::into_typed()` secret-safe by default and require explicit `get_secret()` / `SecretWire` boundaries

## Validation
- `cargo test -p nebula-schema --tests`
- `cargo test -p nebula-schema --tests --features schemars`
- `cargo +nightly fmt --all -- --check`
- git hooks on commit/push passed, including clippy and nextest gate
