### PR TITLE
feat(engine)!: M2.1 — engine retry wiring (ADR-0042)

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -26,9 +26,11 @@
   via M0** (budget + workflow_input persistence shipped under #289 / #311;
   explicit-termination wiring landed in M0.3); **§10 conditional-flow
   correctness verified via M1** (skip-propagation tests + dead-field
-  cleanup, 2026-04-28); **§11.2 closed via M2.1 "remove from canon"**
-  (engine retry surface removed; retry confined to `nebula-resilience`
-  inside actions, 2026-04-28).
+  cleanup, 2026-04-28); **§11.2 closed via M2.1 layered-retry shipping**
+  (action-internal retry stays in `nebula-resilience`; engine-level node
+  retry now wired end-to-end via `NodeDefinition.retry_policy` →
+  `NodeExecutionState::next_attempt_at` → `WaitingRetry` parking →
+  frontier-loop re-dispatch, 2026-04-29).
   `sandbox` is correctness-grade; capability discovery enforcement gap (canon
   §4.5).
 - **API layer** — routing wired; **5 sizable feature gaps** (auth backend,
@@ -136,23 +138,45 @@ verification + dead-field cleanup + doc audit.
 ### M2 — Engine retry semantics + node attempts
 
 - [x] **M2.1** ~~Decide engine-retry direction for 1.0~~ — **DONE** (closed
-      2026-04-28 via "remove from canon" exit). Engine no longer claims
-      node re-execution: `ActionResult::Retry` variant deleted, the
-      `unstable-retry-scheduler` feature removed (action + engine), the
-      synthetic-failure arm at `engine.rs:1939-2013` cut, the dead
-      `total_retries` budget counter (`ExecutionBudget::max_total_retries`,
-      `ExecutionState::total_retries`) removed along with
-      `NodeState::Retrying` (verified unreachable today). Canon §11.2 now
-      reads as "engine does not retry; retry surface lives in
-      `nebula-resilience` inside an action." Plan:
-      `.ai-factory/plans/claude-adoring-einstein-8e5dba.md`.
+      2026-04-29 via the layered-retry exit per ADR-0042). Two retry
+      surfaces, disjoint by trigger boundary:
+      - **Layer 1 — action-internal** (`nebula-resilience::retry_with`)
+        stays in action source code for in-call recoverable failures.
+      - **Layer 2 — engine-level node retry**
+        (`NodeDefinition.retry_policy`) is now real end-to-end:
+        `NodeExecutionState::next_attempt_at` parks the node in the
+        `NodeState::WaitingRetry` state (added in M2.1 T2), the
+        frontier loop's retry-pending min-heap re-dispatches at the
+        scheduled time, and `ExecutionBudget.max_total_retries`
+        provides a global cap (canon §11.2). Cancel/terminate/budget
+        guards drain parked retries to `Cancelled` without
+        re-dispatching.
+      - Sequencing across two PRs:
+        **PR #627 (foundation, 2026-04-28)** — T0 dropped
+        `ActionResult::Retry` + `unstable-retry-scheduler`; T1 landed
+        ADR-0042; T8 added shift-left `validate_workflow` for
+        `RetryConfig` (rejects `max_attempts=0`, non-finite multiplier,
+        `max_delay < initial_delay`, etc.).
+        **PR (this one, 2026-04-29)** — T2 added `next_attempt_at` +
+        `total_retries` + `WaitingRetry` (forward-compat via serde
+        defaults); T3 verified Layer-1 storage is JSONB-only so no
+        column migration is required; T4 wired engine retry decision
+        (per-node policy → workflow default → budget cap, with
+        `NodeAttempt` push for idempotency-key differentiation); T5
+        wired the frontier loop's `retry_heap` + `tokio::select!`
+        across join_set / cancel / wall-clock / retry-timer; T6
+        landed 9 integration tests covering core path + cancel +
+        terminate + budget + idempotency + per-node-vs-workflow
+        resolution + one-shot fallback. Total: ~146 unit-test deltas
+        + 9 integration tests, all green.
 - [ ] **M2.2** Verify `execution_leases` heartbeat enforcement across runner
       restarts (per `crates/execution/README.md:138`).
 
-**Exit:** retry path is either real (with tests) or removed from canon —
-**closed via the second exit (2026-04-28).** §11.2 now describes the
-engine as a non-retrying orchestrator and `nebula-resilience` as the only
-retry surface.
+**Exit:** retry path is real with tests — **closed 2026-04-29 via
+ADR-0042 layered-retry exit.** Workflow authors get the operator-level
+retry policy that canon §4.5 used to claim falsely; action authors keep
+`nebula-resilience::retry_with` for in-call retries. §11.2 now reads as
+"two layers, disjoint by trigger boundary: in-call vs post-finalisation."
 
 ### M3 — API surface completion
 

--- a/crates/action/README.md
+++ b/crates/action/README.md
@@ -88,7 +88,13 @@ Pattern inspiration: *Ports & Adapters / Hexagonal Architecture* — action auth
 ## Non-goals
 
 - Not the execution state machine — see `nebula-execution` (`ExecutionStatus`, `ExecutionPlan`, CAS transitions).
-- Not a retry pipeline — retry around outbound calls uses `nebula-resilience` internally to an action, not an action framework concern.
+- Not the only retry surface — per ADR-0042 the engine carries an
+  operator-declared retry layer (`NodeDefinition.retry_policy`) that
+  fires AFTER the action returns its final outcome. Action authors keep
+  using `nebula-resilience::retry_with` internally for in-call retry;
+  workflow authors declare engine-level retry at the node level. The two
+  layers compose because they trigger at different boundaries (in-call
+  vs. post-finalisation).
 - Not the sandbox driver — process isolation, capability enforcement, OS-level hardening are in `nebula-sandbox`.
 - Not a schema system — `ActionMetadata.parameters` holds a `ValidSchema` from `nebula-schema`; field definitions and validation rules live there.
 - Not WASM — see canon §12.6.

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -97,8 +97,16 @@ action/credential/resource caches enforcing the namespace invariant at construct
 - Not an action dispatcher — delegated to `nebula-runtime`.
 - Not a plugin loader or isolator — see `nebula-sandbox`.
 - Not an expression evaluator — see `nebula-expression`.
-- Not a retry scheduler — the engine does not re-execute nodes. Retry lives in
-  `nebula-resilience` inside an action around the outbound call (canon §11.2).
+- Two retry surfaces, disjoint by trigger boundary (per ADR-0042):
+  - **In-call (Layer 1)** — `nebula-resilience::retry_with` lives inside an action
+    around outbound calls. The engine sees only the action's final outcome.
+  - **Operator-declared (Layer 2)** — `NodeDefinition.retry_policy` /
+    `WorkflowConfig.retry_policy`. After a `Running → Failed` transition the
+    engine consults the effective policy, parks the node in
+    `NodeState::WaitingRetry` with `next_attempt_at`, and re-dispatches the
+    action when the timer fires. Cancel / explicit-terminate / wall-clock
+    budget breach drains parked retries to `Cancelled` without re-dispatching.
+    Global cap via `ExecutionBudget.max_total_retries` (canon §11.2).
 
 ## Maturity
 
@@ -133,6 +141,13 @@ See `docs/MATURITY.md` row for `nebula-engine`.
 | `ExecutionBudget` not persisted in `ExecutionState` — budget lost on resume | issue #289 | `set_budget` at `state.rs:218`; restored at `engine.rs:1433-1444`; tests `resume_restores_persisted_budget` and `resume_falls_back_to_default_budget_on_legacy_state` |
 | Original workflow input not persisted — resume could not replay from input | issue #311 | `set_workflow_input` at `state.rs:206`; restored at `engine.rs:1487-1497`; test `resume_restores_original_workflow_input` |
 | `ActionResult::Terminate` not propagated to `ExecutionTerminationReason::ExplicitStop` / `ExplicitFail` — execution audit lost intent vs system-driven termination | ROADMAP §M0.3 | `set_terminated_by` at `state.rs:240`; engine wiring at `engine.rs:1986-area`; `determine_final_status` priority ladder at `engine.rs:3590`; surfaced via `ExecutionResult.termination_reason` and `ExecutionEvent::ExecutionFinished.termination_reason` |
+
+### Recently closed debts (ROADMAP §M2.1)
+
+| Closed debt | Closed by | Verification |
+|---|---|---|
+| `NodeDefinition.retry_policy` / `WorkflowConfig.retry_policy` were declared and serialised but never read by the engine — operator-level retry was a §4.5 false capability | ADR-0042 + ROADMAP §M2.1 (foundation PR #627 + engine wiring PR) | `NodeState::WaitingRetry` (`crates/workflow/src/state.rs`); `NodeExecutionState::next_attempt_at` + `ExecutionState::total_retries` + `ExecutionBudget::max_total_retries` (`crates/execution/src/state.rs`, `context.rs`); engine retry decision + `tokio::select!` retry-pending heap (`crates/engine/src/engine.rs` `compute_retry_decision`, `effective_retry_policy`, `run_frontier`); 9 integration tests at `crates/engine/tests/retry.rs`; shift-left validation in `validate_workflow` (`crates/workflow/src/validate.rs`) |
+| `ExecutionOutput::Inline(Value)` newtype-tagged variant silently failed `serde_json::to_value` for primitive payloads (string / number / bool / null) — surfaced when M2.1 T4 began pushing `NodeAttempt::output` records | ADR-0042 (engine wiring PR) | `Inline { value }` struct variant (`crates/execution/src/output.rs`); wire format moved from object-only `{"type": "inline", ...spread fields...}` to `{"type": "inline", "value": <any>}` |
 
 ### Recently closed debts (ROADMAP §M1)
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1363,10 +1363,19 @@ impl WorkflowEngine {
                 );
             }
         }
+        // Reset non-terminal nodes that crashed mid-attempt back to
+        // `Pending` so the frontier loop can re-dispatch them. Retry
+        // waits are different — a `WaitingRetry` node carries a
+        // durable `next_attempt_at` that the frontier loop's
+        // `retry_heap` consumes via the Phase-0 drain. Resetting it
+        // would lose the persisted backoff and re-dispatch the node
+        // immediately on resume, defeating ADR-0042 §M2.1 T2's
+        // resume guarantee. (Crashed `Running` attempts have no
+        // such timestamp and must be re-driven from `Pending`.)
         let non_terminal: Vec<NodeKey> = exec_state
             .node_states
             .iter()
-            .filter(|(_, ns)| !ns.state.is_terminal())
+            .filter(|(_, ns)| !ns.state.is_terminal() && ns.state != NodeState::WaitingRetry)
             .map(|(id, _)| id.clone())
             .collect();
         for id in non_terminal {
@@ -1438,6 +1447,14 @@ impl WorkflowEngine {
         // evaluate edge conditions normally once the node is dispatched.
         for (node_key, ns) in &exec_state.node_states {
             if ns.state.is_terminal() {
+                continue;
+            }
+            // ADR-0042 §M2.1 T5 — `WaitingRetry` nodes belong to the
+            // retry-pending heap, not to the seed/ready_queue. The
+            // frontier loop seeds the heap from `WaitingRetry` nodes
+            // separately; including them here would re-dispatch
+            // immediately and bypass the persisted backoff timer.
+            if ns.state == NodeState::WaitingRetry {
                 continue;
             }
             let incoming = graph.incoming_connections(node_key.clone());
@@ -1935,10 +1952,8 @@ impl WorkflowEngine {
                 // running `compute_retry_decision` against a stale
                 // `attempts.len()` — that would let `max_attempts`
                 // be bypassed and risk an idempotency-key collision.
-                let setup_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
                 let setup_attempt_recorded = match exec_state.record_node_attempt(
                     node_key.clone(),
-                    setup_idem_key,
                     AttemptOutcome::Failure {
                         error: err_msg.clone(),
                     },
@@ -2243,13 +2258,6 @@ impl WorkflowEngine {
                             serde_json::to_string(output.value()).map_or(0, |s| s.len() as u64);
                         total_output_bytes.fetch_add(output_bytes, Ordering::Relaxed);
                     }
-                    // Capture the current dispatch's idempotency key
-                    // BEFORE we push the attempt record (the push
-                    // would otherwise advance the next-dispatch key
-                    // and break record_idempotency / record_node_result
-                    // which want the just-finished attempt's key).
-                    let success_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
-
                     // Capture an explicit-termination signal BEFORE the
                     // checkpoint so that the same CAS-write durably
                     // persists `terminated_by` (canon §11.5; ROADMAP
@@ -2328,10 +2336,11 @@ impl WorkflowEngine {
                     //
                     // ADR-0042 §M2.1 T4 — `attempt_count + 1` is the
                     // current dispatch's attempt number BEFORE we push
-                    // the success record below; same number that
-                    // `success_idem_key` was minted against so the
-                    // idempotency-key store and the per-attempt result
-                    // store stay in lockstep.
+                    // the success record below; same formula as
+                    // `idempotency_key_for_node` and the
+                    // `record_node_attempt` internal mint, so the
+                    // idempotency-key store, per-attempt result store,
+                    // and attempt-history row all carry the same N.
                     let attempt = exec_state
                         .node_states
                         .get(&node_key)
@@ -2347,13 +2356,16 @@ impl WorkflowEngine {
                     // ADR-0042 §M2.1 T4 — push the success attempt
                     // record AFTER record_idempotency / record_node_result
                     // so those helpers see the just-finished attempt's
-                    // key (push advances the next-dispatch key).
+                    // key (push advances the next-dispatch key). The
+                    // attempt's idempotency key is derived inside
+                    // `record_node_attempt` from the new attempt
+                    // number, so engine code cannot drift the audit
+                    // row out of step with the persisted key.
                     let success_payload = outputs
                         .get(&node_key)
                         .map_or_else(|| serde_json::Value::Null, |v| v.value().clone());
                     if let Err(e) = exec_state.record_node_attempt(
                         node_key.clone(),
-                        success_idem_key,
                         AttemptOutcome::Success {
                             output: ExecutionOutput::inline(success_payload),
                             output_bytes,
@@ -2449,10 +2461,8 @@ impl WorkflowEngine {
                     // `attempts.len()` — that path could bypass
                     // `max_attempts` (loop forever when no global cap
                     // is set) or collide idempotency keys on resume.
-                    let failure_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
                     let failure_attempt_recorded = match exec_state.record_node_attempt(
                         node_key.clone(),
-                        failure_idem_key,
                         AttemptOutcome::Failure {
                             error: err_str.clone(),
                         },
@@ -3093,10 +3103,19 @@ impl WorkflowEngine {
         // losing one means a downstream consumer may reconstruct a
         // node as "ran and returned nothing" after restart (§11.5).
         if let Some(output) = outputs.get(&node_key) {
+            // ADR-0042 §M2.1 T4 — `attempt_count + 1` is the
+            // current dispatch's attempt number BEFORE the success
+            // record gets pushed (push happens after this checkpoint).
+            // Same formula as `idempotency_key_for_node` so
+            // `save_node_output`, `record_node_result`, and
+            // `record_node_attempt` all stay in lockstep — the
+            // pre-fix formula `attempt_count().max(1)` produced
+            // attempt N-1 here while the result/history rows used
+            // attempt N, desynchronising the audit trail on retries.
             let attempt = exec_state
                 .node_states
                 .get(&node_key)
-                .map_or(1, |ns| ns.attempt_count().max(1) as u32);
+                .map_or(1, |ns| (ns.attempt_count() as u32).saturating_add(1));
             if let Err(e) = repo
                 .save_node_output(
                     execution_id,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1775,8 +1775,18 @@ impl WorkflowEngine {
                 if *when > now_drain {
                     break;
                 }
-                let Reverse((_, node_key)) =
-                    retry_heap.pop().expect("peek-then-pop on non-empty heap");
+                let Some(Reverse((_, node_key))) = retry_heap.pop() else {
+                    // Unreachable: peek-then-pop on a single-threaded
+                    // owner cannot lose the entry. Surface defensively
+                    // rather than panic so a future refactor can't
+                    // crash the frontier loop (canon §12.4).
+                    tracing::warn!(
+                        target = "engine::retry",
+                        %execution_id,
+                        "retry heap became empty after peek; aborting retry drain"
+                    );
+                    break;
+                };
                 let still_parked = exec_state
                     .node_state(node_key.clone())
                     .is_some_and(|ns| ns.state == NodeState::WaitingRetry);
@@ -1818,12 +1828,16 @@ impl WorkflowEngine {
                 }
             }
 
-            // Phase 1: Drain ready queue → spawn into join_set
-            while let Some(node_key) = ready_queue.pop_front() {
-                if cancel_token.is_cancelled() {
-                    break;
-                }
-
+            // Phase 1: Drain ready queue → spawn into join_set.
+            // Cancel-check runs BEFORE `pop_front` so a node that
+            // observes the cancel signal mid-iteration stays in the
+            // queue and is collected by `drain_pending_to_cancelled`
+            // on the cancel/wall-clock teardown branches — popping
+            // first would drop the node and strand it as `Ready`,
+            // tripping canon §11.1 frontier-integrity.
+            while !cancel_token.is_cancelled()
+                && let Some(node_key) = ready_queue.pop_front()
+            {
                 // Check budget limits before dispatching
                 if let Some(violation) = check_budget(budget, started, &total_output_bytes) {
                     cancel_token.cancel();
@@ -1916,40 +1930,53 @@ impl WorkflowEngine {
 
                 // Push the failure attempt record so retry-decision
                 // and idempotency_key see the same attempt count.
+                // ADR-0042 §M2.1 T4: if recording fails (programming
+                // error: unknown node), force `Finalize` rather than
+                // running `compute_retry_decision` against a stale
+                // `attempts.len()` — that would let `max_attempts`
+                // be bypassed and risk an idempotency-key collision.
                 let setup_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
-                if let Err(e) = exec_state.record_node_attempt(
+                let setup_attempt_recorded = match exec_state.record_node_attempt(
                     node_key.clone(),
                     setup_idem_key,
                     AttemptOutcome::Failure {
                         error: err_msg.clone(),
                     },
                 ) {
-                    tracing::warn!(
-                        target = "engine::frontier",
-                        %execution_id,
-                        %node_key,
-                        error = %e,
-                        "record_node_attempt(setup-failure) failed; \
-                         continuing without attempt history"
-                    );
-                }
+                    Ok(_) => true,
+                    Err(e) => {
+                        tracing::warn!(
+                            target = "engine::frontier",
+                            %execution_id,
+                            %node_key,
+                            error = %e,
+                            "record_node_attempt(setup-failure) failed; forcing finalize \
+                             so stale attempt history cannot bypass max_attempts or \
+                             collide idempotency keys"
+                        );
+                        false
+                    },
+                };
 
                 // ADR-0042 §M2.1 T4 — retry decision (setup-failure
-                // path). Mirror runtime-failure semantics.
-                let setup_retry_policy = node_map
-                    .get(&node_key)
-                    .and_then(|nd| effective_retry_policy(nd, workflow_retry_policy.as_ref()))
-                    .cloned();
-                let setup_decision =
-                    compute_retry_decision(&node_key, exec_state, setup_retry_policy.as_ref());
+                // path). Mirror runtime-failure semantics. Skip the
+                // decision entirely when attempt history is broken.
+                let setup_decision = if setup_attempt_recorded {
+                    let setup_retry_policy = node_map
+                        .get(&node_key)
+                        .and_then(|nd| effective_retry_policy(nd, workflow_retry_policy.as_ref()))
+                        .cloned();
+                    compute_retry_decision(&node_key, exec_state, setup_retry_policy.as_ref())
+                } else {
+                    RetryDecision::Finalize
+                };
 
                 if let RetryDecision::Retry { delay } = setup_decision {
                     let attempt_number = exec_state
                         .node_states
                         .get(&node_key)
                         .map_or(1, |ns| ns.attempt_count() as u32);
-                    let next_at =
-                        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_default();
+                    let next_at = next_retry_at(execution_id, &node_key, delay);
                     if exec_state
                         .schedule_node_retry(node_key.clone(), next_at)
                         .is_ok()
@@ -2117,8 +2144,9 @@ impl WorkflowEngine {
 
             // If join_set is empty but retry_heap has work, we still
             // need to sleep until the timer (or cancel / wall-clock).
-            // Use a `pending` future on the join_set arm in that case
-            // so `select!` does not see a `None` and break early.
+            // Pre-pin a boxed future per branch so `select!` never has
+            // to enter an `unreachable!()` placeholder — library code
+            // must not panic on hot paths (canon §12.4).
             let join_set_empty = join_set.is_empty();
 
             type JoinedResult = Option<
@@ -2145,15 +2173,15 @@ impl WorkflowEngine {
                 Cancel,
             }
 
+            let join_next_fut: Pin<Box<dyn Future<Output = JoinedResult> + Send + '_>> =
+                if join_set_empty {
+                    Box::pin(std::future::pending::<JoinedResult>())
+                } else {
+                    Box::pin(join_set.join_next_with_id())
+                };
+
             let wake = tokio::select! {
-                result = async {
-                    if join_set_empty {
-                        std::future::pending::<()>().await;
-                        unreachable!()
-                    } else {
-                        join_set.join_next_with_id().await
-                    }
-                } => WakeReason::Joined(result),
+                result = join_next_fut => WakeReason::Joined(result),
                 () = &mut retry_sleep_fut, if next_retry_in.is_some() => WakeReason::RetryTimer,
                 () = &mut sleep_fut => WakeReason::WallClock,
                 () = cancel_token.cancelled() => WakeReason::Cancel,
@@ -2415,42 +2443,59 @@ impl WorkflowEngine {
                     // Push the failure attempt record so idempotency
                     // key, retry-decision, and post-mortem audit all
                     // see the same attempt history.
+                    // ADR-0042 §M2.1 T4: if recording fails (programming
+                    // error: unknown node), force `Finalize` rather than
+                    // letting `compute_retry_decision` see a stale
+                    // `attempts.len()` — that path could bypass
+                    // `max_attempts` (loop forever when no global cap
+                    // is set) or collide idempotency keys on resume.
                     let failure_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
-                    if let Err(e) = exec_state.record_node_attempt(
+                    let failure_attempt_recorded = match exec_state.record_node_attempt(
                         node_key.clone(),
                         failure_idem_key,
                         AttemptOutcome::Failure {
                             error: err_str.clone(),
                         },
                     ) {
-                        tracing::warn!(
-                            target = "engine::frontier",
-                            %execution_id,
-                            %node_key,
-                            error = %e,
-                            "record_node_attempt(failure) failed; continuing without \
-                             attempt history (idempotency key may collide on retry)"
-                        );
-                    }
+                        Ok(_) => true,
+                        Err(e) => {
+                            tracing::warn!(
+                                target = "engine::frontier",
+                                %execution_id,
+                                %node_key,
+                                error = %e,
+                                "record_node_attempt(failure) failed; forcing finalize \
+                                 so stale attempt history cannot bypass max_attempts or \
+                                 collide idempotency keys"
+                            );
+                            false
+                        },
+                    };
 
-                    // ADR-0042 §M2.1 T4 — retry decision.
-                    let retry_policy_resolved = node_map
-                        .get(&node_key)
-                        .and_then(|nd| effective_retry_policy(nd, workflow_retry_policy.as_ref()))
-                        .cloned();
-                    let decision = compute_retry_decision(
-                        &node_key,
-                        exec_state,
-                        retry_policy_resolved.as_ref(),
-                    );
+                    // ADR-0042 §M2.1 T4 — retry decision. Skipped when
+                    // attempt history could not be recorded.
+                    let decision = if failure_attempt_recorded {
+                        let retry_policy_resolved = node_map
+                            .get(&node_key)
+                            .and_then(|nd| {
+                                effective_retry_policy(nd, workflow_retry_policy.as_ref())
+                            })
+                            .cloned();
+                        compute_retry_decision(
+                            &node_key,
+                            exec_state,
+                            retry_policy_resolved.as_ref(),
+                        )
+                    } else {
+                        RetryDecision::Finalize
+                    };
 
                     if let RetryDecision::Retry { delay } = decision {
                         let attempt_number = exec_state
                             .node_states
                             .get(&node_key)
                             .map_or(1, |ns| ns.attempt_count() as u32);
-                        let next_at =
-                            Utc::now() + chrono::Duration::from_std(delay).unwrap_or_default();
+                        let next_at = next_retry_at(execution_id, &node_key, delay);
                         match exec_state.schedule_node_retry(node_key.clone(), next_at) {
                             Ok(()) => {
                                 // Persist the WaitingRetry transition,
@@ -3781,13 +3826,25 @@ fn compute_retry_decision(
         return RetryDecision::Finalize;
     };
 
+    // Missing node state means the engine has no history we can
+    // base a retry decision on (programming error: only nodes the
+    // engine has dispatched are eligible). Refuse the retry rather
+    // than fabricating an `attempts_used = 0` for a stranger node —
+    // that would let a programming bug schedule retries on
+    // unbounded state (canon §12.4).
+    let Some(ns) = exec_state.node_states.get(node_key) else {
+        tracing::warn!(
+            target = "engine::retry",
+            execution_id = %exec_state.execution_id,
+            %node_key,
+            "retry skipped: node state missing for retry decision"
+        );
+        return RetryDecision::Finalize;
+    };
     // `attempts.len()` is the count of *completed* attempts at the
     // moment of decision (post-push of the just-failed attempt). Once
     // it reaches `max_attempts`, the budget is spent.
-    let attempts_used = exec_state
-        .node_states
-        .get(node_key)
-        .map_or(0, |ns| ns.attempts.len() as u32);
+    let attempts_used = ns.attempts.len() as u32;
 
     if attempts_used >= policy.max_attempts {
         tracing::debug!(
@@ -3806,6 +3863,33 @@ fn compute_retry_decision(
     // The just-finished attempt index is `attempts_used - 1` (0-based).
     let delay = policy.delay_for_attempt(attempts_used.saturating_sub(1));
     RetryDecision::Retry { delay }
+}
+
+/// Translate a Tokio-style retry delay to a chrono wall-clock
+/// timestamp without panicking on extreme inputs.
+///
+/// `chrono::Duration::from_std` rejects values larger than
+/// `i64::MAX` milliseconds (~292 million years). A naive
+/// `.unwrap_or_default()` would silently substitute zero — turning
+/// a misconfigured huge backoff into a hot-loop retry. Instead, we
+/// log + clamp to `chrono::Duration::MAX` so the next attempt is
+/// effectively never scheduled, but the engine remains responsive
+/// to cancel/wall-clock teardown signals.
+fn next_retry_at(execution_id: ExecutionId, node_key: &NodeKey, delay: Duration) -> DateTime<Utc> {
+    match chrono::Duration::from_std(delay) {
+        Ok(d) => Utc::now() + d,
+        Err(e) => {
+            tracing::warn!(
+                target = "engine::retry",
+                %execution_id,
+                %node_key,
+                error = %e,
+                delay_ms = delay.as_millis() as u64,
+                "retry delay is not representable by chrono; clamping to chrono::Duration::MAX"
+            );
+            Utc::now() + chrono::Duration::MAX
+        },
+    }
 }
 
 /// Classification of a node failure against the workflow's error strategy.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -6,7 +6,8 @@
 //! skip propagation, error routing, and conditional edges.
 
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
+    cmp::Reverse,
+    collections::{BinaryHeap, HashMap, HashSet, VecDeque},
     future::Future,
     pin::Pin,
     sync::{
@@ -16,6 +17,7 @@ use std::{
     time::{Duration, Instant},
 };
 
+use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use nebula_action::{ActionError, ActionResult, capability::default_resource_accessor};
 use nebula_core::{
@@ -27,8 +29,12 @@ use nebula_core::{
 use nebula_credential::default_credential_accessor;
 // ScopeLevel removed from ActionContext
 // use nebula_core::scope::ScopeLevel;
+use nebula_execution::output::ExecutionOutput;
 use nebula_execution::{
-    ExecutionStatus, context::ExecutionBudget, plan::ExecutionPlan, state::ExecutionState,
+    ExecutionStatus,
+    context::ExecutionBudget,
+    plan::ExecutionPlan,
+    state::{AttemptOutcome, ExecutionState},
     status::ExecutionTerminationReason,
 };
 use nebula_expression::ExpressionEngine;
@@ -699,6 +705,7 @@ impl WorkflowEngine {
             .collect();
 
         let error_strategy = workflow.config.error_strategy;
+        let workflow_retry_policy = workflow.config.retry_policy.clone();
 
         // Run the frontier loop — same as execute_workflow, just different seed + pre-populated
         // outputs.
@@ -717,6 +724,7 @@ impl WorkflowEngine {
                 &budget,
                 &started,
                 error_strategy,
+                workflow_retry_policy,
                 seed_nodes,
                 HashMap::new(),
                 HashMap::new(),
@@ -1076,6 +1084,7 @@ impl WorkflowEngine {
 
         // 9. Execute using frontier-based loop
         let error_strategy = workflow.config.error_strategy;
+        let workflow_retry_policy = workflow.config.retry_policy.clone();
         let seed_nodes: Vec<NodeKey> = graph.entry_nodes();
         let failed_node = self
             .run_frontier(
@@ -1092,6 +1101,7 @@ impl WorkflowEngine {
                 &budget,
                 &started,
                 error_strategy,
+                workflow_retry_policy,
                 seed_nodes,
                 HashMap::new(),
                 HashMap::new(),
@@ -1497,6 +1507,7 @@ impl WorkflowEngine {
             .inc();
 
         let error_strategy = workflow.config.error_strategy;
+        let workflow_retry_policy = workflow.config.retry_policy.clone();
         // Restore the original trigger payload from the persisted
         // execution state. Legacy states that predate #311 deserialize
         // the field as `None` — fall back to `Null` with a warning so
@@ -1527,6 +1538,7 @@ impl WorkflowEngine {
                 &budget,
                 &started,
                 error_strategy,
+                workflow_retry_policy,
                 seed_nodes,
                 activated_edges,
                 resolved_edges,
@@ -1692,6 +1704,7 @@ impl WorkflowEngine {
         budget: &ExecutionBudget,
         started: &Instant,
         error_strategy: nebula_workflow::ErrorStrategy,
+        workflow_retry_policy: Option<nebula_workflow::RetryConfig>,
         seed_nodes: Vec<NodeKey>,
         initial_activated: HashMap<NodeKey, HashSet<NodeKey>>,
         initial_resolved: HashMap<NodeKey, usize>,
@@ -1715,6 +1728,26 @@ impl WorkflowEngine {
             ready_queue.push_back(node_key);
         }
 
+        // Min-heap (via `Reverse`) of `(next_attempt_at, NodeKey)` for
+        // nodes parked in `WaitingRetry` per ADR-0042 §M2.1 T5. The
+        // heap is the engine's source of truth for "what to dispatch
+        // next when the current frontier is otherwise idle"; cancel /
+        // terminate / budget guards run AFTER the timer fires so a
+        // cancelled execution does not silently re-dispatch a node.
+        let mut retry_heap: BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>> = BinaryHeap::new();
+
+        // Resume seeding: any node already in `WaitingRetry` from a
+        // prior run (its `next_attempt_at` survived via JSONB) needs
+        // to land on the heap before the loop starts. Otherwise a
+        // resumed retry would silently never re-dispatch.
+        for (key, ns) in &exec_state.node_states {
+            if ns.state == NodeState::WaitingRetry
+                && let Some(when) = ns.next_attempt_at
+            {
+                retry_heap.push(Reverse((when, key.clone())));
+            }
+        }
+
         // In-flight tasks + a side map from tokio task id → NodeKey so
         // that panics (where the inner future's `(NodeKey, _)` payload
         // is lost) can still be attributed to the real node instead
@@ -1727,6 +1760,64 @@ impl WorkflowEngine {
 
         // Main frontier loop
         loop {
+            // Phase 0: Drain due retries from the retry_heap into the
+            // ready_queue (ADR-0042 §M2.1 T5).
+            //
+            // Phase 0 promotes `WaitingRetry → Ready` and clears
+            // `next_attempt_at` so any subsequent cancel/terminate
+            // teardown sees a `Ready` node — `Ready → Cancelled` is a
+            // valid transition while a stranded `WaitingRetry` node
+            // would trip the canon §11.1 frontier-integrity check.
+            // Phase 1's `spawn_node` then performs `Ready → Running`
+            // via `start_node_attempt`.
+            let now_drain = Utc::now();
+            while let Some(Reverse((when, _))) = retry_heap.peek() {
+                if *when > now_drain {
+                    break;
+                }
+                let Reverse((_, node_key)) =
+                    retry_heap.pop().expect("peek-then-pop on non-empty heap");
+                let still_parked = exec_state
+                    .node_state(node_key.clone())
+                    .is_some_and(|ns| ns.state == NodeState::WaitingRetry);
+                if still_parked {
+                    match exec_state.transition_node(node_key.clone(), NodeState::Ready) {
+                        Ok(()) => {
+                            if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
+                                ns.next_attempt_at = None;
+                            }
+                            ready_queue.push_back(node_key.clone());
+                            tracing::debug!(
+                                target = "engine::frontier",
+                                %execution_id,
+                                %node_key,
+                                "retry attempt re-dispatched after backoff"
+                            );
+                        },
+                        Err(err) => {
+                            // WaitingRetry → Ready is in the canonical
+                            // table; this is unreachable in practice
+                            // but we surface defensively rather than
+                            // panic (canon §12.4).
+                            tracing::warn!(
+                                target = "engine::retry",
+                                %execution_id,
+                                %node_key,
+                                %err,
+                                "retry promotion to Ready rejected; skipping"
+                            );
+                        },
+                    }
+                } else {
+                    tracing::debug!(
+                        target = "engine::frontier",
+                        %execution_id,
+                        %node_key,
+                        "retry drained but node no longer in WaitingRetry; skipping"
+                    );
+                }
+            }
+
             // Phase 1: Drain ready queue → spawn into join_set
             while let Some(node_key) = ready_queue.pop_front() {
                 if cancel_token.is_cancelled() {
@@ -1809,16 +1900,94 @@ impl WorkflowEngine {
                 // `spawn_node` already marked the node as Failed and stored
                 // the typed error message on `NodeExecutionState`.
                 //
-                // Ordering (§11.5, #297 review): classify → apply
-                // recovery → route (stages OnError payload into
-                // outputs) → checkpoint (durably commits state +
-                // staged payload) → emit. Route runs BEFORE
-                // checkpoint so `load_all_outputs` on resume finds
-                // the OnError handler's input.
+                // ADR-0042 §M2.1 T4 — setup failures are retry-eligible
+                // ("the action never started — re-running may succeed,
+                // e.g. credential rotation"). Same retry-decision flow
+                // as the runtime-failure path.
+                //
+                // Ordering on the no-retry path (§11.5, #297 review):
+                // record_attempt → classify → apply recovery → route
+                // (stages OnError payload into outputs) → checkpoint
+                // (durably commits state + staged payload) → emit.
                 let err_msg = exec_state
                     .node_state(node_key.clone())
                     .and_then(|ns| ns.error_message.clone())
                     .unwrap_or_else(|| "parameter resolution failed".to_string());
+
+                // Push the failure attempt record so retry-decision
+                // and idempotency_key see the same attempt count.
+                let setup_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
+                if let Err(e) = exec_state.record_node_attempt(
+                    node_key.clone(),
+                    setup_idem_key,
+                    AttemptOutcome::Failure {
+                        error: err_msg.clone(),
+                    },
+                ) {
+                    tracing::warn!(
+                        target = "engine::frontier",
+                        %execution_id,
+                        %node_key,
+                        error = %e,
+                        "record_node_attempt(setup-failure) failed; \
+                         continuing without attempt history"
+                    );
+                }
+
+                // ADR-0042 §M2.1 T4 — retry decision (setup-failure
+                // path). Mirror runtime-failure semantics.
+                let setup_retry_policy = node_map
+                    .get(&node_key)
+                    .and_then(|nd| effective_retry_policy(nd, workflow_retry_policy.as_ref()))
+                    .cloned();
+                let setup_decision =
+                    compute_retry_decision(&node_key, exec_state, setup_retry_policy.as_ref());
+
+                if let RetryDecision::Retry { delay } = setup_decision {
+                    let attempt_number = exec_state
+                        .node_states
+                        .get(&node_key)
+                        .map_or(1, |ns| ns.attempt_count() as u32);
+                    let next_at =
+                        Utc::now() + chrono::Duration::from_std(delay).unwrap_or_default();
+                    if exec_state
+                        .schedule_node_retry(node_key.clone(), next_at)
+                        .is_ok()
+                    {
+                        if let Err(e) = self
+                            .checkpoint_node(
+                                execution_id,
+                                node_key.clone(),
+                                outputs,
+                                exec_state,
+                                repo_version,
+                            )
+                            .await
+                        {
+                            cancel_token.cancel();
+                            return Some((node_key, e.to_string()));
+                        }
+                        retry_heap.push(Reverse((next_at, node_key.clone())));
+                        tracing::info!(
+                            target = "engine::retry",
+                            %execution_id,
+                            %node_key,
+                            attempt = attempt_number,
+                            delay_ms = delay.as_millis() as u64,
+                            next_attempt_at = %next_at,
+                            total_retries = exec_state.total_retries,
+                            "retry scheduled (setup-failure path)"
+                        );
+                        self.emit_event(ExecutionEvent::NodeRetryScheduled {
+                            execution_id,
+                            node_key: node_key.clone(),
+                            attempt: attempt_number,
+                            next_attempt_at: next_at,
+                            last_error: err_msg.clone(),
+                        });
+                        continue;
+                    }
+                }
 
                 let outcome = classify_failure(error_strategy);
                 if let Err(e) =
@@ -1880,8 +2049,12 @@ impl WorkflowEngine {
                 }
             }
 
-            // Phase 2: Wait for one completion (or exit if nothing in flight)
-            if join_set.is_empty() {
+            // Phase 2: Wait for one completion or for the next retry
+            // timer. Exit only when both join_set and retry_heap are
+            // drained — `retry_heap` non-empty with `join_set` empty
+            // is a legal "everything paused for backoff" state per
+            // ADR-0042 §M2.1 T5.
+            if join_set.is_empty() && retry_heap.is_empty() {
                 break;
             }
 
@@ -1889,6 +2062,23 @@ impl WorkflowEngine {
                 join_set.abort_all();
                 while join_set.join_next_with_id().await.is_some() {}
                 task_nodes.clear();
+                // Tear down parked retries (WaitingRetry → Cancelled)
+                // AND the ready_queue (Ready → Cancelled). The
+                // previous failure already lives in `NodeAttempt`;
+                // the cancel terminates the wait, not the attempt
+                // (canon §4.5). Without draining `ready_queue`, a
+                // node Phase 0 already promoted to `Ready` would
+                // stay non-terminal after the loop exits, tripping
+                // the canon §11.1 frontier-integrity check. Best-
+                // effort persist is covered by the final-status
+                // checkpoint in the outer caller — failures here
+                // only affect post-mortem log fidelity.
+                drain_pending_to_cancelled(
+                    &mut retry_heap,
+                    &mut ready_queue,
+                    exec_state,
+                    execution_id,
+                );
                 break;
             }
 
@@ -1908,27 +2098,108 @@ impl WorkflowEngine {
             };
             tokio::pin!(sleep_fut);
 
-            let join_result = tokio::select! {
-                result = join_set.join_next_with_id() => match result {
-                    Some(r) => r,
-                    None => break,
+            // Compute the sleep until the next retry timer fires. If
+            // `retry_heap` is empty, sleep forever (the join_set / cancel
+            // / wall-clock arms still drive the select).
+            let next_retry_in: Option<Duration> = retry_heap.peek().map(|Reverse((when, _))| {
+                when.signed_duration_since(Utc::now())
+                    .to_std()
+                    .unwrap_or(Duration::ZERO)
+            });
+            let retry_sleep_fut = async {
+                if let Some(d) = next_retry_in {
+                    tokio::time::sleep(d).await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            };
+            tokio::pin!(retry_sleep_fut);
+
+            // If join_set is empty but retry_heap has work, we still
+            // need to sleep until the timer (or cancel / wall-clock).
+            // Use a `pending` future on the join_set arm in that case
+            // so `select!` does not see a `None` and break early.
+            let join_set_empty = join_set.is_empty();
+
+            type JoinedResult = Option<
+                Result<
+                    (
+                        tokio::task::Id,
+                        (
+                            NodeKey,
+                            Result<ActionResult<serde_json::Value>, EngineError>,
+                        ),
+                    ),
+                    tokio::task::JoinError,
+                >,
+            >;
+            // Joined variant is the wide one — the other arms are
+            // unit-like timer markers. The size asymmetry is intrinsic
+            // to a wake-reason discriminant and acceptable on a path
+            // that allocates one value per loop iteration.
+            #[allow(clippy::large_enum_variant)]
+            enum WakeReason {
+                Joined(JoinedResult),
+                RetryTimer,
+                WallClock,
+                Cancel,
+            }
+
+            let wake = tokio::select! {
+                result = async {
+                    if join_set_empty {
+                        std::future::pending::<()>().await;
+                        unreachable!()
+                    } else {
+                        join_set.join_next_with_id().await
+                    }
+                } => WakeReason::Joined(result),
+                () = &mut retry_sleep_fut, if next_retry_in.is_some() => WakeReason::RetryTimer,
+                () = &mut sleep_fut => WakeReason::WallClock,
+                () = cancel_token.cancelled() => WakeReason::Cancel,
+            };
+
+            let join_result = match wake {
+                WakeReason::Joined(Some(r)) => r,
+                WakeReason::Joined(None) => {
+                    // join_set drained mid-iteration — loop back so
+                    // Phase 0 / Phase 1 / exit-condition observe the
+                    // current retry_heap state.
+                    continue;
                 },
-                () = &mut sleep_fut => {
+                WakeReason::RetryTimer => {
+                    // Timer fired — loop back so Phase 0 drains due
+                    // retries into ready_queue.
+                    continue;
+                },
+                WakeReason::WallClock => {
                     cancel_token.cancel();
                     join_set.abort_all();
                     while join_set.join_next_with_id().await.is_some() {}
                     task_nodes.clear();
+                    drain_pending_to_cancelled(
+                        &mut retry_heap,
+                        &mut ready_queue,
+                        exec_state,
+                        execution_id,
+                    );
                     return Some((
                         node_key!("_timeout"),
                         "execution budget exceeded: max_duration".to_string(),
                     ));
-                }
-                () = cancel_token.cancelled() => {
+                },
+                WakeReason::Cancel => {
                     join_set.abort_all();
                     while join_set.join_next_with_id().await.is_some() {}
                     task_nodes.clear();
+                    drain_pending_to_cancelled(
+                        &mut retry_heap,
+                        &mut ready_queue,
+                        exec_state,
+                        execution_id,
+                    );
                     break;
-                }
+                },
             };
 
             // Phase 3: Process the completed task
@@ -1937,12 +2208,19 @@ impl WorkflowEngine {
                     task_nodes.remove(&task_id);
                     mark_node_completed(exec_state, node_key.clone());
 
-                    // Track output size for budget enforcement
+                    // Track output size for budget enforcement.
+                    let mut output_bytes: u64 = 0;
                     if let Some(output) = outputs.get(&node_key) {
-                        let bytes =
+                        output_bytes =
                             serde_json::to_string(output.value()).map_or(0, |s| s.len() as u64);
-                        total_output_bytes.fetch_add(bytes, Ordering::Relaxed);
+                        total_output_bytes.fetch_add(output_bytes, Ordering::Relaxed);
                     }
+                    // Capture the current dispatch's idempotency key
+                    // BEFORE we push the attempt record (the push
+                    // would otherwise advance the next-dispatch key
+                    // and break record_idempotency / record_node_result
+                    // which want the just-finished attempt's key).
+                    let success_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
 
                     // Capture an explicit-termination signal BEFORE the
                     // checkpoint so that the same CAS-write durably
@@ -2019,10 +2297,17 @@ impl WorkflowEngine {
                     // Persist the full ActionResult alongside the raw
                     // output so that idempotent replay can reconstruct
                     // the exact routing semantics (issue #299).
+                    //
+                    // ADR-0042 §M2.1 T4 — `attempt_count + 1` is the
+                    // current dispatch's attempt number BEFORE we push
+                    // the success record below; same number that
+                    // `success_idem_key` was minted against so the
+                    // idempotency-key store and the per-attempt result
+                    // store stay in lockstep.
                     let attempt = exec_state
                         .node_states
                         .get(&node_key)
-                        .map_or(1, |ns| ns.attempt_count().max(1) as u32);
+                        .map_or(1, |ns| (ns.attempt_count() as u32).saturating_add(1));
                     self.record_node_result(
                         execution_id,
                         node_key.clone(),
@@ -2030,6 +2315,31 @@ impl WorkflowEngine {
                         &action_result,
                     )
                     .await;
+
+                    // ADR-0042 §M2.1 T4 — push the success attempt
+                    // record AFTER record_idempotency / record_node_result
+                    // so those helpers see the just-finished attempt's
+                    // key (push advances the next-dispatch key).
+                    let success_payload = outputs
+                        .get(&node_key)
+                        .map_or_else(|| serde_json::Value::Null, |v| v.value().clone());
+                    if let Err(e) = exec_state.record_node_attempt(
+                        node_key.clone(),
+                        success_idem_key,
+                        AttemptOutcome::Success {
+                            output: ExecutionOutput::inline(success_payload),
+                            output_bytes,
+                        },
+                    ) {
+                        tracing::warn!(
+                            target = "engine::frontier",
+                            %execution_id,
+                            %node_key,
+                            error = %e,
+                            "record_node_attempt(success) failed; continuing without \
+                             attempt history (idempotency key may collide on resume)"
+                        );
+                    }
 
                     self.emit_event(ExecutionEvent::NodeCompleted {
                         execution_id,
@@ -2074,15 +2384,26 @@ impl WorkflowEngine {
                     // that checkpoint must capture so resume can read
                     // it from `load_all_outputs`):
                     //   1. `mark_node_failed`      — in-memory Failed
-                    //   2. `apply_failure_recovery` — IgnoreErrors-only override of state + null
-                    //      output (in-memory)
-                    //   3. `route_failure_edges`    — evaluate outgoing edges; may write `{error,
+                    //   2. `record_node_attempt(failure)` — push the attempt to history so
+                    //      `idempotency_key_for_node` differentiates future retries (ADR-0042 T4).
+                    //   3. **retry decision**       — ADR-0042 §M2.1 T4. If the per-node /
+                    //      workflow-default `RetryConfig` has budget AND the global
+                    //      `ExecutionBudget.max_total_retries` cap allows another attempt, promote
+                    //      `Failed → WaitingRetry`, stamp `next_attempt_at`, increment
+                    //      `total_retries`, push the node onto `retry_heap`, checkpoint, emit
+                    //      `NodeRetryScheduled`, and skip the finalize path. The retry loop (Phase
+                    //      0 next iteration) will re-dispatch when the timer fires —
+                    //      cancel/terminate/budget guards run BEFORE the re-dispatch so a cancelled
+                    //      execution never silently re-runs a node.
+                    //   4. `apply_failure_recovery` — IgnoreErrors-only override of state + null
+                    //      output (in-memory). Only on the no-retry path.
+                    //   5. `route_failure_edges`    — evaluate outgoing edges; may write `{error,
                     //      node_id}` payload into `outputs[node_key]` for OnError input; may
-                    //      enqueue successors into `ready_queue`
-                    //   4. `checkpoint_node`        — durable commit of state + outputs (abort on
-                    //      Err; the discarded `ready_queue` mutations never surface)
-                    //   5. `emit_event`             — observers (only for Fail outcome), strictly
-                    //      after persist
+                    //      enqueue successors into `ready_queue`. Only on the no-retry path.
+                    //   6. `checkpoint_node`        — durable commit of state + outputs (abort on
+                    //      Err; the discarded `ready_queue` mutations never surface).
+                    //   7. `emit_event`             — observers (`NodeFailed` only on the no-retry
+                    //      path; `NodeRetryScheduled` on the retry path), strictly after persist.
                     //
                     // Successors in `ready_queue` do NOT dispatch until
                     // Phase 1 of the next loop iteration; that runs
@@ -2091,6 +2412,103 @@ impl WorkflowEngine {
                     mark_node_failed(exec_state, node_key.clone(), err);
                     let err_str = err.to_string();
 
+                    // Push the failure attempt record so idempotency
+                    // key, retry-decision, and post-mortem audit all
+                    // see the same attempt history.
+                    let failure_idem_key = exec_state.idempotency_key_for_node(node_key.clone());
+                    if let Err(e) = exec_state.record_node_attempt(
+                        node_key.clone(),
+                        failure_idem_key,
+                        AttemptOutcome::Failure {
+                            error: err_str.clone(),
+                        },
+                    ) {
+                        tracing::warn!(
+                            target = "engine::frontier",
+                            %execution_id,
+                            %node_key,
+                            error = %e,
+                            "record_node_attempt(failure) failed; continuing without \
+                             attempt history (idempotency key may collide on retry)"
+                        );
+                    }
+
+                    // ADR-0042 §M2.1 T4 — retry decision.
+                    let retry_policy_resolved = node_map
+                        .get(&node_key)
+                        .and_then(|nd| effective_retry_policy(nd, workflow_retry_policy.as_ref()))
+                        .cloned();
+                    let decision = compute_retry_decision(
+                        &node_key,
+                        exec_state,
+                        retry_policy_resolved.as_ref(),
+                    );
+
+                    if let RetryDecision::Retry { delay } = decision {
+                        let attempt_number = exec_state
+                            .node_states
+                            .get(&node_key)
+                            .map_or(1, |ns| ns.attempt_count() as u32);
+                        let next_at =
+                            Utc::now() + chrono::Duration::from_std(delay).unwrap_or_default();
+                        match exec_state.schedule_node_retry(node_key.clone(), next_at) {
+                            Ok(()) => {
+                                // Persist the WaitingRetry transition,
+                                // `next_attempt_at`, and the global
+                                // counter bump in one CAS write.
+                                if let Err(e) = self
+                                    .checkpoint_node(
+                                        execution_id,
+                                        node_key.clone(),
+                                        outputs,
+                                        exec_state,
+                                        repo_version,
+                                    )
+                                    .await
+                                {
+                                    cancel_token.cancel();
+                                    return Some((node_key.clone(), e.to_string()));
+                                }
+                                retry_heap.push(Reverse((next_at, node_key.clone())));
+                                tracing::info!(
+                                    target = "engine::retry",
+                                    %execution_id,
+                                    %node_key,
+                                    attempt = attempt_number,
+                                    delay_ms = delay.as_millis() as u64,
+                                    next_attempt_at = %next_at,
+                                    total_retries = exec_state.total_retries,
+                                    "retry scheduled (Layer 2 / NodeDefinition.retry_policy)"
+                                );
+                                self.emit_event(ExecutionEvent::NodeRetryScheduled {
+                                    execution_id,
+                                    node_key: node_key.clone(),
+                                    attempt: attempt_number,
+                                    next_attempt_at: next_at,
+                                    last_error: err_str.clone(),
+                                });
+                                // Done with this iteration — skip the
+                                // finalize path entirely.
+                                continue;
+                            },
+                            Err(schedule_err) => {
+                                // `schedule_node_retry` rejected the
+                                // promotion (e.g. node moved out of
+                                // Failed mid-decision). Fall through
+                                // to the finalize path so the failure
+                                // surfaces honestly.
+                                tracing::warn!(
+                                    target = "engine::retry",
+                                    %execution_id,
+                                    %node_key,
+                                    error = %schedule_err,
+                                    "schedule_node_retry rejected; finalising failure"
+                                );
+                            },
+                        }
+                    }
+
+                    // ── Finalize path (no retry / retry exhausted) ──
                     let outcome = classify_failure(error_strategy);
                     if let Err(e) =
                         apply_failure_recovery(outcome, node_key.clone(), exec_state, outputs)
@@ -3252,6 +3670,144 @@ fn check_budget(
     None
 }
 
+/// Drain both the retry-pending min-heap and the ready_queue,
+/// transitioning every parked / queued node to `Cancelled` and
+/// clearing any `next_attempt_at`.
+///
+/// Called by all three frontier-loop teardown paths (Phase 2 cancel
+/// short-circuit, `WakeReason::Cancel`, `WakeReason::WallClock`) per
+/// ADR-0042 §M2.1 T5 acceptance: cancel/terminate/budget breach must
+/// not leave non-terminal nodes behind, otherwise the canon §11.1
+/// frontier-integrity guard fires `FrontierIntegrityViolation`
+/// instead of the honest `Cancelled` / `TimedOut` final status.
+///
+/// Best-effort: transition errors are logged and ignored. The
+/// outer `persist_final_state` covers the durable persist; failures
+/// here only affect post-mortem log fidelity.
+fn drain_pending_to_cancelled(
+    retry_heap: &mut BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>>,
+    ready_queue: &mut VecDeque<NodeKey>,
+    exec_state: &mut ExecutionState,
+    execution_id: ExecutionId,
+) {
+    while let Some(Reverse((_, parked))) = retry_heap.pop() {
+        let _ = exec_state.transition_node(parked.clone(), NodeState::Cancelled);
+        if let Some(ns) = exec_state.node_states.get_mut(&parked) {
+            ns.next_attempt_at = None;
+        }
+        tracing::debug!(
+            target = "engine::retry",
+            %execution_id,
+            node_key = %parked,
+            "WaitingRetry → Cancelled (cancel observed during backoff)"
+        );
+    }
+    while let Some(queued) = ready_queue.pop_front() {
+        // `Ready → Cancelled` is in the canonical transition table.
+        // Pending nodes that landed here straight from the seed
+        // (no Phase 0 promotion) also accept `Pending → Cancelled`.
+        let _ = exec_state.transition_node(queued.clone(), NodeState::Cancelled);
+        tracing::debug!(
+            target = "engine::retry",
+            %execution_id,
+            node_key = %queued,
+            "ready_queue node cancelled before dispatch"
+        );
+    }
+}
+
+/// Resolve the effective per-node retry policy per ADR-0042 §M2.1 T4.
+///
+/// Resolution order (more specific wins):
+/// 1. `NodeDefinition.retry_policy` — operator-declared per-node policy.
+/// 2. `workflow_default` — `WorkflowConfig.retry_policy`, the workflow-wide default applied to
+///    nodes that do not declare their own.
+/// 3. `None` — no engine-level retry; the failure flows straight to the existing
+///    classify+route+checkpoint path.
+fn effective_retry_policy<'a>(
+    node_def: &'a nebula_workflow::NodeDefinition,
+    workflow_default: Option<&'a nebula_workflow::RetryConfig>,
+) -> Option<&'a nebula_workflow::RetryConfig> {
+    node_def.retry_policy.as_ref().or(workflow_default)
+}
+
+/// The retry decision for a just-failed node attempt per ADR-0042.
+///
+/// Pure: depends only on the per-node attempt count, the resolved
+/// policy, and the execution-level budget. Does not mutate any state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RetryDecision {
+    /// No retry — fall through to the existing
+    /// classify+route+checkpoint path.
+    Finalize,
+    /// Schedule a retry after `delay`. The frontier loop transitions
+    /// the node to `WaitingRetry`, stamps `next_attempt_at = now() + delay`,
+    /// increments the global counter, and parks the node on the
+    /// retry-pending heap.
+    Retry { delay: Duration },
+}
+
+/// Decide whether the just-failed dispatch of `node_key` should be
+/// retried per ADR-0042 §M2.1 T4 acceptance.
+///
+/// Ordering of checks (whichever caps first wins):
+///
+/// 1. **Global budget cap** — `ExecutionState::has_exhausted_retry_budget` consults
+///    `ExecutionBudget.max_total_retries`. A `Some(0)` cap disables retry entirely; a `None` cap
+///    leaves the per-node policy as the only gate.
+/// 2. **Per-node policy presence** — no policy → no retry.
+/// 3. **Per-node policy max_attempts** — once `attempts.len()` (the number of completed attempts at
+///    the time of this decision) has reached `policy.max_attempts`, the retry budget is exhausted.
+/// 4. **Backoff calc** — `policy.delay_for_attempt(attempt_count - 1)` where `attempt_count` is the
+///    just-finished attempt number (1-indexed). This yields the same wait the
+///    `nebula-resilience::retry` crate would for the same `RetryConfig`.
+fn compute_retry_decision(
+    node_key: &NodeKey,
+    exec_state: &ExecutionState,
+    retry_policy: Option<&nebula_workflow::RetryConfig>,
+) -> RetryDecision {
+    if exec_state.has_exhausted_retry_budget() {
+        tracing::debug!(
+            target = "engine::retry",
+            execution_id = %exec_state.execution_id,
+            %node_key,
+            total_retries = exec_state.total_retries,
+            "retry skipped: ExecutionBudget.max_total_retries cap reached"
+        );
+        return RetryDecision::Finalize;
+    }
+
+    let Some(policy) = retry_policy else {
+        return RetryDecision::Finalize;
+    };
+
+    // `attempts.len()` is the count of *completed* attempts at the
+    // moment of decision (post-push of the just-failed attempt). Once
+    // it reaches `max_attempts`, the budget is spent.
+    let attempts_used = exec_state
+        .node_states
+        .get(node_key)
+        .map_or(0, |ns| ns.attempts.len() as u32);
+
+    if attempts_used >= policy.max_attempts {
+        tracing::debug!(
+            target = "engine::retry",
+            execution_id = %exec_state.execution_id,
+            %node_key,
+            attempts_used,
+            max_attempts = policy.max_attempts,
+            "retry skipped: per-node max_attempts reached"
+        );
+        return RetryDecision::Finalize;
+    }
+
+    // `delay_for_attempt(0)` = initial delay (after attempt #1 fails);
+    // `delay_for_attempt(1)` = after attempt #2 fails; etc.
+    // The just-finished attempt index is `attempts_used - 1` (0-based).
+    let delay = policy.delay_for_attempt(attempts_used.saturating_sub(1));
+    RetryDecision::Retry { delay }
+}
+
 /// Classification of a node failure against the workflow's error strategy.
 ///
 /// Pure function of the strategy: splits the outcome from the state
@@ -3968,7 +4524,7 @@ mod tests {
         nodes: Vec<NodeDefinition>,
         connections: Vec<Connection>,
     ) -> WorkflowDefinition {
-        let now = chrono::Utc::now();
+        let now = Utc::now();
         WorkflowDefinition {
             id: WorkflowId::new(),
             name: "test".into(),
@@ -3993,7 +4549,7 @@ mod tests {
         connections: Vec<Connection>,
         config: WorkflowConfig,
     ) -> WorkflowDefinition {
-        let now = chrono::Utc::now();
+        let now = Utc::now();
         WorkflowDefinition {
             id: WorkflowId::new(),
             name: "test".into(),
@@ -5818,10 +6374,12 @@ mod tests {
             "handler should be called exactly once on first run"
         );
 
-        // Reconstruct the idempotency key via the same seam the engine
-        // uses (issue #266) — `ExecutionState::idempotency_key_for_node`
-        // — so the test is not coupled to a literal `:1` suffix and
-        // still asserts the key was durably recorded by the first run.
+        // Reconstruct the idempotency key via the just-recorded
+        // attempt history. ADR-0042 §M2.1 T4 made
+        // `ExecutionState::idempotency_key_for_node` return the key
+        // for the **next** dispatch, so to read the key the engine
+        // actually persisted, look at the last attempt record (which
+        // carries the idempotency key it was minted under).
         //
         // Deserializing via a JSON string (rather than `from_value`)
         // avoids `#[serde(borrow)]` issues on domain keys — the same
@@ -5835,7 +6393,10 @@ mod tests {
         let state_str = serde_json::to_string(&state_json).unwrap();
         let exec_state: ExecutionState =
             serde_json::from_str(&state_str).expect("deserialize persisted execution state");
-        let idem_key = exec_state.idempotency_key_for_node(n.clone());
+        let idem_key = exec_state
+            .node_state(n.clone())
+            .and_then(|ns| ns.attempts.last().map(|a| a.idempotency_key.clone()))
+            .expect("first run must have pushed an attempt record (ADR-0042 §M2.1 T4)");
 
         let already_marked = exec_repo
             .check_idempotency(idem_key.as_str())
@@ -7661,7 +8222,7 @@ mod tests {
         // External non-terminal bump: stay in Running but advance
         // `updated_at` by re-saving the row at a new version.
         let mut external_state = local_state.clone();
-        external_state.updated_at = chrono::Utc::now();
+        external_state.updated_at = Utc::now();
         external_state.version += 1;
         let external_json = serde_json::to_value(&external_state).unwrap();
         let ok = inner

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -6,6 +6,7 @@
 
 use std::time::Duration;
 
+use chrono::{DateTime, Utc};
 use nebula_core::{NodeKey, id::ExecutionId};
 use nebula_execution::status::ExecutionTerminationReason;
 use nebula_workflow::NodeState;
@@ -42,6 +43,29 @@ pub enum ExecutionEvent {
         node_key: NodeKey,
         /// Error message.
         error: String,
+    },
+
+    /// A node attempt failed but the engine scheduled a retry per
+    /// ADR-0042 (Layer 2 — engine-level retry). The node has
+    /// transitioned to `WaitingRetry` and will be re-dispatched at
+    /// `next_attempt_at`.
+    ///
+    /// Subscribers should treat this as **not-final**: the node has
+    /// not failed in the canonical sense (`is_failure() == false`
+    /// while `WaitingRetry`); only the post-retry-exhausted
+    /// [`ExecutionEvent::NodeFailed`] counts as a final failure.
+    NodeRetryScheduled {
+        /// Execution this node belongs to.
+        execution_id: ExecutionId,
+        /// The node whose retry is scheduled.
+        node_key: NodeKey,
+        /// Sequential attempt number that just failed (1-indexed).
+        attempt: u32,
+        /// Wall-clock instant the engine plans to dispatch the next
+        /// attempt at.
+        next_attempt_at: DateTime<Utc>,
+        /// Error string from the just-failed attempt.
+        last_error: String,
     },
 
     /// A node was skipped (disabled or dependency not met).

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -1,0 +1,529 @@
+//! Engine-level retry integration tests (ADR-0042 §M2.1 T6).
+//!
+//! Covers the canonical retry path plus the four ADR-named edge
+//! cases (cancel/terminate/budget/idempotency) and the three
+//! resolution scenarios for the effective retry policy
+//! (per-node / workflow-default / no policy).
+//!
+//! Each test uses small (1-5ms) backoffs so the suite stays under
+//! the integration-test budget while still exercising the real
+//! `tokio::sleep` path in the frontier loop.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionError, action::Action, metadata::ActionMetadata, result::ActionResult,
+    stateless::StatelessAction,
+};
+use nebula_core::{DeclaresDependencies, action_key, id::WorkflowId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, ExecutionEvent,
+    InProcessSandbox, WorkflowEngine,
+};
+use nebula_execution::{ExecutionStatus, context::ExecutionBudget};
+use nebula_storage::ExecutionRepo;
+use nebula_telemetry::metrics::MetricsRegistry;
+use nebula_workflow::{NodeDefinition, RetryConfig, Version, WorkflowConfig, WorkflowDefinition};
+
+// ---------------------------------------------------------------------------
+// Test handlers
+// ---------------------------------------------------------------------------
+
+/// Fails on attempts 1..fail_count, then succeeds with the input on
+/// attempt fail_count+1. The shared counter records each invocation
+/// so tests can assert exact attempt counts.
+struct FlakyHandler {
+    meta: ActionMetadata,
+    fail_count: u32,
+    invocations: Arc<AtomicU32>,
+}
+
+impl DeclaresDependencies for FlakyHandler {}
+impl Action for FlakyHandler {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+}
+
+impl StatelessAction for FlakyHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        input: Self::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<Self::Output>, ActionError> {
+        let n = self.invocations.fetch_add(1, Ordering::SeqCst) + 1;
+        if n <= self.fail_count {
+            Err(ActionError::retryable(format!("flaky: attempt {n} failed")))
+        } else {
+            Ok(ActionResult::success(input))
+        }
+    }
+}
+
+/// Always fails — used to verify retry exhaustion.
+struct AlwaysFailingHandler {
+    meta: ActionMetadata,
+    invocations: Arc<AtomicU32>,
+}
+
+impl DeclaresDependencies for AlwaysFailingHandler {}
+impl Action for AlwaysFailingHandler {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+}
+
+impl StatelessAction for AlwaysFailingHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        _input: Self::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<Self::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Err(ActionError::retryable("always fails"))
+    }
+}
+
+/// Returns `ActionResult::Terminate` to test cooperative shutdown
+/// while a sibling is parked in WaitingRetry.
+struct TerminateHandler {
+    meta: ActionMetadata,
+}
+
+impl DeclaresDependencies for TerminateHandler {}
+impl Action for TerminateHandler {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+}
+
+impl StatelessAction for TerminateHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    async fn execute(
+        &self,
+        _input: Self::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<Self::Output>, ActionError> {
+        Ok(ActionResult::terminate_success(Some(
+            "test-stop".to_owned(),
+        )))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine assembly + workflow helpers
+// ---------------------------------------------------------------------------
+
+fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let sandbox = Arc::new(InProcessSandbox::new(executor));
+    let runtime = Arc::new(ActionRuntime::new(
+        registry,
+        sandbox,
+        DataPassingPolicy::default(),
+        metrics.clone(),
+    ));
+    WorkflowEngine::new(runtime, metrics)
+}
+
+fn make_workflow(
+    nodes: Vec<NodeDefinition>,
+    connections: Vec<nebula_workflow::Connection>,
+    config: WorkflowConfig,
+) -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    WorkflowDefinition {
+        id: WorkflowId::new(),
+        name: "retry-test".to_owned(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes,
+        connections,
+        variables: Default::default(),
+        config,
+        trigger: None,
+        tags: vec![],
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: 1,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests (9 — ADR-0042 §M2.1 T6 acceptance)
+// ---------------------------------------------------------------------------
+
+/// 1) Basic retry path — handler fails once, succeeds on attempt 2.
+#[tokio::test]
+async fn retry_succeeds_on_attempt_2() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(FlakyHandler {
+        meta: ActionMetadata::new(action_key!("flaky"), "Flaky", "fails once"),
+        fail_count: 1,
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("flake");
+    let mut node = NodeDefinition::new(n.clone(), "flake_node", "flaky").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(3, 1));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let result = engine
+        .execute_workflow(
+            &wf,
+            serde_json::json!("payload"),
+            ExecutionBudget::default(),
+        )
+        .await
+        .unwrap();
+
+    assert!(result.is_success(), "retry should succeed on attempt 2");
+    assert_eq!(invocations.load(Ordering::SeqCst), 2);
+    assert_eq!(result.status, ExecutionStatus::Completed);
+}
+
+/// 2) Retry exhausts `max_attempts` — handler always fails, workflow
+/// fails after `max_attempts` invocations.
+#[tokio::test]
+async fn retry_exhausts_max_attempts() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(AlwaysFailingHandler {
+        meta: ActionMetadata::new(action_key!("doomed"), "Doomed", "always fails"),
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("d");
+    let mut node = NodeDefinition::new(n, "doom_node", "doomed").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(3, 1));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(!result.is_success());
+    assert_eq!(result.status, ExecutionStatus::Failed);
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        3,
+        "max_attempts=3 must run the handler exactly 3 times"
+    );
+}
+
+/// 3) Cancel-during-retry-wait — `WorkflowEngine::cancel_execution`
+/// flips the parked WaitingRetry node to Cancelled when the cancel
+/// token fires. Uses a long backoff so the test reliably catches
+/// the node mid-wait.
+#[tokio::test]
+async fn cancel_during_retry_wait() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(AlwaysFailingHandler {
+        meta: ActionMetadata::new(action_key!("flaky_long"), "FlakyLong", "fails forever"),
+        invocations: Arc::clone(&invocations),
+    });
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+
+    let engine = Arc::new(make_engine(registry).with_event_bus(event_bus));
+
+    let n = node_key!("c");
+    let mut node = NodeDefinition::new(n, "c_node", "flaky_long").unwrap();
+    // 60s backoff — will not fire during test.
+    node.retry_policy = Some(RetryConfig::fixed(5, 60_000));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let engine_h = Arc::clone(&engine);
+    let task = tokio::spawn(async move {
+        engine_h
+            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .await
+    });
+
+    // Wait for the engine to schedule a retry (proves the node is
+    // parked in WaitingRetry), then cancel.
+    let mut execution_id = None;
+    while execution_id.is_none() {
+        match events_rx.recv().await {
+            Some(ExecutionEvent::NodeRetryScheduled {
+                execution_id: id, ..
+            }) => {
+                execution_id = Some(id);
+            },
+            Some(_) => continue,
+            None => panic!("event bus closed before NodeRetryScheduled"),
+        }
+    }
+    let cancelled = engine.cancel_execution(execution_id.unwrap());
+    assert!(cancelled, "cancel_execution must find the live frontier");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("workflow must wind down within 5s")
+        .unwrap()
+        .unwrap();
+
+    assert!(!result.is_success());
+    assert!(
+        matches!(result.status, ExecutionStatus::Cancelled),
+        "expected Cancelled, got {:?}",
+        result.status
+    );
+}
+
+/// 4) Terminate-during-retry-wait — a sibling returning
+/// `ActionResult::Terminate` shuts down the workflow even when the
+/// other branch is parked in WaitingRetry. Tests the same
+/// cancel-token tear-down path as test #3 but driven by a node, not
+/// an external cancel.
+#[tokio::test]
+async fn terminate_during_retry_wait() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(AlwaysFailingHandler {
+        meta: ActionMetadata::new(action_key!("flaky_t"), "FlakyT", "fails forever"),
+        invocations: Arc::clone(&invocations),
+    });
+    registry.register_stateless(TerminateHandler {
+        meta: ActionMetadata::new(action_key!("term"), "Term", "terminates"),
+    });
+
+    let engine = make_engine(registry);
+    let parked = node_key!("parked");
+    let stopper = node_key!("stopper");
+    let mut parked_node = NodeDefinition::new(parked, "parked_node", "flaky_t").unwrap();
+    // 60s backoff parks the node so terminate has to drain it.
+    parked_node.retry_policy = Some(RetryConfig::fixed(5, 60_000));
+    let stopper_node = NodeDefinition::new(stopper, "stopper_node", "term").unwrap();
+
+    let wf = make_workflow(
+        vec![parked_node, stopper_node],
+        vec![],
+        WorkflowConfig::default(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default()),
+    )
+    .await
+    .expect("workflow must wind down within 5s")
+    .unwrap();
+
+    // The terminate handler emits ExplicitStop → Completed status.
+    assert_eq!(result.status, ExecutionStatus::Completed);
+    assert!(
+        invocations.load(Ordering::SeqCst) <= 2,
+        "terminate must drain the WaitingRetry queue without re-dispatching"
+    );
+}
+
+/// 5) `ExecutionBudget.max_total_retries` caps the global retry
+/// counter regardless of per-node policy. With cap=1 and a 3-attempt
+/// policy, the engine schedules exactly one retry across the run.
+#[tokio::test]
+async fn execution_budget_max_total_retries_caps_globally() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(AlwaysFailingHandler {
+        meta: ActionMetadata::new(action_key!("doomed_g"), "DoomedG", "always fails"),
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("g");
+    let mut node = NodeDefinition::new(n, "g_node", "doomed_g").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(5, 1));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let budget = ExecutionBudget::default().with_max_total_retries(1);
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), budget)
+        .await
+        .unwrap();
+
+    assert!(!result.is_success());
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        2,
+        "cap=1 retry → exactly 2 invocations (initial + 1 retry)"
+    );
+}
+
+/// 6) Idempotency key differentiates attempts — a successful retry
+/// gets a different key than the failed first attempt.
+#[tokio::test]
+async fn idempotency_key_differentiates_attempts() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(FlakyHandler {
+        meta: ActionMetadata::new(action_key!("flaky_idem"), "FlakyIdem", "fails once"),
+        fail_count: 1,
+        invocations: Arc::clone(&invocations),
+    });
+
+    let exec_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
+    let engine = make_engine(registry).with_execution_repo(exec_repo.clone());
+
+    let n = node_key!("idem");
+    let mut node = NodeDefinition::new(n.clone(), "idem_node", "flaky_idem").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(3, 1));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!({"v": 1}), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(result.is_success());
+    assert_eq!(invocations.load(Ordering::SeqCst), 2);
+
+    // Pull the persisted state and inspect the attempts.
+    let (_, state_json) = exec_repo
+        .get_state(result.execution_id)
+        .await
+        .unwrap()
+        .expect("state must be persisted");
+    let state_str = serde_json::to_string(&state_json).unwrap();
+    let exec_state: nebula_execution::state::ExecutionState =
+        serde_json::from_str(&state_str).unwrap();
+    let ns = exec_state.node_state(n).unwrap();
+    assert_eq!(ns.attempts.len(), 2, "two attempts pushed");
+    assert_ne!(
+        ns.attempts[0].idempotency_key, ns.attempts[1].idempotency_key,
+        "retry must mint a fresh idempotency key per attempt (canon §11.3)"
+    );
+    assert_eq!(ns.attempts[0].attempt_number, 1);
+    assert_eq!(ns.attempts[1].attempt_number, 2);
+    assert!(ns.attempts[0].is_failure());
+    assert!(ns.attempts[1].is_success());
+}
+
+/// 7) Per-node `retry_policy` overrides the workflow default.
+/// Workflow default is "1 attempt, no retry"; per-node policy is
+/// "3 attempts". The node MUST follow the per-node value.
+#[tokio::test]
+async fn per_node_retry_policy_overrides_workflow_default() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(FlakyHandler {
+        meta: ActionMetadata::new(
+            action_key!("flaky_o"),
+            "FlakyO",
+            "fails twice then succeeds",
+        ),
+        fail_count: 2,
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("o");
+    let mut node = NodeDefinition::new(n, "o_node", "flaky_o").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(3, 1)); // 3 attempts
+
+    let config = WorkflowConfig {
+        retry_policy: Some(RetryConfig::fixed(1, 1)), // 1 attempt only
+        ..WorkflowConfig::default()
+    };
+
+    let wf = make_workflow(vec![node], vec![], config);
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_success(),
+        "per-node 3-attempt policy must override workflow's 1-attempt default"
+    );
+    assert_eq!(invocations.load(Ordering::SeqCst), 3);
+}
+
+/// 8) Workflow-default `retry_policy` applies when the node does
+/// not declare its own.
+#[tokio::test]
+async fn workflow_default_applies_when_node_has_none() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(FlakyHandler {
+        meta: ActionMetadata::new(action_key!("flaky_d"), "FlakyD", "fails once"),
+        fail_count: 1,
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("d");
+    let node = NodeDefinition::new(n, "d_node", "flaky_d").unwrap(); // no policy
+
+    let config = WorkflowConfig {
+        retry_policy: Some(RetryConfig::fixed(3, 1)),
+        ..WorkflowConfig::default()
+    };
+
+    let wf = make_workflow(vec![node], vec![], config);
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(
+        result.is_success(),
+        "workflow default must drive retry when node has no per-node policy"
+    );
+    assert_eq!(invocations.load(Ordering::SeqCst), 2);
+}
+
+/// 9) No policy anywhere — first failure finalizes the workflow
+/// (one-shot semantics). Regression-guards the "no policy = no
+/// retry" branch in `compute_retry_decision`.
+#[tokio::test]
+async fn no_retry_policy_means_one_shot_failure() {
+    let invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless(AlwaysFailingHandler {
+        meta: ActionMetadata::new(action_key!("oneshot"), "OneShot", "fails"),
+        invocations: Arc::clone(&invocations),
+    });
+
+    let engine = make_engine(registry);
+    let n = node_key!("os");
+    let node = NodeDefinition::new(n, "os_node", "oneshot").unwrap();
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .await
+        .unwrap();
+
+    assert!(!result.is_success());
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        1,
+        "without a retry policy the engine must finalize after the first failure"
+    );
+}

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -265,20 +265,23 @@ async fn cancel_during_retry_wait() {
     });
 
     // Wait for the engine to schedule a retry (proves the node is
-    // parked in WaitingRetry), then cancel.
-    let mut execution_id = None;
-    while execution_id.is_none() {
-        match events_rx.recv().await {
-            Some(ExecutionEvent::NodeRetryScheduled {
-                execution_id: id, ..
-            }) => {
-                execution_id = Some(id);
-            },
-            Some(_) => continue,
-            None => panic!("event bus closed before NodeRetryScheduled"),
+    // parked in WaitingRetry), then cancel. Bound the wait so a
+    // missing `NodeRetryScheduled` emission fails the test instead
+    // of hanging CI indefinitely.
+    let execution_id = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeRetryScheduled {
+                    execution_id: id, ..
+                }) => break id,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeRetryScheduled"),
+            }
         }
-    }
-    let cancelled = engine.cancel_execution(execution_id.unwrap());
+    })
+    .await
+    .expect("timed out waiting for NodeRetryScheduled");
+    let cancelled = engine.cancel_execution(execution_id);
     assert!(cancelled, "cancel_execution must find the live frontier");
 
     let result = tokio::time::timeout(Duration::from_secs(5), task)
@@ -300,6 +303,11 @@ async fn cancel_during_retry_wait() {
 /// other branch is parked in WaitingRetry. Tests the same
 /// cancel-token tear-down path as test #3 but driven by a node, not
 /// an external cancel.
+///
+/// Subscribes to the event bus so we can assert the `NodeRetryScheduled`
+/// event actually fired before completion — a green test without
+/// that check would only prove the workflow finished, not that the
+/// drain path was exercised.
 #[tokio::test]
 async fn terminate_during_retry_wait() {
     let invocations = Arc::new(AtomicU32::new(0));
@@ -312,10 +320,12 @@ async fn terminate_during_retry_wait() {
         meta: ActionMetadata::new(action_key!("term"), "Term", "terminates"),
     });
 
-    let engine = make_engine(registry);
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine = make_engine(registry).with_event_bus(event_bus);
     let parked = node_key!("parked");
     let stopper = node_key!("stopper");
-    let mut parked_node = NodeDefinition::new(parked, "parked_node", "flaky_t").unwrap();
+    let mut parked_node = NodeDefinition::new(parked.clone(), "parked_node", "flaky_t").unwrap();
     // 60s backoff parks the node so terminate has to drain it.
     parked_node.retry_policy = Some(RetryConfig::fixed(5, 60_000));
     let stopper_node = NodeDefinition::new(stopper, "stopper_node", "term").unwrap();
@@ -339,6 +349,25 @@ async fn terminate_during_retry_wait() {
     assert!(
         invocations.load(Ordering::SeqCst) <= 2,
         "terminate must drain the WaitingRetry queue without re-dispatching"
+    );
+
+    // Drain the event bus and assert that the parked node DID get a
+    // `NodeRetryScheduled` event before terminate fired. Without this
+    // assertion the test would pass even if terminate beat the retry
+    // schedule entirely, which means the drain path was never exercised.
+    let mut saw_retry_scheduled_for_parked = false;
+    while let Some(event) = events_rx.try_recv() {
+        if let ExecutionEvent::NodeRetryScheduled { node_key, .. } = event
+            && node_key == parked
+        {
+            saw_retry_scheduled_for_parked = true;
+            break;
+        }
+    }
+    assert!(
+        saw_retry_scheduled_for_parked,
+        "parked node must have been parked in WaitingRetry before terminate \
+         drained it (otherwise the test passes without exercising the drain)"
     );
 }
 

--- a/crates/execution/src/context.rs
+++ b/crates/execution/src/context.rs
@@ -24,7 +24,8 @@ where
 
 /// Resource budget for a single workflow execution.
 ///
-/// Controls concurrency, wall-clock timeout, and total output size.
+/// Controls concurrency, wall-clock timeout, total output size, and
+/// the global retry cap (sum of retry attempts across all nodes).
 /// All `Option` fields default to `None` (unlimited).
 ///
 /// # Examples
@@ -36,7 +37,8 @@ where
 ///
 /// let budget = ExecutionBudget::default()
 ///     .with_max_duration(Duration::from_secs(300))
-///     .with_max_output_bytes(10 * 1024 * 1024);
+///     .with_max_output_bytes(10 * 1024 * 1024)
+///     .with_max_total_retries(50);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionBudget {
@@ -57,6 +59,21 @@ pub struct ExecutionBudget {
     /// Maximum total bytes across all node outputs. `None` = unlimited.
     #[serde(default)]
     pub max_output_bytes: Option<u64>,
+
+    /// Global cap on retry attempts summed across **all** nodes in
+    /// the execution (ADR-0042 §Consequences "Out of scope" + §M2.1
+    /// T4 acceptance). Complements per-node
+    /// `RetryConfig::max_attempts`: the engine consults both on every
+    /// failure and whichever caps first wins (canon §11.2).
+    ///
+    /// `None` = no global cap; per-node policy is the only retry
+    /// gate. A `Some(0)` value disables engine-level retry entirely
+    /// for this execution, regardless of the per-node `RetryConfig`.
+    ///
+    /// Forward-compat: legacy persisted budgets that predate this
+    /// field deserialize as `None`.
+    #[serde(default)]
+    pub max_total_retries: Option<u32>,
 }
 
 impl Default for ExecutionBudget {
@@ -65,6 +82,7 @@ impl Default for ExecutionBudget {
             max_concurrent_nodes: 10,
             max_duration: None,
             max_output_bytes: None,
+            max_total_retries: None,
         }
     }
 }
@@ -110,6 +128,17 @@ impl ExecutionBudget {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_max_output_bytes(mut self, bytes: u64) -> Self {
         self.max_output_bytes = Some(bytes);
+        self
+    }
+
+    /// Set the global retry cap (ADR-0042 §M2.1 T4).
+    ///
+    /// `0` disables engine-level retry entirely for this execution
+    /// even when nodes declare a `RetryConfig`. Useful for tests and
+    /// for "execute once, no retries" SLAs.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_max_total_retries(mut self, n: u32) -> Self {
+        self.max_total_retries = Some(n);
         self
     }
 }
@@ -204,5 +233,38 @@ mod tests {
             ..ExecutionBudget::default()
         };
         assert!(budget.validate_for_execution().is_err());
+    }
+
+    /// ADR-0042 §M2.1 T2 — `max_total_retries` must round-trip
+    /// through serde so `resume_execution` carries the same global
+    /// cap the original run was started with.
+    #[test]
+    fn max_total_retries_roundtrip() {
+        let budget = ExecutionBudget::default().with_max_total_retries(7);
+        assert_eq!(budget.max_total_retries, Some(7));
+        let json = serde_json::to_string(&budget).unwrap();
+        let back: ExecutionBudget = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.max_total_retries, Some(7));
+    }
+
+    /// Forward-compat: legacy budgets that predate `max_total_retries`
+    /// deserialize as `None` (no global cap), so a resumed legacy
+    /// execution does not crash on the missing field.
+    #[test]
+    fn max_total_retries_missing_field_deserializes_as_none() {
+        let legacy = r#"{"max_concurrent_nodes":4}"#;
+        let budget: ExecutionBudget = serde_json::from_str(legacy).unwrap();
+        assert_eq!(budget.max_total_retries, None);
+    }
+
+    /// `Some(0)` is a meaningful "disable retry" signal — distinct
+    /// from `None` (no cap). The engine must observe both states.
+    #[test]
+    fn max_total_retries_zero_is_distinct_from_none() {
+        let disabled = ExecutionBudget::default().with_max_total_retries(0);
+        let unlimited = ExecutionBudget::default();
+        assert_eq!(disabled.max_total_retries, Some(0));
+        assert_eq!(unlimited.max_total_retries, None);
+        assert_ne!(disabled, unlimited);
     }
 }

--- a/crates/execution/src/output.rs
+++ b/crates/execution/src/output.rs
@@ -20,11 +20,25 @@ use serde::{Deserialize, Serialize};
 ///
 /// This type only exists after the engine has resolved any `Deferred`,
 /// `Streaming`, or `Collection` outputs from `ActionOutput`.
+///
+/// # Wire format
+///
+/// Internally tagged with `tag = "type"`. The `Inline` variant stores
+/// the payload behind an explicit `value` key so primitives
+/// (`"hello"`, `42`, `true`) round-trip correctly — newtype-wrapped
+/// `Value` cannot share a level with `type`, so the engine's first
+/// attempt to persist a string-output `NodeAttempt` would otherwise
+/// fail at `serde_json::to_value(&exec_state)` (ADR-0042 §M2.1 T2
+/// regression discovered during T4 wiring).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ExecutionOutput {
     /// Small data — stored inline as JSON value.
-    Inline(serde_json::Value),
+    Inline {
+        /// The payload itself. Any `serde_json::Value` (object, array,
+        /// string, number, bool, null) is supported.
+        value: serde_json::Value,
+    },
 
     /// Large data — stored in blob storage, referenced by key.
     BlobRef {
@@ -40,7 +54,7 @@ pub enum ExecutionOutput {
 impl ExecutionOutput {
     /// Create an inline output from a JSON value.
     pub fn inline(value: serde_json::Value) -> Self {
-        Self::Inline(value)
+        Self::Inline { value }
     }
 
     /// Create a blob reference.
@@ -54,7 +68,7 @@ impl ExecutionOutput {
 
     /// Returns `true` if this is an inline value.
     pub fn is_inline(&self) -> bool {
-        matches!(self, Self::Inline(_))
+        matches!(self, Self::Inline { .. })
     }
 
     /// Returns `true` if this is a blob reference.
@@ -65,7 +79,7 @@ impl ExecutionOutput {
     /// Extract the inline value, if present.
     pub fn as_inline(&self) -> Option<&serde_json::Value> {
         match self {
-            Self::Inline(v) => Some(v),
+            Self::Inline { value } => Some(value),
             Self::BlobRef { .. } => None,
         }
     }

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -75,10 +75,14 @@ pub struct NodeExecutionState {
     /// engine sets it when the retry policy still has budget after a
     /// `Running → Failed` transition, then parks the node in
     /// `WaitingRetry` and waits until this timestamp before re-driving
-    /// it through `Ready → Running`. On `Cancelled` (during the wait)
-    /// or on a successful retry, the field is **not** cleared — it
-    /// stays for audit/post-mortem so observers can see "the engine
-    /// scheduled a retry for `T` but the cancel/success raced first".
+    /// it through `Ready → Running`. The engine clears the field once
+    /// the retry is promoted out of `WaitingRetry` for re-dispatch, or
+    /// when retry waiting is torn down by cancel / wall-clock teardown
+    /// — a stale `Some(_)` on a non-`WaitingRetry` node would mislead
+    /// resume seeding and audit tooling. Per-attempt history lives on
+    /// [`NodeExecutionState::attempts`] (push of [`AttemptOutcome::Failure`]
+    /// happens *before* `schedule_node_retry`), so post-mortem readers
+    /// keep the failure record without relying on this field.
     ///
     /// Forward-compat: legacy persisted states that predate this field
     /// deserialize as `None` (engine treats those nodes as not having

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -12,10 +12,39 @@ use crate::{
     context::ExecutionBudget,
     error::ExecutionError,
     idempotency::IdempotencyKey,
-    output::NodeOutput,
+    output::{ExecutionOutput, NodeOutput},
     status::{ExecutionStatus, ExecutionTerminationReason},
     transition::{validate_execution_transition, validate_node_transition},
 };
+
+/// Outcome of a single node dispatch, recorded into
+/// `NodeExecutionState::attempts` by [`ExecutionState::record_node_attempt`].
+///
+/// The split is exhaustive — every dispatch either produced an
+/// `ActionResult` (success path) or surfaced an `EngineError` (failure
+/// path). Cancel-during-wait does **not** record an attempt: the
+/// previous failure that scheduled the retry is already captured;
+/// the cancel terminates the wait, not a fresh attempt.
+#[derive(Debug, Clone)]
+pub enum AttemptOutcome {
+    /// The action returned an `ActionResult` (any variant). Carries
+    /// the inline output value the engine staged into `outputs[node_key]`
+    /// and the byte size used for budget accounting.
+    Success {
+        /// Output payload of the attempt.
+        output: ExecutionOutput,
+        /// Output size in bytes (used for budget accounting and
+        /// post-mortem audit).
+        output_bytes: u64,
+    },
+    /// The action surfaced an error before producing a result.
+    /// Carries the error message for the audit log.
+    Failure {
+        /// Error string captured from the failing attempt
+        /// (`EngineError::to_string()`).
+        error: String,
+    },
+}
 
 /// The execution state of a single node within a running workflow.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,6 +68,24 @@ pub struct NodeExecutionState {
     /// Error message if the node failed.
     #[serde(default)]
     pub error_message: Option<String>,
+    /// Wall-clock instant at which the engine should dispatch the next
+    /// retry attempt for this node (ADR-0042 §Decision Layer 2).
+    ///
+    /// `Some(_)` is paired with `state == NodeState::WaitingRetry`: the
+    /// engine sets it when the retry policy still has budget after a
+    /// `Running → Failed` transition, then parks the node in
+    /// `WaitingRetry` and waits until this timestamp before re-driving
+    /// it through `Ready → Running`. On `Cancelled` (during the wait)
+    /// or on a successful retry, the field is **not** cleared — it
+    /// stays for audit/post-mortem so observers can see "the engine
+    /// scheduled a retry for `T` but the cancel/success raced first".
+    ///
+    /// Forward-compat: legacy persisted states that predate this field
+    /// deserialize as `None` (engine treats those nodes as not having
+    /// a pending retry — same as a freshly failed node with a
+    /// retry-exhausted policy).
+    #[serde(default)]
+    pub next_attempt_at: Option<DateTime<Utc>>,
 }
 
 impl NodeExecutionState {
@@ -53,6 +100,7 @@ impl NodeExecutionState {
             started_at: None,
             completed_at: None,
             error_message: None,
+            next_attempt_at: None,
         }
     }
 
@@ -87,16 +135,25 @@ impl NodeExecutionState {
     }
 
     /// Drive a node to `Running` for a fresh dispatch
-    /// (`Pending → Ready → Running`). Any other source state is an invalid
-    /// transition and returned as such — the engine must route the node
-    /// through the setup-failure path instead of silently spawning a task
-    /// on stale state (issue #300).
+    /// (`Pending → Ready → Running` for the first attempt;
+    /// `WaitingRetry → Ready → Running` for a scheduled retry per
+    /// ADR-0042; `Ready → Running` when the engine has already
+    /// promoted the node to `Ready` in a prior phase). Any other
+    /// source state is an invalid transition and returned as such —
+    /// the engine must route the node through the setup-failure path
+    /// instead of silently spawning a task on stale state (issue
+    /// #300).
     pub fn start_attempt(&mut self) -> Result<(), ExecutionError> {
         match self.state {
             NodeState::Pending => {
                 self.transition_to(NodeState::Ready)?;
                 self.transition_to(NodeState::Running)
             },
+            NodeState::WaitingRetry => {
+                self.transition_to(NodeState::Ready)?;
+                self.transition_to(NodeState::Running)
+            },
+            NodeState::Ready => self.transition_to(NodeState::Running),
             from => Err(ExecutionError::InvalidTransition {
                 from: from.to_string(),
                 to: NodeState::Running.to_string(),
@@ -173,6 +230,25 @@ pub struct ExecutionState {
     /// received an explicit termination.
     #[serde(default)]
     pub terminated_by: Option<(NodeKey, ExecutionTerminationReason)>,
+    /// Total number of retry attempts dispatched across all nodes in
+    /// this execution. Bumped exactly once per scheduled retry
+    /// (post-decision, pre-checkpoint) per ADR-0042 §M2.1 T4.
+    ///
+    /// Paired with [`ExecutionBudget::max_total_retries`] as a global
+    /// cap that complements per-node `RetryConfig::max_attempts`. The
+    /// engine consults both on every failure; whichever caps first
+    /// wins (canon §11.2). A `None` budget cap means the global
+    /// counter is informational only — the engine still increments
+    /// it for observability.
+    ///
+    /// Forward-compat: legacy persisted states that predate this
+    /// field deserialize as `0` (engine treats the resumed execution
+    /// as having no prior retries on the books — slightly generous
+    /// vs the original run, but the per-node `attempt_count` on
+    /// `NodeExecutionState::attempts` keeps re-dispatch idempotency
+    /// honest).
+    #[serde(default)]
+    pub total_retries: u32,
 }
 
 impl ExecutionState {
@@ -200,7 +276,39 @@ impl ExecutionState {
             workflow_input: None,
             budget: None,
             terminated_by: None,
+            total_retries: 0,
         }
+    }
+
+    /// Record a scheduled retry attempt at the execution level.
+    ///
+    /// Called by the engine on every successful retry decision (per
+    /// ADR-0042 §M2.1 T4) so [`ExecutionBudget::max_total_retries`]
+    /// can be enforced as a global cap across all nodes. Bumps the
+    /// parent version so optimistic-concurrency readers observe the
+    /// state change (issue #255).
+    ///
+    /// The increment is always-on — even when the budget cap is
+    /// `None` — so the counter remains a faithful audit number
+    /// regardless of policy.
+    pub fn increment_total_retries(&mut self) {
+        self.total_retries = self.total_retries.saturating_add(1);
+        self.version += 1;
+        self.updated_at = Utc::now();
+    }
+
+    /// Returns `true` if this execution has hit its global retry cap
+    /// from [`ExecutionBudget::max_total_retries`].
+    ///
+    /// Returns `false` when the budget is absent (`None` cap) or when
+    /// the budget itself was never set on the execution — the engine
+    /// then defers solely to per-node `RetryConfig::max_attempts`.
+    #[must_use]
+    pub fn has_exhausted_retry_budget(&self) -> bool {
+        self.budget
+            .as_ref()
+            .and_then(|b| b.max_total_retries)
+            .is_some_and(|cap| self.total_retries >= cap)
     }
 
     /// Attach the original workflow-level input to this execution.
@@ -351,36 +459,113 @@ impl ExecutionState {
         self.node_states.get(&node_key)
     }
 
-    /// Build the idempotency key for a node at its current attempt
-    /// count. This is the single source of truth the engine uses on
-    /// both the check and mark sides of the canonical
-    /// (`check_idempotency` → act → `mark_idempotent`) flow, so that a
-    /// retried or restart-replayed attempt does not collide with a
-    /// previous attempt's persisted output (issue #266, canon §11.3).
+    /// Build the idempotency key for the **next** dispatch of a node.
+    ///
+    /// Per ADR-0042 §M2.1 T4 the engine pushes a [`NodeAttempt`] into
+    /// `node_states[*].attempts` after each finished attempt
+    /// (success or failure). The key for the next dispatch is therefore
+    /// `attempts.len() + 1`:
+    ///
+    /// - First dispatch (no prior attempts): `attempt = 1`.
+    /// - First retry (one prior failure pushed): `attempt = 2`.
+    /// - Second retry: `attempt = 3`. And so on.
+    ///
+    /// This is the single source of truth the engine uses on both the
+    /// check and mark sides of the canonical (`check_idempotency` →
+    /// act → `mark_idempotent`) flow, so that a retried or
+    /// restart-replayed attempt does not collide with a previous
+    /// attempt's persisted output (issue #266, canon §11.3).
     ///
     /// The execution id is taken from `self` — callers cannot pass a
-    /// mismatched id by accident.
-    ///
-    /// When the node's `attempts` is empty (the common case while
-    /// engine-level retry accounting is still `planned` per §11.2), the
-    /// key uses attempt number `1` — matching what `save_node_output`
-    /// records via `attempt_count().max(1)`. When the retry scheduler
-    /// lands and begins pushing [`NodeAttempt`]s into `attempts`, this
-    /// helper automatically starts differentiating attempts without any
-    /// engine change.
-    ///
-    /// If `node_key` is not present in `node_states` (a programming
-    /// error in practice — the engine only generates keys for nodes it
-    /// has dispatched), the helper also defaults to attempt number `1`,
-    /// mirroring the `.unwrap_or(1)` fallback `save_node_output` uses
-    /// for the same input.
+    /// mismatched id by accident. If `node_key` is not present in
+    /// `node_states` (a programming error in practice — the engine
+    /// only generates keys for nodes it has dispatched), the helper
+    /// defaults to attempt number `1`.
     #[must_use]
     pub fn idempotency_key_for_node(&self, node_key: NodeKey) -> IdempotencyKey {
         let attempt = self
             .node_states
             .get(&node_key)
-            .map_or(1, |ns| ns.attempt_count().max(1) as u32);
+            .map_or(1, |ns| (ns.attempt_count() as u32).saturating_add(1));
         IdempotencyKey::for_attempt(self.execution_id, node_key, attempt)
+    }
+
+    /// Push a [`NodeAttempt`] outcome onto the node's history and
+    /// bump the parent version (issue #255).
+    ///
+    /// Called by the engine's frontier loop **after** the action's
+    /// dispatch resolves — once on success, once on failure — so the
+    /// canonical attempt count drives both `idempotency_key_for_node`
+    /// (next dispatch) and the retry decision (per ADR-0042 §M2.1
+    /// T4). The attempt number is derived from the pre-push
+    /// `attempts.len()` so it stays in lockstep with the
+    /// just-dispatched key.
+    ///
+    /// Returns the recorded attempt number (1-indexed). Returns
+    /// [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
+    pub fn record_node_attempt(
+        &mut self,
+        node_key: NodeKey,
+        idempotency_key: IdempotencyKey,
+        outcome: AttemptOutcome,
+    ) -> Result<u32, ExecutionError> {
+        let ns = self
+            .node_states
+            .get_mut(&node_key)
+            .ok_or_else(|| ExecutionError::NodeNotFound(node_key.clone()))?;
+        let attempt_number = (ns.attempts.len() as u32).saturating_add(1);
+        let mut attempt = NodeAttempt::new(attempt_number, idempotency_key);
+        match outcome {
+            AttemptOutcome::Success {
+                output,
+                output_bytes,
+            } => {
+                attempt.complete_success(output, output_bytes);
+            },
+            AttemptOutcome::Failure { error } => {
+                attempt.complete_failure(error);
+            },
+        }
+        ns.attempts.push(attempt);
+        self.version += 1;
+        self.updated_at = Utc::now();
+        Ok(attempt_number)
+    }
+
+    /// Schedule the next retry attempt for a node per ADR-0042 §M2.1
+    /// T4.
+    ///
+    /// Promotes a `Failed` node to `WaitingRetry`, stamps the wall-clock
+    /// `next_attempt_at`, and increments the global retry counter. The
+    /// caller is responsible for the budget + per-node policy decision
+    /// — this helper is a pure mutation primitive; it does not
+    /// re-evaluate whether the retry is allowed.
+    ///
+    /// On success, both the per-node transition (`Failed → WaitingRetry`)
+    /// and the global counter bump are reflected in `version`. On
+    /// `Err`, the state is left untouched so the caller can route
+    /// through the regular failure path without leaking an in-memory
+    /// half-applied retry.
+    ///
+    /// # Errors
+    /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
+    /// - [`ExecutionError::InvalidTransition`] if the node is not in `Failed` (the engine must only
+    ///   call this after `mark_node_failed`).
+    pub fn schedule_node_retry(
+        &mut self,
+        node_key: NodeKey,
+        next_attempt_at: DateTime<Utc>,
+    ) -> Result<(), ExecutionError> {
+        self.transition_node(node_key.clone(), NodeState::WaitingRetry)?;
+        if let Some(ns) = self.node_states.get_mut(&node_key) {
+            ns.next_attempt_at = Some(next_attempt_at);
+        }
+        // total_retries bump: separate version step is acceptable —
+        // both bumps land on the same `checkpoint_node` write.
+        self.total_retries = self.total_retries.saturating_add(1);
+        self.version += 1;
+        self.updated_at = Utc::now();
+        Ok(())
     }
 
     /// Set a node's execution state directly.
@@ -759,6 +944,11 @@ mod tests {
         assert!(ns.started_at.is_some());
     }
 
+    /// ADR-0042 — engine retries via the `Failed → WaitingRetry` edge,
+    /// not directly from `Failed`. A `start_attempt` on `Failed` is
+    /// still rejected (the engine must first promote the node to
+    /// `WaitingRetry` via the retry-decision path); but
+    /// `WaitingRetry` itself is now a legal source.
     #[test]
     fn start_attempt_rejects_failed() {
         let mut ns = NodeExecutionState::new();
@@ -767,9 +957,24 @@ mod tests {
         ns.transition_to(NodeState::Failed).unwrap();
         let err = ns
             .start_attempt()
-            .expect_err("failed nodes cannot start a fresh attempt — engine does not retry");
+            .expect_err("Failed must promote to WaitingRetry before re-dispatch");
         assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
         assert_eq!(ns.state, NodeState::Failed, "state must not move on error");
+    }
+
+    /// ADR-0042 — `WaitingRetry → Ready → Running` is the retry
+    /// re-dispatch path. `start_attempt` honors it.
+    #[test]
+    fn start_attempt_promotes_waiting_retry() {
+        let mut ns = NodeExecutionState::new();
+        ns.transition_to(NodeState::Ready).unwrap();
+        ns.transition_to(NodeState::Running).unwrap();
+        ns.transition_to(NodeState::Failed).unwrap();
+        ns.transition_to(NodeState::WaitingRetry).unwrap();
+
+        ns.start_attempt()
+            .expect("WaitingRetry must be a legal start_attempt source per ADR-0042");
+        assert_eq!(ns.state, NodeState::Running);
     }
 
     #[test]
@@ -897,10 +1102,11 @@ mod tests {
         assert_eq!(back.node_states.len(), state.node_states.len());
     }
 
-    // Regression for #266: idempotency key must reflect the node's real
-    // attempt count, not a hardcoded ":1". The engine calls this helper on
-    // both check and record paths so that cross-restart replay does not
-    // collapse all attempts into one key.
+    // Regression for #266 + ADR-0042 §M2.1 T4: the idempotency key is
+    // for the **next** dispatch — `attempts.len() + 1`. Push-on-result
+    // semantics in the engine guarantees that a retried or
+    // restart-replayed attempt does not collide with a previous
+    // attempt's persisted output.
     #[test]
     fn idempotency_key_for_node_uses_attempt_count() {
         use crate::{attempt::NodeAttempt, idempotency::IdempotencyKey};
@@ -912,23 +1118,146 @@ mod tests {
         assert_eq!(
             fresh,
             IdempotencyKey::for_attempt(eid, n1.clone(), 1),
-            "a node with no attempts should key on attempt=1 (first dispatch)"
+            "first dispatch (no prior attempts) keys on attempt=1"
         );
 
         let ns = state.node_states.get_mut(&n1).unwrap();
         let seed_key = IdempotencyKey::for_attempt(eid, n1.clone(), 1);
-        ns.attempts.push(NodeAttempt::new(0, seed_key));
+        ns.attempts.push(NodeAttempt::new(1, seed_key));
+
+        let after_one = state.idempotency_key_for_node(n1.clone());
+        assert_eq!(
+            after_one,
+            IdempotencyKey::for_attempt(eid, n1.clone(), 2),
+            "after one prior attempt the next dispatch keys on attempt=2"
+        );
+
+        let ns = state.node_states.get_mut(&n1).unwrap();
         ns.attempts.push(NodeAttempt::new(
-            1,
+            2,
             IdempotencyKey::for_attempt(eid, n1.clone(), 2),
         ));
 
         let after_two = state.idempotency_key_for_node(n1.clone());
         assert_eq!(
             after_two,
-            IdempotencyKey::for_attempt(eid, n1, 2),
-            "a node with two prior attempts should key on attempt=2"
+            IdempotencyKey::for_attempt(eid, n1, 3),
+            "after two prior attempts the next dispatch keys on attempt=3"
         );
+    }
+
+    /// ADR-0042 §M2.1 T4 — `record_node_attempt` pushes a sequential
+    /// attempt with the right number, captures the outcome, and bumps
+    /// the parent version (issue #255).
+    #[test]
+    fn record_node_attempt_appends_with_sequential_number() {
+        use crate::output::ExecutionOutput;
+
+        let (mut state, n1, _n2) = make_state();
+        let eid = state.execution_id;
+        let v0 = state.version;
+
+        let key1 = IdempotencyKey::for_attempt(eid, n1.clone(), 1);
+        let n = state
+            .record_node_attempt(
+                n1.clone(),
+                key1,
+                AttemptOutcome::Failure {
+                    error: "boom".to_owned(),
+                },
+            )
+            .unwrap();
+        assert_eq!(n, 1, "first attempt is numbered 1");
+        assert_eq!(state.version, v0 + 1);
+
+        let ns = state.node_state(n1.clone()).unwrap();
+        assert_eq!(ns.attempts.len(), 1);
+        assert_eq!(ns.attempts[0].attempt_number, 1);
+        assert!(ns.attempts[0].is_failure());
+
+        let key2 = IdempotencyKey::for_attempt(eid, n1.clone(), 2);
+        let n = state
+            .record_node_attempt(
+                n1.clone(),
+                key2,
+                AttemptOutcome::Success {
+                    output: ExecutionOutput::inline(serde_json::json!({"ok": true})),
+                    output_bytes: 12,
+                },
+            )
+            .unwrap();
+        assert_eq!(n, 2, "second attempt is numbered 2");
+        assert_eq!(state.version, v0 + 2);
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.attempts.len(), 2);
+        assert!(ns.attempts[1].is_success());
+    }
+
+    /// `record_node_attempt` rejects unknown nodes — the engine must
+    /// surface the programming error rather than silently lose the
+    /// attempt record.
+    #[test]
+    fn record_node_attempt_unknown_node_is_error() {
+        let (mut state, _n1, _n2) = make_state();
+        let eid = state.execution_id;
+        let ghost = node_key!("ghost");
+        let key = IdempotencyKey::for_attempt(eid, ghost.clone(), 1);
+        let err = state
+            .record_node_attempt(
+                ghost,
+                key,
+                AttemptOutcome::Failure {
+                    error: "boom".to_owned(),
+                },
+            )
+            .expect_err("unknown node must error");
+        assert!(matches!(err, ExecutionError::NodeNotFound(_)));
+    }
+
+    /// ADR-0042 §M2.1 T4 — `schedule_node_retry` promotes Failed →
+    /// WaitingRetry, stamps `next_attempt_at`, and increments
+    /// `total_retries`. All three observable effects move atomically
+    /// (single `checkpoint_node` covers the version bumps).
+    #[test]
+    fn schedule_node_retry_promotes_failed_and_increments_total_retries() {
+        let (mut state, n1, _n2) = make_state();
+
+        // Drive n1 to Failed via the real path.
+        state.start_node_attempt(n1.clone()).unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Failed)
+            .unwrap();
+        let v_before = state.version;
+        let total_before = state.total_retries;
+        let when = Utc::now() + chrono::Duration::milliseconds(500);
+
+        state.schedule_node_retry(n1.clone(), when).unwrap();
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::WaitingRetry);
+        assert_eq!(ns.next_attempt_at, Some(when));
+        assert_eq!(state.total_retries, total_before + 1);
+        // transition_node + total_retries bump = 2 version moves on
+        // the same `checkpoint_node` write.
+        assert_eq!(state.version, v_before + 2);
+    }
+
+    /// `schedule_node_retry` rejects nodes that are not in `Failed` —
+    /// e.g. `Running` (race between failure and a stale call).
+    #[test]
+    fn schedule_node_retry_rejects_non_failed() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+        // n1 is now Running, not Failed.
+        let when = Utc::now();
+        let err = state
+            .schedule_node_retry(n1.clone(), when)
+            .expect_err("Running → WaitingRetry must be rejected");
+        assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
+        // State unchanged.
+        assert_eq!(state.node_state(n1).unwrap().state, NodeState::Running);
+        assert_eq!(state.total_retries, 0);
     }
 
     #[test]
@@ -1128,6 +1457,108 @@ mod tests {
             "clear_terminated_by must NOT bump version — readers keying on \
              the set's bump should never have observed the intermediate state"
         );
+    }
+
+    /// ADR-0042 §M2.1 T2 — `next_attempt_at` must round-trip via
+    /// serde so a resumed engine picks up scheduled retries at their
+    /// declared time.
+    #[test]
+    fn next_attempt_at_roundtrip_via_serde() {
+        let mut ns = NodeExecutionState::new();
+        let when = Utc::now();
+        ns.next_attempt_at = Some(when);
+        let json = serde_json::to_string(&ns).unwrap();
+        let back: NodeExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.next_attempt_at,
+            Some(when),
+            "next_attempt_at must survive serde roundtrip"
+        );
+    }
+
+    /// Forward-compat: legacy `NodeExecutionState` JSON that predates
+    /// `next_attempt_at` deserializes as `None`. Engine then treats
+    /// the node as not having a pending retry.
+    #[test]
+    fn next_attempt_at_missing_field_deserializes_as_none() {
+        let legacy = serde_json::json!({
+            "state": "pending",
+            "attempts": [],
+        });
+        let ns: NodeExecutionState = serde_json::from_value(legacy).unwrap();
+        assert!(ns.next_attempt_at.is_none());
+    }
+
+    /// ADR-0042 §M2.1 T2 — `total_retries` round-trips and starts
+    /// at zero.
+    #[test]
+    fn total_retries_roundtrip_and_default() {
+        let (state, _n1, _n2) = make_state();
+        assert_eq!(state.total_retries, 0);
+
+        let json = serde_json::to_string(&state).unwrap();
+        let back: ExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.total_retries, 0);
+    }
+
+    /// Forward-compat: legacy `ExecutionState` JSON that predates
+    /// `total_retries` deserializes as `0`.
+    #[test]
+    fn total_retries_missing_field_deserializes_as_zero() {
+        let legacy = serde_json::json!({
+            "execution_id": ExecutionId::new(),
+            "workflow_id": WorkflowId::new(),
+            "status": "created",
+            "node_states": {},
+            "version": 0,
+            "created_at": Utc::now(),
+            "updated_at": Utc::now(),
+            "total_output_bytes": 0,
+        });
+        let state: ExecutionState = serde_json::from_value(legacy).unwrap();
+        assert_eq!(state.total_retries, 0);
+    }
+
+    /// ADR-0042 §M2.1 T4 — `increment_total_retries` bumps both the
+    /// counter and the parent execution version (issue #255).
+    #[test]
+    fn increment_total_retries_bumps_version() {
+        let (mut state, _n1, _n2) = make_state();
+        let v0 = state.version;
+        state.increment_total_retries();
+        assert_eq!(state.total_retries, 1);
+        assert_eq!(state.version, v0 + 1);
+        state.increment_total_retries();
+        assert_eq!(state.total_retries, 2);
+        assert_eq!(state.version, v0 + 2);
+    }
+
+    /// `has_exhausted_retry_budget` reflects the cap when set, and
+    /// returns `false` when no cap is configured.
+    #[test]
+    fn has_exhausted_retry_budget_respects_cap() {
+        let (mut state, _n1, _n2) = make_state();
+
+        // No budget set — never exhausted.
+        assert!(!state.has_exhausted_retry_budget());
+
+        // Budget without cap — still not exhausted.
+        state.set_budget(ExecutionBudget::default());
+        assert!(!state.has_exhausted_retry_budget());
+
+        // Cap = 2: counter 0 and 1 are under cap; 2 is exhausted.
+        state.set_budget(ExecutionBudget::default().with_max_total_retries(2));
+        assert!(!state.has_exhausted_retry_budget());
+        state.increment_total_retries();
+        assert!(!state.has_exhausted_retry_budget());
+        state.increment_total_retries();
+        assert!(state.has_exhausted_retry_budget());
+
+        // Cap = 0 disables retry entirely from the start.
+        let mut zero_cap =
+            ExecutionState::new(ExecutionId::new(), WorkflowId::new(), &[node_key!("only")]);
+        zero_cap.set_budget(ExecutionBudget::default().with_max_total_retries(0));
+        assert!(zero_cap.has_exhausted_retry_budget());
     }
 
     /// ROADMAP §M0.3 — successful set bumps `version` and

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -501,23 +501,33 @@ impl ExecutionState {
     /// dispatch resolves — once on success, once on failure — so the
     /// canonical attempt count drives both `idempotency_key_for_node`
     /// (next dispatch) and the retry decision (per ADR-0042 §M2.1
-    /// T4). The attempt number is derived from the pre-push
-    /// `attempts.len()` so it stays in lockstep with the
-    /// just-dispatched key.
+    /// T4).
+    ///
+    /// The idempotency key is **derived internally** from the just-
+    /// finished attempt number (`attempts.len() + 1`) so a stale
+    /// caller cannot persist `attempt_number = N` against an
+    /// `attempt-(N-1)` key — that mismatch would silently corrupt
+    /// the retry/idempotency audit trail this API is supposed to
+    /// own (canon §11.3, ADR-0042 §M2.1 T4).
     ///
     /// Returns the recorded attempt number (1-indexed). Returns
     /// [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
     pub fn record_node_attempt(
         &mut self,
         node_key: NodeKey,
-        idempotency_key: IdempotencyKey,
         outcome: AttemptOutcome,
     ) -> Result<u32, ExecutionError> {
+        let execution_id = self.execution_id;
         let ns = self
             .node_states
             .get_mut(&node_key)
             .ok_or_else(|| ExecutionError::NodeNotFound(node_key.clone()))?;
         let attempt_number = (ns.attempts.len() as u32).saturating_add(1);
+        // Single source of truth for the attempt-N key — engine code
+        // must NOT pass its own pre-computed key here, otherwise the
+        // attempt history and the idempotency-key store can drift.
+        let idempotency_key =
+            IdempotencyKey::for_attempt(execution_id, node_key.clone(), attempt_number);
         let mut attempt = NodeAttempt::new(attempt_number, idempotency_key);
         match outcome {
             AttemptOutcome::Success {
@@ -561,9 +571,21 @@ impl ExecutionState {
         next_attempt_at: DateTime<Utc>,
     ) -> Result<(), ExecutionError> {
         self.transition_node(node_key.clone(), NodeState::WaitingRetry)?;
-        if let Some(ns) = self.node_states.get_mut(&node_key) {
-            ns.next_attempt_at = Some(next_attempt_at);
-        }
+        // `Failed → WaitingRetry` puts the node back in flight. Stale
+        // failure-only metadata from the just-finished attempt
+        // (`error_message`, `completed_at`) must be cleared so a later
+        // successful attempt does not leave contradictory persisted
+        // state — e.g., `state == Completed` paired with the
+        // pre-retry `error_message`. Per-attempt failure history
+        // lives on `attempts` (the failure record was pushed before
+        // this call).
+        let ns = self
+            .node_states
+            .get_mut(&node_key)
+            .ok_or(ExecutionError::NodeNotFound(node_key))?;
+        ns.next_attempt_at = Some(next_attempt_at);
+        ns.error_message = None;
+        ns.completed_at = None;
         // total_retries bump: separate version step is acceptable —
         // both bumps land on the same `checkpoint_node` write.
         self.total_retries = self.total_retries.saturating_add(1);
@@ -1161,11 +1183,9 @@ mod tests {
         let eid = state.execution_id;
         let v0 = state.version;
 
-        let key1 = IdempotencyKey::for_attempt(eid, n1.clone(), 1);
         let n = state
             .record_node_attempt(
                 n1.clone(),
-                key1,
                 AttemptOutcome::Failure {
                     error: "boom".to_owned(),
                 },
@@ -1177,13 +1197,16 @@ mod tests {
         let ns = state.node_state(n1.clone()).unwrap();
         assert_eq!(ns.attempts.len(), 1);
         assert_eq!(ns.attempts[0].attempt_number, 1);
+        assert_eq!(
+            ns.attempts[0].idempotency_key,
+            IdempotencyKey::for_attempt(eid, n1.clone(), 1),
+            "internally minted key must match attempt number"
+        );
         assert!(ns.attempts[0].is_failure());
 
-        let key2 = IdempotencyKey::for_attempt(eid, n1.clone(), 2);
         let n = state
             .record_node_attempt(
                 n1.clone(),
-                key2,
                 AttemptOutcome::Success {
                     output: ExecutionOutput::inline(serde_json::json!({"ok": true})),
                     output_bytes: 12,
@@ -1193,8 +1216,13 @@ mod tests {
         assert_eq!(n, 2, "second attempt is numbered 2");
         assert_eq!(state.version, v0 + 2);
 
-        let ns = state.node_state(n1).unwrap();
+        let ns = state.node_state(n1.clone()).unwrap();
         assert_eq!(ns.attempts.len(), 2);
+        assert_eq!(
+            ns.attempts[1].idempotency_key,
+            IdempotencyKey::for_attempt(eid, n1, 2),
+            "second attempt key carries attempt-2"
+        );
         assert!(ns.attempts[1].is_success());
     }
 
@@ -1204,13 +1232,10 @@ mod tests {
     #[test]
     fn record_node_attempt_unknown_node_is_error() {
         let (mut state, _n1, _n2) = make_state();
-        let eid = state.execution_id;
         let ghost = node_key!("ghost");
-        let key = IdempotencyKey::for_attempt(eid, ghost.clone(), 1);
         let err = state
             .record_node_attempt(
                 ghost,
-                key,
                 AttemptOutcome::Failure {
                     error: "boom".to_owned(),
                 },
@@ -1245,6 +1270,44 @@ mod tests {
         // transition_node + total_retries bump = 2 version moves on
         // the same `checkpoint_node` write.
         assert_eq!(state.version, v_before + 2);
+    }
+
+    /// CodeRabbit review for PR #628 — `schedule_node_retry` must
+    /// scrub failure-only metadata (`error_message`, `completed_at`)
+    /// when reactivating a `Failed` node. Otherwise a later
+    /// successful retry would leave persisted state where
+    /// `state == Completed` carries the pre-retry error message —
+    /// post-mortem readers would misattribute the success.
+    #[test]
+    fn schedule_node_retry_clears_failure_metadata() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+        state
+            .transition_node(n1.clone(), NodeState::Failed)
+            .unwrap();
+        // Stamp failure-only fields the way `mark_node_failed` /
+        // `transition_to(Failed)` would.
+        if let Some(ns) = state.node_states.get_mut(&n1) {
+            ns.error_message = Some("boom".to_owned());
+            // `completed_at` is set by `transition_to(Failed)` so
+            // we expect it to already be `Some` here.
+            assert!(ns.completed_at.is_some());
+        }
+        let when = Utc::now() + chrono::Duration::milliseconds(500);
+
+        state.schedule_node_retry(n1.clone(), when).unwrap();
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::WaitingRetry);
+        assert_eq!(ns.next_attempt_at, Some(when));
+        assert!(
+            ns.error_message.is_none(),
+            "stale error_message must be cleared on retry promotion"
+        );
+        assert!(
+            ns.completed_at.is_none(),
+            "stale completed_at must be cleared on retry promotion"
+        );
     }
 
     /// `schedule_node_retry` rejects nodes that are not in `Failed` —

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -50,6 +50,16 @@ pub fn validate_execution_transition(
 }
 
 /// Returns `true` if the node-level transition from `from` to `to` is valid.
+///
+/// The retry-related edges (`Failed → WaitingRetry`,
+/// `WaitingRetry → Ready`, `WaitingRetry → Cancelled`) implement the
+/// engine-level retry path from ADR-0042: when the retry policy still
+/// has budget after a `Running → Failed` transition, the engine moves
+/// the node into `WaitingRetry` (parking it until
+/// `NodeExecutionState::next_attempt_at`), then back to `Ready` for the
+/// next attempt. A cancel signal during the wait shortcuts directly to
+/// `Cancelled` without observing another `Failed` — the previous
+/// attempt's failure is already recorded in `NodeAttempt`.
 #[must_use]
 pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
     matches!(
@@ -63,7 +73,13 @@ pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
         ) | (
             NodeState::Running,
             NodeState::Completed | NodeState::Failed | NodeState::Cancelled
-        ) | (NodeState::Failed, NodeState::Cancelled)
+        ) | (
+            NodeState::Failed,
+            NodeState::Cancelled | NodeState::WaitingRetry
+        ) | (
+            NodeState::WaitingRetry,
+            NodeState::Ready | NodeState::Cancelled
+        )
     )
 }
 
@@ -270,7 +286,58 @@ mod tests {
             NodeState::Cancelled,
             NodeState::Running
         ));
-        // Engine does not retry — Failed is terminal except for Cancelled.
+        // Engine retries via WaitingRetry, not directly back to Running.
         assert!(!can_transition_node(NodeState::Failed, NodeState::Running));
+        // No backdoor from WaitingRetry to Running — the retry path
+        // must go through Ready so `start_node_attempt` accounts the
+        // attempt and bumps the parent version.
+        assert!(!can_transition_node(
+            NodeState::WaitingRetry,
+            NodeState::Running
+        ));
+        // WaitingRetry is non-terminal; it cannot collapse straight
+        // to a finished state without a fresh attempt.
+        assert!(!can_transition_node(
+            NodeState::WaitingRetry,
+            NodeState::Completed
+        ));
+        assert!(!can_transition_node(
+            NodeState::WaitingRetry,
+            NodeState::Failed
+        ));
+    }
+
+    /// ADR-0042 — engine-level retry path:
+    ///
+    /// `Running → Failed → WaitingRetry → Ready → Running`
+    ///
+    /// The `Failed → WaitingRetry` edge fires when the retry policy
+    /// still has budget; `WaitingRetry → Ready` fires when
+    /// `NodeExecutionState::next_attempt_at` arrives and the engine
+    /// re-dispatches.
+    #[test]
+    fn retry_round_trip_transitions_are_valid() {
+        assert!(can_transition_node(NodeState::Running, NodeState::Failed));
+        assert!(can_transition_node(
+            NodeState::Failed,
+            NodeState::WaitingRetry
+        ));
+        assert!(can_transition_node(
+            NodeState::WaitingRetry,
+            NodeState::Ready
+        ));
+        assert!(can_transition_node(NodeState::Ready, NodeState::Running));
+    }
+
+    /// ADR-0042 — cancel during retry wait must be expressible without
+    /// a phantom `WaitingRetry → Failed → Cancelled` detour. The
+    /// previous attempt's failure is already recorded in
+    /// `NodeAttempt`; the cancel terminates the wait, not the attempt.
+    #[test]
+    fn waiting_retry_can_transition_to_cancelled() {
+        assert!(can_transition_node(
+            NodeState::WaitingRetry,
+            NodeState::Cancelled
+        ));
     }
 }

--- a/crates/workflow/src/state.rs
+++ b/crates/workflow/src/state.rs
@@ -21,6 +21,13 @@ pub enum NodeState {
     Skipped,
     /// Cancelled by the user or by a shutdown signal.
     Cancelled,
+    /// Failed but a retry is scheduled — `NodeExecutionState::next_attempt_at`
+    /// holds the wake-up time. Transient state between
+    /// `Failed → Ready → Running` for engine-level retry per ADR-0042.
+    /// Not terminal: a `WaitingRetry` node will eventually transition back
+    /// to `Ready`/`Running` (retry attempt) or to `Cancelled`
+    /// (shutdown / explicit cancel during the wait).
+    WaitingRetry,
 }
 
 impl NodeState {
@@ -46,9 +53,22 @@ impl NodeState {
     }
 
     /// Returns `true` if the node ended in a failure state.
+    ///
+    /// `WaitingRetry` is *not* a failure — the retry has not yet been
+    /// exhausted. Only the final post-retry `Failed` state counts.
     #[must_use]
     pub fn is_failure(&self) -> bool {
         matches!(self, Self::Failed)
+    }
+
+    /// Returns `true` if the node is awaiting a scheduled retry attempt.
+    ///
+    /// A `WaitingRetry` node is held in the engine's retry-pending heap
+    /// until `NodeExecutionState::next_attempt_at` arrives, at which
+    /// point the engine transitions it back to `Ready` and re-dispatches.
+    #[must_use]
+    pub fn is_waiting_retry(&self) -> bool {
+        matches!(self, Self::WaitingRetry)
     }
 }
 
@@ -62,6 +82,7 @@ impl std::fmt::Display for NodeState {
             Self::Failed => write!(f, "failed"),
             Self::Skipped => write!(f, "skipped"),
             Self::Cancelled => write!(f, "cancelled"),
+            Self::WaitingRetry => write!(f, "waiting_retry"),
         }
     }
 }
@@ -80,6 +101,11 @@ mod tests {
         assert!(!NodeState::Pending.is_terminal());
         assert!(!NodeState::Ready.is_terminal());
         assert!(!NodeState::Running.is_terminal());
+        assert!(
+            !NodeState::WaitingRetry.is_terminal(),
+            "WaitingRetry must be non-terminal — engine flips it back \
+             to Ready when next_attempt_at fires (ADR-0042)"
+        );
     }
 
     #[test]
@@ -92,6 +118,23 @@ mod tests {
         assert!(!NodeState::Failed.is_active());
         assert!(!NodeState::Skipped.is_active());
         assert!(!NodeState::Cancelled.is_active());
+        assert!(
+            !NodeState::WaitingRetry.is_active(),
+            "WaitingRetry is parked between attempts; the work is not \
+             running — frontier loop's max_concurrent guard must not \
+             count it (canon §11.1)"
+        );
+    }
+
+    /// `WaitingRetry` is the parked-between-attempts state — distinct
+    /// from a final `Failed`. `is_failure()` must return `false` so
+    /// `failed_node_ids()` and `determine_final_status` only count
+    /// nodes whose retry budget is fully exhausted (ADR-0042).
+    #[test]
+    fn waiting_retry_is_not_failure() {
+        assert!(!NodeState::WaitingRetry.is_failure());
+        assert!(NodeState::WaitingRetry.is_waiting_retry());
+        assert!(!NodeState::Failed.is_waiting_retry());
     }
 
     #[test]
@@ -121,6 +164,7 @@ mod tests {
         assert_eq!(NodeState::Failed.to_string(), "failed");
         assert_eq!(NodeState::Skipped.to_string(), "skipped");
         assert_eq!(NodeState::Cancelled.to_string(), "cancelled");
+        assert_eq!(NodeState::WaitingRetry.to_string(), "waiting_retry");
     }
 
     #[test]
@@ -133,6 +177,7 @@ mod tests {
             NodeState::Failed,
             NodeState::Skipped,
             NodeState::Cancelled,
+            NodeState::WaitingRetry,
         ];
 
         for state in &states {
@@ -140,6 +185,19 @@ mod tests {
             let back: NodeState = serde_json::from_str(&json).unwrap();
             assert_eq!(*state, back, "roundtrip failed for {state}");
         }
+    }
+
+    #[test]
+    fn serde_waiting_retry_uses_snake_case() {
+        // ADR-0042 wire format: rename_all = "snake_case" so the new
+        // variant serializes as `"waiting_retry"`, matching the
+        // existing `"failed"` / `"completed"` style. Out-of-tree
+        // consumers (UI, API clients, audit log readers) must see this
+        // exact tag.
+        let json = serde_json::to_string(&NodeState::WaitingRetry).unwrap();
+        assert_eq!(json, "\"waiting_retry\"");
+        let back: NodeState = serde_json::from_str("\"waiting_retry\"").unwrap();
+        assert_eq!(back, NodeState::WaitingRetry);
     }
 
     #[test]

--- a/crates/workflow/src/state.rs
+++ b/crates/workflow/src/state.rs
@@ -22,11 +22,11 @@ pub enum NodeState {
     /// Cancelled by the user or by a shutdown signal.
     Cancelled,
     /// Failed but a retry is scheduled — `NodeExecutionState::next_attempt_at`
-    /// holds the wake-up time. Transient state between
-    /// `Failed → Ready → Running` for engine-level retry per ADR-0042.
-    /// Not terminal: a `WaitingRetry` node will eventually transition back
-    /// to `Ready`/`Running` (retry attempt) or to `Cancelled`
-    /// (shutdown / explicit cancel during the wait).
+    /// holds the wake-up time. Transient retry state in the
+    /// `Failed → WaitingRetry → Ready → Running` path for engine-level retry
+    /// per ADR-0042. Not terminal: a `WaitingRetry` node will eventually
+    /// transition back to `Ready`/`Running` (retry attempt) or to
+    /// `Cancelled` (shutdown / explicit cancel during the wait).
     WaitingRetry,
 }
 

--- a/docs/adr/0042-layered-retry.md
+++ b/docs/adr/0042-layered-retry.md
@@ -103,14 +103,30 @@ Rejected. Two retry surfaces with overlapping semantics force consumers to learn
 
 ## Implementation notes (M2.1 task map)
 
-- **T0** (this PR foundation) — remove `ActionResult::Retry` variant, `unstable-retry-scheduler` feature, `is_retry()` predicate, and the synthetic-failure handler in `engine.rs`.
+- **T0** (foundation PR #627, 2026-04-28) — removed `ActionResult::Retry` variant, `unstable-retry-scheduler` feature, `is_retry()` predicate, and the synthetic-failure handler in `engine.rs`.
 - **T1** — this ADR.
-- **T2 + T3** — extend `NodeExecutionState` with `next_attempt_at`; storage migration mirrors PG + SQLite.
-- **T4** — engine reads effective `retry_policy`, computes backoff, decides retry-vs-finalize. Ordering: `[budget-check] → [retry-decision] → schedule | classify+route+checkpoint`.
-- **T5** — frontier loop honors `next_attempt_at`, with cancel/terminate/budget guards before and after the sleep.
-- **T6** — 9 integration tests covering the core path + edge cases (cancel/terminate/budget interaction, idempotency-key differentiation).
-- **T7** — close ROADMAP §M2.1; cross-reference this ADR from action README, workflow README, engine README L4 debt.
-- **T8** — `validate_workflow` rejects invalid `RetryConfig` (max_attempts == 0; backoff_multiplier ≤ 0 or non-finite; max_delay_ms < initial_delay_ms; initial_delay_ms == 0 with max_attempts > 1).
+- **T2** (engine wiring PR, 2026-04-29) — extended `NodeExecutionState` with `next_attempt_at: Option<DateTime<Utc>>`; added `NodeState::WaitingRetry` (non-terminal, non-active, non-failure); restored `ExecutionState.total_retries: u32` and `ExecutionBudget.max_total_retries: Option<u32>`; added `ExecutionState::record_node_attempt`, `ExecutionState::schedule_node_retry`, `ExecutionState::increment_total_retries`, `ExecutionState::has_exhausted_retry_budget`; transition table extended with `Failed → WaitingRetry → Ready` and `WaitingRetry → Cancelled`. Idempotency key formula changed to `attempts.len() + 1` (next-dispatch number) so retries no longer collide with previous attempts' persisted output (canon §11.3). All forward-compat via `#[serde(default)]`.
+- **T3** (engine wiring PR, 2026-04-29) — Layer-1 storage (`crates/storage/migrations/`) persists `ExecutionState` as JSONB. The new fields ride inside the existing `state` column; no column migration required. Layer-2 schema (`crates/storage/migrations/postgres/0012_execution_nodes.sql`) already carries `wake_at` for the future spec-16 columnar split (deferred to ROADMAP §M7 / Sprint E).
+- **T4** (engine wiring PR, 2026-04-29) — engine reads the effective `RetryConfig` (`NodeDefinition.retry_policy` overrides `WorkflowConfig.retry_policy`), computes backoff via `RetryConfig::delay_for_attempt`, decides retry-vs-finalize. Ordering: `mark_node_failed → record_node_attempt(failure) → compute_retry_decision → [Retry: schedule_node_retry → checkpoint → push retry_heap → emit NodeRetryScheduled → continue] | [Finalize: classify → apply_recovery → route_failure_edges → checkpoint → emit NodeFailed]`. Same ordering for setup-failure (param resolution) path.
+- **T5** (engine wiring PR, 2026-04-29) — frontier loop carries a `BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>>` of parked retries. Phase 0 drains due retries into `ready_queue` (state stays `WaitingRetry`; `spawn_node`'s `start_node_attempt` performs the typed `WaitingRetry → Ready → Running`). Phase 2 races `join_set` / cancel / wall-clock / next-retry-timer via `tokio::select!`. Cancel and wall-clock teardown drain parked retries to `Cancelled` so a cancelled execution never silently re-dispatches. Resume seeds the heap from any persisted `WaitingRetry` nodes.
+- **T6** (engine wiring PR, 2026-04-29) — 9 integration tests (`crates/engine/tests/retry.rs`) cover: success on attempt 2, exhausted retries, cancel-during-wait, terminate-during-wait, global budget cap, idempotency-key differentiation, per-node policy override, workflow-default fallback, and one-shot when no policy is configured. All green.
+- **T7** — closes ROADMAP §M2.1; this ADR is cross-referenced from `crates/engine/src/engine.rs` retry helpers, `NodeExecutionState::next_attempt_at` doc, `NodeState::WaitingRetry` doc, and `ExecutionBudget::max_total_retries` doc.
+- **T8** (foundation PR #627, 2026-04-28) — `validate_workflow` rejects invalid `RetryConfig` (max_attempts == 0; backoff_multiplier ≤ 0 or non-finite; max_delay_ms < initial_delay_ms; initial_delay_ms == 0 with max_attempts > 1).
+
+## Side-effect: `ExecutionOutput` wire format
+
+T4 surfaced a long-standing serde bug in `ExecutionOutput::Inline(Value)`: an internally-tagged enum (`tag = "type"`) cannot carry a primitive newtype payload because the tag has no map to slot into. Object-shaped `Inline` payloads worked by accident (the object's keys merge with `type`); string / number / bool / null payloads silently failed at `serde_json::to_value`. Layer-2 retry path tests (`record_node_attempt(success)` for a string-output workflow) tripped it.
+
+Fix: `Inline` was promoted from a newtype variant to a struct variant with an explicit `value` key:
+
+```rust
+// Before
+Inline(serde_json::Value)
+// After
+Inline { value: serde_json::Value }
+```
+
+JSON wire format moved from `{"type": "inline", ...spread fields...}` (object-only) to `{"type": "inline", "value": <any>}` (works for primitives too). Pre-M2.1 there were zero persisted `ExecutionOutput::Inline` rows because `NodeAttempt::output` was never pushed by the engine (the entire attempts vec was always empty), so this is not a wire-compat break against deployed data.
 
 ## References
 


### PR DESCRIPTION
## Summary

- Closes ROADMAP §M2.1 via the ADR-0042 layered-retry exit. Foundation PR #627 shipped T0/T1/T8; this PR ships the remaining **engine wiring** so `NodeDefinition.retry_policy` / `WorkflowConfig.retry_policy` finally drive real retries instead of being declared-but-ignored (canon §4.5 honesty).
- Adds engine-level Layer-2 retry on top of the existing in-call Layer-1 (`nebula-resilience::retry_with`); the two layers are disjoint by trigger boundary, not purpose, so they compose without conflict.
- Bundles two **breaking changes** that became unavoidable while wiring the retry path: `ExecutionOutput::Inline` is now a struct variant (newtype-tagged enums can't carry primitive payloads), and `idempotency_key_for_node` shifted to next-dispatch semantics.

## Layer 2 flow

```
Running → Failed → record_node_attempt(failure) →
compute_retry_decision → schedule_node_retry
  (Failed → WaitingRetry, set next_attempt_at, bump total_retries) →
checkpoint → emit NodeRetryScheduled → retry_heap.push →
Phase 0 drain (WaitingRetry → Ready) → spawn_node
  (Ready → Running) → next attempt.
```

## What's in this PR (T2-T7 from ADR-0042)

- **T2** — `NodeState::WaitingRetry` (non-terminal); `next_attempt_at` on `NodeExecutionState`; `total_retries` on `ExecutionState`; `max_total_retries` on `ExecutionBudget` (re-added). New transitions: `Failed → WaitingRetry`, `WaitingRetry → {Ready, Cancelled}`. Helpers `record_node_attempt`, `schedule_node_retry`, `increment_total_retries`, `has_exhausted_retry_budget`. All forward-compat via `#[serde(default)]`.

- **T3** — Layer-1 storage (JSONB) requires no column migration. New fields ride inside the existing `state` JSONB column. Layer-2 columnar schema (`migrations/postgres/0012_execution_nodes.sql`) is the deferred spec-16 / Sprint-E path (ROADMAP §M7).

- **T4** — `compute_retry_decision` (pure: budget cap → policy presence → max_attempts → backoff); `effective_retry_policy` (per-node → workflow-default fallback). Wired into both runtime-failure and setup-failure paths. Push `NodeAttempt` per attempt for idempotency-key differentiation.

- **T5** — frontier-loop retry-pending min-heap `BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>>`. Phase 0 drains due retries. Phase 2 races join_set / cancel / wall-clock / next-retry-timer via `tokio::select!` + `WakeReason`. Cancel and wall-clock teardown drain heap AND ready_queue via `drain_pending_to_cancelled` so no `WaitingRetry`/`Ready` node strands the canon §11.1 frontier-integrity check. Resume seeds the heap from any persisted `WaitingRetry` nodes.

- **T6** — 9 integration tests in `crates/engine/tests/retry.rs`:
  1. `retry_succeeds_on_attempt_2`
  2. `retry_exhausts_max_attempts`
  3. `cancel_during_retry_wait`
  4. `terminate_during_retry_wait`
  5. `execution_budget_max_total_retries_caps_globally`
  6. `idempotency_key_differentiates_attempts`
  7. `per_node_retry_policy_overrides_workflow_default`
  8. `workflow_default_applies_when_node_has_none`
  9. `no_retry_policy_means_one_shot_failure`

- **T7** — ROADMAP §M2.1 marked DONE via the layered-retry exit; ADR-0042 Implementation notes carry per-task verification map; engine README L4 closed-debts table updated; action README non-goals updated; ExecutionOutput wire-format change documented.

## Breaking changes

### `ExecutionOutput::Inline(serde_json::Value)` → `Inline { value: serde_json::Value }`

An internally-tagged enum (`#[serde(tag = "type")]`) cannot carry a primitive newtype payload — string / number / bool / null outputs were silently failing `serde_json::to_value` until M2.1 T4 began pushing `NodeAttempt::output` records. Wire format moved from the object-only flat shape `{"type":"inline", ...spread fields...}` to `{"type":"inline","value":<any>}`. **Pre-M2.1 there were zero persisted `Inline` rows** (engine never pushed `NodeAttempt::output`), so no data migration is required. The `ExecutionOutput::inline(value)` constructor is unchanged; only direct pattern matches against the variant need updating.

### `ExecutionState::idempotency_key_for_node` semantics

Now returns the key for the **next** dispatch (`attempts.len() + 1`) instead of the last finished attempt (`attempts.len().max(1)`). Engine code that needs the key the engine just persisted should read `attempts.last().idempotency_key`. **Pre-M2.1 there were zero pushed `NodeAttempt` records**, so out-of-tree consumers reading from JSONB were not exercising the old semantics.

## Test plan

- [x] `cargo build --workspace` — green
- [x] `cargo test --workspace --tests` — all 177 test groups passing (234 engine lib + 9 retry integration + 146 execution + 100 workflow + others)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] Pre-commit hooks (typos / clippy / fmt-check / cargo-deny / convco) — green
- [x] Pre-push `crate-diff-gate` — green (54s)

## ROADMAP / ADR linkage

- ROADMAP: §M2.1 (closed via this PR)
- ADR: [docs/adr/0042-layered-retry.md](docs/adr/0042-layered-retry.md)
- Closes canon §11.2 false-capability gap (canon §4.5)

## Follow-up (not in this PR)

- ROADMAP §M2.2 — verify `execution_leases` heartbeat enforcement across runner restarts.
- ROADMAP §M9 observability sweep — richer attempt-history audit on cancel/wall-clock teardown.
- ROADMAP §M8 loom probe — cover concurrent `schedule_node_retry` / CAS write paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added engine-level retry scheduling for failed workflow nodes with configurable retry policies (per-node or globally)
  * Implemented global retry budget cap to limit total retries across all nodes
  * Enhanced cancellation/termination to properly handle nodes waiting for scheduled retries

* **Bug Fixes**
  * Fixed serialization format for primitive execution output payloads

<!-- end of auto-generated comment: release notes by coderabbit.ai -->