### PR TITLE
chore(ci): drop nightly rustfmt; format on pinned 1.95

### DIFF
--- a/.ai-factory/rules/base.md
+++ b/.ai-factory/rules/base.md
@@ -7,10 +7,10 @@
 
 ## Toolchain
 
-- Rust **1.95** stable for build / clippy / test (pinned via `rust-toolchain.toml`
-  and `workspace.package.rust-version`).
-- **Nightly rustfmt** required for formatting (`cargo +nightly fmt --all`) — see
-  `rustfmt.toml`.
+- Rust **1.95** stable for build / clippy / test / fmt (pinned via
+  `rust-toolchain.toml` and `workspace.package.rust-version`).
+- Formatting via `cargo fmt --all` on the pinned toolchain. `rustfmt.toml`
+  is stable-only — no nightly required.
 - Workspace edition: **2024**, resolver: **3**.
 - Test runner: **`cargo nextest run`** for unit/integration tests; doctests run
   via `cargo test --workspace --doc`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,7 +51,7 @@ PR title must follow Conventional Commits (enforced by .github/workflows/pr-vali
 
 ### Local verification
 
-- [ ] `cargo +nightly fmt --all` — formatted
+- [ ] `cargo fmt --all` — formatted
 - [ ] `cargo clippy --workspace -- -D warnings` — clean
 - [ ] `cargo nextest run --workspace` — passes
 - [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -55,7 +55,7 @@ the same branch naming and Conventional Commit rules.
 
 DO NOT comment on:
 
-- **Style / formatting** — rustfmt + nightly handles this. Never suggest reformatting.
+- **Style / formatting** — rustfmt handles this. Never suggest reformatting.
 - **Naming preferences** — no "consider renaming X to Y" unless name is actively misleading.
 - **Generic suggestions** — no "consider adding logging", "consider error handling", "consider tests" without naming a specific case.
 - **Missing comments on private code** — internal fns don't need doc comments.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,17 +54,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      # rustfmt.toml enables unstable options (group_imports,
-      # imports_granularity, wrap_comments, format_code_in_doc_comments)
-      # which only nightly rustfmt honours. Build/clippy/test jobs stay
-      # on stable — only this gate is nightly-only.
-      - name: Install nightly rustfmt
+      - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
-          toolchain: nightly
+          toolchain: "1.95"
           components: rustfmt
       - name: Check formatting
-        run: cargo +nightly fmt --all -- --check
+        run: cargo fmt --all -- --check
 
   # ── Linting ────────────────────────────────────────────────────────────────
   clippy:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Run via `task <name>`. See `task --list` for the full catalog.
 | `task dev:check`         | Pre-PR gate: fmt + clippy + nextest + doctests + deny |
 | `task check`             | Type-check all crates and targets (no codegen) |
 | `task build`             | Debug build (`task build:release` for release) |
-| `task fmt`               | Format (uses **nightly** rustfmt — required) |
+| `task fmt`               | Format (`cargo fmt --all` on the pinned stable toolchain) |
 | `task clippy`            | Workspace clippy with `-D warnings` |
 | `task quality`           | Quick mechanical gate (fmt:check + clippy) |
 | `task deny`              | `cargo-deny`: layer wrappers + advisories + licenses |
@@ -75,7 +75,7 @@ nebula/
 ├── Taskfile.yml        # task runner — see Common Commands above
 ├── deny.toml           # cargo-deny: layer wrappers (CI gate)
 ├── lefthook.yml        # local pre-commit / pre-push (mirrors CI)
-├── rustfmt.toml        # nightly rustfmt config
+├── rustfmt.toml        # rustfmt config (stable-only)
 ├── clippy.toml         # lint thresholds (msrv 1.95)
 ├── crates/             # 34 workspace members (incl. 8 derive companions)
 ├── scripts/            # worktree.sh + lefthook helpers
@@ -117,7 +117,7 @@ between siblings at the same layer.
 | `Cargo.toml`                  | Workspace members, pinned deps, `[workspace.lints]` |
 | `deny.toml`                   | Layer wrappers, licenses, advisories — CI gate |
 | `clippy.toml`                 | Lint thresholds (msrv 1.95) |
-| `rustfmt.toml`                | Nightly rustfmt config |
+| `rustfmt.toml`                | rustfmt config (stable-only, runs on pinned toolchain) |
 | `rust-toolchain.toml`         | Pinned toolchain |
 | `lefthook.yml`                | Local pre-commit / pre-push (mirrors CI) |
 | `Taskfile.yml`                | `task dev:check` = full pre-PR gate; `task --list` for catalog |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -99,12 +99,12 @@ tasks:
   fmt:
     desc: Format all code in place
     cmds:
-      - cargo +nightly fmt --all
+      - cargo fmt --all
 
   fmt:check:
     desc: Check formatting without modifying files (CI)
     cmds:
-      - cargo +nightly fmt --all -- --check
+      - cargo fmt --all -- --check
 
   clippy:
     desc: Run Clippy linter (warnings treated as errors)
@@ -119,7 +119,7 @@ tasks:
   quality:
     desc: Full mechanical gate (fmt check + clippy) — see docs/QUALITY_GATES.md
     cmds:
-      - cargo +nightly fmt --all -- --check
+      - cargo fmt --all -- --check
       - cargo clippy {{.CARGO_FLAGS}} -- -D warnings
 
   deny:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -46,7 +46,6 @@ pre-push:
     crate-diff-gate:
       run: bash scripts/pre-push-crate-diff.sh
 
-    # Doctests/docs/MSRV remain CI-owned checks.
-# Note: 'cargo udeps' is NOT in pre-push. It requires nightly + is slow. Kept in weekly CI workflow.
-
-# Note: 'cargo udeps' is NOT in pre-push. It requires nightly + is slow. Kept in weekly CI workflow.
+# Doctests / docs / MSRV remain CI-owned checks.
+# `cargo udeps` is NOT in pre-push — requires nightly and is slow; kept in
+# the weekly CI workflow instead.

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
       # Per-crate to avoid Windows cmdline length limit (`cargo fmt --all`
       # iterates every workspace member and trips OS error 206 when the
       # working-tree path is deep, e.g. under `.worktrees/`). CI Linux still
-      # runs `cargo +nightly fmt --all -- --check` as the authoritative gate.
+      # runs `cargo fmt --all -- --check` as the authoritative gate.
       run: bash scripts/pre-commit-fmt-check.sh {staged_files}
     clippy:
       glob: "**/*.rs"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -4,9 +4,9 @@
 # without an explicit override to the workspace's declared `rust-version`.
 #
 # Notes:
-# - `cargo +nightly fmt --all` still works: rustup installs nightly on demand
-#   when the `+toolchain` override is used. Nightly rustfmt is required by
-#   `rustfmt.toml` (`unstable_features = true`).
+# - `rustfmt.toml` is stable-only, so `cargo fmt` runs on the pinned toolchain
+#   without warnings. Nightly is still used ad-hoc for tools that require it
+#   (cargo-udeps, loom chaos jobs) via `cargo +nightly <cmd>`.
 # - `rust-src` and `rust-analyzer` are included so IDE / std-expansion features
 #   work out of the box after `rustup show active-toolchain` in a fresh clone.
 # - Legacy `rust-toolchain` (without the `.toml` extension) is still accepted

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,14 +1,11 @@
 # Nebula rustfmt configuration.
 #
-# Uses nightly rustfmt because several high-value options are still
-# unstable. To apply formatting locally run:
+# Stable-only: runs cleanly on the toolchain pinned in `rust-toolchain.toml`
+# (currently 1.95). Apply locally with:
 #
-#     cargo +nightly fmt --all
+#     cargo fmt --all
 #
-# CI formatting check is pinned to nightly in `.github/workflows/ci.yml`.
-# `cargo build`/`clippy`/`test` stay on stable `rust-version` (1.95) from the
-# workspace Cargo.toml (pinned in `rust-toolchain.toml`) — only `cargo fmt`
-# is nightly-only.
+# CI runs `cargo fmt --all -- --check` on the same stable toolchain.
 
 # ── Parser / Style Guide editions ──────────────────────────────────────────
 edition = "2024"
@@ -26,30 +23,3 @@ reorder_modules = true
 use_field_init_shorthand = true
 use_try_shorthand = true
 merge_derives = true
-
-# ── Unstable features (require nightly rustfmt) ────────────────────────────
-unstable_features = true
-
-# Imports: group std → external crates → crate::, then collapse same-crate
-# `use` lines into a single `use { … }` block. Massively reduces churn.
-group_imports = "StdExternalCrate"
-imports_granularity = "Crate"
-
-# Comments: wrap long lines, format code fences inside doc comments, and
-# collapse `#[doc = "…"]` to `///` form.
-wrap_comments = true
-comment_width = 100
-format_code_in_doc_comments = true
-normalize_comments = true
-normalize_doc_attributes = true
-
-# Format the matchers and bodies of `macro_rules!` declarations. `rustfmt`
-# only touches macros it can parse, so this is safe for the token-soup cases.
-format_macro_matchers = true
-format_macro_bodies = true
-
-# Unify hex literal casing to lowercase (`0xFF` → `0xff`).
-hex_literal_case = "Lower"
-
-# Collapse trailing wildcard tuple / struct patterns: `(_, _, _)` → `(..)`.
-condense_wildcard_suffixes = true

--- a/scripts/pre-commit-fmt-check.sh
+++ b/scripts/pre-commit-fmt-check.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Pre-commit fmt-check: format only the crates owning the staged files.
 #
-# Why: `cargo +nightly fmt --all -- --check` builds a long internal command
-# line iterating every workspace member. On Windows with deep working-tree
-# paths (e.g. `C:\Users\<user>\...\.worktrees\nebula\<branch>\`), that line
-# exceeds the ~32k cmdline limit and cargo fails with `OS error 206`.
+# Why: `cargo fmt --all -- --check` builds a long internal command line
+# iterating every workspace member. On Windows with deep working-tree paths
+# (e.g. `C:\Users\<user>\...\.worktrees\nebula\<branch>\`), that line exceeds
+# the ~32k cmdline limit and cargo fails with `OS error 206`.
 #
 # This script mirrors the per-crate strategy used by
 # `pre-push-crate-diff.sh`: walk each staged file up to its owning crate's
@@ -12,7 +12,7 @@
 # `-p` flags. Workspace `rustfmt.toml` is honored because cargo-fmt picks
 # it up from the workspace root regardless of which packages are selected.
 #
-# CI fmt-check on Linux (`cargo +nightly fmt --all -- --check`) remains the
+# CI fmt-check on Linux (`cargo fmt --all -- --check`) remains the
 # authoritative gate; this script is fast-feedback only.
 set -euo pipefail
 
@@ -68,12 +68,12 @@ fi
 # only the failure path surfaces this).
 if [[ ${#pkg_args[@]} -gt 0 ]]; then
   echo "fmt-check (per-crate):" "${pkg_args[@]}"
-  cargo +nightly fmt "${pkg_args[@]}" -- --check
+  cargo fmt "${pkg_args[@]}" -- --check
 fi
 
 # Run each standalone manifest in its own invocation — `--manifest-path`
 # accepts only one value, so we loop instead of batching.
 for manifest in "${standalone_manifests[@]}"; do
   echo "fmt-check (standalone): $manifest"
-  cargo +nightly fmt --manifest-path "$manifest" -- --check
+  cargo fmt --manifest-path "$manifest" -- --check
 done


### PR DESCRIPTION
## Summary

- `rustfmt.toml` previously enabled `unstable_features = true` plus 10+ nightly-only options. On the pinned **1.95** toolchain, plain `cargo fmt` (and IDE invocations like RustRover) printed a `Warning: can't set X, unstable features are only available in nightly channel` for every key, every run.
- Switch the project to stable-only rustfmt. CI fmt gate now runs `cargo fmt --all -- --check` on **1.95** instead of installing a separate nightly toolchain just for the format check.
- Nightly remains in use for cargo-udeps and loom chaos jobs — legitimate non-fmt cases.

## Trade-off

Stable rustfmt does not honour these unstable knobs:

| Option | Loss |
|--------|------|
| `group_imports = "StdExternalCrate"` | std → external → crate import grouping |
| `imports_granularity = "Crate"` | `use foo::{a, b};` collapse |
| `wrap_comments` / `comment_width` | auto-wrap of long `///` |
| `format_code_in_doc_comments` | rustfmt inside doc-fenced Rust blocks |
| `normalize_comments` / `normalize_doc_attributes` | `// →` / `#[doc = "..."]` → `///` normalization |
| `format_macro_matchers` / `format_macro_bodies` | `macro_rules!` body formatting |
| `hex_literal_case` | `0xFF` → `0xff` |
| `condense_wildcard_suffixes` | `(_, _, _)` → `(..)` |

These have been unstable for years with no near-term path to stabilization. Worth giving up for: single-toolchain workflow, zero warnings in IDEs / pre-commit, and a simpler CI fmt gate.

## Files touched

- **Config:** `rustfmt.toml`, `rust-toolchain.toml` comments
- **CI / hooks:** `.github/workflows/ci.yml`, `lefthook.yml`, `scripts/pre-commit-fmt-check.sh`, `Taskfile.yml` (`fmt`, `fmt:check`, `quality`)
- **Docs:** `AGENTS.md`, `.github/copilot-instructions.md`, `.ai-factory/rules/base.md`, `.github/PULL_REQUEST_TEMPLATE.md`

## Test plan

- [x] `cargo fmt --all -- --check` (locally, exits 0, silent)
- [x] `taplo fmt --check` on touched TOML
- [x] convco-validated commit message (`chore(ci): ...`)
- [ ] CI fmt job runs on stable 1.95 and stays green
- [ ] Spot-check that no formatted code regresses (no new fmt-driven diff after `cargo fmt --all`)