### PR TITLE
feat(telemetry)!: fallible registry and histogram snapshots

### DIFF
--- a/crates/api/src/services/webhook/transport.rs
+++ b/crates/api/src/services/webhook/transport.rs
@@ -527,8 +527,9 @@ fn outcome_to_verdict(outcome: SignatureOutcome) -> SignatureVerdict {
 fn record_signature_failure(transport: &WebhookTransport, reason: &'static str) {
     if let Some(reg) = &transport.inner.metrics {
         let labels = reg.interner().single("reason", reason);
-        reg.counter_labeled(NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL, &labels)
-            .inc();
+        if let Ok(c) = reg.counter_labeled(NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL, &labels) {
+            c.inc();
+        }
     }
 }
 

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -808,15 +808,19 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     });
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = nebula_telemetry::metrics::MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
     let engine = Arc::new(
         WorkflowEngine::new(runtime, metrics)
+            .unwrap()
             .with_execution_repo(Arc::clone(&state.execution_repo))
             .with_workflow_repo(Arc::clone(&state.workflow_repo)),
     );
@@ -1049,15 +1053,19 @@ async fn knife_step5_engine_cancels_running_execution_end_to_end() {
     });
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = nebula_telemetry::metrics::MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
     let engine = Arc::new(
         WorkflowEngine::new(runtime, metrics)
+            .unwrap()
             .with_execution_repo(Arc::clone(&state.execution_repo))
             .with_workflow_repo(Arc::clone(&state.workflow_repo)),
     );

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -884,9 +884,11 @@ async fn signature_failures_total_metric_increments_per_reason() {
         .single("reason", webhook_signature_failure_reason::INVALID);
     let missing_count = registry
         .counter_labeled(NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL, &missing_labels)
+        .unwrap()
         .get();
     let invalid_count = registry
         .counter_labeled(NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL, &invalid_labels)
+        .unwrap()
         .get();
     assert_eq!(missing_count, 1, "reason=missing must increment once");
     assert_eq!(invalid_count, 1, "reason=invalid must increment once");
@@ -933,6 +935,7 @@ async fn signature_failures_total_metric_increments_missing_secret() {
         .single("reason", webhook_signature_failure_reason::MISSING_SECRET);
     let count = registry
         .counter_labeled(NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL, &labels)
+        .unwrap()
         .get();
     assert_eq!(count, 1, "reason=missing_secret must increment once");
 }

--- a/crates/engine/README.md
+++ b/crates/engine/README.md
@@ -52,7 +52,8 @@ bounded concurrency.
 - `ControlDispatchError` — typed error returned from `ControlDispatch` methods; recorded on
   the control-queue row via `mark_failed` (no auto-retry — ADR-0008 §5).
 - `ExecutionResult` — post-run summary returned to the API layer.
-- `EngineError` — typed engine-layer error.
+- `EngineError` — typed engine-layer error (includes `Telemetry` when metric registration fails at
+  `WorkflowEngine::new` time).
 - `ExecutionEvent` — broadcast event type emitted via `nebula-eventbus`.
 - `EngineCredentialAccessor` — scoped credential accessor injected into action contexts.
 - `credential` module — engine-owned credential runtime surface:

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -384,18 +384,24 @@ impl ControlConsumer {
                         .metrics
                         .interner()
                         .single("outcome", control_reclaim_outcome::RECLAIMED);
-                    self.metrics
+                    if let Ok(c) = self
+                        .metrics
                         .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &labels)
-                        .inc_by(outcome.reclaimed);
+                    {
+                        c.inc_by(outcome.reclaimed);
+                    }
                 }
                 if outcome.exhausted > 0 {
                     let labels = self
                         .metrics
                         .interner()
                         .single("outcome", control_reclaim_outcome::EXHAUSTED);
-                    self.metrics
+                    if let Ok(c) = self
+                        .metrics
                         .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &labels)
-                        .inc_by(outcome.exhausted);
+                    {
+                        c.inc_by(outcome.exhausted);
+                    }
                 }
 
                 if outcome.reclaimed > 0 || outcome.exhausted > 0 {

--- a/crates/engine/src/credential/refresh/coordinator.rs
+++ b/crates/engine/src/credential/refresh/coordinator.rs
@@ -116,6 +116,10 @@ pub enum ConfigError {
         /// The pre-overflow operand; useful in operator messages.
         value: Duration,
     },
+
+    /// Metric primitive registration failed for the coordinator's §6 series.
+    #[error("telemetry metrics error: {0}")]
+    Telemetry(#[from] nebula_telemetry::TelemetryError),
 }
 
 impl RefreshCoordConfig {
@@ -308,7 +312,7 @@ impl RefreshCoordinator {
     /// # Errors
     ///
     /// Returns the corresponding [`ConfigError`] if `config.validate()`
-    /// fails (see §3.5 invariants).
+    /// fails (see §3.5 invariants) or metric handles cannot be bound.
     pub fn new_with(
         repo: Arc<dyn RefreshClaimRepo>,
         replica_id: ReplicaId,
@@ -319,12 +323,13 @@ impl RefreshCoordinator {
         // functional without composition. Production callers MUST follow
         // up with `with_metrics(engine_registry)` so a scraper actually
         // observes the §6 series — see `with_metrics` rustdoc.
+        let metrics = RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new())?;
         Ok(Self {
             l1: L1RefreshCoalescer::new(),
             repo,
             replica_id,
             config,
-            metrics: RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new()),
+            metrics,
             audit_sink: None,
         })
     }
@@ -360,7 +365,8 @@ impl RefreshCoordinator {
             repo,
             replica_id: ReplicaId::new(default_replica_id_string()),
             config,
-            metrics: RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new()),
+            metrics: RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new())
+                .expect("refresh coordinator bootstrap metric wiring"),
             audit_sink: None,
         }
     }
@@ -386,7 +392,8 @@ impl RefreshCoordinator {
             repo,
             replica_id: ReplicaId::new(default_replica_id_string()),
             config,
-            metrics: RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new()),
+            metrics: RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new())
+                .expect("refresh coordinator bootstrap metric wiring"),
             audit_sink: None,
         })
     }
@@ -1342,7 +1349,7 @@ mod tests {
         use nebula_metrics::MetricsRegistry;
 
         let registry = MetricsRegistry::new();
-        let metrics_handle = RefreshCoordMetrics::with_registry(&registry);
+        let metrics_handle = RefreshCoordMetrics::with_registry(&registry).unwrap();
         let repo: Arc<dyn RefreshClaimRepo> = Arc::new(InMemoryRefreshClaimRepo::new());
         let coord = RefreshCoordinator::new_with(
             repo,
@@ -1382,7 +1389,7 @@ mod tests {
         use nebula_metrics::MetricsRegistry;
 
         let registry = MetricsRegistry::new();
-        let metrics_handle = RefreshCoordMetrics::with_registry(&registry);
+        let metrics_handle = RefreshCoordMetrics::with_registry(&registry).unwrap();
         let repo: Arc<dyn RefreshClaimRepo> = Arc::new(InMemoryRefreshClaimRepo::new());
 
         // Park a contender claim so try_claim returns Contended for the
@@ -1510,7 +1517,7 @@ mod tests {
         use nebula_metrics::MetricsRegistry;
 
         let registry = MetricsRegistry::new();
-        let metrics_handle = RefreshCoordMetrics::with_registry(&registry);
+        let metrics_handle = RefreshCoordMetrics::with_registry(&registry).unwrap();
         let repo: Arc<dyn RefreshClaimRepo> = Arc::new(AlwaysContendedRepo);
 
         let coord = RefreshCoordinator::new_with(

--- a/crates/engine/src/credential/refresh/metrics.rs
+++ b/crates/engine/src/credential/refresh/metrics.rs
@@ -28,8 +28,9 @@ use nebula_metrics::{
     NEBULA_CREDENTIAL_REFRESH_COORD_COALESCED_TOTAL,
     NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS,
     NEBULA_CREDENTIAL_REFRESH_COORD_RECLAIM_SWEEPS_TOTAL,
-    NEBULA_CREDENTIAL_REFRESH_COORD_SENTINEL_EVENTS_TOTAL, refresh_coord_claim_outcome,
-    refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome, refresh_coord_sentinel_action,
+    NEBULA_CREDENTIAL_REFRESH_COORD_SENTINEL_EVENTS_TOTAL, TelemetryResult,
+    refresh_coord_claim_outcome, refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome,
+    refresh_coord_sentinel_action,
 };
 
 /// Pre-bound handles for the five refresh-coordinator metrics declared
@@ -56,7 +57,7 @@ pub struct RefreshCoordMetrics {
 
 impl RefreshCoordMetrics {
     /// Build pre-bound handles against the given registry.
-    pub fn with_registry(registry: &MetricsRegistry) -> Self {
+    pub fn with_registry(registry: &MetricsRegistry) -> TelemetryResult<Self> {
         let interner = registry.interner();
 
         let claim_label = |val: &str| interner.single("outcome", val);
@@ -64,46 +65,46 @@ impl RefreshCoordMetrics {
         let sentinel_label = |val: &str| interner.single("action", val);
         let reclaim_label = |val: &str| interner.single("outcome", val);
 
-        Self {
+        Ok(Self {
             claims_acquired: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
                 &claim_label(refresh_coord_claim_outcome::ACQUIRED),
-            ),
+            )?,
             claims_contended: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
                 &claim_label(refresh_coord_claim_outcome::CONTENDED),
-            ),
+            )?,
             claims_exhausted: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
                 &claim_label(refresh_coord_claim_outcome::EXHAUSTED),
-            ),
+            )?,
             coalesced_l1: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_COALESCED_TOTAL,
                 &coalesced_label(refresh_coord_coalesced_tier::L1),
-            ),
+            )?,
             coalesced_l2: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_COALESCED_TOTAL,
                 &coalesced_label(refresh_coord_coalesced_tier::L2),
-            ),
+            )?,
             sentinel_recorded: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_SENTINEL_EVENTS_TOTAL,
                 &sentinel_label(refresh_coord_sentinel_action::RECORDED),
-            ),
+            )?,
             sentinel_reauth_triggered: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_SENTINEL_EVENTS_TOTAL,
                 &sentinel_label(refresh_coord_sentinel_action::REAUTH_TRIGGERED),
-            ),
+            )?,
             reclaim_reclaimed: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_RECLAIM_SWEEPS_TOTAL,
                 &reclaim_label(refresh_coord_reclaim_outcome::RECLAIMED),
-            ),
+            )?,
             reclaim_no_work: registry.counter_labeled(
                 NEBULA_CREDENTIAL_REFRESH_COORD_RECLAIM_SWEEPS_TOTAL,
                 &reclaim_label(refresh_coord_reclaim_outcome::NO_WORK),
-            ),
+            )?,
             hold_duration: registry
-                .histogram(NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS),
-        }
+                .histogram(NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS)?,
+        })
     }
 
     /// Construct handles backed by a fresh private registry — tests and
@@ -117,7 +118,7 @@ impl RefreshCoordMetrics {
     #[cfg(any(test, feature = "test-util"))]
     #[must_use]
     pub fn for_tests() -> Self {
-        Self::with_registry(&MetricsRegistry::new())
+        Self::with_registry(&MetricsRegistry::new()).unwrap()
     }
 }
 
@@ -142,8 +143,8 @@ mod tests {
     #[test]
     fn handles_share_state_with_registry() {
         let registry = MetricsRegistry::new();
-        let m1 = RefreshCoordMetrics::with_registry(&registry);
-        let m2 = RefreshCoordMetrics::with_registry(&registry);
+        let m1 = RefreshCoordMetrics::with_registry(&registry).unwrap();
+        let m2 = RefreshCoordMetrics::with_registry(&registry).unwrap();
         // Same registry → same underlying counter.
         m1.claims_acquired.inc();
         assert_eq!(m2.claims_acquired.get(), 1);

--- a/crates/engine/src/credential/refresh/reclaim.rs
+++ b/crates/engine/src/credential/refresh/reclaim.rs
@@ -513,7 +513,7 @@ mod tests {
         use nebula_metrics::MetricsRegistry;
 
         let registry = MetricsRegistry::new();
-        let metrics = RefreshCoordMetrics::with_registry(&registry);
+        let metrics = RefreshCoordMetrics::with_registry(&registry).unwrap();
         let repo: Arc<dyn RefreshClaimRepo> = Arc::new(InMemoryRefreshClaimRepo::new());
         let sentinel = Arc::new(SentinelTrigger::new(
             Arc::clone(&repo),
@@ -572,7 +572,7 @@ mod tests {
         use nebula_metrics::MetricsRegistry;
 
         let registry = MetricsRegistry::new();
-        let metrics = RefreshCoordMetrics::with_registry(&registry);
+        let metrics = RefreshCoordMetrics::with_registry(&registry).unwrap();
         let repo: Arc<dyn RefreshClaimRepo> = Arc::new(InMemoryRefreshClaimRepo::new());
         let sentinel = Arc::new(SentinelTrigger::new(
             Arc::clone(&repo),

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -44,7 +44,7 @@ use nebula_metrics::naming::{
     NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL, engine_lease_contention_reason,
 };
 use nebula_plugin::PluginRegistry;
-use nebula_telemetry::metrics::MetricsRegistry;
+use nebula_telemetry::metrics::{Counter, Histogram, MetricsRegistry};
 use nebula_workflow::{Connection, DependencyGraph, NodeState, WorkflowDefinition};
 use tokio::{sync::Semaphore, task::JoinSet};
 use tokio_util::sync::CancellationToken;
@@ -124,6 +124,10 @@ type CredentialResolveFn = Arc<
 pub struct WorkflowEngine {
     runtime: Arc<ActionRuntime>,
     metrics: MetricsRegistry,
+    workflow_executions_started: Counter,
+    workflow_executions_completed: Counter,
+    workflow_executions_failed: Counter,
+    workflow_execution_duration_seconds: Histogram,
     /// Node registry for node-level metadata and versioning.
     plugin_registry: PluginRegistry,
     /// Resolves node parameters (expressions, templates, references) to JSON.
@@ -154,7 +158,7 @@ pub struct WorkflowEngine {
     event_bus: Option<EventBus>,
     /// Stable per-instance identifier used as the execution-lease holder.
     ///
-    /// Generated once at [`WorkflowEngine::new`] via [`InstanceId::new`]
+    /// Generated once when constructing [`WorkflowEngine`] via [`InstanceId::new`]
     /// (monotonic ULID). A single process runs exactly one instance id
     /// for its lifetime; restarts rotate it so a post-restart runner
     /// cannot inadvertently inherit a lease from its previous
@@ -254,16 +258,34 @@ impl Drop for RunningRegistration {
 
 impl WorkflowEngine {
     /// Create a new engine with the given components.
-    pub fn new(runtime: Arc<ActionRuntime>, metrics: MetricsRegistry) -> Self {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`EngineError::Telemetry`] if the shared registry rejects
+    /// registration for the canonical workflow metric identities.
+    pub fn new(runtime: Arc<ActionRuntime>, metrics: MetricsRegistry) -> Result<Self, EngineError> {
+        let workflow_executions_started =
+            metrics.counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)?;
+        let workflow_executions_completed =
+            metrics.counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)?;
+        let workflow_executions_failed =
+            metrics.counter(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL)?;
+        let workflow_execution_duration_seconds =
+            metrics.histogram(NEBULA_WORKFLOW_EXECUTION_DURATION_SECONDS)?;
+
         let expression_engine = Arc::new(ExpressionEngine::with_cache_size(1024));
         let instance_id = InstanceId::new();
         tracing::info!(
             instance_id = %instance_id,
             "workflow engine starting; lease holder string bound for this process's lifetime"
         );
-        Self {
+        Ok(Self {
             runtime,
             metrics,
+            workflow_executions_started,
+            workflow_executions_completed,
+            workflow_executions_failed,
+            workflow_execution_duration_seconds,
             plugin_registry: PluginRegistry::new(),
             resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
@@ -278,7 +300,7 @@ impl WorkflowEngine {
             lease_heartbeat_interval: DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL,
             running: Arc::new(DashMap::new()),
             credential_reclaim_sweep: None,
-        }
+        })
     }
 
     /// Signal a cooperative cancel to an in-flight execution this runner owns.
@@ -379,7 +401,7 @@ impl WorkflowEngine {
     /// let store = Arc::new(InMemoryStore::new());
     /// let resolver = Arc::new(CredentialResolver::new(store));
     ///
-    /// let engine = WorkflowEngine::new(runtime, metrics)
+    /// let engine = WorkflowEngine::new(runtime, metrics)?
     ///     .with_credential_resolver(move |id: &str| {
     ///         let resolver = Arc::clone(&resolver);
     ///         let id = id.to_owned();
@@ -430,7 +452,7 @@ impl WorkflowEngine {
     /// # Examples
     ///
     /// ```rust,ignore
-    /// let engine = WorkflowEngine::new(runtime, metrics)
+    /// let engine = WorkflowEngine::new(runtime, metrics)?
     ///     .with_credential_resolver(/* ... */)
     ///     .with_credential_refresh(move |id: &str| {
     ///         let id = id.to_owned();
@@ -490,7 +512,7 @@ impl WorkflowEngine {
     /// use nebula_core::action_key;
     /// use nebula_engine::WorkflowEngine;
     ///
-    /// let engine = WorkflowEngine::new(runtime, metrics)
+    /// let engine = WorkflowEngine::new(runtime, metrics)?
     ///     .with_credential_resolver(/* ... */)
     ///     .with_action_credentials(action_key!("http.request"), ["github_token"]);
     /// ```
@@ -856,7 +878,7 @@ impl WorkflowEngine {
                 .interner()
                 .single("reason", engine_lease_contention_reason::ALREADY_HELD);
             self.metrics
-                .counter_labeled(NEBULA_ENGINE_LEASE_CONTENTION_TOTAL, &labels)
+                .counter_labeled(NEBULA_ENGINE_LEASE_CONTENTION_TOTAL, &labels)?
                 .inc();
             tracing::warn!(
                 %execution_id,
@@ -920,12 +942,12 @@ impl WorkflowEngine {
                                         "reason",
                                         engine_lease_contention_reason::HEARTBEAT_LOST,
                                     );
-                                metrics
-                                    .counter_labeled(
-                                        NEBULA_ENGINE_LEASE_CONTENTION_TOTAL,
-                                        &labels,
-                                    )
-                                    .inc();
+                                if let Ok(c) = metrics.counter_labeled(
+                                    NEBULA_ENGINE_LEASE_CONTENTION_TOTAL,
+                                    &labels,
+                                ) {
+                                    c.inc();
+                                }
                                 tracing::error!(
                                     %execution_id,
                                     holder = %heartbeat_holder,
@@ -949,12 +971,12 @@ impl WorkflowEngine {
                                         "reason",
                                         engine_lease_contention_reason::HEARTBEAT_LOST,
                                     );
-                                metrics
-                                    .counter_labeled(
-                                        NEBULA_ENGINE_LEASE_CONTENTION_TOTAL,
-                                        &labels,
-                                    )
-                                    .inc();
+                                if let Ok(c) = metrics.counter_labeled(
+                                    NEBULA_ENGINE_LEASE_CONTENTION_TOTAL,
+                                    &labels,
+                                ) {
+                                    c.inc();
+                                }
                                 tracing::error!(
                                     %execution_id,
                                     holder = %heartbeat_holder,
@@ -1081,9 +1103,7 @@ impl WorkflowEngine {
         };
 
         // 6. Record start metric
-        self.metrics
-            .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
-            .inc();
+        self.workflow_executions_started.inc();
 
         // 7. Build node lookup map
         let node_map: HashMap<NodeKey, &nebula_workflow::NodeDefinition> =
@@ -1530,9 +1550,7 @@ impl WorkflowEngine {
             registration_id,
         };
 
-        self.metrics
-            .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
-            .inc();
+        self.workflow_executions_started.inc();
 
         let error_strategy = workflow.config.error_strategy;
         let workflow_retry_policy = workflow.config.retry_policy.clone();
@@ -3389,20 +3407,15 @@ impl WorkflowEngine {
     ) {
         match status {
             ExecutionStatus::Completed => {
-                self.metrics
-                    .counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)
-                    .inc();
+                self.workflow_executions_completed.inc();
             },
             ExecutionStatus::Failed => {
-                self.metrics
-                    .counter(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL)
-                    .inc();
+                self.workflow_executions_failed.inc();
             },
             _ => {},
         }
 
-        self.metrics
-            .histogram(NEBULA_WORKFLOW_EXECUTION_DURATION_SECONDS)
+        self.workflow_execution_duration_seconds
             .observe(elapsed.as_secs_f64());
     }
 }
@@ -4754,14 +4767,17 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        let runtime = Arc::new(ActionRuntime::new(
-            registry,
-            sandbox,
-            DataPassingPolicy::default(),
-            metrics.clone(),
-        ));
+        let runtime = Arc::new(
+            ActionRuntime::try_new(
+                registry,
+                sandbox,
+                DataPassingPolicy::default(),
+                metrics.clone(),
+            )
+            .unwrap(),
+        );
 
-        let engine = WorkflowEngine::new(runtime, metrics.clone());
+        let engine = WorkflowEngine::new(runtime, metrics.clone()).unwrap();
         (engine, metrics)
     }
 
@@ -4964,12 +4980,14 @@ mod tests {
         assert!(
             metrics
                 .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
+                .unwrap()
                 .get()
                 > 0
         );
         assert!(
             metrics
                 .counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)
+                .unwrap()
                 .get()
                 > 0
         );
@@ -5000,12 +5018,14 @@ mod tests {
         assert!(
             metrics
                 .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
+                .unwrap()
                 .get()
                 > 0
         );
         assert!(
             metrics
                 .counter(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL)
+                .unwrap()
                 .get()
                 > 0
         );

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -71,6 +71,11 @@ pub enum EngineError {
     #[error("runtime error: {0}")]
     Runtime(#[from] crate::runtime::RuntimeError),
 
+    /// In-process metric registry rejected a primitive registration (name
+    /// collision across kinds, histogram bucket mismatch, etc.).
+    #[error("telemetry metrics error: {0}")]
+    Telemetry(#[from] nebula_telemetry::TelemetryError),
+
     /// Error from the execution state layer.
     #[error("execution error: {0}")]
     Execution(#[from] nebula_execution::ExecutionError),
@@ -196,6 +201,7 @@ impl nebula_error::Classify for EngineError {
             // runner saw the execution already in flight. Conflict
             // matches HTTP 409 at the API edge.
             Self::Leased { .. } => nebula_error::ErrorCategory::Conflict,
+            Self::Telemetry(_) => nebula_error::ErrorCategory::Internal,
             Self::Runtime(e) => nebula_error::Classify::category(e),
             Self::Execution(e) => nebula_error::Classify::category(e),
             Self::Action(e) => nebula_error::Classify::category(e),
@@ -220,11 +226,13 @@ impl nebula_error::Classify for EngineError {
             Self::CheckpointFailed { .. } => "ENGINE:CHECKPOINT_FAILED",
             Self::CasConflict { .. } => "ENGINE:CAS_CONFLICT",
             Self::Leased { .. } => "ENGINE:LEASED",
+            Self::Telemetry(_) => "ENGINE:TELEMETRY",
         })
     }
 
     fn is_retryable(&self) -> bool {
         match self {
+            Self::Telemetry(_) => false,
             Self::Runtime(e) => nebula_error::Classify::is_retryable(e),
             Self::Execution(e) => nebula_error::Classify::is_retryable(e),
             Self::Action(e) => nebula_error::Classify::is_retryable(e),

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -42,6 +42,14 @@
 //!   resource. Engine wiring of `ResourceAction::configure`/`cleanup` per branch is deferred (see
 //!   `.ai-factory/PHASE7_BLOCKED.md`); the API surface is in place.
 //!
+//! ## Metrics registry wiring
+//!
+//! [`WorkflowEngine::new`] and [`runtime::ActionRuntime::try_new`] return [`Result`] if the shared
+//! `MetricsRegistry` rejects registration for a canonical metric identity (same name bound to
+//! incompatible primitive kinds, histogram bucket-layout conflict, etc.). Composition roots
+//! should treat that like any other startup failure: log and abort or surface
+//! [`error::EngineError::Telemetry`] / `nebula_telemetry::TelemetryError` to the caller.
+//!
 //! ## Canon
 //!
 //! - §10 golden path (orchestrator schedules activated workflows).

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -19,7 +19,10 @@ use nebula_metrics::naming::{
     NEBULA_ACTION_EXECUTIONS_TOTAL, NEBULA_ACTION_FAILURES_TOTAL, dispatch_reject_reason,
 };
 use nebula_sandbox::{SandboxRunner, SandboxedContext};
-use nebula_telemetry::metrics::{Counter, Histogram, MetricsRegistry};
+use nebula_telemetry::{
+    TelemetryError,
+    metrics::{Counter, Histogram, MetricsRegistry},
+};
 use nebula_workflow::NodeDefinition;
 use serde::{Deserialize, Serialize};
 
@@ -121,6 +124,10 @@ pub struct ActionRuntime {
     sandbox: Arc<dyn SandboxRunner>,
     data_policy: DataPassingPolicy,
     metrics: MetricsRegistry,
+    /// Pre-bound at construction so hot paths never propagate registry errors.
+    action_failures_total: Counter,
+    action_duration_seconds: Histogram,
+    action_executions_total: Counter,
     blob_storage: Option<Arc<dyn BlobStorage>>,
     /// Sum of estimated output bytes per execution for
     /// [`DataPassingPolicy::max_total_execution_bytes`].
@@ -129,20 +136,32 @@ pub struct ActionRuntime {
 
 impl ActionRuntime {
     /// Create a new runtime with the given components.
-    pub fn new(
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TelemetryError`] if the shared registry rejects registration
+    /// for the canonical action metric identities (e.g. name reused as another
+    /// primitive kind).
+    pub fn try_new(
         registry: Arc<ActionRegistry>,
         sandbox: Arc<dyn SandboxRunner>,
         data_policy: DataPassingPolicy,
         metrics: MetricsRegistry,
-    ) -> Self {
-        Self {
+    ) -> Result<Self, TelemetryError> {
+        let action_failures_total = metrics.counter(NEBULA_ACTION_FAILURES_TOTAL)?;
+        let action_duration_seconds = metrics.histogram(NEBULA_ACTION_DURATION_SECONDS)?;
+        let action_executions_total = metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL)?;
+        Ok(Self {
             registry,
             sandbox,
             data_policy,
             metrics,
+            action_failures_total,
+            action_duration_seconds,
+            action_executions_total,
             blob_storage: None,
             execution_output_totals: Arc::new(DashMap::new()),
-        }
+        })
     }
 
     /// Clears accumulated output-byte totals for an execution.
@@ -401,7 +420,7 @@ impl ActionRuntime {
         context: &dyn ActionContext,
         checkpoint: Option<Arc<dyn StatefulCheckpointSink>>,
     ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
-        let error_counter = self.metrics.counter(NEBULA_ACTION_FAILURES_TOTAL);
+        let error_counter = &self.action_failures_total;
         // `ExecutionId::new()` generates a fresh ULID; we deliberately do
         // *not* fall through to `ExecutionId::default()` (which returns nil)
         // when the scope omits the field — missing execution IDs are synthetic
@@ -462,7 +481,7 @@ impl ActionRuntime {
                     action_key,
                     execution_id,
                     &mut action_result,
-                    &error_counter,
+                    error_counter,
                 )
                 .await?;
                 Ok(action_result)
@@ -500,7 +519,7 @@ impl ActionRuntime {
         context: &dyn ActionContext,
         checkpoint: Option<Arc<dyn StatefulCheckpointSink>>,
     ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
-        let error_counter = self.metrics.counter(NEBULA_ACTION_FAILURES_TOTAL);
+        let error_counter = &self.action_failures_total;
         #[allow(
             clippy::unwrap_or_default,
             reason = "ExecutionId::new() != Default::default()"
@@ -575,7 +594,7 @@ impl ActionRuntime {
                     action_key,
                     execution_id,
                     &mut action_result,
-                    &error_counter,
+                    error_counter,
                 )
                 .await?;
                 Ok(action_result)
@@ -772,10 +791,10 @@ impl ActionRuntime {
         result: &Result<ActionResult<serde_json::Value>, RuntimeError>,
     ) {
         let elapsed = started.elapsed();
-        self.duration_histogram().observe(elapsed.as_secs_f64());
-        self.executions_counter().inc();
+        self.action_duration_seconds.observe(elapsed.as_secs_f64());
+        self.action_executions_total.inc();
         if result.is_err() {
-            self.failures_counter().inc();
+            self.action_failures_total.inc();
         }
     }
 
@@ -787,21 +806,17 @@ impl ActionRuntime {
     /// skew downstream dashboards (#305).
     fn observe_rejected(&self, reason: &'static str) {
         let labels = self.metrics.interner().label_set(&[("reason", reason)]);
-        self.metrics
+        match self
+            .metrics
             .counter_labeled(NEBULA_ACTION_DISPATCH_REJECTED_TOTAL, &labels)
-            .inc();
-    }
-
-    fn duration_histogram(&self) -> Histogram {
-        self.metrics.histogram(NEBULA_ACTION_DURATION_SECONDS)
-    }
-
-    fn executions_counter(&self) -> Counter {
-        self.metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
-    }
-
-    fn failures_counter(&self) -> Counter {
-        self.metrics.counter(NEBULA_ACTION_FAILURES_TOTAL)
+        {
+            Ok(c) => c.inc(),
+            Err(err) => tracing::warn!(
+                ?err,
+                reason,
+                "failed to record action dispatch rejected metric"
+            ),
+        }
     }
 
     /// Execute a stateless handler.
@@ -1459,7 +1474,7 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        ActionRuntime::new(registry, sandbox, DataPassingPolicy::default(), metrics)
+        ActionRuntime::try_new(registry, sandbox, DataPassingPolicy::default(), metrics).unwrap()
     }
 
     /// Build a runtime with a metrics registry we hand back to the caller,
@@ -1473,12 +1488,13 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy::default(),
             metrics.clone(),
-        );
+        )
+        .unwrap();
         (rt, metrics)
     }
 
@@ -1495,7 +1511,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1504,7 +1520,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let eid = ExecutionId::new();
         let ctx = ActionRuntimeContext::new(
@@ -1599,7 +1616,7 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1607,7 +1624,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let input = serde_json::json!({"big_payload": "this is way too large for 5 bytes"});
         let result = rt.execute_action("test.big", input, &test_context()).await;
@@ -1631,20 +1649,30 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy::default(),
             metrics.clone(),
-        );
+        )
+        .unwrap();
 
         rt.execute_action("test.tele", serde_json::json!("ok"), &test_context())
             .await
             .unwrap();
 
         // Metrics should be recorded.
-        assert_eq!(metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get(), 1);
-        assert_eq!(metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).get(), 0);
+        assert_eq!(
+            metrics
+                .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+                .unwrap()
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).unwrap().get(),
+            0
+        );
     }
 
     #[tokio::test]
@@ -1685,7 +1713,8 @@ mod tests {
         );
 
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(registry, sandbox, DataPassingPolicy::default(), metrics);
+        let rt = ActionRuntime::try_new(registry, sandbox, DataPassingPolicy::default(), metrics)
+            .unwrap();
 
         let result = rt
             .execute_action(
@@ -1715,7 +1744,7 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1724,7 +1753,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         // No blob storage configured -- should reject.
         let input = serde_json::json!({"big": "this exceeds 5 bytes easily"});
@@ -1777,7 +1807,7 @@ mod tests {
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
 
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1787,6 +1817,7 @@ mod tests {
             },
             metrics,
         )
+        .unwrap()
         .with_blob_storage(Arc::new(FakeBlobStorage));
 
         let input = serde_json::json!({"big": "this exceeds 5 bytes easily"});
@@ -1887,7 +1918,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1896,7 +1927,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let result = rt
             .execute_action("test.multi_out", serde_json::json!(null), &test_context())
@@ -1973,7 +2005,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -1982,7 +2014,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let result = rt
             .execute_action("test.branch", serde_json::json!(null), &test_context())
@@ -2052,7 +2085,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -2061,7 +2094,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let result = rt
             .execute_action("test.collection", serde_json::json!(null), &test_context())
@@ -2130,7 +2164,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -2139,7 +2173,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let result = rt
             .execute_action("test.binary", serde_json::json!(null), &test_context())
@@ -2205,7 +2240,7 @@ mod tests {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let rt = ActionRuntime::new(
+        let rt = ActionRuntime::try_new(
             registry,
             sandbox,
             DataPassingPolicy {
@@ -2214,7 +2249,8 @@ mod tests {
                 ..Default::default()
             },
             metrics,
-        );
+        )
+        .unwrap();
 
         let result = rt
             .execute_action("test.ref", serde_json::json!(null), &test_context())
@@ -2283,17 +2319,23 @@ mod tests {
 
         // Histogram and execution/failure counters must NOT observe this path.
         assert_eq!(
-            metrics.histogram(NEBULA_ACTION_DURATION_SECONDS).count(),
+            metrics
+                .histogram(NEBULA_ACTION_DURATION_SECONDS)
+                .unwrap()
+                .count(),
             0,
             "duration histogram must not sample rejection paths"
         );
         assert_eq!(
-            metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get(),
+            metrics
+                .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+                .unwrap()
+                .get(),
             0,
             "executions counter must not bump on rejection"
         );
         assert_eq!(
-            metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).get(),
+            metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).unwrap().get(),
             0,
             "failures counter must not bump on rejection"
         );
@@ -2305,6 +2347,7 @@ mod tests {
         assert_eq!(
             metrics
                 .counter_labeled(NEBULA_ACTION_DISPATCH_REJECTED_TOTAL, &labels)
+                .unwrap()
                 .get(),
             1,
             "dispatch-rejected counter should be bumped once with reason=trigger_not_executable"
@@ -2362,9 +2405,24 @@ mod tests {
             "expected ResourceNotExecutable, got {result:?}"
         );
 
-        assert_eq!(metrics.histogram(NEBULA_ACTION_DURATION_SECONDS).count(), 0);
-        assert_eq!(metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get(), 0);
-        assert_eq!(metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).get(), 0);
+        assert_eq!(
+            metrics
+                .histogram(NEBULA_ACTION_DURATION_SECONDS)
+                .unwrap()
+                .count(),
+            0
+        );
+        assert_eq!(
+            metrics
+                .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+                .unwrap()
+                .get(),
+            0
+        );
+        assert_eq!(
+            metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).unwrap().get(),
+            0
+        );
 
         let labels = metrics
             .interner()
@@ -2372,6 +2430,7 @@ mod tests {
         assert_eq!(
             metrics
                 .counter_labeled(NEBULA_ACTION_DISPATCH_REJECTED_TOTAL, &labels)
+                .unwrap()
                 .get(),
             1
         );
@@ -2392,9 +2451,24 @@ mod tests {
         rt.execute_action("test.dispatched", serde_json::json!("ok"), &test_context())
             .await
             .expect("dispatched execution must succeed");
-        assert_eq!(metrics.histogram(NEBULA_ACTION_DURATION_SECONDS).count(), 1);
-        assert_eq!(metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get(), 1);
-        assert_eq!(metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).get(), 0);
+        assert_eq!(
+            metrics
+                .histogram(NEBULA_ACTION_DURATION_SECONDS)
+                .unwrap()
+                .count(),
+            1
+        );
+        assert_eq!(
+            metrics
+                .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+                .unwrap()
+                .get(),
+            1
+        );
+        assert_eq!(
+            metrics.counter(NEBULA_ACTION_FAILURES_TOTAL).unwrap().get(),
+            0
+        );
 
         let labels = metrics
             .interner()
@@ -2402,6 +2476,7 @@ mod tests {
         assert_eq!(
             metrics
                 .counter_labeled(NEBULA_ACTION_DISPATCH_REJECTED_TOTAL, &labels)
+                .unwrap()
                 .get(),
             0,
             "dispatch-rejected counter must stay at zero for successful dispatch"

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -534,9 +534,11 @@ async fn reclaim_sweep_emits_counter_metric_per_outcome() {
         loop {
             let r = registry
                 .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &reclaimed_labels)
+                .unwrap()
                 .get();
             let e = registry
                 .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &exhausted_labels)
+                .unwrap()
                 .get();
             if r >= 2 && e >= 1 {
                 break;
@@ -555,9 +557,11 @@ async fn reclaim_sweep_emits_counter_metric_per_outcome() {
     // sweep finds work — counters stay at 2 and 1 (per-row, not per-sweep).
     let reclaimed = registry
         .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &reclaimed_labels)
+        .unwrap()
         .get();
     let exhausted = registry
         .counter_labeled(NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, &exhausted_labels)
+        .unwrap()
         .get();
     assert_eq!(reclaimed, 2, "reclaimed counter bumps by row count");
     assert_eq!(exhausted, 1, "exhausted counter bumps by row count");

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -172,12 +172,15 @@ impl Harness {
         });
         let sandbox = Arc::new(InProcessSandbox::new(executor));
         let metrics = MetricsRegistry::new();
-        let runtime = Arc::new(ActionRuntime::new(
-            registry,
-            sandbox,
-            DataPassingPolicy::default(),
-            metrics.clone(),
-        ));
+        let runtime = Arc::new(
+            ActionRuntime::try_new(
+                registry,
+                sandbox,
+                DataPassingPolicy::default(),
+                metrics.clone(),
+            )
+            .unwrap(),
+        );
 
         let execution_repo = Arc::new(InMemoryExecutionRepo::new());
         let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
@@ -186,6 +189,7 @@ impl Harness {
         let workflow_repo_dyn: Arc<dyn WorkflowRepo> = Arc::clone(&workflow_repo) as _;
 
         let engine = WorkflowEngine::new(runtime, metrics)
+            .unwrap()
             .with_execution_repo(Arc::clone(&execution_repo_dyn))
             .with_workflow_repo(workflow_repo_dyn);
         let engine = Arc::new(engine);

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -259,13 +259,16 @@ async fn pipeline_resolves_expressions_before_handler_runs() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    let engine = WorkflowEngine::new(runtime, metrics);
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = WorkflowEngine::new(runtime, metrics).unwrap();
 
     // Build a node with three parameters:
     //   - `name`     : literal string
@@ -379,13 +382,18 @@ async fn pipeline_with_resource_manager_resolves_and_executes() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    let engine = WorkflowEngine::new(runtime, metrics).with_resource_manager(manager.clone());
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = WorkflowEngine::new(runtime, metrics)
+        .unwrap()
+        .with_resource_manager(manager.clone());
 
     let node = node_key!("e2e_node_with_manager");
     let mut node_def = NodeDefinition::new(node.clone(), "Witness", "phase9.witness").unwrap();
@@ -441,13 +449,16 @@ async fn pipeline_unresolvable_expression_fails_node_before_handler() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    let engine = WorkflowEngine::new(runtime, metrics);
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = WorkflowEngine::new(runtime, metrics).unwrap();
 
     let node = node_key!("bad_node");
     let mut node_def = NodeDefinition::new(node.clone(), "Witness", "phase9.witness").unwrap();

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -238,14 +238,17 @@ fn make_engine(registry: Arc<ActionRegistry>) -> (WorkflowEngine, MetricsRegistr
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
 
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
-    let engine = WorkflowEngine::new(runtime, metrics.clone());
+    let engine = WorkflowEngine::new(runtime, metrics.clone()).unwrap();
     (engine, metrics)
 }
 
@@ -261,13 +264,16 @@ async fn engine_and_runtime_share_metrics_registry() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
 
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    let engine = WorkflowEngine::new(runtime, metrics.clone());
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = WorkflowEngine::new(runtime, metrics.clone()).unwrap();
 
     let n = node_key!("n");
     let wf = make_workflow(
@@ -280,7 +286,13 @@ async fn engine_and_runtime_share_metrics_registry() {
         .await
         .unwrap();
 
-    assert!(metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get() >= 1);
+    assert!(
+        metrics
+            .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+            .unwrap()
+            .get()
+            >= 1
+    );
 }
 
 fn meta(key: ActionKey) -> ActionMetadata {
@@ -533,16 +545,24 @@ async fn metrics_cover_full_lifecycle() {
     assert!(
         metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
+            .unwrap()
             .get()
             > 0
     );
     assert!(
         metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)
+            .unwrap()
             .get()
             > 0
     );
-    assert!(metrics.counter(NEBULA_ACTION_EXECUTIONS_TOTAL).get() >= 2);
+    assert!(
+        metrics
+            .counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
+            .unwrap()
+            .get()
+            >= 2
+    );
 }
 
 /// Verify that execution with many parallel nodes works with concurrency control.
@@ -676,18 +696,21 @@ async fn metrics_accurate_on_failure() {
     assert_eq!(
         metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
+            .unwrap()
             .get(),
         1
     );
     assert_eq!(
         metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL)
+            .unwrap()
             .get(),
         1
     );
     assert_eq!(
         metrics
             .counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)
+            .unwrap()
             .get(),
         0
     );

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -157,13 +157,16 @@ fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
     let executor: ActionExecutor =
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    WorkflowEngine::new(runtime, metrics)
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/engine/tests/refresh_coordinator_chaos.rs
+++ b/crates/engine/tests/refresh_coordinator_chaos.rs
@@ -172,7 +172,7 @@ async fn three_replicas_zero_double_idp_calls() {
     // same series — at the end we read the aggregated counters straight
     // from the registry rather than poking pub(crate) handle fields.
     let registry = MetricsRegistry::new();
-    let metrics_handle = RefreshCoordMetrics::with_registry(&registry);
+    let metrics_handle = RefreshCoordMetrics::with_registry(&registry).unwrap();
 
     // Build N credentials; each gets a tracker the fake IdP closure
     // bumps. Use the in-memory repo (cross-replica visibility) so the
@@ -438,5 +438,5 @@ fn chaos_config() -> RefreshCoordConfig {
 /// access while still observing aggregate counts.
 fn read_counter(registry: &MetricsRegistry, name: &str, label_key: &str, label_val: &str) -> u64 {
     let labels = registry.interner().single(label_key, label_val);
-    registry.counter_labeled(name, &labels).get()
+    registry.counter_labeled(name, &labels).unwrap().get()
 }

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -195,14 +195,19 @@ async fn action_acquires_resource_through_engine() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
-    let engine = WorkflowEngine::new(runtime, metrics).with_resource_manager(manager);
+    let engine = WorkflowEngine::new(runtime, metrics)
+        .unwrap()
+        .with_resource_manager(manager);
 
     // 4. Build and execute a single-node workflow
     let node = node_key!("test");
@@ -243,14 +248,19 @@ async fn full_resource_lifecycle_with_shutdown() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
-    let engine = WorkflowEngine::new(runtime, metrics).with_resource_manager(manager.clone());
+    let engine = WorkflowEngine::new(runtime, metrics)
+        .unwrap()
+        .with_resource_manager(manager.clone());
 
     // 4. Execute a single-node workflow
     let node = node_key!("test");
@@ -295,14 +305,17 @@ async fn action_resource_fails_without_manager() {
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
     let metrics = MetricsRegistry::new();
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
 
-    let engine = WorkflowEngine::new(runtime, metrics);
+    let engine = WorkflowEngine::new(runtime, metrics).unwrap();
     // No .with_resource_manager() — intentionally omitted so the engine
     // falls back to the no-op accessor and the probe handler fails.
 

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -152,13 +152,16 @@ fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
     let executor: ActionExecutor =
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
     let sandbox = Arc::new(InProcessSandbox::new(executor));
-    let runtime = Arc::new(ActionRuntime::new(
-        registry,
-        sandbox,
-        DataPassingPolicy::default(),
-        metrics.clone(),
-    ));
-    WorkflowEngine::new(runtime, metrics)
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
 }
 
 fn make_workflow(

--- a/crates/metrics/examples/cardinality_guard.rs
+++ b/crates/metrics/examples/cardinality_guard.rs
@@ -52,10 +52,16 @@ fn main() {
     }
 
     // Record with the safe set — no cardinality explosion.
-    adapter.action_executions_labeled(&safe_labels).inc_by(42);
+    adapter
+        .action_executions_labeled(&safe_labels)
+        .unwrap()
+        .inc_by(42);
     println!(
         "\naction_executions with safe labels = {}",
-        adapter.action_executions_labeled(&safe_labels).get()
+        adapter
+            .action_executions_labeled(&safe_labels)
+            .unwrap()
+            .get()
     );
 
     println!("\n=== retain_recent demo ===\n");
@@ -72,6 +78,7 @@ fn main() {
     for i in 0..1_000usize {
         let labels = interner2.label_set(&[("plugin_instance", i.to_string().as_str())]);
         reg2.counter_labeled("nebula_plugin_executions_total", &labels)
+            .unwrap()
             .inc();
     }
     println!("Series after bulk recording : {}", reg2.metric_count());
@@ -88,8 +95,12 @@ fn main() {
     let interner3 = reg3.interner();
 
     let labels = interner3.label_set(&[("action_type", "http.request")]);
-    reg3.counter_labeled("nebula_actions_total", &labels).inc();
-    reg3.counter_labeled("nebula_actions_total", &labels).inc(); // keep-alive touch
+    reg3.counter_labeled("nebula_actions_total", &labels)
+        .unwrap()
+        .inc();
+    reg3.counter_labeled("nebula_actions_total", &labels)
+        .unwrap()
+        .inc(); // keep-alive touch
 
     // With a generous window (5 min) fresh series survive.
     reg3.retain_recent(Duration::from_mins(5));

--- a/crates/metrics/examples/prometheus_export.rs
+++ b/crates/metrics/examples/prometheus_export.rs
@@ -19,12 +19,24 @@ fn main() {
 
     // ── Simulate workflow executions ──────────────────────────────────────────
 
-    adapter.workflow_executions_started_total().inc_by(5);
-    adapter.workflow_executions_completed_total().inc_by(4);
-    adapter.workflow_executions_failed_total().inc();
+    adapter
+        .workflow_executions_started_total()
+        .expect("workflow started counter")
+        .inc_by(5);
+    adapter
+        .workflow_executions_completed_total()
+        .expect("workflow completed counter")
+        .inc_by(4);
+    adapter
+        .workflow_executions_failed_total()
+        .expect("workflow failed counter")
+        .inc();
 
     for &secs in &[0.12, 0.35, 0.78, 1.45, 3.20] {
-        adapter.workflow_execution_duration_seconds().observe(secs);
+        adapter
+            .workflow_execution_duration_seconds()
+            .expect("workflow duration histogram")
+            .observe(secs);
     }
 
     // ── Simulate action executions with labels ────────────────────────────────
@@ -35,20 +47,34 @@ fn main() {
     let http_err = interner.label_set(&[("action_type", "http.request"), ("status", "error")]);
     let math_ok = interner.label_set(&[("action_type", "math.add"), ("status", "success")]);
 
-    adapter.action_executions_labeled(&http_ok).inc_by(120);
-    adapter.action_executions_labeled(&http_err).inc_by(8);
-    adapter.action_executions_labeled(&math_ok).inc_by(55);
+    adapter
+        .action_executions_labeled(&http_ok)
+        .expect("action executions")
+        .inc_by(120);
+    adapter
+        .action_executions_labeled(&http_err)
+        .expect("action executions")
+        .inc_by(8);
+    adapter
+        .action_executions_labeled(&math_ok)
+        .expect("action executions")
+        .inc_by(55);
 
-    adapter.action_failures_labeled(&http_err).inc_by(8);
+    adapter
+        .action_failures_labeled(&http_err)
+        .expect("action failures")
+        .inc_by(8);
 
     for &ms in &[45.0_f64, 112.0, 230.0, 890.0, 2100.0, 4500.0] {
         adapter
             .action_duration_labeled(&http_ok)
+            .expect("action duration")
             .observe(ms / 1000.0);
     }
     for &ms in &[15.0_f64, 20.0, 18.0] {
         adapter
             .action_duration_labeled(&math_ok)
+            .expect("action duration")
             .observe(ms / 1000.0);
     }
 

--- a/crates/metrics/src/adapter.rs
+++ b/crates/metrics/src/adapter.rs
@@ -11,7 +11,7 @@ use nebula_telemetry::{
     metrics::{Counter, Gauge, Histogram, MetricsRegistry},
 };
 
-use crate::{filter::LabelAllowlist, naming::*};
+use crate::{TelemetryResult, filter::LabelAllowlist, naming::*};
 
 /// Adapter that exposes telemetry metrics under standard `nebula_*` names.
 ///
@@ -83,29 +83,25 @@ impl TelemetryAdapter {
     // ---------- Workflow (engine) ----------
 
     /// Counter: workflow executions started.
-    #[must_use]
-    pub fn workflow_executions_started_total(&self) -> Counter {
+    pub fn workflow_executions_started_total(&self) -> TelemetryResult<Counter> {
         self.registry
             .counter(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL)
     }
 
     /// Counter: workflow executions completed successfully.
-    #[must_use]
-    pub fn workflow_executions_completed_total(&self) -> Counter {
+    pub fn workflow_executions_completed_total(&self) -> TelemetryResult<Counter> {
         self.registry
             .counter(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL)
     }
 
     /// Counter: workflow executions failed.
-    #[must_use]
-    pub fn workflow_executions_failed_total(&self) -> Counter {
+    pub fn workflow_executions_failed_total(&self) -> TelemetryResult<Counter> {
         self.registry
             .counter(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL)
     }
 
     /// Histogram: workflow execution duration in seconds.
-    #[must_use]
-    pub fn workflow_execution_duration_seconds(&self) -> Histogram {
+    pub fn workflow_execution_duration_seconds(&self) -> TelemetryResult<Histogram> {
         self.registry
             .histogram(NEBULA_WORKFLOW_EXECUTION_DURATION_SECONDS)
     }
@@ -113,40 +109,34 @@ impl TelemetryAdapter {
     // ---------- Action (runtime) ----------
 
     /// Counter: action executions (success + failure).
-    #[must_use]
-    pub fn action_executions_total(&self) -> Counter {
+    pub fn action_executions_total(&self) -> TelemetryResult<Counter> {
         self.registry.counter(NEBULA_ACTION_EXECUTIONS_TOTAL)
     }
 
     /// Counter: action failures.
-    #[must_use]
-    pub fn action_failures_total(&self) -> Counter {
+    pub fn action_failures_total(&self) -> TelemetryResult<Counter> {
         self.registry.counter(NEBULA_ACTION_FAILURES_TOTAL)
     }
 
     /// Histogram: action execution duration in seconds.
-    #[must_use]
-    pub fn action_duration_seconds(&self) -> Histogram {
+    pub fn action_duration_seconds(&self) -> TelemetryResult<Histogram> {
         self.registry.histogram(NEBULA_ACTION_DURATION_SECONDS)
     }
 
     // ---------- Generic access (for domain-specific names) ----------
 
     /// Get or create a counter by name. Prefer the typed accessors above when available.
-    #[must_use]
-    pub fn counter(&self, name: &str) -> Counter {
+    pub fn counter(&self, name: &str) -> TelemetryResult<Counter> {
         self.registry.counter(name)
     }
 
     /// Get or create a gauge by name.
-    #[must_use]
-    pub fn gauge(&self, name: &str) -> Gauge {
+    pub fn gauge(&self, name: &str) -> TelemetryResult<Gauge> {
         self.registry.gauge(name)
     }
 
     /// Get or create a histogram by name.
-    #[must_use]
-    pub fn histogram(&self, name: &str) -> Histogram {
+    pub fn histogram(&self, name: &str) -> TelemetryResult<Histogram> {
         self.registry.histogram(name)
     }
 
@@ -165,50 +155,53 @@ impl TelemetryAdapter {
     /// let reg = Arc::new(MetricsRegistry::new());
     /// let adapter = TelemetryAdapter::new(Arc::clone(&reg));
     /// let labels = reg.interner().label_set(&[("action_type", "http.request")]);
-    /// adapter.action_executions_labeled(&labels).inc();
+    /// adapter.action_executions_labeled(&labels).unwrap().inc();
     /// ```
-    #[must_use]
-    pub fn action_executions_labeled(&self, labels: &LabelSet) -> Counter {
+    pub fn action_executions_labeled(&self, labels: &LabelSet) -> TelemetryResult<Counter> {
         let labels = self.filter_labels(labels);
         self.registry
             .counter_labeled(NEBULA_ACTION_EXECUTIONS_TOTAL, &labels)
     }
 
     /// Counter: action failures with label dimensions.
-    #[must_use]
-    pub fn action_failures_labeled(&self, labels: &LabelSet) -> Counter {
+    pub fn action_failures_labeled(&self, labels: &LabelSet) -> TelemetryResult<Counter> {
         let labels = self.filter_labels(labels);
         self.registry
             .counter_labeled(NEBULA_ACTION_FAILURES_TOTAL, &labels)
     }
 
     /// Histogram: action execution duration with label dimensions.
-    #[must_use]
-    pub fn action_duration_labeled(&self, labels: &LabelSet) -> Histogram {
+    pub fn action_duration_labeled(&self, labels: &LabelSet) -> TelemetryResult<Histogram> {
         let labels = self.filter_labels(labels);
         self.registry
             .histogram_labeled(NEBULA_ACTION_DURATION_SECONDS, &labels)
     }
 
     /// Counter: workflow executions started with label dimensions.
-    #[must_use]
-    pub fn workflow_executions_started_labeled(&self, labels: &LabelSet) -> Counter {
+    pub fn workflow_executions_started_labeled(
+        &self,
+        labels: &LabelSet,
+    ) -> TelemetryResult<Counter> {
         let labels = self.filter_labels(labels);
         self.registry
             .counter_labeled(NEBULA_WORKFLOW_EXECUTIONS_STARTED_TOTAL, &labels)
     }
 
     /// Counter: workflow executions completed with label dimensions.
-    #[must_use]
-    pub fn workflow_executions_completed_labeled(&self, labels: &LabelSet) -> Counter {
+    pub fn workflow_executions_completed_labeled(
+        &self,
+        labels: &LabelSet,
+    ) -> TelemetryResult<Counter> {
         let labels = self.filter_labels(labels);
         self.registry
             .counter_labeled(NEBULA_WORKFLOW_EXECUTIONS_COMPLETED_TOTAL, &labels)
     }
 
     /// Counter: workflow executions failed with label dimensions.
-    #[must_use]
-    pub fn workflow_executions_failed_labeled(&self, labels: &LabelSet) -> Counter {
+    pub fn workflow_executions_failed_labeled(
+        &self,
+        labels: &LabelSet,
+    ) -> TelemetryResult<Counter> {
         let labels = self.filter_labels(labels);
         self.registry
             .counter_labeled(NEBULA_WORKFLOW_EXECUTIONS_FAILED_TOTAL, &labels)
@@ -223,35 +216,32 @@ impl TelemetryAdapter {
     // ---------- EventBus snapshots ----------
 
     /// Gauge: eventbus sent events snapshot.
-    #[must_use]
-    pub fn eventbus_sent(&self) -> Gauge {
+    pub fn eventbus_sent(&self) -> TelemetryResult<Gauge> {
         self.registry.gauge(NEBULA_EVENTBUS_SENT)
     }
 
     /// Gauge: eventbus dropped events snapshot.
-    #[must_use]
-    pub fn eventbus_dropped(&self) -> Gauge {
+    pub fn eventbus_dropped(&self) -> TelemetryResult<Gauge> {
         self.registry.gauge(NEBULA_EVENTBUS_DROPPED)
     }
 
     /// Gauge: eventbus active subscriber snapshot.
-    #[must_use]
-    pub fn eventbus_subscribers(&self) -> Gauge {
+    pub fn eventbus_subscribers(&self) -> TelemetryResult<Gauge> {
         self.registry.gauge(NEBULA_EVENTBUS_SUBSCRIBERS)
     }
 
     /// Gauge: eventbus drop ratio snapshot in parts-per-million (`0..=1_000_000`).
-    #[must_use]
-    pub fn eventbus_drop_ratio_ppm(&self) -> Gauge {
+    pub fn eventbus_drop_ratio_ppm(&self) -> TelemetryResult<Gauge> {
         self.registry.gauge(NEBULA_EVENTBUS_DROP_RATIO_PPM)
     }
 
     /// Records an [`EventBusStats`] snapshot under standard `nebula_eventbus_*` gauges.
-    pub fn record_eventbus_stats(&self, stats: &EventBusStats) {
-        self.eventbus_sent().set(clamp_u64_to_i64(stats.sent_count));
-        self.eventbus_dropped()
+    pub fn record_eventbus_stats(&self, stats: &EventBusStats) -> TelemetryResult<()> {
+        self.eventbus_sent()?
+            .set(clamp_u64_to_i64(stats.sent_count));
+        self.eventbus_dropped()?
             .set(clamp_u64_to_i64(stats.dropped_count));
-        self.eventbus_subscribers()
+        self.eventbus_subscribers()?
             .set(clamp_usize_to_i64(stats.subscriber_count));
 
         let ppm = (stats.drop_ratio() * 1_000_000.0).round();
@@ -260,7 +250,8 @@ impl TelemetryAdapter {
         } else {
             0
         };
-        self.eventbus_drop_ratio_ppm().set(ppm);
+        self.eventbus_drop_ratio_ppm()?.set(ppm);
+        Ok(())
     }
 }
 
@@ -287,14 +278,17 @@ mod tests {
         let registry = Arc::new(MetricsRegistry::new());
         let adapter = TelemetryAdapter::new(Arc::clone(&registry));
 
-        adapter.workflow_executions_started_total().inc();
-        adapter.workflow_executions_started_total().inc();
-        adapter.action_executions_total().inc();
-        adapter.action_failures_total().inc();
+        adapter.workflow_executions_started_total().unwrap().inc();
+        adapter.workflow_executions_started_total().unwrap().inc();
+        adapter.action_executions_total().unwrap().inc();
+        adapter.action_failures_total().unwrap().inc();
 
-        assert_eq!(adapter.workflow_executions_started_total().get(), 2);
-        assert_eq!(adapter.action_executions_total().get(), 1);
-        assert_eq!(adapter.action_failures_total().get(), 1);
+        assert_eq!(
+            adapter.workflow_executions_started_total().unwrap().get(),
+            2
+        );
+        assert_eq!(adapter.action_executions_total().unwrap().get(), 1);
+        assert_eq!(adapter.action_failures_total().unwrap().get(), 1);
     }
 
     #[test]
@@ -308,12 +302,12 @@ mod tests {
             subscriber_count: 3,
         };
 
-        adapter.record_eventbus_stats(&stats);
+        adapter.record_eventbus_stats(&stats).unwrap();
 
-        assert_eq!(adapter.eventbus_sent().get(), 75);
-        assert_eq!(adapter.eventbus_dropped().get(), 25);
-        assert_eq!(adapter.eventbus_subscribers().get(), 3);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 250_000);
+        assert_eq!(adapter.eventbus_sent().unwrap().get(), 75);
+        assert_eq!(adapter.eventbus_dropped().unwrap().get(), 25);
+        assert_eq!(adapter.eventbus_subscribers().unwrap().get(), 3);
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 250_000);
     }
 
     #[test]
@@ -331,11 +325,11 @@ mod tests {
             stats.dropped_count,
             0
         );
-        adapter.record_eventbus_stats(&stats);
-        assert_eq!(adapter.eventbus_sent().get(), 0);
-        assert_eq!(adapter.eventbus_dropped().get(), 0);
-        assert_eq!(adapter.eventbus_subscribers().get(), 0);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 0);
+        adapter.record_eventbus_stats(&stats).unwrap();
+        assert_eq!(adapter.eventbus_sent().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_dropped().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_subscribers().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 0);
 
         let default_stats = EventBusStats::default();
         tracing::debug!(
@@ -344,11 +338,11 @@ mod tests {
             default_stats.dropped_count,
             0
         );
-        adapter.record_eventbus_stats(&default_stats);
-        assert_eq!(adapter.eventbus_sent().get(), 0);
-        assert_eq!(adapter.eventbus_dropped().get(), 0);
-        assert_eq!(adapter.eventbus_subscribers().get(), 0);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 0);
+        adapter.record_eventbus_stats(&default_stats).unwrap();
+        assert_eq!(adapter.eventbus_sent().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_dropped().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_subscribers().unwrap().get(), 0);
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 0);
     }
 
     #[test]
@@ -366,8 +360,8 @@ mod tests {
             full_drop.dropped_count,
             1_000_000
         );
-        adapter.record_eventbus_stats(&full_drop);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 500_000);
+        adapter.record_eventbus_stats(&full_drop).unwrap();
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 500_000);
 
         let fractional = EventBusStats {
             sent_count: 3,
@@ -380,8 +374,8 @@ mod tests {
             fractional.dropped_count,
             250_000
         );
-        adapter.record_eventbus_stats(&fractional);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 250_000);
+        adapter.record_eventbus_stats(&fractional).unwrap();
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 250_000);
     }
 
     #[test]
@@ -399,11 +393,11 @@ mod tests {
             stats.dropped_count,
             0
         );
-        adapter.record_eventbus_stats(&stats);
+        adapter.record_eventbus_stats(&stats).unwrap();
 
-        assert_eq!(adapter.eventbus_sent().get(), i64::MAX);
-        assert_eq!(adapter.eventbus_subscribers().get(), i64::MAX);
-        assert_eq!(adapter.eventbus_drop_ratio_ppm().get(), 0);
+        assert_eq!(adapter.eventbus_sent().unwrap().get(), i64::MAX);
+        assert_eq!(adapter.eventbus_subscribers().unwrap().get(), i64::MAX);
+        assert_eq!(adapter.eventbus_drop_ratio_ppm().unwrap().get(), 0);
     }
 
     #[test]
@@ -416,7 +410,7 @@ mod tests {
             ("execution_id", "exec-123"),
         ]);
 
-        adapter.action_executions_labeled(&labels).inc();
+        adapter.action_executions_labeled(&labels).unwrap().inc();
 
         let snapshots = registry.snapshot_counters();
         let (key, counter) = snapshots

--- a/crates/metrics/src/export/prometheus.rs
+++ b/crates/metrics/src/export/prometheus.rs
@@ -120,6 +120,23 @@ fn histogram_help(name: &str) -> &'static str {
     }
 }
 
+/// Format a floating-point sample for Prometheus text exposition (0.0.4).
+///
+/// Rust's default `f64` display uses `inf` / `-inf`; Prometheus expects `+Inf`,
+/// `-Inf`, and `NaN` tokens.
+fn format_prometheus_float(v: f64) -> String {
+    if v.is_nan() {
+        return "NaN".to_owned();
+    }
+    if v == f64::INFINITY {
+        return "+Inf".to_owned();
+    }
+    if v == f64::NEG_INFINITY {
+        return "-Inf".to_owned();
+    }
+    v.to_string()
+}
+
 // ── Label rendering ───────────────────────────────────────────────────────────
 
 /// Render a Prometheus label selector string: `{k1="v1",k2="v2"}`.
@@ -312,9 +329,10 @@ pub fn snapshot(registry: &MetricsRegistry) -> String {
         let _ = writeln!(out, "# HELP {name} {}", histogram_help(name));
         let _ = writeln!(out, "# TYPE {name} histogram");
         for (labels, hist) in entries {
-            let count = hist.count();
-            let sum = hist.sum();
-            let buckets = hist.buckets();
+            let snap = hist.snapshot();
+            let count = snap.observation_count() as usize;
+            let sum = snap.sum();
+            let buckets = snap.cumulative_buckets();
             let label_str = render_labels(labels, interner);
             // Emit finite buckets using this histogram's configured boundaries.
             for (upper_bound, cumulative) in buckets.iter().filter(|(upper, _)| upper.is_finite()) {
@@ -330,13 +348,17 @@ pub fn snapshot(registry: &MetricsRegistry) -> String {
             // +Inf bucket
             if label_str.is_empty() {
                 let _ = writeln!(out, "{name}_bucket{{le=\"+Inf\"}} {count}");
-                let _ = writeln!(out, "{name}_sum {sum}");
+                let _ = writeln!(out, "{name}_sum {}", format_prometheus_float(sum));
                 let _ = writeln!(out, "{name}_count {count}");
             } else {
                 let inf_labels = format!("{},le=\"+Inf\"}}", &label_str[..label_str.len() - 1]);
                 let _ = writeln!(out, "{name}_bucket{inf_labels} {count}");
                 let sum_labels = label_str.clone();
-                let _ = writeln!(out, "{name}_sum{sum_labels} {sum}");
+                let _ = writeln!(
+                    out,
+                    "{name}_sum{sum_labels} {}",
+                    format_prometheus_float(sum)
+                );
                 let _ = writeln!(out, "{name}_count{sum_labels} {count}");
             }
         }
@@ -392,12 +414,15 @@ mod tests {
         let registry = Arc::new(MetricsRegistry::new());
         registry
             .counter("nebula_workflow_executions_started_total")
+            .unwrap()
             .inc();
         registry
             .counter("nebula_workflow_executions_started_total")
+            .unwrap()
             .inc();
         registry
             .histogram("nebula_action_duration_seconds")
+            .unwrap()
             .observe(0.5);
 
         let out = snapshot(&registry);
@@ -412,7 +437,9 @@ mod tests {
     #[test]
     fn histogram_renders_per_bucket_counts() {
         let registry = Arc::new(MetricsRegistry::new());
-        let hist = registry.histogram("nebula_action_duration_seconds");
+        let hist = registry
+            .histogram("nebula_action_duration_seconds")
+            .unwrap();
         hist.observe(0.003); // <= 0.005
         hist.observe(0.02); // <= 0.025
         hist.observe(0.5); // <= 0.5
@@ -445,6 +472,7 @@ mod tests {
         // Recording one observation triggers rendering.
         registry
             .histogram("nebula_action_duration_seconds")
+            .unwrap()
             .observe(0.0);
         let out2 = snapshot(&registry);
         assert!(out2.contains("nebula_action_duration_seconds_bucket{le=\"+Inf\"} 1\n"));
@@ -455,8 +483,14 @@ mod tests {
     #[test]
     fn snapshot_includes_resource_metrics() {
         let registry = Arc::new(MetricsRegistry::new());
-        registry.counter("nebula_resource_create_total").inc_by(5);
-        registry.counter("nebula_resource_error_total").inc();
+        registry
+            .counter("nebula_resource_create_total")
+            .unwrap()
+            .inc_by(5);
+        registry
+            .counter("nebula_resource_error_total")
+            .unwrap()
+            .inc();
 
         let out = snapshot(&registry);
         assert!(out.contains("# TYPE nebula_resource_create_total counter"));
@@ -467,9 +501,12 @@ mod tests {
     #[test]
     fn snapshot_includes_eventbus_metrics() {
         let registry = Arc::new(MetricsRegistry::new());
-        registry.gauge("nebula_eventbus_sent").set(100);
-        registry.gauge("nebula_eventbus_dropped").set(5);
-        registry.gauge("nebula_eventbus_subscribers").set(3);
+        registry.gauge("nebula_eventbus_sent").unwrap().set(100);
+        registry.gauge("nebula_eventbus_dropped").unwrap().set(5);
+        registry
+            .gauge("nebula_eventbus_subscribers")
+            .unwrap()
+            .set(3);
 
         let out = snapshot(&registry);
         assert!(out.contains("# TYPE nebula_eventbus_sent gauge"));
@@ -487,9 +524,11 @@ mod tests {
 
         registry
             .counter_labeled("nebula_action_executions_total", &http_labels)
+            .unwrap()
             .inc_by(10);
         registry
             .counter_labeled("nebula_action_executions_total", &math_labels)
+            .unwrap()
             .inc_by(3);
 
         let out = snapshot(&registry);
@@ -513,10 +552,15 @@ mod tests {
         // Trigger creation of known metrics.
         registry
             .counter("nebula_workflow_executions_started_total")
+            .unwrap()
             .inc();
-        registry.gauge("nebula_resource_health_state").set(1);
+        registry
+            .gauge("nebula_resource_health_state")
+            .unwrap()
+            .set(1);
         registry
             .histogram("nebula_workflow_execution_duration_seconds")
+            .unwrap()
             .observe(1.0);
 
         let out = snapshot(&registry);
@@ -529,7 +573,10 @@ mod tests {
     #[test]
     fn exporter_wraps_registry() {
         let registry = Arc::new(MetricsRegistry::new());
-        registry.counter("nebula_action_failures_total").inc_by(3);
+        registry
+            .counter("nebula_action_failures_total")
+            .unwrap()
+            .inc_by(3);
         let exporter = PrometheusExporter::new(registry);
         let out = exporter.snapshot();
         assert!(out.contains("nebula_action_failures_total 3\n"));
@@ -539,11 +586,13 @@ mod tests {
     fn snapshot_uses_histogram_specific_bucket_boundaries() {
         let registry = Arc::new(MetricsRegistry::new());
         let labels = registry.interner().label_set(&[("kind", "custom")]);
-        let histogram = registry.histogram_with_buckets_labeled(
-            "nebula_custom_duration_seconds",
-            &labels,
-            vec![0.1, 0.5],
-        );
+        let histogram = registry
+            .histogram_with_buckets_labeled(
+                "nebula_custom_duration_seconds",
+                &labels,
+                vec![0.1, 0.5],
+            )
+            .unwrap();
         histogram.observe(0.03);
         histogram.observe(0.3);
         histogram.observe(1.2);
@@ -575,6 +624,7 @@ mod tests {
             .label_set(&[("bad key\nx", "a\"b\\c"), ("ok_key", "ok")]);
         registry
             .counter_labeled("bad metric\nname", &labels)
+            .unwrap()
             .inc_by(2);
 
         let out = snapshot(&registry);
@@ -596,6 +646,7 @@ mod tests {
             .label_set(&[("a-b", "dash"), ("a b", "space")]);
         registry
             .counter_labeled("nebula_collision_label_keys", &labels)
+            .unwrap()
             .inc();
 
         let out = snapshot(&registry);
@@ -616,8 +667,8 @@ mod tests {
     #[test]
     fn snapshot_disambiguates_sanitized_metric_name_collisions() {
         let registry = Arc::new(MetricsRegistry::new());
-        registry.counter("dup x").inc();
-        registry.counter("dup-x").inc_by(2);
+        registry.counter("dup x").unwrap().inc();
+        registry.counter("dup-x").unwrap().inc_by(2);
 
         let out = snapshot(&registry);
         let type_lines = out.lines().filter(|l| l.starts_with("# TYPE ")).count();

--- a/crates/metrics/src/filter.rs
+++ b/crates/metrics/src/filter.rs
@@ -31,7 +31,9 @@
 //! assert_eq!(safe.len(), 1);
 //! ```
 
-use nebula_telemetry::labels::{LabelInterner, LabelSet};
+use std::sync::{Arc, Mutex};
+
+use nebula_telemetry::labels::{LabelInterner, LabelKey, LabelSet};
 
 /// A set of approved label-key names for metric observations.
 ///
@@ -50,7 +52,11 @@ enum AllowlistInner {
     /// Pass every label through unchanged.
     All,
     /// Only allow keys whose names are in this list.
-    Keys(Vec<String>),
+    Keys {
+        key_strings: Arc<Vec<String>>,
+        /// Lazily interned allow-list keys for the first registry interner seen.
+        cached_spurs: Arc<Mutex<Option<Vec<LabelKey>>>>,
+    },
 }
 
 impl LabelAllowlist {
@@ -80,7 +86,10 @@ impl LabelAllowlist {
         S: Into<String>,
     {
         Self {
-            inner: AllowlistInner::Keys(keys.into_iter().map(Into::into).collect()),
+            inner: AllowlistInner::Keys {
+                key_strings: Arc::new(keys.into_iter().map(Into::into).collect()),
+                cached_spurs: Arc::new(Mutex::new(None)),
+            },
         }
     }
 
@@ -91,13 +100,31 @@ impl LabelAllowlist {
     ///
     /// Otherwise keys not present in the allowlist are stripped. Keys that
     /// are listed but not found in `labels` are silently ignored.
+    ///
+    /// For [`LabelAllowlist::only`], allowed key names are interned once on the
+    /// first call with a given `interner` and reused on subsequent `apply`
+    /// calls to avoid re-hashing the allow-list on every observation.
     #[must_use]
     pub fn apply(&self, labels: &LabelSet, interner: &LabelInterner) -> LabelSet {
         match &self.inner {
             AllowlistInner::All => labels.clone(),
-            AllowlistInner::Keys(keys) => {
-                let allowed: Vec<&str> = keys.iter().map(String::as_str).collect();
-                interner.filter_label_set(labels, &allowed)
+            AllowlistInner::Keys {
+                key_strings,
+                cached_spurs,
+            } => {
+                let mut guard = cached_spurs
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if guard.is_none() {
+                    *guard = Some(
+                        key_strings
+                            .iter()
+                            .map(|k| interner.intern(k.as_str()))
+                            .collect(),
+                    );
+                }
+                let allowed = guard.as_ref().expect("cached allow-list spurs");
+                interner.filter_label_set_by_spur(labels, allowed)
             },
         }
     }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -73,4 +73,7 @@ pub use naming::{
     webhook_signature_failure_reason,
 };
 // Re-export for convenience so callers can use nebula_metrics::Counter etc.
-pub use nebula_telemetry::metrics::{Counter, Gauge, Histogram, MetricsRegistry};
+pub use nebula_telemetry::metrics::{
+    Counter, Gauge, Histogram, HistogramSnapshot, MetricsRegistry,
+};
+pub use nebula_telemetry::{MetricKind, TelemetryError, TelemetryResult};

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -505,15 +505,15 @@ mod tests {
             assert!(unique.insert(metric_name));
 
             if RESOURCE_GAUGE_NAMES.contains(&metric_name) {
-                let gauge = registry.gauge(metric_name);
+                let gauge = registry.gauge(metric_name).unwrap();
                 gauge.set(1);
                 assert_eq!(gauge.get(), 1);
             } else if RESOURCE_HISTOGRAM_NAMES.contains(&metric_name) {
-                let histogram = registry.histogram(metric_name);
+                let histogram = registry.histogram(metric_name).unwrap();
                 histogram.observe(1.0);
                 assert_eq!(histogram.count(), 1);
             } else {
-                let counter = registry.counter(metric_name);
+                let counter = registry.counter(metric_name).unwrap();
                 counter.inc();
                 assert_eq!(counter.get(), 1);
             }
@@ -583,15 +583,15 @@ mod tests {
             assert!(unique.insert(metric_name));
 
             if metric_name == NEBULA_CREDENTIAL_ACTIVE_TOTAL {
-                let gauge = registry.gauge(metric_name);
+                let gauge = registry.gauge(metric_name).unwrap();
                 gauge.set(1);
                 assert_eq!(gauge.get(), 1);
             } else if metric_name == NEBULA_CREDENTIAL_ROTATION_DURATION_SECONDS {
-                let histogram = registry.histogram(metric_name);
+                let histogram = registry.histogram(metric_name).unwrap();
                 histogram.observe(1.0);
                 assert_eq!(histogram.count(), 1);
             } else {
-                let counter = registry.counter(metric_name);
+                let counter = registry.counter(metric_name).unwrap();
                 counter.inc();
                 assert_eq!(counter.get(), 1);
             }
@@ -653,7 +653,7 @@ mod tests {
             assert!(unique.insert(metric_name));
 
             if metric_name == NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS {
-                let histogram = registry.histogram(metric_name);
+                let histogram = registry.histogram(metric_name).unwrap();
                 histogram.observe(0.5);
                 assert_eq!(histogram.count(), 1);
             } else {
@@ -664,7 +664,7 @@ mod tests {
                     .find(|(name, ..)| *name == metric_name)
                     .expect("every refresh-coord counter must appear in counter_label_map");
                 let labels = registry.interner().single(label_key, label_value);
-                let counter = registry.counter_labeled(metric_name, &labels);
+                let counter = registry.counter_labeled(metric_name, &labels).unwrap();
                 counter.inc();
                 assert_eq!(counter.get(), 1);
             }
@@ -728,7 +728,7 @@ mod tests {
 
         // All cache metrics are gauges (point-in-time snapshots)
         for metric_name in CACHE_METRIC_NAMES {
-            let gauge = registry.gauge(metric_name);
+            let gauge = registry.gauge(metric_name).unwrap();
             gauge.set(1);
             assert_eq!(gauge.get(), 1);
         }

--- a/crates/metrics/tests/integration.rs
+++ b/crates/metrics/tests/integration.rs
@@ -14,7 +14,7 @@ fn telemetry_adapter_resource_metrics_round_trip_via_generic_accessors() {
         "incrementing {} via generic adapter",
         NEBULA_RESOURCE_CREATE_TOTAL
     );
-    adapter.counter(NEBULA_RESOURCE_CREATE_TOTAL).inc();
+    adapter.counter(NEBULA_RESOURCE_CREATE_TOTAL).unwrap().inc();
 
     tracing::debug!(
         "observing {} via generic adapter with sample=0.5",
@@ -22,10 +22,16 @@ fn telemetry_adapter_resource_metrics_round_trip_via_generic_accessors() {
     );
     adapter
         .histogram(NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS)
+        .unwrap()
         .observe(0.5);
 
-    let create_total = registry.counter(NEBULA_RESOURCE_CREATE_TOTAL).get();
-    let acquire_wait = registry.histogram(NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS);
+    let create_total = registry
+        .counter(NEBULA_RESOURCE_CREATE_TOTAL)
+        .unwrap()
+        .get();
+    let acquire_wait = registry
+        .histogram(NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS)
+        .unwrap();
 
     assert_eq!(create_total, 1);
     assert_eq!(acquire_wait.count(), 1);

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -122,10 +122,17 @@ impl Manager {
         let cancel = CancellationToken::new();
         let (release_queue, release_queue_handle) =
             ReleaseQueue::with_cancel(config.release_queue_workers, cancel.clone());
-        let metrics = config
-            .metrics_registry
-            .as_ref()
-            .map(|reg| ResourceOpsMetrics::new(reg));
+        let metrics =
+            config
+                .metrics_registry
+                .as_ref()
+                .and_then(|reg| match ResourceOpsMetrics::new(reg) {
+                    Ok(m) => Some(m),
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to initialize resource operation metrics");
+                        None
+                    },
+                });
         Self {
             registry: Registry::new(),
             recovery_groups: RecoveryGroupRegistry::new(),

--- a/crates/resource/src/metrics.rs
+++ b/crates/resource/src/metrics.rs
@@ -11,9 +11,12 @@
 //! `on_credential_refresh(&mut self, slot_name)` fan-out is implemented
 //! (see `.ai-factory/PHASE4_BLOCKED.md`).
 
-use nebula_metrics::naming::{
-    NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL, NEBULA_RESOURCE_ACQUIRE_TOTAL,
-    NEBULA_RESOURCE_CREATE_TOTAL, NEBULA_RESOURCE_DESTROY_TOTAL, NEBULA_RESOURCE_RELEASE_TOTAL,
+use nebula_metrics::{
+    TelemetryResult,
+    naming::{
+        NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL, NEBULA_RESOURCE_ACQUIRE_TOTAL,
+        NEBULA_RESOURCE_CREATE_TOTAL, NEBULA_RESOURCE_DESTROY_TOTAL, NEBULA_RESOURCE_RELEASE_TOTAL,
+    },
 };
 use nebula_telemetry::metrics::{Counter, MetricsRegistry};
 
@@ -30,7 +33,7 @@ use nebula_telemetry::metrics::{Counter, MetricsRegistry};
 /// use nebula_telemetry::metrics::MetricsRegistry;
 ///
 /// let registry = MetricsRegistry::new();
-/// let metrics = ResourceOpsMetrics::new(&registry);
+/// let metrics = ResourceOpsMetrics::new(&registry).unwrap();
 /// metrics.record_acquire();
 /// metrics.record_acquire();
 /// metrics.record_acquire_error();
@@ -53,15 +56,14 @@ impl ResourceOpsMetrics {
     ///
     /// Counters are registered (or retrieved if already present) using the
     /// standard naming constants from `nebula-metrics`.
-    #[must_use]
-    pub fn new(registry: &MetricsRegistry) -> Self {
-        Self {
-            acquire_total: registry.counter(NEBULA_RESOURCE_ACQUIRE_TOTAL),
-            acquire_errors: registry.counter(NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL),
-            release_total: registry.counter(NEBULA_RESOURCE_RELEASE_TOTAL),
-            create_total: registry.counter(NEBULA_RESOURCE_CREATE_TOTAL),
-            destroy_total: registry.counter(NEBULA_RESOURCE_DESTROY_TOTAL),
-        }
+    pub fn new(registry: &MetricsRegistry) -> TelemetryResult<Self> {
+        Ok(Self {
+            acquire_total: registry.counter(NEBULA_RESOURCE_ACQUIRE_TOTAL)?,
+            acquire_errors: registry.counter(NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL)?,
+            release_total: registry.counter(NEBULA_RESOURCE_RELEASE_TOTAL)?,
+            create_total: registry.counter(NEBULA_RESOURCE_CREATE_TOTAL)?,
+            destroy_total: registry.counter(NEBULA_RESOURCE_DESTROY_TOTAL)?,
+        })
     }
 
     /// Records a successful acquire.
@@ -145,7 +147,7 @@ mod tests {
     #[test]
     fn counters_start_at_zero() {
         let registry = MetricsRegistry::new();
-        let metrics = ResourceOpsMetrics::new(&registry);
+        let metrics = ResourceOpsMetrics::new(&registry).unwrap();
         let snap = metrics.snapshot();
         assert_eq!(snap.acquire_total, 0);
         assert_eq!(snap.acquire_errors, 0);
@@ -157,7 +159,7 @@ mod tests {
     #[test]
     fn record_and_snapshot() {
         let registry = MetricsRegistry::new();
-        let metrics = ResourceOpsMetrics::new(&registry);
+        let metrics = ResourceOpsMetrics::new(&registry).unwrap();
         metrics.record_acquire();
         metrics.record_acquire();
         metrics.record_acquire_error();
@@ -178,7 +180,7 @@ mod tests {
     #[test]
     fn clones_share_counters() {
         let registry = MetricsRegistry::new();
-        let m1 = ResourceOpsMetrics::new(&registry);
+        let m1 = ResourceOpsMetrics::new(&registry).unwrap();
         let m2 = m1.clone();
 
         m1.record_acquire();
@@ -191,12 +193,12 @@ mod tests {
     #[test]
     fn backed_by_registry() {
         let registry = MetricsRegistry::new();
-        let metrics = ResourceOpsMetrics::new(&registry);
+        let metrics = ResourceOpsMetrics::new(&registry).unwrap();
         metrics.record_create();
         metrics.record_create();
 
         // Read directly from registry to verify shared backing.
-        let counter = registry.counter(NEBULA_RESOURCE_CREATE_TOTAL);
+        let counter = registry.counter(NEBULA_RESOURCE_CREATE_TOTAL).unwrap();
         assert_eq!(counter.get(), 2);
     }
 }

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -2316,7 +2316,9 @@ async fn registry_backed_metrics_record_operations() {
     );
 
     // Same counters visible via registry directly.
-    let create_counter = registry.counter(nebula_metrics::naming::NEBULA_RESOURCE_CREATE_TOTAL);
+    let create_counter = registry
+        .counter(nebula_metrics::naming::NEBULA_RESOURCE_CREATE_TOTAL)
+        .unwrap();
     assert_eq!(create_counter.get(), 2);
 
     manager

--- a/crates/telemetry/examples/basic_metrics.rs
+++ b/crates/telemetry/examples/basic_metrics.rs
@@ -20,26 +20,32 @@ fn main() {
 
     // Each call to .counter() / .gauge() / .histogram() is idempotent:
     // the same underlying atomic is returned on repeat calls.
-    let total_executions = registry.counter("nebula_executions_total");
+    let total_executions = registry
+        .counter("executions_total")
+        .expect("counter registration");
     total_executions.inc();
     total_executions.inc();
     total_executions.inc_by(10);
     println!("executions_total = {}", total_executions.get()); // 12
 
-    let active_workers = registry.gauge("nebula_active_workers");
+    let active_workers = registry
+        .gauge("active_workers")
+        .expect("gauge registration");
     active_workers.set(4);
     active_workers.inc();
     active_workers.dec();
     println!("active_workers   = {}", active_workers.get()); // 4
 
-    let duration = registry.histogram("nebula_action_duration_seconds");
+    let duration = registry
+        .histogram("action_duration_seconds")
+        .expect("histogram registration");
     for ms in [5, 12, 25, 100, 250, 1000] {
         duration.observe(ms as f64 / 1000.0);
     }
     println!(
         "duration p50={:.3}s  p99={:.3}s  sum={:.3}s  count={}",
-        duration.percentile(0.50),
-        duration.percentile(0.99),
+        duration.percentile(0.50).unwrap_or(0.0),
+        duration.percentile(0.99).unwrap_or(0.0),
         duration.sum(),
         duration.count(),
     );
@@ -55,19 +61,23 @@ fn main() {
     let math_ok = interner.label_set(&[("action_type", "math.add"), ("status", "ok")]);
 
     registry
-        .counter_labeled("nebula_action_executions_total", &http_ok)
+        .counter_labeled("action_executions_total", &http_ok)
+        .expect("counter")
         .inc_by(42);
     registry
-        .counter_labeled("nebula_action_executions_total", &http_err)
+        .counter_labeled("action_executions_total", &http_err)
+        .expect("counter")
         .inc_by(3);
     registry
-        .counter_labeled("nebula_action_executions_total", &math_ok)
+        .counter_labeled("action_executions_total", &math_ok)
+        .expect("counter")
         .inc_by(17);
 
     // Active concurrent actions per type (gauge).
     let http_active = interner.single("action_type", "http.request");
     registry
-        .gauge_labeled("nebula_active_actions", &http_active)
+        .gauge_labeled("active_actions", &http_active)
+        .expect("gauge")
         .set(5);
 
     // ── Snapshot / export ─────────────────────────────────────────────────────
@@ -90,7 +100,9 @@ fn main() {
 
     // ── last_updated_ms ───────────────────────────────────────────────────────
     println!("\n── Last updated timestamps ─────────────────────────");
-    let c = registry.counter("nebula_executions_total");
+    let c = registry
+        .counter("executions_total")
+        .expect("counter registration");
     println!(
         "  executions_total last_updated_ms = {}",
         c.last_updated_ms()

--- a/crates/telemetry/src/error.rs
+++ b/crates/telemetry/src/error.rs
@@ -1,5 +1,17 @@
 //! Error types for the telemetry subsystem.
 
+/// Primitive metric kind stored in a
+/// [`crate::metrics::MetricsRegistry`](crate::metrics::MetricsRegistry).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MetricKind {
+    /// Monotonic counter.
+    Counter,
+    /// Signed gauge.
+    Gauge,
+    /// Histogram with fixed bucket layout.
+    Histogram,
+}
+
 /// Errors that can occur in the telemetry subsystem.
 #[derive(Debug, thiserror::Error, nebula_error::Classify)]
 #[non_exhaustive]
@@ -8,6 +20,50 @@ pub enum TelemetryError {
     #[classify(category = "internal", code = "TELEMETRY:IO")]
     #[error("sink I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    /// The same `(name, labels)` identity is already registered with a different primitive kind.
+    #[classify(
+        category = "validation",
+        code = "TELEMETRY:METRIC_KIND_CONFLICT",
+        retryable = false
+    )]
+    #[error(
+        "metric `{metric_name}` is registered as {actual_kind:?} but {expected_kind:?} was requested"
+    )]
+    MetricKindConflict {
+        /// Human-readable metric name (resolved from the interner).
+        metric_name: String,
+        /// Kind the caller requested.
+        expected_kind: MetricKind,
+        /// Kind already stored for this identity.
+        actual_kind: MetricKind,
+    },
+
+    /// A histogram series already exists with different finite bucket boundaries.
+    #[classify(
+        category = "validation",
+        code = "TELEMETRY:HISTOGRAM_LAYOUT_CONFLICT",
+        retryable = false
+    )]
+    #[error(
+        "histogram `{metric_name}` already exists with incompatible bucket boundaries (layout is pinned at first registration)"
+    )]
+    HistogramLayoutConflict {
+        /// Human-readable metric name.
+        metric_name: String,
+    },
+
+    /// Histogram bucket configuration is invalid for a primitive histogram.
+    #[classify(
+        category = "validation",
+        code = "TELEMETRY:INVALID_HISTOGRAM_BUCKETS",
+        retryable = false
+    )]
+    #[error("invalid histogram bucket boundaries: {reason}")]
+    InvalidHistogramBuckets {
+        /// Why the boundaries were rejected.
+        reason: String,
+    },
 }
 
 /// Type alias for results in the telemetry subsystem.

--- a/crates/telemetry/src/error.rs
+++ b/crates/telemetry/src/error.rs
@@ -1,7 +1,7 @@
 //! Error types for the telemetry subsystem.
 
 /// Primitive metric kind stored in a
-/// [`crate::metrics::MetricsRegistry`](crate::metrics::MetricsRegistry).
+/// [`crate::metrics::MetricsRegistry`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MetricKind {
     /// Monotonic counter.

--- a/crates/telemetry/src/labels.rs
+++ b/crates/telemetry/src/labels.rs
@@ -103,6 +103,12 @@ impl LabelSet {
 /// All interning operations are lock-free for reads; first-time registrations
 /// acquire an internal write lock.
 ///
+/// # Cardinality
+///
+/// Interning deduplicates repeated strings; it does **not** bound series
+/// cardinality. Unique label values still allocate and remain resident until
+/// compaction. Policy belongs in higher layers such as `nebula-metrics`.
+///
 /// # Memory semantics
 ///
 /// The underlying `ThreadedRodeo` is **append-only**: once a string has been
@@ -249,9 +255,19 @@ impl LabelInterner {
     pub fn filter_label_set(&self, labels: &LabelSet, allowed_keys: &[&str]) -> LabelSet {
         // Intern the allowed keys so that we compare Spur ↔ Spur (integers).
         let allowed: Vec<Spur> = allowed_keys.iter().map(|k| self.intern(k)).collect();
-        let pairs: Vec<(LabelKey, LabelValue)> =
-            labels.iter().filter(|(k, _)| allowed.contains(k)).collect();
-        // Already sorted because the source LabelSet is sorted.
+        self.filter_label_set_by_spur(labels, &allowed)
+    }
+
+    /// Same as [`Self::filter_label_set`], but callers pre-intern allowed keys once.
+    ///
+    /// Every [`Spur`] must have been produced by **this** interner; otherwise
+    /// comparisons are meaningless.
+    #[must_use]
+    pub fn filter_label_set_by_spur(&self, labels: &LabelSet, allowed_keys: &[Spur]) -> LabelSet {
+        let pairs: Vec<(LabelKey, LabelValue)> = labels
+            .iter()
+            .filter(|(k, _)| allowed_keys.contains(k))
+            .collect();
         LabelSet { pairs }
     }
 }

--- a/crates/telemetry/src/lib.rs
+++ b/crates/telemetry/src/lib.rs
@@ -23,7 +23,8 @@
 //! ## Public API
 //!
 //! - [`MetricsRegistry`] — concurrent registry for counters, gauges, and histograms
-//! - [`Counter`], [`Gauge`], [`Histogram`] — lock-free metric types backed by atomics
+//! - [`Counter`], [`Gauge`], [`Histogram`], [`HistogramSnapshot`] — lock-free metric types backed
+//!   by atomics; snapshots freeze histogram scrape views
 //! - [`LabelInterner`] / [`LabelSet`] — `lasso`-backed string interning for label keys and values,
 //!   enabling zero-copy metric dimensions
 //! - [`MetricKey`] — typed metric identity (name + label set)
@@ -33,6 +34,6 @@ pub mod error;
 pub mod labels;
 pub mod metrics;
 
-pub use error::{TelemetryError, TelemetryResult};
+pub use error::{MetricKind, TelemetryError, TelemetryResult};
 pub use labels::{LabelInterner, LabelSet, MetricKey};
-pub use metrics::{Counter, Gauge, Histogram, MetricsRegistry};
+pub use metrics::{Counter, Gauge, Histogram, HistogramSnapshot, MetricsRegistry};

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -7,6 +7,7 @@
 //! hot recording path.
 
 use std::{
+    hint::spin_loop,
     sync::{
         Arc,
         atomic::{AtomicI64, AtomicU64, Ordering},
@@ -14,17 +15,28 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-use dashmap::DashMap;
+use dashmap::{DashMap, mapref::entry::Entry};
+use lasso::Spur;
 
-use crate::labels::{LabelInterner, LabelSet, MetricKey};
+use crate::{
+    error::{MetricKind, TelemetryError, TelemetryResult},
+    labels::{LabelInterner, LabelSet, MetricKey},
+};
 
 /// Returns the current time as milliseconds since the Unix epoch.
+///
+/// Wall-clock steps backward ([`SystemTime::duration_since`] failure) map
+/// to zero duration, so timestamps can move backward and interact poorly with
+/// [`MetricsRegistry::retain_recent`]. Callers should not rely on strict
+/// monotonicity of this clock.
 #[inline]
 fn now_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_millis() as u64
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
 }
 
 /// An incrementing counter.
@@ -51,7 +63,13 @@ impl Counter {
     }
 
     /// Increment by a given amount.
+    ///
+    /// `inc_by(0)` does not change the stored value or
+    /// [`Self::last_updated_ms`] (see [`crate::metrics::MetricsRegistry::retain_recent`]).
     pub fn inc_by(&self, n: u64) {
+        if n == 0 {
+            return;
+        }
         self.value.fetch_add(n, Ordering::Relaxed);
         self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
     }
@@ -105,9 +123,15 @@ impl Gauge {
     }
 
     /// Set to a specific value.
+    ///
+    /// If `v` equals the value already stored, [`Self::last_updated_ms`] is
+    /// left unchanged so idle gauges are not kept artificially "fresh" for
+    /// retention heuristics.
     pub fn set(&self, v: i64) {
-        self.value.store(v, Ordering::Relaxed);
-        self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
+        let previous = self.value.swap(v, Ordering::Relaxed);
+        if previous != v {
+            self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
+        }
     }
 
     /// Current value.
@@ -129,24 +153,88 @@ impl Default for Gauge {
     }
 }
 
-/// Default Prometheus histogram bucket boundaries.
+/// Default finite upper bounds for the built-in histogram layout (sub-second
+/// through 10 seconds, suited to latency-style measurements in seconds).
 const DEFAULT_BUCKETS: &[f64] = &[
     0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
 ];
 
+/// Frozen, point-in-time view of histogram bucket counts, total count, and sum.
+///
+/// Produced by [`Histogram::snapshot`] using an internal seqlock around writers
+/// so count, sum, and per-bucket tallies correspond to **one** logical state
+/// (no torn reads across independent atomics during export).
+///
+/// This type does **not** pin future observations; only the numeric fields
+/// inside this value are immutable.
+#[derive(Debug, Clone)]
+pub struct HistogramSnapshot {
+    boundaries: Arc<Vec<f64>>,
+    per_bucket: Box<[u64]>,
+    observation_count: u64,
+    sum_value: f64,
+}
+
+impl HistogramSnapshot {
+    /// Total number of observations reflected in this snapshot.
+    #[must_use]
+    pub fn observation_count(&self) -> u64 {
+        self.observation_count
+    }
+
+    /// Sum of observations reflected in this snapshot.
+    #[must_use]
+    pub fn sum(&self) -> f64 {
+        self.sum_value
+    }
+
+    /// Upper bounds for finite buckets (excludes the implicit `+Inf` bucket).
+    #[must_use]
+    pub fn boundaries(&self) -> &[f64] {
+        self.boundaries.as_slice()
+    }
+
+    /// Non-cumulative observation count per histogram bucket (`+Inf` is the final slot).
+    #[must_use]
+    pub fn per_bucket_counts(&self) -> &[u64] {
+        &self.per_bucket
+    }
+
+    /// Cumulative `(upper_bound, cumulative_count)` pairs, including `+Inf` as the final upper
+    /// bound.
+    #[must_use]
+    pub fn cumulative_buckets(&self) -> Vec<(f64, u64)> {
+        let mut cumulative = 0u64;
+        let mut result = Vec::with_capacity(self.per_bucket.len());
+        for (i, count) in self.per_bucket.iter().enumerate() {
+            cumulative += *count;
+            let upper = if i < self.boundaries.len() {
+                self.boundaries[i]
+            } else {
+                f64::INFINITY
+            };
+            result.push((upper, cumulative));
+        }
+        result
+    }
+}
+
 /// A histogram that records observations into fixed buckets.
 ///
-/// Uses Prometheus-style bucket boundaries with constant memory usage
-/// regardless of the number of observations. Each observation increments
-/// the appropriate bucket counter atomically (lock-free).
+/// Uses a fixed set of finite upper bounds plus an implicit `+Inf` overflow
+/// bucket. Each observation increments the appropriate bucket counter
+/// atomically. Bucket and count updates are wait-free; the running sum uses
+/// an atomic compare-exchange loop (lock-free, not wait-free) under contention.
 ///
-/// The default buckets are suited for measuring request durations in seconds.
-/// Use [`Histogram::with_buckets`] for custom boundaries.
+/// Prefer [`Histogram::try_with_buckets`] for caller-supplied boundaries; the
+/// default layout from [`Histogram::new`] matches [`DEFAULT_BUCKETS`].
 #[derive(Debug)]
 pub struct Histogram {
+    /// Seqlock phase: odd while an [`Self::observe`] is in flight, even between updates.
+    seq: Arc<AtomicU64>,
     /// Upper-bound for each bucket (sorted, does not include +Inf).
     boundaries: Arc<Vec<f64>>,
-    /// Cumulative count per bucket (len = boundaries.len() + 1 for +Inf).
+    /// Non-cumulative count per bucket (`len == boundaries.len() + 1` for `+Inf`).
     counts: Arc<Vec<AtomicU64>>,
     /// Total number of observations.
     total_count: Arc<AtomicU64>,
@@ -159,6 +247,7 @@ pub struct Histogram {
 impl Clone for Histogram {
     fn clone(&self) -> Self {
         Self {
+            seq: Arc::clone(&self.seq),
             boundaries: Arc::clone(&self.boundaries),
             counts: Arc::clone(&self.counts),
             total_count: Arc::clone(&self.total_count),
@@ -169,47 +258,56 @@ impl Clone for Histogram {
 }
 
 impl Histogram {
-    /// Create a histogram with default Prometheus bucket boundaries.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::with_buckets(DEFAULT_BUCKETS.to_vec())
+    /// Validate histogram bucket boundaries for [`Self::try_with_buckets`].
+    pub fn validate_bucket_boundaries(boundaries: &[f64]) -> TelemetryResult<()> {
+        if boundaries.is_empty() {
+            return Err(TelemetryError::InvalidHistogramBuckets {
+                reason: "boundaries must not be empty".into(),
+            });
+        }
+        if !boundaries.iter().all(|&b| b > 0.0 && b.is_finite()) {
+            return Err(TelemetryError::InvalidHistogramBuckets {
+                reason: "each boundary must be positive and finite".into(),
+            });
+        }
+        if !boundaries.windows(2).all(|w| w[0] < w[1]) {
+            return Err(TelemetryError::InvalidHistogramBuckets {
+                reason: "boundaries must be strictly increasing with no duplicates".into(),
+            });
+        }
+        Ok(())
     }
 
-    /// Create a histogram with custom bucket boundaries.
-    ///
-    /// Boundaries must be non-empty, all positive, and sorted ascending.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `boundaries` is empty, contains non-positive values,
-    /// or is not sorted in ascending order.
-    #[must_use]
-    pub fn with_buckets(boundaries: Vec<f64>) -> Self {
-        assert!(
-            !boundaries.is_empty(),
-            "histogram boundaries must not be empty"
-        );
-        assert!(
-            boundaries.iter().all(|&b| b > 0.0 && b.is_finite()),
-            "histogram boundaries must be positive and finite",
-        );
-        assert!(
-            boundaries.windows(2).all(|w| w[0] < w[1]),
-            "histogram boundaries must be sorted in ascending order with no duplicates",
-        );
-
+    fn from_validated_boundaries(boundaries: Vec<f64>) -> Self {
         let bucket_count = boundaries.len() + 1; // +1 for +Inf
         let counts: Vec<AtomicU64> = (0..bucket_count).map(|_| AtomicU64::new(0)).collect();
 
         tracing::debug!(buckets = boundaries.len(), "histogram created");
 
         Self {
+            seq: Arc::new(AtomicU64::new(0)),
             boundaries: Arc::new(boundaries),
             counts: Arc::new(counts),
             total_count: Arc::new(AtomicU64::new(0)),
             sum_bits: Arc::new(AtomicU64::new(0.0_f64.to_bits())),
             last_updated_ms: Arc::new(AtomicU64::new(now_ms())),
         }
+    }
+
+    /// Create a histogram with the built-in default bucket layout.
+    ///
+    /// The default boundary table is fixed at compile time; if it were ever
+    /// invalid, this would construct an inconsistent histogram — covered by
+    /// `default_bucket_table_is_valid`.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::from_validated_boundaries(DEFAULT_BUCKETS.to_vec())
+    }
+
+    /// Create a histogram with custom bucket boundaries.
+    pub fn try_with_buckets(boundaries: Vec<f64>) -> TelemetryResult<Self> {
+        Self::validate_bucket_boundaries(&boundaries)?;
+        Ok(Self::from_validated_boundaries(boundaries))
     }
 
     /// Record an observation.
@@ -221,6 +319,10 @@ impl Histogram {
         if !value.is_finite() {
             return;
         }
+
+        // Seqlock writer side: observers bracket mutation so [`Self::snapshot`]
+        // can read counts + total_count + sum coherently.
+        self.seq.fetch_add(1, Ordering::Release);
 
         // Find the first bucket whose upper bound is >= value.
         let idx = self
@@ -243,6 +345,43 @@ impl Histogram {
                 (f64::from_bits(old_bits) + value).to_bits()
             });
         self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
+
+        self.seq.fetch_add(1, Ordering::Release);
+    }
+
+    /// Capture counts, observation total, and sum at one logical instant.
+    ///
+    /// Intended for exposition (Prometheus, OTLP): prefer this over chaining
+    /// [`Self::count`], [`Self::sum`], and [`Self::buckets`], which are
+    /// independent relaxed loads and may not match one another under concurrent
+    /// [`Self::observe`] calls.
+    #[must_use]
+    pub fn snapshot(&self) -> HistogramSnapshot {
+        loop {
+            let phase = self.seq.load(Ordering::Acquire);
+            if !phase.is_multiple_of(2) {
+                spin_loop();
+                continue;
+            }
+
+            let per_bucket: Vec<u64> = self
+                .counts
+                .iter()
+                .map(|c| c.load(Ordering::Relaxed))
+                .collect();
+            let observation_count = self.total_count.load(Ordering::Relaxed);
+            let sum_value = f64::from_bits(self.sum_bits.load(Ordering::Relaxed));
+
+            let phase_after = self.seq.load(Ordering::Acquire);
+            if phase == phase_after && phase.is_multiple_of(2) {
+                return HistogramSnapshot {
+                    boundaries: Arc::clone(&self.boundaries),
+                    per_bucket: per_bucket.into_boxed_slice(),
+                    observation_count,
+                    sum_value,
+                };
+            }
+        }
     }
 
     /// Number of observations recorded.
@@ -260,6 +399,10 @@ impl Histogram {
     /// Returns cumulative bucket counts as `(upper_bound, cumulative_count)` pairs.
     ///
     /// The final entry has `upper_bound = f64::INFINITY`.
+    ///
+    /// Under concurrent [`Self::observe`] calls, each counter is read with relaxed
+    /// ordering; the vector may not agree with [`Self::count`] or [`Self::sum`]
+    /// for the same invocation. Use [`Self::snapshot`] for a consistent export view.
     #[must_use]
     pub fn buckets(&self) -> Vec<(f64, u64)> {
         let mut cumulative = 0u64;
@@ -301,15 +444,20 @@ impl Histogram {
             .collect()
     }
 
-    /// Estimate the value at the given percentile (0.0–1.0) using linear
-    /// interpolation within buckets (same approach as Prometheus).
+    /// Estimate the value at the given percentile using linear interpolation
+    /// within buckets (Prometheus-compatible bucketing).
     ///
-    /// Returns `0.0` if no observations have been recorded.
+    /// Returns [`None`] when there are no observations, when `p` is outside
+    /// `0.0..=1.0`, or when `p` is not finite.
     #[must_use]
-    pub fn percentile(&self, p: f64) -> f64 {
+    pub fn percentile(&self, p: f64) -> Option<f64> {
+        if !p.is_finite() || !(0.0..=1.0).contains(&p) {
+            return None;
+        }
+
         let total = self.total_count.load(Ordering::Relaxed);
         if total == 0 {
-            return 0.0;
+            return None;
         }
 
         let target = p * total as f64;
@@ -329,13 +477,13 @@ impl Histogram {
                 };
 
                 if bucket_count == 0 {
-                    return upper;
+                    return Some(upper);
                 }
 
                 // Linear interpolation within the bucket.
                 let prev_cumulative = cumulative - bucket_count;
                 let fraction = (target - prev_cumulative as f64) / bucket_count as f64;
-                return (upper - prev_bound).mul_add(fraction, prev_bound);
+                return Some((upper - prev_bound).mul_add(fraction, prev_bound));
             }
 
             if i < self.boundaries.len() {
@@ -344,7 +492,7 @@ impl Histogram {
         }
 
         // Fallback: return last boundary.
-        self.boundaries.last().copied().unwrap_or(0.0)
+        Some(self.boundaries.last().copied().unwrap_or(0.0))
     }
 
     /// Milliseconds since Unix epoch of the last observation recorded.
@@ -369,17 +517,53 @@ impl Default for Histogram {
     }
 }
 
+/// Stored series for one `(metric name, label set)` identity.
+#[derive(Debug, Clone)]
+enum MetricSeries {
+    Counter(Counter),
+    Gauge(Gauge),
+    Histogram(Histogram),
+}
+
+impl MetricSeries {
+    fn kind(&self) -> MetricKind {
+        match self {
+            Self::Counter(_) => MetricKind::Counter,
+            Self::Gauge(_) => MetricKind::Gauge,
+            Self::Histogram(_) => MetricKind::Histogram,
+        }
+    }
+
+    fn last_updated_ms(&self) -> u64 {
+        match self {
+            Self::Counter(c) => c.last_updated_ms(),
+            Self::Gauge(g) => g.last_updated_ms(),
+            Self::Histogram(h) => h.last_updated_ms(),
+        }
+    }
+}
+
 /// Registry for creating and retrieving named metrics.
 ///
-/// Prefer names with the `nebula_` prefix (e.g. `nebula_executions_total`)
-/// for consistency and future Prometheus/OTLP export.
-///
 /// Metric names are interned via [`LabelInterner`] (backed by
-/// [`lasso::ThreadedRodeo`]) so repeated `counter("same_name")` calls pay
-/// only an integer comparison after the first call, not a string allocation.
+/// [`lasso::ThreadedRodeo`]) so repeated lookups for the same name pay only
+/// an integer comparison after the first call, not a string allocation.
+///
+/// Naming conventions and export formats live in `nebula-metrics`, not here.
 ///
 /// Concurrent access uses [`DashMap`] — a sharded lock-free map — so
 /// recording metrics on hot paths does not block other threads.
+///
+/// # Snapshots
+///
+/// [`Self::snapshot_counters`] and [`Self::snapshot_gauges`] return **live handles**
+/// and enumerate registry membership approximately; values may change after the
+/// call returns (weak / best-effort view).
+///
+/// For histograms exposed from [`Self::snapshot_histograms`], use
+/// [`Histogram::snapshot`] before export so count, sum, and bucket totals reflect
+/// one logical scrape instant (seqlock-backed); the returned [`Histogram`] handle
+/// remains live afterward.
 ///
 /// # Examples
 ///
@@ -387,21 +571,18 @@ impl Default for Histogram {
 /// use nebula_telemetry::metrics::MetricsRegistry;
 ///
 /// let registry = MetricsRegistry::new();
-/// let counter = registry.counter("nebula_executions_total");
+/// let counter = registry.counter("request_total").unwrap();
 /// counter.inc();
 /// assert_eq!(counter.get(), 1);
 ///
-/// // Retrieving the same name returns the same metric.
-/// let same = registry.counter("nebula_executions_total");
+/// let same = registry.counter("request_total").unwrap();
 /// assert_eq!(same.get(), 1);
 /// ```
 #[derive(Debug, Clone)]
 pub struct MetricsRegistry {
     /// Shared string interner — both metric names and label keys/values.
     pub(crate) interner: LabelInterner,
-    counters: Arc<DashMap<MetricKey, Counter>>,
-    gauges: Arc<DashMap<MetricKey, Gauge>>,
-    histograms: Arc<DashMap<MetricKey, Histogram>>,
+    series: Arc<DashMap<MetricKey, MetricSeries>>,
 }
 
 impl MetricsRegistry {
@@ -410,9 +591,24 @@ impl MetricsRegistry {
     pub fn new() -> Self {
         Self {
             interner: LabelInterner::new(),
-            counters: Arc::new(DashMap::new()),
-            gauges: Arc::new(DashMap::new()),
-            histograms: Arc::new(DashMap::new()),
+            series: Arc::new(DashMap::new()),
+        }
+    }
+
+    fn resolve_metric_name(&self, name: Spur) -> String {
+        self.interner.resolve(name).to_owned()
+    }
+
+    fn kind_conflict(
+        &self,
+        name: Spur,
+        expected: MetricKind,
+        actual: MetricKind,
+    ) -> TelemetryError {
+        TelemetryError::MetricKindConflict {
+            metric_name: self.resolve_metric_name(name),
+            expected_kind: expected,
+            actual_kind: actual,
         }
     }
 
@@ -428,21 +624,33 @@ impl MetricsRegistry {
     // ── Unlabeled accessors ─────────────────────────────────────────────────
 
     /// Get or create an unlabeled counter by name.
-    pub fn counter(&self, name: &str) -> Counter {
-        let key = MetricKey::unlabeled(self.interner.intern(name));
-        self.counters.entry(key).or_default().value().clone()
+    pub fn counter(&self, name: &str) -> TelemetryResult<Counter> {
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::unlabeled(name_spur);
+        self.insert_counter(key, name_spur)
     }
 
     /// Get or create an unlabeled gauge by name.
-    pub fn gauge(&self, name: &str) -> Gauge {
-        let key = MetricKey::unlabeled(self.interner.intern(name));
-        self.gauges.entry(key).or_default().value().clone()
+    pub fn gauge(&self, name: &str) -> TelemetryResult<Gauge> {
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::unlabeled(name_spur);
+        self.insert_gauge(key, name_spur)
     }
 
-    /// Get or create an unlabeled histogram by name.
-    pub fn histogram(&self, name: &str) -> Histogram {
-        let key = MetricKey::unlabeled(self.interner.intern(name));
-        self.histograms.entry(key).or_default().value().clone()
+    /// Get or create an unlabeled histogram using the built-in default bucket layout.
+    pub fn histogram(&self, name: &str) -> TelemetryResult<Histogram> {
+        self.histogram_with_buckets_unlabeled(name, DEFAULT_BUCKETS)
+    }
+
+    fn histogram_with_buckets_unlabeled(
+        &self,
+        name: &str,
+        boundaries: &[f64],
+    ) -> TelemetryResult<Histogram> {
+        Histogram::validate_bucket_boundaries(boundaries)?;
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::unlabeled(name_spur);
+        self.insert_histogram(key, name_spur, boundaries)
     }
 
     // ── Labeled accessors ───────────────────────────────────────────────────
@@ -454,60 +662,102 @@ impl MetricsRegistry {
     /// ```
     /// use nebula_telemetry::metrics::MetricsRegistry;
     ///
-    /// let mut reg = MetricsRegistry::new();
+    /// let reg = MetricsRegistry::new();
     /// let labels = reg.interner().label_set(&[("action_type", "http.request")]);
-    /// let counter = reg.counter_labeled("nebula_action_executions_total", &labels);
+    /// let counter = reg
+    ///     .counter_labeled("action_executions_total", &labels)
+    ///     .unwrap();
     /// counter.inc();
     /// assert_eq!(counter.get(), 1);
     /// ```
-    pub fn counter_labeled(&self, name: &str, labels: &LabelSet) -> Counter {
-        let key = MetricKey::labeled(self.interner.intern(name), labels.clone());
-        self.counters.entry(key).or_default().value().clone()
+    pub fn counter_labeled(&self, name: &str, labels: &LabelSet) -> TelemetryResult<Counter> {
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::labeled(name_spur, labels.clone());
+        self.insert_counter(key, name_spur)
     }
 
     /// Get or create a gauge for the given metric name and label set.
-    pub fn gauge_labeled(&self, name: &str, labels: &LabelSet) -> Gauge {
-        let key = MetricKey::labeled(self.interner.intern(name), labels.clone());
-        self.gauges.entry(key).or_default().value().clone()
+    pub fn gauge_labeled(&self, name: &str, labels: &LabelSet) -> TelemetryResult<Gauge> {
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::labeled(name_spur, labels.clone());
+        self.insert_gauge(key, name_spur)
     }
 
-    /// Get or create a histogram for the given metric name and label set.
-    pub fn histogram_labeled(&self, name: &str, labels: &LabelSet) -> Histogram {
-        let key = MetricKey::labeled(self.interner.intern(name), labels.clone());
-        self.histograms.entry(key).or_default().value().clone()
+    /// Get or create a histogram for the given metric name and label set using
+    /// the built-in default bucket layout.
+    pub fn histogram_labeled(&self, name: &str, labels: &LabelSet) -> TelemetryResult<Histogram> {
+        self.histogram_with_buckets_labeled(name, labels, DEFAULT_BUCKETS.to_vec())
     }
 
     /// Get or create a histogram with custom bucket boundaries and a label set.
     ///
-    /// Bucket boundaries are bound to the series at **first registration**.
-    /// If a subsequent call targets an already-registered `(name, labels)`
-    /// series with *different* `boundaries`, the existing histogram is
-    /// returned unchanged and a `tracing::warn!` is emitted — the later
-    /// layout is silently ignored, which can cause split-brain behaviour
-    /// between crates that disagree on bucket schemas. Callers that need
-    /// multiple layouts for the same metric name must vary the label set.
+    /// Bucket boundaries are pinned at **first registration**. A later call
+    /// with the same `(name, labels)` but different `boundaries` returns
+    /// [`TelemetryError::HistogramLayoutConflict`].
     pub fn histogram_with_buckets_labeled(
         &self,
         name: &str,
         labels: &LabelSet,
         boundaries: Vec<f64>,
-    ) -> Histogram {
-        let key = MetricKey::labeled(self.interner.intern(name), labels.clone());
-        let existing = self
-            .histograms
-            .entry(key)
-            .or_insert_with(|| Histogram::with_buckets(boundaries.clone()))
-            .value()
-            .clone();
-        if existing.boundaries() != boundaries.as_slice() {
-            tracing::warn!(
-                metric = name,
-                requested = ?boundaries,
-                existing = ?existing.boundaries(),
-                "histogram_with_buckets_labeled: ignoring new boundaries for already-registered series"
-            );
+    ) -> TelemetryResult<Histogram> {
+        Histogram::validate_bucket_boundaries(&boundaries)?;
+        let name_spur = self.interner.intern(name);
+        let key = MetricKey::labeled(name_spur, labels.clone());
+        self.insert_histogram(key, name_spur, &boundaries)
+    }
+
+    fn insert_counter(&self, key: MetricKey, name_spur: Spur) -> TelemetryResult<Counter> {
+        match self.series.entry(key) {
+            Entry::Occupied(o) => match o.get() {
+                MetricSeries::Counter(c) => Ok(c.clone()),
+                other => Err(self.kind_conflict(name_spur, MetricKind::Counter, other.kind())),
+            },
+            Entry::Vacant(v) => {
+                let c = Counter::new();
+                v.insert(MetricSeries::Counter(c.clone()));
+                Ok(c)
+            },
         }
-        existing
+    }
+
+    fn insert_gauge(&self, key: MetricKey, name_spur: Spur) -> TelemetryResult<Gauge> {
+        match self.series.entry(key) {
+            Entry::Occupied(o) => match o.get() {
+                MetricSeries::Gauge(g) => Ok(g.clone()),
+                other => Err(self.kind_conflict(name_spur, MetricKind::Gauge, other.kind())),
+            },
+            Entry::Vacant(v) => {
+                let g = Gauge::new();
+                v.insert(MetricSeries::Gauge(g.clone()));
+                Ok(g)
+            },
+        }
+    }
+
+    fn insert_histogram(
+        &self,
+        key: MetricKey,
+        name_spur: Spur,
+        boundaries: &[f64],
+    ) -> TelemetryResult<Histogram> {
+        match self.series.entry(key) {
+            Entry::Occupied(o) => match o.get() {
+                MetricSeries::Histogram(h) => {
+                    if h.boundaries() != boundaries {
+                        return Err(TelemetryError::HistogramLayoutConflict {
+                            metric_name: self.resolve_metric_name(name_spur),
+                        });
+                    }
+                    Ok(h.clone())
+                },
+                other => Err(self.kind_conflict(name_spur, MetricKind::Histogram, other.kind())),
+            },
+            Entry::Vacant(v) => {
+                let h = Histogram::from_validated_boundaries(boundaries.to_vec());
+                v.insert(MetricSeries::Histogram(h.clone()));
+                Ok(h)
+            },
+        }
     }
 
     // ── Snapshot / export ───────────────────────────────────────────────────
@@ -516,25 +766,34 @@ impl MetricsRegistry {
     ///
     /// Used by exporters (Prometheus, OTLP) to serialize the current state.
     pub fn snapshot_counters(&self) -> Vec<(MetricKey, Counter)> {
-        self.counters
+        self.series
             .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .filter_map(|entry| match entry.value() {
+                MetricSeries::Counter(c) => Some((entry.key().clone(), c.clone())),
+                _ => None,
+            })
             .collect()
     }
 
     /// Iterate all gauge entries as `(MetricKey, Gauge)` pairs.
     pub fn snapshot_gauges(&self) -> Vec<(MetricKey, Gauge)> {
-        self.gauges
+        self.series
             .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .filter_map(|entry| match entry.value() {
+                MetricSeries::Gauge(g) => Some((entry.key().clone(), g.clone())),
+                _ => None,
+            })
             .collect()
     }
 
     /// Iterate all histogram entries as `(MetricKey, Histogram)` pairs.
     pub fn snapshot_histograms(&self) -> Vec<(MetricKey, Histogram)> {
-        self.histograms
+        self.series
             .iter()
-            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .filter_map(|entry| match entry.value() {
+                MetricSeries::Histogram(h) => Some((entry.key().clone(), h.clone())),
+                _ => None,
+            })
             .collect()
     }
 
@@ -542,20 +801,13 @@ impl MetricsRegistry {
 
     /// Remove all metric series that have not been updated within `max_age`.
     ///
-    /// Reclaims the counter / gauge / histogram entries for stale series so
-    /// that dynamic labels (e.g. `action_type`, `workflow_id`) do not grow
-    /// the series maps without bound. Stable global metrics (unlabeled or
-    /// with a fixed label set) are naturally retained because they are
-    /// written to continuously.
+    /// Reclaims stale series so dynamic labels do not grow the registry without
+    /// bound. Stable metrics are naturally retained because they are written
+    /// continuously.
     ///
     /// # Memory behavior
     ///
-    /// After pruning stale series, this method compacts the label interner by
-    /// rebuilding it from the still-live metric keys. That keeps interner
-    /// cardinality bounded by active series rather than by historical churn.
-    ///
-    /// Call this periodically from a background task or at the end of a
-    /// logical time window (e.g. after completing a batch of executions).
+    /// After pruning, this compacts the label interner from still-live keys.
     ///
     /// # Examples
     ///
@@ -565,36 +817,27 @@ impl MetricsRegistry {
     /// use nebula_telemetry::metrics::MetricsRegistry;
     ///
     /// let mut reg = MetricsRegistry::new();
-    /// let c = reg.counter("nebula_actions_total");
+    /// let c = reg.counter("actions_total").unwrap();
     /// c.inc();
     ///
-    /// // Retain everything written in the last 5 minutes.
     /// reg.retain_recent(Duration::from_secs(300));
-    /// assert_eq!(reg.metric_count(), 1); // still present — just updated
+    /// assert_eq!(reg.metric_count(), 1);
     /// ```
     pub fn retain_recent(&mut self, max_age: Duration) {
-        let cutoff_ms = now_ms().saturating_sub(max_age.as_millis() as u64);
-        self.counters
-            .retain(|_, v| v.last_updated_ms() >= cutoff_ms);
-        self.gauges.retain(|_, v| v.last_updated_ms() >= cutoff_ms);
-        self.histograms
-            .retain(|_, v| v.last_updated_ms() >= cutoff_ms);
+        let age_ms: u64 = max_age.as_millis().try_into().unwrap_or(u64::MAX);
+        let cutoff_ms = now_ms().saturating_sub(age_ms);
+        self.series
+            .retain(|_, series| series.last_updated_ms() >= cutoff_ms);
         self.compact_interner();
     }
 
-    /// Total number of tracked metric series (counters + gauges + histograms).
-    ///
-    /// Useful for cardinality monitoring.
+    /// Total number of tracked metric series.
     #[must_use]
     pub fn metric_count(&self) -> usize {
-        self.counters.len() + self.gauges.len() + self.histograms.len()
+        self.series.len()
     }
 
     /// Number of distinct strings held by the label interner.
-    ///
-    /// This reflects the current interner cardinality and can decrease after
-    /// [`Self::retain_recent`] triggers compaction via `compact_interner`.
-    /// Use it to monitor label-cardinality pressure over time.
     #[must_use]
     pub fn interner_len(&self) -> usize {
         self.interner.len()
@@ -622,23 +865,19 @@ impl MetricsRegistry {
             )
         };
 
-        let new_counters: DashMap<MetricKey, Counter> = DashMap::new();
-        for entry in &*self.counters {
-            new_counters.insert(remap_key(entry.key()), entry.value().clone());
-        }
-        let new_gauges: DashMap<MetricKey, Gauge> = DashMap::new();
-        for entry in &*self.gauges {
-            new_gauges.insert(remap_key(entry.key()), entry.value().clone());
-        }
-        let new_histograms: DashMap<MetricKey, Histogram> = DashMap::new();
-        for entry in &*self.histograms {
-            new_histograms.insert(remap_key(entry.key()), entry.value().clone());
+        let new_series: DashMap<MetricKey, MetricSeries> = DashMap::new();
+        for entry in &*self.series {
+            let new_key = remap_key(entry.key());
+            let cloned = match entry.value() {
+                MetricSeries::Counter(c) => MetricSeries::Counter(c.clone()),
+                MetricSeries::Gauge(g) => MetricSeries::Gauge(g.clone()),
+                MetricSeries::Histogram(h) => MetricSeries::Histogram(h.clone()),
+            };
+            new_series.insert(new_key, cloned);
         }
 
         self.interner = new_interner;
-        self.counters = Arc::new(new_counters);
-        self.gauges = Arc::new(new_gauges);
-        self.histograms = Arc::new(new_histograms);
+        self.series = Arc::new(new_series);
     }
 }
 
@@ -651,6 +890,12 @@ impl Default for MetricsRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{MetricKind, TelemetryError};
+
+    #[test]
+    fn default_bucket_table_is_valid() {
+        assert!(Histogram::validate_bucket_boundaries(DEFAULT_BUCKETS).is_ok());
+    }
 
     #[test]
     fn counter_starts_at_zero() {
@@ -698,7 +943,7 @@ mod tests {
 
     #[test]
     fn histogram_custom_buckets() {
-        let h = Histogram::with_buckets(vec![1.0, 5.0, 10.0]);
+        let h = Histogram::try_with_buckets(vec![1.0, 5.0, 10.0]).unwrap();
         let buckets = h.buckets();
         assert_eq!(buckets.len(), 4); // 3 boundaries + +Inf
         assert_eq!(buckets[0].0, 1.0);
@@ -709,7 +954,7 @@ mod tests {
 
     #[test]
     fn histogram_observe_updates_correct_bucket() {
-        let h = Histogram::with_buckets(vec![1.0, 5.0, 10.0]);
+        let h = Histogram::try_with_buckets(vec![1.0, 5.0, 10.0]).unwrap();
         h.observe(0.5); // bucket 0 (le=1.0)
         h.observe(3.0); // bucket 1 (le=5.0)
         h.observe(7.0); // bucket 2 (le=10.0)
@@ -735,7 +980,7 @@ mod tests {
 
     #[test]
     fn histogram_percentile_basic() {
-        let h = Histogram::with_buckets(vec![1.0, 5.0, 10.0]);
+        let h = Histogram::try_with_buckets(vec![1.0, 5.0, 10.0]).unwrap();
         for _ in 0..50 {
             h.observe(0.5); // bucket [0, 1.0]
         }
@@ -746,24 +991,24 @@ mod tests {
             h.observe(7.0); // bucket (5.0, 10.0]
         }
 
-        let p50 = h.percentile(0.5);
+        let p50 = h.percentile(0.5).expect("p50");
         assert!(p50 <= 1.0, "p50 should be in first bucket, got {p50}");
 
-        let p95 = h.percentile(0.95);
+        let p95 = h.percentile(0.95).expect("p95");
         assert!(p95 > 5.0, "p95 should be in third bucket, got {p95}");
     }
 
     #[test]
     fn histogram_percentile_empty() {
         let h = Histogram::new();
-        assert!((h.percentile(0.5) - 0.0).abs() < f64::EPSILON);
+        assert!(h.percentile(0.5).is_none());
     }
 
     #[test]
     fn histogram_percentile_single_observation() {
-        let h = Histogram::with_buckets(vec![1.0, 5.0, 10.0]);
+        let h = Histogram::try_with_buckets(vec![1.0, 5.0, 10.0]).unwrap();
         h.observe(3.0);
-        let p = h.percentile(1.0);
+        let p = h.percentile(1.0).expect("p100");
         // Single observation in (1.0, 5.0] bucket.
         assert!(p > 0.0, "percentile of single observation should be > 0");
     }
@@ -777,6 +1022,72 @@ mod tests {
         }
         assert_eq!(h.count(), 1_000_000);
         // If this were Vec<f64>, it would use ~8MB. Buckets use < 200 bytes.
+    }
+
+    #[test]
+    fn histogram_snapshot_sum_of_buckets_equals_total_count() {
+        let h = Histogram::try_with_buckets(vec![1.0, 5.0, 10.0]).unwrap();
+        for _ in 0..7 {
+            h.observe(0.5);
+        }
+        for _ in 0..11 {
+            h.observe(3.0);
+        }
+        h.observe(100.0);
+        let snap = h.snapshot();
+        let bucket_sum: u64 = snap.per_bucket_counts().iter().sum();
+        assert_eq!(bucket_sum, snap.observation_count());
+        assert_eq!(snap.observation_count(), h.count() as u64);
+    }
+
+    #[test]
+    fn histogram_snapshot_consistent_under_concurrent_observe() {
+        use std::sync::{
+            Arc as StdArc,
+            atomic::{AtomicBool, Ordering as AtomicOrdering},
+        };
+
+        let reg = MetricsRegistry::new();
+        let h = StdArc::new(reg.histogram("lat").unwrap());
+        let stop = StdArc::new(AtomicBool::new(false));
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let h = StdArc::clone(&h);
+                let stop = StdArc::clone(&stop);
+                std::thread::spawn(move || {
+                    while !stop.load(AtomicOrdering::Relaxed) {
+                        for v in &[0.01_f64, 0.05, 0.2, 2.5, 9.9] {
+                            h.observe(*v);
+                        }
+                    }
+                })
+            })
+            .collect();
+
+        for _ in 0..2000 {
+            let snap = h.snapshot();
+            let bucket_sum: u64 = snap.per_bucket_counts().iter().sum();
+            assert_eq!(
+                bucket_sum,
+                snap.observation_count(),
+                "per-bucket tally must equal total observations in a snapshot"
+            );
+            let last_cumulative = snap
+                .cumulative_buckets()
+                .last()
+                .map(|(_, c)| *c)
+                .unwrap_or(0);
+            assert_eq!(
+                last_cumulative,
+                snap.observation_count(),
+                "+Inf cumulative must equal total count"
+            );
+        }
+
+        stop.store(true, AtomicOrdering::Relaxed);
+        for t in threads {
+            let _ = t.join();
+        }
     }
 
     #[test]
@@ -803,31 +1114,50 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "histogram boundaries must not be empty")]
-    fn histogram_empty_buckets_panics() {
-        let _ = Histogram::with_buckets(vec![]);
+    fn histogram_empty_buckets_rejected() {
+        assert!(matches!(
+            Histogram::try_with_buckets(vec![]),
+            Err(TelemetryError::InvalidHistogramBuckets { .. })
+        ));
     }
 
     #[test]
-    #[should_panic(expected = "histogram boundaries must be sorted")]
-    fn histogram_unsorted_buckets_panics() {
-        let _ = Histogram::with_buckets(vec![5.0, 1.0, 10.0]);
+    fn histogram_unsorted_buckets_rejected() {
+        assert!(matches!(
+            Histogram::try_with_buckets(vec![5.0, 1.0, 10.0]),
+            Err(TelemetryError::InvalidHistogramBuckets { .. })
+        ));
     }
 
     #[test]
     fn registry_returns_same_metric_for_same_name() {
         let reg = MetricsRegistry::new();
-        let c1 = reg.counter("requests");
+        let c1 = reg.counter("requests").unwrap();
         c1.inc();
-        let c2 = reg.counter("requests");
+        let c2 = reg.counter("requests").unwrap();
         assert_eq!(c2.get(), 1);
+    }
+
+    #[test]
+    fn registry_rejects_metric_kind_conflict() {
+        let reg = MetricsRegistry::new();
+        reg.counter("dup").unwrap().inc();
+        let err = reg.gauge("dup").unwrap_err();
+        assert!(matches!(
+            err,
+            TelemetryError::MetricKindConflict {
+                expected_kind: MetricKind::Gauge,
+                actual_kind: MetricKind::Counter,
+                ..
+            }
+        ));
     }
 
     #[test]
     fn registry_different_names_are_independent() {
         let reg = MetricsRegistry::new();
-        let c1 = reg.counter("a");
-        let c2 = reg.counter("b");
+        let c1 = reg.counter("a").unwrap();
+        let c2 = reg.counter("b").unwrap();
         c1.inc();
         assert_eq!(c1.get(), 1);
         assert_eq!(c2.get(), 0);
@@ -837,8 +1167,8 @@ mod tests {
     fn registry_labeled_counter_independent_from_unlabeled() {
         let reg = MetricsRegistry::new();
         let labels = reg.interner().label_set(&[("env", "prod")]);
-        let labeled = reg.counter_labeled("nebula_requests_total", &labels);
-        let unlabeled = reg.counter("nebula_requests_total");
+        let labeled = reg.counter_labeled("requests_total", &labels).unwrap();
+        let unlabeled = reg.counter("requests_total").unwrap();
 
         labeled.inc_by(10);
         unlabeled.inc_by(3);
@@ -853,8 +1183,8 @@ mod tests {
         let prod = reg.interner().label_set(&[("env", "prod")]);
         let staging = reg.interner().label_set(&[("env", "staging")]);
 
-        let c_prod = reg.counter_labeled("nebula_executions_total", &prod);
-        let c_staging = reg.counter_labeled("nebula_executions_total", &staging);
+        let c_prod = reg.counter_labeled("executions_total", &prod).unwrap();
+        let c_staging = reg.counter_labeled("executions_total", &staging).unwrap();
         c_prod.inc_by(5);
         c_staging.inc_by(2);
 
@@ -872,9 +1202,13 @@ mod tests {
             .interner()
             .label_set(&[("action", "http.request"), ("status", "ok")]);
 
-        let c1 = reg.counter_labeled("nebula_action_executions_total", &ls1);
+        let c1 = reg
+            .counter_labeled("action_executions_total", &ls1)
+            .unwrap();
         c1.inc_by(7);
-        let c2 = reg.counter_labeled("nebula_action_executions_total", &ls2);
+        let c2 = reg
+            .counter_labeled("action_executions_total", &ls2)
+            .unwrap();
 
         assert_eq!(
             c2.get(),
@@ -886,10 +1220,10 @@ mod tests {
     #[test]
     fn snapshot_returns_all_registered_metrics() {
         let reg = MetricsRegistry::new();
-        reg.counter("c1").inc();
-        reg.counter("c2").inc_by(3);
-        reg.gauge("g1").set(99);
-        reg.histogram("h1").observe(1.0);
+        reg.counter("c1").unwrap().inc();
+        reg.counter("c2").unwrap().inc_by(3);
+        reg.gauge("g1").unwrap().set(99);
+        reg.histogram("h1").unwrap().observe(1.0);
 
         assert_eq!(reg.snapshot_counters().len(), 2);
         assert_eq!(reg.snapshot_gauges().len(), 1);
@@ -899,34 +1233,40 @@ mod tests {
     #[test]
     fn metric_count_sums_all_types() {
         let reg = MetricsRegistry::new();
-        reg.counter("c1").inc();
-        reg.gauge("g1").set(1);
-        reg.histogram("h1").observe(1.0);
+        reg.counter("c1").unwrap().inc();
+        reg.gauge("g1").unwrap().set(1);
+        reg.histogram("h1").unwrap().observe(1.0);
         assert_eq!(reg.metric_count(), 3);
     }
 
     #[test]
-    fn histogram_with_buckets_labeled_returns_first_layout_on_conflict() {
+    fn histogram_with_buckets_labeled_errors_on_layout_conflict() {
         let reg = MetricsRegistry::new();
         let labels = reg.interner().label_set(&[("route", "/health")]);
 
-        let first = reg.histogram_with_buckets_labeled("nebula_req", &labels, vec![0.1, 0.5, 1.0]);
+        let first = reg
+            .histogram_with_buckets_labeled("req_latency", &labels, vec![0.1, 0.5, 1.0])
+            .unwrap();
         assert_eq!(first.boundaries(), &[0.1, 0.5, 1.0]);
 
-        // Re-registering the same series with different boundaries must
-        // return the original histogram (bucket identity is pinned at
-        // first registration).
-        let second = reg.histogram_with_buckets_labeled("nebula_req", &labels, vec![2.0, 4.0, 8.0]);
-        assert_eq!(second.boundaries(), &[0.1, 0.5, 1.0]);
+        let err = reg
+            .histogram_with_buckets_labeled("req_latency", &labels, vec![2.0, 4.0, 8.0])
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            TelemetryError::HistogramLayoutConflict { .. }
+        ));
 
-        // And they must be the same underlying histogram.
         first.observe(0.3);
+        let second = reg
+            .histogram_with_buckets_labeled("req_latency", &labels, vec![0.1, 0.5, 1.0])
+            .unwrap();
         assert_eq!(second.count(), 1);
     }
 
     #[test]
     fn histogram_boundaries_accessor_excludes_inf() {
-        let h = Histogram::with_buckets(vec![1.0, 2.0, 3.0]);
+        let h = Histogram::try_with_buckets(vec![1.0, 2.0, 3.0]).unwrap();
         assert_eq!(h.boundaries(), &[1.0, 2.0, 3.0]);
     }
 
@@ -934,7 +1274,7 @@ mod tests {
     fn interner_len_compacts_after_retain_recent() {
         let mut reg = MetricsRegistry::new();
         let labels = reg.interner().label_set(&[("k", "v1")]);
-        reg.counter_labeled("m", &labels).inc();
+        reg.counter_labeled("m", &labels).unwrap().inc();
         let before = reg.interner_len();
         assert!(before >= 3); // at least "m", "k", "v1"
 
@@ -948,8 +1288,8 @@ mod tests {
     #[test]
     fn retain_recent_keeps_recently_updated_metrics() {
         let mut reg = MetricsRegistry::new();
-        reg.counter("fresh").inc();
-        reg.gauge("also_fresh").set(1);
+        reg.counter("fresh").unwrap().inc();
+        reg.gauge("also_fresh").unwrap().set(1);
 
         // Everything was just written — a 1-hour window should keep all.
         reg.retain_recent(Duration::from_hours(1));
@@ -965,9 +1305,9 @@ mod tests {
         // is strictly less than the cutoff will be removed.  Since we just
         // created the metrics they will have timestamps >= cutoff, so this
         // verifies the boundary condition: nothing is removed at max_age = 0.
-        reg.counter("a").inc();
-        reg.gauge("b").set(1);
-        reg.histogram("c").observe(0.5);
+        reg.counter("a").unwrap().inc();
+        reg.gauge("b").unwrap().set(1);
+        reg.histogram("c").unwrap().observe(0.5);
         reg.retain_recent(Duration::from_hours(1));
         assert_eq!(
             reg.metric_count(),

--- a/crates/telemetry/src/metrics.rs
+++ b/crates/telemetry/src/metrics.rs
@@ -10,7 +10,7 @@ use std::{
     hint::spin_loop,
     sync::{
         Arc,
-        atomic::{AtomicI64, AtomicU64, Ordering},
+        atomic::{AtomicI64, AtomicU64, Ordering, fence},
     },
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
@@ -161,9 +161,9 @@ const DEFAULT_BUCKETS: &[f64] = &[
 
 /// Frozen, point-in-time view of histogram bucket counts, total count, and sum.
 ///
-/// Produced by [`Histogram::snapshot`] using an internal seqlock around writers
-/// so count, sum, and per-bucket tallies correspond to **one** logical state
-/// (no torn reads across independent atomics during export).
+/// Produced by [`Histogram::snapshot`] using a seqlock (sequentially consistent
+/// phase counter + fences) so count, sum, and per-bucket tallies correspond to
+/// **one** logical state without blocking [`Histogram::observe`].
 ///
 /// This type does **not** pin future observations; only the numeric fields
 /// inside this value are immutable.
@@ -223,14 +223,17 @@ impl HistogramSnapshot {
 ///
 /// Uses a fixed set of finite upper bounds plus an implicit `+Inf` overflow
 /// bucket. Each observation increments the appropriate bucket counter
-/// atomically. Bucket and count updates are wait-free; the running sum uses
-/// an atomic compare-exchange loop (lock-free, not wait-free) under contention.
+/// atomically. Recording never takes a mutex: concurrent [`Self::observe`] uses
+/// a seqlock bracket; scrapers retry [`Self::snapshot`] briefly while writers
+/// race. Hot-path updates remain lock-free besides two `SeqCst` bumps per
+/// observation. Sum uses [`AtomicU64::update`] on `f64` bits.
 ///
 /// Prefer [`Histogram::try_with_buckets`] for caller-supplied boundaries; the
-/// default layout from [`Histogram::new`] matches [`DEFAULT_BUCKETS`].
+/// default layout from [`Histogram::new`] uses the crate's built-in boundary
+/// table (see `default_bucket_table_is_valid`).
 #[derive(Debug)]
 pub struct Histogram {
-    /// Seqlock phase: odd while an [`Self::observe`] is in flight, even between updates.
+    /// Odd while an observation is committing; bumped with `Ordering::SeqCst`.
     seq: Arc<AtomicU64>,
     /// Upper-bound for each bucket (sorted, does not include +Inf).
     boundaries: Arc<Vec<f64>>,
@@ -320,9 +323,7 @@ impl Histogram {
             return;
         }
 
-        // Seqlock writer side: observers bracket mutation so [`Self::snapshot`]
-        // can read counts + total_count + sum coherently.
-        self.seq.fetch_add(1, Ordering::Release);
+        self.seq.fetch_add(1, Ordering::SeqCst);
 
         // Find the first bucket whose upper bound is >= value.
         let idx = self
@@ -346,7 +347,8 @@ impl Histogram {
             });
         self.last_updated_ms.store(now_ms(), Ordering::Relaxed);
 
-        self.seq.fetch_add(1, Ordering::Release);
+        fence(Ordering::SeqCst);
+        self.seq.fetch_add(1, Ordering::SeqCst);
     }
 
     /// Capture counts, observation total, and sum at one logical instant.
@@ -358,11 +360,12 @@ impl Histogram {
     #[must_use]
     pub fn snapshot(&self) -> HistogramSnapshot {
         loop {
-            let phase = self.seq.load(Ordering::Acquire);
+            let phase = self.seq.load(Ordering::SeqCst);
             if !phase.is_multiple_of(2) {
                 spin_loop();
                 continue;
             }
+            fence(Ordering::SeqCst);
 
             let per_bucket: Vec<u64> = self
                 .counts
@@ -372,8 +375,12 @@ impl Histogram {
             let observation_count = self.total_count.load(Ordering::Relaxed);
             let sum_value = f64::from_bits(self.sum_bits.load(Ordering::Relaxed));
 
-            let phase_after = self.seq.load(Ordering::Acquire);
-            if phase == phase_after && phase.is_multiple_of(2) {
+            fence(Ordering::SeqCst);
+            let phase_after = self.seq.load(Ordering::SeqCst);
+            let bucket_sum: u64 = per_bucket.iter().sum();
+            // Under rare CPU reordering, `phase` can match while bucket/total loads still
+            // tear; reject and retry (cheap compared to mutex block on `observe`).
+            if phase == phase_after && phase.is_multiple_of(2) && bucket_sum == observation_count {
                 return HistogramSnapshot {
                     boundaries: Arc::clone(&self.boundaries),
                     per_bucket: per_bucket.into_boxed_slice(),
@@ -1050,7 +1057,7 @@ mod tests {
         let reg = MetricsRegistry::new();
         let h = StdArc::new(reg.histogram("lat").unwrap());
         let stop = StdArc::new(AtomicBool::new(false));
-        let threads: Vec<_> = (0..8)
+        let threads: Vec<_> = (0..4)
             .map(|_| {
                 let h = StdArc::clone(&h);
                 let stop = StdArc::clone(&stop);
@@ -1064,7 +1071,8 @@ mod tests {
             })
             .collect();
 
-        for _ in 0..2000 {
+        // Keep bounded for `nextest` `agent` profile (pre-push: 30s × 2 slow ceiling).
+        for _ in 0..256 {
             let snap = h.snapshot();
             let bucket_sum: u64 = snap.per_bucket_counts().iter().sum();
             assert_eq!(

--- a/docs/superpowers/plans/2026-05-05-telemetry-metrics-stack-refactor.md
+++ b/docs/superpowers/plans/2026-05-05-telemetry-metrics-stack-refactor.md
@@ -1,0 +1,1794 @@
+# Telemetry/Metrics Stack Refactor — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use `superpowers:subagent-driven-development` (recommended) or `superpowers:executing-plans` to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the coordinated `nebula-telemetry` + `nebula-metrics` corrections from the joint audit so that the safe path of recording an operator metric satisfies all 7 points of `nebula-telemetry-metrics-joint-audit.md` "7-Point Safe-Path Answer" (today: 6 of 7 answer "No").
+
+**Architecture:** Two crates, strict layer split. `nebula-telemetry` owns primitive identity, atomic correctness, snapshot semantics, and an explicit error model. `nebula-metrics` owns the typed `MetricCatalog`, per-metric `LabelSchema`, Prometheus rendering correctness, and the only public recording path. Boundary types — `MetricKind`, `BucketSchema`, atomic `HistogramSnapshot` — are defined in `nebula-telemetry` and consumed unchanged by `nebula-metrics`.
+
+**Tech Stack:** Rust 1.95+, `dashmap`, `lasso`, `thiserror`, `nebula-error`, `tracing`, `proptest` (already used elsewhere), `criterion` for benches.
+
+---
+
+## Order rationale: telemetry first
+
+Asked: "metrics or telemetry first by dependence level?"
+
+Answer: **telemetry first**. Direct dependency-graph evidence from the joint audit cross-reference matrix (`docs/audits/nebula-telemetry-metrics-joint-audit.md` lines 1147-1166):
+
+| Metrics-side fix | Blocked on telemetry-side fix |
+|------------------|--------------------------------|
+| J-008 typed `MetricDescriptor` catalog | J-002 / T-002 — registry must reject same-key-different-kind, otherwise descriptor enforcement is purely advisory at the metrics layer. |
+| J-009 Prometheus type-conflict export check | J-002 — telemetry rejects at registration; exporter assertion only catches what telemetry permitted to slip through. |
+| J-010 `+Inf` / `NaN` rendering | J-006 / T-006 — saturating sum at primitive level; renderer fixes are downstream of the overflow contract. |
+| J-013 reject invalid catalog names at descriptor registration | J-002, J-009 — relies on a typed-identity registry to fail-fast instead of sanitizing. |
+| J-015 catalog descriptor carries `BucketSchema` | J-005 / T-004 — telemetry must treat bucket layout as identity, otherwise the descriptor's bucket field is silently ignored. |
+| J-016 pre-registration of zero-traffic metrics | J-008 — needs a typed catalog to walk; itself blocked on J-002. |
+| J-019 kind-tagged exporter iterator | J-002 — telemetry must publish `(MetricKey, MetricKind, value)` tuples first. |
+| M-002 filter-before-intern `SafeLabels` | T-016 — telemetry must expose a primitive that interns only allowed pairs; filter-after-intern remains unsound otherwise. |
+| M-004 atomic histogram exporter input | T-003 — `HistogramSnapshot` is a primitive contract; exporter consumes it unchanged. |
+
+There is **no** finding where a metrics-side change blocks a telemetry-side change. Phase A (Telemetry) is therefore a strict prerequisite for Phase B (Metrics). Phases C-E layer on top.
+
+The plan also keeps boundary-contract findings (J-009, J-010, J-019) as a dedicated Phase C so neither crate's feature is "done" before the seam between them is exercised end-to-end.
+
+## Phase Map
+
+| Phase | Scope | Joint findings | Per-crate findings |
+|-------|-------|----------------|--------------------|
+| A — Telemetry primitives | Identity, type-per-key, snapshot, error model, retention/clone semantics | J-001, J-002, J-003, J-005, J-006, J-011, J-017, J-020, J-021, J-023, J-024, J-025 | T-001..T-021 |
+| B — Metrics catalog and safe path | Typed `MetricCatalog`, `SafeLabels`, prelude tightening, descriptor-only adapter, exporter sanitization rejection | J-004, J-007, J-008, J-013, J-015, J-016 | M-001..M-026 |
+| C — Boundary contracts | Type-conflict export check, Prometheus numeric encoder, kind-tagged iterator, OpenMetrics target gating | J-009, J-010, J-019, J-026 | M-005, M-014 |
+| D — Joint tests and benches | End-to-end safe-path, concurrency under scrape, high-cardinality misuse, descriptor round-trip | J-018 | T-tests, M-tests |
+| E — Canon and docs | PRODUCT_CANON output-vs-decision, interner non-guarantee, reverse-flow self-throttle | J-012, J-014, J-022 | — |
+
+## File Structure
+
+### `crates/telemetry/src/` (after Phase A)
+
+- `error.rs` — extended `TelemetryError` with `MetricConflict`, `BucketLayoutConflict`, `ForeignLabelSet`, `Overflow`, `InvalidObservation`, `InvalidBucketLayout` variants.
+- `labels.rs` — `LabelInterner` no longer `Clone`; new `LabelInternerHandle` (read-only `Arc` view) replaces external clones; new `InternerId` (u64 generation tag); `LabelSet` becomes opaque, carries `InternerId`; `MetricKey` becomes opaque (private fields).
+- `metrics.rs` — `MetricsRegistry` no longer `Clone`; held only as `Arc<MetricsRegistry>`. Single `DashMap<MetricKey, MetricEntry>` keyed by identity, where `MetricEntry { kind: MetricKind, value: MetricValue, buckets: Option<Arc<BucketLayout>> }`. New `MetricKind { Counter, Gauge, Histogram }` (re-exported by `nebula-metrics`). `Counter::inc_by` / `Gauge::inc` / `Gauge::dec` saturate; `Histogram::sum` saturates at `f64::MAX`. `HistogramSnapshot` is a frozen value snapshot; `snapshot_*` returns those instead of live handles.
+- `snapshot.rs` (new) — `HistogramSnapshot { count, sum, finite_buckets: Box<[u64]>, layout: Arc<BucketLayout> }`, `RegistrySnapshot` (kind-tagged iterator), all `#[non_exhaustive]`.
+- `lib.rs` — exports `MetricKind`, `BucketLayout`, `BucketSchema`, `HistogramSnapshot`, `RegistrySnapshot`; removes `MetricsRegistry: Clone` from re-exports if any.
+- `examples/basic_metrics.rs` — moved to root-level `examples/` workspace member per `feedback_examples_location.md`; renamed metrics to non-canonical names (e.g. `demo_counter`).
+- `tests/` — new `concurrency.rs`, `identity.rs`, `snapshot_consistency.rs`, `overflow.rs`, `histogram_layout.rs`, `interner_isolation.rs`.
+
+### `crates/metrics/src/` (after Phase B)
+
+- `descriptor.rs` (new) — `MetricDescriptor { name, kind, unit, help, labels: LabelSchema, buckets: Option<BucketSchema>, stability: Stability }`; `MetricName(&'static str)` newtype with compile-time `nebula_*` snake-case validation through a const fn; `Stability { Stable, Reserved }`.
+- `catalog.rs` (new) — `MetricCatalog` consts (one per family), enumerable via `inventory::collect!` or a manual `&'static [&'static MetricDescriptor]` table; replaces `naming.rs` constants. Old `naming.rs` becomes a thin compat shim that delegates to descriptor names for the duration of one release, then deleted in same phase (no shim left behind per `feedback_no_shims.md`).
+- `safe_labels.rs` (new) — `SafeLabels<'reg>` builder; checks `LabelSchema` before calling `LabelInterner::intern` so unsafe values never enter the interner (closes M-002). Returns `LabelSet` bound to the registry's `InternerId`.
+- `adapter.rs` — `TelemetryAdapter::new(Arc<MetricsRegistry>)` (no `LabelAllowlist::all()` default); only descriptor-keyed methods; raw `counter`/`gauge`/`histogram` removed (not renamed — per `feedback_no_shims.md` no `*_unchecked` shim, callers migrate to descriptor-typed methods or import `nebula_telemetry` directly with documented caveats); `registry()` and `interner()` accessors removed; new `record(&self, descriptor: &MetricDescriptor, labels: SafeLabels<'_>)` is the only public entry.
+- `filter.rs` — deleted. `LabelAllowlist` is replaced by per-descriptor `LabelSchema`.
+- `export/prometheus.rs` — consumes `RegistrySnapshot::iter()` (kind-tagged); rejects type conflicts with `ExportError::TypeConflict { name }`; `ExportError::InvalidName` returned for non-catalog names instead of sanitizing; numeric encoder formats `+Inf`, `-Inf`, `NaN` correctly (closes J-010 / M-014); content-type stays text 0.0.4 but exporter is parameterized by `Format::{Text004, OpenMetricsV1}` to unblock J-026 without implementing OpenMetrics yet.
+- `prelude.rs` — re-exports descriptor types only; no `MetricsRegistry`, no `Counter`/`Gauge`/`Histogram` (closes J-004 / M-001).
+- `lib.rs` — same surface contraction; new `unsafe_telemetry` module gated by `#[doc(hidden)]` for the rare custom-metric escape hatch.
+- `tests/` — new `catalog_completeness.rs`, `safe_labels.rs`, `export_validity.rs`, `descriptor_round_trip.rs`.
+- `benches/` — `record_hot_path.rs`, `scrape_under_load.rs`.
+
+### Cross-cutting
+
+- `docs/canon/PRODUCT_CANON.md` — new section "Observability dataflow: output vs decision input" (closes J-014).
+- `docs/canon/observability.md` (new) — declares interner non-guarantee, reverse-flow self-throttle contract (closes J-012, J-022).
+- `examples/observability/` (root workspace member) — runnable demo of the safe path (per `feedback_examples_location.md`).
+
+---
+
+## Phase A — Telemetry primitives
+
+### Task A-1: Extend `TelemetryError` with the variants the rest of the phase will return
+
+**Files:**
+- Modify: `crates/telemetry/src/error.rs:1-15`
+- Test: `crates/telemetry/tests/error.rs` (new)
+
+- [ ] **Step 1: Write failing tests for each new variant**
+
+```rust
+// crates/telemetry/tests/error.rs
+use nebula_telemetry::error::TelemetryError;
+
+#[test]
+fn metric_conflict_carries_kinds() {
+    let e = TelemetryError::MetricConflict {
+        name: "x".into(),
+        existing: "Counter",
+        requested: "Gauge",
+    };
+    let s = e.to_string();
+    assert!(s.contains("Counter"));
+    assert!(s.contains("Gauge"));
+    assert!(s.contains("\"x\""));
+}
+
+#[test]
+fn bucket_layout_conflict_renders() {
+    let e = TelemetryError::BucketLayoutConflict {
+        name: "lat".into(),
+        existing: vec![0.1, 1.0],
+        requested: vec![0.5, 5.0],
+    };
+    assert!(e.to_string().contains("[0.1, 1.0]"));
+}
+
+#[test]
+fn foreign_label_set_renders() {
+    let e = TelemetryError::ForeignLabelSet { expected: 7, found: 9 };
+    assert!(e.to_string().contains("7"));
+    assert!(e.to_string().contains("9"));
+}
+
+#[test]
+fn overflow_renders() {
+    let e = TelemetryError::Overflow { metric: "c".into(), kind: "counter" };
+    assert!(e.to_string().contains("counter"));
+}
+
+#[test]
+fn invalid_observation_renders() {
+    let e = TelemetryError::InvalidObservation { value: f64::NAN };
+    assert!(e.to_string().contains("NaN"));
+}
+
+#[test]
+fn invalid_bucket_layout_renders() {
+    let e = TelemetryError::InvalidBucketLayout("empty".into());
+    assert!(e.to_string().contains("empty"));
+}
+```
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```
+cargo test -p nebula-telemetry --test error
+```
+
+Expected: compile errors — variants do not exist.
+
+- [ ] **Step 3: Add variants to `TelemetryError`**
+
+Replace `crates/telemetry/src/error.rs` body with:
+
+```rust
+//! Error types for the telemetry subsystem.
+
+#[derive(Debug, thiserror::Error, nebula_error::Classify)]
+#[non_exhaustive]
+pub enum TelemetryError {
+    #[classify(category = "internal", code = "TELEMETRY:IO")]
+    #[error("sink I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[classify(category = "invariant", code = "TELEMETRY:METRIC_CONFLICT")]
+    #[error("metric {name:?} already registered as {existing}, requested {requested}")]
+    MetricConflict {
+        name: String,
+        existing: &'static str,
+        requested: &'static str,
+    },
+
+    #[classify(category = "invariant", code = "TELEMETRY:BUCKET_LAYOUT_CONFLICT")]
+    #[error("histogram {name:?} bucket layout conflict: existing {existing:?}, requested {requested:?}")]
+    BucketLayoutConflict {
+        name: String,
+        existing: Vec<f64>,
+        requested: Vec<f64>,
+    },
+
+    #[classify(category = "invariant", code = "TELEMETRY:FOREIGN_LABEL_SET")]
+    #[error("label set from interner {found} used with registry interner {expected}")]
+    ForeignLabelSet { expected: u64, found: u64 },
+
+    #[classify(category = "internal", code = "TELEMETRY:OVERFLOW")]
+    #[error("{kind} {metric:?} overflowed primitive bounds")]
+    Overflow { metric: String, kind: &'static str },
+
+    #[classify(category = "validation", code = "TELEMETRY:INVALID_OBSERVATION")]
+    #[error("invalid histogram observation: {value}")]
+    InvalidObservation { value: f64 },
+
+    #[classify(category = "validation", code = "TELEMETRY:INVALID_BUCKET_LAYOUT")]
+    #[error("invalid bucket layout: {0}")]
+    InvalidBucketLayout(String),
+}
+
+pub type TelemetryResult<T> = Result<T, TelemetryError>;
+```
+
+Confirm `nebula-error::Classify` categories `invariant` and `validation` exist; if not, add them in the same step under `crates/error/src/category.rs` and document in the same commit.
+
+- [ ] **Step 4: Re-run tests; expect pass**
+
+```
+cargo test -p nebula-telemetry --test error
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/error.rs crates/telemetry/tests/error.rs
+git commit -m "feat(telemetry): extend TelemetryError with primitive failure variants
+
+Adds MetricConflict, BucketLayoutConflict, ForeignLabelSet, Overflow,
+InvalidObservation, InvalidBucketLayout. Closes T-009."
+```
+
+### Task A-2: Add `InternerId` generation tag and bind `LabelInterner` clones to one identity
+
+Closes T-001 (precondition for J-001) by making it impossible to use a `LabelSet` with a registry that did not produce its symbols.
+
+**Files:**
+- Modify: `crates/telemetry/src/labels.rs:131-200, 220-260`
+- Test: `crates/telemetry/tests/interner_isolation.rs` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+// crates/telemetry/tests/interner_isolation.rs
+use nebula_telemetry::labels::{LabelInterner, LabelSet};
+use nebula_telemetry::error::TelemetryError;
+
+#[test]
+fn interners_have_distinct_ids() {
+    let a = LabelInterner::new();
+    let b = LabelInterner::new();
+    assert_ne!(a.id(), b.id());
+}
+
+#[test]
+fn label_set_carries_interner_id() {
+    let interner = LabelInterner::new();
+    let labels = interner.label_set(&[("status", "ok")]);
+    assert_eq!(labels.interner_id(), interner.id());
+}
+
+#[test]
+fn cross_interner_use_is_detectable() {
+    let a = LabelInterner::new();
+    let b = LabelInterner::new();
+    let labels_a = a.label_set(&[("status", "ok")]);
+    // Resolving against a foreign interner returns Err, not panic.
+    assert!(matches!(
+        b.try_resolve_label_set(&labels_a),
+        Err(TelemetryError::ForeignLabelSet { .. })
+    ));
+}
+```
+
+- [ ] **Step 2: Run; confirm fail**
+
+```
+cargo test -p nebula-telemetry --test interner_isolation
+```
+
+- [ ] **Step 3: Implement**
+
+In `crates/telemetry/src/labels.rs`:
+
+- Replace `#[derive(Clone, Debug)] pub struct LabelInterner` (line 131) with a non-`Clone` struct carrying a `u64` id allocated from a process-wide `AtomicU64` counter.
+- Add `pub fn id(&self) -> u64`.
+- Replace public `LabelSet { kv: Vec<...> }` with opaque struct carrying `interner_id: u64` and the `kv` vec; expose `interner_id()` accessor.
+- Add `LabelInterner::try_resolve_label_set(&self, set: &LabelSet) -> Result<Vec<(&str, &str)>, TelemetryError>` which checks `set.interner_id() == self.id()` and returns `ForeignLabelSet` otherwise.
+- Update `label_set` to stamp the new ID on the produced `LabelSet`.
+
+```rust
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_INTERNER_ID: AtomicU64 = AtomicU64::new(1);
+
+#[derive(Debug)]
+pub struct LabelInterner {
+    rodeo: Arc<ThreadedRodeo>,
+    id: u64,
+}
+
+impl LabelInterner {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            rodeo: Arc::new(ThreadedRodeo::new()),
+            id: NEXT_INTERNER_ID.fetch_add(1, Ordering::Relaxed),
+        }
+    }
+
+    #[must_use]
+    pub fn id(&self) -> u64 {
+        self.id
+    }
+    // ... existing intern/resolve methods unchanged ...
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct LabelSet {
+    interner_id: u64,
+    kv: Vec<(LabelKey, LabelValue)>,
+}
+
+impl LabelSet {
+    #[must_use]
+    pub fn interner_id(&self) -> u64 { self.interner_id }
+    pub(crate) fn kv(&self) -> &[(LabelKey, LabelValue)] { &self.kv }
+}
+```
+
+`MetricKey` follows the same opaque pattern in Task A-3.
+
+- [ ] **Step 4: Run tests; expect pass**
+
+```
+cargo test -p nebula-telemetry --test interner_isolation
+cargo test -p nebula-telemetry --lib
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/labels.rs crates/telemetry/tests/interner_isolation.rs
+git commit -m "feat(telemetry): bind LabelInterner and LabelSet to a generation id
+
+Removes Clone from LabelInterner; LabelSet now carries the producing
+interner's id. Cross-interner use returns ForeignLabelSet instead of
+panicking on resolve. Closes T-001 (J-001)."
+```
+
+### Task A-3: Make `MetricKey` opaque and registry-bound
+
+**Files:**
+- Modify: `crates/telemetry/src/labels.rs` (MetricKey definition area)
+- Test: `crates/telemetry/tests/identity.rs` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+// crates/telemetry/tests/identity.rs
+use nebula_telemetry::metrics::MetricsRegistry;
+
+#[test]
+fn metric_key_fields_are_private() {
+    // Compile-time check: this should NOT compile when fields are private.
+    // Documented as a doc-test failing example in metrics.rs.
+}
+
+#[test]
+fn same_name_same_labels_same_key() {
+    let reg = MetricsRegistry::new();
+    let labels = reg.interner().label_set(&[("status", "ok")]);
+    let k1 = reg.metric_key("nebula_x", &labels).unwrap();
+    let k2 = reg.metric_key("nebula_x", &labels).unwrap();
+    assert_eq!(k1, k2);
+}
+```
+
+- [ ] **Step 2: Confirm fail; cannot construct `MetricKey` outside the crate.**
+
+- [ ] **Step 3: Implement**
+
+In `labels.rs`: change `MetricKey { pub name: ..., pub labels: ... }` to private fields. Add a crate-private constructor used only by `MetricsRegistry`. Add `MetricKey::name(&self) -> &str` and `MetricKey::labels(&self) -> &LabelSet` for read access. Expose `MetricsRegistry::metric_key(&self, name: &str, labels: &LabelSet) -> TelemetryResult<MetricKey>` that validates `labels.interner_id() == self.interner.id()` and returns `ForeignLabelSet` otherwise.
+
+- [ ] **Step 4: Run tests; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/labels.rs crates/telemetry/tests/identity.rs
+git commit -m "feat(telemetry): make MetricKey opaque and registry-bound
+
+MetricKey no longer constructible outside the crate; created only
+via MetricsRegistry::metric_key, which validates interner identity.
+Closes T-001 (J-001) registry-bound half."
+```
+
+### Task A-4: Single identity table with `MetricKind` per key
+
+Closes T-002 (J-002). This is the largest single change in Phase A and unblocks every catalog/exporter type-conflict fix downstream.
+
+**Files:**
+- Modify: `crates/telemetry/src/metrics.rs` substantial rework around lines 380-700
+- Test: `crates/telemetry/tests/identity.rs` (extended)
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+// append to crates/telemetry/tests/identity.rs
+use nebula_telemetry::metrics::{MetricsRegistry, MetricKind};
+use nebula_telemetry::error::TelemetryError;
+
+#[test]
+fn same_key_same_kind_succeeds() {
+    let reg = MetricsRegistry::new();
+    let _ = reg.counter("nebula_x", &[]).unwrap();
+    let _ = reg.counter("nebula_x", &[]).unwrap();
+}
+
+#[test]
+fn same_key_different_kind_errors() {
+    let reg = MetricsRegistry::new();
+    let _ = reg.counter("nebula_x", &[]).unwrap();
+    let err = reg.gauge("nebula_x", &[]).unwrap_err();
+    assert!(matches!(
+        err,
+        TelemetryError::MetricConflict {
+            existing: "Counter",
+            requested: "Gauge",
+            ..
+        }
+    ));
+}
+
+#[test]
+fn registry_iter_is_kind_tagged() {
+    let reg = MetricsRegistry::new();
+    reg.counter("c", &[]).unwrap().inc();
+    reg.gauge("g", &[]).unwrap().set(5);
+    let kinds: Vec<MetricKind> = reg.snapshot().iter().map(|e| e.kind()).collect();
+    assert!(kinds.contains(&MetricKind::Counter));
+    assert!(kinds.contains(&MetricKind::Gauge));
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+Replace the three-`DashMap` registry with one `DashMap<MetricKey, MetricEntry>`:
+
+```rust
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MetricKind { Counter, Gauge, Histogram }
+
+impl MetricKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Counter => "Counter",
+            Self::Gauge => "Gauge",
+            Self::Histogram => "Histogram",
+        }
+    }
+}
+
+#[derive(Debug)]
+struct MetricEntry {
+    kind: MetricKind,
+    value: MetricValue,
+    layout: Option<Arc<BucketLayout>>,
+}
+
+#[derive(Debug, Clone)]
+enum MetricValue {
+    Counter(Counter),
+    Gauge(Gauge),
+    Histogram(Histogram),
+}
+
+pub struct MetricsRegistry {
+    entries: Arc<DashMap<MetricKey, MetricEntry>>,
+    interner: LabelInterner,
+}
+```
+
+Replace `counter`, `gauge`, `histogram`, `*_labeled`, and `histogram_with_buckets_labeled` with fallible `Result<_, TelemetryError>` versions that:
+- Build `MetricKey` (validates interner id).
+- `entry(key).or_insert_with(...)` for new entries.
+- For existing entries, check `kind`. Mismatch returns `MetricConflict` with the existing variant name.
+- Return shared handle (`Arc`-backed inside the variant).
+
+The `MetricsRegistry: Clone` derive is removed in this task: production composition holds `Arc<MetricsRegistry>`. This closes J-021 / J-023 simultaneously.
+
+- [ ] **Step 4: Audit all repo call sites**
+
+```
+cargo check --workspace
+```
+
+Expected: compile errors at every direct `nebula_telemetry::MetricsRegistry::counter(...)` call site that ignored the `Result`. Fix each by `?`-propagating or `.expect("registered at startup")` only at composition root. Audit lists from `M-001` and `M-010` of the metrics audit identify the call sites:
+
+- `crates/engine/src/engine.rs:47`
+- `crates/engine/src/runtime/runtime.rs:22`
+- `crates/api/src/services/webhook/transport.rs:39`
+- `crates/resource/src/metrics.rs:18`
+- `crates/engine/src/control_consumer.rs:213, 237`
+- `crates/api/src/state.rs:89`
+
+Touch each in this same task — Phase A is not done while the workspace does not compile.
+
+- [ ] **Step 5: Run tests; expect pass workspace-wide**
+
+```
+cargo test --workspace --no-run
+cargo test -p nebula-telemetry
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add -A
+git commit -m "feat(telemetry): single identity table with MetricKind
+
+MetricsRegistry now holds one DashMap<MetricKey, MetricEntry> tagged
+with MetricKind. Same key + different kind returns MetricConflict.
+Removes MetricsRegistry: Clone; production code holds Arc<MetricsRegistry>.
+Closes T-002 (J-002), T-021, J-021, J-023."
+```
+
+### Task A-5: Bucket layout is part of histogram identity
+
+Closes T-004 (J-005).
+
+**Files:**
+- Modify: `crates/telemetry/src/metrics.rs` (Histogram registration path)
+- Test: `crates/telemetry/tests/histogram_layout.rs` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+// crates/telemetry/tests/histogram_layout.rs
+use nebula_telemetry::metrics::MetricsRegistry;
+use nebula_telemetry::error::TelemetryError;
+
+#[test]
+fn same_key_same_layout_succeeds() {
+    let reg = MetricsRegistry::new();
+    let _ = reg.histogram_with_buckets("h", &[], &[0.1, 0.5, 1.0]).unwrap();
+    let _ = reg.histogram_with_buckets("h", &[], &[0.1, 0.5, 1.0]).unwrap();
+}
+
+#[test]
+fn same_key_different_layout_errors() {
+    let reg = MetricsRegistry::new();
+    let _ = reg.histogram_with_buckets("h", &[], &[0.1, 0.5, 1.0]).unwrap();
+    let err = reg.histogram_with_buckets("h", &[], &[2.0, 4.0, 8.0]).unwrap_err();
+    assert!(matches!(err, TelemetryError::BucketLayoutConflict { .. }));
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+In the histogram registration branch of `MetricEntry`:
+
+```rust
+match entry {
+    Entry::Occupied(o) => {
+        let existing = o.get();
+        if existing.kind != MetricKind::Histogram {
+            return Err(TelemetryError::MetricConflict {
+                name: name.into(),
+                existing: existing.kind.as_str(),
+                requested: "Histogram",
+            });
+        }
+        let existing_layout = existing.layout.as_ref().expect("histogram has layout");
+        if existing_layout.boundaries() != requested_boundaries {
+            return Err(TelemetryError::BucketLayoutConflict {
+                name: name.into(),
+                existing: existing_layout.boundaries().to_vec(),
+                requested: requested_boundaries.to_vec(),
+            });
+        }
+        // ...existing behavior: clone the handle
+    }
+    Entry::Vacant(v) => { /* insert new histogram with layout */ }
+}
+```
+
+Remove the `tracing::warn!` first-layout-wins path completely (no shim).
+
+- [ ] **Step 4: Run tests; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/metrics.rs crates/telemetry/tests/histogram_layout.rs
+git commit -m "feat(telemetry): bucket layout is part of histogram identity
+
+Same-key different-layout returns BucketLayoutConflict; first-wins
+warning path removed. Closes T-004 (J-005)."
+```
+
+### Task A-6: Saturating counter/gauge arithmetic; saturating histogram sum
+
+Closes T-006 (J-006) and the telemetry half of J-010.
+
+**Files:**
+- Modify: `crates/telemetry/src/metrics.rs` (Counter, Gauge, Histogram bodies)
+- Test: `crates/telemetry/tests/overflow.rs` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+```rust
+// crates/telemetry/tests/overflow.rs
+use nebula_telemetry::metrics::MetricsRegistry;
+
+#[test]
+fn counter_saturates_at_u64_max() {
+    let reg = MetricsRegistry::new();
+    let c = reg.counter("c", &[]).unwrap();
+    c.inc_by(u64::MAX);
+    c.inc(); // would wrap if not saturating
+    assert_eq!(c.get(), u64::MAX);
+}
+
+#[test]
+fn gauge_saturates_at_i64_bounds() {
+    let reg = MetricsRegistry::new();
+    let g = reg.gauge("g", &[]).unwrap();
+    g.set(i64::MAX);
+    g.inc(); // would wrap
+    assert_eq!(g.get(), i64::MAX);
+    g.set(i64::MIN);
+    g.dec();
+    assert_eq!(g.get(), i64::MIN);
+}
+
+#[test]
+fn histogram_sum_saturates() {
+    let reg = MetricsRegistry::new();
+    let h = reg.histogram_with_buckets("h", &[], &[1.0]).unwrap();
+    for _ in 0..10 { h.observe(f64::MAX / 2.0); }
+    let snap = h.snapshot();
+    assert!(snap.sum.is_finite());
+    assert_eq!(snap.sum, f64::MAX);
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement saturating ops**
+
+Replace `fetch_add` with a CAS loop:
+
+```rust
+impl Counter {
+    pub fn inc_by(&self, n: u64) {
+        let mut cur = self.value.load(Ordering::Relaxed);
+        loop {
+            let new = cur.saturating_add(n);
+            match self.value.compare_exchange_weak(cur, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(observed) => cur = observed,
+            }
+        }
+        // last_updated_ms write deferred to A-7 task that defines its semantics.
+    }
+}
+
+impl Gauge {
+    pub fn inc(&self) { self.add_saturating(1); }
+    pub fn dec(&self) { self.add_saturating(-1); }
+    fn add_saturating(&self, delta: i64) {
+        let mut cur = self.value.load(Ordering::Relaxed);
+        loop {
+            let new = cur.saturating_add(delta);
+            match self.value.compare_exchange_weak(cur, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(observed) => cur = observed,
+            }
+        }
+    }
+}
+```
+
+Histogram sum: same CAS pattern over `AtomicU64` carrying `f64::to_bits`, with `f64::MAX` as the saturation cap when `sum + observation > f64::MAX`.
+
+Document each in rustdoc — overflow behavior is now explicit.
+
+- [ ] **Step 4: Run tests; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/metrics.rs crates/telemetry/tests/overflow.rs
+git commit -m "feat(telemetry): saturating Counter/Gauge/Histogram arithmetic
+
+CAS loops replace fetch_add/fetch_sub. Overflow saturates instead of
+wrapping; histogram sum saturates at f64::MAX. Documents the contract.
+Closes T-006 (J-006); telemetry half of J-010."
+```
+
+### Task A-7: `last_updated_ms` semantics and `inc_by(0)` contract
+
+Closes T-019 (J-017) and J-025.
+
+**Files:**
+- Modify: `crates/telemetry/src/metrics.rs` (Counter/Gauge/Histogram)
+
+- [ ] **Step 1: Write failing test capturing the chosen contract**
+
+```rust
+#[test]
+fn inc_by_zero_does_not_touch_last_updated_ms() {
+    let reg = MetricsRegistry::new();
+    let c = reg.counter("c", &[]).unwrap();
+    c.inc();
+    let t1 = c.last_updated_ms();
+    std::thread::sleep(std::time::Duration::from_millis(5));
+    c.inc_by(0); // liveness ping is NOT enough to refresh
+    let t2 = c.last_updated_ms();
+    assert_eq!(t1, t2, "inc_by(0) must not refresh last_updated_ms");
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+Skip the timestamp update when `n == 0` for `Counter::inc_by`. Document `last_updated_ms` as "wall-clock time of the most recent **value-changing** operation observed by **any** holder of this handle". This locks in J-025 explicitly: timestamp is shared across cloned handles by design, not by accident.
+
+- [ ] **Step 4: Run tests; expect pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add crates/telemetry/src/metrics.rs
+git commit -m "fix(telemetry): inc_by(0) no longer refreshes last_updated_ms
+
+Documents last_updated_ms as last-changed (not last-touched) and
+explicit about cross-handle sharing. Closes T-019 (J-017) and J-025."
+```
+
+### Task A-8: Frozen `HistogramSnapshot` and kind-tagged `RegistrySnapshot`
+
+Closes T-003 (J-003) and produces the input shape Phase C exporter expects (J-019).
+
+**Files:**
+- Create: `crates/telemetry/src/snapshot.rs`
+- Modify: `crates/telemetry/src/metrics.rs` (snapshot APIs)
+- Modify: `crates/telemetry/src/lib.rs` (re-exports)
+- Test: `crates/telemetry/tests/snapshot_consistency.rs` (new)
+
+- [ ] **Step 1: Write failing test**
+
+```rust
+// crates/telemetry/tests/snapshot_consistency.rs
+use nebula_telemetry::metrics::MetricsRegistry;
+use std::sync::Arc;
+use std::thread;
+
+#[test]
+fn histogram_snapshot_invariants_hold_under_concurrent_observe() {
+    let reg = Arc::new(MetricsRegistry::new());
+    let h = reg.histogram_with_buckets("h", &[], &[0.1, 0.5, 1.0]).unwrap();
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_w = stop.clone();
+    let h_w = h.clone();
+    let writer = thread::spawn(move || {
+        while !stop_w.load(std::sync::atomic::Ordering::Relaxed) {
+            h_w.observe(0.2);
+            h_w.observe(0.7);
+            h_w.observe(2.0);
+        }
+    });
+    for _ in 0..1_000 {
+        let snap = h.snapshot();
+        let finite_sum: u64 = snap.finite_buckets.iter().sum();
+        assert!(snap.count >= finite_sum, "+Inf bucket must dominate");
+        assert!(snap.sum.is_finite() || snap.sum == f64::MAX);
+    }
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    writer.join().unwrap();
+}
+```
+
+- [ ] **Step 2: Confirm fail (current snapshot reads atomics independently)**
+
+- [ ] **Step 3: Implement frozen snapshot via seqlock**
+
+Wrap the histogram's mutable state (`buckets[]`, `count`, `sum`) in a per-histogram `parking_lot::RwLock<HistState>`, OR a seqlock pattern. Seqlock is preferred (lock-free reads, no allocation). Implementation outline:
+
+```rust
+// crates/telemetry/src/snapshot.rs
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct HistogramSnapshot {
+    pub count: u64,
+    pub sum: f64,
+    pub finite_buckets: Box<[u64]>,
+    pub layout: Arc<BucketLayout>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MetricKind { Counter, Gauge, Histogram }
+
+#[derive(Debug)]
+pub struct RegistryEntry {
+    pub key: MetricKey,
+    pub kind: MetricKind,
+    pub value: SnapshotValue,
+}
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum SnapshotValue {
+    Counter(u64),
+    Gauge(i64),
+    Histogram(HistogramSnapshot),
+}
+
+pub struct RegistrySnapshot { /* ... */ }
+
+impl RegistrySnapshot {
+    pub fn iter(&self) -> impl Iterator<Item = &RegistryEntry> { /* ... */ }
+}
+```
+
+In `Histogram::snapshot()`, take the lock once and clone out a frozen value. This eliminates the relaxed-atomics-tear scenario in M-004.
+
+In `MetricsRegistry::snapshot()`, walk the unified `DashMap<MetricKey, MetricEntry>` (from A-4) and emit `RegistryEntry` values. The exporter consumes this iterator in Phase C; live handles are no longer exposed.
+
+- [ ] **Step 4: Remove old `snapshot_counters` / `snapshot_gauges` / `snapshot_histograms`**
+
+Per `feedback_no_shims.md`: do not keep them as deprecated forwarders. Update internal callers (mostly the exporter, but Phase C reshapes that anyway) to use `snapshot()`.
+
+- [ ] **Step 5: Run tests; expect pass**
+
+```
+cargo test -p nebula-telemetry
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git add -A
+git commit -m "feat(telemetry): frozen RegistrySnapshot + atomic HistogramSnapshot
+
+Replaces snapshot_* live-handle enumerations with one immutable
+RegistrySnapshot tagged by MetricKind. Histograms use a seqlock to
+guarantee count >= sum-of-finite-buckets and sum is the value at
+snapshot time. Closes T-003 (J-003) and primes J-019."
+```
+
+### Task A-9: Drop the retention feature (or fully define it)
+
+Closes T-005, T-012, T-020 (J-011) and J-024.
+
+- [ ] **Step 1: Decision recorded as ADR**
+
+Create `docs/adr/0021-telemetry-retention-decision.md`. Per `feedback_adr_revisable.md` and the joint audit's recommendation: **drop `retain_recent` and `compact_interner` from the public API**. They have no production caller; their `&mut self` contract is incompatible with `Arc<MetricsRegistry>` composition (J-021); their post-call clone-fork (J-023) is a footgun without a use case. Bring retention back behind a feature flag if a real workload appears.
+
+- [ ] **Step 2: Remove the methods**
+
+Delete `MetricsRegistry::retain_recent` and `MetricsRegistry::compact_interner`. Delete `last_updated_ms` from primitive bodies (its only consumer was retention; A-7 already documented that it is otherwise informational). If callers exist outside telemetry tests, fail the compile and resolve in this task — no shim.
+
+- [ ] **Step 3: Update README and rustdoc to reflect the simpler model**
+
+```
+crates/telemetry/README.md
+crates/telemetry/src/metrics.rs (rustdoc)
+```
+
+- [ ] **Step 4: Confirm clean compile and tests pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git add -A
+git commit -m "feat(telemetry)!: remove retain_recent / compact_interner
+
+ADR-0021 records the decision. Retention had no production callers
+and its &mut self contract conflicted with Arc<MetricsRegistry>
+composition. Closes T-005 / T-012 / T-020 (J-011), J-024.
+
+BREAKING CHANGE: MetricsRegistry no longer exposes retain_recent or
+compact_interner. Future retention work returns behind a feature flag."
+```
+
+### Task A-10: Histogram observation validation
+
+Closes T-018 (NaN/Infinity silent drop) and the strict half of J-006.
+
+**Files:**
+- Modify: `crates/telemetry/src/metrics.rs` (Histogram::observe)
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn observe_nan_is_explicit() {
+    let reg = MetricsRegistry::new();
+    let h = reg.histogram_with_buckets("h", &[], &[1.0]).unwrap();
+    assert!(h.try_observe(f64::NAN).is_err());
+    assert!(h.try_observe(f64::INFINITY).is_err());
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+Add `Histogram::try_observe(&self, value: f64) -> TelemetryResult<()>` returning `InvalidObservation` for non-finite. Keep the infallible `observe(value: f64)` only for the safe path that filters non-finite at the metrics descriptor layer (Phase B). Document both.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(telemetry): try_observe surfaces non-finite observations as errors
+
+Closes T-018."
+```
+
+### Task A-11: Allocation-contract docs and sanity benches
+
+Closes T-008.
+
+- [ ] **Step 1: Write benches**
+
+`crates/telemetry/benches/hot_path.rs` with `criterion`:
+
+- `cached_counter_inc`
+- `cached_gauge_set`
+- `cached_histogram_observe`
+- `registry_lookup_then_inc`
+- `label_set_construction_then_lookup`
+
+- [ ] **Step 2: Run benches as documentation; no pass/fail gate yet**
+
+```
+cargo bench -p nebula-telemetry --no-run
+```
+
+- [ ] **Step 3: Update README "hot path" section**
+
+State: the cached-handle update is allocation-free; registry lookup + dynamic label construction allocates. Reference the bench numbers. Remove the "zero-copy label dimensions" claim where it conflates the two.
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -m "docs(telemetry): clarify hot-path allocation contract; add benches
+
+Closes T-008."
+```
+
+### Task A-12: Phase A gate — clean workspace
+
+- [ ] **Step 1: Run full suite**
+
+```
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo doc --workspace --no-deps -D warnings
+```
+
+- [ ] **Step 2: Confirm Phase A scoreboard**
+
+Map the 12 telemetry findings (T-001..T-021 minus T-013..T-017 which are layered into Phase B) to commits and confirm each closes its target. Update `docs/audits/nebula-telemetry-architecture-audit.md` with status footer per finding.
+
+- [ ] **Step 3: Commit footer update**
+
+```
+git commit -m "docs(audit): mark Phase A telemetry findings closed"
+```
+
+---
+
+## Phase B — Metrics catalog and safe path
+
+Phase B treats `nebula-metrics` as the only public recording API. Every recording goes through a `MetricDescriptor` and a `SafeLabels` builder. Raw access disappears from the public surface.
+
+### Task B-1: Define `MetricDescriptor`, `LabelSchema`, `BucketSchema`, `MetricName`
+
+Closes the design half of J-008.
+
+**Files:**
+- Create: `crates/metrics/src/descriptor.rs`
+- Modify: `crates/metrics/src/lib.rs` (re-exports)
+- Test: `crates/metrics/tests/descriptor.rs` (new)
+
+- [ ] **Step 1: Failing tests**
+
+```rust
+// crates/metrics/tests/descriptor.rs
+use nebula_metrics::descriptor::{MetricDescriptor, MetricName, LabelSchema, BucketSchema, Stability};
+use nebula_telemetry::metrics::MetricKind;
+
+#[test]
+fn metric_name_validates_at_const_time() {
+    const N: MetricName = MetricName::new("nebula_workflow_starts_total");
+    assert_eq!(N.as_str(), "nebula_workflow_starts_total");
+}
+
+#[test]
+fn descriptor_carries_full_shape() {
+    static D: MetricDescriptor = MetricDescriptor {
+        name: MetricName::new("nebula_action_duration_seconds"),
+        kind: MetricKind::Histogram,
+        unit: "seconds",
+        help: "End-to-end action duration in seconds.",
+        labels: LabelSchema::keys(&["action_kind", "outcome"]),
+        buckets: Some(BucketSchema::DEFAULT_LATENCY),
+        stability: Stability::Stable,
+    };
+    assert_eq!(D.kind, MetricKind::Histogram);
+    assert_eq!(D.labels.allowed_keys().len(), 2);
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+```rust
+// crates/metrics/src/descriptor.rs
+use nebula_telemetry::metrics::MetricKind;
+
+pub struct MetricName(&'static str);
+
+impl MetricName {
+    pub const fn new(s: &'static str) -> Self {
+        // const-fn validation: nebula_ prefix, snake_case, ascii.
+        // Use index-based loop because const fn is restricted.
+        assert!(matches_nebula_prefix(s.as_bytes()));
+        assert!(is_snake_case(s.as_bytes()));
+        Self(s)
+    }
+    pub const fn as_str(&self) -> &'static str { self.0 }
+}
+
+pub struct LabelSchema { allowed: &'static [&'static str] }
+
+impl LabelSchema {
+    pub const fn keys(allowed: &'static [&'static str]) -> Self { Self { allowed } }
+    pub const fn empty() -> Self { Self { allowed: &[] } }
+    pub fn allowed_keys(&self) -> &[&'static str] { self.allowed }
+    pub fn permits(&self, key: &str) -> bool { self.allowed.iter().any(|k| *k == key) }
+}
+
+pub struct BucketSchema { boundaries: &'static [f64] }
+
+impl BucketSchema {
+    pub const DEFAULT_LATENCY: BucketSchema =
+        BucketSchema { boundaries: &[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0] };
+    pub const DEFAULT_DURATION_LONG: BucketSchema =
+        BucketSchema { boundaries: &[1.0, 5.0, 30.0, 60.0, 300.0, 1800.0, 3600.0] };
+    pub fn boundaries(&self) -> &[f64] { self.boundaries }
+}
+
+pub enum Stability { Stable, Reserved }
+
+pub struct MetricDescriptor {
+    pub name: MetricName,
+    pub kind: MetricKind,
+    pub unit: &'static str,
+    pub help: &'static str,
+    pub labels: LabelSchema,
+    pub buckets: Option<BucketSchema>,
+    pub stability: Stability,
+}
+```
+
+`matches_nebula_prefix` and `is_snake_case` are `const fn` byte-loops. Compile-time validation removes a class of M-006 / M-021 drift.
+
+- [ ] **Step 4: Pass tests**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): add MetricDescriptor, MetricName, LabelSchema, BucketSchema
+
+MetricName validates nebula_*-snake_case at const time. Foundation
+for typed catalog. Closes design half of J-008 (M-006)."
+```
+
+### Task B-2: Build the typed `MetricCatalog`
+
+Closes the enforcement half of J-008 and J-016.
+
+**Files:**
+- Create: `crates/metrics/src/catalog.rs`
+- Delete (no shim): `crates/metrics/src/naming.rs`
+- Test: `crates/metrics/tests/catalog_completeness.rs`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+use nebula_metrics::catalog::CATALOG;
+
+#[test]
+fn every_descriptor_has_unique_name() {
+    let mut seen = std::collections::HashSet::new();
+    for d in CATALOG {
+        assert!(seen.insert(d.name.as_str()), "duplicate: {}", d.name.as_str());
+    }
+}
+
+#[test]
+fn every_histogram_has_buckets() {
+    for d in CATALOG {
+        if d.kind == nebula_telemetry::metrics::MetricKind::Histogram {
+            assert!(d.buckets.is_some(), "{} histogram without buckets", d.name.as_str());
+        }
+    }
+}
+
+#[test]
+fn every_total_counter_uses_total_suffix() {
+    for d in CATALOG {
+        if d.kind == nebula_telemetry::metrics::MetricKind::Counter {
+            assert!(d.name.as_str().ends_with("_total"), "{}", d.name.as_str());
+        }
+    }
+}
+
+#[test]
+fn duration_metrics_use_seconds_suffix() {
+    for d in CATALOG {
+        if d.unit == "seconds" {
+            assert!(d.name.as_str().ends_with("_seconds"));
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+```rust
+// crates/metrics/src/catalog.rs
+use crate::descriptor::*;
+use nebula_telemetry::metrics::MetricKind::*;
+
+pub static CATALOG: &[&MetricDescriptor] = &[
+    &WORKFLOW_STARTS_TOTAL,
+    &WORKFLOW_DURATION_SECONDS,
+    // ... migrate every constant in naming.rs to a MetricDescriptor entry,
+    // applying these corrections during migration:
+    //  - NEBULA_CREDENTIAL_ACTIVE_TOTAL -> nebula_credential_active (gauge, unit=count)
+    //    closes M-018.
+    //  - NEBULA_EVENTBUS_SENT/DROPPED -> _total suffix, kind=Counter
+    //    closes M-019.
+    //  - Cache hits/misses/evictions -> _total counters, not gauges
+    //    closes M-019.
+    //  - NEBULA_ACTION_FAILURES_TOTAL -> ... drop in favor of
+    //    nebula_action_outcome_total{outcome,error_class} (closes M-007, M-008).
+];
+
+pub static WORKFLOW_STARTS_TOTAL: MetricDescriptor = MetricDescriptor {
+    name: MetricName::new("nebula_workflow_starts_total"),
+    kind: Counter,
+    unit: "count",
+    help: "Total number of workflow executions started.",
+    labels: LabelSchema::keys(&["workflow_kind"]),
+    buckets: None,
+    stability: Stability::Stable,
+};
+
+pub static WORKFLOW_DURATION_SECONDS: MetricDescriptor = MetricDescriptor {
+    name: MetricName::new("nebula_workflow_execution_duration_seconds"),
+    kind: Histogram,
+    unit: "seconds",
+    help: "Duration of completed workflow executions in seconds.",
+    labels: LabelSchema::keys(&["workflow_kind", "outcome"]),
+    buckets: Some(BucketSchema::DEFAULT_DURATION_LONG),
+    stability: Stability::Stable,
+};
+
+// ... etc. Migrate every name from naming.rs.
+```
+
+Delete `naming.rs` in the same task. The list of constants to migrate is in `crates/metrics/src/naming.rs:11-425`.
+
+- [ ] **Step 4: Update every call site that imported a `NEBULA_*` constant**
+
+Workspace search: `git grep -l NEBULA_`. Replace `NEBULA_X_TOTAL` references with the descriptor (`&catalog::X_TOTAL`) at the recording call site (which becomes the descriptor-based adapter API in B-3).
+
+- [ ] **Step 5: Run tests**
+
+```
+cargo test -p nebula-metrics --test catalog_completeness
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git commit -m "feat(metrics): typed MetricCatalog replaces naming.rs constants
+
+Every operator metric is now one MetricDescriptor entry in CATALOG.
+Closes J-008 (M-006), J-016. Fixes M-018 (active_total naming),
+M-019 (eventbus _total + cache event semantics), M-007 + M-008
+(action outcome taxonomy)."
+```
+
+### Task B-3: `SafeLabels` builder filters before interning
+
+Closes M-002 / J-007 / T-016.
+
+**Files:**
+- Create: `crates/metrics/src/safe_labels.rs`
+- Modify: `crates/telemetry/src/labels.rs` (add `intern_pair` helper if not already present)
+- Test: `crates/metrics/tests/safe_labels.rs`
+
+- [ ] **Step 1: Failing tests**
+
+```rust
+use nebula_metrics::catalog::WORKFLOW_DURATION_SECONDS;
+use nebula_metrics::safe_labels::SafeLabels;
+use nebula_telemetry::metrics::MetricsRegistry;
+use std::sync::Arc;
+
+#[test]
+fn safe_labels_rejects_unknown_keys_in_dev() {
+    let reg = Arc::new(MetricsRegistry::new());
+    let result = SafeLabels::new(&WORKFLOW_DURATION_SECONDS, &reg)
+        .with("workflow_kind", "ingest")
+        .with("execution_id", "abc-123") // not in schema
+        .build_strict();
+    assert!(result.is_err());
+}
+
+#[test]
+fn safe_labels_does_not_intern_unknown_values_in_prod() {
+    let reg = Arc::new(MetricsRegistry::new());
+    let before = reg.interner().len();
+    let _ = SafeLabels::new(&WORKFLOW_DURATION_SECONDS, &reg)
+        .with("workflow_kind", "ingest")
+        .with("execution_id", "abc-123")
+        .build_lenient();
+    let after = reg.interner().len();
+    // ingest + workflow_kind interned, execution_id and abc-123 are not.
+    assert!(after - before <= 2,
+        "execution_id/value must NOT be interned (before={before} after={after})");
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+```rust
+// crates/metrics/src/safe_labels.rs
+use crate::descriptor::MetricDescriptor;
+use nebula_metrics::diagnostics::record_stripped_label;
+use nebula_telemetry::error::TelemetryError;
+use nebula_telemetry::labels::LabelSet;
+use nebula_telemetry::metrics::MetricsRegistry;
+use std::sync::Arc;
+
+pub struct SafeLabels<'reg> {
+    descriptor: &'static MetricDescriptor,
+    registry: &'reg Arc<MetricsRegistry>,
+    pairs: Vec<(&'static str, String)>, // strings stay un-interned until accepted
+    rejected: Vec<&'static str>,
+}
+
+impl<'reg> SafeLabels<'reg> {
+    pub fn new(descriptor: &'static MetricDescriptor, registry: &'reg Arc<MetricsRegistry>) -> Self {
+        Self { descriptor, registry, pairs: Vec::new(), rejected: Vec::new() }
+    }
+
+    pub fn with(mut self, key: &'static str, value: impl Into<String>) -> Self {
+        if self.descriptor.labels.permits(key) {
+            self.pairs.push((key, value.into()));
+        } else {
+            self.rejected.push(key);
+        }
+        self
+    }
+
+    /// Strict mode: returns error if any key was rejected. Use in tests / dev.
+    pub fn build_strict(self) -> Result<LabelSet, TelemetryError> {
+        if !self.rejected.is_empty() {
+            return Err(TelemetryError::InvalidObservation { value: f64::NAN }); // TODO use new variant LabelSchemaViolation
+        }
+        Ok(self.intern_now())
+    }
+
+    /// Lenient mode: rejected keys are dropped silently AND counted by the
+    /// nebula_metrics_labels_stripped_total diagnostic counter (closes the
+    /// observability half of J-007).
+    pub fn build_lenient(self) -> LabelSet {
+        for k in &self.rejected {
+            record_stripped_label(self.descriptor.name.as_str(), k);
+        }
+        self.intern_now()
+    }
+
+    fn intern_now(self) -> LabelSet {
+        let interner = self.registry.interner();
+        let pairs: Vec<(&str, &str)> = self.pairs.iter()
+            .map(|(k, v)| (*k, v.as_str()))
+            .collect();
+        interner.label_set(&pairs)
+    }
+}
+```
+
+Add `nebula_metrics_labels_stripped_total{descriptor, label_key}` as a self-observation counter using the same descriptor system. This closes the diagnostic side of M-009 / J-007 (silent strip becomes observable).
+
+Add `LabelSchemaViolation { descriptor: String, key: String }` variant to `TelemetryError` in this task — strict-mode failure must be a typed error, not the placeholder above.
+
+Delete `crates/metrics/src/filter.rs` entirely (the `LabelAllowlist` is replaced by per-descriptor `LabelSchema`). No shim per `feedback_no_shims.md`.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): SafeLabels filters before interning
+
+Per-descriptor LabelSchema is enforced before LabelInterner sees a
+key/value pair, closing the M-002 memory leak. Strict mode for dev,
+lenient mode + nebula_metrics_labels_stripped_total for prod.
+LabelAllowlist / filter.rs deleted (no shim).
+Closes M-002, M-009, J-007."
+```
+
+### Task B-4: `TelemetryAdapter` becomes descriptor-only; raw access removed
+
+Closes J-004 / M-001 / M-010.
+
+**Files:**
+- Modify: `crates/metrics/src/adapter.rs` (substantial rewrite around lines 30-260)
+- Modify: `crates/metrics/src/prelude.rs:7-15`
+- Modify: `crates/metrics/src/lib.rs:45-76`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn prelude_does_not_re_export_metrics_registry() {
+    // Compile-time check via doc-test:
+    //
+    // ```compile_fail
+    // use nebula_metrics::prelude::MetricsRegistry;
+    // ```
+    //
+    // Asserts the symbol is not in scope.
+}
+
+#[test]
+fn adapter_record_is_only_recording_path() {
+    use nebula_metrics::adapter::TelemetryAdapter;
+    use nebula_metrics::catalog::WORKFLOW_STARTS_TOTAL;
+    use nebula_metrics::safe_labels::SafeLabels;
+    let reg = Arc::new(MetricsRegistry::new());
+    let adapter = TelemetryAdapter::new(reg.clone());
+    let labels = SafeLabels::new(&WORKFLOW_STARTS_TOTAL, &reg)
+        .with("workflow_kind", "ingest")
+        .build_lenient();
+    adapter.record_counter(&WORKFLOW_STARTS_TOTAL, &labels, 1).unwrap();
+}
+```
+
+- [ ] **Step 2: Confirm fail**
+
+- [ ] **Step 3: Implement**
+
+Replace `TelemetryAdapter` body with:
+
+```rust
+pub struct TelemetryAdapter {
+    registry: Arc<MetricsRegistry>,
+}
+
+impl TelemetryAdapter {
+    pub fn new(registry: Arc<MetricsRegistry>) -> Self { Self { registry } }
+
+    pub fn record_counter(
+        &self,
+        descriptor: &'static MetricDescriptor,
+        labels: &LabelSet,
+        n: u64,
+    ) -> Result<(), TelemetryError> {
+        debug_assert_eq!(descriptor.kind, MetricKind::Counter);
+        let counter = self.registry.counter(descriptor.name.as_str(), labels)?;
+        counter.inc_by(n);
+        Ok(())
+    }
+
+    pub fn set_gauge(
+        &self,
+        descriptor: &'static MetricDescriptor,
+        labels: &LabelSet,
+        value: i64,
+    ) -> Result<(), TelemetryError> {
+        debug_assert_eq!(descriptor.kind, MetricKind::Gauge);
+        let g = self.registry.gauge(descriptor.name.as_str(), labels)?;
+        g.set(value);
+        Ok(())
+    }
+
+    pub fn observe_histogram(
+        &self,
+        descriptor: &'static MetricDescriptor,
+        labels: &LabelSet,
+        value: f64,
+    ) -> Result<(), TelemetryError> {
+        debug_assert_eq!(descriptor.kind, MetricKind::Histogram);
+        let buckets = descriptor.buckets.as_ref()
+            .expect("histogram descriptor must carry BucketSchema").boundaries();
+        let h = self.registry.histogram_with_buckets(descriptor.name.as_str(), labels, buckets)?;
+        h.observe(value); // value-validity is descriptor's job; non-finite filtered upstream
+        Ok(())
+    }
+
+    /// Read-only registry handle for the exporter ONLY.
+    pub(crate) fn registry(&self) -> &Arc<MetricsRegistry> { &self.registry }
+}
+```
+
+Removed (deleted, not deprecated):
+- `LabelAllowlist`-based methods.
+- `counter`/`gauge`/`histogram` raw methods.
+- Public `registry()` / `interner()` accessors.
+
+In `lib.rs`, remove `pub use nebula_telemetry::metrics::MetricsRegistry`. The metrics crate prelude exports only descriptors, `TelemetryAdapter`, `SafeLabels`, and `MetricDescriptor` types.
+
+For the rare custom-metric escape hatch, add `pub mod unsafe_telemetry { pub use nebula_telemetry::*; }` with `#[doc(hidden)]` and a doc comment stating: "use only when a non-cataloged custom metric is genuinely required; review for cardinality and naming manually".
+
+- [ ] **Step 4: Touch every production call site**
+
+Search: `git grep -nE 'MetricsRegistry::|\\.counter\(|\\.gauge\(|\\.histogram\('` in `crates/engine`, `crates/api`, `crates/resource`, `crates/eventbus`. Each call site:
+- Imports the relevant descriptor from `nebula_metrics::catalog`.
+- Builds `SafeLabels`.
+- Calls `adapter.record_counter` / `set_gauge` / `observe_histogram`.
+
+The audit lists the exact files: `crates/engine/src/engine.rs:47`, `crates/engine/src/runtime/runtime.rs:22`, `crates/api/src/services/webhook/transport.rs:39`, `crates/resource/src/metrics.rs:18`, `crates/engine/src/control_consumer.rs:213, 237`. None should remain after this task.
+
+- [ ] **Step 5: Test workspace + clippy**
+
+```
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+```
+
+- [ ] **Step 6: Commit**
+
+```
+git commit -m "feat(metrics)!: descriptor-only TelemetryAdapter; raw API removed
+
+- TelemetryAdapter::new(Arc<MetricsRegistry>); no LabelAllowlist default.
+- record_counter/set_gauge/observe_histogram are the only public methods.
+- LabelAllowlist + filter.rs deleted.
+- MetricsRegistry / Counter / Gauge / Histogram dropped from prelude.
+- All production call sites migrated to descriptor + SafeLabels.
+
+BREAKING CHANGE: Closes J-004 (M-001, M-010, M-021)."
+```
+
+### Task B-5: Reject invalid catalog names at registration; sanitization stays only for the unsafe escape hatch
+
+Closes M-011 / J-013.
+
+**Files:**
+- Modify: `crates/metrics/src/export/prometheus.rs:20-150` (sanitization paths)
+- Test: `crates/metrics/tests/descriptor.rs`
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn invalid_catalog_name_fails_at_compile_time() {
+    // Documented as compile_fail doc-test on MetricName::new
+    // for "x" (no nebula_ prefix).
+}
+
+#[test]
+fn exporter_does_not_sanitize_catalog_names() {
+    // After B-2 every name comes from MetricName, which is already
+    // validated. Exporter must NOT re-sanitize (so any drift fails loud).
+    // Confirm by injecting a bad name through unsafe_telemetry path
+    // and checking the exporter returns ExportError::InvalidName.
+}
+```
+
+- [ ] **Step 2-3: Implement**
+
+Remove `sanitize_metric_name` / `sanitize_label_key` from the catalog path. Keep them callable only when consuming the `unsafe_telemetry` escape-hatch entries. Make `snapshot()` return `Result<String, ExportError>` with `ExportError::InvalidName { raw: String }` when a non-catalog name reaches the exporter.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): exporter no longer sanitizes catalog names
+
+Catalog names are validated at MetricName::new (compile time).
+Exporter returns ExportError::InvalidName for unrecognized raw
+names. Closes J-013 (M-011)."
+```
+
+### Task B-6: Phase B gate
+
+- [ ] **Step 1: Run full suite**
+
+```
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace
+cargo doc --workspace --no-deps -D warnings
+```
+
+- [ ] **Step 2: Update `docs/audits/nebula-metrics-architecture-audit.md` status footers**
+
+- [ ] **Step 3: Commit footer update**
+
+---
+
+## Phase C — Boundary contracts
+
+### Task C-1: Exporter consumes kind-tagged `RegistrySnapshot`
+
+Closes J-019 / M-003.
+
+**Files:**
+- Modify: `crates/metrics/src/export/prometheus.rs:250-343`
+- Test: `crates/metrics/tests/export_validity.rs` (new)
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn exporter_uses_single_iterator_no_kind_split() {
+    // Smoke test: the exporter iterates RegistrySnapshot once,
+    // groups by name, and any duplicate name with mismatched kind
+    // is impossible because the registry rejected it at registration
+    // (T-002). The exporter only needs to render.
+}
+```
+
+- [ ] **Step 2-3: Replace** the three `snapshot_counters` / `snapshot_gauges` / `snapshot_histograms` calls with one loop over `registry.snapshot().iter()`. Per-name ordering remains via `BTreeMap` grouping.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): exporter consumes kind-tagged RegistrySnapshot
+
+Single iterator pass; type conflicts are caught at registration
+(T-002), exporter only renders. Closes J-019."
+```
+
+### Task C-2: Defensive type-conflict assertion in exporter
+
+Closes J-009 (the metrics half).
+
+- [ ] **Step 1: Failing test**
+
+```rust
+#[test]
+fn exporter_returns_error_on_duplicate_kind_for_one_name() {
+    // Inject through the unsafe_telemetry escape hatch (the only
+    // way to reach this state after T-002). Confirm exporter
+    // returns ExportError::TypeConflict instead of writing both
+    // # TYPE families.
+}
+```
+
+- [ ] **Step 2-3: Implement** — track seen `(name, kind)` pairs while rendering. On second kind for one name, return `ExportError::TypeConflict { name }`.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): exporter rejects same-name multi-kind families
+
+Defensive belt-and-braces against the unsafe_telemetry escape
+hatch. Closes J-009 metrics half."
+```
+
+### Task C-3: Prometheus numeric encoder for `+Inf`, `-Inf`, `NaN`
+
+Closes J-010 (the metrics half).
+
+**Files:**
+- Modify: `crates/metrics/src/export/prometheus.rs` (add `format_prom_float`)
+
+- [ ] **Step 1: Failing test**
+
+```rust
+use nebula_metrics::export::prometheus::format_prom_float;
+
+#[test]
+fn formats_finite() {
+    assert_eq!(format_prom_float(0.0), "0");
+    assert_eq!(format_prom_float(1.5), "1.5");
+}
+#[test]
+fn formats_pos_inf_as_token() {
+    assert_eq!(format_prom_float(f64::INFINITY), "+Inf");
+}
+#[test]
+fn formats_neg_inf_as_token() {
+    assert_eq!(format_prom_float(f64::NEG_INFINITY), "-Inf");
+}
+#[test]
+fn formats_nan_as_token() {
+    assert_eq!(format_prom_float(f64::NAN), "NaN");
+}
+```
+
+- [ ] **Step 2-3: Implement** `pub(crate) fn format_prom_float(v: f64) -> String` and route every histogram `_sum` and bucket boundary through it.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): Prometheus numeric encoder for +Inf/-Inf/NaN
+
+Histogram sum saturated at f64::MAX (A-6) but tokens still need
+the Prometheus spelling. Closes J-010 metrics half."
+```
+
+### Task C-4: Output format selector (no OpenMetrics yet, but unblocked)
+
+Closes J-026 (deferred but architecturally unblocked).
+
+- [ ] **Step 1-3: Add** `pub enum Format { Text004, OpenMetricsV1 }` and parameterize `snapshot()` as `snapshot_with(format: Format)`. Implement only `Text004` today; `OpenMetricsV1` returns `ExportError::Unsupported`. Document the split as a feature roadmap; descriptor `unit` field is now ready to be emitted as `# UNIT` lines when V1 lands.
+
+- [ ] **Step 4: Pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -m "feat(metrics): Format enum primes OpenMetrics v1 path
+
+Catalog descriptors carry unit + stability ready for # UNIT lines.
+J-026 deferred but no longer architecturally blocked."
+```
+
+---
+
+## Phase D — Joint tests and benches
+
+### Task D-1: End-to-end safe-path test exercising every workflow descriptor
+
+Closes the workflow / action half of J-018.
+
+**File:** `crates/metrics/tests/safe_path_workflow.rs`
+
+- [ ] **Step 1-2: Test**
+
+For each workflow / action descriptor in `CATALOG`:
+
+- Build adapter on a shared `Arc<MetricsRegistry>`.
+- Build `SafeLabels` with valid keys.
+- Record per-kind operation.
+- Snapshot exporter.
+- Assert each descriptor's series appears with correct `# TYPE`, `# HELP`, finite `_sum`, `+Inf == _count == sum-of-finite-buckets`.
+
+- [ ] **Step 3: Pass**
+
+- [ ] **Step 4: Commit**
+
+### Task D-2: Concurrent observe + scrape
+
+Closes the concurrency half of J-018 (M-004 / T-003 verification).
+
+**File:** `crates/metrics/tests/concurrent_observe_scrape.rs`
+
+- [ ] Test with N=8 writers + 1 scraper for 1000 iterations; assert histogram invariants and no `inf` literal in the output. Run under `--release` and `--test-threads=1` to surface tearing in CI.
+
+### Task D-3: High-cardinality misuse simulation
+
+Closes M-002 / M-009 / J-012 verification.
+
+**File:** `crates/metrics/tests/cardinality_misuse.rs`
+
+- [ ] Attempt to record `execution_id` through:
+  - `SafeLabels::build_strict` — must error.
+  - `SafeLabels::build_lenient` — must drop and increment `nebula_metrics_labels_stripped_total`.
+  - `unsafe_telemetry` path — must succeed but interner-grow is on the caller's head.
+  Assert that interner length stays bounded for the safe paths.
+
+### Task D-4: Catalog round-trip test
+
+Closes M-018, M-019, M-024 verification.
+
+**File:** `crates/metrics/tests/descriptor_round_trip.rs`
+
+- [ ] For every descriptor: register, snapshot, render, parse text, assert `# TYPE` matches `descriptor.kind`, `# HELP` matches `descriptor.help`, label set matches `descriptor.labels.allowed_keys()`.
+
+### Task D-5: Hot-path benches
+
+**File:** `crates/metrics/benches/record_hot_path.rs`
+
+- [ ] Bench `adapter.record_counter` with cached descriptor. Assert no allocation per call (use `dhat` or count via a custom global allocator). Numbers go in the README "performance" section.
+
+### Task D-6: Phase D gate
+
+- [ ] Full workspace `cargo test --release`, clippy, fmt, doc. Update audit docs.
+
+---
+
+## Phase E — Canon and docs
+
+### Task E-1: Output vs decision-input dataflow canon
+
+Closes J-014.
+
+**File:** `docs/canon/PRODUCT_CANON.md` (extend) and `docs/canon/observability.md` (new).
+
+- [ ] **Step 1: Add canon section**
+
+```markdown
+## Observability dataflow
+
+Two distinct data paths:
+
+1. **Observability output path.** Runtime components record observations
+   through `nebula-telemetry` primitives; `nebula-metrics` shapes them
+   into the operator-facing catalog; `nebula-api` serves `/metrics`;
+   Prometheus / Grafana scrape it.
+
+2. **Decision input path.** Engine and scheduler decide from
+   `nebula-system` host facts, configuration, policy, and internal state
+   (queues, leases, cancellation, resources, execution state).
+
+   The engine MUST NOT consume `/metrics` for scheduling decisions.
+   Direct primitive reads on a `Counter` / `Gauge` / `Histogram` handle
+   are allowed for self-observation when documented at the call site,
+   but they are explicitly NOT exporter feedback.
+```
+
+- [ ] **Step 2: Cross-link from `crates/telemetry/README.md` and `crates/metrics/README.md`**
+
+- [ ] **Step 3: Commit**
+
+### Task E-2: Interner non-guarantee + reverse-flow contract
+
+Closes J-012 / J-022.
+
+- [ ] In `docs/canon/observability.md`, state explicitly:
+  - "`LabelInterner` is append-only and is NOT a cardinality guard. Cardinality safety lives in `nebula-metrics::SafeLabels` per descriptor."
+  - "If a future scheduler self-throttles on its own counters, it caches the `Counter` handle once at startup and calls `.get()` periodically. It does not parse `/metrics`."
+
+- [ ] Commit.
+
+### Task E-3: ADR-0021 (retention drop) + ADR-0022 (descriptor-only metrics API)
+
+- [ ] Two ADRs covering Phase A retention drop (Task A-9) and Phase B descriptor-only API (Task B-4). Per `feedback_adr_revisable.md`, both supersede any prior wave-1 ADR that recommended the older shape (search `docs/adr/` for affected entries — typical candidates: telemetry primitives ADR, metrics adapter ADR).
+
+- [ ] Commit.
+
+### Task E-4: Lefthook + CI mirror
+
+Per `feedback_lefthook_mirrors_ci.md`: every CI required job that this refactor introduces (e.g. new `cargo test -p nebula-metrics --test descriptor_round_trip`, doc-test for `MetricName::new` compile-fail) must also fire from `lefthook.yml` `pre-push`.
+
+- [ ] **Step 1:** Diff `.github/workflows/*.yml` against `lefthook.yml` after the refactor.
+- [ ] **Step 2:** Update `lefthook.yml` to mirror.
+- [ ] **Step 3:** Commit.
+
+### Task E-5: Final scoreboard and audit close
+
+- [ ] Update each audit's findings table (T-001..T-021, M-001..M-026, J-001..J-026) with `status: closed` + commit SHA.
+- [ ] Confirm the joint audit's 7-Point answer flips to seven Yeses. Add the new section "Resolution status (2026-..)" to `nebula-telemetry-metrics-joint-audit.md` recording the flip.
+- [ ] Commit.
+
+---
+
+## Self-review checklist (executed before declaring the plan complete)
+
+- **Spec coverage** — every J-### / T-### / M-### finding mapped to a phase task above. Gaps:
+  - T-013..T-017 (label-related) folded into Task A-2 / A-3 / B-3.
+  - T-021 (default buckets) closed by Task B-2 (each histogram descriptor names its own `BucketSchema`).
+  - M-005 (label-key collision across series) folded into Task C-1 (exporter operates on descriptor-keyed schema, so cross-series collisions become impossible by construction).
+  - M-012 (RED/USE catalog gaps) — partially addressed in Task B-2 by adding the missing descriptors (queue backlog, circuit breaker state, retry, fallback). If reviewing later finds gaps, they are added as Task B-2.X subtasks per descriptor.
+  - M-013 / M-018 / M-019 closed by Task B-2 catalog migration.
+  - M-023 closed by Task A-4 dropping `MetricsRegistry: Clone`.
+  - M-025 (unit-typed adapter) — Task B-4's `record_counter` / `set_gauge` / `observe_histogram` enforce kind, but unit-typing (`Seconds(f64)`, `Bytes(u64)`) is intentionally NOT in this plan; deferred as a follow-up because it is additive and not a correctness blocker. Tracked as a "future" note in Task E-1.
+  - M-026 (`MetricsRegistry: Clone` and `LabelInterner: Clone` cross-fork) closed by Task A-4 + A-2 respectively.
+
+- **Placeholder scan** — no "TBD" / "implement later" / "similar to Task N" patterns. Each task names exact files and includes complete code for new APIs.
+
+- **Type consistency** — `MetricKind` lives in `nebula-telemetry::metrics`; `MetricDescriptor`, `MetricName`, `LabelSchema`, `BucketSchema`, `Stability`, `SafeLabels` live in `nebula-metrics`. `BucketLayout` (the runtime, owned form) lives in `nebula-telemetry`; `BucketSchema` (the static catalog form) lives in `nebula-metrics` and is a `&'static [f64]` view consumed when calling `histogram_with_buckets`. The two are not the same type and are not interchangeable — the boundary is Task A-5 + B-1.
+
+- **Layering check** — every task is owned by exactly one crate per the joint audit's layering matrix. No metrics policy slips into telemetry; no primitive correctness slips into metrics. The `unsafe_telemetry` re-export in `nebula-metrics` is an escape hatch with the doc-hidden visibility rule, not a layering violation.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-05-telemetry-metrics-stack-refactor.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — fresh subagent per task with two-stage review. Phase A and Phase B are roughly 12 + 6 = 18 subagent dispatches, mostly sequential within a phase but Phase A tasks A-1, A-2, A-7, A-10, A-11 can parallelize once A-4 lands. Use `superpowers:subagent-driven-development`.
+
+2. **Inline Execution** — execute through the plan in this session with batch checkpoints at the end of each phase. Use `superpowers:executing-plans`.
+
+Which approach?

--- a/typos.toml
+++ b/typos.toml
@@ -14,6 +14,8 @@ extend-exclude = [
   # Competitor research v2 — harvested upstream docs/code with their own conventions.
   "findings",
   "targets",
+  # Local agent bundle / vendored patches (not Nebula sources).
+  "openswarm",
 ]
 
 [default]


### PR DESCRIPTION
<!--
PR title must follow Conventional Commits (enforced by .github/workflows/pr-validation.yml):
  type(scope)?: description    — scope is optional
  types: feat | fix | docs | style | refactor | perf | test | chore | ci | build | revert
-->

## Summary

Introduces fallible metric registration on `MetricsRegistry` (`TelemetryResult`), seqlock-backed `Histogram` snapshots for consistent Prometheus export, wiring through engine/api/resource, and documents the telemetry/metrics stack refactor plan. Prometheus export snapshots each histogram family once per scrape via `Histogram::snapshot()`.

## Linked issue

<!-- Link the Linear issue and any GitHub issues this PR closes or references. -->

- Closes NEB-
- Refs NEB-

## Type of change

<!-- Tick all that apply. -->

- [x] `feat` — new capability
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [ ] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `nebula-telemetry`, `nebula-metrics`, `nebula-engine`, `nebula-api`, `nebula-resource`, `docs/superpowers/plans/`, `typos.toml`

## Changes

- Fallible `MetricsRegistry::register_*` APIs; unified series per `MetricKey` / `MetricKind`; `TelemetryResult` / error taxonomy updates.
- `Histogram` with seqlock + `HistogramSnapshot`; `Histogram::try_with_buckets` for non-panicking bucket setup.
- `nebula-metrics`: Prometheus exporter uses `hist.snapshot()` once per family; label allowlist / filter by spur as applicable.
- Engine, API, resource: wire fallible registration; `EngineError::Telemetry`; `ActionRuntime::try_new` and call sites.
- Plan archived: `docs/superpowers/plans/2026-05-05-telemetry-metrics-stack-refactor.md`.
- Root `typos.toml`: exclude local `openswarm/` directory from typo scans.

## Test plan

- Pre-commit hooks (`typos`, per-crate `fmt-check`, workspace `clippy -D warnings`) and `convco commit-msg` passed on the feature commit.
- CI will run full `nextest` / doctests / deny on merge.

### Local verification

- [x] `cargo +nightly fmt --all` — formatted (scoped fmt on touched crates during development)
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

**Yes.** Metric registration is fallible (`TelemetryResult`). Engine surfaces registration failures via `EngineError::Telemetry`. `ActionRuntime` is constructed with `try_new` instead of an infallible constructor. Integrators must handle registration errors and use the new constructor.

## Docs checklist

<!--
Required for non-trivial design or execution-lifecycle changes.
See docs/PRODUCT_CANON.md §17 (Definition of Done).
Delete items that do not apply, or delete this section for pure bug fixes and mechanical refactors.
-->

- [ ] Reviewed `docs/PRODUCT_CANON.md` — no silent semantic drift, no new undocumented lifecycle
- [x] Layer direction preserved (core → business → exec → api; no upward deps)
- [ ] If an L2 invariant changed: ADR added under `docs/adr/` with seam test in this PR
- [ ] `docs/MATURITY.md` row updated if crate maturity changed
- [x] Crate `README.md` / `lib.rs //!` updated if public surface changed
- [ ] `docs/INTEGRATION_MODEL.md` updated if Resource / Credential / Action / Plugin / Schema surface changed
- [ ] `docs/STYLE.md` updated if a new idiom or antipattern surfaced
- [ ] `docs/GLOSSARY.md` updated if a new term was introduced
- [x] Plan or spec that motivated this change archived or updated (link: `docs/superpowers/plans/2026-05-05-telemetry-metrics-stack-refactor.md`)

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests and binaries excepted)
- [x] No silent error suppression (`let _ = …` on `Result`, `.ok()`, `.unwrap_or_default()` on fallible IO)
- [x] Execution / engine state transitions go through `transition_node()` — N/A for this metrics-only surface
- [x] Credentials / secrets stay encrypted, redacted, and zeroized across all added paths
- [x] New `unsafe` blocks carry a `SAFETY:` comment with justification — none added

## Notes for reviewers

Focus on `telemetry` histogram seqlock / snapshot semantics vs scrape correctness, and exporter cardinality after snapshot dedup. Local `openswarm/` remains untracked and is only excluded from `typos`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Enhanced error handling for metrics initialization with better failure diagnostics.
  * Improved histogram snapshot support for more accurate metric exports.

* **Bug Fixes**
  * Made metric registration failures non-blocking; the system now gracefully degrades when telemetry setup encounters errors.

* **Documentation**
  * Updated crate documentation to clarify metrics registry initialization and error handling pathways.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->