### PR TITLE
feat(schema): symmetric integration API across action, credential, resource

### DIFF
--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -312,6 +312,12 @@ impl ActionMetadata {
         self
     }
 
+    /// Terminal builder for API consistency with other metadata types.
+    #[must_use]
+    pub fn build(self) -> Self {
+        self
+    }
+
     /// Validate that this metadata update is version-compatible with `previous`.
     ///
     /// Delegates `key immutable / version monotonic / schema-break-requires-

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -76,6 +76,15 @@ pub trait StatelessAction: Action {
     /// Output type produced on success (wrapped in [`ActionResult`]).
     type Output: Send + Sync;
 
+    /// Returns the schema for this action's input parameters.
+    /// Default: derives from `Input` via `HasSchema`.
+    fn schema() -> nebula_schema::ValidSchema
+    where
+        Self: Sized,
+    {
+        <Self::Input as nebula_schema::HasSchema>::schema()
+    }
+
     /// Execute the action with the given input and context.
     ///
     /// Returns [`ActionResult`] for flow control (Success, Skip, Branch, Wait, etc.)

--- a/crates/credential/Cargo.toml
+++ b/crates/credential/Cargo.toml
@@ -70,6 +70,7 @@ chrono = { workspace = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
 tracing = { workspace = true }
 humantime-serde = "1.1"
+semver = { workspace = true }
 
 # Caching
 lru = { workspace = true }
@@ -85,7 +86,6 @@ futures = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true, features = ["io-util", "macros", "net", "rt", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
-semver = { workspace = true }
 insta = { workspace = true }
 mockall = { workspace = true }
 pretty_assertions = { workspace = true }

--- a/crates/credential/src/contract/credential.rs
+++ b/crates/credential/src/contract/credential.rs
@@ -81,7 +81,7 @@ use crate::{
 ///     const KEY: &'static str = "slack_bot_token";
 ///
 ///     fn metadata() -> CredentialMetadata { /* ... */ }
-///     fn parameters() -> ValidSchema { /* ... */ }
+///     fn schema() -> ValidSchema { /* ... */ }
 ///     fn project(state: &SecretToken) -> SecretToken { state.clone() }
 ///
 ///     fn resolve(
@@ -98,7 +98,7 @@ use crate::{
 pub trait Credential: Send + Sync + 'static {
     /// Typed shape of the setup-form fields.
     ///
-    /// The canonical [`parameters()`](Credential::parameters) schema is
+    /// The canonical [`schema()`](Credential::schema) is
     /// auto-derived via `<Self::Input as HasSchema>::schema()`. Use
     /// [`FieldValues`] for legacy credentials that do not yet declare a
     /// typed input (the blanket [`HasSchema`](nebula_schema::HasSchema)
@@ -145,16 +145,29 @@ pub trait Credential: Send + Sync + 'static {
     where
         Self: Sized;
 
-    /// Parameter schema for the setup form.
+    /// Returns the schema for credential input parameters.
     ///
     /// The default implementation derives the schema from [`Self::Input`],
     /// which must implement [`HasSchema`](nebula_schema::HasSchema). Override
     /// only if the form layout must differ from the `Input` struct (rare).
-    fn parameters() -> ValidSchema
+    fn schema() -> ValidSchema
     where
         Self: Sized,
     {
         <Self::Input as nebula_schema::HasSchema>::schema()
+    }
+
+    /// Alias for backward compatibility.
+    ///
+    /// # Deprecated
+    ///
+    /// Use [`schema()`](Credential::schema) instead.
+    #[deprecated(since = "0.1.0", note = "use `schema()` instead")]
+    fn parameters() -> ValidSchema
+    where
+        Self: Sized,
+    {
+        Self::schema()
     }
 
     /// Extract consumer-facing auth material from stored state.

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -69,7 +69,7 @@ impl Credential for ApiKeyCredential {
             .key(nebula_core::credential_key!("api_key"))
             .name("API Key")
             .description("Static API key or bearer token for HTTP APIs.")
-            .schema(Self::parameters())
+            .schema(Self::schema())
             .pattern(crate::AuthPattern::SecretToken)
             .icon("key")
             .build()
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn parameters_contains_server_and_api_key() {
-        let params = ApiKeyCredential::parameters();
+        let params = ApiKeyCredential::schema();
         assert!(params.fields().iter().any(|f| f.key().as_str() == "server"));
         assert!(
             params
@@ -156,7 +156,7 @@ mod tests {
 
     #[test]
     fn server_is_optional() {
-        let params = ApiKeyCredential::parameters();
+        let params = ApiKeyCredential::schema();
         let server = params
             .fields()
             .iter()

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -54,7 +54,7 @@ impl Credential for BasicAuthCredential {
             .key(nebula_core::credential_key!("basic_auth"))
             .name("Basic Auth")
             .description("HTTP Basic authentication (username + password).")
-            .schema(Self::parameters())
+            .schema(Self::schema())
             .pattern(crate::AuthPattern::IdentityPassword)
             .icon("lock")
             .build()

--- a/crates/credential/src/credentials/oauth2/credential.rs
+++ b/crates/credential/src/credentials/oauth2/credential.rs
@@ -341,7 +341,7 @@ impl Credential for OAuth2Credential {
             .key(nebula_core::credential_key!("oauth2"))
             .name("OAuth2")
             .description("OAuth2 authentication supporting Authorization Code, Client Credentials, and Device Code grant types.")
-            .schema(Self::parameters())
+            .schema(Self::schema())
             .pattern(crate::AuthPattern::OAuth2)
             .icon("oauth2")
             .build()
@@ -775,7 +775,7 @@ mod tests {
 
     #[test]
     fn parameters_has_all_fields() {
-        let params = OAuth2Credential::parameters();
+        let params = OAuth2Credential::schema();
         let has = |k: &str| params.fields().iter().any(|f| f.key().as_str() == k);
         assert!(has("client_id"));
         assert!(has("client_secret"));

--- a/crates/credential/src/metadata/metadata.rs
+++ b/crates/credential/src/metadata/metadata.rs
@@ -1,6 +1,7 @@
 use nebula_core::CredentialKey;
 use nebula_metadata::{BaseMetadata, Metadata};
 use nebula_schema::ValidSchema;
+use semver::Version;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -67,14 +68,18 @@ impl CredentialMetadata {
         C: crate::Credential,
     {
         Self {
-            base: BaseMetadata::new(
-                key,
-                name,
-                description,
-                <C::Input as nebula_schema::HasSchema>::schema(),
-            ),
+            base: BaseMetadata::new(key, name, description, C::schema()),
             pattern,
         }
+    }
+
+    /// Set the interface version from `(major, minor)` components.
+    ///
+    /// Equivalent to setting `base.version = Version::new(major, minor, 0)`.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_version(mut self, major: u64, minor: u64) -> Self {
+        self.base.version = Version::new(major, minor, 0);
+        self
     }
 
     /// Start building credential metadata with the given required fields.

--- a/crates/engine/tests/credential_pending_lifecycle_tests.rs
+++ b/crates/engine/tests/credential_pending_lifecycle_tests.rs
@@ -81,7 +81,7 @@ impl Credential for InteractiveTestCredential {
             nebula_core::credential_key!("interactive_test"),
             "Interactive Test",
             "Test credential for pending lifecycle",
-            Self::parameters(),
+            Self::schema(),
             nebula_credential::AuthPattern::SecretToken,
         )
     }
@@ -148,7 +148,7 @@ impl Credential for RetryAwareCredential {
             nebula_core::credential_key!("retry_aware"),
             "Retry Aware",
             "Test credential for retry-poll pending lifecycle",
-            Self::parameters(),
+            Self::schema(),
             nebula_credential::AuthPattern::SecretToken,
         )
     }

--- a/crates/engine/tests/credential_thundering_herd_tests.rs
+++ b/crates/engine/tests/credential_thundering_herd_tests.rs
@@ -54,7 +54,7 @@ impl Credential for ThunderingHerdCredential {
             nebula_core::credential_key!("thundering_herd_test"),
             "Thundering Herd Test",
             "Test credential for thundering herd prevention",
-            Self::parameters(),
+            Self::schema(),
             nebula_credential::AuthPattern::SecretToken,
         )
     }

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -32,6 +32,7 @@ tokio-util = { workspace = true }
 # Core
 nebula-error = { workspace = true }
 arc-swap = { workspace = true }
+semver = { workspace = true }
 dashmap = { workspace = true }
 smallvec = { workspace = true }
 thiserror = { workspace = true }
@@ -39,7 +40,6 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
-semver = { workspace = true }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -90,6 +90,18 @@ pub enum MetadataCompatibilityError {
 
 impl ResourceMetadata {
     /// Build resource metadata with explicit catalog-level fields.
+    #[must_use]
+    pub fn builder(
+        key: ResourceKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> ResourceMetadataBuilder {
+        ResourceMetadataBuilder {
+            inner: Self::new(key, name, description, nebula_schema::ValidSchema::empty()),
+        }
+    }
+
+    /// Build resource metadata with explicit catalog-level fields.
     pub fn new(
         key: ResourceKey,
         name: impl Into<String>,
@@ -145,6 +157,37 @@ impl ResourceMetadata {
     ) -> Result<(), MetadataCompatibilityError> {
         nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
         Ok(())
+    }
+}
+
+/// Fluent builder for [`ResourceMetadata`].
+///
+/// Obtain one via [`ResourceMetadata::builder`] and call
+/// [`build`](ResourceMetadataBuilder::build) when done.
+#[derive(Debug, Clone)]
+pub struct ResourceMetadataBuilder {
+    inner: ResourceMetadata,
+}
+
+impl ResourceMetadataBuilder {
+    /// Set the configuration schema for this resource.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_schema(mut self, schema: nebula_schema::ValidSchema) -> Self {
+        self.inner.base.schema = schema;
+        self
+    }
+
+    /// Set the interface version from `(major, minor)` components.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_version(mut self, major: u64, minor: u64) -> Self {
+        self.inner.base.version = semver::Version::new(major, minor, 0);
+        self
+    }
+
+    /// Finalise the builder and return the [`ResourceMetadata`].
+    #[must_use]
+    pub fn build(self) -> ResourceMetadata {
+        self.inner
     }
 }
 
@@ -231,9 +274,27 @@ pub trait Resource: Send + Sync + 'static {
         async { Ok(()) }
     }
 
+    /// Returns the schema for this resource's configuration.
+    ///
+    /// Default: derives from `Config` via [`HasSchema`](nebula_schema::HasSchema).
+    fn schema() -> nebula_schema::ValidSchema
+    where
+        Self: Sized,
+    {
+        <Self::Config as nebula_schema::HasSchema>::schema()
+    }
+
     /// Returns metadata for UI and diagnostics.
-    fn metadata() -> ResourceMetadata {
-        ResourceMetadata::from_key(&Self::key())
+    fn metadata() -> ResourceMetadata
+    where
+        Self: Sized,
+    {
+        ResourceMetadata::new(
+            Self::key(),
+            Self::key().to_string(),
+            String::new(),
+            Self::schema(),
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

Unify the integration surface across the three core pillars — **Action**, **Credential**, and **Resource** — by adding a consistent n schema() method to each trait, and aligning their metadata builders for a symmetric developer experience.

## Changes

### Resource (
ebula-resource)
- Add n schema() to Resource trait with auto-derivation from Config
- Fix Resource::metadata() default to use derived schema instead of empty
- Add ResourceMetadataBuilder with fluent with_schema/with_version/uild

### Action (
ebula-action)
- Add n schema() to StatelessAction trait
- Add terminal .build() to ActionMetadata for API symmetry

### Credential (
ebula-credential)
- Add n schema() to Credential trait, deprecate parameters()
- Add fluent with_version to CredentialMetadata
- Update all internal callers from parameters() to schema()

### Engine tests
- Update credential_pending_lifecycle_tests.rs and credential_thundering_herd_tests.rs to use schema()

## Verification
- \cargo clippy --workspace\ — clean
- \cargo nextest run\ — 1083 tests pass
- \cargo +nightly fmt --all -- --check\ — clean