### PR TITLE
fix(engine): refresh_coalesced semaphore bypass (post-П2 audit B6)

### DIFF
--- a/crates/credential/src/pending_store_memory.rs
+++ b/crates/credential/src/pending_store_memory.rs
@@ -49,6 +49,15 @@ use crate::{
 /// ```
 #[derive(Clone)]
 pub struct InMemoryPendingStore {
+    /// Test-shim store. `tokio::sync::RwLock` is chosen here for
+    /// trait-impl ergonomics — every `async fn` body locks, mutates the
+    /// map, and returns without awaiting under the guard, so a
+    /// `parking_lot::RwLock` in a sync block would be cheaper. Perf is
+    /// irrelevant in this shim; production storage lives in
+    /// `nebula-storage` per ADR-0029 §4 / ADR-0032 §7. Do **NOT**
+    /// cargo-cult this `tokio::RwLock<HashMap<...>>` pattern into a
+    /// production module where the guard could cross an `.await` —
+    /// that's the issue-#587-shaped perf cost the audit flagged.
     entries: Arc<RwLock<HashMap<String, PendingEntry>>>,
 }
 

--- a/crates/credential/src/store_memory.rs
+++ b/crates/credential/src/store_memory.rs
@@ -27,6 +27,15 @@ use crate::store::{CredentialStore, PutMode, StoreError, StoredCredential};
 /// Cloning produces a handle to the **same** underlying data (cheap `Arc` clone).
 #[derive(Clone)]
 pub struct InMemoryStore {
+    /// Test-shim store. `tokio::sync::RwLock` is chosen here for
+    /// trait-impl ergonomics — every `async fn` body locks, mutates the
+    /// map, and returns without awaiting under the guard, so a
+    /// `parking_lot::RwLock` in a sync block would be cheaper. Perf is
+    /// irrelevant in this shim; production storage lives in
+    /// `nebula-storage` per ADR-0032. Do **NOT** cargo-cult this
+    /// `tokio::RwLock<HashMap<...>>` pattern into a production module
+    /// where the guard could cross an `.await` — that's the
+    /// issue-#587-shaped perf cost the audit flagged.
     data: Arc<RwLock<HashMap<String, StoredCredential>>>,
 }
 

--- a/crates/engine/src/credential/refresh/coordinator.rs
+++ b/crates/engine/src/credential/refresh/coordinator.rs
@@ -568,6 +568,40 @@ impl RefreshCoordinator {
             l1.complete(&credential_id_for_guard);
         });
 
+        // Global rate-limit gate (audit B6 / wave-2 regression).
+        //
+        // Wave-2 introduced this typed entry point but silently bypassed
+        // the L1 global concurrency semaphore (`refresh_semaphore`,
+        // default 32 permits). Per-credential L1 coalescing alone does
+        // not bound the case where many *distinct* credentials expire
+        // near-simultaneously — e.g. on a daily TTL boundary or after
+        // a replica restart with stale tokens — and a 200-credential
+        // expiry burst would issue 200 concurrent IdP POSTs, recreating
+        // the cascading-429 / refresh-storm pattern the cap is meant to
+        // prevent. Only the legacy `String`-id path
+        // (`resolver.rs::refresh_via_l1_only`) consumed permits, so
+        // typed callers were unprotected.
+        //
+        // Acquired AFTER `try_refresh` (Winner-only — Waiters already
+        // park on the oneshot above and do not need a permit) and BEFORE
+        // L2 backoff so the bound covers the entire IdP POST window.
+        // The order also keeps `_l1_complete` declared first so its
+        // guard fires on every cancel/Drop path even if `acquire_permit`
+        // itself is cancelled (its `await` is cancel-safe per
+        // `L1RefreshCoalescer::acquire_permit` rustdoc — dropping the
+        // future does not consume a permit).
+        //
+        // RAII: `_permit` holds an `OwnedSemaphorePermit` until end of
+        // function (after explicit synchronous release on the success
+        // path; after `l2_teardown` fires on every other path), so the
+        // permit is released on every exit including Drop and panic.
+        // Regression test
+        // `refresh_coalesced_respects_global_concurrency_cap` proves
+        // the cap gates concurrent typed refreshes (mutation: removing
+        // this line makes the test observe `counter == 4` instead of
+        // `2`).
+        let _permit = self.l1.acquire_permit().await;
+
         // L2: durable claim with backoff per §3.6.
         let claim = self
             .try_acquire_l2_with_backoff(credential_id, &needs_refresh_after_backoff)
@@ -979,6 +1013,13 @@ impl RefreshCoordinator {
     }
 
     /// **Legacy.** Acquire a permit from the L1 concurrency limiter.
+    ///
+    /// Only the standalone permit-grab API is deprecated; the underlying
+    /// global concurrency semaphore is **not** going away. The typed-path
+    /// `Self::refresh_coalesced` acquires from the same semaphore
+    /// internally (Winner-only, RAII-scoped), so callers migrating off
+    /// the legacy `String`-id surface inherit the rate-limit defense
+    /// without any explicit wiring. See audit B6 / wave-2 regression.
     #[deprecated(
         since = "0.1.0",
         note = "use refresh_coalesced; remove when typed CredentialId migration completes — П3+"
@@ -1910,5 +1951,105 @@ mod tests {
             matches!(attempt, ClaimAttempt::Acquired(_)),
             "drop must not leave the L2 row held — got {attempt:?}"
         );
+    }
+
+    /// B6 wave-2 regression — global concurrency cap MUST gate the
+    /// typed `refresh_coalesced` path. Without the per-Winner permit
+    /// acquisition, 200 distinct credentials expiring near-simultaneously
+    /// would issue 200 concurrent IdP POSTs with no rate-limit defense
+    /// — the cascading-429 / refresh-storm scenario the 32-permit cap
+    /// (default) was designed to bound. Wave-2 silently bypassed this
+    /// for the typed code path; only the legacy `String`-id path
+    /// (`resolver.rs::refresh_via_l1_only`) consumed permits.
+    ///
+    /// Strategy under `start_paused = true`:
+    ///   1. Build coordinator with `max_concurrent=2`.
+    ///   2. Spawn 4 concurrent `refresh_coalesced` calls on different credentials. Each closure
+    ///      increments an atomic counter, then parks on `Notify::notified()` (no time involvement
+    ///      so virtual time does not advance and heartbeat ticks never fire during the assertion
+    ///      windows).
+    ///   3. Sleep 1ms (virtual) to let the runtime drive all 4 tasks to a parked state — two on
+    ///      `notified()` after running the closure, two on the semaphore's `acquire_owned()`.
+    ///   4. Assert counter == 2 — only the first two acquired permits.
+    ///   5. Wake the parked closures; the first two complete and drop their permits, freeing the
+    ///      semaphore for the remaining two.
+    ///   6. Sleep 1ms again; assert counter == 4.
+    ///
+    /// Pre-fix (no `acquire_permit` in `refresh_coalesced`): all 4
+    /// closures start immediately; counter reaches 4 before any notify
+    /// fires; the first assertion fails with `observed 4 started`.
+    /// Verified by mutation during construction — removing the
+    /// `let _permit = self.l1.acquire_permit().await;` line causes
+    /// this test to fail at the first assertion.
+    #[tokio::test(start_paused = true)]
+    async fn refresh_coalesced_respects_global_concurrency_cap() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use tokio::sync::Notify;
+
+        let coord = Arc::new(
+            RefreshCoordinator::with_max_concurrent(2).expect("max=2 is a valid concurrency limit"),
+        );
+
+        let started = Arc::new(AtomicUsize::new(0));
+        let notify = Arc::new(Notify::new());
+
+        let cids: Vec<CredentialId> = (0..4).map(|_| CredentialId::new()).collect();
+        let mut handles = Vec::with_capacity(cids.len());
+
+        for cid in &cids {
+            let coord = Arc::clone(&coord);
+            let started = Arc::clone(&started);
+            let notify = Arc::clone(&notify);
+            let cid = *cid;
+            handles.push(tokio::spawn(async move {
+                coord
+                    .refresh_coalesced(
+                        &cid,
+                        |_| async { true },
+                        move |_claim| async move {
+                            started.fetch_add(1, Ordering::SeqCst);
+                            notify.notified().await;
+                            Ok::<i32, RefreshError>(7)
+                        },
+                    )
+                    .await
+            }));
+        }
+
+        // Sleep 1ms (virtual time) so the runtime drives all 4 spawned
+        // tasks to a parked state. 1ms is well below the default
+        // `heartbeat_interval` (10s), so no heartbeat tick fires during
+        // the assertion windows.
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(
+            started.load(Ordering::SeqCst),
+            2,
+            "with max_concurrent=2, only two closures must run concurrently; \
+             observed {} started",
+            started.load(Ordering::SeqCst)
+        );
+
+        // Wake the two parked closures. They return `Ok(7)`, drop their
+        // permits via RAII; the semaphore then wakes the two waiters
+        // parked on `acquire_owned()`.
+        notify.notify_waiters();
+        tokio::time::sleep(Duration::from_millis(1)).await;
+
+        assert_eq!(
+            started.load(Ordering::SeqCst),
+            4,
+            "after two permits released, the remaining two closures must run; \
+             observed {} started",
+            started.load(Ordering::SeqCst)
+        );
+
+        // Drain remaining tasks so the test exits cleanly.
+        notify.notify_waiters();
+        for handle in handles {
+            let outcome = handle.await.expect("spawned task did not panic");
+            assert_eq!(outcome.expect("refresh closure returned Ok"), 7);
+        }
     }
 }

--- a/crates/engine/src/credential/refresh/coordinator.rs
+++ b/crates/engine/src/credential/refresh/coordinator.rs
@@ -526,6 +526,24 @@ impl RefreshCoordinator {
         P: Fn(&CredentialId) -> PFut + Sync,
         PFut: Future<Output = bool> + Send,
     {
+        // NOTE (audit C12 — future-bloat trade-off): this fn is
+        // intentionally large (~250 lines after the B6 permit fix; 8
+        // generic parameters; two scopeguard closures plus a
+        // `tokio::time::timeout` over a `tokio::select!`). The
+        // acquisition / release / teardown ordering is load-bearing —
+        // inlining keeps the strict sequence (try_refresh → permit →
+        // L2 backoff → heartbeat spawn → user closure → defuse +
+        // synchronous release) visible end-to-end so a reviewer can
+        // verify cancel-safety in one pass. If a future profiler shows
+        // `Future::poll` dominating refresh latency (the generated
+        // state machine is substantial), the post-acquisition block
+        // (heartbeat spawn + closure run + release path) can be
+        // extracted into a helper `async fn run_under_claim<T, F,
+        // Fut>(claim, ...) -> Result<T, RefreshError>`; per the post-П2
+        // audit C12 sketch this shrinks the outer state machine
+        // without obscuring the ordering. Defer until profiler
+        // evidence — refresh is rare relative to dispatch.
+        //
         // L1: in-process coalescing.
         //
         // The L1 layer is keyed by string, so we hash on the typed id's

--- a/crates/engine/src/credential/refresh/l1.rs
+++ b/crates/engine/src/credential/refresh/l1.rs
@@ -71,6 +71,17 @@ pub(crate) struct L1RefreshCoalescer {
     ///
     /// Prevents cascading failures when many credentials expire simultaneously
     /// and the provider rate-limits (429). Default: 32 concurrent refreshes.
+    ///
+    /// Consumed by **both** entry points:
+    /// - `RefreshCoordinator::refresh_coalesced` (typed `CredentialId` path) — acquires a permit
+    ///   Winner-only after the L1 in-flight check, holds it for the L2 acquisition + IdP POST
+    ///   window, releases on RAII Drop.
+    /// - `RefreshCoordinator::acquire_permit` (legacy `String`-id path, deprecated — see
+    ///   coordinator.rs) — caller binds the permit explicitly via `let _permit = ...`.
+    ///
+    /// The Winner-only acquisition pattern matches the per-credential
+    /// coalescing model: Waiters already park on the in-flight oneshot
+    /// receiver and never issue an IdP POST themselves.
     refresh_semaphore: Arc<tokio::sync::Semaphore>,
 }
 


### PR DESCRIPTION
## Summary

Closes a wave-2 regression where `RefreshCoordinator::refresh_coalesced` (the typed `CredentialId` entry point shipped in #583) silently bypassed the L1 global concurrency semaphore. Per-credential coalescing alone does not bound the case where many *distinct* credentials expire near-simultaneously (daily TTL boundary, replica restart with stale tokens) — a 200-credential burst would issue 200 concurrent IdP POSTs and recreate the cascading-429 / refresh-storm pattern the 32-permit cap was designed to prevent. Only the legacy `String`-id path (`resolver.rs::refresh_via_l1_only`) consumed permits, so typed callers were unprotected.

Two commits:

- `aa3ee41b fix(engine)` — Winner-only `acquire_permit().await` after the L1 in-flight check and before L2 backoff; RAII drop covers every exit path (panic / cancel / Drop / Ok / Err). Includes regression test `refresh_coalesced_respects_global_concurrency_cap` (mutation-verified — removing the new permit line makes the test observe `counter == 4` instead of `2`). Field docstring on `l1.rs:refresh_semaphore` now enumerates both consumers (typed + legacy) so the cap's load-bearing role survives the П3 deprecation removal of the standalone `acquire_permit` API.
- `db10b726 docs(credential)` — A2 cargo-cult-prevention comments on the test-shim `tokio::sync::RwLock<HashMap<...>>` fields in `store_memory.rs` / `pending_store_memory.rs` flagging issue-#587-shaped perf cost if the pattern is copied into a production module where the guard would cross an `.await`. C12 NOTE at the top of `refresh_coalesced` documenting the conscious size trade-off (~250 lines, 8 generics — load-bearing acquisition/release/teardown ordering) plus the future extraction-sketch reference (`async fn run_under_claim<T, F, Fut>`).

## Context — review-miss on PR #583

This was missed by **all 5 reviewer waves on #583**. The audit methodology only checked the legacy `acquire_permit` callsite at `resolver.rs:339` (which still consumes permits via the explicit `let _permit = ...; let _guard = scopeguard::guard(...)` shape) and did not separately verify the typed-path entry point. A second audit pass (two `rust-senior` agents independently) reached verdict "safe" on B6 — the controller caught the gap by independent grep + read of `refresh_coalesced` and confirmed the typed path issued zero `acquire_permit` calls. Audit report at `_audit_credential_async_hazards.md` (workspace root, untracked workflow artifact); the report's verdict reflects the second agent's view and the fix in this PR closes the actual gap.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- [x] `cargo nextest run --workspace --profile ci --no-tests=pass` — `3622 tests run: 3622 passed, 15 skipped`
- [x] `cargo nextest run -p nebula-engine --features rotation --profile ci --no-tests=pass` — `321 tests run: 321 passed, 1 skipped`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --workspace --no-deps` — exit 0
- [x] New regression test `refresh_coalesced_respects_global_concurrency_cap` mutation-verified (RED before fix → GREEN after)
- [x] Lefthook pre-push crate-diff gate green on changed crates (`credential`, `engine`)

## Risk surface

- Behavior change scope: typed `refresh_coalesced` only — legacy `refresh_via_l1_only` path unchanged.
- Cancel-safety preserved: `acquire_permit().await` is cancel-safe per `L1RefreshCoalescer::acquire_permit` rustdoc (dropping the future does not consume a permit), and ordering keeps `_l1_complete` declared first so its scopeguard fires on every cancel/Drop path.
- No new error variants; no new metrics; no DB schema change.
- Memory cost: under a 200-credential burst, all 200 hold an `Arc<InFlightEntry>` in the L1 in-flight map while parked on the semaphore. Each entry is a `Vec<oneshot::Sender<()>>` plus an `Arc` — cheap. Heartbeat tasks are spawned only AFTER permit + L2 succeed, so the parked-on-permit window does NOT amplify heartbeat traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper enforcement of concurrency limits for credential refresh operations. Multiple concurrent refreshes now correctly respect the configured maximum concurrency setting.

* **Tests**
  * Added regression test to verify concurrent credential refresh behavior is properly rate-limited.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->