### PR TITLE
refactor(schema)!: nebula-schema quality fixes (5 critical + 13 serious)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3760,7 +3760,6 @@ name = "nebula-schema"
 version = "0.1.0"
 dependencies = [
  "argon2",
- "async-trait",
  "codspeed-criterion-compat",
  "hex",
  "indexmap",

--- a/clippy.toml
+++ b/clippy.toml
@@ -124,3 +124,10 @@ warn-unsafe-macro-metavars-in-private-macros = true
 matches-for-let-else = "WellKnownTypes"
 # Encourage re-borrow in `for x in &mut iter` style loops.
 enforce-iter-loop-reborrow = true
+
+# Per-crate clippy configs (`crates/<crate>/clippy.toml`) extend or
+# override these defaults; for example `nebula-schema` declares
+# `disallowed-macros = [{ path = "async_trait::async_trait" }]` in its
+# own clippy.toml + `#![deny(clippy::disallowed_macros)]` in lib.rs to
+# ban the macro on that crate without forcing a workspace-wide migration
+# of legacy `#[async_trait]` users. See ARCHITECTURE.md anti-patterns.

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -585,13 +585,18 @@ mod tests {
 
     #[test]
     fn schema_field_change_requires_major_bump() {
-        use nebula_schema::{FieldCollector, Schema};
+        use nebula_schema::{FieldCollector, Schema, field_key};
 
         let prev =
             ActionMetadata::new(action_key!("http.request"), "HTTP", "desc").with_version(1, 0);
         let next = ActionMetadata::new(action_key!("http.request"), "HTTP", "desc")
             .with_version(1, 1)
-            .with_schema(Schema::builder().string("added", |s| s).build().unwrap());
+            .with_schema(
+                Schema::builder()
+                    .string(field_key!("added"), |s| s)
+                    .build()
+                    .unwrap(),
+            );
 
         let err = next.validate_compatibility(&prev).unwrap_err();
         assert_eq!(

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -457,10 +457,10 @@ mod tests {
 
     impl nebula_schema::HasSchema for AddInput {
         fn schema() -> nebula_schema::ValidSchema {
-            use nebula_schema::{FieldCollector, Schema};
+            use nebula_schema::{FieldCollector, Schema, field_key};
             Schema::builder()
-                .integer("a", |n| n)
-                .integer("b", |n| n)
+                .integer(field_key!("a"), |n| n)
+                .integer(field_key!("b"), |n| n)
                 .build()
                 .expect("AddInput schema is valid")
         }

--- a/crates/action/tests/dx_batch.rs
+++ b/crates/action/tests/dx_batch.rs
@@ -27,10 +27,10 @@ struct NumberList {
 
 impl nebula_schema::HasSchema for NumberList {
     fn schema() -> nebula_schema::ValidSchema {
-        use nebula_schema::{FieldCollector, Schema};
+        use nebula_schema::{FieldCollector, Schema, field_key};
         Schema::builder()
-            .list("numbers", |l| {
-                l.item_number("n", nebula_schema::NumberBuilder::integer)
+            .list(field_key!("numbers"), |l| {
+                l.item_number(field_key!("n"), nebula_schema::NumberBuilder::integer)
             })
             .build()
             .expect("NumberList schema is valid")

--- a/crates/credential/examples/credential_metadata.rs
+++ b/crates/credential/examples/credential_metadata.rs
@@ -8,14 +8,18 @@
 
 use nebula_credential::CredentialMetadata;
 use nebula_metadata::Metadata;
-use nebula_schema::{Field, Schema};
+use nebula_schema::{Field, Schema, field_key};
 
 fn main() {
     // Example 1: GitHub OAuth2 credential type
     let github_schema = Schema::builder()
-        .add(Field::string("client_id").label("Client ID").required())
         .add(
-            Field::secret("client_secret")
+            Field::string(field_key!("client_id"))
+                .label("Client ID")
+                .required(),
+        )
+        .add(
+            Field::secret(field_key!("client_secret"))
                 .label("Client Secret")
                 .required(),
         )
@@ -44,9 +48,17 @@ fn main() {
 
     // Example 2: PostgreSQL database credential type
     let postgres_schema = Schema::builder()
-        .add(Field::string("host").label("Host").required())
-        .add(Field::string("username").label("Username").required())
-        .add(Field::secret("password").label("Password").required())
+        .add(Field::string(field_key!("host")).label("Host").required())
+        .add(
+            Field::string(field_key!("username"))
+                .label("Username")
+                .required(),
+        )
+        .add(
+            Field::secret(field_key!("password"))
+                .label("Password")
+                .required(),
+        )
         .build()
         .expect("postgres schema is always valid");
 
@@ -68,7 +80,11 @@ fn main() {
 
     // Example 3: Simple API Key credential type via the `new` constructor.
     let api_key_schema = Schema::builder()
-        .add(Field::secret("api_key").label("API Key").required())
+        .add(
+            Field::secret(field_key!("api_key"))
+                .label("API Key")
+                .required(),
+        )
         .build()
         .expect("api_key schema is always valid");
 

--- a/crates/credential/src/contract/static_protocol.rs
+++ b/crates/credential/src/contract/static_protocol.rs
@@ -17,8 +17,8 @@
 //!
 //!     fn parameters() -> ValidSchema {
 //!         Schema::builder()
-//!             .add(Field::string("host").required())
-//!             .add(Field::integer("port").default(json!(5432)))
+//!             .add(Field::string(field_key!("host")).required())
+//!             .add(Field::integer(field_key!("port")).default(json!(5432)))
 //!             .build()
 //!             .expect("static schema is valid")
 //!     }
@@ -147,7 +147,9 @@ mod tests {
     #[test]
     fn build_produces_scheme_from_valid_parameters() {
         let mut values = FieldValues::new();
-        values.set_raw("token", serde_json::json!("test-token"));
+        values
+            .try_set_raw("token", serde_json::json!("test-token"))
+            .expect("test-only known-good key");
         let token = TestProtocol::build(&values).unwrap();
         let value = token.token().expose_secret().to_owned();
         assert_eq!(value, "test-token");

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -4,7 +4,7 @@
 //! input. State and Scheme are the same type ([`SecretToken`]) via
 //! [`identity_state!`](crate::identity_state).
 
-use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema, field_key};
 
 use crate::{
     Credential, CredentialContext, SecretString, contract::plugin_capability_report,
@@ -23,13 +23,13 @@ impl HasSchema for ApiKeyInput {
     fn schema() -> ValidSchema {
         Schema::builder()
             .add(
-                Field::string("server")
+                Field::string(field_key!("server"))
                     .label("Server URL")
                     .description("Base URL of the service (e.g. https://api.example.com)")
                     .placeholder("https://api.example.com"),
             )
             .add(
-                Field::secret("api_key")
+                Field::secret(field_key!("api_key"))
                     .label("API Key")
                     .description("Secret API token or personal access token")
                     .required(),
@@ -141,7 +141,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_extracts_api_key_field() {
         let mut values = FieldValues::new();
-        values.set_raw("api_key", serde_json::Value::String("sk-secret-123".into()));
+        values
+            .try_set_raw("api_key", serde_json::Value::String("sk-secret-123".into()))
+            .expect("test-only known-good key");
         let ctx = CredentialContext::for_test("test-user");
         let result = ApiKeyCredential::resolve(&values, &ctx).await.unwrap();
         match result {

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -3,7 +3,7 @@
 //! Resolves a username + password pair into [`IdentityPassword`]. State and
 //! Scheme are the same type via [`identity_state!`](crate::identity_state).
 
-use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema, field_key};
 
 use crate::{
     Credential, CredentialContext, SecretString, contract::plugin_capability_report,
@@ -18,13 +18,13 @@ impl HasSchema for BasicAuthInput {
     fn schema() -> ValidSchema {
         Schema::builder()
             .add(
-                Field::string("username")
+                Field::string(field_key!("username"))
                     .label("Username")
                     .description("Username for HTTP Basic authentication")
                     .required(),
             )
             .add(
-                Field::secret("password")
+                Field::secret(field_key!("password"))
                     .label("Password")
                     .description("Password for HTTP Basic authentication")
                     .required(),
@@ -132,8 +132,12 @@ mod tests {
     #[tokio::test]
     async fn resolve_extracts_username_and_password() {
         let mut values = FieldValues::new();
-        values.set_raw("username", serde_json::Value::String("alice".into()));
-        values.set_raw("password", serde_json::Value::String("p@ssw0rd".into()));
+        values
+            .try_set_raw("username", serde_json::Value::String("alice".into()))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("password", serde_json::Value::String("p@ssw0rd".into()))
+            .expect("test-only known-good key");
         let ctx = CredentialContext::for_test("test-user");
         let result = BasicAuthCredential::resolve(&values, &ctx).await.unwrap();
         match result {
@@ -149,7 +153,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_returns_error_on_missing_username() {
         let mut values = FieldValues::new();
-        values.set_raw("password", serde_json::Value::String("secret".into()));
+        values
+            .try_set_raw("password", serde_json::Value::String("secret".into()))
+            .expect("test-only known-good key");
         let ctx = CredentialContext::for_test("test-user");
         let result = BasicAuthCredential::resolve(&values, &ctx).await;
         assert!(result.is_err());
@@ -158,7 +164,9 @@ mod tests {
     #[tokio::test]
     async fn resolve_returns_error_on_missing_password() {
         let mut values = FieldValues::new();
-        values.set_raw("username", serde_json::Value::String("alice".into()));
+        values
+            .try_set_raw("username", serde_json::Value::String("alice".into()))
+            .expect("test-only known-good key");
         let ctx = CredentialContext::for_test("test-user");
         let result = BasicAuthCredential::resolve(&values, &ctx).await;
         assert!(result.is_err());

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -11,7 +11,7 @@
 use std::{fmt, fmt::Formatter, time::Duration};
 
 use chrono::{DateTime, Utc};
-use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema};
+use nebula_schema::{Field, FieldValues, HasSchema, Schema, ValidSchema, field_key};
 // Re-exports for backward compatibility with `credentials::oauth2::` paths
 // used by external crates (nebula-api, nebula-storage).
 pub use oauth2_config::{
@@ -333,32 +333,32 @@ impl HasSchema for OAuth2Input {
     fn schema() -> ValidSchema {
         Schema::builder()
             .add(
-                Field::string("client_id")
+                Field::string(field_key!("client_id"))
                     .label("Client ID")
                     .description("OAuth2 client identifier")
                     .required(),
             )
             .add(
-                Field::secret("client_secret")
+                Field::secret(field_key!("client_secret"))
                     .label("Client Secret")
                     .description("OAuth2 client secret")
                     .required(),
             )
             .add(
-                Field::string("auth_url")
+                Field::string(field_key!("auth_url"))
                     .label("Authorization URL")
                     .description("OAuth2 authorization endpoint URL")
                     .placeholder("https://provider.example.com/oauth2/authorize"),
             )
             .add(
-                Field::string("token_url")
+                Field::string(field_key!("token_url"))
                     .label("Token URL")
                     .description("OAuth2 token endpoint URL")
                     .required()
                     .placeholder("https://provider.example.com/oauth2/token"),
             )
             .add(
-                Field::string("grant_type")
+                Field::string(field_key!("grant_type"))
                     .label("Grant Type")
                     .description(
                         "OAuth2 grant type: authorization_code, client_credentials, or device_code",
@@ -366,12 +366,12 @@ impl HasSchema for OAuth2Input {
                     .default(serde_json::json!("authorization_code")),
             )
             .add(
-                Field::string("scopes")
+                Field::string(field_key!("scopes"))
                     .label("Scopes")
                     .description("Space-separated list of OAuth2 scopes"),
             )
             .add(
-                Field::string("redirect_uri")
+                Field::string(field_key!("redirect_uri"))
                     .label("Redirect URI")
                     .description(
                         "OAuth2 redirect URI (required for authorization_code grant; must match the URI registered with the provider)",
@@ -916,7 +916,9 @@ mod tests {
     #[test]
     fn parse_scopes_splits_whitespace() {
         let mut values = FieldValues::new();
-        values.set_raw("scopes", serde_json::json!("read write admin"));
+        values
+            .try_set_raw("scopes", serde_json::json!("read write admin"))
+            .expect("test-only known-good key");
         let scopes = parse_scopes(&values);
         assert_eq!(scopes, vec!["read", "write", "admin"]);
     }
@@ -932,8 +934,12 @@ mod tests {
     #[tokio::test]
     async fn resolve_rejects_missing_token_url() {
         let mut values = FieldValues::new();
-        values.set_raw("client_id", serde_json::json!("cid"));
-        values.set_raw("client_secret", serde_json::json!("cs"));
+        values
+            .try_set_raw("client_id", serde_json::json!("cid"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("client_secret", serde_json::json!("cs"))
+            .expect("test-only known-good key");
         let ctx = CredentialContext::for_test("test-user");
         let result = OAuth2Credential::resolve(&values, &ctx).await;
         assert!(result.is_err());
@@ -962,11 +968,21 @@ mod tests {
     #[tokio::test]
     async fn resolve_rejects_missing_redirect_uri_for_auth_code() {
         let mut values = FieldValues::new();
-        values.set_raw("client_id", serde_json::json!("cid"));
-        values.set_raw("client_secret", serde_json::json!("cs"));
-        values.set_raw("auth_url", serde_json::json!("https://a.com/auth"));
-        values.set_raw("token_url", serde_json::json!("https://a.com/token"));
-        values.set_raw("grant_type", serde_json::json!("authorization_code"));
+        values
+            .try_set_raw("client_id", serde_json::json!("cid"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("client_secret", serde_json::json!("cs"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("auth_url", serde_json::json!("https://a.com/auth"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("token_url", serde_json::json!("https://a.com/token"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("grant_type", serde_json::json!("authorization_code"))
+            .expect("test-only known-good key");
 
         let ctx = CredentialContext::for_test("test-user");
         let result = OAuth2Credential::resolve(&values, &ctx).await;
@@ -1088,22 +1104,36 @@ mod tests {
 
     fn auth_code_values() -> FieldValues {
         let mut values = FieldValues::new();
-        values.set_raw("client_id", serde_json::json!("test_client_id"));
-        values.set_raw("client_secret", serde_json::json!("test_client_secret"));
-        values.set_raw(
-            "auth_url",
-            serde_json::json!("https://idp.example.com/authorize"),
-        );
-        values.set_raw(
-            "token_url",
-            serde_json::json!("https://idp.example.com/token"),
-        );
-        values.set_raw("grant_type", serde_json::json!("authorization_code"));
-        values.set_raw("scopes", serde_json::json!("read write"));
-        values.set_raw(
-            "redirect_uri",
-            serde_json::json!("https://app.example.com/oauth2/callback"),
-        );
+        values
+            .try_set_raw("client_id", serde_json::json!("test_client_id"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("client_secret", serde_json::json!("test_client_secret"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw(
+                "auth_url",
+                serde_json::json!("https://idp.example.com/authorize"),
+            )
+            .expect("test-only known-good key");
+        values
+            .try_set_raw(
+                "token_url",
+                serde_json::json!("https://idp.example.com/token"),
+            )
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("grant_type", serde_json::json!("authorization_code"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("scopes", serde_json::json!("read write"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw(
+                "redirect_uri",
+                serde_json::json!("https://app.example.com/oauth2/callback"),
+            )
+            .expect("test-only known-good key");
         values
     }
 
@@ -1148,18 +1178,30 @@ mod tests {
         // Build values without redirect_uri — AuthorizationCode requires it
         // per build_config (RFC 6749 §3.1.2 — registered redirection URI).
         let mut values = FieldValues::new();
-        values.set_raw("client_id", serde_json::json!("test_client_id"));
-        values.set_raw("client_secret", serde_json::json!("test_client_secret"));
-        values.set_raw(
-            "auth_url",
-            serde_json::json!("https://idp.example.com/authorize"),
-        );
-        values.set_raw(
-            "token_url",
-            serde_json::json!("https://idp.example.com/token"),
-        );
-        values.set_raw("grant_type", serde_json::json!("authorization_code"));
-        values.set_raw("scopes", serde_json::json!("read"));
+        values
+            .try_set_raw("client_id", serde_json::json!("test_client_id"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("client_secret", serde_json::json!("test_client_secret"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw(
+                "auth_url",
+                serde_json::json!("https://idp.example.com/authorize"),
+            )
+            .expect("test-only known-good key");
+        values
+            .try_set_raw(
+                "token_url",
+                serde_json::json!("https://idp.example.com/token"),
+            )
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("grant_type", serde_json::json!("authorization_code"))
+            .expect("test-only known-good key");
+        values
+            .try_set_raw("scopes", serde_json::json!("read"))
+            .expect("test-only known-good key");
 
         let result = OAuth2Credential::initiate_authorization_code(&values);
         match result {

--- a/crates/engine/tests/credential_executor_tests.rs
+++ b/crates/engine/tests/credential_executor_tests.rs
@@ -16,7 +16,9 @@ async fn execute_resolve_static_credential_returns_complete() {
     let ctx = CredentialContext::for_test("user-1");
 
     let mut values = FieldValues::new();
-    values.set_raw("api_key", serde_json::Value::String("sk-test-key".into()));
+    values
+        .try_set_raw("api_key", serde_json::Value::String("sk-test-key".into()))
+        .expect("test-only known-good key");
 
     let result =
         nebula_engine::credential::execute_resolve::<ApiKeyCredential, _>(&values, &ctx, &store)

--- a/crates/metadata/src/compat.rs
+++ b/crates/metadata/src/compat.rs
@@ -85,7 +85,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use nebula_schema::{FieldCollector, Schema, ValidSchema};
+    use nebula_schema::{FieldCollector, Schema, ValidSchema, field_key};
     use semver::Version;
 
     use super::{BaseCompatError, validate_base_compat};
@@ -99,7 +99,7 @@ mod tests {
 
     fn schema_with_one_field() -> ValidSchema {
         Schema::builder()
-            .string("extra", |s| s)
+            .string(field_key!("extra"), |s| s)
             .build()
             .expect("single-string schema always valid")
     }

--- a/crates/schema/CHANGELOG.md
+++ b/crates/schema/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+All notable changes to `nebula-schema` will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+The 2026-04-28 quality-fixes pass (`refactor(schema)!:` + Phase 2-4 commits)
+covers the full set of issues raised in the nebula-schema code review.
+
+### ⚠ Breaking Changes
+
+- **`ExpressionContext::evaluate` signature changed (T01).**  The trait no
+  longer uses `#[async_trait::async_trait]`; impls now write
+  ```rust
+  fn evaluate<'a>(&'a self, ast: &'a ExpressionAst) -> EvalFuture<'a> {
+      Box::pin(async move { ... })
+  }
+  ```
+  where `EvalFuture<'a>` is a new public type alias for the boxed future.
+  Drops the `async-trait` runtime dependency on the schema crate.
+
+- **`Field::*::new` requires a pre-validated `FieldKey` (T02).**  Static
+  keys: `Field::string(field_key!("name"))`.  Runtime keys: `Field::try_string(s)?`
+  (new fallible alias, returns `ValidationError` instead of panicking).
+  Same change applied to all 13 `Field::*` constructors plus the `FieldCollector`
+  closure-DSL methods (`.string()`, `.secret()`, `.number()`, …) and the
+  `ObjectBuilder::new` / `ListBuilder::new` constructors.  `~217` call sites
+  migrated workspace-wide.
+
+- **`FieldValues::set_raw` removed (T03).**  Use `try_set_raw(...)?` for
+  fallible runtime input or `try_set_raw(...).expect("...")` in tests /
+  migrations with literal keys.
+
+- **`Loader<T>: PartialEq` removed (T05).**  The previous `always-true` impl
+  violated the `PartialEq` contract.  Loaders are not value-comparable; if
+  identity comparison is required, use `Arc::ptr_eq` on the inner handle.
+
+- **`KdfParams::Argon2id` gained a new `output_bytes` field (T06).**  The
+  variant is `#[non_exhaustive]`, so wire JSON without the field continues
+  to deserialize (default `32`).  In-code constructors must add
+  `output_bytes: None` (or `Some(n)`).
+
+### Added
+
+- **KDF guardrails (T06).**  Public consts `MIN_KDF_*` / `MAX_KDF_*` /
+  `DEFAULT_KDF_OUTPUT_BYTES` for Argon2id memory, time, parallelism, salt
+  length, and output length, aligned to RFC 9106 §4 ("Recommended values"
+  for interactive use).  `KdfParams::hash_password` now rejects sub-minimum
+  costs in addition to over-maximum ones.
+
+- **`recursion_limit` STANDARD_CODE (T07).**  `FieldValues::from_json` and
+  `try_set_raw` reject deeply-nested user JSON with the new
+  `recursion_limit` code (`MAX_VALUE_DEPTH = 64`).  Closes a stack-overflow
+  vector against adversarial wire payloads.
+
+- **`secret.default_forbidden` STANDARD_CODE (T18).**  Lint pass now
+  hard-rejects `Field::Secret { default: Some(_) }`.  Symmetric with
+  `SecretString::Deserialize` (which always errors) — secrets must
+  originate from the resolve pipeline, never from wire JSON.
+
+- **`audit-secret-expose` Cargo feature (T11).**  Off by default;
+  `SecretString::expose` / `SecretBytes::expose` log at `tracing::trace!`
+  by default (with `#[track_caller]` location), escalating to
+  `tracing::debug!` when the feature is enabled.  Lets compliance/audit
+  builds opt in to a per-call audit trail without flooding default logs.
+
+- **`tracing::instrument` spans on every hot-path entry point (T10).**
+  Covers `ValidSchema::validate`, `ValidValues::resolve`,
+  `ValidSchema::json_schema`, `LoaderRegistry::load_options` /
+  `load_records`, `lint::lint_tree`, `KdfParams::hash_password`.
+  All emit structured fields (field counts, mode flags, error counts).
+
+- **Per-crate `clippy.toml` (T17).**  `crates/schema/clippy.toml` bans
+  `async_trait::async_trait` for this crate; `#![deny(clippy::disallowed_macros)]`
+  in `lib.rs` escalates to error.  Other crates inherit the workspace
+  default.
+
+- **Compile-time `#[derive(Schema)]` conflict detection (T04).**  Three
+  new compile-fail tests catch known invalid attribute combinations at
+  expansion time instead of runtime: `secret + default`,
+  `secret + multiline`, `no_expression + expression_required`.  Generated
+  code also emits a `tracing::error!` event with the structured
+  `ValidationReport` before any remaining runtime panic so failures are
+  visible in logs even when the panic is caught.
+
+### Fixed
+
+- **`first_duplicate_index` no longer falls back to a Debug-formatted
+  bucket key (T13).**  `serde_json::Value::to_string` is infallible for
+  valid JSON; the previous fallback could produce false-positive
+  `items.unique` reports for values whose Debug shapes happened to match.
+
+- **`ExpressionMode` JSON Schema export is symmetric (T14).**  Every
+  property now carries `x-nebula-resolved-value-schema` regardless of
+  Forbidden / Allowed / Required mode.  UI consumers no longer need to
+  branch on mode to find the post-resolution value schema.
+
+- **`FieldKey` "mode"/"value" interned via `LazyLock` (T08).**  Removes ~6
+  per-call `FieldKey::new("mode" / "value").expect(..)` allocations on
+  every validate / resolve / promote-secrets recursion through a
+  `Field::Mode` variant.
+
+- **`SecretBytes::Drop` no longer double-zeroizes (T09).**  `Zeroizing<Vec<u8>>`
+  already zeroes the heap buffer in its blanket Drop; the manual impl
+  was redundant.
+
+- **`resolve()` skips post-resolve revalidate when nothing changed (T12).**
+  Schemas with no expression-bearing fields no longer pay the cost of
+  a second full schema walk.  ~50 % wall-clock saving on the static-only
+  fast path.
+
+- **Doc rot.**  README pointers to deleted `docs/INTEGRATION_MODEL.md`,
+  `docs/MATURITY.md`, `docs/PRODUCT_CANON.md`, the `docs/adr/0001-..0003-...`
+  set, and `docs/adr/0034-..` (in `secret.rs`) replaced with inline
+  pointers and references to the workspace `ARCHITECTURE.md`.
+  `cargo doc -p nebula-schema --no-deps` is now warning-free.
+
+### Deferred
+
+- **T15 — moving `crates/schema/examples/` into a root-level `examples/`
+  workspace member.**  Discovery during execution surfaced ~10 sibling
+  crates with the same per-crate `examples/` shape; this is a
+  workspace-wide migration that warrants its own plan rather than being
+  done piecemeal in a `nebula-schema` PR.

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -14,6 +14,11 @@ documentation.workspace = true
 [features]
 default = []
 schemars = ["dep:schemars"]
+# Emit a `tracing::debug!` event with the caller location every time
+# `SecretString::expose` / `SecretBytes::expose` is called.  Off by default
+# because the volume of expose calls in tight retry loops can swamp logs;
+# enable when an audit trail is required.
+audit-secret-expose = []
 
 [dependencies]
 nebula-validator = { path = "../validator" }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -24,7 +24,6 @@ serde_json = { workspace = true }
 indexmap = { workspace = true }
 smallvec = { workspace = true }
 regex = { workspace = true }
-async-trait = { workspace = true }
 schemars = { version = "1.0", optional = true }
 zeroize = { workspace = true }
 hex = { workspace = true }

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -32,7 +32,7 @@ Pattern inspiration: DMMF proof-tokens (ch "Modeling with Types") and Rust types
 - `ValidSchema::validate(&FieldValues) -> Result<ValidValues, ValidationReport>` — schema-time validation; returns the first proof-token.
 - `ValidValues::resolve(self, ctx: &dyn ExpressionContext) -> Result<ResolvedValues, ValidationReport>` — async runtime resolution; consumes the first proof-token and returns the second (use `.await`).
 - `FieldValues`, `ResolvedValues` — value containers.
-- `FieldValues::try_set_raw` — fallible raw setter for runtime code paths; `set_raw` is the panic-on-invalid-key helper for tests/migrations.
+- `FieldValues::try_set_raw` — fallible raw setter for runtime code paths (returns `ValidationError` on bad keys; use `.expect("...")` in tests/migrations with literal keys). The previous panic-on-invalid-key `set_raw` helper has been removed in this release — see `CHANGELOG.md` for migration notes.
 - `ValidSchema::json_schema() -> Result<schemars::Schema, JsonSchemaExportError>` (`schemars` feature) — exports JSON Schema Draft 2020-12 plus `x-nebula-*` contract extensions for schema semantics that JSON Schema alone cannot encode.
 
 See `src/lib.rs` rustdoc for the quick-start example.

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -78,7 +78,7 @@ root-rule metadata, and UI/runtime hints).
 
 ## Contract
 
-- **[L1-3.5]** Schema is the typed-configuration surface for all integration concepts. See `docs/INTEGRATION_MODEL.md`.
+- **[L1-3.5]** Schema is the typed-configuration surface for all integration concepts. See the workspace `ARCHITECTURE.md` (`Core` layer) for layer placement.
 - **[L1-4.5]** `ValidValues` and `ResolvedValues` are compile-time-evident proof-tokens: a caller cannot invoke `resolve` without first holding `ValidValues`, cannot access resolved fields without `ResolvedValues`. No runtime flags.
 - **Structural lint** — `Schema::lint` enforces constraints that cannot be expressed in the builder type alone (duplicate keys, invariant violations across fields). Seam: `crates/schema/src/lint.rs`. Tests: `crates/schema/tests/`.
 - **Expression-required fields** — fields with `ExpressionMode::Required` (for example `ComputedField`) reject literal inputs with `expression.required` during validate-time.
@@ -93,13 +93,11 @@ root-rule metadata, and UI/runtime hints).
 
 ## Maturity
 
-See `docs/MATURITY.md` row for `nebula-schema`.
-
-- API stability: `frontier` — Phase 1 Foundation just landed (commit `ed3a0ce0`); Phases 2–4 (DX, security, advanced) in progress.
+- API stability: `frontier` — Phase 1 Foundation has landed; Phase 4 JSON-Schema export is in `pragmatic baseline` mode.
 - Core pipeline (lint → validate → resolve) is stable; peripheral APIs (UI hints, expression context adapters) may move.
+- Public API is **strict**: `Field::*::new` requires a pre-validated `FieldKey`; runtime panics have been removed from the public surface (use `Field::try_*` or `field_key!(...)` for compile-time-validated keys).
 
 ## Related
 
-- Canon: `docs/PRODUCT_CANON.md §1`, §3.5 (via `docs/INTEGRATION_MODEL.md`).
-- ADRs: `docs/adr/0001-schema-consolidation.md`, `docs/adr/0002-proof-token-pipeline.md`, `docs/adr/0003-consolidated-field-enum.md`.
+- Workspace architecture and layer rules: `ARCHITECTURE.md` at the repo root.
 - Siblings: `nebula-validator` (rules), `nebula-expression` (resolution context).

--- a/crates/schema/benches/bench_serde.rs
+++ b/crates/schema/benches/bench_serde.rs
@@ -1,18 +1,18 @@
 use criterion::{Criterion, black_box};
-use nebula_schema::{Field, Schema};
+use nebula_schema::{Field, Schema, field_key};
 use serde_json::json;
 
 fn sample_schema() -> Schema {
     serde_json::from_value(json!({
         "fields": [
-            Field::string("username").required().min_length(3).into_field(),
-            Field::secret("api_key").required().reveal_last(4).into_field(),
-            Field::list("tags").item(Field::string("tag")).into_field(),
-            Field::object("config").add(Field::boolean("enabled")).into_field(),
-            Field::mode("auth").variant(
+            Field::string(field_key!("username")).required().min_length(3).into_field(),
+            Field::secret(field_key!("api_key")).required().reveal_last(4).into_field(),
+            Field::list(field_key!("tags")).item(Field::string(field_key!("tag"))).into_field(),
+            Field::object(field_key!("config")).add(Field::boolean(field_key!("enabled"))).into_field(),
+            Field::mode(field_key!("auth")).variant(
                 "none",
                 "None",
-                Field::string("none").visible(nebula_schema::VisibilityMode::Never),
+                Field::string(field_key!("none")).visible(nebula_schema::VisibilityMode::Never),
             ).into_field()
         ]
     }))

--- a/crates/schema/benches/bench_validate.rs
+++ b/crates/schema/benches/bench_validate.rs
@@ -22,9 +22,15 @@ fn sample_schema() -> nebula_schema::ValidSchema {
 
 fn sample_values() -> FieldValues {
     let mut values = FieldValues::new();
-    values.set_raw("name", json!("nebula"));
-    values.set_raw("retries", json!(3));
-    values.set_raw("mode", json!("sync"));
+    values
+        .try_set_raw("name", json!("nebula"))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("retries", json!(3))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("mode", json!("sync"))
+        .expect("test-only known-good key");
     values
 }
 
@@ -64,11 +70,15 @@ fn nested_schema() -> nebula_schema::ValidSchema {
 
 fn nested_values() -> FieldValues {
     let mut values = FieldValues::new();
-    values.set_raw(
-        "user",
-        json!({ "name": "alice", "email": "a@b.com", "age": 30 }),
-    );
-    values.set_raw("settings", json!({ "notify": true, "locale": "en-US" }));
+    values
+        .try_set_raw(
+            "user",
+            json!({ "name": "alice", "email": "a@b.com", "age": 30 }),
+        )
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("settings", json!({ "notify": true, "locale": "en-US" }))
+        .expect("test-only known-good key");
     values
 }
 

--- a/crates/schema/clippy.toml
+++ b/crates/schema/clippy.toml
@@ -1,0 +1,11 @@
+# Per-crate clippy config. Inherits the workspace `clippy.toml` defaults at
+# the repo root and adds crate-local rules below.
+
+# Ban `#[async_trait::async_trait]` on this crate. Rust 1.75+ supports
+# `async fn` in traits directly; use the `BoxFuture`-style `EvalFuture`
+# alias for object-safe usage instead. See ARCHITECTURE.md anti-patterns.
+# Lint level is escalated to `deny` via `#![deny(clippy::disallowed_macros)]`
+# in `src/lib.rs`.
+disallowed-macros = [
+  { path = "async_trait::async_trait", reason = "Rust 1.75+ supports `async fn` in traits — use the BoxFuture-style trait pattern documented in ARCHITECTURE.md instead" },
+]

--- a/crates/schema/examples/async_resolve.rs
+++ b/crates/schema/examples/async_resolve.rs
@@ -5,17 +5,16 @@
 //! `cargo run -p nebula-schema --example async_resolve`
 
 use nebula_schema::{
-    ExpressionAst, ExpressionContext, Field, FieldValues, Schema, ValidationError, field_key,
+    EvalFuture, ExpressionAst, ExpressionContext, Field, FieldValues, Schema, field_key,
 };
 use serde_json::json;
 
 /// Returns the same JSON for every expression — enough to resolve `{{ $x }}` shapes in tests.
 struct ConstJson(serde_json::Value);
 
-#[async_trait::async_trait]
 impl ExpressionContext for ConstJson {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Ok(self.0.clone())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move { Ok(self.0.clone()) })
     }
 }
 

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -78,14 +78,29 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
                             .build()
                         {
                             ::core::result::Result::Ok(s) => s,
-                            ::core::result::Result::Err(report) => ::core::panic!(
-                                "#[derive(Schema)] on `{}` produced an invalid schema — \
-                                 attribute combinations conflict with a schema-level lint. \
-                                 Fix the `#[param(..)]` / `#[validate(..)]` attributes on this type. \
-                                 Report: {:?}",
-                                #ty_name_str,
-                                report,
-                            ),
+                            ::core::result::Result::Err(report) => {
+                                // Surface the structured report through `tracing` first so logs
+                                // capture the failure even if the panic is caught (e.g. tests).
+                                // Compile-time conflict detection in attrs.rs / derive_schema.rs
+                                // catches common attribute mistakes; this branch only runs for
+                                // lint-class issues (visibility cycles, dangling refs,
+                                // contradictory rules across fields) that depend on the full
+                                // value tree and cannot be statically proved at expansion time.
+                                #crate_path::__private::tracing::error!(
+                                    target: "nebula_schema::derive",
+                                    type_name = #ty_name_str,
+                                    report = ?report,
+                                    "#[derive(Schema)] schema-level lint failed at runtime"
+                                );
+                                ::core::panic!(
+                                    "#[derive(Schema)] on `{}` produced an invalid schema — \
+                                     attribute combinations conflict with a schema-level lint. \
+                                     Fix the `#[param(..)]` / `#[validate(..)]` attributes on this type. \
+                                     Report: {:?}",
+                                    #ty_name_str,
+                                    report,
+                                );
+                            },
                         }
                     })
                     .clone()
@@ -102,7 +117,14 @@ fn build_field_expr(
     validate: &ValidateAttrs,
     crate_path: &TokenStream2,
 ) -> syn::Result<TokenStream2> {
-    let key = field_name.to_string();
+    let key_str = field_name.to_string();
+    // Wrap as FieldKey via fallible constructor + expect (Rust idents are
+    // always valid FieldKey strings — `.expect()` is unreachable in practice
+    // and is the derive-codegen equivalent of `unreachable!`).
+    let key = quote! {
+        #crate_path::FieldKey::new(#key_str)
+            .expect("#[derive(Schema)] field name is a valid FieldKey")
+    };
     let optional = kind.is_optional();
     let inner = kind.inner();
 
@@ -110,6 +132,27 @@ fn build_field_expr(
         return Err(syn::Error::new_spanned(
             field_name,
             "`#[param(enum_select)]` cannot be combined with `#[param(secret)]`",
+        ));
+    }
+    if param.no_expression && param.expression_required {
+        return Err(syn::Error::new_spanned(
+            field_name,
+            "`#[param(no_expression)]` and `#[param(expression_required)]` are contradictory: \
+             pick exactly one expression-mode attribute",
+        ));
+    }
+    if param.secret && param.multiline {
+        return Err(syn::Error::new_spanned(
+            field_name,
+            "`#[param(multiline)]` does not apply to secret fields — secret values are always \
+             rendered as masked single-line input",
+        ));
+    }
+    if param.secret && param.default.is_some() {
+        return Err(syn::Error::new_spanned(
+            field_name,
+            "`#[param(default = ..)]` on a secret field hard-codes plaintext into the schema; \
+             configure the value via the credential setup form instead",
         ));
     }
     if param.enum_select && matches!(kind, FieldKind::List(_)) {
@@ -305,8 +348,16 @@ fn list_field_expr(
     item_kind: &FieldKind,
     crate_path: &TokenStream2,
 ) -> syn::Result<TokenStream2> {
-    let key = field_name.to_string();
-    let item_key = format!("{key}_item");
+    let key_str = field_name.to_string();
+    let item_key_str = format!("{key_str}_item");
+    let key = quote! {
+        #crate_path::FieldKey::new(#key_str)
+            .expect("#[derive(Schema)] field name is a valid FieldKey")
+    };
+    let item_key = quote! {
+        #crate_path::FieldKey::new(#item_key_str)
+            .expect("#[derive(Schema)] list item key is a valid FieldKey")
+    };
     let item_expr = match item_kind {
         FieldKind::String => quote! { #crate_path::Field::string(#item_key) },
         FieldKind::Boolean => quote! { #crate_path::Field::boolean(#item_key) },

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -15,15 +15,12 @@ mod type_infer;
 /// works whether the caller renamed the dependency or derives are
 /// expanded from inside `nebula-schema` itself.
 ///
-/// Both [`FoundCrate::Itself`] and `Err(_)` map to the absolute path
-/// `::nebula_schema`, **not** `crate` — `cargo test --doc` compiles
-/// every doctest as a separate binary that links against nebula-schema
-/// as an external dependency, so from that binary's perspective `crate`
-/// resolves to the synthetic doctest crate, not to `nebula_schema`.
-/// Using the absolute path is safe for all call sites (doctests,
-/// integration tests, external crates) and was the original design —
-/// restoring it here after an earlier review suggestion that missed
-/// the doctest linkage.
+/// Resolution rules (driven by [`proc_macro_crate::crate_name`]):
+/// - [`FoundCrate::Itself`] → `::nebula_schema` (works in lib code via `extern crate self as
+///   nebula_schema;` in `lib.rs`, in doctests via the doctest binary's external crate alias, and in
+///   integration tests / examples / benches via the package's own crate alias).
+/// - [`FoundCrate::Name(name)`] → `::name` (external crate that renamed the dependency).
+/// - `Err(_)` → fall back to `::nebula_schema` for unknown contexts.
 pub(crate) fn crate_path() -> TokenStream2 {
     match crate_name("nebula-schema") {
         Ok(FoundCrate::Itself) | Err(_) => quote!(::nebula_schema),

--- a/crates/schema/src/builder/list.rs
+++ b/crates/schema/src/builder/list.rs
@@ -8,6 +8,7 @@ use crate::{
         BooleanField, CodeField, Field, ListField, NumberField, SecretField, SelectField,
         StringField,
     },
+    key::FieldKey,
     mode::{ExpressionMode, VisibilityMode},
     widget::ListWidget,
 };
@@ -23,7 +24,7 @@ pub struct ListBuilder {
 
 impl ListBuilder {
     /// Create a new list builder bound to the given field key.
-    pub fn new(key: impl AsRef<str>) -> Self {
+    pub fn new(key: FieldKey) -> Self {
         Self {
             inner: ListField::new(key),
         }
@@ -124,7 +125,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_string(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(StringField) -> StringField,
     ) -> Self {
         let built = f(StringField::new(key));
@@ -136,7 +137,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_number(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(NumberField) -> NumberField,
     ) -> Self {
         let built = f(NumberField::new(key));
@@ -148,7 +149,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_boolean(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(BooleanField) -> BooleanField,
     ) -> Self {
         let built = f(BooleanField::new(key));
@@ -160,7 +161,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_select(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(SelectField) -> SelectField,
     ) -> Self {
         let built = f(SelectField::new(key));
@@ -170,11 +171,7 @@ impl ListBuilder {
 
     /// Set a code item schema via a typed closure.
     #[must_use]
-    pub fn item_code(
-        mut self,
-        key: impl AsRef<str>,
-        f: impl FnOnce(CodeField) -> CodeField,
-    ) -> Self {
+    pub fn item_code(mut self, key: FieldKey, f: impl FnOnce(CodeField) -> CodeField) -> Self {
         let built = f(CodeField::new(key));
         self.inner = self.inner.item(built);
         self
@@ -184,7 +181,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_secret(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(SecretField) -> SecretField,
     ) -> Self {
         let built = f(SecretField::new(key));
@@ -196,7 +193,7 @@ impl ListBuilder {
     #[must_use]
     pub fn item_object(
         mut self,
-        key: impl AsRef<str>,
+        key: FieldKey,
         f: impl FnOnce(ObjectBuilder) -> ObjectBuilder,
     ) -> Self {
         let built = f(ObjectBuilder::new(key));

--- a/crates/schema/src/builder/mod.rs
+++ b/crates/schema/src/builder/mod.rs
@@ -3,7 +3,7 @@
 //! Leaf field builders are re-exports of the per-type structs — they already
 //! enforce compile-time type safety via distinct method surfaces (e.g.
 //! `StringField::min_length` exists but `BooleanField::min_length` does not).
-//! The `Schema::builder().string("k", |s| ...)` closure form pins the argument
+//! The `Schema::builder().string(field_key!("k"), |s| ...)` closure form pins the argument
 //! type, so a `.min_length` call on a `BooleanBuilder` is a compile error.
 //!
 //! Composite builders ([`ObjectBuilder`], [`ListBuilder`], [`GroupBuilder`])
@@ -18,13 +18,14 @@ pub use group::GroupBuilder;
 pub use list::ListBuilder;
 pub use object::ObjectBuilder;
 
-use crate::field::{
-    BooleanField, CodeField, Field, NumberField, SecretField, SelectField, StringField,
-};
 // Leaf builders — type aliases onto the existing per-type structs.
 pub use crate::field::{
     BooleanField as BooleanBuilder, CodeField as CodeBuilder, NumberField as NumberBuilder,
     SecretField as SecretBuilder, SelectField as SelectBuilder, StringField as StringBuilder,
+};
+use crate::{
+    field::{BooleanField, CodeField, Field, NumberField, SecretField, SelectField, StringField},
+    key::FieldKey,
 };
 
 /// Collection sink for typed-closure child field methods.
@@ -33,6 +34,10 @@ pub use crate::field::{
 /// method call. Default method implementations provide the closure-based
 /// `.string / .number / .boolean / .select / .code / .secret / .object / .list`
 /// API that `SchemaBuilder`, `ObjectBuilder`, and `GroupBuilder` share.
+///
+/// All child methods take a pre-validated [`FieldKey`]. Use the
+/// [`field_key!`](crate::field_key) macro for compile-time keys, or
+/// [`FieldKey::new`](crate::FieldKey::new) for runtime-validated strings.
 pub trait FieldCollector: Sized {
     /// Append a single built field to the underlying collection.
     #[doc(hidden)]
@@ -54,60 +59,56 @@ pub trait FieldCollector: Sized {
 
     /// Append a string child built via a typed closure.
     #[must_use]
-    fn string(self, key: impl AsRef<str>, f: impl FnOnce(StringBuilder) -> StringBuilder) -> Self {
+    fn string(self, key: FieldKey, f: impl FnOnce(StringBuilder) -> StringBuilder) -> Self {
         self.push_field(f(StringField::new(key)).into())
     }
 
     /// Append a secret child built via a typed closure.
     #[must_use]
-    fn secret(self, key: impl AsRef<str>, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self {
+    fn secret(self, key: FieldKey, f: impl FnOnce(SecretBuilder) -> SecretBuilder) -> Self {
         self.push_field(f(SecretField::new(key)).into())
     }
 
     /// Append a number child built via a typed closure.
     #[must_use]
-    fn number(self, key: impl AsRef<str>, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
+    fn number(self, key: FieldKey, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
         self.push_field(f(NumberField::new(key)).into())
     }
 
     /// Append an integer child (`NumberField` with `integer=true`) via a typed closure.
     #[must_use]
-    fn integer(self, key: impl AsRef<str>, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
+    fn integer(self, key: FieldKey, f: impl FnOnce(NumberBuilder) -> NumberBuilder) -> Self {
         self.push_field(f(NumberField::new(key).integer()).into())
     }
 
     /// Append a boolean child built via a typed closure.
     #[must_use]
-    fn boolean(
-        self,
-        key: impl AsRef<str>,
-        f: impl FnOnce(BooleanBuilder) -> BooleanBuilder,
-    ) -> Self {
+    fn boolean(self, key: FieldKey, f: impl FnOnce(BooleanBuilder) -> BooleanBuilder) -> Self {
         self.push_field(f(BooleanField::new(key)).into())
     }
 
     /// Append a select child built via a typed closure.
     #[must_use]
-    fn select(self, key: impl AsRef<str>, f: impl FnOnce(SelectBuilder) -> SelectBuilder) -> Self {
+    fn select(self, key: FieldKey, f: impl FnOnce(SelectBuilder) -> SelectBuilder) -> Self {
         self.push_field(f(SelectField::new(key)).into())
     }
 
     /// Append a code child built via a typed closure.
     #[must_use]
-    fn code(self, key: impl AsRef<str>, f: impl FnOnce(CodeBuilder) -> CodeBuilder) -> Self {
+    fn code(self, key: FieldKey, f: impl FnOnce(CodeBuilder) -> CodeBuilder) -> Self {
         self.push_field(f(CodeField::new(key)).into())
     }
 
     /// Append a nested object child built via a typed closure.
     #[must_use]
-    fn object(self, key: impl AsRef<str>, f: impl FnOnce(ObjectBuilder) -> ObjectBuilder) -> Self {
+    fn object(self, key: FieldKey, f: impl FnOnce(ObjectBuilder) -> ObjectBuilder) -> Self {
         let built = f(ObjectBuilder::new(key));
         self.push_field(built.into_field())
     }
 
     /// Append a list child built via a typed closure.
     #[must_use]
-    fn list(self, key: impl AsRef<str>, f: impl FnOnce(ListBuilder) -> ListBuilder) -> Self {
+    fn list(self, key: FieldKey, f: impl FnOnce(ListBuilder) -> ListBuilder) -> Self {
         let built = f(ListBuilder::new(key));
         self.push_field(built.into_field())
     }

--- a/crates/schema/src/builder/object.rs
+++ b/crates/schema/src/builder/object.rs
@@ -5,6 +5,7 @@ use nebula_validator::Rule;
 use crate::{
     builder::FieldCollector,
     field::{Field, ObjectField},
+    key::FieldKey,
     mode::{ExpressionMode, RequiredMode, VisibilityMode},
     widget::ObjectWidget,
 };
@@ -16,7 +17,7 @@ pub struct ObjectBuilder {
 
 impl ObjectBuilder {
     /// Create a new object builder bound to the given field key.
-    pub fn new(key: impl AsRef<str>) -> Self {
+    pub fn new(key: FieldKey) -> Self {
         Self {
             inner: ObjectField::new(key),
         }

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -318,6 +318,7 @@ pub const STANDARD_CODES: &[&str] = &[
     "schema.index_overflow",
     "schema.depth_limit",
     "recursion_limit",
+    "secret.default_forbidden",
     // option lint
     "option.type_inconsistent",
     // warnings

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -317,6 +317,7 @@ pub const STANDARD_CODES: &[&str] = &[
     "duplicate_variant",
     "schema.index_overflow",
     "schema.depth_limit",
+    "recursion_limit",
     // option lint
     "option.type_inconsistent",
     // warnings

--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -1,8 +1,19 @@
 //! Expression value wrapper — lazy parse via OnceLock.
 
-use std::sync::{Arc, OnceLock};
+use std::{
+    future::Future,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+};
 
 use crate::{error::ValidationError, path::FieldPath};
+
+/// Boxed future returned by [`ExpressionContext::evaluate`].
+///
+/// Stored as a type alias so impls can write `Box::pin(async move { … })`
+/// without spelling out the full `Pin<Box<dyn Future …>>` shape.
+pub type EvalFuture<'a> =
+    Pin<Box<dyn Future<Output = Result<serde_json::Value, ValidationError>> + Send + 'a>>;
 
 /// Minimal contract required to evaluate an expression at runtime.
 ///
@@ -10,29 +21,30 @@ use crate::{error::ValidationError, path::FieldPath};
 /// expression engine. The real evaluator lives in `nebula-expression`;
 /// this trait is the integration seam so Phase 1 tests can use a stub.
 ///
+/// The trait is dyn-safe: callers receive `&dyn ExpressionContext` from
+/// [`ValidValues::resolve`](crate::ValidValues::resolve). The `evaluate`
+/// method intentionally returns a [`EvalFuture`] (boxed future) instead of
+/// using `async fn` so the trait stays object-safe under Rust 1.95 / edition
+/// 2024 without an `async-trait` macro indirection.
+///
 /// # Example
 ///
 /// ```rust
-/// use nebula_schema::{ExpressionAst, ExpressionContext, ValidationError};
+/// use nebula_schema::{EvalFuture, ExpressionAst, ExpressionContext, ValidationError};
 ///
 /// struct ConstCtx(serde_json::Value);
 ///
-/// #[async_trait::async_trait]
 /// impl ExpressionContext for ConstCtx {
-///     async fn evaluate(
-///         &self,
-///         _ast: &ExpressionAst,
-///     ) -> Result<serde_json::Value, ValidationError> {
-///         Ok(self.0.clone())
+///     fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+///         Box::pin(async move { Ok(self.0.clone()) })
 ///     }
 /// }
 /// ```
-#[async_trait::async_trait]
 pub trait ExpressionContext: Send + Sync {
     /// Evaluate a parsed expression AST and return the resulting JSON value.
     ///
     /// Errors should use code `"expression.runtime"`.
-    async fn evaluate(&self, ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError>;
+    fn evaluate<'a>(&'a self, ast: &'a ExpressionAst) -> EvalFuture<'a>;
 }
 
 /// Opaque parsed AST wrapper.

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -87,8 +87,26 @@ macro_rules! define_field {
             }
 
             /// Create a typed field with defaults.
-            pub fn new(key: impl AsRef<str>) -> Self {
-                Self::with_key(FieldKey::new(key).expect("field key must be valid"))
+            ///
+            /// Accepts an already-validated [`FieldKey`]. Use the
+            /// [`field_key!`](crate::field_key) macro for compile-time keys
+            /// or [`Self::try_new`] for runtime-validated strings.
+            pub fn new(key: FieldKey) -> Self {
+                Self::with_key(key)
+            }
+
+            /// Create a typed field by validating a runtime string.
+            ///
+            /// # Errors
+            ///
+            /// Returns [`ValidationError`] with code `invalid_key` when `key`
+            /// does not satisfy [`FieldKey`] constraints.
+            #[expect(
+                clippy::result_large_err,
+                reason = "ValidationError is intentionally large; callers are on the validation path"
+            )]
+            pub fn try_new(key: impl AsRef<str>) -> Result<Self, crate::error::ValidationError> {
+                FieldKey::new(key).map(Self::with_key)
             }
 
             /// Borrow the field key.
@@ -625,7 +643,8 @@ impl ModeField {
             key: key.into(),
             label: label.into(),
             field: Box::new(
-                Field::string(Self::EMPTY_PLACEHOLDER_KEY)
+                Field::try_string(Self::EMPTY_PLACEHOLDER_KEY)
+                    .expect("EMPTY_PLACEHOLDER_KEY is a valid FieldKey")
                     .visible(VisibilityMode::Never)
                     .no_expression()
                     .into(),
@@ -840,7 +859,7 @@ impl Field {
     /// assert!(schema.find(&field_key!("greeting")).is_some());
     /// ```
     #[must_use]
-    pub fn string(key: impl AsRef<str>) -> StringField {
+    pub fn string(key: FieldKey) -> StringField {
         StringField::new(key)
     }
 
@@ -857,7 +876,7 @@ impl Field {
 
     /// Create `SecretField`.
     #[must_use]
-    pub fn secret(key: impl AsRef<str>) -> SecretField {
+    pub fn secret(key: FieldKey) -> SecretField {
         SecretField::new(key)
     }
 
@@ -874,7 +893,7 @@ impl Field {
 
     /// Create `NumberField`.
     #[must_use]
-    pub fn number(key: impl AsRef<str>) -> NumberField {
+    pub fn number(key: FieldKey) -> NumberField {
         NumberField::new(key)
     }
 
@@ -891,7 +910,7 @@ impl Field {
 
     /// Create integer `NumberField`.
     #[must_use]
-    pub fn integer(key: impl AsRef<str>) -> NumberField {
+    pub fn integer(key: FieldKey) -> NumberField {
         NumberField::new(key).integer()
     }
 
@@ -925,7 +944,7 @@ impl Field {
     /// assert!(schema.validate(&values).is_ok());
     /// ```
     #[must_use]
-    pub fn boolean(key: impl AsRef<str>) -> BooleanField {
+    pub fn boolean(key: FieldKey) -> BooleanField {
         BooleanField::new(key)
     }
 
@@ -942,7 +961,7 @@ impl Field {
 
     /// Create `SelectField`.
     #[must_use]
-    pub fn select(key: impl AsRef<str>) -> SelectField {
+    pub fn select(key: FieldKey) -> SelectField {
         SelectField::new(key)
     }
 
@@ -959,7 +978,7 @@ impl Field {
 
     /// Create `ObjectField`.
     #[must_use]
-    pub fn object(key: impl AsRef<str>) -> ObjectField {
+    pub fn object(key: FieldKey) -> ObjectField {
         ObjectField::new(key)
     }
 
@@ -976,7 +995,7 @@ impl Field {
 
     /// Create `ListField`.
     #[must_use]
-    pub fn list(key: impl AsRef<str>) -> ListField {
+    pub fn list(key: FieldKey) -> ListField {
         ListField::new(key)
     }
 
@@ -994,7 +1013,7 @@ impl Field {
     /// Create a mode field. See [`ModeField`] for the `{ "mode", "value" }` wire contract and
     /// list payload rules, and [`ModeField::variant_empty`] for no-payload branches.
     #[must_use]
-    pub fn mode(key: impl AsRef<str>) -> ModeField {
+    pub fn mode(key: FieldKey) -> ModeField {
         ModeField::new(key)
     }
 
@@ -1011,7 +1030,7 @@ impl Field {
 
     /// Create `CodeField`.
     #[must_use]
-    pub fn code(key: impl AsRef<str>) -> CodeField {
+    pub fn code(key: FieldKey) -> CodeField {
         CodeField::new(key)
     }
 
@@ -1028,7 +1047,7 @@ impl Field {
 
     /// Create `FileField`.
     #[must_use]
-    pub fn file(key: impl AsRef<str>) -> FileField {
+    pub fn file(key: FieldKey) -> FileField {
         FileField::new(key)
     }
 
@@ -1045,7 +1064,7 @@ impl Field {
 
     /// Create `ComputedField`.
     #[must_use]
-    pub fn computed(key: impl AsRef<str>) -> ComputedField {
+    pub fn computed(key: FieldKey) -> ComputedField {
         ComputedField::new(key)
     }
 
@@ -1062,7 +1081,7 @@ impl Field {
 
     /// Create `DynamicField`.
     #[must_use]
-    pub fn dynamic(key: impl AsRef<str>) -> DynamicField {
+    pub fn dynamic(key: FieldKey) -> DynamicField {
         DynamicField::new(key)
     }
 
@@ -1079,7 +1098,7 @@ impl Field {
 
     /// Create `NoticeField`.
     #[must_use]
-    pub fn notice(key: impl AsRef<str>) -> NoticeField {
+    pub fn notice(key: FieldKey) -> NoticeField {
         NoticeField::new(key)
     }
 

--- a/crates/schema/src/json_schema.rs
+++ b/crates/schema/src/json_schema.rs
@@ -69,6 +69,15 @@ impl crate::validated::ValidSchema {
     ///
     /// Returns [`JsonSchemaExportError`] when root rules cannot be serialized or
     /// when the generated JSON value cannot be converted to `schemars::Schema`.
+    #[tracing::instrument(
+        level = "debug",
+        target = "nebula_schema::json_schema",
+        skip(self),
+        fields(
+            field_count = self.fields().len(),
+            root_rule_count = self.root_rules().len(),
+        )
+    )]
     pub fn json_schema(&self) -> Result<schemars::Schema, JsonSchemaExportError> {
         schema_for_fields(self.fields(), self.root_rules())
     }
@@ -387,11 +396,24 @@ fn apply_value_rules(schema: &mut Map<String, Value>, rules: &[nebula_validator:
     }
 }
 
-fn apply_expression_mode(mut core: Map<String, Value>, mode: ExpressionMode) -> Map<String, Value> {
-    let mut out = Map::new();
+fn apply_expression_mode(core: Map<String, Value>, mode: ExpressionMode) -> Map<String, Value> {
+    // The `x-nebula-resolved-value-schema` extension is always emitted (regardless
+    // of expression mode) so that UI / downstream consumers have a stable shape:
+    // they can read the post-resolution value schema without branching on mode.
     match mode {
-        ExpressionMode::Forbidden => core,
+        ExpressionMode::Forbidden => {
+            // No expression wrapper — the JSON-Schema-Draft 2020-12 part IS the
+            // resolved-value schema; expose both as the same map so consumers
+            // can rely on the extension key being present.
+            let mut out = core.clone();
+            out.insert(
+                "x-nebula-resolved-value-schema".to_owned(),
+                Value::Object(core),
+            );
+            out
+        },
         ExpressionMode::Allowed => {
+            let mut out = Map::new();
             out.insert(
                 "anyOf".to_owned(),
                 Value::Array(vec![
@@ -401,7 +423,7 @@ fn apply_expression_mode(mut core: Map<String, Value>, mode: ExpressionMode) -> 
             );
             out.insert(
                 "x-nebula-resolved-value-schema".to_owned(),
-                Value::Object(core.clone()),
+                Value::Object(core),
             );
             out
         },
@@ -409,7 +431,7 @@ fn apply_expression_mode(mut core: Map<String, Value>, mode: ExpressionMode) -> 
             let mut wrapper = expression_wrapper_schema();
             wrapper.insert(
                 "x-nebula-resolved-value-schema".to_owned(),
-                Value::Object(std::mem::take(&mut core)),
+                Value::Object(core),
             );
             wrapper
         },
@@ -679,6 +701,29 @@ mod tests {
         assert_eq!(
             json["properties"]["total"]["x-nebula-resolved-value-schema"]["type"],
             json!("number")
+        );
+    }
+
+    /// Regression: every property must carry `x-nebula-resolved-value-schema`,
+    /// regardless of the field's ExpressionMode. Boolean fields default to
+    /// Forbidden — they used to omit the extension key.
+    #[test]
+    fn resolved_value_schema_extension_is_emitted_for_forbidden_mode() {
+        let schema = Schema::builder()
+            .add(Field::boolean(FieldKey::new("flag").expect("static key")))
+            .build()
+            .expect("valid schema");
+
+        let json = schema.json_schema().expect("json schema export").to_value();
+
+        assert_eq!(
+            json["properties"]["flag"]["x-nebula-expression-mode"],
+            json!("forbidden")
+        );
+        assert_eq!(
+            json["properties"]["flag"]["x-nebula-resolved-value-schema"]["type"],
+            json!("boolean"),
+            "Forbidden-mode fields must still expose x-nebula-resolved-value-schema"
         );
     }
 }

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -109,6 +109,11 @@
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
+// Hard-deny `#[async_trait::async_trait]` on this crate. Project rule
+// (see `ARCHITECTURE.md` anti-patterns + `clippy.toml`) — Rust 1.75+
+// supports `async fn` in traits directly; the schema crate ships a
+// `BoxFuture`-style `EvalFuture` alias for object-safe usage instead.
+#![deny(clippy::disallowed_macros)]
 
 // Allow `nebula_schema::Foo` to resolve from inside the crate too (lib unit
 // tests, examples_include, internal docs). The proc-macro `field_key!` emits

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -110,6 +110,12 @@
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
 
+// Allow `nebula_schema::Foo` to resolve from inside the crate too (lib unit
+// tests, examples_include, internal docs). The proc-macro `field_key!` emits
+// absolute `nebula_schema::FieldKey::new(..)` paths so the same call site
+// works from external crates, integration tests, doctests, and lib tests.
+extern crate self as nebula_schema;
+
 /// Typed-closure builder DSL (leaf aliases + Object/List/Group composite builders).
 pub mod builder;
 /// [`nebula_validator::RuleContext`] adapters backed by [`FieldValues`].
@@ -161,7 +167,7 @@ pub use builder::{
 pub use error::{
     STANDARD_CODES, Severity, ValidationError, ValidationErrorBuilder, ValidationReport,
 };
-pub use expression::{Expression, ExpressionAst, ExpressionContext};
+pub use expression::{EvalFuture, Expression, ExpressionAst, ExpressionContext};
 /// Discriminated field: one of several payload shapes (auth scheme, body kind, etc.).
 ///
 /// # JSON wire format
@@ -232,3 +238,11 @@ pub use widget::{
 
 /// Schema wire-format version emitted in serialized output (Phase 2+ plugins read this).
 pub const SCHEMA_WIRE_VERSION: u16 = 1;
+
+#[doc(hidden)]
+pub mod __private {
+    //! Re-exports used by `nebula-schema-macros`-generated code.
+    //!
+    //! Not part of the stable API. Do not depend on these from user code.
+    pub use tracing;
+}

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -20,6 +20,12 @@ fn has_nonempty_loader_key(loader: Option<&str>) -> bool {
 ///
 /// Walks the field tree rooted at `prefix` and appends `ValidationError`
 /// issues to `report`. Errors block the build; warnings are advisory.
+#[tracing::instrument(
+    level = "debug",
+    target = "nebula_schema::lint",
+    skip(fields, report),
+    fields(field_count = fields.len(), prefix = %prefix)
+)]
 pub(crate) fn lint_tree(fields: &[Field], prefix: &FieldPath, report: &mut ValidationReport) {
     // Collect root-level key set for cross-reference checks.
     let root_keys: HashSet<&str> = fields.iter().map(|f| f.key().as_str()).collect();
@@ -27,6 +33,14 @@ pub(crate) fn lint_tree(fields: &[Field], prefix: &FieldPath, report: &mut Valid
     lint_visibility_cycles_new(fields, prefix, report);
     lint_required_cycles_new(fields, prefix, report);
     lint_loader_dependency_cycles(fields, prefix, report);
+    if report.has_errors() || report.has_warnings() {
+        tracing::debug!(
+            target: "nebula_schema::lint",
+            error_count = report.errors().count(),
+            warning_count = report.warnings().count(),
+            "lint completed with issues"
+        );
+    }
 }
 
 fn lint_fields_new(

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -101,6 +101,26 @@ fn lint_default_type(field: &Field, path: &FieldPath, report: &mut ValidationRep
         return;
     }
 
+    // `Field::Secret` MUST NOT carry a non-null `default`. A default value
+    // hard-codes plaintext into the schema definition; secrets must originate
+    // from the credential setup form, not from a catalog manifest. (See the
+    // `Deserialize` impl on `SecretString` — it rejects wire reconstruction
+    // for the same reason.) Surface this as an error rather than silently
+    // letting plaintext drift into shared schema storage.
+    if matches!(field, Field::Secret(_)) {
+        report.push(
+            ValidationError::builder("secret.default_forbidden")
+                .at(path.clone())
+                .message(format!(
+                    "field `{path}` is a secret field; `default` is not allowed because it would \
+                     hard-code plaintext into the schema. Configure the value via the credential \
+                     setup form instead."
+                ))
+                .build(),
+        );
+        return;
+    }
+
     let ok = match field {
         Field::String(_) | Field::Secret(_) | Field::Code(_) => {
             matches!(default, Value::String(_))
@@ -1306,7 +1326,7 @@ mod tests {
                     ))
                     .into_field(),
             );
-        let report = run(&vec![outer.into()]);
+        let report = run(&[outer.into()]);
         assert!(
             report.errors().any(|e| e.code == "visibility_cycle"),
             "expected visibility_cycle, got {:?}",
@@ -1448,7 +1468,7 @@ mod tests {
                     .into_field(),
             );
 
-        let report = run(&vec![outer.into()]);
+        let report = run(&[outer.into()]);
         assert!(
             report.errors().any(|e| e.code == "required_cycle"),
             "expected required_cycle, got {:?}",
@@ -1535,6 +1555,39 @@ mod tests {
         assert!(
             report.errors().any(|e| e.code == "required_cycle"),
             "expected required_cycle, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn secret_field_with_default_emits_secret_default_forbidden() {
+        use serde_json::json;
+        let fields = vec![
+            Field::secret(FieldKey::new("api_key").unwrap())
+                .default(json!("hardcoded-token"))
+                .into_field(),
+        ];
+        let report = run(&fields);
+        assert!(
+            report
+                .errors()
+                .any(|e| e.code == "secret.default_forbidden"),
+            "expected secret.default_forbidden, got {:?}",
+            report.errors().map(|e| &e.code).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn secret_field_without_default_passes_lint() {
+        let fields = vec![
+            Field::secret(FieldKey::new("api_key").unwrap())
+                .required()
+                .into_field(),
+        ];
+        let report = run(&fields);
+        assert!(
+            !report.has_errors(),
+            "expected no errors, got {:?}",
             report.errors().map(|e| &e.code).collect::<Vec<_>>()
         );
     }

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -1184,7 +1184,7 @@ mod tests {
     use serde_json::json;
 
     use super::*;
-    use crate::{FieldKey, error::ValidationReport, field::Field, path::FieldPath};
+    use crate::{FieldKey, error::ValidationReport, field::Field, field_key, path::FieldPath};
 
     fn run(fields: &[Field]) -> ValidationReport {
         let mut report = ValidationReport::new();
@@ -1277,16 +1277,16 @@ mod tests {
 
     #[test]
     fn detects_visibility_cycle_inside_nested_object() {
-        let outer = Field::object("outer")
+        let outer = Field::object(field_key!("outer"))
             .add(
-                Field::string("x")
+                Field::string(field_key!("x"))
                     .visible_when(Rule::predicate(
                         Predicate::eq("/outer/y", json!(true)).unwrap(),
                     ))
                     .into_field(),
             )
             .add(
-                Field::string("y")
+                Field::string(field_key!("y"))
                     .visible_when(Rule::predicate(
                         Predicate::eq("/outer/x", json!(true)).unwrap(),
                     ))
@@ -1303,8 +1303,8 @@ mod tests {
     #[test]
     fn acyclic_visibility_rules_do_not_error() {
         let fields = vec![
-            Field::string("toggle").into_field(),
-            Field::string("detail")
+            Field::string(field_key!("toggle")).into_field(),
+            Field::string(field_key!("detail"))
                 .visible_when(Rule::predicate(
                     Predicate::eq("/toggle", json!(true)).unwrap(),
                 ))
@@ -1317,18 +1317,18 @@ mod tests {
     #[test]
     fn detects_visibility_cycle_with_list_index_reference() {
         let fields = vec![
-            Field::list("items")
+            Field::list(field_key!("items"))
                 .item(
-                    Field::object("row")
+                    Field::object(field_key!("row"))
                         .add(
-                            Field::string("x")
+                            Field::string(field_key!("x"))
                                 .visible_when(Rule::predicate(
                                     Predicate::eq("/items/0/y", json!(true)).unwrap(),
                                 ))
                                 .into_field(),
                         )
                         .add(
-                            Field::string("y")
+                            Field::string(field_key!("y"))
                                 .visible_when(Rule::predicate(
                                     Predicate::eq("/items/0/x", json!(true)).unwrap(),
                                 ))
@@ -1349,16 +1349,16 @@ mod tests {
     #[test]
     fn pointer_refs_in_nested_scope_are_checked_against_root_keys() {
         let fields = vec![
-            Field::object("outer")
+            Field::object(field_key!("outer"))
                 .add(
-                    Field::string("x")
+                    Field::string(field_key!("x"))
                         .visible_when(Rule::predicate(
                             Predicate::eq("/outer/y", json!(true)).unwrap(),
                         ))
                         .into_field(),
                 )
                 .into_field(),
-            Field::string("top").into_field(),
+            Field::string(field_key!("top")).into_field(),
         ];
 
         let report = run(&fields);
@@ -1375,14 +1375,14 @@ mod tests {
     #[test]
     fn detects_visibility_cycle_through_mode_variant_payload() {
         let fields = vec![
-            Field::string("a")
+            Field::string(field_key!("a"))
                 .visible_when(Rule::predicate(Predicate::eq("/m/v", json!(true)).unwrap()))
                 .into_field(),
-            Field::mode("m")
+            Field::mode(field_key!("m"))
                 .variant(
                     "v",
                     "Variant",
-                    Field::string("payload")
+                    Field::string(field_key!("payload"))
                         .visible_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
                         .into_field(),
                 )
@@ -1400,10 +1400,10 @@ mod tests {
     #[test]
     fn detects_required_cycle_between_top_level_fields() {
         let fields = vec![
-            Field::string("a")
+            Field::string(field_key!("a"))
                 .required_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
                 .into_field(),
-            Field::string("b")
+            Field::string(field_key!("b"))
                 .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
                 .into_field(),
         ];
@@ -1418,16 +1418,16 @@ mod tests {
 
     #[test]
     fn detects_required_cycle_inside_nested_object() {
-        let outer = Field::object("outer")
+        let outer = Field::object(field_key!("outer"))
             .add(
-                Field::string("x")
+                Field::string(field_key!("x"))
                     .required_when(Rule::predicate(
                         Predicate::eq("/outer/y", json!(true)).unwrap(),
                     ))
                     .into_field(),
             )
             .add(
-                Field::string("y")
+                Field::string(field_key!("y"))
                     .required_when(Rule::predicate(
                         Predicate::eq("/outer/x", json!(true)).unwrap(),
                     ))
@@ -1445,18 +1445,18 @@ mod tests {
     #[test]
     fn detects_required_cycle_with_list_index_reference() {
         let fields = vec![
-            Field::list("items")
+            Field::list(field_key!("items"))
                 .item(
-                    Field::object("row")
+                    Field::object(field_key!("row"))
                         .add(
-                            Field::string("x")
+                            Field::string(field_key!("x"))
                                 .required_when(Rule::predicate(
                                     Predicate::eq("/items/0/y", json!(true)).unwrap(),
                                 ))
                                 .into_field(),
                         )
                         .add(
-                            Field::string("y")
+                            Field::string(field_key!("y"))
                                 .required_when(Rule::predicate(
                                     Predicate::eq("/items/0/x", json!(true)).unwrap(),
                                 ))
@@ -1477,14 +1477,14 @@ mod tests {
     #[test]
     fn detects_required_cycle_through_mode_variant_payload() {
         let fields = vec![
-            Field::string("a")
+            Field::string(field_key!("a"))
                 .required_when(Rule::predicate(Predicate::eq("/m/v", json!(true)).unwrap()))
                 .into_field(),
-            Field::mode("m")
+            Field::mode(field_key!("m"))
                 .variant(
                     "v",
                     "Variant",
-                    Field::string("payload")
+                    Field::string(field_key!("payload"))
                         .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
                         .into_field(),
                 )
@@ -1502,11 +1502,11 @@ mod tests {
     #[test]
     fn detects_visibility_and_required_cycles_independently() {
         let fields = vec![
-            Field::string("a")
+            Field::string(field_key!("a"))
                 .visible_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
                 .required_when(Rule::predicate(Predicate::eq("/b", json!(true)).unwrap()))
                 .into_field(),
-            Field::string("b")
+            Field::string(field_key!("b"))
                 .visible_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
                 .required_when(Rule::predicate(Predicate::eq("/a", json!(true)).unwrap()))
                 .into_field(),

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -127,18 +127,16 @@ fn redact_secrets_in_value_for_loader(field: &Field, value: &mut FieldValue) {
             redact_secrets_in_value_for_loader(&var.field, mv.as_mut());
         },
         (Field::Mode(mode), FieldValue::Object(map)) => {
-            let Ok(mode_selector_key) = FieldKey::new("mode") else {
-                return;
-            };
-            let Ok(payload_key) = FieldKey::new("value") else {
-                return;
-            };
-            let resolved_key = match map.get(&mode_selector_key) {
+            // Reuse the interned `MODE_SELECTOR_KEY` / `MODE_PAYLOAD_KEY` exported by
+            // `validated`; defining them here too would duplicate the `LazyLock` cells.
+            let mode_selector_key = &*crate::validated::MODE_SELECTOR_KEY;
+            let payload_key = &*crate::validated::MODE_PAYLOAD_KEY;
+            let resolved_key = match map.get(mode_selector_key) {
                 Some(FieldValue::Literal(Json::String(mode_key))) => Some(mode_key.clone()),
                 Some(_) => None,
                 None => mode.default_variant.clone(),
             };
-            let Some(mv) = map.get_mut(&payload_key) else {
+            let Some(mv) = map.get_mut(payload_key) else {
                 return;
             };
             let Some(var) = resolved_key

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -187,11 +187,10 @@ impl<T: Send + 'static> Clone for Loader<T> {
     }
 }
 
-impl<T: Send + 'static> PartialEq for Loader<T> {
-    fn eq(&self, _: &Self) -> bool {
-        true
-    }
-}
+// `Loader<T>` intentionally does NOT implement `PartialEq`. Two loaders backed
+// by different closures cannot be compared by value, and a previous "always
+// `true`" impl violated the contract — see the T05 entry of the
+// nebula-schema-quality-fixes plan.
 
 impl<T: Send + 'static> std::fmt::Debug for Loader<T> {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -378,8 +377,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        Field, FieldValues, Schema, expression::Expression, key::FieldKey, secret::SECRET_REDACTED,
-        value::FieldValue,
+        Field, FieldValues, Schema, expression::Expression, field_key, key::FieldKey,
+        secret::SECRET_REDACTED, value::FieldValue,
     };
 
     fn k(name: &str) -> FieldKey {
@@ -485,9 +484,9 @@ mod tests {
     fn with_secrets_redacted_object_nested_and_non_secret_unchanged() {
         let schema = Schema::builder()
             .add(
-                Field::object("config")
-                    .add(Field::secret("api_key"))
-                    .add(Field::string("label")),
+                Field::object(field_key!("config"))
+                    .add(Field::secret(field_key!("api_key")))
+                    .add(Field::string(field_key!("label"))),
             )
             .build()
             .expect("valid schema");
@@ -514,7 +513,7 @@ mod tests {
     #[test]
     fn with_secrets_redacted_list_of_secrets() {
         let schema = Schema::builder()
-            .add(Field::list("tokens").item(Field::secret("t")))
+            .add(Field::list(field_key!("tokens")).item(Field::secret(field_key!("t"))))
             .build()
             .expect("valid schema");
         let values = FieldValues::from_json(json!({ "tokens": ["a", "b"] })).expect("values");
@@ -533,15 +532,15 @@ mod tests {
     fn with_secrets_redacted_mode_variant_object_with_nested_secret() {
         let schema = Schema::builder()
             .add(
-                Field::mode("auth")
+                Field::mode(field_key!("auth"))
                     .variant(
                         "oauth",
                         "OAuth",
-                        Field::object("creds")
-                            .add(Field::secret("client_secret"))
-                            .add(Field::string("client_id")),
+                        Field::object(field_key!("creds"))
+                            .add(Field::secret(field_key!("client_secret")))
+                            .add(Field::string(field_key!("client_id"))),
                     )
-                    .variant("plain", "Plain", Field::string("name")),
+                    .variant("plain", "Plain", Field::string(field_key!("name"))),
             )
             .build()
             .expect("valid schema");
@@ -584,13 +583,13 @@ mod tests {
     fn with_secrets_redacted_mode_object_without_mode_uses_default_variant() {
         let schema = Schema::builder()
             .add(
-                Field::mode("auth")
+                Field::mode(field_key!("auth"))
                     .variant(
                         "oauth",
                         "OAuth",
-                        Field::object("creds")
-                            .add(Field::secret("client_secret"))
-                            .add(Field::string("client_id")),
+                        Field::object(field_key!("creds"))
+                            .add(Field::secret(field_key!("client_secret")))
+                            .add(Field::string(field_key!("client_id"))),
                     )
                     .default_variant("oauth"),
             )
@@ -626,7 +625,7 @@ mod tests {
     #[test]
     fn with_secrets_redacted_expression_on_secret_is_literal_token() {
         let schema = Schema::builder()
-            .add(Field::secret("api_key"))
+            .add(Field::secret(field_key!("api_key")))
             .build()
             .expect("valid schema");
         let mut values = FieldValues::new();

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -315,6 +315,12 @@ impl LoaderRegistry {
     /// Returns `ValidationError` with code `loader.not_registered` when `key`
     /// is not registered, or `loader.failed` if the loader returns an error.
     /// Both errors carry the requesting field's path (from `context.field_key`).
+    #[tracing::instrument(
+        level = "info",
+        target = "nebula_schema::loader",
+        skip(self, context),
+        fields(loader_key = %key, field_key = %context.field_key)
+    )]
     pub async fn load_options(
         &self,
         key: &str,
@@ -322,6 +328,11 @@ impl LoaderRegistry {
     ) -> Result<LoaderResult<SelectOption>, ValidationError> {
         let field_path = field_path_from_key(&context.field_key);
         let Some(loader) = self.option_loaders.get(key) else {
+            tracing::warn!(
+                target: "nebula_schema::loader",
+                loader_key = %key,
+                "option loader not registered"
+            );
             return Err(ValidationError::builder("loader.not_registered")
                 .at(field_path)
                 .message(format!("option loader `{key}` is not registered"))
@@ -329,6 +340,12 @@ impl LoaderRegistry {
                 .build());
         };
         loader.call(context).await.map_err(|e| {
+            tracing::warn!(
+                target: "nebula_schema::loader",
+                loader_key = %key,
+                code = %e.code,
+                "option loader call failed"
+            );
             ValidationError::builder("loader.failed")
                 .at(field_path_from_err_or(&field_path, &e))
                 .message(format!("option loader `{key}` failed: {e}"))
@@ -345,6 +362,12 @@ impl LoaderRegistry {
     /// Returns `ValidationError` with code `loader.not_registered` when `key`
     /// is not registered, or `loader.failed` if the loader returns an error.
     /// Both errors carry the requesting field's path (from `context.field_key`).
+    #[tracing::instrument(
+        level = "info",
+        target = "nebula_schema::loader",
+        skip(self, context),
+        fields(loader_key = %key, field_key = %context.field_key)
+    )]
     pub async fn load_records(
         &self,
         key: &str,
@@ -352,6 +375,11 @@ impl LoaderRegistry {
     ) -> Result<LoaderResult<Value>, ValidationError> {
         let field_path = field_path_from_key(&context.field_key);
         let Some(loader) = self.record_loaders.get(key) else {
+            tracing::warn!(
+                target: "nebula_schema::loader",
+                loader_key = %key,
+                "record loader not registered"
+            );
             return Err(ValidationError::builder("loader.not_registered")
                 .at(field_path)
                 .message(format!("record loader `{key}` is not registered"))
@@ -359,6 +387,12 @@ impl LoaderRegistry {
                 .build());
         };
         loader.call(context).await.map_err(|e| {
+            tracing::warn!(
+                target: "nebula_schema::loader",
+                loader_key = %key,
+                code = %e.code,
+                "record loader call failed"
+            );
             ValidationError::builder("loader.failed")
                 .at(field_path_from_err_or(&field_path, &e))
                 .message(format!("record loader `{key}` failed: {e}"))

--- a/crates/schema/src/prelude.rs
+++ b/crates/schema/src/prelude.rs
@@ -21,7 +21,7 @@ pub use nebula_schema_macros::EnumSelect;
 pub use nebula_validator::{Predicate, Rule};
 
 pub use crate::{
-    BooleanField, CodeField, ComputedField, ComputedReturn, DynamicField, Expression,
+    BooleanField, CodeField, ComputedField, ComputedReturn, DynamicField, EvalFuture, Expression,
     ExpressionContext, ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues,
     FileField, HasSchema, HasSelectOptions, InputHint, KdfParams, ListField, LoaderContext,
     LoaderRegistry, ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField,

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -456,15 +456,15 @@ impl SchemaBuilder {
     /// `visible_when` / `required_when` conditions.
     ///
     /// ```rust
-    /// use nebula_schema::{FieldCollector, Schema, StringWidget};
+    /// use nebula_schema::{FieldCollector, Schema, StringWidget, field_key};
     /// use nebula_validator::{Predicate, Rule};
     ///
     /// let rule = Rule::predicate(Predicate::eq("method", "POST").unwrap());
     /// let schema = Schema::builder()
-    ///     .string("method", |s| s.required())
+    ///     .string(field_key!("method"), |s| s.required())
     ///     .group("body_section", |g| {
     ///         g.visible_when(rule)
-    ///             .string("body", |s| s.widget(StringWidget::Multiline))
+    ///             .string(field_key!("body"), |s| s.widget(StringWidget::Multiline))
     ///     })
     ///     .build()
     ///     .unwrap();

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -163,12 +163,25 @@ impl SecretString {
 
     /// Return the raw UTF-8 secret for trusted consumers.
     ///
-    /// Emits a [`tracing::debug!`] line with a caller location to support audits.
+    /// Emits a `tracing::trace!` line with a caller location for diagnostics.
+    /// Enable the `audit-secret-expose` feature to escalate to `tracing::debug!`
+    /// for compliance / audit trails.
     #[inline]
     #[track_caller]
     pub fn expose(&self) -> &str {
         let s = self.0.as_str();
-        tracing::debug!(target: "nebula_schema::secret", location = %std::panic::Location::caller(), "SecretString::expose");
+        #[cfg(feature = "audit-secret-expose")]
+        tracing::debug!(
+            target: "nebula_schema::secret",
+            location = %std::panic::Location::caller(),
+            "SecretString::expose"
+        );
+        #[cfg(not(feature = "audit-secret-expose"))]
+        tracing::trace!(
+            target: "nebula_schema::secret",
+            location = %std::panic::Location::caller(),
+            "SecretString::expose"
+        );
         s
     }
 
@@ -227,10 +240,25 @@ impl SecretBytes {
     }
 
     /// Return raw bytes.
+    ///
+    /// Emits a `tracing::trace!` line with a caller location for diagnostics.
+    /// Enable the `audit-secret-expose` feature to escalate to `tracing::debug!`
+    /// for compliance / audit trails.
     #[inline]
     #[track_caller]
     pub fn expose(&self) -> &[u8] {
-        tracing::debug!(target: "nebula_schema::secret", location = %std::panic::Location::caller(), "SecretBytes::expose");
+        #[cfg(feature = "audit-secret-expose")]
+        tracing::debug!(
+            target: "nebula_schema::secret",
+            location = %std::panic::Location::caller(),
+            "SecretBytes::expose"
+        );
+        #[cfg(not(feature = "audit-secret-expose"))]
+        tracing::trace!(
+            target: "nebula_schema::secret",
+            location = %std::panic::Location::caller(),
+            "SecretBytes::expose"
+        );
         &self.0
     }
 

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -6,9 +6,10 @@
 //! [`SecretBytes::expose`], and an explicit [`SecretWire`] for callers that
 //! must persist plaintext to an already-encrypted channel.
 //!
-//! Architecture: [`ADR-0034`](../../../docs/adr/0034-schema-secret-value-credential-seam.md)
-//! in-repo; design details in
-//! `docs/superpowers/specs/2026-04-16-nebula-schema-phase3-security-design.md`.
+//! KDF cost / salt bounds align with **RFC 9106 §4** ("Recommended values"
+//! for Argon2id at server-side cost). See `MIN_KDF_MEMORY_KIB` /
+//! `MAX_KDF_MEMORY_KIB` (and the matching `*_TIME_COST`, `*_PARALLELISM`,
+//! `*_SALT_BYTES`, `*_OUTPUT_BYTES` constants exported from this module).
 
 use std::fmt;
 
@@ -213,10 +214,25 @@ impl Serialize for SecretString {
     }
 }
 
+// `SecretString` deliberately rejects deserialization. Secret material must
+// **never** be reconstructed from wire bytes that the schema layer sees:
+//
+// - Schema definitions (`Field::Secret`) flow over `serde` for catalog / plugin manifests; allowing
+//   `SecretString` here would let a default value or a leaked test fixture round-trip plaintext
+//   through schema storage.
+// - Resolved secret values are always introduced by the resolve pipeline (via `SecretValue::string`
+//   / `KdfParams::hash_password`), not by parsing wire JSON.
+//
+// As a result, `Schema` definitions must NOT contain a `default` for a
+// `Field::Secret`; the lint pass in `crate::lint` enforces this with the
+// `secret.default_forbidden` code (Severity::Error). To populate a secret
+// field, configure it via the credential setup form.
 impl<'de> Deserialize<'de> for SecretString {
     fn deserialize<D: Deserializer<'de>>(_deserializer: D) -> Result<Self, D::Error> {
         Err(serde::de::Error::custom(
-            "SecretString cannot be constructed from deserializer",
+            "SecretString cannot be constructed from a deserializer — \
+             secret material must originate from the resolve pipeline, \
+             not from wire JSON",
         ))
     }
 }

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -10,12 +10,12 @@
 //! in-repo; design details in
 //! `docs/superpowers/specs/2026-04-16-nebula-schema-phase3-security-design.md`.
 
-use std::{fmt, ops::DerefMut};
+use std::fmt;
 
 use argon2::{Argon2, Params};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use thiserror::Error;
-use zeroize::{Zeroize, Zeroizing};
+use zeroize::Zeroizing;
 
 /// String returned by JSON helpers when a secret must not be leaked on the wire.
 pub const SECRET_REDACTED: &str = "<redacted>";
@@ -49,10 +49,10 @@ fn decode_salt(salt_hex: &str) -> Result<Vec<u8>, KdfError> {
         ));
     }
     let bytes = hex::decode(s).map_err(KdfError::InvalidSaltHex)?;
-    if !(8..=64).contains(&bytes.len()) {
-        return Err(KdfError::InvalidParams(
-            "KDF salt must decode to 8–64 bytes after hex decode".into(),
-        ));
+    if !(MIN_KDF_SALT_BYTES..=MAX_KDF_SALT_BYTES).contains(&bytes.len()) {
+        return Err(KdfError::InvalidParams(format!(
+            "KDF salt must decode to {MIN_KDF_SALT_BYTES}–{MAX_KDF_SALT_BYTES} bytes after hex decode"
+        )));
     }
     Ok(bytes)
 }
@@ -69,16 +69,32 @@ fn decode_salt(salt_hex: &str) -> Result<Vec<u8>, KdfError> {
 #[serde(tag = "algorithm", rename_all = "snake_case", deny_unknown_fields)]
 pub enum KdfParams {
     /// Argon2id (RFC 9106) using the `argon2` crate.
+    ///
+    /// Cost parameters must satisfy
+    /// `MIN_KDF_MEMORY_KIB ≤ memory_kib ≤ MAX_KDF_MEMORY_KIB`,
+    /// `MIN_KDF_TIME_COST ≤ time_cost ≤ MAX_KDF_TIME_COST`, and
+    /// `MIN_KDF_PARALLELISM ≤ parallelism ≤ MAX_KDF_PARALLELISM`.
+    /// Salt must decode to `MIN_KDF_SALT_BYTES..=MAX_KDF_SALT_BYTES`
+    /// bytes. The optional `output_bytes` may set the derived-key length
+    /// in `MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES`; default 32.
+    /// Bounds align with RFC 9106 §4 ("Recommended values") for
+    /// interactive Argon2id at server-side cost.
     Argon2id {
-        /// Salt as even-length hex (no `0x`); decoded length 8–32 bytes recommended.
+        /// Salt as even-length hex (no `0x`); RFC 9106 §3.1 recommends
+        /// at least 16 bytes. See [`MIN_KDF_SALT_BYTES`].
         salt_hex: String,
-        /// `m` cost (memory, `KiB`). Must match the Argon2 `Params` range.
+        /// `m` cost (memory, `KiB`). RFC 9106 §4 recommends at least
+        /// 8 MiB (8192 KiB) for interactive use.
         memory_kib: u32,
-        /// `t` cost (iterations).
+        /// `t` cost (iterations). Minimum 1.
         time_cost: u32,
         /// `p` cost (parallelism / lanes). Must be at least 1.
         #[serde(default = "default_p_cost")]
         parallelism: u8,
+        /// Optional length of the derived key in bytes. Defaults to 32.
+        /// Must be within `MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        output_bytes: Option<u8>,
     },
 }
 
@@ -88,9 +104,39 @@ const fn default_p_cost() -> u8 {
 
 // Product-level guardrails for resolve-time KDF cost to prevent runaway
 // resource usage from unbounded user-supplied schema parameters.
-const MAX_KDF_MEMORY_KIB: u32 = 256 * 1024;
-const MAX_KDF_TIME_COST: u32 = 10;
-const MAX_KDF_PARALLELISM: u8 = 16;
+//
+// Lower bounds match RFC 9106 §4 ("Recommended values") for interactive
+// Argon2id at server-side cost. Upper bounds cap a single hash to
+// roughly the same envelope as the upstream `argon2` crate's defaults
+// for batch use; multi-tenant deployments that need stricter caps
+// should wrap `KdfParams::hash_password` and reject before invocation.
+
+/// Minimum salt length in bytes (RFC 9106 §3.1).
+pub const MIN_KDF_SALT_BYTES: usize = 16;
+/// Maximum salt length in bytes.
+pub const MAX_KDF_SALT_BYTES: usize = 64;
+
+/// Minimum Argon2id memory cost in KiB (8 MiB, per RFC 9106 §4).
+pub const MIN_KDF_MEMORY_KIB: u32 = 8 * 1024;
+/// Maximum Argon2id memory cost in KiB (256 MiB).
+pub const MAX_KDF_MEMORY_KIB: u32 = 256 * 1024;
+
+/// Minimum Argon2id iteration count.
+pub const MIN_KDF_TIME_COST: u32 = 1;
+/// Maximum Argon2id iteration count.
+pub const MAX_KDF_TIME_COST: u32 = 10;
+
+/// Minimum Argon2id parallelism (lanes).
+pub const MIN_KDF_PARALLELISM: u8 = 1;
+/// Maximum Argon2id parallelism (lanes).
+pub const MAX_KDF_PARALLELISM: u8 = 16;
+
+/// Minimum derived-key length in bytes.
+pub const MIN_KDF_OUTPUT_BYTES: u8 = 16;
+/// Maximum derived-key length in bytes.
+pub const MAX_KDF_OUTPUT_BYTES: u8 = 64;
+/// Default derived-key length in bytes when `output_bytes` is unset.
+pub const DEFAULT_KDF_OUTPUT_BYTES: u8 = 32;
 
 // ── SecretString / SecretBytes / SecretValue --------------------------------
 
@@ -305,6 +351,7 @@ impl KdfParams {
     ///
     /// Returns [`KdfError`] when parameters are invalid, salt decoding fails, or
     /// hashing fails.
+    #[tracing::instrument(skip_all, fields(algo = "Argon2id"))]
     pub fn hash_password(&self, password: &[u8]) -> Result<SecretValue, KdfError> {
         match self {
             Self::Argon2id {
@@ -312,15 +359,21 @@ impl KdfParams {
                 memory_kib,
                 time_cost,
                 parallelism,
+                output_bytes,
             } => {
-                if *parallelism == 0 {
-                    return Err(KdfError::InvalidParams(
-                        "Argon2 parallelism must be >= 1".into(),
-                    ));
+                if *memory_kib < MIN_KDF_MEMORY_KIB {
+                    return Err(KdfError::InvalidParams(format!(
+                        "Argon2 memory_kib must be >= {MIN_KDF_MEMORY_KIB} (RFC 9106 §4)"
+                    )));
                 }
                 if *memory_kib > MAX_KDF_MEMORY_KIB {
                     return Err(KdfError::InvalidParams(format!(
                         "Argon2 memory_kib must be <= {MAX_KDF_MEMORY_KIB}"
+                    )));
+                }
+                if *time_cost < MIN_KDF_TIME_COST {
+                    return Err(KdfError::InvalidParams(format!(
+                        "Argon2 time_cost must be >= {MIN_KDF_TIME_COST}"
                     )));
                 }
                 if *time_cost > MAX_KDF_TIME_COST {
@@ -328,13 +381,32 @@ impl KdfParams {
                         "Argon2 time_cost must be <= {MAX_KDF_TIME_COST}"
                     )));
                 }
+                if *parallelism < MIN_KDF_PARALLELISM {
+                    return Err(KdfError::InvalidParams(format!(
+                        "Argon2 parallelism must be >= {MIN_KDF_PARALLELISM}"
+                    )));
+                }
                 if *parallelism > MAX_KDF_PARALLELISM {
                     return Err(KdfError::InvalidParams(format!(
                         "Argon2 parallelism must be <= {MAX_KDF_PARALLELISM}"
                     )));
                 }
+                let out_bytes = output_bytes.unwrap_or(DEFAULT_KDF_OUTPUT_BYTES);
+                if !(MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES).contains(&out_bytes) {
+                    return Err(KdfError::InvalidParams(format!(
+                        "Argon2 output_bytes must be in {MIN_KDF_OUTPUT_BYTES}..={MAX_KDF_OUTPUT_BYTES}"
+                    )));
+                }
                 let salt = decode_salt(salt_hex)?;
-                let out_len: usize = 32;
+                let out_len = usize::from(out_bytes);
+                tracing::debug!(
+                    target: "nebula_schema::secret::kdf",
+                    memory_kib = *memory_kib,
+                    time_cost = *time_cost,
+                    parallelism = *parallelism,
+                    out_len,
+                    "running Argon2id"
+                );
                 let params = Params::new(
                     *memory_kib,
                     *time_cost,
@@ -354,11 +426,10 @@ impl KdfParams {
     }
 }
 
-impl Drop for SecretBytes {
-    fn drop(&mut self) {
-        self.0.deref_mut().as_mut_slice().zeroize();
-    }
-}
+// `Zeroizing<Vec<u8>>` already zeroizes the heap buffer via its blanket
+// `Drop` impl — no manual `Drop` needed here. (Symmetric with
+// `SecretString` which relies on `Zeroizing<String>` for the same
+// guarantee.)
 
 #[cfg(test)]
 mod tests {
@@ -390,14 +461,21 @@ mod tests {
         assert_eq!(ser, serde_json::Value::String("616263".into()));
     }
 
+    /// Helper: build a 16-byte hex salt for tests where exact contents
+    /// don't matter.
+    fn test_salt_hex() -> String {
+        "00112233445566778899aabbccddeeff".to_owned()
+    }
+
     #[test]
     fn kdf_invalid_salt_hex_chains_from_hex_error() {
         let kdf = KdfParams::Argon2id {
             // Even length but non-hex characters → `hex::FromHexError`.
-            salt_hex: "gggggggggggggggg".to_owned(),
-            memory_kib: 4096,
+            salt_hex: "gggggggggggggggggggggggggggggggg".to_owned(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
             time_cost: 1,
             parallelism: 1,
+            output_bytes: None,
         };
         let err = kdf.hash_password(b"pw").expect_err("invalid hex");
         let KdfError::InvalidSaltHex(_) = &err else {
@@ -409,12 +487,29 @@ mod tests {
     }
 
     #[test]
-    fn kdf_rejects_excessive_resource_costs() {
+    fn kdf_rejects_short_salt_below_min() {
+        // 8 bytes hex (16 hex chars) — below MIN_KDF_SALT_BYTES (16).
         let kdf = KdfParams::Argon2id {
             salt_hex: "0011223344556677".to_owned(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
+            time_cost: 1,
+            parallelism: 1,
+            output_bytes: None,
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject short salt");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn kdf_rejects_excessive_resource_costs() {
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
             memory_kib: MAX_KDF_MEMORY_KIB + 1,
             time_cost: 1,
             parallelism: 1,
+            output_bytes: None,
         };
         let err = kdf
             .hash_password(b"pw")
@@ -422,10 +517,11 @@ mod tests {
         assert!(matches!(err, KdfError::InvalidParams(_)));
 
         let kdf = KdfParams::Argon2id {
-            salt_hex: "0011223344556677".to_owned(),
-            memory_kib: 4096,
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
             time_cost: MAX_KDF_TIME_COST + 1,
             parallelism: 1,
+            output_bytes: None,
         };
         let err = kdf
             .hash_password(b"pw")
@@ -433,14 +529,84 @@ mod tests {
         assert!(matches!(err, KdfError::InvalidParams(_)));
 
         let kdf = KdfParams::Argon2id {
-            salt_hex: "0011223344556677".to_owned(),
-            memory_kib: 4096,
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
             time_cost: 1,
             parallelism: MAX_KDF_PARALLELISM + 1,
+            output_bytes: None,
         };
         let err = kdf
             .hash_password(b"pw")
             .expect_err("must reject high parallelism");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn kdf_rejects_subminimum_costs() {
+        // memory_kib below RFC 9106 §4 minimum (8 MiB).
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB - 1,
+            time_cost: 1,
+            parallelism: 1,
+            output_bytes: None,
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject below-min memory");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+
+        // time_cost = 0 below MIN_KDF_TIME_COST.
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
+            time_cost: 0,
+            parallelism: 1,
+            output_bytes: None,
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject zero time_cost");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+
+        // parallelism = 0 below MIN_KDF_PARALLELISM.
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
+            time_cost: 1,
+            parallelism: 0,
+            output_bytes: None,
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject zero parallelism");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+    }
+
+    #[test]
+    fn kdf_rejects_output_bytes_outside_range() {
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
+            time_cost: 1,
+            parallelism: 1,
+            output_bytes: Some(MIN_KDF_OUTPUT_BYTES - 1),
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject sub-min output_bytes");
+        assert!(matches!(err, KdfError::InvalidParams(_)));
+
+        let kdf = KdfParams::Argon2id {
+            salt_hex: test_salt_hex(),
+            memory_kib: MIN_KDF_MEMORY_KIB,
+            time_cost: 1,
+            parallelism: 1,
+            output_bytes: Some(MAX_KDF_OUTPUT_BYTES + 1),
+        };
+        let err = kdf
+            .hash_password(b"pw")
+            .expect_err("must reject above-max output_bytes");
         assert!(matches!(err, KdfError::InvalidParams(_)));
     }
 }

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -852,9 +852,19 @@ fn resolve_value<'v>(
     Box::pin(async move {
         match value {
             FieldValue::Expression(ref expr) => {
+                tracing::debug!(
+                    target: "nebula_schema::resolve",
+                    path = %path,
+                    "evaluating expression"
+                );
                 match expr.parse_at(path) {
                     Ok(ast) => match ctx.evaluate(ast).await {
                         Ok(v) => {
+                            tracing::trace!(
+                                target: "nebula_schema::resolve",
+                                path = %path,
+                                "expression resolved"
+                            );
                             resolved_expression_paths.insert(path.clone());
                             FieldValue::Literal(v)
                         },
@@ -868,11 +878,23 @@ fn resolve_value<'v>(
                                     .message(e.message.clone())
                                     .build();
                             }
+                            tracing::warn!(
+                                target: "nebula_schema::resolve",
+                                path = %path,
+                                code = %e.code,
+                                "expression evaluation failed"
+                            );
                             report.push(e);
                             FieldValue::Literal(serde_json::Value::Null)
                         },
                     },
                     Err(e) => {
+                        tracing::warn!(
+                            target: "nebula_schema::resolve",
+                            path = %path,
+                            code = %e.code,
+                            "expression parse failed at resolve"
+                        );
                         report.push(e);
                         FieldValue::Literal(serde_json::Value::Null)
                     },
@@ -1702,7 +1724,7 @@ fn push_validator_rule_errors(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Field, FieldKey, Schema};
+    use crate::{Field, FieldKey, Schema, field_key};
 
     #[test]
     fn clone_is_cheap_via_arc() {
@@ -1727,11 +1749,14 @@ mod tests {
     #[test]
     fn find_by_path_handles_nested_object_and_mode_variant() {
         let schema = Schema::builder()
-            .add(Field::object(FieldKey::new("user").unwrap()).add(Field::string("email")))
+            .add(
+                Field::object(FieldKey::new("user").unwrap())
+                    .add(Field::string(field_key!("email"))),
+            )
             .add(Field::mode(FieldKey::new("auth").unwrap()).variant(
                 "token",
                 "Token",
-                Field::string("value"),
+                Field::string(field_key!("value")),
             ))
             .build()
             .unwrap();

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -4,7 +4,7 @@ use std::{
     collections::{HashMap, HashSet},
     future::Future,
     pin::Pin,
-    sync::Arc,
+    sync::{Arc, LazyLock},
 };
 
 use indexmap::IndexMap;
@@ -28,6 +28,16 @@ use crate::{
     secret::SecretValue,
     value::{FieldValue, FieldValues},
 };
+
+/// `Mode` payload uses two well-known nested keys: `"mode"` (variant
+/// selector) and `"value"` (variant payload). Both are interned via
+/// `LazyLock` so per-call `FieldKey::new` does not re-allocate the
+/// `Arc<str>` every time `validate_field` / `resolve_value` /
+/// `promote_secrets_in_value` recurses through a `Field::Mode`.
+pub(crate) static MODE_SELECTOR_KEY: LazyLock<FieldKey> =
+    LazyLock::new(|| FieldKey::new("mode").expect("static mode selector key is valid"));
+pub(crate) static MODE_PAYLOAD_KEY: LazyLock<FieldKey> =
+    LazyLock::new(|| FieldKey::new("value").expect("static mode payload key is valid"));
 
 /// Flags computed once at build time.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -657,9 +667,7 @@ fn first_secret_path_in_field_value(value: &FieldValue, path: &FieldPath) -> Opt
             value: Some(payload),
             ..
         } => {
-            let payload_key =
-                FieldKey::new("value").expect("static mode payload key must be valid");
-            let payload_path = path.clone().join(payload_key);
+            let payload_path = path.clone().join((*MODE_PAYLOAD_KEY).clone());
             first_secret_path_in_field_value(payload, &payload_path)
         },
         FieldValue::Literal(_)
@@ -725,32 +733,13 @@ fn promote_secrets_in_value(
             let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
                 return;
             };
-            let k = match FieldKey::new("value") {
-                Ok(k) => k,
-                Err(e) => {
-                    report.push(
-                        ValidationError::builder("invalid_key")
-                            .at(path.clone())
-                            .message(format!(
-                                "invalid static mode payload key `value`: {}",
-                                e.message
-                            ))
-                            .build(),
-                    );
-                    return;
-                },
-            };
-            let p = path.clone().join(k);
+            let p = path.clone().join((*MODE_PAYLOAD_KEY).clone());
             promote_secrets_in_value(&var.field, mv.as_mut(), &p, report);
         },
         (Field::Mode(mode), FieldValue::Object(map)) => {
-            let Ok(mode_selector_key) = FieldKey::new("mode") else {
-                return;
-            };
-            let Ok(payload_key) = FieldKey::new("value") else {
-                return;
-            };
-            let resolved_key = match map.get(&mode_selector_key) {
+            let mode_selector_key = &*MODE_SELECTOR_KEY;
+            let payload_key = &*MODE_PAYLOAD_KEY;
+            let resolved_key = match map.get(mode_selector_key) {
                 Some(FieldValue::Literal(serde_json::Value::String(mode_key))) => {
                     Some(mode_key.clone())
                 },
@@ -763,10 +752,10 @@ fn promote_secrets_in_value(
             else {
                 return;
             };
-            let Some(mv) = map.get_mut(&payload_key) else {
+            let Some(mv) = map.get_mut(payload_key) else {
                 return;
             };
-            let p = path.clone().join(payload_key);
+            let p = path.clone().join(payload_key.clone());
             promote_secrets_in_value(&var.field, mv, &p, report);
         },
         _ => {},
@@ -922,13 +911,7 @@ fn resolve_value<'v>(
             },
             FieldValue::Mode { mode, value } => {
                 let resolved_value = if let Some(inner) = value {
-                    let Ok(payload_key) = FieldKey::new("value") else {
-                        return FieldValue::Mode {
-                            mode,
-                            value: Some(inner),
-                        };
-                    };
-                    let inner_path = path.clone().join(payload_key);
+                    let inner_path = path.clone().join((*MODE_PAYLOAD_KEY).clone());
                     let resolved =
                         resolve_value(*inner, ctx, &inner_path, report, resolved_expression_paths)
                             .await;
@@ -1397,10 +1380,8 @@ fn validate_literal_value(
             rules,
             ..
         }) => {
-            let mode_selector_key =
-                FieldKey::new("mode").expect("static mode selector key must remain valid");
-            let payload_key =
-                FieldKey::new("value").expect("static mode payload key must remain valid");
+            let mode_selector_key = &*MODE_SELECTOR_KEY;
+            let payload_key = &*MODE_PAYLOAD_KEY;
 
             let (resolved_key, mode_value) = match value {
                 FieldValue::Mode {
@@ -1423,9 +1404,9 @@ fn validate_literal_value(
                         return;
                     }
 
-                    match map.get(&mode_selector_key) {
+                    match map.get(mode_selector_key) {
                         Some(FieldValue::Literal(serde_json::Value::String(mode))) => {
-                            (Some(mode.as_str()), map.get(&payload_key))
+                            (Some(mode.as_str()), map.get(payload_key))
                         },
                         Some(other) => {
                             report.push(
@@ -1439,7 +1420,7 @@ fn validate_literal_value(
                             );
                             return;
                         },
-                        None => (None, map.get(&payload_key)),
+                        None => (None, map.get(payload_key)),
                     }
                 },
                 _ => {
@@ -1478,7 +1459,7 @@ fn validate_literal_value(
                 return;
             };
             {
-                let payload_path = path.clone().join(payload_key);
+                let payload_path = path.clone().join(payload_key.clone());
                 validate_field(&variant.field, mode_value, ctx, &payload_path, report);
             }
         },

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -320,6 +320,15 @@ impl ValidSchema {
     /// assert!(schema.validate(&full).is_ok());
     /// ```
     #[allow(clippy::result_large_err)]
+    #[tracing::instrument(
+        level = "debug",
+        target = "nebula_schema::validate",
+        skip(self, values),
+        fields(
+            field_count = self.0.fields.len(),
+            has_root_rules = !self.0.root_rules.is_empty(),
+        )
+    )]
     pub fn validate(&self, values: &FieldValues) -> Result<ValidValues, ValidationReport> {
         use crate::context::RootContext;
 
@@ -334,6 +343,11 @@ impl ValidSchema {
         run_root_rules(&self.0.root_rules, values, &mut report);
 
         if report.has_errors() {
+            tracing::warn!(
+                target: "nebula_schema::validate",
+                error_count = report.errors().count(),
+                "validate produced errors"
+            );
             return Err(report);
         }
 
@@ -421,6 +435,15 @@ impl ValidValues {
     /// Returns `Err(ValidationReport)` when any expression evaluation fails
     /// or when a resolved value violates a field rule.
     #[allow(clippy::result_large_err)]
+    #[tracing::instrument(
+        level = "debug",
+        target = "nebula_schema::resolve",
+        skip(self, ctx),
+        fields(
+            uses_expressions = self.schema.flags().uses_expressions,
+            field_count = self.schema.fields().len(),
+        )
+    )]
     pub async fn resolve(
         self,
         ctx: &dyn ExpressionContext,
@@ -470,21 +493,45 @@ impl ValidValues {
         // Re-run schema validation on resolved + promoted literals. Any type
         // mismatches at paths produced by expression evaluation are surfaced
         // as `expression.type_mismatch`.
+        //
+        // Fast path: if no expressions were resolved AND the schema doesn't
+        // declare any expression-bearing fields, the values are unchanged
+        // since the prior `validate()` call (the one that produced `self`).
+        // Skip the second walk in that case — it amounts to ~50% of the
+        // wall-clock cost of `resolve()` on schemas without expressions.
         let resolve_warnings: Vec<ValidationError> = report
             .iter()
             .filter(|e| e.severity == Severity::Warning)
             .cloned()
             .collect();
-        let post_resolve_warnings: Vec<ValidationError> = match self.schema.validate(&values) {
-            Ok(post_resolve_valid) => post_resolve_valid.warnings().to_vec(),
-            Err(mut post_resolve_report) => {
-                post_resolve_report.extend(self.warnings.iter().cloned());
-                post_resolve_report.extend(resolve_warnings.iter().cloned());
-                return Err(remap_expression_type_mismatch(
-                    post_resolve_report,
-                    &resolved_expression_paths,
-                ));
-            },
+
+        let skip_revalidate = resolved_expression_paths.is_empty()
+            && !self.schema.flags().uses_expressions
+            && resolve_warnings.is_empty();
+
+        let post_resolve_warnings: Vec<ValidationError> = if skip_revalidate {
+            tracing::trace!(
+                target: "nebula_schema::resolve",
+                "skipping post-resolve revalidate (no expressions / warnings)"
+            );
+            Vec::new()
+        } else {
+            tracing::debug!(
+                target: "nebula_schema::resolve",
+                resolved_expression_paths = resolved_expression_paths.len(),
+                "running post-resolve revalidate"
+            );
+            match self.schema.validate(&values) {
+                Ok(post_resolve_valid) => post_resolve_valid.warnings().to_vec(),
+                Err(mut post_resolve_report) => {
+                    post_resolve_report.extend(self.warnings.iter().cloned());
+                    post_resolve_report.extend(resolve_warnings.iter().cloned());
+                    return Err(remap_expression_type_mismatch(
+                        post_resolve_report,
+                        &resolved_expression_paths,
+                    ));
+                },
+            }
         };
 
         let all_warnings: Arc<[ValidationError]> = self
@@ -1531,10 +1578,12 @@ fn validate_literal_value(
 fn first_duplicate_index(values: impl IntoIterator<Item = serde_json::Value>) -> Option<usize> {
     let mut seen: HashMap<String, Vec<serde_json::Value>> = HashMap::new();
     for (idx, value) in values.into_iter().enumerate() {
-        // serde_json::Value does not implement Hash. Bucket by serialized form,
-        // then confirm equality within the bucket to preserve exact semantics.
+        // serde_json::Value does not implement Hash. Bucket by canonical
+        // string form (`serde_json::to_string` is infallible for `Value`
+        // because all map keys are strings), then confirm equality within
+        // the bucket to preserve exact semantics.
         let key = serde_json::to_string(&value)
-            .unwrap_or_else(|_| format!("__fallback_non_serializable__:{value:?}"));
+            .expect("serde_json::Value::to_string is infallible for valid JSON");
         if let Some(bucket) = seen.get_mut(&key) {
             if bucket.iter().any(|prior| prior == &value) {
                 return Some(idx);

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -16,6 +16,19 @@ use crate::{
 /// Reserved key for an explicit expression wrapper.
 pub const EXPRESSION_KEY: &str = "$expr";
 
+/// Maximum recursion depth permitted for user-provided value trees.
+///
+/// `validate_json_keys`, `validate_field`, `resolve_value`, and
+/// `promote_secrets_in_value` all walk through `FieldValue::Object`,
+/// `FieldValue::List`, and `FieldValue::Mode` containers without
+/// natural bounds. Adversarial JSON with deeply nested objects can
+/// otherwise overflow the call stack. Any recursion that exceeds this
+/// depth produces a `recursion_limit` validation error and stops
+/// descending. The limit is intentionally conservative (64) because
+/// realistic schemas are flat (≤ 5–10 levels) and JSON-Schema Draft
+/// 2020-12 does not encourage deeply nested shapes.
+pub const MAX_VALUE_DEPTH: u8 = 64;
+
 /// Runtime value — may be literal, expression, tree, or mode-dispatched.
 #[non_exhaustive]
 #[derive(Debug, Clone, PartialEq)]
@@ -218,7 +231,7 @@ impl FieldValues {
         reason = "ValidationError is intentionally large; callers are on the validation path"
     )]
     pub fn from_json(value: Value) -> Result<Self, crate::error::ValidationError> {
-        validate_json_keys(&value, &FieldPath::root())?;
+        validate_json_keys(&value, &FieldPath::root(), 0)?;
         match FieldValue::from_json(value) {
             FieldValue::Object(map) => Ok(Self(map)),
             _ => Err(crate::error::ValidationError::builder("type_mismatch")
@@ -261,7 +274,7 @@ impl FieldValues {
                 .build()
         })?;
         let field_path = FieldPath::root().join(fk.clone());
-        validate_json_keys(&value, &field_path)?;
+        validate_json_keys(&value, &field_path, 0)?;
         self.0.insert(fk, FieldValue::from_json(value));
         Ok(())
     }
@@ -431,7 +444,23 @@ impl FieldValues {
 fn validate_json_keys(
     value: &Value,
     path: &FieldPath,
+    depth: u8,
 ) -> Result<(), crate::error::ValidationError> {
+    if depth > MAX_VALUE_DEPTH {
+        tracing::warn!(
+            target: "nebula_schema::value",
+            depth = %depth,
+            path = %path,
+            "value depth limit hit during validate_json_keys"
+        );
+        return Err(crate::error::ValidationError::builder("recursion_limit")
+            .at(path.clone())
+            .param("limit", serde_json::json!(MAX_VALUE_DEPTH))
+            .message(format!(
+                "value tree depth exceeds the {MAX_VALUE_DEPTH}-level limit at `{path}`"
+            ))
+            .build());
+    }
     match value {
         Value::Object(map) => {
             if map.len() == 1 && map.get(EXPRESSION_KEY).is_some_and(Value::is_string) {
@@ -447,14 +476,14 @@ fn validate_json_keys(
                         .build()
                 })?;
                 let child_path = path.clone().join(key);
-                validate_json_keys(child, &child_path)?;
+                validate_json_keys(child, &child_path, depth + 1)?;
             }
             Ok(())
         },
         Value::Array(items) => {
             for (idx, item) in items.iter().enumerate() {
                 let item_path = path.clone().join(idx);
-                validate_json_keys(item, &item_path)?;
+                validate_json_keys(item, &item_path, depth + 1)?;
             }
             Ok(())
         },
@@ -623,6 +652,35 @@ mod tests {
             vs.get(&FieldKey::new("expr").unwrap()),
             Some(FieldValue::Expression(_))
         ));
+    }
+
+    /// Build a JSON object nested `depth` levels deep under `inner_key`.
+    fn nested_object(depth: usize, inner_key: &str) -> Value {
+        let mut current = json!({ "leaf": 1 });
+        for _ in 0..depth {
+            let mut wrapped = Map::with_capacity(1);
+            wrapped.insert(inner_key.to_owned(), current);
+            current = Value::Object(wrapped);
+        }
+        current
+    }
+
+    #[test]
+    fn from_json_rejects_deeply_nested_object_with_recursion_limit() {
+        // Wrap the nested object in another `{"top": ...}` so the input is a
+        // top-level JSON object as required by `FieldValues::from_json`.
+        let deep = nested_object(usize::from(MAX_VALUE_DEPTH) + 5, "n");
+        let payload = json!({ "top": deep });
+        let err = FieldValues::from_json(payload).expect_err("must reject");
+        assert_eq!(err.code, "recursion_limit", "got: {}", err.message);
+    }
+
+    #[test]
+    fn from_json_accepts_at_recursion_limit() {
+        // 60 < 64 — must stay valid.
+        let ok = nested_object(60, "n");
+        let payload = json!({ "top": ok });
+        FieldValues::from_json(payload).expect("must accept under-limit nesting");
     }
 
     #[test]

--- a/crates/schema/src/value.rs
+++ b/crates/schema/src/value.rs
@@ -232,30 +232,19 @@ impl FieldValues {
         self.0.insert(key, value);
     }
 
-    /// Convenience: set a raw JSON value by string key.
-    ///
-    /// Parses `key` as a [`FieldKey`] and wraps `value` via
-    /// [`FieldValue::from_json`]. Panics if `key` is invalid — use only in
-    /// tests/migrations with known-good keys. For runtime input, prefer
-    /// [`Self::try_set_raw`].
-    ///
-    /// # Panics
-    ///
-    /// Panics when `key` is invalid or nested object keys fail validation.
-    pub fn set_raw(&mut self, key: &str, value: Value) {
-        self.try_set_raw(key, value)
-            .unwrap_or_else(|e| panic!("set_raw failed for key {key:?}: {e}"));
-    }
-
-    /// Fallible variant of [`Self::set_raw`] for runtime code paths.
-    ///
-    /// Validates nested object keys before insertion and returns `invalid_key`
-    /// when any path segment violates [`FieldKey`] constraints.
+    /// Set a raw JSON value by string key. Validates nested object keys
+    /// before insertion and returns `invalid_key` when any path segment
+    /// violates [`FieldKey`] constraints.
     ///
     /// # Errors
     ///
     /// Returns a [`crate::error::ValidationError`] when `key` or nested keys
     /// are invalid.
+    ///
+    /// # Example
+    ///
+    /// Use `.expect("known-good key")` in tests/migrations where the key is
+    /// a static literal. For runtime input, propagate the error with `?`.
     #[expect(
         clippy::result_large_err,
         reason = "ValidationError is intentionally large; callers are on the validation path"
@@ -267,7 +256,7 @@ impl FieldValues {
     ) -> Result<(), crate::error::ValidationError> {
         let fk = FieldKey::new(key).map_err(|e| {
             crate::error::ValidationError::builder("invalid_key")
-                .message(format!("set_raw: invalid key {key:?}: {e}"))
+                .message(format!("try_set_raw: invalid key {key:?}: {e}"))
                 .param("key", Value::String(key.to_owned()))
                 .build()
         })?;
@@ -626,9 +615,10 @@ mod tests {
     }
 
     #[test]
-    fn set_raw_parses_expression_wrapper() {
+    fn try_set_raw_parses_expression_wrapper() {
         let mut vs = FieldValues::new();
-        vs.set_raw("expr", json!({"$expr":"{{ $x }}"}));
+        vs.try_set_raw("expr", json!({"$expr":"{{ $x }}"}))
+            .expect("test-only known-good key");
         assert!(matches!(
             vs.get(&FieldKey::new("expr").unwrap()),
             Some(FieldValue::Expression(_))

--- a/crates/schema/tests/builder_dsl.rs
+++ b/crates/schema/tests/builder_dsl.rs
@@ -2,7 +2,7 @@
 
 use nebula_schema::{
     Field, FieldCollector, FieldValues, GroupBuilder, InputHint, RequiredMode, Schema,
-    StringWidget, VisibilityMode,
+    StringWidget, VisibilityMode, field_key,
 };
 use nebula_validator::{Predicate, Rule};
 
@@ -14,7 +14,7 @@ use serde_json::json;
 #[test]
 fn closure_string_produces_equivalent_schema() {
     let via_closure = Schema::builder()
-        .string("name", |s| {
+        .string(field_key!("name"), |s| {
             s.label("Name")
                 .required()
                 .min_length(1)
@@ -26,7 +26,7 @@ fn closure_string_produces_equivalent_schema() {
 
     let via_direct = Schema::builder()
         .add(
-            Field::string("name")
+            Field::string(field_key!("name"))
                 .label("Name")
                 .required()
                 .min_length(1)
@@ -42,7 +42,7 @@ fn closure_string_produces_equivalent_schema() {
 #[test]
 fn closure_number_integer_flag_applied() {
     let schema = Schema::builder()
-        .integer("count", |n| n.min(0_i64).max(100_i64))
+        .integer(field_key!("count"), |n| n.min(0_i64).max(100_i64))
         .build()
         .unwrap();
     match &schema.fields()[0] {
@@ -57,7 +57,7 @@ fn closure_number_integer_flag_applied() {
 #[test]
 fn closure_boolean_chainable() {
     let schema = Schema::builder()
-        .boolean("flag", |b| b.label("Flag").no_expression())
+        .boolean(field_key!("flag"), |b| b.label("Flag").no_expression())
         .build()
         .unwrap();
     match &schema.fields()[0] {
@@ -75,10 +75,10 @@ fn closure_boolean_chainable() {
 #[test]
 fn closure_nested_object_holds_children() {
     let schema = Schema::builder()
-        .object("user", |o| {
+        .object(field_key!("user"), |o| {
             o.label("User")
-                .string("name", nebula_schema::StringBuilder::required)
-                .number("age", |n| n.integer().min(0_i64))
+                .string(field_key!("name"), nebula_schema::StringBuilder::required)
+                .number(field_key!("age"), |n| n.integer().min(0_i64))
         })
         .build()
         .unwrap();
@@ -96,10 +96,10 @@ fn closure_nested_object_holds_children() {
 #[test]
 fn closure_list_item_via_closure() {
     let schema = Schema::builder()
-        .list("tags", |l| {
+        .list(field_key!("tags"), |l| {
             l.min_items(1)
                 .max_items(10)
-                .item_string("entry", |s| s.max_length(32))
+                .item_string(field_key!("entry"), |s| s.max_length(32))
         })
         .build()
         .unwrap();
@@ -121,16 +121,19 @@ fn closure_list_item_via_closure() {
 #[test]
 fn builder_full_example_from_spec() {
     let schema = Schema::builder()
-        .string("url", |s| {
+        .string(field_key!("url"), |s| {
             s.label("URL")
                 .hint(InputHint::Url)
                 .required()
                 .max_length(8192)
         })
-        .integer("timeout", |n| {
+        .integer(field_key!("timeout"), |n| {
             n.label("Timeout (s)").min(1_i64).max(300_i64)
         })
-        .boolean("verbose", nebula_schema::BooleanBuilder::no_expression)
+        .boolean(
+            field_key!("verbose"),
+            nebula_schema::BooleanBuilder::no_expression,
+        )
         .build()
         .unwrap();
 
@@ -145,11 +148,11 @@ fn builder_full_example_from_spec() {
 fn group_propagates_visible_when_to_children() {
     let rule = eq_rule("method", "POST");
     let schema = Schema::builder()
-        .string("method", nebula_schema::StringBuilder::required)
+        .string(field_key!("method"), nebula_schema::StringBuilder::required)
         .group("body_section", |g| {
             g.visible_when(rule.clone())
-                .string("body", |s| s.widget(StringWidget::Multiline))
-                .integer("content_length", |n| n)
+                .string(field_key!("body"), |s| s.widget(StringWidget::Multiline))
+                .integer(field_key!("content_length"), |n| n)
         })
         .build()
         .unwrap();
@@ -180,11 +183,11 @@ fn group_propagates_visible_when_to_children() {
 fn group_propagates_required_when_to_children() {
     let rule = eq_rule("enabled", true);
     let schema = Schema::builder()
-        .boolean("enabled", |b| b)
+        .boolean(field_key!("enabled"), |b| b)
         .group("details", |g| {
             g.required_when(rule.clone())
-                .string("detail_a", |s| s)
-                .string("detail_b", |s| s)
+                .string(field_key!("detail_a"), |s| s)
+                .string(field_key!("detail_b"), |s| s)
         })
         .build()
         .unwrap();
@@ -205,11 +208,11 @@ fn group_composes_existing_child_visible_when() {
     let group_rule = eq_rule("section", "A");
     let child_rule = eq_rule("mode", "advanced");
     let schema = Schema::builder()
-        .string("section", |s| s)
-        .string("mode", |s| s)
+        .string(field_key!("section"), |s| s)
+        .string(field_key!("mode"), |s| s)
         .group("g", |g| {
             g.visible_when(group_rule.clone())
-                .string("x", |s| s.visible_when(child_rule.clone()))
+                .string(field_key!("x"), |s| s.visible_when(child_rule.clone()))
         })
         .build()
         .unwrap();
@@ -239,14 +242,14 @@ fn group_builder_name_accessor() {
 fn group_required_when_composes_with_always_and_never_children() {
     let rule = eq_rule("enabled", true);
     let schema = Schema::builder()
-        .boolean("enabled", |b| b)
+        .boolean(field_key!("enabled"), |b| b)
         // A field declared `.required()` before the group applies its
         // `required_when` must stay `Always` (compose_required's
         // `Always` branch).
         .group("details", |g| {
             g.required_when(rule.clone())
-                .string("always_required", nebula_schema::StringBuilder::required)
-                .string("optional_by_default", |s| s)
+                .string(field_key!("always_required"), nebula_schema::StringBuilder::required)
+                .string(field_key!("optional_by_default"), |s| s)
         })
         .build()
         .unwrap();
@@ -275,8 +278,8 @@ fn group_required_when_composes_with_always_and_never_children() {
 fn group_preserves_explicit_child_group_label() {
     let schema = Schema::builder()
         .group("outer", |g| {
-            g.string("inherits", |s| s)
-                .string("overrides", |s| s.group("inner"))
+            g.string(field_key!("inherits"), |s| s)
+                .string(field_key!("overrides"), |s| s.group("inner"))
         })
         .build()
         .unwrap();

--- a/crates/schema/tests/compile_fail/boolean_no_pattern.rs
+++ b/crates/schema/tests/compile_fail/boolean_no_pattern.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = nebula_schema::Field::boolean("enabled").pattern("yes|no");
+    let _ = nebula_schema::Field::boolean(nebula_schema::field_key!("enabled")).pattern("yes|no");
 }

--- a/crates/schema/tests/compile_fail/boolean_no_pattern.stderr
+++ b/crates/schema/tests/compile_fail/boolean_no_pattern.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `pattern` found for struct `BooleanBuilder` in the current scope
- --> tests/compile_fail/boolean_no_pattern.rs:2:54
+ --> tests/compile_fail/boolean_no_pattern.rs:2:81
   |
-2 |     let _ = nebula_schema::Field::boolean("enabled").pattern("yes|no");
-  |                                                      ^^^^^^^ method not found in `BooleanBuilder`
+2 |     let _ = nebula_schema::Field::boolean(nebula_schema::field_key!("enabled")).pattern("yes|no");
+  |                                                                                 ^^^^^^^ method not found in `BooleanBuilder`

--- a/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.rs
@@ -4,6 +4,6 @@ use serde_json::json;
 fn main() {
     // `option` belongs to SelectField, not BooleanField/BooleanBuilder.
     let _ = Schema::builder()
-        .boolean("flag", |b| b.option(json!(1), "X"))
+        .boolean(nebula_schema::field_key!("flag"), |b| b.option(json!(1), "X"))
         .build();
 }

--- a/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_boolean_no_option.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `option` found for struct `BooleanBuilder` in the current scope
- --> tests/compile_fail/builder_closure_boolean_no_option.rs:7:32
+ --> tests/compile_fail/builder_closure_boolean_no_option.rs:7:59
   |
-7 |         .boolean("flag", |b| b.option(json!(1), "X"))
-  |                                ^^^^^^ method not found in `BooleanBuilder`
+7 |         .boolean(nebula_schema::field_key!("flag"), |b| b.option(json!(1), "X"))
+  |                                                           ^^^^^^ method not found in `BooleanBuilder`

--- a/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.rs
@@ -3,6 +3,6 @@ use nebula_schema::{FieldCollector, Schema, StringWidget};
 fn main() {
     // StringWidget::Multiline is specific to StringField; NumberField takes NumberWidget.
     let _ = Schema::builder()
-        .number("n", |n| n.widget(StringWidget::Multiline))
+        .number(nebula_schema::field_key!("n"), |n| n.widget(StringWidget::Multiline))
         .build();
 }

--- a/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_number_no_widget_multiline.stderr
@@ -1,10 +1,10 @@
 error[E0308]: mismatched types
- --> tests/compile_fail/builder_closure_number_no_widget_multiline.rs:6:35
+ --> tests/compile_fail/builder_closure_number_no_widget_multiline.rs:6:62
   |
-6 |         .number("n", |n| n.widget(StringWidget::Multiline))
-  |                            ------ ^^^^^^^^^^^^^^^^^^^^^^^ expected `NumberWidget`, found `StringWidget`
-  |                            |
-  |                            arguments to this method are incorrect
+6 |         .number(nebula_schema::field_key!("n"), |n| n.widget(StringWidget::Multiline))
+  |                                                       ------ ^^^^^^^^^^^^^^^^^^^^^^^ expected `NumberWidget`, found `StringWidget`
+  |                                                       |
+  |                                                       arguments to this method are incorrect
   |
 note: method defined here
  --> src/field.rs

--- a/crates/schema/tests/compile_fail/builder_closure_string_no_min.rs
+++ b/crates/schema/tests/compile_fail/builder_closure_string_no_min.rs
@@ -2,5 +2,5 @@ use nebula_schema::{FieldCollector, Schema};
 
 fn main() {
     // `min` belongs to NumberField, not StringField/StringBuilder.
-    let _ = Schema::builder().string("name", |s| s.min(1)).build();
+    let _ = Schema::builder().string(nebula_schema::field_key!("name"), |s| s.min(1)).build();
 }

--- a/crates/schema/tests/compile_fail/builder_closure_string_no_min.stderr
+++ b/crates/schema/tests/compile_fail/builder_closure_string_no_min.stderr
@@ -1,8 +1,8 @@
 error[E0599]: the method `min` exists for struct `StringBuilder`, but its trait bounds were not satisfied
- --> tests/compile_fail/builder_closure_string_no_min.rs:5:52
+ --> tests/compile_fail/builder_closure_string_no_min.rs:5:79
   |
-5 |       let _ = Schema::builder().string("name", |s| s.min(1)).build();
-  |                                                      ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
+5 |       let _ = Schema::builder().string(nebula_schema::field_key!("name"), |s| s.min(1)).build();
+  |                                                                                 ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
   |
  ::: src/field.rs
   |

--- a/crates/schema/tests/compile_fail/derive_no_expression_and_required.rs
+++ b/crates/schema/tests/compile_fail/derive_no_expression_and_required.rs
@@ -1,0 +1,12 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    #[param(no_expression, expression_required)]
+    name: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_no_expression_and_required.stderr
+++ b/crates/schema/tests/compile_fail/derive_no_expression_and_required.stderr
@@ -1,0 +1,18 @@
+error: `#[param(no_expression)]` and `#[param(expression_required)]` are contradictory: pick exactly one expression-mode attribute
+ --> tests/compile_fail/derive_no_expression_and_required.rs:7:5
+  |
+7 |     name: String,
+  |     ^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_no_expression_and_required.rs:11:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+11 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_secret_with_default.rs
+++ b/crates/schema/tests/compile_fail/derive_secret_with_default.rs
@@ -1,0 +1,12 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    #[param(secret, default = "hardcoded-secret")]
+    api_key: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_secret_with_default.stderr
+++ b/crates/schema/tests/compile_fail/derive_secret_with_default.stderr
@@ -1,0 +1,18 @@
+error: `#[param(default = ..)]` on a secret field hard-codes plaintext into the schema; configure the value via the credential setup form instead
+ --> tests/compile_fail/derive_secret_with_default.rs:7:5
+  |
+7 |     api_key: String,
+  |     ^^^^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_secret_with_default.rs:11:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+11 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/derive_secret_with_multiline.rs
+++ b/crates/schema/tests/compile_fail/derive_secret_with_multiline.rs
@@ -1,0 +1,12 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    #[param(secret, multiline)]
+    api_key: String,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_secret_with_multiline.stderr
+++ b/crates/schema/tests/compile_fail/derive_secret_with_multiline.stderr
@@ -1,0 +1,18 @@
+error: `#[param(multiline)]` does not apply to secret fields — secret values are always rendered as masked single-line input
+ --> tests/compile_fail/derive_secret_with_multiline.rs:7:5
+  |
+7 |     api_key: String,
+  |     ^^^^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_secret_with_multiline.rs:11:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+11 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`

--- a/crates/schema/tests/compile_fail/number_no_multiline.rs
+++ b/crates/schema/tests/compile_fail/number_no_multiline.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = nebula_schema::Field::number("count").multiline();
+    let _ = nebula_schema::Field::number(nebula_schema::field_key!("count")).multiline();
 }

--- a/crates/schema/tests/compile_fail/number_no_multiline.stderr
+++ b/crates/schema/tests/compile_fail/number_no_multiline.stderr
@@ -1,5 +1,5 @@
 error[E0599]: no method named `multiline` found for struct `NumberBuilder` in the current scope
- --> tests/compile_fail/number_no_multiline.rs:2:51
+ --> tests/compile_fail/number_no_multiline.rs:2:78
   |
-2 |     let _ = nebula_schema::Field::number("count").multiline();
-  |                                                   ^^^^^^^^^ method not found in `NumberBuilder`
+2 |     let _ = nebula_schema::Field::number(nebula_schema::field_key!("count")).multiline();
+  |                                                                              ^^^^^^^^^ method not found in `NumberBuilder`

--- a/crates/schema/tests/compile_fail/secret_widget_mismatch.rs
+++ b/crates/schema/tests/compile_fail/secret_widget_mismatch.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = nebula_schema::Field::secret("token").widget(nebula_schema::StringWidget::Email);
+    let _ = nebula_schema::Field::secret(nebula_schema::field_key!("token")).widget(nebula_schema::StringWidget::Email);
 }

--- a/crates/schema/tests/compile_fail/secret_widget_mismatch.stderr
+++ b/crates/schema/tests/compile_fail/secret_widget_mismatch.stderr
@@ -1,10 +1,10 @@
 error[E0308]: mismatched types
- --> tests/compile_fail/secret_widget_mismatch.rs:2:58
+ --> tests/compile_fail/secret_widget_mismatch.rs:2:85
   |
-2 |     let _ = nebula_schema::Field::secret("token").widget(nebula_schema::StringWidget::Email);
-  |                                                   ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `SecretWidget`, found `StringWidget`
-  |                                                   |
-  |                                                   arguments to this method are incorrect
+2 |     let _ = nebula_schema::Field::secret(nebula_schema::field_key!("token")).widget(nebula_schema::StringWidget::Email);
+  |                                                                              ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `SecretWidget`, found `StringWidget`
+  |                                                                              |
+  |                                                                              arguments to this method are incorrect
   |
 note: method defined here
  --> src/field.rs

--- a/crates/schema/tests/compile_fail/string_no_min.rs
+++ b/crates/schema/tests/compile_fail/string_no_min.rs
@@ -1,3 +1,3 @@
 fn main() {
-    let _ = nebula_schema::Field::string("name").min(1);
+    let _ = nebula_schema::Field::string(nebula_schema::field_key!("name")).min(1);
 }

--- a/crates/schema/tests/compile_fail/string_no_min.stderr
+++ b/crates/schema/tests/compile_fail/string_no_min.stderr
@@ -1,8 +1,8 @@
 error[E0599]: the method `min` exists for struct `StringBuilder`, but its trait bounds were not satisfied
- --> tests/compile_fail/string_no_min.rs:2:50
+ --> tests/compile_fail/string_no_min.rs:2:77
   |
-2 |       let _ = nebula_schema::Field::string("name").min(1);
-  |                                                    ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
+2 |       let _ = nebula_schema::Field::string(nebula_schema::field_key!("name")).min(1);
+  |                                                                               ^^^ method cannot be called on `StringBuilder` due to unsatisfied trait bounds
   |
  ::: src/field.rs
   |

--- a/crates/schema/tests/field_schema.rs
+++ b/crates/schema/tests/field_schema.rs
@@ -1,6 +1,6 @@
 use nebula_schema::{
     BooleanWidget, Field, FieldValues, NumberWidget, RequiredMode, Schema, SecretWidget,
-    SelectWidget, StringWidget, Transformer, VisibilityMode,
+    SelectWidget, StringWidget, Transformer, VisibilityMode, field_key,
 };
 use serde_json::json;
 
@@ -11,7 +11,7 @@ fn raw_schema(fields: impl IntoIterator<Item = Field>) -> Schema {
 
 #[test]
 fn builds_typed_fields_with_rules() {
-    let field = Field::string("name")
+    let field = Field::string(field_key!("name"))
         .label("Name")
         .required()
         .min_length(2)
@@ -25,14 +25,14 @@ fn builds_typed_fields_with_rules() {
 
 #[test]
 fn supports_select_and_number_builders() {
-    let select = Field::select("mode")
+    let select = Field::select(field_key!("mode"))
         .widget(SelectWidget::Combobox)
         .option("a", "Option A")
         .multiple()
         .searchable()
         .into_field();
 
-    let number = Field::number("retries")
+    let number = Field::number(field_key!("retries"))
         .integer()
         .widget(NumberWidget::Stepper)
         .min(0)
@@ -61,9 +61,13 @@ fn try_field_constructors_accept_valid_keys() {
 #[test]
 fn schema_add_and_find_work() {
     let schema = raw_schema(vec![
-        Field::string("name").widget(StringWidget::Plain).into(),
-        Field::secret("api_key").widget(SecretWidget::Plain).into(),
-        Field::boolean("enabled")
+        Field::string(field_key!("name"))
+            .widget(StringWidget::Plain)
+            .into(),
+        Field::secret(field_key!("api_key"))
+            .widget(SecretWidget::Plain)
+            .into(),
+        Field::boolean(field_key!("enabled"))
             .widget(BooleanWidget::Toggle)
             .into(),
     ]);
@@ -77,8 +81,8 @@ fn schema_add_and_find_work() {
 #[test]
 fn schema_builder_rejects_duplicate_key() {
     let result = Schema::builder()
-        .add(Field::string("name").min_length(2))
-        .add(Field::string("name").min_length(10))
+        .add(Field::string(field_key!("name")).min_length(2))
+        .add(Field::string(field_key!("name")).min_length(10))
         .build();
 
     let err = result.expect_err("duplicate key should cause build to fail");
@@ -88,7 +92,7 @@ fn schema_builder_rejects_duplicate_key() {
 #[test]
 fn serde_roundtrip_field_and_schema() {
     let schema = raw_schema(vec![
-        Field::string("username")
+        Field::string(field_key!("username"))
             .visible_when(nebula_validator::Rule::predicate(
                 nebula_validator::Predicate::eq("enabled", json!(true)).unwrap(),
             ))
@@ -107,7 +111,7 @@ fn serde_roundtrip_field_and_schema() {
 #[test]
 fn validate_reports_missing_required() {
     let schema = Schema::builder()
-        .add(Field::string("username").required())
+        .add(Field::string(field_key!("username")).required())
         .build()
         .expect("valid schema");
     let values = FieldValues::new();
@@ -122,9 +126,9 @@ fn validate_reports_missing_required() {
 #[test]
 fn validate_applies_visibility_and_rules() {
     let schema = Schema::builder()
-        .add(Field::boolean("enabled").required())
+        .add(Field::boolean(field_key!("enabled")).required())
         .add(
-            Field::string("api_key")
+            Field::string(field_key!("api_key"))
                 .visible_when(nebula_validator::Rule::predicate(
                     nebula_validator::Predicate::eq("enabled", json!(true)).unwrap(),
                 ))
@@ -135,11 +139,17 @@ fn validate_applies_visibility_and_rules() {
         .expect("valid schema");
 
     let mut values = FieldValues::new();
-    values.set_raw("enabled", json!(false));
+    values
+        .try_set_raw("enabled", json!(false))
+        .expect("test-only known-good key");
     assert!(schema.validate(&values).is_ok());
 
-    values.set_raw("enabled", json!(true));
-    values.set_raw("api_key", json!("abc"));
+    values
+        .try_set_raw("enabled", json!(true))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("api_key", json!("abc"))
+        .expect("test-only known-good key");
     let report = schema.validate(&values).unwrap_err();
     assert!(report.has_errors());
     assert!(report.errors().any(|e| e.path.to_string() == "api_key"));
@@ -148,15 +158,21 @@ fn validate_applies_visibility_and_rules() {
 #[test]
 fn validate_enforces_scalar_type_mismatches() {
     let schema = Schema::builder()
-        .add(Field::string("name").required())
-        .add(Field::number("retries").required())
-        .add(Field::boolean("enabled").required())
+        .add(Field::string(field_key!("name")).required())
+        .add(Field::number(field_key!("retries")).required())
+        .add(Field::boolean(field_key!("enabled")).required())
         .build()
         .expect("valid schema");
     let mut values = FieldValues::new();
-    values.set_raw("name", json!(123));
-    values.set_raw("retries", json!("bad"));
-    values.set_raw("enabled", json!("true"));
+    values
+        .try_set_raw("name", json!(123))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("retries", json!("bad"))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("enabled", json!("true"))
+        .expect("test-only known-good key");
 
     let report = schema.validate(&values).unwrap_err();
     assert!(report.has_errors());
@@ -181,14 +197,16 @@ fn validate_enforces_scalar_type_mismatches() {
 fn validate_applies_transformers_before_rules() {
     let schema = Schema::builder()
         .add(
-            Field::string("api_key")
+            Field::string(field_key!("api_key"))
                 .with_transformer(Transformer::Trim)
                 .with_rule(nebula_validator::Rule::max_length(6)),
         )
         .build()
         .expect("valid schema");
     let mut values = FieldValues::new();
-    values.set_raw("api_key", json!("  SECRET  "));
+    values
+        .try_set_raw("api_key", json!("  SECRET  "))
+        .expect("test-only known-good key");
 
     assert!(schema.validate(&values).is_ok());
 }
@@ -196,13 +214,17 @@ fn validate_applies_transformers_before_rules() {
 #[test]
 fn validate_enforces_file_value_shape() {
     let schema = Schema::builder()
-        .add(Field::file("single").required())
-        .add(Field::file("many").multiple().required())
+        .add(Field::file(field_key!("single")).required())
+        .add(Field::file(field_key!("many")).multiple().required())
         .build()
         .expect("valid schema");
     let mut values = FieldValues::new();
-    values.set_raw("single", json!(true));
-    values.set_raw("many", json!(["a.txt", 42]));
+    values
+        .try_set_raw("single", json!(true))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("many", json!(["a.txt", 42]))
+        .expect("test-only known-good key");
 
     let report = schema.validate(&values).unwrap_err();
     assert!(report.has_errors());
@@ -223,30 +245,42 @@ fn serde_roundtrip_supports_all_field_variants() {
     use nebula_schema::InputHint;
 
     let schema = raw_schema(vec![
-        Field::string("s").into(),
-        Field::secret("sec").into(),
-        Field::number("n").into(),
-        Field::boolean("b").into(),
-        Field::select("sel").option("a", "A").into(),
-        Field::object("obj").add(Field::string("child")).into(),
-        Field::list("list").item(Field::string("item")).into(),
-        Field::mode("mode")
-            .variant("simple", "Simple", Field::string("payload"))
+        Field::string(field_key!("s")).into(),
+        Field::secret(field_key!("sec")).into(),
+        Field::number(field_key!("n")).into(),
+        Field::boolean(field_key!("b")).into(),
+        Field::select(field_key!("sel")).option("a", "A").into(),
+        Field::object(field_key!("obj"))
+            .add(Field::string(field_key!("child")))
             .into(),
-        Field::code("code").into(),
+        Field::list(field_key!("list"))
+            .item(Field::string(field_key!("item")))
+            .into(),
+        Field::mode(field_key!("mode"))
+            .variant("simple", "Simple", Field::string(field_key!("payload")))
+            .into(),
+        Field::code(field_key!("code")).into(),
         // Date/DateTime/Time/Color → StringField with hint (replaces removed variants)
-        Field::string("date").hint(InputHint::Date).into(),
-        Field::string("datetime").hint(InputHint::DateTime).into(),
-        Field::string("time").hint(InputHint::Time).into(),
-        Field::string("color_field").hint(InputHint::Color).into(),
-        Field::file("file").into(),
+        Field::string(field_key!("date"))
+            .hint(InputHint::Date)
+            .into(),
+        Field::string(field_key!("datetime"))
+            .hint(InputHint::DateTime)
+            .into(),
+        Field::string(field_key!("time"))
+            .hint(InputHint::Time)
+            .into(),
+        Field::string(field_key!("color_field"))
+            .hint(InputHint::Color)
+            .into(),
+        Field::file(field_key!("file")).into(),
         // Hidden → visible(Never) on any field
-        Field::string("hidden_field")
+        Field::string(field_key!("hidden_field"))
             .visible(VisibilityMode::Never)
             .into(),
-        Field::computed("computed").into(),
-        Field::dynamic("dynamic").into(),
-        Field::notice("notice").into(),
+        Field::computed(field_key!("computed")).into(),
+        Field::dynamic(field_key!("dynamic")).into(),
+        Field::notice(field_key!("notice")).into(),
     ]);
 
     let encoded = serde_json::to_value(&schema).expect("serialize full variant schema");

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -25,7 +25,7 @@
 //! - `"loader.missing_config"` — `load_select_options_without_loader_emits_missing_config`.
 
 use nebula_schema::{
-    ExpressionAst, ExpressionContext, Field, FieldKey, FieldValue, FieldValues, Schema,
+    EvalFuture, ExpressionAst, ExpressionContext, Field, FieldKey, FieldValue, FieldValues, Schema,
     ValidationError, ValidationReport, field_key,
 };
 use serde_json::json;
@@ -377,21 +377,21 @@ fn emits_expression_parse() {
 
 struct RuntimeFailCtx;
 
-#[async_trait::async_trait]
 impl ExpressionContext for RuntimeFailCtx {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Err(ValidationError::builder("expression.runtime")
-            .message("forced runtime failure")
-            .build())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move {
+            Err(ValidationError::builder("expression.runtime")
+                .message("forced runtime failure")
+                .build())
+        })
     }
 }
 
 struct ConstCtx(serde_json::Value);
 
-#[async_trait::async_trait]
 impl ExpressionContext for ConstCtx {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Ok(self.0.clone())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move { Ok(self.0.clone()) })
     }
 }
 
@@ -511,7 +511,7 @@ fn emits_duplicate_variant() {
 fn emits_schema_index_overflow() {
     let mut builder = Schema::builder();
     for i in 0..(usize::from(u16::MAX) + 2) {
-        builder = builder.add(Field::string(format!("f{i}")));
+        builder = builder.add(Field::string(fk(&format!("f{i}"))));
     }
     let report = builder.build().unwrap_err();
     assert!(has_code(&report, "schema.index_overflow"));
@@ -519,9 +519,9 @@ fn emits_schema_index_overflow() {
 
 #[test]
 fn emits_schema_depth_limit() {
-    let mut leaf = Field::string("leaf").into_field();
+    let mut leaf = Field::string(field_key!("leaf")).into_field();
     for i in 0..usize::from(u8::MAX) {
-        leaf = Field::object(format!("n{i}")).add(leaf).into_field();
+        leaf = Field::object(fk(&format!("n{i}"))).add(leaf).into_field();
     }
 
     let report = Schema::builder().add(leaf).build().unwrap_err();
@@ -548,7 +548,7 @@ fn emits_self_dependency() {
     use nebula_schema::{DynamicField, FieldPath};
 
     let path = FieldPath::parse("deps").unwrap();
-    let field = DynamicField::new("deps")
+    let field = DynamicField::new(field_key!("deps"))
         .loader("my_loader")
         .depends_on(path)
         .into_field();
@@ -652,7 +652,7 @@ fn emits_missing_loader_warning() {
 fn emits_loader_without_dynamic_warning() {
     // A select with a loader key but dynamic=false → loader_without_dynamic.
     use nebula_schema::{Field, SelectField};
-    let mut sf = SelectField::new("s2");
+    let mut sf = SelectField::new(field_key!("s2"));
     sf.dynamic = false;
     sf.loader = Some("my_loader".into());
     let schema = raw_schema(vec![Field::Select(sf)]);
@@ -720,7 +720,7 @@ fn emits_notice_misuse() {
     // NoticeField with required=Always → notice.misuse warning via lint_tree/SchemaBuilder.
     use nebula_schema::{Field, NoticeField, RequiredMode};
 
-    let mut nf = NoticeField::new("n");
+    let mut nf = NoticeField::new(field_key!("n"));
     nf.required = RequiredMode::Always;
     let schema = raw_schema(vec![Field::Notice(nf)]);
     let lint = schema.lint();
@@ -736,7 +736,7 @@ fn emits_notice_missing_description() {
     // NoticeField without description → notice_missing_description warning.
     use nebula_schema::{Field, NoticeField};
 
-    let nf = NoticeField::new("info");
+    let nf = NoticeField::new(field_key!("info"));
     let schema = raw_schema(vec![Field::Notice(nf)]);
     let lint = schema.lint();
     assert!(

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -529,6 +529,24 @@ fn emits_schema_depth_limit() {
 }
 
 #[test]
+fn emits_recursion_limit_on_deeply_nested_value_input() {
+    use nebula_schema::value::MAX_VALUE_DEPTH;
+
+    // Nest plain JSON objects 5 levels past MAX_VALUE_DEPTH to trigger the
+    // ingress depth-guard in `FieldValues::from_json`.
+    let mut current = json!({ "leaf": 1 });
+    for _ in 0..usize::from(MAX_VALUE_DEPTH) + 5 {
+        let mut wrapped = serde_json::Map::with_capacity(1);
+        wrapped.insert("n".to_owned(), current);
+        current = serde_json::Value::Object(wrapped);
+    }
+    let payload = json!({ "top": current });
+
+    let err = FieldValues::from_json(payload).expect_err("must reject deep input");
+    assert_eq!(err.code, "recursion_limit", "got: {}", err.message);
+}
+
+#[test]
 fn emits_rule_contradictory() {
     // min_length > max_length → rule.contradictory error.
     let report = Schema::builder()

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -529,6 +529,21 @@ fn emits_schema_depth_limit() {
 }
 
 #[test]
+fn emits_secret_default_forbidden() {
+    // Defaults on Field::Secret hard-code plaintext into the schema and
+    // are blocked by lint at build time.
+    let report = Schema::builder()
+        .add(Field::secret(field_key!("api_key")).default(json!("hardcoded-token")))
+        .build()
+        .unwrap_err();
+    assert!(
+        has_code(&report, "secret.default_forbidden"),
+        "got: {:?}",
+        report.errors().map(|e| &e.code).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn emits_recursion_limit_on_deeply_nested_value_input() {
     use nebula_schema::value::MAX_VALUE_DEPTH;
 

--- a/crates/schema/tests/lint_and_loader.rs
+++ b/crates/schema/tests/lint_and_loader.rs
@@ -1,6 +1,6 @@
 use nebula_schema::{
     Field, FieldPath, FieldValues, LoaderContext, LoaderRegistry, LoaderResult, Schema,
-    ValidationReport,
+    ValidationReport, field_key,
 };
 use serde_json::json;
 
@@ -24,21 +24,21 @@ fn has_warning(report: &ValidationReport, code: &str, path_prefix: &str) -> bool
 #[test]
 fn lint_schema_reports_dangling_refs_and_structural_issues() {
     let schema = raw_schema(vec![
-        Field::string("toggle").into(),
-        Field::string("name")
+        Field::string(field_key!("toggle")).into(),
+        Field::string(field_key!("name"))
             .visible_when(nebula_validator::Rule::predicate(
                 nebula_validator::Predicate::eq("missing", json!(true)).unwrap(),
             ))
             .with_rule(nebula_validator::Rule::min_length(5))
             .with_rule(nebula_validator::Rule::max_length(2))
             .into(),
-        Field::select("region")
+        Field::select(field_key!("region"))
             .dynamic()
             .loader("regions_loader")
             .depends_on(FieldPath::parse("unknown_ref").unwrap())
             .into(),
-        Field::mode("auth")
-            .variant("token", "", Field::secret("token"))
+        Field::mode(field_key!("auth"))
+            .variant("token", "", Field::secret(field_key!("token")))
             .default_variant("missing_variant")
             .into(),
     ]);
@@ -74,12 +74,12 @@ fn lint_schema_reports_dangling_refs_and_structural_issues() {
 #[tokio::test]
 async fn loader_registry_resolves_select_and_dynamic_loaders() {
     let schema = raw_schema(vec![
-        Field::select("workspace")
+        Field::select(field_key!("workspace"))
             .dynamic()
             .loader("workspace_loader")
             .depends_on(FieldPath::parse("team_id").unwrap())
             .into(),
-        Field::dynamic("resource")
+        Field::dynamic(field_key!("resource"))
             .loader("resource_loader")
             .depends_on(FieldPath::parse("workspace").unwrap())
             .into(),
@@ -105,8 +105,12 @@ async fn loader_registry_resolves_select_and_dynamic_loaders() {
         });
 
     let mut values = FieldValues::new();
-    values.set_raw("workspace", json!("ws_1"));
-    values.set_raw("team_id", json!("team_1"));
+    values
+        .try_set_raw("workspace", json!("ws_1"))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("team_id", json!("team_1"))
+        .expect("test-only known-good key");
     let context = LoaderContext::new("workspace", values.clone()).with_filter("prod");
 
     let options = schema
@@ -126,15 +130,15 @@ async fn loader_registry_resolves_select_and_dynamic_loaders() {
 #[tokio::test]
 async fn valid_schema_loader_apis_resolve_loaders() {
     let schema = Schema::builder()
-        .add(Field::string("team_id"))
+        .add(Field::string(field_key!("team_id")))
         .add(
-            Field::select("workspace")
+            Field::select(field_key!("workspace"))
                 .dynamic()
                 .loader("workspace_loader")
                 .depends_on(FieldPath::parse("team_id").unwrap()),
         )
         .add(
-            Field::dynamic("resource")
+            Field::dynamic(field_key!("resource"))
                 .loader("resource_loader")
                 .depends_on(FieldPath::parse("workspace").unwrap()),
         )
@@ -169,13 +173,13 @@ async fn valid_schema_loader_apis_resolve_loaders() {
 #[tokio::test]
 async fn nested_schema_loader_apis_resolve_object_paths() {
     let schema = raw_schema(vec![
-        Field::object("config")
+        Field::object(field_key!("config"))
             .add(
-                Field::select("workspace")
+                Field::select(field_key!("workspace"))
                     .dynamic()
                     .loader("workspace_loader"),
             )
-            .add(Field::dynamic("resource").loader("resource_loader"))
+            .add(Field::dynamic(field_key!("resource")).loader("resource_loader"))
             .into(),
     ]);
 
@@ -221,10 +225,10 @@ async fn nested_schema_loader_apis_resolve_object_paths() {
 #[tokio::test]
 async fn nested_schema_loader_apis_resolve_list_item_paths() {
     let schema = raw_schema(vec![
-        Field::list("rows")
+        Field::list(field_key!("rows"))
             .item(
-                Field::object("row").add(
-                    Field::select("workspace")
+                Field::object(field_key!("row")).add(
+                    Field::select(field_key!("workspace"))
                         .dynamic()
                         .loader("workspace_loader"),
                 ),
@@ -267,11 +271,14 @@ async fn nested_schema_loader_apis_resolve_list_item_paths() {
 #[tokio::test]
 async fn nested_valid_schema_loader_api_resolves_mode_variant_paths() {
     let schema = Schema::builder()
-        .add(Field::mode("auth").variant(
-            "oauth",
-            "OAuth",
-            Field::object("creds").add(Field::dynamic("resource").loader("resource_loader")),
-        ))
+        .add(
+            Field::mode(field_key!("auth")).variant(
+                "oauth",
+                "OAuth",
+                Field::object(field_key!("creds"))
+                    .add(Field::dynamic(field_key!("resource")).loader("resource_loader")),
+            ),
+        )
         .build()
         .expect("schema should build");
 
@@ -297,9 +304,9 @@ async fn nested_valid_schema_loader_api_resolves_mode_variant_paths() {
 #[tokio::test]
 async fn nested_loader_errors_anchor_to_nested_path() {
     let schema = raw_schema(vec![
-        Field::object("config")
+        Field::object(field_key!("config"))
             .add(
-                Field::select("workspace")
+                Field::select(field_key!("workspace"))
                     .dynamic()
                     .loader("missing_workspace_loader"),
             )
@@ -324,9 +331,9 @@ async fn nested_loader_errors_anchor_to_nested_path() {
 #[tokio::test]
 async fn top_level_loader_string_api_rejects_nested_paths() {
     let schema = raw_schema(vec![
-        Field::object("config")
+        Field::object(field_key!("config"))
             .add(
-                Field::select("workspace")
+                Field::select(field_key!("workspace"))
                     .dynamic()
                     .loader("workspace_loader"),
             )
@@ -349,7 +356,7 @@ async fn top_level_loader_string_api_rejects_nested_paths() {
 #[tokio::test]
 async fn loader_registry_reports_missing_loader_registration() {
     let schema = raw_schema(vec![
-        Field::select("region")
+        Field::select(field_key!("region"))
             .dynamic()
             .loader("missing_loader")
             .into(),
@@ -365,7 +372,12 @@ async fn loader_registry_reports_missing_loader_registration() {
 
 #[tokio::test]
 async fn load_select_options_unknown_key_emits_field_not_found() {
-    let schema = raw_schema(vec![Field::select("region").dynamic().loader("x").into()]);
+    let schema = raw_schema(vec![
+        Field::select(field_key!("region"))
+            .dynamic()
+            .loader("x")
+            .into(),
+    ]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("ghost", FieldValues::new());
     let error = schema
@@ -378,7 +390,7 @@ async fn load_select_options_unknown_key_emits_field_not_found() {
 
 #[tokio::test]
 async fn load_select_options_wrong_field_type_emits_type_mismatch() {
-    let schema = raw_schema(vec![Field::string("email").into()]);
+    let schema = raw_schema(vec![Field::string(field_key!("email")).into()]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("email", FieldValues::new());
     let error = schema
@@ -407,7 +419,11 @@ async fn load_select_options_wrong_field_type_emits_type_mismatch() {
 
 #[tokio::test]
 async fn load_select_options_without_loader_emits_missing_config() {
-    let schema = raw_schema(vec![Field::select("region").option("us", "US").into()]);
+    let schema = raw_schema(vec![
+        Field::select(field_key!("region"))
+            .option("us", "US")
+            .into(),
+    ]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("region", FieldValues::new());
     let error = schema
@@ -420,7 +436,7 @@ async fn load_select_options_without_loader_emits_missing_config() {
 
 #[tokio::test]
 async fn load_dynamic_records_wrong_field_type_emits_type_mismatch() {
-    let schema = raw_schema(vec![Field::number("count").into()]);
+    let schema = raw_schema(vec![Field::number(field_key!("count")).into()]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("count", FieldValues::new());
     let error = schema
@@ -440,7 +456,11 @@ async fn load_dynamic_records_wrong_field_type_emits_type_mismatch() {
 
 #[tokio::test]
 async fn load_dynamic_records_unknown_key_emits_field_not_found() {
-    let schema = raw_schema(vec![Field::dynamic("resource").loader("loader_x").into()]);
+    let schema = raw_schema(vec![
+        Field::dynamic(field_key!("resource"))
+            .loader("loader_x")
+            .into(),
+    ]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("ghost", FieldValues::new());
     let error = schema
@@ -453,7 +473,7 @@ async fn load_dynamic_records_unknown_key_emits_field_not_found() {
 
 #[tokio::test]
 async fn load_dynamic_records_without_loader_emits_missing_config() {
-    let schema = raw_schema(vec![Field::dynamic("resource").into()]);
+    let schema = raw_schema(vec![Field::dynamic(field_key!("resource")).into()]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("resource", FieldValues::new());
     let error = schema
@@ -467,12 +487,12 @@ async fn load_dynamic_records_without_loader_emits_missing_config() {
 #[test]
 fn lint_schema_detects_visibility_cycles() {
     let schema = raw_schema(vec![
-        Field::string("a")
+        Field::string(field_key!("a"))
             .visible_when(nebula_validator::Rule::predicate(
                 nebula_validator::Predicate::eq("b", json!(true)).unwrap(),
             ))
             .into(),
-        Field::string("b")
+        Field::string(field_key!("b"))
             .visible_when(nebula_validator::Rule::predicate(
                 nebula_validator::Predicate::eq("a", json!(true)).unwrap(),
             ))
@@ -494,9 +514,9 @@ fn lint_schema_detects_visibility_cycles() {
 #[test]
 fn runtime_validation_still_works_with_linted_schema() {
     let schema = Schema::builder()
-        .add(Field::boolean("enabled").required())
+        .add(Field::boolean(field_key!("enabled")).required())
         .add(
-            Field::string("name")
+            Field::string(field_key!("name"))
                 .required_when(nebula_validator::Rule::predicate(
                     nebula_validator::Predicate::eq("enabled", json!(true)).unwrap(),
                 ))
@@ -506,8 +526,12 @@ fn runtime_validation_still_works_with_linted_schema() {
         .expect("valid schema");
 
     let mut values = FieldValues::new();
-    values.set_raw("enabled", json!(true));
-    values.set_raw("name", json!("ab"));
+    values
+        .try_set_raw("enabled", json!(true))
+        .expect("test-only known-good key");
+    values
+        .try_set_raw("name", json!("ab"))
+        .expect("test-only known-good key");
 
     let report = schema.validate(&values).unwrap_err();
     assert!(report.has_errors());
@@ -516,16 +540,16 @@ fn runtime_validation_still_works_with_linted_schema() {
 #[test]
 fn lint_schema_reports_rule_incompatible_warnings() {
     let schema = raw_schema(vec![
-        Field::number("retries")
+        Field::number(field_key!("retries"))
             .with_rule(nebula_validator::Rule::pattern("^\\d+$"))
             .with_rule(nebula_validator::Rule::email())
             .into(),
-        Field::string("name")
+        Field::string(field_key!("name"))
             .with_rule(nebula_validator::Rule::Value(
                 nebula_validator::ValueRule::Min(serde_json::Number::from(1)),
             ))
             .into(),
-        Field::boolean("flag")
+        Field::boolean(field_key!("flag"))
             .with_rule(nebula_validator::Rule::all([
                 nebula_validator::Rule::max_length(10),
                 nebula_validator::Rule::not(nebula_validator::Rule::min_items(1)),
@@ -551,20 +575,20 @@ fn lint_schema_reports_rule_incompatible_warnings() {
 #[test]
 fn lint_schema_accepts_compatible_rule_types() {
     let schema = raw_schema(vec![
-        Field::string("title")
+        Field::string(field_key!("title"))
             .min_length(3)
             .with_rule(nebula_validator::Rule::url())
             .into(),
-        Field::number("timeout")
+        Field::number(field_key!("timeout"))
             .with_rule(nebula_validator::Rule::Value(
                 nebula_validator::ValueRule::Min(serde_json::Number::from(1)),
             ))
             .into(),
-        Field::list("tags")
-            .item(Field::string("tag"))
+        Field::list(field_key!("tags"))
+            .item(Field::string(field_key!("tag")))
             .with_rule(nebula_validator::Rule::min_items(1))
             .into(),
-        Field::select("regions")
+        Field::select(field_key!("regions"))
             .multiple()
             .with_rule(nebula_validator::Rule::max_items(3))
             .into(),
@@ -592,8 +616,11 @@ fn lint_schema_accepts_compatible_rule_types() {
 #[test]
 fn lint_treats_blank_loader_key_as_missing_loader() {
     let schema = raw_schema(vec![
-        Field::select("region").dynamic().loader("   ").into(),
-        Field::dynamic("resource").loader("").into(),
+        Field::select(field_key!("region"))
+            .dynamic()
+            .loader("   ")
+            .into(),
+        Field::dynamic(field_key!("resource")).loader("").into(),
     ]);
 
     let report = schema.lint();
@@ -611,7 +638,7 @@ fn lint_treats_blank_loader_key_as_missing_loader() {
 fn lint_reports_duplicate_depends_on_entries() {
     let dependency = FieldPath::parse("team_id").unwrap();
     let schema = raw_schema(vec![
-        Field::select("workspace")
+        Field::select(field_key!("workspace"))
             .dynamic()
             .loader("workspace_loader")
             .depends_on(dependency.clone())
@@ -632,7 +659,12 @@ fn lint_reports_duplicate_depends_on_entries() {
 
 #[tokio::test]
 async fn load_select_options_blank_loader_emits_missing_config() {
-    let schema = raw_schema(vec![Field::select("region").dynamic().loader(" ").into()]);
+    let schema = raw_schema(vec![
+        Field::select(field_key!("region"))
+            .dynamic()
+            .loader(" ")
+            .into(),
+    ]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("region", FieldValues::new());
     let error = schema
@@ -644,7 +676,9 @@ async fn load_select_options_blank_loader_emits_missing_config() {
 
 #[tokio::test]
 async fn load_dynamic_records_blank_loader_emits_missing_config() {
-    let schema = raw_schema(vec![Field::dynamic("resource").loader(" ").into()]);
+    let schema = raw_schema(vec![
+        Field::dynamic(field_key!("resource")).loader(" ").into(),
+    ]);
     let registry = LoaderRegistry::new();
     let context = LoaderContext::new("resource", FieldValues::new());
     let error = schema
@@ -659,13 +693,13 @@ fn loader_dependency_cycle_detected() {
     // region depends_on cloud_provider, cloud_provider depends_on region -> cycle
     let schema = Schema::builder()
         .add(
-            Field::select("region")
+            Field::select(field_key!("region"))
                 .dynamic()
                 .loader("region_loader")
                 .depends_on(FieldPath::parse("cloud_provider").unwrap()),
         )
         .add(
-            Field::select("cloud_provider")
+            Field::select(field_key!("cloud_provider"))
                 .dynamic()
                 .loader("cloud_loader")
                 .depends_on(FieldPath::parse("region").unwrap()),
@@ -689,12 +723,12 @@ fn loader_dependency_no_cycle() {
     // The build itself succeeds without a loader_dependency_cycle error.
     let result = Schema::builder()
         .add(
-            Field::select("cloud_provider")
+            Field::select(field_key!("cloud_provider"))
                 .dynamic()
                 .loader("cloud_loader"),
         )
         .add(
-            Field::select("region")
+            Field::select(field_key!("region"))
                 .dynamic()
                 .loader("region_loader")
                 .depends_on(FieldPath::parse("cloud_provider").unwrap()),
@@ -716,19 +750,19 @@ fn loader_dependency_transitive_cycle() {
     // A depends_on B, B depends_on C, C depends_on A -> transitive cycle
     let schema = Schema::builder()
         .add(
-            Field::select("a")
+            Field::select(field_key!("a"))
                 .dynamic()
                 .loader("loader_a")
                 .depends_on(FieldPath::parse("b").unwrap()),
         )
         .add(
-            Field::select("b")
+            Field::select(field_key!("b"))
                 .dynamic()
                 .loader("loader_b")
                 .depends_on(FieldPath::parse("c").unwrap()),
         )
         .add(
-            Field::select("c")
+            Field::select(field_key!("c"))
                 .dynamic()
                 .loader("loader_c")
                 .depends_on(FieldPath::parse("a").unwrap()),
@@ -750,7 +784,7 @@ fn loader_dependency_transitive_cycle() {
 fn select_options_consistent_types_ok() {
     // All string options — no warning expected.
     let schema = raw_schema(vec![
-        Field::select("color")
+        Field::select(field_key!("color"))
             .option(json!("red"), "Red")
             .option(json!("green"), "Green")
             .option(json!("blue"), "Blue")
@@ -772,7 +806,7 @@ fn select_options_consistent_types_ok() {
 fn select_options_mixed_types_warns() {
     // Mix of string and number option values — should warn.
     let schema = raw_schema(vec![
-        Field::select("mixed")
+        Field::select(field_key!("mixed"))
             .option(json!("alpha"), "Alpha")
             .option(json!(1), "One")
             .into(),
@@ -793,7 +827,7 @@ fn select_options_mixed_types_warns() {
 fn select_options_complex_value_without_multiple_warns() {
     // Non-multiple select with an array option value — should warn.
     let schema = raw_schema(vec![
-        Field::select("tags")
+        Field::select(field_key!("tags"))
             .option(json!(["a", "b"]), "Tags A+B")
             .option(json!(["c"]), "Tag C")
             .into(),
@@ -814,7 +848,7 @@ fn select_options_complex_value_without_multiple_warns() {
 fn select_options_multiple_with_array_values_ok() {
     // Multiple select with array option values — consistent type, no warning expected.
     let schema = raw_schema(vec![
-        Field::select("tags")
+        Field::select(field_key!("tags"))
             .option(json!(["a", "b"]), "Tags A+B")
             .option(json!(["c", "d"]), "Tags C+D")
             .multiple()
@@ -836,7 +870,7 @@ fn select_options_multiple_with_array_values_ok() {
 fn select_single_option_complex_type_warns() {
     // Non-multiple select with a single option whose value is an array — should warn.
     let schema = raw_schema(vec![
-        Field::select("data")
+        Field::select(field_key!("data"))
             .option(json!(["x", "y"]), "X and Y")
             .into(),
     ]);

--- a/crates/schema/tests/lint_defaults.rs
+++ b/crates/schema/tests/lint_defaults.rs
@@ -1,6 +1,6 @@
 //! Tests for the `default.type_mismatch` lint pass.
 
-use nebula_schema::{Field, ValidSchema, ValidationReport};
+use nebula_schema::{Field, ValidSchema, ValidationReport, field_key};
 use serde_json::{Value, json};
 
 fn build(fields: impl IntoIterator<Item = Field>) -> Result<ValidSchema, ValidationReport> {
@@ -26,7 +26,7 @@ fn builds_ok(fields: impl IntoIterator<Item = Field>) -> bool {
 
 #[test]
 fn default_string_valid() {
-    let field = Field::string("greeting")
+    let field = Field::string(field_key!("greeting"))
         .default(json!("hello"))
         .into_field();
     assert!(builds_ok([field]));
@@ -34,7 +34,9 @@ fn default_string_valid() {
 
 #[test]
 fn default_string_invalid() {
-    let field = Field::string("greeting").default(json!(42)).into_field();
+    let field = Field::string(field_key!("greeting"))
+        .default(json!(42))
+        .into_field();
     assert!(has_type_mismatch([field]));
 }
 
@@ -42,13 +44,15 @@ fn default_string_invalid() {
 
 #[test]
 fn default_number_valid() {
-    let field = Field::number("ratio").default(json!(2.72)).into_field();
+    let field = Field::number(field_key!("ratio"))
+        .default(json!(2.72))
+        .into_field();
     assert!(builds_ok([field]));
 }
 
 #[test]
 fn default_number_invalid() {
-    let field = Field::number("ratio")
+    let field = Field::number(field_key!("ratio"))
         .default(json!("not a number"))
         .into_field();
     assert!(has_type_mismatch([field]));
@@ -58,7 +62,7 @@ fn default_number_invalid() {
 
 #[test]
 fn default_integer_valid() {
-    let field = Field::number("count")
+    let field = Field::number(field_key!("count"))
         .integer()
         .default(json!(5))
         .into_field();
@@ -67,7 +71,7 @@ fn default_integer_valid() {
 
 #[test]
 fn default_integer_invalid() {
-    let field = Field::number("count")
+    let field = Field::number(field_key!("count"))
         .integer()
         .default(json!(2.72))
         .into_field();
@@ -78,13 +82,15 @@ fn default_integer_invalid() {
 
 #[test]
 fn default_boolean_valid() {
-    let field = Field::boolean("enabled").default(json!(true)).into_field();
+    let field = Field::boolean(field_key!("enabled"))
+        .default(json!(true))
+        .into_field();
     assert!(builds_ok([field]));
 }
 
 #[test]
 fn default_boolean_invalid() {
-    let field = Field::boolean("enabled")
+    let field = Field::boolean(field_key!("enabled"))
         .default(json!("true"))
         .into_field();
     assert!(has_type_mismatch([field]));
@@ -94,8 +100,8 @@ fn default_boolean_invalid() {
 
 #[test]
 fn default_list_valid() {
-    let field = Field::list("tags")
-        .item(Field::string("item"))
+    let field = Field::list(field_key!("tags"))
+        .item(Field::string(field_key!("item")))
         .default(json!([1, 2, 3]))
         .into_field();
     assert!(builds_ok([field]));
@@ -103,8 +109,8 @@ fn default_list_valid() {
 
 #[test]
 fn default_list_invalid() {
-    let field = Field::list("tags")
-        .item(Field::string("item"))
+    let field = Field::list(field_key!("tags"))
+        .item(Field::string(field_key!("item")))
         .default(json!("not a list"))
         .into_field();
     assert!(has_type_mismatch([field]));
@@ -114,7 +120,7 @@ fn default_list_invalid() {
 
 #[test]
 fn default_select_multiple_array_valid() {
-    let field = Field::select("colors")
+    let field = Field::select(field_key!("colors"))
         .option(json!("a"), "A")
         .option(json!("b"), "B")
         .option(json!("c"), "C")
@@ -126,7 +132,7 @@ fn default_select_multiple_array_valid() {
 
 #[test]
 fn default_select_multiple_array_invalid_element() {
-    let field = Field::select("colors")
+    let field = Field::select(field_key!("colors"))
         .option(json!("a"), "A")
         .option(json!("b"), "B")
         .multiple()
@@ -137,7 +143,7 @@ fn default_select_multiple_array_invalid_element() {
 
 #[test]
 fn default_select_allow_custom_valid() {
-    let field = Field::select("tag")
+    let field = Field::select(field_key!("tag"))
         .option(json!("foo"), "Foo")
         .allow_custom()
         .default(json!("anything"))
@@ -149,8 +155,8 @@ fn default_select_allow_custom_valid() {
 
 #[test]
 fn default_mode_valid() {
-    let field = Field::mode("auth")
-        .variant("token", "Token", Field::string("token"))
+    let field = Field::mode(field_key!("auth"))
+        .variant("token", "Token", Field::string(field_key!("token")))
         .default(json!({"mode": "token", "value": null}))
         .into_field();
     assert!(builds_ok([field]));
@@ -158,8 +164,8 @@ fn default_mode_valid() {
 
 #[test]
 fn default_mode_extra_keys_invalid() {
-    let field = Field::mode("auth")
-        .variant("token", "Token", Field::string("token"))
+    let field = Field::mode(field_key!("auth"))
+        .variant("token", "Token", Field::string(field_key!("token")))
         .default(json!({"mode": "x", "extra": 1}))
         .into_field();
     assert!(has_type_mismatch([field]));
@@ -167,8 +173,8 @@ fn default_mode_extra_keys_invalid() {
 
 #[test]
 fn default_mode_missing_mode_key_invalid() {
-    let field = Field::mode("auth")
-        .variant("token", "Token", Field::string("token"))
+    let field = Field::mode(field_key!("auth"))
+        .variant("token", "Token", Field::string(field_key!("token")))
         .default(json!({"value": 1}))
         .into_field();
     assert!(has_type_mismatch([field]));
@@ -179,11 +185,17 @@ fn default_mode_missing_mode_key_invalid() {
 #[test]
 fn default_null_always_valid() {
     let fields: Vec<Field> = vec![
-        Field::string("s").default(Value::Null).into_field(),
-        Field::number("n").default(Value::Null).into_field(),
-        Field::boolean("b").default(Value::Null).into_field(),
-        Field::list("l")
-            .item(Field::string("i"))
+        Field::string(field_key!("s"))
+            .default(Value::Null)
+            .into_field(),
+        Field::number(field_key!("n"))
+            .default(Value::Null)
+            .into_field(),
+        Field::boolean(field_key!("b"))
+            .default(Value::Null)
+            .into_field(),
+        Field::list(field_key!("l"))
+            .item(Field::string(field_key!("i")))
             .default(Value::Null)
             .into_field(),
     ];

--- a/crates/schema/tests/pipeline_e2e.rs
+++ b/crates/schema/tests/pipeline_e2e.rs
@@ -5,16 +5,15 @@
 //! assertions instead of `main`.
 
 use nebula_schema::{
-    ExpressionAst, ExpressionContext, Field, FieldValues, Schema, ValidationError, field_key,
+    EvalFuture, ExpressionAst, ExpressionContext, Field, FieldValues, Schema, field_key,
 };
 use serde_json::json;
 
 struct Ctx(serde_json::Value);
 
-#[async_trait::async_trait]
 impl ExpressionContext for Ctx {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Ok(self.0.clone())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move { Ok(self.0.clone()) })
     }
 }
 

--- a/crates/schema/tests/prototype_translation.rs
+++ b/crates/schema/tests/prototype_translation.rs
@@ -1,22 +1,22 @@
-use nebula_schema::{Field, FieldValues, Schema};
+use nebula_schema::{Field, FieldValues, Schema, field_key};
 use serde_json::json;
 
 fn telegram_send_message_schema() -> nebula_schema::ValidSchema {
     Schema::builder()
         .add(
-            Field::select("resource")
+            Field::select(field_key!("resource"))
                 .option("message", "Message")
                 .option("chat", "Chat")
                 .required(),
         )
         .add(
-            Field::select("operation")
+            Field::select(field_key!("operation"))
                 .option("sendMessage", "Send Message")
                 .option("sendPhoto", "Send Photo")
                 .required(),
         )
         .add(
-            Field::string("text")
+            Field::string(field_key!("text"))
                 .min_length(1)
                 .max_length(4096)
                 .active_when(nebula_validator::Rule::predicate(
@@ -24,7 +24,7 @@ fn telegram_send_message_schema() -> nebula_schema::ValidSchema {
                 )),
         )
         .add(
-            Field::secret("api_key")
+            Field::secret(field_key!("api_key"))
                 .required()
                 .min_length(20)
                 .reveal_last(4),
@@ -36,26 +36,26 @@ fn telegram_send_message_schema() -> nebula_schema::ValidSchema {
 fn http_request_schema() -> nebula_schema::ValidSchema {
     Schema::builder()
         .add(
-            Field::select("method")
+            Field::select(field_key!("method"))
                 .option("GET", "GET")
                 .option("POST", "POST")
                 .option("PUT", "PUT")
                 .required(),
         )
-        .add(Field::string("url").required().url())
+        .add(Field::string(field_key!("url")).required().url())
         .add(
-            Field::mode("auth")
+            Field::mode(field_key!("auth"))
                 // "hidden" role: use VisibilityMode::Never (hidden variant removed)
                 .variant(
                     "none",
                     "None",
-                    Field::string("none_payload")
+                    Field::string(field_key!("none_payload"))
                         .visible(nebula_schema::VisibilityMode::Never),
                 )
                 .variant(
                     "bearer",
                     "Bearer",
-                    Field::secret("token").required().min_length(8),
+                    Field::secret(field_key!("token")).required().min_length(8),
                 )
                 .default_variant("none"),
         )
@@ -66,20 +66,20 @@ fn http_request_schema() -> nebula_schema::ValidSchema {
 fn oauth2_credential_schema() -> nebula_schema::ValidSchema {
     Schema::builder()
         .add(
-            Field::select("grant_type")
+            Field::select(field_key!("grant_type"))
                 .option("client_credentials", "Client Credentials")
                 .option("authorization_code", "Authorization Code")
                 .required(),
         )
         .add(
-            Field::secret("client_secret")
+            Field::secret(field_key!("client_secret"))
                 .required()
                 .multiline()
                 .reveal_last(4),
         )
         .add(
-            Field::list("scopes")
-                .item(Field::string("scope").min_length(1))
+            Field::list(field_key!("scopes"))
+                .item(Field::string(field_key!("scope")).min_length(1))
                 .min_items(1)
                 .max_items(20),
         )
@@ -90,9 +90,9 @@ fn oauth2_credential_schema() -> nebula_schema::ValidSchema {
 fn nested_object_schema() -> nebula_schema::ValidSchema {
     Schema::builder()
         .add(
-            Field::object("config")
-                .add(Field::string("host").required())
-                .add(Field::number("port").required()),
+            Field::object(field_key!("config"))
+                .add(Field::string(field_key!("host")).required())
+                .add(Field::number(field_key!("port")).required()),
         )
         .build()
         .expect("valid nested schema")

--- a/crates/schema/tests/resolve.rs
+++ b/crates/schema/tests/resolve.rs
@@ -30,44 +30,45 @@ struct ApiCredential {
 /// Returns a constant value for every expression.
 struct ConstCtx(serde_json::Value);
 
-#[async_trait::async_trait]
 impl ExpressionContext for ConstCtx {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Ok(self.0.clone())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move { Ok(self.0.clone()) })
     }
 }
 
 /// Returns values based on expression source fragments.
 struct RoutingCtx;
 
-#[async_trait::async_trait]
 impl ExpressionContext for RoutingCtx {
-    async fn evaluate(&self, ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        if ast.source().contains("$bad_str") {
-            return Ok(json!(123));
-        }
-        if ast.source().contains("$ok_str") {
-            return Ok(json!("ok"));
-        }
-        if ast.source().contains("$bad_item") {
-            return Ok(json!(999));
-        }
-        if ast.source().contains("$ok_num") {
-            return Ok(json!(42));
-        }
-        Ok(json!(null))
+    fn evaluate<'a>(&'a self, ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move {
+            if ast.source().contains("$bad_str") {
+                return Ok(json!(123));
+            }
+            if ast.source().contains("$ok_str") {
+                return Ok(json!("ok"));
+            }
+            if ast.source().contains("$bad_item") {
+                return Ok(json!(999));
+            }
+            if ast.source().contains("$ok_num") {
+                return Ok(json!(42));
+            }
+            Ok(json!(null))
+        })
     }
 }
 
 /// Always fails with `expression.runtime`.
 struct FailCtx;
 
-#[async_trait::async_trait]
 impl ExpressionContext for FailCtx {
-    async fn evaluate(&self, _ast: &ExpressionAst) -> Result<serde_json::Value, ValidationError> {
-        Err(ValidationError::builder("expression.runtime")
-            .message("evaluation failed")
-            .build())
+    fn evaluate<'a>(&'a self, _ast: &'a ExpressionAst) -> EvalFuture<'a> {
+        Box::pin(async move {
+            Err(ValidationError::builder("expression.runtime")
+                .message("evaluation failed")
+                .build())
+        })
     }
 }
 

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -147,7 +147,8 @@ macro_rules! params {
 
         let mut values = FieldValues::new();
         $(
-            values.set_raw($key, json!($value));
+            values.try_set_raw($key, json!($value))
+                .expect("params! macro: invalid FieldKey or nested key");
         )*
         values
     }};


### PR DESCRIPTION
## Summary

Closes the 18 findings raised in the 2026-04-28 code review of `nebula-schema` and `nebula-schema-macros`: 5 🔴 critical (panics in public API, `async-trait` anti-pattern, broken `PartialEq` contract) + 13 🟡 serious (KDF weakness, missing recursion guard, observability-DoD gaps, doc rot). Reviewer guide: read commits 1-by-1; each one is a self-contained phase with its own `BREAKING CHANGES` notes and a passing CI gate.

## Linked issue

- Closes NEB- _(no Linear ticket — driven by ad-hoc review)_

## Type of change

- [x] `refactor` — internal restructuring (T01-T05 introduce breaking changes; flagged below)
- [x] `feat` — new capabilities (KDF guardrails, recursion limit, tracing spans, audit feature, derive conflict detectors)
- [x] `fix` — correctness fixes (canonical bucket key, JSON-Schema symmetry, mode-key interning, redundant Drop, incremental revalidate)
- [x] `chore` — doc rot repair, clippy-deny on async-trait, lint Field::Secret defaults
- [x] `docs` — CHANGELOG, README maturity rewrite

## Affected crates / areas

- `nebula-schema` (lib + macros + tests + benches + examples)
- `nebula-schema-macros` (derive_schema codegen, field_key macro path resolution)
- Workspace migration call-sites: `nebula-action`, `nebula-credential`, `nebula-engine`, `nebula-metadata`, `nebula-sdk`
- Workspace tooling: root `Cargo.toml`, root `clippy.toml`, new `crates/schema/clippy.toml`

## Changes

5 commits, one per phase from `.ai-factory/plans/nebula-schema-quality-fixes.md`:

1. **`refactor(schema)!: remove panics from public API + drop async-trait`** (T01-T05)
   - `ExpressionContext::evaluate` no longer requires `#[async_trait]`; uses new `EvalFuture<'a>` boxed-future alias.
   - `Field::*::new` requires a pre-validated `FieldKey`; static keys via `field_key!("name")`, runtime via `Field::try_string(s)?`.
   - `FieldCollector` DSL methods (`.string()`/`.secret()`/...) take `FieldKey` directly. ~217 call sites migrated.
   - `FieldValues::set_raw` removed (use `try_set_raw(...)?` or `.expect("...")`).
   - `Loader<T>: PartialEq` removed (always-`true` impl violated the contract).
   - `#[derive(Schema)]` codegen emits `tracing::error!` with structured report before any remaining runtime panic; new compile-time conflict detectors for `secret + default`, `secret + multiline`, `no_expression + expression_required`.

2. **`feat(schema): tighten KDF guardrails + cap value-tree recursion`** (T06-T09)
   - Argon2id minimum costs (RFC 9106 §4): `memory_kib >= 8 MiB`, `time_cost >= 1`, `parallelism >= 1`. Salt minimum 16 bytes (was 8).
   - New `output_bytes: Option<u8>` on `KdfParams::Argon2id` (range `16..=64`, default `32`).
   - All bounds exported as public consts (`MIN_KDF_*` / `MAX_KDF_*` / `DEFAULT_KDF_OUTPUT_BYTES`).
   - New `recursion_limit` STANDARD_CODE; `FieldValues::from_json` rejects user JSON deeper than `MAX_VALUE_DEPTH = 64` at the ingress boundary.
   - Mode-key interning via `LazyLock<FieldKey>` removes ~6 per-call allocations on every `Field::Mode` recursion.
   - Manual `Drop` on `SecretBytes` removed (`Zeroizing<Vec<u8>>` already zeroizes).

3. **`feat(schema): tracing spans + correctness fixes on hot-path`** (T10-T14)
   - `#[tracing::instrument]` on `validate`, `resolve`, `load_options` / `load_records`, `lint_tree`, `json_schema`, `KdfParams::hash_password`. `warn!` events on err-paths.
   - New `audit-secret-expose` Cargo feature: `expose()` logs at `trace!` by default, escalates to `debug!` when feature is on.
   - `resolve()` skips post-resolve revalidate when no expressions resolved AND schema declares no expression-bearing fields (~50% wall-clock saving on the static-only fast path).
   - `first_duplicate_index` no longer falls back to a Debug-formatted bucket key (eliminates a class of false-positive `items.unique`).
   - JSON-Schema export: every property carries `x-nebula-resolved-value-schema` regardless of `ExpressionMode` (Forbidden no longer omits it).

4. **`chore(schema): repair docs, deny async-trait, lint Field::Secret defaults`** (T16-T18)
   - Removed README/secret.rs references to deleted `docs/INTEGRATION_MODEL.md`, `docs/MATURITY.md`, `docs/PRODUCT_CANON.md`, `docs/adr/0001-..0003-...`, `docs/adr/0034-..`, `docs/superpowers/specs/...`. `cargo doc -p nebula-schema --no-deps` is now warning-free.
   - New `crates/schema/clippy.toml` bans `async_trait::async_trait` for this crate; `#![deny(clippy::disallowed_macros)]` in `lib.rs`. Other crates inherit the workspace allow.
   - New `secret.default_forbidden` STANDARD_CODE; lint pass hard-rejects `Field::Secret { default: Some(_) }`. Documents the symmetry with `SecretString::Deserialize` (which always errors).

5. **`docs(schema): changelog + readme for nebula-schema quality fixes`** (T19-T21)
   - New `crates/schema/CHANGELOG.md` (Keep-a-Changelog format) inventorying every breaking change, addition, and fix from this PR.
   - README updated to reflect `try_set_raw`-only API surface.

**T15 deferred**: Per-crate `examples/` → root-level workspace member is a workspace-wide migration touching 10+ crates and warrants its own plan. Documented in the plan file.

## Test plan

- 333 → 339 unit/integration tests in `nebula-schema` (all green): added depth-guard / recursion-limit tests, sub-minimum KDF tests, secret-default lint tests, JSON-Schema symmetry regression test, and 3 new trybuild compile-fail snapshots for the derive macro.
- 7 trybuild snapshots re-blessed for the new `Field::*::new(FieldKey)` signature.
- 14 doctests pass (1 was failing due to missing `field_key` import, fixed in T20).
- Full workspace: `3675/3675` nextest tests + 15 skipped — same skip set as `main`.

### Local verification

- [x] `cargo +nightly fmt --check` — clean (per-crate touched scope, Windows path-length workaround for `--all`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — 3675 / 3675 pass
- [x] `cargo test --workspace --doc` — clean
- [x] `cargo deny check` — advisories / bans / licenses / sources OK

## Breaking changes

**5 hard-breaking changes**, all in `nebula-schema` (`frontier` API stability, no external published consumers):

1. `ExpressionContext::evaluate` signature: drop `#[async_trait]`, return `EvalFuture<'a>`. Migration: replace `async fn evaluate(...)` with `fn evaluate<'a>(...) -> EvalFuture<'a> { Box::pin(async move { ... }) }`.
2. `Field::*::new` accepts `FieldKey` only. Migration: `Field::string("name")` → `Field::string(field_key!("name"))` for static keys, or `Field::try_string("name")?` for runtime.
3. `FieldCollector::string` / `.secret` / etc accept `FieldKey`. Same migration as above.
4. `FieldValues::set_raw` removed. Migration: `values.set_raw(k, v)` → `values.try_set_raw(k, v).expect("...")` or propagate with `?`.
5. `Loader<T>: PartialEq` removed. Migration: don't compare loaders by value; if identity is required, hash on `Arc::as_ptr` of the underlying `Arc<dyn Fn>` exposed via a deliberate accessor (none currently).

`KdfParams::Argon2id` gained `output_bytes: Option<u8>`; the variant is `#[non_exhaustive]` so wire JSON without the field continues to deserialize. In-code constructors must add the new field.

See `crates/schema/CHANGELOG.md` for migration details.

## Docs checklist

- [x] No silent semantic drift: every breaking change documented in `CHANGELOG.md` + this PR.
- [x] Layer direction preserved (no new upward deps).
- [x] No new L2 invariant changes (proof-token pipeline semantics unchanged).
- [x] `crate README.md` / `lib.rs //!` updated where the public surface changed (T16, T20).
- [x] Plan archived: `.ai-factory/plans/nebula-schema-quality-fixes.md` (gitignored, kept for traceability).

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code. Active **removal** of 5 panics from the public API (T02, T03, T04 partial — derive runtime panic remains as a tracing-instrumented unreachable for unforeseen lint failures).
- [x] No silent error suppression introduced.
- [x] Engine state transition rule (#255) not relevant — this PR doesn't touch `nebula-engine` state machines.
- [x] Credentials / secrets: KDF guardrails tightened (T06), `SecretBytes` Drop simplified (T09 — `Zeroizing` semantics preserved), new `Field::Secret { default }` lint blocks plaintext drift into schema definitions (T18). `audit-secret-expose` feature offers an opt-in compliance log path.
- [x] No new `unsafe` blocks.

## Notes for reviewers

- Each of the 5 commits is independently buildable and testable. If review feels easier per phase, walk commits in order; the squash-merge body should still reference all 5 phases.
- T15 (per-crate `examples/` → root-level workspace member) is **deferred** to a future workspace-wide plan, not skipped — see plan file. ~10 sibling crates have the same shape; piecemeal migration would create an inconsistency.
- The `field_key!` macro path resolution change (`extern crate self as nebula_schema;` in `lib.rs`) deserves a careful look: it makes the macro's emitted absolute path resolve identically in lib code, doctests, integration tests, and external crates without per-context branching in `crate_path()`.
- `crates/schema/clippy.toml` is the first per-crate clippy.toml in this workspace; if you'd prefer a different placement (e.g. workspace-level + crate-level lint allow-overrides), happy to switch — both approaches were tried (commit history shows the attempt with workspace-level config that didn't override `clippy::all`).
