### PR TITLE
feat(credential-vault): first concrete LeasedProvider per ADR-0051 Phase C

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3481,6 +3481,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-credential-vault"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "nebula-credential",
+ "nebula-storage",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "wiremock",
+]
+
+[[package]]
 name = "nebula-engine"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
   "crates/core",
   "crates/credential",
   "crates/credential-builtin",
+  "crates/credential-vault",
   "crates/engine",
   "crates/eventbus",
   "crates/execution",

--- a/crates/credential-vault/Cargo.toml
+++ b/crates/credential-vault/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "nebula-credential-vault"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+authors.workspace = true
+description = "HashiCorp Vault backend for Nebula's ExternalProvider / LeasedProvider trait surface (KV v2 + dynamic secrets, lease renew/revoke)."
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+nebula-credential = { path = "../credential" }
+
+reqwest = { workspace = true, default-features = false, features = ["json", "rustls"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+chrono = { workspace = true, features = ["serde"] }
+url = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+nebula-storage = { path = "../storage" }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = { workspace = true }
+serde_json = { workspace = true }
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/crates/credential-vault/README.md
+++ b/crates/credential-vault/README.md
@@ -1,0 +1,121 @@
+# nebula-credential-vault
+
+HashiCorp Vault backend for Nebula's `ExternalProvider` / `LeasedProvider`
+trait surface (ADR-0051). First concrete `LeasedProvider` implementation —
+companion to the `ProviderCacheLayer` (in `nebula-storage`) and the
+`ExternalProviderChain` (in `nebula-credential`).
+
+Plugin authors and downstream code depend on the contract crate
+(`nebula-credential`). This crate ships the first-party Vault backend that
+composition roots wire in via `Arc<dyn ExternalProvider>`.
+
+## What it does
+
+- **KV v2 reads** — `GET /v1/{mount}/data/{path}?version=N`. Returns a
+  `ProviderResolution::from_secret` with no lease metadata.
+- **Dynamic secrets** — `GET /v1/{mount}/creds/{role}` and any equivalent
+  Vault dynamic-secret endpoint (`database/`, `aws/`, `gcp/`, …). Returns a
+  `ProviderResolution::with_lease` carrying a `LeaseHandle` attributed to
+  `"vault"`.
+- **Lease lifecycle** — `LeasedProvider::renew` (`PUT /v1/sys/leases/renew`)
+  and `LeasedProvider::revoke` (`PUT /v1/sys/leases/revoke`). Surfaced to
+  composed providers (chain / cache layer) via the
+  `ExternalProvider::lease_renewal` capability discovery hook.
+
+## Path convention
+
+The `ExternalReference::path` field is interpreted by prefix:
+
+| `path` shape                 | Backend route                       | Resolution            |
+|------------------------------|-------------------------------------|-----------------------|
+| `<secret-path>`              | `GET /v1/{kv_mount}/data/{path}`    | `from_secret`         |
+| `dyn/<mount>/creds/<role>`   | `GET /v1/<mount>/creds/<role>`      | `with_lease`          |
+| `dyn/<anything>`             | `GET /v1/<anything>`                | `with_lease`          |
+
+`ExternalReference::version` is honoured for KV v2 reads (added as
+`?version=N`). `ExternalReference::field` is a top-level key lookup against
+the response data — if set, only that field's value is returned; otherwise
+the entire data map is JSON-encoded (BTreeMap → sorted keys, so the output
+is deterministic).
+
+The `dyn/` prefix is deliberately explicit: no path-shape sniffing, no
+"try KV first then fall back". Operators control routing through the
+reference value stored in their credential record.
+
+## Configuration
+
+```rust
+use nebula_credential::SecretString;
+use nebula_credential_vault::{VaultConfig, VaultProvider};
+use url::Url;
+
+let config = VaultConfig::new(
+    Url::parse("https://vault.example.com:8200/")?,
+    SecretString::new(std::env::var("VAULT_TOKEN")?),
+);
+let provider = VaultProvider::new(config)?;
+```
+
+Defaults: `kv_mount = "secret"` (Vault's `vault kv` CLI default),
+`request_timeout = 10s`. Override via the public `VaultConfig` fields.
+`VaultProvider::with_client` lets you reuse a caller-managed
+`reqwest::Client` — useful when the composition root pins a shared
+connection pool or CA bundle.
+
+## Composing with the cache layer
+
+`nebula-storage::credential::ProviderCacheLayer` wraps any
+`Arc<dyn ExternalProvider>` and honours per-entry TTLs. Dynamic
+resolutions carry a Vault-supplied `lease_duration`, so they cache
+automatically; KV v2 reads need either an explicit `default_ttl` in the
+config or an inner provider that supplies one.
+
+```rust
+use std::{sync::Arc, time::Duration};
+use nebula_credential::provider::ExternalProvider;
+use nebula_credential_vault::{VaultConfig, VaultProvider};
+use nebula_storage::credential::{ProviderCacheConfig, ProviderCacheLayer};
+
+let provider = VaultProvider::new(VaultConfig::new(addr, token))?;
+let cached = ProviderCacheLayer::new(
+    Arc::new(provider) as Arc<dyn ExternalProvider>,
+    ProviderCacheConfig {
+        max_entries: 1_000,
+        default_ttl: Duration::from_secs(60),
+    },
+);
+```
+
+`cache.lease_renewal()` returns a `LeasedProvider` view that invalidates
+cached entries holding the matching lease id before forwarding revoke /
+renew to Vault. See `tests/cache_integration.rs` for the round-trip
+verification.
+
+## Error classification
+
+Mapped per ADR-0051's fall-through semantics — only `NotFound` causes an
+`ExternalProviderChain` to fall through to the next provider; every other
+variant short-circuits.
+
+| Vault outcome           | Mapped to                       |
+|-------------------------|---------------------------------|
+| HTTP 404                | `ProviderError::NotFound`       |
+| HTTP 403                | `ProviderError::AccessDenied`   |
+| HTTP 5xx, transport err | `ProviderError::Unavailable`    |
+| Other 4xx, decode err   | `ProviderError::Backend`        |
+
+The `Debug` impl on `VaultProvider` deliberately omits the auth token —
+the address and KV mount are safe to surface for diagnostics, the bearer
+token is not.
+
+## See also
+
+- [`docs/adr/0051-external-provider-redesign.md`][adr0051] — design rationale and the
+  trait surface.
+- [`crates/credential/src/provider/`][credential-provider] — the trait definitions.
+- [`crates/storage/src/credential/provider_cache.rs`][cache] — the cache layer this
+  backend composes with.
+
+[adr0051]: ../../docs/adr/0051-external-provider-redesign.md
+[credential-provider]: ../credential/src/provider/
+[cache]: ../storage/src/credential/provider_cache.rs

--- a/crates/credential-vault/src/lib.rs
+++ b/crates/credential-vault/src/lib.rs
@@ -1,0 +1,45 @@
+//! # nebula-credential-vault
+//!
+//! HashiCorp Vault backend for Nebula's [`ExternalProvider`] /
+//! [`LeasedProvider`] trait surface (ADR-0051). Supports the two canonical
+//! Vault read shapes:
+//!
+//! - **KV v2 static secrets** (`/v1/{mount}/data/{path}`) — the default path
+//!   shape. Returns a [`ProviderResolution::from_secret`] with no lease.
+//! - **Dynamic secrets** (`/v1/{mount}/creds/{role}` and the equivalent
+//!   `aws/`, `pki/`, etc. endpoints) — opt-in via the `dyn/` path prefix
+//!   convention. Returns a [`ProviderResolution::with_lease`] carrying a
+//!   [`LeaseHandle`] attributed to `"vault"`.
+//!
+//! Lease lifecycle (`/sys/leases/renew`, `/sys/leases/revoke`) is exposed
+//! through the [`LeasedProvider`] sub-trait — surfaced to composed
+//! providers (chain / cache layer) via the
+//! [`ExternalProvider::lease_renewal`] capability discovery hook.
+//!
+//! # Path convention
+//!
+//! [`ExternalReference::path`] is interpreted by prefix:
+//!
+//! | Prefix      | Backend route                | Resolution shape                                  |
+//! |-------------|------------------------------|---------------------------------------------------|
+//! | _(none)_    | `GET /v1/{kv_mount}/data/{path}` | `from_secret` (no lease)                      |
+//! | `dyn/<rest>`| `GET /v1/{rest}`              | `with_lease` (lease_id + TTL from response)      |
+//!
+//! `ExternalReference::version` is honoured for KV v2 (added as
+//! `?version=N`). `ExternalReference::field` is interpreted as a JSON-pointer-
+//! free field lookup against the response's data map: if set, only that
+//! field is returned; otherwise the entire data map is JSON-encoded.
+//!
+//! [`ExternalProvider`]: nebula_credential::provider::ExternalProvider
+//! [`LeasedProvider`]: nebula_credential::provider::LeasedProvider
+//! [`ProviderResolution::from_secret`]: nebula_credential::provider::ProviderResolution::from_secret
+//! [`ProviderResolution::with_lease`]: nebula_credential::provider::ProviderResolution::with_lease
+//! [`LeaseHandle`]: nebula_credential::provider::LeaseHandle
+//! [`ExternalProvider::lease_renewal`]: nebula_credential::provider::ExternalProvider::lease_renewal
+//! [`ExternalReference::path`]: nebula_credential::provider::ExternalReference::path
+#![forbid(unsafe_code)]
+
+mod provider;
+mod wire;
+
+pub use provider::{VaultConfig, VaultError, VaultProvider};

--- a/crates/credential-vault/src/provider.rs
+++ b/crates/credential-vault/src/provider.rs
@@ -1,0 +1,866 @@
+//! `VaultProvider` — HashiCorp Vault implementation of the
+//! [`ExternalProvider`] / [`LeasedProvider`] trait surface.
+//!
+//! See the crate-level docs for the path-shape convention used to switch
+//! between KV v2 static reads and dynamic-secret reads.
+
+use std::{borrow::Cow, time::Duration};
+
+use chrono::Utc;
+use nebula_credential::{
+    SecretString,
+    provider::{
+        ExternalProvider, ExternalReference, LeaseHandle, LeasedProvider, ProviderError,
+        ProviderFuture, ProviderResolution,
+    },
+};
+use reqwest::{Client, Response, StatusCode};
+use serde_json::{Map, Value};
+use tracing::Instrument as _;
+use url::Url;
+
+use crate::wire::{DynamicSecretEnvelope, KvV2Envelope, LeaseRenewEnvelope};
+
+/// Provider attribution stamped onto every [`LeaseHandle`] this backend issues.
+///
+/// Matches [`ExternalProvider::provider_name`] so the default
+/// [`LeasedProvider::handles_lease`] routes correctly through composed
+/// providers (chain / cache layer).
+const PROVIDER_NAME: &str = "vault";
+
+/// Prefix on [`ExternalReference::path`] that routes the resolution to the
+/// dynamic-secret read path (`GET /v1/<rest>`). Anything else is treated as
+/// a KV v2 path under the configured mount.
+const DYNAMIC_PATH_PREFIX: &str = "dyn/";
+
+/// Header carrying the Vault token on every request.
+const TOKEN_HEADER: &str = "X-Vault-Token";
+
+/// Construction-time errors for [`VaultProvider`].
+///
+/// These are surfaced when wiring the backend (typically at process start),
+/// not on the hot resolve path — separate from [`ProviderError`] so a
+/// composition root can react synchronously.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum VaultError {
+    /// The supplied address could not be parsed as an absolute URL or had a
+    /// non-HTTP(S) scheme.
+    #[error("vault address must be an absolute http(s) URL: {reason}")]
+    InvalidAddress {
+        /// Human-readable cause.
+        reason: String,
+    },
+    /// `reqwest::Client::build` failed (TLS misconfiguration, runtime issue).
+    #[error("failed to build reqwest client: {reason}")]
+    ClientBuild {
+        /// Human-readable cause.
+        reason: String,
+    },
+}
+
+/// Builder-style configuration for [`VaultProvider`].
+///
+/// `kv_mount` is the canonical KV v2 mount path Vault projects ship with
+/// (`secret/`) — keep it without a leading slash; the provider joins it into
+/// the URL itself.
+#[derive(Debug, Clone)]
+pub struct VaultConfig {
+    /// Vault server address — e.g. `https://vault.example.com:8200/`.
+    /// Trailing slash is permitted; the provider normalises away the
+    /// difference.
+    pub address: Url,
+    /// Vault authentication token. Treated as a secret — never logged.
+    pub token: SecretString,
+    /// KV v2 mount path. `"secret"` is the Vault default for `vault kv` CLI.
+    pub kv_mount: String,
+    /// Per-request timeout for the underlying HTTP client.
+    pub request_timeout: Duration,
+}
+
+impl VaultConfig {
+    /// Build a config with the workspace defaults (`kv_mount = "secret"`,
+    /// `request_timeout = 10s`).
+    #[must_use]
+    pub fn new(address: Url, token: SecretString) -> Self {
+        Self {
+            address,
+            token,
+            kv_mount: "secret".to_owned(),
+            request_timeout: Duration::from_secs(10),
+        }
+    }
+}
+
+/// HashiCorp Vault backend implementing
+/// [`ExternalProvider`] + [`LeasedProvider`].
+///
+/// See the crate-level docs for the path-shape convention and the request
+/// semantics. Errors classify per ADR-0051:
+///
+/// - 404 → [`ProviderError::NotFound`] (chain fall-through).
+/// - 403 → [`ProviderError::AccessDenied`] (short-circuit).
+/// - Network / timeout / 5xx → [`ProviderError::Unavailable`] (short-circuit).
+/// - Other 4xx, decode failure → [`ProviderError::Backend`] (short-circuit).
+pub struct VaultProvider {
+    address: Url,
+    token: SecretString,
+    kv_mount: String,
+    client: Client,
+}
+
+impl std::fmt::Debug for VaultProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Do NOT print the token — it is a bearer credential against the
+        // Vault server. The address is safe to surface.
+        f.debug_struct("VaultProvider")
+            .field("address", &self.address.as_str())
+            .field("kv_mount", &self.kv_mount)
+            .finish_non_exhaustive()
+    }
+}
+
+impl VaultProvider {
+    /// Build a provider with a fresh `reqwest::Client`.
+    ///
+    /// Use [`Self::with_client`] when sharing an `HTTP/2` pool across
+    /// providers, or when a host policy (proxy, root CA pinning) requires
+    /// a pre-configured client.
+    pub fn new(config: VaultConfig) -> Result<Self, VaultError> {
+        validate_address(&config.address)?;
+        let client = Client::builder()
+            .timeout(config.request_timeout)
+            .build()
+            .map_err(|err| VaultError::ClientBuild {
+                reason: err.to_string(),
+            })?;
+        Ok(Self::with_client(config, client))
+    }
+
+    /// Build a provider over a caller-supplied `reqwest::Client`. The
+    /// timeout in `config.request_timeout` is ignored on this path — the
+    /// caller's client owns that policy.
+    #[must_use]
+    pub fn with_client(config: VaultConfig, client: Client) -> Self {
+        Self {
+            address: config.address,
+            token: config.token,
+            kv_mount: config.kv_mount,
+            client,
+        }
+    }
+
+    /// `<address>/v1/<segments>` with normalised slashes.
+    fn api_url(&self, segments: &str) -> Result<Url, ProviderError> {
+        // `Url::join` is fussy about base trailing slashes; rebuild from
+        // the address path to avoid surprises like a missing slash dropping
+        // the last segment of the base.
+        let mut base = self.address.clone();
+        let base_path = base.path().trim_end_matches('/').to_owned();
+        let trimmed = segments.trim_start_matches('/');
+        base.set_path(&format!("{base_path}/v1/{trimmed}"));
+        Ok(base)
+    }
+
+    /// KV v2 read URL with optional `?version=` query.
+    fn kv_url(&self, secret_path: &str, version: Option<&str>) -> Result<Url, ProviderError> {
+        let secret_path = secret_path.trim_start_matches('/');
+        let mount = self.kv_mount.trim_matches('/');
+        let mut url = self.api_url(&format!("{mount}/data/{secret_path}"))?;
+        if let Some(v) = version {
+            url.query_pairs_mut().append_pair("version", v);
+        }
+        Ok(url)
+    }
+
+    /// Apply common request headers (token) and execute the request,
+    /// classifying transport-layer failures into [`ProviderError`].
+    async fn send(&self, request: reqwest::RequestBuilder) -> Result<Response, ProviderError> {
+        request
+            .header(TOKEN_HEADER, self.token.expose_secret())
+            .send()
+            .await
+            .map_err(classify_transport_error)
+    }
+
+    async fn do_resolve(
+        &self,
+        reference: &ExternalReference,
+    ) -> Result<ProviderResolution, ProviderError> {
+        if let Some(rest) = reference.path.strip_prefix(DYNAMIC_PATH_PREFIX) {
+            let span = tracing::debug_span!(
+                "vault_resolve",
+                kind = "dynamic",
+                path = %reference.path,
+            );
+            self.resolve_dynamic(rest, reference.field.as_deref())
+                .instrument(span)
+                .await
+        } else {
+            let span = tracing::debug_span!(
+                "vault_resolve",
+                kind = "kv2",
+                path = %reference.path,
+                mount = %self.kv_mount,
+            );
+            self.resolve_kv_v2(
+                &reference.path,
+                reference.version.as_deref(),
+                reference.field.as_deref(),
+            )
+            .instrument(span)
+            .await
+        }
+    }
+
+    async fn resolve_kv_v2(
+        &self,
+        secret_path: &str,
+        version: Option<&str>,
+        field: Option<&str>,
+    ) -> Result<ProviderResolution, ProviderError> {
+        let url = self.kv_url(secret_path, version)?;
+        tracing::debug!(target: "nebula_credential_vault", url = %url, "vault kv2 GET");
+        let response = self.send(self.client.get(url)).await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(classify_status(status, secret_path));
+        }
+        let envelope: KvV2Envelope = response.json().await.map_err(|err| {
+            ProviderError::Backend(format!("vault kv2 body decode: {err}").into())
+        })?;
+        let secret = extract_secret(envelope.data.data, field)?;
+        Ok(ProviderResolution::from_secret(SecretString::new(secret)))
+    }
+
+    async fn resolve_dynamic(
+        &self,
+        rest_path: &str,
+        field: Option<&str>,
+    ) -> Result<ProviderResolution, ProviderError> {
+        let url = self.api_url(rest_path)?;
+        tracing::debug!(target: "nebula_credential_vault", url = %url, "vault dynamic GET");
+        let response = self.send(self.client.get(url)).await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(classify_status(status, rest_path));
+        }
+        let envelope: DynamicSecretEnvelope = response.json().await.map_err(|err| {
+            ProviderError::Backend(format!("vault dynamic body decode: {err}").into())
+        })?;
+        let lease = LeaseHandle::new(
+            Cow::Borrowed(PROVIDER_NAME),
+            envelope.lease_id,
+            Utc::now(),
+            Duration::from_secs(envelope.lease_duration),
+        );
+        let secret = extract_secret(envelope.data, field)?;
+        Ok(ProviderResolution::with_lease(
+            SecretString::new(secret),
+            lease,
+        ))
+    }
+
+    async fn do_renew(&self, lease: &LeaseHandle) -> Result<ProviderResolution, ProviderError> {
+        let url = self.api_url("sys/leases/renew")?;
+        tracing::debug!(
+            target: "nebula_credential_vault",
+            url = %url,
+            lease_id = %lease.lease_id,
+            "vault renew",
+        );
+        let body = serde_json::json!({
+            "lease_id": lease.lease_id,
+            "increment": lease.ttl.as_secs(),
+        });
+        let response = self.send(self.client.put(url).json(&body)).await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(classify_status(status, &lease.lease_id));
+        }
+        let envelope: LeaseRenewEnvelope = response.json().await.map_err(|err| {
+            ProviderError::Backend(format!("vault renew body decode: {err}").into())
+        })?;
+        // `/sys/leases/renew` returns lease metadata only — the original
+        // secret payload is not echoed. The resolution is metadata-only;
+        // callers refresh from the cache layer or re-resolve to pick up
+        // any rolled credential.
+        let lease = LeaseHandle::new(
+            Cow::Borrowed(PROVIDER_NAME),
+            envelope.lease_id,
+            Utc::now(),
+            Duration::from_secs(envelope.lease_duration),
+        );
+        Ok(ProviderResolution::with_lease(
+            SecretString::new(String::new()),
+            lease,
+        ))
+    }
+
+    async fn do_revoke(&self, lease: &LeaseHandle) -> Result<ProviderResolution, ProviderError> {
+        let url = self.api_url("sys/leases/revoke")?;
+        tracing::debug!(
+            target: "nebula_credential_vault",
+            url = %url,
+            lease_id = %lease.lease_id,
+            "vault revoke",
+        );
+        let body = serde_json::json!({ "lease_id": lease.lease_id });
+        let response = self.send(self.client.put(url).json(&body)).await?;
+        let status = response.status();
+        if !status.is_success() {
+            return Err(classify_status(status, &lease.lease_id));
+        }
+        Ok(ProviderResolution::empty())
+    }
+}
+
+impl ExternalProvider for VaultProvider {
+    fn resolve<'a>(&'a self, reference: &'a ExternalReference) -> ProviderFuture<'a> {
+        ProviderFuture::new(async move { self.do_resolve(reference).await })
+    }
+
+    fn provider_name(&self) -> &str {
+        PROVIDER_NAME
+    }
+
+    fn lease_renewal(&self) -> Option<&dyn LeasedProvider> {
+        Some(self)
+    }
+}
+
+impl LeasedProvider for VaultProvider {
+    fn renew<'a>(&'a self, lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        ProviderFuture::new(async move {
+            // Defensive routing: the chain / cache layer call `handles_lease`
+            // before dispatching, but a hand-built dispatcher might not —
+            // refuse to act on a lease attributed to a different backend.
+            if !self.handles_lease(lease) {
+                tracing::warn!(
+                    target: "nebula_credential_vault",
+                    lease_id = %lease.lease_id,
+                    lease_provider = %lease.provider,
+                    "renew rejected: lease not attributed to this provider",
+                );
+                return Err(ProviderError::NotFound {
+                    path: format!(
+                        "lease {} attributed to {}, not {}",
+                        lease.lease_id, lease.provider, PROVIDER_NAME
+                    ),
+                });
+            }
+            self.do_renew(lease).await
+        })
+    }
+
+    fn revoke<'a>(&'a self, lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        ProviderFuture::new(async move {
+            if !self.handles_lease(lease) {
+                tracing::warn!(
+                    target: "nebula_credential_vault",
+                    lease_id = %lease.lease_id,
+                    lease_provider = %lease.provider,
+                    "revoke rejected: lease not attributed to this provider",
+                );
+                return Err(ProviderError::NotFound {
+                    path: format!(
+                        "lease {} attributed to {}, not {}",
+                        lease.lease_id, lease.provider, PROVIDER_NAME
+                    ),
+                });
+            }
+            self.do_revoke(lease).await
+        })
+    }
+}
+
+fn validate_address(address: &Url) -> Result<(), VaultError> {
+    match address.scheme() {
+        "http" | "https" => Ok(()),
+        other => Err(VaultError::InvalidAddress {
+            reason: format!("unsupported scheme: {other}"),
+        }),
+    }
+}
+
+/// Map an HTTP status into a [`ProviderError`].
+///
+/// 4xx codes other than 404/403 fall into [`ProviderError::Backend`] because
+/// they typically signal malformed requests (sealed Vault, wrong API
+/// version) that no fall-through retry would heal — short-circuiting the
+/// chain there is the safer default.
+fn classify_status(status: StatusCode, context: &str) -> ProviderError {
+    match status {
+        StatusCode::NOT_FOUND => ProviderError::NotFound {
+            path: context.to_owned(),
+        },
+        StatusCode::FORBIDDEN => ProviderError::AccessDenied {
+            reason: format!("vault rejected token for {context}"),
+        },
+        s if s.is_server_error() => {
+            tracing::warn!(
+                target: "nebula_credential_vault",
+                status = %s,
+                context = %context,
+                "vault server error",
+            );
+            ProviderError::Unavailable {
+                reason: format!("vault status {s}"),
+            }
+        },
+        s => {
+            tracing::warn!(
+                target: "nebula_credential_vault",
+                status = %s,
+                context = %context,
+                "vault client error",
+            );
+            ProviderError::Backend(format!("vault unexpected status {s}").into())
+        },
+    }
+}
+
+/// Map a `reqwest` transport error into a [`ProviderError`].
+///
+/// Connect / timeout / decode-at-transport all classify as [`Unavailable`]
+/// — the request never reached a meaningful status. Treating these as
+/// `Backend` would mask retryable network issues behind the chain's
+/// short-circuit; treating them as `NotFound` would mask connectivity
+/// loss as "not configured", which is worse.
+fn classify_transport_error(err: reqwest::Error) -> ProviderError {
+    ProviderError::Unavailable {
+        reason: format!("vault transport: {err}"),
+    }
+}
+
+/// Extract the requested field from a Vault `data` map, encoding the full
+/// payload when no field is requested.
+///
+/// Strings are returned verbatim (so a `password` field containing
+/// `"hunter2"` decodes cleanly). Non-string scalars / objects are
+/// JSON-encoded — that matches what `vault kv get -format=json` emits and
+/// lets callers parse structured payloads downstream.
+fn extract_secret(
+    mut data: std::collections::BTreeMap<String, Value>,
+    field: Option<&str>,
+) -> Result<String, ProviderError> {
+    if let Some(name) = field {
+        let Some(value) = data.remove(name) else {
+            return Err(ProviderError::NotFound {
+                path: format!("field {name}"),
+            });
+        };
+        return Ok(match value {
+            Value::String(s) => s,
+            other => other.to_string(),
+        });
+    }
+    // `BTreeMap<String, Value>` serialises as a JSON object with
+    // sorted keys — deterministic output is useful for caching /
+    // diffing the resolved blob.
+    let map: Map<String, Value> = data.into_iter().collect();
+    serde_json::to_string(&Value::Object(map))
+        .map_err(|err| ProviderError::Backend(format!("vault data encode: {err}").into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_credential::provider::ProviderKind;
+    use serde_json::json;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_json, header, method, path, query_param},
+    };
+
+    use super::*;
+
+    // ────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────
+
+    /// Build a `VaultProvider` pointed at `server` with a fixed token.
+    fn vault(server: &MockServer) -> VaultProvider {
+        let url = Url::parse(&server.uri()).expect("mock server URL parses");
+        let config = VaultConfig::new(url, SecretString::new("test-token"));
+        VaultProvider::new(config).expect("provider builds")
+    }
+
+    fn kv_ref(p: &str, field: Option<&str>) -> ExternalReference {
+        ExternalReference {
+            provider: ProviderKind::Vault,
+            path: p.to_owned(),
+            version: None,
+            field: field.map(str::to_owned),
+        }
+    }
+
+    fn lease(provider: &'static str, id: &str) -> LeaseHandle {
+        LeaseHandle::new(provider, id, Utc::now(), Duration::from_mins(1))
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // C2 — KV v2 static path.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn kv_v2_happy_path_returns_requested_field() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/my-app/db"))
+            .and(header(TOKEN_HEADER, "test-token"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": {
+                    "data": { "password": "hunter2", "username": "svc" },
+                    "metadata": { "version": 1 }
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let res = provider
+            .resolve(&kv_ref("my-app/db", Some("password")))
+            .await
+            .expect("resolve succeeds");
+        assert_eq!(res.secret.expose_secret(), "hunter2");
+        assert!(res.lease.is_none(), "static KV resolutions carry no lease");
+        assert!(res.ttl.is_none(), "static KV resolutions carry no TTL");
+    }
+
+    #[tokio::test]
+    async fn kv_v2_version_appended_as_query_param() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/my-app/db"))
+            .and(query_param("version", "3"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": { "data": { "password": "v3" }, "metadata": {} }
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let mut reference = kv_ref("my-app/db", Some("password"));
+        reference.version = Some("3".to_owned());
+        let res = provider.resolve(&reference).await.expect("resolve ok");
+        assert_eq!(res.secret.expose_secret(), "v3");
+    }
+
+    #[tokio::test]
+    async fn kv_v2_404_maps_to_not_found() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/missing"))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+
+        let err = vault(&server)
+            .resolve(&kv_ref("missing", None))
+            .await
+            .expect_err("404 must be NotFound");
+        assert!(
+            matches!(err, ProviderError::NotFound { .. }),
+            "expected NotFound, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn kv_v2_403_maps_to_access_denied() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/forbidden"))
+            .respond_with(ResponseTemplate::new(403))
+            .mount(&server)
+            .await;
+
+        let err = vault(&server)
+            .resolve(&kv_ref("forbidden", None))
+            .await
+            .expect_err("403 must be AccessDenied");
+        assert!(
+            matches!(err, ProviderError::AccessDenied { .. }),
+            "expected AccessDenied, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn kv_v2_5xx_maps_to_unavailable() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/secret/data/down"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let err = vault(&server)
+            .resolve(&kv_ref("down", None))
+            .await
+            .expect_err("5xx must be Unavailable");
+        assert!(
+            matches!(err, ProviderError::Unavailable { .. }),
+            "expected Unavailable, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn transport_failure_maps_to_unavailable() {
+        // Target a privileged port that no test process can bind: 127.0.0.1:1
+        // refuses connections on every platform the workspace targets,
+        // producing a `reqwest` transport error rather than a status code.
+        // Classifying that as `Unavailable` keeps connectivity loss
+        // distinguishable from "secret not configured" (`NotFound` would
+        // mask the operational signal and trigger chain fall-through).
+        let provider = VaultProvider::new(VaultConfig {
+            address: Url::parse("http://127.0.0.1:1/").expect("URL parses"),
+            token: SecretString::new("test-token"),
+            kv_mount: "secret".to_owned(),
+            // Tight timeout so the test fails fast on hosts that drop the
+            // connect attempt silently (some VPNs / EDRs do).
+            request_timeout: Duration::from_secs(2),
+        })
+        .expect("provider builds");
+
+        let err = provider
+            .resolve(&kv_ref("anything", None))
+            .await
+            .expect_err("closed port must surface as transport error");
+        assert!(
+            matches!(err, ProviderError::Unavailable { .. }),
+            "expected Unavailable, got {err:?}"
+        );
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // C3 — dynamic secrets path.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn dynamic_path_returns_resolution_with_lease() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/database/creds/my-role"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "request_id": "abc",
+                "lease_id": "database/creds/my-role/xyz",
+                "lease_duration": 3600,
+                "renewable": true,
+                "data": { "username": "u-1", "password": "p-1" }
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let res = provider
+            .resolve(&kv_ref("dyn/database/creds/my-role", Some("password")))
+            .await
+            .expect("dynamic resolve succeeds");
+        assert_eq!(res.secret.expose_secret(), "p-1");
+        let lease = res
+            .lease
+            .as_ref()
+            .expect("dynamic resolutions carry a lease");
+        assert_eq!(
+            lease.provider, "vault",
+            "lease attributed to the vault backend"
+        );
+        assert_eq!(lease.lease_id, "database/creds/my-role/xyz");
+        assert_eq!(
+            lease.ttl,
+            Duration::from_hours(1),
+            "TTL is the Vault-reported lease_duration"
+        );
+        // The convenience constructor copies the lease TTL into the
+        // resolution-level `ttl` field so the cache layer sees it without
+        // a lease.unwrap().
+        assert_eq!(res.ttl, Some(Duration::from_hours(1)));
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // C4 — LeasedProvider lifecycle.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[test]
+    fn handles_lease_matches_provider_name() {
+        // Defensive routing rule: a Vault provider must claim only leases
+        // it issued. Attribution comes from `LeaseHandle::provider`, which
+        // we stamp as "vault" at resolve time.
+        let provider = VaultProvider::new(VaultConfig::new(
+            Url::parse("http://127.0.0.1:1").expect("URL parses"),
+            SecretString::new("token"),
+        ))
+        .expect("provider builds");
+        assert!(
+            provider.handles_lease(&lease("vault", "lease-1")),
+            "lease attributed to vault is handled"
+        );
+        assert!(
+            !provider.handles_lease(&lease("aws-sm", "lease-2")),
+            "lease attributed to another backend is rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn renew_extends_lease_and_returns_metadata_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/sys/leases/renew"))
+            .and(body_json(json!({ "lease_id": "lease-1", "increment": 60 })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "lease_id": "lease-1",
+                "lease_duration": 7200,
+                "renewable": true
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let res = provider
+            .renew(&lease("vault", "lease-1"))
+            .await
+            .expect("renew succeeds");
+        let renewed = res.lease.as_ref().expect("renew returns lease metadata");
+        assert_eq!(renewed.lease_id, "lease-1");
+        assert_eq!(
+            renewed.ttl,
+            Duration::from_hours(2),
+            "renew honours the server-reported new lease_duration"
+        );
+        // Vault's `/renew` doesn't echo the secret payload — the resolution
+        // is intentionally metadata-only.
+        assert!(
+            res.secret.expose_secret().is_empty(),
+            "renew resolution carries no secret material"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_returns_empty_resolution() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/v1/sys/leases/revoke"))
+            .and(body_json(json!({ "lease_id": "lease-1" })))
+            .respond_with(ResponseTemplate::new(204))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let res = provider
+            .revoke(&lease("vault", "lease-1"))
+            .await
+            .expect("revoke succeeds");
+        assert!(res.secret.expose_secret().is_empty());
+        assert!(res.lease.is_none());
+        assert!(res.ttl.is_none());
+    }
+
+    #[tokio::test]
+    async fn renew_misroute_rejected_with_not_found() {
+        // Per the Phase B contract: a hand-built dispatcher that routes a
+        // foreign lease through this backend must NOT silently act on it.
+        // No mock — the test asserts the provider rejects before any HTTP
+        // call is made.
+        let server = MockServer::start().await;
+        // Register a catch-all that would respond 200 if reached; the test
+        // proves it's never reached.
+        Mock::given(method("PUT"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "lease_id": "foreign",
+                "lease_duration": 10
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = vault(&server);
+        let err = provider
+            .renew(&lease("aws-sm", "foreign"))
+            .await
+            .expect_err("misrouted renew must fail");
+        assert!(
+            matches!(err, ProviderError::NotFound { .. }),
+            "expected NotFound for foreign attribution, got {err:?}"
+        );
+        // The mock recorded zero matching requests because the provider
+        // returned before the HTTP layer.
+        let requests = server.received_requests().await.expect("recorder");
+        assert!(
+            requests.is_empty(),
+            "misrouted renew must short-circuit before any HTTP call"
+        );
+    }
+
+    #[tokio::test]
+    async fn revoke_misroute_rejected_with_not_found() {
+        let server = MockServer::start().await;
+        let provider = vault(&server);
+        let err = provider
+            .revoke(&lease("aws-sm", "foreign"))
+            .await
+            .expect_err("misrouted revoke must fail");
+        assert!(matches!(err, ProviderError::NotFound { .. }));
+        let requests = server.received_requests().await.expect("recorder");
+        assert!(requests.is_empty());
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Capability discovery + attribution sanity.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn lease_renewal_surfaces_self() {
+        let server = MockServer::start().await;
+        let provider = vault(&server);
+        let view = provider
+            .lease_renewal()
+            .expect("vault advertises lease capability");
+        assert_eq!(view.provider_name(), "vault");
+    }
+
+    #[test]
+    fn invalid_address_rejected_at_construction() {
+        // The validator runs before any HTTP call so a bad config fails
+        // synchronously — important for composition roots that want to
+        // surface misconfiguration at startup rather than on the first
+        // resolve.
+        let err = VaultProvider::new(VaultConfig::new(
+            Url::parse("ftp://vault.example.com/").expect("URL parses"),
+            SecretString::new("token"),
+        ))
+        .expect_err("non-http schemes are rejected");
+        assert!(
+            matches!(err, VaultError::InvalidAddress { .. }),
+            "expected InvalidAddress, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn extract_secret_returns_whole_data_when_no_field() {
+        let mut data = std::collections::BTreeMap::new();
+        data.insert("a".to_owned(), Value::String("1".to_owned()));
+        data.insert("b".to_owned(), Value::Number(serde_json::Number::from(2)));
+        let s = extract_secret(data, None).expect("encode ok");
+        // BTreeMap keeps keys sorted, so output is deterministic.
+        assert_eq!(s, r#"{"a":"1","b":2}"#);
+    }
+
+    #[test]
+    fn extract_secret_missing_field_is_not_found() {
+        let data = std::collections::BTreeMap::new();
+        let err = extract_secret(data, Some("absent")).expect_err("missing field surfaces");
+        assert!(matches!(err, ProviderError::NotFound { .. }));
+    }
+
+    #[test]
+    fn provider_debug_does_not_leak_token() {
+        let provider = VaultProvider::new(VaultConfig::new(
+            Url::parse("https://vault.example.com/").expect("URL parses"),
+            SecretString::new("super-secret-token"),
+        ))
+        .expect("provider builds");
+        let rendered = format!("{provider:?}");
+        assert!(
+            !rendered.contains("super-secret-token"),
+            "Debug must redact the auth token"
+        );
+    }
+}

--- a/crates/credential-vault/src/wire.rs
+++ b/crates/credential-vault/src/wire.rs
@@ -1,0 +1,62 @@
+//! Wire types for the subset of the Vault HTTP API this crate calls.
+//!
+//! Only the response shapes we actually consume are modelled. Vault returns
+//! a JSON envelope with a common top-level `data` field; the KV v2 secret
+//! engine nests another `data` inside that envelope (and a sibling
+//! `metadata` object), while dynamic-secret engines put credentials
+//! directly in `data` and carry lease metadata at the envelope root
+//! (`lease_id`, `lease_duration`, `renewable`).
+//!
+//! Fields not consumed here are silently ignored at decode time
+//! (`serde_json` default behaviour), which keeps the wire surface tolerant
+//! to Vault server version drift.
+
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
+
+/// Top-level envelope returned by `GET /v1/{mount}/data/{path}`.
+///
+/// Vault wraps the actual KV v2 payload in a `data.data` nested object so
+/// that secret metadata (`data.metadata.version`, etc.) lives at a sibling
+/// path without collision against arbitrary user keys.
+#[derive(Debug, Deserialize)]
+pub(crate) struct KvV2Envelope {
+    pub(crate) data: KvV2Data,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct KvV2Data {
+    /// The actual key/value map stored at the secret path. `serde_json::Value`
+    /// rather than `BTreeMap<String, String>` because Vault permits nested
+    /// JSON objects as values, and the field-extraction logic should
+    /// surface those verbatim rather than fail to deserialize them.
+    pub(crate) data: BTreeMap<String, serde_json::Value>,
+}
+
+/// Envelope for dynamic-secret responses
+/// (`GET /v1/{mount}/creds/{role}` and equivalents on `aws/`, `gcp/`, …).
+///
+/// Carries credentials in `data` and lease metadata at the envelope root.
+#[derive(Debug, Deserialize)]
+pub(crate) struct DynamicSecretEnvelope {
+    /// Vault-assigned lease identifier — opaque, used for `renew`/`revoke`.
+    pub(crate) lease_id: String,
+    /// Lease duration in seconds. Vault sends `0` when the issued credential
+    /// is non-leasable; we still build a `LeaseHandle` so the caller can
+    /// distinguish "issued but eternal" from "static KV value".
+    pub(crate) lease_duration: u64,
+    /// The credential payload — same shape as KV v2 `data.data`, but not
+    /// nested under another `data` layer because dynamic secrets don't
+    /// carry version metadata.
+    pub(crate) data: BTreeMap<String, serde_json::Value>,
+}
+
+/// Response shape for `PUT /v1/sys/leases/renew`. Vault echoes the lease
+/// id and the (possibly clamped) new TTL; the secret payload is **not**
+/// included — renew is metadata-only by design.
+#[derive(Debug, Deserialize)]
+pub(crate) struct LeaseRenewEnvelope {
+    pub(crate) lease_id: String,
+    pub(crate) lease_duration: u64,
+}

--- a/crates/credential-vault/tests/cache_integration.rs
+++ b/crates/credential-vault/tests/cache_integration.rs
@@ -1,0 +1,221 @@
+//! Integration tests proving the Phase A `ProviderCacheLayer` composes
+//! correctly over the Phase C `VaultProvider` backend.
+//!
+//! These run with the same wiremock pattern as the unit tests but cross
+//! the crate boundary into `nebula-storage` so we exercise the real
+//! cache layer rather than a hand-rolled in-test cache.
+
+use std::{sync::Arc, time::Duration};
+
+use nebula_credential::{
+    SecretString,
+    provider::{ExternalProvider, ExternalReference, ProviderKind},
+};
+use nebula_credential_vault::{VaultConfig, VaultProvider};
+use nebula_storage::credential::{ProviderCacheConfig, ProviderCacheLayer};
+use serde_json::json;
+use url::Url;
+use wiremock::{
+    Mock, MockServer, ResponseTemplate,
+    matchers::{method, path},
+};
+
+fn vault_at(server: &MockServer) -> Arc<VaultProvider> {
+    let url = Url::parse(&server.uri()).expect("mock server URL parses");
+    Arc::new(
+        VaultProvider::new(VaultConfig::new(
+            url,
+            SecretString::new("integration-token"),
+        ))
+        .expect("provider builds"),
+    )
+}
+
+fn kv_ref(p: &str) -> ExternalReference {
+    ExternalReference {
+        provider: ProviderKind::Vault,
+        path: p.to_owned(),
+        version: None,
+        field: Some("value".to_owned()),
+    }
+}
+
+#[tokio::test]
+async fn kv_v2_resolution_is_cached_under_default_ttl() {
+    // `ProviderCacheConfig::default()` sets `default_ttl: ZERO` — KV v2
+    // responses carry no provider-supplied TTL, so the effective TTL is
+    // ZERO (bypass). Configure a positive `default_ttl` so the layer
+    // actually caches the static response, then prove the second resolve
+    // does not reach Vault.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/secret/data/cached"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "data": { "data": { "value": "v1" }, "metadata": { "version": 1 } }
+        })))
+        .expect(1) // exactly one upstream call across both resolves
+        .mount(&server)
+        .await;
+
+    let inner = vault_at(&server);
+    let layer = ProviderCacheLayer::new(
+        inner as Arc<dyn ExternalProvider>,
+        ProviderCacheConfig {
+            max_entries: 100,
+            default_ttl: Duration::from_mins(1),
+        },
+    );
+
+    let first = layer
+        .resolve(&kv_ref("cached"))
+        .await
+        .expect("first resolve");
+    let second = layer
+        .resolve(&kv_ref("cached"))
+        .await
+        .expect("second resolve");
+    assert_eq!(first.secret.expose_secret(), "v1");
+    assert_eq!(second.secret.expose_secret(), "v1");
+    // Mock's `.expect(1)` is asserted on drop, but a hit-rate sanity check
+    // here surfaces the failure with a clearer message in the test output.
+    let stats = layer.stats();
+    assert_eq!(stats.misses, 1, "exactly one inner call recorded");
+    assert!(stats.hits >= 1, "second resolve must have been a cache hit");
+}
+
+#[tokio::test]
+async fn dynamic_resolution_is_cached_using_response_ttl() {
+    // Dynamic resolutions carry a `lease.ttl` ⇒ resolution.ttl = lease.ttl,
+    // so the cache layer caches even with the default ZERO fallback — the
+    // per-entry TTL comes from the provider response. This is the canonical
+    // use case for the cache layer (ADR-0051 §3.2 of the cache plan).
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/v1/database/creds/role-a"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "lease_id": "database/creds/role-a/abc",
+            "lease_duration": 600,
+            "renewable": true,
+            "data": { "value": "p-1" }
+        })))
+        .expect(1) // one upstream call → second resolve served from cache
+        .mount(&server)
+        .await;
+
+    let inner = vault_at(&server);
+    let layer = ProviderCacheLayer::new(
+        inner as Arc<dyn ExternalProvider>,
+        ProviderCacheConfig::default(),
+    );
+
+    let reference = kv_ref("dyn/database/creds/role-a");
+    let first = layer.resolve(&reference).await.expect("first resolve");
+    let second = layer.resolve(&reference).await.expect("second resolve");
+    assert_eq!(first.secret.expose_secret(), "p-1");
+    assert_eq!(second.secret.expose_secret(), "p-1");
+
+    // The cached resolution must keep the lease the inner provider
+    // attributed to itself — the cache layer is a pass-through for that
+    // metadata, otherwise renew/revoke routing would lose attribution.
+    let cached_lease = second
+        .lease
+        .as_ref()
+        .expect("dynamic resolution carries a lease");
+    assert_eq!(cached_lease.provider, "vault");
+    assert_eq!(cached_lease.lease_id, "database/creds/role-a/abc");
+}
+
+#[tokio::test]
+async fn revoke_invalidates_cache_and_calls_vault_once() {
+    // The single load-bearing integration assertion: revoking through the
+    // cache layer's `LeasedProvider` view both (a) drops the cached entry
+    // so the next resolve must re-hit Vault, and (b) forwards exactly one
+    // call to Vault's `/sys/leases/revoke`. Without (a), a revoked lease
+    // would remain visible from the cache until natural TTL expiry;
+    // without (b), the lease would never reach the upstream revocation
+    // path on the server.
+    let server = MockServer::start().await;
+
+    // Resolve mock: served twice — once before revoke (warms cache) and
+    // once after revoke (proves invalidation, since post-revoke the cache
+    // must miss). Vault would normally rotate credentials on the second
+    // call; we use distinct lease ids so we can also verify the post-revoke
+    // resolve picked up a fresh resolution.
+    let resolve_responder = ResponseTemplate::new(200).set_body_json(json!({
+        "lease_id": "database/creds/role-b/first",
+        "lease_duration": 300,
+        "renewable": true,
+        "data": { "value": "before" }
+    }));
+    Mock::given(method("GET"))
+        .and(path("/v1/database/creds/role-b"))
+        .respond_with(resolve_responder)
+        .up_to_n_times(1)
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/v1/database/creds/role-b"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "lease_id": "database/creds/role-b/second",
+            "lease_duration": 300,
+            "renewable": true,
+            "data": { "value": "after" }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Revoke mock: must be hit exactly once — this is the integration
+    // contract Phase A wired in (cache.revoke ⇒ inner.revoke).
+    Mock::given(method("PUT"))
+        .and(path("/v1/sys/leases/revoke"))
+        .respond_with(ResponseTemplate::new(204))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let inner = vault_at(&server);
+    let layer = ProviderCacheLayer::new(
+        inner as Arc<dyn ExternalProvider>,
+        ProviderCacheConfig::default(),
+    );
+
+    let reference = kv_ref("dyn/database/creds/role-b");
+
+    // First resolve: warms the cache with lease "first".
+    let first = layer.resolve(&reference).await.expect("first resolve");
+    assert_eq!(first.secret.expose_secret(), "before");
+    let lease = first.lease.as_ref().expect("dynamic lease").clone();
+
+    // Second resolve hits the cache — should NOT reach the mock.
+    let cached = layer.resolve(&reference).await.expect("cached resolve");
+    assert_eq!(cached.secret.expose_secret(), "before");
+
+    // Revoke through the cache-layer view: must invalidate the cached
+    // entry AND forward to Vault.
+    let view = layer
+        .lease_renewal()
+        .expect("cache layer surfaces lease capability");
+    let revoke_result = view.revoke(&lease).await.expect("revoke succeeds");
+    assert!(
+        revoke_result.secret.expose_secret().is_empty(),
+        "revoke success returns the empty marker"
+    );
+
+    // Third resolve: cache MUST miss (the entry was invalidated) and Vault
+    // returns the second lease.
+    let after = layer
+        .resolve(&reference)
+        .await
+        .expect("post-revoke resolve");
+    assert_eq!(after.secret.expose_secret(), "after");
+    let after_lease = after.lease.as_ref().expect("post-revoke lease");
+    assert_eq!(
+        after_lease.lease_id, "database/creds/role-b/second",
+        "post-revoke resolve must produce a fresh lease"
+    );
+
+    // All `.expect(N)` mock assertions fire on `server` drop; the
+    // assertions above are a faster signal for the load-bearing properties.
+}

--- a/deny.toml
+++ b/deny.toml
@@ -84,6 +84,12 @@ deny = [
   { crate = "nebula-storage", wrappers = [
     "nebula-engine",
     "nebula-api",
+    # Dev-only: `crates/credential-vault/tests/cache_integration.rs`
+    # exercises `ProviderCacheLayer` over `VaultProvider` to prove the
+    # cache/lease wiring from ADR-0051 Phase A composes with the Vault
+    # backend introduced in Phase C. Same pattern as the engine dev-dep
+    # carved out above for the §13 knife integration test.
+    "nebula-credential-vault",
   ], reason = "Storage is exec-layer; business and core crates must not depend on it directly" },
   { crate = "nebula-sdk", wrappers = [
     "nebula-examples",
@@ -141,6 +147,17 @@ deny = [
   { crate = "nebula-credential-builtin", wrappers = [
     "nebula-credential-builtin",
   ], reason = "Built-in credential types are a first-party scaffold; П1 has only the self-reference (the crate's own dev-deps), П3+ extends this allowlist with composition-root crates that wire concrete types" },
+
+  # nebula-credential-vault is the first concrete LeasedProvider impl per
+  # ADR-0051 Phase C — Business-tier backend wrapping the HashiCorp Vault
+  # HTTP API (KV v2 + dynamic secrets). Plugin authors depend on the
+  # contract crate (`nebula-credential`); composition roots wire this
+  # backend in via `Arc<dyn ExternalProvider>` so it stays decoupled from
+  # any specific Exec/API consumer. The wrapper allowlist starts empty
+  # and is widened as composition roots adopt the provider.
+  { crate = "nebula-credential-vault", wrappers = [
+    "nebula-credential-vault",
+  ], reason = "Vault is a first-party LeasedProvider backend (ADR-0051 Phase C); consumers wire it through their composition root, not via direct deps from upper tiers" },
 ]
 skip = [
   "bitflags",

--- a/docs/adr/0051-external-provider-redesign.md
+++ b/docs/adr/0051-external-provider-redesign.md
@@ -179,3 +179,53 @@ The first concrete `LeasedProvider` implementation is still pending (Vault
 dynamic-secret backend is the expected first consumer); shipping the
 trait ahead of an implementor lets the cache layer and chain wiring be
 reviewed once rather than as a series of churn-y follow-ups.
+
+## Update — 2026-05-13 (Phase C)
+
+The first concrete `LeasedProvider` implementation lands in a new
+Business-tier crate `nebula-credential-vault`
+(`crates/credential-vault/`). Sibling to `nebula-credential-builtin`;
+HTTP stack is `reqwest` + `rustls` to match the workspace TLS policy
+(see `crates/api/Cargo.toml`).
+
+The Vault backend covers both canonical read shapes the design
+anticipated:
+
+1. **KV v2 static reads** — `GET /v1/{kv_mount}/data/{path}?version=N`.
+   `ProviderResolution::from_secret` with no lease metadata; caching
+   requires the consumer to set a non-zero `ProviderCacheConfig::default_ttl`
+   (the `ZERO` default is bypass per Phase A).
+2. **Dynamic secrets** — opt-in via a `dyn/<rest>` prefix on
+   `ExternalReference::path`, routed to `GET /v1/<rest>` and decoded
+   into a `ProviderResolution::with_lease(secret, LeaseHandle::new("vault",
+   …))`. The lease's `ttl` is the Vault-reported `lease_duration`, which
+   `ProviderResolution::with_lease` mirrors into the envelope-level
+   `ttl` — so cache eviction tracks the upstream lease lifetime without
+   further wiring.
+
+`LeasedProvider::renew` and `revoke` hit `/v1/sys/leases/renew` and
+`/v1/sys/leases/revoke` respectively; `renew` returns a metadata-only
+resolution because Vault's `/renew` endpoint never echoes the secret
+payload. Both methods short-circuit with `ProviderError::NotFound` when
+the supplied `LeaseHandle::provider` is not `"vault"` — defence against
+hand-built dispatchers that bypass the chain / cache routing.
+
+Error mapping matches the Phase B + cache-layer contract:
+
+| Vault outcome           | `ProviderError`                    |
+|-------------------------|------------------------------------|
+| HTTP 404                | `NotFound`   (chain fall-through)  |
+| HTTP 403                | `AccessDenied`                     |
+| HTTP 5xx, transport err | `Unavailable`                      |
+| Other 4xx, decode err   | `Backend`                          |
+
+Layer placement is enforced through `deny.toml`: an empty `[wrappers]`
+allowlist on `nebula-credential-vault` ensures upper-tier crates wire it
+through their composition root rather than via direct deps. The
+integration test (`crates/credential-vault/tests/cache_integration.rs`)
+proves the cache layer + Vault composition end-to-end — KV v2 caching,
+dynamic-secret caching via `lease_duration`, and `cache.revoke`
+invalidating the cached entry while forwarding to Vault exactly once.
+
+Phase D (engine-side consumption of the `LeasedProvider` capability —
+proactive renew, revoke-on-rotation) remains tracked separately.


### PR DESCRIPTION
## Summary

- **Phase C** of the ADR-0051 follow-up plan: first concrete `LeasedProvider`
  implementation.
- New `nebula-credential-vault` crate (Business tier) wrapping HashiCorp Vault:
  KV v2 static reads + dynamic-secret reads + `renew` / `revoke` against
  `/sys/leases/*`.
- Integration test proves `ProviderCacheLayer` (Phase A, [#664]) composes
  correctly over the Vault backend — `cache.revoke` invalidates the cached
  entry **and** forwards exactly one call to Vault.

## Path-shape convention

`ExternalReference::path` is routed by prefix — no path-shape sniffing, no
\"try KV first\" fall-back. Operators control routing through the reference
value stored in their credential record.

| `path`                       | Backend route                       | Resolution     |
|------------------------------|-------------------------------------|----------------|
| `<secret-path>`              | `GET /v1/{kv_mount}/data/{path}`    | `from_secret`  |
| `dyn/<rest>`                 | `GET /v1/<rest>`                    | `with_lease`   |

`version` → `?version=N`, `field` → top-level key lookup against the
response data map (deterministic JSON encoding when no field selected).

## LeasedProvider wiring

- `provider_name()` → `\"vault\"` ⇒ `LeaseHandle::provider` attribution
  matches; default `handles_lease` routes correctly through the chain /
  cache layer dispatchers from [#665].
- `renew` / `revoke` short-circuit with `NotFound` when a foreign lease is
  routed in by a hand-built dispatcher (defensive contract per Phase B).
- `renew` returns a **metadata-only** resolution because Vault's
  `/sys/leases/renew` never echoes the secret payload — callers refresh
  through the cache layer or re-resolve.

## Error classification

| Vault outcome           | `ProviderError`                    |
|-------------------------|------------------------------------|
| HTTP 404                | `NotFound`   (chain fall-through)  |
| HTTP 403                | `AccessDenied`                     |
| HTTP 5xx, transport err | `Unavailable`                      |
| Other 4xx, decode err   | `Backend`                          |

`VaultProvider::Debug` deliberately omits the auth token.

## Layer placement

`deny.toml` carves out an empty `[wrappers]` allowlist for the new crate
so upper-tier crates wire it via their composition root rather than via
direct deps. The `nebula-storage` allowlist gains a dev-only entry to
permit the integration test (same pattern as the existing `nebula-engine`
+ `nebula-api` knife-test carve-out).

## Test plan

- [x] `cargo check -p nebula-credential-vault --all-features`
- [x] `cargo test -p nebula-credential-vault --all-features` — 17 unit tests +
      3 integration tests pass on Windows host (wiremock-backed; no live
      Vault required).
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt -p nebula-credential-vault -- --check`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps -p nebula-credential-vault`
- [x] `cargo deny check` — \`advisories ok, bans ok, licenses ok, sources ok\`

## References

- ADR-0051 (Phase C \`## Update\` block added in this PR):
  \`docs/adr/0051-external-provider-redesign.md\`
- Phase A — `ProviderCacheLayer`: [#664]
- Phase B — `LeasedProvider` sub-trait: [#665]

Phase D (engine-side consumption — proactive renew, revoke-on-rotation)
is tracked separately.

[#664]: https://github.com/vanyastaff/nebula/pull/664
[#665]: https://github.com/vanyastaff/nebula/pull/665

🤖 Generated with [Claude Code](https://claude.com/claude-code)