### PR TITLE
fix(resilience): bulkhead fail-fast, pipeline retry/sink, docs

### DIFF
--- a/crates/resilience/README.md
+++ b/crates/resilience/README.md
@@ -29,16 +29,16 @@ yet implemented.
 
 ## Public API
 
-- `ResiliencePipeline<E>` — composable pipeline builder: `.timeout()`, `.retry()`, `.circuit_breaker()`, `.bulkhead()`, `.rate_limit()`, `.fallback()`, `.hedge()`, `.build()`.
+- `ResiliencePipeline<E>` — composable pipeline: `.classifier()`, `.classify_errors()`, `.with_sink()`, `.timeout()`, `.retry()`, `.circuit_breaker()`, `.bulkhead()`, `.rate_limiter()` / `.rate_limiter_from()`, `.load_shed()`, then `.build()`. Hedging stays in the `hedge` module (no `.hedge()` builder step on the pipeline). For graceful degradation after the pipeline returns, use `ResiliencePipeline::call_with_fallback` (separate from the builder).
 - `CallError<E>` — wrapper error returned by all pipeline calls; no type erasure, no forced mapping.
 - `retry::RetryConfig`, `retry::BackoffConfig`, `retry::retry_with` — standalone retry with `Classify`-aware error filtering.
 - `circuit_breaker::CircuitBreaker`, `circuit_breaker::CircuitBreakerConfig` — half-open/open/closed state machine.
 - `bulkhead::Bulkhead`, `bulkhead::BulkheadConfig` — concurrency-limiting bulkhead.
 - `rate_limiter::RateLimiter` (+ optional `governor` feature for GCRA algorithm).
-- `timeout::timeout` — standalone timeout combinator.
-- `fallback::Fallback` — default-value fallback on failure.
-- `hedge::Hedge` — speculative execution (hedged requests).
-- `observe::ObservabilityHooks` — observability hooks for pipeline events.
+- `timeout::{timeout, TimeoutExecutor}` and `load_shed::{load_shed, load_shed_with_sink}` — standalone timeout / load-shed combinators.
+- `fallback::{FallbackStrategy, ValueFallback, FunctionFallback, CacheFallback, ChainFallback, PriorityFallback, FallbackOperation}` — graceful degradation strategies.
+- `hedge::{HedgeConfig, HedgeExecutor, AdaptiveHedgeExecutor}` — speculative execution (hedged requests).
+- `sink::{MetricsSink, ResilienceEvent, ResilienceEventKind, RecordingSink}` — observability hooks for pipeline and pattern events.
 
 ## Contract
 
@@ -57,7 +57,7 @@ yet implemented.
 See `docs/MATURITY.md` row for `nebula-resilience`.
 
 - API stability: `stable` — `ResiliencePipeline`, `RetryConfig`, `CircuitBreaker`, and `CallError` are in active use; benchmarks cover all seven patterns.
-- Observability hooks and `hedge` pattern are newer and may have minor API refinements.
+- `MetricsSink`-based observability hooks and hedge-related APIs are newer and may still get minor refinements.
 
 ## Related
 
@@ -70,10 +70,11 @@ See `docs/MATURITY.md` row for `nebula-resilience`.
 Extended documentation lives in `crates/resilience/docs/`:
 
 - `README.md` — overview and pattern guide
-- `PATTERNS.md` — per-pattern usage
+- `docs/README.md` — overview and feature matrix
 - `api-reference.md` — full API surface reference
 - `composition.md` — pipeline composition guide
 - `observability.md` — observability hooks
+- `gate.md` — cooperative shutdown barrier
 - `architecture.md` — internal architecture notes
 
 ```bash

--- a/crates/resilience/docs/api-reference.md
+++ b/crates/resilience/docs/api-reference.md
@@ -1,28 +1,7 @@
 # nebula-resilience — API Reference
 
-Complete public API reference. All types live in `nebula_resilience` unless noted.
-
----
-
-## Table of Contents
-
-- [Core Types](#core-types)
-- [Circuit Breaker](#circuit-breaker)
-- [Retry](#retry)
-- [Bulkhead](#bulkhead)
-- [Rate Limiter](#rate-limiter)
-- [Timeout](#timeout)
-- [Fallback](#fallback)
-- [Hedge](#hedge)
-- [Load Shed](#load-shed)
-- [Gate](#gate)
-- [Pipeline](#pipeline)
-- [Sink / Events](#sink--events)
-- [Observability Hooks](#observability-hooks)
-- [Signals](#signals)
-- [Policy Source](#policy-source)
-- [Cancellation](#cancellation)
-- [Prelude / Re-exports](#prelude--re-exports)
+This document tracks the current public surface of `nebula-resilience`.
+For exhaustive item-level details, prefer the generated rustdoc from `src/lib.rs`.
 
 ---
 
@@ -30,571 +9,341 @@ Complete public API reference. All types live in `nebula_resilience` unless note
 
 ### `CallError<E>`
 
-Returned by all resilience operations. `E` is the caller's own error type.
-
-```rust
-pub enum CallError<E> {
-    /// The operation returned an error (possibly after retries).
-    Operation(E),
-    /// Circuit breaker is open — request rejected immediately.
-    CircuitOpen,
-    /// Bulkhead is at capacity — request rejected.
-    BulkheadFull,
-    /// Timeout elapsed before the operation completed.
-    Timeout(Duration),
-    /// All retry attempts exhausted.
-    RetriesExhausted { attempts: u32, last: E },
-    /// Operation was cancelled.
-    Cancelled { reason: Option<String> },
-    /// Load shed — system is overloaded, request rejected.
-    LoadShed,
-    /// Rate limit exceeded.
-    RateLimited { retry_after: Option<Duration> },
-    /// The fallback strategy itself failed.
-    FallbackFailed { reason: Option<String> },
-}
-
-impl<E> CallError<E> {
-    /// True only if this is a `Cancelled` variant.
-    pub const fn is_cancellation(&self) -> bool;
-
-    /// All pattern errors return false — operation retryability is predicate-driven.
-    pub const fn is_retriable(&self) -> bool;
-
-    /// Map the inner operation error, leaving pattern errors unchanged.
-    pub fn map_operation<F, E2>(self, f: F) -> CallError<E2>
-    where F: FnOnce(E) -> E2;
-
-    /// Map the inner error with a fallible function that can also produce a `CallError`.
-    pub fn flat_map_inner<E2>(self, f: impl FnOnce(E) -> CallError<E2>) -> CallError<E2>;
-}
-```
-
----
-
-### `ConfigError`
-
-Returned by pattern constructors when configuration is invalid.
-
-```rust
-#[derive(Debug, Clone, thiserror::Error)]
-#[error("invalid resilience config: {message}")]
-pub struct ConfigError {
-    pub field: &'static str,
-    pub message: String,
-}
-
-impl ConfigError {
-    pub fn new(field: &'static str, message: impl Into<String>) -> Self;
-}
-```
-
----
-
-### `CallResult<T, E>`
-
-```rust
-pub type CallResult<T, E> = Result<T, CallError<E>>;
-```
-
----
-
-## Circuit Breaker
-
-### `CircuitBreakerConfig`
-
-Plain struct, `Serialize` / `Deserialize`, `Default`.
-
-```rust
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct CircuitBreakerConfig {
-    pub failure_threshold: u32,         // Min: 1. Default: 5
-    pub reset_timeout: Duration,         // Default: 30s
-    pub max_half_open_operations: u32,   // Default: 1
-    pub min_operations: u32,             // Default: 5
-    pub failure_rate_threshold: f64,     // 0.0..=1.0, validated but not yet used. Default: 0.5
-    pub sliding_window: Duration,        // Default: 60s
-    pub count_timeouts_as_failures: bool,// Default: true
-}
-
-impl CircuitBreakerConfig {
-    /// Validate. Called internally by CircuitBreaker::new().
-    pub fn validate(&self) -> Result<(), ConfigError>;
-}
-```
-
----
-
-### `CircuitBreaker`
-
-```rust
-impl CircuitBreaker {
-    pub fn new(config: CircuitBreakerConfig) -> Result<Self, ConfigError>;
-
-    /// New with custom sink for observability.
-    pub fn with_sink(config: CircuitBreakerConfig, sink: Arc<dyn MetricsSink>)
-        -> Result<Self, ConfigError>;
-
-    /// Execute the operation through the circuit breaker.
-    pub async fn call<T, E, F, Fut>(&self, f: F) -> Result<T, CallError<E>>
-    where
-        F: Fn() -> Fut + Send + Sync,
-        Fut: Future<Output = Result<T, E>> + Send,
-        T: Send;
-
-    /// Manually record an outcome (for use with non-closure-based callers).
-    pub fn record_outcome(&self, outcome: Outcome);
-
-    /// Current circuit state.
-    pub fn state(&self) -> CircuitState;
-}
-```
-
-### `Outcome`
-
-```rust
-#[derive(Debug, Clone, Copy)]
-pub enum Outcome {
-    Success,
-    Failure,
-    Timeout,
-}
-```
-
----
-
-## Retry
-
-### `BackoffConfig`
-
-```rust
-#[derive(Debug, Clone)]
-pub enum BackoffConfig {
-    Fixed(Duration),
-    Linear { base: Duration, max: Duration },
-    Exponential { base: Duration, multiplier: f64, max: Duration },
-}
-
-impl BackoffConfig {
-    /// Standard exponential: 100ms base, 2× multiplier, 30s cap.
-    pub const fn exponential_default() -> Self;
-}
-```
-
----
-
-### `JitterConfig`
-
-```rust
-#[derive(Debug, Clone, Default)]
-pub enum JitterConfig {
-    #[default]
-    None,
-    /// Add a random fraction up to `factor` (0.0–1.0) of the delay.
-    Full { factor: f64 },
-}
-```
-
----
-
-### `RetryConfig<E>`
-
-```rust
-impl<E: Send + 'static> RetryConfig<E> {
-    /// Create with `max_attempts`. Returns `Err(ConfigError)` if 0.
-    pub fn new(max_attempts: u32) -> Result<Self, ConfigError>;
-
-    /// Set backoff strategy.
-    pub fn backoff(self, config: BackoffConfig) -> Self;
-
-    /// Set jitter.
-    pub fn jitter(self, config: JitterConfig) -> Self;
-
-    /// Set a predicate controlling which errors are retried.
-    /// By default all errors are retried.
-    pub fn retry_if(self, predicate: impl Fn(&E) -> bool + Send + Sync + 'static) -> Self;
-}
-```
-
----
-
-### Free functions
-
-```rust
-/// Retry `f` up to `n` times with exponential_default() backoff, retrying all errors.
-pub async fn retry<T, E, F, Fut>(n: NonZeroU32, f: F) -> Result<T, CallError<E>>
-where
-    F: Fn() -> Fut,
-    Fut: Future<Output = Result<T, E>>,
-    E: Send + 'static;
-
-/// Retry `f` using explicit `config`.
-pub async fn retry_with<T, E, F, Fut>(
-    config: RetryConfig<E>,
-    f: F,
-) -> Result<T, CallError<E>>
-where
-    F: Fn() -> Fut + Send + Sync + 'static,
-    Fut: Future<Output = Result<T, E>> + Send,
-    T: Send + 'static,
-    E: Send + 'static;
-```
-
----
-
-## Bulkhead
-
-### `BulkheadConfig`
-
-```rust
-pub struct BulkheadConfig {
-    pub max_concurrency: usize,     // Default: 10
-    pub queue_size: usize,          // Default: 100
-    pub timeout: Option<Duration>,  // Default: Some(30s)
-}
-```
-
----
-
-### `Bulkhead`
-
-```rust
-impl Bulkhead {
-    pub fn new(max_concurrency: usize) -> Self;
-    pub fn with_config(config: BulkheadConfig) -> Self;
-
-    pub async fn call<T, E, F, Fut>(&self, f: F) -> Result<T, CallError<E>>
-    where
-        F: Fn() -> Fut + Send + Sync,
-        Fut: Future<Output = Result<T, E>> + Send,
-        T: Send;
-
-    pub fn active_operations(&self) -> usize;
-    pub fn available_permits(&self) -> usize;
-    pub fn max_concurrency(&self) -> usize;
-    pub fn is_at_capacity(&self) -> bool;
-}
-```
-
----
-
-## Rate Limiter
-
-### `RateLimiter` trait
-
-```rust
-pub trait RateLimiter: Send + Sync {
-    fn acquire(&self) -> impl Future<Output = Result<(), CallError<()>>> + Send;
-
-    /// Acquire then call. Default impl calls `acquire()` then the operation.
-    fn call<T, E, F, Fut>(&self, operation: F)
-        -> impl Future<Output = Result<T, CallError<E>>> + Send
-    where
-        F: FnOnce() -> Fut + Send,
-        Fut: Future<Output = Result<T, E>> + Send,
-        T: Send;
-}
-```
-
-### Implementations
-
-| Type | Algorithm | Constructor |
-|------|-----------|-------------|
-| `TokenBucket` | Token bucket | `TokenBucket::new(capacity: usize, refill_rate: f64)` |
-| `LeakyBucket` | Leaky bucket | `LeakyBucket::new(capacity: usize, leak_rate: f64)` |
-| `SlidingWindow` | Sliding time window | `SlidingWindow::new(max_requests: usize, window: Duration)` |
-| `AdaptiveRateLimiter` | Error-rate adaptive | `AdaptiveRateLimiter::new(base_rate: f64)` |
-
----
-
-## Timeout
-
-```rust
-/// Hard deadline. Returns Err(CallError::Timeout) on expiry.
-pub async fn timeout<T, E, F>(
-    duration: Duration,
-    future: F,
-) -> Result<T, CallError<E>>
-where
-    F: Future<Output = Result<T, E>>;
-
-pub struct TimeoutExecutor {
-    pub duration: Duration,
-}
-
-impl TimeoutExecutor {
-    pub fn new(duration: Duration) -> Self;
-    pub async fn call<T, E, F, Fut>(&self, f: F) -> Result<T, CallError<E>>
-    where …;
-}
-```
-
----
-
-## Fallback
-
-### `FallbackStrategy<T, E>`
-
-```rust
-pub trait FallbackStrategy<T, E>: Send + Sync {
-    fn fallback<'a>(&'a self, error: CallError<E>)
-        -> Pin<Box<dyn Future<Output = Result<T, CallError<E>>> + Send + 'a>>;
-    fn should_fallback(&self, error: &CallError<E>) -> bool { true }
-}
-```
-
-Returns `CallError::FallbackFailed` if the fallback itself fails.
-
-### `ValueFallback<T>`
-
-Returns a cloned constant value:
-
-```rust
-let fallback = ValueFallback::new("default".to_string());
-```
-
-### `ChainFallback<T, E>`
-
-Chains multiple fallback strategies, trying each in order:
-
-```rust
-let chain = ChainFallback::new()
-    .then(Arc::new(first_fallback))
-    .then(Arc::new(second_fallback));
-```
-
----
-
-## Hedge
-
-### `HedgeConfig`
-
-```rust
-pub struct HedgeConfig {
-    pub hedge_delay: Duration,       // Default: 50ms
-    pub max_hedges: usize,           // Default: 2
-    pub exponential_backoff: bool,   // Default: true
-    pub backoff_multiplier: f64,     // Default: 2.0
-}
-```
-
-### `HedgeExecutor`
-
-```rust
-impl HedgeExecutor {
-    pub fn new(config: HedgeConfig) -> Result<Self, ConfigError>;
-
-    pub async fn call<T, E, F, Fut>(&self, operation: F) -> Result<T, CallError<E>>
-    where
-        F: Fn() -> Fut + Send + Sync,
-        Fut: Future<Output = Result<T, E>> + Send,
-        T: Send;
-}
-```
-
----
-
-## Load Shed
-
-```rust
-/// Reject immediately when `should_shed()` returns true.
-///
-/// Returns Err(CallError::LoadShed) if shed, otherwise executes f().
-pub async fn load_shed<T, E, S, F>(
-    should_shed: S,
-    f: F,
-) -> Result<T, CallError<E>>
-where
-    S: Fn() -> bool,
-    F: FnOnce() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>>;
-```
-
-Integrate with `LoadSignal` for adaptive decisions:
-
-```rust
-let signal: Arc<dyn LoadSignal> = …;
-let result = load_shed(
-    || signal.load_factor() > 0.9,
-    || Box::pin(do_work()),
-).await;
-```
-
----
-
-## Gate
-
-See [gate.md](gate.md) for full usage guide.
-
-```rust
-pub struct Gate;  // Clone — all clones share the same underlying state
-
-impl Gate {
-    pub fn new() -> Self;
-    pub fn enter(&self) -> Result<GateGuard, GateClosed>;
-    pub async fn close(&self);
-    pub fn is_closed(&self) -> bool;
-}
-
-pub struct GateGuard;  // RAII; returns one permit on drop
-
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-#[non_exhaustive]
-#[error("gate is closed — new enter() calls are rejected")]
-pub struct GateClosed;
-```
+Returned by every resilience pattern and by `ResiliencePipeline`.
+
+Variants:
+
+- `Operation(E)`
+- `CircuitOpen`
+- `BulkheadFull`
+- `Timeout(Duration)`
+- `RetriesExhausted { attempts, last }`
+- `Cancelled { reason }`
+- `LoadShed`
+- `RateLimited { retry_after }`
+- `FallbackFailed { reason }`
+
+Helpers on `CallError<E>`:
+
+- `cancelled()`, `cancelled_with(reason)`
+- `fallback_failed()`, `fallback_failed_with(reason)`
+- `rate_limited()`, `rate_limited_after(duration)`
+- `is_retryable()`
+- `is_cancellation()`
+- `into_operation()`, `operation()`
+- `map_operation()`, `flat_map_inner()`
+- `retry_after()`
+- `kind() -> CallErrorKind`
+
+Related types:
+
+- `CallErrorKind`
+- `CallResult<T, E>`
+- `ConfigError { field, message }`
 
 ---
 
 ## Pipeline
 
-See [composition.md](composition.md) for full guide.
+Root re-exports:
 
-```rust
-pub struct PipelineBuilder<E: 'static> { … }
+- `ResiliencePipeline<E>`
+- `PipelineBuilder<E>`
+- `RateLimitCheck`
+- `LoadShedPredicate`
 
-impl<E: Send + 'static> PipelineBuilder<E> {
-    pub const fn new() -> Self;
+`PipelineBuilder<E>` methods:
 
-    #[must_use] pub fn timeout(self, d: Duration) -> Self;
-    #[must_use] pub fn retry(self, config: RetryConfig<E>) -> Self;
-    #[must_use] pub fn circuit_breaker(self, cb: Arc<CircuitBreaker>) -> Self;
-    #[must_use] pub fn bulkhead(self, bh: Arc<Bulkhead>) -> Self;
+- `new()`
+- `classifier(Arc<dyn ErrorClassifier<E>>)`
+- `classify_errors()` when `E: nebula_error::Classify`
+- `with_sink(sink)`
+- `timeout(duration)`
+- `retry(config)`
+- `circuit_breaker(Arc<CircuitBreaker>)`
+- `bulkhead(Arc<Bulkhead>)`
+- `rate_limiter(check)`
+- `rate_limiter_from(Arc<impl RateLimiter>)`
+- `load_shed(predicate)`
+- `build()`
 
-    /// Emits tracing::warn! if timeout is inside retry.
-    #[must_use] pub fn build(self) -> ResiliencePipeline<E>;
-}
+`ResiliencePipeline<E>` methods:
 
-pub struct ResiliencePipeline<E: 'static> { … }
+- `builder()`
+- `call(factory)`
+- `call_with_fallback(factory, &dyn FallbackStrategy<T, E>)`
 
-impl<E: Send + 'static> ResiliencePipeline<E> {
-    pub const fn builder() -> PipelineBuilder<E>;
+Notes:
 
-    pub async fn call<T, F>(&self, f: F) -> Result<T, CallError<E>>
-    where
-        T: Send + 'static,
-        F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>>
-            + Clone + Send + Sync + 'static;
-}
-```
-
----
-
-## Sink / Events
-
-See [observability.md](observability.md) for full guide.
-
-```rust
-pub trait MetricsSink: Send + Sync {
-    fn record(&self, event: ResilienceEvent);
-}
-
-pub struct NoopSink;    // default, zero cost
-pub struct RecordingSink;
-
-impl RecordingSink {
-    pub fn new() -> Self;
-    pub fn events(&self) -> Vec<ResilienceEvent>;
-    pub fn count(&self, kind: ResilienceEventKind) -> usize;
-    pub fn has_state_change(&self, to: CircuitState) -> bool;
-}
-
-pub enum ResilienceEvent {
-    CircuitStateChanged { from: CircuitState, to: CircuitState },
-    RetryAttempt { attempt: u32, will_retry: bool },
-    BulkheadRejected,
-    TimeoutElapsed { duration: Duration },
-    HedgeFired { hedge_number: u32 },
-    RateLimitExceeded,
-    LoadShed,
-}
-
-impl ResilienceEvent {
-    /// Returns the kind discriminant for counting / filtering.
-    pub const fn kind(&self) -> ResilienceEventKind;
-}
-
-#[non_exhaustive]
-pub enum ResilienceEventKind {
-    CircuitStateChanged,
-    RetryAttempt,
-    BulkheadRejected,
-    TimeoutElapsed,
-    HedgeFired,
-    RateLimitExceeded,
-    LoadShed,
-}
-
-pub enum CircuitState { Closed, Open, HalfOpen }
-```
+- First added step is the outermost wrapper.
+- Recommended order: `load_shed -> rate_limiter -> timeout -> retry -> circuit_breaker -> bulkhead`.
+- Pipeline retry preserves `RetryConfig` backoff, jitter, classifier / predicate, callback, sink, and total budget.
+- Pipeline retry does not apply `retry_hint().after` as a delay floor; use standalone `retry_with()` when you need per-error retry-after handling.
+- `with_sink()` records pipeline-level `TimeoutElapsed`, `RateLimitExceeded`, and `LoadShed` events.
 
 ---
 
-## Policy (Signals + Policy Source)
+## Retry
 
-```rust
-pub trait LoadSignal: Send + Sync {
-    fn load_factor(&self) -> f64;   // 0.0 idle .. 1.0 saturated
-    fn error_rate(&self) -> f64;    // 0.0..1.0
-    fn p99_latency(&self) -> Duration;
-}
+Root re-exports:
 
-pub struct ConstantLoad {
-    pub factor: f64,
-    pub error_rate: f64,
-    pub p99_latency: Duration,
-}
+- `retry(n, factory)`
+- `retry_with(config, factory)`
+- `RetryConfig<E>`
+- `BackoffConfig`
+- `JitterConfig`
 
-impl ConstantLoad {
-    pub const fn idle() -> Self;      // 0% load, 0% errors, 5ms latency
-    pub const fn saturated() -> Self; // 100% load, 50% errors, 2s latency
-}
-```
+`RetryConfig<E>` builder methods:
 
-### `PolicySource<C>`
+- `new(max_attempts) -> Result<Self, ConfigError>`
+- `backoff(BackoffConfig)`
+- `jitter(JitterConfig)`
+- `total_budget(Duration)`
+- `with_classifier(Arc<dyn ErrorClassifier<E>>)`
+- `retry_if(predicate)`
+- `on_retry(callback)`
+- `with_sink(sink)`
 
-```rust
-pub trait PolicySource<C: Clone>: Send + Sync {
-    fn current(&self) -> C;
-}
+`BackoffConfig` variants:
 
-// Blanket impl — any Clone + Send + Sync value is a static PolicySource.
-impl<C: Clone + Send + Sync> PolicySource<C> for C { … }
-```
+- `Fixed(Duration)`
+- `Linear { base, max }`
+- `Exponential { base, multiplier, max }`
+- `Fibonacci { base, max }`
+- `Custom(SmallVec<[Duration; 8]>)`
 
-All types in this section live in the `policy` module.
+`JitterConfig` variants:
 
----
-
-## Cancellation
-
-```rust
-pub struct CancellationContext { … }
-
-impl CancellationContext {
-    pub fn from_token(token: tokio_util::sync::CancellationToken) -> Self;
-    pub fn is_cancelled(&self) -> bool;
-}
-```
+- `None`
+- `Full { factor, seed }`
 
 ---
 
-## Re-exports
+## Circuit Breaker
 
-`use nebula_resilience::*;` provides:
+Root re-exports:
 
-- `CallError<E>`, `CallErrorKind`, `CallResult<T, E>`, `ConfigError`
-- `CancellationContext`, `CancellableFuture`, `CancellationExt`
-- `PolicySource`, `LoadSignal`, `ConstantLoad`
-- `Bulkhead`, `BulkheadConfig`
-- `CircuitBreaker`, `CircuitBreakerConfig`
-- `FallbackStrategy`, `ValueFallback`
-- `HedgeConfig`, `HedgeExecutor`
-- `load_shed`
-- `AdaptiveRateLimiter`, `LeakyBucket`, `RateLimiter`, `SlidingWindow`, `TokenBucket`
-- `BackoffConfig`, `JitterConfig`, `RetryConfig`, `retry`, `retry_with`
-- `TimeoutExecutor`, `timeout`
-- `CircuitState`, `MetricsSink`, `NoopSink`, `RecordingSink`, `ResilienceEvent`, `ResilienceEventKind`
-- `Gate`, `GateClosed`, `GateGuard`
-- `PipelineBuilder`, `ResiliencePipeline`, `LoadShedPredicate`, `RateLimitCheck`
+- `CircuitBreaker`
+- `CircuitBreakerConfig`
 
-Note: `Outcome` is not re-exported at the crate root — use `circuit_breaker::Outcome`.
+`CircuitBreakerConfig` fields:
+
+- `failure_threshold`
+- `reset_timeout`
+- `max_half_open_operations`
+- `min_operations`
+- `count_timeouts_as_failures`
+- `break_duration_multiplier`
+- `max_break_duration`
+- `slow_call_threshold`
+- `slow_call_rate_threshold`
+- `sliding_window_size`
+- `failure_rate_threshold`
+
+Key `CircuitBreaker` methods:
+
+- `new(config) -> Result<Self, ConfigError>`
+- `with_sink(sink)`
+- `with_clock(clock)`
+- `call(factory)`
+- `call_with_classifier(factory, classifier)`
+- `try_acquire()`
+- `record_outcome(outcome)`
+- `circuit_state()`
+- `stats()`
+- `force_open()`
+- `force_close()`
+
+Module-level public type:
+
+- `circuit_breaker::Outcome`
+
+---
+
+## Bulkhead
+
+Root re-exports:
+
+- `Bulkhead`
+- `BulkheadConfig`
+
+`BulkheadConfig` fields:
+
+- `max_concurrency`
+- `queue_size`
+- `timeout`
+
+Key methods:
+
+- `Bulkhead::new(config) -> Result<Self, ConfigError>`
+- `with_sink(sink)`
+- `call(factory)`
+- `acquire()`
+- `stats()`
+- `active_operations()`
+- `available_permits()`
+- `is_at_capacity()`
+- `max_concurrency()`
+
+Queueing:
+
+- `queue_size` may be `0` (no wait queue: if no permit is free, return `BulkheadFull` immediately).
+- When `queue_size` is at least `1`, that many callers may wait for a permit; further callers get `BulkheadFull`.
+
+---
+
+## Rate Limiting
+
+Root re-exports:
+
+- `RateLimiter`
+- `TokenBucket`
+- `LeakyBucket`
+- `SlidingWindow`
+- `AdaptiveRateLimiter`
+
+Feature-gated module export:
+
+- `rate_limiter::GovernorRateLimiter` with feature `governor`
+
+Constructors:
+
+- `TokenBucket::new(capacity, refill_rate)`
+- `LeakyBucket::new(capacity, leak_rate)`
+- `SlidingWindow::new(window_duration, max_requests)`
+- `AdaptiveRateLimiter::new(initial_rate, min_rate, max_rate)`
+- `GovernorRateLimiter::new(rate_per_second, burst_capacity)` when enabled
+
+Notable extras:
+
+- `TokenBucket::with_burst()`, `update_rate()`, `update_burst()`
+- `AdaptiveRateLimiter::record_success()`, `record_error()`
+
+---
+
+## Timeout and Load Shedding
+
+Root re-exports:
+
+- `timeout(duration, future)`
+- `TimeoutExecutor`
+- `load_shed(predicate, factory)`
+- `load_shed_with_sink(predicate, factory, sink)`
+
+Notable methods:
+
+- `TimeoutExecutor::new(duration)`
+- `TimeoutExecutor::with_sink(sink)`
+- `TimeoutExecutor::call(future)`
+
+Notes:
+
+- `timeout_with_sink()` exists in the `timeout` module and is used by `TimeoutExecutor`.
+- `load_shed_with_sink()` emits `ResilienceEvent::LoadShed`.
+
+---
+
+## Fallbacks
+
+Public module: `nebula_resilience::fallback`
+
+Root re-exports:
+
+- `FallbackStrategy<T, E>`
+- `ValueFallback<T>`
+
+Module types:
+
+- `FunctionFallback<T, F, Fut>`
+- `CacheFallback<T>`
+- `ChainFallback<T, E>`
+- `PriorityFallback<T, E>`
+- `FallbackOperation<T, E>`
+
+---
+
+## Hedging
+
+Root re-exports:
+
+- `HedgeConfig`
+- `HedgeExecutor`
+
+Public module: `nebula_resilience::hedge`
+
+Additional module type:
+
+- `AdaptiveHedgeExecutor`
+
+Notable methods:
+
+- `HedgeExecutor::new(config) -> Result<Self, ConfigError>`
+- `HedgeExecutor::with_sink(sink)`
+- `HedgeExecutor::call(factory)`
+- `AdaptiveHedgeExecutor::new(config) -> Result<Self, ConfigError>`
+- `AdaptiveHedgeExecutor::with_target_percentile(percentile)`
+- `AdaptiveHedgeExecutor::with_max_samples(max_samples)`
+- `AdaptiveHedgeExecutor::with_sink(sink)`
+- `AdaptiveHedgeExecutor::call(factory)`
+
+Important caveat:
+
+- Hedged calls are intentionally not cancel-safe; dropping the returned future does not automatically stop already-spawned hedge tasks.
+
+---
+
+## Cancellation and Gate
+
+Root re-exports:
+
+- `CancellationContext`
+- `CancellableFuture<F>`
+- `CancellationExt`
+- `Gate`
+- `GateGuard`
+- `GateClosed`
+
+Notable methods:
+
+- `CancellationContext::new()`
+- `CancellationContext::with_reason(reason)`
+- `CancellationContext::child()`
+- `CancellationContext::cancel()`
+- `CancellationContext::call(factory)`
+- `CancellationContext::call_with_timeout(factory, timeout)`
+- `Gate::new()`
+- `Gate::enter()`
+- `Gate::close()`
+
+---
+
+## Observability and Policy
+
+Root re-exports:
+
+- `MetricsSink`
+- `NoopSink`
+- `RecordingSink`
+- `ResilienceEvent`
+- `ResilienceEventKind`
+- `CircuitState`
+- `PolicySource<C>`
+- `LoadSignal`
+- `ConstantLoad`
+
+`ResilienceEvent` variants:
+
+- `CircuitStateChanged { from, to }`
+- `RetryAttempt { attempt, will_retry }`
+- `BulkheadRejected`
+- `TimeoutElapsed { duration }`
+- `HedgeFired { hedge_number }`
+- `RateLimitExceeded`
+- `LoadShed`
+
+`RecordingSink` helpers:
+
+- `new()`
+- `events()`
+- `count(kind)`
+- `has_state_change(state)`

--- a/crates/resilience/docs/composition.md
+++ b/crates/resilience/docs/composition.md
@@ -51,7 +51,10 @@ let cb = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
     ..Default::default()
 })?);
 
-let bh = Arc::new(Bulkhead::new(20));
+let bh = Arc::new(Bulkhead::new(BulkheadConfig {
+    max_concurrency: 20,
+    ..Default::default()
+})?);
 
 let pipeline = ResiliencePipeline::<MyError>::builder()
     .timeout(Duration::from_secs(10))
@@ -78,6 +81,10 @@ impl<E: Send + 'static> PipelineBuilder<E> {
     /// Add a retry step with explicit config.
     #[must_use]
     pub fn retry(self, config: RetryConfig<E>) -> Self
+
+    /// Inject a sink for pipeline-level timeout / rate-limit / load-shed events.
+    #[must_use]
+    pub fn with_sink(self, sink: impl MetricsSink + 'static) -> Self
 
     /// Add a circuit breaker step. Takes Arc so it can be shared / inspected externally.
     #[must_use]
@@ -138,10 +145,9 @@ retry step receives:
 
 ### `CircuitBreaker` and `Bulkhead` unwrapping
 
-These steps call the remaining pipeline through an `unwrap_inner` shim that maps
-`Ok(v)` and `Err(Operation(e))` to the `Result<T, E>` their `.call()` methods expect.
-Any other `CallError` variant inside a `CircuitBreaker` or `Bulkhead` step is
-**unreachable** in a correctly ordered pipeline (timeout and retry must be outside).
+These steps operate on the shared `CallError<E>` model from the inner pipeline.
+Structural errors such as `CircuitOpen`, `BulkheadFull`, `Timeout`, `RateLimited`,
+and `LoadShed` propagate unchanged rather than being retried as operation failures.
 
 ---
 
@@ -193,7 +199,10 @@ let cb = Arc::new(CircuitBreaker::new(CircuitBreakerConfig {
     ..Default::default()
 })?);
 
-let bh = Arc::new(Bulkhead::new(20));
+let bh = Arc::new(Bulkhead::new(BulkheadConfig {
+    max_concurrency: 20,
+    ..Default::default()
+})?);
 
 let pipeline = ResiliencePipeline::<reqwest::Error>::builder()
     .timeout(Duration::from_secs(10))
@@ -213,7 +222,7 @@ let response = pipeline.call(|| Box::pin(async {
 
 ### Sharing a pipeline across concurrent tasks
 
-`ResiliencePipeline` is `Clone` (internal state is `Arc`):
+Wrap the pipeline in `Arc` when you want to share it across concurrent tasks:
 
 ```rust
 let pipeline = Arc::new(
@@ -237,9 +246,10 @@ use nebula_resilience::sink::{RecordingSink, ResilienceEventKind};
 use nebula_resilience::circuit_breaker::CircuitBreaker;
 use std::sync::Arc;
 
-let sink = Arc::new(RecordingSink::new());
+let sink = RecordingSink::new();
 let cb = Arc::new(
-    CircuitBreaker::with_sink(CircuitBreakerConfig::default(), sink.clone())?
+    CircuitBreaker::new(CircuitBreakerConfig::default())?
+        .with_sink(sink.clone())
 );
 
 // ... run pipeline ...

--- a/crates/resilience/docs/observability.md
+++ b/crates/resilience/docs/observability.md
@@ -80,10 +80,10 @@ pub enum CircuitState {
 For test assertions — records all events in memory:
 
 ```rust
-let sink = Arc::new(RecordingSink::new());
+let sink = RecordingSink::new();
 
 // Inject into CircuitBreaker
-let cb = CircuitBreaker::with_sink(config, sink.clone())?;
+let cb = CircuitBreaker::new(config)?.with_sink(sink.clone());
 
 // ... run operations ...
 
@@ -115,13 +115,14 @@ Use `event.kind()` to get the `ResilienceEventKind` from a `ResilienceEvent`.
 
 ## Injecting a Sink
 
-Currently `CircuitBreaker` accepts a sink via `with_sink()`. Other patterns use the
-sink at construction time where applicable.
+Sink injection is available on the pattern types that own their own observability
+(`CircuitBreaker`, `Bulkhead`, `RetryConfig`, `HedgeExecutor`, `AdaptiveHedgeExecutor`,
+`TimeoutExecutor`) and on `ResiliencePipeline::with_sink()` for pipeline-level timeout /
+rate-limit / load-shed events.
 
 ```rust
 use nebula_resilience::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use nebula_resilience::sink::{MetricsSink, ResilienceEvent};
-use std::sync::Arc;
 
 struct PrometheusSink { /* ... */ }
 
@@ -139,8 +140,8 @@ impl MetricsSink for PrometheusSink {
     }
 }
 
-let sink = Arc::new(PrometheusSink { /* ... */ });
-let cb = CircuitBreaker::with_sink(CircuitBreakerConfig::default(), sink)?;
+let cb = CircuitBreaker::new(CircuitBreakerConfig::default())?
+    .with_sink(PrometheusSink { /* ... */ });
 ```
 
 ---
@@ -152,20 +153,17 @@ Complete observability setup for a production service:
 ```rust
 use nebula_resilience::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use nebula_resilience::sink::{MetricsSink, RecordingSink, ResilienceEventKind};
-use std::sync::Arc;
 use std::time::Duration;
 
 // MetricsSink for structured events
-let sink = Arc::new(RecordingSink::new()); // or your custom impl
+let sink = RecordingSink::new(); // or your custom impl
 
-let cb = CircuitBreaker::with_sink(
-    CircuitBreakerConfig {
+let cb = CircuitBreaker::new(CircuitBreakerConfig {
         failure_threshold: 5,
         reset_timeout: Duration::from_secs(30),
         ..Default::default()
-    },
-    sink.clone(),
-)?;
+    })?
+    .with_sink(sink.clone());
 
 // After running operations, inspect
 let events = sink.events();

--- a/crates/resilience/src/bulkhead.rs
+++ b/crates/resilience/src/bulkhead.rs
@@ -22,7 +22,10 @@ use crate::{
 pub struct BulkheadConfig {
     /// Maximum number of concurrent operations. Min: 1.
     pub max_concurrency: usize,
-    /// Maximum number of operations allowed to queue waiting for a permit.
+    /// Maximum number of operations allowed to queue while waiting for a permit.
+    ///
+    /// `0` means **no queue**: if no permit is free, [`Bulkhead::acquire`] returns
+    /// [`CallError::BulkheadFull`] immediately (fail-fast) instead of waiting in line.
     pub queue_size: usize,
     /// Optional timeout while waiting for a permit.
     pub timeout: Option<std::time::Duration>,
@@ -43,13 +46,11 @@ impl BulkheadConfig {
     ///
     /// # Errors
     ///
-    /// Returns `Err(ConfigError)` if `max_concurrency` or `queue_size` is 0.
+    /// Returns `Err(ConfigError)` if `max_concurrency` is 0. `queue_size` may be `0` for a
+    /// no-queue, fail-fast bulkhead (see [`BulkheadConfig::queue_size`](Self::queue_size)).
     pub fn validate(&self) -> Result<(), ConfigError> {
         if self.max_concurrency == 0 {
             return Err(ConfigError::new("max_concurrency", "must be >= 1"));
-        }
-        if self.queue_size == 0 {
-            return Err(ConfigError::new("queue_size", "must be >= 1"));
         }
         Ok(())
     }
@@ -160,6 +161,11 @@ impl Bulkhead {
         // Fast path — permit immediately available
         if let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() {
             return Ok(BulkheadPermit { _permit: permit });
+        }
+
+        if self.config.queue_size == 0 {
+            self.sink.record(ResilienceEvent::BulkheadRejected);
+            return Err(CallError::BulkheadFull);
         }
 
         // Try to enqueue via `try_update` (Rust 1.95).
@@ -303,8 +309,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_immediately_when_queue_size_zero() {
+        let bh = Bulkhead::new(BulkheadConfig {
+            max_concurrency: 1,
+            queue_size: 0,
+            timeout: None,
+        })
+        .unwrap();
+
+        let permit = bh.acquire::<&str>().await.unwrap();
+        let err = bh.acquire::<&str>().await.unwrap_err();
+        assert!(matches!(err, CallError::BulkheadFull));
+        drop(permit);
+    }
+
+    #[tokio::test]
     async fn rejects_when_queue_full() {
-        // queue_size=0 is invalid, use 1 with saturation
+        // queue_size=1: at most one waiter; third acquire while saturated fails.
         let bh = Bulkhead::new(BulkheadConfig {
             max_concurrency: 1,
             queue_size: 1,

--- a/crates/resilience/src/lib.rs
+++ b/crates/resilience/src/lib.rs
@@ -169,7 +169,7 @@ pub use gate::{Gate, GateClosed, GateGuard};
 #[doc(hidden)]
 pub use hedge::LatencyTracker;
 pub use hedge::{HedgeConfig, HedgeExecutor};
-pub use load_shed::load_shed;
+pub use load_shed::{load_shed, load_shed_with_sink};
 pub use pipeline::{LoadShedPredicate, PipelineBuilder, RateLimitCheck, ResiliencePipeline};
 pub use policy::{ConstantLoad, LoadSignal, PolicySource};
 pub use rate_limiter::{AdaptiveRateLimiter, LeakyBucket, RateLimiter, SlidingWindow, TokenBucket};

--- a/crates/resilience/src/load_shed.rs
+++ b/crates/resilience/src/load_shed.rs
@@ -2,7 +2,10 @@
 
 use std::future::Future;
 
-use crate::CallError;
+use crate::{
+    CallError,
+    sink::{MetricsSink, NoopSink, ResilienceEvent},
+};
 
 /// Shed load immediately when `should_shed()` returns `true`.
 ///
@@ -19,7 +22,27 @@ where
     Fut: Future<Output = Result<T, E>>,
     F: FnOnce() -> Fut,
 {
+    load_shed_with_sink(should_shed, f, &NoopSink).await
+}
+
+/// Like [`load_shed`] but emits [`ResilienceEvent::LoadShed`] via `sink`.
+///
+/// # Errors
+///
+/// Returns `Err(CallError::LoadShed)` when the shed predicate fires,
+/// or `Err(CallError::Operation)` if the operation itself fails.
+pub async fn load_shed_with_sink<T, E, S, Fut, F>(
+    should_shed: S,
+    f: F,
+    sink: &dyn MetricsSink,
+) -> Result<T, CallError<E>>
+where
+    S: Fn() -> bool,
+    Fut: Future<Output = Result<T, E>>,
+    F: FnOnce() -> Fut,
+{
     if should_shed() {
+        sink.record(ResilienceEvent::LoadShed);
         return Err(CallError::LoadShed);
     }
     f().await.map_err(CallError::Operation)
@@ -28,6 +51,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{RecordingSink, ResilienceEventKind};
 
     #[tokio::test]
     async fn load_shed_rejects_when_signaled() {
@@ -46,5 +70,16 @@ mod tests {
         let result: Result<u32, CallError<&str>> =
             load_shed(|| false, || async { Err("fail") }).await;
         assert!(matches!(result, Err(CallError::Operation("fail"))));
+    }
+
+    #[tokio::test]
+    async fn load_shed_with_sink_emits_event() {
+        let sink = RecordingSink::new();
+
+        let result: Result<u32, CallError<()>> =
+            load_shed_with_sink(|| true, || async { Ok(1u32) }, &sink).await;
+
+        assert!(matches!(result, Err(CallError::LoadShed)));
+        assert_eq!(sink.count(ResilienceEventKind::LoadShed), 1);
     }
 }

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -90,7 +90,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
     /// When set, the circuit breaker step uses
     /// [`call_with_classifier`](CircuitBreaker::call_with_classifier) instead of
     /// [`call`](CircuitBreaker::call). The retry step combines this with any classifier on
-    /// [`RetryConfig`](crate::retry::RetryConfig) (per-retry classifier wins for retry
+    /// [`RetryConfig`] (per-retry classifier wins for retry
     /// decisions; the pipeline classifier still applies to the circuit breaker).
     ///
     /// Without a **pipeline** classifier, operation errors that reach the circuit breaker are
@@ -199,7 +199,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
 impl<E: nebula_error::Classify + Send + Sync + 'static> PipelineBuilder<E> {
     /// Use [`NebulaClassifier`](crate::classifier::NebulaClassifier) to automatically
     /// map [`ErrorCategory`](nebula_error::ErrorCategory) to
-    /// [`ErrorClass`](crate::classifier::ErrorClass).
+    /// [`ErrorClass`].
     ///
     /// This is the recommended default for pipelines where `E: Classify`.
     #[must_use]

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -13,8 +13,9 @@ use crate::{
     CallError,
     bulkhead::Bulkhead,
     circuit_breaker::{CircuitBreaker, Outcome, ProbeGuard},
-    classifier::ErrorClassifier,
+    classifier::{ErrorClass, ErrorClassifier, FnClassifier},
     retry::{RetryConfig, retry_with_inner},
+    sink::{MetricsSink, NoopSink, ResilienceEvent},
 };
 
 // ── Execution ────────────────────────────────────────────────────────────────
@@ -56,6 +57,7 @@ enum Step<E: 'static> {
 pub struct PipelineBuilder<E: 'static> {
     steps: Vec<Step<E>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Option<Arc<dyn MetricsSink>>,
 }
 
 impl<E: 'static> fmt::Debug for PipelineBuilder<E> {
@@ -79,6 +81,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
         Self {
             steps: Vec::new(),
             classifier: None,
+            sink: None,
         }
     }
 
@@ -86,13 +89,28 @@ impl<E: Send + 'static> PipelineBuilder<E> {
     ///
     /// When set, the circuit breaker step uses
     /// [`call_with_classifier`](CircuitBreaker::call_with_classifier) instead of
-    /// [`call`](CircuitBreaker::call), and the retry step inherits the classifier.
+    /// [`call`](CircuitBreaker::call). The retry step combines this with any classifier on
+    /// [`RetryConfig`](crate::retry::RetryConfig) (per-retry classifier wins for retry
+    /// decisions; the pipeline classifier still applies to the circuit breaker).
     ///
-    /// Without a classifier, the pipeline behaves as before: all operation errors
-    /// count as CB failures and retry uses `Classify::is_retryable()`.
+    /// Without a **pipeline** classifier, operation errors that reach the circuit breaker are
+    /// all counted as [`Failure`](crate::circuit_breaker::Outcome::Failure) for CB state. The
+    /// retry step, when neither a pipeline nor a per-retry classifier is set, treats every
+    /// operation error as retryable (the historical pipeline default). For
+    /// [`Classify`](nebula_error::Classify) semantics like standalone
+    /// [`retry_with`](crate::retry::retry_with), set [`classify_errors()`](Self::classify_errors)
+    /// and/or per-retry [`retry_if`](crate::retry::RetryConfig::retry_if) /
+    /// [`with_classifier`](crate::retry::RetryConfig::with_classifier).
     #[must_use]
     pub fn classifier(mut self, classifier: Arc<dyn ErrorClassifier<E>>) -> Self {
         self.classifier = Some(classifier);
+        self
+    }
+
+    /// Inject a metrics sink for pipeline-level timeout / rate-limit / load-shed events.
+    #[must_use]
+    pub fn with_sink(mut self, sink: impl MetricsSink + 'static) -> Self {
+        self.sink = Some(Arc::new(sink));
         self
     }
 
@@ -171,6 +189,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
         ResiliencePipeline {
             steps: Arc::new(self.steps),
             classifier: self.classifier,
+            sink: self.sink.unwrap_or_else(|| Arc::new(NoopSink)),
         }
     }
 }
@@ -233,6 +252,7 @@ fn validate_order<E>(steps: &[Step<E>]) {
 pub struct ResiliencePipeline<E: 'static> {
     steps: Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Arc<dyn MetricsSink>,
 }
 
 impl<E: 'static> fmt::Debug for ResiliencePipeline<E> {
@@ -270,6 +290,7 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
         execute_pipeline(
             Arc::clone(&self.steps),
             self.classifier.clone(),
+            Arc::clone(&self.sink),
             Arc::new(boxed),
         )
         .await
@@ -310,6 +331,7 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
 async fn execute_pipeline<T, E, F>(
     steps: Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Arc<dyn MetricsSink>,
     f: Arc<F>,
 ) -> Result<T, CallError<E>>
 where
@@ -317,7 +339,7 @@ where
     E: Send + 'static,
     F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>> + Send + Sync + 'static,
 {
-    run_operation_with_shells(&steps, classifier, 0, f).await
+    run_operation_with_shells(&steps, classifier, sink, 0, f).await
 }
 
 /// Recursively apply pipeline steps (one `Box::pin` per Timeout/Retry shell),
@@ -325,6 +347,7 @@ where
 fn run_operation_with_shells<T, E, F>(
     steps: &Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Arc<dyn MetricsSink>,
     idx: usize,
     f: Arc<F>,
 ) -> Pin<Box<dyn Future<Output = Result<T, CallError<E>>> + Send>>
@@ -344,20 +367,42 @@ where
                 let d = *d;
                 tokio::time::timeout(
                     d,
-                    run_operation_with_shells(&steps, classifier.clone(), idx + 1, f),
+                    run_operation_with_shells(
+                        &steps,
+                        classifier.clone(),
+                        Arc::clone(&sink),
+                        idx + 1,
+                        f,
+                    ),
                 )
                 .await
-                .unwrap_or_else(|_| Err(CallError::Timeout(d)))
+                .unwrap_or_else(|_| {
+                    sink.record(ResilienceEvent::TimeoutElapsed { duration: d });
+                    Err(CallError::Timeout(d))
+                })
             },
             Step::Retry(config) => {
-                run_retry_step(config, Arc::clone(&steps), classifier, idx, f).await
+                run_retry_step(
+                    config,
+                    Arc::clone(&steps),
+                    classifier,
+                    Arc::clone(&sink),
+                    idx,
+                    f,
+                )
+                .await
             },
             Step::CircuitBreaker(cb) => {
                 cb.try_acquire()?;
                 let mut guard = ProbeGuard::new(cb);
-                let result =
-                    run_operation_with_shells(&steps, classifier.clone(), idx + 1, Arc::clone(&f))
-                        .await;
+                let result = run_operation_with_shells(
+                    &steps,
+                    classifier.clone(),
+                    Arc::clone(&sink),
+                    idx + 1,
+                    Arc::clone(&f),
+                )
+                .await;
                 guard.defuse();
 
                 let outcome = classify_cb_outcome(&result, classifier.as_ref());
@@ -366,19 +411,23 @@ where
             },
             Step::Bulkhead(bh) => {
                 let _permit = bh.acquire().await?;
-                run_operation_with_shells(&steps, classifier, idx + 1, f).await
+                run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
             },
             Step::RateLimiter(check) => {
-                check().await.map_err(|e| CallError::RateLimited {
-                    retry_after: e.retry_after(),
-                })?;
-                run_operation_with_shells(&steps, classifier, idx + 1, f).await
+                if let Err(e) = check().await {
+                    sink.record(ResilienceEvent::RateLimitExceeded);
+                    return Err(CallError::RateLimited {
+                        retry_after: e.retry_after(),
+                    });
+                }
+                run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
             },
             Step::LoadShed(predicate) => {
                 if predicate() {
+                    sink.record(ResilienceEvent::LoadShed);
                     Err(CallError::LoadShed)
                 } else {
-                    run_operation_with_shells(&steps, classifier, idx + 1, f).await
+                    run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
                 }
             },
         }
@@ -413,6 +462,7 @@ async fn run_retry_step<T, E, F>(
     config: &RetryConfig<E>,
     steps: Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Arc<dyn MetricsSink>,
     idx: usize,
     f: Arc<F>,
 ) -> Result<T, CallError<E>>
@@ -427,42 +477,52 @@ where
     // errors (CircuitOpen, BulkheadFull, etc.) indicate the inner pipeline is
     // unreachable — retrying would hit the same structural error.
     let bail: Arc<Mutex<Option<CallError<E>>>> = Arc::new(Mutex::new(None));
-    let bail_check = Arc::clone(&bail);
-
-    // Combine the bail-check (stops on structural errors like CircuitOpen)
-    // with the pipeline's classifier (if set) for retry decisions.
-    // The inner retry wraps E in Option<E>: Some(e) = real error, None = bail.
+    let config_classifier = config.classifier.clone();
     let pipeline_classifier = classifier.clone();
     let mut inner_config = RetryConfig::<Option<E>>::new_unchecked(config.max_attempts)
         .backoff(config.backoff.clone())
-        .jitter(config.jitter.clone())
-        .retry_if(move |e: &Option<E>| {
-            // None = bail signal (structural error) → stop retrying
-            let Some(inner) = e else { return false };
-            // Structural error already captured → stop retrying
-            if bail_check.lock().is_some() {
-                return false;
-            }
-            // Use pipeline classifier if available, otherwise retry all
-            pipeline_classifier
-                .as_ref()
-                .is_none_or(|c| c.classify(inner).is_retryable())
-        });
+        .jitter(config.jitter.clone());
     inner_config.total_budget = config.total_budget;
+    inner_config.sink = Arc::clone(&config.sink);
+    inner_config.classifier = Some(Arc::new(FnClassifier::new(move |e: &Option<E>| {
+        let Some(inner) = e else {
+            return ErrorClass::Permanent;
+        };
+        config_classifier.as_ref().map_or_else(
+            || {
+                pipeline_classifier
+                    .as_ref()
+                    .map_or(ErrorClass::Transient, |classifier| {
+                        classifier.classify(inner)
+                    })
+            },
+            |classifier| classifier.classify(inner),
+        )
+    })));
+    inner_config.on_retry = config.on_retry.as_ref().map(|notify| {
+        let notify = Arc::clone(notify);
+        Arc::new(move |e: &Option<E>, delay: Duration, attempt: u32| {
+            if let Some(inner) = e {
+                notify(inner, delay, attempt);
+            }
+        }) as Arc<dyn Fn(&Option<E>, Duration, u32) + Send + Sync>
+    });
 
     let result = retry_with_inner(inner_config, {
         let steps = Arc::clone(&steps);
         let f = Arc::clone(&f);
         let bail = Arc::clone(&bail);
         let classifier = classifier.clone();
+        let sink = Arc::clone(&sink);
         move || {
             let steps = Arc::clone(&steps);
             let f = Arc::clone(&f);
             let bail = Arc::clone(&bail);
             let classifier = classifier.clone();
+            let sink = Arc::clone(&sink);
             Box::pin(async move {
                 classify_inner(
-                    run_operation_with_shells(&steps, classifier, idx + 1, f).await,
+                    run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await,
                     &bail,
                 )
             })
@@ -515,12 +575,17 @@ fn map_retry_result<T, E: Send>(
 #[cfg(test)]
 mod tests {
     use std::{
-        sync::atomic::{AtomicU32, Ordering},
+        sync::{
+            Mutex as StdMutex,
+            atomic::{AtomicU32, Ordering},
+        },
         time::Duration,
     };
 
     use super::*;
-    use crate::{CallError, CircuitBreaker, retry::BackoffConfig};
+    use crate::{
+        CallError, CircuitBreaker, RecordingSink, ResilienceEventKind, retry::BackoffConfig,
+    };
 
     #[tokio::test]
     async fn pipeline_timeout_wraps_retry() {
@@ -583,6 +648,72 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pipeline_retry_preserves_retry_if_predicate() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&attempts);
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(RetryConfig::new(3).unwrap().retry_if(|_: &&str| false))
+            .build();
+
+        let result = pipeline
+            .call(move || {
+                let seen = Arc::clone(&seen);
+                Box::pin(async move {
+                    seen.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, &str>("permanent")
+                })
+            })
+            .await;
+
+        assert!(matches!(result, Err(CallError::Operation("permanent"))));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_retry_preserves_retry_hooks() {
+        let sink = RecordingSink::new();
+        let notifications: Arc<StdMutex<Vec<(u32, Duration)>>> =
+            Arc::new(StdMutex::new(Vec::new()));
+        let seen_notifications = Arc::clone(&notifications);
+        let attempts = Arc::new(AtomicU32::new(0));
+        let seen_attempts = Arc::clone(&attempts);
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(
+                RetryConfig::new(3)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::from_millis(1)))
+                    .with_sink(sink.clone())
+                    .on_retry(move |_err: &&str, delay: Duration, attempt: u32| {
+                        seen_notifications.lock().unwrap().push((attempt, delay));
+                    }),
+            )
+            .build();
+
+        let result = pipeline
+            .call(move || {
+                let seen_attempts = Arc::clone(&seen_attempts);
+                Box::pin(async move {
+                    seen_attempts.fetch_add(1, Ordering::SeqCst);
+                    Err::<u32, &str>("transient")
+                })
+            })
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::RetriesExhausted {
+                attempts: 3,
+                last: "transient",
+            })
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+        assert_eq!(sink.count(ResilienceEventKind::RetryAttempt), 3);
+        assert_eq!(notifications.lock().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
     async fn pipeline_timeout_fires() {
         let pipeline = ResiliencePipeline::<&str>::builder()
             .timeout(Duration::from_millis(10))
@@ -620,6 +751,67 @@ mod tests {
 
         // Should return RateLimited, not panic
         assert!(matches!(result, Err(CallError::RateLimited { .. })));
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_emits_timeout_event() {
+        let sink = RecordingSink::new();
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .timeout(Duration::from_millis(10))
+            .build();
+
+        let result = pipeline
+            .call(|| {
+                Box::pin(async {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                    Ok::<u32, &str>(42)
+                })
+            })
+            .await;
+
+        assert!(matches!(result, Err(CallError::Timeout(_))));
+        assert_eq!(sink.count(ResilienceEventKind::TimeoutElapsed), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_emits_rate_limit_event() {
+        let sink = RecordingSink::new();
+        let rate_limiter: RateLimitCheck = Arc::new(|| {
+            Box::pin(async { Err(CallError::rate_limited_after(Duration::from_secs(2))) })
+        });
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .rate_limiter(rate_limiter)
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Ok::<u32, &str>(42) }))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::RateLimited {
+                retry_after: Some(duration),
+            }) if duration == Duration::from_secs(2)
+        ));
+        assert_eq!(sink.count(ResilienceEventKind::RateLimitExceeded), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_emits_load_shed_event() {
+        let sink = RecordingSink::new();
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .load_shed(Arc::new(|| true))
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Ok::<u32, &str>(42) }))
+            .await;
+
+        assert!(matches!(result, Err(CallError::LoadShed)));
+        assert_eq!(sink.count(ResilienceEventKind::LoadShed), 1);
     }
 
     #[tokio::test]

--- a/crates/resilience/src/retry.rs
+++ b/crates/resilience/src/retry.rs
@@ -132,7 +132,7 @@ pub enum JitterConfig {
 // ── RetryConfig ───────────────────────────────────────────────────────────────
 
 /// Type alias for the on-retry notification callback.
-type RetryNotify<E> = Box<dyn Fn(&E, Duration, u32) + Send + Sync>;
+type RetryNotify<E> = Arc<dyn Fn(&E, Duration, u32) + Send + Sync>;
 
 /// Configuration for the retry pattern.
 ///
@@ -154,9 +154,9 @@ pub struct RetryConfig<E = ()> {
     /// delay would exceed this duration. This bounds the total time spent retrying,
     /// including both operation execution and sleep time.
     pub total_budget: Option<Duration>,
-    classifier: Option<Arc<dyn ErrorClassifier<E>>>,
-    on_retry: Option<RetryNotify<E>>,
-    sink: Arc<dyn MetricsSink>,
+    pub(crate) classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    pub(crate) on_retry: Option<RetryNotify<E>>,
+    pub(crate) sink: Arc<dyn MetricsSink>,
 }
 
 impl<E> fmt::Debug for RetryConfig<E> {
@@ -256,7 +256,7 @@ impl<E: 'static> RetryConfig<E> {
     where
         F: Fn(&E, Duration, u32) + Send + Sync + 'static,
     {
-        self.on_retry = Some(Box::new(f));
+        self.on_retry = Some(Arc::new(f));
         self
     }
 


### PR DESCRIPTION
## Summary

Hardens \
ebula-resilience\ so the pipeline matches standalone patterns where it matters, documents the real surface area, and adds a common bulkhead configuration.

### Bulkhead
- \queue_size: 0\ is now valid: **no wait queue** — if no permit is free, return \BulkheadFull\ immediately (fail-fast) instead of forcing a minimum queue depth.

### ResiliencePipeline
- Retry step preserves \RetryConfig\ semantics: backoff, jitter, total budget, per-retry classifier / \etry_if\, \on_retry\, and metrics \sink\, composed with an optional pipeline-level classifier.
- \with_sink\ on the builder records \TimeoutElapsed\, \RateLimitExceeded\, and \LoadShed\ for the corresponding steps.
- Doc comments on \PipelineBuilder::classifier\ now match behavior (default retry vs \Classify\-aligned \etry_with\ when using \classify_errors\ / per-retry classifiers).

### load_shed / docs
- Align load-shed observability with the pipeline path where applicable.
- Refresh \README.md\, \pi-reference.md\, \composition.md\, and \observability.md\ so they reflect the current public API (no false builder steps for hedge/fallback).

## Verification
- \cargo test -p nebula-resilience\
- \cargo clippy -p nebula-resilience --all-features -- -D warnings\
- Pre-push: nextest for changed crate (172 tests)


Made with [Cursor](https://cursor.com)