### PR TITLE
chore(scripts): add post-merge worktree cleanup

### DIFF
--- a/.cursor/rules/agent-workflow.mdc
+++ b/.cursor/rules/agent-workflow.mdc
@@ -22,5 +22,11 @@ Commit staged changes through:
 bash scripts/worktree.sh commit <type> <scope> <summary>
 ```
 
+After the task PR is merged, clean up through:
+
+```sh
+bash scripts/worktree.sh finish <slug>
+```
+
 Do not create alternate persistent worktree directories for Cursor. Follow the
 same branch and commit rules as Claude, Codex, and Copilot.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,12 @@ This creates `.worktrees/<slug>` from `origin/main` and branch
 bash scripts/worktree.sh commit <type> <scope> <summary>
 ```
 
+After the task PR is merged, clean up with:
+
+```sh
+bash scripts/worktree.sh finish <slug>
+```
+
 Copilot cloud coding environments that cannot use `.worktrees/` must still use
 the same branch naming and Conventional Commit rules.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,10 @@ Use the repository wrapper for all persistent task branches:
   `bash scripts/worktree.sh remove <slug>` or `task wt:remove` with `WT_NAME`.
   Do not hand-roll alternate persistent worktree locations for Claude, Codex,
   Cursor, or Copilot.
+- After a PR is merged, run `bash scripts/worktree.sh finish <slug>` or
+  `task wt:finish` with `WT_NAME`. This fast-forwards local `main`, removes
+  `.worktrees/<slug>`, prunes stale worktree metadata, and deletes the merged
+  local branch with `git branch -d`.
 - Commit staged changes with
   `bash scripts/worktree.sh commit <type> <scope> <summary>`. This produces
   `<type>(<scope>): <summary>` and validates it with `convco`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,8 @@
 - Treat `AGENTS.md` as the source of truth for project rules.
 - For persistent Nebula task branches, create worktrees with
   `bash scripts/worktree.sh new <slug> <type> <scope>`.
+- After the task PR is merged, clean up with
+  `bash scripts/worktree.sh finish <slug>`.
 - Do not rely on Claude's default `--worktree` location for persistent repo
   work unless the user explicitly asks for a disposable Claude-managed
   worktree.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,6 +48,13 @@ tasks:
     cmds:
       - bash scripts/worktree.sh remove "{{.WT_NAME}}"
 
+  wt:finish:
+    desc: "After merge: sync main, remove .worktrees/<name>, and delete the merged local branch (env: WT_NAME)"
+    requires:
+      vars: [WT_NAME]
+    cmds:
+      - bash scripts/worktree.sh finish "{{.WT_NAME}}" "{{if .WT_BRANCH}}{{.WT_BRANCH}}{{end}}" "{{if .WT_MAIN}}{{.WT_MAIN}}{{else}}main{{end}}"
+
   git:commit:
     desc: "Commit staged changes with Conventional Commits (env: WT_TYPE, WT_SCOPE, WT_MSG)"
     requires:

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -16,10 +16,12 @@ Usage:
   bash scripts/worktree.sh new <name> <type> <scope> [base]
   bash scripts/worktree.sh list
   bash scripts/worktree.sh remove <name>
+  bash scripts/worktree.sh finish <name> [branch] [main-branch]
   bash scripts/worktree.sh commit <type> <scope> <message...>
 
 Examples:
   bash scripts/worktree.sh new retry-pipeline fix resilience
+  bash scripts/worktree.sh finish retry-pipeline
   bash scripts/worktree.sh commit fix resilience "harden retry semantics"
 USAGE
 }
@@ -114,6 +116,24 @@ list_worktrees() {
   git worktree list
 }
 
+primary_worktree_root() {
+  git worktree list --porcelain \
+    | sed -n '1s/^worktree //p' \
+    | sed 's#\\#/#g'
+}
+
+ensure_clean_checkout() {
+  local path="$1"
+  local label="$2"
+
+  if ! git -C "$path" diff --quiet --exit-code; then
+    die "$label has unstaged changes: $path"
+  fi
+  if ! git -C "$path" diff --cached --quiet --exit-code; then
+    die "$label has staged changes: $path"
+  fi
+}
+
 validate_commit_message() {
   local message="$1"
 
@@ -144,6 +164,56 @@ remove_worktree() {
 
   git worktree remove "$path"
   git worktree prune
+}
+
+finish_worktree() {
+  local name_raw="${1:-}"
+  local branch="${2:-}"
+  local main_branch="${3:-main}"
+
+  [[ -n "$name_raw" ]] || {
+    usage
+    exit 2
+  }
+
+  local name primary path current_branch
+  name="$(slugify "$name_raw")"
+  ensure_clean_name "name" "$name"
+
+  primary="$(primary_worktree_root)"
+  [[ -n "$primary" ]] || die "could not determine primary worktree"
+
+  path="${primary}/${WORKTREE_DIR}/${name}"
+  [[ -d "$path" ]] || die "worktree path does not exist: $path"
+
+  ensure_clean_checkout "$primary" "primary worktree"
+  ensure_clean_checkout "$path" "target worktree"
+
+  if [[ -z "$branch" ]]; then
+    branch="$(git -C "$path" branch --show-current)"
+  fi
+  [[ -n "$branch" ]] || die "could not determine target branch for $path"
+
+  cd "$primary"
+
+  current_branch="$(git -C "$primary" branch --show-current)"
+  if [[ "$current_branch" != "$main_branch" ]]; then
+    git -C "$primary" switch "$main_branch"
+  fi
+
+  git -C "$primary" fetch origin "$main_branch"
+  git -C "$primary" pull --ff-only origin "$main_branch"
+  git -C "$primary" worktree remove "$path"
+  git -C "$primary" worktree prune
+
+  if git -C "$primary" show-ref --verify --quiet "refs/heads/$branch"; then
+    git -C "$primary" branch -d "$branch"
+  fi
+
+  echo "Finished worktree:"
+  echo "  removed: $path"
+  echo "  branch:  $branch"
+  echo "  main:    $main_branch"
 }
 
 commit_staged() {
@@ -190,6 +260,9 @@ main() {
       ;;
     remove)
       remove_worktree "$@"
+      ;;
+    finish)
+      finish_worktree "$@"
       ;;
     commit)
       commit_staged "$@"

--- a/scripts/worktree.sh
+++ b/scripts/worktree.sh
@@ -122,15 +122,36 @@ primary_worktree_root() {
     | sed 's#\\#/#g'
 }
 
+find_worktree_path() {
+  local suffix="$1"
+
+  git worktree list --porcelain \
+    | sed -n 's/^worktree //p' \
+    | sed 's#\\#/#g' \
+    | awk -v suffix="/$suffix" 'substr($0, length($0) - length(suffix) + 1) == suffix { print; exit }'
+}
+
 ensure_clean_checkout() {
   local path="$1"
   local label="$2"
+  local status
 
-  if ! git -C "$path" diff --quiet --exit-code; then
-    die "$label has unstaged changes: $path"
+  status="$(git -C "$path" status --porcelain --untracked-files=all)"
+  if [[ -n "$status" ]]; then
+    echo "$status" >&2
+    die "$label has uncommitted or untracked files: $path"
   fi
-  if ! git -C "$path" diff --cached --quiet --exit-code; then
-    die "$label has staged changes: $path"
+}
+
+main_remote() {
+  local main_branch="$1"
+  local remote
+
+  remote="$(git config --get "branch.${main_branch}.remote" || true)"
+  if [[ -n "$remote" ]]; then
+    printf '%s\n' "$remote"
+  elif git remote get-url origin >/dev/null 2>&1; then
+    printf '%s\n' origin
   fi
 }
 
@@ -176,17 +197,16 @@ finish_worktree() {
     exit 2
   }
 
-  local name primary path current_branch
+  local name primary path current_branch remote
   name="$(slugify "$name_raw")"
   ensure_clean_name "name" "$name"
 
   primary="$(primary_worktree_root)"
   [[ -n "$primary" ]] || die "could not determine primary worktree"
 
-  path="${primary}/${WORKTREE_DIR}/${name}"
+  path="$(find_worktree_path "${WORKTREE_DIR}/${name}")"
   [[ -d "$path" ]] || die "worktree path does not exist: $path"
 
-  ensure_clean_checkout "$primary" "primary worktree"
   ensure_clean_checkout "$path" "target worktree"
 
   if [[ -z "$branch" ]]; then
@@ -196,13 +216,21 @@ finish_worktree() {
 
   cd "$primary"
 
+  ensure_clean_checkout "$primary" "primary worktree"
+
   current_branch="$(git -C "$primary" branch --show-current)"
   if [[ "$current_branch" != "$main_branch" ]]; then
     git -C "$primary" switch "$main_branch"
   fi
 
-  git -C "$primary" fetch origin "$main_branch"
-  git -C "$primary" pull --ff-only origin "$main_branch"
+  remote="$(main_remote "$main_branch")"
+  if [[ -n "$remote" ]]; then
+    git -C "$primary" fetch "$remote" "$main_branch"
+    git -C "$primary" pull --ff-only "$remote" "$main_branch"
+  else
+    echo "nebula-worktree: no remote configured for $main_branch; skipping fetch/pull" >&2
+  fi
+
   git -C "$primary" worktree remove "$path"
   git -C "$primary" worktree prune
 
@@ -214,6 +242,7 @@ finish_worktree() {
   echo "  removed: $path"
   echo "  branch:  $branch"
   echo "  main:    $main_branch"
+  [[ -z "$remote" ]] || echo "  remote:  $remote"
 }
 
 commit_staged() {


### PR DESCRIPTION
## Summary
- add scripts/worktree.sh finish for post-merge cleanup
- expose wt:finish through Taskfile.yml
- document the cleanup command for AGENTS, Claude, Cursor, and Copilot

## Validation
- bash -n scripts/worktree.sh
- task --dry wt:finish
- smoke-tested finish with .worktrees/smoke-finish-cleanup from main
- lefthook pre-push