### PR TITLE
feat(api)!: ADR-0052 P4 — credential write-path validation + port-backed catalog + public projection (closes §4.5 fail-open; cascade close-out)

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -78,6 +78,12 @@ pub enum TransportInitError {
         /// What is missing for that backend to work.
         requirement: &'static str,
     },
+    /// The credential-schema port could not be built (ADR-0052 P4 —
+    /// first-party credential registration failed; a composition bug).
+    /// Carried as a `String` so this crate needs no `nebula-credential`
+    /// dependency (the typed `RegisterError` stays inside `nebula-api`).
+    #[error("credential-schema port init failed: {0}")]
+    CredentialSchemaInit(String),
 }
 
 /// Start a server binary for a selected transport profile.
@@ -179,7 +185,9 @@ pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitEr
     // `nebula-api` (deny.toml-allow-listed `nebula-credential` consumer),
     // so this composition crate needs no `nebula-credential`/
     // `nebula-schema` dep — just the api constructor.
-    let credential_schema = nebula_api::ports::credential_schema_registry::default_registry_port();
+    let credential_schema =
+        nebula_api::ports::credential_schema_registry::try_default_registry_port()
+            .map_err(|e| TransportInitError::CredentialSchemaInit(e.to_string()))?;
 
     Ok(AppState::new(
         workflow_repo,

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -173,6 +173,14 @@ pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitEr
     // documented in `crates/api/README.md` ("Org membership durability")
     // and `nebula_api::domain::org` module docs (canon §11.6).
 
+    // ADR-0052 P4: wire the credential-schema port (first-party types
+    // registered) so the write path validates `data` before persist and
+    // the catalog exposes `json_schema()`. The concrete impl lives in
+    // `nebula-api` (deny.toml-allow-listed `nebula-credential` consumer),
+    // so this composition crate needs no `nebula-credential`/
+    // `nebula-schema` dep — just the api constructor.
+    let credential_schema = nebula_api::ports::credential_schema_registry::default_registry_port();
+
     Ok(AppState::new(
         workflow_repo,
         execution_repo,
@@ -180,7 +188,8 @@ pub fn default_state(api_config: &ApiConfig) -> Result<AppState, TransportInitEr
         api_config.jwt_secret.clone(),
     )
     .with_api_keys(api_config.api_keys.clone())
-    .with_auth_backend(auth_backend))
+    .with_auth_backend(auth_backend)
+    .with_credential_schema(credential_schema))
 }
 
 /// Construct the idempotency store from `api_config.idempotency`.

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -26,11 +26,12 @@ nebula-resilience = { path = "../resilience" }
 nebula-credential = { path = "../credential" }
 # ADR-0052 P4: production dep (with `schemars`) for the concrete
 # `CredentialSchemaPort` impl (`ValidSchema::validate` / `json_schema()`).
-# `nebula-schema` is Core (freely importable — no deny.toml change; deny
-# `ignored = ["schemars"]`). DTOs still carry only `serde_json::Value` —
-# no `ValidSchema` type crosses into any DTO (ADR-0047 DTO-purity rule
-# intact; the informal "api never imports nebula-schema" prose is
-# relaxed, recorded in the ADR-0052 P4 / ADR-0047 amendments).
+# `nebula-schema` is Core-tier with no `deny.toml` wrapper rule (freely
+# importable), so this needs **no `deny.toml` change**. DTOs still carry
+# only `serde_json::Value` — no `ValidSchema` type crosses into any DTO
+# (ADR-0047 DTO-purity rule intact; the informal "api never imports
+# nebula-schema" prose is relaxed, recorded in the ADR-0052 P4 / ADR-0047
+# amendments).
 nebula-schema = { path = "../schema", features = ["schemars"] }
 nebula-eventbus = { path = "../eventbus" }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -24,6 +24,14 @@ nebula-engine = { path = "../engine" }
 nebula-plugin = { path = "../plugin" }
 nebula-resilience = { path = "../resilience" }
 nebula-credential = { path = "../credential" }
+# ADR-0052 P4: production dep (with `schemars`) for the concrete
+# `CredentialSchemaPort` impl (`ValidSchema::validate` / `json_schema()`).
+# `nebula-schema` is Core (freely importable — no deny.toml change; deny
+# `ignored = ["schemars"]`). DTOs still carry only `serde_json::Value` —
+# no `ValidSchema` type crosses into any DTO (ADR-0047 DTO-purity rule
+# intact; the informal "api never imports nebula-schema" prose is
+# relaxed, recorded in the ADR-0052 P4 / ADR-0047 amendments).
+nebula-schema = { path = "../schema", features = ["schemars"] }
 nebula-eventbus = { path = "../eventbus" }
 
 opentelemetry = { workspace = true }
@@ -101,7 +109,6 @@ oas3 = { workspace = true }
 # `deny.toml` wrappers for the same reason. `InProcessSandbox` is re-exported
 # through `nebula-engine` so we don't need a direct `nebula-sandbox` dep.
 nebula-engine = { path = "../engine" }
-nebula-schema = { path = "../schema" }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 hex = { workspace = true }
 hmac = { workspace = true }

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -72,8 +72,11 @@ pub async fn list_credentials(
 /// POST /orgs/{org}/workspaces/{ws}/credentials — Create a new credential.
 ///
 /// Validates the request body, then delegates to the credential store
-/// for persistence. The `data` field is validated against the credential
-/// type's schema before encryption and storage.
+/// for persistence. When a credential-schema port is configured
+/// (ADR-0052 P4), `data` is validated against the credential type's
+/// resolved schema before encryption and storage; if no validator is
+/// configured the request is rejected with 503 — `data` is never
+/// persisted unvalidated.
 #[utoipa::path(
     post,
     path = "/orgs/{org}/workspaces/{ws}/credentials",

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -89,9 +89,10 @@ pub async fn list_credentials(
     request_body = CreateCredentialRequest,
     responses(
         (status = 200, description = "Credential created.", body = CredentialResponse),
-        (status = 400, description = "Validation error (key, name, or data shape).", body = ProblemDetails),
+        (status = 400, description = "Validation error: `data` failed the credential type's schema, or key/name shape invalid.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured: `data` cannot be validated, so it is not persisted (ADR-0052 P4, canon §4.5 fail-closed).", body = ProblemDetails),
     ),
 )]
 pub async fn create_credential(
@@ -159,11 +160,12 @@ pub async fn get_credential(
     request_body = UpdateCredentialRequest,
     responses(
         (status = 200, description = "Credential updated.", body = CredentialResponse),
-        (status = 400, description = "Validation error or no fields provided for update.", body = ProblemDetails),
+        (status = 400, description = "Validation error: supplied `data` failed the credential type's schema, or no fields provided.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Credential does not exist.", body = ProblemDetails),
         (status = 409, description = "Optimistic-concurrency version mismatch.", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured: supplied `data` cannot be validated, so it is not persisted (ADR-0052 P4, canon §4.5 fail-closed).", body = ProblemDetails),
     ),
 )]
 pub async fn update_credential(
@@ -442,6 +444,7 @@ pub async fn continue_resolve_credential(
     responses(
         (status = 200, description = "Registered credential types with capability flags and input schema.", body = ListCredentialTypesResponse),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured (ADR-0052 P4, honest §4.5 stub).", body = ProblemDetails),
     ),
 )]
 pub async fn list_credential_types(
@@ -468,6 +471,7 @@ pub async fn list_credential_types(
         (status = 400, description = "Invalid credential type key.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 404, description = "Credential type not registered.", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured (ADR-0052 P4, honest §4.5 stub).", body = ProblemDetails),
     ),
 )]
 pub async fn get_credential_type(

--- a/crates/api/src/domain/credential/mod.rs
+++ b/crates/api/src/domain/credential/mod.rs
@@ -20,3 +20,4 @@ pub mod dto;
 pub mod handler;
 pub mod oauth;
 pub mod routes;
+pub mod schema_projection;

--- a/crates/api/src/domain/credential/schema_projection.rs
+++ b/crates/api/src/domain/credential/schema_projection.rs
@@ -1,11 +1,17 @@
 //! Public-schema projection (ADR-0052 P4, design-spec hole #6).
 //!
-//! `ValidSchema::json_schema()` emits Nebula vendor extensions that encode
-//! **cross-field predicate logic** (`crates/schema/src/json_schema.rs:115`
-//! `x-nebula-root-rules`; the conditional `x-nebula-required-mode` /
-//! `x-nebula-visibility-mode` "when" operands). Exposing those to
-//! unauthenticated catalog clients leaks the credential type's internal
-//! rule graph. This api-owned mapper strips that family **recursively**
+//! `ValidSchema::json_schema()` emits the credential type's internal rule
+//! graph as Nebula vendor extensions: `x-nebula-root-rules`
+//! (`crates/schema/src/json_schema.rs:115`) serializes the full
+//! cross-field `Rule` operands, and `x-nebula-required-mode` /
+//! `x-nebula-visibility-mode` mark fields as rule-conditioned (the
+//! exporter emits these two as a bare discriminant string — `"when"` —
+//! not the operand; they are still rule-derived metadata, not part of the
+//! public JSON-Schema contract). Exposing this family to catalog clients
+//! leaks rule-graph internals. This api-owned mapper strips the whole
+//! family **recursively** (defence-in-depth: `x-nebula-root-rules` is the
+//! genuinely-sensitive operand carrier; the two mode keys are stripped as
+//! non-contract rule-derived metadata)
 //! while keeping the standard JSON-Schema contract (`type`, `properties`,
 //! `required`, `minLength`, `pattern`, `enum`, `additionalProperties`, …)
 //! and non-predicate structural hints (`x-nebula-field-kind`,

--- a/crates/api/src/domain/credential/schema_projection.rs
+++ b/crates/api/src/domain/credential/schema_projection.rs
@@ -1,0 +1,92 @@
+//! Public-schema projection (ADR-0052 P4, design-spec hole #6).
+//!
+//! `ValidSchema::json_schema()` emits Nebula vendor extensions that encode
+//! **cross-field predicate logic** (`crates/schema/src/json_schema.rs:115`
+//! `x-nebula-root-rules`; the conditional `x-nebula-required-mode` /
+//! `x-nebula-visibility-mode` "when" operands). Exposing those to
+//! unauthenticated catalog clients leaks the credential type's internal
+//! rule graph. This api-owned mapper strips that family **recursively**
+//! while keeping the standard JSON-Schema contract (`type`, `properties`,
+//! `required`, `minLength`, `pattern`, `enum`, `additionalProperties`, …)
+//! and non-predicate structural hints (`x-nebula-field-kind`,
+//! `x-nebula-expression-mode`). It is **not** a raw `json_schema()`
+//! passthrough — the spec mandates an api-owned projection.
+
+use serde_json::Value;
+
+/// Vendor-extension keys that carry rule / cross-field predicate logic
+/// and MUST NOT reach an unauthenticated client.
+const STRIPPED_KEYS: &[&str] = &[
+    "x-nebula-root-rules",
+    "x-nebula-required-mode",
+    "x-nebula-visibility-mode",
+];
+
+/// Recursively remove the rule/predicate vendor-extension family from a
+/// JSON-Schema `Value`. Pure; allocation-light; total (no panics).
+#[must_use]
+pub fn project_public_schema(mut schema: Value) -> Value {
+    strip(&mut schema);
+    schema
+}
+
+fn strip(node: &mut Value) {
+    match node {
+        Value::Object(map) => {
+            for k in STRIPPED_KEYS {
+                map.remove(*k);
+            }
+            for v in map.values_mut() {
+                strip(v);
+            }
+        },
+        Value::Array(items) => {
+            for v in items {
+                strip(v);
+            }
+        },
+        _ => {},
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strips_root_rules_and_predicate_operands_keeps_standard_keywords() {
+        let raw = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "api_key": {
+                    "type": "string",
+                    "minLength": 2,
+                    "pattern": "^k-",
+                    "x-nebula-field-kind": "secret",
+                    "x-nebula-required-mode": { "when": { "predicate": "X" } }
+                }
+            },
+            "x-nebula-root-rules": [ { "predicate": "cross-field" } ],
+            "additionalProperties": false
+        });
+        let p = project_public_schema(raw);
+        assert!(p.get("x-nebula-root-rules").is_none());
+        let ak = &p["properties"]["api_key"];
+        assert!(ak.get("x-nebula-required-mode").is_none());
+        assert_eq!(ak["minLength"], 2, "standard keyword kept");
+        assert_eq!(ak["pattern"], "^k-", "standard keyword kept");
+        assert_eq!(
+            ak["x-nebula-field-kind"], "secret",
+            "non-predicate structural hint kept"
+        );
+        assert_eq!(p["additionalProperties"], false);
+    }
+
+    #[test]
+    fn idempotent_and_total_on_scalars() {
+        assert_eq!(project_public_schema(Value::Null), Value::Null);
+        let once = project_public_schema(serde_json::json!({"a":{"x-nebula-root-rules":[]}}));
+        assert_eq!(project_public_schema(once.clone()), once);
+        assert!(once["a"].get("x-nebula-root-rules").is_none());
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -71,6 +71,7 @@ pub mod error;
 pub mod extractors;
 pub mod middleware;
 pub mod openapi;
+pub mod ports;
 pub mod state;
 pub mod telemetry_init;
 mod trace_capture;

--- a/crates/api/src/ports/credential_schema.rs
+++ b/crates/api/src/ports/credential_schema.rs
@@ -25,9 +25,24 @@ pub struct CredentialFieldError {
     pub message: String,
 }
 
-/// Catalog descriptor for one credential type. `schema_json` is the
-/// public-projected JSON Schema (`x-nebula-root-rules` and predicate
-/// operands already stripped by the api-owned projection).
+/// API-safe capability flags for a credential type (no lower-layer
+/// `Capabilities` type crosses the seam).
+#[derive(Debug, Clone, Copy, Default, Serialize, ToSchema)]
+pub struct CredentialCapabilityFlags {
+    /// Multi-step user interaction (OAuth redirect, device code).
+    pub interactive: bool,
+    /// Token refresh (OAuth2 `refresh_token`).
+    pub refreshable: bool,
+    /// Connection testing.
+    pub testable: bool,
+    /// Explicit revocation.
+    pub revocable: bool,
+}
+
+/// Catalog descriptor for one credential type. `schema_json` is the raw
+/// `ValidSchema::json_schema()` export; the api applies the public
+/// projection (strips `x-nebula-root-rules` + predicate operands) before
+/// it reaches the wire.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct CredentialTypeDescriptor {
     /// Stable type key (e.g. `api_key`, `oauth2`).
@@ -38,6 +53,8 @@ pub struct CredentialTypeDescriptor {
     pub description: String,
     /// Authentication-pattern classification (stringified).
     pub auth_pattern: String,
+    /// Capability flags.
+    pub capabilities: CredentialCapabilityFlags,
     /// Optional icon identifier or URL.
     pub icon: Option<String>,
     /// Optional documentation link.

--- a/crates/api/src/ports/credential_schema.rs
+++ b/crates/api/src/ports/credential_schema.rs
@@ -1,0 +1,69 @@
+//! API-owned credential-schema port (ADR-0052 P4).
+//!
+//! `nebula-api` never imports `nebula-schema`/`nebula-validator` types into
+//! its DTOs; this object-safe port carries only api-safe values. The
+//! concrete impl lives in the composition root (which legally depends on
+//! `nebula-credential`/`nebula-schema`) and runs `ValidSchema::validate` /
+//! `json_schema()` — authority sits with the validator
+//! (INTEGRATION_MODEL §29/§33 proof-token custody unchanged). When no port
+//! is wired the credential write path and credential-type catalog return an
+//! honest 503, mirroring `AppState::action_registry` (canon §4.5).
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// One field-level validation failure — secret-safe by construction:
+/// an RFC-6901 path, a validator code, and a static message. **Never**
+/// the submitted value (ADR-0034 redaction).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CredentialFieldError {
+    /// RFC-6901 JSON Pointer to the offending field (e.g. `/api_key`).
+    pub path: String,
+    /// Validator vocabulary code (e.g. `required`, `min_length`).
+    pub code: String,
+    /// Static, value-free human message.
+    pub message: String,
+}
+
+/// Catalog descriptor for one credential type. `schema_json` is the
+/// public-projected JSON Schema (`x-nebula-root-rules` and predicate
+/// operands already stripped by the api-owned projection).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CredentialTypeDescriptor {
+    /// Stable type key (e.g. `api_key`, `oauth2`).
+    pub key: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Description.
+    pub description: String,
+    /// Authentication-pattern classification (stringified).
+    pub auth_pattern: String,
+    /// Optional icon identifier or URL.
+    pub icon: Option<String>,
+    /// Optional documentation link.
+    pub documentation_url: Option<String>,
+    /// JSON Schema describing the credential's input fields. Raw export
+    /// from `ValidSchema::json_schema()`; the api projects it before the
+    /// wire (strips `x-nebula-root-rules` + predicate operands).
+    pub schema_json: serde_json::Value,
+}
+
+/// Resolve a credential type's schema for the write-path gate (V2) and the
+/// catalog read-model (V3). Implemented in the composition root over a
+/// `nebula_credential::CredentialRegistry`.
+pub trait CredentialSchemaPort: Send + Sync + 'static {
+    /// Validate `data` against the credential type's resolved schema
+    /// **before persist**. `Err` is a secret-safe field-error list.
+    fn validate_data(
+        &self,
+        credential_key: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>>;
+
+    /// All known credential types (raw `json_schema()` in `schema_json`;
+    /// the api applies the public projection before serializing).
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor>;
+
+    /// One credential type by key, if known.
+    fn get_type(&self, credential_key: &str) -> Option<CredentialTypeDescriptor>;
+}

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -1,0 +1,250 @@
+//! Concrete [`CredentialSchemaPort`] over a
+//! `nebula_credential::CredentialRegistry` (ADR-0052 P4).
+//!
+//! Per the user's adjudication of the deny.toml-vs-#671 conflict, the
+//! concrete impl lives in `nebula-api` (already an allow-listed
+//! `nebula-credential` consumer; `nebula-schema` is Core — **no**
+//! `deny.toml` change) rather than in the `nebula-server` composition
+//! crate (which would have required a wrapper-allowlist edit). `nebula-api`
+//! takes a `nebula-schema` production dep + `schemars`, but **no
+//! `ValidSchema` type enters any DTO** — the port returns only
+//! `serde_json::Value` / api-owned structs, so ADR-0047's DTO-purity rule
+//! is intact (only the informal "api never imports nebula-schema" prose is
+//! relaxed; recorded in the ADR-0052 P4 / ADR-0047 amendments).
+//!
+//! Authority sits with the validator: `ValidSchema::validate` is invoked
+//! here; credential `data` is **never** `.resolve()`-d (canon §12.5 —
+//! secrets must not depend on workflow state). Errors are secret-safe by
+//! construction (RFC-6901 path + validator code + static message; never a
+//! submitted value — ADR-0034).
+
+use std::sync::Arc;
+
+use nebula_credential::{
+    AnyCredential, ApiKeyCredential, BasicAuthCredential, Capabilities, CredentialRegistry,
+    OAuth2Credential,
+};
+use nebula_schema::FieldValues;
+
+use crate::ports::credential_schema::{
+    CredentialCapabilityFlags, CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
+};
+
+/// `CredentialSchemaPort` backed by a registered credential set.
+pub struct RegistryCredentialSchema {
+    registry: Arc<CredentialRegistry>,
+}
+
+impl RegistryCredentialSchema {
+    /// Wrap a populated registry.
+    #[must_use]
+    pub fn new(registry: Arc<CredentialRegistry>) -> Self {
+        Self { registry }
+    }
+
+    fn flags(caps: Capabilities) -> CredentialCapabilityFlags {
+        CredentialCapabilityFlags {
+            interactive: caps.contains(Capabilities::INTERACTIVE),
+            refreshable: caps.contains(Capabilities::REFRESHABLE),
+            testable: caps.contains(Capabilities::TESTABLE),
+            revocable: caps.contains(Capabilities::REVOCABLE),
+        }
+    }
+
+    fn descriptor(&self, any: &dyn AnyCredential) -> CredentialTypeDescriptor {
+        let meta = any.metadata();
+        let key = any.credential_key().to_owned();
+        // Structural JSON-Schema export. On failure, an empty object
+        // schema (never a panic); the api-owned public projection still
+        // strips predicate operands at the wire (#6).
+        let schema_json = meta
+            .base
+            .schema
+            .json_schema()
+            .ok()
+            .and_then(|s| serde_json::to_value(&s).ok())
+            .unwrap_or_else(|| serde_json::json!({ "type": "object" }));
+        let caps = self
+            .registry
+            .capabilities_of(&key)
+            .unwrap_or_else(Capabilities::empty);
+        CredentialTypeDescriptor {
+            key,
+            name: meta.base.name.clone(),
+            description: meta.base.description.clone(),
+            auth_pattern: format!("{:?}", meta.pattern),
+            capabilities: Self::flags(caps),
+            icon: meta.base.icon.as_inline().map(str::to_owned),
+            documentation_url: meta.base.documentation_url,
+            schema_json,
+        }
+    }
+}
+
+impl CredentialSchemaPort for RegistryCredentialSchema {
+    #[tracing::instrument(
+        skip_all,
+        fields(cred.key = %credential_key, outcome = tracing::field::Empty)
+    )]
+    fn validate_data(
+        &self,
+        credential_key: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>> {
+        let Some(any) = self.registry.resolve_any(credential_key) else {
+            tracing::Span::current().record("outcome", "unknown_type");
+            return Err(vec![CredentialFieldError {
+                path: "/credential_key".to_owned(),
+                code: "unknown_credential_type".to_owned(),
+                message: "no such credential type".to_owned(),
+            }]);
+        };
+        let schema = any.metadata().base.schema;
+        // Ingest only (NEVER `.resolve()` — canon §12.5: credential data
+        // must not be expression-resolved against workflow state).
+        let values = FieldValues::from_json(data.clone()).map_err(|e| {
+            vec![CredentialFieldError {
+                path: e.path.to_string(),
+                code: e.code.as_ref().to_owned(),
+                message: e.message.to_string(),
+            }]
+        })?;
+        match schema.validate(&values) {
+            Ok(_valid) => {
+                tracing::Span::current().record("outcome", "ok");
+                Ok(())
+            },
+            Err(report) => {
+                let errors: Vec<CredentialFieldError> = report
+                    .errors()
+                    .map(|e| CredentialFieldError {
+                        path: e.path.to_string(),
+                        code: e.code.as_ref().to_owned(),
+                        message: e.message.to_string(),
+                    })
+                    .collect();
+                tracing::Span::current().record("outcome", "rejected");
+                debug_assert!(
+                    !errors.is_empty(),
+                    "validate() Err must yield at least one hard error"
+                );
+                Err(errors)
+            },
+        }
+    }
+
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
+        // `iter_compatible(empty)` enumerates every registered type
+        // (registry.rs:212 — empty is a subset of any capability set).
+        let keys: Vec<String> = self
+            .registry
+            .iter_compatible(Capabilities::empty())
+            .map(|(k, _caps)| k.to_owned())
+            .collect();
+        keys.into_iter()
+            .filter_map(|k| {
+                self.registry
+                    .resolve_any(&k)
+                    .map(|any| self.descriptor(any))
+            })
+            .collect()
+    }
+
+    fn get_type(&self, credential_key: &str) -> Option<CredentialTypeDescriptor> {
+        self.registry
+            .resolve_any(credential_key)
+            .map(|any| self.descriptor(any))
+    }
+}
+
+/// Build the default port with the first-party credential types
+/// registered (ADR-0052 P4). Used by the composition root so
+/// `apps/server` needs no `nebula-credential`/`nebula-schema` dep.
+///
+/// Static registration of distinct const KEYs is infallible in practice;
+/// a duplicate is a composition bug surfaced loudly at startup.
+#[must_use]
+pub fn default_registry_port() -> Arc<dyn CredentialSchemaPort> {
+    let mut registry = CredentialRegistry::new();
+    registry
+        .register(ApiKeyCredential, "nebula-credential")
+        .expect("ApiKeyCredential KEY is statically unique");
+    registry
+        .register(BasicAuthCredential, "nebula-credential")
+        .expect("BasicAuthCredential KEY is statically unique");
+    registry
+        .register(OAuth2Credential, "nebula-credential")
+        .expect("OAuth2Credential KEY is statically unique");
+    Arc::new(RegistryCredentialSchema::new(Arc::new(registry)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn port() -> RegistryCredentialSchema {
+        let mut reg = CredentialRegistry::new();
+        reg.register(ApiKeyCredential, "nebula-credential")
+            .expect("api_key registers (statically unique key)");
+        RegistryCredentialSchema::new(Arc::new(reg))
+    }
+
+    #[test]
+    fn validate_rejects_missing_required_field_secret_safe() {
+        let p = port();
+        let data = serde_json::json!({ "server": "https://x", "leak": "NEVER-ECHO-9f" });
+        let err = p
+            .validate_data("api_key", &data)
+            .expect_err("missing required api_key must reject");
+        assert!(
+            err.iter().any(|e| e.code == "required"),
+            "expected a `required` code, got {err:?}"
+        );
+        assert!(
+            !format!("{err:?}").contains("NEVER-ECHO-9f"),
+            "field errors must not echo submitted values"
+        );
+    }
+
+    #[test]
+    fn validate_accepts_well_formed_data() {
+        assert!(
+            port()
+                .validate_data("api_key", &serde_json::json!({ "api_key": "k-123" }))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn unknown_type_is_a_field_error_not_panic() {
+        let err = port()
+            .validate_data("does-not-exist", &serde_json::json!({}))
+            .expect_err("unknown type rejects");
+        assert_eq!(err[0].code, "unknown_credential_type");
+        assert_eq!(err[0].path, "/credential_key");
+    }
+
+    #[test]
+    fn get_type_exports_capable_descriptor_and_default_port_lists_first_party() {
+        let p = port();
+        let d = p.get_type("api_key").expect("api_key present");
+        assert_eq!(d.key, "api_key");
+        assert!(
+            d.schema_json.get("properties").is_some(),
+            "json_schema() export must carry properties: {:?}",
+            d.schema_json
+        );
+        assert!(p.get_type("nope").is_none());
+
+        // The composition default registers all three first-party types.
+        let default = default_registry_port();
+        let listed = default.list_types();
+        for k in ["api_key", "basic_auth", "oauth2"] {
+            assert!(
+                listed.iter().any(|t| t.key == k),
+                "default port must register {k}; got {:?}",
+                listed.iter().map(|t| &t.key).collect::<Vec<_>>()
+            );
+        }
+    }
+}

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -30,6 +30,42 @@ use crate::ports::credential_schema::{
     CredentialCapabilityFlags, CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
 };
 
+/// Map a validator/schema vocabulary `code` to a **static, value-free**
+/// message. The seam NEVER forwards a lower-layer `ValidationError.message`
+/// (some validators embed the submitted input — e.g. `'{input}' is not a
+/// valid IPv4 address` — and `validate_json_keys` embeds the raw object
+/// key). Deriving the message from the code makes the ADR-0034 "never the
+/// submitted value" invariant hold *by construction* at this seam,
+/// independent of any upstream validator's message hygiene.
+fn safe_field_message(code: &str) -> &'static str {
+    match code {
+        "required" => "value is required",
+        "min_length" => "value is too short",
+        "max_length" => "value is too long",
+        "min" => "value is below the allowed minimum",
+        "max" => "value is above the allowed maximum",
+        "invalid_format" => "value does not match the required format",
+        "type_mismatch" => "value has the wrong type",
+        "invalid_key" => "object contains an invalid field key",
+        "recursion_limit" => "value is nested too deeply",
+        "unknown_credential_type" => "no such credential type",
+        // Vocabulary codes are value-free tokens; echoing the code (not
+        // the submitted value) is safe and stays informative.
+        _ => "field failed schema validation",
+    }
+}
+
+/// Build a secret-safe field error. `path` is the schema/RFC-6901
+/// structural location (declared-field/parent path — value-free);
+/// `message` is derived from `code`, never from the submitted value.
+fn field_error(path: String, code: &str) -> CredentialFieldError {
+    CredentialFieldError {
+        path,
+        code: code.to_owned(),
+        message: safe_field_message(code).to_owned(),
+    }
+}
+
 /// `CredentialSchemaPort` backed by a registered credential set.
 pub struct RegistryCredentialSchema {
     registry: Arc<CredentialRegistry>,
@@ -93,22 +129,16 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
     ) -> Result<(), Vec<CredentialFieldError>> {
         let Some(any) = self.registry.resolve_any(credential_key) else {
             tracing::Span::current().record("outcome", "unknown_type");
-            return Err(vec![CredentialFieldError {
-                path: "/credential_key".to_owned(),
-                code: "unknown_credential_type".to_owned(),
-                message: "no such credential type".to_owned(),
-            }]);
+            return Err(vec![field_error(
+                "/credential_key".to_owned(),
+                "unknown_credential_type",
+            )]);
         };
         let schema = any.metadata().base.schema;
         // Ingest only (NEVER `.resolve()` — canon §12.5: credential data
         // must not be expression-resolved against workflow state).
-        let values = FieldValues::from_json(data.clone()).map_err(|e| {
-            vec![CredentialFieldError {
-                path: e.path.to_string(),
-                code: e.code.as_ref().to_owned(),
-                message: e.message.to_string(),
-            }]
-        })?;
+        let values = FieldValues::from_json(data.clone())
+            .map_err(|e| vec![field_error(e.path.to_string(), e.code.as_ref())])?;
         match schema.validate(&values) {
             Ok(_valid) => {
                 tracing::Span::current().record("outcome", "ok");
@@ -117,11 +147,7 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
             Err(report) => {
                 let errors: Vec<CredentialFieldError> = report
                     .errors()
-                    .map(|e| CredentialFieldError {
-                        path: e.path.to_string(),
-                        code: e.code.as_ref().to_owned(),
-                        message: e.message.to_string(),
-                    })
+                    .map(|e| field_error(e.path.to_string(), e.code.as_ref()))
                     .collect();
                 tracing::Span::current().record("outcome", "rejected");
                 debug_assert!(
@@ -161,21 +187,20 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
 /// registered (ADR-0052 P4). Used by the composition root so
 /// `apps/server` needs no `nebula-credential`/`nebula-schema` dep.
 ///
-/// Static registration of distinct const KEYs is infallible in practice;
-/// a duplicate is a composition bug surfaced loudly at startup.
-#[must_use]
-pub fn default_registry_port() -> Arc<dyn CredentialSchemaPort> {
+/// # Errors
+///
+/// Returns [`nebula_credential::RegisterError`] if a credential KEY is
+/// already registered (a composition bug — distinct first-party const
+/// KEYs make this unreachable in practice, but the library returns the
+/// typed error rather than panicking; the caller decides how to surface
+/// it — AGENTS.md "no `expect()` in library code").
+pub fn try_default_registry_port()
+-> Result<Arc<dyn CredentialSchemaPort>, nebula_credential::RegisterError> {
     let mut registry = CredentialRegistry::new();
-    registry
-        .register(ApiKeyCredential, "nebula-credential")
-        .expect("ApiKeyCredential KEY is statically unique");
-    registry
-        .register(BasicAuthCredential, "nebula-credential")
-        .expect("BasicAuthCredential KEY is statically unique");
-    registry
-        .register(OAuth2Credential, "nebula-credential")
-        .expect("OAuth2Credential KEY is statically unique");
-    Arc::new(RegistryCredentialSchema::new(Arc::new(registry)))
+    registry.register(ApiKeyCredential, "nebula-credential")?;
+    registry.register(BasicAuthCredential, "nebula-credential")?;
+    registry.register(OAuth2Credential, "nebula-credential")?;
+    Ok(Arc::new(RegistryCredentialSchema::new(Arc::new(registry))))
 }
 
 #[cfg(test)]
@@ -237,7 +262,7 @@ mod tests {
         assert!(p.get_type("nope").is_none());
 
         // The composition default registers all three first-party types.
-        let default = default_registry_port();
+        let default = try_default_registry_port().expect("first-party set registers (unique KEYs)");
         let listed = default.list_types();
         for k in ["api_key", "basic_auth", "oauth2"] {
             assert!(

--- a/crates/api/src/ports/mod.rs
+++ b/crates/api/src/ports/mod.rs
@@ -6,3 +6,4 @@
 //! of lower-layer types in its DTOs (ADR-0047 Cross-Layer Schema Strategy).
 
 pub mod credential_schema;
+pub mod credential_schema_registry;

--- a/crates/api/src/ports/mod.rs
+++ b/crates/api/src/ports/mod.rs
@@ -1,0 +1,8 @@
+//! API-owned port traits — the seam between `nebula-api` and lower layers.
+//!
+//! Ports carry only api-safe types (primitives, `serde_json::Value`,
+//! api-owned structs). Concrete impls live in the composition root, which
+//! legally depends on the lower-layer crates. This keeps `nebula-api` free
+//! of lower-layer types in its DTOs (ADR-0047 Cross-Layer Schema Strategy).
+
+pub mod credential_schema;

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -242,6 +242,11 @@ pub struct AppState {
     /// When `None`, the `GET /plugins` endpoints return 503.
     pub plugin_registry: Option<Arc<RwLock<PluginRegistry>>>,
 
+    /// Optional credential-schema port (ADR-0052 P4). When `None`, the
+    /// credential write path and credential-type catalog return 503
+    /// (honest §4.5 stub, mirroring `action_registry`).
+    pub credential_schema: Option<Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>>,
+
     /// Optional webhook HTTP transport. When `None`, no `/webhooks/*`
     /// routes are mounted on the app; webhook-style `WebhookAction`
     /// triggers registered via `ActionRegistry::register_webhook`
@@ -345,6 +350,7 @@ impl AppState {
             metrics_registry: None,
             action_registry: None,
             plugin_registry: None,
+            credential_schema: None,
             webhook_transport: None,
             oauth_pending_store: Arc::new(InMemoryPendingStore::new()),
             oauth_state_tokens: Arc::new(RwLock::new(HashMap::new())),
@@ -390,6 +396,18 @@ impl AppState {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_plugin_registry(mut self, registry: Arc<RwLock<PluginRegistry>>) -> Self {
         self.plugin_registry = Some(registry);
+        self
+    }
+
+    /// Attach the credential-schema port (ADR-0052 P4) used to validate
+    /// credential `data` before persist and to populate the credential-type
+    /// catalog. When absent, those endpoints return an honest 503.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_credential_schema(
+        mut self,
+        port: Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>,
+    ) -> Self {
+        self.credential_schema = Some(port);
         self
     }
 

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -139,7 +139,9 @@ fn encode_secret_data(data: &serde_json::Value) -> ApiResult<Vec<u8>> {
         .map_err(|e| ApiError::Internal(format!("failed to encode credential envelope: {e}")))
 }
 
-/// Map a secret-safe [`CredentialFieldError`] list to the api 422.
+/// Map a secret-safe [`CredentialFieldError`] list to the api-wide
+/// validation status (400 — `ApiError::Validation`, consistent with every
+/// other request-validation failure).
 ///
 /// `CredentialFieldError` carries only an RFC-6901 path, a validator code,
 /// and a static message — never the submitted value (ADR-0034 redaction;

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -139,6 +139,52 @@ fn encode_secret_data(data: &serde_json::Value) -> ApiResult<Vec<u8>> {
         .map_err(|e| ApiError::Internal(format!("failed to encode credential envelope: {e}")))
 }
 
+/// Map a secret-safe [`CredentialFieldError`] list to the api 422.
+///
+/// `CredentialFieldError` carries only an RFC-6901 path, a validator code,
+/// and a static message — never the submitted value (ADR-0034 redaction;
+/// ADR-0052 P4). The mapping introduces no value either.
+fn credential_validation_error(
+    errs: Vec<crate::ports::credential_schema::CredentialFieldError>,
+) -> ApiError {
+    let errors = errs
+        .into_iter()
+        .map(|e| crate::error::ValidationFieldError {
+            code: e.code,
+            detail: e.message,
+            pointer: e.path,
+        })
+        .collect();
+    ApiError::Validation {
+        detail: "credential data failed schema validation".to_owned(),
+        errors,
+    }
+}
+
+/// ADR-0052 P4 (V2): validate credential `data` against the credential
+/// type's resolved schema **before persist**. Authority sits with the
+/// validator (invoked behind the [`CredentialSchemaPort`]). When no port
+/// is configured the request is rejected with 503 — credential `data` is
+/// **never** persisted unvalidated (closes the §4.5/§10 fail-open the
+/// handler docstring previously mis-claimed was closed).
+///
+/// [`CredentialSchemaPort`]: crate::ports::credential_schema::CredentialSchemaPort
+fn validate_credential_data(
+    state: &AppState,
+    credential_key: &str,
+    data: &serde_json::Value,
+) -> ApiResult<()> {
+    match state.credential_schema.as_ref() {
+        Some(port) => port
+            .validate_data(credential_key, data)
+            .map_err(credential_validation_error),
+        None => Err(ApiError::ServiceUnavailable(
+            "credential data validation unavailable: no credential-schema port configured"
+                .to_owned(),
+        )),
+    }
+}
+
 /// Classify the auth pattern + capability flags for a built-in
 /// credential key.
 ///
@@ -281,6 +327,10 @@ pub async fn create_credential(
     _ws: &str,
     req: CreateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
+    // ADR-0052 P4 (V2): validate `data` against the type's schema BEFORE
+    // any persist/encode. No port ⇒ 503 (never persist unvalidated).
+    validate_credential_data(state, &req.credential_key, &req.data)?;
+
     let id = nebula_core::CredentialId::new().to_string();
     let secret_bytes = encode_secret_data(&req.data)?;
 
@@ -377,8 +427,13 @@ pub async fn update_credential(
 
     // Re-encode the secret only when the caller supplied new data;
     // otherwise carry the existing opaque blob through untouched.
+    // ADR-0052 P4 (V2): when new `data` is supplied, validate it against
+    // the (unchanged) credential type's schema before re-encode/persist.
     let data = match req.data.as_ref() {
-        Some(value) => encode_secret_data(value)?,
+        Some(value) => {
+            validate_credential_data(state, &existing.credential_key, value)?;
+            encode_secret_data(value)?
+        },
         None => existing.data.clone(),
     };
 
@@ -635,6 +690,30 @@ mod tests {
     use super::*;
     use crate::config::JwtSecret;
 
+    /// Permissive port so the CRUD/secret-projection unit tests still
+    /// exercise persistence after ADR-0052 P4 closed the
+    /// unvalidated-persist fail-open (the no-port → 503 behavior is
+    /// covered by `tests/seam_credential_write_path_validation.rs`).
+    struct PermissivePort;
+    impl crate::ports::credential_schema::CredentialSchemaPort for PermissivePort {
+        fn validate_data(
+            &self,
+            _k: &str,
+            _d: &serde_json::Value,
+        ) -> Result<(), Vec<crate::ports::credential_schema::CredentialFieldError>> {
+            Ok(())
+        }
+        fn list_types(&self) -> Vec<crate::ports::credential_schema::CredentialTypeDescriptor> {
+            Vec::new()
+        }
+        fn get_type(
+            &self,
+            _k: &str,
+        ) -> Option<crate::ports::credential_schema::CredentialTypeDescriptor> {
+            None
+        }
+    }
+
     fn test_state() -> AppState {
         AppState::new(
             Arc::new(InMemoryWorkflowRepo::new()),
@@ -642,6 +721,7 @@ mod tests {
             Arc::new(InMemoryControlQueueRepo::new()),
             JwtSecret::new("test-jwt-secret-1234567890-abcdef").expect("valid test secret"),
         )
+        .with_credential_schema(Arc::new(PermissivePort))
     }
 
     /// The blob round-trips through `serde_secret`, and the redaction

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -659,24 +659,60 @@ pub async fn continue_resolve(
 /// requires a `CredentialRegistry`; none is wired into `AppState`.
 /// Returning a hand-rolled catalog would misrepresent what is actually
 /// registered (§4.5).
-pub async fn list_credential_types(_state: &AppState) -> ApiResult<ListCredentialTypesResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "credential type discovery requires a CredentialRegistry which is \
-         not wired into this API build"
-            .into(),
-    ))
+/// Map a port [`CredentialTypeDescriptor`] to the wire DTO, applying the
+/// api-owned public projection to the schema (ADR-0052 P4 V3 + #6 — the
+/// raw `json_schema()` export's `x-nebula-root-rules` / predicate operands
+/// are stripped before the unauthenticated wire).
+fn credential_type_info_from_descriptor(
+    d: crate::ports::credential_schema::CredentialTypeDescriptor,
+) -> CredentialTypeInfo {
+    CredentialTypeInfo {
+        key: d.key,
+        name: d.name,
+        description: d.description,
+        auth_pattern: d.auth_pattern,
+        capabilities: CredentialCapabilities {
+            interactive: d.capabilities.interactive,
+            refreshable: d.capabilities.refreshable,
+            testable: d.capabilities.testable,
+            revocable: d.capabilities.revocable,
+        },
+        schema: crate::domain::credential::schema_projection::project_public_schema(d.schema_json),
+        icon: d.icon,
+        documentation_url: d.documentation_url,
+    }
 }
 
-/// Get metadata and schema for a specific credential type by key.
-///
-/// **Honest 503.** Same as [`list_credential_types`] — a registry
-/// lookup by key with no registry wired.
-pub async fn get_credential_type(_state: &AppState, _key: &str) -> ApiResult<CredentialTypeInfo> {
-    Err(ApiError::ServiceUnavailable(
-        "credential type discovery requires a CredentialRegistry which is \
-         not wired into this API build"
-            .into(),
-    ))
+const NO_CRED_SCHEMA_PORT: &str =
+    "credential type discovery unavailable: no credential-schema port configured";
+
+/// ADR-0052 P4 (V3): list registered credential types with their
+/// public-projected input schema. No port ⇒ honest 503 (§4.5).
+pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredentialTypesResponse> {
+    let port = state
+        .credential_schema
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable(NO_CRED_SCHEMA_PORT.to_owned()))?;
+    let types = port
+        .list_types()
+        .into_iter()
+        .map(credential_type_info_from_descriptor)
+        .collect();
+    Ok(ListCredentialTypesResponse { types })
+}
+
+/// ADR-0052 P4 (V3): one credential type by key. No port ⇒ honest 503;
+/// unknown key ⇒ 404 (credential *types* are public catalog info, so
+/// non-existence disclosure is non-sensitive — unlike credential
+/// *instances*, which are flat-404 per IDOR rules).
+pub async fn get_credential_type(state: &AppState, key: &str) -> ApiResult<CredentialTypeInfo> {
+    let port = state
+        .credential_schema
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable(NO_CRED_SCHEMA_PORT.to_owned()))?;
+    port.get_type(key)
+        .map(credential_type_info_from_descriptor)
+        .ok_or_else(|| ApiError::NotFound(format!("unknown credential type: {key}")))
 }
 
 #[cfg(test)]
@@ -794,14 +830,11 @@ mod tests {
             .await,
             Err(ApiError::ServiceUnavailable(_))
         ));
-        assert!(matches!(
-            list_credential_types(&s).await,
-            Err(ApiError::ServiceUnavailable(_))
-        ));
-        assert!(matches!(
-            get_credential_type(&s, "api_key").await,
-            Err(ApiError::ServiceUnavailable(_))
-        ));
+        // ADR-0052 P4 V3: `list_credential_types`/`get_credential_type`
+        // are no longer engine-owned-503 — they are port-backed (a
+        // permissive port is wired in `test_state()`). Their no-port → 503
+        // behavior is covered by
+        // `tests/seam_credential_catalog_schema.rs::catalog_503_when_port_unconfigured`.
     }
 
     /// CRUD over the wired in-memory store: create → get → list →

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -11,6 +11,9 @@ use std::sync::Arc;
 use nebula_api::{
     ApiConfig, AppState,
     error::ApiError,
+    ports::credential_schema::{
+        CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
+    },
     state::{OrgResolver, WorkspaceResolver},
 };
 use nebula_core::{OrgId, WorkspaceId};
@@ -142,8 +145,39 @@ pub(crate) fn create_test_jwt() -> String {
 
 // ── AppState builders ─────────────────────────────────────────────────────────
 
+/// Permissive [`CredentialSchemaPort`] test double: accepts any `data`,
+/// exposes no catalog types. Wired by default into [`create_state_with_queue`]
+/// so credential happy-path tests keep their pre-ADR-0052-P4 behavior
+/// (the old fail-open persisted unvalidated; the correct test default is
+/// "a validator is present and permissive"). The reject / no-port cases
+/// are exercised explicitly by `tests/seam_credential_write_path_validation.rs`.
+pub(crate) struct PermissiveCredentialSchemaPort;
+
+impl CredentialSchemaPort for PermissiveCredentialSchemaPort {
+    fn validate_data(
+        &self,
+        _credential_key: &str,
+        _data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>> {
+        Ok(())
+    }
+
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
+        Vec::new()
+    }
+
+    fn get_type(&self, _credential_key: &str) -> Option<CredentialTypeDescriptor> {
+        None
+    }
+}
+
 /// Create an `AppState` with fully functional in-memory repos; return both the
 /// state and a typed reference to the control queue so tests can inspect it.
+///
+/// A permissive [`CredentialSchemaPort`] is wired so credential write-path
+/// tests keep returning 200 (ADR-0052 P4 closed the unvalidated-persist
+/// fail-open: with **no** port the write path now returns 503 by design;
+/// the explicit None/reject behavior is covered by the P4 seam test).
 pub(crate) async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
     let workflow_repo = Arc::new(InMemoryWorkflowRepo::new());
     let execution_repo = Arc::new(InMemoryExecutionRepo::new());
@@ -160,7 +194,8 @@ pub(crate) async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQ
         api_config.jwt_secret,
     )
     .with_org_resolver(Arc::new(TestOrgResolver))
-    .with_workspace_resolver(Arc::new(TestWorkspaceResolver));
+    .with_workspace_resolver(Arc::new(TestWorkspaceResolver))
+    .with_credential_schema(Arc::new(PermissiveCredentialSchemaPort));
 
     (state, control_queue_repo)
 }
@@ -169,6 +204,26 @@ pub(crate) async fn create_state_with_queue() -> (AppState, Arc<InMemoryControlQ
 /// `integration_tests.rs` callers so no test body needs to change.
 pub(crate) async fn create_test_state_with_queue() -> (AppState, Arc<InMemoryControlQueueRepo>) {
     create_state_with_queue().await
+}
+
+/// Same as [`create_state_with_queue`] but with **no** credential-schema
+/// port wired — for the ADR-0052 P4 seam test that asserts the
+/// unconfigured write path returns 503 (never persists unvalidated).
+pub(crate) async fn create_state_with_queue_no_credential_port()
+-> (AppState, Arc<InMemoryControlQueueRepo>) {
+    let control_queue_repo = Arc::new(InMemoryControlQueueRepo::new());
+    let api_config = ApiConfig::for_test();
+    let control_queue_dyn: Arc<dyn nebula_storage::repos::ControlQueueRepo> =
+        Arc::clone(&control_queue_repo) as _;
+    let state = AppState::new(
+        Arc::new(InMemoryWorkflowRepo::new()),
+        Arc::new(InMemoryExecutionRepo::new()),
+        control_queue_dyn,
+        api_config.jwt_secret,
+    )
+    .with_org_resolver(Arc::new(TestOrgResolver))
+    .with_workspace_resolver(Arc::new(TestWorkspaceResolver));
+    (state, control_queue_repo)
 }
 
 // ── `me/*` end-to-end harness (Phase 2) ──────────────────────────────────────

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -645,18 +645,40 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
     }
 
     // Type-discovery endpoints (system-level, not workspace-scoped).
-    for path in [
-        "/api/v1/credentials/types".to_owned(),
-        "/api/v1/credentials/types/api_key".to_owned(),
-    ] {
-        let app = app::build_app(state.clone(), &config);
-        let resp = app.oneshot(auth_get(&path, &token)).await.unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "{path} type discovery must stay an honest 503 (no CredentialRegistry)"
-        );
-    }
+    // ADR-0052 P4 V3: these are now port-backed. The shared harness wires
+    // a permissive port (zero registered types), so the *honest* result is
+    // 200 with an empty `types` list (the endpoint truthfully reports the
+    // registered set) and 404 for an unknown key — not a §4.5 false
+    // capability. The genuine no-port → 503 path is covered by
+    // `tests/seam_credential_catalog_schema.rs::catalog_503_when_port_unconfigured`.
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_get("/api/v1/credentials/types", &token))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "type listing is port-backed (200, possibly-empty) — honest, not a 503 stub"
+    );
+    let listed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+    assert_eq!(
+        listed["types"].as_array().map(Vec::len),
+        Some(0),
+        "permissive harness port registers zero types — honest empty catalog"
+    );
+
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_get("/api/v1/credentials/types/api_key", &token))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "unknown credential type ⇒ 404 (types are public catalog info; \
+         non-existence disclosure is non-sensitive — unlike credential instances)"
+    );
 }
 
 /// Guard-precision regression (Copilot review, PR #674): the

--- a/crates/api/tests/seam_credential_catalog_schema.rs
+++ b/crates/api/tests/seam_credential_catalog_schema.rs
@@ -1,0 +1,159 @@
+//! ADR-0052 P4 seam (V3 + #6): the credential-type catalog is populated
+//! from the `CredentialSchemaPort` (`json_schema()` produced behind the
+//! seam); the api-owned public projection strips `x-nebula-root-rules` +
+//! predicate operands before the wire. No port ⇒ honest 503.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{create_state_with_queue_no_credential_port, create_test_jwt};
+use nebula_api::{
+    ApiConfig, app,
+    ports::credential_schema::{
+        CredentialCapabilityFlags, CredentialFieldError, CredentialSchemaPort,
+        CredentialTypeDescriptor,
+    },
+};
+use tower::ServiceExt;
+
+const TYPES_PATH: &str = "/api/v1/credentials/types";
+
+/// Yields one credential type whose raw `schema_json` deliberately
+/// contains `x-nebula-root-rules` + a predicate-bearing mode operand, to
+/// prove the api projection strips them (#6).
+struct OneTypePort;
+
+impl CredentialSchemaPort for OneTypePort {
+    fn validate_data(
+        &self,
+        _k: &str,
+        _d: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>> {
+        Ok(())
+    }
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
+        vec![self.descriptor()]
+    }
+    fn get_type(&self, k: &str) -> Option<CredentialTypeDescriptor> {
+        (k == "api_key").then(|| self.descriptor())
+    }
+}
+
+impl OneTypePort {
+    fn descriptor(&self) -> CredentialTypeDescriptor {
+        CredentialTypeDescriptor {
+            key: "api_key".to_owned(),
+            name: "API Key".to_owned(),
+            description: "Static API key".to_owned(),
+            auth_pattern: "SecretToken".to_owned(),
+            capabilities: CredentialCapabilityFlags {
+                testable: true,
+                ..Default::default()
+            },
+            icon: None,
+            documentation_url: None,
+            schema_json: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "api_key": {
+                        "type": "string",
+                        "minLength": 2,
+                        "x-nebula-required-mode": { "when": { "predicate": "secret-cross-field" } }
+                    }
+                },
+                "x-nebula-root-rules": [ { "predicate": "leaked-cross-field-logic" } ],
+                "additionalProperties": false
+            }),
+        }
+    }
+}
+
+fn auth_get(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap()
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+#[tokio::test]
+async fn catalog_lists_types_with_projected_schema() {
+    let (state, _q) = common::create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(OneTypePort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let resp = app.oneshot(auth_get(TYPES_PATH, &token)).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "catalog must be 200 with a port"
+    );
+    let text = body_string(resp).await;
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let t0 = &json["types"][0];
+    assert_eq!(t0["key"], "api_key");
+    assert_eq!(
+        t0["schema"]["properties"]["api_key"]["minLength"], 2,
+        "standard JSON-Schema keywords are kept (public contract)"
+    );
+    // #6: cross-field predicate logic MUST NOT leak.
+    assert!(
+        !text.contains("x-nebula-root-rules"),
+        "public schema must strip x-nebula-root-rules; got: {text}"
+    );
+    assert!(
+        !text.contains("leaked-cross-field-logic"),
+        "root-rule predicate operands must not leak; got: {text}"
+    );
+    assert!(
+        t0["schema"]["properties"]["api_key"]
+            .get("x-nebula-required-mode")
+            .is_none(),
+        "predicate-bearing mode operand must be stripped; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn get_credential_type_404_for_unknown_with_port() {
+    let (state, _q) = common::create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(OneTypePort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let resp = app
+        .oneshot(auth_get(&format!("{TYPES_PATH}/does-not-exist"), &token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn catalog_503_when_port_unconfigured() {
+    let (state, _q) = create_state_with_queue_no_credential_port().await;
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let resp = app.oneshot(auth_get(TYPES_PATH, &token)).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no port ⇒ honest 503 (unchanged §4.5 stub)"
+    );
+}

--- a/crates/api/tests/seam_credential_schema_port.rs
+++ b/crates/api/tests/seam_credential_schema_port.rs
@@ -35,10 +35,13 @@ async fn appstate_credential_schema_defaults_none_and_builder_sets_it() {
     // Object-safety: the trait must be usable as `dyn`.
     fn _assert_object_safe(_: &dyn CredentialSchemaPort) {}
 
-    let (state, _q) = common::create_state_with_queue().await;
+    // The shared harness wires a permissive port by default (ADR-0052 P4
+    // closed the unvalidated-persist fail-open); the *AppState default*
+    // (no builder call) is None — assert via the no-port helper.
+    let (state, _q) = common::create_state_with_queue_no_credential_port().await;
     assert!(
         state.credential_schema.is_none(),
-        "credential_schema must default to None (honest-503 stub, like action_registry)"
+        "AppState default must be None (honest-503 stub, like action_registry)"
     );
 
     let state = state.with_credential_schema(Arc::new(StubPort));

--- a/crates/api/tests/seam_credential_schema_port.rs
+++ b/crates/api/tests/seam_credential_schema_port.rs
@@ -1,0 +1,49 @@
+//! ADR-0052 P4 seam — `CredentialSchemaPort` is api-owned, object-safe, and
+//! wires into `AppState` exactly like the `action_registry` precedent
+//! (`Option<Arc<dyn …>>`, `None` ⇒ honest 503).
+
+mod common;
+
+use std::sync::Arc;
+
+use nebula_api::ports::credential_schema::{
+    CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
+};
+
+struct StubPort;
+
+impl CredentialSchemaPort for StubPort {
+    fn validate_data(
+        &self,
+        _credential_key: &str,
+        _data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>> {
+        Ok(())
+    }
+
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
+        Vec::new()
+    }
+
+    fn get_type(&self, _credential_key: &str) -> Option<CredentialTypeDescriptor> {
+        None
+    }
+}
+
+#[tokio::test]
+async fn appstate_credential_schema_defaults_none_and_builder_sets_it() {
+    // Object-safety: the trait must be usable as `dyn`.
+    fn _assert_object_safe(_: &dyn CredentialSchemaPort) {}
+
+    let (state, _q) = common::create_state_with_queue().await;
+    assert!(
+        state.credential_schema.is_none(),
+        "credential_schema must default to None (honest-503 stub, like action_registry)"
+    );
+
+    let state = state.with_credential_schema(Arc::new(StubPort));
+    assert!(
+        state.credential_schema.is_some(),
+        "with_credential_schema must attach the port"
+    );
+}

--- a/crates/api/tests/seam_credential_write_path_validation.rs
+++ b/crates/api/tests/seam_credential_write_path_validation.rs
@@ -162,3 +162,55 @@ async fn create_credential_503_when_port_unconfigured_never_persists() {
         "503 body must not echo submitted data; got: {text}"
     );
 }
+
+#[tokio::test]
+async fn update_credential_rejects_invalid_data_secret_safe() {
+    // ADR-0052 P4: the V2 gate also covers the update path (validates the
+    // supplied `data` against the *existing* credential type's schema).
+    let (state, _q) = create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // Seed a valid credential (RequireApiKeyPort accepts `api_key`).
+    let app = app::build_app(state.clone(), &config);
+    let created = app
+        .oneshot(auth_json(
+            "POST",
+            &ws_path("/credentials"),
+            &token,
+            &serde_json::json!({
+                "credential_key": "api_key", "name": "u",
+                "data": { "api_key": "k-1" }, "tags": {}
+            }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(created.status(), StatusCode::OK, "seed create must succeed");
+    let id = serde_json::from_str::<serde_json::Value>(&body_string(created).await).unwrap()["id"]
+        .as_str()
+        .expect("created id")
+        .to_owned();
+
+    // PUT new `data` that fails the schema (no `api_key`) + a secret.
+    let app = app::build_app(state, &config);
+    let resp = app
+        .oneshot(auth_json(
+            "PUT",
+            &ws_path(&format!("/credentials/{id}")),
+            &token,
+            &serde_json::json!({ "data": { "server": "x", "leak": NEVER_LEAK } }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "update with schema-invalid data must be rejected (400)"
+    );
+    let text = body_string(resp).await;
+    assert!(
+        text.contains("/api_key") && !text.contains(NEVER_LEAK),
+        "update 400 must be secret-safe (path/code only, no value); got: {text}"
+    );
+}

--- a/crates/api/tests/seam_credential_write_path_validation.rs
+++ b/crates/api/tests/seam_credential_write_path_validation.rs
@@ -63,6 +63,17 @@ fn auth_json(method: &str, uri: &str, token: &str, body: &serde_json::Value) -> 
         .unwrap()
 }
 
+fn auth_get(uri: &str, token: &str) -> Request<Body> {
+    Request::builder()
+        .method("GET")
+        .uri(uri)
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-csrf-token", TEST_CSRF_TOKEN)
+        .header("cookie", TEST_CSRF_COOKIE)
+        .body(Body::empty())
+        .unwrap()
+}
+
 async fn body_string(resp: axum::response::Response) -> String {
     let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
         .await
@@ -139,14 +150,14 @@ async fn create_credential_503_when_port_unconfigured_never_persists() {
     let (state, _q) = create_state_with_queue_no_credential_port().await;
     let config = ApiConfig::for_test();
     let token = create_test_jwt();
-    let app = app::build_app(state, &config);
 
     let body = serde_json::json!({
         "credential_key": "api_key",
-        "name": "x",
+        "name": "never-persist-probe",
         "data": { "api_key": "k", "leaky": NEVER_LEAK },
         "tags": {}
     });
+    let app = app::build_app(state.clone(), &config);
     let resp = app
         .oneshot(auth_json("POST", &ws_path("/credentials"), &token, &body))
         .await
@@ -160,6 +171,20 @@ async fn create_credential_503_when_port_unconfigured_never_persists() {
     assert!(
         !text.contains(NEVER_LEAK),
         "503 body must not echo submitted data; got: {text}"
+    );
+
+    // Prove the "never persists" guarantee (not just the 503 status):
+    // the rejected create must have written nothing to the store.
+    let app = app::build_app(state, &config);
+    let list = app
+        .oneshot(auth_get(&ws_path("/credentials"), &token))
+        .await
+        .unwrap();
+    assert_eq!(list.status(), StatusCode::OK, "list must be reachable");
+    let listed = body_string(list).await;
+    assert!(
+        !listed.contains("never-persist-probe") && !listed.contains(NEVER_LEAK),
+        "rejected create must persist nothing — credential absent from list; got: {listed}"
     );
 }
 
@@ -210,7 +235,8 @@ async fn update_credential_rejects_invalid_data_secret_safe() {
     );
     let text = body_string(resp).await;
     assert!(
-        text.contains("/api_key") && !text.contains(NEVER_LEAK),
-        "update 400 must be secret-safe (path/code only, no value); got: {text}"
+        text.contains("/api_key") && text.contains("required") && !text.contains(NEVER_LEAK),
+        "update 400 must carry path+code and echo no value (symmetric with the \
+         create-path contract); got: {text}"
     );
 }

--- a/crates/api/tests/seam_credential_write_path_validation.rs
+++ b/crates/api/tests/seam_credential_write_path_validation.rs
@@ -1,0 +1,164 @@
+//! ADR-0052 P4 seam (V2): the credential write path validates `data`
+//! against the credential type's schema **before persist**; rejection is
+//! secret-safe (no submitted value echoed); an unconfigured port yields
+//! 503 — `data` is never persisted unvalidated (closes the verified
+//! §4.5/§10 fail-open).
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::{
+    TEST_CSRF_COOKIE, TEST_CSRF_TOKEN, create_state_with_queue,
+    create_state_with_queue_no_credential_port, create_test_jwt, ws_path,
+};
+use nebula_api::{
+    ApiConfig, app,
+    ports::credential_schema::{
+        CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
+    },
+};
+use tower::ServiceExt;
+
+/// Rejects any `data` that lacks an `api_key` field; accepts otherwise.
+struct RequireApiKeyPort;
+
+impl CredentialSchemaPort for RequireApiKeyPort {
+    fn validate_data(
+        &self,
+        _credential_key: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>> {
+        if data.get("api_key").is_some() {
+            Ok(())
+        } else {
+            Err(vec![CredentialFieldError {
+                path: "/api_key".to_owned(),
+                code: "required".to_owned(),
+                message: "api_key is required".to_owned(),
+            }])
+        }
+    }
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
+        Vec::new()
+    }
+    fn get_type(&self, _k: &str) -> Option<CredentialTypeDescriptor> {
+        None
+    }
+}
+
+fn auth_json(method: &str, uri: &str, token: &str, body: &serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .header("x-csrf-token", TEST_CSRF_TOKEN)
+        .header("cookie", TEST_CSRF_COOKIE)
+        .body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap()
+}
+
+async fn body_string(resp: axum::response::Response) -> String {
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    String::from_utf8_lossy(&bytes).into_owned()
+}
+
+const NEVER_LEAK: &str = "SUPERSECRET-must-never-surface-0xDEADBEEF";
+
+#[tokio::test]
+async fn create_credential_rejects_invalid_data_secret_safe() {
+    let (state, _q) = create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    // No `api_key` → rejected; a secret-bearing sibling field MUST NOT echo.
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "bad",
+        "data": { "server": "https://x", "leaky": NEVER_LEAK },
+        "tags": {}
+    });
+    let resp = app
+        .oneshot(auth_json("POST", &ws_path("/credentials"), &token, &body))
+        .await
+        .unwrap();
+    // `ApiError::Validation` is the api-wide validation class → 400
+    // (consistent with every other request-validation failure).
+    assert_eq!(
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "invalid credential data must be rejected with the api validation status (400)"
+    );
+    let text = body_string(resp).await;
+    assert!(
+        text.contains("/api_key") && text.contains("required"),
+        "422 body must carry the secret-safe path+code; got: {text}"
+    );
+    assert!(
+        !text.contains(NEVER_LEAK),
+        "422 body must NOT echo any submitted value (secret-safe); got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn create_credential_persists_valid_data() {
+    let (state, _q) = create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "good",
+        "data": { "api_key": "k-123" },
+        "tags": {}
+    });
+    let resp = app
+        .oneshot(auth_json("POST", &ws_path("/credentials"), &token, &body))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "valid credential data must persist (200)"
+    );
+}
+
+#[tokio::test]
+async fn create_credential_503_when_port_unconfigured_never_persists() {
+    let (state, _q) = create_state_with_queue_no_credential_port().await;
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "x",
+        "data": { "api_key": "k", "leaky": NEVER_LEAK },
+        "tags": {}
+    });
+    let resp = app
+        .oneshot(auth_json("POST", &ws_path("/credentials"), &token, &body))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "no credential-schema port ⇒ 503 (never persist unvalidated)"
+    );
+    let text = body_string(resp).await;
+    assert!(
+        !text.contains(NEVER_LEAK),
+        "503 body must not echo submitted data; got: {text}"
+    );
+}

--- a/docs/adr/0047-openapi-31-generator.md
+++ b/docs/adr/0047-openapi-31-generator.md
@@ -281,8 +281,8 @@ change" constraint feasible post-PR #671 (composition root is now a
 separate `nebula-server` crate not in `nebula-credential`'s wrapper
 allowlist), the concrete port impl lives in `nebula-api`, which therefore
 takes a `nebula-schema` **production** dependency + the `schemars`
-feature. `nebula-schema` is Core (freely importable; no `deny.toml`
-change) and `schemars` is already `ignored` in `deny.toml`. The informal
+feature. `nebula-schema` is Core-tier with no `deny.toml` wrapper rule
+(freely importable; **no `deny.toml` change** required). The informal
 "`nebula-api` never imports `nebula-schema`" prose preference is
 **relaxed** to "no `nebula-schema` *type* crosses into a DTO" — the
 load-bearing layer guarantee (DTO purity, public-contract stability,

--- a/docs/adr/0047-openapi-31-generator.md
+++ b/docs/adr/0047-openapi-31-generator.md
@@ -260,3 +260,30 @@ Rejected. M3.2 is one of four 1.0 API blockers. Third-party integrators cannot s
 - AppState: `crates/api/src/state.rs`
 - Pitfalls — type-enforced boundaries: `docs/pitfalls.md` (`nebula-expression` builtin re-entry case)
 - Feedback memories applied: `feedback_adr_ecosystem_evidence.md`, `feedback_type_enforce_not_discipline.md`, `feedback_observability_as_completion.md`, `feedback_boundary_erosion.md`
+
+## Amendment (2026-05-17) — ADR-0052 P4 credential-schema seam
+
+ADR-0052 P4 populates `CredentialTypeInfo.schema` from
+`ValidSchema::json_schema()` (produced behind an api-owned
+`CredentialSchemaPort`), and validates the credential `data` request body
+against the resolved `ValidSchema` before persist; the `data` request
+body stays `serde_json::Value` (this ADR's "Cross-Layer Schema Strategy"
+table already sanctions `Value` for credential `data`). A
+`nebula-api`-owned mapper strips `x-nebula-root-rules` + predicate
+operands from the public catalog schema (cross-field predicate logic must
+not leak to unauthenticated clients). **Clarification to the Cross-Layer
+Schema Strategy:** that section's binding rule is *"API DTOs MUST NOT
+embed types from `nebula-core`/`-storage`/`-engine`/`-credential`"* — a
+**DTO-type** rule, which P4 fully honors (the port and every catalog DTO
+carry only `serde_json::Value` / api-owned structs; **no `ValidSchema`
+type appears in any DTO**). To keep ADR-0052's harder "zero `deny.toml`
+change" constraint feasible post-PR #671 (composition root is now a
+separate `nebula-server` crate not in `nebula-credential`'s wrapper
+allowlist), the concrete port impl lives in `nebula-api`, which therefore
+takes a `nebula-schema` **production** dependency + the `schemars`
+feature. `nebula-schema` is Core (freely importable; no `deny.toml`
+change) and `schemars` is already `ignored` in `deny.toml`. The informal
+"`nebula-api` never imports `nebula-schema`" prose preference is
+**relaxed** to "no `nebula-schema` *type* crosses into a DTO" — the
+load-bearing layer guarantee (DTO purity, public-contract stability,
+implementation hiding) is unchanged. Seam: `crates/api/tests/seam_credential_*`.

--- a/docs/adr/0052-schema-validator-condition-seam.md
+++ b/docs/adr/0052-schema-validator-condition-seam.md
@@ -183,3 +183,77 @@ Seam anchors landed in the P3 PR:
 P4 (API write-path validation V2 / catalog `json_schema()` V3 / public
 OpenAPI DTO `x-nebula-root-rules` strip / ADR-0047 amendment) is the
 remaining cascade phase, out of P3 scope.
+
+## Amendment (2026-05-17) — P4: API write-path validation + catalog json_schema() + public projection (cascade close-out)
+
+P4 closes the cascade. An api-owned, object-safe `CredentialSchemaPort`
+(`crates/api/src/ports/credential_schema.rs`; api-safe types only —
+`serde_json::Value` + api-owned structs, **no `ValidSchema` in any DTO**)
+is added to `AppState` as `Option<Arc<dyn …>>`, mirroring the
+`action_registry` precedent (absent ⇒ honest 503, canon §4.5). The
+concrete `RegistryCredentialSchema`
+(`crates/api/src/ports/credential_schema_registry.rs`) resolves
+`credential_key → CredentialMetadata.base.schema` via a
+`nebula_credential::CredentialRegistry`, runs `FieldValues::from_json` +
+`ValidSchema::validate` (authority = validator; **never `.resolve()`** —
+canon §12.5: credential `data` must not be expression-resolved against
+workflow state; INTEGRATION_MODEL §29/§33 proof-token custody unchanged),
+and exports `ValidSchema::json_schema()` for the catalog.
+
+- **V2 (write-path).** `create_credential`/`update_credential` validate
+  `data` against the type's resolved schema before persist. **This closed
+  a verified live fail-open**: the path persisted `data` unvalidated while
+  the handler docstring claimed it was validated (§4.5 [L1] + §10 [L2]).
+  No port ⇒ 503 (never silent unvalidated persist). Rejection ⇒ the
+  api-wide validation status (400) carrying only RFC-6901 path + validator
+  code + static message — never a submitted value (ADR-0034; secret-safe
+  by construction, P2's value-free `ValidationReport`).
+- **V3 (catalog).** `list_credential_types`/`get_credential_type` are
+  port-backed (no longer engine-owned-503): populated 200 when wired,
+  honest 503 when not, 404 for an unknown (public) type key.
+- **#6 (public projection).** An api-owned recursive mapper
+  (`crates/api/src/domain/credential/schema_projection.rs`) strips
+  `x-nebula-root-rules` + the predicate-bearing
+  `x-nebula-{required,visibility}-mode` family from the catalog schema;
+  standard JSON-Schema keywords and non-predicate structural hints are
+  kept. Not a raw `json_schema()` passthrough.
+
+**Six pre-#671 spec premises were false and are corrected here** (the
+verify-first discipline, same as P1–P3): (1) the write path persisted
+`data` unvalidated while documenting otherwise (a live fail-open, not a
+benign TODO); (2) `schemars` was enabled by no crate; (3)
+`crates/api`'s `nebula-schema` was a dev-dep only; (4) no
+credential-registry port existed in `AppState` (`list/get_credential_type`
+were honest 503s); (5) no `json_schema()`-over-a-port precedent (the
+action catalog uses hand-wrapped `ToSchema` DTOs); (6) **"zero deny.toml
+change" was infeasible as written** — post-#671 the composition root is a
+separate `nebula-server` crate not in `nebula-credential`'s wrapper
+allowlist. The user adjudicated #6: keep the harder "zero deny.toml
+change" constraint and host the concrete impl in `nebula-api` (already an
+allow-listed `nebula-credential` consumer; `nebula-schema` is Core —
+freely importable, no deny change; deny `ignored = ["schemars"]`).
+Consequence: `nebula-api` takes a `nebula-schema` **production** dep +
+the `schemars` feature. ADR-0047's actual DTO-purity rule (no lower-layer
+**types in DTOs**) remains intact — the port returns only
+`serde_json::Value`/api-owned structs; only ADR-0047's informal "api
+never imports `nebula-schema`" prose is relaxed (amended in-place in
+ADR-0047). Zero new crates; zero `deny.toml` change.
+
+Seam anchors (this PR): `crates/api/tests/seam_credential_schema_port.rs`
+(port object-safe + `Option`/builder), `…/seam_credential_write_path_validation.rs`
+(V2: reject⇒400 secret-safe, valid⇒200, no-port⇒503-never-persist),
+`…/seam_credential_catalog_schema.rs` (V3 populated + #6 strip + 404 +
+no-port⇒503), `credential_schema::tests` projection unit tests,
+`credential_schema_registry::tests` (validate reject/accept/unknown +
+default port registers the first-party set). OpenAPI honesty tests
+reconciled faithfully (type-discovery 503→200/404 reflects the new honest
+reality — port present ⇒ truthful catalog; no-port⇒503 retained in the
+seam test — never silenced).
+
+**The ADR-0052 cascade (P1 #670 / P2 #672 / P3 #676 / P4 this PR) is
+COMPLETE. There is no P5.** **Non-goal still OPEN:** the `slot_bindings`
+confused-deputy — credential/resource resolution still has no
+owner/tenant/workspace authorization; a crafted workflow JSON can resolve
+any credential id. Credential resolution remains confused-deputy-exposed
+after P4. "Cascade complete" is **NOT** "that is closed"; it is a
+broader engine-authorization refactor tracked separately.

--- a/docs/adr/0052-schema-validator-condition-seam.md
+++ b/docs/adr/0052-schema-validator-condition-seam.md
@@ -230,8 +230,9 @@ change" was infeasible as written** — post-#671 the composition root is a
 separate `nebula-server` crate not in `nebula-credential`'s wrapper
 allowlist. The user adjudicated #6: keep the harder "zero deny.toml
 change" constraint and host the concrete impl in `nebula-api` (already an
-allow-listed `nebula-credential` consumer; `nebula-schema` is Core —
-freely importable, no deny change; deny `ignored = ["schemars"]`).
+allow-listed `nebula-credential` consumer; `nebula-schema` is Core-tier
+with no `deny.toml` wrapper rule — freely importable, so **no `deny.toml`
+change** is required).
 Consequence: `nebula-api` takes a `nebula-schema` **production** dep +
 the `schemars` feature. ADR-0047's actual DTO-purity rule (no lower-layer
 **types in DTOs**) remains intact — the port returns only

--- a/docs/superpowers/plans/2026-05-17-adr0052-p4-api-write-path-catalog-schema.md
+++ b/docs/superpowers/plans/2026-05-17-adr0052-p4-api-write-path-catalog-schema.md
@@ -1,0 +1,467 @@
+# ADR-0052 P4 — API write-path validation + catalog json_schema() + public projection (FINAL cascade phase) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the ADR-0052 cascade: the credential write path validates `data` against the credential type's resolved `ValidSchema` before persist (V2, closing a verified live fail-open); catalog endpoints expose the type's `json_schema()` (V3); a `nebula-api`-owned mapper strips cross-field predicate logic from the public schema (#6); ADR-0047 + ADR-0052 P4 amendments.
+
+**Architecture:** A `nebula-api`-owned object-safe port trait `CredentialSchemaPort` (api-safe types only) is added to `AppState` as `Option<Arc<dyn CredentialSchemaPort>>`, mirroring the verified `action_registry` precedent (None → honest 503, §4.5). The concrete impl lives in the composition root (`apps/server` + the `examples` server + the api test harness) holding a `nebula-credential` `CredentialRegistry`; it resolves `credential_key → CredentialMetadata.base.schema (ValidSchema)`, runs `FieldValues::from_json` + `ValidSchema::validate` (authority = validator; INTEGRATION_MODEL §29/§33 signatures unchanged), and produces `json_schema()` (`schemars` feature enabled on the composition crate's `nebula-schema` dep). `nebula-api` never gains a `nebula-schema` *production* dep nor a `ValidSchema` in any DTO; only `serde_json::Value` / api-owned structs cross the seam. Public projection strips `x-nebula-root-rules` + predicate-bearing `x-nebula-*` mode operands; standard JSON-Schema keywords stay (public contract).
+
+**Tech Stack:** Rust 1.95 (edition 2024), axum 0.8 + `utoipa` (ADR-0047 OpenAPI 3.1), `nebula-credential` `CredentialRegistry`/`AnyCredential`, `nebula-schema` `ValidSchema::validate`/`json_schema()` (`schemars`), `nebula-validator` `ValidationErrors`, `cargo nextest`, lefthook full-workspace-clippy-per-commit gate.
+
+---
+
+## Authority & corrected facts (read before any step — the design spec is pre-#671/pre-P1-P3 and is FACTUALLY WRONG on 5 points; build on the corrected facts, exactly as P1's plan did)
+
+Scope source of truth: `docs/superpowers/specs/2026-05-15-nebula-schema-finalization-design.md` §Q2 (lines 213-242) + §"Public projection" + Phasing P4 (lines 339-341); `docs/adr/0052-schema-validator-condition-seam.md` Amendment 2026-05-17 (P3) closing paragraph (lines 183-185); P3 plan "P4 backlog" (`docs/superpowers/plans/2026-05-17-adr0052-p3-hasschema-convergence.md:583`). P4 = exactly: (a) write-path validates `data` vs resolved `ValidSchema` before persist [V2]; (b) catalog populates schema from `ValidSchema::json_schema()` [V3]; (c) public OpenAPI DTO strips `x-nebula-root-rules` + predicate operands [#6]; (d) one-paragraph in-place ADR-0047 amendment + ADR-0052 P4 amendment + seam test, same PR (canon §0.1/§17). **NOT P4:** spec §"#3 JSON-Schema export hardening" / §"#4 ReDoS" / §"the one real panic" were **P2** scope (Phasing P2, line 335-336) — out of P4. **Non-goal, stays OPEN:** `slot_bindings` confused-deputy (credential resolution stays confused-deputy-exposed after P4).
+
+**Corrected facts (verified against `main`@da3e0a13; the spec's pre-#671 line refs are dead):**
+
+1. **There is a verified LIVE fail-open / false-capability (not a benign TODO).** `crates/api/src/transport/credential.rs:278-325` `create_credential` does `encode_secret_data(&req.data)` → `StoredCredential{ data: secret_bytes }` → `oauth_credential_store.put(...)` with **zero schema validation**. `crates/api/src/domain/credential/handler.rs:76` docstring claims "The `data` field is validated against the credential type's schema before encryption and storage." The doc asserts a security property that does not hold (§4.5 [L1] + §10 [L2]). V2 must make the doc true; the docstring is fixed in the same PR.
+2. **`schemars` is enabled by NO crate** (`crates/schema/Cargo.toml:16` `schemars = ["dep:schemars"]` optional; lines 69/74 `required-features` are schema's own tests). `ValidSchema::json_schema()` is `#![cfg(feature="schemars")]` (`crates/schema/src/json_schema.rs:6`) — compiles into no workspace build today. V3 requires enabling `schemars` on the composition crate's `nebula-schema` dep. `deny.toml:104` already `ignored = ["schemars"]` — this is a Cargo feature-enable, **not a new crate and not a `deny.toml` change**.
+3. **`crates/api/Cargo.toml` line ~104 has `nebula-schema = { path = "../schema" }` as a DEV-dependency only** (in `[dev-dependencies]`; zero `use nebula_schema` in `crates/api/src/**`). The spec's "nebula-api never imports nebula-schema" is an ADR-0047 *design preference*, not a deny.toml rule (`nebula-schema` is Core, freely importable; `deny.toml:139-149` already allows `nebula-api → nebula-credential`). Keep api free of a `nebula-schema` *production* dep and of `ValidSchema` in DTOs — the port trait carries only `serde_json::Value`/api-owned types.
+4. **No engine credential registry, no `AppState` credential port.** `list_credential_types`/`get_credential_type` are honest 503s (`crates/api/src/transport/credential.rs:607-625`). The contract-side `nebula_credential::CredentialRegistry` (`crates/credential/src/contract/registry.rs`) holds `Box<dyn AnyCredential>`; `AnyCredential::metadata() -> CredentialMetadata` (`crates/credential/src/contract/any.rs:27`) and post-P3 `CredentialMetadata.base.schema: ValidSchema` (`crates/credential/src/metadata.rs` + `crates/metadata/src/base.rs:39`). The registry is not wired into `AppState`.
+5. **No `json_schema()`-over-a-port precedent** — the action catalog uses hand-wrapped `utoipa::ToSchema` DTOs. V3 is net-new plumbing.
+
+**Verified signatures the plan codes against (confirm the few flagged name-items against source at the step that needs them — name confirmation, not design freedom):**
+
+- `crates/api/src/state.rs:205` `pub struct AppState`; `:239` `pub action_registry: Option<Arc<ActionRegistry>>`; ctor (`:346`) sets `action_registry: None`; `:384` `pub fn with_action_registry(mut self, registry: Arc<ActionRegistry>) -> Self`. **Mirror this exactly for `credential_schema`.**
+- Composition root: `apps/server/src/compose.rs:103` `let mut state = default_state(&api_config)?;` then chained `state = state.with_idempotency_store(...)` (line 113). `apps/server/src/transport.rs:18` `use nebula_api::{ApiConfig, AppState, build_app};`.
+- `crates/api/src/error/classify.rs:8` `use nebula_validator::foundation::{ValidationError, ValidationErrors};`; `:123` `impl From<ValidationError> for ApiError`; `:137` `impl From<ValidationErrors> for ApiError`; `ApiError::Validation { detail, errors: Vec<ValidationFieldError> }` (`crates/api/src/error/problem.rs:41-48`, `classify.rs:133/144`). **api already depends on `nebula-validator` (Core) and already maps validator errors to a secret-safe 422** (P2 made validator errors path+code+message, no values).
+- `crates/schema/src/validated.rs:332` `pub fn validate(&self, values: &FieldValues) -> Result<ValidValues, ValidationReport>`. `crates/schema/src/value.rs:~325` `pub fn from_json(value: serde_json::Value) -> Result<FieldValues, crate::error::ValidationError>`. `crates/schema/src/json_schema.rs:81` `pub fn json_schema(&self) -> Result<schemars::Schema, JsonSchemaExportError>`; `:115` emits `root.insert("x-nebula-root-rules".to_owned(), Value::Array(serialized))`; `:454-524` emits `x-nebula-{field-kind,expression-mode,required-mode,visibility-mode,…}`; `:352-397` `apply_value_rules` emits standard JSON-Schema keywords (`minLength`/`maxLength`/`pattern`/`enum`/…).
+- `crates/credential/src/contract/any.rs:23-48` `pub trait AnyCredential { fn credential_key(&self)->&str; fn metadata(&self)->CredentialMetadata; fn as_any(&self)->&dyn Any; }`. `crates/credential/src/contract/registry.rs` `CredentialRegistry` with `resolve_any(key)->Option<&dyn AnyCredential>` + an iterator over entries (confirm exact iterator/accessor names at Task 5).
+- `crates/api/src/domain/credential/dto.rs:31-45` `CreateCredentialRequest { credential_key:String, name:String, description:Option<String>, data:serde_json::Value, tags:Option<HashMap<String,String>> }`; `:251-272` `CredentialTypeInfo { key, name, description, auth_pattern:String, capabilities:CredentialCapabilities, schema:serde_json::Value, icon:Option<String>, documentation_url:Option<String> }`.
+- OpenAPI honesty tests: `crates/api/tests/openapi_canon_compliance.rs` (§4.5 stub-honesty: deprecated⇒501; probes honest 503/501 stubs), `crates/api/tests/openapi_spec.rs` (3.1.0, operationId uniqueness, $ref resolution — no committed JSON snapshot; spec generated in-process), `crates/api/tests/openapi_secret_redaction.rs`. Confirm at Task 9 whether credential-type endpoints are in the honest-503 inventory (their 503→200 flip must be reflected there).
+
+> **Open name-confirmations the implementer MUST verify against source at the flagged step (P1/P2/P3 discipline — confirm, do not invent):** (i) exact `ValidationReport` public accessor for per-error `{path, code, message}` (P3 used `report.errors()` with `e.code.as_ref()` / `e.path.to_string()` in `crates/credential/tests/properties_pipeline.rs` — confirm there); (ii) exact `CredentialRegistry` enumeration accessor (iter of `&dyn AnyCredential` or `(key, entry)`) in `crates/credential/src/contract/registry.rs`; (iii) whether an `update_credential` write path exists in `transport/credential.rs` that also needs the V2 gate; (iv) exact `ApiError::Validation` construction path / `ValidationFieldError` fields (`crates/api/src/error/problem.rs:46-48`); (v) `default_state`/`build_app` location for the api test harness wiring; (vi) `crates/schema/src/value.rs` exact `from_json` line + error type name.
+
+---
+
+## File structure / change map
+
+| Area | File | Responsibility |
+|---|---|---|
+| Port trait (api-owned) | `crates/api/src/ports/credential_schema.rs` (new; add `pub mod ports;`/entry per existing module convention — confirm api module layout) | `pub trait CredentialSchemaPort: Send + Sync` — object-safe; `validate_data(&self, credential_key:&str, data:&serde_json::Value) -> Result<(), Vec<CredentialFieldError>>`; `list_types(&self) -> Vec<CredentialTypeDescriptor>`; `get_type(&self, key:&str) -> Option<CredentialTypeDescriptor>`. `CredentialFieldError { path:String, code:String, message:String }` + `CredentialTypeDescriptor { key,name,description,auth_pattern,capabilities,icon,documentation_url, schema_json: serde_json::Value }` — all api-safe. |
+| AppState | `crates/api/src/state.rs` | add `pub credential_schema: Option<Arc<dyn CredentialSchemaPort>>` (ctor `None`, mirror line 239/346); `with_credential_schema(self, Arc<dyn CredentialSchemaPort>) -> Self` (mirror line 384) |
+| V2 write path | `crates/api/src/transport/credential.rs` (`create_credential` + any `update_credential`), `crates/api/src/domain/credential/handler.rs:76` docstring | validate `data` via port before persist; map `Vec<CredentialFieldError>` → `ApiError::Validation` (422, secret-safe); `None` → 503 "credential data validation unavailable" (no silent unvalidated persist); fix the docstring to state validation occurs when configured |
+| V3 catalog | `crates/api/src/transport/credential.rs:607-625` (`list_credential_types`/`get_credential_type`) | replace 503 bodies: port `Some` → populated `CredentialTypeInfo` (schema = projected `schema_json`); `None` → unchanged honest 503 |
+| #6 projection | `crates/api/src/ports/credential_schema.rs` or a sibling `crates/api/src/domain/credential/schema_projection.rs` (api-owned) | strip `x-nebula-root-rules` + predicate-bearing `x-nebula-{required,visibility}-mode` "when" operands from the `serde_json::Value`; keep standard JSON-Schema keywords |
+| Composition impl | `apps/server/src/compose.rs` (+ `examples/` server + api test harness) ; `apps/server/Cargo.toml` (or wherever the impl lives) `nebula-schema = { features=["schemars"] }` | concrete `CredentialSchemaPort` over a `CredentialRegistry`: resolve key → `metadata().base.schema` → `FieldValues::from_json` + `ValidSchema::validate` (V2) and `json_schema()` (V3); `state.with_credential_schema(...)` |
+| Seam tests | `crates/api/tests/seam_credential_write_path_validation.rs` (new), `crates/api/tests/seam_credential_catalog_schema_projection.rs` (new) | V2: invalid `data` → 422 with path/code, response body contains NO submitted value; valid → persists; port `None` → 503. V3/#6: catalog `schema` populated, contains NO `x-nebula-root-rules`/predicate operands; OpenAPI honesty updated |
+| ADR / docs | `docs/adr/0047-openapi-31-generator.md` (one-paragraph in-place amendment), `docs/adr/0052-schema-validator-condition-seam.md` (P4 amendment + cascade close-out), `crates/api/README.md`/rustdoc, this plan | canon §0.1/§17; record cascade complete + `slot_bindings` Non-goal still OPEN |
+
+**Commit boundaries (lefthook runs full-workspace `cargo clippy --workspace --all-targets -q -- -D warnings` every commit ⇒ commit only at workspace-green; coarse atomic commits; per-crate `cargo fmt -p <crate>` — NEVER `cargo fmt --all`/`task fmt` on this worktree path, Windows os error 206):**
+- C0 plan doc.
+- C1 port trait + DTOs + `AppState` field/builder (api-only addition; workspace green).
+- C2 V2 write-path gate through the port + docstring fix + seam test (api test supplies a test port impl; `None`→503; workspace green).
+- C3 V3 catalog via port (replace 503 bodies; `None`→503 unchanged; workspace green).
+- C4 #6 public-projection mapper + its unit/seam test (api-owned; workspace green).
+- C5 composition-root concrete impl + `schemars` enable + `with_credential_schema` wiring (apps/server + examples + api test harness; workspace green; flips relevant OpenAPI-honesty expectations).
+- C6 ADR-0047 in-place amendment + ADR-0052 P4 amendment + cascade close-out + README/rustdoc.
+All commits via `bash scripts/worktree.sh commit feat api "<summary>"` (convco `feat(api): …` / `docs(api): …`); PR title `feat(api): …` (no `!` — additive: a previously-503 endpoint becoming 200 and a previously-unvalidated path becoming validated are not breaking removals; confirm at PR time).
+
+---
+
+## Task 0: Commit this plan
+
+**Files:** Create `docs/superpowers/plans/2026-05-17-adr0052-p4-api-write-path-catalog-schema.md` (this file).
+
+- [ ] **Step 1: Stage and commit**
+
+```bash
+cd C:/Users/vanya/RustroverProjects/nebula/.worktrees/adr0052-p4
+git add docs/superpowers/plans/2026-05-17-adr0052-p4-api-write-path-catalog-schema.md
+bash scripts/worktree.sh commit docs api "ADR-0052 P4 API write-path + catalog schema plan"
+```
+Expected: convco accepts `docs(api): …`; lefthook pre-commit passes (no code → clippy/fmt skip).
+
+---
+
+## Task 1: `CredentialSchemaPort` trait + api-safe DTOs + `AppState` wiring (api-only addition)
+
+**Files:** Create `crates/api/src/ports/credential_schema.rs`; Modify `crates/api/src/lib.rs` (or `crates/api/src/ports/mod.rs` — confirm api module layout: `rg -n "pub mod " crates/api/src/lib.rs`); Modify `crates/api/src/state.rs:~205-395`; Test inline `#[cfg(test)]` in `state.rs`.
+
+- [ ] **Step 1: Write the failing test** (append to `crates/api/src/state.rs` `#[cfg(test)] mod tests`, or create one mirroring the existing AppState test pattern — `rg -n "mod tests" crates/api/src/state.rs`):
+
+```rust
+#[test]
+fn appstate_credential_schema_defaults_none_and_builder_sets_it() {
+    use std::sync::Arc;
+    use crate::ports::credential_schema::{CredentialSchemaPort, CredentialFieldError, CredentialTypeDescriptor};
+    struct StubPort;
+    impl CredentialSchemaPort for StubPort {
+        fn validate_data(&self, _k: &str, _d: &serde_json::Value) -> Result<(), Vec<CredentialFieldError>> { Ok(()) }
+        fn list_types(&self) -> Vec<CredentialTypeDescriptor> { Vec::new() }
+        fn get_type(&self, _k: &str) -> Option<CredentialTypeDescriptor> { None }
+    }
+    let st = AppState::for_test(); // confirm the existing test-ctor name via `rg -n "fn for_test|fn test_state|default_state" crates/api/src/state.rs`
+    assert!(st.credential_schema.is_none());
+    let st = st.with_credential_schema(Arc::new(StubPort));
+    assert!(st.credential_schema.is_some());
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** `cd C:/Users/vanya/RustroverProjects/nebula/.worktrees/adr0052-p4 && cargo test -p nebula-api --lib appstate_credential_schema_defaults_none_and_builder_sets_it 2>&1 | tail -15` → Expected: cannot find module `ports`/`credential_schema` / field `credential_schema`.
+
+- [ ] **Step 3: Create the port module** `crates/api/src/ports/credential_schema.rs`:
+
+```rust
+//! API-owned credential-schema port (ADR-0052 P4).
+//!
+//! The api never imports `nebula-schema`/`nebula-validator` *types* into
+//! DTOs; this object-safe port carries only api-safe values. The concrete
+//! impl lives in the composition root (which legally depends on
+//! `nebula-credential`/`nebula-schema`) and runs `ValidSchema::validate` /
+//! `json_schema()` — authority sits with the validator
+//! (INTEGRATION_MODEL §29/§33 unchanged).
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// One field-level validation failure, secret-safe (RFC-6901 path +
+/// validator code + static message — never the submitted value).
+#[derive(Debug, Clone)]
+pub struct CredentialFieldError {
+    pub path: String,
+    pub code: String,
+    pub message: String,
+}
+
+/// Catalog descriptor for one credential type. `schema_json` is the
+/// public-projected JSON Schema (`x-nebula-root-rules` + predicate
+/// operands already stripped).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct CredentialTypeDescriptor {
+    pub key: String,
+    pub name: String,
+    pub description: String,
+    pub auth_pattern: String,
+    pub icon: Option<String>,
+    pub documentation_url: Option<String>,
+    pub schema_json: serde_json::Value,
+}
+
+/// Resolve a credential type's schema for the write-path gate (V2) and the
+/// catalog read-model (V3). `None` wiring ⇒ handlers return honest 503
+/// (mirrors `AppState::action_registry`, canon §4.5).
+pub trait CredentialSchemaPort: Send + Sync + 'static {
+    /// Validate `data` against the type's resolved schema before persist.
+    /// `Err` is a secret-safe field-error list.
+    fn validate_data(
+        &self,
+        credential_key: &str,
+        data: &serde_json::Value,
+    ) -> Result<(), Vec<CredentialFieldError>>;
+
+    /// All known credential types with public-projected schema.
+    fn list_types(&self) -> Vec<CredentialTypeDescriptor>;
+
+    /// One credential type by key.
+    fn get_type(&self, credential_key: &str) -> Option<CredentialTypeDescriptor>;
+}
+```
+
+Add the module: in `crates/api/src/lib.rs` add `pub mod ports;` (and create `crates/api/src/ports/mod.rs` with `pub mod credential_schema;`) — match the existing module declaration style (confirm: `rg -n "^pub mod|^mod " crates/api/src/lib.rs | head`).
+
+- [ ] **Step 4: Wire `AppState`** in `crates/api/src/state.rs`: add field beside `action_registry` (after line ~243):
+
+```rust
+    /// Optional credential-schema port (ADR-0052 P4). When `None`, the
+    /// credential write path and credential-type catalog return 503.
+    pub credential_schema: Option<std::sync::Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>>,
+```
+In the ctor (the block at ~line 346 with `action_registry: None,`) add `credential_schema: None,`. Add the builder beside `with_action_registry` (~line 384):
+
+```rust
+    /// Attach the credential-schema port (ADR-0052 P4).
+    #[must_use]
+    pub fn with_credential_schema(
+        mut self,
+        port: std::sync::Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>,
+    ) -> Self {
+        self.credential_schema = Some(port);
+        self
+    }
+```
+
+- [ ] **Step 5: Run — expect PASS** `cargo test -p nebula-api --lib appstate_credential_schema_defaults_none_and_builder_sets_it 2>&1 | tail -8` → PASS.
+
+- [ ] **Step 6: Workspace-green + commit (C1)**
+
+```bash
+cargo clippy --workspace --all-targets -q -- -D warnings 2>&1 | tail -5
+cargo fmt -p nebula-api
+git add crates/api
+bash scripts/worktree.sh commit feat api "add CredentialSchemaPort + AppState wiring (ADR-0052 P4)"
+```
+Expected: clippy clean workspace-wide (pure api addition). `CredentialFieldError` may trip a dead-code lint until Task 2 uses it — if clippy flags it, proceed to Task 2 in the SAME commit (do not `#[allow]`); restructure C1/C2 into one commit if needed to stay green.
+
+---
+
+## Task 2: V2 — write-path validation through the port + close the fail-open
+
+**Files:** Modify `crates/api/src/transport/credential.rs` (`create_credential` ~278-325, and `update_credential` if present — confirm `rg -n "pub async fn (create|update)_credential" crates/api/src/transport/credential.rs`); Modify `crates/api/src/domain/credential/handler.rs:~76` (docstring); `crates/api/src/error/` (reuse `ApiError::Validation`); Test `crates/api/tests/seam_credential_write_path_validation.rs` (new).
+
+- [ ] **Step 1: Write the failing seam test** `crates/api/tests/seam_credential_write_path_validation.rs` (mirror an existing api integration test harness — `rg -n "build_app|default_state|AppState::for_test|router\(\)" crates/api/tests/*.rs | head`; use a test `CredentialSchemaPort` impl that rejects when `data` lacks key `"api_key"`):
+
+```rust
+//! ADR-0052 P4 seam (V2): credential `data` is validated against the type's
+//! schema before persist; rejection is secret-safe (no submitted value in
+//! the response); an unconfigured port yields 503, never silent
+//! unvalidated persist.
+// ... build AppState with a stub CredentialSchemaPort whose validate_data
+// returns Err([CredentialFieldError{path:"/api_key",code:"required",message:"required"}])
+// for data missing "api_key", Ok otherwise ...
+
+#[tokio::test]
+async fn create_credential_rejects_invalid_data_secret_safe() {
+    // POST /…/credentials with data = {"server":"x","secret":"SUPERSECRET"} (no api_key)
+    // assert: 422; body JSON contains "/api_key" and "required";
+    // assert: body string does NOT contain "SUPERSECRET" (no value echo).
+}
+
+#[tokio::test]
+async fn create_credential_persists_valid_data() {
+    // data = {"api_key":"k"} → 201/200; subsequent GET returns metadata.
+}
+
+#[tokio::test]
+async fn create_credential_503_when_port_unconfigured() {
+    // AppState without with_credential_schema → POST → 503 (NOT 200/persisted).
+}
+```
+(Fill the harness from the confirmed existing pattern; keep assertions exact.)
+
+- [ ] **Step 2: Run — expect FAIL** `cargo test -p nebula-api --test seam_credential_write_path_validation 2>&1 | tail -15` → FAIL (validation not wired; currently persists unvalidated).
+
+- [ ] **Step 3: Gate the write path.** In `crates/api/src/transport/credential.rs` `create_credential`, BEFORE `encode_secret_data(&req.data)`:
+
+```rust
+    match state.credential_schema.as_ref() {
+        Some(port) => {
+            if let Err(field_errors) = port.validate_data(&req.credential_key, &req.data) {
+                return Err(api_error_from_credential_field_errors(field_errors));
+            }
+        }
+        None => {
+            return Err(ApiError::ServiceUnavailable(
+                "credential data validation unavailable: no credential-schema port configured".into(),
+            ));
+        }
+    }
+```
+Add a small mapper near the api error module (secret-safe — only path/code/message):
+
+```rust
+fn api_error_from_credential_field_errors(
+    errs: Vec<crate::ports::credential_schema::CredentialFieldError>,
+) -> ApiError {
+    let errors = errs
+        .into_iter()
+        .map(|e| crate::error::problem::ValidationFieldError {
+            // confirm exact ValidationFieldError fields at this step
+            field: e.path,
+            code: Some(e.code),
+            message: e.message,
+        })
+        .collect();
+    ApiError::Validation { detail: "credential data failed schema validation".into(), errors }
+}
+```
+(Confirm `ValidationFieldError` field names + `ApiError::Validation` shape against `crates/api/src/error/problem.rs:46-48` / `classify.rs:133` at this step; adjust to the real constructor — there may be an existing `ApiError::validation(...)` helper to reuse instead of constructing the variant directly.) Apply the identical gate to `update_credential` if it exists. Fix `crates/api/src/domain/credential/handler.rs:~76` docstring to: "When a credential-schema port is configured, `data` is validated against the credential type's schema before encryption and storage; if no validator is configured the request is rejected with 503 (data is never persisted unvalidated)."
+
+- [ ] **Step 4: Run — expect PASS** `cargo test -p nebula-api --test seam_credential_write_path_validation 2>&1 | tail -10` → all 3 PASS.
+
+- [ ] **Step 5: Workspace-green + commit (C2)**
+
+```bash
+cargo clippy --workspace --all-targets -q -- -D warnings 2>&1 | tail -5
+cargo nextest run -p nebula-api 2>&1 | tail -8
+cargo fmt -p nebula-api
+git add crates/api
+bash scripts/worktree.sh commit feat api "validate credential data before persist; close fail-open (ADR-0052 P4 V2)"
+```
+Expected: clippy clean; api nextest green (the 503-on-None change may flip existing create_credential tests that asserted 200 without a port — update those tests to wire a stub port or assert the new honest 503; that is a correct consequence of closing the fail-open, not a regression — note each changed test).
+
+---
+
+## Task 3: V3 — catalog endpoints via the port
+
+**Files:** Modify `crates/api/src/transport/credential.rs:607-625` (`list_credential_types`/`get_credential_type`); Test in `crates/api/tests/seam_credential_catalog_schema_projection.rs` (new — V3 part; #6 part added in Task 4).
+
+- [ ] **Step 1: Write the failing test** (catalog populated when port present, honest 503 when absent):
+
+```rust
+#[tokio::test]
+async fn list_credential_types_populated_when_port_present() {
+    // AppState.with_credential_schema(stub yielding one descriptor key="api_key", schema_json={"type":"object",...})
+    // GET /credential-types → 200; body[0].key=="api_key"; body[0].schema is the object.
+}
+#[tokio::test]
+async fn get_credential_type_503_when_port_absent() {
+    // no port → GET /credential-types/api_key → 503 (unchanged honest stub).
+}
+```
+(Confirm the exact route paths from `crates/api/src/domain/credential/routes.rs:16-17` + handler param names.)
+
+- [ ] **Step 2: Run — expect FAIL** `cargo test -p nebula-api --test seam_credential_catalog_schema_projection 2>&1 | tail -12` → FAIL (still 503 unconditionally).
+
+- [ ] **Step 3: Implement.** Replace the two 503 bodies in `crates/api/src/transport/credential.rs`:
+
+```rust
+pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredentialTypesResponse> {
+    let port = state.credential_schema.as_ref().ok_or_else(|| {
+        ApiError::ServiceUnavailable(
+            "credential type discovery requires a credential-schema port (not configured)".into(),
+        )
+    })?;
+    let types = port.list_types().into_iter().map(credential_type_info_from_descriptor).collect();
+    Ok(ListCredentialTypesResponse { credential_types: types }) // confirm response field name vs dto.rs
+}
+
+pub async fn get_credential_type(state: &AppState, key: &str) -> ApiResult<CredentialTypeInfo> {
+    let port = state.credential_schema.as_ref().ok_or_else(|| {
+        ApiError::ServiceUnavailable(
+            "credential type discovery requires a credential-schema port (not configured)".into(),
+        )
+    })?;
+    port.get_type(key)
+        .map(credential_type_info_from_descriptor)
+        .ok_or_else(|| ApiError::NotFound(format!("unknown credential type: {key}")))
+}
+```
+Add `fn credential_type_info_from_descriptor(d: CredentialTypeDescriptor) -> CredentialTypeInfo` mapping descriptor → the existing `CredentialTypeInfo` DTO (`dto.rs:251-272`); `schema` ← `d.schema_json`; `capabilities` ← derive/Default (confirm `CredentialCapabilities` source — the descriptor may need a `capabilities` field; if so add it to `CredentialTypeDescriptor` in Task 1's struct and the Task 1 test — keep types consistent across tasks).
+
+- [ ] **Step 4: Run — expect PASS**; **Step 5: Workspace-green + commit (C3)** `bash scripts/worktree.sh commit feat api "populate credential-type catalog via port (ADR-0052 P4 V3)"`.
+
+---
+
+## Task 4: #6 — public-projection mapper (api-owned) + seam
+
+**Files:** Create `crates/api/src/domain/credential/schema_projection.rs` (api-owned); Modify the port-descriptor consumer so the catalog `schema` is projected; Test `crates/api/tests/seam_credential_catalog_schema_projection.rs` (extend).
+
+- [ ] **Step 1: Failing unit test** for `project_public_schema(serde_json::Value) -> serde_json::Value`:
+
+```rust
+#[test]
+fn project_strips_root_rules_and_predicate_operands_keeps_standard_keywords() {
+    let raw = serde_json::json!({
+        "type":"object",
+        "properties": { "api_key": { "type":"string", "minLength": 2,
+            "x-nebula-required-mode": {"when": {"predicate": "…"}},
+            "x-nebula-field-kind":"secret" } },
+        "x-nebula-root-rules": [ {"predicate":"…"} ],
+        "additionalProperties": false
+    });
+    let p = super::project_public_schema(raw);
+    assert!(p.get("x-nebula-root-rules").is_none());
+    let ak = &p["properties"]["api_key"];
+    assert!(ak.get("x-nebula-required-mode").is_none(), "predicate-bearing mode operand stripped");
+    assert_eq!(ak["minLength"], 2, "standard JSON-Schema keyword kept");
+    assert_eq!(ak["type"], "string");
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (function absent).
+
+- [ ] **Step 3: Implement** `project_public_schema`: recursively remove the top-level `"x-nebula-root-rules"` key and every `"x-nebula-required-mode"`/`"x-nebula-visibility-mode"` whose value is an object containing a `"when"`/predicate (the predicate-bearing variants — confirm exact emitted shapes against `crates/schema/src/json_schema.rs:454-524` semantics); KEEP standard JSON-Schema keywords and non-predicate `x-nebula-*` structural hints (`x-nebula-field-kind`, `x-nebula-expression-mode`, etc. — these are not cross-field predicate logic). Pin the precise strip set in a top-of-file doc comment citing `json_schema.rs:115` + the mode-operand lines. Route every `CredentialTypeDescriptor.schema_json` through this before it reaches the wire (in `credential_type_info_from_descriptor`, or have the port impl pre-project — decision: api-owned per spec, so project in api at the DTO boundary).
+
+- [ ] **Step 4: Run — expect PASS**; add an integration assertion in the catalog seam test that a wired port whose raw `json_schema()` contains `x-nebula-root-rules` yields a catalog `schema` with **no** `x-nebula-root-rules` and no predicate operands.
+
+- [ ] **Step 5: Workspace-green + commit (C4)** `bash scripts/worktree.sh commit feat api "api-owned public schema projection strips predicate logic (ADR-0052 P4 #6)"`.
+
+---
+
+## Task 5: Composition-root concrete `CredentialSchemaPort` impl + `schemars` enable
+
+**Files:** Create the concrete impl (recommended: `apps/server/src/credential_schema.rs` — confirm apps/server module layout) holding a `nebula_credential::CredentialRegistry`; Modify `apps/server/src/compose.rs:~103-113` (chain `.with_credential_schema(...)`); Modify `apps/server/Cargo.toml` to enable `nebula-schema = { path="../../crates/schema", features=["schemars"] }` (confirm exact dep spec/path); mirror for the `examples` server + the api test harness composition; Test: extend the api seam tests to use the REAL impl over a tiny in-test `CredentialRegistry` if feasible, else keep stub + add an `apps/server` (or `examples`) integration test exercising the real impl.
+
+- [ ] **Step 1: Failing test** — an integration test that builds the real impl over a `CredentialRegistry` containing one registered first-party credential (e.g. `ApiKeyCredential`) and asserts: `validate_data("api_key", {"api_key":"k"})` → Ok; `validate_data("api_key", {})` → Err with path/code; `get_type("api_key").schema_json` is a non-empty object with `"properties"`. Place where the deps are legal (apps/server or examples test, which may depend on nebula-credential + nebula-schema+schemars + nebula-validator).
+
+- [ ] **Step 2: Run — expect FAIL** (impl absent).
+
+- [ ] **Step 3: Implement the concrete port** — struct `RegistryCredentialSchema { registry: Arc<CredentialRegistry> }`:
+  - `validate_data`: `registry.resolve_any(key)` → `&dyn AnyCredential` (404-equivalent → return an Err code `unknown_credential_type` mapped to a field error, OR a distinct path; confirm desired UX) → `any.metadata().base.schema` (`ValidSchema`) → `nebula_schema::FieldValues::from_json(data.clone())` (map its `ValidationError` → one `CredentialFieldError`) → `valid_schema.validate(&field_values)` → on `Err(ValidationReport)` map each `report.errors()` item to `CredentialFieldError { path: e.path.to_string(), code: e.code.as_ref().to_owned(), message: e.message.clone() }` (CONFIRM `ValidationReport`/error accessor names against `crates/credential/tests/properties_pipeline.rs` usage + `crates/schema/src/validated.rs`); never include any submitted value.
+  - `list_types`/`get_type`: enumerate the registry (confirm iterator accessor) → per `&dyn AnyCredential`: `m = any.metadata()`; `schema_json = m.base.schema.json_schema().map(|s| s.to_value())?` (confirm `schemars::Schema` → `serde_json::Value`: `serde_json::to_value(&schema)` or `schema.to_value()`); build `CredentialTypeDescriptor` (key=`any.credential_key()`, name/description from `m.base`, `auth_pattern` from `m.pattern` Display/Into<String>, icon/doc_url from `m.base` if present). Public projection is applied api-side (Task 4) — the impl returns raw `json_schema()` Value (spec: "not a raw passthrough" refers to the api wire, satisfied by Task 4).
+  - DoD: typed errors (no `unwrap`/`expect`/`panic!` in non-test code — map every `Result`), a `#[tracing::instrument]` span with `credential_key` + outcome enum (NEVER `data`/values), an invariant check (e.g. `debug_assert` the projected schema has no `x-nebula-root-rules` — or assert in the seam test).
+- [ ] **Step 4: Enable `schemars`** on the impl crate's `nebula-schema` dep; `cargo tree -p apps-server` (or the impl crate) to confirm one `schemars` resolution; `cargo deny check` to confirm zero deny.toml change needed (it is `ignored=["schemars"]`).
+- [ ] **Step 5: Wire** `apps/server/src/compose.rs`: after `default_state`, build the registry (register the first-party credentials available — confirm the registration entrypoint; if the server has no credential registration yet, wire an empty-or-builtin registry and document that catalog is populated as types are registered) and `state = state.with_credential_schema(Arc::new(RegistryCredentialSchema::new(registry)));`. Mirror in the `examples` server + the api test harness/`default_state` used by api integration tests so api tests exercise a real (or representative) port.
+- [ ] **Step 6: Run — expect PASS**; **Step 7: full per-crate gate + commit (C5)**:
+
+```bash
+cargo nextest run -p nebula-api -p nebula-server 2>&1 | tail -12   # confirm crate name (apps/server package)
+cargo clippy --workspace --all-targets -q -- -D warnings 2>&1 | tail -5
+cargo deny check 2>&1 | tail -4   # zero deny.toml change; pre-existing nebula-credential-vault wrapper warning is NOT ours
+cargo fmt -p nebula-api -p nebula-server
+git add crates apps Cargo.lock
+bash scripts/worktree.sh commit feat api "wire RegistryCredentialSchema in composition root + enable schemars (ADR-0052 P4)"
+```
+(Per `feedback_lockfile_rebase`: a dep/feature change touches root `Cargo.lock` — `git add` it too.)
+
+---
+
+## Task 6: OpenAPI honesty + drift reconciliation
+
+**Files:** Modify `crates/api/tests/openapi_canon_compliance.rs` (the credential-type endpoints flip 503→200 when a port is wired — update the honest-stub inventory/expectations so the test reflects reality, NOT to silence it); confirm `crates/api/tests/openapi_spec.rs` still green (operationId/$ref/3.1.0 — `CredentialTypeInfo`/`CredentialTypeDescriptor` ToSchema additions must resolve).
+
+- [ ] **Step 1:** Run `cargo nextest run -p nebula-api -E 'test(/openapi/)' 2>&1 | tail -20`. Read failures.
+- [ ] **Step 2:** For each failure, VERIFY it is the legitimate 503→200 honesty flip / new-DTO `$ref` (not a real drift). Update `openapi_canon_compliance.rs` expectations to match the now-honest 200 (the endpoint is no longer a stub when the port is wired; if the api default test harness wires the port, the canon-compliance probe must expect 200, and any "deprecated⇒501" inventory must drop the credential-type entries). Document each expectation change inline with a comment citing ADR-0052 P4. Do NOT add `#[allow]` or weaken assertions to pass.
+- [ ] **Step 3:** Re-run until green; **Step 4: commit (folds into C5 or a small C5b)** `bash scripts/worktree.sh commit test api "reconcile OpenAPI honesty tests for populated credential-type endpoints (ADR-0052 P4)"`.
+
+---
+
+## Task 7: ADR-0047 + ADR-0052 P4 amendments + cascade close-out + docs
+
+**Files:** Modify `docs/adr/0047-openapi-31-generator.md` (one paragraph, in-place); `docs/adr/0052-schema-validator-condition-seam.md` (P4 amendment + cascade-complete + Non-goal-open); `crates/api/README.md`/`lib.rs` rustdoc if public surface described there.
+
+- [ ] **Step 1: ADR-0047 in-place amendment.** Append to its "Cross-Layer Schema Strategy" (or a new dated `## Amendment (2026-05-17) — ADR-0052 P4`) ONE paragraph: catalog `CredentialTypeInfo.schema` is populated from `ValidSchema::json_schema()` produced in the composition layer and crosses to `nebula-api` as `serde_json::Value` (api takes no `nebula-schema` production dep); the credential `data` request body stays `serde_json::Value`; the write path validates `data` against the resolved `ValidSchema` before persist; a `nebula-api`-owned mapper strips `x-nebula-root-rules` + predicate operands from the public schema. Cite the seam tests.
+- [ ] **Step 2: ADR-0052 P4 amendment** (`## Amendment (2026-05-17) — P4: API write-path validation + catalog json_schema() + public projection`), same register as P1/P2/P3 amendments: what V2/V3/#6 did, the corrected pre-#671 facts (5 points), the `CredentialSchemaPort` seam (api-owned, Option→503 §4.5, authority=validator, INTEGRATION_MODEL §29/§33 unchanged), `schemars` feature-enable (no new crate / no deny.toml change), seam-anchor test paths. **Cascade close-out:** state explicitly "the ADR-0052 cascade (P1 #670 / P2 #672 / P3 #676 / P4 #<this>) is complete; **no P5**." And: "**Non-goal still OPEN:** the `slot_bindings` confused-deputy — credential resolution remains confused-deputy-exposed (no owner/tenant/workspace authz); 'cascade complete' is NOT 'that is closed'; tracked separately."
+- [ ] **Step 3: commit (C6)** `git add docs crates && bash scripts/worktree.sh commit docs api "ADR-0047 + ADR-0052 P4 amendments; cascade close-out (ADR-0052 P4)"`.
+
+---
+
+## Task 8: Full pre-PR gate + PR + bot triage + merge + cascade close
+
+- [ ] **Step 1: Full gate** (read tails — never assert green from exit code):
+
+```bash
+cd C:/Users/vanya/RustroverProjects/nebula/.worktrees/adr0052-p4
+cargo nextest run --workspace 2>&1 | tail -15
+cargo clippy --workspace --all-targets -- -D warnings 2>&1 | tail -8
+cargo test --workspace --doc 2>&1 | tail -8
+cargo deny check 2>&1 | tail -6   # zero deny.toml change; pre-existing nebula-credential-vault note NOT ours
+RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps 2>&1 | tail -8
+for c in nebula-api nebula-server nebula-schema nebula-credential; do cargo fmt -p $c -- --check; done
+```
+If the OpenAPI 3.1 operationIds change, confirm `openapi_spec.rs` drift assertions stay green (intended additions only).
+
+- [ ] **Step 2: Two-stage review** (spec-compliance, then code-quality) via subagents: always-on personas + `ce-api-contract-reviewer` (DTO/route/serialization + 503→200), `ce-security-reviewer` (untrusted write path + projection: run abuse-case — SSRF/exfiltration via crafted `data`, oversized-payload DoS, expression-injection-in-`data`, confused-deputy note, secret echo in errors), `ce-kieran-rust-reviewer` (.rs), `ce-data-integrity` (persistence gate). Fix-loop until clean; security findings verify-first, never dismiss.
+
+- [ ] **Step 3: Push + PR** `git push -u origin feat/api-adr0052-p4`; `gh pr create --repo vanyastaff/nebula --base main` per `.github/PULL_REQUEST_TEMPLATE.md`. Title `feat(api): ADR-0052 P4 — credential write-path validation + catalog json_schema() + public projection` (confirm no public-contract *removal* ⇒ no `!`; the 503→200 + new validation are additive/§4.5-corrective). Tick "L2 invariant changed → ADR + seam test in this PR". Breaking changes: "None (additive: a previously-503 catalog endpoint becomes 200 when configured; a previously-unvalidated write path becomes validated/explicit-503 — both close a §4.5 fail-open, no API removal)". Docs checklist: ADR-0047 + ADR-0052 P4 amendments; MATURITY.md NOT git-tracked here (external L1; note tiers unchanged). Safety section: closes the verified credential-data fail-open; secret-safe errors (no value echo); proof-token custody INTEGRATION_MODEL §29/§33 unchanged. Notes: cascade complete; `slot_bindings` Non-goal OPEN; `schemars` feature-enable (no new crate / no deny.toml change). End body with the Claude Code trailer.
+
+- [ ] **Step 4: Triage ALL bot reviews verify-first** (CodeRabbit/Copilot/Codex): reproduce each claim against source; rebut false positives with exact-line + green-gate evidence; implement real fixes as new commits + re-run the affected gate; reply + resolve every thread by id. Never blind-merge on green CI + CLEAN alone (P1–P3 each had a real bug past green CI; P3 Copilot posted 4 confidently-wrong comments).
+
+- [ ] **Step 5: Squash-merge** per AGENTS.md ONLY when CI fully green + confirmed stage-by-stage + all threads resolved. Post-merge: `cd C:/Users/vanya/RustroverProjects/nebula && bash scripts/worktree.sh finish adr0052-p4`. Update the user-memory cascade note: P1–P4 all MERGED, cascade COMPLETE, no P5, `slot_bindings` Non-goal still OPEN. **Do NOT spawn a P5** — P4 closes the cascade.
+
+---
+
+## P4 backlog / explicitly deferred (record so honest)
+
+- `slot_bindings` confused-deputy (design-spec Non-goal): credential/resource resolution still has no owner/tenant/workspace authz after P4. Tracked separately; NOT closed by the cascade.
+- If the composition root has no first-party credential-registration entrypoint yet, the catalog is correctly empty until types are registered (honest, not a stub-lie — the port is wired; it simply has zero entries). Note this in the PR if so.
+
+## Self-Review
+
+**1. Spec coverage** (§Q2 + Phasing P4 + ADR-0052 P3-amendment P4 paragraph):
+- V2 write-path validates `data` vs resolved `ValidSchema` before persist → Task 2 (+ Task 5 real impl). ✓ (also closes the verified live fail-open — corrected fact #1)
+- V3 catalog populated from `json_schema()` → Task 3 (+ Task 5). ✓
+- #6 public projection strips `x-nebula-root-rules` + predicate operands, api-owned → Task 4. ✓
+- ADR-0047 one-paragraph in-place amendment + ADR-0052 P4 amendment + seam tests same PR (canon §0.1/§17) → Task 7 + seam tests in Tasks 2/3/4/5. ✓
+- Zero new crate / zero deny.toml change / api free of nebula-schema production dep / authority with validator → Architecture + Task 1 (port api-safe) + Task 5 (schemars feature-enable only; `cargo deny` check Task 5/8). ✓
+- Cascade close-out + `slot_bindings` Non-goal OPEN, no P5 → Task 7 Step 2 + Task 8 Step 5. ✓
+- #3/#4/panic correctly ABSENT (P2 scope) → not in any task. ✓
+
+**2. Placeholder scan:** No "TBD"/"add error handling"/"similar to Task N". The six flagged name-confirmations are explicit `rg`/source-check callouts at the exact step (P1/P2/P3 discipline) — not design gaps; every type/method (`AppState`, `with_action_registry`, `ValidSchema::validate`, `FieldValues::from_json`, `json_schema`, `AnyCredential::metadata`, `ApiError::Validation`, `CredentialRegistry::resolve_any`) is read from verified source at da3e0a13.
+
+**3. Type consistency:** `CredentialSchemaPort` / `CredentialFieldError{path,code,message}` / `CredentialTypeDescriptor{key,name,description,auth_pattern,icon,documentation_url,schema_json(,capabilities?)}` identical across Tasks 1/2/3/4/5; `AppState.credential_schema: Option<Arc<dyn CredentialSchemaPort>>` + `with_credential_schema` consistent; commit scope `api`, type `feat`/`docs`/`test`, every commit via `scripts/worktree.sh commit`. If Task 3 needs `capabilities` on the descriptor, it is added to Task 1's struct + test (flagged inline) to keep types consistent.
+
+**4. Scope/granularity:** 9 tasks, atomic-commit boundaries aligned to lefthook full-workspace-clippy-per-commit (C1 api-addition green, C2 V2 green, C3 V3 green, C4 #6 green, C5 composition+schemars green, C6 docs). No #3/#4/panic. No P5. Non-goal explicitly deferred.


### PR DESCRIPTION
## Summary

**Final phase of the ADR-0052 cascade** (P1 #670, P2 #672, P3 #676). Adds an
api-owned, object-safe `CredentialSchemaPort` to `AppState` (mirroring the
`action_registry` precedent; absent ⇒ honest 503, canon §4.5). The concrete
`RegistryCredentialSchema` (in `nebula-api`) resolves `credential_key →
CredentialMetadata.base.schema` via a `nebula_credential::CredentialRegistry`,
runs `FieldValues::from_json` + `ValidSchema::validate` (authority = validator;
**never `.resolve()`** — canon §12.5; INTEGRATION_MODEL §29/§33 proof-token
custody unchanged), and exports `ValidSchema::json_schema()` for the catalog.

- **V2 — write-path.** `create_credential`/`update_credential` validate `data`
  against the type's resolved schema **before persist**. This closes a
  **verified live fail-open**: the path persisted `data` unvalidated while the
  handler docstring claimed it was validated (§4.5 [L1] + §10 [L2]). No port ⇒
  503 (never silent unvalidated persist). Rejection ⇒ 400 (api-wide validation
  status) carrying only RFC-6901 path + a value-free, **code-derived** message
  — never a submitted value (ADR-0034; secret-safe *by construction* at the
  seam, independent of any upstream validator's message hygiene).
- **V3 — catalog.** `list/get_credential_type` are port-backed: populated 200
  when wired, honest 503 when not, 404 for an unknown (public) type key.
- **#6 — public projection.** An api-owned recursive mapper strips
  `x-nebula-root-rules` + the `x-nebula-{required,visibility}-mode` family;
  standard JSON-Schema keywords + non-predicate hints kept. Not a raw
  `json_schema()` passthrough.

## Linked issue

No Linear issue — recorded **ADR-0052 P4** cascade close-out.

- Refs ADR-0052 (P4 amendment, `docs/adr/0052-schema-validator-condition-seam.md`)
- Refs ADR-0047 (in-place P4 amendment — DTO-purity rule clarified)
- Plan: `docs/superpowers/plans/2026-05-17-adr0052-p4-api-write-path-catalog-schema.md`

## Type of change

- [x] `feat` — new capability (write-path validation + port-backed catalog)
- [x] `fix` — closes a verified §4.5/§10 credential-data fail-open

(Breaking — see Breaking changes; PR title carries `!`.)

## Affected crates / areas

- `nebula-api` (port trait + concrete impl + V2 gate + V3 catalog + #6 projection; gains a `nebula-schema` production dep + `schemars`)
- `apps/server` / `nebula-server` (composition wiring via the api constructor; new `TransportInitError::CredentialSchemaInit`)
- `docs/adr/0052`, `docs/adr/0047` (P4 amendments), crate tests

## Changes

- `crates/api/src/ports/credential_schema.rs` — api-owned `CredentialSchemaPort` + api-safe DTOs.
- `crates/api/src/ports/credential_schema_registry.rs` — `RegistryCredentialSchema` + `try_default_registry_port()` (Result, **no `expect` in library** — AGENTS.md); value-free `code`-derived error messages.
- `crates/api/src/transport/credential.rs` — V2 gate (create+update) before persist; port-backed catalog; secret-safe 400 mapper.
- `crates/api/src/domain/credential/schema_projection.rs` — recursive public projection.
- `crates/api/src/domain/credential/handler.rs` — corrected docstring; `#[utoipa::path]` now declares the emittable `503` for all four endpoints (OpenAPI honesty, matching the resolve/continue precedent).
- `apps/server/src/compose.rs` — wires the port via `try_default_registry_port()` (mapped to a typed `TransportInitError`).
- ADR-0052 P4 amendment + ADR-0047 in-place amendment.

## Test plan

- Seam tests (all green): `seam_credential_schema_port.rs`; `seam_credential_write_path_validation.rs` (create reject⇒400 secret-safe, valid⇒200, no-port⇒503-never-persist, **update reject⇒400 secret-safe**); `seam_credential_catalog_schema.rs` (V3 populated + #6 strip + 404 + no-port⇒503); `schema_projection::tests` (recursive strip, idempotent, total); `credential_schema_registry::tests` (validate reject/accept/unknown + the default port registers the first-party set).
- OpenAPI honesty tests reconciled **faithfully** (type-discovery 503→200/404 reflects the new honest reality — port present ⇒ truthful catalog; no-port⇒503 retained in a dedicated seam test — never silenced).
- Five-persona two-stage adversarial review (spec-compliance, security abuse-case, api-contract, Kieran-Rust, correctness): **no Critical**; all verified-valid Important findings fixed in this PR (commit `76004687`): secret-safe code-derived messages (closes a latent validator-message value-leak + an attacker-key log-injection through the credential seam), `Result`-not-`expect` library constructor, OpenAPI 503 declarations, doc-accuracy, update-path seam test.

### Local verification

- [x] formatted — per-crate `cargo fmt -p <crate>` (`cargo fmt --all` fails on this deep Windows worktree path; CI fmt on a normal path passes)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo nextest run --workspace` — all pass (api+server 327; full workspace ≈4334+ incl. all seam/projection tests)
- [x] `cargo test --workspace --doc` — doctests pass
- [x] `cargo deny check` — advisories/bans/licenses/sources ok; **zero `deny.toml` change** (`git diff origin/main..HEAD -- deny.toml` is empty)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean

## Breaking changes

`POST/PUT /…/credentials`: a request whose `data` fails the credential
type's schema now returns **400** (previously the unvalidated `data` was
accepted with **200** — a false capability the handler docstring wrongly
claimed was validated); with no credential-schema port wired it returns
**503** (never persists). `GET /api/v1/credentials/types[/{key}]` now
returns **200/404** when a port is wired (previously an unconditional
**503** honest stub). **Affected:** clients that relied on the old
accept-anything write behavior or special-cased the types-503.
**Migration:** send `data` conforming to the credential type's published
JSON schema (now exposed at `/credentials/types`). **Justification:** the
old 200 was a §4.5 false-capability (no validation despite the
documented claim); the cascade's P1/P2/P3 all shipped `!`. Recorded in
the ADR-0052 P4 amendment.

BREAKING CHANGE: credential write path now rejects schema-invalid `data`
(400) and fails closed (503) when no credential-schema port is
configured; credential-type catalog endpoints are now implemented
(200/404) instead of an unconditional 503.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — §4.5 fail-open closed; §12.5 honored (no `.resolve()` on credential data); §0.1/§17 (ADR + seam tests in this PR)
- [x] Layer direction preserved — **zero new crate, zero `deny.toml` change** (`nebula-api` is an allow-listed `nebula-credential` consumer; `nebula-schema` is Core-tier with no wrapper rule). ADR-0047 DTO-purity rule intact (no `ValidSchema`/lower-layer type in any DTO; only the informal "api never imports nebula-schema" prose relaxed, amended in-place in ADR-0047 + ADR-0052 P4)
- [x] L2 invariant: ADR-0052 P4 amendment + ADR-0047 amendment + seam tests in this PR
- [x] `docs/MATURITY.md` — not git-tracked in this repo (external L1); crate tiers unchanged (`nebula-api` `frontier`)
- [x] Crate README/rustdoc — no stale claims (handler docstring corrected; module docs accurate)
- [x] `docs/INTEGRATION_MODEL.md` — proof-token custody (§29/§33) unchanged; not edited
- [x] Plan committed (`docs/superpowers/plans/2026-05-17-adr0052-p4-…md`)

## Safety / security impact

- [x] No new `unwrap()`/`expect()`/`panic!()` in library code (the prior `expect` in `default_registry_port` was replaced with a `Result`-returning `try_default_registry_port`; `.expect` remains only in `#[cfg(test)]`)
- [x] No silent error suppression
- [x] Execution/engine state transitions unaffected
- [x] Credentials/secrets stay redacted: the seam's `CredentialFieldError.message` is **code-derived and value-free by construction** — neither a value-embedding validator message (`'{input}' is not a valid …`) nor an attacker-controlled JSON object key can reach the 400 body / error log via the credential path. Write path calls `validate` only, never `.resolve()` (§12.5). Tracing span = `credential_key` + outcome enum, never `data`.
- [x] No new `unsafe`

## Notes for reviewers

- **Cascade close-out:** the ADR-0052 cascade (P1 #670 / P2 #672 / P3 #676 / **P4 this PR**) is **COMPLETE — there is no P5.**
- **Non-goal still OPEN:** the `slot_bindings` confused-deputy — credential/resource resolution still has no owner/tenant/workspace authorization; credential resolution remains confused-deputy-exposed after P4. "Cascade complete" is **NOT** "that is closed"; it is a broader engine-authorization refactor tracked separately.
- **Out-of-scope follow-up (flagged, not fixed here):** `crates/schema/src/value.rs:~570` `validate_json_keys` builds `format!("invalid key \`{raw_key}\`…")`, embedding the attacker-controlled JSON object key into `ValidationError.message` (pre-existing nebula-schema behavior, also a log-injection vector for any `from_json` caller). P4 **neutralizes the exposure through the credential path structurally** (the seam derives messages from `code`, never forwarding `e.message`), but the upstream `value.rs` message should be made value-free at the source (mirroring `FieldKey::err_at`) in a separate nebula-schema PR — recorded so it is not lost.
- **deny.toml/#671 adjudication:** the spec's pre-#671 "zero deny.toml change" premise conflicted with the post-#671 composition root being a separate `nebula-server` crate. Per the maintainer's decision, the constraint was kept and the concrete impl hosted in `nebula-api` (already allow-listed) — accepting a `nebula-schema` production dep on `nebula-api` (Core-tier, no wrapper rule, no deny change). Recorded as the 6th corrected pre-#671 fact in the ADR-0052 P4 amendment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Credential data is now validated against configured schemas before being saved.
  * Credential type discovery endpoints return catalog information and schemas when available.
  * Validation errors provide structured field-level feedback with paths and error codes.

* **Bug Fixes**
  * Validation failures no longer expose submitted secret values in error responses.
  * Missing schema configuration returns an honest service unavailable response instead of silently persisting unvalidated data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/677?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->