### PR TITLE
fix(api): unshadow /credentials/resolve from the tenancy {cred} matcher

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -285,10 +285,11 @@ types have no `data` field, so `get` / `list` cannot echo the secret.
 > (`nebula-engine::credential`, ADR-0030/ADR-0041) and/or a
 > `CredentialRegistry` that is not wired into this build, so they
 > deliberately refuse rather than fake a credential capability. The
-> generic `resolve` / `resolve/continue` routes are additionally
-> shadowed by the tenancy `{cred}` path matcher (a pre-existing
-> route-ordering condition) and surface as a flat 404 before the
-> handler — still §4.5-honest (no false success).
+> tenancy path resolver special-cases the literal `resolve` sub-route,
+> so `resolve` / `resolve/continue` are **not** shadowed by the
+> `{cred}` matcher — they reach the handler and return the honest 503
+> above (not a pre-handler 404); the genuine `/credentials/{cred}`
+> position stays strictly ULID-validated.
 
 ### Org membership durability (canon §11.6 / §11.5)
 

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -363,6 +363,7 @@ pub async fn revoke_credential(
         (status = 400, description = "Validation error (key or data shape).", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
+        (status = 503, description = "Honest stub (canon §4.5): the route is reachable but generic credential resolution is engine-owned (`Credential::resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
     ),
 )]
 pub async fn resolve_credential(
@@ -401,6 +402,7 @@ pub async fn resolve_credential(
         (status = 400, description = "Validation error (e.g. empty `pending_token`).", body = ProblemDetails),
         (status = 401, description = "Authentication required or pending token expired/already-consumed.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
+        (status = 503, description = "Honest stub (canon §4.5): the route is reachable but generic interactive continuation is engine-owned (`Interactive::continue_resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
     ),
 )]
 pub async fn continue_resolve_credential(

--- a/crates/api/src/middleware/tenancy.rs
+++ b/crates/api/src/middleware/tenancy.rs
@@ -90,7 +90,15 @@ async fn resolve_path_ids(state: &AppState, path: &str) -> Result<Option<Resolve
                 "executions" => {
                     ids.execution_id = Some(resolve_typed_id::<ExecutionId>(segments[7])?);
                 },
-                "credentials" => {
+                // `/credentials/resolve` and
+                // `/credentials/resolve/continue` are literal acquisition
+                // sub-routes, not a `{cred}` path parameter. The guard
+                // skips this arm for the literal `resolve` (otherwise
+                // parsing it as a `CredentialId` fails ULID validation and
+                // 404s the route before its handler runs — a route-shadow).
+                // The genuine `/credentials/{cred}` position still parses
+                // and is strictly validated here.
+                "credentials" if segments[7] != "resolve" => {
                     ids.credential_id = Some(resolve_typed_id::<CredentialId>(segments[7])?);
                 },
                 _ => {},

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -21,15 +21,16 @@
 //! §4.5 false capability (the worst class for a credential surface).
 //!
 //! Note: the generic `resolve_credential` / `continue_resolve`
-//! functions are honest-503 at the function boundary, but their routes
-//! are additionally **shadowed by the tenancy `{cred}` path matcher**
-//! (`crate::middleware::tenancy::resolve_path_ids` parses the segment
-//! after `credentials` as a `CredentialId`; the literal `resolve` fails
-//! ULID parsing → a flat 404 before the handler). This is a
-//! pre-existing route-ordering condition, not introduced by Phase 4,
-//! and is still §4.5-honest (no false success — the caller cannot
-//! obtain a fake credential). The honest-503 at the function is pinned
-//! by the unit test below regardless of the route shadow.
+//! functions are honest-503 at the function boundary, and their routes
+//! **reach the handler**: `crate::middleware::tenancy::resolve_path_ids`
+//! special-cases the literal `resolve` sub-route so it is not parsed as
+//! a `{cred}` `CredentialId` (an earlier route-shadow returned a flat
+//! 404 *before* the handler — fixed). A request to
+//! `…/credentials/resolve[/continue]` therefore surfaces this honest
+//! **503** (no false success — the caller cannot obtain a fake
+//! credential); the genuine `…/credentials/{cred}` position stays
+//! strictly ULID-validated. The honest-503 is pinned by the unit test
+//! below and the `credential_e2e` route-reachability regression guard.
 //!
 //! ## §12.5 secret handling
 //!

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -598,16 +598,27 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
     // dispatch is not wired into this API build); the genuine `{cred}`
     // position stays strictly ULID-validated. Regression guard for the
     // route-shadow.
+    // The sentinel is placed in the submitted credential material
+    // (`data` / `user_input`) so the no-secret assertion below is a
+    // *real* redaction guard, not vacuous: the honest-503 problem body
+    // must never echo caller-submitted secret material (§12.5 / §13 —
+    // same contract as the forced-error bodies elsewhere in this file).
     let resolve_503: &[(&str, String, serde_json::Value)] = &[
         (
             "POST",
             ws_path("/credentials/resolve"),
-            serde_json::json!({ "credential_key": "api_key", "data": {} }),
+            serde_json::json!({
+                "credential_key": "api_key",
+                "data": { "api_key": SECRET_TOKEN }
+            }),
         ),
         (
             "POST",
             ws_path("/credentials/resolve/continue"),
-            serde_json::json!({ "pending_token": "tok", "user_input": {} }),
+            serde_json::json!({
+                "pending_token": "tok",
+                "user_input": { "code": SECRET_TOKEN }
+            }),
         ),
     ];
 
@@ -627,7 +638,9 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         let problem = body_string(resp).await;
         assert!(
             !problem.contains(SECRET_TOKEN),
-            "503 body must never carry a secret: {problem}"
+            "honest-503 problem body must not echo caller-submitted \
+             credential material (SECRET_TOKEN was in the request \
+             `data`/`user_input`): {problem}"
         );
     }
 

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -645,3 +645,53 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         );
     }
 }
+
+/// Guard-precision regression (Copilot review, PR #674): the
+/// `"credentials" if segments[7] != "resolve"` tenancy match guard must
+/// keep rejecting a **non-`resolve`, non-ULID** `{cred}` segment
+/// *before* the handler. Locks the other half of the contract so a
+/// future broadening of the guard cannot silently weaken `{cred}` ULID
+/// validation — the route-shadow fix only carves out the literal
+/// `resolve`, nothing else.
+#[tokio::test]
+async fn tenancy_still_rejects_non_ulid_cred_segment_before_handler() {
+    let (state, _q) = create_state_with_queue().await;
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // "not-a-valid-ulid" is neither the literal `resolve` sub-route nor a
+    // `cred_<ULID>` → the tenancy `{cred}` matcher must 404 before any
+    // handler runs (bare `{cred}` GET, and the `{cred}/test` POST
+    // sub-route — both put the bad segment at the `{cred}` position).
+    let bad = "not-a-valid-ulid";
+
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_get(&ws_path(&format!("/credentials/{bad}")), &token))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "GET /credentials/{bad}: a non-`resolve`, non-ULID `{{cred}}` segment \
+         must be rejected by tenancy ULID validation *before* the handler — \
+         the route-shadow guard must not weaken `{{cred}}` validation"
+    );
+
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_json(
+            "POST",
+            &ws_path(&format!("/credentials/{bad}/test")),
+            &token,
+            &serde_json::json!({}),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "POST /credentials/{bad}/test: the `{{cred}}` segment is still strictly \
+         ULID-validated by tenancy before the handler"
+    );
+}

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -586,18 +586,19 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         );
     }
 
-    // `resolve` / `resolve/continue` are **structurally unreachable**
-    // behind the tenancy middleware: it parses the path segment after
-    // `credentials` as a `CredentialId`, and the literal `resolve`
-    // segment fails ULID parsing → a flat **404 before any handler
-    // runs** (see `crates/api/src/middleware/tenancy.rs`
-    // `resolve_path_ids`). This is a pre-existing route-ordering
-    // condition, not a Phase-4 regression (the prior 503 stub was
-    // equally unreachable). It is still §4.5-honest — the caller
-    // cannot obtain a fake credential; they get a hard 404. The
-    // generic-resolve handler itself stays an honest 503 (asserted by
-    // the transport unit test); the route fix is tracked separately.
-    let post_404: &[(&str, String, serde_json::Value)] = &[
+    // `resolve` / `resolve/continue` reach the handler. The tenancy
+    // middleware special-cases the literal `resolve` sub-route so it is
+    // NOT parsed as a `{cred}` `CredentialId` (see
+    // `crates/api/src/middleware/tenancy.rs` `resolve_path_ids`).
+    // Without that guard the literal `resolve` segment failed ULID
+    // parsing and every acquisition request was a flat 404 before any
+    // handler ran — a route-shadow that made these endpoints
+    // structurally unreachable. They now hit the handler, which returns
+    // the honest engine-owned 503 (generic `Credential::resolve`
+    // dispatch is not wired into this API build); the genuine `{cred}`
+    // position stays strictly ULID-validated. Regression guard for the
+    // route-shadow.
+    let resolve_503: &[(&str, String, serde_json::Value)] = &[
         (
             "POST",
             ws_path("/credentials/resolve"),
@@ -610,7 +611,7 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         ),
     ];
 
-    for (method, path, body) in post_404 {
+    for (method, path, body) in resolve_503 {
         let app = app::build_app(state.clone(), &config);
         let resp = app
             .oneshot(auth_json(method, path, &token, body))
@@ -618,14 +619,15 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
             .unwrap();
         assert_eq!(
             resp.status(),
-            StatusCode::NOT_FOUND,
-            "{method} {path} is shadowed by the tenancy `{{cred}}` matcher → \
-             honest 404 (no false capability; pre-existing route condition)"
+            StatusCode::SERVICE_UNAVAILABLE,
+            "{method} {path} must reach the handler and return the honest \
+             engine-owned 503 — NOT a pre-handler 404 (that is the tenancy \
+             route-shadow this guards against)"
         );
         let problem = body_string(resp).await;
         assert!(
             !problem.contains(SECRET_TOKEN),
-            "404 body must never carry a secret: {problem}"
+            "503 body must never carry a secret: {problem}"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes a pre-existing **route-shadow** in the tenancy middleware that made the generic credential-acquisition endpoints structurally unreachable.

`crates/api/src/middleware/tenancy.rs::resolve_path_ids` parsed the path segment after `credentials` as a `CredentialId` unconditionally. For the literal acquisition sub-routes:

- `POST /api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve`
- `POST /api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve/continue`

the literal `resolve` failed `CredentialId` ULID parsing → the tenancy middleware returned a flat **404 before the handler ran**. The spec advertised routes no caller could ever exercise, even once implemented.

## Fix

A match guard — `"credentials" if segments[7] != "resolve"` — skips credential-id resolution for the literal `resolve` sub-route so the request reaches the handler. The genuine `/credentials/{cred}` position (and `{cred}/test|refresh|revoke`) is unchanged and still strictly ULID-validated; `resolve` is the only non-id literal at that segment for workspace-scoped credential routes.

These endpoints remain **honest-503 stubs** (generic `Credential::resolve` dispatch is engine-owned and not wired into this API build — canon §4.5). The fix makes them *reachably* honest (handler → 503) instead of *unreachably* 404. No false capability is introduced; the genuine `{cred}` validation is not weakened.

## Test (TDD)

The existing `credential_e2e::credential_engine_owned_endpoints_stay_honest_503` test previously *documented* the shadow as a "pre-existing route condition … tracked separately" and asserted **404**. It now asserts the honest **503** and is the route-shadow **regression guard**. Transformed the assertion → ran RED (`left: 404, right: 503`, proving the bug) → applied the fix → GREEN. `crates/api/README.md` synced (the "shadowed … flat 404" note was now false).

## Verification

- `cargo nextest run -p nebula-api` → **309 passed, 1 skipped** (incl. knife, execution_terminate, openapi_canon_compliance)
- `cargo clippy -p nebula-api --tests -- -D warnings` → clean
- `cargo fmt -p nebula-api -- --check` → clean
- lefthook pre-commit (full-workspace clippy `-D warnings` + typos + fmt-check) + convco → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
