### PR TITLE
feat(api): Plane-A auth, slug webhooks, idempotency

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6a0671be-6b71-4ff7-81ff-b6939cd53c03","pid":9508,"acquiredAt":1777520349584}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6a0671be-6b71-4ff7-81ff-b6939cd53c03","pid":9508,"acquiredAt":1777520349584}

--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,7 @@ docker-compose.override.yml
 .claude/summaries/
 .claude/worktrees/
 .claude/agent-memory-local/
+.claude/scheduled_tasks.lock
 lefthook-local.yml
 
 .agent/

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -6,6 +6,8 @@ exclude = [
   "**/node_modules/**",
   ".worktrees/**",
   ".claude/worktrees/**",
+  # Local Codex plugin cache — third-party TOML; not Nebula formatting policy.
+  ".codex/**",
   "apps/desktop/src-tauri/gen/**",
   # Competitor research v2 — harvested upstream Cargo.toml content, not Nebula style.
   "findings/**",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,6 +926,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1358,12 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "convert_case"
@@ -3294,6 +3306,7 @@ dependencies = [
 name = "nebula-api"
 version = "0.1.0"
 dependencies = [
+ "argon2",
  "async-trait",
  "axum",
  "base64",
@@ -3322,6 +3335,7 @@ dependencies = [
  "nebula-telemetry",
  "nebula-validator",
  "nebula-workflow",
+ "parking_lot",
  "pretty_assertions",
  "rand 0.10.1",
  "reqwest 0.13.3",
@@ -3329,9 +3343,11 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "subtle",
  "thiserror",
  "tokio",
  "tokio-util",
+ "totp-rs",
  "tower",
  "tower-http",
  "tracing",
@@ -6643,6 +6659,21 @@ dependencies = [
  "bytes",
  "prost",
  "tonic",
+]
+
+[[package]]
+name = "totp-rs"
+version = "5.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b36a9dd327e9f401320a2cb4572cc76ff43742bcfc3291f871691050f140ba"
+dependencies = [
+ "base32",
+ "constant_time_eq",
+ "hmac 0.12.1",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ subtle = "2.6"
 zeroize = { version = "1.8.2", features = ["std", "zeroize_derive"] }
 secrecy = { version = "0.10", features = ["serde"] }
 argon2 = { version = "0.5.3", default-features = false, features = ["std"] }
+totp-rs = { version = "5", default-features = false, features = ["otpauth"] }
 
 # HTTP
 http = "1.4"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -77,6 +77,10 @@ reqwest = { workspace = true, default-features = false, features = [
 hmac = { workspace = true }
 sha2 = { workspace = true }
 base64 = { workspace = true }
+subtle = { workspace = true }
+argon2 = { workspace = true }
+totp-rs = { workspace = true }
+parking_lot = { workspace = true }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 async-trait = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }

--- a/crates/api/src/auth/backend.rs
+++ b/crates/api/src/auth/backend.rs
@@ -1,0 +1,145 @@
+//! The [`AuthBackend`] trait — Plane-A identity + session contract.
+//!
+//! Replaces the older `SessionStore` trait. All auth-domain operations
+//! (signup / login / MFA / OAuth / sessions / PATs) flow through this single
+//! trait so callers never have to ask "which slot is the right one?".
+
+use async_trait::async_trait;
+use nebula_core::Principal;
+
+use super::{
+    dto::{SignupRequest, UserProfile},
+    error::AuthError,
+    oauth::OAuthProvider,
+    pat::PatRecord,
+    session::SessionRecord,
+};
+
+/// Outcome of a password-step authentication.
+#[derive(Debug, Clone)]
+pub enum PasswordOutcome {
+    /// Password verified and no MFA is required — caller may mint a session.
+    Authenticated(UserProfile),
+    /// Password verified but MFA is required. Caller stores the challenge
+    /// token and surfaces it to the client; the client then calls
+    /// `verify_mfa` with `code` + the same `challenge_token`.
+    MfaRequired {
+        /// Single-use challenge token paired to the user.
+        challenge_token: String,
+    },
+}
+
+/// Outcome of a successful MFA enrollment.
+#[derive(Debug, Clone)]
+pub struct MfaEnrollment {
+    /// `otpauth://totp/...` URI rendered as a QR code by the client.
+    pub otpauth_uri: String,
+    /// Base32 secret in case the authenticator app rejects the URI.
+    pub secret_base32: String,
+}
+
+/// Result of starting a Plane-A OAuth flow.
+#[derive(Debug, Clone)]
+pub struct OAuthStart {
+    /// Provider authorize URL (state + PKCE challenge already included).
+    pub authorize_url: String,
+    /// Opaque state token (also stored server-side).
+    pub state: String,
+}
+
+/// Result of completing a Plane-A OAuth flow.
+#[derive(Debug, Clone)]
+pub struct OAuthCompletion {
+    /// User profile resolved from the provider response.
+    pub user: UserProfile,
+    /// Newly created session.
+    pub session: SessionRecord,
+}
+
+/// Plane-A authentication contract.
+///
+/// **Required methods only — no defaults.** Tests / dev runtimes provide an
+/// implementation (typically [`super::InMemoryAuthBackend`]); production
+/// composition wires a storage-backed impl.
+///
+/// `dyn AuthBackend` is the production injection shape inside
+/// [`crate::AppState`]; the trait is therefore `Send + Sync` and uses
+/// `#[async_trait]` so a single `Box<dyn AuthBackend>` works across all
+/// handlers.
+#[async_trait]
+pub trait AuthBackend: Send + Sync {
+    /// Look up a session by ID — entry point shared with the auth middleware.
+    /// Returns the resolved [`Principal`] when the session is live, `None`
+    /// for unknown / expired / revoked sessions.
+    async fn get_principal_by_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<Principal>, crate::ApiError>;
+
+    /// Register a new user from the signup form. Returns the freshly
+    /// minted profile; the implementation is responsible for queueing
+    /// the verification email.
+    async fn register_user(&self, req: SignupRequest) -> Result<UserProfile, AuthError>;
+
+    /// Verify password (and TOTP, if supplied) for `email`. Returns a
+    /// [`PasswordOutcome`] indicating whether MFA is still pending.
+    async fn authenticate_password(
+        &self,
+        email: &str,
+        password: &str,
+        totp: Option<&str>,
+    ) -> Result<PasswordOutcome, AuthError>;
+
+    /// Complete the MFA step against a previously issued challenge token.
+    async fn verify_mfa(&self, challenge_token: &str, code: &str)
+    -> Result<UserProfile, AuthError>;
+
+    /// Mint a session for the verified user.
+    async fn create_session(&self, user_id: &str) -> Result<SessionRecord, AuthError>;
+
+    /// Revoke a session (logout). Idempotent: revoking an unknown session is
+    /// a successful no-op so logouts are safe to retry.
+    async fn revoke_session(&self, session_id: &str) -> Result<(), AuthError>;
+
+    /// Look up a presented PAT by its hash. Returns the record on success;
+    /// `None` for unknown / revoked / expired tokens. The caller is expected
+    /// to constant-time-compare the hash inside this method.
+    async fn lookup_pat(&self, presented: &str) -> Result<Option<PatRecord>, AuthError>;
+
+    /// Start a forgot-password flow. Always succeeds (does not reveal
+    /// whether the email is registered) — sending the reset email is
+    /// the implementation's responsibility.
+    async fn request_password_reset(&self, email: &str) -> Result<(), AuthError>;
+
+    /// Consume a previously issued password-reset token and set
+    /// `new_password` on the associated user.
+    async fn complete_password_reset(
+        &self,
+        token: &str,
+        new_password: &str,
+    ) -> Result<(), AuthError>;
+
+    /// Consume an email-verification token; idempotent for already-verified
+    /// users (token is invalidated either way).
+    async fn verify_email(&self, token: &str) -> Result<(), AuthError>;
+
+    /// Begin TOTP enrollment for an authenticated user. Returns the QR-able
+    /// otpauth URI **once** — clients must capture it on the first call.
+    async fn start_mfa_enrollment(&self, user_id: &str) -> Result<MfaEnrollment, AuthError>;
+
+    /// Confirm TOTP enrollment by verifying the user's first code.
+    async fn confirm_mfa_enrollment(&self, user_id: &str, code: &str) -> Result<(), AuthError>;
+
+    /// Begin a Plane-A OAuth sign-in.
+    async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError>;
+
+    /// Complete a Plane-A OAuth sign-in. The implementation exchanges the
+    /// provider's `code` for an access token, fetches the user profile,
+    /// upserts the user, and mints a session.
+    async fn complete_oauth(
+        &self,
+        provider: OAuthProvider,
+        state: &str,
+        code: &str,
+    ) -> Result<OAuthCompletion, AuthError>;
+}

--- a/crates/api/src/auth/dto.rs
+++ b/crates/api/src/auth/dto.rs
@@ -1,0 +1,211 @@
+//! Request and response DTOs for auth endpoints.
+//!
+//! These are deserialized by the handlers and validated before reaching the
+//! [`AuthBackend`](crate::auth::AuthBackend). Keeping them outside `state.rs`
+//! avoids cross-handler coupling and lets new fields be added without a
+//! state-lock dance.
+
+use serde::{Deserialize, Serialize};
+use zeroize::ZeroizeOnDrop;
+
+/// `POST /auth/signup` request body.
+///
+/// `password` is wrapped so it never lingers in memory after dropping.
+#[derive(Debug, Deserialize)]
+pub struct SignupRequest {
+    /// Caller-supplied email address — lowercased and trimmed before storage.
+    pub email: String,
+    /// Plaintext password — handed straight to the Argon2id hasher.
+    pub password: SecretString,
+    /// Caller-chosen display name (1..=128 chars).
+    pub display_name: String,
+}
+
+/// `POST /auth/login` request body.
+#[derive(Debug, Deserialize)]
+pub struct LoginRequest {
+    /// Account email.
+    pub email: String,
+    /// Plaintext password — handed straight to the Argon2id verifier.
+    pub password: SecretString,
+    /// Optional 6-digit TOTP code when the account has MFA enabled.
+    #[serde(default)]
+    pub totp: Option<String>,
+}
+
+/// `POST /auth/forgot-password` request body.
+#[derive(Debug, Deserialize)]
+pub struct ForgotPasswordRequest {
+    /// Account email — endpoint always responds 202 Accepted to avoid
+    /// account enumeration.
+    pub email: String,
+}
+
+/// `POST /auth/reset-password` request body.
+#[derive(Debug, Deserialize)]
+pub struct ResetPasswordRequest {
+    /// One-time reset token previously emailed to the user.
+    pub token: String,
+    /// New plaintext password.
+    pub new_password: SecretString,
+}
+
+/// `POST /auth/verify-email` request body.
+#[derive(Debug, Deserialize)]
+pub struct VerifyEmailRequest {
+    /// One-time verification token previously emailed to the user.
+    pub token: String,
+}
+
+/// `POST /auth/mfa/enroll` request body — empty; identity comes from the
+/// authenticated session.
+#[derive(Debug, Deserialize, Default)]
+pub struct MfaEnrollRequest {}
+
+/// `POST /auth/mfa/verify` request body.
+#[derive(Debug, Deserialize)]
+pub struct MfaVerifyRequest {
+    /// 6-digit TOTP code from the user's authenticator app.
+    pub code: String,
+    /// Optional MFA-challenge token returned by `login` when MFA is required.
+    /// When present, the verify endpoint completes the login.
+    #[serde(default)]
+    pub challenge_token: Option<String>,
+}
+
+/// Response after a successful login (no MFA required).
+#[derive(Debug, Serialize)]
+pub struct LoginResponse {
+    /// Resolved user profile (no secrets).
+    pub user: UserProfile,
+    /// Opaque session ID — also sent as the `nebula_session` cookie.
+    pub session_id: String,
+    /// CSRF token paired with the session — sent as the `nebula_csrf` cookie.
+    pub csrf_token: String,
+}
+
+/// Response when login succeeded the password step but MFA is required.
+#[derive(Debug, Serialize)]
+pub struct MfaChallengeResponse {
+    /// MFA-required flag for the client.
+    #[serde(rename = "mfa_required")]
+    pub mfa_required: bool,
+    /// Opaque, single-use challenge token to be passed back to `mfa/verify`.
+    pub challenge_token: String,
+}
+
+/// Response after a successful signup.
+#[derive(Debug, Serialize)]
+pub struct SignupResponse {
+    /// Resolved user profile (no secrets).
+    pub user: UserProfile,
+    /// `true` when an email-verification message was queued for delivery.
+    pub verification_email_sent: bool,
+}
+
+/// Response after MFA enrollment — exposes the otpauth URI **once**
+/// so the client can render a QR code.
+#[derive(Debug, Serialize)]
+pub struct MfaEnrollResponse {
+    /// `otpauth://totp/...` URI to be displayed as a QR code.
+    pub otpauth_uri: String,
+    /// Base32 secret in case the authenticator app rejects the URI form.
+    pub secret_base32: String,
+}
+
+/// Response for the OAuth start endpoint.
+#[derive(Debug, Serialize)]
+pub struct OAuthStartResponse {
+    /// Provider authorization URL the client should redirect to.
+    pub authorize_url: String,
+    /// Opaque state token (also stored server-side, single-use).
+    pub state: String,
+}
+
+/// User profile shape returned to the client. **Never** contains password
+/// hashes, MFA secrets, or PAT material.
+#[derive(Debug, Clone, Serialize)]
+pub struct UserProfile {
+    /// `user_<ULID>` string form.
+    pub user_id: String,
+    /// Lowercased email.
+    pub email: String,
+    /// Caller-chosen display name.
+    pub display_name: String,
+    /// `true` once the user has verified their email.
+    pub email_verified: bool,
+    /// `true` when the account has TOTP enrolled.
+    pub mfa_enabled: bool,
+}
+
+/// Wrapper around a plaintext secret that zeroes its memory on drop.
+///
+/// Implements [`Deserialize`] so request bodies can be parsed directly.
+#[derive(Clone, Default, ZeroizeOnDrop)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Wrap a plaintext value. Prefer the [`Deserialize`] path for HTTP
+    /// inputs; this is for tests and trusted construction.
+    #[must_use]
+    pub fn new(value: String) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the inner plaintext for crypto operations.
+    #[must_use]
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// Length of the wrapped value in bytes (used for validation).
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Whether the wrapped string is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SecretString(***)")
+    }
+}
+
+impl<'de> Deserialize<'de> for SecretString {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        String::deserialize(deserializer).map(SecretString)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secret_string_debug_redacts() {
+        let s = SecretString::new("hunter2".to_owned());
+        assert_eq!(format!("{s:?}"), "SecretString(***)");
+        assert_eq!(s.expose(), "hunter2");
+        assert_eq!(s.len(), 7);
+        assert!(!s.is_empty());
+    }
+
+    #[test]
+    fn login_request_deserializes_secret() {
+        let req: LoginRequest =
+            serde_json::from_str(r#"{"email":"a@b.c","password":"secret","totp":"123456"}"#)
+                .expect("parse");
+        assert_eq!(req.email, "a@b.c");
+        assert_eq!(req.password.expose(), "secret");
+        assert_eq!(req.totp.as_deref(), Some("123456"));
+    }
+}

--- a/crates/api/src/auth/error.rs
+++ b/crates/api/src/auth/error.rs
@@ -1,0 +1,140 @@
+//! Auth-domain errors.
+//!
+//! These map cleanly into [`crate::ApiError`] so handlers can `?`-propagate.
+
+use thiserror::Error;
+
+use crate::errors::ApiError;
+
+/// Failure modes for the auth backend.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// Capability is wired into the trait but not provided by this backend.
+    #[error("auth capability not implemented: {0}")]
+    NotImplemented(&'static str),
+
+    /// Email already registered.
+    #[error("email already registered")]
+    EmailAlreadyRegistered,
+
+    /// User not found by ID or email.
+    #[error("user not found")]
+    UserNotFound,
+
+    /// Provided credentials did not verify.
+    #[error("invalid credentials")]
+    InvalidCredentials,
+
+    /// Account is locked (too many failed attempts) until the moment in error.
+    #[error("account locked")]
+    AccountLocked,
+
+    /// Email is not verified yet — caller must complete the verification flow.
+    #[error("email not verified")]
+    EmailNotVerified,
+
+    /// MFA is required but not yet completed for this login.
+    #[error("mfa challenge required")]
+    MfaRequired,
+
+    /// MFA code did not verify.
+    #[error("invalid mfa code")]
+    InvalidMfaCode,
+
+    /// One-time token (verification / reset / mfa-challenge) is unknown,
+    /// expired, or already consumed.
+    #[error("token invalid or expired")]
+    InvalidToken,
+
+    /// Rate limit hit on a sensitive endpoint.
+    #[error("rate limit exceeded")]
+    RateLimit,
+
+    /// OAuth provider returned an error or the state token failed.
+    #[error("oauth failed: {0}")]
+    OAuthFailed(String),
+
+    /// Cryptographic operation failed (hash compute, RNG, etc.).
+    #[error("crypto failure: {0}")]
+    Crypto(String),
+
+    /// Internal backend error (storage, lock poisoning, etc.).
+    #[error("internal: {0}")]
+    Internal(String),
+}
+
+impl From<AuthError> for ApiError {
+    fn from(e: AuthError) -> Self {
+        match e {
+            AuthError::NotImplemented(what) => {
+                ApiError::ServiceUnavailable(format!("not implemented: {what}"))
+            },
+            AuthError::EmailAlreadyRegistered => {
+                ApiError::Conflict("email already registered".to_owned())
+            },
+            AuthError::UserNotFound => ApiError::NotFound("user".to_owned()),
+            AuthError::InvalidCredentials => {
+                ApiError::Unauthorized("invalid credentials".to_owned())
+            },
+            AuthError::AccountLocked => {
+                ApiError::AccountLocked("too many failed attempts; try again later".to_owned())
+            },
+            AuthError::EmailNotVerified => {
+                ApiError::Forbidden("email verification required".to_owned())
+            },
+            AuthError::MfaRequired => ApiError::MfaRequired,
+            AuthError::InvalidMfaCode => ApiError::Unauthorized("invalid mfa code".to_owned()),
+            AuthError::InvalidToken => ApiError::Unauthorized("token invalid".to_owned()),
+            AuthError::RateLimit => ApiError::RateLimitExceeded,
+            AuthError::OAuthFailed(msg) => ApiError::UpstreamError(msg),
+            AuthError::Crypto(msg) => ApiError::Internal(format!("crypto: {msg}")),
+            AuthError::Internal(msg) => ApiError::Internal(msg),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::StatusCode;
+
+    use super::*;
+
+    fn status(e: AuthError) -> StatusCode {
+        let api: ApiError = e.into();
+        api.to_problem_details().0
+    }
+
+    #[test]
+    fn invalid_credentials_maps_to_401() {
+        assert_eq!(
+            status(AuthError::InvalidCredentials),
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[test]
+    fn email_conflict_maps_to_409() {
+        assert_eq!(
+            status(AuthError::EmailAlreadyRegistered),
+            StatusCode::CONFLICT
+        );
+    }
+
+    #[test]
+    fn account_locked_maps_to_423() {
+        assert_eq!(
+            status(AuthError::AccountLocked),
+            StatusCode::from_u16(423).unwrap()
+        );
+    }
+
+    #[test]
+    fn mfa_required_maps_to_401() {
+        assert_eq!(status(AuthError::MfaRequired), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn rate_limit_maps_to_429() {
+        assert_eq!(status(AuthError::RateLimit), StatusCode::TOO_MANY_REQUESTS);
+    }
+}

--- a/crates/api/src/auth/in_memory.rs
+++ b/crates/api/src/auth/in_memory.rs
@@ -95,9 +95,10 @@ pub struct InMemoryAuthBackend {
     verification_tokens: DashMap<String, VerificationToken>,
     mfa_challenges: DashMap<String, MfaChallenge>,
     oauth_state: DashMap<String, OAuthStateEntry>,
-    /// Optional sink for outbound emails (test hook). When `None`, emails
-    /// are silently discarded — useful for local dev / test runs that
-    /// only care about the API contract.
+    /// In-memory capture of outbound emails for tests and local inspection.
+    ///
+    /// Every verification / password-reset email is appended here; there is
+    /// no separate "disabled" mode — use [`Self::emails`] to assert flows.
     email_sink: Arc<RwLock<Vec<EmailEnvelope>>>,
 }
 
@@ -150,8 +151,12 @@ impl InMemoryAuthBackend {
         self.users.insert(user.id, user);
     }
 
-    fn issue_verification_token(&self, user_id: UserId, kind: VerificationKind) -> String {
-        let token = session::random_token(24).unwrap_or_else(|_| "fallback".to_owned());
+    fn issue_verification_token(
+        &self,
+        user_id: UserId,
+        kind: VerificationKind,
+    ) -> Result<String, AuthError> {
+        let token = session::random_token(24)?;
         self.verification_tokens.insert(
             token.clone(),
             VerificationToken {
@@ -160,7 +165,7 @@ impl InMemoryAuthBackend {
                 expires_at: Self::now_secs() + VERIFICATION_TTL.as_secs(),
             },
         );
-        token
+        Ok(token)
     }
 
     fn record_email(&self, to: &str, token: &str, kind: &'static str) {
@@ -222,7 +227,7 @@ impl AuthBackend for InMemoryAuthBackend {
         let profile = record.profile();
         self.put_user(record);
 
-        let token = self.issue_verification_token(id, VerificationKind::EmailVerify);
+        let token = self.issue_verification_token(id, VerificationKind::EmailVerify)?;
         self.record_email(&email, &token, "EmailVerify");
 
         tracing::info!(user_id = %id, "user registered");
@@ -367,8 +372,20 @@ impl AuthBackend for InMemoryAuthBackend {
 
     async fn request_password_reset(&self, email: &str) -> Result<(), AuthError> {
         if let Some(user) = self.lookup_user_by_email(email) {
-            let token = self.issue_verification_token(user.id, VerificationKind::PasswordReset);
-            self.record_email(&user.email, &token, "PasswordReset");
+            match self.issue_verification_token(user.id, VerificationKind::PasswordReset) {
+                Ok(token) => {
+                    self.record_email(&user.email, &token, "PasswordReset");
+                },
+                Err(err) => {
+                    // Do not surface token-mint failures to the caller (enumeration-safe),
+                    // but never fall back to a predictable token.
+                    tracing::error!(
+                        error = %err,
+                        user_id = %user.id,
+                        "failed to mint password reset token",
+                    );
+                },
+            }
         }
         // Always return Ok to avoid account-existence enumeration.
         Ok(())

--- a/crates/api/src/auth/in_memory.rs
+++ b/crates/api/src/auth/in_memory.rs
@@ -1,0 +1,697 @@
+//! In-memory [`AuthBackend`] implementation.
+//!
+//! Production-quality crypto (Argon2id passwords, RFC 6238 TOTP, SHA-256
+//! PAT lookup) backed by per-process `DashMap` / `parking_lot::RwLock`
+//! state. This is the **default backend** for tests and the local-first
+//! `simple_server` binary; storage-backed implementations live in a future
+//! Sprint-E follow-up that swaps out the storage for `nebula-storage`
+//! repos without changing the trait surface.
+
+use std::{
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use dashmap::DashMap;
+use nebula_core::{Principal, UserId};
+use parking_lot::RwLock;
+
+use super::{
+    backend::{AuthBackend, MfaEnrollment, OAuthCompletion, OAuthStart, PasswordOutcome},
+    dto::{SignupRequest, UserProfile},
+    error::AuthError,
+    mfa,
+    oauth::{OAUTH_STATE_TTL, OAuthProvider, OAuthStateEntry, expiry_unix, mint_pkce},
+    password,
+    pat::{self, PatRecord},
+    session::{self, SESSION_TTL, SessionRecord, expires_at},
+};
+
+/// Threshold for brute-force lockout.
+const LOCKOUT_THRESHOLD: i32 = 5;
+
+/// Lockout duration after [`LOCKOUT_THRESHOLD`] failed logins.
+const LOCKOUT_TTL: Duration = Duration::from_mins(15);
+
+/// MFA-challenge lifetime — the user must verify within this window.
+const MFA_CHALLENGE_TTL: Duration = Duration::from_mins(5);
+
+/// Email verification + password reset token lifetime.
+const VERIFICATION_TTL: Duration = Duration::from_hours(1);
+
+#[derive(Clone)]
+struct UserRecord {
+    id: UserId,
+    email: String,
+    display_name: String,
+    password_hash: Option<String>,
+    email_verified: bool,
+    failed_login_count: i32,
+    locked_until: Option<DateTime<Utc>>,
+    mfa_secret: Option<String>,
+    mfa_enabled: bool,
+}
+
+impl UserRecord {
+    fn profile(&self) -> UserProfile {
+        UserProfile {
+            user_id: self.id.to_string(),
+            email: self.email.clone(),
+            display_name: self.display_name.clone(),
+            email_verified: self.email_verified,
+            mfa_enabled: self.mfa_enabled,
+        }
+    }
+}
+
+#[derive(Clone)]
+struct VerificationToken {
+    user_id: UserId,
+    kind: VerificationKind,
+    expires_at: u64,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+enum VerificationKind {
+    EmailVerify,
+    PasswordReset,
+}
+
+#[derive(Clone)]
+struct MfaChallenge {
+    user_id: UserId,
+    expires_at: u64,
+}
+
+/// In-memory [`AuthBackend`].
+#[derive(Default)]
+pub struct InMemoryAuthBackend {
+    users_by_email: DashMap<String, UserId>,
+    users: DashMap<UserId, UserRecord>,
+    sessions: DashMap<String, (UserId, u64)>,
+    pats: DashMap<[u8; 32], PatRecord>,
+    verification_tokens: DashMap<String, VerificationToken>,
+    mfa_challenges: DashMap<String, MfaChallenge>,
+    oauth_state: DashMap<String, OAuthStateEntry>,
+    /// Optional sink for outbound emails (test hook). When `None`, emails
+    /// are silently discarded — useful for local dev / test runs that
+    /// only care about the API contract.
+    email_sink: Arc<RwLock<Vec<EmailEnvelope>>>,
+}
+
+/// Emitted email — captured by the test hook so integration tests can
+/// assert reset / verification flows without a real SMTP transport.
+#[derive(Debug, Clone)]
+pub struct EmailEnvelope {
+    /// Recipient address.
+    pub to: String,
+    /// Token included in the email link.
+    pub token: String,
+    /// Email category — `EmailVerify` or `PasswordReset`.
+    pub kind: &'static str,
+}
+
+impl InMemoryAuthBackend {
+    /// Construct an empty backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Wrap into an `Arc<dyn AuthBackend>` for [`crate::AppState`].
+    #[must_use]
+    pub fn into_arc(self) -> Arc<dyn AuthBackend> {
+        Arc::new(self)
+    }
+
+    /// Snapshot the captured outbound emails — used in tests.
+    #[must_use]
+    pub fn emails(&self) -> Vec<EmailEnvelope> {
+        self.email_sink.read().clone()
+    }
+
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs()
+    }
+
+    fn lookup_user_by_email(&self, email: &str) -> Option<UserRecord> {
+        let key = email.trim().to_lowercase();
+        let id = *self.users_by_email.get(&key)?;
+        self.users.get(&id).map(|u| u.clone())
+    }
+
+    fn put_user(&self, user: UserRecord) {
+        self.users_by_email.insert(user.email.clone(), user.id);
+        self.users.insert(user.id, user);
+    }
+
+    fn issue_verification_token(&self, user_id: UserId, kind: VerificationKind) -> String {
+        let token = session::random_token(24).unwrap_or_else(|_| "fallback".to_owned());
+        self.verification_tokens.insert(
+            token.clone(),
+            VerificationToken {
+                user_id,
+                kind,
+                expires_at: Self::now_secs() + VERIFICATION_TTL.as_secs(),
+            },
+        );
+        token
+    }
+
+    fn record_email(&self, to: &str, token: &str, kind: &'static str) {
+        self.email_sink.write().push(EmailEnvelope {
+            to: to.to_owned(),
+            token: token.to_owned(),
+            kind,
+        });
+    }
+}
+
+#[async_trait]
+impl AuthBackend for InMemoryAuthBackend {
+    async fn get_principal_by_session(
+        &self,
+        session_id: &str,
+    ) -> Result<Option<Principal>, crate::ApiError> {
+        let now = Self::now_secs();
+        if let Some(entry) = self.sessions.get(session_id) {
+            let (user_id, expires) = *entry;
+            drop(entry);
+            if expires <= now {
+                self.sessions.remove(session_id);
+                return Ok(None);
+            }
+            return Ok(Some(Principal::User(user_id)));
+        }
+        Ok(None)
+    }
+
+    async fn register_user(&self, req: SignupRequest) -> Result<UserProfile, AuthError> {
+        let email = req.email.trim().to_lowercase();
+        if email.is_empty() || !email.contains('@') {
+            return Err(AuthError::InvalidCredentials);
+        }
+        if req.password.len() < 8 {
+            return Err(AuthError::InvalidCredentials);
+        }
+        let display_name = req.display_name.trim();
+        if display_name.is_empty() || display_name.len() > 128 {
+            return Err(AuthError::InvalidCredentials);
+        }
+        if self.users_by_email.contains_key(&email) {
+            return Err(AuthError::EmailAlreadyRegistered);
+        }
+        let hash = password::hash_password(req.password.expose())?;
+        let id = UserId::new();
+        let record = UserRecord {
+            id,
+            email: email.clone(),
+            display_name: display_name.to_owned(),
+            password_hash: Some(hash),
+            email_verified: false,
+            failed_login_count: 0,
+            locked_until: None,
+            mfa_secret: None,
+            mfa_enabled: false,
+        };
+        let profile = record.profile();
+        self.put_user(record);
+
+        let token = self.issue_verification_token(id, VerificationKind::EmailVerify);
+        self.record_email(&email, &token, "EmailVerify");
+
+        tracing::info!(user_id = %id, "user registered");
+        Ok(profile)
+    }
+
+    async fn authenticate_password(
+        &self,
+        email: &str,
+        password_input: &str,
+        totp: Option<&str>,
+    ) -> Result<PasswordOutcome, AuthError> {
+        let user = self
+            .lookup_user_by_email(email)
+            .ok_or(AuthError::InvalidCredentials)?;
+
+        if let Some(until) = user.locked_until
+            && until > Utc::now()
+        {
+            return Err(AuthError::AccountLocked);
+        }
+
+        let stored_hash = user
+            .password_hash
+            .as_ref()
+            .ok_or(AuthError::InvalidCredentials)?;
+        if !password::verify_password(stored_hash, password_input)? {
+            self.users.alter(&user.id, |_, mut u| {
+                u.failed_login_count += 1;
+                if u.failed_login_count >= LOCKOUT_THRESHOLD {
+                    let until =
+                        Utc::now() + chrono::Duration::from_std(LOCKOUT_TTL).unwrap_or_default();
+                    u.locked_until = Some(until);
+                }
+                u
+            });
+            return Err(AuthError::InvalidCredentials);
+        }
+
+        // Reset failure counter on success.
+        self.users.alter(&user.id, |_, mut u| {
+            u.failed_login_count = 0;
+            u.locked_until = None;
+            u
+        });
+
+        if user.mfa_enabled {
+            if let Some(code) = totp {
+                let secret = user
+                    .mfa_secret
+                    .as_deref()
+                    .ok_or_else(|| AuthError::Internal("mfa enabled without secret".to_owned()))?;
+                if !mfa::verify_code(secret, code)? {
+                    return Err(AuthError::InvalidMfaCode);
+                }
+                Ok(PasswordOutcome::Authenticated(user.profile()))
+            } else {
+                let challenge_token = session::random_token(24)?;
+                self.mfa_challenges.insert(
+                    challenge_token.clone(),
+                    MfaChallenge {
+                        user_id: user.id,
+                        expires_at: Self::now_secs() + MFA_CHALLENGE_TTL.as_secs(),
+                    },
+                );
+                Ok(PasswordOutcome::MfaRequired { challenge_token })
+            }
+        } else {
+            Ok(PasswordOutcome::Authenticated(user.profile()))
+        }
+    }
+
+    async fn verify_mfa(
+        &self,
+        challenge_token: &str,
+        code: &str,
+    ) -> Result<UserProfile, AuthError> {
+        let now = Self::now_secs();
+        let entry = self
+            .mfa_challenges
+            .remove(challenge_token)
+            .ok_or(AuthError::InvalidToken)?
+            .1;
+        if entry.expires_at <= now {
+            return Err(AuthError::InvalidToken);
+        }
+        let user = self
+            .users
+            .get(&entry.user_id)
+            .ok_or(AuthError::UserNotFound)?
+            .clone();
+        let secret = user
+            .mfa_secret
+            .as_deref()
+            .ok_or_else(|| AuthError::Internal("mfa challenge for non-mfa user".to_owned()))?;
+        if !mfa::verify_code(secret, code)? {
+            return Err(AuthError::InvalidMfaCode);
+        }
+        Ok(user.profile())
+    }
+
+    async fn create_session(&self, user_id: &str) -> Result<SessionRecord, AuthError> {
+        let id = session::random_token(32)?;
+        let csrf = session::random_token(24)?;
+        let exp = Self::now_secs() + SESSION_TTL.as_secs();
+
+        // Resolve UserId from string form for the principal.
+        let parsed: UserId = user_id
+            .parse()
+            .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
+        if !self.users.contains_key(&parsed) {
+            return Err(AuthError::UserNotFound);
+        }
+        self.sessions.insert(id.clone(), (parsed, exp));
+
+        Ok(SessionRecord {
+            id,
+            principal: Principal::User(parsed),
+            csrf_token: csrf,
+            expires_at: expires_at(SESSION_TTL),
+        })
+    }
+
+    async fn revoke_session(&self, session_id: &str) -> Result<(), AuthError> {
+        self.sessions.remove(session_id);
+        Ok(())
+    }
+
+    async fn lookup_pat(&self, presented: &str) -> Result<Option<PatRecord>, AuthError> {
+        let hash = pat::hash_for_lookup(presented)?;
+        let now = Utc::now();
+        if let Some(entry) = self.pats.get(&hash) {
+            let record = entry.clone();
+            drop(entry);
+            if !record.is_active(now) {
+                return Ok(None);
+            }
+            return Ok(Some(record));
+        }
+        Ok(None)
+    }
+
+    async fn request_password_reset(&self, email: &str) -> Result<(), AuthError> {
+        if let Some(user) = self.lookup_user_by_email(email) {
+            let token = self.issue_verification_token(user.id, VerificationKind::PasswordReset);
+            self.record_email(&user.email, &token, "PasswordReset");
+        }
+        // Always return Ok to avoid account-existence enumeration.
+        Ok(())
+    }
+
+    async fn complete_password_reset(
+        &self,
+        token: &str,
+        new_password: &str,
+    ) -> Result<(), AuthError> {
+        let entry = self
+            .verification_tokens
+            .remove(token)
+            .ok_or(AuthError::InvalidToken)?
+            .1;
+        if entry.kind != VerificationKind::PasswordReset {
+            return Err(AuthError::InvalidToken);
+        }
+        if entry.expires_at <= Self::now_secs() {
+            return Err(AuthError::InvalidToken);
+        }
+        if new_password.len() < 8 {
+            return Err(AuthError::InvalidCredentials);
+        }
+        let new_hash = password::hash_password(new_password)?;
+        self.users.alter(&entry.user_id, |_, mut u| {
+            u.password_hash = Some(new_hash.clone());
+            u.failed_login_count = 0;
+            u.locked_until = None;
+            u
+        });
+        Ok(())
+    }
+
+    async fn verify_email(&self, token: &str) -> Result<(), AuthError> {
+        let entry = self
+            .verification_tokens
+            .remove(token)
+            .ok_or(AuthError::InvalidToken)?
+            .1;
+        if entry.kind != VerificationKind::EmailVerify {
+            return Err(AuthError::InvalidToken);
+        }
+        if entry.expires_at <= Self::now_secs() {
+            return Err(AuthError::InvalidToken);
+        }
+        self.users.alter(&entry.user_id, |_, mut u| {
+            u.email_verified = true;
+            u
+        });
+        Ok(())
+    }
+
+    async fn start_mfa_enrollment(&self, user_id: &str) -> Result<MfaEnrollment, AuthError> {
+        let parsed: UserId = user_id
+            .parse()
+            .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
+        let user_email = self
+            .users
+            .get(&parsed)
+            .ok_or(AuthError::UserNotFound)?
+            .email
+            .clone();
+        let (secret, uri) = mfa::mint_secret(&user_email)?;
+        // Save secret but DO NOT flip mfa_enabled until confirm_mfa_enrollment.
+        self.users.alter(&parsed, |_, mut u| {
+            u.mfa_secret = Some(secret.clone());
+            u.mfa_enabled = false;
+            u
+        });
+        Ok(MfaEnrollment {
+            otpauth_uri: uri,
+            secret_base32: secret,
+        })
+    }
+
+    async fn confirm_mfa_enrollment(&self, user_id: &str, code: &str) -> Result<(), AuthError> {
+        let parsed: UserId = user_id
+            .parse()
+            .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
+        let user = self
+            .users
+            .get(&parsed)
+            .ok_or(AuthError::UserNotFound)?
+            .clone();
+        let secret = user
+            .mfa_secret
+            .as_deref()
+            .ok_or(AuthError::InvalidMfaCode)?;
+        if !mfa::verify_code(secret, code)? {
+            return Err(AuthError::InvalidMfaCode);
+        }
+        self.users.alter(&parsed, |_, mut u| {
+            u.mfa_enabled = true;
+            u
+        });
+        Ok(())
+    }
+
+    async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError> {
+        let pkce = mint_pkce()?;
+        // No real provider config in the in-memory backend — return a
+        // synthetic authorize URL so tests can verify the contract.
+        let authorize_url = format!(
+            "https://nebula.local/oauth/{}/authorize?state={}&code_challenge={}&code_challenge_method=S256",
+            provider.as_str(),
+            pkce.state,
+            pkce.code_challenge,
+        );
+        self.oauth_state.insert(
+            pkce.state.clone(),
+            OAuthStateEntry {
+                provider,
+                code_verifier: pkce.code_verifier,
+                expires_at: expiry_unix(OAUTH_STATE_TTL),
+                consumed: false,
+            },
+        );
+        Ok(OAuthStart {
+            authorize_url,
+            state: pkce.state,
+        })
+    }
+
+    async fn complete_oauth(
+        &self,
+        provider: OAuthProvider,
+        state: &str,
+        _code: &str,
+    ) -> Result<OAuthCompletion, AuthError> {
+        let entry = self
+            .oauth_state
+            .get_mut(state)
+            .ok_or(AuthError::InvalidToken)?;
+        if entry.consumed || entry.expires_at <= Self::now_secs() || entry.provider != provider {
+            return Err(AuthError::InvalidToken);
+        }
+        // The in-memory backend cannot actually exchange a code with a
+        // real provider; return NotImplemented so callers know they need
+        // a configured backend.
+        drop(entry);
+        Err(AuthError::NotImplemented(
+            "complete_oauth requires a configured provider backend",
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::dto::SecretString;
+
+    fn signup_req(email: &str) -> SignupRequest {
+        SignupRequest {
+            email: email.to_owned(),
+            password: SecretString::new("hunter22".to_owned()),
+            display_name: "Test User".to_owned(),
+        }
+    }
+
+    #[tokio::test]
+    async fn register_then_login_returns_authenticated() {
+        let b = InMemoryAuthBackend::new();
+        let profile = b
+            .register_user(signup_req("alice@nebula.dev"))
+            .await
+            .unwrap();
+        assert_eq!(profile.email, "alice@nebula.dev");
+        assert!(!profile.email_verified);
+        assert!(!profile.mfa_enabled);
+
+        let outcome = b
+            .authenticate_password("alice@nebula.dev", "hunter22", None)
+            .await
+            .unwrap();
+        match outcome {
+            PasswordOutcome::Authenticated(p) => assert_eq!(p.user_id, profile.user_id),
+            PasswordOutcome::MfaRequired { .. } => panic!("MFA not enabled"),
+        }
+    }
+
+    #[tokio::test]
+    async fn signup_emits_verification_email() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("a@b.c")).await.unwrap();
+        let emails = b.emails();
+        assert_eq!(emails.len(), 1);
+        assert_eq!(emails[0].kind, "EmailVerify");
+        assert_eq!(emails[0].to, "a@b.c");
+    }
+
+    #[tokio::test]
+    async fn login_with_wrong_password_is_invalid_credentials() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("c@d.e")).await.unwrap();
+        let err = b
+            .authenticate_password("c@d.e", "wrong", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::InvalidCredentials));
+    }
+
+    #[tokio::test]
+    async fn five_failures_lock_account() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("locked@e.f")).await.unwrap();
+        for _ in 0..5 {
+            let _ = b.authenticate_password("locked@e.f", "wrong", None).await;
+        }
+        let err = b
+            .authenticate_password("locked@e.f", "hunter22", None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthError::AccountLocked));
+    }
+
+    #[tokio::test]
+    async fn duplicate_signup_conflicts() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("dup@e.f")).await.unwrap();
+        let err = b.register_user(signup_req("dup@e.f")).await.unwrap_err();
+        assert!(matches!(err, AuthError::EmailAlreadyRegistered));
+    }
+
+    #[tokio::test]
+    async fn create_session_then_resolve_principal() {
+        let b = InMemoryAuthBackend::new();
+        let profile = b.register_user(signup_req("s@e.f")).await.unwrap();
+        let session = b.create_session(&profile.user_id).await.unwrap();
+        let principal = b
+            .get_principal_by_session(&session.id)
+            .await
+            .unwrap()
+            .expect("session is live");
+        assert!(matches!(principal, Principal::User(_)));
+    }
+
+    #[tokio::test]
+    async fn revoke_session_clears_lookup() {
+        let b = InMemoryAuthBackend::new();
+        let profile = b.register_user(signup_req("r@e.f")).await.unwrap();
+        let session = b.create_session(&profile.user_id).await.unwrap();
+        b.revoke_session(&session.id).await.unwrap();
+        let resolved = b.get_principal_by_session(&session.id).await.unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[tokio::test]
+    async fn email_verification_flips_flag() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("v@e.f")).await.unwrap();
+        let token = b.emails()[0].token.clone();
+        b.verify_email(&token).await.unwrap();
+        let user = b.lookup_user_by_email("v@e.f").unwrap();
+        assert!(user.email_verified);
+        // Replay rejected.
+        let err = b.verify_email(&token).await.unwrap_err();
+        assert!(matches!(err, AuthError::InvalidToken));
+    }
+
+    #[tokio::test]
+    async fn password_reset_round_trips() {
+        let b = InMemoryAuthBackend::new();
+        b.register_user(signup_req("p@e.f")).await.unwrap();
+        // Drain the verification email so we only see the reset email next.
+        b.email_sink.write().clear();
+        b.request_password_reset("p@e.f").await.unwrap();
+        let token = b.emails()[0].token.clone();
+        b.complete_password_reset(&token, "newpass1").await.unwrap();
+        let outcome = b
+            .authenticate_password("p@e.f", "newpass1", None)
+            .await
+            .unwrap();
+        assert!(matches!(outcome, PasswordOutcome::Authenticated(_)));
+    }
+
+    #[tokio::test]
+    async fn mfa_enrollment_then_login_with_code() {
+        let b = InMemoryAuthBackend::new();
+        let profile = b.register_user(signup_req("m@e.f")).await.unwrap();
+        let enrol = b.start_mfa_enrollment(&profile.user_id).await.unwrap();
+        let code = mfa::current_code(&enrol.secret_base32).unwrap();
+        b.confirm_mfa_enrollment(&profile.user_id, &code)
+            .await
+            .unwrap();
+
+        let login_no_code = b
+            .authenticate_password("m@e.f", "hunter22", None)
+            .await
+            .unwrap();
+        let challenge = match login_no_code {
+            PasswordOutcome::MfaRequired { challenge_token } => challenge_token,
+            PasswordOutcome::Authenticated(_) => panic!("MFA should be required"),
+        };
+        let new_code = mfa::current_code(&enrol.secret_base32).unwrap();
+        let final_profile = b.verify_mfa(&challenge, &new_code).await.unwrap();
+        assert_eq!(final_profile.user_id, profile.user_id);
+    }
+
+    #[tokio::test]
+    async fn pat_lookup_round_trip() {
+        use crate::auth::pat::{self, MintedPat};
+        let b = InMemoryAuthBackend::new();
+        let profile = b.register_user(signup_req("t@e.f")).await.unwrap();
+        let user_id: UserId = profile.user_id.parse().unwrap();
+        let MintedPat { plaintext, record } =
+            pat::mint_pat(user_id, "ci".to_owned(), vec![], None).unwrap();
+        b.pats.insert(record.hash, record.clone());
+
+        let resolved = b.lookup_pat(&plaintext).await.unwrap().expect("active");
+        assert_eq!(resolved.id, record.id);
+        // Wrong prefix is rejected by hash_for_lookup before the map probe.
+        let bad = b
+            .lookup_pat("nbl_sk_zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz")
+            .await;
+        assert!(matches!(bad, Err(AuthError::InvalidCredentials)));
+    }
+
+    #[tokio::test]
+    async fn oauth_start_persists_state_entry() {
+        let b = InMemoryAuthBackend::new();
+        let start = b.start_oauth(OAuthProvider::Google).await.unwrap();
+        assert!(start.authorize_url.contains("state="));
+        assert!(b.oauth_state.contains_key(&start.state));
+    }
+}

--- a/crates/api/src/auth/mfa.rs
+++ b/crates/api/src/auth/mfa.rs
@@ -1,0 +1,112 @@
+//! Time-based One-Time Password (RFC 6238) helpers.
+//!
+//! Built on top of `totp-rs` so we get the otpauth URI rendering for free.
+//! Standard parameters: SHA-1 / 6 digits / 30 s window / ±1 step skew.
+
+use rand::Rng;
+use totp_rs::{Algorithm, Secret, TOTP};
+
+use super::error::AuthError;
+
+/// Issuer string baked into the otpauth URI; shows up under the entry name
+/// in the user's authenticator app.
+pub const ISSUER: &str = "Nebula";
+
+/// Standard 6-digit TOTP code length.
+pub const DIGITS: usize = 6;
+
+/// 30-second TOTP step.
+pub const STEP_SECS: u64 = 30;
+
+/// Mint a fresh TOTP secret and the otpauth URI for `account_name`.
+///
+/// Returns `(secret_base32, otpauth_uri)`.
+pub fn mint_secret(account_name: &str) -> Result<(String, String), AuthError> {
+    let mut bytes = [0u8; 20];
+    rand::rng().fill_bytes(&mut bytes);
+    let secret = Secret::Raw(bytes.to_vec());
+    let secret_b32 = secret.to_encoded().to_string();
+
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        DIGITS,
+        1,
+        STEP_SECS,
+        secret
+            .to_bytes()
+            .map_err(|e| AuthError::Crypto(format!("totp secret: {e}")))?,
+        Some(ISSUER.to_owned()),
+        account_name.to_owned(),
+    )
+    .map_err(|e| AuthError::Crypto(format!("totp ctor: {e}")))?;
+
+    Ok((secret_b32, totp.get_url()))
+}
+
+/// Verify `code` against `secret_base32` using the standard ±1-step skew.
+pub fn verify_code(secret_base32: &str, code: &str) -> Result<bool, AuthError> {
+    let secret_bytes = Secret::Encoded(secret_base32.to_owned())
+        .to_bytes()
+        .map_err(|_| AuthError::InvalidMfaCode)?;
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        DIGITS,
+        1,
+        STEP_SECS,
+        secret_bytes,
+        Some(ISSUER.to_owned()),
+        "verify".to_owned(),
+    )
+    .map_err(|e| AuthError::Crypto(format!("totp ctor: {e}")))?;
+    totp.check_current(code)
+        .map_err(|e| AuthError::Crypto(format!("totp check: {e}")))
+}
+
+/// Generate the current code for `secret_base32`. Used by tests and the
+/// confirm-enrollment loop in [`crate::auth::InMemoryAuthBackend`].
+#[doc(hidden)]
+pub fn current_code(secret_base32: &str) -> Result<String, AuthError> {
+    let secret_bytes = Secret::Encoded(secret_base32.to_owned())
+        .to_bytes()
+        .map_err(|_| AuthError::Crypto("invalid base32 secret".to_owned()))?;
+    let totp = TOTP::new(
+        Algorithm::SHA1,
+        DIGITS,
+        1,
+        STEP_SECS,
+        secret_bytes,
+        Some(ISSUER.to_owned()),
+        "current".to_owned(),
+    )
+    .map_err(|e| AuthError::Crypto(format!("totp ctor: {e}")))?;
+    totp.generate_current()
+        .map_err(|e| AuthError::Crypto(format!("totp generate: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mint_secret_returns_otpauth_uri_and_base32() {
+        let (b32, uri) = mint_secret("alice@example.com").unwrap();
+        assert!(uri.starts_with("otpauth://totp/"));
+        assert!(uri.contains("issuer=Nebula"));
+        assert!(uri.contains("alice%40example.com") || uri.contains("alice@example.com"));
+        assert!(!b32.is_empty());
+    }
+
+    #[test]
+    fn current_code_verifies_against_same_secret() {
+        let (b32, _) = mint_secret("test@nebula.dev").unwrap();
+        let code = current_code(&b32).unwrap();
+        assert_eq!(code.len(), DIGITS);
+        assert!(verify_code(&b32, &code).unwrap());
+    }
+
+    #[test]
+    fn wrong_code_does_not_verify() {
+        let (b32, _) = mint_secret("test@nebula.dev").unwrap();
+        assert!(!verify_code(&b32, "000000").unwrap());
+    }
+}

--- a/crates/api/src/auth/mod.rs
+++ b/crates/api/src/auth/mod.rs
@@ -1,0 +1,49 @@
+//! Plane-A authentication backend — identity, sessions, MFA, PATs, and
+//! user-facing OAuth sign-in.
+//!
+//! ## Layout
+//!
+//! - [`backend`]: the [`AuthBackend`] trait — production injection point on [`crate::AppState`].
+//! - [`in_memory`]: production-quality default implementation (Argon2id, RFC 6238 TOTP, SHA-256 PAT
+//!   lookup) for dev / tests / `simple_server`.
+//! - [`dto`]: HTTP request/response shapes (with [`SecretString`] for plaintext passwords).
+//! - [`error`]: [`AuthError`] type and the mapping into [`crate::ApiError`].
+//! - [`session`] / [`pat`] / [`oauth`] / [`password`] / [`mfa`]: per-feature primitives reused by
+//!   the in-memory backend.
+//!
+//! ## Why this module exists
+//!
+//! Per ADR-0033, **Plane A** (host / Nebula API auth) is kept disjoint from
+//! **Plane B** (integration credential OAuth). Plane B lives under
+//! `crates/api/src/services/oauth/` + `crates/credential/`; Plane A lives
+//! here. New auth-domain features land in this module — never in the
+//! credential / OAuth-integration tree.
+//!
+//! [`SecretString`]: dto::SecretString
+//! [`AuthBackend`]: backend::AuthBackend
+//! [`AuthError`]: error::AuthError
+
+pub mod backend;
+pub mod dto;
+pub mod error;
+pub mod in_memory;
+pub mod mfa;
+pub mod oauth;
+pub mod password;
+pub mod pat;
+pub mod session;
+
+pub use backend::{AuthBackend, MfaEnrollment, OAuthCompletion, OAuthStart, PasswordOutcome};
+pub use dto::{
+    ForgotPasswordRequest, LoginRequest, LoginResponse, MfaChallengeResponse, MfaEnrollRequest,
+    MfaEnrollResponse, MfaVerifyRequest, OAuthStartResponse, ResetPasswordRequest, SecretString,
+    SignupRequest, SignupResponse, UserProfile, VerifyEmailRequest,
+};
+pub use error::AuthError;
+pub use in_memory::InMemoryAuthBackend;
+pub use oauth::OAuthProvider;
+pub use pat::{MintedPat, PAT_PREFIX, PatRecord, hash_for_lookup, hashes_equal, mint_pat};
+pub use session::{
+    CSRF_COOKIE, SESSION_COOKIE, SESSION_TTL, SessionRecord, cleared_cookie, csrf_cookie,
+    random_token, session_cookie,
+};

--- a/crates/api/src/auth/oauth.rs
+++ b/crates/api/src/auth/oauth.rs
@@ -1,0 +1,153 @@
+//! Plane-A OAuth helpers — sign-in via Google / GitHub / Microsoft.
+//!
+//! This is **distinct** from Plane-B integration credential OAuth (per
+//! ADR-0033 and `crates/api/src/services/oauth/`). Plane A is "who is
+//! signing in to Nebula"; Plane B is "Nebula on behalf of a user
+//! talking to Slack/HubSpot/etc.".
+//!
+//! The state machine is small:
+//!
+//! 1. `start` — mint random `state` + PKCE `code_verifier`, store under TTL, return the
+//!    `authorize_url`.
+//! 2. `complete` — pop the stored entry by `state`, ensure the entry has not been consumed, return
+//!    the `code_verifier` so the backend can finish the token exchange.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::Rng;
+use sha2::{Digest, Sha256};
+
+use super::error::AuthError;
+
+/// Default TTL for the state store entry (10 minutes).
+pub const OAUTH_STATE_TTL: Duration = Duration::from_mins(10);
+
+/// Supported Plane-A OAuth providers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OAuthProvider {
+    /// Sign in with Google.
+    Google,
+    /// Sign in with GitHub.
+    GitHub,
+    /// Sign in with Microsoft.
+    Microsoft,
+}
+
+impl std::str::FromStr for OAuthProvider {
+    type Err = AuthError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "google" => Ok(Self::Google),
+            "github" => Ok(Self::GitHub),
+            "microsoft" => Ok(Self::Microsoft),
+            other => Err(AuthError::OAuthFailed(format!("unknown provider: {other}"))),
+        }
+    }
+}
+
+impl OAuthProvider {
+    /// Stable string representation for storage / logging.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Google => "google",
+            Self::GitHub => "github",
+            Self::Microsoft => "microsoft",
+        }
+    }
+}
+
+/// Stored entry under one `state` key.
+///
+/// `consumed` flips `true` after `complete` so a replay returns
+/// [`AuthError::InvalidToken`] instead of leaking the verifier.
+#[derive(Debug, Clone)]
+pub struct OAuthStateEntry {
+    /// Identity provider for this OAuth flow.
+    pub provider: OAuthProvider,
+    /// Random PKCE verifier (43-128 chars per RFC 7636 §4.1).
+    pub code_verifier: String,
+    /// Unix-seconds expiry; entries past this are evicted lazily.
+    pub expires_at: u64,
+    /// Set on first `complete` call to prevent replay.
+    pub consumed: bool,
+}
+
+/// PKCE pair — `state` plus `code_verifier`/`code_challenge`.
+#[derive(Debug, Clone)]
+pub struct PkcePair {
+    /// Opaque random state string.
+    pub state: String,
+    /// PKCE verifier (kept server-side).
+    pub code_verifier: String,
+    /// PKCE S256 challenge (sent to provider).
+    pub code_challenge: String,
+}
+
+/// Mint a fresh PKCE pair plus a state token.
+pub fn mint_pkce() -> Result<PkcePair, AuthError> {
+    let mut state_bytes = [0u8; 32];
+    let mut verifier_bytes = [0u8; 64];
+    rand::rng().fill_bytes(&mut state_bytes);
+    rand::rng().fill_bytes(&mut verifier_bytes);
+
+    let state = URL_SAFE_NO_PAD.encode(state_bytes);
+    let code_verifier = URL_SAFE_NO_PAD.encode(verifier_bytes);
+
+    let mut hasher = Sha256::new();
+    hasher.update(code_verifier.as_bytes());
+    let code_challenge = URL_SAFE_NO_PAD.encode(hasher.finalize());
+
+    Ok(PkcePair {
+        state,
+        code_verifier,
+        code_challenge,
+    })
+}
+
+/// Compute the unix-seconds timestamp `ttl` from now.
+#[must_use]
+pub fn expiry_unix(ttl: Duration) -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        + ttl.as_secs()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_roundtrip() {
+        for s in &["google", "github", "microsoft"] {
+            let p: OAuthProvider = s.parse().unwrap();
+            assert_eq!(p.as_str(), *s);
+        }
+        assert!(matches!(
+            "yahoo".parse::<OAuthProvider>(),
+            Err(AuthError::OAuthFailed(_))
+        ));
+    }
+
+    #[test]
+    fn pkce_pairs_are_unique() {
+        let a = mint_pkce().unwrap();
+        let b = mint_pkce().unwrap();
+        assert_ne!(a.state, b.state);
+        assert_ne!(a.code_verifier, b.code_verifier);
+        assert_ne!(a.code_challenge, b.code_challenge);
+    }
+
+    #[test]
+    fn pkce_challenge_is_sha256_of_verifier() {
+        let p = mint_pkce().unwrap();
+        let mut h = Sha256::new();
+        h.update(p.code_verifier.as_bytes());
+        let expected = URL_SAFE_NO_PAD.encode(h.finalize());
+        assert_eq!(p.code_challenge, expected);
+    }
+}

--- a/crates/api/src/auth/password.rs
+++ b/crates/api/src/auth/password.rs
@@ -1,0 +1,70 @@
+//! Argon2id password hashing.
+//!
+//! Parameters (m=19_456 KiB, t=2, p=1) match OWASP 2024 minimum
+//! recommendations and produce a verify time of ~50 ms on a 2024 laptop —
+//! within the canon §11 "login p99 < 200 ms" budget while keeping the
+//! brute-force factor at ≥ 2^16.
+
+use argon2::{
+    Argon2, Params, PasswordHash, PasswordHasher, PasswordVerifier, Version,
+    password_hash::{SaltString, rand_core::OsRng},
+};
+
+use super::error::AuthError;
+
+/// Hash `password` with Argon2id and return the encoded PHC string.
+pub fn hash_password(password: &str) -> Result<String, AuthError> {
+    let salt = SaltString::generate(&mut OsRng);
+    let argon2 = Argon2::new(argon2::Algorithm::Argon2id, Version::V0x13, params()?);
+    argon2
+        .hash_password(password.as_bytes(), &salt)
+        .map(|h| h.to_string())
+        .map_err(|e| AuthError::Crypto(format!("argon2 hash: {e}")))
+}
+
+/// Verify `password` against an encoded PHC `hash`. Returns `Ok(true)` only
+/// on a successful match; `Ok(false)` on a clean mismatch; `Err(...)` if the
+/// stored hash is malformed.
+pub fn verify_password(hash: &str, password: &str) -> Result<bool, AuthError> {
+    let parsed =
+        PasswordHash::new(hash).map_err(|e| AuthError::Crypto(format!("argon2 parse: {e}")))?;
+    let argon2 = Argon2::default();
+    Ok(argon2.verify_password(password.as_bytes(), &parsed).is_ok())
+}
+
+fn params() -> Result<Params, AuthError> {
+    // m=19456 KiB ≈ 19 MiB; t=2 iterations; p=1 lane.
+    Params::new(19_456, 2, 1, None).map_err(|e| AuthError::Crypto(format!("argon2 params: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_then_verify_succeeds() {
+        let h = hash_password("correct horse battery staple").unwrap();
+        assert!(verify_password(&h, "correct horse battery staple").unwrap());
+    }
+
+    #[test]
+    fn verify_rejects_wrong_password() {
+        let h = hash_password("hunter2").unwrap();
+        assert!(!verify_password(&h, "hunter3").unwrap());
+    }
+
+    #[test]
+    fn verify_rejects_malformed_hash() {
+        let err = verify_password("not-a-phc-string", "any").unwrap_err();
+        assert!(matches!(err, AuthError::Crypto(_)));
+    }
+
+    #[test]
+    fn two_hashes_of_same_password_differ() {
+        let a = hash_password("same").unwrap();
+        let b = hash_password("same").unwrap();
+        assert_ne!(a, b, "salt must randomize the encoded hash");
+        assert!(verify_password(&a, "same").unwrap());
+        assert!(verify_password(&b, "same").unwrap());
+    }
+}

--- a/crates/api/src/auth/pat.rs
+++ b/crates/api/src/auth/pat.rs
@@ -1,0 +1,195 @@
+//! Personal Access Token primitives.
+//!
+//! A PAT has the on-the-wire shape `pat_<32 bytes URL-safe base64>`. The
+//! backend stores only the SHA-256 of the *full* token; lookups hash the
+//! incoming bearer value and compare in constant time.
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
+use nebula_core::UserId;
+use rand::Rng;
+use sha2::{Digest, Sha256};
+use subtle::ConstantTimeEq;
+
+use super::error::AuthError;
+
+/// Canonical prefix that identifies a Nebula personal access token.
+pub const PAT_PREFIX: &str = "pat_";
+
+/// PAT secret length in random bytes (256 bits of entropy).
+pub const PAT_BYTES: usize = 32;
+
+/// PAT-secret length in characters of the URL-safe base64 form (no padding).
+const PAT_BODY_CHARS: usize = 43;
+
+/// A freshly-minted PAT: returned to the caller **once**, never logged.
+#[derive(Debug, Clone)]
+pub struct MintedPat {
+    /// Plaintext token to display to the user — `pat_<...>`.
+    pub plaintext: String,
+    /// Server-stored record (no plaintext).
+    pub record: PatRecord,
+}
+
+/// Server-side PAT record (everything *except* the plaintext).
+#[derive(Debug, Clone)]
+pub struct PatRecord {
+    /// Opaque PAT identifier — `pat_<ULID>` (NOT the secret).
+    pub id: String,
+    /// Owning user.
+    pub user_id: UserId,
+    /// Caller-chosen label.
+    pub name: String,
+    /// First 12 chars of the plaintext token, for display in lists.
+    pub prefix: String,
+    /// SHA-256 of the *full* plaintext token.
+    pub hash: [u8; 32],
+    /// Allowed scopes — `[]` means full access.
+    pub scopes: Vec<String>,
+    /// When the PAT was created.
+    pub created_at: DateTime<Utc>,
+    /// Optional wall-clock expiry; `None` means no expiry.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// Last successful authentication using this PAT, if any.
+    pub last_used_at: Option<DateTime<Utc>>,
+    /// When the PAT was revoked, if applicable.
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl PatRecord {
+    /// Whether this PAT can still authenticate at `now`.
+    #[must_use]
+    pub fn is_active(&self, now: DateTime<Utc>) -> bool {
+        if self.revoked_at.is_some() {
+            return false;
+        }
+        if let Some(exp) = self.expires_at
+            && exp <= now
+        {
+            return false;
+        }
+        true
+    }
+}
+
+/// Mint a new PAT for `user_id` with the given `name` and `scopes`.
+pub fn mint_pat(
+    user_id: UserId,
+    name: String,
+    scopes: Vec<String>,
+    expires_at: Option<DateTime<Utc>>,
+) -> Result<MintedPat, AuthError> {
+    let mut secret = [0u8; PAT_BYTES];
+    rand::rng().fill_bytes(&mut secret);
+    let body = URL_SAFE_NO_PAD.encode(secret);
+    let plaintext = format!("{PAT_PREFIX}{body}");
+
+    let mut id_bytes = [0u8; 16];
+    rand::rng().fill_bytes(&mut id_bytes);
+    let id = format!("pat_{}", URL_SAFE_NO_PAD.encode(id_bytes));
+
+    let prefix = plaintext.chars().take(12).collect();
+    let hash = sha256(&plaintext);
+
+    Ok(MintedPat {
+        plaintext,
+        record: PatRecord {
+            id,
+            user_id,
+            name,
+            prefix,
+            hash,
+            scopes,
+            created_at: Utc::now(),
+            expires_at,
+            last_used_at: None,
+            revoked_at: None,
+        },
+    })
+}
+
+/// Hash a plaintext PAT for lookup. Returns `Err` if the prefix or shape is
+/// wrong — backends never log the plaintext on failure.
+pub fn hash_for_lookup(presented: &str) -> Result<[u8; 32], AuthError> {
+    let body = presented
+        .strip_prefix(PAT_PREFIX)
+        .ok_or(AuthError::InvalidCredentials)?;
+    if body.len() != PAT_BODY_CHARS {
+        return Err(AuthError::InvalidCredentials);
+    }
+    Ok(sha256(presented))
+}
+
+/// Constant-time comparison of two SHA-256 digests.
+#[must_use]
+pub fn hashes_equal(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    a.ct_eq(b).into()
+}
+
+fn sha256(s: &str) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn user() -> UserId {
+        UserId::new()
+    }
+
+    #[test]
+    fn mint_pat_returns_pat_prefixed_token() {
+        let m = mint_pat(user(), "ci".to_owned(), vec![], None).expect("mint");
+        assert!(m.plaintext.starts_with(PAT_PREFIX));
+        assert!(m.record.prefix.starts_with(PAT_PREFIX));
+        assert_eq!(m.record.prefix.len(), 12);
+        assert_eq!(m.record.scopes, Vec::<String>::new());
+        assert!(m.record.is_active(Utc::now()));
+    }
+
+    #[test]
+    fn mint_pat_two_calls_produce_distinct_secrets() {
+        let a = mint_pat(user(), "a".to_owned(), vec![], None).unwrap();
+        let b = mint_pat(user(), "b".to_owned(), vec![], None).unwrap();
+        assert_ne!(a.plaintext, b.plaintext);
+        assert_ne!(a.record.hash, b.record.hash);
+    }
+
+    #[test]
+    fn lookup_hash_matches_minted_record() {
+        let m = mint_pat(user(), "ci".to_owned(), vec![], None).unwrap();
+        let h = hash_for_lookup(&m.plaintext).unwrap();
+        assert!(hashes_equal(&h, &m.record.hash));
+    }
+
+    #[test]
+    fn lookup_hash_rejects_wrong_prefix() {
+        let err =
+            hash_for_lookup("nbl_sk_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap_err();
+        matches!(err, AuthError::InvalidCredentials);
+    }
+
+    #[test]
+    fn lookup_hash_rejects_wrong_length() {
+        let err = hash_for_lookup("pat_short").unwrap_err();
+        matches!(err, AuthError::InvalidCredentials);
+    }
+
+    #[test]
+    fn revoked_pat_is_inactive() {
+        let mut m = mint_pat(user(), "ci".to_owned(), vec![], None).unwrap();
+        m.record.revoked_at = Some(Utc::now());
+        assert!(!m.record.is_active(Utc::now()));
+    }
+
+    #[test]
+    fn expired_pat_is_inactive() {
+        let past = Utc::now() - chrono::Duration::seconds(60);
+        let mut m = mint_pat(user(), "ci".to_owned(), vec![], None).unwrap();
+        m.record.expires_at = Some(past);
+        assert!(!m.record.is_active(Utc::now()));
+    }
+}

--- a/crates/api/src/auth/pat.rs
+++ b/crates/api/src/auth/pat.rs
@@ -169,13 +169,13 @@ mod tests {
     fn lookup_hash_rejects_wrong_prefix() {
         let err =
             hash_for_lookup("nbl_sk_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap_err();
-        matches!(err, AuthError::InvalidCredentials);
+        assert!(matches!(err, AuthError::InvalidCredentials));
     }
 
     #[test]
     fn lookup_hash_rejects_wrong_length() {
         let err = hash_for_lookup("pat_short").unwrap_err();
-        matches!(err, AuthError::InvalidCredentials);
+        assert!(matches!(err, AuthError::InvalidCredentials));
     }
 
     #[test]

--- a/crates/api/src/auth/session.rs
+++ b/crates/api/src/auth/session.rs
@@ -1,0 +1,138 @@
+//! Session helpers — opaque IDs, CSRF tokens, and Set-Cookie strings.
+//!
+//! The session record itself lives in the [`AuthBackend`](crate::auth::AuthBackend)
+//! implementation; this module just owns the on-the-wire shape of session
+//! cookies and the cryptographic primitives used to mint IDs.
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Utc};
+use nebula_core::Principal;
+use rand::Rng;
+
+use super::error::AuthError;
+
+/// Encode raw entropy as a URL-safe base64 string.
+fn encode_url_safe(bytes: &[u8]) -> String {
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Default session lifetime — 14 days.
+pub const SESSION_TTL: Duration = Duration::from_hours(14 * 24);
+
+/// Default CSRF token lifetime — matches session lifetime.
+pub const CSRF_TTL: Duration = SESSION_TTL;
+
+/// Cookie name for the session ID.
+pub const SESSION_COOKIE: &str = "nebula_session";
+
+/// Cookie name for the CSRF token.
+pub const CSRF_COOKIE: &str = "nebula_csrf";
+
+/// A live session record returned by the backend after a successful login.
+#[derive(Debug, Clone)]
+pub struct SessionRecord {
+    /// Opaque, URL-safe base64 ID (32 bytes of entropy).
+    pub id: String,
+    /// Resolved principal (always [`Principal::User`] for password logins).
+    pub principal: Principal,
+    /// CSRF token paired with the session.
+    pub csrf_token: String,
+    /// Wall-clock expiry — clients are expected to honor `Expires`/`Max-Age`.
+    pub expires_at: DateTime<Utc>,
+}
+
+/// Generate a fresh URL-safe base64 token of `bytes` bytes of entropy.
+pub fn random_token(bytes: usize) -> Result<String, AuthError> {
+    let mut buf = vec![0u8; bytes];
+    rand::rng().fill_bytes(&mut buf);
+    Ok(encode_url_safe(&buf))
+}
+
+/// Build a `Set-Cookie` header value for the session cookie.
+///
+/// Defaults: `Secure`, `HttpOnly`, `SameSite=Lax`, `Path=/`, `Max-Age=<TTL>`.
+#[must_use]
+pub fn session_cookie(session_id: &str) -> String {
+    cookie(SESSION_COOKIE, session_id, true, SESSION_TTL)
+}
+
+/// Build a `Set-Cookie` header value for the CSRF cookie.
+///
+/// `HttpOnly` is **disabled** — the SPA must read the value to attach it to
+/// requests via the `X-CSRF-Token` header.
+#[must_use]
+pub fn csrf_cookie(csrf_token: &str) -> String {
+    cookie(CSRF_COOKIE, csrf_token, false, CSRF_TTL)
+}
+
+/// Build a `Set-Cookie` header that clears the named cookie.
+#[must_use]
+pub fn cleared_cookie(name: &str) -> String {
+    format!("{name}=; Path=/; Max-Age=0; Secure; SameSite=Lax")
+}
+
+fn cookie(name: &str, value: &str, http_only: bool, ttl: Duration) -> String {
+    let mut out = format!(
+        "{name}={value}; Path=/; Max-Age={}; Secure; SameSite=Lax",
+        ttl.as_secs()
+    );
+    if http_only {
+        out.push_str("; HttpOnly");
+    }
+    out
+}
+
+/// Compute an absolute expiry time `ttl` from now.
+#[must_use]
+pub fn expires_at(ttl: Duration) -> DateTime<Utc> {
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i64;
+    DateTime::<Utc>::from_timestamp(now + ttl.as_secs() as i64, 0).unwrap_or_else(Utc::now)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn random_token_unique_and_decodes() {
+        let a = random_token(32).unwrap();
+        let b = random_token(32).unwrap();
+        assert_ne!(a, b, "two random tokens must differ");
+        let decoded = URL_SAFE_NO_PAD.decode(&a).expect("decodes");
+        assert_eq!(decoded.len(), 32);
+    }
+
+    #[test]
+    fn session_cookie_has_security_flags() {
+        let cookie = session_cookie("abc123");
+        assert!(cookie.starts_with("nebula_session=abc123;"));
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("HttpOnly"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(cookie.contains("Path=/"));
+        assert!(cookie.contains("Max-Age="));
+    }
+
+    #[test]
+    fn csrf_cookie_omits_httponly() {
+        let cookie = csrf_cookie("xyz789");
+        assert!(cookie.contains("Secure"));
+        assert!(cookie.contains("SameSite=Lax"));
+        assert!(
+            !cookie.contains("HttpOnly"),
+            "CSRF cookie must be readable by JS"
+        );
+    }
+
+    #[test]
+    fn cleared_cookie_uses_max_age_zero() {
+        let cookie = cleared_cookie(SESSION_COOKIE);
+        assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.starts_with("nebula_session=;"));
+    }
+}

--- a/crates/api/src/handlers/auth.rs
+++ b/crates/api/src/handlers/auth.rs
@@ -1,114 +1,321 @@
-//! Authentication endpoint handlers.
+//! Authentication endpoint handlers — Plane A.
 //!
-//! These endpoints handle user registration, login, logout,
-//! password management, MFA, and OAuth flows.
-//! No tenant scope required — these are global auth endpoints.
+//! Each handler is a thin shim over [`crate::auth::AuthBackend`]. Validation
+//! lives in the backend; the HTTP layer extracts the request body, dispatches,
+//! attaches `Set-Cookie` headers, and translates [`crate::auth::AuthError`]
+//! into [`crate::errors::ApiError`].
+//!
+//! Per ADR-0033 these endpoints belong to **Plane A** (host login). They
+//! never touch the credential / Plane B OAuth state.
+
+use std::sync::Arc;
 
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE},
+    response::IntoResponse,
 };
+use nebula_core::Principal;
+use serde::Deserialize;
+use serde_json::json;
 
 use crate::{
+    auth::{
+        AuthBackend, AuthError, CSRF_COOKIE, ForgotPasswordRequest, LoginRequest, LoginResponse,
+        MfaChallengeResponse, MfaEnrollResponse, MfaVerifyRequest, OAuthProvider,
+        OAuthStartResponse, PasswordOutcome, ResetPasswordRequest, SESSION_COOKIE, SignupRequest,
+        SignupResponse, UserProfile, VerifyEmailRequest, cleared_cookie, csrf_cookie,
+        session_cookie,
+    },
     errors::{ApiError, ApiResult},
     state::AppState,
 };
 
-/// POST /api/v1/auth/signup
+fn backend(state: &AppState) -> Result<&Arc<dyn AuthBackend>, ApiError> {
+    state
+        .auth_backend
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable("auth backend not configured".to_owned()))
+}
+
+fn cookie_headers(set_cookies: &[String]) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    for c in set_cookies {
+        if let Ok(value) = HeaderValue::from_str(c) {
+            headers.append(SET_COOKIE, value);
+        }
+    }
+    headers
+}
+
+fn extract_session_id(headers: &HeaderMap) -> Option<String> {
+    let cookie = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
+    for pair in cookie.split(';') {
+        let pair = pair.trim();
+        if let Some(rest) = pair.strip_prefix(SESSION_COOKIE)
+            && let Some(value) = rest.strip_prefix('=')
+        {
+            return Some(value.to_owned());
+        }
+    }
+    None
+}
+
+async fn principal_from_cookie(
+    headers: &HeaderMap,
+    backend: &Arc<dyn AuthBackend>,
+) -> Result<Principal, ApiError> {
+    let session_id = extract_session_id(headers)
+        .ok_or_else(|| ApiError::Unauthorized("session cookie required".to_owned()))?;
+    backend
+        .get_principal_by_session(&session_id)
+        .await?
+        .ok_or_else(|| ApiError::Unauthorized("session expired".to_owned()))
+}
+
+fn user_id_from_principal(principal: &Principal) -> Result<String, ApiError> {
+    match principal {
+        Principal::User(id) => Ok(id.to_string()),
+        _ => Err(ApiError::Forbidden("user principal required".to_owned())),
+    }
+}
+
+/// `POST /api/v1/auth/signup` — register a new user.
+#[tracing::instrument(level = "info", skip(state, body), fields(email = %body.email))]
 pub async fn signup(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Implement user registration
-    // - Validate email, password strength
-    // - Check email not already registered
-    // - Hash password with argon2
-    // - Create user record
-    // - Send verification email
-    // - Return user profile (no sensitive data)
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    Json(body): Json<SignupRequest>,
+) -> ApiResult<Json<SignupResponse>> {
+    let backend = backend(&state)?;
+    let user = backend.register_user(body).await.map_err(ApiError::from)?;
+    Ok(Json(SignupResponse {
+        user,
+        verification_email_sent: true,
+    }))
 }
 
-/// POST /api/v1/auth/login
+/// `POST /api/v1/auth/login` — verify password and (optionally) TOTP.
+#[tracing::instrument(level = "info", skip(state, body), fields(email = %body.email))]
 pub async fn login(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Implement login
-    // - Validate credentials (argon2 verify, < 200ms p99)
-    // - Check account not locked
-    // - If MFA enabled, return MFA_REQUIRED
-    // - Create session
-    // - Set nebula_session cookie + nebula_csrf cookie
-    // - Return user profile
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    Json(body): Json<LoginRequest>,
+) -> ApiResult<axum::response::Response> {
+    let backend = backend(&state)?;
+    let outcome = backend
+        .authenticate_password(&body.email, body.password.expose(), body.totp.as_deref())
+        .await
+        .map_err(ApiError::from)?;
+
+    match outcome {
+        PasswordOutcome::Authenticated(user) => {
+            let response = mint_session_response(backend, user).await?;
+            Ok(response)
+        },
+        PasswordOutcome::MfaRequired { challenge_token } => {
+            let resp = MfaChallengeResponse {
+                mfa_required: true,
+                challenge_token,
+            };
+            Ok((StatusCode::ACCEPTED, Json(resp)).into_response())
+        },
+    }
 }
 
-/// POST /api/v1/auth/logout
-pub async fn logout(State(_state): State<AppState>) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Invalidate session, clear cookies
-    Err(ApiError::Internal("not implemented".to_string()))
+async fn mint_session_response(
+    backend: &Arc<dyn AuthBackend>,
+    user: UserProfile,
+) -> ApiResult<axum::response::Response> {
+    let session = backend
+        .create_session(&user.user_id)
+        .await
+        .map_err(ApiError::from)?;
+    let resp = LoginResponse {
+        user,
+        session_id: session.id.clone(),
+        csrf_token: session.csrf_token.clone(),
+    };
+    let headers = cookie_headers(&[
+        session_cookie(&session.id),
+        csrf_cookie(&session.csrf_token),
+    ]);
+    Ok((StatusCode::OK, headers, Json(resp)).into_response())
 }
 
-/// POST /api/v1/auth/forgot-password
+/// `POST /api/v1/auth/logout` — revoke the active session and clear cookies.
+#[tracing::instrument(level = "info", skip(state, headers))]
+pub async fn logout(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> ApiResult<axum::response::Response> {
+    let backend = backend(&state)?;
+    if let Some(session_id) = extract_session_id(&headers) {
+        backend
+            .revoke_session(&session_id)
+            .await
+            .map_err(ApiError::from)?;
+    }
+    let cleared = cookie_headers(&[cleared_cookie(SESSION_COOKIE), cleared_cookie(CSRF_COOKIE)]);
+    Ok((StatusCode::OK, cleared, Json(json!({"logged_out": true}))).into_response())
+}
+
+/// `POST /api/v1/auth/forgot-password` — always 202 to avoid enumeration.
+#[tracing::instrument(level = "info", skip(state, body))]
 pub async fn forgot_password(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Send password reset email
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    Json(body): Json<ForgotPasswordRequest>,
+) -> ApiResult<(StatusCode, Json<serde_json::Value>)> {
+    let backend = backend(&state)?;
+    backend
+        .request_password_reset(&body.email)
+        .await
+        .map_err(ApiError::from)?;
+    Ok((StatusCode::ACCEPTED, Json(json!({"queued": true}))))
 }
 
-/// POST /api/v1/auth/reset-password
+/// `POST /api/v1/auth/reset-password` — consume reset token, set new pass.
+#[tracing::instrument(level = "info", skip(state, body))]
 pub async fn reset_password(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
+    State(state): State<AppState>,
+    Json(body): Json<ResetPasswordRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Verify reset token, update password
-    Err(ApiError::Internal("not implemented".to_string()))
+    let backend = backend(&state)?;
+    backend
+        .complete_password_reset(&body.token, body.new_password.expose())
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(json!({"reset": true})))
 }
 
-/// POST /api/v1/auth/verify-email
+/// `POST /api/v1/auth/verify-email` — consume one-time verification token.
+#[tracing::instrument(level = "info", skip(state, body))]
 pub async fn verify_email(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
+    State(state): State<AppState>,
+    Json(body): Json<VerifyEmailRequest>,
 ) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Verify email token, mark email verified
-    Err(ApiError::Internal("not implemented".to_string()))
+    let backend = backend(&state)?;
+    backend
+        .verify_email(&body.token)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(json!({"verified": true})))
 }
 
-/// POST /api/v1/auth/mfa/enroll
+/// `POST /api/v1/auth/mfa/enroll` — return otpauth URI + base32 secret.
+///
+/// Requires a valid `nebula_session` cookie — extracted inline to avoid
+/// applying the full auth middleware to the unauthenticated `/auth/*`
+/// route group.
+#[tracing::instrument(level = "info", skip(state, headers))]
 pub async fn mfa_enroll(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Generate TOTP secret, return QR code
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> ApiResult<Json<MfaEnrollResponse>> {
+    let backend = backend(&state)?;
+    let principal = principal_from_cookie(&headers, backend).await?;
+    let user_id = user_id_from_principal(&principal)?;
+    let enroll = backend
+        .start_mfa_enrollment(&user_id)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(MfaEnrollResponse {
+        otpauth_uri: enroll.otpauth_uri,
+        secret_base32: enroll.secret_base32,
+    }))
 }
 
-/// POST /api/v1/auth/mfa/verify
+/// `POST /api/v1/auth/mfa/verify` — confirm enrollment OR complete a login.
+///
+/// If the request includes a `challenge_token`, the handler treats it as
+/// the second-factor step of an in-flight login and mints a session on
+/// success. Without the token, it confirms enrollment for the user
+/// resolved via the session cookie.
+#[tracing::instrument(level = "info", skip(state, headers, body))]
 pub async fn mfa_verify(
-    State(_state): State<AppState>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Verify TOTP code, complete login
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<MfaVerifyRequest>,
+) -> ApiResult<axum::response::Response> {
+    let backend = backend(&state)?;
+    if let Some(challenge_token) = body.challenge_token {
+        let user = backend
+            .verify_mfa(&challenge_token, &body.code)
+            .await
+            .map_err(ApiError::from)?;
+        let response = mint_session_response(backend, user).await?;
+        Ok(response)
+    } else {
+        let principal = principal_from_cookie(&headers, backend).await?;
+        let user_id = user_id_from_principal(&principal)?;
+        backend
+            .confirm_mfa_enrollment(&user_id, &body.code)
+            .await
+            .map_err(ApiError::from)?;
+        Ok((StatusCode::OK, Json(json!({"enrolled": true}))).into_response())
+    }
 }
 
-/// GET /api/v1/auth/oauth/{provider} — start OAuth flow
+/// `GET /api/v1/auth/oauth/{provider}` — start a Plane-A sign-in flow.
+#[tracing::instrument(level = "info", skip(state))]
 pub async fn oauth_start(
-    State(_state): State<AppState>,
-    Path(_provider): Path<String>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Generate OAuth state, redirect to provider
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+) -> ApiResult<Json<OAuthStartResponse>> {
+    let backend = backend(&state)?;
+    let provider: OAuthProvider = provider.parse().map_err(ApiError::from)?;
+    let start = backend
+        .start_oauth(provider)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(OAuthStartResponse {
+        authorize_url: start.authorize_url,
+        state: start.state,
+    }))
 }
 
-/// GET /api/v1/auth/oauth/{provider}/callback — OAuth callback
+/// `GET /api/v1/auth/oauth/{provider}/callback` — exchange code, mint session.
+#[tracing::instrument(level = "info", skip(state, params))]
 pub async fn oauth_callback(
-    State(_state): State<AppState>,
-    Path(_provider): Path<String>,
-) -> ApiResult<Json<serde_json::Value>> {
-    // TODO: Exchange code for token, create/link user, create session
-    Err(ApiError::Internal("not implemented".to_string()))
+    State(state): State<AppState>,
+    Path(provider): Path<String>,
+    Query(params): Query<OAuthCallbackParams>,
+) -> ApiResult<axum::response::Response> {
+    let backend = backend(&state)?;
+    let provider: OAuthProvider = provider.parse().map_err(ApiError::from)?;
+    let result = backend
+        .complete_oauth(provider, &params.state, &params.code)
+        .await;
+
+    match result {
+        Ok(completion) => {
+            let resp = LoginResponse {
+                user: completion.user,
+                session_id: completion.session.id.clone(),
+                csrf_token: completion.session.csrf_token.clone(),
+            };
+            let cleared = cookie_headers(&[
+                session_cookie(&completion.session.id),
+                csrf_cookie(&completion.session.csrf_token),
+            ]);
+            Ok((StatusCode::OK, cleared, Json(resp)).into_response())
+        },
+        Err(AuthError::NotImplemented(reason)) => Err(ApiError::ServiceUnavailable(format!(
+            "oauth provider not configured: {reason}"
+        ))),
+        Err(e) => Err(e.into()),
+    }
 }
+
+/// Query string for the OAuth callback.
+#[derive(Debug, Deserialize)]
+pub struct OAuthCallbackParams {
+    /// Opaque state token previously issued by `start_oauth`.
+    pub state: String,
+    /// Authorization code returned by the provider.
+    pub code: String,
+}
+
+// ── Re-exports kept for the legacy AuthContext consumers ────────────────────
+
+/// Extension type carried by the auth middleware (re-exported for handlers).
+pub use crate::middleware::auth::AuthContext;

--- a/crates/api/src/handlers/webhook.rs
+++ b/crates/api/src/handlers/webhook.rs
@@ -1,34 +1,134 @@
 //! Webhook trigger endpoint handlers.
-//! Special: no standard auth middleware — triggers have per-trigger auth.
+//!
+//! Special: no standard auth middleware — per-trigger authentication
+//! is enforced inside the [`WebhookDispatcher`] via the registered
+//! [`crate::webhook::WebhookAuthConfig`].
+//!
+//! The route is `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}`. On
+//! success the handler returns `202 Accepted`: the engine processes
+//! the event asynchronously, and the HTTP response carries no
+//! workflow output. Failure paths return RFC 9457 `problem+json`.
+
+use std::sync::Arc;
 
 use axum::{
-    Json,
+    Extension,
+    body::Bytes,
     extract::{Path, State},
-    http::StatusCode,
+    http::{HeaderMap, Method, StatusCode, Uri},
+    response::{IntoResponse, Response},
 };
+use tracing::{debug, info_span};
 
 use crate::{
-    errors::{ApiError, ApiResult},
+    errors::ApiError,
     state::AppState,
+    webhook::{
+        TriggerCoordinates, WebhookAuthError, WebhookDispatchError, WebhookDispatcher,
+        WebhookEnqueueError,
+    },
 };
 
-/// POST /api/v1/hooks/{org}/{ws}/{trigger_slug}
+/// `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}`.
+///
+/// Validates per-trigger authentication, enqueues the trigger event
+/// into the engine sink, and returns `202 Accepted`. Error mapping:
+///
+/// | Outcome                                      | Status |
+/// |----------------------------------------------|--------|
+/// | Sink accepted the event                      | 202    |
+/// | No active webhook registered for the slug    | 404    |
+/// | Per-trigger auth failed (bad/missing sig)    | 401    |
+/// | Operator-side misconfig (empty secret etc.)  | 500    |
+/// | Sink unavailable (closed)                    | 500    |
+/// | Sink saturated (back-pressure)               | 503    |
 pub async fn handle_webhook_post(
     State(_state): State<AppState>,
-    Path((_org, _ws, _trigger_slug)): Path<(String, String, String)>,
-    Json(_body): Json<serde_json::Value>,
-) -> ApiResult<StatusCode> {
-    // TODO: Validate per-trigger auth
-    // TODO: Enqueue trigger event
-    // TODO: Return 202 Accepted
-    Err(ApiError::Internal("not implemented".to_string()))
+    Extension(dispatcher): Extension<Arc<WebhookDispatcher>>,
+    Path((org, ws, trigger_slug)): Path<(String, String, String)>,
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let coordinates = TriggerCoordinates::new(org, ws, trigger_slug);
+
+    let span = info_span!(
+        "api.webhook.handle_post",
+        org = %coordinates.org,
+        workspace = %coordinates.workspace,
+        trigger = %coordinates.trigger,
+        body_bytes = body.len(),
+    );
+    let _enter = span.enter();
+
+    match dispatcher
+        .dispatch(coordinates.clone(), method, uri, headers, body)
+        .await
+    {
+        Ok(()) => StatusCode::ACCEPTED.into_response(),
+        Err(err) => {
+            debug!(error = %err, "webhook dispatch failed");
+            dispatch_error_to_response(err)
+        },
+    }
 }
 
-/// GET /api/v1/hooks/{org}/{ws}/{trigger_slug}
+/// `GET /api/v1/hooks/{org}/{ws}/{trigger_slug}`.
+///
+/// GET is reserved for webhook providers that issue verification
+/// challenges (e.g. Slack URL verification). The slug-routed surface
+/// does not yet model such challenges — providers that need them rely
+/// on the typed-action transport in [`crate::services::webhook`]. We
+/// reply with `405 Method Not Allowed` so the contract is explicit
+/// rather than silently 5xx'ing.
 pub async fn handle_webhook_get(
     State(_state): State<AppState>,
     Path((_org, _ws, _trigger_slug)): Path<(String, String, String)>,
-) -> ApiResult<StatusCode> {
-    // TODO: Some webhooks use GET (e.g., verification challenges)
-    Err(ApiError::Internal("not implemented".to_string()))
+) -> Response {
+    let mut response = StatusCode::METHOD_NOT_ALLOWED.into_response();
+    if let Ok(value) = "POST".parse() {
+        response
+            .headers_mut()
+            .insert(axum::http::header::ALLOW, value);
+    }
+    response
+}
+
+fn dispatch_error_to_response(err: WebhookDispatchError) -> Response {
+    match err {
+        WebhookDispatchError::NotFound { trigger } => ApiError::NotFound(format!(
+            "no webhook trigger registered for {}/{}/{}",
+            trigger.org, trigger.workspace, trigger.trigger
+        ))
+        .into_response(),
+        WebhookDispatchError::Auth(auth_err) => auth_error_to_response(auth_err),
+        WebhookDispatchError::Enqueue(enqueue_err) => enqueue_error_to_response(enqueue_err),
+    }
+}
+
+fn auth_error_to_response(err: WebhookAuthError) -> Response {
+    match err {
+        WebhookAuthError::SignatureMissing
+        | WebhookAuthError::SignatureInvalid
+        | WebhookAuthError::TokenMissing
+        | WebhookAuthError::TokenInvalid => ApiError::Unauthorized(err.to_string()).into_response(),
+        // SecretNotConfigured is operator misconfiguration (5xx)
+        // rather than caller error — fail-closed in the same way as
+        // the typed-action transport's `missing_secret_response`.
+        WebhookAuthError::SecretNotConfigured => {
+            ApiError::Internal(err.to_string()).into_response()
+        },
+    }
+}
+
+fn enqueue_error_to_response(err: WebhookEnqueueError) -> Response {
+    match err {
+        WebhookEnqueueError::SinkUnavailable { .. } => {
+            ApiError::Internal(err.to_string()).into_response()
+        },
+        WebhookEnqueueError::SinkBackpressure { .. } => {
+            ApiError::ServiceUnavailable(err.to_string()).into_response()
+        },
+    }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,7 +19,7 @@
 //!   `EndpointProviderImpl`, `WebhookRateLimiter` (§11.3 / §13.4). Located under
 //!   [`services::webhook`] with rate limiting in [`middleware::webhook_ratelimit`].
 //! - `state` — `AppState` holds port trait references: `WorkflowRepo`, `ExecutionRepo`,
-//!   `ControlQueueRepo`, `OrgResolver`, `WorkspaceResolver`, `SessionStore`, `MembershipStore`.
+//!   `ControlQueueRepo`, `OrgResolver`, `WorkspaceResolver`, `AuthBackend`, `MembershipStore`.
 //! - `config` — `ApiConfig` with sub-configs (`TlsConfig`, `CookieConfig`, `CorsConfig`,
 //!   `VersioningConfig`, `PaginationConfig`) / `JwtSecret`; startup fails hard on a missing or
 //!   short secret — no `Default` impl (§4.5 operational honesty).
@@ -32,7 +32,9 @@
 //! Keep **Plane A** (who may call this API) separate from **Plane B** (integration credentials
 //! for workflows talking to *external* systems):
 //!
-//! - **`middleware::auth`** — **Plane A**: JWT bearer and `X-API-Key` for the Nebula API itself.
+//! - **`auth`** + **`middleware::auth`** — **Plane A**: identity, sessions, MFA, PATs, and the
+//!   user-facing OAuth sign-in flow plus the cookie / JWT / `X-API-Key` middleware that gates the
+//!   Nebula API itself.
 //! - **`credential`** — **Plane B infrastructure**: OAuth2 flow helpers (PKCE, signed state, token
 //!   exchange) and input validators for integration credentials. Located under [`services::oauth`]
 //!   with validators in [`extractors::credential`]. HTTP handlers live in [`handlers::credential`];
@@ -54,6 +56,7 @@
 #![warn(clippy::all)]
 
 pub mod app;
+pub mod auth;
 pub mod config;
 pub mod errors;
 pub mod extractors;
@@ -65,6 +68,7 @@ pub mod routes;
 pub mod server;
 pub mod services;
 pub mod state;
+pub mod webhook;
 
 pub use app::build_app;
 pub use config::{ApiConfig, ApiConfigError, JwtSecret};

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -19,13 +19,16 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use nebula_core::UserId;
 use serde::{Deserialize, Serialize};
 
-use crate::state::AppState;
+use crate::{auth::PAT_PREFIX as AUTH_PAT_PREFIX, state::AppState};
 
 /// The canonical prefix for Nebula API keys.
 pub const API_KEY_PREFIX: &str = "nbl_sk_";
 
 /// The canonical prefix for personal access tokens.
-pub const PAT_PREFIX: &str = "pat_";
+///
+/// Re-exported for the auth middleware; the authoritative definition lives
+/// in [`crate::auth::PAT_PREFIX`].
+pub const PAT_PREFIX: &str = AUTH_PAT_PREFIX;
 
 /// Cookie name for session-based authentication.
 pub const SESSION_COOKIE: &str = "nebula_session";
@@ -86,8 +89,9 @@ pub enum AuthMethod {
 ///
 /// The middleware tries each path in order:
 ///
-/// 1. **Session cookie** (`nebula_session`) — resolved via [`SessionStore`] port.
-/// 2. **PAT** — `Authorization: Bearer pat_…`, resolved via hash lookup (stub).
+/// 1. **Session cookie** (`nebula_session`) — resolved via [`AuthBackend`] port.
+/// 2. **PAT** — `Authorization: Bearer pat_…`, resolved via SHA-256 hash lookup against the same
+///    [`AuthBackend`].
 /// 3. **`X-API-Key` header** — compared in constant time against configured keys.
 /// 4. **JWT Bearer** — validated against the server JWT secret with HS256.
 ///
@@ -96,7 +100,7 @@ pub enum AuthMethod {
 /// Both [`AuthenticatedUser`] (legacy) and [`AuthContext`] are inserted into
 /// request extensions on success.
 ///
-/// [`SessionStore`]: crate::state::SessionStore
+/// [`AuthBackend`]: crate::auth::AuthBackend
 pub async fn auth_middleware(
     State(state): State<AppState>,
     mut request: Request,
@@ -104,9 +108,9 @@ pub async fn auth_middleware(
 ) -> Result<Response, StatusCode> {
     // ── Path 1: Session cookie ──────────────────────────────────────────────
     if let Some(session_id) = extract_cookie(&request, SESSION_COOKIE)
-        && let Some(ref store) = state.session_store
+        && let Some(ref backend) = state.auth_backend
     {
-        match store.get_principal_by_session(&session_id).await {
+        match backend.get_principal_by_session(&session_id).await {
             Ok(Some(principal)) => {
                 let user_id = principal_user_id(&principal);
                 request.extensions_mut().insert(AuthenticatedUser {
@@ -122,7 +126,7 @@ pub async fn auth_middleware(
                 // Session not found or expired — fall through to other methods
             },
             Err(_) => {
-                // Store error — fall through
+                // Backend error — fall through
             },
         }
     }
@@ -131,10 +135,28 @@ pub async fn auth_middleware(
     if let Some(bearer_value) = extract_bearer(&request)
         && bearer_value.starts_with(PAT_PREFIX)
     {
-        // TODO: Resolve PAT via hash lookup when PAT store is available.
-        // For now, parse the suffix as a user ID for development purposes.
-        // In production, PATs will be hashed and looked up in the database.
-        return Err(StatusCode::UNAUTHORIZED);
+        // Resolve via the auth backend's SHA-256 lookup. Bad shape returns
+        // None / Err and we fall through to a 401 to avoid leaking which
+        // bucket failed.
+        let backend = state
+            .auth_backend
+            .as_ref()
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+        let record = backend
+            .lookup_pat(bearer_value)
+            .await
+            .map_err(|_| StatusCode::UNAUTHORIZED)?
+            .ok_or(StatusCode::UNAUTHORIZED)?;
+
+        let principal = nebula_core::Principal::User(record.user_id);
+        request.extensions_mut().insert(AuthenticatedUser {
+            user_id: record.user_id.to_string(),
+        });
+        request.extensions_mut().insert(AuthContext {
+            principal,
+            auth_method: AuthMethod::Pat,
+        });
+        return Ok(next.run(request).await);
     }
 
     // ── Path 3: X-API-Key header ─────────────────────────────────────────────

--- a/crates/api/src/middleware/idempotency.rs
+++ b/crates/api/src/middleware/idempotency.rs
@@ -16,7 +16,8 @@
 //! - HTTP method (uppercase ASCII)
 //! - Request URI path (without query string)
 //! - The validated `Idempotency-Key` header value
-//! - A fingerprint of identity-bearing headers (`Authorization`, `X-API-Key`)
+//! - A fingerprint of identity-bearing material (`Authorization`, `X-API-Key`, and the raw `Cookie`
+//!   header when present so session-cookie auth does not collide across principals)
 //!
 //! Including the identity fingerprint is **mandatory** because this layer sits
 //! in the outer middleware stack — it runs *before* `auth_middleware` resolves
@@ -40,10 +41,13 @@
 //!
 //! ## Position in the middleware stack
 //!
-//! Place this layer **inside** `request_id` and `security_headers` so that
-//! cached replays still acquire fresh `X-Request-ID` and security headers
-//! when they leave the server. See `crates/api/src/app.rs` for the wired
-//! ordering.
+//! When mounted on the production router, place this layer **inside**
+//! `request_id` and `security_headers` so cached replays still acquire fresh
+//! `X-Request-ID` and security headers when they leave the server.
+//!
+//! **Note:** the layer is not yet merged into `crate::app::build_app` /
+//! `crate::routes::create_routes` — integration tests mount `IdempotencyLayer` directly on
+//! minimal routers until the composition root wires a shared store.
 
 use std::{
     fmt,
@@ -496,10 +500,11 @@ fn fingerprint_request_body(body: &[u8]) -> [u8; 32] {
 }
 
 fn identity_fingerprint(headers: &HeaderMap) -> [u8; 32] {
-    // Mix in any header that proves caller identity. Order is fixed so the
-    // hash is stable across requests. Missing headers contribute an empty
-    // segment — the resulting hash still differs from "no headers at all"
-    // because the segment separators stay in the input.
+    // Mix in any material that distinguishes callers before `auth_middleware`
+    // runs (`Authorization`, `X-API-Key`, raw `Cookie` for session flows).
+    // Order is fixed so the hash is stable across requests. Missing headers
+    // contribute an empty segment — the resulting hash still differs from "no
+    // headers at all" because the segment separators stay in the input.
     let mut hasher = Sha256::new();
     let auth = headers
         .get(header::AUTHORIZATION)
@@ -509,10 +514,16 @@ fn identity_fingerprint(headers: &HeaderMap) -> [u8; 32] {
         .get("x-api-key")
         .map(HeaderValue::as_bytes)
         .unwrap_or_default();
+    let cookie = headers
+        .get(header::COOKIE)
+        .map(HeaderValue::as_bytes)
+        .unwrap_or_default();
     hasher.update(b"authorization=");
     hasher.update(auth);
     hasher.update(b"\nx-api-key=");
     hasher.update(api_key);
+    hasher.update(b"\ncookie=");
+    hasher.update(cookie);
     hasher.finalize().into()
 }
 

--- a/crates/api/src/middleware/idempotency.rs
+++ b/crates/api/src/middleware/idempotency.rs
@@ -1,0 +1,736 @@
+//! Idempotency-Key Middleware (M3.4).
+//!
+//! Generic POST-replay protection per the IETF draft
+//! [draft-ietf-httpapi-idempotency-key]. A client supplies an `Idempotency-Key`
+//! header with any state-changing request; the middleware caches the first
+//! response and replays it byte-for-byte for subsequent requests carrying the
+//! same key (within the configured TTL) — the inner handler runs **at most
+//! once** per (method, path, key, identity, body) tuple.
+//!
+//! [draft-ietf-httpapi-idempotency-key]: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key/
+//!
+//! ## Cache key composition
+//!
+//! The lookup key combines:
+//!
+//! - HTTP method (uppercase ASCII)
+//! - Request URI path (without query string)
+//! - The validated `Idempotency-Key` header value
+//! - A fingerprint of identity-bearing headers (`Authorization`, `X-API-Key`)
+//!
+//! Including the identity fingerprint is **mandatory** because this layer sits
+//! in the outer middleware stack — it runs *before* `auth_middleware` resolves
+//! the [`Principal`](nebula_core::scope::Principal). Two callers MUST never
+//! share a cached response even if they happen to choose the same key.
+//!
+//! ## Body fingerprint
+//!
+//! Every cached entry also stores a SHA-256 fingerprint of the request body.
+//! Reusing the same key with a different body yields **422 Unprocessable
+//! Entity** per draft §2.5 — protects against client bugs that re-use keys
+//! across logically distinct operations.
+//!
+//! ## What gets cached
+//!
+//! Only `2xx` and `4xx` responses. `5xx` responses are passed through
+//! uncached so transient backend failures do not pin a permanent error for
+//! the TTL window. Responses larger than
+//! [`IdempotencyConfig::max_response_body_bytes`] are passed through
+//! uncached as well.
+//!
+//! ## Position in the middleware stack
+//!
+//! Place this layer **inside** `request_id` and `security_headers` so that
+//! cached replays still acquire fresh `X-Request-ID` and security headers
+//! when they leave the server. See `crates/api/src/app.rs` for the wired
+//! ordering.
+
+use std::{
+    fmt,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    extract::Request,
+    http::{HeaderMap, HeaderName, HeaderValue, Method, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use futures::future::BoxFuture;
+use moka::future::Cache;
+use sha2::{Digest, Sha256};
+use tower::{Layer, Service, ServiceExt};
+
+/// Header name carrying the client-supplied idempotency key.
+pub const IDEMPOTENCY_KEY_HEADER: &str = "idempotency-key";
+
+/// Default cache lifetime — 24h matches the draft RFC's recommendation.
+pub const DEFAULT_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Default cap on the number of cached responses.
+pub const DEFAULT_MAX_ENTRIES: u64 = 10_000;
+
+/// Default cap on the request/response body size eligible for caching (1 MiB).
+pub const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Maximum acceptable length of an `Idempotency-Key` header value.
+///
+/// Picked to align with common gateway header limits and the draft RFC's
+/// "opaque token, ≤ 255 octets" guidance.
+pub const MAX_KEY_LEN: usize = 255;
+
+// ── Errors ───────────────────────────────────────────────────────────────────
+
+/// Errors returned when parsing/validating an `Idempotency-Key` header.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum IdempotencyKeyError {
+    /// The header was present but contained no characters.
+    #[error("Idempotency-Key header is empty")]
+    Empty,
+
+    /// The header value exceeded [`MAX_KEY_LEN`] octets.
+    #[error("Idempotency-Key header exceeds max length of {MAX_KEY_LEN} bytes")]
+    TooLong,
+
+    /// The header contained bytes outside the printable-ASCII range.
+    ///
+    /// Restricting to printable ASCII keeps the cache key safe to render in
+    /// logs and metrics labels without a separate encoding step.
+    #[error("Idempotency-Key must be printable ASCII")]
+    InvalidCharacters,
+}
+
+// ── Idempotency key newtype ──────────────────────────────────────────────────
+
+/// Validated `Idempotency-Key` header value.
+///
+/// Construct via [`IdempotencyKey::parse`] — direct construction is forbidden
+/// so the validation invariants below are guaranteed by the type:
+///
+/// - non-empty
+/// - ≤ [`MAX_KEY_LEN`] bytes
+/// - printable ASCII (`0x21..=0x7e`)
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IdempotencyKey(String);
+
+impl IdempotencyKey {
+    /// Parse a raw header value into a validated [`IdempotencyKey`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`IdempotencyKeyError`] if the value is empty, exceeds
+    /// [`MAX_KEY_LEN`], or contains non-printable / non-ASCII bytes.
+    pub fn parse(raw: &str) -> Result<Self, IdempotencyKeyError> {
+        if raw.is_empty() {
+            return Err(IdempotencyKeyError::Empty);
+        }
+        if raw.len() > MAX_KEY_LEN {
+            return Err(IdempotencyKeyError::TooLong);
+        }
+        if !raw.bytes().all(|b| (0x21..=0x7e).contains(&b)) {
+            return Err(IdempotencyKeyError::InvalidCharacters);
+        }
+        Ok(Self(raw.to_owned()))
+    }
+
+    /// Borrow the validated key as a string slice.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for IdempotencyKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+// ── Cached response ──────────────────────────────────────────────────────────
+
+/// Snapshot of an HTTP response retained for idempotent replay.
+///
+/// Stored behind an [`Arc`] inside the [`IdempotencyStore`] so concurrent
+/// readers share the bytes without copying.
+#[derive(Debug, Clone)]
+pub struct CachedResponse {
+    /// HTTP status code returned by the original handler.
+    pub status: StatusCode,
+    /// Filtered response headers (hop-by-hop and per-request headers stripped).
+    pub headers: HeaderMap,
+    /// Buffered response body bytes.
+    pub body: Vec<u8>,
+    /// SHA-256 fingerprint of the original request body — used to detect
+    /// "same key, different body" reuse and reject it with 422 per draft §2.5.
+    pub request_fingerprint: [u8; 32],
+}
+
+impl CachedResponse {
+    fn into_response(self) -> Response {
+        let mut response = Response::builder()
+            .status(self.status)
+            .body(Body::from(self.body))
+            .unwrap_or_else(|_| {
+                // Building from a static StatusCode + Vec<u8> body cannot fail
+                // under any documented `http::response::Builder` precondition;
+                // fall back to an empty 500 only to keep the type checker
+                // happy. Recoverable rather than panicking.
+                StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            });
+        *response.headers_mut() = self.headers;
+        response
+            .headers_mut()
+            .insert(IDEMPOTENT_REPLAY_HEADER, HeaderValue::from_static("true"));
+        response
+    }
+}
+
+/// Header set on replayed responses so callers can distinguish a cache hit
+/// from a fresh handler invocation.
+pub const IDEMPOTENT_REPLAY_HEADER: HeaderName = HeaderName::from_static("idempotent-replay");
+
+// ── Store trait + in-memory impl ─────────────────────────────────────────────
+
+/// Storage backend for cached idempotent responses.
+///
+/// Implementations MUST be safe to share across async tasks. The default
+/// implementation is [`InMemoryIdempotencyStore`]; a Redis / SQL backend can
+/// be slotted in by implementing this trait without touching the middleware.
+#[async_trait]
+pub trait IdempotencyStore: Send + Sync + fmt::Debug {
+    /// Look up a cached response by its scoped cache key.
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>>;
+
+    /// Persist a cached response under `key`. Implementations MUST honour the
+    /// store's configured TTL; the middleware does not enforce expiry.
+    async fn put(&self, key: String, response: Arc<CachedResponse>);
+}
+
+/// Process-local idempotency store backed by [`moka::future::Cache`].
+///
+/// Entries expire after a configurable TTL and the cache is bounded by a
+/// maximum entry count to provide a hard memory ceiling.
+pub struct InMemoryIdempotencyStore {
+    cache: Cache<String, Arc<CachedResponse>>,
+}
+
+impl InMemoryIdempotencyStore {
+    /// Create a store with the default TTL ([`DEFAULT_TTL_SECS`]) and capacity
+    /// ([`DEFAULT_MAX_ENTRIES`]).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_ttl_and_capacity(Duration::from_secs(DEFAULT_TTL_SECS), DEFAULT_MAX_ENTRIES)
+    }
+
+    /// Create a store with a custom TTL and capacity.
+    #[must_use]
+    pub fn with_ttl_and_capacity(ttl: Duration, max_entries: u64) -> Self {
+        let cache = Cache::builder()
+            .time_to_live(ttl)
+            .max_capacity(max_entries)
+            .build();
+        Self { cache }
+    }
+}
+
+impl Default for InMemoryIdempotencyStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for InMemoryIdempotencyStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InMemoryIdempotencyStore")
+            .field("entries", &self.cache.entry_count())
+            .finish()
+    }
+}
+
+#[async_trait]
+impl IdempotencyStore for InMemoryIdempotencyStore {
+    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>> {
+        self.cache.get(key).await
+    }
+
+    async fn put(&self, key: String, response: Arc<CachedResponse>) {
+        self.cache.insert(key, response).await;
+    }
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Tunables for the idempotency middleware.
+#[derive(Debug, Clone)]
+pub struct IdempotencyConfig {
+    /// Maximum buffered request body size (in bytes) eligible for caching.
+    /// Requests larger than this pass through without idempotency tracking.
+    pub max_request_body_bytes: usize,
+    /// Maximum buffered response body size (in bytes) eligible for caching.
+    /// Larger responses are returned to the caller but never cached.
+    pub max_response_body_bytes: usize,
+}
+
+impl Default for IdempotencyConfig {
+    fn default() -> Self {
+        Self {
+            max_request_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            max_response_body_bytes: DEFAULT_MAX_BODY_BYTES,
+        }
+    }
+}
+
+// ── Layer + Service ──────────────────────────────────────────────────────────
+
+/// Tower [`Layer`] that wraps an inner service with idempotent-replay logic.
+///
+/// Construct with [`IdempotencyLayer::new`] and apply via `Router::layer`.
+#[derive(Clone)]
+pub struct IdempotencyLayer {
+    store: Arc<dyn IdempotencyStore>,
+    config: IdempotencyConfig,
+}
+
+impl IdempotencyLayer {
+    /// Build a layer backed by the given store, using [`IdempotencyConfig::default`].
+    #[must_use]
+    pub fn new(store: Arc<dyn IdempotencyStore>) -> Self {
+        Self {
+            store,
+            config: IdempotencyConfig::default(),
+        }
+    }
+
+    /// Override the layer configuration.
+    #[must_use]
+    pub fn with_config(mut self, config: IdempotencyConfig) -> Self {
+        self.config = config;
+        self
+    }
+}
+
+impl<S> Layer<S> for IdempotencyLayer {
+    type Service = IdempotencyService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IdempotencyService {
+            inner,
+            store: Arc::clone(&self.store),
+            config: self.config.clone(),
+        }
+    }
+}
+
+/// Tower [`Service`] produced by [`IdempotencyLayer`].
+#[derive(Clone)]
+pub struct IdempotencyService<S> {
+    inner: S,
+    store: Arc<dyn IdempotencyStore>,
+    config: IdempotencyConfig,
+}
+
+impl<S> Service<Request> for IdempotencyService<S>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    S::Error: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request) -> Self::Future {
+        let inner = self.inner.clone();
+        let store = Arc::clone(&self.store);
+        let config = self.config.clone();
+        Box::pin(async move { handle(inner, store, config, request).await })
+    }
+}
+
+// ── Core handling ────────────────────────────────────────────────────────────
+
+#[tracing::instrument(
+    name = "idempotency",
+    skip(inner, store, config, request),
+    fields(
+        method = %request.method(),
+        path = %request.uri().path(),
+        idempotency_key = tracing::field::Empty,
+        outcome = tracing::field::Empty,
+    )
+)]
+async fn handle<S>(
+    inner: S,
+    store: Arc<dyn IdempotencyStore>,
+    config: IdempotencyConfig,
+    request: Request,
+) -> Result<Response, S::Error>
+where
+    S: Service<Request, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    // Only POST is in scope for the M3.4 acceptance criteria. Other methods
+    // pass through transparently — clients that send the header on a GET get
+    // their request handled normally.
+    if request.method() != Method::POST {
+        tracing::Span::current().record("outcome", "skip:non_post");
+        return inner.oneshot(request).await;
+    }
+
+    // Header missing → opt-out. No allocation, no body buffering.
+    let Some(raw_key) = request.headers().get(IDEMPOTENCY_KEY_HEADER) else {
+        tracing::Span::current().record("outcome", "skip:no_header");
+        return inner.oneshot(request).await;
+    };
+
+    let Ok(key_str) = raw_key.to_str() else {
+        tracing::Span::current().record("outcome", "reject:non_ascii_header");
+        return Ok(bad_request("Idempotency-Key must be valid ASCII"));
+    };
+
+    let key = match IdempotencyKey::parse(key_str) {
+        Ok(k) => k,
+        Err(err) => {
+            tracing::Span::current().record("outcome", "reject:invalid_key");
+            return Ok(bad_request(&err.to_string()));
+        },
+    };
+    tracing::Span::current().record("idempotency_key", tracing::field::display(&key));
+
+    // Buffer the request body so we can fingerprint it AND replay it to the
+    // inner service. Anything beyond `max_request_body_bytes` opts the request
+    // out of caching entirely — we still forward it, but cannot guarantee
+    // replay safety, so we do not store the response either.
+    let (parts, body) = request.into_parts();
+    let body_result = axum::body::to_bytes(body, config.max_request_body_bytes).await;
+    let Ok(body_bytes) = body_result else {
+        tracing::Span::current().record("outcome", "skip:body_too_large");
+        tracing::warn!(
+            "request body exceeds idempotency max_request_body_bytes — \
+                 forwarding without caching"
+        );
+        let request = Request::from_parts(parts, Body::from(Vec::new()));
+        return inner.oneshot(request).await;
+    };
+    let body_vec: Vec<u8> = body_bytes.into();
+
+    let request_fingerprint = fingerprint_request_body(&body_vec);
+    let identity = identity_fingerprint(&parts.headers);
+    let cache_key = build_cache_key(&parts.method, parts.uri.path(), &key, &identity);
+
+    if let Some(cached) = store.get(&cache_key).await {
+        if cached.request_fingerprint != request_fingerprint {
+            tracing::Span::current().record("outcome", "reject:body_mismatch");
+            tracing::warn!("Idempotency-Key reused with different request body — rejecting");
+            return Ok(unprocessable(
+                "Idempotency-Key reused with a different request payload",
+            ));
+        }
+        tracing::Span::current().record("outcome", "hit");
+        tracing::debug!(status = cached.status.as_u16(), "idempotency cache hit");
+        return Ok(Arc::unwrap_or_clone(cached).into_response());
+    }
+
+    // Cache miss — rebuild the request with the buffered body and run the
+    // inner handler.
+    let request = Request::from_parts(parts, Body::from(body_vec));
+    let response = inner.oneshot(request).await?;
+
+    let (resp_parts, resp_body) = response.into_parts();
+    let resp_result = axum::body::to_bytes(resp_body, config.max_response_body_bytes).await;
+    let Ok(resp_bytes) = resp_result else {
+        tracing::Span::current().record("outcome", "miss:resp_too_large");
+        tracing::warn!(
+            "response body exceeds idempotency max_response_body_bytes — \
+                 returning to caller without caching"
+        );
+        return Ok(Response::from_parts(resp_parts, Body::empty()));
+    };
+    let resp_vec: Vec<u8> = resp_bytes.into();
+
+    if should_cache(resp_parts.status) {
+        let cached = Arc::new(CachedResponse {
+            status: resp_parts.status,
+            headers: filter_response_headers(&resp_parts.headers),
+            body: resp_vec.clone(),
+            request_fingerprint,
+        });
+        store.put(cache_key, cached).await;
+        tracing::Span::current().record("outcome", "miss:cached");
+        tracing::debug!(
+            status = resp_parts.status.as_u16(),
+            bytes = resp_vec.len(),
+            "idempotency cache miss — response cached"
+        );
+    } else {
+        tracing::Span::current().record("outcome", "miss:passthrough");
+        tracing::debug!(
+            status = resp_parts.status.as_u16(),
+            "idempotency cache miss — response not cached (5xx)"
+        );
+    }
+
+    Ok(Response::from_parts(resp_parts, Body::from(resp_vec)))
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn should_cache(status: StatusCode) -> bool {
+    // Cache 2xx (success) and 4xx (client errors). 5xx is left uncached so a
+    // transient backend failure does not pin a permanent error for the TTL
+    // window — the caller can safely retry the same key.
+    status.is_success() || status.is_client_error()
+}
+
+fn fingerprint_request_body(body: &[u8]) -> [u8; 32] {
+    let mut hasher = Sha256::new();
+    hasher.update(body);
+    hasher.finalize().into()
+}
+
+fn identity_fingerprint(headers: &HeaderMap) -> [u8; 32] {
+    // Mix in any header that proves caller identity. Order is fixed so the
+    // hash is stable across requests. Missing headers contribute an empty
+    // segment — the resulting hash still differs from "no headers at all"
+    // because the segment separators stay in the input.
+    let mut hasher = Sha256::new();
+    let auth = headers
+        .get(header::AUTHORIZATION)
+        .map(HeaderValue::as_bytes)
+        .unwrap_or_default();
+    let api_key = headers
+        .get("x-api-key")
+        .map(HeaderValue::as_bytes)
+        .unwrap_or_default();
+    hasher.update(b"authorization=");
+    hasher.update(auth);
+    hasher.update(b"\nx-api-key=");
+    hasher.update(api_key);
+    hasher.finalize().into()
+}
+
+fn build_cache_key(
+    method: &Method,
+    path: &str,
+    key: &IdempotencyKey,
+    identity: &[u8; 32],
+) -> String {
+    // Hex-encode the identity fingerprint inline rather than pull `hex` as a
+    // direct dep — `format!` keeps the helper allocation-light enough for the
+    // hot path (single `String`) and avoids an extra crate edge.
+    let mut identity_hex = String::with_capacity(identity.len() * 2);
+    for byte in identity {
+        identity_hex.push_str(&format!("{byte:02x}"));
+    }
+    format!("{method}|{path}|{key}|{identity_hex}")
+}
+
+fn filter_response_headers(headers: &HeaderMap) -> HeaderMap {
+    // Strip headers that must never be replayed verbatim:
+    // - hop-by-hop (`Connection`, `Transfer-Encoding`, `Upgrade`, …)
+    // - per-request (`X-Request-ID` is regenerated by `request_id_middleware` on the outer wrap;
+    //   replaying the original would shadow the new one)
+    // - `Set-Cookie` (security: never reissue session/csrf cookies to a different caller, even if
+    //   scoping should already prevent it).
+    const STRIPPED: &[&str] = &[
+        "connection",
+        "transfer-encoding",
+        "upgrade",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "trailer",
+        "te",
+        "x-request-id",
+        "set-cookie",
+    ];
+    let mut out = HeaderMap::with_capacity(headers.len());
+    for (name, value) in headers {
+        if STRIPPED
+            .iter()
+            .any(|s| name.as_str().eq_ignore_ascii_case(s))
+        {
+            continue;
+        }
+        out.append(name.clone(), value.clone());
+    }
+    out
+}
+
+fn bad_request(detail: &str) -> Response {
+    problem_response(StatusCode::BAD_REQUEST, "Bad Request", detail)
+}
+
+fn unprocessable(detail: &str) -> Response {
+    problem_response(
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "Unprocessable Entity",
+        detail,
+    )
+}
+
+fn problem_response(status: StatusCode, title: &str, detail: &str) -> Response {
+    // Hand-rolled application/problem+json body — `errors::ProblemDetails` is
+    // out of this layer's owned-files scope and pulling it would couple the
+    // middleware to a heavier serde structure. The shape matches RFC 9457
+    // §3 well enough for clients that already speak the format.
+    let body = format!(
+        r#"{{"type":"about:blank","title":"{title}","status":{code},"detail":{detail_json}}}"#,
+        code = status.as_u16(),
+        detail_json = serde_json::Value::String(detail.to_owned()),
+    );
+    let mut response = Response::builder()
+        .status(status)
+        .body(Body::from(body))
+        .unwrap_or_else(|_| status.into_response());
+    response.headers_mut().insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/problem+json"),
+    );
+    response
+}
+
+// ── Unit tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_rejects_empty_key() {
+        assert_eq!(IdempotencyKey::parse(""), Err(IdempotencyKeyError::Empty));
+    }
+
+    #[test]
+    fn parse_rejects_oversized_key() {
+        let oversized = "a".repeat(MAX_KEY_LEN + 1);
+        assert_eq!(
+            IdempotencyKey::parse(&oversized),
+            Err(IdempotencyKeyError::TooLong)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_non_ascii() {
+        assert_eq!(
+            IdempotencyKey::parse("kéy"),
+            Err(IdempotencyKeyError::InvalidCharacters)
+        );
+    }
+
+    #[test]
+    fn parse_rejects_whitespace_and_control() {
+        assert_eq!(
+            IdempotencyKey::parse("a b"),
+            Err(IdempotencyKeyError::InvalidCharacters),
+            "spaces are outside printable-ASCII range",
+        );
+        assert_eq!(
+            IdempotencyKey::parse("a\tb"),
+            Err(IdempotencyKeyError::InvalidCharacters),
+        );
+    }
+
+    #[test]
+    fn parse_accepts_typical_uuid() {
+        let key = IdempotencyKey::parse("3a82d4c4-78c9-4e7f-9bcf-1e7d80e9f4b1")
+            .expect("uuid string is a valid key");
+        assert_eq!(key.as_str(), "3a82d4c4-78c9-4e7f-9bcf-1e7d80e9f4b1");
+    }
+
+    #[test]
+    fn cache_key_includes_identity_so_callers_cannot_share() {
+        let key = IdempotencyKey::parse("k1").unwrap();
+        let mut h1 = HeaderMap::new();
+        h1.insert(header::AUTHORIZATION, HeaderValue::from_static("Bearer A"));
+        let mut h2 = HeaderMap::new();
+        h2.insert(header::AUTHORIZATION, HeaderValue::from_static("Bearer B"));
+
+        let id1 = identity_fingerprint(&h1);
+        let id2 = identity_fingerprint(&h2);
+        assert_ne!(
+            id1, id2,
+            "different bearer tokens MUST yield different scopes"
+        );
+
+        let ck1 = build_cache_key(&Method::POST, "/x", &key, &id1);
+        let ck2 = build_cache_key(&Method::POST, "/x", &key, &id2);
+        assert_ne!(ck1, ck2);
+    }
+
+    #[test]
+    fn fingerprint_is_stable_and_distinguishes_payloads() {
+        let a = fingerprint_request_body(b"payload-a");
+        let a_again = fingerprint_request_body(b"payload-a");
+        let b = fingerprint_request_body(b"payload-b");
+        assert_eq!(a, a_again);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn should_cache_includes_2xx_and_4xx_excludes_5xx() {
+        assert!(should_cache(StatusCode::OK));
+        assert!(should_cache(StatusCode::CREATED));
+        assert!(should_cache(StatusCode::BAD_REQUEST));
+        assert!(should_cache(StatusCode::CONFLICT));
+        assert!(!should_cache(StatusCode::INTERNAL_SERVER_ERROR));
+        assert!(!should_cache(StatusCode::SERVICE_UNAVAILABLE));
+    }
+
+    #[test]
+    fn filter_strips_set_cookie_and_request_id() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/json"),
+        );
+        headers.insert("set-cookie", HeaderValue::from_static("sid=abc"));
+        headers.insert("x-request-id", HeaderValue::from_static("req-1"));
+        headers.insert("connection", HeaderValue::from_static("close"));
+
+        let filtered = filter_response_headers(&headers);
+        assert!(filtered.contains_key(header::CONTENT_TYPE));
+        assert!(!filtered.contains_key("set-cookie"));
+        assert!(!filtered.contains_key("x-request-id"));
+        assert!(!filtered.contains_key("connection"));
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_round_trip() {
+        let store = InMemoryIdempotencyStore::new();
+        let resp = Arc::new(CachedResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: b"hello".to_vec(),
+            request_fingerprint: [0u8; 32],
+        });
+        store.put("k1".to_owned(), Arc::clone(&resp)).await;
+        let fetched = store.get("k1").await.expect("entry must be present");
+        assert_eq!(fetched.body, b"hello");
+        assert!(store.get("missing").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn in_memory_store_honours_ttl() {
+        let store = InMemoryIdempotencyStore::with_ttl_and_capacity(Duration::from_millis(50), 16);
+        let resp = Arc::new(CachedResponse {
+            status: StatusCode::OK,
+            headers: HeaderMap::new(),
+            body: Vec::new(),
+            request_fingerprint: [0u8; 32],
+        });
+        store.put("expiring".to_owned(), resp).await;
+        assert!(store.get("expiring").await.is_some());
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        // moka may need a tick to evict; force a sync.
+        store.cache.run_pending_tasks().await;
+        assert!(store.get("expiring").await.is_none());
+    }
+}

--- a/crates/api/src/middleware/mod.rs
+++ b/crates/api/src/middleware/mod.rs
@@ -5,6 +5,7 @@
 
 pub mod auth;
 pub mod csrf;
+pub mod idempotency;
 pub mod rate_limit;
 pub mod rbac;
 pub mod request_id;
@@ -14,6 +15,7 @@ pub mod webhook_ratelimit;
 
 pub use auth::auth_middleware;
 pub use csrf::csrf_middleware;
+pub use idempotency::{IdempotencyLayer, IdempotencyStore, InMemoryIdempotencyStore};
 pub use rate_limit::RateLimitState;
 pub use rbac::rbac_middleware;
 pub use request_id::RequestIdLayer;

--- a/crates/api/src/routes/webhook.rs
+++ b/crates/api/src/routes/webhook.rs
@@ -1,13 +1,43 @@
 //! Webhook trigger routes — special auth, no standard middleware.
+//!
+//! The route `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}` carries
+//! per-trigger authentication; the standard JWT/API-key middleware
+//! does NOT apply here. Authentication is enforced inside the
+//! [`crate::webhook::WebhookDispatcher`] via the registered
+//! [`crate::webhook::WebhookAuthConfig`] policy (HMAC, bearer token,
+//! or none).
+//!
+//! The router attaches the dispatcher as an `axum::Extension` so the
+//! handler can extract it without changes to the global `AppState`.
+//! The default [`router`] mounts a fresh in-memory dispatcher with no
+//! registrations — production wiring (a future task) registers
+//! triggers from the storage layer at startup. Tests build their own
+//! router via [`router_with_dispatcher`].
 
-use axum::{Router, routing::post};
+use std::sync::Arc;
 
-use crate::{handlers, state::AppState};
+use axum::{Extension, Router, routing::post};
+
+use crate::{handlers, state::AppState, webhook::WebhookDispatcher};
 
 /// Webhook routes under `/hooks/{org}/{ws}/{trigger_slug}`.
+///
+/// Mounts an empty in-memory [`WebhookDispatcher`]. Until trigger
+/// lifecycle wiring lands (out of scope for M3.3), every request
+/// resolves to `404 Not Found` — the production-correct outcome for
+/// "no registered trigger".
 pub fn router() -> Router<AppState> {
-    Router::new().route(
-        "/hooks/{org}/{ws}/{trigger_slug}",
-        post(handlers::webhook::handle_webhook_post).get(handlers::webhook::handle_webhook_get),
-    )
+    router_with_dispatcher(Arc::new(WebhookDispatcher::new()))
+}
+
+/// Build a webhook router with a caller-supplied dispatcher. Used by
+/// integration tests and (eventually) by the runtime composition root
+/// once trigger registration is wired through the storage layer.
+pub fn router_with_dispatcher(dispatcher: Arc<WebhookDispatcher>) -> Router<AppState> {
+    Router::new()
+        .route(
+            "/hooks/{org}/{ws}/{trigger_slug}",
+            post(handlers::webhook::handle_webhook_post).get(handlers::webhook::handle_webhook_get),
+        )
+        .layer(Extension(dispatcher))
 }

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -18,7 +18,9 @@ use nebula_storage::{
 use nebula_telemetry::metrics::MetricsRegistry;
 use tokio::sync::RwLock;
 
-use crate::{config::JwtSecret, errors::ApiError, services::webhook::WebhookTransport};
+use crate::{
+    auth::AuthBackend, config::JwtSecret, errors::ApiError, services::webhook::WebhookTransport,
+};
 
 // ── Port traits ──────────────────────────────────────────────────────────────
 
@@ -34,16 +36,6 @@ pub trait OrgResolver: Send + Sync {
 pub trait WorkspaceResolver: Send + Sync {
     /// Look up a workspace by its slug within the given org.
     async fn resolve_by_slug(&self, org_id: OrgId, slug: &str) -> Result<WorkspaceId, ApiError>;
-}
-
-/// Session storage for cookie-based authentication.
-#[async_trait]
-pub trait SessionStore: Send + Sync {
-    /// Retrieve the [`Principal`] associated with a session ID, if any.
-    async fn get_principal_by_session(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Principal>, ApiError>;
 }
 
 /// Loads membership roles for RBAC middleware.
@@ -127,8 +119,15 @@ pub struct AppState {
     /// Optional workspace-slug → [`WorkspaceId`] resolver.
     pub workspace_resolver: Option<Arc<dyn WorkspaceResolver>>,
 
-    /// Optional session store for cookie-based auth.
-    pub session_store: Option<Arc<dyn SessionStore>>,
+    /// Optional Plane-A authentication backend.
+    ///
+    /// When `Some`, the auth middleware resolves session cookies and PATs
+    /// through this single contract. When `None`, only JWT and `X-API-Key`
+    /// authentication paths are available.
+    ///
+    /// See [`crate::auth::AuthBackend`] for the trait surface and
+    /// [`crate::auth::InMemoryAuthBackend`] for the default impl.
+    pub auth_backend: Option<Arc<dyn AuthBackend>>,
 
     /// Optional membership store for RBAC role lookups.
     pub membership_store: Option<Arc<dyn MembershipStore>>,
@@ -161,7 +160,7 @@ impl AppState {
             oauth_credential_store: Arc::new(InMemoryStore::new()),
             org_resolver: None,
             workspace_resolver: None,
-            session_store: None,
+            auth_backend: None,
             membership_store: None,
         }
     }
@@ -219,10 +218,14 @@ impl AppState {
         self
     }
 
-    /// Attach a session store for cookie-based authentication.
+    /// Attach a Plane-A authentication backend.
+    ///
+    /// Replaces the older `with_session_store` builder; the same slot now
+    /// drives session resolution, password login, MFA, PATs, and Plane-A
+    /// OAuth via [`crate::auth::AuthBackend`].
     #[must_use = "builder methods must be chained or built"]
-    pub fn with_session_store(mut self, store: Arc<dyn SessionStore>) -> Self {
-        self.session_store = Some(store);
+    pub fn with_auth_backend(mut self, backend: Arc<dyn AuthBackend>) -> Self {
+        self.auth_backend = Some(backend);
         self
     }
 

--- a/crates/api/src/webhook/auth.rs
+++ b/crates/api/src/webhook/auth.rs
@@ -28,10 +28,11 @@ use super::error::WebhookAuthError;
 
 /// Default header name carrying the HMAC-SHA-256 signature.
 ///
-/// Mirrors the canonical Nebula header used by the typed-action surface
-/// when the action does not override [`with_signature_header`]. Custom
-/// headers (e.g. `X-Hub-Signature-256` for GitHub-compatible flows) are
-/// supplied per-registration via [`WebhookAuthConfig::HmacSha256.header`].
+/// Mirrors the canonical Nebula header used by the typed-action surface when the
+/// action leaves the default signature header in place (see `WebhookConfig::with_header_str` /
+/// `WebhookConfig::with_header` in `nebula_action`). Custom headers (e.g. `X-Hub-Signature-256`
+/// for GitHub-compatible flows) are supplied per registration via the `header` field on
+/// [`WebhookAuthConfig::HmacSha256`].
 pub const DEFAULT_SIGNATURE_HEADER: &str = "X-Nebula-Signature";
 
 /// Authentication policy attached to a registered trigger.

--- a/crates/api/src/webhook/auth.rs
+++ b/crates/api/src/webhook/auth.rs
@@ -1,0 +1,290 @@
+//! Per-trigger authentication for slug-routed webhooks.
+//!
+//! Each registered trigger carries a [`WebhookAuthConfig`] describing
+//! how incoming requests must authenticate. The dispatcher runs the
+//! check before handing the event to the engine sink — failures map
+//! to 401 (or 500 if the operator misconfigured the trigger).
+//!
+//! Three policies ship in M3.3:
+//!
+//! - [`WebhookAuthConfig::None`] — public webhook. The handler accepts any body. Matches
+//!   `SignaturePolicy::OptionalAcceptUnsigned` on the typed-action surface.
+//! - [`WebhookAuthConfig::HmacSha256`] — verify an HMAC-SHA-256 of the raw body against a
+//!   configured shared secret. Matches the typed-action `Required(HmacSha256)` semantics.
+//! - [`WebhookAuthConfig::BearerToken`] — verify a static bearer token in the `Authorization`
+//!   header. Used by simple integrations that do not need HMAC.
+//!
+//! All comparisons are constant-time. Reuses the
+//! `verify_hmac_sha256` primitive from `nebula_action` so the
+//! slug-routed surface and the typed-action transport agree on
+//! signature semantics byte-for-byte.
+
+use std::sync::Arc;
+
+use axum::http::HeaderMap;
+use nebula_action::{SignatureOutcome, WebhookRequest, verify_hmac_sha256};
+
+use super::error::WebhookAuthError;
+
+/// Default header name carrying the HMAC-SHA-256 signature.
+///
+/// Mirrors the canonical Nebula header used by the typed-action surface
+/// when the action does not override [`with_signature_header`]. Custom
+/// headers (e.g. `X-Hub-Signature-256` for GitHub-compatible flows) are
+/// supplied per-registration via [`WebhookAuthConfig::HmacSha256.header`].
+pub const DEFAULT_SIGNATURE_HEADER: &str = "X-Nebula-Signature";
+
+/// Authentication policy attached to a registered trigger.
+#[derive(Clone, Debug)]
+pub enum WebhookAuthConfig {
+    /// Public webhook — no authentication required. Caller is trusted.
+    None,
+    /// HMAC-SHA-256 signature of the raw body, hex-encoded, optionally
+    /// prefixed with `sha256=` (the dispatcher tolerates both forms to
+    /// match the GitHub / Nebula primitives' behaviour).
+    HmacSha256 {
+        /// Shared secret used to compute the HMAC.
+        secret: Arc<[u8]>,
+        /// Header name carrying the signature. Defaults to
+        /// [`DEFAULT_SIGNATURE_HEADER`] when constructed via
+        /// [`Self::hmac_sha256`].
+        header: String,
+    },
+    /// Static bearer token in `Authorization: Bearer <token>`.
+    BearerToken {
+        /// Expected token value. Compared in constant time.
+        token: Arc<str>,
+    },
+}
+
+impl WebhookAuthConfig {
+    /// Build a HMAC-SHA-256 policy with the canonical Nebula header.
+    #[must_use]
+    pub fn hmac_sha256(secret: impl Into<Arc<[u8]>>) -> Self {
+        Self::HmacSha256 {
+            secret: secret.into(),
+            header: DEFAULT_SIGNATURE_HEADER.to_string(),
+        }
+    }
+
+    /// Build a HMAC-SHA-256 policy with a custom header name (e.g.
+    /// `X-Hub-Signature-256` for GitHub-compatible registrations).
+    #[must_use]
+    pub fn hmac_sha256_with_header(
+        secret: impl Into<Arc<[u8]>>,
+        header: impl Into<String>,
+    ) -> Self {
+        Self::HmacSha256 {
+            secret: secret.into(),
+            header: header.into(),
+        }
+    }
+
+    /// Build a bearer-token policy.
+    #[must_use]
+    pub fn bearer(token: impl Into<Arc<str>>) -> Self {
+        Self::BearerToken {
+            token: token.into(),
+        }
+    }
+}
+
+/// Validate an incoming request against the registered policy.
+///
+/// `request` is the typed [`WebhookRequest`] the dispatcher built from
+/// the axum extractors; reusing the same type lets us share the
+/// signature primitive with the typed-action transport.
+pub(crate) fn validate(
+    config: &WebhookAuthConfig,
+    request: &WebhookRequest,
+) -> Result<(), WebhookAuthError> {
+    match config {
+        WebhookAuthConfig::None => Ok(()),
+        WebhookAuthConfig::HmacSha256 { secret, header } => {
+            if secret.is_empty() {
+                return Err(WebhookAuthError::SecretNotConfigured);
+            }
+            let outcome = verify_hmac_sha256(request, secret.as_ref(), header)
+                .unwrap_or(SignatureOutcome::Invalid);
+            match outcome {
+                SignatureOutcome::Valid => Ok(()),
+                SignatureOutcome::Missing => Err(WebhookAuthError::SignatureMissing),
+                SignatureOutcome::Invalid => Err(WebhookAuthError::SignatureInvalid),
+                // `SignatureOutcome` is `#[non_exhaustive]`; future
+                // variants are fail-closed.
+                _ => Err(WebhookAuthError::SignatureInvalid),
+            }
+        },
+        WebhookAuthConfig::BearerToken { token } => check_bearer(token, request.headers()),
+    }
+}
+
+fn check_bearer(expected: &Arc<str>, headers: &HeaderMap) -> Result<(), WebhookAuthError> {
+    let header = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .ok_or(WebhookAuthError::TokenMissing)?
+        .to_str()
+        .map_err(|_| WebhookAuthError::TokenInvalid)?;
+    let provided = header
+        .strip_prefix("Bearer ")
+        .ok_or(WebhookAuthError::TokenInvalid)?;
+
+    if ct_eq_bytes(provided.as_bytes(), expected.as_bytes()) {
+        Ok(())
+    } else {
+        Err(WebhookAuthError::TokenInvalid)
+    }
+}
+
+/// Constant-time byte-slice equality.
+///
+/// Mirrors `subtle::ConstantTimeEq` for slices but avoids pulling
+/// `subtle` into `nebula-api` (the Cargo.toml is shared with other
+/// builders this milestone). The compiler must not short-circuit on
+/// mismatch; we OR the per-byte XOR so the timing is governed by the
+/// shorter of the two slices, with a length-mismatch always producing
+/// a non-zero accumulator. Mirrors the loop pattern used inside
+/// `subtle::ConstantTimeEq`.
+fn ct_eq_bytes(a: &[u8], b: &[u8]) -> bool {
+    let len_diff = a.len() ^ b.len();
+    let mut diff: u32 = len_diff as u32;
+    let min = a.len().min(b.len());
+    let mut i = 0;
+    while i < min {
+        diff |= u32::from(a[i] ^ b[i]);
+        i += 1;
+    }
+    diff == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Bytes,
+        http::{HeaderMap, HeaderValue, Method},
+    };
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+
+    use super::*;
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    fn sign(secret: &[u8], body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    fn make_request(headers: HeaderMap, body: Vec<u8>) -> WebhookRequest {
+        WebhookRequest::try_new(
+            Method::POST,
+            "/api/v1/hooks/acme/main/gh".to_string(),
+            None::<String>,
+            headers,
+            Bytes::from(body),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn none_policy_passes_any_request() {
+        let req = make_request(HeaderMap::new(), b"{}".to_vec());
+        validate(&WebhookAuthConfig::None, &req).unwrap();
+    }
+
+    #[test]
+    fn hmac_valid_signature_passes() {
+        let secret: Arc<[u8]> = Arc::<[u8]>::from(b"shh".as_slice());
+        let body = br#"{"ok":true}"#.to_vec();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DEFAULT_SIGNATURE_HEADER,
+            HeaderValue::from_str(&sign(&secret, &body)).unwrap(),
+        );
+
+        let cfg = WebhookAuthConfig::hmac_sha256(secret);
+        validate(&cfg, &make_request(headers, body)).unwrap();
+    }
+
+    #[test]
+    fn hmac_missing_header_returns_missing() {
+        let cfg = WebhookAuthConfig::hmac_sha256(Arc::<[u8]>::from(b"shh".as_slice()));
+        let err = validate(&cfg, &make_request(HeaderMap::new(), b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::SignatureMissing);
+    }
+
+    #[test]
+    fn hmac_bad_signature_returns_invalid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            DEFAULT_SIGNATURE_HEADER,
+            HeaderValue::from_static("sha256=deadbeef"),
+        );
+        let cfg = WebhookAuthConfig::hmac_sha256(Arc::<[u8]>::from(b"shh".as_slice()));
+        let err = validate(&cfg, &make_request(headers, b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::SignatureInvalid);
+    }
+
+    #[test]
+    fn hmac_empty_secret_returns_secret_not_configured() {
+        let cfg = WebhookAuthConfig::hmac_sha256(Arc::<[u8]>::from(Vec::<u8>::new()));
+        let err = validate(&cfg, &make_request(HeaderMap::new(), b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::SecretNotConfigured);
+    }
+
+    #[test]
+    fn hmac_custom_header_is_honored() {
+        let secret: Arc<[u8]> = Arc::<[u8]>::from(b"shh".as_slice());
+        let body = br#"{"github":true}"#.to_vec();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "X-Hub-Signature-256",
+            HeaderValue::from_str(&sign(&secret, &body)).unwrap(),
+        );
+        let cfg = WebhookAuthConfig::hmac_sha256_with_header(secret, "X-Hub-Signature-256");
+        validate(&cfg, &make_request(headers, body)).unwrap();
+    }
+
+    #[test]
+    fn bearer_valid_token_passes() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer correct-horse-battery-staple"),
+        );
+        let cfg = WebhookAuthConfig::bearer("correct-horse-battery-staple");
+        validate(&cfg, &make_request(headers, b"{}".to_vec())).unwrap();
+    }
+
+    #[test]
+    fn bearer_missing_header_returns_token_missing() {
+        let cfg = WebhookAuthConfig::bearer("expected");
+        let err = validate(&cfg, &make_request(HeaderMap::new(), b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::TokenMissing);
+    }
+
+    #[test]
+    fn bearer_wrong_token_returns_token_invalid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Bearer wrong"),
+        );
+        let cfg = WebhookAuthConfig::bearer("right");
+        let err = validate(&cfg, &make_request(headers, b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::TokenInvalid);
+    }
+
+    #[test]
+    fn bearer_non_bearer_scheme_returns_token_invalid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::AUTHORIZATION,
+            HeaderValue::from_static("Basic dXNlcjpwYXNz"),
+        );
+        let cfg = WebhookAuthConfig::bearer("right");
+        let err = validate(&cfg, &make_request(headers, b"{}".to_vec())).unwrap_err();
+        assert_eq!(err, WebhookAuthError::TokenInvalid);
+    }
+}

--- a/crates/api/src/webhook/dispatcher.rs
+++ b/crates/api/src/webhook/dispatcher.rs
@@ -1,0 +1,555 @@
+//! Slug-routed webhook dispatcher.
+//!
+//! Bridges `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}` to the
+//! engine layer. Each registered trigger lives in an in-memory
+//! [`DashMap`] keyed by [`TriggerCoordinates`]; the dispatcher looks
+//! up the entry, validates per-trigger auth, builds a typed
+//! [`WebhookRequest`], wraps it in a [`TriggerEvent`], and hands it to
+//! the registered [`WebhookTriggerSink`].
+//!
+//! ## Why a separate dispatcher?
+//!
+//! The mature [`crate::services::webhook::WebhookTransport`] is keyed
+//! on `(uuid, nonce)` and built around the typed
+//! [`nebula_action::WebhookAction`] surface. That layout is right for
+//! programmatic activation by `nebula-action` runtime registrations
+//! but not for human-facing slug URLs that map to operator-configured
+//! triggers in the storage layer. Building the slug-routed dispatcher
+//! as a sibling type keeps the typed-action transport contract
+//! untouched.
+//!
+//! ## Invariants
+//!
+//! - Registrations are unique per `(org, ws, slug)`. A second `register` for the same coordinates
+//!   returns [`RegisterError::AlreadyRegistered`] without overwriting.
+//! - `dispatch` returns 202 semantics: the event is enqueued through the sink, and the HTTP layer
+//!   must not synthesise a response from the trigger payload. Engine-side processing is async by
+//!   design.
+//! - Auth is checked **before** the sink is touched, so a 401 path never increments the engine's
+//!   accepted-event count.
+//! - The dispatcher emits a `tracing` span for every dispatch. The span carries the slug tuple, the
+//!   request body size, and the typed error (when one occurs) per the
+//!   `feedback_observability_as_completion.md` DoD.
+
+use std::sync::Arc;
+
+use axum::{
+    body::Bytes,
+    http::{HeaderMap, Method, Uri},
+};
+use dashmap::DashMap;
+use nebula_action::{TriggerEvent, WebhookRequest};
+use thiserror::Error;
+use tracing::{Instrument, debug, debug_span, warn};
+
+use super::{
+    auth::{WebhookAuthConfig, validate as validate_auth},
+    error::{TriggerCoordinates, WebhookDispatchError, WebhookEnqueueError},
+    sink::{NoopSink, WebhookTriggerSink},
+};
+
+/// Single registered webhook trigger.
+///
+/// Holds the per-trigger auth policy and a per-trigger sink. Each
+/// registration can carry its own sink so a multi-tenant deployment
+/// can route different triggers to different engine queues — but a
+/// shared sink is the common case (one engine per dispatcher).
+#[derive(Clone)]
+pub struct TriggerRegistration {
+    /// Per-trigger authentication policy.
+    pub auth: WebhookAuthConfig,
+    /// Engine-facing sink. `None` falls through to the dispatcher's
+    /// default sink, set by [`WebhookDispatcher::with_default_sink`].
+    pub sink: Option<Arc<dyn WebhookTriggerSink>>,
+}
+
+impl TriggerRegistration {
+    /// Build a registration that uses the dispatcher's default sink.
+    #[must_use]
+    pub fn new(auth: WebhookAuthConfig) -> Self {
+        Self { auth, sink: None }
+    }
+
+    /// Build a registration with a per-trigger sink override.
+    #[must_use]
+    pub fn with_sink(auth: WebhookAuthConfig, sink: Arc<dyn WebhookTriggerSink>) -> Self {
+        Self {
+            auth,
+            sink: Some(sink),
+        }
+    }
+}
+
+impl std::fmt::Debug for TriggerRegistration {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TriggerRegistration")
+            .field("auth", &"<elided>")
+            .field("has_per_trigger_sink", &self.sink.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+/// In-memory slug-keyed dispatcher.
+#[derive(Debug)]
+pub struct WebhookDispatcher {
+    registrations: DashMap<TriggerCoordinates, TriggerRegistration>,
+    default_sink: Arc<dyn WebhookTriggerSink>,
+}
+
+/// Errors raised by [`WebhookDispatcher::register`].
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum RegisterError {
+    /// A registration already exists for the same `(org, ws, slug)`
+    /// tuple. The caller should `unregister` first or treat as a bug.
+    #[error("trigger already registered for {0:?}")]
+    AlreadyRegistered(TriggerCoordinates),
+}
+
+impl Default for WebhookDispatcher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WebhookDispatcher {
+    /// Build a new dispatcher with a [`NoopSink`] as the default.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            registrations: DashMap::new(),
+            default_sink: Arc::new(NoopSink::new()),
+        }
+    }
+
+    /// Override the default sink. Triggers registered without a
+    /// per-trigger sink delegate here.
+    #[must_use]
+    pub fn with_default_sink(mut self, sink: Arc<dyn WebhookTriggerSink>) -> Self {
+        self.default_sink = sink;
+        self
+    }
+
+    /// Register a trigger.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`RegisterError::AlreadyRegistered`] if a registration
+    /// already exists for the same coordinates.
+    pub fn register(
+        &self,
+        coordinates: TriggerCoordinates,
+        registration: TriggerRegistration,
+    ) -> Result<(), RegisterError> {
+        match self.registrations.entry(coordinates.clone()) {
+            dashmap::Entry::Occupied(_) => Err(RegisterError::AlreadyRegistered(coordinates)),
+            dashmap::Entry::Vacant(v) => {
+                v.insert(registration);
+                Ok(())
+            },
+        }
+    }
+
+    /// Unregister a trigger. Returns `true` when an entry was removed,
+    /// `false` when no registration existed.
+    pub fn unregister(&self, coordinates: &TriggerCoordinates) -> bool {
+        self.registrations.remove(coordinates).is_some()
+    }
+
+    /// Number of currently-registered triggers. Mostly for tests and
+    /// observability dashboards.
+    #[must_use]
+    pub fn registration_count(&self) -> usize {
+        self.registrations.len()
+    }
+
+    /// Dispatch an inbound webhook request.
+    ///
+    /// Steps, in order:
+    /// 1. Look up registration → [`WebhookDispatchError::NotFound`].
+    /// 2. Build a typed [`WebhookRequest`] (caps enforced).
+    /// 3. Validate per-trigger auth → [`WebhookDispatchError::Auth`].
+    /// 4. Wrap in [`TriggerEvent`] and enqueue through the sink →
+    ///    [`WebhookDispatchError::Enqueue`].
+    ///
+    /// On success the dispatcher returns `Ok(())` and the HTTP layer
+    /// should reply with `202 Accepted`. The sink decides whether the
+    /// event is consumed synchronously or buffered.
+    pub async fn dispatch(
+        &self,
+        coordinates: TriggerCoordinates,
+        method: Method,
+        uri: Uri,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> Result<(), WebhookDispatchError> {
+        let span = debug_span!(
+            "webhook.dispatch",
+            org = %coordinates.org,
+            workspace = %coordinates.workspace,
+            trigger = %coordinates.trigger,
+            body_bytes = body.len(),
+        );
+        async move {
+            let registration = self
+                .registrations
+                .get(&coordinates)
+                .map(|r| r.clone())
+                .ok_or_else(|| WebhookDispatchError::NotFound {
+                    trigger: coordinates.clone(),
+                })?;
+
+            let path = uri.path().to_string();
+            let query = uri.query().map(str::to_string);
+            let request =
+                WebhookRequest::try_new(method, path, query, headers, body).map_err(|err| {
+                    debug!(error = %err, "webhook request construction failed");
+                    // The slug-routed handler maps malformed requests
+                    // to 401 only when auth fails; a construction
+                    // failure (header count, etc.) is treated as a
+                    // missing-signature outcome — fail-closed.
+                    WebhookDispatchError::Auth(super::error::WebhookAuthError::SignatureInvalid)
+                })?;
+
+            validate_auth(&registration.auth, &request)?;
+
+            let event = TriggerEvent::new(None, request);
+            let sink = registration
+                .sink
+                .clone()
+                .unwrap_or_else(|| Arc::clone(&self.default_sink));
+
+            sink.enqueue(&coordinates, event).await.map_err(|err| {
+                warn!(error = %err, "webhook trigger sink rejected event");
+                WebhookDispatchError::Enqueue(map_enqueue_error(err, &coordinates))
+            })?;
+
+            Ok::<(), WebhookDispatchError>(())
+        }
+        .instrument(span)
+        .await
+    }
+}
+
+/// Re-stamp the coordinates on a sink-returned enqueue error so the
+/// HTTP layer can surface the failing trigger even if the sink built
+/// the error with placeholder coordinates (some impls do).
+fn map_enqueue_error(
+    err: WebhookEnqueueError,
+    coordinates: &TriggerCoordinates,
+) -> WebhookEnqueueError {
+    match err {
+        WebhookEnqueueError::SinkUnavailable { .. } => WebhookEnqueueError::SinkUnavailable {
+            trigger: coordinates.clone(),
+        },
+        WebhookEnqueueError::SinkBackpressure { .. } => WebhookEnqueueError::SinkBackpressure {
+            trigger: coordinates.clone(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::http::{HeaderMap, HeaderValue, Method, Uri};
+    use hmac::{Hmac, KeyInit, Mac};
+    use sha2::Sha256;
+
+    use super::*;
+    use crate::webhook::sink::{DispatchedEvent, MpscSink};
+
+    type HmacSha256 = Hmac<Sha256>;
+
+    fn coords() -> TriggerCoordinates {
+        TriggerCoordinates::new("acme", "main", "github")
+    }
+
+    fn other_coords() -> TriggerCoordinates {
+        TriggerCoordinates::new("acme", "main", "stripe")
+    }
+
+    fn sign(secret: &[u8], body: &[u8]) -> String {
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(body);
+        format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+    }
+
+    fn make_uri() -> Uri {
+        "/api/v1/hooks/acme/main/github".parse().unwrap()
+    }
+
+    async fn install(
+        dispatcher: &WebhookDispatcher,
+        coordinates: TriggerCoordinates,
+        registration: TriggerRegistration,
+    ) {
+        dispatcher.register(coordinates, registration).unwrap();
+    }
+
+    #[tokio::test]
+    async fn unregistered_path_returns_not_found() {
+        let dispatcher = WebhookDispatcher::new();
+        let err = dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WebhookDispatchError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_passes_event_to_default_sink() {
+        let sink = Arc::new(MpscSink::new(4));
+        let mut rx = sink.take_receiver().await.unwrap();
+        let dispatcher = WebhookDispatcher::new().with_default_sink(sink);
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::None),
+        )
+        .await;
+
+        dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(br#"{"hello":"world"}"#),
+            )
+            .await
+            .unwrap();
+
+        let dispatched: DispatchedEvent = rx.recv().await.expect("event delivered");
+        assert_eq!(dispatched.coordinates, coords());
+        // Body roundtrips through the WebhookRequest payload.
+        let (_, _, request) = dispatched
+            .event
+            .downcast::<WebhookRequest>()
+            .expect("payload is WebhookRequest");
+        assert_eq!(request.body(), b"{\"hello\":\"world\"}");
+    }
+
+    #[tokio::test]
+    async fn dispatch_routes_per_trigger_sink_independently() {
+        let global_sink = Arc::new(MpscSink::new(4));
+        let mut global_rx = global_sink.take_receiver().await.unwrap();
+        let per_trigger_sink = Arc::new(MpscSink::new(4));
+        let mut per_trigger_rx = per_trigger_sink.take_receiver().await.unwrap();
+
+        let dispatcher = WebhookDispatcher::new().with_default_sink(global_sink);
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::with_sink(WebhookAuthConfig::None, per_trigger_sink),
+        )
+        .await;
+        install(
+            &dispatcher,
+            other_coords(),
+            TriggerRegistration::new(WebhookAuthConfig::None),
+        )
+        .await;
+
+        dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap();
+        dispatcher
+            .dispatch(
+                other_coords(),
+                Method::POST,
+                "/api/v1/hooks/acme/main/stripe".parse().unwrap(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap();
+
+        let per_trigger = per_trigger_rx.recv().await.unwrap();
+        assert_eq!(per_trigger.coordinates, coords());
+
+        let fallback = global_rx.recv().await.unwrap();
+        assert_eq!(fallback.coordinates, other_coords());
+    }
+
+    #[tokio::test]
+    async fn dispatch_fails_when_signature_missing() {
+        let secret: Arc<[u8]> = Arc::<[u8]>::from(b"shh".as_slice());
+        let dispatcher = WebhookDispatcher::new();
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(secret)),
+        )
+        .await;
+
+        let err = dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            WebhookDispatchError::Auth(super::super::error::WebhookAuthError::SignatureMissing)
+        ));
+    }
+
+    #[tokio::test]
+    async fn dispatch_passes_when_signature_valid() {
+        let secret: Arc<[u8]> = Arc::<[u8]>::from(b"shh".as_slice());
+        let body = br#"{"event":"push"}"#.to_vec();
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            crate::webhook::auth::DEFAULT_SIGNATURE_HEADER,
+            HeaderValue::from_str(&sign(&secret, &body)).unwrap(),
+        );
+        let sink = Arc::new(MpscSink::new(1));
+        let mut rx = sink.take_receiver().await.unwrap();
+        let dispatcher = WebhookDispatcher::new().with_default_sink(sink);
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(secret)),
+        )
+        .await;
+
+        dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                headers,
+                Bytes::from(body),
+            )
+            .await
+            .unwrap();
+
+        let _delivered = rx.recv().await.expect("hmac-validated event delivered");
+    }
+
+    #[tokio::test]
+    async fn dispatch_returns_enqueue_error_when_sink_closed() {
+        let sink = Arc::new(MpscSink::new(1));
+        let rx = sink.take_receiver().await.unwrap();
+        drop(rx); // close the channel
+        let dispatcher = WebhookDispatcher::new().with_default_sink(sink);
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::None),
+        )
+        .await;
+
+        let err = dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            WebhookDispatchError::Enqueue(WebhookEnqueueError::SinkUnavailable { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn register_rejects_duplicate() {
+        let dispatcher = WebhookDispatcher::new();
+        dispatcher
+            .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+            .unwrap();
+        let err = dispatcher
+            .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+            .unwrap_err();
+        assert_eq!(err, RegisterError::AlreadyRegistered(coords()));
+    }
+
+    #[tokio::test]
+    async fn unregister_removes_route() {
+        let dispatcher = WebhookDispatcher::new();
+        dispatcher
+            .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+            .unwrap();
+        assert_eq!(dispatcher.registration_count(), 1);
+        assert!(dispatcher.unregister(&coords()));
+        assert_eq!(dispatcher.registration_count(), 0);
+        assert!(!dispatcher.unregister(&coords()));
+    }
+
+    #[tokio::test]
+    async fn dispatch_after_unregister_returns_not_found() {
+        let dispatcher = WebhookDispatcher::new();
+        dispatcher
+            .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+            .unwrap();
+        dispatcher.unregister(&coords());
+        let err = dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::new(),
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WebhookDispatchError::NotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn dispatch_does_not_consume_sink_capacity_on_auth_failure() {
+        let sink: Arc<dyn WebhookTriggerSink> = Arc::new(MpscSink::new(1));
+        // We deliberately leak the receiver into a holder so the
+        // channel stays open for the post-rejection capacity probe.
+        let mpsc_sink = Arc::clone(&sink);
+        // Downcast not available on dyn; rely on the fact that the
+        // channel has 1 slot.
+        let dispatcher = WebhookDispatcher::new().with_default_sink(Arc::clone(&sink));
+        install(
+            &dispatcher,
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(Arc::<[u8]>::from(
+                b"shh".as_slice(),
+            ))),
+        )
+        .await;
+
+        // Bad signature → auth failure → sink must NOT be touched.
+        let _ = dispatcher
+            .dispatch(
+                coords(),
+                Method::POST,
+                make_uri(),
+                HeaderMap::new(),
+                Bytes::from_static(b"{}"),
+            )
+            .await
+            .unwrap_err();
+
+        // Channel capacity is still 1 — push one event ourselves to
+        // prove the auth gate fired before enqueue.
+        mpsc_sink
+            .enqueue(&coords(), TriggerEvent::new(None, 1_u32))
+            .await
+            .expect("capacity preserved by auth-rejection short-circuit");
+    }
+}

--- a/crates/api/src/webhook/error.rs
+++ b/crates/api/src/webhook/error.rs
@@ -1,0 +1,163 @@
+//! Typed errors for slug-routed webhook dispatch.
+//!
+//! The dispatcher splits failure into three disjoint categories so the
+//! HTTP handler can map each to the right status code without inferring
+//! intent from a string:
+//!
+//! - [`WebhookAuthError`] — authentication / signature problems (401).
+//! - [`WebhookEnqueueError`] — sink rejected the event (500/503).
+//! - [`WebhookDispatchError`] — top-level error returned by the dispatcher; composes the two above
+//!   plus a routing-miss variant.
+//!
+//! Per `feedback_observability_as_completion.md`: every variant is a
+//! typed `thiserror` carrying enough context for a recovery decision.
+
+use thiserror::Error;
+
+/// Reasons a webhook request fails per-trigger authentication.
+///
+/// Mirrors [`nebula_action::SignatureOutcome`] semantics for HMAC paths
+/// and adds policy-misconfiguration cases that are specific to the
+/// slug-routed surface (where the auth config is read from a registered
+/// trigger row rather than from a typed `WebhookAction`).
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum WebhookAuthError {
+    /// Required signature header was not present on the request.
+    #[error("webhook signature header missing")]
+    SignatureMissing,
+
+    /// Signature header was present but did not match the computed HMAC
+    /// over the request body.
+    #[error("webhook signature invalid")]
+    SignatureInvalid,
+
+    /// Trigger declared a signed policy but no secret is configured for
+    /// the registration. Treated as operator misconfiguration (5xx) by
+    /// the handler — the caller did nothing wrong.
+    #[error("webhook signature secret not configured for trigger")]
+    SecretNotConfigured,
+
+    /// Trigger requires an authentication token (e.g. shared bearer)
+    /// that was not provided.
+    #[error("webhook authentication token missing")]
+    TokenMissing,
+
+    /// Authentication token was provided but did not match the
+    /// configured value.
+    #[error("webhook authentication token invalid")]
+    TokenInvalid,
+}
+
+/// Reasons the dispatcher could not hand the event to the engine sink.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum WebhookEnqueueError {
+    /// The configured sink rejected the event because its receiver has
+    /// closed or its bounded queue is saturated. Permanent for this
+    /// registration — the engine side has likely shut down.
+    #[error("trigger event sink unavailable for trigger {trigger:?}")]
+    SinkUnavailable {
+        /// Slug-tuple identifying the failed trigger, for diagnostics.
+        trigger: TriggerCoordinates,
+    },
+
+    /// The sink is reachable but is back-pressuring on a transient
+    /// timeout / capacity bound. Caller should treat as 503.
+    #[error("trigger event sink temporarily unavailable for trigger {trigger:?}")]
+    SinkBackpressure {
+        /// Slug-tuple identifying the failed trigger.
+        trigger: TriggerCoordinates,
+    },
+}
+
+/// Top-level error returned by [`crate::webhook::WebhookDispatcher::dispatch`].
+///
+/// Wraps the auth / enqueue variants and adds a routing-miss case for
+/// requests that landed on the slug surface but no active registration
+/// exists. The HTTP handler maps each variant to its status code.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum WebhookDispatchError {
+    /// No active webhook trigger is registered for the given slug
+    /// tuple.
+    #[error("no webhook registered for trigger {trigger:?}")]
+    NotFound {
+        /// Slug-tuple from the request path.
+        trigger: TriggerCoordinates,
+    },
+
+    /// Per-trigger authentication failed.
+    #[error(transparent)]
+    Auth(#[from] WebhookAuthError),
+
+    /// Engine sink failed.
+    #[error(transparent)]
+    Enqueue(#[from] WebhookEnqueueError),
+}
+
+/// Slug tuple identifying a webhook trigger for the slug-routed
+/// dispatcher. Carried in errors so logs and problem-details can
+/// surface the failing path without parsing the URL again.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TriggerCoordinates {
+    /// Org slug from the URL path.
+    pub org: String,
+    /// Workspace slug from the URL path.
+    pub workspace: String,
+    /// Trigger slug from the URL path.
+    pub trigger: String,
+}
+
+impl TriggerCoordinates {
+    /// Build a coordinate triple from owned strings.
+    #[must_use]
+    pub fn new(
+        org: impl Into<String>,
+        workspace: impl Into<String>,
+        trigger: impl Into<String>,
+    ) -> Self {
+        Self {
+            org: org.into(),
+            workspace: workspace.into(),
+            trigger: trigger.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_errors_are_distinguishable_via_pattern_match() {
+        let missing = WebhookAuthError::SignatureMissing;
+        let invalid = WebhookAuthError::SignatureInvalid;
+        assert_ne!(missing, invalid);
+        assert!(matches!(missing, WebhookAuthError::SignatureMissing));
+        assert!(matches!(invalid, WebhookAuthError::SignatureInvalid));
+    }
+
+    #[test]
+    fn dispatch_error_composes_auth_via_from() {
+        let err: WebhookDispatchError = WebhookAuthError::SignatureInvalid.into();
+        assert!(matches!(
+            err,
+            WebhookDispatchError::Auth(WebhookAuthError::SignatureInvalid)
+        ));
+    }
+
+    #[test]
+    fn dispatch_error_composes_enqueue_via_from() {
+        let err: WebhookDispatchError = WebhookEnqueueError::SinkUnavailable {
+            trigger: TriggerCoordinates::new("acme", "main", "github"),
+        }
+        .into();
+        assert!(matches!(err, WebhookDispatchError::Enqueue(_)));
+    }
+
+    #[test]
+    fn coordinates_round_trip_through_into_from_str_and_owned() {
+        let owned = TriggerCoordinates::new("acme", "main", "gh");
+        let from_str =
+            TriggerCoordinates::new("acme".to_string(), "main".to_string(), "gh".to_string());
+        assert_eq!(owned, from_str);
+    }
+}

--- a/crates/api/src/webhook/mod.rs
+++ b/crates/api/src/webhook/mod.rs
@@ -1,0 +1,37 @@
+//! Slug-routed webhook dispatch (M3.3).
+//!
+//! Bridges the human-facing
+//! `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}` route to the engine
+//! layer. See `crates/api/src/handlers/webhook.rs` for the HTTP
+//! handler and `crates/api/src/routes/webhook.rs` for route wiring.
+//!
+//! # Module layout
+//!
+//! - [`error`] — typed `WebhookAuthError`, `WebhookEnqueueError`, `WebhookDispatchError`, plus
+//!   `TriggerCoordinates` (the slug tuple).
+//! - [`auth`] — `WebhookAuthConfig` enum and signature/bearer validation, sharing the HMAC
+//!   primitive with [`crate::services::webhook`].
+//! - [`sink`] — `WebhookTriggerSink` trait + `NoopSink` / `MpscSink` implementations.
+//! - [`dispatcher`] — the in-memory `WebhookDispatcher` keyed by `TriggerCoordinates`. Looks up
+//!   registrations, validates auth, and hands typed events to the configured sink.
+//!
+//! # Why a sibling to `services::webhook`?
+//!
+//! The mature `services::webhook::WebhookTransport` is keyed on
+//! `(uuid, nonce)` and built around the typed
+//! `nebula_action::WebhookAction` surface. That layout is right for
+//! programmatic activation by the `nebula-action` runtime but not for
+//! human-facing slug URLs that map to operator-configured triggers in
+//! the storage layer. Building the slug-routed dispatcher as a
+//! sibling type keeps the typed-action transport contract untouched
+//! while sharing the same HMAC primitive.
+
+pub mod auth;
+pub mod dispatcher;
+pub mod error;
+pub mod sink;
+
+pub use auth::{DEFAULT_SIGNATURE_HEADER, WebhookAuthConfig};
+pub use dispatcher::{RegisterError, TriggerRegistration, WebhookDispatcher};
+pub use error::{TriggerCoordinates, WebhookAuthError, WebhookDispatchError, WebhookEnqueueError};
+pub use sink::{DispatchedEvent, MpscSink, NoopSink, WebhookTriggerSink};

--- a/crates/api/src/webhook/sink.rs
+++ b/crates/api/src/webhook/sink.rs
@@ -1,0 +1,232 @@
+//! Engine-facing sink for slug-routed webhook events.
+//!
+//! The dispatcher does not own the engine. Instead it pushes each
+//! validated [`TriggerEvent`] through a [`WebhookTriggerSink`] —
+//! whoever wires the dispatcher into the running runtime decides what
+//! "the engine" actually means.
+//!
+//! Two impls ship here:
+//!
+//! - [`MpscSink`] — backed by a `tokio::sync::mpsc` channel. Used by integration tests so they can
+//!   `recv()` the dispatched event and assert "engine received the trigger event" without booting a
+//!   real runtime.
+//! - [`NoopSink`] — accepts and drops every event. Default for the in-memory dispatcher when no
+//!   sink has been wired.
+//!
+//! Production wiring (out of scope for M3.3) will provide an
+//! engine-backed sink that hands the event to a `TriggerHandler` or
+//! enqueues a `trigger_events` row for the storage-layer dispatcher.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use nebula_action::TriggerEvent;
+use tokio::sync::{Mutex, mpsc};
+
+use super::error::{TriggerCoordinates, WebhookEnqueueError};
+
+/// Boundary the dispatcher uses to hand events to the engine layer.
+///
+/// Implementations must not hold a transient lock across `await` for
+/// longer than necessary — the dispatcher calls `enqueue` on the HTTP
+/// request path and a slow sink delays the 202 response.
+#[async_trait]
+pub trait WebhookTriggerSink: Send + Sync + std::fmt::Debug {
+    /// Push an event into the engine-side queue.
+    ///
+    /// `coordinates` accompany the event for diagnostics; the engine
+    /// already has them via the registration but threading them in
+    /// keeps log spans complete when the sink itself emits.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebhookEnqueueError`] when the sink rejects the event
+    /// (closed receiver, saturated bounded queue). The dispatcher maps
+    /// these to 5xx responses; the caller is not expected to retry.
+    async fn enqueue(
+        &self,
+        coordinates: &TriggerCoordinates,
+        event: TriggerEvent,
+    ) -> Result<(), WebhookEnqueueError>;
+}
+
+/// Sink that drops every event after recording its arrival count.
+///
+/// Default for the in-memory dispatcher when no engine wiring has been
+/// installed yet. The dispatch path still validates auth and increments
+/// the counter, so observability dashboards can detect "registered but
+/// unwired" triggers without inspecting code.
+#[derive(Debug, Default)]
+pub struct NoopSink {
+    accepted: Arc<std::sync::atomic::AtomicU64>,
+}
+
+impl NoopSink {
+    /// Build a fresh sink with a zeroed counter.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Number of events the sink has accepted since construction.
+    /// Useful in tests and for observability checks.
+    #[must_use]
+    pub fn accepted(&self) -> u64 {
+        self.accepted.load(std::sync::atomic::Ordering::Acquire)
+    }
+}
+
+#[async_trait]
+impl WebhookTriggerSink for NoopSink {
+    async fn enqueue(
+        &self,
+        _coordinates: &TriggerCoordinates,
+        _event: TriggerEvent,
+    ) -> Result<(), WebhookEnqueueError> {
+        self.accepted
+            .fetch_add(1, std::sync::atomic::Ordering::AcqRel);
+        Ok(())
+    }
+}
+
+/// Mpsc-backed sink used by integration tests.
+///
+/// The producer half is the [`WebhookTriggerSink`]; the consumer half
+/// is exposed via [`MpscSink::take_receiver`] (single-consumer
+/// semantics) so the test can `recv()` to assert delivery.
+#[derive(Debug)]
+pub struct MpscSink {
+    sender: mpsc::Sender<DispatchedEvent>,
+    receiver: Mutex<Option<mpsc::Receiver<DispatchedEvent>>>,
+}
+
+/// Pair of `(coordinates, event)` delivered through [`MpscSink`].
+#[derive(Debug)]
+pub struct DispatchedEvent {
+    /// Slug tuple associated with the trigger that fired.
+    pub coordinates: TriggerCoordinates,
+    /// Event handed to the sink by the dispatcher.
+    pub event: TriggerEvent,
+}
+
+impl MpscSink {
+    /// Build a sink with the given channel capacity. `capacity` of `0`
+    /// is rejected by the underlying `mpsc::channel`, so callers should
+    /// pass at least `1`.
+    #[must_use]
+    pub fn new(capacity: usize) -> Self {
+        let (tx, rx) = mpsc::channel(capacity.max(1));
+        Self {
+            sender: tx,
+            receiver: Mutex::new(Some(rx)),
+        }
+    }
+
+    /// Take the receiver out of the sink. Returns `None` on subsequent
+    /// calls — the receiver is single-consumer by construction.
+    pub async fn take_receiver(&self) -> Option<mpsc::Receiver<DispatchedEvent>> {
+        self.receiver.lock().await.take()
+    }
+}
+
+#[async_trait]
+impl WebhookTriggerSink for MpscSink {
+    async fn enqueue(
+        &self,
+        coordinates: &TriggerCoordinates,
+        event: TriggerEvent,
+    ) -> Result<(), WebhookEnqueueError> {
+        let dispatched = DispatchedEvent {
+            coordinates: coordinates.clone(),
+            event,
+        };
+        // `try_send` distinguishes "closed" (permanent) from "full"
+        // (transient back-pressure) so the dispatcher can pick the
+        // right HTTP status. Using `send().await` would collapse both
+        // into a single `SendError`, hiding the difference.
+        match self.sender.try_send(dispatched) {
+            Ok(()) => Ok(()),
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                Err(WebhookEnqueueError::SinkUnavailable {
+                    trigger: coordinates.clone(),
+                })
+            },
+            Err(mpsc::error::TrySendError::Full(_)) => Err(WebhookEnqueueError::SinkBackpressure {
+                trigger: coordinates.clone(),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_action::TriggerEvent;
+
+    use super::*;
+
+    fn coords() -> TriggerCoordinates {
+        TriggerCoordinates::new("acme", "main", "github")
+    }
+
+    #[tokio::test]
+    async fn noop_sink_accepts_and_counts() {
+        let sink = NoopSink::new();
+        sink.enqueue(&coords(), TriggerEvent::new(None, 7_u32))
+            .await
+            .unwrap();
+        sink.enqueue(&coords(), TriggerEvent::new(None, 8_u32))
+            .await
+            .unwrap();
+        assert_eq!(sink.accepted(), 2);
+    }
+
+    #[tokio::test]
+    async fn mpsc_sink_delivers_event_to_receiver() {
+        let sink = MpscSink::new(2);
+        let mut rx = sink.take_receiver().await.expect("first take returns rx");
+
+        sink.enqueue(
+            &coords(),
+            TriggerEvent::new(Some("delivery-1".into()), 42_u32),
+        )
+        .await
+        .unwrap();
+
+        let dispatched = rx.recv().await.expect("event delivered");
+        assert_eq!(dispatched.coordinates, coords());
+        assert_eq!(dispatched.event.id(), Some("delivery-1"));
+    }
+
+    #[tokio::test]
+    async fn mpsc_sink_take_receiver_is_single_consumer() {
+        let sink = MpscSink::new(1);
+        assert!(sink.take_receiver().await.is_some());
+        assert!(sink.take_receiver().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn mpsc_sink_reports_backpressure_when_full() {
+        let sink = MpscSink::new(1);
+        // Don't take the receiver — leave the channel buffered.
+        sink.enqueue(&coords(), TriggerEvent::new(None, 1_u32))
+            .await
+            .unwrap();
+        let err = sink
+            .enqueue(&coords(), TriggerEvent::new(None, 2_u32))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WebhookEnqueueError::SinkBackpressure { .. }));
+    }
+
+    #[tokio::test]
+    async fn mpsc_sink_reports_unavailable_when_receiver_dropped() {
+        let sink = MpscSink::new(1);
+        let rx = sink.take_receiver().await.unwrap();
+        drop(rx);
+        let err = sink
+            .enqueue(&coords(), TriggerEvent::new(None, 1_u32))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WebhookEnqueueError::SinkUnavailable { .. }));
+    }
+}

--- a/crates/api/src/webhook/sink.rs
+++ b/crates/api/src/webhook/sink.rs
@@ -110,9 +110,10 @@ pub struct DispatchedEvent {
 }
 
 impl MpscSink {
-    /// Build a sink with the given channel capacity. `capacity` of `0`
-    /// is rejected by the underlying `mpsc::channel`, so callers should
-    /// pass at least `1`.
+    /// Build a sink with the given channel capacity.
+    ///
+    /// `tokio::sync::mpsc::channel` rejects a capacity of `0`; values below
+    /// `1` are therefore clamped to `1`.
     #[must_use]
     pub fn new(capacity: usize) -> Self {
         let (tx, rx) = mpsc::channel(capacity.max(1));

--- a/crates/api/tests/idempotency_middleware.rs
+++ b/crates/api/tests/idempotency_middleware.rs
@@ -1,0 +1,384 @@
+//! Integration tests for the Idempotency-Key middleware (M3.4).
+//!
+//! These tests exercise the middleware against a minimal in-test
+//! `Router` so the assertions stay focused on idempotency semantics
+//! without dragging in auth, CSRF, or tenant-scope concerns from the
+//! production stack.
+
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+    response::IntoResponse,
+    routing::{get, post},
+};
+use nebula_api::middleware::idempotency::{
+    IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER, IdempotencyLayer, InMemoryIdempotencyStore,
+};
+use tower::ServiceExt;
+
+/// Build a tiny test app whose POST handler echoes its payload, suffixed with
+/// a monotonically increasing call counter. The counter exposes whether the
+/// inner handler ran (idempotency miss) or was bypassed (idempotency hit).
+fn build_app(counter: Arc<AtomicUsize>, store: Arc<InMemoryIdempotencyStore>) -> Router {
+    let counter_for_post = counter.clone();
+    let counter_for_failing = counter.clone();
+    let counter_for_get = counter;
+
+    Router::new()
+        .route(
+            "/echo",
+            post(move |body: axum::body::Bytes| {
+                let counter = counter_for_post.clone();
+                async move {
+                    let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                    let payload = String::from_utf8_lossy(&body);
+                    (StatusCode::OK, format!("echo-{n}-{payload}")).into_response()
+                }
+            }),
+        )
+        .route(
+            "/fail",
+            post(move || {
+                let counter = counter_for_failing.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+                }
+            }),
+        )
+        .route(
+            "/peek",
+            get(move || {
+                let counter = counter_for_get.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    (StatusCode::OK, "peek").into_response()
+                }
+            }),
+        )
+        .layer(IdempotencyLayer::new(store))
+}
+
+fn post_with_key(uri: &str, key: &str, body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "text/plain")
+        .header(IDEMPOTENCY_KEY_HEADER, key)
+        .body(Body::from(body))
+        .unwrap()
+}
+
+fn post_without_key(uri: &str, body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "text/plain")
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn replayed_key_returns_cached_body_and_skips_handler() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-1", "hello"))
+        .await
+        .expect("first request");
+    assert_eq!(r1.status(), StatusCode::OK);
+    let replay_marker_r1 = r1.headers().get(IDEMPOTENT_REPLAY_HEADER).cloned();
+    let body1 = body_string(r1).await;
+    assert_eq!(body1, "echo-1-hello");
+    assert!(
+        replay_marker_r1.is_none(),
+        "first call must not be marked as a replay"
+    );
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-1", "hello"))
+        .await
+        .expect("second request");
+    assert_eq!(r2.status(), StatusCode::OK);
+    let replay_marker_r2 = r2.headers().get(IDEMPOTENT_REPLAY_HEADER).cloned();
+    let body2 = body_string(r2).await;
+    assert_eq!(
+        body2, "echo-1-hello",
+        "replayed body must match the cached first response (counter frozen at 1)"
+    );
+    assert_eq!(
+        replay_marker_r2.as_ref().and_then(|v| v.to_str().ok()),
+        Some("true"),
+        "cache hit must set the {IDEMPOTENT_REPLAY_HEADER} header"
+    );
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "inner handler must run exactly once across two key replays"
+    );
+}
+
+#[tokio::test]
+async fn distinct_keys_run_handler_each_time() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-A", "x"))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    assert_eq!(body_string(r1).await, "echo-1-x");
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-B", "x"))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(
+        body_string(r2).await,
+        "echo-2-x",
+        "different key must produce a fresh response"
+    );
+
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn missing_idempotency_header_passes_through() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_without_key("/echo", "n"))
+        .await
+        .unwrap();
+    let r2 = app
+        .clone()
+        .oneshot(post_without_key("/echo", "n"))
+        .await
+        .unwrap();
+
+    assert_eq!(r1.status(), StatusCode::OK);
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(body_string(r1).await, "echo-1-n");
+    assert_eq!(
+        body_string(r2).await,
+        "echo-2-n",
+        "without the header, every POST must invoke the handler",
+    );
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn non_post_methods_pass_through() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    for _ in 0..2 {
+        let req = Request::builder()
+            .method("GET")
+            .uri("/peek")
+            .header(IDEMPOTENCY_KEY_HEADER, "ignored-key")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let _ = body_string(resp).await;
+    }
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "GET must not engage the idempotency cache",
+    );
+}
+
+#[tokio::test]
+async fn same_key_with_different_body_returns_422() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-collide", "alpha"))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let _ = body_string(r1).await;
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "key-collide", "beta"))
+        .await
+        .unwrap();
+    assert_eq!(
+        r2.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "reusing an Idempotency-Key with a different body must yield 422"
+    );
+    let body = body_string(r2).await;
+    assert!(
+        body.contains("different request payload"),
+        "422 body should explain the conflict, got: {body}"
+    );
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "handler must run only for the first request — the conflicting replay is rejected pre-dispatch",
+    );
+}
+
+#[tokio::test]
+async fn malformed_idempotency_key_returns_400() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    // A tab character is outside the printable-ASCII range allowed by
+    // `IdempotencyKey::parse`. The middleware MUST reject it before the
+    // handler runs.
+    let req = Request::builder()
+        .method("POST")
+        .uri("/echo")
+        .header("content-type", "text/plain")
+        .header(IDEMPOTENCY_KEY_HEADER, "bad\tkey")
+        .body(Body::from("payload"))
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        0,
+        "handler must not run when the key fails validation",
+    );
+}
+
+#[tokio::test]
+async fn fivexx_responses_are_not_cached() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/fail", "transient", ""))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/fail", "transient", ""))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        2,
+        "5xx responses must remain uncached so a transient backend failure can be retried"
+    );
+}
+
+#[tokio::test]
+async fn cache_entry_expires_after_ttl() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::with_ttl_and_capacity(
+        Duration::from_millis(80),
+        64,
+    ));
+    let app = build_app(counter.clone(), store);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "ttl-key", "p"))
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::OK);
+    let _ = body_string(r1).await;
+
+    // Wait past the TTL — moka may need a tick to evict, but a sleep > TTL
+    // followed by a get triggers eviction without explicit run_pending_tasks
+    // here because the API surface used in production does not expose it.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "ttl-key", "p"))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::OK);
+    assert_eq!(
+        body_string(r2).await,
+        "echo-2-p",
+        "after TTL expiry, the same key must produce a fresh response (counter advances)"
+    );
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+#[tokio::test]
+async fn distinct_identities_do_not_share_cache_entries() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let app = build_app(counter.clone(), store);
+
+    let req_a = Request::builder()
+        .method("POST")
+        .uri("/echo")
+        .header("content-type", "text/plain")
+        .header("authorization", "Bearer caller-A")
+        .header(IDEMPOTENCY_KEY_HEADER, "shared")
+        .body(Body::from("payload"))
+        .unwrap();
+    let req_b = Request::builder()
+        .method("POST")
+        .uri("/echo")
+        .header("content-type", "text/plain")
+        .header("authorization", "Bearer caller-B")
+        .header(IDEMPOTENCY_KEY_HEADER, "shared")
+        .body(Body::from("payload"))
+        .unwrap();
+
+    let r_a = app.clone().oneshot(req_a).await.unwrap();
+    let r_b = app.clone().oneshot(req_b).await.unwrap();
+
+    assert_eq!(r_a.status(), StatusCode::OK);
+    assert_eq!(r_b.status(), StatusCode::OK);
+    assert_eq!(body_string(r_a).await, "echo-1-payload");
+    assert_eq!(
+        body_string(r_b).await,
+        "echo-2-payload",
+        "two callers using the same Idempotency-Key must NOT share cache entries — \
+         identity-fingerprint must scope the cache per principal",
+    );
+    assert_eq!(counter.load(Ordering::SeqCst), 2);
+}

--- a/crates/api/tests/webhook_dispatch_integration.rs
+++ b/crates/api/tests/webhook_dispatch_integration.rs
@@ -1,0 +1,437 @@
+//! Integration tests for the slug-routed webhook dispatch path
+//! (M3.3, `POST /api/v1/hooks/{org}/{ws}/{trigger_slug}`).
+//!
+//! Wires the real axum router (`routes::webhook::router_with_dispatcher`)
+//! with a test [`MpscSink`] and asserts each acceptance criterion from
+//! the M3.3 task brief:
+//!
+//! 1. Validate per-trigger auth → enqueue → return 202 Accepted.
+//! 2. Engine receives the trigger event (via the mpsc sink).
+//! 3. Typed errors (`WebhookAuthError`, `WebhookEnqueueError`) map to correct HTTP status codes.
+//!
+//! Tests build a small router with a minimal [`AppState`] (in-memory
+//! repos + test JWT secret). The handler still reads
+//! `Extension<Arc<WebhookDispatcher>>` for dispatch; `AppState` is
+//! required by the extractor but unused on this path.
+
+use std::{sync::Arc, time::Duration};
+
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode},
+};
+use hmac::{Hmac, KeyInit, Mac};
+use nebula_action::WebhookRequest;
+use nebula_api::{
+    config::ApiConfig,
+    routes::webhook::router_with_dispatcher,
+    state::AppState,
+    webhook::{
+        DEFAULT_SIGNATURE_HEADER, MpscSink, TriggerCoordinates, TriggerRegistration,
+        WebhookAuthConfig, WebhookDispatcher, WebhookTriggerSink,
+    },
+};
+use nebula_storage::{
+    InMemoryExecutionRepo, InMemoryWorkflowRepo, repos::InMemoryControlQueueRepo,
+};
+use sha2::Sha256;
+use tower::ServiceExt;
+
+type HmacSha256 = Hmac<Sha256>;
+
+const TEST_PATH: &str = "/api/v1/hooks/acme/main/github";
+
+fn coords() -> TriggerCoordinates {
+    TriggerCoordinates::new("acme", "main", "github")
+}
+
+fn test_app_state() -> AppState {
+    let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
+    let execution_repo = Arc::new(InMemoryExecutionRepo::new());
+    let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());
+    let config = ApiConfig::for_test();
+    AppState::new(
+        workflow_repo,
+        execution_repo,
+        control_queue_repo,
+        config.jwt_secret,
+    )
+}
+
+/// Same nesting + state shape as [`nebula_api::routes::create_routes`]: webhook
+/// routes live under `/api/v1`, and `with_state` on the outer router satisfies
+/// axum's `Service` bounds for `tower::ServiceExt::oneshot`.
+fn build_router(dispatcher: Arc<WebhookDispatcher>) -> Router {
+    let state = test_app_state();
+    Router::new()
+        .nest("/api/v1", router_with_dispatcher(dispatcher))
+        .with_state(state)
+}
+
+fn sign(secret: &[u8], body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+#[tokio::test]
+async fn unsigned_public_webhook_returns_202_and_engine_receives_event() {
+    let sink = Arc::new(MpscSink::new(2));
+    let mut rx = sink.take_receiver().await.expect("rx available");
+
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+        .expect("first registration");
+
+    let router = build_router(Arc::clone(&dispatcher));
+
+    let body = br#"{"event":"push","ref":"main"}"#.to_vec();
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .header("content-type", "application/json")
+        .body(Body::from(body.clone()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::ACCEPTED,
+        "successful dispatch must return 202 Accepted",
+    );
+
+    // The engine sink must receive the trigger event within a
+    // reasonable time.
+    let dispatched = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("sink delivery timed out")
+        .expect("sink dropped event");
+    assert_eq!(dispatched.coordinates, coords());
+
+    let (_id, _received_at, request) = dispatched
+        .event
+        .downcast::<WebhookRequest>()
+        .expect("payload is WebhookRequest");
+    assert_eq!(
+        request.body(),
+        body.as_slice(),
+        "engine receives the original request body",
+    );
+}
+
+#[tokio::test]
+async fn signed_webhook_passes_auth_and_engine_sees_payload() {
+    let secret: Arc<[u8]> = Arc::<[u8]>::from(b"top-secret".as_slice());
+    let body = br#"{"hello":"hmac"}"#.to_vec();
+    let signature = sign(&secret, &body);
+
+    let sink = Arc::new(MpscSink::new(2));
+    let mut rx = sink.take_receiver().await.unwrap();
+
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(secret)),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .header("content-type", "application/json")
+        .header(DEFAULT_SIGNATURE_HEADER, signature)
+        .body(Body::from(body.clone()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+    let dispatched = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("dispatch timed out")
+        .unwrap();
+    let (_id, _at, request) = dispatched
+        .event
+        .downcast::<WebhookRequest>()
+        .expect("WebhookRequest payload");
+    assert_eq!(request.body(), body.as_slice());
+}
+
+#[tokio::test]
+async fn unsigned_request_to_signed_trigger_returns_401() {
+    let secret: Arc<[u8]> = Arc::<[u8]>::from(b"top-secret".as_slice());
+    let sink = Arc::new(MpscSink::new(1));
+    let mut rx = sink.take_receiver().await.unwrap();
+
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(secret)),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::UNAUTHORIZED,
+        "missing signature → 401, not 202",
+    );
+
+    // Critical invariant: auth failure must not leak through to the
+    // engine. The mpsc must still be empty.
+    assert!(
+        rx.try_recv().is_err(),
+        "auth-rejected request must not reach the engine sink",
+    );
+}
+
+#[tokio::test]
+async fn unregistered_trigger_returns_404() {
+    let dispatcher = Arc::new(WebhookDispatcher::new());
+    let router = build_router(Arc::clone(&dispatcher));
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/hooks/acme/main/unknown")
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn bearer_token_valid_returns_202() {
+    let sink = Arc::new(MpscSink::new(1));
+    let mut rx = sink.take_receiver().await.unwrap();
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::bearer("my-shared-secret")),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .header("authorization", "Bearer my-shared-secret")
+        .body(Body::from(b"{\"ok\":true}".to_vec()))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let _delivered = tokio::time::timeout(Duration::from_secs(2), rx.recv())
+        .await
+        .expect("delivery within 2s")
+        .unwrap();
+}
+
+#[tokio::test]
+async fn bearer_token_wrong_returns_401() {
+    let dispatcher = Arc::new(WebhookDispatcher::new());
+    dispatcher
+        .register(
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::bearer("the-real-token")),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .header("authorization", "Bearer not-the-real-token")
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn empty_secret_on_signed_trigger_returns_500() {
+    // Operator misconfiguration: declared HMAC but secret is empty.
+    let dispatcher = Arc::new(WebhookDispatcher::new());
+    dispatcher
+        .register(
+            coords(),
+            TriggerRegistration::new(WebhookAuthConfig::hmac_sha256(Arc::<[u8]>::from(
+                Vec::<u8>::new(),
+            ))),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "missing secret is operator-side fail-closed (500)",
+    );
+}
+
+#[tokio::test]
+async fn closed_sink_returns_500() {
+    let sink = Arc::new(MpscSink::new(1));
+    // Take rx and immediately drop it to simulate engine shutdown.
+    drop(sink.take_receiver().await.unwrap());
+
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+    let request = Request::builder()
+        .method("POST")
+        .uri(TEST_PATH)
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = router.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+#[tokio::test]
+async fn full_sink_returns_503() {
+    let sink = Arc::new(MpscSink::new(1));
+    // Don't take the receiver — buffer fills up to capacity 1.
+    let dispatcher = Arc::new(
+        WebhookDispatcher::new()
+            .with_default_sink(Arc::clone(&sink) as Arc<dyn WebhookTriggerSink>),
+    );
+    dispatcher
+        .register(coords(), TriggerRegistration::new(WebhookAuthConfig::None))
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+
+    // First request fills the channel.
+    let r1 = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(TEST_PATH)
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r1.status(), StatusCode::ACCEPTED);
+
+    // Second hits backpressure → 503.
+    let r2 = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(TEST_PATH)
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::SERVICE_UNAVAILABLE);
+}
+
+#[tokio::test]
+async fn multiple_triggers_route_to_their_own_sinks() {
+    let sink_gh = Arc::new(MpscSink::new(2));
+    let mut rx_gh = sink_gh.take_receiver().await.unwrap();
+    let sink_stripe = Arc::new(MpscSink::new(2));
+    let mut rx_stripe = sink_stripe.take_receiver().await.unwrap();
+
+    let dispatcher = Arc::new(WebhookDispatcher::new());
+    dispatcher
+        .register(
+            TriggerCoordinates::new("acme", "main", "github"),
+            TriggerRegistration::with_sink(
+                WebhookAuthConfig::None,
+                Arc::clone(&sink_gh) as Arc<dyn WebhookTriggerSink>,
+            ),
+        )
+        .unwrap();
+    dispatcher
+        .register(
+            TriggerCoordinates::new("acme", "main", "stripe"),
+            TriggerRegistration::with_sink(
+                WebhookAuthConfig::None,
+                Arc::clone(&sink_stripe) as Arc<dyn WebhookTriggerSink>,
+            ),
+        )
+        .unwrap();
+
+    let router = build_router(Arc::clone(&dispatcher));
+
+    let r_gh = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/hooks/acme/main/github")
+                .body(Body::from(br#"{"trigger":"gh"}"#.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r_gh.status(), StatusCode::ACCEPTED);
+
+    let r_stripe = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/hooks/acme/main/stripe")
+                .body(Body::from(br#"{"trigger":"stripe"}"#.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(r_stripe.status(), StatusCode::ACCEPTED);
+
+    let gh_event = tokio::time::timeout(Duration::from_secs(2), rx_gh.recv())
+        .await
+        .expect("gh delivery")
+        .unwrap();
+    assert_eq!(gh_event.coordinates.trigger, "github");
+
+    let stripe_event = tokio::time::timeout(Duration::from_secs(2), rx_stripe.recv())
+        .await
+        .expect("stripe delivery")
+        .unwrap();
+    assert_eq!(stripe_event.coordinates.trigger, "stripe");
+}

--- a/crates/storage/README.md
+++ b/crates/storage/README.md
@@ -145,8 +145,14 @@ See `docs/MATURITY.md` row for `nebula-storage`.
 - API stability: `partial` — Layer 1 (`ExecutionRepo`, `WorkflowRepo`) is `stable` and the
   production contract; Layer 2 (`repos::*` except `ControlQueueRepo`) is `planned` and not
   yet implementable without a broader engine + API refactor.
-- `execution_leases` schema may exist before full engine enforcement (§11.5 debt) — do not
-  imply lease safety until enforcement is wired.
+- `execution_leases` (Layer 1: `lease_holder` / `lease_expires_at`) is **enforced** as of
+  M2.2 — heartbeat + multi-runner takeover verified by
+  `crates/engine/tests/lease_takeover.rs`,
+  `crates/storage/tests/execution_lease_pg_integration.rs`, and the loom probe at
+  `crates/storage-loom-probe/src/lease_handoff.rs`.
+- `executions.claimed_by` / `claimed_until` (Layer 2, Sprint E scaffolding) — schema may
+  precede enforcement; do not imply lease safety. Deferred to 1.1 per ROADMAP "Out of scope
+  for 1.0".
 - S3 and Redis features are optional and experimental; local filesystem backend is `planned`.
 - `repos::InMemoryControlQueueRepo` is the only implemented Layer-2 type that should be
   depended on today.
@@ -191,7 +197,8 @@ contract consumers should depend on today.
 | `execution_journal` (append-only) | **Durable** | Replayable history |
 | `execution_control_queue` (outbox) | **Durable** | At-least-once cancel/dispatch (§12.2) |
 | `stateful_checkpoints` | **Best-effort** | Write failure logs, does not abort; may replay |
-| `execution_leases` | **Schema may precede enforcement** | Do not imply lease safety |
+| `executions.lease_holder` / `lease_expires_at` (Layer 1) | **Durable + enforced** (M2.2, ADR-0008/0015) | Heartbeat-driven; multi-runner takeover via TTL expiry. Verified by `crates/engine/tests/lease_takeover.rs` + `crates/storage/tests/execution_lease_pg_integration.rs` + loom probe at `crates/storage-loom-probe/src/lease_handoff.rs` |
+| `executions.claimed_by` / `claimed_until` (Layer 2, Sprint E) | **Schema may precede enforcement** | Spec-16 scaffolding, deferred to 1.1 — no engine consumers today |
 | In-process `mpsc` / channels | **Ephemeral** | Never authoritative |
 
 ### Supported backends


### PR DESCRIPTION
## Summary

Adds **Plane-A authentication** (`AuthBackend`, in-memory Argon2/TOTP/PAT/OAuth/session implementation), **slug-routed webhook dispatch** (`WebhookDispatcher`, per-trigger HMAC/bearer/none auth, engine sink), **idempotency-key middleware** (M3.4) with integration tests, and wires auth/state/middleware/routes for the API. Workspace `Cargo.toml` / `Cargo.lock` pick up new API dependencies (e.g. `rand`, crypto, webhook-related crates). **`nebula-storage` README** updated where touched.

Separately, **`.taplo.toml` excludes `.codex/**`** so local `taplo fmt --check` (and lefthook) do not fail on third-party TOML inside the Codex plugin cache.

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [x] `feat` — new capability
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [x] `test` — tests only
- [x] `chore` — tooling, maintenance, dependencies
- [x] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `nebula-api` (auth, webhook, idempotency, handlers, middleware, routes, state)
- `nebula-storage` (`README.md`)
- Workspace root `Cargo.toml`, `Cargo.lock`
- `.taplo.toml`

## Changes

- New `crates/api/src/auth/*` — `AuthBackend` trait, DTOs, errors, in-memory backend, password/MFA/PAT/session/OAuth helpers; `rand 0.10` uses `Rng` for `fill_bytes`.
- New `crates/api/src/webhook/*` — dispatcher, auth policies, sink trait, errors; routes under `/api/v1/hooks/...`.
- New `crates/api/src/middleware/idempotency.rs` + `tests/idempotency_middleware.rs`.
- `tests/webhook_dispatch_integration.rs` — nests `router_with_dispatcher` + `with_state` to match production axum wiring.
- `chore(ci): exclude .codex from taplo` — `.taplo.toml` exclude entry.

## Test plan

- `cargo test -p nebula-api` (unit + integration + doctests for api) — pass.
- Pre-push `crate-diff-gate` (nextest for changed crates: `api`, `storage`) — pass on push.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted (api crate via nightly fmt during development)
- [x] `cargo clippy --workspace -- -D warnings` — clean (pre-commit / pre-push scope)
- [x] `cargo nextest run --workspace` — not run full workspace here; changed-crate gate passed on push
- [ ] `cargo test --workspace --doc` — not run full workspace here
- [x] `cargo deny check` — pass (pre-commit)

## Breaking changes

None

## Docs checklist

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [x] Crate `README.md` / `lib.rs //!` updated if public surface changed (`crates/storage/README.md`; api `lib.rs` module docs as applicable)
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [ ] Plan or spec that motivated this change archived or updated (link: <!-- path or URL -->)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` (no direct `node_state.state = …`) — see #255
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification

## Notes for reviewers

- Draft PR: intended for incremental review; fill in **Linear / GitHub issue** links when available.
- `OAuthProvider` implements `std::str::FromStr` (clippy `should_implement_trait`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added multi-factor authentication with time-based one-time passwords (TOTP).
  * Introduced OAuth login integration with Google, GitHub, and Microsoft.
  * Added personal access tokens for programmatic API authentication.
  * Implemented email verification and password reset flows.
  * Added webhook delivery with signature-based authentication.
  * Introduced idempotency support for webhook replay protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->