### PR TITLE
fix(ci): trybuild false-TIMEOUT under agent profile (not a stale fixture) + webhook doc path

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -28,6 +28,18 @@ success-output = "never"
 fail-fast = true
 slow-timeout = { period = "30s", terminate-after = 2 }
 
+# trybuild UI tests (the `*compile_fail*` binaries across the workspace,
+# plus the validator `ui` binary) shell out to `cargo`/`rustc` to
+# compile each probe fixture. On a cold target dir the first invocation
+# must build the whole fixture dependency closure, which exceeds the
+# tight default agent slow-timeout above and is killed as a false
+# TIMEOUT — the probes themselves are correct and pass once the cache
+# is warm. Give just those binaries cold-compile headroom (agent
+# profile only; `ci` already allows 180s and runs against a warm cache).
+[[profile.agent.overrides]]
+filter = 'binary(/compile_fail/) | (package(=nebula-validator) & binary(=ui))'
+slow-timeout = { period = "120s", terminate-after = 4 }
+
 [profile.chaos]
 # Long-running chaos profile (e.g. nightly-chaos.yml).
 # Inherits nothing from `ci` — the chaos-full plane intentionally runs

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -1593,7 +1593,7 @@ impl<A: WebhookAction> WebhookTriggerAdapter<A> {
     ///
     /// Runtime code that wraps an action into a `WebhookTriggerAdapter`
     /// reads this and forwards it to
-    /// `nebula_api::services::webhook::WebhookTransport::activate`. Tests can
+    /// `nebula_api::transport::webhook::WebhookTransport::activate`. Tests can
     /// also inspect it to assert the resulting policy shape.
     #[must_use]
     pub fn config(&self) -> &WebhookConfig {


### PR DESCRIPTION
## TL;DR

The reported "2 pre-existing failing `nebula-action` trybuild tests" are **not a code bug**. The fixtures, `.stderr` snapshots, and the `#[derive(Action)]` macro are all **correct and pass**. The failure is a **false `TIMEOUT`**: the tight `agent` nextest profile (`slow-timeout 30s × terminate-after 2` = 60s kill) vs trybuild's cold-cache compile. Fixed at the real source — the nextest profile — **without** corrupting correct snapshots.

## Investigation (systematic-debugging)

Reproduction did **not** match the task's premise:

| Condition | Result |
|---|---|
| Cold cache + `--profile agent` | `derive_action_compile_fail_probes` + `trigger_source_required_compile_fail::missing_source_fails` **TIMEOUT** at 60s (still "Checking <dep>") |
| Warm + plain `cargo test` (no wall-cap) | **both pass** — `derive_action_compile_fail_probes ... ok` (33.6s, 8 probes), `missing_source_fails ... ok` (1.5s) |
| Warm + `--profile agent` | **424/424 pass** in 8s |
| `main` CI (`--profile ci`, 180s + warm + retries) | **green** at `001e9022` |

Root cause: trybuild shells out to `cargo`/`rustc` to compile each probe fixture. On a cold target dir the first invocation must build the whole `nebula-action-tests` fixture dependency closure (>60s), so the `agent` profile kills it as a false `TIMEOUT`. There is **no stale fixture, no stale `.stderr`, no missing `Source` impl, no macro bug** — `missing_source_fails` is a *compile-fail* probe whose `E0046 missing: Source` is the **expected, asserted** output (Tech Spec §2.2.3). The named `derive_action_compile_pass_positive` was never failing; the task's framing was inaccurate (verified, not trusted).

Running `TRYBUILD=overwrite` or emitting a `Source` impl in the macro — as the task suggested — would have **corrupted correct snapshots and broken the intentional negative test**. Deliberately not done.

## Fix

**`.config/nextest.toml`** — a `[[profile.agent.overrides]]` giving exactly the trybuild binaries cold-compile headroom:

```toml
filter = 'binary(/compile_fail/) | (package(=nebula-validator) & binary(=ui))'
slow-timeout = { period = "120s", terminate-after = 4 }   # 480s, bounded
```

Workspace-wide (the footgun also affects credential ×13, resource, schema, validator-`ui`). **Agent profile only** — `ci` already allows 180s and runs warm; `default`/`chaos` untouched; **zero CI impact**. This stops agents getting a false `TIMEOUT` and being lured into destructively "fixing" correct snapshots.

**`crates/action/src/webhook/mod.rs`** — `WebhookTriggerAdapter::config` doc comment: `nebula_api::services::webhook` → `nebula_api::transport::webhook` (the `services/`→`transport/` rename landed via #671; prose-only doc, intentionally deferred out of #671 to keep its scope).

## Verification

- `cargo nextest run -p nebula-action --profile agent` → **424 passed, 0 skipped**
- Filterset resolves to **exactly** the trybuild binaries (action ×3, credential ×13, resource/schema/validator-`ui`), no false positives
- `cargo clippy -p nebula-action -- -D warnings` → clean
- `cargo fmt -p nebula-action -- --check` → clean
- lefthook pre-commit (full-workspace clippy `-D warnings` + typos + taplo + fmt-check) + convco → pass on both commits. No `--no-verify`, no test deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
