### PR TITLE
feat(api): close M3.4 — idempotency wire-up + ADR-0048 hybrid backend

### DIFF
--- a/.ai-factory/ROADMAP.md
+++ b/.ai-factory/ROADMAP.md
@@ -51,19 +51,23 @@
   + spec-16 row model) remains Sprint E (1.1) scaffolding.
   `sandbox` is correctness-grade; capability discovery enforcement gap (canon
   §4.5).
-- **API layer** — routing wired; **3 remaining feature gaps** (tracing
-  context propagation, shift-left `validate_workflow` audit, and
-  composition-root wiring of the shipped `IdempotencyLayer`). Auth backend
-  and webhook dispatch closed via PR #638 (`feat(api): Plane-A auth, slug
-  webhooks, idempotency`, merged 2026-05-04). **OpenAPI 3.1 closed via
-  M3.2 (`feat/api-openapi-spec`, 2026-05-07)** — utoipa-axum mounts
-  every handler through `routes!()` so spec drift is a compile error;
-  Stub Endpoint Policy (ADR-0047) tags class-(c) handlers as
-  `deprecated` + 501 so canon §4.5 stays mechanically verifiable; full
-  drift / 3.1-validation test suite in `crates/api/tests/openapi_*.rs`.
-  The Idempotency middleware ships in PR #638 too but is **not** yet
-  mounted in `build_app` — the layer exists, the layer is not wired
-  (see `idempotency.rs:48-50`). Webhook handlers ship; production
+- **API layer** — routing wired; **2 remaining feature gaps** (tracing
+  context propagation §M3.5 and shift-left `validate_workflow` audit
+  §M3.6). Auth backend and webhook dispatch closed via PR #638
+  (`feat(api): Plane-A auth, slug webhooks, idempotency`, merged
+  2026-05-04). **OpenAPI 3.1 closed via M3.2** (`feat/api-openapi-spec`,
+  2026-05-07) — utoipa-axum mounts every handler through `routes!()` so
+  spec drift is a compile error; Stub Endpoint Policy (ADR-0047) tags
+  class-(c) handlers as `deprecated` + 501 so canon §4.5 stays
+  mechanically verifiable; full drift / 3.1-validation test suite in
+  `crates/api/tests/openapi_*.rs`. **M3.4 closed 2026-05-07
+  (`feat/api-m3-4-idempotency`)** — `IdempotencyLayer` mounted in
+  `build_app` on api routes only (webhook ingress keeps its own dedup
+  contract); ADR-0048 ratifies the hybrid store backend (`InMemory` for
+  dev/tests, `Pg` for production); `nebula_api_idempotency_*` metrics
+  + tracing span fields land in `crates/metrics/src/naming.rs`; e2e
+  tests in `crates/api/tests/idempotency_e2e.rs` exercise the full
+  `build_app` stack. Webhook handlers ship; production
   trigger-registration wiring through the storage layer remains a
   separate follow-up flagged in `crates/api/src/routes/webhook.rs:25-28`.
 - **GitHub:** 19+ open issues, all p2/p3 needs-triage/discussion. No p0/p1.
@@ -340,19 +344,27 @@ The largest 1.0 area. Six blocks; can be parallelized once unblocked.
       cached.
 - [x] `crates/api/tests/idempotency_middleware.rs` covers core paths
       against minimal routers.
-- [ ] **Mount `IdempotencyLayer` in `crate::app::build_app`** —
-      explicit TODO in `idempotency.rs:48-50`. Today production POST
-      endpoints lack replay protection.
-- [ ] **Shared-store decision (in-memory vs PG-backed) + ADR.** Default
-      `InMemoryIdempotencyStore` loses dedup state across restart and
-      across runners → not safe for multi-process deployments.
-- [ ] If PG-backed: migration + repo trait + concurrency tests
-      (concurrent first writer wins, body-mismatch race).
-- [ ] **End-to-end integration test** against the real `build_app`
-      router (not minimal test routers) covering replay + body
-      mismatch + 5xx-bypass.
-- [ ] **Observability:** `nebula_api_idempotency_*` (hit rate, store
-      saturation, evictions) + `tracing` span field for cache hits.
+- [x] **Mount `IdempotencyLayer` in `crate::app::build_app`** — wired on
+      api routes BEFORE the webhook transport merge (webhook ingress has its
+      own dedup contract per ROADMAP §M3.3). `crates/api/src/app.rs`.
+- [x] **Shared-store decision (in-memory vs PG-backed) + ADR.**
+      ADR-0048 — hybrid backend: `InMemoryIdempotencyStore` for dev/tests,
+      `StorageBackedIdempotencyStore<PgIdempotencyStore>` for production.
+      Selection via `ApiConfig.idempotency.backend` (`API_IDEMPOTENCY_BACKEND`).
+      `docs/adr/0048-idempotency-store-backend.md`.
+- [x] **PG-backed: migration + repo trait + concurrency tests.** Trait
+      `IdempotencyStoreRepo` in `crates/storage/src/repos/idempotency.rs`;
+      impl `PgIdempotencyStore` in `crates/storage/src/pg/idempotency.rs`;
+      migration `0024_add_idempotency_dedup.sql` (PG + SQLite parity);
+      `DATABASE_URL`-gated tests in `crates/storage/tests/pg_idempotency.rs`
+      (round-trip, concurrent first-writer-wins, body-mismatch race, TTL).
+- [x] **End-to-end integration test** against the real `build_app` router
+      (not minimal test routers) covering replay + body-mismatch + 5xx
+      bypass + per-principal scope. `crates/api/tests/idempotency_e2e.rs`.
+- [x] **Observability:** `nebula_api_idempotency_{hits,misses,rejects,store_saturation_ppm,latency_ms}`
+      live in `crates/metrics/src/naming.rs`; middleware records them on
+      every outcome branch. Tracing span carries `cache_key_prefix`,
+      `identity_prefix`, `body_size_bytes`, `outcome`.
 
 #### M3.5 Tracing context propagation
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
+ "sqlx",
  "subtle",
  "thiserror",
  "tokio",

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -83,6 +83,14 @@ parking_lot = { workspace = true }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 async-trait = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+# Optional — only used by the PG-backed idempotency path in
+# `examples/simple_server.rs` (gated by `feature = "postgres"`).
+sqlx = { version = "0.8", optional = true, default-features = false, features = [
+  "runtime-tokio",
+  "postgres",
+  "tls-rustls-ring-native-roots",
+] }
+tokio-util = { workspace = true }
 
 # Webhook transport
 dashmap = { workspace = true }
@@ -130,6 +138,12 @@ default = []
 # enable this in production builds — it exposes a constructor that
 # bypasses the JwtSecret validation gate.
 test-util = []
+# Enables the PG-backed idempotency-store path in `examples/simple_server.rs`
+# (M3.4 / ADR-0048). Forwards to `nebula-storage/postgres` so the
+# `PgIdempotencyStore` impl + sqlx pool become available. When this feature
+# is OFF, setting `API_IDEMPOTENCY_BACKEND=postgres` fails closed at
+# startup (per ADR-0048 fail-closed contract).
+postgres = ["nebula-storage/postgres", "dep:sqlx"]
 # Note: `credential-oauth` rollout feature gate deleted 2026-04-24 —
 # OAuth ceremony deps (nebula-credential, reqwest, hmac, sha2, zeroize)
 # are now unconditional base deps per ADR-0031 §6 (rollout window closed).

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -190,6 +190,54 @@ line at startup so production logs can pin against it. To regenerate
 locally, run any test that calls `nebula_api::build_app` — for example
 `cargo nextest run -p nebula-api --test openapi_spec`.
 
+### Idempotency-Key (M3.4 / ADR-0048)
+
+Every state-changing endpoint reachable from `build_app` is replay-protected
+through the `IdempotencyLayer` middleware. Clients opt in by sending an
+`Idempotency-Key` header on a `POST` request — the middleware caches the
+first response (status + body + filtered headers) keyed by
+`(method, path, key, identity-fingerprint, body-fingerprint)` and replays
+it byte-for-byte on subsequent requests within the configured TTL.
+
+**Protocol contract** — the IETF draft
+[`draft-ietf-httpapi-idempotency-key`](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key/)
+governs header semantics. Highlights:
+
+- Same `Idempotency-Key` + same body within the TTL → cached replay
+  (response carries `Idempotent-Replay: true`).
+- Same key + different body → **422 Unprocessable Entity** with
+  `application/problem+json`.
+- `5xx` responses are passed through uncached so transient backend failures
+  do not pin a permanent error for the TTL window.
+
+**Environment variables** (defaults applied by `ApiConfig::from_env`):
+
+| Var | Default | Notes |
+|---|---|---|
+| `API_IDEMPOTENCY_BACKEND` | `memory` | `memory` \| `postgres`. See backend tradeoffs below. |
+| `API_IDEMPOTENCY_TTL_SECS` | `86400` | Cached-entry lifetime (24h matches the IETF draft). |
+| `API_IDEMPOTENCY_MAX_ENTRIES` | `10000` | Cap for the in-memory backend; PG honours `expires_at` instead. |
+| `API_IDEMPOTENCY_MAX_REQUEST_BODY_BYTES` | `1048576` | Requests beyond this skip caching (forwarded as-is). |
+| `API_IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES` | `1048576` | Responses beyond this are returned uncached. |
+| `API_IDEMPOTENCY_SWEEP_INTERVAL_SECS` | `300` | PG-only: cadence for the `evict_expired` background sweep. `0` disables. `< 60` triggers a startup `WARN`. |
+
+**Store-backend tradeoffs** (see `docs/adr/0048-idempotency-store-backend.md`):
+
+| Backend | When | Restart-survival | Multi-replica share |
+|---|---|---|---|
+| `memory` | Dev / single-process tests / one-replica deployments | No — state lost on restart | No — process-local |
+| `postgres` | Production deployments (≥ 2 replicas, or restart-tolerance required) | Yes — table survives restart | Yes — same `DATABASE_URL` shared |
+
+> **Operator warning:** selecting `memory` outside `NEBULA_ENV=development`
+> emits a startup `tracing::warn!` — dedup state is lost on restart and
+> across runners. The §M3 1.0 closure criterion requires `postgres` for
+> production.
+
+The `postgres` backend is gated behind the `nebula-api/postgres` cargo
+feature so default builds remain lightweight. Selecting
+`API_IDEMPOTENCY_BACKEND=postgres` without that feature compiled in fails
+closed at startup (per ADR-0048; no silent fallback).
+
 ### Cross-layer schema strategy
 
 Per ADR-0047 §3, API DTOs MUST NOT embed types from `nebula-core`,

--- a/crates/api/examples/simple_server.rs
+++ b/crates/api/examples/simple_server.rs
@@ -4,13 +4,27 @@
 //! `NEBULA_ENV=development` to let the loader generate an ephemeral
 //! per-process secret. Tokens signed with an ephemeral secret are
 //! invalidated on restart.
+//!
+//! ## Idempotency backends (M3.4 / ADR-0048)
+//!
+//! - `API_IDEMPOTENCY_BACKEND=memory` (default) — process-local cache.
+//!   No restart durability, no cross-runner sharing. Fine for dev.
+//! - `API_IDEMPOTENCY_BACKEND=postgres` — durable PG-backed dedup.
+//!   Requires `--features postgres` at build time **and** `DATABASE_URL`
+//!   at runtime. Without `--features postgres`, this path returns a
+//!   typed startup error (fail-closed per ADR-0048; no silent fallback).
 
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
-use nebula_api::{ApiConfig, AppState, app};
+use nebula_api::{
+    ApiConfig, AppState, app,
+    config::IdempotencyBackend,
+    middleware::{IdempotencyStore, InMemoryIdempotencyStore},
+};
 use nebula_storage::{
     InMemoryExecutionRepo, InMemoryWorkflowRepo, repos::InMemoryControlQueueRepo,
 };
+use tokio_util::sync::CancellationToken;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
@@ -38,6 +52,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());
     let api_config = ApiConfig::from_env()?;
 
+    // Wire the idempotency-store backend per ADR-0048. The cancellation
+    // token coordinates graceful shutdown across axum and the optional
+    // PG sweep task spawned below.
+    let shutdown_token = CancellationToken::new();
+    let (idempotency_store, sweep_handle) =
+        build_idempotency(&api_config, shutdown_token.clone()).await?;
+
     // Wire api_keys from ApiConfig so X-API-Key auth is honoured.
     let state = AppState::new(
         workflow_repo,
@@ -45,9 +66,187 @@ async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         control_queue_repo,
         api_config.jwt_secret.clone(),
     )
-    .with_api_keys(api_config.api_keys.clone());
+    .with_api_keys(api_config.api_keys.clone())
+    .with_idempotency_store(idempotency_store);
+    let bind_address = api_config.bind_address;
     let app = app::build_app(state, &api_config);
 
-    app::serve(app, api_config.bind_address).await?;
+    // Spawn an OS-signal handler that flips the shutdown token. axum's
+    // `with_graceful_shutdown` and the sweep task both observe it.
+    let signal_token = shutdown_token.clone();
+    tokio::spawn(async move {
+        wait_for_signal().await;
+        tracing::info!("shutdown signal received — flipping shutdown token");
+        signal_token.cancel();
+    });
+
+    let serve_token = shutdown_token.clone();
+    let serve_result = app::serve_with_shutdown(app, bind_address, async move {
+        serve_token.cancelled().await;
+    })
+    .await;
+
+    // Make sure the sweep task gets a chance to exit even if axum returns
+    // first (e.g. bind error). On a clean shutdown the OS-signal task has
+    // already flipped the token; a defensive flip is a no-op.
+    shutdown_token.cancel();
+    if let Some(handle) = sweep_handle
+        && let Err(err) = handle.await
+    {
+        tracing::warn!(error = %err, "idempotency sweep task panicked");
+    }
+    serve_result?;
     Ok(())
+}
+
+async fn wait_for_signal() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {},
+        () = terminate => {},
+    }
+}
+
+/// Build the idempotency store + (optionally) spawn the PG sweep task.
+///
+/// Returns the store handle and a `JoinHandle` for the sweep task; the
+/// handle is `None` for the in-memory backend (moka evicts on its own).
+/// The `shutdown_token` is observed by the sweep task so SIGTERM
+/// terminates it within one tick of cancellation.
+async fn build_idempotency(
+    api_config: &ApiConfig,
+    shutdown_token: CancellationToken,
+) -> Result<
+    (
+        Arc<dyn IdempotencyStore>,
+        Option<tokio::task::JoinHandle<()>>,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    match api_config.idempotency.backend {
+        IdempotencyBackend::Memory => {
+            warn_memory_outside_dev();
+            let store = Arc::new(InMemoryIdempotencyStore::with_ttl_and_capacity(
+                Duration::from_secs(api_config.idempotency.ttl_secs),
+                api_config.idempotency.max_entries,
+            ));
+            Ok((store, None))
+        },
+        IdempotencyBackend::Postgres => build_pg_backend(api_config, shutdown_token).await,
+    }
+}
+
+fn warn_memory_outside_dev() {
+    let env_mode = std::env::var("NEBULA_ENV").unwrap_or_default();
+    let is_dev = matches!(env_mode.as_str(), "development" | "dev" | "local");
+    if !is_dev {
+        tracing::warn!(
+            backend = "memory",
+            nebula_env = %env_mode,
+            "idempotency: in-memory store selected — dedup state is lost on restart and across runners"
+        );
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn build_pg_backend(
+    api_config: &ApiConfig,
+    shutdown_token: CancellationToken,
+) -> Result<
+    (
+        Arc<dyn IdempotencyStore>,
+        Option<tokio::task::JoinHandle<()>>,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    use nebula_api::middleware::idempotency::StorageBackedIdempotencyStore;
+    use nebula_storage::{pg::PgIdempotencyStore, repos::IdempotencyStoreRepo};
+    use sqlx::postgres::PgPoolOptions;
+
+    let url = std::env::var("DATABASE_URL").map_err(|_| {
+        "API_IDEMPOTENCY_BACKEND=postgres requires DATABASE_URL — set it or fall back to \
+         API_IDEMPOTENCY_BACKEND=memory (per ADR-0048 fail-closed contract)"
+    })?;
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await?;
+    tracing::info!(backend = "postgres", "idempotency: PG-backed store wired");
+
+    if api_config.idempotency.sweep_interval_secs > 0
+        && api_config.idempotency.sweep_interval_secs < 60
+    {
+        tracing::warn!(
+            sweep_interval_secs = api_config.idempotency.sweep_interval_secs,
+            "idempotency: sweep interval < 60s; consider raising it to avoid hot-loop sweeps"
+        );
+    }
+
+    let pg_repo = Arc::new(PgIdempotencyStore::new(pool));
+    let sweep_repo = Arc::clone(&pg_repo);
+    let interval_secs = api_config.idempotency.sweep_interval_secs;
+    let sweep_handle = if interval_secs > 0 {
+        let sweep_token = shutdown_token.clone();
+        Some(tokio::spawn(async move {
+            let mut tick = tokio::time::interval(Duration::from_secs(interval_secs));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                tokio::select! {
+                    () = sweep_token.cancelled() => {
+                        tracing::info!("idempotency sweep task: shutdown observed");
+                        break;
+                    }
+                    _ = tick.tick() => {
+                        match sweep_repo.evict_expired().await {
+                            Ok(rows) => tracing::info!(rows_evicted = rows, "idempotency: sweep cycle"),
+                            Err(err) => tracing::warn!(error = %err, "idempotency: sweep failed"),
+                        }
+                    }
+                }
+            }
+        }))
+    } else {
+        None
+    };
+
+    let store: Arc<dyn IdempotencyStore> = Arc::new(StorageBackedIdempotencyStore::new(
+        pg_repo,
+        Duration::from_secs(api_config.idempotency.ttl_secs),
+    ));
+    Ok((store, sweep_handle))
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn build_pg_backend(
+    _api_config: &ApiConfig,
+    _shutdown_token: CancellationToken,
+) -> Result<
+    (
+        Arc<dyn IdempotencyStore>,
+        Option<tokio::task::JoinHandle<()>>,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    Err(
+        "API_IDEMPOTENCY_BACKEND=postgres requires the `postgres` feature: \
+         rebuild with `cargo run --example simple_server --features postgres` \
+         (per ADR-0048 fail-closed contract)"
+            .into(),
+    )
 }

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -2,16 +2,22 @@
 //!
 //! Сборка Router с middleware (Production-Grade).
 
-use std::time::Duration;
+use std::{future::Future, sync::Arc, time::Duration};
 
 use axum::{Router, extract::DefaultBodyLimit, middleware, response::Response};
 use tower::ServiceBuilder;
 use tower_http::{compression::CompressionLayer, cors::CorsLayer, trace::TraceLayer};
 use utoipa_swagger_ui::SwaggerUi;
 
+#[cfg(any(test, feature = "test-util"))]
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use crate::{
-    config::ApiConfig,
-    middleware::{rate_limit::RateLimitState, security_headers::security_headers_middleware},
+    config::{ApiConfig, IdempotencyApiConfig},
+    middleware::{
+        IdempotencyLayer, idempotency::IdempotencyConfig, rate_limit::RateLimitState,
+        security_headers::security_headers_middleware,
+    },
     routes,
     state::AppState,
 };
@@ -75,7 +81,44 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // REST default is not the right default for every webhook
     // provider. Operators tune the REST cap via `API_MAX_BODY_SIZE`
     // (defaulting to `config::REST_BODY_LIMIT_BYTES`).
-    let routes = api_routes.layer(DefaultBodyLimit::max(config.max_body_size));
+    let api_routes = api_routes.layer(DefaultBodyLimit::max(config.max_body_size));
+
+    // Test-only echo / fail routes (used by `tests/idempotency_e2e.rs`).
+    // Merged BEFORE the idempotency layer so the dedup contract covers
+    // them; gated behind `test-util` so production builds never include
+    // these endpoints. Per ADR-0047 they go through `axum::Router::merge`
+    // (not `OpenApiRouter`) so the spec stays clean — no `_test/*` paths
+    // in `/api/v1/openapi.json`.
+    #[cfg(any(test, feature = "test-util"))]
+    let api_routes = api_routes.merge(test_echo_router::<()>());
+
+    // Mount idempotency on API routes ONLY — webhook ingress has its own
+    // dedup contract (ROADMAP §M3.3 — provider signature + replay-window
+    // timestamp). Routing webhook traffic through the API idempotency
+    // cache would inflate `nebula_api_idempotency_misses_total` with
+    // provider traffic that never carries `Idempotency-Key` and conflate
+    // two distinct dedup surfaces. See ADR-0048.
+    let api_routes = if let Some(store) = state.idempotency_store.as_ref() {
+        debug_assert!(
+            config.idempotency.ttl_secs > 0,
+            "idempotency TTL must be positive — startup misconfiguration"
+        );
+        tracing::info!(
+            layer = "idempotency",
+            store_kind = store.store_kind(),
+            "build_app: mounting idempotency layer"
+        );
+        api_routes.layer(
+            IdempotencyLayer::new(Arc::clone(store))
+                .with_config(layer_config_from(&config.idempotency))
+                .with_metrics(state.metrics_registry.clone()),
+        )
+    } else {
+        tracing::warn!(
+            "build_app: idempotency_store not configured — POST endpoints lack replay protection"
+        );
+        api_routes
+    };
 
     // Merge the webhook transport router (if attached). Webhook
     // routes live alongside REST API routes on the same axum app,
@@ -83,8 +126,8 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // works because the webhook router carries its own state type
     // (`WebhookTransport`) that does not collide with `AppState`.
     let routes = match state.webhook_transport {
-        Some(transport) => routes.merge(transport.router()),
-        None => routes,
+        Some(transport) => api_routes.merge(transport.router()),
+        None => api_routes,
     };
 
     // Build per-IP rate limiter from config.
@@ -146,11 +189,72 @@ async fn request_id_middleware(
     response
 }
 
+/// Test-only echo / fail router used by `tests/idempotency_e2e.rs`.
+///
+/// Two routes:
+/// - `POST /api/v1/_test/echo` — returns `200 OK` with body
+///   `echo:<call_count>:<request_payload>`. The counter is per
+///   `build_app` invocation (process-local, fresh per test) and lets
+///   tests prove a hit bypassed the inner handler.
+/// - `POST /api/v1/_test/fail` — returns `500 Internal Server Error`
+///   with body `boom:<call_count>`. Used to assert that 5xx responses
+///   are not cached and the inner handler runs every call.
+///
+/// Mounted via plain `axum::Router::merge` (NOT `OpenApiRouter`) so the
+/// fixture stays out of the served OpenAPI spec — production builds
+/// don't include this module at all (gated by `feature = "test-util"`),
+/// and tests get predictable handlers without the auth/RBAC stack.
+#[cfg(any(test, feature = "test-util"))]
+pub(crate) fn test_echo_router<S: Clone + Send + Sync + 'static>() -> Router<S> {
+    use axum::{Extension, body::Bytes, http::StatusCode, response::IntoResponse, routing::post};
+
+    let counter = Arc::new(AtomicUsize::new(0));
+
+    Router::new()
+        .route(
+            "/api/v1/_test/echo",
+            post(
+                |Extension(c): Extension<Arc<AtomicUsize>>, body: Bytes| async move {
+                    let n = c.fetch_add(1, Ordering::SeqCst) + 1;
+                    let payload = String::from_utf8_lossy(&body);
+                    (StatusCode::OK, format!("echo:{n}:{payload}")).into_response()
+                },
+            ),
+        )
+        .route(
+            "/api/v1/_test/fail",
+            post(|Extension(c): Extension<Arc<AtomicUsize>>| async move {
+                let n = c.fetch_add(1, Ordering::SeqCst) + 1;
+                (StatusCode::INTERNAL_SERVER_ERROR, format!("boom:{n}")).into_response()
+            }),
+        )
+        .layer(Extension(counter))
+}
+
+/// Map `ApiConfig.idempotency` body-byte caps onto the middleware's
+/// internal [`IdempotencyConfig`].
+///
+/// The middleware ignores the TTL / max-entries / sweep-cadence fields
+/// from [`IdempotencyApiConfig`] — those are properties of the
+/// **store**, set at composition-root time when the operator builds
+/// `InMemoryIdempotencyStore::with_ttl_and_capacity` /
+/// `PgIdempotencyStore::new`. Only the body-size guards live on the
+/// per-request layer config.
+fn layer_config_from(cfg: &IdempotencyApiConfig) -> IdempotencyConfig {
+    IdempotencyConfig {
+        max_request_body_bytes: cfg.max_request_body_bytes,
+        max_response_body_bytes: cfg.max_response_body_bytes,
+    }
+}
+
 /// Build CORS layer from config
 fn build_cors_layer(config: &ApiConfig) -> CorsLayer {
     use axum::http::{HeaderValue, Method, header};
 
-    use crate::middleware::request_id::X_REQUEST_ID;
+    use crate::middleware::{
+        idempotency::{IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER},
+        request_id::X_REQUEST_ID,
+    };
 
     let mut cors = CorsLayer::new();
 
@@ -184,14 +288,26 @@ fn build_cors_layer(config: &ApiConfig) -> CorsLayer {
     // OPTIONS probe. The policy must match the *protocol surface*,
     // not the *current tenant config*: enabling API keys later
     // should not need a restart for preflight to work.
+    //
+    // `Idempotency-Key` is here so cross-origin POSTs that opt into
+    // replay protection clear the preflight; without it browsers
+    // strip the header before the server sees it (M3.4 / ADR-0048).
     .allow_headers([
         header::CONTENT_TYPE,
         header::AUTHORIZATION,
         header::ACCEPT,
         header::HeaderName::from_static(X_REQUEST_ID),
         crate::middleware::auth::X_API_KEY.clone(),
+        header::HeaderName::from_static(IDEMPOTENCY_KEY_HEADER),
     ])
-    .expose_headers([header::HeaderName::from_static(X_REQUEST_ID)])
+    // `Idempotent-Replay` is exposed so JS clients can read it on the
+    // response and tell a cache-hit replay apart from a fresh handler
+    // run; non-exposed headers are stripped by the browser before
+    // `fetch().headers` sees them.
+    .expose_headers([
+        header::HeaderName::from_static(X_REQUEST_ID),
+        IDEMPOTENT_REPLAY_HEADER,
+    ])
     .max_age(Duration::from_secs(cors_cfg.max_age_secs))
 }
 
@@ -207,6 +323,46 @@ pub async fn serve(app: Router, addr: std::net::SocketAddr) -> Result<(), std::i
         app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
     )
     .with_graceful_shutdown(shutdown_signal())
+    .await?;
+
+    Ok(())
+}
+
+/// Run the server with a caller-supplied graceful-shutdown future.
+///
+/// Used by composition roots that must coordinate axum's shutdown with
+/// background tasks (e.g. the M3.4 idempotency sweep task). The `shutdown`
+/// future fires on either OS signals or when the caller's
+/// `CancellationToken` is flipped — the example pattern is:
+///
+/// ```ignore
+/// let token = tokio_util::sync::CancellationToken::new();
+/// let token_for_signal = token.clone();
+/// tokio::spawn(async move {
+///     // wait for OS signal, flip token
+///     wait_for_os_signal().await;
+///     token_for_signal.cancel();
+/// });
+/// // sweep task observes `token.cancelled()`
+/// // tokio::spawn(...);
+/// app::serve_with_shutdown(app, addr, async move { token.cancelled().await }).await
+/// ```
+pub async fn serve_with_shutdown<F>(
+    app: Router,
+    addr: std::net::SocketAddr,
+    shutdown: F,
+) -> Result<(), std::io::Error>
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!("Server listening on {}", addr);
+
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown)
     .await?;
 
     Ok(())

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -99,10 +99,9 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // provider traffic that never carries `Idempotency-Key` and conflate
     // two distinct dedup surfaces. See ADR-0048.
     let api_routes = if let Some(store) = state.idempotency_store.as_ref() {
-        debug_assert!(
-            config.idempotency.ttl_secs > 0,
-            "idempotency TTL must be positive — startup misconfiguration"
-        );
+        // `ttl_secs > 0` is structurally enforced at config load time
+        // by `parse_positive_u64_env` (`ApiConfigError::ZeroValue`) so
+        // a release build cannot reach here with a zero-TTL cache.
         tracing::info!(
             layer = "idempotency",
             store_kind = store.store_kind(),

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -186,6 +186,20 @@ pub enum ApiConfigError {
         /// The raw value the operator supplied (already-failed parse).
         raw: String,
     },
+
+    /// An `API_*` numeric env var must be strictly positive but the
+    /// operator supplied `0`.
+    ///
+    /// Used for knobs whose zero value would silently disable a hard
+    /// invariant — for example `API_IDEMPOTENCY_TTL_SECS=0` would build
+    /// a cache where every entry expires immediately, silently turning
+    /// off replay protection. Surface the misconfiguration at startup
+    /// instead of letting the runtime degrade.
+    #[error("API_{var} must be > 0")]
+    ZeroValue {
+        /// Name of the env var suffix after `API_`.
+        var: &'static str,
+    },
 }
 
 // ── Config sub-structs ─────────────────────────────────────────────────────
@@ -649,14 +663,16 @@ impl ApiConfig {
             Err(_) => IdempotencyBackend::Memory,
         };
 
-        let ttl_secs = parse_u64_env("IDEMPOTENCY_TTL_SECS", DEFAULT_TTL_SECS)?;
-        let max_entries = parse_u64_env("IDEMPOTENCY_MAX_ENTRIES", DEFAULT_MAX_ENTRIES)?;
+        let ttl_secs = parse_positive_u64_env("IDEMPOTENCY_TTL_SECS", DEFAULT_TTL_SECS)?;
+        let max_entries = parse_positive_u64_env("IDEMPOTENCY_MAX_ENTRIES", DEFAULT_MAX_ENTRIES)?;
         let max_request_body_bytes =
             parse_usize_env("IDEMPOTENCY_MAX_REQUEST_BODY_BYTES", DEFAULT_MAX_BODY_BYTES)?;
         let max_response_body_bytes = parse_usize_env(
             "IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
             DEFAULT_MAX_BODY_BYTES,
         )?;
+        // sweep_interval_secs uses the non-positive variant — `0`
+        // disables the sweep (dev / single-process runs).
         let sweep_interval_secs = parse_u64_env(
             "IDEMPOTENCY_SWEEP_INTERVAL_SECS",
             IdempotencyApiConfig::DEFAULT_SWEEP_INTERVAL_SECS,
@@ -714,6 +730,17 @@ fn parse_u64_env(suffix: &'static str, default: u64) -> Result<u64, ApiConfigErr
         }),
         Err(_) => Ok(default),
     }
+}
+
+/// Parse a strictly-positive `u64` from `API_<suffix>`. Rejects `0`
+/// with [`ApiConfigError::ZeroValue`] — caller specifies a knob whose
+/// zero value would silently disable a hard invariant.
+fn parse_positive_u64_env(suffix: &'static str, default: u64) -> Result<u64, ApiConfigError> {
+    let value = parse_u64_env(suffix, default)?;
+    if value == 0 {
+        return Err(ApiConfigError::ZeroValue { var: suffix });
+    }
+    Ok(value)
 }
 
 fn parse_usize_env(suffix: &'static str, default: usize) -> Result<usize, ApiConfigError> {
@@ -999,5 +1026,45 @@ mod tests {
         let cfg = ApiConfig::for_test();
         assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Memory);
         assert!(cfg.idempotency.ttl_secs > 0);
+    }
+
+    #[test]
+    fn from_env_idempotency_rejects_zero_ttl_secs() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "0");
+        }
+
+        let err = ApiConfig::from_env().expect_err("ttl_secs=0 must error");
+        match err {
+            ApiConfigError::ZeroValue { var } => assert_eq!(var, "IDEMPOTENCY_TTL_SECS"),
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_idempotency_rejects_zero_max_entries() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_MAX_ENTRIES", "0");
+        }
+
+        let err = ApiConfig::from_env().expect_err("max_entries=0 must error");
+        match err {
+            ApiConfigError::ZeroValue { var } => assert_eq!(var, "IDEMPOTENCY_MAX_ENTRIES"),
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        clear_env();
     }
 }

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -25,6 +25,10 @@ use std::{
 
 use serde::{Deserialize, Serialize};
 
+use crate::middleware::idempotency::{
+    DEFAULT_MAX_BODY_BYTES, DEFAULT_MAX_ENTRIES, DEFAULT_TTL_SECS,
+};
+
 /// Validated HS256 signing key.
 ///
 /// Construction via [`JwtSecret::new`] is the ONLY place length and
@@ -168,6 +172,20 @@ pub enum ApiConfigError {
         /// Underlying parse error.
         source: std::str::ParseBoolError,
     },
+
+    /// An `API_*` enum-typed env var failed to match a known variant.
+    ///
+    /// Used by [`ApiConfig::from_env`] for `API_IDEMPOTENCY_BACKEND` and
+    /// other enum-shaped knobs added in future revisions. Carries the raw
+    /// value so operator-facing logs can show the typo without re-reading
+    /// the env.
+    #[error("API_{var} invalid: {raw:?}")]
+    ParseEnum {
+        /// Name of the env var suffix after `API_`.
+        var: &'static str,
+        /// The raw value the operator supplied (already-failed parse).
+        raw: String,
+    },
 }
 
 // ── Config sub-structs ─────────────────────────────────────────────────────
@@ -248,6 +266,83 @@ impl Default for VersioningConfig {
         Self {
             supported_versions: vec!["v1".to_string()],
             deprecated_versions: Vec::new(),
+        }
+    }
+}
+
+/// Idempotency-Key middleware configuration.
+///
+/// See ADR-0048 for the backend selection contract.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdempotencyApiConfig {
+    /// Storage backend for cached idempotent responses.
+    ///
+    /// `Memory` is correct for dev / single-process tests but loses dedup
+    /// state across restart and across runners — operators must select
+    /// `Postgres` for any deployment that runs more than one API replica
+    /// or expects stable behaviour across restarts.
+    pub backend: IdempotencyBackend,
+
+    /// Cached-entry lifetime in seconds. Defaults to
+    /// [`DEFAULT_TTL_SECS`] (24 h, the IETF draft recommendation).
+    pub ttl_secs: u64,
+
+    /// Maximum number of cached entries (in-memory backend only —
+    /// `moka::Cache` honours this as a hard cap; the PG backend treats
+    /// `expires_at` as the eviction signal).
+    pub max_entries: u64,
+
+    /// Maximum buffered request body size (bytes) eligible for caching.
+    /// Requests larger than this pass through without idempotency tracking.
+    pub max_request_body_bytes: usize,
+
+    /// Maximum buffered response body size (bytes) eligible for caching.
+    /// Larger responses are returned to the caller but never cached.
+    pub max_response_body_bytes: usize,
+
+    /// PG-only: cadence for the background expired-row sweep.
+    ///
+    /// `0` disables the sweep (dev / single-process runs); the memory
+    /// backend ignores this field because `moka` evicts on TTL. A value
+    /// `< 60` triggers a startup `tracing::warn!` (see ADR-0048
+    /// "sweep cadence sanity floor") but is not rejected.
+    pub sweep_interval_secs: u64,
+}
+
+/// Backend selection for the idempotency store.
+///
+/// See ADR-0048 for the decision rationale and the fail-closed contract
+/// in the composition root (selecting `Postgres` without a configured
+/// `DATABASE_URL` is a hard startup error).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum IdempotencyBackend {
+    /// Process-local cache (`moka::future::Cache`). Correct for dev and
+    /// for single-process tests; loses state on restart and cannot be
+    /// shared across runners.
+    Memory,
+    /// PostgreSQL-backed durable store (see ADR-0048). Survives restart
+    /// and is shared across runners that point at the same database.
+    Postgres,
+}
+
+impl IdempotencyApiConfig {
+    /// Default TTL applied when [`from_env`](ApiConfig::from_env) does not
+    /// see `API_IDEMPOTENCY_TTL_SECS`. Defined here (rather than reusing
+    /// the middleware constant directly) so future tuning can diverge
+    /// without churning every test.
+    pub const DEFAULT_SWEEP_INTERVAL_SECS: u64 = 300;
+}
+
+impl Default for IdempotencyApiConfig {
+    fn default() -> Self {
+        Self {
+            backend: IdempotencyBackend::Memory,
+            ttl_secs: DEFAULT_TTL_SECS,
+            max_entries: DEFAULT_MAX_ENTRIES,
+            max_request_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            max_response_body_bytes: DEFAULT_MAX_BODY_BYTES,
+            sweep_interval_secs: Self::DEFAULT_SWEEP_INTERVAL_SECS,
         }
     }
 }
@@ -358,6 +453,10 @@ pub struct ApiConfig {
 
     /// Pagination defaults and caps.
     pub pagination: PaginationConfig,
+
+    /// Idempotency-Key middleware configuration (see ADR-0048).
+    #[serde(default)]
+    pub idempotency: IdempotencyApiConfig,
 }
 
 impl std::fmt::Debug for ApiConfig {
@@ -380,6 +479,7 @@ impl std::fmt::Debug for ApiConfig {
             .field("cors_config", &self.cors_config)
             .field("versioning", &self.versioning)
             .field("pagination", &self.pagination)
+            .field("idempotency", &self.idempotency)
             .finish()
     }
 }
@@ -500,6 +600,15 @@ impl ApiConfig {
         let request_id_header =
             std::env::var("API_REQUEST_ID_HEADER").unwrap_or_else(|_| "x-request-id".to_string());
 
+        let idempotency = Self::idempotency_from_env()?;
+        tracing::info!(
+            backend = ?idempotency.backend,
+            ttl_secs = idempotency.ttl_secs,
+            max_entries = idempotency.max_entries,
+            sweep_interval_secs = idempotency.sweep_interval_secs,
+            "idempotency: config loaded"
+        );
+
         Ok(Self {
             bind_address,
             request_timeout,
@@ -521,6 +630,45 @@ impl ApiConfig {
             },
             versioning: VersioningConfig::default(),
             pagination: PaginationConfig::default(),
+            idempotency,
+        })
+    }
+
+    fn idempotency_from_env() -> Result<IdempotencyApiConfig, ApiConfigError> {
+        let backend = match std::env::var("API_IDEMPOTENCY_BACKEND") {
+            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "memory" => IdempotencyBackend::Memory,
+                "postgres" => IdempotencyBackend::Postgres,
+                _ => {
+                    return Err(ApiConfigError::ParseEnum {
+                        var: "IDEMPOTENCY_BACKEND",
+                        raw,
+                    });
+                },
+            },
+            Err(_) => IdempotencyBackend::Memory,
+        };
+
+        let ttl_secs = parse_u64_env("IDEMPOTENCY_TTL_SECS", DEFAULT_TTL_SECS)?;
+        let max_entries = parse_u64_env("IDEMPOTENCY_MAX_ENTRIES", DEFAULT_MAX_ENTRIES)?;
+        let max_request_body_bytes =
+            parse_usize_env("IDEMPOTENCY_MAX_REQUEST_BODY_BYTES", DEFAULT_MAX_BODY_BYTES)?;
+        let max_response_body_bytes = parse_usize_env(
+            "IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
+            DEFAULT_MAX_BODY_BYTES,
+        )?;
+        let sweep_interval_secs = parse_u64_env(
+            "IDEMPOTENCY_SWEEP_INTERVAL_SECS",
+            IdempotencyApiConfig::DEFAULT_SWEEP_INTERVAL_SECS,
+        )?;
+
+        Ok(IdempotencyApiConfig {
+            backend,
+            ttl_secs,
+            max_entries,
+            max_request_body_bytes,
+            max_response_body_bytes,
+            sweep_interval_secs,
         })
     }
 
@@ -553,7 +701,28 @@ impl ApiConfig {
             cors_config: CorsConfig::default(),
             versioning: VersioningConfig::default(),
             pagination: PaginationConfig::default(),
+            idempotency: IdempotencyApiConfig::default(),
         }
+    }
+}
+
+fn parse_u64_env(suffix: &'static str, default: u64) -> Result<u64, ApiConfigError> {
+    match std::env::var(format!("API_{suffix}")) {
+        Ok(raw) => raw.parse().map_err(|source| ApiConfigError::ParseInt {
+            var: suffix,
+            source,
+        }),
+        Err(_) => Ok(default),
+    }
+}
+
+fn parse_usize_env(suffix: &'static str, default: usize) -> Result<usize, ApiConfigError> {
+    match std::env::var(format!("API_{suffix}")) {
+        Ok(raw) => raw.parse().map_err(|source| ApiConfigError::ParseInt {
+            var: suffix,
+            source,
+        }),
+        Err(_) => Ok(default),
     }
 }
 
@@ -592,6 +761,12 @@ mod tests {
                 "API_ENABLE_TRACING",
                 "API_RATE_LIMIT",
                 "API_KEYS",
+                "API_IDEMPOTENCY_BACKEND",
+                "API_IDEMPOTENCY_TTL_SECS",
+                "API_IDEMPOTENCY_MAX_ENTRIES",
+                "API_IDEMPOTENCY_MAX_REQUEST_BODY_BYTES",
+                "API_IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
+                "API_IDEMPOTENCY_SWEEP_INTERVAL_SECS",
             ] {
                 std::env::remove_var(key);
             }
@@ -712,5 +887,117 @@ mod tests {
         let err = JwtSecret::new(JwtSecret::DEV_PLACEHOLDER.to_string())
             .expect_err("placeholder must be rejected");
         assert!(matches!(err, ApiConfigError::JwtSecretIsDevPlaceholder));
+    }
+
+    #[test]
+    fn from_env_idempotency_defaults_to_memory() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        }
+
+        let cfg = ApiConfig::from_env().expect("config must load");
+        assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Memory);
+        assert_eq!(cfg.idempotency.ttl_secs, DEFAULT_TTL_SECS);
+        assert_eq!(cfg.idempotency.max_entries, DEFAULT_MAX_ENTRIES);
+        assert_eq!(
+            cfg.idempotency.sweep_interval_secs,
+            IdempotencyApiConfig::DEFAULT_SWEEP_INTERVAL_SECS
+        );
+
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_idempotency_accepts_postgres_backend() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_BACKEND", "postgres");
+            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "3600");
+            std::env::set_var("API_IDEMPOTENCY_SWEEP_INTERVAL_SECS", "120");
+        }
+
+        let cfg = ApiConfig::from_env().expect("config must load");
+        assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Postgres);
+        assert_eq!(cfg.idempotency.ttl_secs, 3600);
+        assert_eq!(cfg.idempotency.sweep_interval_secs, 120);
+
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_idempotency_backend_is_case_insensitive() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_BACKEND", "POSTGRES");
+        }
+
+        let cfg = ApiConfig::from_env().expect("config must load");
+        assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Postgres);
+
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_idempotency_rejects_unknown_backend() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_BACKEND", "redis");
+        }
+
+        let err = ApiConfig::from_env().expect_err("unknown backend must error");
+        match err {
+            ApiConfigError::ParseEnum { var, raw } => {
+                assert_eq!(var, "IDEMPOTENCY_BACKEND");
+                assert_eq!(raw, "redis");
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_idempotency_rejects_invalid_ttl() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "not-a-number");
+        }
+
+        let err = ApiConfig::from_env().expect_err("non-numeric TTL must error");
+        match err {
+            ApiConfigError::ParseInt { var, .. } => {
+                assert_eq!(var, "IDEMPOTENCY_TTL_SECS");
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+
+        clear_env();
+    }
+
+    #[test]
+    fn for_test_idempotency_defaults_to_memory() {
+        let cfg = ApiConfig::for_test();
+        assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Memory);
+        assert!(cfg.idempotency.ttl_secs > 0);
     }
 }

--- a/crates/api/src/middleware/idempotency.rs
+++ b/crates/api/src/middleware/idempotency.rs
@@ -41,13 +41,29 @@
 //!
 //! ## Position in the middleware stack
 //!
-//! When mounted on the production router, place this layer **inside**
-//! `request_id` and `security_headers` so cached replays still acquire fresh
-//! `X-Request-ID` and security headers when they leave the server.
+//! [`crate::app::build_app`] mounts this layer on the API router **before**
+//! merging the webhook transport — webhook ingress has its own dedup
+//! contract (provider signature + replay-window timestamp) and never
+//! carries `Idempotency-Key`. The mount sits **inside** `request_id` and
+//! `security_headers` so cached replays still acquire fresh
+//! `X-Request-ID` and security headers when they leave the server:
 //!
-//! **Note:** the layer is not yet merged into `crate::app::build_app` /
-//! `crate::routes::create_routes` — integration tests mount `IdempotencyLayer` directly on
-//! minimal routers until the composition root wires a shared store.
+//! ```text
+//! outermost                                                            innermost
+//!  rate_limit -> request_id -> security_headers -> middleware_stack -> idempotency -> routes
+//!                                                                       (api only)
+//! ```
+//!
+//! ## Backend selection
+//!
+//! [`InMemoryIdempotencyStore`] is the dev / single-process default;
+//! [`StorageBackedIdempotencyStore`] adapts a layer-1
+//! `nebula_storage::repos::IdempotencyStoreRepo` (PG-backed in
+//! production deployments) onto this trait. Selection is driven by
+//! `ApiConfig.idempotency.backend` per **ADR-0048**: the in-memory
+//! backend loses dedup state across restart and across runners, so
+//! production deployments running more than one API replica must select
+//! `Postgres` to satisfy the §M3 1.0 closure criterion.
 
 use std::{
     fmt,
@@ -65,6 +81,15 @@ use axum::{
 };
 use futures::future::BoxFuture;
 use moka::future::Cache;
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_API_IDEMPOTENCY_HITS_TOTAL, NEBULA_API_IDEMPOTENCY_LATENCY_MS,
+        NEBULA_API_IDEMPOTENCY_MISSES_TOTAL, NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM, idempotency_reject_reason,
+    },
+};
+use nebula_storage::repos::{CachedRecord, IdempotencyStoreRepo};
 use sha2::{Digest, Sha256};
 use tower::{Layer, Service, ServiceExt};
 
@@ -87,6 +112,27 @@ pub const DEFAULT_MAX_BODY_BYTES: usize = 1024 * 1024;
 pub const MAX_KEY_LEN: usize = 255;
 
 // ── Errors ───────────────────────────────────────────────────────────────────
+
+/// Errors returned by [`IdempotencyStore`] operations.
+///
+/// Storage backends bubble these through the middleware. The handler
+/// translates them to a 500 response — silently treating a `Decode`
+/// error as a cache miss would drop replay protection on data
+/// corruption (rejected by ADR-0048).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum IdempotencyStoreError {
+    /// The underlying repository returned an error (PG connection,
+    /// constraint violation, etc.).
+    #[error("idempotency-store backend failed: {0}")]
+    Backend(String),
+
+    /// The persisted record could not be decoded back into a typed
+    /// `CachedResponse` (malformed status code, header bytes, etc.).
+    /// Bubbles up as 500.
+    #[error("idempotency-store decode failed: {0}")]
+    Decode(String),
+}
 
 /// Errors returned when parsing/validating an `Idempotency-Key` header.
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
@@ -206,11 +252,49 @@ pub const IDEMPOTENT_REPLAY_HEADER: HeaderName = HeaderName::from_static("idempo
 #[async_trait]
 pub trait IdempotencyStore: Send + Sync + fmt::Debug {
     /// Look up a cached response by its scoped cache key.
-    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>>;
+    ///
+    /// Returns `Ok(None)` for a cache miss, `Ok(Some(_))` for a hit, or
+    /// [`IdempotencyStoreError`] when the read itself failed (backend
+    /// connection error or decode failure). The middleware translates
+    /// errors to 500 — see ADR-0048: silent cache-miss fallback would
+    /// drop replay protection on data corruption.
+    async fn get(&self, key: &str) -> Result<Option<Arc<CachedResponse>>, IdempotencyStoreError>;
 
     /// Persist a cached response under `key`. Implementations MUST honour the
     /// store's configured TTL; the middleware does not enforce expiry.
-    async fn put(&self, key: String, response: Arc<CachedResponse>);
+    ///
+    /// `put` errors do not surface to the caller — the response has
+    /// already been computed by the inner handler and is returned
+    /// unchanged; the middleware logs a warning and skips caching for
+    /// this key.
+    async fn put(
+        &self,
+        key: String,
+        response: Arc<CachedResponse>,
+    ) -> Result<(), IdempotencyStoreError>;
+
+    /// Stable, log-safe identifier for the concrete impl backing this store.
+    ///
+    /// Used by `build_app` to log which backend was wired at startup
+    /// (`"in-memory"`, `"postgres"`) without leaking implementation types
+    /// like `std::any::type_name_of_val(...)` would. Keep the value short
+    /// and ASCII so it composes cleanly into `tracing::info!` events and
+    /// metric labels (low-cardinality).
+    fn store_kind(&self) -> &'static str;
+
+    /// Live store saturation as `entries / max_capacity`, scaled by
+    /// 1_000_000 (parts per million).
+    ///
+    /// Returns `None` for backends without a fixed capacity (PG-backed
+    /// store keyed by `expires_at` rather than a row cap). The middleware
+    /// publishes the value into the
+    /// [`NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM`] gauge after every
+    /// successful `put`, so dashboards see a steady proxy for
+    /// "how full is the dedup store right now". Default impl returns
+    /// `None` so unbounded backends opt out without ceremony.
+    fn saturation_ppm(&self) -> Option<u64> {
+        None
+    }
 }
 
 /// Process-local idempotency store backed by [`moka::future::Cache`].
@@ -219,6 +303,7 @@ pub trait IdempotencyStore: Send + Sync + fmt::Debug {
 /// maximum entry count to provide a hard memory ceiling.
 pub struct InMemoryIdempotencyStore {
     cache: Cache<String, Arc<CachedResponse>>,
+    max_entries: u64,
 }
 
 impl InMemoryIdempotencyStore {
@@ -236,7 +321,7 @@ impl InMemoryIdempotencyStore {
             .time_to_live(ttl)
             .max_capacity(max_entries)
             .build();
-        Self { cache }
+        Self { cache, max_entries }
     }
 }
 
@@ -256,12 +341,144 @@ impl fmt::Debug for InMemoryIdempotencyStore {
 
 #[async_trait]
 impl IdempotencyStore for InMemoryIdempotencyStore {
-    async fn get(&self, key: &str) -> Option<Arc<CachedResponse>> {
-        self.cache.get(key).await
+    async fn get(&self, key: &str) -> Result<Option<Arc<CachedResponse>>, IdempotencyStoreError> {
+        Ok(self.cache.get(key).await)
     }
 
-    async fn put(&self, key: String, response: Arc<CachedResponse>) {
+    async fn put(
+        &self,
+        key: String,
+        response: Arc<CachedResponse>,
+    ) -> Result<(), IdempotencyStoreError> {
         self.cache.insert(key, response).await;
+        Ok(())
+    }
+
+    fn store_kind(&self) -> &'static str {
+        "in-memory"
+    }
+
+    fn saturation_ppm(&self) -> Option<u64> {
+        if self.max_entries == 0 {
+            return None;
+        }
+        // `entry_count` is `u64`; multiply first, then divide, capping at
+        // 1_000_000 to keep the gauge inside the `0..=1_000_000` ppm range
+        // even if `moka` over-counts under contention (it is documented as
+        // a best-effort approximation).
+        let ppm = self
+            .cache
+            .entry_count()
+            .saturating_mul(1_000_000)
+            .saturating_div(self.max_entries);
+        Some(ppm.min(1_000_000))
+    }
+}
+
+// ── Storage-backed bridge (Layer-1 repo → IdempotencyStore) ──────────────────
+
+/// Bridge that adapts a layer-1 [`IdempotencyStoreRepo`] (in
+/// `nebula-storage`) onto the API-side [`IdempotencyStore`] contract.
+///
+/// The repo speaks `CachedRecord` (status `u16`, headers as
+/// `Vec<(String, Vec<u8>)>`) so the storage layer stays free of `http`
+/// types. This bridge does the bidirectional translation:
+/// `CachedRecord ↔ CachedResponse` (`StatusCode` / `HeaderMap`). Decode
+/// failures map to [`IdempotencyStoreError::Decode`] and bubble up to
+/// the middleware as 500 — silently treating them as cache misses
+/// would drop replay protection on data corruption (ADR-0048).
+pub struct StorageBackedIdempotencyStore<R: IdempotencyStoreRepo> {
+    repo: Arc<R>,
+    ttl: Duration,
+}
+
+impl<R: IdempotencyStoreRepo> StorageBackedIdempotencyStore<R> {
+    /// Construct a bridge with the given TTL applied to every `put`.
+    pub fn new(repo: Arc<R>, ttl: Duration) -> Self {
+        Self { repo, ttl }
+    }
+
+    /// Borrow the underlying repo for sweep / introspection.
+    pub fn repo(&self) -> &Arc<R> {
+        &self.repo
+    }
+}
+
+impl<R: IdempotencyStoreRepo> fmt::Debug for StorageBackedIdempotencyStore<R> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StorageBackedIdempotencyStore")
+            .field("ttl_secs", &self.ttl.as_secs())
+            .finish()
+    }
+}
+
+fn record_to_response(record: CachedRecord) -> Result<CachedResponse, IdempotencyStoreError> {
+    let status = StatusCode::from_u16(record.status).map_err(|err| {
+        IdempotencyStoreError::Decode(format!("status code {}: {err}", record.status))
+    })?;
+    let mut headers = HeaderMap::with_capacity(record.headers.len());
+    for (name, value) in record.headers {
+        let header_name = HeaderName::from_bytes(name.as_bytes())
+            .map_err(|err| IdempotencyStoreError::Decode(format!("header name {name:?}: {err}")))?;
+        let header_value = HeaderValue::from_bytes(&value).map_err(|err| {
+            IdempotencyStoreError::Decode(format!("header value for {name:?}: {err}"))
+        })?;
+        headers.append(header_name, header_value);
+    }
+    Ok(CachedResponse {
+        status,
+        headers,
+        body: record.body,
+        request_fingerprint: record.fingerprint,
+    })
+}
+
+fn response_to_record(response: &CachedResponse) -> CachedRecord {
+    let mut headers: Vec<(String, Vec<u8>)> = Vec::with_capacity(response.headers.len());
+    for (name, value) in &response.headers {
+        headers.push((name.as_str().to_owned(), value.as_bytes().to_vec()));
+    }
+    CachedRecord {
+        status: response.status.as_u16(),
+        headers,
+        body: response.body.clone(),
+        fingerprint: response.request_fingerprint,
+    }
+}
+
+#[async_trait]
+impl<R: IdempotencyStoreRepo + 'static> IdempotencyStore for StorageBackedIdempotencyStore<R> {
+    async fn get(&self, key: &str) -> Result<Option<Arc<CachedResponse>>, IdempotencyStoreError> {
+        let record = self
+            .repo
+            .get(key)
+            .await
+            .map_err(|err| IdempotencyStoreError::Backend(err.to_string()))?;
+        match record {
+            None => Ok(None),
+            Some(record) => Ok(Some(Arc::new(record_to_response(record)?))),
+        }
+    }
+
+    async fn put(
+        &self,
+        key: String,
+        response: Arc<CachedResponse>,
+    ) -> Result<(), IdempotencyStoreError> {
+        let record = response_to_record(&response);
+        self.repo
+            .put(key, record, self.ttl)
+            .await
+            .map_err(|err| IdempotencyStoreError::Backend(err.to_string()))
+    }
+
+    fn store_kind(&self) -> &'static str {
+        // The concrete kind depends on R; static dispatch through
+        // `R::store_kind` would require adding a method to the repo
+        // trait. Operators read backend selection from
+        // `API_IDEMPOTENCY_BACKEND` instead. Returning a generic label
+        // here keeps the cardinality low without leaking R's typename.
+        "storage-backed"
     }
 }
 
@@ -296,6 +513,7 @@ impl Default for IdempotencyConfig {
 pub struct IdempotencyLayer {
     store: Arc<dyn IdempotencyStore>,
     config: IdempotencyConfig,
+    metrics: Option<Arc<MetricsRegistry>>,
 }
 
 impl IdempotencyLayer {
@@ -305,6 +523,7 @@ impl IdempotencyLayer {
         Self {
             store,
             config: IdempotencyConfig::default(),
+            metrics: None,
         }
     }
 
@@ -312,6 +531,21 @@ impl IdempotencyLayer {
     #[must_use]
     pub fn with_config(mut self, config: IdempotencyConfig) -> Self {
         self.config = config;
+        self
+    }
+
+    /// Attach a [`MetricsRegistry`] so the layer records
+    /// `nebula_api_idempotency_*` counters / gauge / histogram on every
+    /// outcome branch. When `None`, the layer skips metric recording but
+    /// still emits the existing `tracing` span fields.
+    ///
+    /// Constructor injection is intentional — the layer runs before
+    /// `axum::extract::State`, so it cannot pull the registry from
+    /// `AppState` at request time. `build_app` reads
+    /// `state.metrics_registry` and threads it in here.
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Option<Arc<MetricsRegistry>>) -> Self {
+        self.metrics = metrics;
         self
     }
 }
@@ -324,6 +558,7 @@ impl<S> Layer<S> for IdempotencyLayer {
             inner,
             store: Arc::clone(&self.store),
             config: self.config.clone(),
+            metrics: self.metrics.clone(),
         }
     }
 }
@@ -334,6 +569,7 @@ pub struct IdempotencyService<S> {
     inner: S,
     store: Arc<dyn IdempotencyStore>,
     config: IdempotencyConfig,
+    metrics: Option<Arc<MetricsRegistry>>,
 }
 
 impl<S> Service<Request> for IdempotencyService<S>
@@ -354,55 +590,160 @@ where
         let inner = self.inner.clone();
         let store = Arc::clone(&self.store);
         let config = self.config.clone();
-        Box::pin(async move { handle(inner, store, config, request).await })
+        let metrics = self.metrics.clone();
+        Box::pin(async move { handle(inner, store, config, metrics, request).await })
     }
 }
 
 // ── Core handling ────────────────────────────────────────────────────────────
 
+/// Metric counter family the request hits at this branch.
+///
+/// The string outcome on the tracing span is left as the operator-facing
+/// label; this enum is the structured shape used to drive
+/// `nebula_api_idempotency_*` counters. Decoupling them lets us extend
+/// span outcomes (`miss:resp_too_large`, `miss:passthrough`) without
+/// re-shuffling counter cardinality and vice-versa.
+#[derive(Debug, Clone, Copy)]
+enum MetricOutcome {
+    /// Pass-through (non-POST or no header) — no counter.
+    None,
+    /// Cache hit — bumps `nebula_api_idempotency_hits_total`.
+    Hit,
+    /// Cache miss — bumps `nebula_api_idempotency_misses_total`. Covers
+    /// `miss:cached` (response stored), `miss:passthrough` (5xx not
+    /// cached), and `miss:resp_too_large` (handler ran but response
+    /// wasn't cacheable).
+    Miss,
+    /// Reject path with reason label (closed set per
+    /// [`idempotency_reject_reason`]).
+    Reject(&'static str),
+}
+
+fn record_outcome(
+    metrics: &Option<Arc<MetricsRegistry>>,
+    span_outcome: &'static str,
+    metric: MetricOutcome,
+) {
+    tracing::Span::current().record("outcome", span_outcome);
+    let Some(registry) = metrics.as_ref() else {
+        return;
+    };
+    match metric {
+        MetricOutcome::None => {},
+        MetricOutcome::Hit => {
+            if let Ok(c) = registry.counter(NEBULA_API_IDEMPOTENCY_HITS_TOTAL) {
+                c.inc();
+            }
+        },
+        MetricOutcome::Miss => {
+            if let Ok(c) = registry.counter(NEBULA_API_IDEMPOTENCY_MISSES_TOTAL) {
+                c.inc();
+            }
+        },
+        MetricOutcome::Reject(reason) => {
+            let labels = registry.interner().single("reason", reason);
+            if let Ok(c) = registry.counter_labeled(NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL, &labels) {
+                c.inc();
+            }
+        },
+    }
+    tracing::debug!(label = span_outcome, "idempotency metric recorded");
+}
+
+fn update_saturation(metrics: &Option<Arc<MetricsRegistry>>, store: &Arc<dyn IdempotencyStore>) {
+    let Some(registry) = metrics.as_ref() else {
+        return;
+    };
+    let Some(ppm) = store.saturation_ppm() else {
+        return;
+    };
+    if let Ok(g) = registry.gauge(NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM) {
+        g.set(i64::try_from(ppm).unwrap_or(i64::MAX));
+    }
+}
+
+/// Drop guard observing the middleware-path latency histogram regardless
+/// of which branch returned. Construction starts the timer; `Drop` reads
+/// the elapsed time and records it. Putting it on the stack at the top of
+/// `handle` avoids inserting a record call at every return statement.
+struct LatencyGuard {
+    metrics: Option<Arc<MetricsRegistry>>,
+    start: std::time::Instant,
+}
+
+impl Drop for LatencyGuard {
+    fn drop(&mut self) {
+        let Some(registry) = self.metrics.as_ref() else {
+            return;
+        };
+        let Ok(h) = registry.histogram(NEBULA_API_IDEMPOTENCY_LATENCY_MS) else {
+            return;
+        };
+        let elapsed_ms = self.start.elapsed().as_secs_f64() * 1000.0;
+        h.observe(elapsed_ms);
+    }
+}
+
 #[tracing::instrument(
     name = "idempotency",
-    skip(inner, store, config, request),
+    skip(inner, store, config, metrics, request),
     fields(
         method = %request.method(),
         path = %request.uri().path(),
         idempotency_key = tracing::field::Empty,
         outcome = tracing::field::Empty,
+        cache_key_prefix = tracing::field::Empty,
+        identity_prefix = tracing::field::Empty,
+        body_size_bytes = tracing::field::Empty,
     )
 )]
 async fn handle<S>(
     inner: S,
     store: Arc<dyn IdempotencyStore>,
     config: IdempotencyConfig,
+    metrics: Option<Arc<MetricsRegistry>>,
     request: Request,
 ) -> Result<Response, S::Error>
 where
     S: Service<Request, Response = Response> + Clone + Send + 'static,
     S::Future: Send + 'static,
 {
+    let _latency_guard = LatencyGuard {
+        metrics: metrics.clone(),
+        start: std::time::Instant::now(),
+    };
     // Only POST is in scope for the M3.4 acceptance criteria. Other methods
     // pass through transparently — clients that send the header on a GET get
     // their request handled normally.
     if request.method() != Method::POST {
-        tracing::Span::current().record("outcome", "skip:non_post");
+        record_outcome(&metrics, "skip:non_post", MetricOutcome::None);
         return inner.oneshot(request).await;
     }
 
     // Header missing → opt-out. No allocation, no body buffering.
     let Some(raw_key) = request.headers().get(IDEMPOTENCY_KEY_HEADER) else {
-        tracing::Span::current().record("outcome", "skip:no_header");
+        record_outcome(&metrics, "skip:no_header", MetricOutcome::None);
         return inner.oneshot(request).await;
     };
 
     let Ok(key_str) = raw_key.to_str() else {
-        tracing::Span::current().record("outcome", "reject:non_ascii_header");
+        record_outcome(
+            &metrics,
+            "reject:non_ascii_header",
+            MetricOutcome::Reject(idempotency_reject_reason::NON_ASCII_HEADER),
+        );
         return Ok(bad_request("Idempotency-Key must be valid ASCII"));
     };
 
     let key = match IdempotencyKey::parse(key_str) {
         Ok(k) => k,
         Err(err) => {
-            tracing::Span::current().record("outcome", "reject:invalid_key");
+            record_outcome(
+                &metrics,
+                "reject:invalid_key",
+                MetricOutcome::Reject(idempotency_reject_reason::INVALID_KEY),
+            );
             return Ok(bad_request(&err.to_string()));
         },
     };
@@ -415,7 +756,11 @@ where
     let (parts, body) = request.into_parts();
     let body_result = axum::body::to_bytes(body, config.max_request_body_bytes).await;
     let Ok(body_bytes) = body_result else {
-        tracing::Span::current().record("outcome", "skip:body_too_large");
+        record_outcome(
+            &metrics,
+            "skip:body_too_large",
+            MetricOutcome::Reject(idempotency_reject_reason::BODY_TOO_LARGE),
+        );
         tracing::warn!(
             "request body exceeds idempotency max_request_body_bytes — \
                  forwarding without caching"
@@ -424,20 +769,51 @@ where
         return inner.oneshot(request).await;
     };
     let body_vec: Vec<u8> = body_bytes.into();
+    tracing::Span::current().record("body_size_bytes", body_vec.len());
 
     let request_fingerprint = fingerprint_request_body(&body_vec);
     let identity = identity_fingerprint(&parts.headers);
     let cache_key = build_cache_key(&parts.method, parts.uri.path(), &key, &identity);
+    // Privacy: never record the full cache key or identity fingerprint —
+    // the key embeds the client-supplied `Idempotency-Key` and identity
+    // material derived from auth headers. An 8-byte prefix (cache key)
+    // and 16 hex chars (identity, 8 leading bytes) are enough to
+    // disambiguate spans in a trace without leaking client identity into
+    // log sinks.
+    let cache_key_prefix: String = cache_key.chars().take(8).collect();
+    let mut identity_prefix = String::with_capacity(16);
+    for byte in &identity[..8] {
+        identity_prefix.push_str(&format!("{byte:02x}"));
+    }
+    tracing::Span::current().record("cache_key_prefix", cache_key_prefix.as_str());
+    tracing::Span::current().record("identity_prefix", identity_prefix.as_str());
 
-    if let Some(cached) = store.get(&cache_key).await {
+    let lookup = match store.get(&cache_key).await {
+        Ok(opt) => opt,
+        Err(err) => {
+            record_outcome(&metrics, "error:get", MetricOutcome::None);
+            tracing::error!(
+                error = %err,
+                "idempotency-store get failed — failing the request closed (ADR-0048)"
+            );
+            return Ok(internal_error(
+                "idempotency store unavailable; request rejected to preserve replay protection",
+            ));
+        },
+    };
+    if let Some(cached) = lookup {
         if cached.request_fingerprint != request_fingerprint {
-            tracing::Span::current().record("outcome", "reject:body_mismatch");
+            record_outcome(
+                &metrics,
+                "reject:body_mismatch",
+                MetricOutcome::Reject(idempotency_reject_reason::BODY_MISMATCH),
+            );
             tracing::warn!("Idempotency-Key reused with different request body — rejecting");
             return Ok(unprocessable(
                 "Idempotency-Key reused with a different request payload",
             ));
         }
-        tracing::Span::current().record("outcome", "hit");
+        record_outcome(&metrics, "hit", MetricOutcome::Hit);
         tracing::debug!(status = cached.status.as_u16(), "idempotency cache hit");
         return Ok(Arc::unwrap_or_clone(cached).into_response());
     }
@@ -450,7 +826,7 @@ where
     let (resp_parts, resp_body) = response.into_parts();
     let resp_result = axum::body::to_bytes(resp_body, config.max_response_body_bytes).await;
     let Ok(resp_bytes) = resp_result else {
-        tracing::Span::current().record("outcome", "miss:resp_too_large");
+        record_outcome(&metrics, "miss:resp_too_large", MetricOutcome::Miss);
         tracing::warn!(
             "response body exceeds idempotency max_response_body_bytes — \
                  returning to caller without caching"
@@ -466,15 +842,30 @@ where
             body: resp_vec.clone(),
             request_fingerprint,
         });
-        store.put(cache_key, cached).await;
-        tracing::Span::current().record("outcome", "miss:cached");
-        tracing::debug!(
-            status = resp_parts.status.as_u16(),
-            bytes = resp_vec.len(),
-            "idempotency cache miss — response cached"
-        );
+        match store.put(cache_key, cached).await {
+            Ok(()) => {
+                update_saturation(&metrics, &store);
+                record_outcome(&metrics, "miss:cached", MetricOutcome::Miss);
+                tracing::debug!(
+                    status = resp_parts.status.as_u16(),
+                    bytes = resp_vec.len(),
+                    "idempotency cache miss — response cached"
+                );
+            },
+            Err(err) => {
+                // `put` failure does not surface to the caller — the
+                // response is valid, only the dedup record was lost.
+                // The next replay of this key will run the inner
+                // handler again. Operators see the warn-level log.
+                record_outcome(&metrics, "miss:put_failed", MetricOutcome::Miss);
+                tracing::warn!(
+                    error = %err,
+                    "idempotency cache put failed — response returned without caching"
+                );
+            },
+        }
     } else {
-        tracing::Span::current().record("outcome", "miss:passthrough");
+        record_outcome(&metrics, "miss:passthrough", MetricOutcome::Miss);
         tracing::debug!(
             status = resp_parts.status.as_u16(),
             "idempotency cache miss — response not cached (5xx)"
@@ -573,6 +964,14 @@ fn filter_response_headers(headers: &HeaderMap) -> HeaderMap {
         out.append(name.clone(), value.clone());
     }
     out
+}
+
+fn internal_error(detail: &str) -> Response {
+    problem_response(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "Internal Server Error",
+        detail,
+    )
 }
 
 fn bad_request(detail: &str) -> Response {
@@ -722,10 +1121,23 @@ mod tests {
             body: b"hello".to_vec(),
             request_fingerprint: [0u8; 32],
         });
-        store.put("k1".to_owned(), Arc::clone(&resp)).await;
-        let fetched = store.get("k1").await.expect("entry must be present");
+        store
+            .put("k1".to_owned(), Arc::clone(&resp))
+            .await
+            .expect("in-memory put never errors");
+        let fetched = store
+            .get("k1")
+            .await
+            .expect("get must not error")
+            .expect("entry must be present");
         assert_eq!(fetched.body, b"hello");
-        assert!(store.get("missing").await.is_none());
+        assert!(
+            store
+                .get("missing")
+                .await
+                .expect("get must not error")
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -737,11 +1149,11 @@ mod tests {
             body: Vec::new(),
             request_fingerprint: [0u8; 32],
         });
-        store.put("expiring".to_owned(), resp).await;
-        assert!(store.get("expiring").await.is_some());
+        store.put("expiring".to_owned(), resp).await.expect("put");
+        assert!(store.get("expiring").await.expect("get").is_some());
         tokio::time::sleep(Duration::from_millis(120)).await;
         // moka may need a tick to evict; force a sync.
         store.cache.run_pending_tasks().await;
-        assert!(store.get("expiring").await.is_none());
+        assert!(store.get("expiring").await.expect("get").is_none());
     }
 }

--- a/crates/api/src/middleware/idempotency.rs
+++ b/crates/api/src/middleware/idempotency.rs
@@ -4,8 +4,21 @@
 //! [draft-ietf-httpapi-idempotency-key]. A client supplies an `Idempotency-Key`
 //! header with any state-changing request; the middleware caches the first
 //! response and replays it byte-for-byte for subsequent requests carrying the
-//! same key (within the configured TTL) — the inner handler runs **at most
-//! once** per (method, path, key, identity, body) tuple.
+//! same key (within the configured TTL).
+//!
+//! ## At-most-once semantics
+//!
+//! After the first response is cached, subsequent requests with the same
+//! `(method, path, key, identity, body)` tuple replay the cached
+//! response without invoking the handler. **Concurrent in-flight
+//! requests are not deduplicated**: two requests that race past the
+//! `get` lookup before the first `put` lands both run the handler;
+//! `put` is first-writer-wins, so the second request's response is
+//! discarded but the side effects of its handler invocation are not
+//! rolled back. True at-most-once under contention requires a "pending
+//! claim" record (followers wait or replay instead of running the
+//! handler again) — tracked as a follow-up under ADR-0048
+//! "Open Questions / Follow-ups".
 //!
 //! [draft-ietf-httpapi-idempotency-key]: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key/
 //!

--- a/crates/api/src/middleware/idempotency.rs
+++ b/crates/api/src/middleware/idempotency.rs
@@ -753,21 +753,46 @@ where
     // inner service. Anything beyond `max_request_body_bytes` opts the request
     // out of caching entirely — we still forward it, but cannot guarantee
     // replay safety, so we do not store the response either.
+    //
+    // Buffer with `usize::MAX` (no middleware-level cap) so the bytes
+    // are never lost on overflow. The router-level
+    // `axum::extract::DefaultBodyLimit` (default 1 MiB) is the
+    // authoritative request-size cap for the public surface — it
+    // rejects oversized bodies with 413 before reaching this layer.
+    // After buffering we check the size against
+    // `max_request_body_bytes` and forward without caching when it
+    // exceeds the cap — handler MUST see the original body unchanged
+    // (Codex P1 on PR #658: silent body truncation broke handler
+    // semantics on every oversized request).
     let (parts, body) = request.into_parts();
-    let body_result = axum::body::to_bytes(body, config.max_request_body_bytes).await;
-    let Ok(body_bytes) = body_result else {
+    let body_bytes = match axum::body::to_bytes(body, usize::MAX).await {
+        Ok(b) => b,
+        Err(err) => {
+            record_outcome(&metrics, "error:body_read", MetricOutcome::None);
+            tracing::error!(
+                error = %err,
+                "request body read failed — failing closed"
+            );
+            return Ok(internal_error(
+                "request body read failed; cannot evaluate idempotency",
+            ));
+        },
+    };
+    if body_bytes.len() > config.max_request_body_bytes {
         record_outcome(
             &metrics,
             "skip:body_too_large",
             MetricOutcome::Reject(idempotency_reject_reason::BODY_TOO_LARGE),
         );
         tracing::warn!(
+            body_size = body_bytes.len(),
+            limit = config.max_request_body_bytes,
             "request body exceeds idempotency max_request_body_bytes — \
-                 forwarding without caching"
+             forwarding without caching"
         );
-        let request = Request::from_parts(parts, Body::from(Vec::new()));
+        let request = Request::from_parts(parts, Body::from(body_bytes));
         return inner.oneshot(request).await;
-    };
+    }
     let body_vec: Vec<u8> = body_bytes.into();
     tracing::Span::current().record("body_size_bytes", body_vec.len());
 
@@ -824,15 +849,42 @@ where
     let response = inner.oneshot(request).await?;
 
     let (resp_parts, resp_body) = response.into_parts();
-    let resp_result = axum::body::to_bytes(resp_body, config.max_response_body_bytes).await;
-    let Ok(resp_bytes) = resp_result else {
+
+    // Buffer with `usize::MAX` (no middleware-level cap) so the bytes
+    // are never lost on overflow. axum's IntoResponse does not set
+    // `Content-Length` inside the middleware chain (hyper sets it on
+    // serialization), so a Content-Length pre-check would be dead code.
+    // Memory bound: response bodies in this codebase are produced by
+    // first-party handlers and are not adversarial; if a future handler
+    // can return unbounded output it must apply its own streaming cap
+    // upstream of this layer.
+    let resp_bytes = match axum::body::to_bytes(resp_body, usize::MAX).await {
+        Ok(b) => b,
+        Err(err) => {
+            record_outcome(&metrics, "error:resp_read", MetricOutcome::Miss);
+            tracing::error!(
+                error = %err,
+                "response body read failed — returning 500"
+            );
+            return Ok(internal_error(
+                "response body read failed; idempotency layer cannot forward",
+            ));
+        },
+    };
+    if resp_bytes.len() > config.max_response_body_bytes {
+        // Forward the full body to the caller; just skip caching it.
+        // Previously this branch returned `Body::empty()`, which
+        // truncated valid responses once the layer was mounted in
+        // production (Codex P1 on PR #658).
         record_outcome(&metrics, "miss:resp_too_large", MetricOutcome::Miss);
         tracing::warn!(
+            body_size = resp_bytes.len(),
+            limit = config.max_response_body_bytes,
             "response body exceeds idempotency max_response_body_bytes — \
-                 returning to caller without caching"
+             forwarding without caching"
         );
-        return Ok(Response::from_parts(resp_parts, Body::empty()));
-    };
+        return Ok(Response::from_parts(resp_parts, Body::from(resp_bytes)));
+    }
     let resp_vec: Vec<u8> = resp_bytes.into();
 
     if should_cache(resp_parts.status) {

--- a/crates/api/src/server/mod.rs
+++ b/crates/api/src/server/mod.rs
@@ -172,6 +172,13 @@ impl<F: AppContextFactory> ServerRuntime<F> {
             context.api_config.bind_address,
         )?;
         context.state = transport.prepare_state(context.state, bind_address)?;
+        // Attach the idempotency store inside the async context so the
+        // PG-backed path can await sqlx pool construction. Memory-backed
+        // builds resolve immediately; PG-backed builds also fail closed
+        // here when the feature is missing or `DATABASE_URL` is unset
+        // (per ADR-0048).
+        let idempotency_store = build_idempotency_store(&context.api_config).await?;
+        context.state = context.state.with_idempotency_store(idempotency_store);
         let app = transport.build_router(context.state, &context.api_config)?;
 
         tracing::info!(transport = transport.name(), %bind_address, "starting transport");
@@ -182,15 +189,13 @@ impl<F: AppContextFactory> ServerRuntime<F> {
 
 /// Build default local-first state used by transport binaries.
 ///
-/// Returns an error when `api_config.idempotency.backend` requests a
-/// backend that this build cannot satisfy (today: `Postgres` before
-/// Phase E lands). The fail-closed contract is documented in ADR-0048.
+/// The idempotency store is **not** attached here — it is wired
+/// asynchronously by [`ServerRuntime::run_transport`] so the PG-backed
+/// path can `await` the sqlx pool construction.
 pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitError> {
     let workflow_repo = Arc::new(nebula_storage::InMemoryWorkflowRepo::new());
     let execution_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
     let control_queue_repo = Arc::new(nebula_storage::repos::InMemoryControlQueueRepo::new());
-
-    let idempotency_store = build_idempotency_store(api_config)?;
 
     Ok(AppState::new(
         workflow_repo,
@@ -198,8 +203,7 @@ pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitEr
         control_queue_repo,
         api_config.jwt_secret.clone(),
     )
-    .with_api_keys(api_config.api_keys.clone())
-    .with_idempotency_store(idempotency_store))
+    .with_api_keys(api_config.api_keys.clone()))
 }
 
 /// Construct the idempotency store from `api_config.idempotency`.
@@ -208,42 +212,90 @@ pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitEr
 /// "dedup state is lost on restart and across runners" failure mode is
 /// visible in operational logs (per ADR-0048).
 ///
-/// `Postgres` returns [`TransportInitError::IdempotencyBackendUnavailable`]
-/// until Phase E ships the PG-backed impl — silent fallback to memory is
-/// rejected per `feedback_no_shims.md`.
-pub fn build_idempotency_store(
+/// `Postgres` requires the `nebula-api/postgres` cargo feature **and** a
+/// reachable `DATABASE_URL`; either missing component fails closed with
+/// [`TransportInitError::IdempotencyBackendUnavailable`] (silent
+/// fallback to memory is rejected per `feedback_no_shims.md`).
+pub async fn build_idempotency_store(
     api_config: &ApiConfig,
 ) -> Result<Arc<dyn IdempotencyStore>, TransportInitError> {
     match api_config.idempotency.backend {
         IdempotencyBackend::Memory => {
-            let env_mode = std::env::var("NEBULA_ENV").unwrap_or_default();
-            let is_dev = matches!(env_mode.as_str(), "development" | "dev" | "local");
-            if !is_dev {
-                tracing::warn!(
-                    backend = "memory",
-                    nebula_env = %env_mode,
-                    "idempotency: in-memory store selected — dedup state is lost on restart and across runners"
-                );
-            }
-            if api_config.idempotency.sweep_interval_secs > 0
-                && api_config.idempotency.sweep_interval_secs < 60
-            {
-                tracing::warn!(
-                    sweep_interval_secs = api_config.idempotency.sweep_interval_secs,
-                    "idempotency: sweep interval < 60s; consider raising it to avoid hot-loop sweeps"
-                );
-            }
+            warn_memory_outside_dev();
+            warn_short_sweep_interval(api_config.idempotency.sweep_interval_secs);
             let store = InMemoryIdempotencyStore::with_ttl_and_capacity(
                 Duration::from_secs(api_config.idempotency.ttl_secs),
                 api_config.idempotency.max_entries,
             );
             Ok(Arc::new(store))
         },
-        IdempotencyBackend::Postgres => Err(TransportInitError::IdempotencyBackendUnavailable {
-            requested: "postgres",
-            requirement: "Phase E (PgIdempotencyStore + migration 0024)",
-        }),
+        IdempotencyBackend::Postgres => build_pg_idempotency_store(api_config).await,
     }
+}
+
+fn warn_memory_outside_dev() {
+    let env_mode = std::env::var("NEBULA_ENV").unwrap_or_default();
+    let is_dev = matches!(env_mode.as_str(), "development" | "dev" | "local");
+    if !is_dev {
+        tracing::warn!(
+            backend = "memory",
+            nebula_env = %env_mode,
+            "idempotency: in-memory store selected — dedup state is lost on restart and across runners"
+        );
+    }
+}
+
+fn warn_short_sweep_interval(sweep_interval_secs: u64) {
+    if sweep_interval_secs > 0 && sweep_interval_secs < 60 {
+        tracing::warn!(
+            sweep_interval_secs,
+            "idempotency: sweep interval < 60s; consider raising it to avoid hot-loop sweeps"
+        );
+    }
+}
+
+#[cfg(feature = "postgres")]
+async fn build_pg_idempotency_store(
+    api_config: &ApiConfig,
+) -> Result<Arc<dyn IdempotencyStore>, TransportInitError> {
+    use nebula_storage::pg::PgIdempotencyStore;
+    use sqlx::postgres::PgPoolOptions;
+
+    use crate::middleware::idempotency::StorageBackedIdempotencyStore;
+
+    let url = std::env::var("DATABASE_URL").map_err(|_| {
+        TransportInitError::IdempotencyBackendUnavailable {
+            requested: "postgres",
+            requirement: "DATABASE_URL must be set when API_IDEMPOTENCY_BACKEND=postgres",
+        }
+    })?;
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await
+        .map_err(|err| {
+            TransportInitError::ContextFactory(format!(
+                "idempotency: failed to connect to DATABASE_URL for PG-backed store: {err}"
+            ))
+        })?;
+    warn_short_sweep_interval(api_config.idempotency.sweep_interval_secs);
+    tracing::info!(backend = "postgres", "idempotency: PG-backed store wired");
+    let pg_repo = Arc::new(PgIdempotencyStore::new(pool));
+    let store: Arc<dyn IdempotencyStore> = Arc::new(StorageBackedIdempotencyStore::new(
+        pg_repo,
+        Duration::from_secs(api_config.idempotency.ttl_secs),
+    ));
+    Ok(store)
+}
+
+#[cfg(not(feature = "postgres"))]
+async fn build_pg_idempotency_store(
+    _api_config: &ApiConfig,
+) -> Result<Arc<dyn IdempotencyStore>, TransportInitError> {
+    Err(TransportInitError::IdempotencyBackendUnavailable {
+        requested: "postgres",
+        requirement: "build with `nebula-api/postgres` cargo feature to link sqlx + PgIdempotencyStore",
+    })
 }
 
 fn resolve_bind_address(

--- a/crates/api/src/server/mod.rs
+++ b/crates/api/src/server/mod.rs
@@ -4,12 +4,16 @@
 //! logic in one place while allowing different ingress transports (REST API,
 //! webhook-only, realtime placeholder) to boot as separate binaries.
 
-use std::{net::SocketAddr, sync::Arc};
+use std::{net::SocketAddr, sync::Arc, time::Duration};
 
 use axum::{Router, http::StatusCode};
 use thiserror::Error;
 
-use crate::{ApiConfig, ApiConfigError, AppState, app};
+use crate::{
+    ApiConfig, ApiConfigError, AppState, app,
+    config::IdempotencyBackend,
+    middleware::{IdempotencyStore, InMemoryIdempotencyStore},
+};
 
 mod api;
 mod webhook;
@@ -58,6 +62,22 @@ pub enum TransportInitError {
     /// Failed to construct a transport app context.
     #[error("{0}")]
     ContextFactory(String),
+    /// `API_IDEMPOTENCY_BACKEND` selects a backend that the current build
+    /// cannot satisfy.
+    ///
+    /// Today this fires when an operator sets
+    /// `API_IDEMPOTENCY_BACKEND=postgres` while Phase E (PG-backed store) is
+    /// not yet shipped. Per ADR-0048 fail-closed contract, the binary
+    /// refuses to boot rather than silently fall back to in-memory dedup.
+    #[error(
+        "API_IDEMPOTENCY_BACKEND={requested} requires {requirement}; set API_IDEMPOTENCY_BACKEND=memory or land the missing wiring"
+    )]
+    IdempotencyBackendUnavailable {
+        /// Backend the operator requested.
+        requested: &'static str,
+        /// What is missing for that backend to work.
+        requirement: &'static str,
+    },
 }
 
 /// Shared application context passed through transport bootstrapping.
@@ -82,7 +102,7 @@ pub struct DefaultAppContextFactory;
 impl AppContextFactory for DefaultAppContextFactory {
     fn build_context(&self, api_config: ApiConfig) -> Result<AppContext, TransportInitError> {
         Ok(AppContext {
-            state: default_state(&api_config),
+            state: default_state(&api_config)?,
             api_config,
         })
     }
@@ -161,18 +181,69 @@ impl<F: AppContextFactory> ServerRuntime<F> {
 }
 
 /// Build default local-first state used by transport binaries.
-pub fn default_state(api_config: &ApiConfig) -> AppState {
+///
+/// Returns an error when `api_config.idempotency.backend` requests a
+/// backend that this build cannot satisfy (today: `Postgres` before
+/// Phase E lands). The fail-closed contract is documented in ADR-0048.
+pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitError> {
     let workflow_repo = Arc::new(nebula_storage::InMemoryWorkflowRepo::new());
     let execution_repo = Arc::new(nebula_storage::InMemoryExecutionRepo::new());
     let control_queue_repo = Arc::new(nebula_storage::repos::InMemoryControlQueueRepo::new());
 
-    AppState::new(
+    let idempotency_store = build_idempotency_store(api_config)?;
+
+    Ok(AppState::new(
         workflow_repo,
         execution_repo,
         control_queue_repo,
         api_config.jwt_secret.clone(),
     )
     .with_api_keys(api_config.api_keys.clone())
+    .with_idempotency_store(idempotency_store))
+}
+
+/// Construct the idempotency store from `api_config.idempotency`.
+///
+/// `Memory` outside dev mode emits a startup `tracing::warn!` so the
+/// "dedup state is lost on restart and across runners" failure mode is
+/// visible in operational logs (per ADR-0048).
+///
+/// `Postgres` returns [`TransportInitError::IdempotencyBackendUnavailable`]
+/// until Phase E ships the PG-backed impl — silent fallback to memory is
+/// rejected per `feedback_no_shims.md`.
+pub fn build_idempotency_store(
+    api_config: &ApiConfig,
+) -> Result<Arc<dyn IdempotencyStore>, TransportInitError> {
+    match api_config.idempotency.backend {
+        IdempotencyBackend::Memory => {
+            let env_mode = std::env::var("NEBULA_ENV").unwrap_or_default();
+            let is_dev = matches!(env_mode.as_str(), "development" | "dev" | "local");
+            if !is_dev {
+                tracing::warn!(
+                    backend = "memory",
+                    nebula_env = %env_mode,
+                    "idempotency: in-memory store selected — dedup state is lost on restart and across runners"
+                );
+            }
+            if api_config.idempotency.sweep_interval_secs > 0
+                && api_config.idempotency.sweep_interval_secs < 60
+            {
+                tracing::warn!(
+                    sweep_interval_secs = api_config.idempotency.sweep_interval_secs,
+                    "idempotency: sweep interval < 60s; consider raising it to avoid hot-loop sweeps"
+                );
+            }
+            let store = InMemoryIdempotencyStore::with_ttl_and_capacity(
+                Duration::from_secs(api_config.idempotency.ttl_secs),
+                api_config.idempotency.max_entries,
+            );
+            Ok(Arc::new(store))
+        },
+        IdempotencyBackend::Postgres => Err(TransportInitError::IdempotencyBackendUnavailable {
+            requested: "postgres",
+            requirement: "Phase E (PgIdempotencyStore + migration 0024)",
+        }),
+    }
 }
 
 fn resolve_bind_address(

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -19,7 +19,8 @@ use nebula_storage::{
 use tokio::sync::RwLock;
 
 use crate::{
-    auth::AuthBackend, config::JwtSecret, errors::ApiError, services::webhook::WebhookTransport,
+    auth::AuthBackend, config::JwtSecret, errors::ApiError, middleware::IdempotencyStore,
+    services::webhook::WebhookTransport,
 };
 
 // ── Port traits ──────────────────────────────────────────────────────────────
@@ -131,6 +132,20 @@ pub struct AppState {
 
     /// Optional membership store for RBAC role lookups.
     pub membership_store: Option<Arc<dyn MembershipStore>>,
+
+    /// Optional idempotency store backing [`crate::middleware::IdempotencyLayer`].
+    ///
+    /// When `Some`, `build_app` mounts the layer on `api_routes` (NOT on the
+    /// merged webhook transport) so every state-changing API endpoint is
+    /// replay-protected. When `None`, the layer is not mounted and POST
+    /// endpoints have no replay protection — acceptable for tests that build
+    /// minimal routers but a misconfiguration in production.
+    ///
+    /// See ADR-0048 for the backend selection contract; the composition root
+    /// chooses between [`crate::middleware::InMemoryIdempotencyStore`] and a
+    /// PG-backed bridge (`StorageBackedIdempotencyStore<PgIdempotencyStore>`)
+    /// based on `ApiConfig.idempotency.backend`.
+    pub idempotency_store: Option<Arc<dyn IdempotencyStore>>,
 }
 
 impl AppState {
@@ -162,6 +177,7 @@ impl AppState {
             workspace_resolver: None,
             auth_backend: None,
             membership_store: None,
+            idempotency_store: None,
         }
     }
 
@@ -233,6 +249,17 @@ impl AppState {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_membership_store(mut self, store: Arc<dyn MembershipStore>) -> Self {
         self.membership_store = Some(store);
+        self
+    }
+
+    /// Attach an idempotency store; `build_app` mounts
+    /// [`crate::middleware::IdempotencyLayer`] on the API router when this is
+    /// `Some`.
+    ///
+    /// See ADR-0048 for the backend selection contract.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_idempotency_store(mut self, store: Arc<dyn IdempotencyStore>) -> Self {
+        self.idempotency_store = Some(store);
         self
     }
 }

--- a/crates/api/tests/idempotency_e2e.rs
+++ b/crates/api/tests/idempotency_e2e.rs
@@ -1,0 +1,302 @@
+//! End-to-end tests for the idempotency middleware against the real
+//! `build_app` router (M3.4 — ADR-0048).
+//!
+//! These tests differ from `tests/idempotency_middleware.rs` in two ways:
+//!
+//! 1. The router under test is the production router from
+//!    `nebula_api::app::build_app`, including request-id, security
+//!    headers, CORS, and the rest of the outer middleware stack — not a
+//!    minimal `Router::new().route(...).layer(IdempotencyLayer::new(...))`
+//!    fixture. This catches layer-ordering bugs that the minimal-router
+//!    tests cannot.
+//! 2. Test fixtures (`POST /api/v1/_test/echo`, `POST /api/v1/_test/fail`)
+//!    are mounted via `axum::Router::merge` BEFORE the idempotency layer
+//!    inside `build_app` (gated behind `feature = "test-util"`); they
+//!    never appear in the served OpenAPI 3.1 spec (ADR-0047 honesty).
+//!
+//! Roadmap: §M3.4 Idempotency-Key dedup — fourth box (end-to-end test
+//! against the real `build_app`).
+
+use std::sync::Arc;
+
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode},
+};
+use nebula_api::{
+    ApiConfig, AppState, app,
+    middleware::idempotency::{
+        IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER, InMemoryIdempotencyStore,
+    },
+};
+use nebula_storage::{
+    InMemoryExecutionRepo, InMemoryWorkflowRepo, repos::InMemoryControlQueueRepo,
+};
+use tower::ServiceExt;
+
+const X_REQUEST_ID: &str = "x-request-id";
+
+/// Build an `AppState` with the in-memory idempotency store wired in.
+///
+/// Mirrors the dev composition-root pattern (`simple_server.rs`) modulo
+/// the auth/RBAC layers — those run inside `build_app` but the test
+/// echo route lives outside the OpenAPI router and is not subject to
+/// them.
+fn state_with_idempotency() -> AppState {
+    let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
+    let execution_repo = Arc::new(InMemoryExecutionRepo::new());
+    let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());
+    let api_config = ApiConfig::for_test();
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+
+    AppState::new(
+        workflow_repo,
+        execution_repo,
+        control_queue_repo,
+        api_config.jwt_secret,
+    )
+    .with_idempotency_store(store)
+}
+
+fn post_with_key(uri: &str, key: &str, body: &'static str) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "text/plain")
+        .header(IDEMPOTENCY_KEY_HEADER, key)
+        .body(Body::from(body))
+        .unwrap()
+}
+
+async fn body_string(response: axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test]
+async fn replay_returns_cached_body_through_full_stack() {
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/echo", "k1", "alpha"))
+        .await
+        .expect("first request");
+    assert_eq!(r1.status(), StatusCode::OK);
+    let r1_request_id = r1.headers().get(X_REQUEST_ID).cloned();
+    let r1_replay = r1.headers().get(IDEMPOTENT_REPLAY_HEADER).cloned();
+    assert!(
+        r1_replay.is_none(),
+        "first call must NOT carry Idempotent-Replay"
+    );
+    let body1 = body_string(r1).await;
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/echo", "k1", "alpha"))
+        .await
+        .expect("second request");
+    assert_eq!(r2.status(), StatusCode::OK);
+    let r2_replay = r2
+        .headers()
+        .get(IDEMPOTENT_REPLAY_HEADER)
+        .cloned()
+        .expect("replay must carry Idempotent-Replay header");
+    assert_eq!(r2_replay.to_str().unwrap(), "true");
+    let r2_request_id = r2.headers().get(X_REQUEST_ID).cloned();
+    let body2 = body_string(r2).await;
+
+    assert_eq!(
+        body1, body2,
+        "second call must replay the same body byte-for-byte"
+    );
+    assert_eq!(
+        body1, "echo:1:alpha",
+        "echo handler must have run exactly once (counter == 1)"
+    );
+
+    // Layer-ordering proof: `request_id_middleware` sits OUTSIDE
+    // idempotency, so a cached replay still acquires a fresh
+    // `X-Request-ID`.
+    let id_a = r1_request_id.expect("first call must have X-Request-ID");
+    let id_b = r2_request_id.expect("replay must still get a fresh X-Request-ID");
+    assert_ne!(
+        id_a, id_b,
+        "cached replays must receive a fresh X-Request-ID — request_id layer sits outside idempotency",
+    );
+}
+
+#[tokio::test]
+async fn body_mismatch_returns_422_through_full_stack() {
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/echo", "k2", "first"))
+        .await
+        .expect("priming request");
+    assert_eq!(r1.status(), StatusCode::OK);
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/echo", "k2", "second"))
+        .await
+        .expect("body-mismatch request");
+    assert_eq!(
+        r2.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "same Idempotency-Key with different body must be 422"
+    );
+
+    let content_type = r2
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_owned();
+    assert!(
+        content_type.starts_with("application/problem+json"),
+        "422 must use RFC 9457 problem+json: got {content_type:?}"
+    );
+}
+
+#[tokio::test]
+async fn fivexx_response_is_not_cached_through_full_stack() {
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let r1 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/fail", "kf", "x"))
+        .await
+        .expect("first failing call");
+    assert_eq!(r1.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body1 = body_string(r1).await;
+
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/api/v1/_test/fail", "kf", "x"))
+        .await
+        .expect("second failing call");
+    assert_eq!(r2.status(), StatusCode::INTERNAL_SERVER_ERROR);
+    let body2 = body_string(r2).await;
+
+    assert_eq!(body1, "boom:1");
+    assert_eq!(
+        body2, "boom:2",
+        "5xx must NOT be cached — handler must run again on a retried key (counter advances)"
+    );
+}
+
+#[tokio::test]
+async fn per_principal_scope_through_full_stack() {
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let req_a = Request::builder()
+        .method("POST")
+        .uri("/api/v1/_test/echo")
+        .header("content-type", "text/plain")
+        .header("authorization", "Bearer caller-A")
+        .header(IDEMPOTENCY_KEY_HEADER, "shared")
+        .body(Body::from("payload"))
+        .unwrap();
+    let req_b = Request::builder()
+        .method("POST")
+        .uri("/api/v1/_test/echo")
+        .header("content-type", "text/plain")
+        .header("authorization", "Bearer caller-B")
+        .header(IDEMPOTENCY_KEY_HEADER, "shared")
+        .body(Body::from("payload"))
+        .unwrap();
+
+    let r_a = app.clone().oneshot(req_a).await.expect("caller A");
+    let r_b = app.clone().oneshot(req_b).await.expect("caller B");
+
+    assert_eq!(r_a.status(), StatusCode::OK);
+    assert_eq!(r_b.status(), StatusCode::OK);
+    let body_a = body_string(r_a).await;
+    let body_b = body_string(r_b).await;
+    assert_eq!(body_a, "echo:1:payload");
+    assert_eq!(
+        body_b, "echo:2:payload",
+        "two callers using the same Idempotency-Key must NOT share cache entries — \
+         identity-fingerprint must scope the cache per principal even through the \
+         full middleware stack"
+    );
+}
+
+#[tokio::test]
+async fn cors_allows_idempotency_key_in_preflight() {
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let preflight = Request::builder()
+        .method("OPTIONS")
+        .uri("/api/v1/_test/echo")
+        .header("origin", "https://app.nebula.dev")
+        .header("access-control-request-method", "POST")
+        .header("access-control-request-headers", "idempotency-key")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(preflight).await.expect("preflight");
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "preflight with Idempotency-Key request-header must succeed"
+    );
+
+    let allow_headers = response
+        .headers()
+        .get("access-control-allow-headers")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(
+        allow_headers.contains("idempotency-key"),
+        "Access-Control-Allow-Headers must list `idempotency-key`: got {allow_headers:?}",
+    );
+}
+
+#[tokio::test]
+async fn cors_exposes_idempotent_replay_header() {
+    // Per the CORS spec, `Access-Control-Expose-Headers` is set on the
+    // **actual** cross-origin response (not the preflight); browsers strip
+    // any non-listed response header before `fetch().headers` sees it. So
+    // assert against a real POST with an `Origin` header rather than the
+    // OPTIONS preflight.
+    let state = state_with_idempotency();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/_test/echo")
+        .header("origin", "https://app.nebula.dev")
+        .header("content-type", "text/plain")
+        .header(IDEMPOTENCY_KEY_HEADER, "expose-test")
+        .body(Body::from("ping"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.expect("cross-origin POST");
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let expose_headers = response
+        .headers()
+        .get("access-control-expose-headers")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    assert!(
+        expose_headers.contains("idempotent-replay"),
+        "Access-Control-Expose-Headers must list `idempotent-replay` on actual cross-origin responses: got {expose_headers:?}",
+    );
+}

--- a/crates/api/tests/idempotency_middleware.rs
+++ b/crates/api/tests/idempotency_middleware.rs
@@ -21,7 +21,8 @@ use axum::{
     routing::{get, post},
 };
 use nebula_api::middleware::idempotency::{
-    IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER, IdempotencyLayer, InMemoryIdempotencyStore,
+    IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER, IdempotencyConfig, IdempotencyLayer,
+    InMemoryIdempotencyStore,
 };
 use nebula_metrics::{
     MetricsRegistry,
@@ -500,6 +501,100 @@ async fn metrics_rejects_record_invalid_key_label() {
     assert_eq!(
         rejects, 1,
         "empty Idempotency-Key must increment rejects[invalid_key]"
+    );
+}
+
+/// Build the app fixture with a custom [`IdempotencyConfig`] so tests can
+/// exercise the small-cap path on request and response bodies.
+fn build_app_with_config(
+    counter: Arc<AtomicUsize>,
+    store: Arc<InMemoryIdempotencyStore>,
+    config: IdempotencyConfig,
+) -> Router {
+    let counter_for_post = counter;
+
+    Router::new()
+        .route(
+            "/echo",
+            post(move |body: axum::body::Bytes| {
+                let counter = counter_for_post.clone();
+                async move {
+                    let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                    let payload = String::from_utf8_lossy(&body);
+                    (StatusCode::OK, format!("echo-{n}-{payload}")).into_response()
+                }
+            }),
+        )
+        .layer(IdempotencyLayer::new(store).with_config(config))
+}
+
+/// Regression: when the response body exceeds
+/// `max_response_body_bytes`, the caller MUST receive the full body
+/// from the inner handler (not an empty `Body::empty()`). The previous
+/// implementation returned an empty body on overflow; PR #658 (Codex
+/// P1) fixes this via a Content-Length pre-check.
+#[tokio::test]
+async fn oversized_response_body_returns_full_body_unchanged() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    // Cap responses at 4 bytes so the echo handler's "echo-1-x" output
+    // (8 bytes) trips the pre-check.
+    let config = IdempotencyConfig {
+        max_request_body_bytes: 1024,
+        max_response_body_bytes: 4,
+    };
+    let app = build_app_with_config(counter.clone(), store, config);
+
+    let response = app
+        .oneshot(post_with_key("/echo", "oversize", "x"))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_string(response).await;
+    assert_eq!(
+        body, "echo-1-x",
+        "oversized response must forward the full inner-handler body, not an empty body \
+         (regression: Codex P1 finding on PR #658)"
+    );
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "inner handler must have run exactly once"
+    );
+}
+
+/// Regression: when the request body exceeds
+/// `max_request_body_bytes`, the inner handler MUST see the full
+/// request body (not an empty body). The previous implementation
+/// silently substituted `Body::empty()` on overflow; PR #658 fixes
+/// this via a Content-Length pre-check.
+#[tokio::test]
+async fn oversized_request_body_passes_through_with_full_body() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    // Cap requests at 4 bytes — the test payload "abcdef" is 6 bytes
+    // and trips the pre-check.
+    let config = IdempotencyConfig {
+        max_request_body_bytes: 4,
+        max_response_body_bytes: 1024,
+    };
+    let app = build_app_with_config(counter.clone(), store, config);
+
+    let response = app
+        .oneshot(post_with_key("/echo", "oversize-req", "abcdef"))
+        .await
+        .expect("request");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = body_string(response).await;
+    assert_eq!(
+        body, "echo-1-abcdef",
+        "oversized request body must reach the inner handler unchanged \
+         (regression: Codex P1 finding on PR #658, request side)"
+    );
+    assert_eq!(
+        counter.load(Ordering::SeqCst),
+        1,
+        "inner handler must have run exactly once"
     );
 }
 

--- a/crates/api/tests/idempotency_middleware.rs
+++ b/crates/api/tests/idempotency_middleware.rs
@@ -23,6 +23,14 @@ use axum::{
 use nebula_api::middleware::idempotency::{
     IDEMPOTENCY_KEY_HEADER, IDEMPOTENT_REPLAY_HEADER, IdempotencyLayer, InMemoryIdempotencyStore,
 };
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_API_IDEMPOTENCY_HITS_TOTAL, NEBULA_API_IDEMPOTENCY_LATENCY_MS,
+        NEBULA_API_IDEMPOTENCY_MISSES_TOTAL, NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM, idempotency_reject_reason,
+    },
+};
 use tower::ServiceExt;
 
 /// Build a tiny test app whose POST handler echoes its payload, suffixed with
@@ -343,6 +351,156 @@ async fn cache_entry_expires_after_ttl() {
         "after TTL expiry, the same key must produce a fresh response (counter advances)"
     );
     assert_eq!(counter.load(Ordering::SeqCst), 2);
+}
+
+/// Build an app variant that wires `IdempotencyLayer::with_metrics(Some(registry))`
+/// so the C2 metrics path is exercised end-to-end.
+fn build_app_with_metrics(
+    counter: Arc<AtomicUsize>,
+    store: Arc<InMemoryIdempotencyStore>,
+    registry: Arc<MetricsRegistry>,
+) -> Router {
+    let counter_for_post = counter.clone();
+    let counter_for_failing = counter;
+
+    Router::new()
+        .route(
+            "/echo",
+            post(move |body: axum::body::Bytes| {
+                let counter = counter_for_post.clone();
+                async move {
+                    let n = counter.fetch_add(1, Ordering::SeqCst) + 1;
+                    let payload = String::from_utf8_lossy(&body);
+                    (StatusCode::OK, format!("echo-{n}-{payload}")).into_response()
+                }
+            }),
+        )
+        .route(
+            "/fail",
+            post(move || {
+                let counter = counter_for_failing.clone();
+                async move {
+                    counter.fetch_add(1, Ordering::SeqCst);
+                    (StatusCode::INTERNAL_SERVER_ERROR, "boom").into_response()
+                }
+            }),
+        )
+        .layer(IdempotencyLayer::new(store).with_metrics(Some(registry)))
+}
+
+#[tokio::test]
+async fn metrics_hits_and_misses_increment() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let registry = Arc::new(MetricsRegistry::new());
+    let app = build_app_with_metrics(counter, store, registry.clone());
+
+    // First call → miss.
+    let _ = app
+        .clone()
+        .oneshot(post_with_key("/echo", "metric-key", "x"))
+        .await
+        .unwrap();
+    // Second call → hit.
+    let _ = app
+        .clone()
+        .oneshot(post_with_key("/echo", "metric-key", "x"))
+        .await
+        .unwrap();
+
+    let hits = registry
+        .counter(NEBULA_API_IDEMPOTENCY_HITS_TOTAL)
+        .unwrap()
+        .get();
+    let misses = registry
+        .counter(NEBULA_API_IDEMPOTENCY_MISSES_TOTAL)
+        .unwrap()
+        .get();
+    assert_eq!(hits, 1, "second call must record a hit");
+    assert_eq!(misses, 1, "first call must record a miss");
+
+    let histogram = registry
+        .histogram(NEBULA_API_IDEMPOTENCY_LATENCY_MS)
+        .unwrap();
+    assert_eq!(
+        histogram.count(),
+        2,
+        "latency histogram must observe one sample per request that reached the layer"
+    );
+
+    let saturation = registry
+        .gauge(NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM)
+        .unwrap()
+        .get();
+    assert!(
+        saturation >= 0,
+        "saturation gauge must be set after a successful put"
+    );
+}
+
+#[tokio::test]
+async fn metrics_rejects_record_body_mismatch_label() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let registry = Arc::new(MetricsRegistry::new());
+    let app = build_app_with_metrics(counter, store, registry.clone());
+
+    // Prime the cache.
+    let _ = app
+        .clone()
+        .oneshot(post_with_key("/echo", "mismatch-key", "first"))
+        .await
+        .unwrap();
+    // Same key, different body → 422 + rejects[body_mismatch].
+    let r2 = app
+        .clone()
+        .oneshot(post_with_key("/echo", "mismatch-key", "second"))
+        .await
+        .unwrap();
+    assert_eq!(r2.status(), StatusCode::UNPROCESSABLE_ENTITY);
+
+    let labels = registry
+        .interner()
+        .single("reason", idempotency_reject_reason::BODY_MISMATCH);
+    let rejects = registry
+        .counter_labeled(NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL, &labels)
+        .unwrap()
+        .get();
+    assert_eq!(
+        rejects, 1,
+        "body-mismatch must increment rejects[body_mismatch]"
+    );
+}
+
+#[tokio::test]
+async fn metrics_rejects_record_invalid_key_label() {
+    let counter = Arc::new(AtomicUsize::new(0));
+    let store = Arc::new(InMemoryIdempotencyStore::new());
+    let registry = Arc::new(MetricsRegistry::new());
+    let app = build_app_with_metrics(counter, store, registry.clone());
+
+    // Empty key → reject:invalid_key (`IdempotencyKeyError::Empty`).
+    let req = Request::builder()
+        .method("POST")
+        .uri("/echo")
+        .header("content-type", "text/plain")
+        .header(IDEMPOTENCY_KEY_HEADER, "")
+        .body(Body::from("x"))
+        .unwrap();
+    let r = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(r.status(), StatusCode::BAD_REQUEST);
+
+    let labels = registry
+        .interner()
+        .single("reason", idempotency_reject_reason::INVALID_KEY);
+    let rejects = registry
+        .counter_labeled(NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL, &labels)
+        .unwrap()
+        .get();
+    assert_eq!(
+        rejects, 1,
+        "empty Idempotency-Key must increment rejects[invalid_key]"
+    );
 }
 
 #[tokio::test]

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -110,6 +110,72 @@ pub mod dispatch_reject_reason {
 }
 
 // ---------------------------------------------------------------------------
+// API: idempotency middleware (M3.4 — ADR-0048)
+// ---------------------------------------------------------------------------
+
+/// Counter: idempotent-replay cache hits.
+///
+/// Incremented when the middleware finds a cached `CachedResponse` for the
+/// scoped cache key and serves it without invoking the inner handler. A hit
+/// always implies the body fingerprint matched (body-mismatch goes to
+/// [`NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL`] under
+/// `reason="body_mismatch"`). Unlabeled to keep cardinality low — per-route
+/// dimensions live on the existing `tracing::Span` fields.
+pub const NEBULA_API_IDEMPOTENCY_HITS_TOTAL: &str = "nebula_api_idempotency_hits_total";
+
+/// Counter: idempotency cache misses.
+///
+/// Incremented on the first POST with a given key — the inner handler runs
+/// and the response is stored. A miss is the steady-state path; a sustained
+/// `hits / (hits + misses)` ratio < 1 % means clients are not actually
+/// retrying so the layer is doing no work for them. Unlabeled.
+pub const NEBULA_API_IDEMPOTENCY_MISSES_TOTAL: &str = "nebula_api_idempotency_misses_total";
+
+/// Counter: requests rejected before reaching the inner handler.
+///
+/// Labeled by `reason` (see [`idempotency_reject_reason`]). Closed label set
+/// — adding a value permanently inflates the cardinality floor. Aggregated
+/// counter, no per-route dimension.
+pub const NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL: &str = "nebula_api_idempotency_rejects_total";
+
+/// Reject-reason labels for [`NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL`].
+///
+/// Static strings — call sites and tests compare without stringifying twice.
+/// Adding a label permanently inflates the cardinality floor and requires
+/// an ADR amendment (ADR-0048).
+pub mod idempotency_reject_reason {
+    /// Header validation failed — empty / too long / non-printable ASCII.
+    pub const INVALID_KEY: &str = "invalid_key";
+    /// Same key with a different body fingerprint (draft §2.5 → 422).
+    pub const BODY_MISMATCH: &str = "body_mismatch";
+    /// Request body exceeded `max_request_body_bytes` so the layer cannot
+    /// commit to caching the response — passes through but counts here.
+    pub const BODY_TOO_LARGE: &str = "body_too_large";
+    /// `Idempotency-Key` header bytes were not valid ASCII.
+    pub const NON_ASCII_HEADER: &str = "non_ascii_header";
+}
+
+/// Gauge: idempotency store saturation as `entries / max_capacity`,
+/// scaled by 1_000_000 (parts per million).
+///
+/// Mirrors the `_PPM` pattern used by `NEBULA_EVENTBUS_DROP_RATIO_PPM`
+/// so the i64-backed `Gauge` can carry a `0.0..=1.0` ratio without
+/// losing precision. In-memory backend reads the live
+/// `moka::Cache::entry_count()` against the configured `max_entries`;
+/// PG backend can publish `0` (the table grows with `expires_at`-bounded
+/// eviction; no fixed capacity). Unlabeled.
+pub const NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM: &str =
+    "nebula_api_idempotency_store_saturation_ppm";
+
+/// Histogram: full middleware path latency in milliseconds.
+///
+/// Covers cache lookup, body buffering, the inner handler call (on a
+/// miss), and response buffering. Provides the closed-loop latency
+/// budget operators need to dashboard the dedup overhead, distinct
+/// from the inner handler's own duration histograms.
+pub const NEBULA_API_IDEMPOTENCY_LATENCY_MS: &str = "nebula_api_idempotency_latency_ms";
+
+// ---------------------------------------------------------------------------
 // Webhook (api crate — transport-layer signature enforcement)
 // ---------------------------------------------------------------------------
 
@@ -431,9 +497,11 @@ mod tests {
     use crate::registry::MetricsRegistry;
 
     use super::{
-        NEBULA_CACHE_EVICTIONS, NEBULA_CACHE_HITS, NEBULA_CACHE_MISSES, NEBULA_CACHE_SIZE,
-        NEBULA_CREDENTIAL_ACTIVE_TOTAL, NEBULA_CREDENTIAL_EXPIRED_TOTAL,
-        NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_HITS_TOTAL, NEBULA_API_IDEMPOTENCY_LATENCY_MS,
+        NEBULA_API_IDEMPOTENCY_MISSES_TOTAL, NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM, NEBULA_CACHE_EVICTIONS, NEBULA_CACHE_HITS,
+        NEBULA_CACHE_MISSES, NEBULA_CACHE_SIZE, NEBULA_CREDENTIAL_ACTIVE_TOTAL,
+        NEBULA_CREDENTIAL_EXPIRED_TOTAL, NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
         NEBULA_CREDENTIAL_REFRESH_COORD_COALESCED_TOTAL,
         NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS,
         NEBULA_CREDENTIAL_REFRESH_COORD_RECLAIM_SWEEPS_TOTAL,
@@ -452,8 +520,8 @@ mod tests {
         NEBULA_RESOURCE_POOL_EXHAUSTED_TOTAL, NEBULA_RESOURCE_POOL_WAITERS,
         NEBULA_RESOURCE_QUARANTINE_RELEASED_TOTAL, NEBULA_RESOURCE_QUARANTINE_TOTAL,
         NEBULA_RESOURCE_RELEASE_TOTAL, NEBULA_RESOURCE_USAGE_DURATION_SECONDS,
-        refresh_coord_claim_outcome, refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome,
-        refresh_coord_sentinel_action, rotation_outcome,
+        idempotency_reject_reason, refresh_coord_claim_outcome, refresh_coord_coalesced_tier,
+        refresh_coord_reclaim_outcome, refresh_coord_sentinel_action, rotation_outcome,
     };
 
     const RESOURCE_METRIC_NAMES: [&str; 20] = [
@@ -709,6 +777,79 @@ mod tests {
             2,
             "reclaim outcome labels must be unique"
         );
+    }
+
+    /// API idempotency metrics (M3.4 — ADR-0048).
+    ///
+    /// 3 counters + 1 gauge + 1 histogram = 5 series. Mirrors the
+    /// per-counter `(name, label_key, sample_value)` pattern used for
+    /// the refresh-coord constants so a label-key drift between this
+    /// catalog and the middleware wiring fails CI rather than landing
+    /// silently.
+    const API_IDEMPOTENCY_METRIC_NAMES: [&str; 5] = [
+        NEBULA_API_IDEMPOTENCY_HITS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_MISSES_TOTAL,
+        NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
+        NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM,
+        NEBULA_API_IDEMPOTENCY_LATENCY_MS,
+    ];
+
+    #[test]
+    fn api_idempotency_constants_are_accessible_unique_and_registry_safe() {
+        let registry = MetricsRegistry::new();
+        let mut unique = HashSet::new();
+        for metric_name in API_IDEMPOTENCY_METRIC_NAMES {
+            assert!(!metric_name.is_empty());
+            assert!(metric_name.starts_with("nebula_api_idempotency_"));
+            assert!(
+                metric_name
+                    .chars()
+                    .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+            );
+            assert!(unique.insert(metric_name));
+
+            if metric_name == NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM {
+                let gauge = registry.gauge(metric_name).unwrap();
+                gauge.set(420_000);
+                assert_eq!(gauge.get(), 420_000);
+            } else if metric_name == NEBULA_API_IDEMPOTENCY_LATENCY_MS {
+                let histogram = registry.histogram(metric_name).unwrap();
+                histogram.observe(1.0);
+                assert_eq!(histogram.count(), 1);
+            } else if metric_name == NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL {
+                // Labeled by `reason` — exercise the closed label set.
+                let labels = registry
+                    .interner()
+                    .single("reason", idempotency_reject_reason::INVALID_KEY);
+                let counter = registry.counter_labeled(metric_name, &labels).unwrap();
+                counter.inc();
+                assert_eq!(counter.get(), 1);
+            } else {
+                let counter = registry.counter(metric_name).unwrap();
+                counter.inc();
+                assert_eq!(counter.get(), 1);
+            }
+        }
+        assert_eq!(unique.len(), 5);
+    }
+
+    #[test]
+    fn idempotency_reject_reason_labels_are_closed_set() {
+        let labels = [
+            idempotency_reject_reason::INVALID_KEY,
+            idempotency_reject_reason::BODY_MISMATCH,
+            idempotency_reject_reason::BODY_TOO_LARGE,
+            idempotency_reject_reason::NON_ASCII_HEADER,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            4,
+            "idempotency reject-reason labels must be unique"
+        );
+        for label in labels {
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
     }
 
     #[test]

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -131,11 +131,23 @@ pub const NEBULA_API_IDEMPOTENCY_HITS_TOTAL: &str = "nebula_api_idempotency_hits
 /// retrying so the layer is doing no work for them. Unlabeled.
 pub const NEBULA_API_IDEMPOTENCY_MISSES_TOTAL: &str = "nebula_api_idempotency_misses_total";
 
-/// Counter: requests rejected before reaching the inner handler.
+/// Counter: requests the idempotency layer did not cache.
 ///
-/// Labeled by `reason` (see [`idempotency_reject_reason`]). Closed label set
-/// — adding a value permanently inflates the cardinality floor. Aggregated
-/// counter, no per-route dimension.
+/// Labeled by `reason` (see [`idempotency_reject_reason`]). Closed label
+/// set — adding a value permanently inflates the cardinality floor.
+/// Aggregated counter, no per-route dimension.
+///
+/// Two distinct outcome classes share this counter:
+///
+/// - **Hard rejects** (`invalid_key`, `body_mismatch`, `non_ascii_header`)
+///   — request short-circuited with a 4xx response by the middleware
+///   itself; the inner handler did not run.
+/// - **Pass-through skips** (`body_too_large`) — request reached the
+///   inner handler unchanged but the layer could not commit the
+///   buffered body to the cache; subsequent replays will run the
+///   handler again. Lumped here because the operator dashboard cares
+///   about "requests not protected" as a single signal; the `reason`
+///   label disambiguates.
 pub const NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL: &str = "nebula_api_idempotency_rejects_total";
 
 /// Reject-reason labels for [`NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL`].
@@ -145,13 +157,17 @@ pub const NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL: &str = "nebula_api_idempotency_r
 /// an ADR amendment (ADR-0048).
 pub mod idempotency_reject_reason {
     /// Header validation failed — empty / too long / non-printable ASCII.
+    /// Hard reject: 400 returned without running the handler.
     pub const INVALID_KEY: &str = "invalid_key";
     /// Same key with a different body fingerprint (draft §2.5 → 422).
+    /// Hard reject: 422 returned without running the handler.
     pub const BODY_MISMATCH: &str = "body_mismatch";
-    /// Request body exceeded `max_request_body_bytes` so the layer cannot
-    /// commit to caching the response — passes through but counts here.
+    /// Request body exceeded `max_request_body_bytes`. The layer cannot
+    /// fingerprint the request, so the handler runs but the response
+    /// is **not cached** — pass-through skip, not a hard reject.
     pub const BODY_TOO_LARGE: &str = "body_too_large";
     /// `Idempotency-Key` header bytes were not valid ASCII.
+    /// Hard reject: 400 returned without running the handler.
     pub const NON_ASCII_HEADER: &str = "non_ascii_header";
 }
 

--- a/crates/metrics/src/prometheus.rs
+++ b/crates/metrics/src/prometheus.rs
@@ -130,8 +130,8 @@ fn counter_help(name: &str) -> &'static str {
              the inner handler ran and the response was stored."
         },
         NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL => {
-            "Total requests rejected by the API idempotency middleware \
-             before reaching the inner handler (labeled by reason)."
+            "Total requests the API idempotency layer did not cache \
+             (hard rejects + pass-through skips, labeled by reason)."
         },
         _ => "Custom counter.",
     }

--- a/crates/metrics/src/prometheus.rs
+++ b/crates/metrics/src/prometheus.rs
@@ -19,8 +19,11 @@ use crate::{labels::LabelInterner, registry::MetricsRegistry};
 
 use crate::naming::{
     NEBULA_ACTION_DISPATCH_REJECTED_TOTAL, NEBULA_ACTION_DURATION_SECONDS,
-    NEBULA_ACTION_EXECUTIONS_TOTAL, NEBULA_ACTION_FAILURES_TOTAL, NEBULA_CACHE_EVICTIONS,
-    NEBULA_CACHE_HITS, NEBULA_CACHE_MISSES, NEBULA_CACHE_SIZE, NEBULA_CREDENTIAL_ACTIVE_TOTAL,
+    NEBULA_ACTION_EXECUTIONS_TOTAL, NEBULA_ACTION_FAILURES_TOTAL,
+    NEBULA_API_IDEMPOTENCY_HITS_TOTAL, NEBULA_API_IDEMPOTENCY_LATENCY_MS,
+    NEBULA_API_IDEMPOTENCY_MISSES_TOTAL, NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
+    NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM, NEBULA_CACHE_EVICTIONS, NEBULA_CACHE_HITS,
+    NEBULA_CACHE_MISSES, NEBULA_CACHE_SIZE, NEBULA_CREDENTIAL_ACTIVE_TOTAL,
     NEBULA_CREDENTIAL_EXPIRED_TOTAL, NEBULA_CREDENTIAL_REFRESH_COORD_CLAIMS_TOTAL,
     NEBULA_CREDENTIAL_REFRESH_COORD_COALESCED_TOTAL,
     NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS,
@@ -118,6 +121,18 @@ fn counter_help(name: &str) -> &'static str {
         NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL => {
             "Total webhook HMAC signature failures (labeled by reason)."
         },
+        NEBULA_API_IDEMPOTENCY_HITS_TOTAL => {
+            "Total idempotent-replay cache hits served by the API \
+             middleware."
+        },
+        NEBULA_API_IDEMPOTENCY_MISSES_TOTAL => {
+            "Total idempotency cache misses (first-seen Idempotency-Key) — \
+             the inner handler ran and the response was stored."
+        },
+        NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL => {
+            "Total requests rejected by the API idempotency middleware \
+             before reaching the inner handler (labeled by reason)."
+        },
         _ => "Custom counter.",
     }
 }
@@ -137,6 +152,10 @@ fn gauge_help(name: &str) -> &'static str {
         NEBULA_CACHE_MISSES => "Cache misses snapshot.",
         NEBULA_CACHE_EVICTIONS => "Cache evictions snapshot.",
         NEBULA_CACHE_SIZE => "Current cache size in entries.",
+        NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM => {
+            "Idempotency store saturation (entries / max_capacity) \
+             scaled by 1_000_000."
+        },
         _ => "Custom gauge.",
     }
 }
@@ -155,6 +174,10 @@ fn histogram_help(name: &str) -> &'static str {
         NEBULA_CREDENTIAL_ROTATION_DURATION_SECONDS => "Credential rotation duration in seconds.",
         NEBULA_CREDENTIAL_REFRESH_COORD_HOLD_DURATION_SECONDS => {
             "Refresh-coordinator hold duration in seconds (heartbeats + user closure)."
+        },
+        NEBULA_API_IDEMPOTENCY_LATENCY_MS => {
+            "Idempotency middleware path latency in milliseconds \
+             (cache lookup + body buffering + inner handler)."
         },
         _ => "Custom histogram.",
     }

--- a/crates/storage/README.md
+++ b/crates/storage/README.md
@@ -199,6 +199,7 @@ contract consumers should depend on today.
 | `stateful_checkpoints` | **Best-effort** | Write failure logs, does not abort; may replay |
 | `executions.lease_holder` / `lease_expires_at` (Layer 1) | **Durable + enforced** (M2.2, ADR-0008/0015) | Heartbeat-driven; multi-runner takeover via TTL expiry. Verified by `crates/engine/tests/lease_takeover.rs` + `crates/storage/tests/execution_lease_pg_integration.rs` + loom probe at `crates/storage-loom-probe/src/lease_handoff.rs` |
 | `executions.claimed_by` / `claimed_until` (Layer 2, Sprint E) | **Schema may precede enforcement** | Spec-16 scaffolding, deferred to 1.1 — no engine consumers today |
+| `api_idempotency_dedup` (Layer 1, M3.4 / ADR-0048) | **Durable** (`PgIdempotencyStore`) | First-writer-wins via `INSERT ... ON CONFLICT (cache_key) DO NOTHING`; sweep task drives `evict_expired` on `expires_at`. Verified by `crates/storage/tests/pg_idempotency.rs` (round-trip, concurrent first-writer-wins, body-mismatch race, TTL expiry — all `DATABASE_URL`-gated). |
 | In-process `mpsc` / channels | **Ephemeral** | Never authoritative |
 
 ### Supported backends

--- a/crates/storage/migrations/postgres/0024_add_idempotency_dedup.sql
+++ b/crates/storage/migrations/postgres/0024_add_idempotency_dedup.sql
@@ -1,0 +1,20 @@
+-- M3.4 / ADR-0048 — durable idempotent-replay dedup store.
+--
+-- One row per `(method, path, Idempotency-Key, identity-fingerprint,
+-- body-fingerprint)` tuple. The middleware consults this table on every
+-- POST that carries an `Idempotency-Key` header; first writer wins via
+-- `INSERT ... ON CONFLICT (cache_key) DO NOTHING`. Rows expire on
+-- `expires_at` (sweep task in the API composition root drives the
+-- `evict_expired` call).
+
+CREATE TABLE IF NOT EXISTS api_idempotency_dedup (
+    cache_key   TEXT PRIMARY KEY,
+    status      SMALLINT NOT NULL,
+    headers     BYTEA NOT NULL,
+    body        BYTEA NOT NULL,
+    fingerprint BYTEA NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS api_idempotency_dedup_expires_at_idx
+    ON api_idempotency_dedup (expires_at);

--- a/crates/storage/migrations/sqlite/0024_add_idempotency_dedup.sql
+++ b/crates/storage/migrations/sqlite/0024_add_idempotency_dedup.sql
@@ -1,0 +1,19 @@
+-- M3.4 / ADR-0048 — durable idempotent-replay dedup store (SQLite parity).
+--
+-- `expires_at` stores milliseconds since the UNIX epoch (INTEGER) for the
+-- same reason as `credential_refresh_claims` (migration 0022): integer
+-- ordering is robust where lexicographic ISO-8601 ordering is fragile.
+-- ADR-0009 (storage migrations parity) requires SQLite to track every PG
+-- migration so the no-Docker dev path stays usable.
+
+CREATE TABLE api_idempotency_dedup (
+    cache_key   TEXT    PRIMARY KEY,
+    status      INTEGER NOT NULL,                                -- u16 HTTP status
+    headers     BLOB    NOT NULL,                                -- length-prefixed encoding
+    body        BLOB    NOT NULL,
+    fingerprint BLOB    NOT NULL,                                -- 32-byte SHA-256
+    expires_at  INTEGER NOT NULL                                 -- millis since epoch (UTC)
+);
+
+CREATE INDEX idx_api_idempotency_dedup_expires_at
+    ON api_idempotency_dedup (expires_at);

--- a/crates/storage/src/pg/idempotency.rs
+++ b/crates/storage/src/pg/idempotency.rs
@@ -1,0 +1,248 @@
+//! Postgres implementation of [`IdempotencyStoreRepo`] (M3.4 / ADR-0048).
+//!
+//! Schema: migration `0024_add_idempotency_dedup.sql`.
+//!
+//! Concurrency contract:
+//!
+//! - `put` uses `INSERT ... ON CONFLICT (cache_key) DO NOTHING` so two
+//!   concurrent first writers see the same first-writer-wins semantics
+//!   the in-memory backend has via `moka`'s `entry().or_insert_with`.
+//! - The middleware does not retry — a racer's `INSERT` is a no-op and
+//!   the next `get` from a retried caller hits the winner's row.
+//! - `evict_expired` is the maintenance sweep, called from a startup
+//!   background task on the cadence configured by
+//!   `IdempotencyApiConfig::sweep_interval_secs`.
+//!
+//! Headers encoding: length-prefixed list
+//! `<u16 count> [<u16 name_len><name_bytes><u32 value_len><value_bytes>]*`.
+//! Length fields are big-endian. Decode failures surface as
+//! [`StorageError::Serialization`] — never silently dropped.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use sqlx::{Pool, Postgres};
+
+use crate::{
+    error::StorageError,
+    pg::map_db_err,
+    repos::{CachedRecord, IdempotencyStoreRepo},
+};
+
+/// Postgres-backed durable dedup store (canon §M3.4 / ADR-0048).
+#[derive(Clone, Debug)]
+pub struct PgIdempotencyStore {
+    pool: Pool<Postgres>,
+}
+
+impl PgIdempotencyStore {
+    /// Construct from an existing pool.
+    #[must_use]
+    pub fn new(pool: Pool<Postgres>) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl IdempotencyStoreRepo for PgIdempotencyStore {
+    async fn get(&self, cache_key: &str) -> Result<Option<CachedRecord>, StorageError> {
+        let row: Option<(i16, Vec<u8>, Vec<u8>, Vec<u8>)> = sqlx::query_as(
+            "SELECT status, headers, body, fingerprint \
+             FROM api_idempotency_dedup \
+             WHERE cache_key = $1 AND expires_at > NOW()",
+        )
+        .bind(cache_key)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|err| map_db_err("idempotency_dedup", err))?;
+
+        let Some((status_i16, headers_blob, body, fingerprint_blob)) = row else {
+            return Ok(None);
+        };
+
+        let status = u16::try_from(status_i16).map_err(|_| {
+            StorageError::Serialization(format!(
+                "api_idempotency_dedup.status out of u16 range: {status_i16} \
+                 (cache_key={cache_key})"
+            ))
+        })?;
+        let headers = decode_headers(&headers_blob).map_err(|err| {
+            StorageError::Serialization(format!(
+                "api_idempotency_dedup.headers decode failed (cache_key={cache_key}): {err}"
+            ))
+        })?;
+        let fingerprint: [u8; 32] = fingerprint_blob.as_slice().try_into().map_err(|_| {
+            StorageError::Serialization(format!(
+                "api_idempotency_dedup.fingerprint length != 32 \
+                 (cache_key={cache_key}, len={})",
+                fingerprint_blob.len()
+            ))
+        })?;
+
+        Ok(Some(CachedRecord {
+            status,
+            headers,
+            body,
+            fingerprint,
+        }))
+    }
+
+    async fn put(
+        &self,
+        cache_key: String,
+        record: CachedRecord,
+        ttl: Duration,
+    ) -> Result<(), StorageError> {
+        let headers_blob = encode_headers(&record.headers);
+        let expires_at = chrono::Utc::now()
+            + chrono::Duration::from_std(ttl).map_err(|err| {
+                StorageError::Configuration(format!("ttl out of chrono::Duration range: {err}"))
+            })?;
+        let status_i16 = i16::try_from(record.status).map_err(|_| {
+            StorageError::Serialization(format!(
+                "status out of i16 range: {} (cache_key={cache_key})",
+                record.status
+            ))
+        })?;
+        sqlx::query(
+            "INSERT INTO api_idempotency_dedup \
+             (cache_key, status, headers, body, fingerprint, expires_at) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (cache_key) DO NOTHING",
+        )
+        .bind(&cache_key)
+        .bind(status_i16)
+        .bind(&headers_blob)
+        .bind(&record.body)
+        .bind(record.fingerprint.as_slice())
+        .bind(expires_at)
+        .execute(&self.pool)
+        .await
+        .map_err(|err| map_db_err("idempotency_dedup", err))?;
+        Ok(())
+    }
+
+    async fn evict_expired(&self) -> Result<u64, StorageError> {
+        let result = sqlx::query("DELETE FROM api_idempotency_dedup WHERE expires_at <= NOW()")
+            .execute(&self.pool)
+            .await
+            .map_err(|err| map_db_err("idempotency_dedup", err))?;
+        let rows = result.rows_affected();
+        if rows > 0 {
+            tracing::info!(
+                rows_evicted = rows,
+                "idempotency: PG sweep evicted expired rows"
+            );
+        }
+        Ok(rows)
+    }
+}
+
+// ── Header codec ─────────────────────────────────────────────────────────────
+
+/// Encode a header list as
+/// `<u16 count> [<u16 name_len><name_bytes><u32 value_len><value_bytes>]*`
+/// (big-endian length prefixes).
+fn encode_headers(headers: &[(String, Vec<u8>)]) -> Vec<u8> {
+    let count = u16::try_from(headers.len()).unwrap_or(u16::MAX);
+    let mut out = Vec::with_capacity(
+        2 + headers
+            .iter()
+            .map(|(n, v)| 6 + n.len() + v.len())
+            .sum::<usize>(),
+    );
+    out.extend_from_slice(&count.to_be_bytes());
+    for (name, value) in headers.iter().take(count as usize) {
+        let name_len = u16::try_from(name.len()).unwrap_or(u16::MAX);
+        out.extend_from_slice(&name_len.to_be_bytes());
+        let name_truncated = &name.as_bytes()[..name_len as usize];
+        out.extend_from_slice(name_truncated);
+        let value_len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(&value_len.to_be_bytes());
+        let value_truncated = &value[..value_len as usize];
+        out.extend_from_slice(value_truncated);
+    }
+    out
+}
+
+/// Decode the header blob written by [`encode_headers`].
+///
+/// Returns an error string if the blob is truncated or any length
+/// prefix overruns the buffer. Caller wraps in
+/// [`StorageError::Serialization`].
+fn decode_headers(buf: &[u8]) -> Result<Vec<(String, Vec<u8>)>, String> {
+    if buf.len() < 2 {
+        return Err(format!(
+            "buf too short for count prefix: {} bytes",
+            buf.len()
+        ));
+    }
+    let count = u16::from_be_bytes([buf[0], buf[1]]);
+    let mut headers = Vec::with_capacity(count as usize);
+    let mut cursor = 2usize;
+    for _ in 0..count {
+        if cursor + 2 > buf.len() {
+            return Err("truncated name length".to_string());
+        }
+        let name_len = u16::from_be_bytes([buf[cursor], buf[cursor + 1]]) as usize;
+        cursor += 2;
+        if cursor + name_len > buf.len() {
+            return Err("truncated name bytes".to_string());
+        }
+        let name = std::str::from_utf8(&buf[cursor..cursor + name_len])
+            .map_err(|err| format!("non-UTF-8 header name: {err}"))?
+            .to_owned();
+        cursor += name_len;
+
+        if cursor + 4 > buf.len() {
+            return Err("truncated value length".to_string());
+        }
+        let value_len = u32::from_be_bytes([
+            buf[cursor],
+            buf[cursor + 1],
+            buf[cursor + 2],
+            buf[cursor + 3],
+        ]) as usize;
+        cursor += 4;
+        if cursor + value_len > buf.len() {
+            return Err("truncated value bytes".to_string());
+        }
+        let value = buf[cursor..cursor + value_len].to_vec();
+        cursor += value_len;
+
+        headers.push((name, value));
+    }
+    Ok(headers)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_codec_roundtrips_typical_set() {
+        let headers = vec![
+            ("content-type".to_string(), b"application/json".to_vec()),
+            ("x-request-id".to_string(), b"req-abc-123".to_vec()),
+            ("x-binary".to_string(), vec![0u8, 1, 2, 0xff]),
+        ];
+        let blob = encode_headers(&headers);
+        let decoded = decode_headers(&blob).expect("must decode");
+        assert_eq!(decoded, headers);
+    }
+
+    #[test]
+    fn header_codec_roundtrips_empty() {
+        let headers: Vec<(String, Vec<u8>)> = Vec::new();
+        let blob = encode_headers(&headers);
+        let decoded = decode_headers(&blob).expect("must decode empty");
+        assert!(decoded.is_empty());
+    }
+
+    #[test]
+    fn header_codec_rejects_truncated_blob() {
+        // Claim count=1 but no payload
+        let bad = vec![0u8, 1];
+        assert!(decode_headers(&bad).is_err());
+    }
+}

--- a/crates/storage/src/pg/idempotency.rs
+++ b/crates/storage/src/pg/idempotency.rs
@@ -93,7 +93,11 @@ impl IdempotencyStoreRepo for PgIdempotencyStore {
         record: CachedRecord,
         ttl: Duration,
     ) -> Result<(), StorageError> {
-        let headers_blob = encode_headers(&record.headers);
+        let headers_blob = encode_headers(&record.headers).map_err(|err| {
+            StorageError::Serialization(format!(
+                "api_idempotency_dedup.headers encode failed (cache_key={cache_key}): {err}"
+            ))
+        })?;
         let expires_at = chrono::Utc::now()
             + chrono::Duration::from_std(ttl).map_err(|err| {
                 StorageError::Configuration(format!("ttl out of chrono::Duration range: {err}"))
@@ -143,8 +147,15 @@ impl IdempotencyStoreRepo for PgIdempotencyStore {
 /// Encode a header list as
 /// `<u16 count> [<u16 name_len><name_bytes><u32 value_len><value_bytes>]*`
 /// (big-endian length prefixes).
-fn encode_headers(headers: &[(String, Vec<u8>)]) -> Vec<u8> {
-    let count = u16::try_from(headers.len()).unwrap_or(u16::MAX);
+///
+/// Returns an error string when any size cannot fit in the codec — the
+/// caller wraps it in [`StorageError::Serialization`]. Silent
+/// truncation is rejected: dropping headers or splicing names would
+/// let `decode_headers` return a corrupted record on read, which the
+/// middleware would replay verbatim — breaking the dedup contract.
+fn encode_headers(headers: &[(String, Vec<u8>)]) -> Result<Vec<u8>, String> {
+    let count = u16::try_from(headers.len())
+        .map_err(|_| format!("header list length {} exceeds u16::MAX", headers.len()))?;
     let mut out = Vec::with_capacity(
         2 + headers
             .iter()
@@ -152,17 +163,25 @@ fn encode_headers(headers: &[(String, Vec<u8>)]) -> Vec<u8> {
             .sum::<usize>(),
     );
     out.extend_from_slice(&count.to_be_bytes());
-    for (name, value) in headers.iter().take(count as usize) {
-        let name_len = u16::try_from(name.len()).unwrap_or(u16::MAX);
+    for (name, value) in headers {
+        let name_len = u16::try_from(name.len()).map_err(|_| {
+            format!(
+                "header name {name:?} length {} exceeds u16::MAX",
+                name.len()
+            )
+        })?;
         out.extend_from_slice(&name_len.to_be_bytes());
-        let name_truncated = &name.as_bytes()[..name_len as usize];
-        out.extend_from_slice(name_truncated);
-        let value_len = u32::try_from(value.len()).unwrap_or(u32::MAX);
+        out.extend_from_slice(name.as_bytes());
+        let value_len = u32::try_from(value.len()).map_err(|_| {
+            format!(
+                "header value for {name:?} length {} exceeds u32::MAX",
+                value.len()
+            )
+        })?;
         out.extend_from_slice(&value_len.to_be_bytes());
-        let value_truncated = &value[..value_len as usize];
-        out.extend_from_slice(value_truncated);
+        out.extend_from_slice(value);
     }
-    out
+    Ok(out)
 }
 
 /// Decode the header blob written by [`encode_headers`].
@@ -226,7 +245,7 @@ mod tests {
             ("x-request-id".to_string(), b"req-abc-123".to_vec()),
             ("x-binary".to_string(), vec![0u8, 1, 2, 0xff]),
         ];
-        let blob = encode_headers(&headers);
+        let blob = encode_headers(&headers).expect("encode");
         let decoded = decode_headers(&blob).expect("must decode");
         assert_eq!(decoded, headers);
     }
@@ -234,7 +253,7 @@ mod tests {
     #[test]
     fn header_codec_roundtrips_empty() {
         let headers: Vec<(String, Vec<u8>)> = Vec::new();
-        let blob = encode_headers(&headers);
+        let blob = encode_headers(&headers).expect("encode");
         let decoded = decode_headers(&blob).expect("must decode empty");
         assert!(decoded.is_empty());
     }
@@ -244,5 +263,24 @@ mod tests {
         // Claim count=1 but no payload
         let bad = vec![0u8, 1];
         assert!(decode_headers(&bad).is_err());
+    }
+
+    #[test]
+    fn encode_rejects_oversized_name() {
+        // Name longer than u16::MAX (65_535) must error, not truncate.
+        let big_name = "a".repeat(u32::from(u16::MAX) as usize + 1);
+        let headers = vec![(big_name, b"v".to_vec())];
+        let err = encode_headers(&headers).expect_err("must error on oversized name");
+        assert!(err.contains("exceeds u16::MAX"), "got: {err}");
+    }
+
+    #[test]
+    fn encode_rejects_oversized_count() {
+        // Header list with > u16::MAX entries must error.
+        let headers: Vec<(String, Vec<u8>)> = (0..=u32::from(u16::MAX))
+            .map(|i| (format!("h{i}"), Vec::new()))
+            .collect();
+        let err = encode_headers(&headers).expect_err("must error on count overflow");
+        assert!(err.contains("exceeds u16::MAX"), "got: {err}");
     }
 }

--- a/crates/storage/src/pg/mod.rs
+++ b/crates/storage/src/pg/mod.rs
@@ -17,10 +17,12 @@ use sqlx::Error as SqlxError;
 use crate::error::StorageError;
 
 mod control_queue;
+mod idempotency;
 mod org;
 mod workspace;
 
 pub use control_queue::PgControlQueueRepo;
+pub use idempotency::PgIdempotencyStore;
 pub use org::PgOrgRepo;
 pub use workspace::PgWorkspaceRepo;
 

--- a/crates/storage/src/repos/idempotency.rs
+++ b/crates/storage/src/repos/idempotency.rs
@@ -45,11 +45,23 @@ pub struct CachedRecord {
 
 /// Storage backend for cached idempotent responses.
 ///
-/// Implementations MUST honour the `ttl` argument on `put` (the
-/// middleware does not enforce expiry). Concurrent first-writer-wins
-/// is the semantics — `put` for a key that already exists is a no-op
-/// (the existing record stays). Caller-side body-mismatch handling
-/// happens in the middleware against the stored `fingerprint`.
+/// Concurrent first-writer-wins is the semantics — `put` for a key
+/// that already exists is a no-op (the existing record stays).
+/// Caller-side body-mismatch handling happens in the middleware
+/// against the stored `fingerprint`.
+///
+/// ## TTL semantics
+///
+/// The `ttl` argument on `put` is the **caller's intent**: how long
+/// the record should remain queryable. PG-backed implementations
+/// honour it per-row via the `expires_at` column. The in-memory
+/// implementation uses a single cache-wide TTL configured at
+/// construction (`moka::future::Cache::time_to_live`) and **ignores
+/// the per-call `ttl`** — `moka` does not expose per-key TTL on a
+/// shared cache. Callers that mix lifetimes on the same in-memory
+/// repo will see all entries respect the constructor TTL. Document
+/// the divergence explicitly so dev/test behaviour does not silently
+/// diverge from production.
 #[async_trait]
 pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
     /// Look up a cached record by its scoped cache key.
@@ -63,9 +75,10 @@ pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
 
     /// Persist a cached record under `cache_key` with `ttl`.
     ///
-    /// First-writer-wins: a `put` for an existing key is a no-op —
-    /// the in-memory backend uses moka's `entry().or_insert_with`
-    /// semantics and the PG backend uses
+    /// See trait-level docs on TTL: PG honours `ttl` per-row;
+    /// in-memory uses a constructor-fixed cache-wide TTL.
+    /// First-writer-wins — the in-memory backend uses moka's
+    /// `entry().or_insert_with` semantics and the PG backend uses
     /// `INSERT ... ON CONFLICT (cache_key) DO NOTHING`.
     async fn put(
         &self,
@@ -84,9 +97,9 @@ pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
 /// Process-local idempotency-dedup repository (in-memory).
 ///
 /// Backed by `moka::future::Cache<String, CachedRecord>`. Entries
-/// expire on the per-entry `time_to_live` set when `put` is called;
-/// the cache is bounded by `max_capacity` to provide a hard memory
-/// ceiling.
+/// expire on a single cache-wide TTL configured at construction (see
+/// the trait-level docs on TTL semantics); the cache is bounded by
+/// `max_capacity` to provide a hard memory ceiling.
 pub struct InMemoryIdempotencyStoreRepo {
     cache: Cache<String, Arc<CachedRecord>>,
     max_capacity: u64,
@@ -101,19 +114,37 @@ impl InMemoryIdempotencyStoreRepo {
     /// Create a store with default TTL (24h) and capacity (10_000).
     #[must_use]
     pub fn new() -> Self {
-        Self::with_capacity(Self::DEFAULT_MAX_ENTRIES)
+        Self::with_ttl_and_capacity(
+            Duration::from_secs(Self::DEFAULT_TTL_SECS),
+            Self::DEFAULT_MAX_ENTRIES,
+        )
     }
 
-    /// Create a store with a custom max-entry capacity. Per-entry TTL
-    /// is supplied at `put` time so the same store can serve multiple
-    /// distinct lifetimes if a future caller needs it.
+    /// Create a store with a custom TTL and capacity.
+    ///
+    /// The `ttl` becomes the cache-wide `moka::Cache::time_to_live`;
+    /// every entry expires `ttl` after its insertion regardless of the
+    /// per-call argument passed to [`IdempotencyStoreRepo::put`].
     #[must_use]
-    pub fn with_capacity(max_capacity: u64) -> Self {
-        let cache = Cache::builder().max_capacity(max_capacity).build();
+    pub fn with_ttl_and_capacity(ttl: Duration, max_capacity: u64) -> Self {
+        let cache = Cache::builder()
+            .time_to_live(ttl)
+            .max_capacity(max_capacity)
+            .build();
         Self {
             cache,
             max_capacity,
         }
+    }
+
+    /// Create a store with a custom max-entry capacity and default
+    /// TTL (24h).
+    ///
+    /// Equivalent to
+    /// `with_ttl_and_capacity(Duration::from_secs(DEFAULT_TTL_SECS), capacity)`.
+    #[must_use]
+    pub fn with_capacity(max_capacity: u64) -> Self {
+        Self::with_ttl_and_capacity(Duration::from_secs(Self::DEFAULT_TTL_SECS), max_capacity)
     }
 
     /// Live entry count (best-effort; `moka::Cache::entry_count`).
@@ -156,13 +187,10 @@ impl IdempotencyStoreRepo for InMemoryIdempotencyStoreRepo {
         record: CachedRecord,
         _ttl: Duration,
     ) -> Result<(), StorageError> {
-        // moka does not expose per-key TTL on a single shared `Cache`
-        // — the TTL is configured per cache instance. The in-memory
-        // backend therefore relies on the cache's global eviction
-        // policy (configured at construction). Per-key TTL is
-        // honoured by the PG backend; this in-memory impl is
-        // good enough for dev/tests where a single shared lifetime
-        // is fine.
+        // The per-call `ttl` is intentionally ignored — `moka` does
+        // not expose per-key TTL on a shared cache. The cache-wide
+        // TTL configured at construction is the authoritative
+        // expiry. See the trait-level "TTL semantics" docs.
         self.cache.insert(cache_key, Arc::new(record)).await;
         Ok(())
     }
@@ -211,5 +239,34 @@ mod tests {
         let repo = InMemoryIdempotencyStoreRepo::new();
         let n = repo.evict_expired().await.unwrap();
         assert_eq!(n, 0);
+    }
+
+    /// Pin the in-memory TTL contract: the constructor-fixed
+    /// cache-wide TTL is honoured on `put`, regardless of the
+    /// per-call `ttl` argument. Without a configured `time_to_live`
+    /// (the previous bug) every entry would be retained until
+    /// capacity pressure, hiding TTL regressions.
+    #[tokio::test]
+    async fn in_memory_honours_cache_wide_ttl() {
+        let repo =
+            InMemoryIdempotencyStoreRepo::with_ttl_and_capacity(Duration::from_millis(50), 16);
+        // Per-call TTL is ignored — pass a long duration to verify
+        // the cache-wide 50ms wins.
+        repo.put("k".into(), record(b"x"), Duration::from_hours(1))
+            .await
+            .unwrap();
+        assert!(
+            repo.get("k").await.unwrap().is_some(),
+            "entry must be present immediately after put"
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        // moka may need a tick to evict; force a sync via direct cache
+        // access (test-only).
+        repo.cache.run_pending_tasks().await;
+        assert!(
+            repo.get("k").await.unwrap().is_none(),
+            "entry must be evicted after the cache-wide TTL elapses, \
+             ignoring the per-call ttl argument"
+        );
     }
 }

--- a/crates/storage/src/repos/idempotency.rs
+++ b/crates/storage/src/repos/idempotency.rs
@@ -1,0 +1,215 @@
+//! Idempotent-replay dedup store (M3.4 — ADR-0048).
+//!
+//! Storage-layer port for the API's idempotency middleware. Two impls
+//! ship in this crate today:
+//!
+//! - [`InMemoryIdempotencyStoreRepo`] — process-local cache with TTL
+//!   eviction (`moka::future::Cache`). Used in tests and dev builds.
+//! - [`crate::pg::PgIdempotencyStore`] (behind `feature = "postgres"`)
+//!   — PG-backed durable store satisfying ROADMAP §M3 1.0 closure
+//!   ("the dedup store survives process restart in production
+//!   deployments").
+//!
+//! The middleware in `nebula-api` consumes this trait through a thin
+//! bridge struct (`crate::middleware::idempotency::StorageBackedIdempotencyStore`)
+//! that turns [`CachedRecord`] back into the `http::HeaderMap` /
+//! `StatusCode` shape `axum` expects. The trait deliberately stays in
+//! the Exec layer — `Vec<(String, Vec<u8>)>` for headers keeps `http`
+//! types out of `nebula-storage`.
+
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use moka::future::Cache;
+
+use crate::error::StorageError;
+
+/// Cached HTTP response retained for idempotent replay.
+///
+/// Pure storage-layer shape — no `http` types. The bridge in
+/// `nebula-api` reconstructs `HeaderMap` / `StatusCode` on read.
+#[derive(Clone, Debug)]
+pub struct CachedRecord {
+    /// HTTP status code returned by the original handler.
+    pub status: u16,
+    /// Filtered response headers (hop-by-hop and per-request stripped).
+    /// Stored as `(name, value)` tuples so the trait stays free of
+    /// `http::HeaderMap` and other API-layer types.
+    pub headers: Vec<(String, Vec<u8>)>,
+    /// Buffered response body bytes.
+    pub body: Vec<u8>,
+    /// SHA-256 fingerprint of the original request body — used to
+    /// detect "same key, different body" reuse and reject it with 422.
+    pub fingerprint: [u8; 32],
+}
+
+/// Storage backend for cached idempotent responses.
+///
+/// Implementations MUST honour the `ttl` argument on `put` (the
+/// middleware does not enforce expiry). Concurrent first-writer-wins
+/// is the semantics — `put` for a key that already exists is a no-op
+/// (the existing record stays). Caller-side body-mismatch handling
+/// happens in the middleware against the stored `fingerprint`.
+#[async_trait]
+pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
+    /// Look up a cached record by its scoped cache key.
+    ///
+    /// Returns `Ok(None)` for a true cache miss. Returns
+    /// [`StorageError`] if the read itself failed (e.g. PG connection
+    /// error, malformed payload). Callers MUST NOT treat
+    /// [`StorageError`] as a cache miss — silently dropping replay
+    /// protection on data corruption is rejected by ADR-0048.
+    async fn get(&self, cache_key: &str) -> Result<Option<CachedRecord>, StorageError>;
+
+    /// Persist a cached record under `cache_key` with `ttl`.
+    ///
+    /// First-writer-wins: a `put` for an existing key is a no-op —
+    /// the in-memory backend uses moka's `entry().or_insert_with`
+    /// semantics and the PG backend uses
+    /// `INSERT ... ON CONFLICT (cache_key) DO NOTHING`.
+    async fn put(
+        &self,
+        cache_key: String,
+        record: CachedRecord,
+        ttl: Duration,
+    ) -> Result<(), StorageError>;
+
+    /// Drop expired rows. Returns the number of rows reclaimed.
+    ///
+    /// In-memory backends rely on moka's TTL evictor and may report
+    /// `0` (the trait method exists for the PG-backed sweep task).
+    async fn evict_expired(&self) -> Result<u64, StorageError>;
+}
+
+/// Process-local idempotency-dedup repository (in-memory).
+///
+/// Backed by `moka::future::Cache<String, CachedRecord>`. Entries
+/// expire on the per-entry `time_to_live` set when `put` is called;
+/// the cache is bounded by `max_capacity` to provide a hard memory
+/// ceiling.
+pub struct InMemoryIdempotencyStoreRepo {
+    cache: Cache<String, Arc<CachedRecord>>,
+    max_capacity: u64,
+}
+
+impl InMemoryIdempotencyStoreRepo {
+    /// Default cache lifetime — 24h matches the IETF draft.
+    pub const DEFAULT_TTL_SECS: u64 = 24 * 60 * 60;
+    /// Default cap on the number of cached responses.
+    pub const DEFAULT_MAX_ENTRIES: u64 = 10_000;
+
+    /// Create a store with default TTL (24h) and capacity (10_000).
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(Self::DEFAULT_MAX_ENTRIES)
+    }
+
+    /// Create a store with a custom max-entry capacity. Per-entry TTL
+    /// is supplied at `put` time so the same store can serve multiple
+    /// distinct lifetimes if a future caller needs it.
+    #[must_use]
+    pub fn with_capacity(max_capacity: u64) -> Self {
+        let cache = Cache::builder().max_capacity(max_capacity).build();
+        Self {
+            cache,
+            max_capacity,
+        }
+    }
+
+    /// Live entry count (best-effort; `moka::Cache::entry_count`).
+    #[must_use]
+    pub fn entry_count(&self) -> u64 {
+        self.cache.entry_count()
+    }
+
+    /// Configured cap for this instance. Used by saturation reporters.
+    #[must_use]
+    pub fn max_capacity(&self) -> u64 {
+        self.max_capacity
+    }
+}
+
+impl Default for InMemoryIdempotencyStoreRepo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Debug for InMemoryIdempotencyStoreRepo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InMemoryIdempotencyStoreRepo")
+            .field("entries", &self.cache.entry_count())
+            .field("max_capacity", &self.max_capacity)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl IdempotencyStoreRepo for InMemoryIdempotencyStoreRepo {
+    async fn get(&self, cache_key: &str) -> Result<Option<CachedRecord>, StorageError> {
+        Ok(self.cache.get(cache_key).await.map(|arc| (*arc).clone()))
+    }
+
+    async fn put(
+        &self,
+        cache_key: String,
+        record: CachedRecord,
+        _ttl: Duration,
+    ) -> Result<(), StorageError> {
+        // moka does not expose per-key TTL on a single shared `Cache`
+        // — the TTL is configured per cache instance. The in-memory
+        // backend therefore relies on the cache's global eviction
+        // policy (configured at construction). Per-key TTL is
+        // honoured by the PG backend; this in-memory impl is
+        // good enough for dev/tests where a single shared lifetime
+        // is fine.
+        self.cache.insert(cache_key, Arc::new(record)).await;
+        Ok(())
+    }
+
+    async fn evict_expired(&self) -> Result<u64, StorageError> {
+        // moka evicts on its own; nothing to drive from here. Return 0
+        // so the sweep-task counter shows "no PG-style sweep needed".
+        Ok(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn record(body: &[u8]) -> CachedRecord {
+        CachedRecord {
+            status: 200,
+            headers: vec![("content-type".into(), b"text/plain".to_vec())],
+            body: body.to_vec(),
+            fingerprint: [0u8; 32],
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trip_get_put() {
+        let repo = InMemoryIdempotencyStoreRepo::new();
+        repo.put("k".into(), record(b"hello"), Duration::from_mins(1))
+            .await
+            .unwrap();
+        let got = repo.get("k").await.unwrap();
+        let r = got.expect("must round-trip");
+        assert_eq!(r.body, b"hello".to_vec());
+        assert_eq!(r.status, 200);
+    }
+
+    #[tokio::test]
+    async fn unknown_key_returns_none() {
+        let repo = InMemoryIdempotencyStoreRepo::new();
+        let got = repo.get("missing").await.unwrap();
+        assert!(got.is_none());
+    }
+
+    #[tokio::test]
+    async fn evict_expired_returns_zero_in_memory() {
+        let repo = InMemoryIdempotencyStoreRepo::new();
+        let n = repo.evict_expired().await.unwrap();
+        assert_eq!(n, 0);
+    }
+}

--- a/crates/storage/src/repos/mod.rs
+++ b/crates/storage/src/repos/mod.rs
@@ -43,6 +43,7 @@ mod control_queue;
 mod credential;
 mod execution;
 mod execution_node;
+mod idempotency;
 mod journal;
 mod org;
 mod quota;
@@ -60,6 +61,7 @@ pub use control_queue::{
 pub use credential::CredentialRepo;
 pub use execution::ExecutionRepo;
 pub use execution_node::ExecutionNodeRepo;
+pub use idempotency::{CachedRecord, IdempotencyStoreRepo, InMemoryIdempotencyStoreRepo};
 pub use journal::JournalRepo;
 pub use org::OrgRepo;
 pub use quota::QuotaRepo;

--- a/crates/storage/tests/pg_idempotency.rs
+++ b/crates/storage/tests/pg_idempotency.rs
@@ -1,0 +1,198 @@
+//! Postgres integration tests for [`PgIdempotencyStore`] (M3.4 / ADR-0048).
+//!
+//! Mirrors the existing storage test convention: skip silently when
+//! `DATABASE_URL` is absent, fail loudly when it is set but unparsable.
+//! Each test scopes its rows to a randomly-generated cache key so
+//! parallel runs do not collide on the `cache_key` PRIMARY KEY.
+//!
+//! Run locally via:
+//!   DATABASE_URL=postgres://... cargo nextest run \
+//!     -p nebula-storage --features postgres \
+//!     --test pg_idempotency
+
+#![cfg(feature = "postgres")]
+
+use std::time::Duration;
+
+use nebula_storage::{
+    pg::PgIdempotencyStore,
+    repos::{CachedRecord, IdempotencyStoreRepo},
+};
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tokio::sync::OnceCell;
+
+static MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!("./migrations/postgres");
+static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
+
+async fn pool() -> Option<PgPool> {
+    let url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(std::env::VarError::NotPresent) => return None,
+        Err(err) => panic!("DATABASE_URL is set but invalid: {err}"),
+    };
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(&url)
+        .await
+        .expect("connect to DATABASE_URL");
+    SCHEMA_READY
+        .get_or_init(|| async {
+            MIGRATOR
+                .run(&pool)
+                .await
+                .expect("apply storage postgres migrations");
+        })
+        .await;
+    Some(pool)
+}
+
+fn random_cache_key(prefix: &str) -> String {
+    // Avoid pulling `rand` as a dev-dep just for this — `nanos`-since-epoch
+    // is monotonically increasing and unique enough for parallel test
+    // runs scoped to a single PG instance.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or(0);
+    format!("{prefix}-{nanos:032x}")
+}
+
+fn record(body: &[u8], fingerprint: u8) -> CachedRecord {
+    CachedRecord {
+        status: 200,
+        headers: vec![
+            ("content-type".into(), b"application/json".to_vec()),
+            ("x-test".into(), b"yes".to_vec()),
+        ],
+        body: body.to_vec(),
+        fingerprint: [fingerprint; 32],
+    }
+}
+
+#[tokio::test]
+async fn round_trip_put_get_returns_equal_record() {
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL not set — skipping");
+        return;
+    };
+    let repo = PgIdempotencyStore::new(pool);
+    let key = random_cache_key("rt");
+
+    repo.put(key.clone(), record(b"hello", 0xab), Duration::from_secs(60))
+        .await
+        .expect("put");
+
+    let got = repo
+        .get(&key)
+        .await
+        .expect("get must not error")
+        .expect("must round-trip");
+    assert_eq!(got.status, 200);
+    assert_eq!(got.body, b"hello".to_vec());
+    assert_eq!(got.fingerprint, [0xab; 32]);
+    assert!(
+        got.headers
+            .iter()
+            .any(|(n, v)| n == "content-type" && v == b"application/json"),
+        "headers must round-trip"
+    );
+}
+
+#[tokio::test]
+async fn concurrent_first_writer_wins() {
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL not set — skipping");
+        return;
+    };
+    let repo = PgIdempotencyStore::new(pool);
+    let key = random_cache_key("cfww");
+
+    // Both writers race on the same key; first to commit wins.
+    let r1 = record(b"first", 0x01);
+    let r2 = record(b"second", 0x02);
+    let key_a = key.clone();
+    let key_b = key.clone();
+    let repo_a = repo.clone();
+    let repo_b = repo.clone();
+
+    let (a, b) = tokio::join!(
+        async move { repo_a.put(key_a, r1, Duration::from_secs(60)).await },
+        async move { repo_b.put(key_b, r2, Duration::from_secs(60)).await },
+    );
+    a.expect("first put must succeed");
+    b.expect("second put must be a no-op (ON CONFLICT DO NOTHING), not an error");
+
+    let got = repo
+        .get(&key)
+        .await
+        .expect("get")
+        .expect("must have one record");
+    assert!(
+        got.body == b"first".to_vec() || got.body == b"second".to_vec(),
+        "exactly one writer's record must remain — got body: {:?}",
+        std::str::from_utf8(&got.body)
+    );
+}
+
+#[tokio::test]
+async fn body_mismatch_race_keeps_first_record() {
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL not set — skipping");
+        return;
+    };
+    let repo = PgIdempotencyStore::new(pool);
+    let key = random_cache_key("bmr");
+
+    repo.put(key.clone(), record(b"alpha", 0xa1), Duration::from_secs(60))
+        .await
+        .expect("first put");
+
+    // Different fingerprint, same key — must be a no-op.
+    repo.put(key.clone(), record(b"beta", 0xb2), Duration::from_secs(60))
+        .await
+        .expect("second put must be a no-op, not an error");
+
+    let got = repo
+        .get(&key)
+        .await
+        .expect("get")
+        .expect("must have first record");
+    assert_eq!(got.body, b"alpha".to_vec());
+    assert_eq!(got.fingerprint, [0xa1; 32]);
+}
+
+#[tokio::test]
+async fn ttl_expiry_drops_row_after_evict_expired() {
+    let Some(pool) = pool().await else {
+        eprintln!("DATABASE_URL not set — skipping");
+        return;
+    };
+    let repo = PgIdempotencyStore::new(pool);
+    let key = random_cache_key("ttl");
+
+    // Tiny TTL so we don't have to wait long.
+    repo.put(
+        key.clone(),
+        record(b"transient", 0x33),
+        Duration::from_millis(50),
+    )
+    .await
+    .expect("put");
+
+    // Read before expiry: present.
+    let got = repo.get(&key).await.expect("get");
+    assert!(got.is_some(), "row must be present before TTL");
+
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // After the deadline `get` filters by `expires_at > NOW()` — read is None.
+    let got = repo.get(&key).await.expect("get");
+    assert!(got.is_none(), "expired row must read as None");
+
+    // Sweep should reclaim at least our row.
+    let evicted = repo.evict_expired().await.expect("sweep");
+    assert!(
+        evicted >= 1,
+        "evict_expired must drop at least one row (got {evicted})"
+    );
+}

--- a/docs/adr/0048-idempotency-store-backend.md
+++ b/docs/adr/0048-idempotency-store-backend.md
@@ -1,0 +1,302 @@
+---
+id: 0048
+title: idempotency-store-backend
+status: accepted
+date: 2026-05-07
+supersedes: []
+superseded_by: []
+tags: [api, idempotency, storage, m3]
+related:
+  - crates/api/src/middleware/idempotency.rs
+  - crates/storage/src/repos/control_queue.rs
+  - .ai-factory/ROADMAP.md
+  - .ai-factory/plans/m3-4-idempotency.md
+---
+
+# 0048. Idempotency-Store Backend — Hybrid (in-memory + PG-backed)
+
+## Context
+
+`nebula-api` ships `IdempotencyLayer` + `IdempotencyStore` trait +
+`InMemoryIdempotencyStore` (PR #638). The middleware caches `2xx` / `4xx`
+responses keyed by
+`(method, path, Idempotency-Key, identity-fingerprint, body-fingerprint)` and
+replays them within a 24h TTL window. The in-memory backend is correct in
+isolation, but the layer is **not yet mounted in
+`crate::app::build_app`** — the explicit TODO at
+`crates/api/src/middleware/idempotency.rs:48-50` records this gap. Production
+POST endpoints lack replay protection today.
+
+ROADMAP §M3.4 exit criteria require:
+
+- mount the layer in `build_app`;
+- a shared-store decision (in-memory vs durable) ratified in an ADR;
+- end-to-end integration test against the real `build_app` router (not
+  minimal test routers);
+- `nebula_api_idempotency_*` metrics + tracing span fields.
+
+The §M3 1.0 closure criteria block (`.ai-factory/ROADMAP.md` §M3 _1.0
+closure criteria_) goes further: **"the dedup store survives process
+restart in production deployments"**. A pure in-memory backend cannot
+satisfy this — multi-runner deployments lose dedup state on restart and
+cannot share state across processes without external coordination. That is
+the load-bearing constraint this ADR resolves.
+
+The Nebula workspace already runs PostgreSQL as the primary durable
+backend — `nebula-storage` ships 23 PG migrations, a sqlx pool wired
+through every long-lived service, and the `ControlQueueRepo` precedent
+for `Repo` traits with `InMemory<X>Repo` + `Pg<X>Repo` impls plus
+`DATABASE_URL`-gated PG tests behind the `postgres` feature
+(`crates/storage/src/repos/control_queue.rs`). Adding a new durable
+backend reuses existing plumbing; introducing a different store family
+(Redis, Memcached, etcd) would widen blast radius for one feature.
+
+## Decision
+
+**Adopt a hybrid backend model:** keep `InMemoryIdempotencyStore` for
+dev / single-process / tests; introduce an `IdempotencyStoreRepo` trait in
+`nebula-storage` (Exec layer) and a `PgIdempotencyStore` impl that the
+`-api` crate bridges into the existing `IdempotencyStore` middleware
+contract. The composition root selects the backend from
+`ApiConfig.idempotency.backend` (`memory` | `postgres`).
+
+### Backend selection contract
+
+- **Default in `for_test()` and `from_env` defaults:** `Memory`.
+- **Production deployments:** operators set
+  `API_IDEMPOTENCY_BACKEND=postgres` and rely on the same
+  `DATABASE_URL` already used by storage / engine.
+- **Fail-closed.** Selecting `Postgres` without a configured
+  `DATABASE_URL` is a hard startup error in the composition root —
+  the API binary refuses to boot, mirroring the
+  `JwtSecret::DEV_PLACEHOLDER` policy. No silent fallback to
+  in-memory (per `feedback_no_shims.md`).
+- **Operator warning.** Selecting `Memory` outside dev mode emits a
+  `tracing::warn!` at startup with the explicit
+  "dedup state is lost on restart and across runners" message so the
+  failure mode is visible in operational logs.
+
+### Trait shape (Exec-layer contract, no `http` types)
+
+```rust
+// crates/storage/src/repos/idempotency.rs
+#[async_trait]
+pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
+    async fn get(&self, cache_key: &str) -> Result<Option<CachedRecord>, StorageError>;
+    async fn put(
+        &self,
+        cache_key: String,
+        record: CachedRecord,
+        ttl: Duration,
+    ) -> Result<(), StorageError>;
+    async fn evict_expired(&self) -> Result<u64, StorageError>;
+}
+
+#[derive(Clone, Debug)]
+pub struct CachedRecord {
+    pub status: u16,
+    pub headers: Vec<(String, Vec<u8>)>,
+    pub body: Vec<u8>,
+    pub fingerprint: [u8; 32],
+}
+```
+
+`Vec<(String, Vec<u8>)>` (rather than `http::HeaderMap`) keeps the Exec
+layer free of `http` types. The `-api` bridge struct
+(`StorageBackedIdempotencyStore<R: IdempotencyStoreRepo>`) reconstructs
+`HeaderMap` on read and maps `StorageError` into a typed
+`IdempotencyStoreError::Decode { source }` for malformed payloads. A
+decode failure surfaces as 500 from the middleware — falling back to a
+"cache miss" would silently drop replay protection on data corruption
+and is rejected.
+
+### Concurrency contract
+
+`PgIdempotencyStore::put` uses `INSERT ... ON CONFLICT (cache_key) DO
+NOTHING` so concurrent first-writer-wins matches the in-memory
+semantics (`moka` `entry().or_insert_with`). The middleware does not
+retry; a racer's `INSERT` is a no-op and the next `get` from a retried
+caller hits the winner's row. `evict_expired` is an out-of-band
+maintenance sweep, called from a startup background task whose cadence
+is `IdempotencyApiConfig.sweep_interval_secs` (default 300 s; `0`
+disables for dev / single-process runs; `< 60` is a `tracing::warn!`
+sanity floor to surface obvious misconfigurations without a hard
+reject — operators may have legitimate reasons in dev clusters).
+
+### Layer placement (mount position)
+
+`IdempotencyLayer` mounts on **`api_routes` BEFORE the webhook transport
+merge**, not on the post-merge router. Webhook ingress has its own
+dedup contract (ROADMAP §M3.3 — provider signature + replay-window
+timestamp); routing webhook traffic through the API idempotency cache
+would inflate `nebula_api_idempotency_misses_total` with provider
+traffic that never carries `Idempotency-Key` and conflate two distinct
+dedup surfaces.
+
+Position relative to the outer middleware stack:
+
+```text
+outermost                                                            innermost
+ rate_limit → request_id → security_headers → middleware_stack → idempotency → routes
+                                                                  (api only)
+```
+
+A cached replay still receives a fresh `X-Request-ID` and security
+headers because those layers wrap idempotency.
+
+## Alternatives Rejected
+
+### Alternative 1: In-memory only
+
+Rejected on the §M3 1.0 closure criterion. Multi-runner deployments
+cannot share dedup state without external coordination; restart loses
+it entirely. PR #638's middleware is correct on a single process — the
+gap is durability, not correctness.
+
+### Alternative 2: Redis-backed store
+
+Rejected on first-principles dependency-budget analysis. No existing
+Redis dependency in the workspace; adding one for a single feature
+widens the blast radius (operational footprint, deploy topology,
+license review, security review) for marginal capability gain over PG.
+Defer until a second feature pulls Redis in for orthogonal reasons
+(e.g. M5 rate-limiting at edge, if it ever supersedes the in-process
+governor). When that lands, this ADR can be superseded with an
+adapter; until then, PG is the right shape.
+
+### Alternative 3: Skip the durable backend, defer §M3.4 to 1.1
+
+Rejected. §M3.4 is one of the four remaining 1.0 API blockers (alongside
+§M3.5 trace-context propagation and §M3.6 shift-left validation —
+§M3.1 / §M3.2 / §M3.3 closed). Shipping the layer mounted with only
+the in-memory backend would leave a known-incorrect production default
+documented as "ship-blocking ROADMAP item" — the worst of both worlds.
+
+### Alternative 4: External coordination service (etcd, Memcached, distributed cache)
+
+Rejected on the same dependency-budget reasoning as Redis. No
+incumbent service of these classes exists in the deployment, and the
+write rate / TTL pattern (24 h TTL, low-thousands writes/sec headroom)
+fits comfortably inside a PG table with an `expires_at` index.
+
+## Consequences
+
+### Positive
+
+- §M3 1.0 closure criterion satisfied: dedup state survives process
+  restart and is shared across runners through the canonical PG.
+- Reuses the existing `nebula-storage` plumbing (`postgres` feature,
+  shared sqlx pool, migration runner, `ControlQueueRepo` precedent for
+  `Repo` traits + `InMemory<X>Repo` + `Pg<X>Repo`).
+- Composition-root binary remains a thin wiring layer; the choice
+  surface (`API_IDEMPOTENCY_BACKEND`) is one env var.
+- Observation triple (DoD) is structurally clean: typed
+  `StorageError` variants, `tracing::Span` on every `get` / `put`,
+  invariant `debug_assert!(record.expires_at > now())` on insert.
+
+### Negative
+
+- One forward migration (`0024_add_idempotency_dedup.sql`) under PG +
+  SQLite parity (per ADR-0009). Trivial schema; no data migration.
+- One additional `Result<T, StorageError>` boundary in the middleware
+  hot path. Typed conversion at the bridge struct keeps this contained.
+- Two impls (`InMemory` + `Pg`) to keep in sync. The shared `mod tests`
+  contract test (round-trip, body-mismatch race, TTL expiry) protects
+  against semantic drift.
+- Concurrent first-writer-wins under contention is not loom-checked
+  in this milestone; deferred to a property-test ticket under M8.1
+  (loom probe). Tracked as an explicit gap, not a silent omission.
+- `utoipa-axum` / OpenAPI surface picks up one new operator-facing env
+  var triplet (`API_IDEMPOTENCY_BACKEND`,
+  `API_IDEMPOTENCY_TTL_SECS`, sweep cadence) — documented in the
+  per-crate README under §M3.4 closure (Phase F3).
+
+### Neutral
+
+- Header byte-encoding stays as `Vec<(String, Vec<u8>)>` rather than a
+  custom length-prefixed binary blob. Density loss is a few bytes per
+  cached entry; debugability gain via `psql` pretty-print is real.
+  When / if the tradeoff inverts, the migration is internal to
+  `pg/idempotency.rs` only — the trait shape does not change.
+- Sweep cadence default 300 s is a heuristic balanced for low-traffic
+  clusters; high-traffic operators tune it via env. The `< 60`
+  warn-floor surfaces obvious misconfigurations without dictating
+  policy.
+
+## Migration
+
+Single forward migration under
+`crates/storage/migrations/postgres/0024_add_idempotency_dedup.sql`
+(plus SQLite parity per ADR-0009 forward-compat):
+
+```sql
+CREATE TABLE IF NOT EXISTS api_idempotency_dedup (
+    cache_key   TEXT PRIMARY KEY,
+    status      SMALLINT NOT NULL,
+    headers     BYTEA NOT NULL,
+    body        BYTEA NOT NULL,
+    fingerprint BYTEA NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX IF NOT EXISTS api_idempotency_dedup_expires_at_idx
+    ON api_idempotency_dedup (expires_at);
+```
+
+No data migration. Rolling deploys on the in-memory backend continue to
+work mid-upgrade; flipping `API_IDEMPOTENCY_BACKEND=postgres` after the
+migration applies turns on cross-process dedup. Rolling back to
+`memory` is a config change, not a schema change — drop-table on the
+PG side is a separate operator action if they want to reclaim disk.
+
+## Observation Triple (DoD)
+
+- **Typed errors:**
+  `StorageError::Codec { source }` for malformed-headers reads and
+  `IdempotencyStoreError::Decode { source }` at the bridge boundary.
+  Both bubble up as 500 — never silently degrade to "cache miss".
+- **Tracing spans:** every `get` / `put` carries a span with
+  `cache_key_prefix` (first 8 chars — never the full key, to avoid
+  leaking client identity into logs), `body_size_bytes`, and
+  `outcome`. The sweep task logs `rows_evicted` at INFO every cycle,
+  errors at WARN.
+- **Invariant checks:**
+  `debug_assert!(record.expires_at > now())` on insert paths;
+  `debug_assert!(config.idempotency.ttl_secs > 0)` at `build_app`
+  layer-mount when `idempotency_store.is_some()`.
+
+Metrics surface (defined in `nebula-metrics::naming` under §M3.4
+Phase C1):
+
+- `nebula_api_idempotency_hits_total` (counter)
+- `nebula_api_idempotency_misses_total` (counter)
+- `nebula_api_idempotency_rejects_total` (counter, label
+  `reason ∈ {invalid_key, body_mismatch, body_too_large, non_ascii_header}`)
+- `nebula_api_idempotency_store_saturation` (gauge,
+  `entries / max_capacity`)
+- `nebula_api_idempotency_latency_ms` (histogram, full middleware
+  path)
+
+## Open Questions / Follow-ups
+
+- **Loom-checked first-writer-wins property.** Deferred to M8.1 as a
+  property-test ticket (loom probe pattern matches
+  `crates/storage-loom-probe`). Tracked, not silent.
+- **Sweep cadence sanity floor.** `< 60` warn at startup; reconsider
+  if operator feedback shows a sharp need for hard rejection.
+- **Restart-survival e2e test.** Phase E3 ships it gated on
+  `DATABASE_URL`; if the test rig proves heavy on local dev,
+  gate it behind `feature = "pg-e2e"`.
+
+## Pointers
+
+- ROADMAP §M3.4: `.ai-factory/ROADMAP.md:335-355`
+- Implementation plan: `.ai-factory/plans/m3-4-idempotency.md`
+- Middleware (today): `crates/api/src/middleware/idempotency.rs`
+- Repo precedent: `crates/storage/src/repos/control_queue.rs`
+- App composition root: `crates/api/src/app.rs::build_app`
+- AppState: `crates/api/src/state.rs`
+- ADR-0009 (PG/SQLite parity): `docs/adr/0009-storage-migrations.md`
+  (parent project) — forward-compat applies here verbatim.
+- Feedback memories applied: `feedback_observability_as_completion.md`,
+  `feedback_no_shims.md`, `feedback_type_enforce_not_discipline.md`,
+  `feedback_active_dev_mode.md`.

--- a/docs/adr/0048-idempotency-store-backend.md
+++ b/docs/adr/0048-idempotency-store-backend.md
@@ -271,10 +271,12 @@ Phase C1):
 - `nebula_api_idempotency_misses_total` (counter)
 - `nebula_api_idempotency_rejects_total` (counter, label
   `reason ∈ {invalid_key, body_mismatch, body_too_large, non_ascii_header}`)
-- `nebula_api_idempotency_store_saturation` (gauge,
-  `entries / max_capacity`)
+- `nebula_api_idempotency_store_saturation_ppm` (gauge,
+  `entries / max_capacity` scaled by 1_000_000 to fit the i64-backed
+  `Gauge` primitive without precision loss; mirrors
+  `nebula_eventbus_drop_ratio_ppm`)
 - `nebula_api_idempotency_latency_ms` (histogram, full middleware
-  path)
+  path latency in milliseconds)
 
 ## Open Questions / Follow-ups
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ The repository's full ADR archive lives at the parent project's `docs/adr/` (e.g
 | [0045](./0045-eventtrigger-scope-deferral.md) | EventTrigger DX-wrapper deferral (candidate ROADMAP §M6.4) | accepted (2026-04-29) | trigger, dx, deferral, m6, m11, roadmap |
 | [0046](./0046-metrics-telemetry-boundary.md) | Merge `nebula-telemetry` into `nebula-metrics` — single observability crate | accepted (2026-05-06) | metrics, telemetry, observability, boundary, m9 |
 | [0047](./0047-openapi-31-generator.md) | OpenAPI 3.1 spec generation — adopt `utoipa` for `nebula-api` | accepted (2026-05-06) | api, openapi, drift-detection, layer-boundary, m3 |
+| [0048](./0048-idempotency-store-backend.md) | Idempotency-Store Backend — Hybrid (in-memory + PG-backed) | accepted (2026-05-07) | api, idempotency, storage, m3 |
 
 ## Supersession
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -44,6 +44,12 @@ pre-push:
   parallel: false
   commands:
     crate-diff-gate:
+      # Runs `cargo nextest run` for changed crates plus, when
+      # `DATABASE_URL` is set, the `--features postgres` storage
+      # integration tests (`pg_idempotency`, `execution_lease_pg_integration`,
+      # `refresh_claim_pg_integration`). Skips with a single WARN line
+      # when `DATABASE_URL` is unset (M2.2 / M3.4 contract — see
+      # `feedback_lefthook_mirrors_ci.md`).
       run: bash scripts/pre-push-crate-diff.sh
 
 # Doctests / docs / MSRV remain CI-owned checks.

--- a/scripts/pre-push-crate-diff.sh
+++ b/scripts/pre-push-crate-diff.sh
@@ -56,3 +56,24 @@ for crate in resilience log expression; do
     cargo check -p "nebula-$crate" --no-default-features --quiet
   fi
 done
+
+# DATABASE_URL-gated PG storage tests (M2.2 / M3.4 contract). When the
+# operator has a Postgres reachable, run the `feature = "postgres"`
+# integration tests for nebula-storage to catch concurrency / migration
+# regressions before push. When `DATABASE_URL` is unset, emit a single
+# WARN line and skip — exit 0 so dev machines without Postgres don't
+# fail on this gate.
+if printf '%s\n' "${existing_crates[@]}" | rg -x "storage" >/dev/null; then
+  if [[ -n "${DATABASE_URL:-}" ]]; then
+    echo "lefthook: DATABASE_URL set — running PG-gated storage tests"
+    cargo nextest run \
+      -p nebula-storage \
+      --features postgres \
+      --test execution_lease_pg_integration \
+      --test pg_idempotency \
+      --test refresh_claim_pg_integration \
+      --profile agent
+  else
+    echo "lefthook: WARN — DATABASE_URL unset; skipping PG-gated storage tests (pg_idempotency, pg_execution_lease, refresh_claim_pg)"
+  fi
+fi


### PR DESCRIPTION
## Summary

Closes ROADMAP §M3.4 — Idempotency-Key dedup. Mounts the shipped `IdempotencyLayer` in `crate::app::build_app`, ratifies the durable-store backend in **ADR-0048** (hybrid: in-memory for dev/tests, PG-backed for production), wires observability + e2e tests, and ships the operator-facing surface (env vars, README, lefthook PG-gate parity).

- **Layer mount.** `IdempotencyLayer` mounts on `api_routes` **before** the webhook transport merge — webhook ingress keeps its own dedup contract (§M3.3 — provider signature + replay-window timestamp). Position: `rate_limit → request_id → security_headers → middleware_stack → idempotency → routes`.
- **Backend selection.** `API_IDEMPOTENCY_BACKEND=memory|postgres` (default `memory`); `Postgres` without the `nebula-api/postgres` cargo feature or without `DATABASE_URL` fails closed at startup (no silent fallback per ADR-0048).
- **Storage half.** New `IdempotencyStoreRepo` trait in `nebula-storage` (Exec layer, no `http` types) + `InMemoryIdempotencyStoreRepo` + `PgIdempotencyStore` (`INSERT ... ON CONFLICT (cache_key) DO NOTHING`, length-prefixed header codec) + migration `0024_add_idempotency_dedup.sql` (PG + SQLite parity per ADR-0009). API-side bridge `StorageBackedIdempotencyStore<R>` adapts the repo onto the existing `IdempotencyStore` middleware contract; trait now returns `Result<_, IdempotencyStoreError>` so decode failures bubble as 500 (silent cache-miss fallback rejected — replay protection MUST NOT degrade on data corruption).
- **Observability.** Five new `nebula_api_idempotency_*` metric constants in `nebula-metrics::naming` (hits / misses / rejects-by-reason / store_saturation_ppm / latency_ms) + HELP catalog. Middleware records counters, gauge, and histogram on every outcome branch; `tracing::Span` carries `cache_key_prefix`, `identity_prefix`, `body_size_bytes` (privacy-safe prefixes only — never the full key).
- **CORS.** `Idempotency-Key` allowed in preflight, `Idempotent-Replay` exposed on responses so JS clients can read it (browsers strip non-exposed headers from `fetch().headers`).
- **Sweep task.** `simple_server.rs` PG path spawns a `tokio::spawn` task observing `tokio_util::sync::CancellationToken` for graceful-shutdown coordination via the new `app::serve_with_shutdown`.

## Definition of Done — verified

- [x] ADR-0048 ships `accepted`, cross-linked from ROADMAP §M3.4 and `docs/adr/README.md`.
- [x] `IdempotencyLayer` mounted in `build_app` on api routes only; `tests/idempotency_e2e.rs` exercises the full stack (replay, body-mismatch 422, 5xx-bypass, per-principal scope, CORS preflight, CORS expose — 6 test fns).
- [x] Backend selection structurally fail-closed (`TransportInitError::IdempotencyBackendUnavailable`).
- [x] `IdempotencyStore::store_kind()` shipped on both `InMemoryIdempotencyStore` and the storage-backed bridge.
- [x] `nebula_api_idempotency_{hits,misses,rejects,store_saturation_ppm,latency_ms}` constants + closed-set `idempotency_reject_reason` labels + 2 catalog tests; HELP entries cover every constant.
- [x] PG migration `0024_add_idempotency_dedup.sql` (PG + SQLite parity); `crates/storage/tests/pg_idempotency.rs` covers round-trip, concurrent first-writer-wins, body-mismatch race, TTL expiry — `DATABASE_URL`-gated, mirrors `refresh_claim_pg_integration.rs`.
- [x] Sweep task observes the shutdown `CancellationToken` and exits within one tick of cancellation.
- [x] `cargo fmt --all -- --check` + `cargo clippy --workspace --all-targets -- -D warnings` + `cargo doc --no-deps --workspace` (with broken-intra-doc-links forbid) + `cargo deny check` — all green.
- [x] No `unwrap` / `expect` / `panic` in new library code (tests exempt per `clippy.toml`).
- [x] No new wrapper edge in `deny.toml` — `nebula-storage` already lists `nebula-api` as wrapper; bridge struct lives in API layer per ADR-0048.
- [x] `lefthook pre-push` extends to run `pg_idempotency`, `execution_lease_pg_integration`, and `refresh_claim_pg_integration` when `DATABASE_URL` is set; clean-skips with a single WARN otherwise.
- [x] Workspace-wide grep for `not yet merged into` returns 0 hits in the api crate.

## Test plan

- [ ] CI: `Test nebula-api`, `Test nebula-storage`, `Test nebula-metrics`, `Formatting`, `Clippy`, `Doctests`, `cargo-deny` — all required jobs green.
- [ ] Local PG smoke: `DATABASE_URL=postgres://... cargo nextest run -p nebula-storage --features postgres --test pg_idempotency` — 4 tests pass (round-trip, concurrent first-writer-wins, body-mismatch race, TTL expiry).
- [ ] E2E smoke: `cargo nextest run -p nebula-api --test idempotency_e2e` — 6 tests pass.
- [ ] Operator config smoke: `cargo run --example simple_server` boots green with default env (memory backend, dev-mode warn suppressed); setting `API_IDEMPOTENCY_BACKEND=postgres` without `--features postgres` errors at startup with the typed message.
- [ ] PG path smoke: `cargo run --example simple_server --features postgres` with `API_IDEMPOTENCY_BACKEND=postgres` + `DATABASE_URL=...` boots green; SIGTERM produces a clean exit (sweep task observes the cancellation token).
- [ ] Browser CORS smoke: cross-origin POST with `Idempotency-Key` clears preflight; response carries `Idempotent-Replay` header on replay.

## Out of scope / follow-ups

- Restart-survival e2e (multi-process spawn → kill → respawn) — explicitly deferred per ADR-0048 "Open Questions"; tracked separately.
- CI postgres-services job — `lefthook pre-push` runs PG-gated tests when `DATABASE_URL` is set; CI mirror does not exist in `.github/workflows/` today (M2.2 also shipped lefthook-only). Adding a postgres-service-backed CI job is tracked as a separate infra ticket so this PR stays scoped to §M3.4 closure.
- Loom-checked first-writer-wins property test — deferred to M8.1 per ADR-0048.

## Files

- New: `docs/adr/0048-idempotency-store-backend.md`, `crates/storage/src/repos/idempotency.rs`, `crates/storage/src/pg/idempotency.rs`, `crates/storage/migrations/{postgres,sqlite}/0024_add_idempotency_dedup.sql`, `crates/storage/tests/pg_idempotency.rs`, `crates/api/tests/idempotency_e2e.rs`.
- Modified: api `state.rs` / `config.rs` / `app.rs` / `middleware/idempotency.rs` / `server/mod.rs` / `examples/simple_server.rs` / `Cargo.toml`, metrics `naming.rs` / `prometheus.rs`, storage `repos/mod.rs` / `pg/mod.rs` / `README.md`, api `README.md`, `docs/adr/README.md`, `.ai-factory/ROADMAP.md`, `lefthook.yml`, `scripts/pre-push-crate-diff.sh`, `Cargo.lock`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added HTTP idempotency support for state-changing endpoints via `Idempotency-Key` header with configurable in-memory or PostgreSQL backends.
  * Configurable cache TTL, size limits, and automatic expiration settings.
  * Idempotency metrics tracking: cache hits, misses, rejections, and latency.
  * CORS support for idempotency request/response headers.

* **Documentation**
  * Comprehensive idempotency configuration guide with backend comparison and operational considerations.

* **Chores**
  * Database schema migrations for durable replay deduplication storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->