### PR TITLE
fix(resilience): harden pipeline retry semantics

### DIFF
--- a/crates/resilience/src/circuit_breaker.rs
+++ b/crates/resilience/src/circuit_breaker.rs
@@ -49,8 +49,7 @@ pub struct CircuitBreakerConfig {
     pub failure_threshold: u32,
     /// How long to wait in Open state before transitioning to `HalfOpen`.
     pub reset_timeout: Duration,
-    /// Max concurrent probe operations allowed in `HalfOpen` state. Also the number of
-    /// successful probes required before the circuit closes again. Default: 1.
+    /// Max concurrent probe operations allowed in `HalfOpen` state. Default: 1.
     pub max_half_open_operations: u32,
     /// Minimum number of operations required before failures can trip the breaker. Default: 5.
     pub min_operations: u32,
@@ -456,8 +455,6 @@ struct InnerState {
     total: u32,
     /// Number of active probe operations in `HalfOpen` state.
     half_open_probes: u32,
-    /// Number of successful probes completed in the current `HalfOpen` window.
-    half_open_successes: u32,
     /// Number of consecutive times the circuit has opened (for dynamic break duration).
     consecutive_opens: u32,
     /// Number of slow calls in the current window.
@@ -483,7 +480,6 @@ impl CircuitBreaker {
                 failures: 0,
                 total: 0,
                 half_open_probes: 0,
-                half_open_successes: 0,
                 consecutive_opens: 0,
                 slow_calls: 0,
                 window: if window_size > 0 {
@@ -549,7 +545,6 @@ impl CircuitBreaker {
             opened_at: self.clock.now(),
         };
         inner.half_open_probes = 0;
-        inner.half_open_successes = 0;
         self.atomic_state.store(STATE_OPEN, Ordering::Relaxed);
         drop(inner);
         if prev != CircuitState::Open {
@@ -703,10 +698,7 @@ impl CircuitBreaker {
         let result = match inner.state {
             State::Closed => Ok(()),
             State::HalfOpen => {
-                let admitted = inner
-                    .half_open_successes
-                    .saturating_add(inner.half_open_probes);
-                if admitted >= self.config.max_half_open_operations {
+                if inner.half_open_probes >= self.config.max_half_open_operations {
                     Err(CallError::CircuitOpen)
                 } else {
                     inner.half_open_probes = inner.half_open_probes.saturating_add(1);
@@ -723,7 +715,6 @@ impl CircuitBreaker {
                     inner.total = 0;
                     inner.slow_calls = 0;
                     inner.half_open_probes = 1; // this call is the first probe
-                    inner.half_open_successes = 0;
                     if let Some(ref mut window) = inner.window {
                         window.reset();
                     }
@@ -781,7 +772,6 @@ impl CircuitBreaker {
             opened_at: self.clock.now(),
         };
         inner.half_open_probes = 0;
-        inner.half_open_successes = 0;
         inner.consecutive_opens += 1;
         self.atomic_state.store(STATE_OPEN, Ordering::Relaxed);
         (prev, CircuitState::Open)
@@ -791,7 +781,6 @@ impl CircuitBreaker {
     /// Extracted to deduplicate the identical reset+trip pattern in `record_outcome`.
     fn trip_open_from_half_open(&self, inner: &mut InnerState) -> (CircuitState, CircuitState) {
         inner.half_open_probes = 0;
-        inner.half_open_successes = 0;
         self.trip_open(inner)
     }
 
@@ -802,7 +791,6 @@ impl CircuitBreaker {
         inner.total = 0;
         inner.slow_calls = 0;
         inner.half_open_probes = 0;
-        inner.half_open_successes = 0;
         inner.consecutive_opens = 0;
         if let Some(ref mut window) = inner.window {
             window.reset();
@@ -819,18 +807,11 @@ impl CircuitBreaker {
 
     /// Record a successful half-open probe.
     ///
-    /// The circuit closes only after `max_half_open_operations` successful probes have completed.
-    fn record_half_open_success(
-        &self,
-        inner: &mut InnerState,
-    ) -> Option<(CircuitState, CircuitState)> {
+    /// `max_half_open_operations` is only an admission limit; the first successful probe closes
+    /// the circuit, preserving the historical config meaning.
+    fn record_half_open_success(&self, inner: &mut InnerState) -> (CircuitState, CircuitState) {
         inner.half_open_probes = inner.half_open_probes.saturating_sub(1);
-        inner.half_open_successes = inner.half_open_successes.saturating_add(1);
-        if inner.half_open_successes >= self.config.max_half_open_operations {
-            Some(self.close_from_half_open(inner))
-        } else {
-            None
-        }
+        self.close_from_half_open(inner)
     }
 
     /// Record an operation outcome directly (useful when driving the CB from external code).
@@ -849,7 +830,7 @@ impl CircuitBreaker {
             },
             Outcome::Success => {
                 if inner.state == State::HalfOpen {
-                    transition = self.record_half_open_success(&mut inner);
+                    transition = Some(self.record_half_open_success(&mut inner));
                 } else {
                     inner.failures = inner.failures.saturating_sub(1);
                     inner.total = inner.total.saturating_add(1);
@@ -884,7 +865,7 @@ impl CircuitBreaker {
                     window.record(false, true);
                 }
                 if inner.state == State::HalfOpen {
-                    transition = self.record_half_open_success(&mut inner);
+                    transition = Some(self.record_half_open_success(&mut inner));
                 } else {
                     inner.failures = inner.failures.saturating_sub(1);
                     if self.slow_rate_trips(&inner) {
@@ -1113,7 +1094,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn half_open_requires_configured_successful_probes_before_closing() {
+    async fn half_open_max_operations_is_concurrency_limit_only() {
         let cb = CircuitBreaker::new(CircuitBreakerConfig {
             max_half_open_operations: 2,
             ..default_config()
@@ -1128,14 +1109,12 @@ mod tests {
         tokio::time::sleep(Duration::from_millis(110)).await;
 
         assert!(cb.try_acquire::<&str>().is_ok());
-        cb.record_outcome(Outcome::Success);
-        assert_eq!(
-            cb.circuit_state(),
-            CS::HalfOpen,
-            "one successful probe should not close when two are configured"
-        );
-
         assert!(cb.try_acquire::<&str>().is_ok());
+        assert!(matches!(
+            cb.try_acquire::<&str>(),
+            Err(CallError::CircuitOpen)
+        ));
+
         cb.record_outcome(Outcome::Success);
         assert_eq!(cb.circuit_state(), CS::Closed);
     }

--- a/crates/resilience/src/circuit_breaker.rs
+++ b/crates/resilience/src/circuit_breaker.rs
@@ -49,7 +49,8 @@ pub struct CircuitBreakerConfig {
     pub failure_threshold: u32,
     /// How long to wait in Open state before transitioning to `HalfOpen`.
     pub reset_timeout: Duration,
-    /// Max concurrent probe operations allowed in `HalfOpen` state. Default: 1.
+    /// Max concurrent probe operations allowed in `HalfOpen` state. Also the number of
+    /// successful probes required before the circuit closes again. Default: 1.
     pub max_half_open_operations: u32,
     /// Minimum number of operations required before failures can trip the breaker. Default: 5.
     pub min_operations: u32,
@@ -455,6 +456,8 @@ struct InnerState {
     total: u32,
     /// Number of active probe operations in `HalfOpen` state.
     half_open_probes: u32,
+    /// Number of successful probes completed in the current `HalfOpen` window.
+    half_open_successes: u32,
     /// Number of consecutive times the circuit has opened (for dynamic break duration).
     consecutive_opens: u32,
     /// Number of slow calls in the current window.
@@ -480,6 +483,7 @@ impl CircuitBreaker {
                 failures: 0,
                 total: 0,
                 half_open_probes: 0,
+                half_open_successes: 0,
                 consecutive_opens: 0,
                 slow_calls: 0,
                 window: if window_size > 0 {
@@ -545,6 +549,7 @@ impl CircuitBreaker {
             opened_at: self.clock.now(),
         };
         inner.half_open_probes = 0;
+        inner.half_open_successes = 0;
         self.atomic_state.store(STATE_OPEN, Ordering::Relaxed);
         drop(inner);
         if prev != CircuitState::Open {
@@ -698,7 +703,10 @@ impl CircuitBreaker {
         let result = match inner.state {
             State::Closed => Ok(()),
             State::HalfOpen => {
-                if inner.half_open_probes >= self.config.max_half_open_operations {
+                let admitted = inner
+                    .half_open_successes
+                    .saturating_add(inner.half_open_probes);
+                if admitted >= self.config.max_half_open_operations {
                     Err(CallError::CircuitOpen)
                 } else {
                     inner.half_open_probes = inner.half_open_probes.saturating_add(1);
@@ -715,6 +723,7 @@ impl CircuitBreaker {
                     inner.total = 0;
                     inner.slow_calls = 0;
                     inner.half_open_probes = 1; // this call is the first probe
+                    inner.half_open_successes = 0;
                     if let Some(ref mut window) = inner.window {
                         window.reset();
                     }
@@ -771,6 +780,8 @@ impl CircuitBreaker {
         inner.state = State::Open {
             opened_at: self.clock.now(),
         };
+        inner.half_open_probes = 0;
+        inner.half_open_successes = 0;
         inner.consecutive_opens += 1;
         self.atomic_state.store(STATE_OPEN, Ordering::Relaxed);
         (prev, CircuitState::Open)
@@ -780,6 +791,7 @@ impl CircuitBreaker {
     /// Extracted to deduplicate the identical reset+trip pattern in `record_outcome`.
     fn trip_open_from_half_open(&self, inner: &mut InnerState) -> (CircuitState, CircuitState) {
         inner.half_open_probes = 0;
+        inner.half_open_successes = 0;
         self.trip_open(inner)
     }
 
@@ -790,6 +802,7 @@ impl CircuitBreaker {
         inner.total = 0;
         inner.slow_calls = 0;
         inner.half_open_probes = 0;
+        inner.half_open_successes = 0;
         inner.consecutive_opens = 0;
         if let Some(ref mut window) = inner.window {
             window.reset();
@@ -802,6 +815,22 @@ impl CircuitBreaker {
         Self::reset_counters(inner);
         self.atomic_state.store(STATE_CLOSED, Ordering::Relaxed);
         (prev, CircuitState::Closed)
+    }
+
+    /// Record a successful half-open probe.
+    ///
+    /// The circuit closes only after `max_half_open_operations` successful probes have completed.
+    fn record_half_open_success(
+        &self,
+        inner: &mut InnerState,
+    ) -> Option<(CircuitState, CircuitState)> {
+        inner.half_open_probes = inner.half_open_probes.saturating_sub(1);
+        inner.half_open_successes = inner.half_open_successes.saturating_add(1);
+        if inner.half_open_successes >= self.config.max_half_open_operations {
+            Some(self.close_from_half_open(inner))
+        } else {
+            None
+        }
     }
 
     /// Record an operation outcome directly (useful when driving the CB from external code).
@@ -820,7 +849,7 @@ impl CircuitBreaker {
             },
             Outcome::Success => {
                 if inner.state == State::HalfOpen {
-                    transition = Some(self.close_from_half_open(&mut inner));
+                    transition = self.record_half_open_success(&mut inner);
                 } else {
                     inner.failures = inner.failures.saturating_sub(1);
                     inner.total = inner.total.saturating_add(1);
@@ -855,7 +884,7 @@ impl CircuitBreaker {
                     window.record(false, true);
                 }
                 if inner.state == State::HalfOpen {
-                    transition = Some(self.close_from_half_open(&mut inner));
+                    transition = self.record_half_open_success(&mut inner);
                 } else {
                     inner.failures = inner.failures.saturating_sub(1);
                     if self.slow_rate_trips(&inner) {
@@ -1081,6 +1110,34 @@ mod tests {
         cb.record_outcome(Outcome::Success);
         assert_eq!(cb.circuit_state(), CS::Closed);
         assert!(cb.try_acquire::<&str>().is_ok());
+    }
+
+    #[tokio::test]
+    async fn half_open_requires_configured_successful_probes_before_closing() {
+        let cb = CircuitBreaker::new(CircuitBreakerConfig {
+            max_half_open_operations: 2,
+            ..default_config()
+        })
+        .unwrap();
+
+        for _ in 0..3 {
+            cb.record_outcome(Outcome::Failure);
+        }
+        assert_eq!(cb.circuit_state(), CS::Open);
+
+        tokio::time::sleep(Duration::from_millis(110)).await;
+
+        assert!(cb.try_acquire::<&str>().is_ok());
+        cb.record_outcome(Outcome::Success);
+        assert_eq!(
+            cb.circuit_state(),
+            CS::HalfOpen,
+            "one successful probe should not close when two are configured"
+        );
+
+        assert!(cb.try_acquire::<&str>().is_ok());
+        cb.record_outcome(Outcome::Success);
+        assert_eq!(cb.circuit_state(), CS::Closed);
     }
 
     #[tokio::test]

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -42,7 +42,7 @@ use crate::{
     circuit_breaker::{CircuitBreaker, Outcome, ProbeGuard},
     classifier::{ErrorClass, ErrorClassifier, FnClassifier},
     retry::{RetryConfig, retry_with},
-    sink::{CircuitState, MetricsSink, NoopSink, ResilienceEvent},
+    sink::{MetricsSink, NoopSink, ResilienceEvent},
 };
 
 // ── Execution ────────────────────────────────────────────────────────────────
@@ -161,10 +161,9 @@ impl<E: Send + 'static> PipelineBuilder<E> {
 
     /// Inject a pipeline-wide metrics sink.
     ///
-    /// The sink receives events emitted by pipeline-managed wrappers and is also
-    /// used for retry attempts configured through this builder. Circuit breakers
-    /// and bulkheads passed in as pre-built `Arc`s keep their own sinks, but the
-    /// pipeline mirrors boundary events it observes.
+    /// The sink receives events emitted by pipeline-managed wrappers and is used
+    /// for retry attempts configured through this builder. Circuit breakers and
+    /// bulkheads passed in as pre-built `Arc`s keep their own sinks.
     #[must_use]
     pub fn with_sink(mut self, sink: impl MetricsSink + 'static) -> Self {
         self.sink = Some(Arc::new(sink));
@@ -603,37 +602,20 @@ where
             },
             Step::Retry(config) => run_retry_step(config, ctx, idx, f).await,
             Step::CircuitBreaker(cb) => {
-                let before_acquire = cb.circuit_state();
                 cb.try_acquire()?;
-                emit_circuit_transition(
-                    ctx.sink.as_ref(),
-                    ctx.sink_overrides_steps,
-                    before_acquire,
-                    cb.circuit_state(),
-                );
 
                 let mut guard = ProbeGuard::new(cb);
                 let result = run_operation_with_shells(ctx.clone(), idx + 1, Arc::clone(&f)).await;
                 guard.defuse();
 
                 let outcome = classify_cb_outcome(&result, ctx.classifier.as_ref());
-                let before_record = cb.circuit_state();
                 cb.record_outcome(outcome);
-                emit_circuit_transition(
-                    ctx.sink.as_ref(),
-                    ctx.sink_overrides_steps,
-                    before_record,
-                    cb.circuit_state(),
-                );
                 result
             },
             Step::Bulkhead(bh) => {
                 let _permit = match bh.acquire().await {
                     Ok(permit) => permit,
-                    Err(err) => {
-                        emit_bulkhead_error(ctx.sink.as_ref(), ctx.sink_overrides_steps, &err);
-                        return Err(err);
-                    },
+                    Err(err) => return Err(err),
                 };
                 run_operation_with_shells(ctx, idx + 1, f).await
             },
@@ -656,30 +638,6 @@ where
             },
         }
     })
-}
-
-fn emit_circuit_transition(
-    sink: &dyn MetricsSink,
-    enabled: bool,
-    from: CircuitState,
-    to: CircuitState,
-) {
-    if enabled && from != to {
-        sink.record(ResilienceEvent::CircuitStateChanged { from, to });
-    }
-}
-
-fn emit_bulkhead_error<E>(sink: &dyn MetricsSink, enabled: bool, err: &CallError<E>) {
-    if !enabled {
-        return;
-    }
-    match err {
-        CallError::BulkheadFull => sink.record(ResilienceEvent::BulkheadRejected),
-        CallError::Timeout(duration) => sink.record(ResilienceEvent::TimeoutElapsed {
-            duration: *duration,
-        }),
-        _ => {},
-    }
 }
 
 /// Classify the outcome of an inner pipeline result for the CB step.
@@ -718,6 +676,7 @@ where
     F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>> + Send + Sync + 'static,
 {
     let config_classifier = config.classifier.clone();
+    let has_explicit_retry_classifier = config_classifier.is_some();
     let pipeline_classifier = ctx.classifier.clone();
     let mut inner_config = RetryConfig::<RetryStepError<E>>::new_unchecked(config.max_attempts)
         .backoff(config.backoff.clone())
@@ -740,6 +699,9 @@ where
                 },
                 |classifier| classifier.classify(error),
             ),
+            RetryStepError::RetryablePattern(_) if has_explicit_retry_classifier => {
+                ErrorClass::Permanent
+            },
             RetryStepError::RetryablePattern(_) => ErrorClass::Transient,
             RetryStepError::FatalPattern(_) => ErrorClass::Permanent,
         },
@@ -1228,6 +1190,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn pipeline_retry_classifier_blocks_inner_pattern_retries() {
+        let checks = Arc::new(AtomicU32::new(0));
+        let seen_checks = Arc::clone(&checks);
+        let rate_limiter: RateLimitCheck = Arc::new(move || {
+            let seen_checks = Arc::clone(&seen_checks);
+            Box::pin(async move {
+                reject_first_rate_limit_check(&seen_checks, Duration::from_millis(50))
+            })
+        });
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(RetryConfig::new(3).unwrap().retry_if(|_: &&str| false))
+            .rate_limiter(rate_limiter)
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Ok::<u32, &str>(42) }))
+            .await;
+
+        assert!(matches!(result, Err(CallError::RateLimited { .. })));
+        assert_eq!(checks.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
     async fn pipeline_retry_preserves_retry_hooks() {
         let sink = RecordingSink::new();
         let notifications: Arc<StdMutex<Vec<(u32, Duration)>>> =
@@ -1372,7 +1358,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pipeline_with_sink_mirrors_bulkhead_rejection() {
+    async fn pipeline_with_sink_does_not_double_count_prebuilt_bulkhead_rejection() {
         let sink = RecordingSink::new();
         let bh = Arc::new(
             Bulkhead::new(crate::BulkheadConfig {
@@ -1380,7 +1366,8 @@ mod tests {
                 queue_size: 0,
                 timeout: None,
             })
-            .unwrap(),
+            .unwrap()
+            .with_sink(sink.clone()),
         );
         let _permit = bh.acquire::<&str>().await.unwrap();
 
@@ -1398,7 +1385,9 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pipeline_with_sink_mirrors_circuit_state_change() {
+    async fn pipeline_with_sink_does_not_double_count_prebuilt_circuit_state_change() {
+        use crate::sink::CircuitState;
+
         let sink = RecordingSink::new();
         let cb = Arc::new(
             CircuitBreaker::new(crate::CircuitBreakerConfig {
@@ -1406,7 +1395,8 @@ mod tests {
                 min_operations: 1,
                 ..Default::default()
             })
-            .unwrap(),
+            .unwrap()
+            .with_sink(sink.clone()),
         );
 
         let pipeline = ResiliencePipeline::<&str>::builder()
@@ -1420,6 +1410,7 @@ mod tests {
 
         assert!(matches!(result, Err(CallError::Operation("fail"))));
         assert!(sink.has_state_change(CircuitState::Open));
+        assert_eq!(sink.count(ResilienceEventKind::CircuitStateChanged), 1);
     }
 
     #[tokio::test]

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -150,7 +150,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
     /// retry step, when neither a pipeline nor a per-retry classifier is set, treats every
     /// operation error as retryable (the historical pipeline default). For
     /// [`Classify`](nebula_error::Classify) semantics like standalone
-    /// [`retry_with`](crate::retry::retry_with), set [`classify_errors()`](Self::classify_errors)
+    /// [`retry_with`], set [`classify_errors()`](Self::classify_errors)
     /// and/or per-retry [`retry_if`](crate::retry::RetryConfig::retry_if) /
     /// [`with_classifier`](crate::retry::RetryConfig::with_classifier).
     #[must_use]

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -309,7 +309,9 @@ impl<E: nebula_error::Classify + Send + Sync + 'static> PipelineBuilder<E> {
     #[must_use]
     pub fn classify_errors(mut self) -> Self {
         self.classifier = Some(Arc::new(crate::classifier::NebulaClassifier));
-        self.retry_hint = Some(Arc::new(|e: &E| e.retry_hint().and_then(|h| h.after)));
+        if self.retry_hint.is_none() {
+            self.retry_hint = Some(Arc::new(|e: &E| e.retry_hint().and_then(|h| h.after)));
+        }
         self
     }
 }
@@ -1058,6 +1060,20 @@ mod tests {
             start.elapsed() >= Duration::from_millis(20),
             "Classify retry_hint should act as a retry delay floor"
         );
+    }
+
+    #[test]
+    fn classify_errors_preserves_user_retry_hint() {
+        let builder = ResiliencePipeline::<RetryAfterErr>::builder()
+            .retry_hint(|_: &RetryAfterErr| Some(Duration::from_millis(5)))
+            .classify_errors();
+
+        let hint = builder
+            .retry_hint
+            .as_ref()
+            .and_then(|hint| hint(&RetryAfterErr));
+
+        assert_eq!(hint, Some(Duration::from_millis(5)));
     }
 
     #[tokio::test]

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -36,15 +36,13 @@
 
 use std::{fmt, future::Future, pin::Pin, sync::Arc, time::Duration};
 
-use parking_lot::Mutex;
-
 use crate::{
     CallError,
     bulkhead::Bulkhead,
     circuit_breaker::{CircuitBreaker, Outcome, ProbeGuard},
     classifier::{ErrorClass, ErrorClassifier, FnClassifier},
-    retry::{RetryConfig, retry_with_inner},
-    sink::{MetricsSink, NoopSink, ResilienceEvent},
+    retry::{RetryConfig, retry_with},
+    sink::{CircuitState, MetricsSink, NoopSink, ResilienceEvent},
 };
 
 // ── Execution ────────────────────────────────────────────────────────────────
@@ -60,7 +58,7 @@ use crate::{
 // `run_operation_with_shells` wraps every recursive call in `Box::pin`
 // (required because the async fn is recursive). Timeout and Retry add
 // additional overhead: Timeout for `tokio::time::timeout` wrapping,
-// Retry for the back-off loop with `retry_with_inner`.
+// Retry for the back-off loop with `retry_with`.
 
 /// Async predicate for rate limiting — returns `Ok(())` or `Err(CallError::RateLimited)`.
 pub type RateLimitCheck =
@@ -68,6 +66,8 @@ pub type RateLimitCheck =
 
 /// Predicate for load shedding — returns `true` to shed the request.
 pub type LoadShedPredicate = Arc<dyn Fn() -> bool + Send + Sync>;
+
+type RetryHintFn<E> = Arc<dyn Fn(&E) -> Option<Duration> + Send + Sync>;
 
 // ── Steps ─────────────────────────────────────────────────────────────────────
 
@@ -108,6 +108,7 @@ pub struct PipelineBuilder<E: 'static> {
     steps: Vec<Step<E>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
     sink: Option<Arc<dyn MetricsSink>>,
+    retry_hint: Option<RetryHintFn<E>>,
 }
 
 impl<E: 'static> fmt::Debug for PipelineBuilder<E> {
@@ -132,6 +133,7 @@ impl<E: Send + 'static> PipelineBuilder<E> {
             steps: Vec::new(),
             classifier: None,
             sink: None,
+            retry_hint: None,
         }
     }
 
@@ -157,10 +159,30 @@ impl<E: Send + 'static> PipelineBuilder<E> {
         self
     }
 
-    /// Inject a metrics sink for pipeline-level timeout / rate-limit / load-shed events.
+    /// Inject a pipeline-wide metrics sink.
+    ///
+    /// The sink receives events emitted by pipeline-managed wrappers and is also
+    /// used for retry attempts configured through this builder. Circuit breakers
+    /// and bulkheads passed in as pre-built `Arc`s keep their own sinks, but the
+    /// pipeline mirrors boundary events it observes.
     #[must_use]
     pub fn with_sink(mut self, sink: impl MetricsSink + 'static) -> Self {
         self.sink = Some(Arc::new(sink));
+        self
+    }
+
+    /// Set a retry-delay hint extractor for operation errors.
+    ///
+    /// The returned duration is used as a minimum retry delay, merged with the
+    /// configured [`BackoffConfig`](crate::retry::BackoffConfig). This is useful
+    /// when a custom classifier is used and operation errors carry retry-after
+    /// metadata outside [`Classify`](nebula_error::Classify).
+    #[must_use]
+    pub fn retry_hint<F>(mut self, hint: F) -> Self
+    where
+        F: Fn(&E) -> Option<Duration> + Send + Sync + 'static,
+    {
+        self.retry_hint = Some(Arc::new(hint));
         self
     }
 
@@ -173,10 +195,10 @@ impl<E: Send + 'static> PipelineBuilder<E> {
 
     /// Add a retry step.
     ///
-    /// **Note:** Pipeline retry uses `BackoffConfig` for delay timing.
-    /// [`retry_hint().after`](nebula_error::Classify::retry_hint) from individual errors
-    /// is **not** applied in the pipeline path — use [`retry_with`](crate::retry::retry_with)
-    /// directly if retry-after hints are needed.
+    /// Pipeline retry uses the configured [`BackoffConfig`](crate::retry::BackoffConfig)
+    /// and merges in retry-delay floors from [`retry_hint`](Self::retry_hint).
+    /// When [`classify_errors`](Self::classify_errors) is used, `E: Classify`
+    /// retry-after hints are wired automatically.
     #[must_use]
     pub fn retry(mut self, config: RetryConfig<E>) -> Self {
         self.steps.push(Step::Retry(Box::new(config)));
@@ -251,10 +273,28 @@ impl<E: Send + 'static> PipelineBuilder<E> {
     #[must_use]
     pub fn build(self) -> ResiliencePipeline<E> {
         validate_order(&self.steps);
+        self.build_inner()
+    }
+
+    /// Build the pipeline after sorting layers into the recommended order.
+    ///
+    /// This preserves insertion order among steps of the same kind and orders
+    /// different kinds as: `load_shed -> rate_limiter -> timeout -> retry ->
+    /// circuit_breaker -> bulkhead`.
+    #[must_use]
+    pub fn build_recommended_order(mut self) -> ResiliencePipeline<E> {
+        self.steps.sort_by_key(step_rank);
+        self.build_inner()
+    }
+
+    fn build_inner(self) -> ResiliencePipeline<E> {
+        let sink_overrides_steps = self.sink.is_some();
         ResiliencePipeline {
             steps: Arc::new(self.steps),
             classifier: self.classifier,
             sink: self.sink.unwrap_or_else(|| Arc::new(NoopSink)),
+            sink_overrides_steps,
+            retry_hint: self.retry_hint,
         }
     }
 }
@@ -268,8 +308,21 @@ impl<E: nebula_error::Classify + Send + Sync + 'static> PipelineBuilder<E> {
     ///
     /// This is the recommended default for pipelines where `E: Classify`.
     #[must_use]
-    pub fn classify_errors(self) -> Self {
-        self.classifier(Arc::new(crate::classifier::NebulaClassifier))
+    pub fn classify_errors(mut self) -> Self {
+        self.classifier = Some(Arc::new(crate::classifier::NebulaClassifier));
+        self.retry_hint = Some(Arc::new(|e: &E| e.retry_hint().and_then(|h| h.after)));
+        self
+    }
+}
+
+const fn step_rank<E>(step: &Step<E>) -> u8 {
+    match step {
+        Step::LoadShed(_) => 0,
+        Step::RateLimiter(_) => 1,
+        Step::Timeout(_) => 2,
+        Step::Retry(_) => 3,
+        Step::CircuitBreaker(_) => 4,
+        Step::Bulkhead(_) => 5,
     }
 }
 
@@ -303,8 +356,8 @@ fn validate_order<E>(steps: &[Step<E>]) {
         && rl > r
     {
         tracing::warn!(
-            "ResiliencePipeline: rate_limiter is inside retry (rate-limited rejections trigger retries). \
-             Move rate_limiter before retry to reject before entering the retry loop."
+            "ResiliencePipeline: rate_limiter is inside retry (rate-limited rejections may be retried per attempt). \
+             Move rate_limiter before retry to reject once before entering the retry loop."
         );
     }
 }
@@ -339,6 +392,28 @@ pub struct ResiliencePipeline<E: 'static> {
     steps: Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
     sink: Arc<dyn MetricsSink>,
+    sink_overrides_steps: bool,
+    retry_hint: Option<RetryHintFn<E>>,
+}
+
+struct PipelineRunContext<E: 'static> {
+    steps: Arc<Vec<Step<E>>>,
+    classifier: Option<Arc<dyn ErrorClassifier<E>>>,
+    sink: Arc<dyn MetricsSink>,
+    sink_overrides_steps: bool,
+    retry_hint: Option<RetryHintFn<E>>,
+}
+
+impl<E: 'static> Clone for PipelineRunContext<E> {
+    fn clone(&self) -> Self {
+        Self {
+            steps: Arc::clone(&self.steps),
+            classifier: self.classifier.clone(),
+            sink: Arc::clone(&self.sink),
+            sink_overrides_steps: self.sink_overrides_steps,
+            retry_hint: self.retry_hint.clone(),
+        }
+    }
 }
 
 impl<E: 'static> fmt::Debug for ResiliencePipeline<E> {
@@ -404,6 +479,8 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
             Arc::clone(&self.steps),
             self.classifier.clone(),
             Arc::clone(&self.sink),
+            self.sink_overrides_steps,
+            self.retry_hint.clone(),
             Arc::new(boxed),
         )
         .await
@@ -476,6 +553,8 @@ async fn execute_pipeline<T, E, F>(
     steps: Arc<Vec<Step<E>>>,
     classifier: Option<Arc<dyn ErrorClassifier<E>>>,
     sink: Arc<dyn MetricsSink>,
+    sink_overrides_steps: bool,
+    retry_hint: Option<RetryHintFn<E>>,
     f: Arc<F>,
 ) -> Result<T, CallError<E>>
 where
@@ -483,15 +562,20 @@ where
     E: Send + 'static,
     F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>> + Send + Sync + 'static,
 {
-    run_operation_with_shells(&steps, classifier, sink, 0, f).await
+    let ctx = PipelineRunContext {
+        steps,
+        classifier,
+        sink,
+        sink_overrides_steps,
+        retry_hint,
+    };
+    run_operation_with_shells(ctx, 0, f).await
 }
 
 /// Recursively apply pipeline steps (one `Box::pin` per Timeout/Retry shell),
 /// then call the user function.
 fn run_operation_with_shells<T, E, F>(
-    steps: &Arc<Vec<Step<E>>>,
-    classifier: Option<Arc<dyn ErrorClassifier<E>>>,
-    sink: Arc<dyn MetricsSink>,
+    ctx: PipelineRunContext<E>,
     idx: usize,
     f: Arc<F>,
 ) -> Pin<Box<dyn Future<Output = Result<T, CallError<E>>> + Send>>
@@ -500,7 +584,7 @@ where
     E: Send + 'static,
     F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>> + Send + Sync + 'static,
 {
-    let steps = Arc::clone(steps);
+    let steps = Arc::clone(&ctx.steps);
     Box::pin(async move {
         if idx >= steps.len() {
             return f().await.map_err(CallError::Operation);
@@ -509,73 +593,93 @@ where
         match &steps[idx] {
             Step::Timeout(d) => {
                 let d = *d;
-                tokio::time::timeout(
-                    d,
-                    run_operation_with_shells(
-                        &steps,
-                        classifier.clone(),
-                        Arc::clone(&sink),
-                        idx + 1,
-                        f,
-                    ),
-                )
-                .await
-                .unwrap_or_else(|_| {
-                    sink.record(ResilienceEvent::TimeoutElapsed { duration: d });
-                    Err(CallError::Timeout(d))
-                })
+                tokio::time::timeout(d, run_operation_with_shells(ctx.clone(), idx + 1, f))
+                    .await
+                    .unwrap_or_else(|_| {
+                        ctx.sink
+                            .record(ResilienceEvent::TimeoutElapsed { duration: d });
+                        Err(CallError::Timeout(d))
+                    })
             },
-            Step::Retry(config) => {
-                run_retry_step(
-                    config,
-                    Arc::clone(&steps),
-                    classifier,
-                    Arc::clone(&sink),
-                    idx,
-                    f,
-                )
-                .await
-            },
+            Step::Retry(config) => run_retry_step(config, ctx, idx, f).await,
             Step::CircuitBreaker(cb) => {
+                let before_acquire = cb.circuit_state();
                 cb.try_acquire()?;
+                emit_circuit_transition(
+                    ctx.sink.as_ref(),
+                    ctx.sink_overrides_steps,
+                    before_acquire,
+                    cb.circuit_state(),
+                );
+
                 let mut guard = ProbeGuard::new(cb);
-                let result = run_operation_with_shells(
-                    &steps,
-                    classifier.clone(),
-                    Arc::clone(&sink),
-                    idx + 1,
-                    Arc::clone(&f),
-                )
-                .await;
+                let result = run_operation_with_shells(ctx.clone(), idx + 1, Arc::clone(&f)).await;
                 guard.defuse();
 
-                let outcome = classify_cb_outcome(&result, classifier.as_ref());
+                let outcome = classify_cb_outcome(&result, ctx.classifier.as_ref());
+                let before_record = cb.circuit_state();
                 cb.record_outcome(outcome);
+                emit_circuit_transition(
+                    ctx.sink.as_ref(),
+                    ctx.sink_overrides_steps,
+                    before_record,
+                    cb.circuit_state(),
+                );
                 result
             },
             Step::Bulkhead(bh) => {
-                let _permit = bh.acquire().await?;
-                run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
+                let _permit = match bh.acquire().await {
+                    Ok(permit) => permit,
+                    Err(err) => {
+                        emit_bulkhead_error(ctx.sink.as_ref(), ctx.sink_overrides_steps, &err);
+                        return Err(err);
+                    },
+                };
+                run_operation_with_shells(ctx, idx + 1, f).await
             },
             Step::RateLimiter(check) => {
                 if let Err(e) = check().await {
-                    sink.record(ResilienceEvent::RateLimitExceeded);
+                    ctx.sink.record(ResilienceEvent::RateLimitExceeded);
                     return Err(CallError::RateLimited {
                         retry_after: e.retry_after(),
                     });
                 }
-                run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
+                run_operation_with_shells(ctx, idx + 1, f).await
             },
             Step::LoadShed(predicate) => {
                 if predicate() {
-                    sink.record(ResilienceEvent::LoadShed);
+                    ctx.sink.record(ResilienceEvent::LoadShed);
                     Err(CallError::LoadShed)
                 } else {
-                    run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await
+                    run_operation_with_shells(ctx, idx + 1, f).await
                 }
             },
         }
     })
+}
+
+fn emit_circuit_transition(
+    sink: &dyn MetricsSink,
+    enabled: bool,
+    from: CircuitState,
+    to: CircuitState,
+) {
+    if enabled && from != to {
+        sink.record(ResilienceEvent::CircuitStateChanged { from, to });
+    }
+}
+
+fn emit_bulkhead_error<E>(sink: &dyn MetricsSink, enabled: bool, err: &CallError<E>) {
+    if !enabled {
+        return;
+    }
+    match err {
+        CallError::BulkheadFull => sink.record(ResilienceEvent::BulkheadRejected),
+        CallError::Timeout(duration) => sink.record(ResilienceEvent::TimeoutElapsed {
+            duration: *duration,
+        }),
+        _ => {},
+    }
 }
 
 /// Classify the outcome of an inner pipeline result for the CB step.
@@ -604,9 +708,7 @@ fn classify_cb_outcome<T, E>(
 #[allow(clippy::excessive_nesting)]
 async fn run_retry_step<T, E, F>(
     config: &RetryConfig<E>,
-    steps: Arc<Vec<Step<E>>>,
-    classifier: Option<Arc<dyn ErrorClassifier<E>>>,
-    sink: Arc<dyn MetricsSink>,
+    ctx: PipelineRunContext<E>,
     idx: usize,
     f: Arc<F>,
 ) -> Result<T, CallError<E>>
@@ -615,103 +717,168 @@ where
     E: Send + 'static,
     F: Fn() -> Pin<Box<dyn Future<Output = Result<T, E>> + Send>> + Send + Sync + 'static,
 {
-    // `bail` captures the first non-operation error from the inner pipeline.
-    // Once set, the retry predicate returns `false` (via `bail_check.is_none()`),
-    // stopping retries immediately. It is never cleared because non-operation
-    // errors (CircuitOpen, BulkheadFull, etc.) indicate the inner pipeline is
-    // unreachable — retrying would hit the same structural error.
-    let bail: Arc<Mutex<Option<CallError<E>>>> = Arc::new(Mutex::new(None));
     let config_classifier = config.classifier.clone();
-    let pipeline_classifier = classifier.clone();
-    let mut inner_config = RetryConfig::<Option<E>>::new_unchecked(config.max_attempts)
+    let pipeline_classifier = ctx.classifier.clone();
+    let mut inner_config = RetryConfig::<RetryStepError<E>>::new_unchecked(config.max_attempts)
         .backoff(config.backoff.clone())
         .jitter(config.jitter.clone());
     inner_config.total_budget = config.total_budget;
-    inner_config.sink = Arc::clone(&config.sink);
-    inner_config.classifier = Some(Arc::new(FnClassifier::new(move |e: &Option<E>| {
-        let Some(inner) = e else {
-            return ErrorClass::Permanent;
-        };
-        config_classifier.as_ref().map_or_else(
-            || {
-                pipeline_classifier
-                    .as_ref()
-                    .map_or(ErrorClass::Transient, |classifier| {
-                        classifier.classify(inner)
-                    })
-            },
-            |classifier| classifier.classify(inner),
-        )
-    })));
+    inner_config.sink = if ctx.sink_overrides_steps {
+        Arc::clone(&ctx.sink)
+    } else {
+        Arc::clone(&config.sink)
+    };
+    inner_config.classifier = Some(Arc::new(FnClassifier::new(
+        move |e: &RetryStepError<E>| match e {
+            RetryStepError::Operation { error, .. } => config_classifier.as_ref().map_or_else(
+                || {
+                    pipeline_classifier
+                        .as_ref()
+                        .map_or(ErrorClass::Transient, |classifier| {
+                            classifier.classify(error)
+                        })
+                },
+                |classifier| classifier.classify(error),
+            ),
+            RetryStepError::RetryablePattern(_) => ErrorClass::Transient,
+            RetryStepError::FatalPattern(_) => ErrorClass::Permanent,
+        },
+    )));
     inner_config.on_retry = config.on_retry.as_ref().map(|notify| {
         let notify = Arc::clone(notify);
-        Arc::new(move |e: &Option<E>, delay: Duration, attempt: u32| {
-            if let Some(inner) = e {
-                notify(inner, delay, attempt);
-            }
-        }) as Arc<dyn Fn(&Option<E>, Duration, u32) + Send + Sync>
+        Arc::new(
+            move |e: &RetryStepError<E>, delay: Duration, attempt: u32| {
+                if let RetryStepError::Operation { error, .. } = e {
+                    notify(error, delay, attempt);
+                }
+            },
+        ) as Arc<dyn Fn(&RetryStepError<E>, Duration, u32) + Send + Sync>
     });
 
-    let result = retry_with_inner(inner_config, {
-        let steps = Arc::clone(&steps);
+    let result = retry_with(inner_config, {
+        let ctx = ctx.clone();
         let f = Arc::clone(&f);
-        let bail = Arc::clone(&bail);
-        let classifier = classifier.clone();
-        let sink = Arc::clone(&sink);
         move || {
-            let steps = Arc::clone(&steps);
+            let ctx = ctx.clone();
             let f = Arc::clone(&f);
-            let bail = Arc::clone(&bail);
-            let classifier = classifier.clone();
-            let sink = Arc::clone(&sink);
             Box::pin(async move {
+                let retry_hint = ctx.retry_hint.clone();
                 classify_inner(
-                    run_operation_with_shells(&steps, classifier, sink, idx + 1, f).await,
-                    &bail,
+                    run_operation_with_shells(ctx, idx + 1, f).await,
+                    retry_hint.as_ref(),
                 )
             })
         }
     })
     .await;
 
-    map_retry_result(result, &bail)
+    map_retry_result(result)
+}
+
+enum RetryStepError<E> {
+    Operation {
+        error: E,
+        retry_after: Option<Duration>,
+    },
+    RetryablePattern(CallError<E>),
+    FatalPattern(CallError<E>),
+}
+
+impl<E> RetryStepError<E> {
+    fn into_call_error(self, exhausted_attempts: Option<u32>) -> CallError<E> {
+        match self {
+            Self::Operation { error, .. } => match exhausted_attempts {
+                Some(attempts) => CallError::RetriesExhausted {
+                    attempts,
+                    last: error,
+                },
+                None => CallError::Operation(error),
+            },
+            Self::RetryablePattern(err) | Self::FatalPattern(err) => err,
+        }
+    }
+}
+
+impl<E> nebula_error::Classify for RetryStepError<E> {
+    fn category(&self) -> nebula_error::ErrorCategory {
+        match self {
+            Self::Operation { .. } => nebula_error::ErrorCategory::External,
+            Self::RetryablePattern(CallError::Timeout(_)) => nebula_error::ErrorCategory::Timeout,
+            Self::RetryablePattern(CallError::RateLimited { .. }) => {
+                nebula_error::ErrorCategory::RateLimit
+            },
+            Self::RetryablePattern(CallError::BulkheadFull) => {
+                nebula_error::ErrorCategory::Exhausted
+            },
+            Self::RetryablePattern(_) | Self::FatalPattern(_) => {
+                nebula_error::ErrorCategory::Internal
+            },
+        }
+    }
+
+    fn code(&self) -> nebula_error::ErrorCode {
+        match self {
+            Self::Operation { .. } => {
+                nebula_error::ErrorCode::new("RESILIENCE:PIPELINE_RETRY_OPERATION")
+            },
+            Self::RetryablePattern(CallError::Timeout(_)) => {
+                nebula_error::ErrorCode::new("RESILIENCE:TIMEOUT")
+            },
+            Self::RetryablePattern(CallError::RateLimited { .. }) => {
+                nebula_error::ErrorCode::new("RESILIENCE:RATE_LIMITED")
+            },
+            Self::RetryablePattern(CallError::BulkheadFull) => {
+                nebula_error::ErrorCode::new("RESILIENCE:BULKHEAD_FULL")
+            },
+            Self::RetryablePattern(_) | Self::FatalPattern(_) => {
+                nebula_error::ErrorCode::new("RESILIENCE:PIPELINE_RETRY_PATTERN")
+            },
+        }
+    }
+
+    fn retry_hint(&self) -> Option<nebula_error::RetryHint> {
+        match self {
+            Self::Operation {
+                retry_after: Some(after),
+                ..
+            }
+            | Self::RetryablePattern(CallError::RateLimited {
+                retry_after: Some(after),
+            }) => Some(nebula_error::RetryHint::after(*after)),
+            _ => None,
+        }
+    }
 }
 
 /// Classify an inner pipeline result for the retry layer.
 ///
-/// `Ok` and `Operation` errors pass through; non-operation errors are
-/// stashed in `bail` and signalled as `Err(None)` to stop retrying.
+/// `Operation` errors use the retry classifier for `E`; retryable pattern errors
+/// (`Timeout`, `RateLimited`, `BulkheadFull`) can be retried by layer order; all
+/// other pattern errors stop the retry loop immediately.
 fn classify_inner<T, E>(
     result: Result<T, CallError<E>>,
-    bail: &Arc<Mutex<Option<CallError<E>>>>,
-) -> Result<T, Option<E>> {
+    retry_hint: Option<&RetryHintFn<E>>,
+) -> Result<T, RetryStepError<E>> {
     match result {
         Ok(v) => Ok(v),
-        Err(CallError::Operation(e)) => Err(Some(e)),
-        Err(other) => {
-            *bail.lock() = Some(other);
-            Err(None)
+        Err(CallError::Operation(error)) => {
+            let retry_after = retry_hint.and_then(|hint| hint(&error));
+            Err(RetryStepError::Operation { error, retry_after })
         },
+        Err(other) if other.is_retryable() => Err(RetryStepError::RetryablePattern(other)),
+        Err(other) => Err(RetryStepError::FatalPattern(other)),
     }
 }
 
-/// Map `CallError<Option<E>>` back to `CallError<E>` after retry.
-fn map_retry_result<T, E: Send>(
-    result: Result<T, CallError<Option<E>>>,
-    bail: &Arc<Mutex<Option<CallError<E>>>>,
+/// Map retry-step errors back to the public `CallError<E>` shape after retry.
+fn map_retry_result<T, E>(
+    result: Result<T, CallError<RetryStepError<E>>>,
 ) -> Result<T, CallError<E>> {
-    let take_bail = || bail.lock().take().unwrap_or(CallError::cancelled());
-
     match result {
         Ok(v) => Ok(v),
         Err(e) => Err(e.flat_map_inner(
-            |opt| opt.map_or_else(take_bail, CallError::Operation),
-            |attempts, opt| {
-                opt.map_or_else(take_bail, |e| CallError::RetriesExhausted {
-                    attempts,
-                    last: e,
-                })
-            },
+            |inner| inner.into_call_error(None),
+            |attempts, inner| inner.into_call_error(Some(attempts)),
         )),
     }
 }
@@ -719,6 +886,7 @@ fn map_retry_result<T, E: Send>(
 #[cfg(test)]
 mod tests {
     use std::{
+        fmt,
         sync::{
             Mutex as StdMutex,
             atomic::{AtomicU32, Ordering},
@@ -726,10 +894,64 @@ mod tests {
         time::Duration,
     };
 
+    use nebula_error::{Classify, ErrorCategory, ErrorCode, RetryHint, codes};
+
     use super::*;
     use crate::{
         CallError, CircuitBreaker, RecordingSink, ResilienceEventKind, retry::BackoffConfig,
     };
+
+    #[derive(Debug, Clone, Copy)]
+    struct RetryAfterErr;
+
+    impl fmt::Display for RetryAfterErr {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str("retry after")
+        }
+    }
+
+    impl Classify for RetryAfterErr {
+        fn category(&self) -> ErrorCategory {
+            ErrorCategory::RateLimit
+        }
+
+        fn code(&self) -> ErrorCode {
+            codes::INTERNAL
+        }
+
+        fn retry_hint(&self) -> Option<RetryHint> {
+            Some(RetryHint::after(Duration::from_millis(25)))
+        }
+    }
+
+    async fn delay_first_two_attempts(attempt: u32) {
+        if attempt < 2 {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn reject_first_rate_limit_check(
+        checks: &AtomicU32,
+        retry_after: Duration,
+    ) -> Result<(), CallError<()>> {
+        if checks.fetch_add(1, Ordering::SeqCst) == 0 {
+            Err(CallError::rate_limited_after(retry_after))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn always_reject_rate_limit_check(checks: &AtomicU32) -> Result<(), CallError<()>> {
+        checks.fetch_add(1, Ordering::SeqCst);
+        Err(CallError::rate_limited())
+    }
+
+    fn fail_once_with_retry_hint(attempts: &AtomicU32) -> Result<u32, RetryAfterErr> {
+        if attempts.fetch_add(1, Ordering::SeqCst) == 0 {
+            return Err(RetryAfterErr);
+        }
+        Ok(42)
+    }
 
     #[tokio::test]
     async fn pipeline_timeout_wraps_retry() {
@@ -773,6 +995,197 @@ mod tests {
             )
             .timeout(Duration::from_secs(1))
             .build();
+    }
+
+    #[tokio::test]
+    async fn pipeline_retry_retries_inner_timeout() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&attempts);
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(
+                RetryConfig::new(3)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .timeout(Duration::from_millis(10))
+            .build();
+
+        let result = pipeline
+            .call(move || {
+                let seen = Arc::clone(&seen);
+                Box::pin(async move {
+                    let attempt = seen.fetch_add(1, Ordering::SeqCst);
+                    delay_first_two_attempts(attempt).await;
+                    Ok::<u32, &str>(42)
+                })
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn pipeline_retry_retries_inner_rate_limit_and_respects_retry_after() {
+        let checks = Arc::new(AtomicU32::new(0));
+        let seen_checks = Arc::clone(&checks);
+        let operations = Arc::new(AtomicU32::new(0));
+        let seen_operations = Arc::clone(&operations);
+        let retry_after = Duration::from_millis(25);
+
+        let rate_limiter: RateLimitCheck = Arc::new(move || {
+            let seen_checks = Arc::clone(&seen_checks);
+            Box::pin(async move { reject_first_rate_limit_check(&seen_checks, retry_after) })
+        });
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(
+                RetryConfig::new(2)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .rate_limiter(rate_limiter)
+            .build();
+
+        let start = std::time::Instant::now();
+        let result = pipeline
+            .call(move || {
+                let seen_operations = Arc::clone(&seen_operations);
+                Box::pin(async move {
+                    seen_operations.fetch_add(1, Ordering::SeqCst);
+                    Ok::<u32, &str>(42)
+                })
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(checks.load(Ordering::SeqCst), 2);
+        assert_eq!(operations.load(Ordering::SeqCst), 1);
+        assert!(
+            start.elapsed() >= Duration::from_millis(20),
+            "retry_after should act as a retry delay floor"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_retry_respects_operation_retry_hint_from_classify_errors() {
+        let attempts = Arc::new(AtomicU32::new(0));
+        let seen = Arc::clone(&attempts);
+
+        let pipeline = ResiliencePipeline::<RetryAfterErr>::builder()
+            .classify_errors()
+            .retry(
+                RetryConfig::new(2)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .build();
+
+        let start = std::time::Instant::now();
+        let result = pipeline
+            .call(move || {
+                let seen = Arc::clone(&seen);
+                Box::pin(async move { fail_once_with_retry_hint(&seen) })
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts.load(Ordering::SeqCst), 2);
+        assert!(
+            start.elapsed() >= Duration::from_millis(20),
+            "Classify retry_hint should act as a retry delay floor"
+        );
+    }
+
+    #[tokio::test]
+    async fn pipeline_retry_does_not_retry_inner_circuit_open() {
+        let cb = Arc::new(CircuitBreaker::new(crate::CircuitBreakerConfig::default()).unwrap());
+        cb.force_open();
+        let operations = Arc::new(AtomicU32::new(0));
+        let seen_operations = Arc::clone(&operations);
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(
+                RetryConfig::new(3)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .circuit_breaker(cb)
+            .build();
+
+        let result = pipeline
+            .call(move || {
+                let seen_operations = Arc::clone(&seen_operations);
+                Box::pin(async move {
+                    seen_operations.fetch_add(1, Ordering::SeqCst);
+                    Ok::<u32, &str>(42)
+                })
+            })
+            .await;
+
+        assert!(matches!(result, Err(CallError::CircuitOpen)));
+        assert_eq!(operations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn build_recommended_order_rejects_before_retry() {
+        let checks = Arc::new(AtomicU32::new(0));
+        let seen_checks = Arc::clone(&checks);
+        let operations = Arc::new(AtomicU32::new(0));
+        let seen_operations = Arc::clone(&operations);
+
+        let rate_limiter: RateLimitCheck = Arc::new(move || {
+            let seen_checks = Arc::clone(&seen_checks);
+            Box::pin(async move { always_reject_rate_limit_check(&seen_checks) })
+        });
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .retry(
+                RetryConfig::new(3)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .rate_limiter(rate_limiter)
+            .build_recommended_order();
+
+        let result = pipeline
+            .call(move || {
+                let seen_operations = Arc::clone(&seen_operations);
+                Box::pin(async move {
+                    seen_operations.fetch_add(1, Ordering::SeqCst);
+                    Ok::<u32, &str>(42)
+                })
+            })
+            .await;
+
+        assert!(matches!(result, Err(CallError::RateLimited { .. })));
+        assert_eq!(checks.load(Ordering::SeqCst), 1);
+        assert_eq!(operations.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_overrides_retry_config_sink() {
+        let sink = RecordingSink::new();
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .retry(
+                RetryConfig::new(2)
+                    .unwrap()
+                    .backoff(BackoffConfig::Fixed(Duration::ZERO)),
+            )
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Err::<u32, &str>("fail") }))
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(CallError::RetriesExhausted { attempts: 2, .. })
+        ));
+        assert_eq!(sink.count(ResilienceEventKind::RetryAttempt), 2);
     }
 
     #[tokio::test]
@@ -956,6 +1369,57 @@ mod tests {
 
         assert!(matches!(result, Err(CallError::LoadShed)));
         assert_eq!(sink.count(ResilienceEventKind::LoadShed), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_mirrors_bulkhead_rejection() {
+        let sink = RecordingSink::new();
+        let bh = Arc::new(
+            Bulkhead::new(crate::BulkheadConfig {
+                max_concurrency: 1,
+                queue_size: 0,
+                timeout: None,
+            })
+            .unwrap(),
+        );
+        let _permit = bh.acquire::<&str>().await.unwrap();
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .bulkhead(bh)
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Ok::<u32, &str>(42) }))
+            .await;
+
+        assert!(matches!(result, Err(CallError::BulkheadFull)));
+        assert_eq!(sink.count(ResilienceEventKind::BulkheadRejected), 1);
+    }
+
+    #[tokio::test]
+    async fn pipeline_with_sink_mirrors_circuit_state_change() {
+        let sink = RecordingSink::new();
+        let cb = Arc::new(
+            CircuitBreaker::new(crate::CircuitBreakerConfig {
+                failure_threshold: 1,
+                min_operations: 1,
+                ..Default::default()
+            })
+            .unwrap(),
+        );
+
+        let pipeline = ResiliencePipeline::<&str>::builder()
+            .with_sink(sink.clone())
+            .circuit_breaker(cb)
+            .build();
+
+        let result = pipeline
+            .call(|| Box::pin(async { Err::<u32, &str>("fail") }))
+            .await;
+
+        assert!(matches!(result, Err(CallError::Operation("fail"))));
+        assert!(sink.has_state_change(CircuitState::Open));
     }
 
     #[tokio::test]

--- a/crates/resilience/src/rate_limiter.rs
+++ b/crates/resilience/src/rate_limiter.rs
@@ -1095,6 +1095,26 @@ mod tests {
     }
 
     #[test]
+    fn leaky_bucket_partial_drain_preserves_fractional_leak_time() {
+        let limiter = LeakyBucket::new(4, 4.0).unwrap();
+        let start = Instant::now();
+        let now = start + Duration::from_millis(600);
+
+        let (level, leaked_duration) = {
+            let mut state = limiter.state.lock();
+            state.level = 3;
+            state.last_leak = start;
+
+            LeakyBucket::leak_locked(&mut state, limiter.leak_rate, now);
+
+            (state.level, state.last_leak.duration_since(start))
+        };
+
+        assert_eq!(level, 1);
+        assert_eq!(leaked_duration, Duration::from_millis(500));
+    }
+
+    #[test]
     fn sliding_window_rejects_zero_requests() {
         assert!(SlidingWindow::new(Duration::from_secs(1), 0).is_err());
     }

--- a/crates/resilience/src/rate_limiter.rs
+++ b/crates/resilience/src/rate_limiter.rs
@@ -422,21 +422,49 @@ impl LeakyBucket {
             leak_rate,
         })
     }
+
+    // Reason: f64/usize conversions are acceptable for approximate leak accounting.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_sign_loss
+    )]
+    fn leak_locked(state: &mut LeakyBucketState, leak_rate: f64, now: Instant) {
+        if state.level == 0 {
+            state.last_leak = now;
+            return;
+        }
+
+        let elapsed = now.duration_since(state.last_leak).as_secs_f64();
+        let leaked = (elapsed * leak_rate) as usize;
+
+        if leaked == 0 {
+            return;
+        }
+
+        if leaked >= state.level {
+            state.level = 0;
+            state.last_leak = now;
+            return;
+        }
+
+        state.level -= leaked;
+        let leaked_secs = leaked as f64 / leak_rate;
+        let drain_duration = Duration::from_secs_f64(leaked_secs);
+        state.last_leak = state.last_leak.checked_add(drain_duration).unwrap_or(now);
+    }
 }
 
 impl RateLimiter for LeakyBucket {
-    // Reason: f64 leak amount cast to usize — acceptable for bucket level calculation.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     async fn acquire(&self) -> Result<(), CallError<()>> {
         let mut state = self.state.lock();
-
         let now = Instant::now();
-        let elapsed = now.duration_since(state.last_leak).as_secs_f64();
-        let leaked = (elapsed * self.leak_rate) as usize;
-        state.level = state.level.saturating_sub(leaked);
-        state.last_leak = now;
+        Self::leak_locked(&mut state, self.leak_rate, now);
 
         if state.level < self.capacity {
+            if state.level == 0 {
+                state.last_leak = now;
+            }
             state.level += 1;
             drop(state);
             Ok(())
@@ -1042,6 +1070,28 @@ mod tests {
     #[test]
     fn leaky_bucket_accepts_valid_config() {
         assert!(LeakyBucket::new(10, 1.0).is_ok());
+    }
+
+    #[tokio::test]
+    async fn leaky_bucket_preserves_fractional_leak_time_between_rejections() {
+        let limiter = LeakyBucket::new(1, 4.0).unwrap();
+
+        limiter.acquire().await.unwrap();
+
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        assert!(matches!(
+            limiter.acquire().await,
+            Err(CallError::RateLimited { .. })
+        ));
+
+        tokio::time::sleep(Duration::from_millis(75)).await;
+        assert!(matches!(
+            limiter.acquire().await,
+            Err(CallError::RateLimited { .. })
+        ));
+
+        tokio::time::sleep(Duration::from_millis(140)).await;
+        assert!(limiter.acquire().await.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Retry pipeline-internal retryable pattern errors (`Timeout`, `RateLimited`, `BulkheadFull`) when no explicit retry classifier narrows retry behavior.
- Keep `RetryConfig::retry_if` / `with_classifier` authoritative for pipeline retry decisions, including internal pattern failures.
- Wire retry-after floors through pipeline retry via `classify_errors()` / `retry_hint()` and preserve user-provided `retry_hint(...)` when `classify_errors()` is chained later.
- Add `build_recommended_order()` for canonical layer ordering.
- Preserve `max_half_open_operations` as a half-open concurrency limit while keeping half-open probe accounting cancel-safe.
- Avoid racy/double-counted pipeline mirroring for pre-built circuit breakers and bulkheads; those wrappers keep their own sinks.
- Preserve fractional leaky-bucket drain time across rejected acquisitions, including partial-drain coverage.

## Test plan

- `cargo fmt -p nebula-resilience`
- `cargo test -p nebula-resilience`
- `cargo clippy -p nebula-resilience --all-features --all-targets -- -D warnings`
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p nebula-resilience`
- `git diff --check`
- pre-push `crate-diff-gate` for changed crate `resilience`: 212 nextest passed

## Scope

Only `crates/resilience` files are changed:

- `crates/resilience/src/pipeline.rs`
- `crates/resilience/src/circuit_breaker.rs`
- `crates/resilience/src/rate_limiter.rs