### PR TITLE
docs(resource): align AcquireResilience preset comments with max_attempts semantics

### DIFF
--- a/crates/resource/src/integration/resilience.rs
+++ b/crates/resource/src/integration/resilience.rs
@@ -45,7 +45,7 @@ pub struct AcquireRetryConfig {
 }
 
 impl AcquireResilience {
-    /// Balanced defaults: 30 s timeout, 3 retries.
+    /// Balanced defaults: 30 s timeout, max_attempts = 3 (1 initial + 2 retries).
     pub fn standard() -> Self {
         Self {
             timeout: Some(Duration::from_secs(30)),
@@ -57,7 +57,7 @@ impl AcquireResilience {
         }
     }
 
-    /// Low-latency: 10 s timeout, 2 retries.
+    /// Low-latency: 10 s timeout, max_attempts = 2 (1 initial + 1 retry).
     pub fn fast() -> Self {
         Self {
             timeout: Some(Duration::from_secs(10)),
@@ -69,7 +69,7 @@ impl AcquireResilience {
         }
     }
 
-    /// Tolerant: 60 s timeout, 5 retries.
+    /// Tolerant: 60 s timeout, max_attempts = 5 (1 initial + 4 retries).
     pub fn slow() -> Self {
         Self {
             timeout: Some(Duration::from_mins(1)),

--- a/crates/resource/tests/dx_audit.rs
+++ b/crates/resource/tests/dx_audit.rs
@@ -498,7 +498,7 @@ async fn use_case_3_db_pool_with_resilience_and_shutdown() {
     // FRICTION NOTE [RESILIENCE WIRING]: AcquireResilience presets are easy
     // to find and use. `AcquireResilience::standard()` is discoverable from
     // lib.rs re-exports. This part of the API is actually good.
-    let resilience = AcquireResilience::fast(); // 10s timeout, 2 retries
+    let resilience = AcquireResilience::fast(); // 10s timeout, max_attempts = 2
 
     manager
         .register(


### PR DESCRIPTION
## Summary

The doc comments on `AcquireResilience::standard()` / `fast()` / `slow()` said "3 retries / 2 retries / 5 retries", but those numbers are the `max_attempts` field, which is `1 initial try + (N-1) retries` per the `AcquireRetryConfig::max_attempts` field doc. So `standard()` is actually 2 retries, not 3. The discrepancy was caught during the nebula-resource П4 doc rewrite, which fixed the user-facing `api-reference.md` prose but left the source-side method docs inconsistent.

## Linked issue

- Refs `claude/resource-p4-doc-rewrite` branch (`docs(resource): clarify max_attempts semantics in AcquireResilience prose`)

## Type of change

- [x] `docs` — documentation only

## Affected crates / areas

- `nebula-resource` (source-side doc comments only)

## Changes

- [crates/resource/src/integration/resilience.rs:48,60,72](crates/resource/src/integration/resilience.rs) — preset method docs now use `max_attempts = N (1 initial + K retries)` form matching the `AcquireRetryConfig::max_attempts` field doc.
- [crates/resource/tests/dx_audit.rs:501](crates/resource/tests/dx_audit.rs) — matching inline comment updated to the same terminology.

## Test plan

- `cargo doc -p nebula-resource --no-deps` — clean, no warnings.
- No code paths touched, no test impact.

### Local verification

- [x] `cargo doc -p nebula-resource --no-deps` — clean
- pre-commit hooks (fmt-check / typos / clippy) — passed via lefthook

## Breaking changes

None.

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code
- [x] No silent error suppression
- [x] No state-transition or credential paths touched
- [x] No new `unsafe`

## Notes for reviewers

Pure comment-wording fix; no behavior, no public API change. The "doc rot" was that "N retries" suggested `N + 1 = total attempts`, but the implementation treats the same `N` as `max_attempts`. The user-facing api-reference.md was already corrected on a parallel branch — this PR just brings the source comments in line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved clarity of resilience configuration documentation to better explain that preset values define total maximum attempts, including the initial request, rather than retry count alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->