### PR TITLE
chore(engine): M1 — verify skip-propagation + drop dead expression_engine field

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -22,8 +22,10 @@
   (Layer 1 traits stable, 23 PG migrations + 9 common, CAS, outbox, reclaim).
   `engine` is ~80% — orchestration solid, **§11.5 durability debts closed
   via M0** (budget + workflow_input persistence shipped under #289 / #311;
-  explicit-termination wiring landed in M0.3); remaining engine debts are
-  full-graph edge gating (M1.1) and engine-level retry execution (M2.1).
+  explicit-termination wiring landed in M0.3); **§10 conditional-flow
+  correctness verified via M1** (skip-propagation tests + dead-field
+  cleanup, 2026-04-28); remaining engine debt is engine-level retry
+  execution (M2.1).
   `sandbox` is correctness-grade; capability discovery enforcement gap (canon
   §4.5).
 - **API layer** — routing wired; **5 sizable feature gaps** (auth backend,
@@ -93,19 +95,40 @@ Pure data debt, no architectural rework needed.
 test (`Terminate` → `ExplicitStop` round-trips through `ExecutionResult` and
 `ExecutionEvent`); M0.4 brings README/canon back in sync.
 
-### M1 — Engine correctness: full-graph edge gating
+### M1 — Engine correctness verification + cleanup (canon §10)
 
-- [ ] **M1.1** Replace local-edge skip propagation with full-graph
-      transitive blocking. Today `crates/engine/src/engine.rs:1808`
-      blocks only direct successors; multi-hop conditional flows can
-      read stale outputs from skipped branches.
-- [ ] **M1.2** Decide and document fate of `expression_engine` field
-      (`crates/engine/src/engine.rs:124-128`, currently
-      `#[expect(dead_code)]`): wire dynamic edge conditions for 1.0 OR
-      remove the field and downgrade canon §10 claims.
+**Why re-scoped.** The original M1.1 entry described a "local-edge gating"
+defect that recon (2026-04-28) showed didn't exist — `propagate_skip`
+(engine.rs:3267-3313) was already full-graph recursive via the
+`resolved == required && activated == 0` ladder. M1.2 option A ("wire
+dynamic edge conditions") contradicted Spec 28 §2.2 which already settled
+conditional routing via explicit `ControlAction` nodes. Re-scoped to
+verification + dead-field cleanup + doc audit.
 
-**Exit:** §10 conditional-flow text matches behaviour; no `#[expect(dead_code)]`
-in engine.
+- [x] **M1.1** ~~Verify full-graph skip propagation in non-trivial
+      topologies~~ — **DONE** (closed 2026-04-28). Added 5 integration tests
+      covering transitive 3-hop chain, diamond with one skipped branch,
+      mixed-source aggregate, all-sources-skipped aggregate, and multi-hop
+      skip with sibling activation (`crates/engine/tests/integration.rs`).
+      All pass on the existing `propagate_skip` recursion.
+- [x] **M1.2** ~~Remove dead `WorkflowEngine.expression_engine` field~~ —
+      **DONE** (closed 2026-04-28). Field at `engine.rs:125-130` (annotated
+      `#[expect(dead_code)]`) removed; the shared `Arc<ExpressionEngine>`
+      lives in `ParamResolver` (the only consumer, used for parameter
+      expression / template resolution). Spec 28 §2.2 already settled the
+      conditional-routing question via `ControlAction` nodes — there is no
+      engine-level edge expression to evaluate.
+- [x] **M1.3** ~~Sync canon §10 / docs with Spec 28 §2.2 port-driven
+      routing~~ — **DONE** (closed 2026-04-28). Updated
+      `crates/workflow/README.md` Public API section to describe `Connection`
+      as a pure wire (no `EdgeCondition` / `ResultMatcher` / `ErrorMatcher`);
+      added stale-doc warning + drift table to
+      `crates/workflow/docs/Architecture.md` (880-line pre-Spec-28 planning
+      doc). `connection.rs` and `builder.rs` already frame the removed
+      types as historical context (verified).
+
+**Exit:** skip-propagation correctness verified by tests; no
+`#[expect(dead_code)]` in engine; docs match shipping code.
 
 ### M2 — Engine retry semantics + node attempts
 

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -124,7 +124,6 @@ See `docs/MATURITY.md` row for `nebula-engine`.
 
 | Gap | Location | Canon impact |
 |---|---|---|
-| Downstream-edge gate blocks only **local** edges, not the full graph | `src/engine.rs:1808` | §10 conditional-flow gate is narrower than advertised |
 | `ExecutionBudget` moved to `nebula-execution` — import cleanup pending | `src/engine.rs` | documentation / import hygiene |
 
 ### Recently closed debts (ROADMAP §M0)
@@ -134,6 +133,14 @@ See `docs/MATURITY.md` row for `nebula-engine`.
 | `ExecutionBudget` not persisted in `ExecutionState` — budget lost on resume | issue #289 | `set_budget` at `state.rs:218`; restored at `engine.rs:1433-1444`; tests `resume_restores_persisted_budget` and `resume_falls_back_to_default_budget_on_legacy_state` |
 | Original workflow input not persisted — resume could not replay from input | issue #311 | `set_workflow_input` at `state.rs:206`; restored at `engine.rs:1487-1497`; test `resume_restores_original_workflow_input` |
 | `ActionResult::Terminate` not propagated to `ExecutionTerminationReason::ExplicitStop` / `ExplicitFail` — execution audit lost intent vs system-driven termination | ROADMAP §M0.3 | `set_terminated_by` at `state.rs:240`; engine wiring at `engine.rs:1986-area`; `determine_final_status` priority ladder at `engine.rs:3590`; surfaced via `ExecutionResult.termination_reason` and `ExecutionEvent::ExecutionFinished.termination_reason` |
+
+### Recently closed debts (ROADMAP §M1)
+
+| Closed debt | Closed by | Verification |
+|---|---|---|
+| Skip-propagation correctness on non-trivial topologies (multi-hop chain, diamond, mixed-source aggregate, all-sources-skipped, sibling activation) was undocumented and untested — `propagate_skip` recursion was not exercised beyond a single linear-3-node test | ROADMAP §M1.1 | 5 integration tests at `crates/engine/tests/integration.rs` (`skip_propagates_transitively_through_three_hop_chain`, `diamond_with_one_skipped_branch_still_completes`, `aggregate_with_one_skipped_source_fires`, `aggregate_with_all_sources_skipped_propagates_skip`, `multi_hop_skip_with_sibling_activation_still_runs`); all green |
+| Dead `WorkflowEngine.expression_engine` field with misleading `#[expect(dead_code)]` reason ("wired up... but not yet called at runtime"). Spec 28 §2.2 already settled conditional routing via `ControlAction` nodes — no engine-level edge expression to evaluate; the shared `Arc<ExpressionEngine>` lives in `ParamResolver` (the only consumer) | ROADMAP §M1.2 | Field removed at `engine.rs:125-130`; struct init at `engine.rs:262` no longer clones; `cargo clippy --workspace --all-targets -- -D warnings` green |
+| Stale Public API listing in `crates/workflow/README.md` advertising removed types (`EdgeCondition`, `ErrorMatcher`, `ResultMatcher`); 880-line `crates/workflow/docs/Architecture.md` pre-Spec-28 planning doc with no stale-marker | ROADMAP §M1.3 | `workflow/README.md` rewritten to describe `Connection` as a pure wire; `Architecture.md` frontmatter status changed to `stale-pre-spec-28` with drift table at top |
 
 ### Architecture notes
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -3207,14 +3207,16 @@ fn process_outgoing_edges(
 /// Port-driven routing (spec 28 §2.2): the engine matches the edge's
 /// effective source port (`from_port`, defaulting to `"main"`) against the
 /// port the upstream `ActionResult` produced on. There is no "edge
-/// condition" — conditionals are carried by explicit control-flow nodes
-/// (`If`, `Switch`, `Router`, `ErrorRouter`) whose own `ActionResult`
-/// decides which port fires.
+/// condition" — conditionals are carried by explicit `ControlAction` nodes
+/// (e.g. `If`, `Switch`, `Router` — the canonical 7 from
+/// `nebula_action::control`) whose own `ActionResult` decides which port
+/// fires.
 ///
 /// Rules:
 /// - `Skip` / `Drop` / `Terminate` → no edges activate on any port.
 /// - Failed node → only edges with `from_port == "error"` activate; action authors wire their
-///   failure path to an `ErrorRouter` or recovery node.
+///   failure path to whichever `ControlAction` fits (typically a `Switch` keyed on error class) or
+///   to a recovery node.
 /// - `Success` → activates edges on `"main"` (or `None`).
 /// - `Branch { selected }` → activates edges whose effective source port equals `selected` (legacy
 ///   alias for `Route`).
@@ -3238,8 +3240,9 @@ fn evaluate_edge(
 
     let effective_port = conn.effective_from_port();
 
-    // Failures route exclusively through the `"error"` port. Downstream must
-    // wire an explicit `ErrorRouter` / recovery node to fan out by error class.
+    // Failures route exclusively through the `"error"` port. Downstream
+    // must wire an explicit `ControlAction` (typically a `Switch` keyed on
+    // error class) or recovery node to fan out by error class.
     if node_failed {
         return effective_port == "error";
     }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -122,12 +122,6 @@ pub struct WorkflowEngine {
     plugin_registry: PluginRegistry,
     /// Resolves node parameters (expressions, templates, references) to JSON.
     resolver: ParamResolver,
-    /// Expression engine for evaluating edge conditions.
-    #[expect(
-        dead_code,
-        reason = "field reserved for expression-based edge condition evaluation; wired up in construction but not yet called at runtime"
-    )]
-    expression_engine: Arc<ExpressionEngine>,
     /// Optional resource manager for providing resources to actions.
     resource_manager: Option<Arc<nebula_resource::Manager>>,
     /// Optional execution repository for persistent state storage.
@@ -265,8 +259,7 @@ impl WorkflowEngine {
             runtime,
             metrics,
             plugin_registry: PluginRegistry::new(),
-            resolver: ParamResolver::new(expression_engine.clone()),
-            expression_engine,
+            resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
             execution_repo: None,
             workflow_repo: None,

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -197,9 +197,9 @@ impl StatelessAction for CounterHandler {
 }
 
 /// Returns `ActionResult::Skip` — exercises the engine's `propagate_skip`
-/// (engine.rs:3267-3313) recursive ladder. A skipped node's outgoing edges
-/// do not activate (per `evaluate_edge`), so successors with no other active
-/// source are transitively skipped.
+/// recursive ladder. A skipped node's outgoing edges do not activate (per
+/// `evaluate_edge`), so successors with no other active source are
+/// transitively skipped.
 struct SkipHandler {
     meta: ActionMetadata,
 }
@@ -806,13 +806,12 @@ async fn disabled_node_is_skipped_and_successor_executes() {
 // ---------------------------------------------------------------------------
 // Skip-propagation regression tests (ROADMAP §M1.1)
 //
-// Pin behaviour of `engine::propagate_skip` (engine.rs:3267-3313) — the
-// recursive ladder that walks the graph when a node returns
-// `ActionResult::Skip` (or any non-activating result) and transitively marks
-// unreachable successors as Skipped. The pre-existing
-// `disabled_node_is_skipped_and_successor_executes` covers the
-// disabled-node BYPASS (which activates outgoing edges with null and is a
-// different code path); these tests cover the propagate_skip ladder
+// Pin behaviour of `engine::propagate_skip` — the recursive ladder that
+// walks the graph when a node returns `ActionResult::Skip` (or any
+// non-activating result) and transitively marks unreachable successors as
+// Skipped. The pre-existing `disabled_node_is_skipped_and_successor_executes`
+// covers the disabled-node BYPASS (which activates outgoing edges with null
+// and is a different code path); these tests cover the propagate_skip ladder
 // triggered by non-activating `ActionResult` variants.
 // ---------------------------------------------------------------------------
 
@@ -1099,5 +1098,58 @@ async fn multi_hop_skip_with_sibling_activation_still_runs() {
     assert!(
         result.node_output(&d).is_some(),
         "D fires via sibling's edge despite the A→B→C branch skipping"
+    );
+}
+
+/// Duplicate edges from the same skipped source: `X(skip)` has two parallel
+/// `Connection` edges into `Z`. Locks the per-edge counter invariant
+/// documented inline at `propagate_skip`'s edge loop ("Increment per-edge
+/// count (not per-source) so that multiple edges from the same skipped
+/// source to the same target are each counted").
+///
+/// Expected: `Z` has `required = 2` (two incoming edges, even though only
+/// one source). `X`'s single Skip resolves both edges via the per-edge loop;
+/// resolved=2, required=2, activated=0 → `propagate_skip(Z)`. A regression
+/// that switched to per-source counting would leave `Z` with resolved=1
+/// forever, hanging or never skipping.
+#[tokio::test]
+async fn duplicate_edges_from_skipped_source_count_per_edge() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let x = node_key!("x");
+    let z = node_key!("z");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(x.clone(), "X", "skip").unwrap(),
+            NodeDefinition::new(z.clone(), "Z", "echo").unwrap(),
+        ],
+        vec![
+            // Two parallel edges from the same skipped source to the same target.
+            Connection::new(x.clone(), z.clone()),
+            Connection::new(x.clone(), z.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!("in"), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&x).is_none() && !result.node_errors.contains_key(&x),
+        "X skipped"
+    );
+    assert!(
+        result.node_output(&z).is_none() && !result.node_errors.contains_key(&z),
+        "Z transitively skipped — both duplicate edges from X resolved without activating"
     );
 }

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -196,6 +196,34 @@ impl StatelessAction for CounterHandler {
     }
 }
 
+/// Returns `ActionResult::Skip` — exercises the engine's `propagate_skip`
+/// (engine.rs:3267-3313) recursive ladder. A skipped node's outgoing edges
+/// do not activate (per `evaluate_edge`), so successors with no other active
+/// source are transitively skipped.
+struct SkipHandler {
+    meta: ActionMetadata,
+}
+
+impl DeclaresDependencies for SkipHandler {}
+impl Action for SkipHandler {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+}
+
+impl StatelessAction for SkipHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        _input: Self::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<Self::Output>, ActionError> {
+        Ok(ActionResult::skip("test skip"))
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -772,5 +800,304 @@ async fn disabled_node_is_skipped_and_successor_executes() {
         result.node_output(&c),
         Some(&serde_json::json!(null)),
         "C should execute after B is skipped, receiving null (B produced no output)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Skip-propagation regression tests (ROADMAP §M1.1)
+//
+// Pin behaviour of `engine::propagate_skip` (engine.rs:3267-3313) — the
+// recursive ladder that walks the graph when a node returns
+// `ActionResult::Skip` (or any non-activating result) and transitively marks
+// unreachable successors as Skipped. The pre-existing
+// `disabled_node_is_skipped_and_successor_executes` covers the
+// disabled-node BYPASS (which activates outgoing edges with null and is a
+// different code path); these tests cover the propagate_skip ladder
+// triggered by non-activating `ActionResult` variants.
+// ---------------------------------------------------------------------------
+
+/// Three-hop chain A → B → C → D where B returns `ActionResult::Skip`.
+///
+/// Expected: A=Completed, B=Skipped, C=Skipped (one hop transitive), D=Skipped
+/// (two hops transitive). Verifies the recursive `propagate_skip` walk via
+/// `resolved == required && activated == 0` reaches the full chain, not just
+/// the direct successor.
+#[tokio::test]
+async fn skip_propagates_transitively_through_three_hop_chain() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
+    let d = node_key!("d");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "skip").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+            NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(b.clone(), c.clone()),
+            Connection::new(c.clone(), d.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_success(),
+        "workflow should succeed even when middle node skips"
+    );
+    assert_eq!(
+        result.node_output(&a),
+        Some(&serde_json::json!("hi")),
+        "A should execute normally"
+    );
+    assert!(
+        result.node_output(&b).is_none() && !result.node_errors.contains_key(&b),
+        "B returned Skip — no output, no error"
+    );
+    assert!(
+        result.node_output(&c).is_none() && !result.node_errors.contains_key(&c),
+        "C transitively skipped (one hop from B)"
+    );
+    assert!(
+        result.node_output(&d).is_none() && !result.node_errors.contains_key(&d),
+        "D transitively skipped (two hops from B)"
+    );
+}
+
+/// Diamond pattern: A → {B, C} → D, where B returns Skip and C echoes.
+///
+/// Expected: D fires because at least one input edge (from C) activated —
+/// resolved=2, required=2, activated=1. Verifies that `propagate_skip` does
+/// NOT block a node that has any active source.
+#[tokio::test]
+async fn diamond_with_one_skipped_branch_still_completes() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
+    let d = node_key!("d");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "skip").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+            NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(a.clone(), c.clone()),
+            Connection::new(b.clone(), d.clone()),
+            Connection::new(c.clone(), d.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(result.node_output(&a).is_some(), "A executed");
+    assert!(
+        result.node_output(&b).is_none() && !result.node_errors.contains_key(&b),
+        "B skipped"
+    );
+    assert!(
+        result.node_output(&c).is_some(),
+        "C executed via the active branch"
+    );
+    assert!(
+        result.node_output(&d).is_some(),
+        "D fires because at least one input edge (from C) activated"
+    );
+}
+
+/// Mixed-source aggregate: X(skip) and Y(echo) both feed Z. Z has resolved=2,
+/// required=2, activated=1 → fires.
+#[tokio::test]
+async fn aggregate_with_one_skipped_source_fires() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let x = node_key!("x");
+    let y = node_key!("y");
+    let z = node_key!("z");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(x.clone(), "X", "skip").unwrap(),
+            NodeDefinition::new(y.clone(), "Y", "echo").unwrap(),
+            NodeDefinition::new(z.clone(), "Z", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(x.clone(), z.clone()),
+            Connection::new(y.clone(), z.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(42), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&x).is_none() && !result.node_errors.contains_key(&x),
+        "X skipped"
+    );
+    assert!(result.node_output(&y).is_some(), "Y executed");
+    assert!(
+        result.node_output(&z).is_some(),
+        "Z fires because Y's edge activates (1 of 2 sources)"
+    );
+}
+
+/// All-sources-skipped aggregate: X(skip) and Y(skip) both feed Z. Z has
+/// resolved=2, required=2, activated=0 → propagate_skip(Z) recurs from
+/// the second arrival (whichever Skip-node's edge resolution fills the
+/// counter last).
+#[tokio::test]
+async fn aggregate_with_all_sources_skipped_propagates_skip() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let x = node_key!("x");
+    let y = node_key!("y");
+    let z = node_key!("z");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(x.clone(), "X", "skip").unwrap(),
+            NodeDefinition::new(y.clone(), "Y", "skip").unwrap(),
+            NodeDefinition::new(z.clone(), "Z", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(x.clone(), z.clone()),
+            Connection::new(y.clone(), z.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(0), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(
+        result.node_output(&x).is_none() && !result.node_errors.contains_key(&x),
+        "X skipped"
+    );
+    assert!(
+        result.node_output(&y).is_none() && !result.node_errors.contains_key(&y),
+        "Y skipped"
+    );
+    assert!(
+        result.node_output(&z).is_none() && !result.node_errors.contains_key(&z),
+        "Z transitively skipped — no source activated"
+    );
+}
+
+/// Multi-hop skip with sibling activation:
+///
+/// ```text
+///     A ──► B(skip) ──► C ──► D
+///                             ▲
+///     Sib ────────────────────┘
+/// ```
+///
+/// The A→B→C path dies at B's Skip and propagates to C; the Sib→D edge gives
+/// D a sibling source. Expected: A=Completed, B=Skipped, C=Skipped (transitive),
+/// Sib=Completed, D=Completed (D fires because Sib's edge activated). Pins
+/// the interaction between propagate_skip from one branch and an active
+/// sibling source feeding the same downstream join.
+#[tokio::test]
+async fn multi_hop_skip_with_sibling_activation_still_runs() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(EchoHandler {
+        meta: meta(action_key!("echo")),
+    });
+    registry.register_stateless(SkipHandler {
+        meta: meta(action_key!("skip")),
+    });
+    let (engine, _) = make_engine(registry);
+
+    let a = node_key!("a");
+    let b = node_key!("b");
+    let c = node_key!("c");
+    let d = node_key!("d");
+    let sib = node_key!("sib");
+
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(a.clone(), "A", "echo").unwrap(),
+            NodeDefinition::new(b.clone(), "B", "skip").unwrap(),
+            NodeDefinition::new(c.clone(), "C", "echo").unwrap(),
+            NodeDefinition::new(d.clone(), "D", "echo").unwrap(),
+            NodeDefinition::new(sib.clone(), "Sib", "echo").unwrap(),
+        ],
+        vec![
+            Connection::new(a.clone(), b.clone()),
+            Connection::new(b.clone(), c.clone()),
+            Connection::new(c.clone(), d.clone()),
+            Connection::new(sib.clone(), d.clone()),
+        ],
+    );
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert!(result.node_output(&a).is_some(), "A executed");
+    assert!(
+        result.node_output(&b).is_none() && !result.node_errors.contains_key(&b),
+        "B skipped"
+    );
+    assert!(
+        result.node_output(&c).is_none() && !result.node_errors.contains_key(&c),
+        "C transitively skipped from B"
+    );
+    assert!(result.node_output(&sib).is_some(), "sibling root executed");
+    assert!(
+        result.node_output(&d).is_some(),
+        "D fires via sibling's edge despite the A→B→C branch skipping"
     );
 }

--- a/crates/workflow/README.md
+++ b/crates/workflow/README.md
@@ -38,10 +38,13 @@ cannot activate a workflow without explicitly handling the result.
   `RateLimit`, `RetryConfig`, position.
 - `ParamValue` — typed value variant for node parameters (static literal or expression string).
 - `Connection` — directed wire `(from_node, to_node, from_port, to_port)`. Edges carry no
-  conditions or matchers; conditional routing lives in explicit `ControlAction` nodes
-  (`If`, `Switch`, `Router`, `ErrorRouter`) per Spec 28 §2.2 (see `src/connection.rs` module
-  doc for the activation contract). The pre-Spec-28 `EdgeCondition` / `ResultMatcher` /
-  `ErrorMatcher` trio was removed when this design landed.
+  conditions or matchers; conditional and error routing live in explicit `ControlAction`
+  nodes (the trait lives in `nebula_action::control`; canonical implementations — `If`,
+  `Switch`, `Router`, `Filter`, `NoOp`, `Stop`, `Fail` — ship downstream in a reference /
+  plugin crate, not this workspace) per Spec 28 §2.2. Failed nodes activate only edges
+  whose `from_port == "error"` — authors wire that port into whichever `ControlAction`
+  fits. See `src/connection.rs` module doc for the full activation contract. The pre-Spec-28
+  `EdgeCondition` / `ResultMatcher` / `ErrorMatcher` trio was removed when this design landed.
 - `DependencyGraph` — `petgraph`-backed wrapper: topological sort, per-level batching (feeds
   `ExecutionPlan` in `nebula-execution`).
 - `WorkflowBuilder` — fluent, validated construction API.

--- a/crates/workflow/README.md
+++ b/crates/workflow/README.md
@@ -37,8 +37,11 @@ cannot activate a workflow without explicitly handling the result.
 - `NodeDefinition` — individual step: `ActionKey`, params (`HashMap<String, ParamValue>`),
   `RateLimit`, `RetryConfig`, position.
 - `ParamValue` — typed value variant for node parameters (static literal or expression string).
-- `Connection`, `EdgeCondition` — directed edges between nodes with conditional routing.
-- `ErrorMatcher`, `ResultMatcher` — pattern-match on action outcomes for edge routing.
+- `Connection` — directed wire `(from_node, to_node, from_port, to_port)`. Edges carry no
+  conditions or matchers; conditional routing lives in explicit `ControlAction` nodes
+  (`If`, `Switch`, `Router`, `ErrorRouter`) per Spec 28 §2.2 (see `src/connection.rs` module
+  doc for the activation contract). The pre-Spec-28 `EdgeCondition` / `ResultMatcher` /
+  `ErrorMatcher` trio was removed when this design landed.
 - `DependencyGraph` — `petgraph`-backed wrapper: topological sort, per-level batching (feeds
   `ExecutionPlan` in `nebula-execution`).
 - `WorkflowBuilder` — fluent, validated construction API.

--- a/crates/workflow/docs/Architecture.md
+++ b/crates/workflow/docs/Architecture.md
@@ -16,7 +16,7 @@ updated: 2026-04-28
 > |---|---|
 > | `NodeId`, `ActionId` | `NodeKey`, `ActionKey` (`nebula-core`) |
 > | `Edge { from, to, condition: Option<EdgeCondition> }` | `Connection { from_node, to_node, from_port, to_port }` (`src/connection.rs`) |
-> | `EdgeCondition::{Always, Expression, OnResult, OnError}` | Removed; routing is port-driven via `ControlAction` nodes (`If` / `Switch` / `Router` / `ErrorRouter`) |
+> | `EdgeCondition::{Always, Expression, OnResult, OnError}` | Removed; routing is port-driven via `ControlAction` nodes (canonical 7: `If`, `Switch`, `Router`, `Filter`, `NoOp`, `Stop`, `Fail` — shipped downstream, not in this workspace). Error routing happens by wiring the `"error"` port into whichever `ControlAction` fits (no shipped `ErrorRouter` type). |
 > | `WorkflowExecutor` | `WorkflowEngine` lives in `nebula-engine`, not in this crate |
 > | `state.status = ExecutionStatus::Running` (direct mutation) | Versioned CAS via `ExecutionState::transition_node` (issue #255) |
 >

--- a/crates/workflow/docs/Architecture.md
+++ b/crates/workflow/docs/Architecture.md
@@ -1,10 +1,28 @@
 ---
 title: Architecture
-tags: [nebula, nebula-workflow, crate, architecture, dag]
-status: production-ready
+tags: [nebula, nebula-workflow, crate, architecture, dag, stale]
+status: stale-pre-spec-28
 created: 2025-08-17
-updated: 2025-11-09
+updated: 2026-04-28
 ---
+
+> **⚠️ Stale planning document — does NOT reflect shipping code.**
+>
+> This file was authored before Spec 28 §2.2 (port-driven edge routing) and several
+> identifier renames landed. It is preserved as historical context but **must not be
+> used as a current-state reference**. Notable divergences from shipping code:
+>
+> | This document says | Shipping code |
+> |---|---|
+> | `NodeId`, `ActionId` | `NodeKey`, `ActionKey` (`nebula-core`) |
+> | `Edge { from, to, condition: Option<EdgeCondition> }` | `Connection { from_node, to_node, from_port, to_port }` (`src/connection.rs`) |
+> | `EdgeCondition::{Always, Expression, OnResult, OnError}` | Removed; routing is port-driven via `ControlAction` nodes (`If` / `Switch` / `Router` / `ErrorRouter`) |
+> | `WorkflowExecutor` | `WorkflowEngine` lives in `nebula-engine`, not in this crate |
+> | `state.status = ExecutionStatus::Running` (direct mutation) | Versioned CAS via `ExecutionState::transition_node` (issue #255) |
+>
+> **Authoritative current state:** `crates/workflow/src/connection.rs` module doc
+> (port-driven activation contract); `crates/workflow/README.md` (public API list);
+> `crates/engine/README.md` (engine orchestration model).
 
 # Workflow Architecture
 

--- a/crates/workflow/src/connection.rs
+++ b/crates/workflow/src/connection.rs
@@ -2,12 +2,18 @@
 //!
 //! Connections are pure wires: they carry an output from one node's port to
 //! another node's port and nothing else. All routing logic (conditionals,
-//! error handling, branch selection) lives in explicit
-//! `ControlAction` nodes (`If` / `Switch` / `Router` / `ErrorRouter` —
-//! defined in the `nebula_action::control` module) — so the shape of
-//! a workflow is always visible on the graph, never hiding inside edge
-//! metadata. Spec 28 §2.2 replaced the previous `EdgeCondition` /
-//! `ResultMatcher` / `ErrorMatcher` trio with this port-driven routing.
+//! error handling, branch selection) lives in explicit `ControlAction`
+//! nodes — the trait is defined in `nebula_action::control`; the 7 canonical
+//! implementations (`If`, `Switch`, `Router`, `Filter`, `NoOp`, `Stop`,
+//! `Fail`) are shipped downstream in a reference / plugin crate, not in
+//! this workspace. The shape of a workflow is therefore always visible on
+//! the graph, never hiding inside edge metadata. Spec 28 §2.2 replaced the
+//! previous `EdgeCondition` / `ResultMatcher` / `ErrorMatcher` trio with
+//! this port-driven routing. Error routing follows the same model: failed
+//! nodes activate only edges whose `from_port == "error"` (see
+//! `engine::evaluate_edge`); authors wire that port into whichever
+//! `ControlAction` (typically a `Switch` keyed on error class, or a
+//! recovery node) fits their workflow.
 //!
 //! ## Edge activation contract
 //!
@@ -32,9 +38,9 @@ use serde::{Deserialize, Serialize};
 ///
 /// Edges are pure wires — they do not carry conditions, matchers, or
 /// expressions. Authors wire conditional flow through explicit
-/// `ControlAction` nodes (`If`, `Switch`, `Router`, `ErrorRouter`), and the
-/// engine picks which outgoing edge to activate based solely on the source
-/// node's output port (see module docs).
+/// `ControlAction` nodes (e.g. `If`, `Switch`, `Router`); the engine picks
+/// which outgoing edge to activate based solely on the source node's output
+/// port (see module docs for the canonical 7 and the error-routing model).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Connection {
     /// Source node.


### PR DESCRIPTION
## Summary

- Re-scoped ROADMAP §M1 after recon found the original entry described a defect that didn't exist — `propagate_skip` (engine.rs:3267-3313) was already full-graph recursive via `resolved == required && activated == 0` ladder. Original M1.2 option A ("wire dynamic edge conditions") contradicted Spec 28 §2.2 which already settled conditional routing via explicit `ControlAction` nodes.
- Closed §M1 with verification + cleanup in 4 tasks: (T1) 5 integration tests for skip-propagation in non-trivial topologies; (T2) removed dead `WorkflowEngine.expression_engine` field; (T3) audited workflow docs vs Spec 28 §2.2; (T4) ROADMAP §M1 + engine README L4 debt sync.

## Changes

**`crates/engine/tests/integration.rs`** — added `SkipHandler` + 5 tests exercising the `propagate_skip` recursive ladder:
- `skip_propagates_transitively_through_three_hop_chain` — 3-hop chain A→B(skip)→C→D, all transitively skipped
- `diamond_with_one_skipped_branch_still_completes` — A→{B(skip), C}→D, D fires via C
- `aggregate_with_one_skipped_source_fires` — X(skip), Y→Z, Z fires (1-of-2 active)
- `aggregate_with_all_sources_skipped_propagates_skip` — X(skip), Y(skip)→Z, Z transitively skipped
- `multi_hop_skip_with_sibling_activation_still_runs` — A→B(skip)→C→D plus sibling root→D, D fires via sibling

All pass on the existing `propagate_skip` recursion — confirms correctness on diamond / aggregate / mixed-source cases the previous lone linear-3-node test did not cover.

**`crates/engine/src/engine.rs`** — removed dead `WorkflowEngine.expression_engine` field at lines 125-130 (had `#[expect(dead_code)]` with misleading "wired up... but not yet called" reason). Shared `Arc<ExpressionEngine>` lives in `ParamResolver` (the only consumer, used for parameter expression / template resolution). Per Spec 28 §2.2 there is no engine-level edge expression to evaluate — routing is port-driven via `ControlAction` nodes. `cargo clippy --workspace --all-targets -- -D warnings` clean after removal.

**`crates/workflow/README.md`** — Public API section: rewrote `Connection` / `EdgeCondition` / `ErrorMatcher` / `ResultMatcher` entry to describe `Connection` as a pure wire and explicitly note the pre-Spec-28 trio was removed.

**`crates/workflow/docs/Architecture.md`** — added stale-doc warning + 5-row drift table at top; flipped frontmatter `status: production-ready` → `stale-pre-spec-28`. The 880-line file is a pre-Spec-28 planning doc using `NodeId`/`Edge`/`EdgeCondition` (none of which exist in shipping code); preserved as historical context.

**`.ai-factory/ROADMAP.md`** — §M1 rewritten (M1.1, M1.2, M1.3 all DONE 2026-04-28); Status Snapshot updated to drop "full-graph edge gating" from remaining-debts list.

**`crates/engine/README.md`** — L4 debt table: removed false-premise "local edges, not the full graph" row; added "Recently closed debts (ROADMAP §M1)" table with 3 closure rows.

## Test plan

- [x] `cargo +nightly fmt --all -- --check` — clean
- [x] `cargo check --workspace --tests` — green
- [x] `cargo nextest run -p nebula-engine` — 307/307 (302 baseline + 5 new T1 tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — green
- [x] `cargo deny check` — green (advisories ok, bans ok, licenses ok, sources ok)
- [x] `cargo test --workspace --doc` — green
- [x] lefthook pre-commit (typos, fmt-check, clippy, convco) — green
- [x] lefthook pre-push (nextest 394/394, crate-diff-gate) — green

Closes ROADMAP §M1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Roadmap updated to mark M1 verification/cleanup done and adjust exit criteria
  * Engine/workflow docs and architecture page clarified and realigned with current routing semantics; guidance added to authoritative sources

* **Tests**
  * New integration suite validating skip-propagation across multiple complex workflow topologies

* **Chores**
  * Removed an unused internal field to tidy engine state representation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->