### PR TITLE
chore(scripts): standardize agent worktree workflow

### DIFF
--- a/.cursor/rules/agent-workflow.mdc
+++ b/.cursor/rules/agent-workflow.mdc
@@ -1,0 +1,26 @@
+---
+alwaysApply: true
+---
+
+# Nebula Agent Workflow
+
+Use `AGENTS.md` as the source of truth for project layout, architecture, Git
+workflow, and coding rules.
+
+For persistent task branches, create worktrees through the repository wrapper:
+
+```sh
+bash scripts/worktree.sh new <slug> <type> <scope>
+```
+
+This creates `.worktrees/<slug>` from `origin/main` and branch
+`<type>/<scope>-<slug>`.
+
+Commit staged changes through:
+
+```sh
+bash scripts/worktree.sh commit <type> <scope> <summary>
+```
+
+Do not create alternate persistent worktree directories for Cursor. Follow the
+same branch and commit rules as Claude, Codex, and Copilot.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,25 @@ Architecture: Core → Business → Exec → API (one-way deps, no upward).
 Universal data type: serde_json::Value.
 Error handling: thiserror in libs, anyhow in binaries.
 
+## Agent Git Workflow
+
+Use `AGENTS.md` as the source of truth for repository rules. For local
+persistent task branches, create worktrees with:
+
+```sh
+bash scripts/worktree.sh new <slug> <type> <scope>
+```
+
+This creates `.worktrees/<slug>` from `origin/main` and branch
+`<type>/<scope>-<slug>`. Commit staged changes with:
+
+```sh
+bash scripts/worktree.sh commit <type> <scope> <summary>
+```
+
+Copilot cloud coding environments that cannot use `.worktrees/` must still use
+the same branch naming and Conventional Commit rules.
+
 ## What to Flag in Reviews
 
 ### Critical (always comment)

--- a/.gitignore
+++ b/.gitignore
@@ -172,7 +172,10 @@ lefthook-local.yml
 
 .agent/
 .agents/
-.cursor/
+.cursor/*
+!.cursor/
+!.cursor/rules/
+!.cursor/rules/*.mdc
 .codex/
 .junie/
 .qoder/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ agent-facing summary.
 nebula/
 ├── Cargo.toml                  # workspace root, pinned deps
 ├── README.md                   # product overview, architecture, principles
+├── CLAUDE.md                   # Claude Code entry point; imports AGENTS.md
 ├── CONTRIBUTING.md             # branch / commit / PR rules
 ├── AGENTS.md                   # this file
 ├── CODE_OF_CONDUCT.md
@@ -50,6 +51,8 @@ nebula/
 ├── .claude/                    # Claude Code skills + agents
 │   ├── skills/                 # /aif-* skills
 │   └── agents/                 # subagents (sidecars, workers, loop roles)
+├── .cursor/                    # Cursor project rules
+│   └── rules/                  # tracked shared rules for Cursor agents
 ├── .github/
 │   ├── CODEOWNERS              # auto-reviewer mapping
 │   ├── PULL_REQUEST_TEMPLATE.md
@@ -60,6 +63,10 @@ nebula/
 │   ├── ISSUE_TEMPLATE/
 │   ├── labeler.yml
 │   └── dependabot.yml
+├── scripts/                    # shared developer / hook helper scripts
+│   ├── worktree.sh             # canonical worktree + commit wrapper
+│   ├── pre-commit-fmt-check.sh
+│   └── pre-push-crate-diff.sh
 └── crates/                     # 35+ workspace members
     ├── core/                   # Core    — primitives, IDs, traits
     ├── error/  +/macros/       # Cross   — error taxonomy
@@ -117,6 +124,7 @@ between siblings at the same layer.
 | `rust-toolchain.toml`         | Pinned toolchain |
 | `lefthook.yml`                | Local pre-commit / pre-push (mirrors CI) |
 | `Taskfile.yml`                | `task dev:check` = full pre-PR gate; `task --list` for catalog |
+| `scripts/worktree.sh`         | Canonical helper behind `task wt:*` and `task git:commit` |
 | `.github/workflows/ci.yml`    | CI required jobs: fmt, clippy, nextest, doctests, MSRV, deny |
 | `.github/CODEOWNERS`          | Auto-reviewer + security-sensitive path gates |
 | `crates/<crate>/README.md`    | Per-crate human entry point |
@@ -140,14 +148,38 @@ between siblings at the same layer.
 | File                          | Purpose |
 |-------------------------------|---------|
 | `AGENTS.md`                   | This file — project map for any AI agent |
+| `CLAUDE.md`                   | Claude Code shim that imports `AGENTS.md` |
 | `.ai-factory/config.yaml`     | AI Factory settings (language, paths, git, rules) |
 | `.ai-factory/DESCRIPTION.md`  | Agent-facing project summary |
 | `.ai-factory/ARCHITECTURE.md` | Agent-actionable architecture subset |
 | `.ai-factory/rules/base.md`   | Distilled coding rules for agents |
 | `.ai-factory.json`            | AI Factory install manifest (managed by tooling) |
 | `.github/copilot-instructions.md` | GitHub Copilot guidance |
+| `.cursor/rules/*.mdc`         | Cursor project rules that point back to `AGENTS.md` |
 | `.claude/skills/`             | Claude Code `/aif-*` skill definitions |
 | `.claude/agents/`             | Subagent definitions (sidecars, workers, loop roles) |
+
+## Agent Git Workflow
+
+Use the repository wrapper for all persistent task branches:
+
+- Create worktrees with `bash scripts/worktree.sh new <slug> <type> <scope>`
+  or the `task wt:new` wrapper using `WT_NAME`, `WT_TYPE`, and `WT_SCOPE`.
+  This creates `.worktrees/<slug>` from `origin/main` and a branch named
+  `<type>/<scope>-<slug>`.
+- Use `task wt:list` to inspect worktrees. Remove clean worktrees with
+  `bash scripts/worktree.sh remove <slug>` or `task wt:remove` with `WT_NAME`.
+  Do not hand-roll alternate persistent worktree locations for Claude, Codex,
+  Cursor, or Copilot.
+- Commit staged changes with
+  `bash scripts/worktree.sh commit <type> <scope> <summary>`. This produces
+  `<type>(<scope>): <summary>` and validates it with `convco`.
+- Allowed commit / branch types are `build`, `chore`, `ci`, `docs`, `feat`,
+  `fix`, `perf`, `refactor`, `revert`, `style`, and `test`.
+- Scope is the crate name without `nebula-` (`resilience`, `engine`, `api`) or
+  a top-level area (`docs`, `ci`, `scripts`, `github`).
+- Managed cloud/IDE worktrees that cannot be configured to `.worktrees/` must
+  still follow the same branch and commit rules, with CI/lefthook as the gate.
 
 ## Agent Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+## Claude Code
+
+- Treat `AGENTS.md` as the source of truth for project rules.
+- For persistent Nebula task branches, create worktrees with
+  `bash scripts/worktree.sh new <slug> <type> <scope>`.
+- Do not rely on Claude's default `--worktree` location for persistent repo
+  work unless the user explicitly asks for a disposable Claude-managed
+  worktree.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -27,6 +27,34 @@ tasks:
     cmds:
       - task --list
 
+  # ── Git / Worktrees ───────────────────────────────────────────────────────
+
+  wt:new:
+    desc: "Create a worktree under .worktrees/ from origin/main (env: WT_NAME, WT_TYPE, WT_SCOPE)"
+    requires:
+      vars: [WT_NAME, WT_TYPE, WT_SCOPE]
+    cmds:
+      - bash scripts/worktree.sh new "{{.WT_NAME}}" "{{.WT_TYPE}}" "{{.WT_SCOPE}}" "{{if .WT_BASE}}{{.WT_BASE}}{{else}}origin/main{{end}}"
+
+  wt:list:
+    desc: List Git worktrees
+    cmds:
+      - bash scripts/worktree.sh list
+
+  wt:remove:
+    desc: "Remove a worktree under .worktrees/ (env: WT_NAME)"
+    requires:
+      vars: [WT_NAME]
+    cmds:
+      - bash scripts/worktree.sh remove "{{.WT_NAME}}"
+
+  git:commit:
+    desc: "Commit staged changes with Conventional Commits (env: WT_TYPE, WT_SCOPE, WT_MSG)"
+    requires:
+      vars: [WT_TYPE, WT_SCOPE, WT_MSG]
+    cmds:
+      - bash scripts/worktree.sh commit "{{.WT_TYPE}}" "{{.WT_SCOPE}}" "{{.WT_MSG}}"
+
   # ── Build ──────────────────────────────────────────────────────────────────
 
   build:

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -102,7 +102,7 @@ new_worktree() {
   git rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
     || die "base ref not found: $base"
 
-  git worktree add "$path" -b "$branch" "$base"
+  git worktree add -b "$branch" "$path" "$base"
 
   echo "Created worktree:"
   echo "  path:   $path"

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly WORKTREE_DIR=".worktrees"
+readonly DEFAULT_BASE="${NEBULA_WORKTREE_BASE:-origin/main}"
+readonly VALID_TYPES="build chore ci docs feat fix perf refactor revert style test"
+
+die() {
+  echo "nebula-worktree: $*" >&2
+  exit 1
+}
+
+usage() {
+  cat >&2 <<'USAGE'
+Usage:
+  bash scripts/worktree.sh new <name> <type> <scope> [base]
+  bash scripts/worktree.sh list
+  bash scripts/worktree.sh remove <name>
+  bash scripts/worktree.sh commit <type> <scope> <message...>
+
+Examples:
+  bash scripts/worktree.sh new retry-pipeline fix resilience
+  bash scripts/worktree.sh commit fix resilience "harden retry semantics"
+USAGE
+}
+
+repo_root() {
+  git rev-parse --show-toplevel 2>/dev/null || die "not inside a git repository"
+}
+
+slugify() {
+  local raw="$1"
+  printf '%s' "$raw" \
+    | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9._-]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+validate_type() {
+  local type="$1"
+  for valid in $VALID_TYPES; do
+    if [[ "$type" == "$valid" ]]; then
+      return 0
+    fi
+  done
+  die "invalid type '$type'; expected one of: $VALID_TYPES"
+}
+
+ensure_clean_name() {
+  local label="$1"
+  local value="$2"
+  [[ -n "$value" ]] || die "$label cannot be empty"
+  [[ "$value" != "." && "$value" != ".." ]] || die "$label cannot be '$value'"
+  [[ "$value" != *"/"* && "$value" != *"\\"* ]] || die "$label cannot contain path separators"
+}
+
+fetch_base_if_remote() {
+  local base="$1"
+  if [[ "${NEBULA_WORKTREE_NO_FETCH:-0}" == "1" ]]; then
+    return 0
+  fi
+
+  if [[ "$base" == */* ]]; then
+    local remote="${base%%/*}"
+    local branch="${base#*/}"
+    if git remote get-url "$remote" >/dev/null 2>&1; then
+      git fetch "$remote" "$branch"
+    fi
+  fi
+}
+
+new_worktree() {
+  local name_raw="${1:-}"
+  local type_raw="${2:-}"
+  local scope_raw="${3:-}"
+  local base="${4:-$DEFAULT_BASE}"
+
+  [[ -n "$name_raw" && -n "$type_raw" && -n "$scope_raw" ]] || {
+    usage
+    exit 2
+  }
+
+  local name type scope branch path
+  name="$(slugify "$name_raw")"
+  type="$(slugify "$type_raw")"
+  scope="$(slugify "$scope_raw")"
+
+  ensure_clean_name "name" "$name"
+  ensure_clean_name "scope" "$scope"
+  validate_type "$type"
+
+  branch="${type}/${scope}-${name}"
+  path="${WORKTREE_DIR}/${name}"
+
+  mkdir -p "$WORKTREE_DIR"
+
+  [[ ! -e "$path" ]] || die "worktree path already exists: $path"
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    die "local branch already exists: $branch"
+  fi
+
+  fetch_base_if_remote "$base"
+  git rev-parse --verify --quiet "${base}^{commit}" >/dev/null \
+    || die "base ref not found: $base"
+
+  git worktree add "$path" -b "$branch" "$base"
+
+  echo "Created worktree:"
+  echo "  path:   $path"
+  echo "  branch: $branch"
+  echo "  base:   $base"
+}
+
+list_worktrees() {
+  git worktree list
+}
+
+validate_commit_message() {
+  local message="$1"
+
+  if command -v convco >/dev/null 2>&1; then
+    printf '%s\n' "$message" | convco check --from-stdin
+  elif command -v convco.exe >/dev/null 2>&1; then
+    printf '%s\n' "$message" | convco.exe check --from-stdin
+  elif command -v pwsh.exe >/dev/null 2>&1; then
+    printf '%s\n' "$message" | pwsh.exe -NoProfile -Command '$input | convco check --from-stdin'
+  elif command -v powershell.exe >/dev/null 2>&1; then
+    printf '%s\n' "$message" | powershell.exe -NoProfile -Command '$input | convco check --from-stdin'
+  else
+    die "convco is required to validate commits"
+  fi
+}
+
+remove_worktree() {
+  local name_raw="${1:-}"
+  [[ -n "$name_raw" ]] || {
+    usage
+    exit 2
+  }
+
+  local name path
+  name="$(slugify "$name_raw")"
+  ensure_clean_name "name" "$name"
+  path="${WORKTREE_DIR}/${name}"
+
+  git worktree remove "$path"
+  git worktree prune
+}
+
+commit_staged() {
+  [[ $# -ge 3 ]] || {
+    usage
+    exit 2
+  }
+
+  local type_raw="$1"
+  local scope_raw="$2"
+  shift 2
+
+  local description="$*"
+  local type scope message
+  type="$(slugify "$type_raw")"
+  scope="$(slugify "$scope_raw")"
+
+  ensure_clean_name "scope" "$scope"
+  validate_type "$type"
+
+  if git diff --cached --quiet --exit-code; then
+    die "no staged changes to commit"
+  fi
+
+  message="${type}(${scope}): ${description}"
+  validate_commit_message "$message"
+  git commit -m "$message"
+}
+
+main() {
+  local root
+  root="$(repo_root)"
+  cd "$root"
+
+  local command="${1:-}"
+  shift || true
+
+  case "$command" in
+    new)
+      new_worktree "$@"
+      ;;
+    list)
+      list_worktrees
+      ;;
+    remove)
+      remove_worktree "$@"
+      ;;
+    commit)
+      commit_staged "$@"
+      ;;
+    -h|--help|help|"")
+      usage
+      ;;
+    *)
+      usage
+      die "unknown command: $command"
+      ;;
+  esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a shared scripts/worktree.sh wrapper for Nebula worktree and commit flow
- expose wt:* and git:commit tasks through Taskfile.yml
- align AGENTS, Claude, Cursor, and Copilot instructions around the shared workflow

## Validation
- bash -n scripts/worktree.sh
- task --dry wt:new
- task --dry git:commit
- lefthook pre-push

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive agent workflow documentation and Claude Code integration guidelines.
  * Expanded agent and project rules documentation with updated workspace layout references.

* **Chores**
  * Introduced new script and task utilities for managing Git worktrees and standardized commits.
  * Updated configuration to selectively preserve worktree and rules directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->