### PR TITLE
feat(engine): engine-side lease lifecycle per ADR-0051 Phase D

### DIFF
--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -173,8 +173,8 @@ pub use pending_store_memory::InMemoryPendingStore;
 // - Lease lifecycle (LeasedProvider) — renew / revoke, capability-discovered
 //   via ExternalProvider::lease_renewal (no runtime downcasts).
 pub use provider::{
-    ExternalProvider, ExternalProviderChain, ExternalReference, LeaseHandle, LeasedProvider,
-    ProviderError, ProviderFuture, ProviderKind, ProviderResolution,
+    ExternalProvider, ExternalProviderChain, ExternalReference, LeaseEvent, LeaseExpiryReason,
+    LeaseHandle, LeasedProvider, ProviderError, ProviderFuture, ProviderKind, ProviderResolution,
 };
 // Refresh coordination — moved to nebula-engine::credential::refresh (ADR-0030 §3 amendment)
 // Re-exports removed: RefreshAttempt, RefreshCoordinator now live in nebula-engine.

--- a/crates/credential/src/metrics.rs
+++ b/crates/credential/src/metrics.rs
@@ -40,6 +40,27 @@ impl CredentialMetrics {
     pub const DYNAMIC_LEASE_RELEASED_TOTAL: &'static str =
         "nebula.credential.dynamic_lease_released_total";
 
+    /// Total dynamic credential lease renewals attempted (success or failure).
+    /// Engine-side lease lifecycle counter; labels: `outcome`, `provider`.
+    pub const DYNAMIC_LEASE_RENEWED_TOTAL: &'static str =
+        "nebula.credential.dynamic_lease_renewed_total";
+
+    /// Total dynamic credential lease revocations attempted (success or failure).
+    /// Engine-side lease lifecycle counter; labels: `outcome`, `provider`.
+    pub const DYNAMIC_LEASE_REVOKED_TOTAL: &'static str =
+        "nebula.credential.dynamic_lease_revoked_total";
+
+    /// Total dynamic credential lease renewal failures, labelled by reason.
+    /// Distinct from `_RENEWED_TOTAL{outcome=failure}` because individual
+    /// failed attempts within a retry budget are observable separately.
+    /// Labels: `reason`, `provider`.
+    pub const DYNAMIC_LEASE_RENEW_FAILED_TOTAL: &'static str =
+        "nebula.credential.dynamic_lease_renew_failed_total";
+
+    /// Gauge of currently-tracked dynamic credential leases.
+    /// No labels — pre-aggregated across providers.
+    pub const DYNAMIC_LEASE_ACTIVE: &'static str = "nebula.credential.dynamic_lease_active";
+
     /// Total tamper detection events.
     pub const TAMPER_DETECTION_TOTAL: &'static str = "nebula.credential.tamper_detection_total";
 
@@ -56,6 +77,9 @@ impl CredentialMetrics {
 
     /// Label: refresh failure reason.
     pub const LABEL_FAILURE_REASON: &'static str = "reason";
+
+    /// Label: external provider name (e.g. `"vault"`).
+    pub const LABEL_PROVIDER: &'static str = "provider";
 
     // ── Helper methods ─────────────────────────────────────────────────
 

--- a/crates/credential/src/provider/event.rs
+++ b/crates/credential/src/provider/event.rs
@@ -38,6 +38,11 @@ pub enum LeaseExpiryReason {
     /// Provider responded with `NotFound` / `AccessDenied` — the upstream
     /// lease no longer exists, retries are pointless.
     NotFoundUpstream,
+    /// Provider succeeded a `renew` call but reported a zero TTL on the
+    /// refreshed lease (the Vault convention for "this grant is not
+    /// renewable"); the lifecycle dropped it rather than busy-loop on
+    /// instant re-renewal.
+    NonRenewable,
     /// The lifecycle was shut down via its `CancellationToken` while the
     /// lease was still active.
     Shutdown,

--- a/crates/credential/src/provider/event.rs
+++ b/crates/credential/src/provider/event.rs
@@ -1,0 +1,199 @@
+//! Lease lifecycle events for cross-crate signaling.
+//!
+//! Emitted via `EventBus<LeaseEvent>` by the engine's lease lifecycle
+//! subsystem (`nebula_engine::credential::lease`). Subscribers (audit
+//! sinks, metric scrapers, ops dashboards) consume these to track the
+//! health of dynamic-secret grants without reaching into provider
+//! internals.
+//!
+//! Like [`CredentialEvent`](crate::CredentialEvent), payloads carry
+//! identifiers only — **never the secret value**.
+//!
+//! # Why a separate event type
+//!
+//! Lease events carry richer payload than the simple
+//! `{credential_id}` shape of [`CredentialEvent`], and a significant
+//! subset of leases are unattributed to a nebula `CredentialId` (e.g.
+//! ad-hoc provider use through composition root). Publishing on
+//! `EventBus<LeaseEvent>` rather than overloading `CredentialEvent`
+//! keeps subscriber filtering crisp and avoids forcing every variant to
+//! accept an `Option<CredentialId>`.
+
+use std::borrow::Cow;
+use std::time::Duration;
+
+use crate::CredentialId;
+
+/// Reason a lease left the lifecycle registry.
+///
+/// Carried by [`LeaseEvent::LeaseExpired`] to distinguish failure modes
+/// for observability — a Vault `NotFound` (lease already gone upstream)
+/// is operationally different from a renewal-budget exhaustion.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LeaseExpiryReason {
+    /// Lease was renewed `max_retries` times without success against an
+    /// `Unavailable` / `Backend` backend; the lifecycle dropped it.
+    RenewalFailed,
+    /// Provider responded with `NotFound` / `AccessDenied` — the upstream
+    /// lease no longer exists, retries are pointless.
+    NotFoundUpstream,
+    /// The lifecycle was shut down via its `CancellationToken` while the
+    /// lease was still active.
+    Shutdown,
+}
+
+/// Lease lifecycle event.
+///
+/// Emitted after every state transition the lifecycle observes (renew
+/// success, renew failure, revoke success, revoke failure, expiry).
+/// `#[non_exhaustive]` so additive variants do not break subscribers.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub enum LeaseEvent {
+    /// Lease was renewed against its issuing provider; the registry
+    /// reset its next-renew schedule to the new TTL.
+    LeaseRenewed {
+        /// Optional credential id this lease is attributed to. `None`
+        /// for orphan leases tracked without a nebula credential record.
+        credential_id: Option<CredentialId>,
+        /// Provider-specific lease identifier.
+        lease_id: String,
+        /// Issuing provider's `provider_name()`.
+        provider: Cow<'static, str>,
+        /// New TTL communicated by the provider on renew.
+        new_ttl: Duration,
+    },
+
+    /// Lease was explicitly revoked through `LeasedProvider::revoke` and
+    /// removed from the registry.
+    LeaseRevoked {
+        /// Optional credential id this lease was attributed to.
+        credential_id: Option<CredentialId>,
+        /// Provider-specific lease identifier.
+        lease_id: String,
+        /// Issuing provider's `provider_name()`.
+        provider: Cow<'static, str>,
+    },
+
+    /// A renewal attempt failed. The lifecycle will retry per its backoff
+    /// schedule; emit one of these per failed attempt for observability.
+    LeaseRenewalFailed {
+        /// Optional credential id this lease is attributed to.
+        credential_id: Option<CredentialId>,
+        /// Provider-specific lease identifier.
+        lease_id: String,
+        /// Issuing provider's `provider_name()`.
+        provider: Cow<'static, str>,
+        /// Short reason string from `ProviderError::Display`.
+        reason: String,
+    },
+
+    /// A revoke attempt failed. Rotation pipelines DO NOT block on this
+    /// — local state has already committed. Treat as audit signal.
+    LeaseRevocationFailed {
+        /// Optional credential id this lease was attributed to.
+        credential_id: Option<CredentialId>,
+        /// Provider-specific lease identifier.
+        lease_id: String,
+        /// Issuing provider's `provider_name()`.
+        provider: Cow<'static, str>,
+        /// Short reason string from `ProviderError::Display`.
+        reason: String,
+    },
+
+    /// Lease left the registry without successful revoke — either
+    /// renewal budget exhausted, upstream removed it, or lifecycle
+    /// shutdown.
+    LeaseExpired {
+        /// Optional credential id this lease was attributed to.
+        credential_id: Option<CredentialId>,
+        /// Provider-specific lease identifier.
+        lease_id: String,
+        /// Issuing provider's `provider_name()`.
+        provider: Cow<'static, str>,
+        /// Why the lease left the registry.
+        reason: LeaseExpiryReason,
+    },
+}
+
+impl LeaseEvent {
+    /// Provider-specific lease identifier for any variant.
+    #[must_use]
+    pub fn lease_id(&self) -> &str {
+        match self {
+            Self::LeaseRenewed { lease_id, .. }
+            | Self::LeaseRevoked { lease_id, .. }
+            | Self::LeaseRenewalFailed { lease_id, .. }
+            | Self::LeaseRevocationFailed { lease_id, .. }
+            | Self::LeaseExpired { lease_id, .. } => lease_id,
+        }
+    }
+
+    /// Issuing provider name for any variant.
+    #[must_use]
+    pub fn provider(&self) -> &str {
+        match self {
+            Self::LeaseRenewed { provider, .. }
+            | Self::LeaseRevoked { provider, .. }
+            | Self::LeaseRenewalFailed { provider, .. }
+            | Self::LeaseRevocationFailed { provider, .. }
+            | Self::LeaseExpired { provider, .. } => provider.as_ref(),
+        }
+    }
+
+    /// Attributed credential id for any variant, if known.
+    #[must_use]
+    pub fn credential_id(&self) -> Option<CredentialId> {
+        match self {
+            Self::LeaseRenewed { credential_id, .. }
+            | Self::LeaseRevoked { credential_id, .. }
+            | Self::LeaseRenewalFailed { credential_id, .. }
+            | Self::LeaseRevocationFailed { credential_id, .. }
+            | Self::LeaseExpired { credential_id, .. } => *credential_id,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accessors_return_payload() {
+        let id = CredentialId::new();
+        let ev = LeaseEvent::LeaseRenewed {
+            credential_id: Some(id),
+            lease_id: "lease-abc".to_owned(),
+            provider: Cow::Borrowed("vault"),
+            new_ttl: Duration::from_hours(1),
+        };
+        assert_eq!(ev.lease_id(), "lease-abc");
+        assert_eq!(ev.provider(), "vault");
+        assert_eq!(ev.credential_id(), Some(id));
+    }
+
+    #[test]
+    fn orphan_lease_event_has_no_credential_id() {
+        let ev = LeaseEvent::LeaseExpired {
+            credential_id: None,
+            lease_id: "orphan".to_owned(),
+            provider: Cow::Borrowed("vault"),
+            reason: LeaseExpiryReason::Shutdown,
+        };
+        assert_eq!(ev.credential_id(), None);
+        assert_eq!(ev.lease_id(), "orphan");
+    }
+
+    #[test]
+    fn expiry_reason_distinguishes_failure_modes() {
+        // Three distinct variants — observability subscribers route on
+        // these, so the API contract is that they remain distinguishable.
+        let r1 = LeaseExpiryReason::RenewalFailed;
+        let r2 = LeaseExpiryReason::NotFoundUpstream;
+        let r3 = LeaseExpiryReason::Shutdown;
+        assert_ne!(r1, r2);
+        assert_ne!(r2, r3);
+        assert_ne!(r1, r3);
+    }
+}

--- a/crates/credential/src/provider/mod.rs
+++ b/crates/credential/src/provider/mod.rs
@@ -29,6 +29,7 @@
 //! [`ExternalProvider`] (Liskov), so nested chains compose.
 
 mod chain;
+mod event;
 mod future;
 mod leased;
 mod resolution;
@@ -36,6 +37,7 @@ mod resolution;
 use std::fmt;
 
 pub use chain::ExternalProviderChain;
+pub use event::{LeaseEvent, LeaseExpiryReason};
 pub use future::ProviderFuture;
 pub use leased::LeasedProvider;
 pub use resolution::{LeaseHandle, ProviderResolution};

--- a/crates/engine/src/credential/lease/mod.rs
+++ b/crates/engine/src/credential/lease/mod.rs
@@ -61,7 +61,9 @@ mod scheduler;
 use std::sync::Arc;
 
 use nebula_core::accessor::MetricsEmitter;
-use nebula_credential::{CredentialId, LeaseEvent, LeasedProvider, ProviderResolution};
+use nebula_credential::{
+    CredentialId, LeaseEvent, LeasedProvider, ProviderError, ProviderResolution,
+};
 use nebula_eventbus::EventBus;
 use tokio::sync::{mpsc, oneshot};
 use tokio_util::sync::CancellationToken;
@@ -156,7 +158,7 @@ impl LeaseLifecycle {
         let outcome = reply_rx.await.map_err(|_| LeaseLifecycleError::Shutdown)?;
         match outcome {
             RevokeOutcome::Revoked | RevokeOutcome::Unknown => Ok(()),
-            RevokeOutcome::ProviderFailed(reason) => Err(LeaseLifecycleError::Revoke { reason }),
+            RevokeOutcome::ProviderFailed(err) => Err(LeaseLifecycleError::Revoke(err)),
         }
     }
 
@@ -177,13 +179,27 @@ impl LeaseLifecycle {
             })
             .is_err()
         {
+            tracing::warn!(
+                target: "nebula_engine::credential::lease",
+                %credential_id,
+                "lease lifecycle is shut down; revoke_for_credential is a no-op"
+            );
             return 0;
         }
-        reply_rx.await.unwrap_or(0)
+        reply_rx.await.unwrap_or_else(|_| {
+            tracing::warn!(
+                target: "nebula_engine::credential::lease",
+                %credential_id,
+                "lease lifecycle dropped reply during revoke_for_credential"
+            );
+            0
+        })
     }
 
     /// Current count of tracked leases. Useful for observability and
-    /// shutdown drains.
+    /// shutdown drains. A return value of `0` is overloaded — it can
+    /// mean either "no leases" or "scheduler is gone"; the latter case
+    /// emits a `warn` at this site so the degraded state is observable.
     pub async fn active_lease_count(&self) -> usize {
         let (reply_tx, reply_rx) = oneshot::channel();
         if self
@@ -192,9 +208,19 @@ impl LeaseLifecycle {
             .send(Command::Snapshot { reply: reply_tx })
             .is_err()
         {
+            tracing::warn!(
+                target: "nebula_engine::credential::lease",
+                "lease lifecycle is shut down; active_lease_count returns 0"
+            );
             return 0;
         }
-        reply_rx.await.unwrap_or(0)
+        reply_rx.await.unwrap_or_else(|_| {
+            tracing::warn!(
+                target: "nebula_engine::credential::lease",
+                "lease lifecycle dropped reply during active_lease_count"
+            );
+            0
+        })
     }
 }
 
@@ -215,11 +241,13 @@ pub enum LeaseLifecycleError {
     /// The provider returned an error from `revoke`. The lease has
     /// still been removed from the registry; future `track` calls with
     /// the same lease id will create a fresh entry.
-    #[error("provider revoke failed: {reason}")]
-    Revoke {
-        /// Provider error message.
-        reason: String,
-    },
+    ///
+    /// Carries the underlying [`ProviderError`] so callers can
+    /// distinguish transient (`Unavailable`) from auth
+    /// (`AccessDenied`) failure modes and walk the source chain for
+    /// observability, rather than parsing a stringified message.
+    #[error("provider revoke failed: {0}")]
+    Revoke(#[source] ProviderError),
 
     /// The scheduler task has shut down (cancellation token fired) and
     /// is no longer accepting commands.

--- a/crates/engine/src/credential/lease/mod.rs
+++ b/crates/engine/src/credential/lease/mod.rs
@@ -1,0 +1,604 @@
+//! Lease lifecycle subsystem — engine-side consumption of the
+//! [`LeasedProvider`] capability introduced by ADR-0051.
+//!
+//! # Role
+//!
+//! Phases A–C of the ADR-0051 follow-up landed the lease primitives
+//! (envelope, capability sub-trait, cache layer, first concrete Vault
+//! impl). Nothing in the engine called `renew` or `revoke` — a Vault
+//! dynamic-secret lease would silently expire unless someone happened to
+//! resolve the credential again before the TTL elapsed. This module is
+//! the missing consumer: a single background task per engine that
+//! tracks leases, renews them at 70% of TTL, and revokes them on
+//! credential rotation.
+//!
+//! # Surface
+//!
+//! - [`LeaseLifecycle`] — `Arc`-shared public handle. Construction is
+//!   via [`LeaseLifecycle::spawn`]; callers send work through the
+//!   `track` / `revoke` / `revoke_for_credential` async methods.
+//! - [`LeaseLifecycleError`] — typed errors returned to the caller. The
+//!   scheduler task itself never panics; transient renewal failures are
+//!   absorbed into the backoff schedule.
+//! - [`LeaseLifecycleConfig`] / [`RenewalPolicy`] — tuning knobs. Defaults
+//!   match Vault Agent guidance.
+//! - [`LeaseToken`] — opaque registry key returned by `track`.
+//!
+//! # Wiring
+//!
+//! ```ignore
+//! use std::sync::Arc;
+//! use nebula_engine::credential::lease::{
+//!     LeaseLifecycle, LeaseLifecycleConfig,
+//! };
+//! use tokio_util::sync::CancellationToken;
+//!
+//! let shutdown = CancellationToken::new();
+//! let lifecycle = LeaseLifecycle::spawn(
+//!     LeaseLifecycleConfig::default(),
+//!     None,           // optional EventBus<LeaseEvent>
+//!     None,           // optional MetricsEmitter
+//!     shutdown.clone(),
+//! );
+//!
+//! // When a credential resolution carries a lease, register it:
+//! // let token = lifecycle.track(provider, resolution, Some(credential_id)).await?;
+//!
+//! // On credential rotation commit:
+//! // lifecycle.revoke_for_credential(credential_id).await;
+//! ```
+//!
+//! # Single-replica
+//!
+//! Phase D ships single-replica semantics — every engine that calls
+//! `track` will independently try to renew. Cross-replica coordination
+//! (only one replica per lease renews) is a separate follow-up.
+
+mod policy;
+mod registry;
+mod scheduler;
+
+use std::sync::Arc;
+
+use nebula_core::accessor::MetricsEmitter;
+use nebula_credential::{CredentialId, LeaseEvent, LeasedProvider, ProviderResolution};
+use nebula_eventbus::EventBus;
+use tokio::sync::{mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
+
+pub use policy::RenewalPolicy;
+pub use registry::LeaseToken;
+pub use scheduler::LeaseLifecycleConfig;
+
+use scheduler::{Command, RevokeOutcome, SchedulerInputs};
+
+/// Public handle to the lease lifecycle scheduler.
+///
+/// Cheap to clone — internally an `Arc` over an unbounded command
+/// channel. The scheduler task is spawned at construction time and
+/// runs until the supplied [`CancellationToken`] fires.
+#[derive(Clone)]
+pub struct LeaseLifecycle {
+    inner: Arc<LeaseLifecycleInner>,
+}
+
+struct LeaseLifecycleInner {
+    commands: mpsc::UnboundedSender<Command>,
+}
+
+impl LeaseLifecycle {
+    /// Spawn the lease lifecycle scheduler.
+    pub fn spawn(
+        config: LeaseLifecycleConfig,
+        lease_bus: Option<Arc<EventBus<LeaseEvent>>>,
+        metrics: Option<Arc<dyn MetricsEmitter>>,
+        shutdown: CancellationToken,
+    ) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+        let inputs = SchedulerInputs {
+            config,
+            commands: rx,
+            lease_bus,
+            metrics,
+            shutdown,
+        };
+        tokio::spawn(scheduler::run(inputs));
+        Self {
+            inner: Arc::new(LeaseLifecycleInner { commands: tx }),
+        }
+    }
+
+    /// Register a lease for proactive renewal.
+    ///
+    /// `resolution` must carry a `Some(lease)`; orphan resolutions
+    /// (`lease.is_none()`) are rejected with
+    /// [`LeaseLifecycleError::ResolutionMissingLease`].
+    ///
+    /// `credential_id` attributes the lease to a nebula credential
+    /// record so [`revoke_for_credential`](Self::revoke_for_credential)
+    /// can scan-and-revoke on rotation. Pass `None` for ad-hoc
+    /// provider use without a credential record.
+    pub async fn track(
+        &self,
+        provider: Arc<dyn LeasedProvider>,
+        resolution: ProviderResolution,
+        credential_id: Option<CredentialId>,
+    ) -> Result<LeaseToken, LeaseLifecycleError> {
+        let lease = resolution
+            .lease
+            .ok_or(LeaseLifecycleError::ResolutionMissingLease)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.inner
+            .commands
+            .send(Command::Track {
+                provider,
+                lease,
+                credential_id,
+                reply: reply_tx,
+            })
+            .map_err(|_| LeaseLifecycleError::Shutdown)?;
+        reply_rx.await.map_err(|_| LeaseLifecycleError::Shutdown)
+    }
+
+    /// Revoke a tracked lease through its issuing provider and remove
+    /// it from the registry. Returns `Ok(())` for both success and the
+    /// "lease already gone" case; provider-side failures are surfaced
+    /// as [`LeaseLifecycleError::Revoke`].
+    pub async fn revoke(&self, token: LeaseToken) -> Result<(), LeaseLifecycleError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.inner
+            .commands
+            .send(Command::Revoke {
+                token,
+                reply: reply_tx,
+            })
+            .map_err(|_| LeaseLifecycleError::Shutdown)?;
+        let outcome = reply_rx.await.map_err(|_| LeaseLifecycleError::Shutdown)?;
+        match outcome {
+            RevokeOutcome::Revoked | RevokeOutcome::Unknown => Ok(()),
+            RevokeOutcome::ProviderFailed(reason) => Err(LeaseLifecycleError::Revoke { reason }),
+        }
+    }
+
+    /// Revoke every tracked lease attributed to `credential_id`.
+    ///
+    /// Returns the number of leases successfully revoked. Failed revokes
+    /// do not propagate — they are logged + emitted as audit events but
+    /// the rotation pipeline that called this MUST NOT block on them.
+    /// See spec §4: revoke-on-rotate is best-effort cleanup.
+    pub async fn revoke_for_credential(&self, credential_id: CredentialId) -> usize {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .inner
+            .commands
+            .send(Command::RevokeForCredential {
+                credential_id,
+                reply: reply_tx,
+            })
+            .is_err()
+        {
+            return 0;
+        }
+        reply_rx.await.unwrap_or(0)
+    }
+
+    /// Current count of tracked leases. Useful for observability and
+    /// shutdown drains.
+    pub async fn active_lease_count(&self) -> usize {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .inner
+            .commands
+            .send(Command::Snapshot { reply: reply_tx })
+            .is_err()
+        {
+            return 0;
+        }
+        reply_rx.await.unwrap_or(0)
+    }
+}
+
+/// Errors returned from the [`LeaseLifecycle`] public surface.
+///
+/// The scheduler task itself never panics and absorbs transient renewal
+/// failures into its backoff schedule; the errors here are only the
+/// public-facing ones a caller can act on.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum LeaseLifecycleError {
+    /// `track` was called with a `ProviderResolution` whose `lease`
+    /// field was `None`. Caller should resolve through a leased
+    /// provider before invoking the lifecycle.
+    #[error("provider resolution carries no lease — nothing to track")]
+    ResolutionMissingLease,
+
+    /// The provider returned an error from `revoke`. The lease has
+    /// still been removed from the registry; future `track` calls with
+    /// the same lease id will create a fresh entry.
+    #[error("provider revoke failed: {reason}")]
+    Revoke {
+        /// Provider error message.
+        reason: String,
+    },
+
+    /// The scheduler task has shut down (cancellation token fired) and
+    /// is no longer accepting commands.
+    #[error("lease lifecycle is shut down")]
+    Shutdown,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::time::Duration;
+
+    use nebula_credential::{
+        CredentialId, ExternalProvider, ExternalReference, LeaseHandle, LeasedProvider,
+        ProviderError, ProviderFuture, ProviderResolution, SecretString,
+    };
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::credential::lease::scheduler::LeaseLifecycleConfig;
+
+    // ────────────────────────────────────────────────────────────────────
+    // Mock leased provider with configurable renew / revoke behaviour.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[derive(Debug, Default)]
+    struct CountingProvider {
+        renew_calls: AtomicU32,
+        revoke_calls: AtomicU32,
+        renew_failures: AtomicU32,
+        /// Number of times to fail renew with `Unavailable` before
+        /// succeeding. 0 = always succeed.
+        unavailable_until: AtomicU32,
+        /// If true, every renew returns `NotFound`.
+        permanent_not_found: AtomicU32,
+        /// TTL reported on each renew success.
+        renew_ttl_secs: AtomicU32,
+        name: &'static str,
+    }
+
+    impl CountingProvider {
+        fn new(name: &'static str, renew_ttl_secs: u32) -> Arc<Self> {
+            let p = Arc::new(Self {
+                name,
+                ..Self::default()
+            });
+            p.renew_ttl_secs.store(renew_ttl_secs, Ordering::SeqCst);
+            p
+        }
+
+        fn fail_n_then_succeed(self: &Arc<Self>, n: u32) {
+            self.unavailable_until.store(n, Ordering::SeqCst);
+        }
+
+        fn always_not_found(self: &Arc<Self>) {
+            self.permanent_not_found.store(1, Ordering::SeqCst);
+        }
+    }
+
+    impl ExternalProvider for CountingProvider {
+        fn resolve<'a>(&'a self, _r: &'a ExternalReference) -> ProviderFuture<'a> {
+            ProviderFuture::ready(Ok(ProviderResolution::from_secret(SecretString::new(
+                "ignored",
+            ))))
+        }
+
+        fn provider_name(&self) -> &str {
+            self.name
+        }
+
+        fn lease_renewal(&self) -> Option<&dyn LeasedProvider> {
+            Some(self)
+        }
+    }
+
+    impl LeasedProvider for CountingProvider {
+        fn renew<'a>(&'a self, lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+            self.renew_calls.fetch_add(1, Ordering::SeqCst);
+            if self.permanent_not_found.load(Ordering::SeqCst) > 0 {
+                self.renew_failures.fetch_add(1, Ordering::SeqCst);
+                return ProviderFuture::ready(Err(ProviderError::NotFound {
+                    path: format!("lease {} gone", lease.lease_id),
+                }));
+            }
+            let remaining = self.unavailable_until.load(Ordering::SeqCst);
+            if remaining > 0 {
+                self.unavailable_until
+                    .store(remaining - 1, Ordering::SeqCst);
+                self.renew_failures.fetch_add(1, Ordering::SeqCst);
+                return ProviderFuture::ready(Err(ProviderError::Unavailable {
+                    reason: "transient".to_owned(),
+                }));
+            }
+            let new_ttl =
+                Duration::from_secs(u64::from(self.renew_ttl_secs.load(Ordering::SeqCst)));
+            let refreshed = LeaseHandle::new(
+                Cow::Borrowed(self.name),
+                lease.lease_id.clone(),
+                chrono::Utc::now(),
+                new_ttl,
+            );
+            ProviderFuture::ready(Ok(ProviderResolution::with_lease(
+                SecretString::new("renewed"),
+                refreshed,
+            )))
+        }
+
+        fn revoke<'a>(&'a self, _lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+            self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+            ProviderFuture::ready(Ok(ProviderResolution::empty()))
+        }
+    }
+
+    fn make_resolution(provider: &str, ttl_secs: u64, id: &str) -> ProviderResolution {
+        let lease = LeaseHandle::new(
+            Cow::Owned(provider.to_owned()),
+            id,
+            chrono::Utc::now(),
+            Duration::from_secs(ttl_secs),
+        );
+        ProviderResolution::with_lease(SecretString::new("secret"), lease)
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Tests — exercise the scheduler with `tokio::time::pause` so renew
+    // attempts fire deterministically.
+    // ────────────────────────────────────────────────────────────────────
+
+    #[tokio::test(start_paused = true)]
+    async fn track_returns_token_and_increments_active_count() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+
+        let token = lifecycle
+            .track(
+                provider as Arc<dyn LeasedProvider>,
+                make_resolution("mock", 100, "lease-1"),
+                None,
+            )
+            .await
+            .expect("track succeeds");
+
+        let count = lifecycle.active_lease_count().await;
+        assert_eq!(count, 1);
+        assert_eq!(token, LeaseToken(0));
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn track_rejects_resolution_without_lease() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+
+        let result = lifecycle
+            .track(
+                provider as Arc<dyn LeasedProvider>,
+                ProviderResolution::from_secret(SecretString::new("static")),
+                None,
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(LeaseLifecycleError::ResolutionMissingLease)
+        ));
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_renews_at_seventy_percent_of_ttl() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        lifecycle
+            .track(provider_arc, make_resolution("mock", 100, "lease-x"), None)
+            .await
+            .expect("track ok");
+
+        // 70% of 100s = 70s. Advance just under: no renew yet.
+        tokio::time::advance(Duration::from_secs(69)).await;
+        assert_eq!(provider.renew_calls.load(Ordering::SeqCst), 0);
+
+        // Advance past 70s — renew fires.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        // Give the scheduler one yield to run the renew future.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert_eq!(provider.renew_calls.load(Ordering::SeqCst), 1);
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn unavailable_triggers_backoff_then_recovers() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        provider.fail_n_then_succeed(2);
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        lifecycle
+            .track(provider_arc, make_resolution("mock", 100, "lease-y"), None)
+            .await
+            .expect("track ok");
+
+        // First renew at 70s — fails (Unavailable).
+        tokio::time::advance(Duration::from_secs(71)).await;
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(provider.renew_failures.load(Ordering::SeqCst), 1);
+        // Backoff = 1s; next attempt at ~71s + 1s.
+        tokio::time::advance(Duration::from_secs(2)).await;
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(provider.renew_failures.load(Ordering::SeqCst), 2);
+        // Backoff = 2s; next attempt succeeds.
+        tokio::time::advance(Duration::from_secs(3)).await;
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(provider.renew_calls.load(Ordering::SeqCst), 3);
+        // Lease should still be active.
+        assert_eq!(lifecycle.active_lease_count().await, 1);
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn not_found_drops_lease_immediately() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        provider.always_not_found();
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        lifecycle
+            .track(provider_arc, make_resolution("mock", 100, "lease-z"), None)
+            .await
+            .expect("track ok");
+
+        tokio::time::advance(Duration::from_secs(71)).await;
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(provider.renew_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.active_lease_count().await, 0);
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn revoke_calls_provider_and_removes_from_registry() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        let token = lifecycle
+            .track(provider_arc, make_resolution("mock", 100, "lease-r"), None)
+            .await
+            .expect("track ok");
+        lifecycle.revoke(token).await.expect("revoke ok");
+        assert_eq!(provider.revoke_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(lifecycle.active_lease_count().await, 0);
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn revoke_for_credential_revokes_only_matching_entries() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        let target_id = CredentialId::new();
+        let other_id = CredentialId::new();
+
+        lifecycle
+            .track(
+                Arc::clone(&provider) as Arc<dyn LeasedProvider>,
+                make_resolution("mock", 100, "lease-a"),
+                Some(target_id),
+            )
+            .await
+            .unwrap();
+        lifecycle
+            .track(
+                Arc::clone(&provider) as Arc<dyn LeasedProvider>,
+                make_resolution("mock", 100, "lease-b"),
+                Some(target_id),
+            )
+            .await
+            .unwrap();
+        lifecycle
+            .track(
+                Arc::clone(&provider) as Arc<dyn LeasedProvider>,
+                make_resolution("mock", 100, "lease-c"),
+                Some(other_id),
+            )
+            .await
+            .unwrap();
+
+        let revoked = lifecycle.revoke_for_credential(target_id).await;
+        assert_eq!(revoked, 2);
+        // One unrelated lease should remain.
+        assert_eq!(lifecycle.active_lease_count().await, 1);
+        assert_eq!(provider.revoke_calls.load(Ordering::SeqCst), 2);
+
+        shutdown.cancel();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_drains_registry_without_blocking() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        lifecycle
+            .track(provider_arc, make_resolution("mock", 100, "lease-s"), None)
+            .await
+            .expect("track ok");
+
+        shutdown.cancel();
+        // Give the task one tick to observe cancellation.
+        tokio::task::yield_now().await;
+        // The lifecycle handle now returns 0 because the channel is
+        // closed; the public surface degrades gracefully.
+        let count = lifecycle.active_lease_count().await;
+        assert_eq!(count, 0);
+        // We did NOT attempt upstream revoke on shutdown.
+        assert_eq!(provider.revoke_calls.load(Ordering::SeqCst), 0);
+    }
+}

--- a/crates/engine/src/credential/lease/mod.rs
+++ b/crates/engine/src/credential/lease/mod.rs
@@ -403,6 +403,53 @@ mod tests {
         shutdown.cancel();
     }
 
+    /// Regression guard for Codex P1: a lease registered with an
+    /// `issued_at` already in the past (cached resolution, slow
+    /// composition root) must schedule its first renewal off the lease
+    /// issue time, not off "now". A 100s lease that was issued 60s ago
+    /// should fire after ~10s (70s renewal point minus 60s already
+    /// elapsed), not after a fresh 70s window.
+    #[tokio::test(start_paused = true)]
+    async fn scheduler_first_renew_accounts_for_lease_age() {
+        let shutdown = CancellationToken::new();
+        let lifecycle = LeaseLifecycle::spawn(
+            LeaseLifecycleConfig::default(),
+            None,
+            None,
+            shutdown.clone(),
+        );
+        let provider = CountingProvider::new("mock", 100);
+        let provider_arc = Arc::clone(&provider) as Arc<dyn LeasedProvider>;
+
+        // Back-date the lease's `issued_at` by 60 seconds.
+        let backdated = LeaseHandle::new(
+            Cow::Borrowed("mock"),
+            "aged-lease",
+            chrono::Utc::now() - chrono::Duration::seconds(60),
+            Duration::from_secs(100),
+        );
+        let resolution = ProviderResolution::with_lease(SecretString::new("secret"), backdated);
+
+        lifecycle
+            .track(provider_arc, resolution, None)
+            .await
+            .expect("track ok");
+
+        // Only 10s of remaining-to-renew (70% of 100s = 70s, minus 60s
+        // already aged). Advancing by 11s tokio-time should fire.
+        tokio::time::advance(Duration::from_secs(11)).await;
+        for _ in 0..4 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(
+            provider.renew_calls.load(Ordering::SeqCst),
+            1,
+            "aged lease should renew quickly, not wait a full 70s window"
+        );
+
+        shutdown.cancel();
+    }
+
     #[tokio::test(start_paused = true)]
     async fn scheduler_renews_at_seventy_percent_of_ttl() {
         let shutdown = CancellationToken::new();

--- a/crates/engine/src/credential/lease/policy.rs
+++ b/crates/engine/src/credential/lease/policy.rs
@@ -1,0 +1,119 @@
+//! Renewal policy for [`LeaseLifecycle`](super::LeaseLifecycle).
+//!
+//! Defaults follow the Vault Agent recommendation: renew at 70% of the
+//! issued TTL, then bounded exponential backoff `[1s, 2s, 4s, 8s, 16s]`
+//! with a five-attempt budget before the lease is dropped.
+
+use std::time::Duration;
+
+/// Policy controlling when the lifecycle renews a tracked lease and how
+/// it backs off on transient failure.
+///
+/// The defaults match the standard HashiCorp Vault Agent guidance — 70%
+/// renewal point, exponential backoff, finite retry budget. Production
+/// composition is expected to keep the defaults; the fields are public
+/// for tests that need a tight clock.
+#[derive(Debug, Clone)]
+pub struct RenewalPolicy {
+    /// Fraction of the issued TTL at which renewal fires. Must be in
+    /// `(0.0, 1.0]`. Default `0.7`.
+    pub ratio: f32,
+    /// Backoff schedule on `Unavailable` / `Backend` errors. The lease
+    /// is dropped after `backoff.len()` consecutive failures even before
+    /// `max_retries` is consulted — both bounds protect against runaway
+    /// renewal storms.
+    pub backoff: Vec<Duration>,
+    /// Maximum consecutive renewal failures before the lease is dropped.
+    /// Set as a guard alongside `backoff.len()` so callers can tune
+    /// retry budget independently from the wait schedule.
+    pub max_retries: u32,
+}
+
+impl Default for RenewalPolicy {
+    fn default() -> Self {
+        Self {
+            ratio: 0.7,
+            backoff: vec![
+                Duration::from_secs(1),
+                Duration::from_secs(2),
+                Duration::from_secs(4),
+                Duration::from_secs(8),
+                Duration::from_secs(16),
+            ],
+            max_retries: 5,
+        }
+    }
+}
+
+impl RenewalPolicy {
+    /// Compute the next renewal delay relative to lease issue time given
+    /// the provider-reported TTL. Honours the policy ratio.
+    #[must_use]
+    pub fn renew_after(&self, ttl: Duration) -> Duration {
+        let clamped_ratio = self.ratio.clamp(f32::MIN_POSITIVE, 1.0);
+        let secs_f = ttl.as_secs_f64() * f64::from(clamped_ratio);
+        // `Duration::from_secs_f64` panics on `NaN` / `Inf`; convert
+        // defensively through a finite check.
+        if secs_f.is_finite() && secs_f >= 0.0 {
+            Duration::from_secs_f64(secs_f)
+        } else {
+            Duration::ZERO
+        }
+    }
+
+    /// Backoff duration for the `attempt`-th consecutive failure
+    /// (0-indexed). Returns `None` when the retry budget is exhausted.
+    #[must_use]
+    pub fn backoff_for(&self, attempt: u32) -> Option<Duration> {
+        if attempt >= self.max_retries {
+            return None;
+        }
+        let idx = usize::try_from(attempt).unwrap_or(usize::MAX);
+        self.backoff.get(idx).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_renew_after_picks_seventy_percent() {
+        let p = RenewalPolicy::default();
+        let after = p.renew_after(Duration::from_secs(100));
+        // f32 ratio carries ~1ms of imprecision at the 100s scale; allow
+        // a small tolerance rather than demanding exact equality.
+        let target = Duration::from_secs(70);
+        let diff = after.abs_diff(target);
+        assert!(
+            diff < Duration::from_millis(10),
+            "after={after:?}, target={target:?}"
+        );
+    }
+
+    #[test]
+    fn renew_after_ratio_clamped_to_unit_interval() {
+        let p = RenewalPolicy {
+            ratio: 1.5,
+            ..RenewalPolicy::default()
+        };
+        // Clamps to 1.0 → full TTL.
+        let after = p.renew_after(Duration::from_secs(10));
+        assert_eq!(after, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn renew_after_zero_ttl_yields_zero() {
+        let p = RenewalPolicy::default();
+        assert_eq!(p.renew_after(Duration::ZERO), Duration::ZERO);
+    }
+
+    #[test]
+    fn backoff_schedule_exhausts_after_budget() {
+        let p = RenewalPolicy::default();
+        assert_eq!(p.backoff_for(0), Some(Duration::from_secs(1)));
+        assert_eq!(p.backoff_for(4), Some(Duration::from_secs(16)));
+        assert_eq!(p.backoff_for(5), None);
+        assert_eq!(p.backoff_for(100), None);
+    }
+}

--- a/crates/engine/src/credential/lease/registry.rs
+++ b/crates/engine/src/credential/lease/registry.rs
@@ -1,0 +1,43 @@
+//! In-memory registry of leases under lifecycle management.
+//!
+//! The scheduler task owns the only mutable view; the public
+//! [`LeaseLifecycle`](super::LeaseLifecycle) handle communicates with
+//! the worker through a command channel, so the registry does not need
+//! its own lock. The token type is opaque to callers.
+
+use std::sync::Arc;
+
+use nebula_credential::{CredentialId, LeaseHandle, LeasedProvider};
+use tokio::time::Instant;
+
+/// Opaque registry key — handed back from
+/// [`LeaseLifecycle::track`](super::LeaseLifecycle::track) and accepted
+/// by [`LeaseLifecycle::revoke`](super::LeaseLifecycle::revoke).
+///
+/// Internally a monotonic `u64`; the wrapping type forbids external
+/// fabrication so callers cannot pass a stale or guessed token in.
+/// Ord/PartialOrd derived because the scheduler heap entry is keyed
+/// `(Instant, LeaseToken)` and needs a total order for tie-breaking.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct LeaseToken(pub(super) u64);
+
+/// One tracked lease in the registry.
+///
+/// Carries the lease metadata, the provider that can renew / revoke it,
+/// optional attribution to a credential record, the next scheduled
+/// renew instant, and the consecutive-failure counter for backoff.
+#[derive(Clone)]
+pub(super) struct LeaseEntry {
+    /// Lease handle as received from the resolution envelope.
+    pub(super) lease: LeaseHandle,
+    /// Provider capable of renewing / revoking this lease.
+    pub(super) provider: Arc<dyn LeasedProvider>,
+    /// Optional credential record this lease was resolved for. Used by
+    /// `revoke_for_credential` to scan-and-revoke on rotation.
+    pub(super) credential_id: Option<CredentialId>,
+    /// When the next renew attempt should fire.
+    pub(super) next_renew_at: Instant,
+    /// Consecutive renewal failure count — drives the policy's backoff
+    /// schedule. Reset to 0 on a successful renew.
+    pub(super) consecutive_failures: u32,
+}

--- a/crates/engine/src/credential/lease/scheduler.rs
+++ b/crates/engine/src/credential/lease/scheduler.rs
@@ -1,0 +1,582 @@
+//! Background scheduler driving lease renewals and revocations.
+//!
+//! One scheduler task per [`LeaseLifecycle`](super::LeaseLifecycle).
+//! Owns the registry and a min-heap of `(next_renew_at, LeaseToken)`,
+//! drains commands from an `mpsc`, and wakes itself with
+//! [`tokio::time::sleep_until`] on the earliest renewal. Cancellation
+//! drops all outstanding leases with a `Shutdown` reason.
+
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use nebula_core::accessor::MetricsEmitter;
+use nebula_credential::{
+    CredentialId, CredentialMetrics, LeaseEvent, LeaseExpiryReason, LeaseHandle, LeasedProvider,
+    ProviderError, ProviderResolution,
+};
+use nebula_eventbus::EventBus;
+use tokio::sync::{mpsc, oneshot};
+use tokio::time::Instant;
+use tokio_util::sync::CancellationToken;
+
+use super::policy::RenewalPolicy;
+use super::registry::{LeaseEntry, LeaseToken};
+
+/// Configuration for the lease lifecycle.
+#[derive(Debug, Clone, Default)]
+pub struct LeaseLifecycleConfig {
+    /// Renewal policy. Defaults to the Vault Agent recommendation (see
+    /// [`RenewalPolicy`]).
+    pub policy: RenewalPolicy,
+}
+
+/// Command messages the public handle sends to the scheduler task.
+pub(super) enum Command {
+    Track {
+        provider: Arc<dyn LeasedProvider>,
+        lease: LeaseHandle,
+        credential_id: Option<CredentialId>,
+        reply: oneshot::Sender<LeaseToken>,
+    },
+    Revoke {
+        token: LeaseToken,
+        reply: oneshot::Sender<RevokeOutcome>,
+    },
+    RevokeForCredential {
+        credential_id: CredentialId,
+        reply: oneshot::Sender<usize>,
+    },
+    Snapshot {
+        reply: oneshot::Sender<usize>,
+    },
+}
+
+/// Outcome of a `Revoke` command, distinct from a generic error type so
+/// the public surface can downgrade "unknown token" to a typed result.
+pub(super) enum RevokeOutcome {
+    /// Lease was found, revoke completed successfully.
+    Revoked,
+    /// Lease was found, but the provider returned an error. Carries the
+    /// underlying message; the revoke event already fired.
+    ProviderFailed(String),
+    /// No lease found under that token — likely already expired or
+    /// previously revoked.
+    Unknown,
+}
+
+/// Inputs assembled by [`LeaseLifecycle::spawn`](super::LeaseLifecycle::spawn).
+pub(super) struct SchedulerInputs {
+    pub(super) config: LeaseLifecycleConfig,
+    pub(super) commands: mpsc::UnboundedReceiver<Command>,
+    pub(super) lease_bus: Option<Arc<EventBus<LeaseEvent>>>,
+    pub(super) metrics: Option<Arc<dyn MetricsEmitter>>,
+    pub(super) shutdown: CancellationToken,
+}
+
+/// The scheduler's mutable state.
+struct Scheduler {
+    inputs: SchedulerInputs,
+    registry: HashMap<LeaseToken, LeaseEntry>,
+    heap: BinaryHeap<Reverse<(Instant, LeaseToken)>>,
+    next_id: u64,
+}
+
+/// Entry point for the spawned task.
+pub(super) async fn run(inputs: SchedulerInputs) {
+    let mut scheduler = Scheduler {
+        inputs,
+        registry: HashMap::new(),
+        heap: BinaryHeap::new(),
+        next_id: 0,
+    };
+    scheduler.run_loop().await;
+}
+
+impl Scheduler {
+    async fn run_loop(&mut self) {
+        loop {
+            // Compute next wake-up: earliest non-stale heap entry, or
+            // far future if registry is empty. The heap is a soft
+            // schedule — entries can be stale when an earlier revoke
+            // removed the token; we skip stale heads at wake.
+            let next_wake = self.peek_next_wake();
+            let sleep = match next_wake {
+                Some(when) => tokio::time::sleep_until(when),
+                None => tokio::time::sleep(Duration::from_hours(1)),
+            };
+            tokio::pin!(sleep);
+
+            tokio::select! {
+                () = self.inputs.shutdown.cancelled() => {
+                    self.drain_on_shutdown();
+                    return;
+                }
+                cmd = self.inputs.commands.recv() => {
+                    if let Some(c) = cmd {
+                        self.handle_command(c).await;
+                    } else {
+                        // Sender dropped — no more commands will arrive.
+                        // Treat as graceful shutdown.
+                        self.drain_on_shutdown();
+                        return;
+                    }
+                }
+                () = &mut sleep => {
+                    if next_wake.is_some() {
+                        self.tick().await;
+                    }
+                }
+            }
+        }
+    }
+
+    fn peek_next_wake(&self) -> Option<Instant> {
+        self.heap.peek().map(|Reverse((when, _))| *when)
+    }
+
+    async fn handle_command(&mut self, cmd: Command) {
+        match cmd {
+            Command::Track {
+                provider,
+                lease,
+                credential_id,
+                reply,
+            } => {
+                let token = self.allocate_token();
+                let policy = &self.inputs.config.policy;
+                let renew_after = policy.renew_after(lease.ttl);
+                let next_renew_at = Instant::now() + renew_after;
+                let provider_name = provider.provider_name().to_owned();
+                let lease_id = lease.lease_id.clone();
+
+                let entry = LeaseEntry {
+                    lease,
+                    provider,
+                    credential_id,
+                    next_renew_at,
+                    consecutive_failures: 0,
+                };
+                self.registry.insert(token, entry);
+                self.heap.push(Reverse((next_renew_at, token)));
+                self.update_active_gauge();
+
+                tracing::debug!(
+                    target: "nebula_engine::credential::lease",
+                    provider = %provider_name,
+                    lease_id = %lease_id,
+                    ttl_secs = renew_after.as_secs(),
+                    "lease tracked; renewal scheduled"
+                );
+                // Best-effort reply — caller may have dropped the future.
+                let _ = reply.send(token);
+            },
+            Command::Revoke { token, reply } => {
+                let outcome = self.do_revoke(token).await;
+                let _ = reply.send(outcome);
+            },
+            Command::RevokeForCredential {
+                credential_id,
+                reply,
+            } => {
+                let tokens: Vec<LeaseToken> = self
+                    .registry
+                    .iter()
+                    .filter_map(|(t, e)| (e.credential_id == Some(credential_id)).then_some(*t))
+                    .collect();
+                let mut count = 0;
+                for token in tokens {
+                    match self.do_revoke(token).await {
+                        RevokeOutcome::Revoked => count += 1,
+                        // Revoke failures during rotation are best-effort
+                        // — already logged + emitted as event; do not
+                        // block the rotation pipeline.
+                        RevokeOutcome::ProviderFailed(_) | RevokeOutcome::Unknown => {},
+                    }
+                }
+                let _ = reply.send(count);
+            },
+            Command::Snapshot { reply } => {
+                let _ = reply.send(self.registry.len());
+            },
+        }
+    }
+
+    fn allocate_token(&mut self) -> LeaseToken {
+        let t = LeaseToken(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        t
+    }
+
+    /// Fired when the timer for the heap head elapses. Process every
+    /// due entry; the head may be stale if the entry was revoked or
+    /// rescheduled — skip such heads.
+    async fn tick(&mut self) {
+        let now = Instant::now();
+        while let Some(Reverse((when, token))) = self.heap.peek().copied() {
+            if when > now {
+                break;
+            }
+            // Pop the stale or current head.
+            let _ = self.heap.pop();
+            // If the entry was already revoked / dropped, skip.
+            let Some(entry) = self.registry.get(&token) else {
+                continue;
+            };
+            // If the schedule was bumped after this heap entry was
+            // queued (e.g. a successful renew rescheduled further out),
+            // skip this stale firing.
+            if entry.next_renew_at > now {
+                continue;
+            }
+            self.attempt_renew(token).await;
+        }
+    }
+
+    /// Run one renewal attempt against the lease's provider. Re-schedules
+    /// on success, backs off on transient failure, drops on permanent.
+    async fn attempt_renew(&mut self, token: LeaseToken) {
+        let (provider, lease, credential_id, attempt) = {
+            let Some(entry) = self.registry.get(&token) else {
+                return;
+            };
+            (
+                Arc::clone(&entry.provider),
+                entry.lease.clone(),
+                entry.credential_id,
+                entry.consecutive_failures,
+            )
+        };
+        let provider_name = provider.provider_name().to_owned();
+        let lease_id = lease.lease_id.clone();
+        let span = tracing::info_span!(
+            target: "nebula_engine::credential::lease",
+            "lease.renew",
+            provider = %provider_name,
+            lease_id = %lease_id,
+        );
+        let _enter = span.enter();
+
+        let result = provider.renew(&lease).await;
+        match result {
+            Ok(resolution) => {
+                self.on_renew_success(token, &provider_name, &lease_id, credential_id, &resolution);
+            },
+            Err(err) => {
+                self.on_renew_failure(
+                    token,
+                    &provider_name,
+                    &lease_id,
+                    credential_id,
+                    attempt,
+                    err,
+                );
+            },
+        }
+    }
+
+    fn on_renew_success(
+        &mut self,
+        token: LeaseToken,
+        provider_name: &str,
+        lease_id: &str,
+        credential_id: Option<CredentialId>,
+        resolution: &ProviderResolution,
+    ) {
+        // Pull the refreshed TTL from the renewed lease (preferred) or
+        // the envelope-level ttl as a fallback. Vault's `/sys/leases/renew`
+        // returns the new `lease_duration` in both places via
+        // `ProviderResolution::with_lease`.
+        let new_ttl = resolution
+            .lease
+            .as_ref()
+            .map(|l| l.ttl)
+            .or(resolution.ttl)
+            .unwrap_or(Duration::ZERO);
+
+        // If the provider reports zero TTL on renew, treat that as a
+        // signal that no further renew is meaningful (some backends
+        // return zero to indicate "non-renewable").
+        let renew_after = self.inputs.config.policy.renew_after(new_ttl);
+        if renew_after.is_zero() {
+            self.drop_lease(
+                token,
+                lease_id,
+                provider_name,
+                credential_id,
+                LeaseExpiryReason::NotFoundUpstream,
+            );
+            return;
+        }
+
+        let next_renew_at = Instant::now() + renew_after;
+        if let Some(entry) = self.registry.get_mut(&token) {
+            // Update the stored lease so future renew calls carry the
+            // refreshed metadata (lease_id may change on some backends).
+            if let Some(refreshed) = resolution.lease.clone() {
+                entry.lease = refreshed;
+            } else {
+                entry.lease.ttl = new_ttl;
+                entry.lease.issued_at = chrono::Utc::now();
+            }
+            entry.next_renew_at = next_renew_at;
+            entry.consecutive_failures = 0;
+        }
+        self.heap.push(Reverse((next_renew_at, token)));
+
+        tracing::debug!(
+            target: "nebula_engine::credential::lease",
+            provider = provider_name,
+            lease_id = lease_id,
+            new_ttl_secs = new_ttl.as_secs(),
+            "lease renewed; renewal rescheduled"
+        );
+        self.emit_lease_event(LeaseEvent::LeaseRenewed {
+            credential_id,
+            lease_id: lease_id.to_owned(),
+            provider: std::borrow::Cow::Owned(provider_name.to_owned()),
+            new_ttl,
+        });
+        self.emit_counter(
+            CredentialMetrics::DYNAMIC_LEASE_RENEWED_TOTAL,
+            &[
+                (CredentialMetrics::LABEL_OUTCOME, "success"),
+                (CredentialMetrics::LABEL_PROVIDER, provider_name),
+            ],
+        );
+    }
+
+    fn on_renew_failure(
+        &mut self,
+        token: LeaseToken,
+        provider_name: &str,
+        lease_id: &str,
+        credential_id: Option<CredentialId>,
+        attempt: u32,
+        err: ProviderError,
+    ) {
+        let reason = err.to_string();
+        let permanent = matches!(
+            err,
+            ProviderError::NotFound { .. } | ProviderError::AccessDenied { .. }
+        );
+
+        tracing::warn!(
+            target: "nebula_engine::credential::lease",
+            provider = provider_name,
+            lease_id = lease_id,
+            attempt,
+            error = %reason,
+            permanent,
+            "lease renewal failed"
+        );
+        self.emit_lease_event(LeaseEvent::LeaseRenewalFailed {
+            credential_id,
+            lease_id: lease_id.to_owned(),
+            provider: std::borrow::Cow::Owned(provider_name.to_owned()),
+            reason,
+        });
+        self.emit_counter(
+            CredentialMetrics::DYNAMIC_LEASE_RENEWED_TOTAL,
+            &[
+                (CredentialMetrics::LABEL_OUTCOME, "failure"),
+                (CredentialMetrics::LABEL_PROVIDER, provider_name),
+            ],
+        );
+        self.emit_counter(
+            CredentialMetrics::DYNAMIC_LEASE_RENEW_FAILED_TOTAL,
+            &[
+                (
+                    CredentialMetrics::LABEL_FAILURE_REASON,
+                    failure_reason_label(&err),
+                ),
+                (CredentialMetrics::LABEL_PROVIDER, provider_name),
+            ],
+        );
+
+        if permanent {
+            self.drop_lease(
+                token,
+                lease_id,
+                provider_name,
+                credential_id,
+                LeaseExpiryReason::NotFoundUpstream,
+            );
+            return;
+        }
+
+        // Transient: consult the backoff schedule. Exhaustion drops the lease.
+        let next_attempt = attempt + 1;
+        match self.inputs.config.policy.backoff_for(attempt) {
+            Some(wait) => {
+                let next_renew_at = Instant::now() + wait;
+                if let Some(entry) = self.registry.get_mut(&token) {
+                    entry.consecutive_failures = next_attempt;
+                    entry.next_renew_at = next_renew_at;
+                }
+                self.heap.push(Reverse((next_renew_at, token)));
+            },
+            None => {
+                self.drop_lease(
+                    token,
+                    lease_id,
+                    provider_name,
+                    credential_id,
+                    LeaseExpiryReason::RenewalFailed,
+                );
+            },
+        }
+    }
+
+    /// Remove an entry without attempting upstream revoke. Emits a
+    /// `LeaseExpired` event and decrements the gauge.
+    fn drop_lease(
+        &mut self,
+        token: LeaseToken,
+        lease_id: &str,
+        provider_name: &str,
+        credential_id: Option<CredentialId>,
+        reason: LeaseExpiryReason,
+    ) {
+        if self.registry.remove(&token).is_none() {
+            return;
+        }
+        self.update_active_gauge();
+        tracing::info!(
+            target: "nebula_engine::credential::lease",
+            provider = provider_name,
+            lease_id = lease_id,
+            ?reason,
+            "lease dropped from lifecycle"
+        );
+        self.emit_lease_event(LeaseEvent::LeaseExpired {
+            credential_id,
+            lease_id: lease_id.to_owned(),
+            provider: std::borrow::Cow::Owned(provider_name.to_owned()),
+            reason,
+        });
+    }
+
+    async fn do_revoke(&mut self, token: LeaseToken) -> RevokeOutcome {
+        let Some(entry) = self.registry.remove(&token) else {
+            return RevokeOutcome::Unknown;
+        };
+        let provider_name = entry.provider.provider_name().to_owned();
+        let lease_id = entry.lease.lease_id.clone();
+        let credential_id = entry.credential_id;
+
+        let span = tracing::info_span!(
+            target: "nebula_engine::credential::lease",
+            "lease.revoke",
+            provider = %provider_name,
+            lease_id = %lease_id,
+        );
+        let _enter = span.enter();
+
+        let result = entry.provider.revoke(&entry.lease).await;
+        self.update_active_gauge();
+        match result {
+            Ok(_) => {
+                tracing::debug!(
+                    target: "nebula_engine::credential::lease",
+                    provider = %provider_name,
+                    lease_id = %lease_id,
+                    "lease revoked upstream"
+                );
+                self.emit_lease_event(LeaseEvent::LeaseRevoked {
+                    credential_id,
+                    lease_id,
+                    provider: std::borrow::Cow::Owned(provider_name.clone()),
+                });
+                self.emit_counter(
+                    CredentialMetrics::DYNAMIC_LEASE_REVOKED_TOTAL,
+                    &[
+                        (CredentialMetrics::LABEL_OUTCOME, "success"),
+                        (CredentialMetrics::LABEL_PROVIDER, &provider_name),
+                    ],
+                );
+                RevokeOutcome::Revoked
+            },
+            Err(err) => {
+                let reason = err.to_string();
+                tracing::warn!(
+                    target: "nebula_engine::credential::lease",
+                    provider = %provider_name,
+                    lease_id = %lease_id,
+                    error = %reason,
+                    "lease revoke failed; lease removed from registry anyway"
+                );
+                self.emit_lease_event(LeaseEvent::LeaseRevocationFailed {
+                    credential_id,
+                    lease_id,
+                    provider: std::borrow::Cow::Owned(provider_name.clone()),
+                    reason: reason.clone(),
+                });
+                self.emit_counter(
+                    CredentialMetrics::DYNAMIC_LEASE_REVOKED_TOTAL,
+                    &[
+                        (CredentialMetrics::LABEL_OUTCOME, "failure"),
+                        (CredentialMetrics::LABEL_PROVIDER, &provider_name),
+                    ],
+                );
+                RevokeOutcome::ProviderFailed(reason)
+            },
+        }
+    }
+
+    /// Cancellation path: drop every outstanding lease with `Shutdown`
+    /// reason. We do NOT attempt upstream revoke — shutdown can be
+    /// triggered by process termination and we must not block on I/O.
+    fn drain_on_shutdown(&mut self) {
+        let entries: Vec<_> = self.registry.drain().collect();
+        self.update_active_gauge();
+        for (_, entry) in entries {
+            let provider_name = entry.provider.provider_name().to_owned();
+            tracing::info!(
+                target: "nebula_engine::credential::lease",
+                provider = %provider_name,
+                lease_id = %entry.lease.lease_id,
+                "lease lifecycle shutdown — lease left to expire upstream"
+            );
+            self.emit_lease_event(LeaseEvent::LeaseExpired {
+                credential_id: entry.credential_id,
+                lease_id: entry.lease.lease_id.clone(),
+                provider: std::borrow::Cow::Owned(provider_name),
+                reason: LeaseExpiryReason::Shutdown,
+            });
+        }
+    }
+
+    fn emit_lease_event(&self, event: LeaseEvent) {
+        if let Some(bus) = &self.inputs.lease_bus {
+            let _ = bus.emit(event);
+        }
+    }
+
+    fn emit_counter(&self, name: &str, labels: &[(&str, &str)]) {
+        if let Some(m) = &self.inputs.metrics {
+            m.counter(name, 1, labels);
+        }
+    }
+
+    fn update_active_gauge(&self) {
+        if let Some(m) = &self.inputs.metrics {
+            #[allow(clippy::cast_precision_loss)] // counts beyond f64 mantissa are not realistic
+            let value = self.registry.len() as f64;
+            m.gauge(CredentialMetrics::DYNAMIC_LEASE_ACTIVE, value, &[]);
+        }
+    }
+}
+
+fn failure_reason_label(err: &ProviderError) -> &'static str {
+    match err {
+        ProviderError::NotFound { .. } => "not_found",
+        ProviderError::Unavailable { .. } => "unavailable",
+        ProviderError::AccessDenied { .. } => "access_denied",
+        ProviderError::Backend(_) => "backend",
+        // `ProviderError` is `#[non_exhaustive]`; future variants will
+        // label as `other` until classified explicitly.
+        _ => "other",
+    }
+}

--- a/crates/engine/src/credential/lease/scheduler.rs
+++ b/crates/engine/src/credential/lease/scheduler.rs
@@ -77,8 +77,10 @@ pub(super) enum RevokeOutcome {
     /// Lease was found, revoke completed successfully.
     Revoked,
     /// Lease was found, but the provider returned an error. Carries the
-    /// underlying message; the revoke event already fired.
-    ProviderFailed(String),
+    /// typed [`ProviderError`] so callers preserve variant semantics
+    /// (transient `Unavailable` vs. auth `AccessDenied`) and the source
+    /// chain. The revoke event already fired before this is returned.
+    ProviderFailed(ProviderError),
     /// No lease found under that token — likely already expired or
     /// previously revoked.
     Unknown,
@@ -428,13 +430,11 @@ impl Scheduler {
             provider: std::borrow::Cow::Owned(provider_name.to_owned()),
             reason,
         });
-        self.emit_counter(
-            CredentialMetrics::DYNAMIC_LEASE_RENEWED_TOTAL,
-            &[
-                (CredentialMetrics::LABEL_OUTCOME, "failure"),
-                (CredentialMetrics::LABEL_PROVIDER, provider_name),
-            ],
-        );
+        // `DYNAMIC_LEASE_RENEWED_TOTAL` counts only successful renewals
+        // — failures are surfaced exclusively through
+        // `DYNAMIC_LEASE_RENEW_FAILED_TOTAL` (labelled by reason). This
+        // keeps dashboards built on the obvious metric name correct and
+        // avoids double-counting failed attempts across both counters.
         self.emit_counter(
             CredentialMetrics::DYNAMIC_LEASE_RENEW_FAILED_TOTAL,
             &[
@@ -575,7 +575,7 @@ impl Scheduler {
                     credential_id,
                     lease_id,
                     provider: std::borrow::Cow::Owned(provider_name.clone()),
-                    reason: reason.clone(),
+                    reason,
                 });
                 self.emit_counter(
                     CredentialMetrics::DYNAMIC_LEASE_REVOKED_TOTAL,
@@ -584,7 +584,7 @@ impl Scheduler {
                         (CredentialMetrics::LABEL_PROVIDER, &provider_name),
                     ],
                 );
-                RevokeOutcome::ProviderFailed(reason)
+                RevokeOutcome::ProviderFailed(err)
             },
         }
     }
@@ -614,7 +614,18 @@ impl Scheduler {
 
     fn emit_lease_event(&self, event: LeaseEvent) {
         if let Some(bus) = &self.inputs.lease_bus {
-            let _ = bus.emit(event);
+            // Emission is best-effort — a no-subscriber bus or a
+            // lagged broadcast channel must not interrupt the lifecycle
+            // loop. Surface failures at debug so a quiet event bus is
+            // observable when subscribers are expected.
+            let outcome = bus.emit(event);
+            if !outcome.is_sent() {
+                tracing::debug!(
+                    target: "nebula_engine::credential::lease",
+                    ?outcome,
+                    "lease event bus emit did not reach any subscriber"
+                );
+            }
         }
     }
 

--- a/crates/engine/src/credential/lease/scheduler.rs
+++ b/crates/engine/src/credential/lease/scheduler.rs
@@ -20,16 +20,34 @@ use nebula_eventbus::EventBus;
 use tokio::sync::{mpsc, oneshot};
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 
 use super::policy::RenewalPolicy;
 use super::registry::{LeaseEntry, LeaseToken};
 
 /// Configuration for the lease lifecycle.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct LeaseLifecycleConfig {
     /// Renewal policy. Defaults to the Vault Agent recommendation (see
     /// [`RenewalPolicy`]).
     pub policy: RenewalPolicy,
+    /// Hard upper bound on a single `renew` / `revoke` call. Protects
+    /// the single scheduler task from a hung backend monopolising the
+    /// loop and starving other due leases. Mirrors the 30s framework
+    /// timeout used elsewhere in `nebula-engine` (see
+    /// `CredentialResolver::perform_refresh`). On elapsed the call is
+    /// treated as `ProviderError::Unavailable` — the standard backoff
+    /// schedule applies.
+    pub provider_call_timeout: Duration,
+}
+
+impl Default for LeaseLifecycleConfig {
+    fn default() -> Self {
+        Self {
+            policy: RenewalPolicy::default(),
+            provider_call_timeout: Duration::from_secs(30),
+        }
+    }
 }
 
 /// Command messages the public handle sends to the scheduler task.
@@ -146,8 +164,19 @@ impl Scheduler {
             } => {
                 let token = self.allocate_token();
                 let policy = &self.inputs.config.policy;
-                let renew_after = policy.renew_after(lease.ttl);
-                let next_renew_at = Instant::now() + renew_after;
+                // Compute the renewal point from the lease's *issue time*,
+                // not from "now": a resolution may sit in a cache for a
+                // non-trivial fraction of its TTL before reaching the
+                // lifecycle, and scheduling a full fresh window from now
+                // would let the lease expire before the first renew. If
+                // the lease is already past its renewal point, fire
+                // immediately (the heap pop loop tolerates `next_renew_at
+                // <= now`).
+                let renew_after_from_issue = policy.renew_after(lease.ttl);
+                let aged = chrono::Utc::now().signed_duration_since(lease.issued_at);
+                let aged_std = aged.to_std().unwrap_or(Duration::ZERO);
+                let remaining = renew_after_from_issue.saturating_sub(aged_std);
+                let next_renew_at = Instant::now() + remaining;
                 let provider_name = provider.provider_name().to_owned();
                 let lease_id = lease.lease_id.clone();
 
@@ -166,7 +195,8 @@ impl Scheduler {
                     target: "nebula_engine::credential::lease",
                     provider = %provider_name,
                     lease_id = %lease_id,
-                    ttl_secs = renew_after.as_secs(),
+                    renew_in_secs = remaining.as_secs(),
+                    aged_secs = aged_std.as_secs(),
                     "lease tracked; renewal scheduled"
                 );
                 // Best-effort reply — caller may have dropped the future.
@@ -256,9 +286,21 @@ impl Scheduler {
             provider = %provider_name,
             lease_id = %lease_id,
         );
-        let _enter = span.enter();
 
-        let result = provider.renew(&lease).await;
+        // Bounded provider call: instrument via `Instrument` so the
+        // span propagates correctly across the `.await` (an `Entered`
+        // guard would not survive task scheduling on a multi-thread
+        // runtime). Timeout maps to `Unavailable` so the standard
+        // backoff schedule absorbs a hung backend instead of stalling
+        // the lifecycle.
+        let timeout = self.inputs.config.provider_call_timeout;
+        let result =
+            match tokio::time::timeout(timeout, provider.renew(&lease).instrument(span)).await {
+                Ok(r) => r,
+                Err(_) => Err(ProviderError::Unavailable {
+                    reason: format!("provider renew timed out after {}s", timeout.as_secs()),
+                }),
+            };
         match result {
             Ok(resolution) => {
                 self.on_renew_success(token, &provider_name, &lease_id, credential_id, &resolution);
@@ -297,7 +339,9 @@ impl Scheduler {
 
         // If the provider reports zero TTL on renew, treat that as a
         // signal that no further renew is meaningful (some backends
-        // return zero to indicate "non-renewable").
+        // return zero to indicate "non-renewable"). Distinct from
+        // `NotFoundUpstream` (the lease is gone) — the renew succeeded
+        // but the grant is exhausted.
         let renew_after = self.inputs.config.policy.renew_after(new_ttl);
         if renew_after.is_zero() {
             self.drop_lease(
@@ -305,11 +349,18 @@ impl Scheduler {
                 lease_id,
                 provider_name,
                 credential_id,
-                LeaseExpiryReason::NotFoundUpstream,
+                LeaseExpiryReason::NonRenewable,
             );
             return;
         }
 
+        // Use the refreshed lease_id (when the backend rotated it) for
+        // the renewed event so subscribers can correlate against the
+        // identifier the lifecycle now tracks.
+        let event_lease_id = resolution
+            .lease
+            .as_ref()
+            .map_or_else(|| lease_id.to_owned(), |l| l.lease_id.clone());
         let next_renew_at = Instant::now() + renew_after;
         if let Some(entry) = self.registry.get_mut(&token) {
             // Update the stored lease so future renew calls carry the
@@ -328,13 +379,13 @@ impl Scheduler {
         tracing::debug!(
             target: "nebula_engine::credential::lease",
             provider = provider_name,
-            lease_id = lease_id,
+            lease_id = %event_lease_id,
             new_ttl_secs = new_ttl.as_secs(),
             "lease renewed; renewal rescheduled"
         );
         self.emit_lease_event(LeaseEvent::LeaseRenewed {
             credential_id,
-            lease_id: lease_id.to_owned(),
+            lease_id: event_lease_id,
             provider: std::borrow::Cow::Owned(provider_name.to_owned()),
             new_ttl,
         });
@@ -472,9 +523,22 @@ impl Scheduler {
             provider = %provider_name,
             lease_id = %lease_id,
         );
-        let _enter = span.enter();
 
-        let result = entry.provider.revoke(&entry.lease).await;
+        // Same bounded-call pattern as renew: a hung backend must not
+        // monopolise the scheduler. Span propagated via `Instrument`
+        // because an `Entered` guard would not survive task scheduling.
+        let timeout = self.inputs.config.provider_call_timeout;
+        let result = match tokio::time::timeout(
+            timeout,
+            entry.provider.revoke(&entry.lease).instrument(span),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(ProviderError::Unavailable {
+                reason: format!("provider revoke timed out after {}s", timeout.as_secs()),
+            }),
+        };
         self.update_active_gauge();
         match result {
             Ok(_) => {

--- a/crates/engine/src/credential/mod.rs
+++ b/crates/engine/src/credential/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod dispatchers;
 pub mod executor;
+pub mod lease;
 pub mod refresh;
 pub mod registry;
 pub mod resolver;
@@ -16,6 +17,9 @@ pub mod rotation;
 
 pub use dispatchers::{dispatch_release, dispatch_revoke, dispatch_test};
 pub use executor::{ExecutorError, ResolveResponse, execute_continue, execute_resolve};
+pub use lease::{
+    LeaseLifecycle, LeaseLifecycleConfig, LeaseLifecycleError, LeaseToken, RenewalPolicy,
+};
 // Re-export TestResult for the dispatchers module to reference, and to
 // give downstream callers a single import surface for the capability
 // dispatch path.

--- a/crates/engine/src/credential/rotation/transaction.rs
+++ b/crates/engine/src/credential/rotation/transaction.rs
@@ -571,7 +571,15 @@ impl RotationTransaction {
         self.transition_to(RotationState::Committing)
     }
 
-    /// Mark rotation as committed
+    /// Mark rotation as committed.
+    ///
+    /// **Revoke-on-rotate hook (ADR-0051 Phase D).** Composition roots
+    /// that wire a [`LeaseLifecycle`](crate::credential::LeaseLifecycle)
+    /// SHOULD call
+    /// [`LeaseLifecycle::revoke_for_credential(self.credential_id)`](crate::credential::LeaseLifecycle::revoke_for_credential)
+    /// after this transition succeeds, so any upstream lease attributed
+    /// to the rotated credential is torn down. Revoke failures are
+    /// best-effort — they do NOT roll the rotation back.
     pub fn mark_committed(&mut self) -> RotationResult<()> {
         self.transition_to(RotationState::Committed)
     }

--- a/crates/engine/tests/credential_lease_lifecycle.rs
+++ b/crates/engine/tests/credential_lease_lifecycle.rs
@@ -1,0 +1,193 @@
+//! End-to-end exercise of the engine-side lease lifecycle (ADR-0051 Phase D).
+//!
+//! Demonstrates the canonical wiring pattern:
+//!
+//! 1. The engine spawns a [`LeaseLifecycle`] with a `CancellationToken`.
+//! 2. A composition root resolves a credential through a leased provider
+//!    and registers the issued lease with `track`.
+//! 3. The scheduler proactively renews at 70% of the TTL — verified
+//!    through a `tokio::time::pause` clock.
+//! 4. On credential rotation commit the orchestrator calls
+//!    [`LeaseLifecycle::revoke_for_credential`] — the lease is torn down
+//!    upstream and removed from the registry.
+//!
+//! The mock provider is a minimal `LeasedProvider` that counts renew /
+//! revoke calls — sufficient to assert the lifecycle is doing what it
+//! says without bringing in a real backend.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::time::Duration;
+
+use nebula_credential::{
+    CredentialId, ExternalProvider, ExternalReference, LeaseHandle, LeasedProvider, ProviderError,
+    ProviderFuture, ProviderResolution, SecretString,
+};
+use nebula_engine::credential::{LeaseLifecycle, LeaseLifecycleConfig};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Default)]
+struct RenewRevokeProvider {
+    renew_calls: AtomicU32,
+    revoke_calls: AtomicU32,
+    ttl_secs: u32,
+}
+
+impl RenewRevokeProvider {
+    fn new(ttl_secs: u32) -> Arc<Self> {
+        Arc::new(Self {
+            renew_calls: AtomicU32::new(0),
+            revoke_calls: AtomicU32::new(0),
+            ttl_secs,
+        })
+    }
+}
+
+impl ExternalProvider for RenewRevokeProvider {
+    fn resolve<'a>(&'a self, _r: &'a ExternalReference) -> ProviderFuture<'a> {
+        ProviderFuture::ready(Ok(ProviderResolution::from_secret(SecretString::new(
+            "irrelevant",
+        ))))
+    }
+    fn provider_name(&self) -> &'static str {
+        "mock-leased"
+    }
+    fn lease_renewal(&self) -> Option<&dyn LeasedProvider> {
+        Some(self)
+    }
+}
+
+impl LeasedProvider for RenewRevokeProvider {
+    fn renew<'a>(&'a self, lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        self.renew_calls.fetch_add(1, Ordering::SeqCst);
+        let refreshed = LeaseHandle::new(
+            Cow::Borrowed("mock-leased"),
+            lease.lease_id.clone(),
+            chrono::Utc::now(),
+            Duration::from_secs(u64::from(self.ttl_secs)),
+        );
+        ProviderFuture::ready(Ok(ProviderResolution::with_lease(
+            SecretString::new("renewed"),
+            refreshed,
+        )))
+    }
+    fn revoke<'a>(&'a self, _lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        self.revoke_calls.fetch_add(1, Ordering::SeqCst);
+        ProviderFuture::ready(Ok(ProviderResolution::empty()))
+    }
+}
+
+#[derive(Debug)]
+struct UnavailableProvider;
+
+impl ExternalProvider for UnavailableProvider {
+    fn resolve<'a>(&'a self, _r: &'a ExternalReference) -> ProviderFuture<'a> {
+        ProviderFuture::ready(Err(ProviderError::Unavailable {
+            reason: "test".to_owned(),
+        }))
+    }
+    fn provider_name(&self) -> &'static str {
+        "mock-unavailable"
+    }
+    fn lease_renewal(&self) -> Option<&dyn LeasedProvider> {
+        Some(self)
+    }
+}
+
+impl LeasedProvider for UnavailableProvider {
+    fn renew<'a>(&'a self, _lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        ProviderFuture::ready(Err(ProviderError::Unavailable {
+            reason: "test".to_owned(),
+        }))
+    }
+    fn revoke<'a>(&'a self, _lease: &'a LeaseHandle) -> ProviderFuture<'a> {
+        ProviderFuture::ready(Err(ProviderError::Unavailable {
+            reason: "test".to_owned(),
+        }))
+    }
+}
+
+fn lease_resolution(provider: &str, lease_id: &str, ttl_secs: u64) -> ProviderResolution {
+    let lease = LeaseHandle::new(
+        Cow::Owned(provider.to_owned()),
+        lease_id,
+        chrono::Utc::now(),
+        Duration::from_secs(ttl_secs),
+    );
+    ProviderResolution::with_lease(SecretString::new("secret"), lease)
+}
+
+#[tokio::test(start_paused = true)]
+async fn lifecycle_renews_then_rotation_revokes_for_credential() {
+    let shutdown = CancellationToken::new();
+    let lifecycle = LeaseLifecycle::spawn(
+        LeaseLifecycleConfig::default(),
+        None,
+        None,
+        shutdown.clone(),
+    );
+    let provider = RenewRevokeProvider::new(200);
+    let credential_id = CredentialId::new();
+
+    // Step 1: register a Vault-style dynamic lease.
+    let _token = lifecycle
+        .track(
+            Arc::clone(&provider) as Arc<dyn LeasedProvider>,
+            lease_resolution("mock-leased", "lease-1", 200),
+            Some(credential_id),
+        )
+        .await
+        .expect("track succeeds");
+    assert_eq!(lifecycle.active_lease_count().await, 1);
+
+    // Step 2: advance past 70% of TTL — scheduler renews automatically.
+    tokio::time::advance(Duration::from_secs(141)).await;
+    for _ in 0..4 {
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(provider.renew_calls.load(Ordering::SeqCst), 1);
+
+    // Step 3: rotation commits — the orchestrator calls
+    // `revoke_for_credential`. Mirrors the wiring point documented on
+    // `RotationTransaction::mark_committed`.
+    let revoked = lifecycle.revoke_for_credential(credential_id).await;
+    assert_eq!(revoked, 1);
+    assert_eq!(provider.revoke_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(lifecycle.active_lease_count().await, 0);
+
+    shutdown.cancel();
+}
+
+#[tokio::test(start_paused = true)]
+async fn revoke_for_credential_with_provider_failure_does_not_block_rotation() {
+    // Revoke-on-rotate is best-effort cleanup: if the provider is
+    // unavailable, the rotation pipeline MUST still proceed. The lease
+    // is removed from the registry regardless.
+    let shutdown = CancellationToken::new();
+    let lifecycle = LeaseLifecycle::spawn(
+        LeaseLifecycleConfig::default(),
+        None,
+        None,
+        shutdown.clone(),
+    );
+    let credential_id = CredentialId::new();
+
+    lifecycle
+        .track(
+            Arc::new(UnavailableProvider) as Arc<dyn LeasedProvider>,
+            lease_resolution("mock-unavailable", "lease-flaky", 600),
+            Some(credential_id),
+        )
+        .await
+        .expect("track succeeds");
+
+    // Provider revoke will fail with Unavailable; the helper returns 0
+    // (no successful revokes) but does not propagate the error. The
+    // lease is dropped from the registry either way.
+    let revoked = lifecycle.revoke_for_credential(credential_id).await;
+    assert_eq!(revoked, 0);
+    assert_eq!(lifecycle.active_lease_count().await, 0);
+
+    shutdown.cancel();
+}

--- a/docs/adr/0051-external-provider-redesign.md
+++ b/docs/adr/0051-external-provider-redesign.md
@@ -229,3 +229,67 @@ invalidating the cached entry while forwarding to Vault exactly once.
 
 Phase D (engine-side consumption of the `LeasedProvider` capability —
 proactive renew, revoke-on-rotation) remains tracked separately.
+
+## Update — 2026-05-13 (Phase D)
+
+Engine-side consumption of the `LeasedProvider` capability lands as a
+new `nebula_engine::credential::lease` subsystem
+(`crates/engine/src/credential/lease/`). One background tokio task per
+engine owns a min-heap-driven scheduler that proactively renews tracked
+leases at 70% of TTL and accepts on-demand revoke through an opaque
+[`LeaseToken`](nebula_engine::credential::LeaseToken).
+
+Default policy mirrors HashiCorp Vault Agent guidance: 70% renewal
+ratio, bounded backoff `[1s, 2s, 4s, 8s, 16s]`, five-attempt budget.
+`ProviderError::NotFound` and `AccessDenied` drop the lease immediately
+(the upstream grant is gone, retries are useless); `Unavailable` and
+`Backend` retry on the backoff schedule, then drop with `Expired
+{ reason: RenewalFailed }`.
+
+Cross-crate signalling uses a new `LeaseEvent` enum at
+`crates/credential/src/provider/event.rs` (sibling to `LeaseHandle`),
+published on `EventBus<LeaseEvent>` — not folded into `CredentialEvent`
+because lease events carry richer payload (lease id, provider name,
+new TTL, expiry reason) and a sizeable subset of leases will be
+unattributed to a nebula `CredentialId`. Variants cover the full state
+machine: `LeaseRenewed`, `LeaseRevoked`, `LeaseRenewalFailed`,
+`LeaseRevocationFailed`, `LeaseExpired { reason: RenewalFailed |
+NotFoundUpstream | Shutdown }`.
+
+Revoke-on-rotation is wired through
+`LeaseLifecycle::revoke_for_credential(id)` — a registry scan that
+fires `revoke` on every tracked lease attributed to the credential.
+Failed revokes are best-effort: logged, emitted as
+`LeaseRevocationFailed`, but **do not block** rotation. The integration
+point is documented inline on `RotationTransaction::mark_committed` so
+future composition-root work has a clear hook. The orchestrator pattern
+is exercised end-to-end in
+`crates/engine/tests/credential_lease_lifecycle.rs`.
+
+New `CredentialMetrics` constants (engine-side lease lifecycle counters):
+
+| Metric                                          | Type      | Labels             |
+|-------------------------------------------------|-----------|--------------------|
+| `nebula.credential.dynamic_lease_renewed_total` | counter   | `outcome`,`provider` |
+| `nebula.credential.dynamic_lease_revoked_total` | counter   | `outcome`,`provider` |
+| `nebula.credential.dynamic_lease_renew_failed_total` | counter | `reason`,`provider` |
+| `nebula.credential.dynamic_lease_active`        | gauge     | (none)             |
+
+### Non-goals
+
+Two follow-ups stay explicitly out of scope of Phase D — flagged here
+so future cascade waves do not re-litigate them:
+
+- **Wiring `ExternalProvider::resolve` into `CredentialResolver`.** The
+  resolver still operates on `CredentialStore` state today. Phase D
+  delivers the lease lifecycle mechanism so the bridge work only has
+  to call `LeaseLifecycle::track` at resolve time.
+- **Cross-replica lease coordination.** Phase D ships single-replica
+  semantics — every engine instance that calls `track` will
+  independently try to renew. Multi-replica coordination would gate
+  renewal through `RefreshCoordinator`'s L2 claim repo; deferred to a
+  separate ADR.
+
+Phase D closes the ADR-0051 follow-up cascade. The cascade's PR chain
+is #664 (cache) → #665 (sub-trait + routing) → #666 (Vault impl) →
+this PR.

--- a/docs/adr/0051-external-provider-redesign.md
+++ b/docs/adr/0051-external-provider-redesign.md
@@ -241,10 +241,18 @@ leases at 70% of TTL and accepts on-demand revoke through an opaque
 
 Default policy mirrors HashiCorp Vault Agent guidance: 70% renewal
 ratio, bounded backoff `[1s, 2s, 4s, 8s, 16s]`, five-attempt budget.
+Each individual `renew` / `revoke` call is additionally bounded by a
+`provider_call_timeout` (default `30s`) so a hung backend cannot
+monopolise the single scheduler task and starve other due leases —
+timeouts map to `ProviderError::Unavailable` and count against the
+five-attempt budget like any other transient failure.
 `ProviderError::NotFound` and `AccessDenied` drop the lease immediately
 (the upstream grant is gone, retries are useless); `Unavailable` and
 `Backend` retry on the backoff schedule, then drop with `Expired
-{ reason: RenewalFailed }`.
+{ reason: RenewalFailed }`. A renew that succeeds but returns a
+zero TTL (the Vault convention for non-renewable grants) drops the
+lease with `Expired { reason: NonRenewable }` — distinct from
+`NotFoundUpstream` for clean observability.
 
 Cross-crate signalling uses a new `LeaseEvent` enum at
 `crates/credential/src/provider/event.rs` (sibling to `LeaseHandle`),
@@ -254,7 +262,7 @@ new TTL, expiry reason) and a sizeable subset of leases will be
 unattributed to a nebula `CredentialId`. Variants cover the full state
 machine: `LeaseRenewed`, `LeaseRevoked`, `LeaseRenewalFailed`,
 `LeaseRevocationFailed`, `LeaseExpired { reason: RenewalFailed |
-NotFoundUpstream | Shutdown }`.
+NotFoundUpstream | NonRenewable | Shutdown }`.
 
 Revoke-on-rotation is wired through
 `LeaseLifecycle::revoke_for_credential(id)` — a registry scan that

--- a/docs/superpowers/specs/2026-05-13-engine-lease-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-13-engine-lease-lifecycle-design.md
@@ -1,0 +1,192 @@
+# Engine-side LeasedProvider consumption — Phase D of ADR-0051
+
+**Status:** Drafted 2026-05-13. Closes the ADR-0051 follow-up cascade.
+
+## Context
+
+Phases A–C of the ADR-0051 follow-up landed:
+
+- **Phase A** (#664) — `ProviderCacheLayer` in `nebula-storage`.
+- **Phase B** (#665) — `LeasedProvider: ExternalProvider` sub-trait with
+  `handles_lease` / `renew` / `revoke`, plus `LeaseHandle::provider`
+  attribution routed through `ExternalProviderChain` and `ProviderCacheLayer`.
+- **Phase C** (#666) — `nebula-credential-vault` crate as the first concrete
+  `LeasedProvider` (KV v2 + dynamic-secret reads with `lease_duration`).
+
+What's missing: the engine never **calls** `renew` or `revoke`. A Vault
+dynamic lease carries a TTL but nothing in the runtime proactively refreshes
+it, and rotating a credential record does not revoke the upstream grant.
+Survey across `crates/engine/src/credential/` confirms `ExternalProvider` /
+`LeasedProvider` have zero call sites in the engine today — Phase D both
+provides the mechanism and wires the rotation hook so future credential→
+provider bridging only has to register leases.
+
+## Decision
+
+A self-contained `LeaseLifecycle` subsystem in `crates/engine/src/credential/lease/`
+sibling to `refresh` / `rotation` / `registry` / `resolver`. Public API is
+the registration entry point; everything else (renewal scheduling, retries,
+event emission, metrics) is private to the module.
+
+### Module layout
+
+```
+crates/engine/src/credential/lease/
+├── mod.rs        # Public surface: LeaseLifecycle, LeaseLifecycleError, LeaseToken
+├── registry.rs   # In-process registry of tracked leases keyed by LeaseToken
+├── scheduler.rs  # Background tokio task driving renewals + revocations
+└── policy.rs     # RenewalPolicy (ratio, backoff schedule, max retries)
+```
+
+`LeaseEvent` lands in `crates/credential/src/provider/event.rs` (re-exported
+through `provider::mod`) — domain type lives next to `LeaseHandle`, just like
+`CredentialEvent` lives in `nebula-credential` and is published by the
+engine. Published on a dedicated `EventBus<LeaseEvent>` (not shoehorned into
+`CredentialEvent`) because lease events carry richer payload (lease id,
+provider name, TTL remaining) and a sizeable subset of leases will be
+unattributed to a `CredentialId`.
+
+### Decisions on the five open points
+
+1. **Scheduler vs inline (decided: dedicated scheduler).** A single
+   `tokio::spawn` per engine owns a `BinaryHeap<(Reverse<Instant>,
+   LeaseToken)>` priority queue plus a `HashMap<LeaseToken, LeaseEntry>`.
+   Driven by `tokio::select!` over `sleep_until(next_renew)` / command
+   `mpsc` / `CancellationToken::cancelled()`. Inline renewal would either
+   require periodic polling (same cost, worse coupling) or risk silent
+   expiry during idle workflows that hold a lease for hours. One task per
+   engine — not per credential.
+
+2. **Renewal policy.** Renew at `issued_at + ttl * 0.7` (Vault Agent
+   recommendation, also AWS STS guidance). On `ProviderError::Unavailable`
+   or `Backend` apply bounded backoff `[1s, 2s, 4s, 8s, 16s]` with max 5
+   retries before dropping the lease and emitting `LeaseEvent::Expired { ..,
+   reason: RenewalFailed }`. On `ProviderError::NotFound` or `AccessDenied`
+   drop immediately with `Expired { reason: NotFoundUpstream }` — Vault has
+   already invalidated the lease, retries are useless.
+
+3. **Revoke-on-rotate hook.** `LeaseLifecycle::revoke_for_credential(id)`
+   scans the registry for entries whose `credential_id == Some(id)` and
+   revokes each through `LeasedProvider::revoke`. Wiring is opt-in: the
+   composition root passes an `Arc<LeaseLifecycle>` to the rotation
+   orchestrator, which calls the method post-commit. The rotation
+   pipeline's local `RotationTransaction` is untouched — no breaking
+   signature change. Leases unattributed to a `CredentialId` (orphan
+   resolutions) are unaffected.
+
+4. **Failure semantics.**
+   - `renew` failures are observable but never propagate up: log
+     `tracing::warn`, increment `nebula.credential.dynamic_lease_renew_failed_total`,
+     retry per backoff, emit `LeaseEvent::RenewalFailed` per attempt,
+     drop + `Expired` after the budget is exhausted.
+   - `revoke` failures during rotation: `tracing::warn` + metric +
+     `LeaseEvent::RevocationFailed`, **do not block rotation** — local
+     state has already committed; upstream cleanup is best-effort. A
+     downstream audit subscriber can flag unrevoked leases via the
+     event stream.
+   - Public surface returns typed `LeaseLifecycleError` (thiserror): `Renew`,
+     `Revoke`, `Expired`, `Unattributed`, `Shutdown`.
+   - **No `unwrap` / `expect` / `panic!`** anywhere on the lifecycle path.
+
+5. **Observability.**
+   - Metric constants added to `CredentialMetrics`:
+     - `DYNAMIC_LEASE_RENEWED_TOTAL` — counter, labels: `outcome`, `provider`.
+     - `DYNAMIC_LEASE_REVOKED_TOTAL` — counter, labels: `outcome`, `provider`.
+     - `DYNAMIC_LEASE_RENEW_FAILED_TOTAL` — counter, labels: `reason`,
+       `provider`.
+     - `DYNAMIC_LEASE_ACTIVE` — gauge of currently-tracked leases.
+   - Spans: `lease.renew`, `lease.revoke`, `lease.expired` — each with
+     `provider`, `lease_id`, and (when present) `credential_id`.
+   - Events on `EventBus<LeaseEvent>`:
+     - `LeaseRenewed { credential_id: Option<CredentialId>, lease_id, provider, new_ttl }`.
+     - `LeaseRevoked { credential_id, lease_id, provider }`.
+     - `LeaseRenewalFailed { credential_id, lease_id, provider, reason }`.
+     - `LeaseRevocationFailed { credential_id, lease_id, provider, reason }`.
+     - `LeaseExpired { credential_id, lease_id, provider, reason }`.
+   - Every new state transition (track → renew-scheduled, scheduled →
+     renewing, renewing → re-scheduled / dropped) emits exactly one of the
+     above (DoD per AGENTS.md).
+
+### Public API surface
+
+```rust
+pub struct LeaseLifecycle { /* Arc-shared handle to the scheduler task */ }
+
+pub struct LeaseToken { /* opaque registry key */ }
+
+impl LeaseLifecycle {
+    pub fn spawn(
+        config: LeaseLifecycleConfig,
+        event_bus: Option<Arc<EventBus<LeaseEvent>>>,
+        metrics: Option<Arc<dyn MetricsEmitter>>,
+        shutdown: CancellationToken,
+    ) -> Self;
+
+    pub fn track(
+        &self,
+        provider: Arc<dyn LeasedProvider>,
+        resolution: ProviderResolution,
+        credential_id: Option<CredentialId>,
+    ) -> Result<LeaseToken, LeaseLifecycleError>;
+
+    pub async fn revoke(&self, token: LeaseToken) -> Result<(), LeaseLifecycleError>;
+
+    pub async fn revoke_for_credential(&self, id: CredentialId) -> usize;
+
+    pub fn active_lease_count(&self) -> usize;
+}
+```
+
+`LeaseLifecycleConfig` carries `RenewalPolicy { ratio: f32, backoff:
+Vec<Duration>, max_retries: u32 }` with a Vault-style default.
+
+### Non-goals (for Phase D)
+
+- **Wiring `ExternalProvider::resolve` into `CredentialResolver`.** That's a
+  separate redesign — the resolver currently operates on `CredentialStore`,
+  not on provider-resolved secrets. Phase D delivers the lifecycle
+  mechanism so the future bridge only has to call `LeaseLifecycle::track`.
+- **Persisting tracked leases across engine restarts.** The registry is
+  in-memory; on engine restart the lease is left to expire upstream at its
+  natural TTL. ADR-0051 explicitly rejected pre-staged fallback secrets;
+  the symmetric pattern here is "no silent persistence of lease tokens"
+  either.
+- **Cross-replica lease coordination.** Renewal is best run by exactly one
+  replica per lease, but Phase D ships single-replica semantics. The
+  follow-up (separate ADR) would gate renewal through the existing
+  `RefreshCoordinator` L2 claim repo.
+
+## Tests
+
+- **Unit (in `crates/engine/src/credential/lease/`)**:
+  - Scheduler picks renewal time at 70% of TTL.
+  - Successful renew reschedules at 70% of refreshed TTL.
+  - `Unavailable` triggers backoff; recovery before max retries succeeds.
+  - Backoff exhaustion drops the lease and emits `Expired`.
+  - `NotFound` drops immediately without retries.
+  - `revoke` removes from registry, emits `LeaseRevoked`.
+  - `revoke_for_credential` revokes only matching entries.
+  - Shutdown via `CancellationToken` is graceful; outstanding leases drop
+    with `Shutdown` reason.
+
+- **Integration**:
+  - Mock `LeasedProvider` (reuse the `LeasedMock` pattern from
+    `crates/credential/src/provider/leased.rs`) — exercise the full
+    track → auto-renew → revoke path with a manually-advanced
+    `tokio::time::pause()` clock.
+
+## Verification gate
+
+```
+cargo check  --workspace --all-features
+cargo test   -p nebula-engine --all-features
+cargo test   -p nebula-credential --all-features
+cargo clippy --workspace --all-targets -q -- -D warnings
+cargo fmt --all -- --check
+RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace
+cargo deny check
+```
+
+Then conventional commit (`feat(engine): …`), `gh pr create` referencing
+ADR-0051 and PRs #664 / #665 / #666. ADR-0051 grows its third `## Update`
+block on landing.

--- a/docs/superpowers/specs/2026-05-13-engine-lease-lifecycle-design.md
+++ b/docs/superpowers/specs/2026-05-13-engine-lease-lifecycle-design.md
@@ -84,8 +84,15 @@ unattributed to a `CredentialId`.
      state has already committed; upstream cleanup is best-effort. A
      downstream audit subscriber can flag unrevoked leases via the
      event stream.
-   - Public surface returns typed `LeaseLifecycleError` (thiserror): `Renew`,
-     `Revoke`, `Expired`, `Unattributed`, `Shutdown`.
+   - Public surface returns typed `LeaseLifecycleError` (thiserror).
+     Only three variants need to escape the lifecycle — internal failures
+     are absorbed by the backoff / event-publishing path and do not
+     surface to callers:
+     - `ResolutionMissingLease` — `track` called with an empty
+       `ProviderResolution.lease`.
+     - `Revoke { reason }` — provider returned an error from `revoke`.
+       The lease is still removed from the registry.
+     - `Shutdown` — scheduler task no longer accepting commands.
    - **No `unwrap` / `expect` / `panic!`** anywhere on the lifecycle path.
 
 5. **Observability.**
@@ -102,7 +109,10 @@ unattributed to a `CredentialId`.
      - `LeaseRevoked { credential_id, lease_id, provider }`.
      - `LeaseRenewalFailed { credential_id, lease_id, provider, reason }`.
      - `LeaseRevocationFailed { credential_id, lease_id, provider, reason }`.
-     - `LeaseExpired { credential_id, lease_id, provider, reason }`.
+     - `LeaseExpired { credential_id, lease_id, provider, reason }`
+       where `reason` is one of `RenewalFailed` (budget exhausted) /
+       `NotFoundUpstream` (gone upstream) / `NonRenewable` (renewed
+       with zero TTL) / `Shutdown` (lifecycle cancelled).
    - Every new state transition (track → renew-scheduled, scheduled →
      renewing, renewing → re-scheduled / dropped) emits exactly one of the
      above (DoD per AGENTS.md).
@@ -138,7 +148,12 @@ impl LeaseLifecycle {
 ```
 
 `LeaseLifecycleConfig` carries `RenewalPolicy { ratio: f32, backoff:
-Vec<Duration>, max_retries: u32 }` with a Vault-style default.
+Vec<Duration>, max_retries: u32 }` with a Vault-style default plus a
+`provider_call_timeout: Duration` (default 30s) that bounds each
+`renew` / `revoke` call so a hung backend cannot monopolise the
+scheduler task. On timeout the call is mapped to
+`ProviderError::Unavailable` and the standard backoff schedule
+absorbs it.
 
 ### Non-goals (for Phase D)
 


### PR DESCRIPTION
## Summary

Closes the ADR-0051 follow-up cascade by wiring the engine to call `renew` / `revoke` on `LeasedProvider`. Phases A ([#664](https://github.com/vanyastaff/nebula/pull/664)), B ([#665](https://github.com/vanyastaff/nebula/pull/665)) and C ([#666](https://github.com/vanyastaff/nebula/pull/666)) shipped the lease primitives — a Vault dynamic-secret lease would silently expire because nothing in the runtime called the lifecycle methods. This PR is the consumer.

- New `nebula_engine::credential::lease` subsystem — `LeaseLifecycle::spawn` plus `track` / `revoke` / `revoke_for_credential`. One background tokio task per engine drives a min-heap-scheduled renewal loop.
- Renewal policy mirrors Vault Agent guidance: 70% TTL ratio, bounded backoff `[1s, 2s, 4s, 8s, 16s]`, five-attempt budget. `NotFound` / `AccessDenied` drop immediately; transient errors retry then drop with `LeaseExpired { reason: RenewalFailed }`.
- Cross-crate signalling through a new `LeaseEvent` enum in `nebula-credential` (sibling to `LeaseHandle`), published on `EventBus<LeaseEvent>` — kept distinct from `CredentialEvent` because variants carry richer payload (lease id, provider, expiry reason).
- Revoke-on-rotate hook: `LeaseLifecycle::revoke_for_credential` scans the registry for matching attribution and fires `revoke` per entry. Documented inline on `RotationTransaction::mark_committed`. Best-effort: revoke failures log + emit `LeaseRevocationFailed` but do NOT block the rotation pipeline.
- Observability per AGENTS.md DoD: typed `LeaseLifecycleError`, tracing spans on every state transition (`lease.renew`, `lease.revoke`), four new `CredentialMetrics` constants (`dynamic_lease_renewed_total`, `dynamic_lease_revoked_total`, `dynamic_lease_renew_failed_total` counters + `dynamic_lease_active` gauge).
- Spec at `docs/superpowers/specs/2026-05-13-engine-lease-lifecycle-design.md`; ADR-0051 grows its third `## Update` block.

## Non-goals (explicitly out of scope)

- **Wiring `ExternalProvider::resolve` into `CredentialResolver`** — the resolver still operates on `CredentialStore` state. Phase D delivers the lifecycle mechanism so the future bridge only has to call `LeaseLifecycle::track`.
- **Cross-replica lease coordination** — Phase D ships single-replica semantics. Multi-replica gating through `RefreshCoordinator`'s L2 claim repo is a separate ADR.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test -p nebula-engine` (188 lib unit tests + 2 new integration tests, all green)
- [x] `cargo test -p nebula-credential` (185 unit tests + new `LeaseEvent` tests)
- [x] `cargo clippy --workspace --all-targets -q -- -D warnings`
- [x] `cargo fmt -p nebula-engine -p nebula-credential -- --check`
- [x] `RUSTDOCFLAGS=\"-D warnings\" cargo doc --no-deps --workspace`
- [x] `cargo deny check` (advisories / bans / licenses / sources all ok)
- [x] Unit tests cover: 70% renewal timing, `Unavailable` backoff with recovery, `NotFound` permanent drop, revoke from registry, `revoke_for_credential` selective scan, graceful shutdown drain.
- [x] Integration test (`tests/credential_lease_lifecycle.rs`) exercises the canonical wiring pattern: track → auto-renew → rotate → revoke, under `tokio::time::pause()`.

## References

ADR-0051 (`docs/adr/0051-external-provider-redesign.md`) — Phase D `## Update` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added automatic renewal of dynamic credential leases before expiration to prevent credential invalidation.
  * Added automatic revocation of leases during credential rotation.
  * Added observability metrics tracking lease lifecycle events (renewals, revocations, expirations, and failures).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/667)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->