### PR TITLE
feat(engine): wire resource rotation fan-out — dispatch path live + 3 latent P1s fixed

### DIFF
--- a/crates/engine/src/credential/rotation.rs
+++ b/crates/engine/src/credential/rotation.rs
@@ -6,6 +6,7 @@
 //! remain in `nebula_credential::rotation`.
 
 pub mod blue_green;
+pub mod fanout_driver;
 pub mod grace_period;
 pub mod resource_fanout;
 pub mod scheduler;
@@ -19,6 +20,7 @@ pub use blue_green::{
     BlueGreenRotation, BlueGreenState, DatabasePrivilege, enumerate_required_privileges,
     validate_privileges,
 };
+pub use fanout_driver::ResourceFanoutDriver;
 pub use grace_period::{
     GracePeriodConfig, GracePeriodState, GracePeriodTracker, UsageMetrics,
     cleanup_expired_credentials, track_credential_usage,

--- a/crates/engine/src/credential/rotation/fanout_driver.rs
+++ b/crates/engine/src/credential/rotation/fanout_driver.rs
@@ -71,14 +71,97 @@
 //! already guarantee no credential/secret material reaches any span
 //! (ADR-0030 §4); this driver adds only key-free counts.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use nebula_credential::{CredentialEvent, CredentialId, LeaseEvent};
 use nebula_eventbus::EventBus;
 use nebula_resource::Manager;
 
 use super::resource_fanout::{ResourceFanoutIndex, RotationOutcome};
+
+/// Time window in which a second revoke for the same `CredentialId` is
+/// treated as a duplicate of the first and skipped.
+///
+/// **Why this exists.** A single logical credential revoke surfaces on
+/// *two* independent buses. `CredentialService::revoke` first calls
+/// `LeaseLifecycle::revoke_for_credential`, which makes the lease
+/// scheduler emit one [`LeaseEvent::LeaseRevoked`] **per released lease**,
+/// and *then* the facade emits one [`CredentialEvent::Revoked`]. The
+/// driver subscribes both, so without dedupe a single revoke would invoke
+/// [`ResourceFanoutIndex::dispatch_revoke`] (and therefore every bound
+/// resource's `on_credential_revoke` hook) two-or-more times for one
+/// logical event: non-idempotent hooks double-fire and the
+/// [`RotationOutcome`] metrics are inflated.
+///
+/// The window is a few seconds — comfortably longer than the gap between
+/// the lease-scheduler `LeaseRevoked` emission(s) and the facade
+/// `CredentialEvent::Revoked` for the *same* revoke (both happen inline
+/// inside one `CredentialService::revoke` call), yet short enough that a
+/// genuinely *new* revoke of the same credential after re-registration is
+/// not suppressed. Taint is idempotent and a re-revoke after the window
+/// is harmless, so erring slightly long is safe; erring short would
+/// re-introduce the double-fire. Refresh is **not** deduped — a refresh
+/// arrives on one bus only (`CredentialEvent::Refreshed`) and a real
+/// re-refresh must always fan out.
+const REVOKE_DEDUPE_WINDOW: Duration = Duration::from_secs(5);
+
+/// Bounded last-seen set of recently-dispatched credential revokes, used
+/// to collapse the lease-bus + credential-bus double-emission of one
+/// logical revoke (see [`REVOKE_DEDUPE_WINDOW`]).
+///
+/// A small FIFO of `(CredentialId, dispatched_at)`: every revoke prunes
+/// entries older than the window, then either observes its `cid` already
+/// present (a duplicate — skipped) or records it and proceeds. Capacity
+/// is bounded so a long-lived driver under heavy revoke churn cannot grow
+/// it without limit; the oldest entry is evicted past the cap (it is
+/// necessarily the least likely to still be inside the window).
+#[derive(Debug)]
+struct RevokeDedupe {
+    seen: VecDeque<(CredentialId, Instant)>,
+}
+
+impl RevokeDedupe {
+    /// Hard cap on retained entries. The window is seconds-long and the
+    /// duplicate pair arrives back-to-back, so a handful of slots covers
+    /// the realistic concurrent-revoke fan-in; the cap only bounds a
+    /// pathological burst.
+    const MAX_ENTRIES: usize = 256;
+
+    fn new() -> Self {
+        Self {
+            seen: VecDeque::new(),
+        }
+    }
+
+    /// Records a revoke dispatch for `cid` at `now` and returns whether
+    /// it should be **dispatched** (`true`) or **skipped as a duplicate**
+    /// (`false`).
+    ///
+    /// Prunes entries older than [`REVOKE_DEDUPE_WINDOW`] first so the
+    /// check is strictly time-bounded, then: if `cid` is still present it
+    /// is a duplicate of an in-window dispatch (skip, do not refresh the
+    /// timestamp — the window is anchored at the *first* dispatch); else
+    /// it is recorded and dispatched.
+    fn admit(&mut self, cid: CredentialId, now: Instant) -> bool {
+        while let Some(&(_, ts)) = self.seen.front() {
+            if now.duration_since(ts) >= REVOKE_DEDUPE_WINDOW {
+                self.seen.pop_front();
+            } else {
+                break;
+            }
+        }
+        if self.seen.iter().any(|&(seen_cid, _)| seen_cid == cid) {
+            return false;
+        }
+        self.seen.push_back((cid, now));
+        if self.seen.len() > Self::MAX_ENTRIES {
+            self.seen.pop_front();
+        }
+        true
+    }
+}
 
 /// Per-resource fan-out timeout budget applied to every resolved
 /// resource row by [`ResourceFanoutIndex::dispatch_refresh`] /
@@ -138,32 +221,60 @@ impl ResourceFanoutDriver {
         let mut credential_sub = credential_bus.subscribe();
         let mut lease_sub = lease_bus.map(|bus| bus.subscribe());
         let handle = tokio::spawn(async move {
+            // Per-driver revoke dedupe: one logical credential revoke
+            // double-emits (lease bus `LeaseRevoked`(s) + facade
+            // `CredentialEvent::Revoked`); this collapses them within
+            // `REVOKE_DEDUPE_WINDOW`. Owned by the loop task so it needs
+            // no lock.
+            let mut revoke_dedupe = RevokeDedupe::new();
             loop {
-                // A `None` from either subscriber means the bus was
-                // dropped (the credential-runtime composition root went
-                // away) — no further rotation signals can arrive, so
-                // the driver retires. `tokio::select!` over both so a
-                // refresh and a lease-revoke are both observed promptly.
+                // `tokio::select!` over both subscribers so a refresh and
+                // a lease-revoke are both observed promptly. The two
+                // buses are independent `Arc`s (credential-runtime
+                // `EventMetricObserver::{event_bus, lease_bus}`): a
+                // closed *lease* bus does not imply the *credential* bus
+                // is gone, so it degrades to credential-only rather than
+                // retiring the whole driver (mirrors the no-lease-bus
+                // deployment path below). Only the credential bus closing
+                // (the composition root went away — no further rotation
+                // signals possible) retires the driver.
                 match &mut lease_sub {
                     Some(lsub) => {
                         tokio::select! {
                             ev = credential_sub.recv() => match ev {
                                 Some(ev) => {
-                                    Self::on_credential_event(&index, &manager, ev).await;
+                                    Self::on_credential_event(
+                                        &index, &manager, &mut revoke_dedupe, ev,
+                                    ).await;
                                 },
                                 None => break,
                             },
-                            ev = lsub.recv() => match ev {
-                                Some(ev) => {
-                                    Self::on_lease_event(&index, &manager, ev).await;
-                                },
-                                None => break,
+                            ev = lsub.recv() => if let Some(ev) = ev {
+                                Self::on_lease_event(
+                                    &index, &manager, &mut revoke_dedupe, ev,
+                                ).await;
+                            } else {
+                                // Lease bus closed but the credential bus
+                                // is a separate live `Arc` — degrade to
+                                // credential-only instead of retiring (a
+                                // credential-level `CredentialEvent::Revoked`
+                                // still drives revoke fan-out, exactly the
+                                // no-lease-bus deployment path).
+                                lease_sub = None;
+                                tracing::debug!(
+                                    target: "nebula_engine::credential::rotation",
+                                    "resource rotation fan-out driver: lease signal \
+                                     bus closed; degrading to credential-only \
+                                     (CredentialEvent::Revoked still fans out revoke)"
+                                );
+                                continue;
                             },
                         }
                     },
                     None => match credential_sub.recv().await {
                         Some(ev) => {
-                            Self::on_credential_event(&index, &manager, ev).await;
+                            Self::on_credential_event(&index, &manager, &mut revoke_dedupe, ev)
+                                .await;
                         },
                         None => break,
                     },
@@ -178,26 +289,33 @@ impl ResourceFanoutDriver {
     }
 
     /// Route a `CredentialEvent`: `Refreshed` → refresh fan-out,
-    /// `Revoked` → revoke fan-out. `ReauthRequired` (and any future
-    /// additive variant) is not a rotation/revoke of stored material, so
-    /// it is intentionally not fanned out.
+    /// `Revoked` → (deduped) revoke fan-out. `ReauthRequired` (and any
+    /// future additive variant) is not a rotation/revoke of stored
+    /// material, so it is intentionally not fanned out.
     async fn on_credential_event(
         index: &ResourceFanoutIndex,
         manager: &Manager,
+        revoke_dedupe: &mut RevokeDedupe,
         ev: CredentialEvent,
     ) {
         match ev {
             CredentialEvent::Refreshed { credential_id } => {
+                // Refresh is intentionally NOT deduped: it arrives on one
+                // bus only and a real re-refresh must always fan out.
                 let outcome = index
                     .dispatch_refresh(credential_id, manager, PER_RESOURCE_ROTATION_TIMEOUT)
                     .await;
                 Self::record(credential_id, "refresh", outcome);
             },
             CredentialEvent::Revoked { credential_id } => {
-                let outcome = index
-                    .dispatch_revoke(credential_id, manager, PER_RESOURCE_ROTATION_TIMEOUT)
-                    .await;
-                Self::record(credential_id, "revoke", outcome);
+                Self::dispatch_revoke_deduped(
+                    index,
+                    manager,
+                    revoke_dedupe,
+                    credential_id,
+                    "credential bus",
+                )
+                .await;
             },
             // Not a rotation of stored material — the sentinel/reauth
             // surface is consumed elsewhere; nothing to fan out.
@@ -210,18 +328,21 @@ impl ResourceFanoutDriver {
     }
 
     /// Route a `LeaseEvent`: only `LeaseRevoked` with an attributed
-    /// `credential_id` drives a revoke fan-out. Renew/expiry/failure
-    /// variants do not revoke stored credential material, and an orphan
-    /// lease (`credential_id == None`) cannot address a reverse-index
-    /// row.
-    async fn on_lease_event(index: &ResourceFanoutIndex, manager: &Manager, ev: LeaseEvent) {
+    /// `credential_id` drives a (deduped) revoke fan-out. Renew/expiry/
+    /// failure variants do not revoke stored credential material, and an
+    /// orphan lease (`credential_id == None`) cannot address a
+    /// reverse-index row.
+    async fn on_lease_event(
+        index: &ResourceFanoutIndex,
+        manager: &Manager,
+        revoke_dedupe: &mut RevokeDedupe,
+        ev: LeaseEvent,
+    ) {
         if let LeaseEvent::LeaseRevoked { credential_id, .. } = ev {
             match credential_id {
                 Some(cid) => {
-                    let outcome = index
-                        .dispatch_revoke(cid, manager, PER_RESOURCE_ROTATION_TIMEOUT)
+                    Self::dispatch_revoke_deduped(index, manager, revoke_dedupe, cid, "lease bus")
                         .await;
-                    Self::record(cid, "revoke", outcome);
                 },
                 None => {
                     // Orphan lease with no nebula credential record — no
@@ -235,6 +356,40 @@ impl ResourceFanoutDriver {
                 },
             }
         }
+    }
+
+    /// Revoke fan-out with the per-credential dedupe window applied.
+    ///
+    /// A single logical credential revoke surfaces on both buses
+    /// (`LeaseEvent::LeaseRevoked` × N released leases, then
+    /// `CredentialEvent::Revoked`). The first arrival within
+    /// [`REVOKE_DEDUPE_WINDOW`] dispatches; later arrivals for the same
+    /// `CredentialId` inside the window are skipped (debug-logged, the
+    /// taint they would re-apply is already applied and idempotent). This
+    /// keeps non-idempotent `on_credential_revoke` hooks single-fire and
+    /// the [`RotationOutcome`] metrics un-inflated per logical revoke.
+    async fn dispatch_revoke_deduped(
+        index: &ResourceFanoutIndex,
+        manager: &Manager,
+        revoke_dedupe: &mut RevokeDedupe,
+        credential_id: CredentialId,
+        source: &'static str,
+    ) {
+        if !revoke_dedupe.admit(credential_id, Instant::now()) {
+            tracing::debug!(
+                target: "nebula_engine::credential::rotation",
+                %credential_id,
+                source,
+                "resource rotation fan-out: duplicate revoke within dedupe window \
+                 (lease-bus + credential-bus double-emission of one logical revoke); \
+                 skipped — first dispatch already tainted/drained the bound rows"
+            );
+            return;
+        }
+        let outcome = index
+            .dispatch_revoke(credential_id, manager, PER_RESOURCE_ROTATION_TIMEOUT)
+            .await;
+        Self::record(credential_id, "revoke", outcome);
     }
 
     /// Consume the [`RotationOutcome`] — **never silently dropped**
@@ -298,5 +453,102 @@ impl Drop for ResourceFanoutDriver {
         // Cancel the spawned task so the driver never outlives the
         // engine that started it (mirrors `ReclaimSweepHandle`).
         self.handle.abort();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The lease-bus + credential-bus double-emission of one logical
+    /// revoke (`LeaseRevoked` then `CredentialEvent::Revoked` for the same
+    /// `CredentialId`, back-to-back) must collapse to a single dispatch
+    /// inside the window. This is the pure-logic core of the
+    /// `dispatch_revoke_deduped` guard the driver applies.
+    #[test]
+    fn second_revoke_same_credential_within_window_is_skipped() {
+        let mut d = RevokeDedupe::new();
+        let cid = CredentialId::new();
+        let t0 = Instant::now();
+
+        // First (e.g. the lease-bus `LeaseRevoked`): dispatch.
+        assert!(d.admit(cid, t0), "first revoke must dispatch");
+        // The facade `CredentialEvent::Revoked` arrives back-to-back for
+        // the SAME credential — a duplicate of one logical revoke: skip.
+        assert!(
+            !d.admit(cid, t0 + Duration::from_millis(1)),
+            "the back-to-back second revoke for the same credential must be \
+             skipped as a duplicate"
+        );
+        // A third in-window arrival (e.g. a second released lease's
+        // `LeaseRevoked`) is also a duplicate.
+        assert!(
+            !d.admit(cid, t0 + Duration::from_millis(2)),
+            "further in-window revokes for the same credential are duplicates"
+        );
+    }
+
+    /// A different credential is never suppressed by another credential's
+    /// in-window dispatch (the dedupe is strictly per-`CredentialId`).
+    #[test]
+    fn distinct_credentials_do_not_dedupe_each_other() {
+        let mut d = RevokeDedupe::new();
+        let a = CredentialId::new();
+        let b = CredentialId::new();
+        let t0 = Instant::now();
+        assert!(d.admit(a, t0));
+        assert!(
+            d.admit(b, t0 + Duration::from_millis(1)),
+            "a different credential's revoke must dispatch even within \
+             another credential's window"
+        );
+    }
+
+    /// A genuinely new revoke of the same credential *after* the window
+    /// has elapsed (e.g. re-registered then revoked again) must dispatch —
+    /// the dedupe collapses a double-emission, not a real later revoke.
+    #[test]
+    fn revoke_after_window_elapsed_dispatches_again() {
+        let mut d = RevokeDedupe::new();
+        let cid = CredentialId::new();
+        let t0 = Instant::now();
+        assert!(d.admit(cid, t0));
+        assert!(
+            !d.admit(cid, t0 + Duration::from_millis(10)),
+            "still inside the window — duplicate"
+        );
+        assert!(
+            d.admit(cid, t0 + REVOKE_DEDUPE_WINDOW + Duration::from_millis(1)),
+            "a new revoke strictly after the dedupe window must dispatch"
+        );
+    }
+
+    /// Pruning is time-bounded: stale entries are evicted on the next
+    /// `admit`, so the set never retains entries older than the window
+    /// and stays bounded under churn.
+    #[test]
+    fn stale_entries_are_pruned_on_admit() {
+        let mut d = RevokeDedupe::new();
+        let t0 = Instant::now();
+        let first = CredentialId::new();
+        assert!(d.admit(first, t0));
+        // Many distinct revokes after the window — each prunes the now
+        // stale older entries; the set cannot grow unbounded.
+        for i in 1..32u64 {
+            let cid = CredentialId::new();
+            let t = t0 + REVOKE_DEDUPE_WINDOW + Duration::from_millis(i);
+            assert!(d.admit(cid, t), "post-window distinct revoke dispatches");
+        }
+        assert!(
+            d.seen.len() <= RevokeDedupe::MAX_ENTRIES,
+            "the dedupe set must stay bounded"
+        );
+        assert!(
+            d.seen.iter().all(|&(_, ts)| {
+                let now = t0 + REVOKE_DEDUPE_WINDOW + Duration::from_millis(31);
+                now.duration_since(ts) < REVOKE_DEDUPE_WINDOW
+            }),
+            "no retained entry may be older than the dedupe window"
+        );
     }
 }

--- a/crates/engine/src/credential/rotation/fanout_driver.rs
+++ b/crates/engine/src/credential/rotation/fanout_driver.rs
@@ -1,0 +1,302 @@
+//! Production wiring that drives the [`ResourceFanoutIndex`] from the
+//! credential-rotation / lease-revoke event streams.
+//!
+//! # Why this exists
+//!
+//! [`ResourceFanoutIndex`] is the engine-owned reverse index + per-slot
+//! fan-out port (ADR-0067 §D1). Until this module, every
+//! `bind` / `dispatch_refresh` / `dispatch_revoke` caller was a
+//! `#[cfg(test)]` test — the index was implemented but unwired (ADR-0067
+//! §Deferred "Rotation fan-out is implemented but unwired"). This module
+//! closes that: it is the single production consumer that turns a
+//! completed credential refresh / revoke into the typed
+//! `nebula_resource::Manager` slot ports for every resolved resource row
+//! that bound the rotated credential.
+//!
+//! # Layering (no `nebula-resource → nebula-engine` edge)
+//!
+//! The rotation/revoke *signals* originate in the credential-runtime
+//! composition root (`nebula-credential-runtime`, ADR-0066), which owns
+//! the resolver, the [`RefreshCoordinator`](super::super::RefreshCoordinator),
+//! and the lease lifecycle. That crate must **not** depend on
+//! `nebula-resource` (deny.toml `[[bans]]` `nebula-resource` wrapper
+//! allowlist; ADR-0067 §D1). The signals reach this driver as plain
+//! [`nebula-eventbus`](nebula_eventbus) events
+//! ([`CredentialEvent`] on `EventBus<CredentialEvent>`,
+//! [`LeaseEvent`] on `EventBus<LeaseEvent>`) — the AGENTS.md
+//! cross-crate-signal-via-eventbus rule, **not** a direct sibling import.
+//!
+//! Only `nebula-engine` simultaneously holds `Arc<ResourceFanoutIndex>`
+//! and the `Arc<nebula_resource::Manager>` the engine already owns, and
+//! only `nebula-engine` legitimately depends on `nebula-resource`
+//! downward. So the fan-out driver is engine-owned: it subscribes the
+//! two credential buses and drives the typed `Manager` slot ports.
+//!
+//! # What it does, per event
+//!
+//! - [`CredentialEvent::Refreshed`] — the credential-runtime facade has
+//!   already CAS-persisted the fresh material into the store
+//!   (`CredentialService::refresh`) before emitting this. That is exactly
+//!   the ADR-0067 §D1 "engine has stored the fresh material" point, so
+//!   the driver calls
+//!   [`ResourceFanoutIndex::dispatch_refresh`].
+//! - [`CredentialEvent::Revoked`] and
+//!   [`LeaseEvent::LeaseRevoked`] — the credential / dynamic-secret lease
+//!   was revoked (`CredentialService::revoke` →
+//!   `LeaseLifecycle::revoke_for_credential` → the lease scheduler emits
+//!   `LeaseRevoked`; the facade additionally emits
+//!   `CredentialEvent::Revoked`). Either triggers
+//!   [`ResourceFanoutIndex::dispatch_revoke`]. The fan-out itself is
+//!   already two-phase + cancellation-safe internally (ADR-0067
+//!   §Deferred / #681): synchronous `taint_slot_for` outside the
+//!   per-resource timeout, then the timeout-wrapped
+//!   `drain_and_revoke` tail. This driver does **not** re-implement
+//!   that — it only invokes `dispatch_revoke`.
+//!
+//! A `LeaseRevoked` whose `credential_id` is `None` (an orphan lease
+//! tracked without a nebula credential record — `LeaseEvent` doc) cannot
+//! address a reverse-index row, so it is a no-op fan-out (logged at
+//! `debug`, not an error).
+//!
+//! # Observability (ADR-0028 §4 — eventbus is not audit)
+//!
+//! Each dispatch returns a [`RotationOutcome`] aggregate. It is **never
+//! silently dropped**: a credential-data-free `tracing` event records
+//! `credential_id` / counts, and a non-zero `failed` / `timed_out`
+//! escalates to `warn!`. Per ADR-0028 §4 this aggregate is a
+//! metrics/observability signal **only** — it is *not* an audit write
+//! and is *not* re-emitted on an eventbus (that dashboard emission stays
+//! a deferred Non-goal of this unit; ADR-0067 §Deferred
+//! "`RotationOutcome` → eventbus emission"). The fan-out internals
+//! already guarantee no credential/secret material reaches any span
+//! (ADR-0030 §4); this driver adds only key-free counts.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nebula_credential::{CredentialEvent, CredentialId, LeaseEvent};
+use nebula_eventbus::EventBus;
+use nebula_resource::Manager;
+
+use super::resource_fanout::{ResourceFanoutIndex, RotationOutcome};
+
+/// Per-resource fan-out timeout budget applied to every resolved
+/// resource row by [`ResourceFanoutIndex::dispatch_refresh`] /
+/// [`dispatch_revoke`](ResourceFanoutIndex::dispatch_revoke).
+///
+/// There is no dedicated rotation-timeout knob on any engine config
+/// today, so this driver pins the same 30s budget every other
+/// engine-side credential I/O bound uses
+/// (`executor::CREDENTIAL_TIMEOUT`,
+/// `LeaseLifecycleConfig::provider_call_timeout` default,
+/// `token_http::OAUTH_TOKEN_HTTP_TIMEOUT`) rather than inventing a
+/// magic literal. It is a **per-resource** budget (one slow resource
+/// cannot cascade-fail siblings — ADR-0036 invariant, enforced inside
+/// the fan-out), not a global one.
+const PER_RESOURCE_ROTATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Handle for the background fan-out driver task.
+///
+/// Mirrors
+/// [`ReclaimSweepHandle`](super::super::refresh::ReclaimSweepHandle):
+/// holding the handle keeps the task alive; dropping it (or calling
+/// [`abort`](Self::abort)) cancels it, so the driver never outlives the
+/// engine that started it. The task itself loops forever — this handle
+/// is the only path to shutdown.
+pub struct ResourceFanoutDriver {
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl std::fmt::Debug for ResourceFanoutDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceFanoutDriver")
+            .field("is_finished", &self.handle.is_finished())
+            .finish()
+    }
+}
+
+impl ResourceFanoutDriver {
+    /// Spawn the driver: subscribe `credential_bus` (+ optionally
+    /// `lease_bus`) and drive the typed `Manager` slot ports through
+    /// `index` for every resolved resource row that bound a rotated /
+    /// revoked credential.
+    ///
+    /// `index` and `manager` are the engine-held `Arc`s
+    /// (`WorkflowEngine` owns both); `credential_bus` /  `lease_bus`
+    /// are the buses the credential-runtime composition root publishes
+    /// on (`EventMetricObserver::{event_bus, lease_bus}`). `lease_bus`
+    /// is optional because a deployment without dynamic-secret leases
+    /// (no `LeasedProvider`) has no lease bus — credential-level
+    /// `CredentialEvent::Revoked` still drives revoke fan-out in that
+    /// case.
+    pub fn spawn(
+        index: Arc<ResourceFanoutIndex>,
+        manager: Arc<Manager>,
+        credential_bus: Arc<EventBus<CredentialEvent>>,
+        lease_bus: Option<Arc<EventBus<LeaseEvent>>>,
+    ) -> Self {
+        let mut credential_sub = credential_bus.subscribe();
+        let mut lease_sub = lease_bus.map(|bus| bus.subscribe());
+        let handle = tokio::spawn(async move {
+            loop {
+                // A `None` from either subscriber means the bus was
+                // dropped (the credential-runtime composition root went
+                // away) — no further rotation signals can arrive, so
+                // the driver retires. `tokio::select!` over both so a
+                // refresh and a lease-revoke are both observed promptly.
+                match &mut lease_sub {
+                    Some(lsub) => {
+                        tokio::select! {
+                            ev = credential_sub.recv() => match ev {
+                                Some(ev) => {
+                                    Self::on_credential_event(&index, &manager, ev).await;
+                                },
+                                None => break,
+                            },
+                            ev = lsub.recv() => match ev {
+                                Some(ev) => {
+                                    Self::on_lease_event(&index, &manager, ev).await;
+                                },
+                                None => break,
+                            },
+                        }
+                    },
+                    None => match credential_sub.recv().await {
+                        Some(ev) => {
+                            Self::on_credential_event(&index, &manager, ev).await;
+                        },
+                        None => break,
+                    },
+                }
+            }
+            tracing::debug!(
+                target: "nebula_engine::credential::rotation",
+                "resource rotation fan-out driver stopped: credential signal bus closed"
+            );
+        });
+        Self { handle }
+    }
+
+    /// Route a `CredentialEvent`: `Refreshed` → refresh fan-out,
+    /// `Revoked` → revoke fan-out. `ReauthRequired` (and any future
+    /// additive variant) is not a rotation/revoke of stored material, so
+    /// it is intentionally not fanned out.
+    async fn on_credential_event(
+        index: &ResourceFanoutIndex,
+        manager: &Manager,
+        ev: CredentialEvent,
+    ) {
+        match ev {
+            CredentialEvent::Refreshed { credential_id } => {
+                let outcome = index
+                    .dispatch_refresh(credential_id, manager, PER_RESOURCE_ROTATION_TIMEOUT)
+                    .await;
+                Self::record(credential_id, "refresh", outcome);
+            },
+            CredentialEvent::Revoked { credential_id } => {
+                let outcome = index
+                    .dispatch_revoke(credential_id, manager, PER_RESOURCE_ROTATION_TIMEOUT)
+                    .await;
+                Self::record(credential_id, "revoke", outcome);
+            },
+            // Not a rotation of stored material — the sentinel/reauth
+            // surface is consumed elsewhere; nothing to fan out.
+            // `CredentialEvent` is `#[non_exhaustive]`; any future
+            // additive variant defaults to "not a rotation/revoke of
+            // resolved material" until a unit deliberately wires it.
+            CredentialEvent::ReauthRequired { .. } => {},
+            _ => {},
+        }
+    }
+
+    /// Route a `LeaseEvent`: only `LeaseRevoked` with an attributed
+    /// `credential_id` drives a revoke fan-out. Renew/expiry/failure
+    /// variants do not revoke stored credential material, and an orphan
+    /// lease (`credential_id == None`) cannot address a reverse-index
+    /// row.
+    async fn on_lease_event(index: &ResourceFanoutIndex, manager: &Manager, ev: LeaseEvent) {
+        if let LeaseEvent::LeaseRevoked { credential_id, .. } = ev {
+            match credential_id {
+                Some(cid) => {
+                    let outcome = index
+                        .dispatch_revoke(cid, manager, PER_RESOURCE_ROTATION_TIMEOUT)
+                        .await;
+                    Self::record(cid, "revoke", outcome);
+                },
+                None => {
+                    // Orphan lease with no nebula credential record — no
+                    // reverse-index row can be keyed by it (LeaseEvent
+                    // doc). A no-op fan-out, not an error.
+                    tracing::debug!(
+                        target: "nebula_engine::credential::rotation",
+                        "lease revoked for an orphan lease (no credential id); \
+                         resource rotation fan-out skipped"
+                    );
+                },
+            }
+        }
+    }
+
+    /// Consume the [`RotationOutcome`] — **never silently dropped**
+    /// (ADR-0028 §4: an observability signal, not an audit write and not
+    /// an eventbus re-emission). Only `credential_id` + counts reach the
+    /// span; the fan-out internals already guarantee no credential /
+    /// secret material on any observability surface (ADR-0030 §4). A
+    /// non-zero `failed` / `timed_out` escalates to `warn!` so a partial
+    /// fan-out is operator-visible.
+    fn record(credential_id: CredentialId, op: &'static str, outcome: RotationOutcome) {
+        if outcome.dispatched() == 0 {
+            // No resource row bound this credential — an expected no-op
+            // for a credential no resource resolved.
+            tracing::debug!(
+                target: "nebula_engine::credential::rotation",
+                %credential_id,
+                op,
+                "resource rotation fan-out: no bound resource rows (no-op)"
+            );
+            return;
+        }
+        if outcome.failed > 0 || outcome.timed_out > 0 {
+            tracing::warn!(
+                target: "nebula_engine::credential::rotation",
+                %credential_id,
+                op,
+                success = outcome.success,
+                failed = outcome.failed,
+                timed_out = outcome.timed_out,
+                dispatched = outcome.dispatched(),
+                "resource rotation fan-out completed with non-success rows; \
+                 siblings unaffected (per-resource isolation)"
+            );
+        } else {
+            tracing::info!(
+                target: "nebula_engine::credential::rotation",
+                %credential_id,
+                op,
+                success = outcome.success,
+                dispatched = outcome.dispatched(),
+                "resource rotation fan-out completed"
+            );
+        }
+    }
+
+    /// Abort the running driver task. Safe to call multiple times.
+    pub fn abort(&self) {
+        self.handle.abort();
+    }
+
+    /// Whether the underlying task has finished (e.g. via abort or a
+    /// closed signal bus).
+    #[must_use]
+    pub fn is_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
+}
+
+impl Drop for ResourceFanoutDriver {
+    fn drop(&mut self) {
+        // Cancel the spawned task so the driver never outlives the
+        // engine that started it (mirrors `ReclaimSweepHandle`).
+        self.handle.abort();
+    }
+}

--- a/crates/engine/src/credential/rotation/resource_fanout.rs
+++ b/crates/engine/src/credential/rotation/resource_fanout.rs
@@ -398,15 +398,22 @@ impl ResourceFanoutIndex {
                             return RowOutcome::Failed;
                         },
                     };
-                    // Phase 2 — ONLY the cancellation-safe drain + revoke
-                    // hook is timeout-wrapped. The row is already tainted; a
-                    // timed-out or dropped tail leaves it tainted (new
-                    // acquires stay rejected) and is recorded `timed_out`,
-                    // never un-tainted.
-                    let drain = mgr.drain_and_revoke(tainted);
-                    match tokio::time::timeout(per_resource_timeout, drain).await {
-                        Ok(Ok(())) => RowOutcome::Success,
-                        Ok(Err(err)) => {
+                    // Phase 2 — the cancellation-safe drain + revoke hook.
+                    // `drain_and_revoke` is the SINGLE owner of the
+                    // per-resource budget: it bounds the drain (best-effort
+                    // — a timed-out drain still runs the hook) and the hook
+                    // itself (a wedged hook is the only thing the budget
+                    // cuts). It is therefore called WITHOUT an outer
+                    // `tokio::time::timeout` wrapper — that wrapper used to
+                    // be able to elapse on a slow drain and drop the whole
+                    // future *before the hook ran*, silently skipping the
+                    // documented "hook still runs after a timed-out drain"
+                    // guarantee (ADR-0067 §Deferred / #690 review). The row
+                    // is already tainted (phase 1); every tail outcome
+                    // leaves it tainted.
+                    match mgr.drain_and_revoke(tainted, per_resource_timeout).await {
+                        nebula_resource::RevokeTail::Done => RowOutcome::Success,
+                        nebula_resource::RevokeTail::HookFailed(err) => {
                             tracing::warn!(
                                 credential_id = %cid,
                                 resource_key = %b.resource_key,
@@ -418,16 +425,16 @@ impl ResourceFanoutIndex {
                             );
                             RowOutcome::Failed
                         },
-                        Err(_elapsed) => {
+                        nebula_resource::RevokeTail::HookTimedOut => {
                             tracing::warn!(
                                 credential_id = %cid,
                                 resource_key = %b.resource_key,
                                 slot = %b.slot_name,
                                 slot_identity = b.slot_identity,
                                 timeout_ms = per_resource_timeout.as_millis() as u64,
-                                "rotation fan-out: per-resource revoke drain/hook timed \
-                                 out (row stays tainted, no new leases); siblings \
-                                 unaffected",
+                                "rotation fan-out: per-resource revoke hook timed out \
+                                 (drain already completed or also timed out; row stays \
+                                 tainted, no new leases); siblings unaffected",
                             );
                             RowOutcome::TimedOut
                         },
@@ -1064,10 +1071,12 @@ mod tests {
 
             // Phase 2 constructed, polled until it parks in the per-resource
             // drain (the held guard keeps the counter > 0), then explicitly
-            // DROPPED while still pending — models the fan-out's
-            // `tokio::time::timeout` elapsing and dropping the wrapped future.
+            // DROPPED while still pending — models a generic task-abort /
+            // runtime-shutdown cancellation of the awaiting task (post-#690
+            // the fan-out no longer wraps this in an outer timeout; the
+            // synchronous-phase-1 taint must still survive any such drop).
             {
-                let mut fut = Box::pin(mgr.drain_and_revoke(tainted));
+                let mut fut = Box::pin(mgr.drain_and_revoke(tainted, Duration::from_secs(30)));
                 let parked = tokio::time::timeout(Duration::from_millis(150), &mut fut).await;
                 assert!(
                     parked.is_err(),

--- a/crates/engine/src/credential/rotation/resource_fanout.rs
+++ b/crates/engine/src/credential/rotation/resource_fanout.rs
@@ -292,6 +292,23 @@ impl ResourceFanoutIndex {
     /// or timed-out row's future resolves on its own and cannot abort or
     /// fail a sibling — every row's outcome is recorded independently.
     ///
+    /// **Revoke is two-phase and cancellation-safe (ADR-0067 §Deferred).**
+    /// `Manager::revoke_slot_for` is *not* called inside the timeout: a Rust
+    /// `async fn` body is lazy, so a timeout future dropped before its first
+    /// poll would skip the synchronous taint and leave new acquires accepted
+    /// on a credential whose revoke "timed out". Instead the synchronous
+    /// `Manager::taint_slot_for` runs **first, outside and before** the
+    /// `tokio::time::timeout` (the taint is fully applied the instant it
+    /// returns), and **only** the cancellation-safe
+    /// `Manager::drain_and_revoke` tail is wrapped in the per-resource
+    /// timeout. A timed-out (or otherwise dropped) drain tail therefore
+    /// leaves the row tainted — recorded `timed_out`, never silently
+    /// un-revoked. A failed *taint* (resolution miss / shutting down) is the
+    /// row's terminal outcome (`failed`); the drain tail is then not entered.
+    /// Refresh has no pre-`await` state mutation (the engine already stored
+    /// the fresh material before this is called), so it stays a single
+    /// timeout-wrapped `refresh_slot_for` call.
+    ///
     /// Each row's `Bind` is moved into its own dispatch future (the snapshot
     /// from [`affected`](Self::affected) is already an owned `Vec`, so no
     /// clone is added over the snapshot), keeping every future self-contained
@@ -314,56 +331,107 @@ impl ResourceFanoutIndex {
 
         let op_name = op.as_str();
         let dispatches = rows.into_iter().map(|b| async move {
-            // The port future borrows `b`; it is constructed and awaited
-            // entirely inside this per-row future, which owns `b`, so no
-            // cross-future borrow and no clone beyond the owned snapshot.
-            let port = async {
-                match op {
-                    FanoutOp::Refresh => {
-                        mgr.refresh_slot_for(
-                            &b.resource_key,
-                            b.scope.clone(),
-                            &b.slot_name,
-                            b.slot_identity,
-                        )
-                        .await
-                    },
-                    FanoutOp::Revoke => {
-                        mgr.revoke_slot_for(
-                            &b.resource_key,
-                            b.scope.clone(),
-                            &b.slot_name,
-                            b.slot_identity,
-                        )
-                        .await
-                    },
-                }
-            };
-            match tokio::time::timeout(per_resource_timeout, port).await {
-                Ok(Ok(())) => RowOutcome::Success,
-                Ok(Err(err)) => {
-                    // Resource-crate errors are already credential-free
-                    // (key/slot/scope only); safe to log verbatim.
-                    tracing::warn!(
-                        credential_id = %cid,
-                        resource_key = %b.resource_key,
-                        slot = %b.slot_name,
-                        slot_identity = b.slot_identity,
-                        error = %err,
-                        "rotation fan-out: per-resource {op_name} failed; siblings unaffected",
+            match op {
+                FanoutOp::Refresh => {
+                    // Refresh has no pre-`await` state mutation, so the whole
+                    // call is safe to wrap in the per-resource timeout.
+                    let refresh = mgr.refresh_slot_for(
+                        &b.resource_key,
+                        b.scope.clone(),
+                        &b.slot_name,
+                        b.slot_identity,
                     );
-                    RowOutcome::Failed
+                    match tokio::time::timeout(per_resource_timeout, refresh).await {
+                        Ok(Ok(())) => RowOutcome::Success,
+                        Ok(Err(err)) => {
+                            // Resource-crate errors are already
+                            // credential-free (key/slot/scope only).
+                            tracing::warn!(
+                                credential_id = %cid,
+                                resource_key = %b.resource_key,
+                                slot = %b.slot_name,
+                                slot_identity = b.slot_identity,
+                                error = %err,
+                                "rotation fan-out: per-resource refresh failed; \
+                                 siblings unaffected",
+                            );
+                            RowOutcome::Failed
+                        },
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                credential_id = %cid,
+                                resource_key = %b.resource_key,
+                                slot = %b.slot_name,
+                                slot_identity = b.slot_identity,
+                                timeout_ms = per_resource_timeout.as_millis() as u64,
+                                "rotation fan-out: per-resource refresh timed out; \
+                                 siblings unaffected",
+                            );
+                            RowOutcome::TimedOut
+                        },
+                    }
                 },
-                Err(_elapsed) => {
-                    tracing::warn!(
-                        credential_id = %cid,
-                        resource_key = %b.resource_key,
-                        slot = %b.slot_name,
-                        slot_identity = b.slot_identity,
-                        timeout_ms = per_resource_timeout.as_millis() as u64,
-                        "rotation fan-out: per-resource {op_name} timed out; siblings unaffected",
-                    );
-                    RowOutcome::TimedOut
+                FanoutOp::Revoke => {
+                    // Phase 1 — SYNCHRONOUS taint, OUTSIDE the timeout. It is
+                    // fully applied before `taint_slot_for` returns, so a
+                    // subsequently-dropped timeout on the drain tail can
+                    // never skip it (ADR-0067 §Deferred). A taint failure
+                    // (resolution miss / manager shutting down) is this
+                    // row's terminal outcome — the drain tail is not entered.
+                    let tainted = match mgr.taint_slot_for(
+                        &b.resource_key,
+                        b.scope.clone(),
+                        &b.slot_name,
+                        b.slot_identity,
+                    ) {
+                        Ok(t) => t,
+                        Err(err) => {
+                            tracing::warn!(
+                                credential_id = %cid,
+                                resource_key = %b.resource_key,
+                                slot = %b.slot_name,
+                                slot_identity = b.slot_identity,
+                                error = %err,
+                                "rotation fan-out: per-resource revoke taint failed; \
+                                 siblings unaffected",
+                            );
+                            return RowOutcome::Failed;
+                        },
+                    };
+                    // Phase 2 — ONLY the cancellation-safe drain + revoke
+                    // hook is timeout-wrapped. The row is already tainted; a
+                    // timed-out or dropped tail leaves it tainted (new
+                    // acquires stay rejected) and is recorded `timed_out`,
+                    // never un-tainted.
+                    let drain = mgr.drain_and_revoke(tainted);
+                    match tokio::time::timeout(per_resource_timeout, drain).await {
+                        Ok(Ok(())) => RowOutcome::Success,
+                        Ok(Err(err)) => {
+                            tracing::warn!(
+                                credential_id = %cid,
+                                resource_key = %b.resource_key,
+                                slot = %b.slot_name,
+                                slot_identity = b.slot_identity,
+                                error = %err,
+                                "rotation fan-out: per-resource revoke hook failed \
+                                 (row stays tainted); siblings unaffected",
+                            );
+                            RowOutcome::Failed
+                        },
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                credential_id = %cid,
+                                resource_key = %b.resource_key,
+                                slot = %b.slot_name,
+                                slot_identity = b.slot_identity,
+                                timeout_ms = per_resource_timeout.as_millis() as u64,
+                                "rotation fan-out: per-resource revoke drain/hook timed \
+                                 out (row stays tainted, no new leases); siblings \
+                                 unaffected",
+                            );
+                            RowOutcome::TimedOut
+                        },
+                    }
                 },
             }
         });
@@ -400,8 +468,10 @@ enum FanoutOp {
     /// `Manager::refresh_slot_for` — credential rotated, fresh material
     /// already resolved and stored by the engine.
     Refresh,
-    /// `Manager::revoke_slot_for` — credential revoked (e.g. ADR-0051 lease
-    /// revoke); taint → drain → revoke hook.
+    /// Credential revoked (e.g. ADR-0051 lease revoke). Driven as the
+    /// two-phase port: synchronous `Manager::taint_slot_for` outside the
+    /// timeout, then the timeout-wrapped cancellation-safe
+    /// `Manager::drain_and_revoke` tail (ADR-0067 §Deferred).
     Revoke,
 }
 
@@ -710,7 +780,10 @@ mod tests {
         /// Register `identities.len()` distinct tenants under ONE
         /// `(key, scope)` (distinct `slot_identity`), warm each resident
         /// runtime, bind every row into a fresh index under `cid`, and
-        /// return `(index, manager, cid, scope, ledger)`.
+        /// return `(index, manager, cid, scope, org, ledger)`. `org` is the
+        /// `OrgId` backing `scope` so a caller can build an acquire
+        /// `ResourceContext` for the registered scope without re-deriving it
+        /// from `scope` (no destructure-or-panic at the call site).
         async fn setup(
             identities: &[u64],
         ) -> (
@@ -718,6 +791,7 @@ mod tests {
             Arc<Manager>,
             CredentialId,
             ScopeLevel,
+            OrgId,
             Ledger,
         ) {
             let ledger = Ledger::default();
@@ -763,7 +837,7 @@ mod tests {
                 idx.bind(cid, CtlResource::key(), scope.clone(), "db", id);
             }
 
-            (idx, mgr, cid, scope, ledger)
+            (idx, mgr, cid, scope, org, ledger)
         }
 
         /// Isolation invariant: one resource that times out must NOT abort
@@ -772,7 +846,7 @@ mod tests {
         #[tokio::test]
         async fn refresh_fanout_isolates_a_timed_out_resource() {
             let (a, b, c) = (0xAAAA_u64, 0xBBBB_u64, 0xCCCC_u64);
-            let (idx, mgr, cid, _scope, ledger) = setup(&[a, b, c]).await;
+            let (idx, mgr, cid, _scope, _org, ledger) = setup(&[a, b, c]).await;
             ledger.set(a, Behaviour::FastOk);
             ledger.set(b, Behaviour::Hang);
             ledger.set(c, Behaviour::FastOk);
@@ -807,7 +881,7 @@ mod tests {
         #[tokio::test]
         async fn refresh_fanout_mixed_outcomes_each_independent() {
             let (a, b, c, d) = (0x1_u64, 0x2_u64, 0x3_u64, 0x4_u64);
-            let (idx, mgr, cid, _scope, ledger) = setup(&[a, b, c, d]).await;
+            let (idx, mgr, cid, _scope, _org, ledger) = setup(&[a, b, c, d]).await;
             ledger.set(a, Behaviour::FastOk);
             ledger.set(b, Behaviour::FastErr);
             ledger.set(c, Behaviour::Hang);
@@ -832,7 +906,7 @@ mod tests {
         #[tokio::test]
         async fn revoke_fanout_isolates_a_timed_out_resource() {
             let (a, b, c) = (0xDEAD_u64, 0xBEEF_u64, 0xF00D_u64);
-            let (idx, mgr, cid, _scope, ledger) = setup(&[a, b, c]).await;
+            let (idx, mgr, cid, _scope, _org, ledger) = setup(&[a, b, c]).await;
             ledger.set(a, Behaviour::FastOk);
             ledger.set(b, Behaviour::Hang);
             ledger.set(c, Behaviour::FastOk);
@@ -857,11 +931,190 @@ mod tests {
             );
         }
 
+        /// Builds an acquire context for the registered Organization scope
+        /// without re-deriving it from a `ScopeLevel` (no destructure-or-
+        /// panic): `setup` hands back the `OrgId` directly.
+        fn ctx_for(org: OrgId) -> ResourceContext {
+            ResourceContext::minimal(
+                Scope {
+                    org_id: Some(org),
+                    ..Default::default()
+                },
+                CancellationToken::new(),
+            )
+        }
+
+        /// #681 — the cancellation-safety invariant of the two-phase port.
+        ///
+        /// A revoke whose `drain_and_revoke` tail times out (the revoke hook
+        /// hangs) MUST still have left the row **tainted**: the synchronous
+        /// `taint_slot_for` ran *outside* the per-resource timeout, so a
+        /// timed-out drain/hook cannot un-revoke the credential. Asserts both
+        /// that the fan-out records `timed_out` (not success, not dropped)
+        /// **and** that a fresh acquire on that exact resolved row is
+        /// rejected *after* the timed-out fan-out returned — proof the taint
+        /// survived the timeout.
+        #[tokio::test]
+        async fn revoke_fanout_timed_out_drain_still_left_row_tainted() {
+            use nebula_error::{Classify, ErrorCategory};
+            use nebula_resource::AcquireOptions;
+
+            let hung = 0x5151_u64;
+            let (idx, mgr, cid, _scope, org, ledger) = setup(&[hung]).await;
+            // The revoke hook never returns -> `drain_and_revoke` (the
+            // timeout-wrapped phase 2) times out.
+            ledger.set(hung, Behaviour::Hang);
+
+            let out = idx
+                .dispatch_revoke(cid, &mgr, Duration::from_millis(150))
+                .await;
+
+            assert_eq!(
+                out,
+                RotationOutcome {
+                    success: 0,
+                    failed: 0,
+                    timed_out: 1,
+                },
+                "a hung revoke hook must record timed_out — never success, never dropped",
+            );
+            assert_eq!(
+                ledger.revoke_entered.load(Ordering::SeqCst),
+                1,
+                "phase 2 (drain_and_revoke) did run and reached the hung hook",
+            );
+
+            // The decisive #681 assertion: the row is STILL tainted after the
+            // timed-out fan-out returned. If the taint had been inside the
+            // timeout future it would have been skipped/rolled back; here it
+            // ran synchronously *before* the timeout, so new acquires on this
+            // exact resolved row stay rejected.
+            let ctx = ctx_for(org);
+            let acquired = mgr
+                .acquire_resident_for::<CtlResource>(&ctx, &AcquireOptions::default(), hung)
+                .await;
+            let err = match acquired {
+                Err(e) => e,
+                Ok(_) => {
+                    // guard-justified: a live guard here is the exact #681
+                    // regression (taint lost across the timeout); fail the
+                    // test loudly with no salvage path.
+                    unreachable!(
+                        "acquire after a timed-out revoke must be rejected — \
+                         the row must stay tainted (#681)"
+                    )
+                },
+            };
+            assert_eq!(
+                err.category(),
+                ErrorCategory::Unavailable,
+                "post-timeout acquire must be the Revoked/Unavailable taint rejection, got: {err}",
+            );
+        }
+
+        /// #681 — cancellation: dropping the `drain_and_revoke` future the
+        /// instant after `taint_slot_for` returns must leave the row tainted.
+        ///
+        /// This drives the two-phase port directly (the exact split the
+        /// fan-out uses): synchronous `taint_slot_for` first, then *drop* the
+        /// still-pending `drain_and_revoke` future mid-flight (a
+        /// `tokio::time::timeout` elapsing and dropping the wrapped future is
+        /// the real-world trigger). A real in-flight guard is held so the
+        /// per-resource drain genuinely parks the future (it cannot complete
+        /// on its first poll). Because the taint already completed
+        /// synchronously in phase 1, no acquire on the row may succeed
+        /// afterward.
+        #[tokio::test]
+        async fn revoke_two_phase_dropping_drain_future_keeps_taint() {
+            use nebula_error::{Classify, ErrorCategory};
+            use nebula_resource::AcquireOptions;
+
+            let id = 0x7A1D_u64;
+            let (_idx, mgr, _cid, scope, org, ledger) = setup(&[id]).await;
+            // Even a hook that *would* succeed: we never let phase 2 run.
+            ledger.set(id, Behaviour::FastOk);
+
+            // Hold a real in-flight guard so phase 2's per-resource drain
+            // blocks (counter stays at 1) — `drain_and_revoke` parks instead
+            // of completing on its first poll, making the subsequent drop a
+            // true mid-flight cancellation.
+            let in_flight = match mgr
+                .acquire_resident_for::<CtlResource>(&ctx_for(org), &AcquireOptions::default(), id)
+                .await
+            {
+                Ok(g) => g,
+                Err(e) => {
+                    // guard-justified: `setup` registered+warmed this row, so
+                    // an acquire on the un-tainted resource cannot fail here;
+                    // a failure is a broken-test invariant, not a real path.
+                    unreachable!("acquire on the freshly warmed row must succeed: {e}")
+                },
+            };
+
+            // Phase 1: synchronous taint, outside any timeout.
+            let tainted = match mgr.taint_slot_for(&CtlResource::key(), scope, "db", id) {
+                Ok(t) => t,
+                Err(e) => {
+                    // guard-justified: the row was just registered+warmed by
+                    // `setup`, so phase-1 resolution cannot fail here; a
+                    // failure is a broken-test invariant, not a runtime path.
+                    unreachable!("taint_slot_for must resolve the freshly bound row: {e}")
+                },
+            };
+
+            // Phase 2 constructed, polled until it parks in the per-resource
+            // drain (the held guard keeps the counter > 0), then explicitly
+            // DROPPED while still pending — models the fan-out's
+            // `tokio::time::timeout` elapsing and dropping the wrapped future.
+            {
+                let mut fut = Box::pin(mgr.drain_and_revoke(tainted));
+                let parked = tokio::time::timeout(Duration::from_millis(150), &mut fut).await;
+                assert!(
+                    parked.is_err(),
+                    "drain_and_revoke must still be parked in the per-resource \
+                     drain while the in-flight guard is held",
+                );
+                drop(fut);
+            }
+            assert_eq!(
+                ledger.revoke_entered.load(Ordering::SeqCst),
+                0,
+                "the dropped (never-completed) drain future must not have run \
+                 the revoke hook",
+            );
+
+            // Invariant: taint survived the dropped tail (it ran in phase 1).
+            // Drop the in-flight guard first so this fresh acquire is gated
+            // only by the taint, not by the still-held lease.
+            drop(in_flight);
+            let ctx = ctx_for(org);
+            let acquired = mgr
+                .acquire_resident_for::<CtlResource>(&ctx, &AcquireOptions::default(), id)
+                .await;
+            let err = match acquired {
+                Err(e) => e,
+                Ok(_) => {
+                    // guard-justified: a guard after a dropped drain future
+                    // means phase-1 taint did not stick — the exact #681
+                    // cancellation hole; fail loudly, no salvage.
+                    unreachable!(
+                        "no acquire may succeed after a dropped drain future — \
+                         the synchronous phase-1 taint already revoked the row (#681)"
+                    )
+                },
+            };
+            assert_eq!(
+                err.category(),
+                ErrorCategory::Unavailable,
+                "dropped-tail acquire must still hit the Revoked/Unavailable taint, got: {err}",
+            );
+        }
+
         /// All-OK fast path: every bound row refreshes, no failures/timeouts.
         #[tokio::test]
         async fn refresh_fanout_all_ok() {
             let ids = [10_u64, 20, 30];
-            let (idx, mgr, cid, _scope, ledger) = setup(&ids).await;
+            let (idx, mgr, cid, _scope, _org, ledger) = setup(&ids).await;
             for id in ids {
                 ledger.set(id, Behaviour::FastOk);
             }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -162,6 +162,27 @@ pub struct WorkflowEngine {
     ///
     /// [`plugin_registry`]: Self::plugin_registry
     resource_registrars: ResourceRegistrarRegistry,
+    /// Engine-owned reverse index `CredentialId → resolved resource rows`
+    /// for the per-slot rotation fan-out (ADR-0067 §D1).
+    ///
+    /// Always constructed (an empty index is a no-op fan-out), held here
+    /// next to [`resource_registrars`] and the
+    /// [`resource_manager`](Self::resource_manager) it is driven against
+    /// because the three are the resource-rotation triad: the registrar
+    /// path [`bind`](nebula_credential_rotation_index_bind)s a row when a
+    /// credential resolves into a `#[credential]` slot, and the
+    /// [`ResourceFanoutDriver`](crate::credential::rotation::ResourceFanoutDriver)
+    /// drains it on a rotation/revoke event into the `Manager` slot ports.
+    /// No `nebula-resource → nebula-engine` edge: the index lives in
+    /// `nebula-engine` and the rotation signal arrives via
+    /// `nebula-eventbus` (ADR-0067 §D1; AGENTS.md).
+    ///
+    /// Feature-gated with the index itself (`rotation`).
+    ///
+    /// [`resource_registrars`]: Self::resource_registrars
+    /// [`nebula_credential_rotation_index_bind`]: crate::credential::rotation::ResourceFanoutIndex::bind
+    #[cfg(feature = "rotation")]
+    resource_fanout_index: Arc<crate::credential::rotation::ResourceFanoutIndex>,
     /// Resolves node parameters (expressions, templates, references) to JSON.
     resolver: ParamResolver,
     /// Optional resource manager for providing resources to actions.
@@ -320,6 +341,8 @@ impl WorkflowEngine {
             workflow_execution_duration_seconds,
             plugin_registry: PluginRegistry::new(),
             resource_registrars: ResourceRegistrarRegistry::new(),
+            #[cfg(feature = "rotation")]
+            resource_fanout_index: Arc::new(crate::credential::rotation::ResourceFanoutIndex::new()),
             resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
             execution_repo: None,
@@ -425,6 +448,66 @@ impl WorkflowEngine {
     #[must_use]
     pub fn resource_registrars(&self) -> &ResourceRegistrarRegistry {
         &self.resource_registrars
+    }
+
+    /// The engine-owned per-slot rotation reverse index (ADR-0067 §D1).
+    ///
+    /// This is the [`bind`](crate::credential::rotation::ResourceFanoutIndex::bind)
+    /// producer for the §M11.5 fan-out: the resource-activation path
+    /// (`ResourceRegistrarRegistry::register` →
+    /// `Manager::register_from_value`, which resolves a credential into a
+    /// `#[credential]` slot) records a row here so a later rotation /
+    /// revoke fans to exactly that resolved row. It is also the index the
+    /// [`spawn_resource_rotation_fanout`](Self::spawn_resource_rotation_fanout)
+    /// driver drains. Empty until a row binds — an empty index is a
+    /// no-op fan-out, never an error.
+    #[cfg(feature = "rotation")]
+    #[must_use]
+    pub fn resource_fanout_index(&self) -> &Arc<crate::credential::rotation::ResourceFanoutIndex> {
+        &self.resource_fanout_index
+    }
+
+    /// Spawn the production rotation fan-out driver wiring the engine's
+    /// [`resource_fanout_index`](Self::resource_fanout_index) +
+    /// [`resource_manager`](Self::with_resource_manager) to the
+    /// credential-rotation / lease-revoke event streams the
+    /// credential-runtime composition root publishes.
+    ///
+    /// `credential_bus` / `lease_bus` are the buses
+    /// `EventMetricObserver::{event_bus, lease_bus}`
+    /// (`nebula-credential-runtime`, ADR-0066) emits on after a refresh
+    /// CAS-persists fresh material or a lease is revoked. This closes the
+    /// ADR-0067 §Deferred "Rotation fan-out is implemented but unwired"
+    /// gap: a `CredentialEvent::Refreshed` drives
+    /// `ResourceFanoutIndex::dispatch_refresh`, and
+    /// `CredentialEvent::Revoked` / `LeaseEvent::LeaseRevoked` drive
+    /// `dispatch_revoke`, for every resolved resource row that bound the
+    /// credential.
+    ///
+    /// Returns a [`ResourceFanoutDriver`](crate::credential::rotation::ResourceFanoutDriver)
+    /// handle; **hold it** for as long as fan-out should run — dropping
+    /// it aborts the driver task. Returns `None` (a no-op — there is
+    /// nothing to fan rotations *to*) when no resource manager was wired
+    /// via [`with_resource_manager`](Self::with_resource_manager).
+    ///
+    /// No `nebula-resource → nebula-engine` edge: the index lives in
+    /// `nebula-engine` and the rotation signal arrives via
+    /// `nebula-eventbus` (ADR-0067 §D1; AGENTS.md cross-crate signal
+    /// rule).
+    #[cfg(feature = "rotation")]
+    #[must_use = "the returned driver handle must be held; dropping it aborts the fan-out"]
+    pub fn spawn_resource_rotation_fanout(
+        &self,
+        credential_bus: Arc<nebula_eventbus::EventBus<nebula_credential::CredentialEvent>>,
+        lease_bus: Option<Arc<nebula_eventbus::EventBus<nebula_credential::LeaseEvent>>>,
+    ) -> Option<crate::credential::rotation::ResourceFanoutDriver> {
+        let manager = Arc::clone(self.resource_manager.as_ref()?);
+        Some(crate::credential::rotation::ResourceFanoutDriver::spawn(
+            Arc::clone(&self.resource_fanout_index),
+            manager,
+            credential_bus,
+            lease_bus,
+        ))
     }
 
     /// Attach a resource manager for providing resources to actions.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -183,6 +183,22 @@ pub struct WorkflowEngine {
     /// [`nebula_credential_rotation_index_bind`]: crate::credential::rotation::ResourceFanoutIndex::bind
     #[cfg(feature = "rotation")]
     resource_fanout_index: Arc<crate::credential::rotation::ResourceFanoutIndex>,
+    /// Single-shot guard for
+    /// [`spawn_resource_rotation_fanout`](Self::spawn_resource_rotation_fanout).
+    ///
+    /// The driver subscribes the credential/lease buses; spawning it
+    /// twice would subscribe twice and **double-dispatch every
+    /// refresh/revoke** to the resource fan-out (non-idempotent hooks
+    /// fire 2×, `RotationOutcome` metrics inflated). The composition root
+    /// owns the single spawn, but a defensive structural guard (not a
+    /// "remember to call it once" convention) makes a second call a
+    /// no-op `None` rather than a silent double-subscribe. An
+    /// `AtomicBool` (flipped via `compare_exchange`) so the `&self`
+    /// method is single-shot even under a concurrent double-call.
+    ///
+    /// Feature-gated with the index itself (`rotation`).
+    #[cfg(feature = "rotation")]
+    resource_fanout_spawned: std::sync::atomic::AtomicBool,
     /// Resolves node parameters (expressions, templates, references) to JSON.
     resolver: ParamResolver,
     /// Optional resource manager for providing resources to actions.
@@ -343,6 +359,8 @@ impl WorkflowEngine {
             resource_registrars: ResourceRegistrarRegistry::new(),
             #[cfg(feature = "rotation")]
             resource_fanout_index: Arc::new(crate::credential::rotation::ResourceFanoutIndex::new()),
+            #[cfg(feature = "rotation")]
+            resource_fanout_spawned: std::sync::atomic::AtomicBool::new(false),
             resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
             execution_repo: None,
@@ -486,9 +504,24 @@ impl WorkflowEngine {
     ///
     /// Returns a [`ResourceFanoutDriver`](crate::credential::rotation::ResourceFanoutDriver)
     /// handle; **hold it** for as long as fan-out should run — dropping
-    /// it aborts the driver task. Returns `None` (a no-op — there is
-    /// nothing to fan rotations *to*) when no resource manager was wired
-    /// via [`with_resource_manager`](Self::with_resource_manager).
+    /// it aborts the driver task.
+    ///
+    /// Returns `None` (spawning nothing) when either:
+    ///
+    /// - no resource manager was wired via
+    ///   [`with_resource_manager`](Self::with_resource_manager) (there is
+    ///   nothing to fan rotations *to*); or
+    /// - the driver was **already spawned** by a prior call. This method
+    ///   is **single-shot / idempotent**: each spawn subscribes the
+    ///   credential + lease buses, so spawning twice would subscribe
+    ///   twice and double-dispatch every refresh/revoke to the resource
+    ///   fan-out. The first call that has a manager spawns and returns
+    ///   `Some(driver)`; every later call is a no-op `None` and does
+    ///   **not** subscribe again (the guard is claimed atomically, so a
+    ///   concurrent double-call still yields exactly one driver). A
+    ///   no-manager call spawns nothing and does **not** consume the
+    ///   single-shot — a later call once a manager is wired can still
+    ///   spawn.
     ///
     /// No `nebula-resource → nebula-engine` edge: the index lives in
     /// `nebula-engine` and the rotation signal arrives via
@@ -501,7 +534,30 @@ impl WorkflowEngine {
         credential_bus: Arc<nebula_eventbus::EventBus<nebula_credential::CredentialEvent>>,
         lease_bus: Option<Arc<nebula_eventbus::EventBus<nebula_credential::LeaseEvent>>>,
     ) -> Option<crate::credential::rotation::ResourceFanoutDriver> {
+        use std::sync::atomic::Ordering;
+
+        // Only a deployment with a resource manager has anything to fan
+        // rotations to. Resolve it *before* claiming the single-shot so a
+        // no-manager call does not burn the guard.
         let manager = Arc::clone(self.resource_manager.as_ref()?);
+
+        // Single-shot: claim the guard atomically. If it was already set,
+        // the driver is already running on its own subscriber pair —
+        // spawning again would double-subscribe and double-dispatch every
+        // event, so return `None` and subscribe nothing.
+        if self
+            .resource_fanout_spawned
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            tracing::debug!(
+                target: "nebula_engine::credential::rotation",
+                "spawn_resource_rotation_fanout called again; fan-out driver \
+                 already running — no second subscriber spawned (idempotent)"
+            );
+            return None;
+        }
+
         Some(crate::credential::rotation::ResourceFanoutDriver::spawn(
             Arc::clone(&self.resource_fanout_index),
             manager,

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -186,6 +186,29 @@ pub struct RegisterRequest<'a> {
     /// asserted against the resource's declared slots inside the typed
     /// call.
     pub slot_bindings: HashMap<String, nebula_core::CredentialKey>,
+    /// Slot-name → resolved `CredentialId` for the rotation fan-out
+    /// reverse index (ADR-0067 §D1).
+    ///
+    /// `slot_bindings` carries the `CredentialKey` (the credential
+    /// *name*, what `Manager::register_from_value` hashes into the
+    /// structural `slot_identity`); the rotation fan-out index and the
+    /// rotation/lease-revoke events are keyed by `CredentialId` (the
+    /// resolved credential *record* — `CredentialEvent` /
+    /// `LeaseEvent`). Both are needed to bind a row: the `CredentialId`
+    /// is the index key, the `CredentialKey` recomputes the matching
+    /// `slot_identity`. **Only the caller that resolved the credential
+    /// knows both**, so it threads this map per slot it bound; an entry
+    /// is added to the reverse index for every `(slot_name,
+    /// CredentialId)` whose `slot_name` also appears in `slot_bindings`.
+    ///
+    /// Empty (the default via [`HashMap::new`]) when the caller resolved
+    /// no credential into a slot, or when no fan-out index is threaded
+    /// to [`ResourceRegistrarRegistry::register`] — registration then
+    /// proceeds exactly as before with no reverse-index row (a later
+    /// rotation for an unbound credential is a correct no-op fan-out).
+    /// Never fabricated: a slot whose `CredentialId` the caller does not
+    /// have is simply absent here rather than bound under a guessed id.
+    pub credential_ids: HashMap<String, nebula_credential::CredentialId>,
     /// Registration scope.
     pub scope: ScopeLevel,
     /// Optional acquire-time resilience policy.
@@ -219,6 +242,18 @@ pub trait ErasedResourceRegistrar: Send + Sync {
         manager: &'a Manager,
         request: RegisterRequest<'a>,
     ) -> BoxFut<'a, Result<(), nebula_resource::Error>>;
+
+    /// The static, type-level [`ResourceKey`](nebula_core::ResourceKey)
+    /// (`R::key()`) of the concrete resource this registrar registers.
+    ///
+    /// The erased boundary hides `R`, but the rotation reverse index
+    /// ([`ResourceFanoutIndex`](crate::credential::rotation::ResourceFanoutIndex))
+    /// keys a bound row by `(ResourceKey, ScopeLevel, slot_identity)`.
+    /// Without `R` the registry cannot name the row it just registered,
+    /// so the erased registrar exposes the key explicitly (the same
+    /// `R::key()` `register_from_value` registers the row under). Cheap,
+    /// pure, and type-stable — it is a `const`-ish accessor, not I/O.
+    fn resource_key(&self) -> nebula_core::ResourceKey;
 
     /// Validate `config_json` against this kind's `R::Config` schema
     /// **without registering anything**.
@@ -318,6 +353,10 @@ where
         })
     }
 
+    fn resource_key(&self) -> nebula_core::ResourceKey {
+        <R as Resource>::key()
+    }
+
     fn validate(&self, config_json: serde_json::Value) -> Result<(), nebula_resource::Error> {
         // No `resource_factory` / `topology_factory` are invoked: validation
         // is purely a function of the config JSON and the monomorphized
@@ -388,6 +427,10 @@ impl ResourceRegistrarRegistry {
     /// Resolves `kind` through the closed allowlist and dispatches into
     /// its typed registrar.
     ///
+    /// Equivalent to [`register_and_bind`](Self::register_and_bind) with
+    /// no rotation fan-out index — registration only, no reverse-index
+    /// row recorded.
+    ///
     /// # Errors
     ///
     /// - [`RegistrarError::UnknownKind`] if `kind` is not in the
@@ -416,6 +459,113 @@ impl ResourceRegistrarRegistry {
                 kind: kind.to_owned(),
                 source,
             })
+    }
+
+    /// Resolves `kind` through the closed allowlist, dispatches into its
+    /// typed registrar, and — on success — records the resolved row in
+    /// the rotation fan-out reverse index (ADR-0067 §D1).
+    ///
+    /// This is the §M11.5 `bind` seam: the registered row resolved one
+    /// or more `#[credential]` slots, so a later rotation / lease-revoke
+    /// of any of those credentials must fan out to *this exact resolved
+    /// row*. The structural row identity
+    /// (`slot_identity`) is recomputed here **verbatim** the way
+    /// `Manager::register_from_value` computes it
+    /// ([`nebula_resource::slot_identity`] over the `(slot_key,
+    /// CredentialKey)` pairs in `request.slot_bindings`), so the index
+    /// addresses the same registry row the manager just created. For
+    /// every `(slot_name, CredentialId)` in `request.credential_ids`
+    /// whose `slot_name` also appears in `slot_bindings`, one
+    /// [`ResourceFanoutIndex::bind`](crate::credential::rotation::ResourceFanoutIndex::bind)
+    /// is recorded. `bind` is idempotent, so a re-registration of the
+    /// same resolved row does not duplicate the entry.
+    ///
+    /// Binding happens **only after `register` returns `Ok`**: a
+    /// registration that failed schema / deserialize / slot validation
+    /// created no registry row, so no reverse-index row may exist for it
+    /// either (no orphan binds, no bogus future `failed` fan-out rows).
+    /// `fanout_index = None` (or an empty `credential_ids`) skips the
+    /// bind entirely — registration is unchanged.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`register`](Self::register): the bind step runs only on
+    /// the `Ok` path and cannot itself fail (it is an in-memory index
+    /// insert), so it does not add an error variant.
+    ///
+    /// Feature-gated with the reverse index itself (`rotation`): the
+    /// `ResourceFanoutIndex` type only exists under that feature, so the
+    /// bind seam follows it. A non-`rotation` build registers via
+    /// [`register`](Self::register) (no reverse-index row — there is no
+    /// fan-out to feed).
+    #[cfg(feature = "rotation")]
+    pub async fn register_and_bind(
+        &self,
+        kind: &str,
+        manager: &Manager,
+        request: RegisterRequest<'_>,
+        fanout_index: Option<&crate::credential::rotation::ResourceFanoutIndex>,
+    ) -> Result<(), RegistrarError> {
+        let registrar = self
+            .registrars
+            .get(kind)
+            .ok_or_else(|| RegistrarError::UnknownKind(kind.to_owned()))?;
+
+        // Snapshot the bind inputs before `request` is moved into the
+        // typed `register` call. Cheap clones (a small slot map + scope);
+        // the resource key comes from the erased registrar so the
+        // reverse index addresses the same `(key, scope, slot_identity)`
+        // row `register_from_value` registers under.
+        let bind_plan = fanout_index.map(|idx| {
+            (
+                idx,
+                registrar.resource_key(),
+                request.scope.clone(),
+                request.slot_bindings.clone(),
+                request.credential_ids.clone(),
+            )
+        });
+
+        registrar
+            .register(manager, request)
+            .await
+            .map_err(|source| RegistrarError::Register {
+                kind: kind.to_owned(),
+                source,
+            })?;
+
+        // Registration succeeded — the registry row exists. Record the
+        // reverse-index binding so a later rotation / lease-revoke fans
+        // to this exact resolved row.
+        if let Some((idx, resource_key, scope, slot_bindings, credential_ids)) = bind_plan {
+            // Recompute the structural slot identity EXACTLY as
+            // `Manager::register_from_value` does (a stable hash over the
+            // `(slot_key, CredentialKey)` pairs) so the reverse-index row
+            // and the manager registry row share one identity. Mismatch
+            // here would route a rotation to a non-existent row
+            // (`Ambiguous` / silent miss).
+            let slot_identity = nebula_resource::slot_identity(
+                slot_bindings
+                    .iter()
+                    .map(|(slot, key)| (slot.as_str(), key.as_str())),
+            );
+            for (slot_name, cred_id) in &credential_ids {
+                // Only bind slots the resource actually declared (those
+                // present in `slot_bindings`): a stray `credential_ids`
+                // entry for an unbound slot must not create a phantom
+                // reverse-index row.
+                if slot_bindings.contains_key(slot_name) {
+                    idx.bind(
+                        *cred_id,
+                        resource_key.clone(),
+                        scope.clone(),
+                        slot_name.clone(),
+                        slot_identity,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Resolves `kind` through the closed allowlist and validates
@@ -592,6 +742,7 @@ mod tests {
             config_json: serde_json::json!({ "name": "from-registry" }),
             expr_engine,
             slot_bindings: HashMap::new(),
+            credential_ids: HashMap::new(),
             scope: ScopeLevel::Global,
             resilience: None,
             recovery_gate: None,

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -488,6 +488,33 @@ impl ResourceRegistrarRegistry {
     /// `fanout_index = None` (or an empty `credential_ids`) skips the
     /// bind entirely — registration is unchanged.
     ///
+    /// # Ordering contract — caller must quiesce fan-out during activation
+    ///
+    /// `register(...).await` makes the `Manager` row **discoverable**
+    /// before this method records the reverse-index bind. Those two
+    /// steps are deliberately **not** atomic (atomicity would require a
+    /// transactional `Manager::register_from_value` "register-then-
+    /// publish" surface — a heavy Manager API change with no production
+    /// consumer yet). There is therefore a window in which the Manager
+    /// row exists but the reverse-index row does not: a credential
+    /// rotation / lease-revoke for this row that the fan-out driver
+    /// processes *inside that window* would fan to zero rows (a silent
+    /// miss for this row) even though the row is live.
+    ///
+    /// **The caller MUST ensure the rotation fan-out is quiescent for
+    /// the credentials being bound while it activates a row through this
+    /// seam** (e.g. activate before the driver is spawned, or serialise
+    /// activation against rotation for the affected credentials). This
+    /// is a documented contract, not an enforced invariant, because the
+    /// seam has **no production caller today**: *bind-population* (the
+    /// production credential→slot resolution that would call this) is the
+    /// deferred resource-activation path (ADR-0067 §Deferred — *bind-
+    /// population producer*). The driver cannot observe a row that
+    /// nothing activated, so the window is not reachable in production
+    /// until that deferred producer lands; when it does, it must honour
+    /// this contract (or the seam must first gain a transactional
+    /// register+bind surface).
+    ///
     /// # Errors
     ///
     /// Same as [`register`](Self::register): the bind step runs only on

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -247,7 +247,8 @@ pub trait ErasedResourceRegistrar: Send + Sync {
     /// (`R::key()`) of the concrete resource this registrar registers.
     ///
     /// The erased boundary hides `R`, but the rotation reverse index
-    /// ([`ResourceFanoutIndex`](crate::credential::rotation::ResourceFanoutIndex))
+    /// (`ResourceFanoutIndex`, the `rotation`-feature-gated reverse
+    /// index in `crate::credential::rotation`)
     /// keys a bound row by `(ResourceKey, ScopeLevel, slot_identity)`.
     /// Without `R` the registry cannot name the row it just registered,
     /// so the erased registrar exposes the key explicitly (the same
@@ -427,9 +428,9 @@ impl ResourceRegistrarRegistry {
     /// Resolves `kind` through the closed allowlist and dispatches into
     /// its typed registrar.
     ///
-    /// Equivalent to [`register_and_bind`](Self::register_and_bind) with
-    /// no rotation fan-out index — registration only, no reverse-index
-    /// row recorded.
+    /// Equivalent to `register_and_bind` (the `rotation`-feature-gated
+    /// variant) with no rotation fan-out index — registration only, no
+    /// reverse-index row recorded.
     ///
     /// # Errors
     ///

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -336,6 +336,7 @@ async fn wired_registrar_performs_typed_registration() {
                 config_json: serde_json::json!({ "label": "wired" }),
                 expr_engine: &expr,
                 slot_bindings: HashMap::new(),
+                credential_ids: HashMap::new(),
                 scope: ScopeLevel::Global,
                 resilience: None,
                 recovery_gate: None,

--- a/crates/engine/tests/resource_rotation_fanout_wiring.rs
+++ b/crates/engine/tests/resource_rotation_fanout_wiring.rs
@@ -28,8 +28,13 @@ use std::time::Duration;
 
 use nebula_core::{OrgId, ResourceKey, ScopeLevel, resource_key, scope::Scope};
 use nebula_credential::{CredentialEvent, CredentialId, LeaseEvent};
-use nebula_engine::credential::rotation::{ResourceFanoutDriver, ResourceFanoutIndex};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessSandbox,
+    WorkflowEngine,
+    credential::rotation::{ResourceFanoutDriver, ResourceFanoutIndex},
+};
 use nebula_eventbus::EventBus;
+use nebula_metrics::MetricsRegistry;
 use nebula_resource::{
     AcquireOptions, Manager, RegisterOptions, ResidentConfig, Resource, ResourceConfig,
     ResourceContext, error::Error as ResourceError, resource::ResourceMetadata,
@@ -456,5 +461,208 @@ async fn rotation_after_resource_removed_fans_to_zero_rows() {
         "after the resource was removed, a rotation must NOT deliver its \
          hook again (fans to a now-dead row, recorded failed — not a \
          second hook call)"
+    );
+}
+
+/// #690 review (P1, comment 3255603311 / 3255606374) — one logical
+/// credential revoke double-emits across the two buses
+/// (`LeaseEvent::LeaseRevoked` then the facade `CredentialEvent::Revoked`,
+/// back-to-back inside one `CredentialService::revoke`). The driver's
+/// per-credential dedupe window must collapse them so
+/// `on_credential_revoke` fans out **exactly once** per logical revoke
+/// (non-idempotent hooks must not double-fire).
+#[tokio::test]
+async fn duplicate_revoke_across_both_buses_fans_out_once() {
+    let w = wire(Behaviour::Ok).await;
+
+    // Lease bus first (the lease scheduler emits LeaseRevoked for the
+    // released lease) ...
+    w.lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: Some(w.cid),
+        lease_id: "lease-dup".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+    // ... then the facade emits CredentialEvent::Revoked for the SAME
+    // credential — the second surfacing of one logical revoke.
+    w.cred_bus.emit(CredentialEvent::Revoked {
+        credential_id: w.cid,
+    });
+
+    // The first revoke is delivered.
+    eventually("first revoke hook delivered", || {
+        w.rec.revoke.load(Ordering::SeqCst) == 1
+    })
+    .await;
+
+    // Drive a refresh afterwards and wait for it: the driver processes
+    // events in order on its single task, so once the refresh is
+    // observed the duplicate revoke (emitted before it) has definitely
+    // been processed too — and must have been skipped by the dedupe.
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+    eventually("post-duplicate refresh delivered", || {
+        w.rec.refresh.load(Ordering::SeqCst) == 1
+    })
+    .await;
+    assert_eq!(
+        w.rec.revoke.load(Ordering::SeqCst),
+        1,
+        "the lease-bus + credential-bus double-emission of ONE logical \
+         revoke must fan out the revoke hook exactly once (deduped)"
+    );
+}
+
+/// #690 review (CodeRabbit nitpick, fix J) — a `LeaseRevoked` carrying a
+/// `credential_id` that was **never bound** (a real credential id, but no
+/// reverse-index row for it) exercises the "lookup succeeds, zero binds"
+/// branch — distinct from the "no credential id" orphan branch
+/// ([`orphan_lease_revoked_is_noop`]). Processing must continue and the
+/// revoke hook count must stay 0 (nothing bound that credential).
+#[tokio::test]
+async fn lease_revoked_for_never_bound_credential_is_zero_binds_noop() {
+    let w = wire(Behaviour::Ok).await;
+
+    // A real, attributed credential id — but one that no resource row
+    // ever bound (distinct from `w.cid`, which is the bound one). The
+    // reverse-index lookup succeeds yet yields zero rows.
+    let never_bound = CredentialId::new();
+    assert_ne!(never_bound, w.cid, "must be a different credential id");
+    w.lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: Some(never_bound),
+        lease_id: "lease-unbound".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+
+    // Prove the driver is still alive and processing after the
+    // zero-binds revoke: a real refresh for the BOUND credential is
+    // still delivered.
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+    eventually("post-zero-binds refresh delivered", || {
+        w.rec.refresh.load(Ordering::SeqCst) == 1
+    })
+    .await;
+    assert_eq!(
+        w.rec.revoke.load(Ordering::SeqCst),
+        0,
+        "a LeaseRevoked for a never-bound credential must fan to zero rows \
+         — no revoke hook delivered (lookup-succeeds-zero-binds branch)"
+    );
+}
+
+// ── Fix D: idempotent engine driver spawn ───────────────────────────
+
+/// No-op action executor — the engine under test never dispatches a
+/// workflow; it only exercises `spawn_resource_rotation_fanout`.
+fn noop_engine_with_manager(manager: Arc<Manager>) -> WorkflowEngine {
+    let registry = Arc::new(ActionRegistry::new());
+    let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+        Box::pin(async move { Ok(nebula_action::result::ActionResult::success(input)) })
+    });
+    let sandbox = Arc::new(InProcessSandbox::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .expect("ActionRuntime::try_new"),
+    );
+    WorkflowEngine::new(runtime, metrics)
+        .expect("WorkflowEngine::new")
+        .with_resource_manager(manager)
+}
+
+/// #690 review (Major, comment 3255607651) —
+/// `WorkflowEngine::spawn_resource_rotation_fanout` must be **single-shot**:
+/// a second call must NOT spawn a second subscriber pair (which would
+/// double-dispatch every refresh/revoke). The second call returns `None`,
+/// and a single emitted refresh is delivered to the bound resource hook
+/// **exactly once** (a second subscriber would deliver it twice).
+#[tokio::test]
+async fn engine_spawn_resource_rotation_fanout_is_idempotent() {
+    let rec = Recorder::default();
+    let org = OrgId::new();
+    let scope = ScopeLevel::Organization(org);
+    let mgr = Arc::new(Manager::new());
+    let cid = CredentialId::new();
+    let slot_identity: u64 = 0xD1D1_D1D1;
+
+    mgr.register_resident_with(
+        Recording {
+            behaviour: Behaviour::Ok,
+            rec: rec.clone(),
+        },
+        NoCfg,
+        ResidentConfig::default(),
+        RegisterOptions::default()
+            .with_scope(scope.clone())
+            .with_slot_identity(slot_identity),
+    )
+    .expect("register resolved-credential row");
+
+    let ctx = ResourceContext::minimal(
+        Scope {
+            org_id: Some(org),
+            ..Default::default()
+        },
+        CancellationToken::new(),
+    );
+    let _g = mgr
+        .acquire_resident_for::<Recording>(&ctx, &AcquireOptions::default(), slot_identity)
+        .await
+        .expect("warm resident runtime");
+    drop(_g);
+
+    let engine = noop_engine_with_manager(Arc::clone(&mgr));
+    // Bind the resolved row into the engine-owned reverse index so a
+    // rotation has a row to fan to.
+    engine
+        .resource_fanout_index()
+        .bind(cid, Recording::key(), scope.clone(), "db", slot_identity);
+
+    let cred_bus = Arc::new(EventBus::<CredentialEvent>::new(16));
+    let lease_bus = Arc::new(EventBus::<LeaseEvent>::new(16));
+
+    // First spawn: succeeds.
+    let _driver = engine
+        .spawn_resource_rotation_fanout(Arc::clone(&cred_bus), Some(Arc::clone(&lease_bus)))
+        .expect("first spawn must return a driver");
+
+    // Second spawn: idempotent — must NOT spawn a second subscriber.
+    let second =
+        engine.spawn_resource_rotation_fanout(Arc::clone(&cred_bus), Some(Arc::clone(&lease_bus)));
+    assert!(
+        second.is_none(),
+        "a second spawn_resource_rotation_fanout must return None (driver \
+         already running) — no second subscriber"
+    );
+
+    // One refresh emitted. With a single subscriber the bound resource
+    // hook fires exactly once; a leaked second subscriber would fire it
+    // twice.
+    cred_bus.emit(CredentialEvent::Refreshed { credential_id: cid });
+
+    // Wait for the hook, then drain extra scheduler turns and assert the
+    // count never exceeds 1 (the double-subscribe regression).
+    for _ in 0..2000 {
+        if rec.refresh.load(Ordering::SeqCst) >= 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    for _ in 0..200 {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        rec.refresh.load(Ordering::SeqCst),
+        1,
+        "exactly one refresh-hook delivery — a second spawn must not have \
+         created a second subscriber that double-dispatches"
     );
 }

--- a/crates/engine/tests/resource_rotation_fanout_wiring.rs
+++ b/crates/engine/tests/resource_rotation_fanout_wiring.rs
@@ -1,0 +1,460 @@
+#![cfg(feature = "rotation")]
+
+//! End-to-end: the production rotation fan-out **wiring** (ADR-0067
+//! §Deferred "Rotation fan-out is implemented but unwired"; closes #679 /
+//! #680 / #681 prerequisites).
+//!
+//! Unlike `rotation_resource_fanout.rs` (which calls
+//! `ResourceFanoutIndex::dispatch_*` directly), this exercises the REAL
+//! engine path: a [`ResourceFanoutDriver`] spawned over real
+//! `nebula-eventbus` buses, driven by **emitting the exact events the
+//! credential-runtime composition root emits in production**
+//! ([`CredentialEvent::Refreshed`] / [`CredentialEvent::Revoked`] on
+//! `EventBus<CredentialEvent>`, [`LeaseEvent::LeaseRevoked`] on
+//! `EventBus<LeaseEvent>` — the `EventMetricObserver` shape, ADR-0066).
+//! Nothing here calls `dispatch_refresh` / `dispatch_revoke` itself; the
+//! driver's bus subscription does, exactly as in production.
+//!
+//! Wired path under test:
+//! `EventBus → ResourceFanoutDriver subscriber → ResourceFanoutIndex
+//!  ::dispatch_{refresh,revoke} → Manager::{refresh_slot_for,
+//!  taint_slot_for + drain_and_revoke} → resource on_credential_* hook`.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+
+use nebula_core::{OrgId, ResourceKey, ScopeLevel, resource_key, scope::Scope};
+use nebula_credential::{CredentialEvent, CredentialId, LeaseEvent};
+use nebula_engine::credential::rotation::{ResourceFanoutDriver, ResourceFanoutIndex};
+use nebula_eventbus::EventBus;
+use nebula_resource::{
+    AcquireOptions, Manager, RegisterOptions, ResidentConfig, Resource, ResourceConfig,
+    ResourceContext, error::Error as ResourceError, resource::ResourceMetadata,
+    topology::resident::Resident,
+};
+use tokio_util::sync::CancellationToken;
+
+// ── Test resource recording every rotation/revoke hook delivery ──────
+
+#[derive(Debug)]
+struct HookError(&'static str);
+impl std::fmt::Display for HookError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+impl std::error::Error for HookError {}
+impl From<HookError> for ResourceError {
+    fn from(e: HookError) -> Self {
+        ResourceError::transient(e.0)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Behaviour {
+    /// Hook returns `Ok` immediately.
+    Ok,
+    /// Hook never completes — models a wedged resource so the
+    /// per-resource timeout must fire (`timed_out`) without ever
+    /// un-tainting the row (the #681 invariant, end-to-end).
+    Hang,
+}
+
+#[derive(Clone, Default)]
+struct Recorder {
+    refresh: Arc<AtomicUsize>,
+    revoke: Arc<AtomicUsize>,
+}
+
+#[derive(Clone)]
+struct Recording {
+    behaviour: Behaviour,
+    rec: Recorder,
+}
+
+impl Resource for Recording {
+    type Config = NoCfg;
+    type Runtime = ();
+    type Lease = ();
+    type Error = HookError;
+
+    fn key() -> ResourceKey {
+        resource_key!("fanout-wiring-rec")
+    }
+
+    async fn create(&self, _c: &NoCfg, _x: &ResourceContext) -> Result<(), HookError> {
+        Ok(())
+    }
+
+    async fn on_credential_refresh(&self, _s: &str, _r: &()) -> Result<(), HookError> {
+        self.rec.refresh.fetch_add(1, Ordering::SeqCst);
+        drive(self.behaviour).await
+    }
+
+    async fn on_credential_revoke(&self, _s: &str, _r: &()) -> Result<(), HookError> {
+        self.rec.revoke.fetch_add(1, Ordering::SeqCst);
+        drive(self.behaviour).await
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for Recording {
+    fn is_alive_sync(&self, _r: &()) -> bool {
+        true
+    }
+}
+
+async fn drive(b: Behaviour) -> Result<(), HookError> {
+    match b {
+        Behaviour::Ok => Ok(()),
+        Behaviour::Hang => {
+            std::future::pending::<()>().await;
+            // guard-justified: `std::future::pending()` never resolves,
+            // so this line is statically unreachable (the wedged arm).
+            unreachable!()
+        },
+    }
+}
+
+#[derive(Clone)]
+struct NoCfg;
+nebula_schema::impl_empty_has_schema!(NoCfg);
+impl ResourceConfig for NoCfg {
+    fn validate(&self) -> Result<(), ResourceError> {
+        Ok(())
+    }
+}
+
+// ── Harness ─────────────────────────────────────────────────────────
+
+/// Spin up a real `Manager` + bound resident row under one
+/// `(key, scope)` keyed by `slot_identity == cid.bits`, a real
+/// `EventBus<CredentialEvent>` + `EventBus<LeaseEvent>`, and the
+/// production [`ResourceFanoutDriver`] spawned over them. Returns the
+/// pieces a test drives the wired path with.
+struct Wired {
+    cred_bus: Arc<EventBus<CredentialEvent>>,
+    lease_bus: Arc<EventBus<LeaseEvent>>,
+    mgr: Arc<Manager>,
+    cid: CredentialId,
+    org: OrgId,
+    slot_identity: u64,
+    rec: Recorder,
+    // Held: dropping aborts the driver task.
+    _driver: ResourceFanoutDriver,
+}
+
+async fn wire(behaviour: Behaviour) -> Wired {
+    let rec = Recorder::default();
+    let org = OrgId::new();
+    let scope = ScopeLevel::Organization(org);
+    let mgr = Arc::new(Manager::new());
+    let index = Arc::new(ResourceFanoutIndex::new());
+    let cid = CredentialId::new();
+    // A stable non-zero slot identity for the single resolved row.
+    let slot_identity: u64 = 0xC0FF_EE01;
+
+    mgr.register_resident_with(
+        Recording {
+            behaviour,
+            rec: rec.clone(),
+        },
+        NoCfg,
+        ResidentConfig::default(),
+        RegisterOptions::default()
+            .with_scope(scope.clone())
+            .with_slot_identity(slot_identity),
+    )
+    .expect("register resolved-credential row");
+
+    // Resident materializes its shared runtime lazily on first acquire —
+    // warm it so the rotation/revoke hook has a live `&Runtime`.
+    let ctx = ResourceContext::minimal(
+        Scope {
+            org_id: Some(org),
+            ..Default::default()
+        },
+        CancellationToken::new(),
+    );
+    let _g = mgr
+        .acquire_resident_for::<Recording>(&ctx, &AcquireOptions::default(), slot_identity)
+        .await
+        .expect("warm resident runtime");
+    drop(_g);
+
+    // The bind seam: this is what the resource-activation path records
+    // when a credential resolves into a `#[credential]` slot. We bind
+    // directly here (the production registrar bind path is covered by
+    // the registrar unit tests) so this test isolates the *driver*
+    // wiring: bus event → driver → fan-out → hook.
+    index.bind(cid, Recording::key(), scope.clone(), "db", slot_identity);
+
+    let cred_bus = Arc::new(EventBus::<CredentialEvent>::new(16));
+    let lease_bus = Arc::new(EventBus::<LeaseEvent>::new(16));
+    let driver = ResourceFanoutDriver::spawn(
+        Arc::clone(&index),
+        Arc::clone(&mgr),
+        Arc::clone(&cred_bus),
+        Some(Arc::clone(&lease_bus)),
+    );
+
+    Wired {
+        cred_bus,
+        lease_bus,
+        mgr,
+        cid,
+        org,
+        slot_identity,
+        rec,
+        _driver: driver,
+    }
+}
+
+/// Poll `cond` up to ~2s (yielding) — the driver runs on its own task,
+/// so a bus emission is observed asynchronously. Fails loudly on
+/// timeout rather than hanging the runner.
+async fn eventually(label: &str, mut cond: impl FnMut() -> bool) {
+    for _ in 0..2000 {
+        if cond() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    panic!("condition `{label}` not reached within ~2s — driver wiring did not fire");
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+/// A `CredentialEvent::Refreshed` on the credential bus (exactly what
+/// `EventMetricObserver::on_refresh` emits after a refresh CAS-persists
+/// fresh material) must drive `dispatch_refresh` through the spawned
+/// driver and deliver `on_credential_refresh` to the bound resource.
+#[tokio::test]
+async fn refreshed_event_drives_fanout_to_resource_hook() {
+    let w = wire(Behaviour::Ok).await;
+
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+
+    eventually("refresh hook delivered", || {
+        w.rec.refresh.load(Ordering::SeqCst) == 1
+    })
+    .await;
+    assert_eq!(
+        w.rec.revoke.load(Ordering::SeqCst),
+        0,
+        "a Refreshed event must not drive the revoke hook"
+    );
+}
+
+/// A `CredentialEvent::Revoked` (the facade-level revoke signal)
+/// must drive `dispatch_revoke` → taint → drain → `on_credential_revoke`.
+#[tokio::test]
+async fn credential_revoked_event_drives_revoke_fanout() {
+    let w = wire(Behaviour::Ok).await;
+
+    w.cred_bus.emit(CredentialEvent::Revoked {
+        credential_id: w.cid,
+    });
+
+    eventually("revoke hook delivered", || {
+        w.rec.revoke.load(Ordering::SeqCst) == 1
+    })
+    .await;
+}
+
+/// A `LeaseEvent::LeaseRevoked` carrying an attributed `credential_id`
+/// (what the lease scheduler emits via `EventBus<LeaseEvent>` after
+/// `LeaseLifecycle::revoke_for_credential`) must drive the revoke
+/// fan-out: the row is tainted (a subsequent acquire on that exact
+/// resolved row is rejected) and `on_credential_revoke` is delivered —
+/// the ADR-0051 → ADR-0067 path end-to-end.
+#[tokio::test]
+async fn lease_revoked_event_taints_row_and_delivers_revoke_hook() {
+    use nebula_error::{Classify, ErrorCategory};
+
+    let w = wire(Behaviour::Ok).await;
+
+    w.lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: Some(w.cid),
+        lease_id: "lease-xyz".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+
+    eventually("revoke hook delivered via lease bus", || {
+        w.rec.revoke.load(Ordering::SeqCst) == 1
+    })
+    .await;
+
+    // The decisive cross-ADR assertion: the revoke fan-out tainted the
+    // resolved row, so a fresh acquire on it is now rejected.
+    let ctx = ResourceContext::minimal(
+        Scope {
+            org_id: Some(w.org),
+            ..Default::default()
+        },
+        CancellationToken::new(),
+    );
+    let acquired = w
+        .mgr
+        .acquire_resident_for::<Recording>(&ctx, &AcquireOptions::default(), w.slot_identity)
+        .await;
+    let err = match acquired {
+        Err(e) => e,
+        Ok(_) => unreachable!(
+            // guard-justified: a live guard here means the lease-revoke
+            // fan-out did not taint the row — the exact wiring
+            // regression this test exists to catch; fail loudly.
+            "acquire after a LeaseRevoked-driven revoke must be rejected (row tainted)"
+        ),
+    };
+    assert_eq!(
+        err.category(),
+        ErrorCategory::Unavailable,
+        "post-revoke acquire must be the Revoked/Unavailable taint rejection, got: {err}"
+    );
+}
+
+/// #681 end-to-end through the wired path: a `LeaseRevoked` whose
+/// resource revoke hook **hangs** must record `timed_out` inside the
+/// fan-out yet still leave the row tainted (the synchronous
+/// `taint_slot_for` ran outside the per-resource timeout). Proven via
+/// the wired driver, not a direct `dispatch_revoke`.
+#[tokio::test]
+async fn lease_revoked_with_hung_hook_still_taints_row() {
+    use nebula_error::{Classify, ErrorCategory};
+
+    let w = wire(Behaviour::Hang).await;
+
+    w.lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: Some(w.cid),
+        lease_id: "lease-hang".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+
+    // The hung hook is entered (phase 2 reached it) — proof the revoke
+    // fan-out ran through the wired driver even though it will time out.
+    eventually("hung revoke hook entered", || {
+        w.rec.revoke.load(Ordering::SeqCst) == 1
+    })
+    .await;
+
+    // Even while the drain tail is still timing out, the synchronous
+    // phase-1 taint already revoked the row: a fresh acquire is
+    // rejected. The hook having been entered above proves phase 2
+    // started, which means phase 1 (the synchronous taint) already
+    // completed — so the row is tainted *now*. One acquire attempt,
+    // bounded so a wiring regression (taint not applied ⇒ the resident
+    // acquire would otherwise succeed) fails loudly instead of hanging.
+    let ctx = ResourceContext::minimal(
+        Scope {
+            org_id: Some(w.org),
+            ..Default::default()
+        },
+        CancellationToken::new(),
+    );
+    let acquired = tokio::time::timeout(
+        Duration::from_secs(2),
+        w.mgr
+            .acquire_resident_for::<Recording>(&ctx, &AcquireOptions::default(), w.slot_identity),
+    )
+    .await
+    .expect("acquire on a tainted row must resolve immediately (rejected), not hang");
+    let err = match acquired {
+        Err(e) => e,
+        Ok(_) => unreachable!(
+            // guard-justified: a live guard means the synchronous
+            // phase-1 taint did not stick across the hung phase-2 —
+            // the exact #681 wiring regression; fail loudly.
+            "acquire during a hung revoke must be rejected — phase-1 taint \
+             ran synchronously before the timeout (#681)"
+        ),
+    };
+    assert_eq!(
+        err.category(),
+        ErrorCategory::Unavailable,
+        "hung-revoke acquire must hit the Revoked/Unavailable taint, got: {err}"
+    );
+}
+
+/// Orphan lease (`credential_id == None`) cannot address a reverse-index
+/// row — the driver must treat it as a no-op fan-out, never an error,
+/// and never touch the bound resource.
+#[tokio::test]
+async fn orphan_lease_revoked_is_noop() {
+    let w = wire(Behaviour::Ok).await;
+
+    w.lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: None,
+        lease_id: "orphan".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+
+    // Drive a real refresh afterwards so we can prove the driver is
+    // alive and processing — and that the orphan revoke did NOT deliver
+    // a revoke hook.
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+    eventually("post-orphan refresh delivered", || {
+        w.rec.refresh.load(Ordering::SeqCst) == 1
+    })
+    .await;
+    assert_eq!(
+        w.rec.revoke.load(Ordering::SeqCst),
+        0,
+        "an orphan LeaseRevoked (no credential id) must not deliver any revoke hook"
+    );
+}
+
+/// After the bound resource is removed from the manager, a subsequent
+/// rotation for that credential fans to zero rows: no stale `Bind`, no
+/// bogus `failed`. Proven through the wired driver (emit `Refreshed`
+/// post-remove; the resource hook must NOT be delivered and nothing
+/// errors).
+#[tokio::test]
+async fn rotation_after_resource_removed_fans_to_zero_rows() {
+    let w = wire(Behaviour::Ok).await;
+
+    // First refresh: delivered (sanity that wiring is live).
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+    eventually("pre-remove refresh delivered", || {
+        w.rec.refresh.load(Ordering::SeqCst) == 1
+    })
+    .await;
+
+    // Remove the resource from the manager.
+    w.mgr.remove(&Recording::key()).expect("resource removed");
+
+    // Second refresh after removal. The reverse index still holds the
+    // bind (unbind on remove is the registrar/activation path's job,
+    // covered separately), so the fan-out DOES dispatch — but
+    // `refresh_slot_for` now resolves no live row and records `failed`,
+    // NOT a delivered hook. The decisive assertion: the resource hook
+    // is not delivered a second time and the driver does not panic.
+    w.cred_bus.emit(CredentialEvent::Refreshed {
+        credential_id: w.cid,
+    });
+
+    // Give the driver ample time to process the second event.
+    for _ in 0..200 {
+        tokio::time::sleep(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+    }
+    assert_eq!(
+        w.rec.refresh.load(Ordering::SeqCst),
+        1,
+        "after the resource was removed, a rotation must NOT deliver its \
+         hook again (fans to a now-dead row, recorded failed — not a \
+         second hook call)"
+    );
+}

--- a/crates/engine/tests/resource_rotation_wiring_redaction.rs
+++ b/crates/engine/tests/resource_rotation_wiring_redaction.rs
@@ -1,0 +1,317 @@
+#![cfg(feature = "rotation")]
+
+//! Redaction gate for the **wired** rotation fan-out path (ADR-0030 §4,
+//! PRODUCT_CANON §12.5).
+//!
+//! `resource_rotation_redaction.rs` proves the fan-out *port*
+//! (`dispatch_*` called directly) leaks no credential material. This
+//! mirrors that gate one layer up: the secret travels the full
+//! production wiring — a `CredentialEvent` / `LeaseEvent` emitted on a
+//! real `nebula-eventbus` bus → the spawned [`ResourceFanoutDriver`]
+//! subscriber → `dispatch_{refresh,revoke}` → the secret-bearing
+//! resource hook. The driver adds its own credential-data-free
+//! `tracing` event (`record`), so this gate also covers *that* surface,
+//! not just the fan-out internals.
+//!
+//! Capture harness is the verbatim `CaptureBuf` + `tracing-subscriber`
+//! `MakeWriter` shape from `crates/credential/tests/redaction.rs` and
+//! `resource_rotation_redaction.rs` (reused, not re-invented, so the
+//! span/event capture semantics are identical to the established
+//! ADR-0030 §4 gate). Because the driver runs on a `tokio::spawn`ed
+//! task, the capture subscriber is installed process-wide via
+//! `tracing::subscriber::set_global_default` for the test so the
+//! spawned task's spans/events are also captured.
+
+use std::io::{self, Write};
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::time::Duration;
+
+use nebula_core::{OrgId, ResourceKey, ScopeLevel, resource_key, scope::Scope};
+use nebula_credential::{CredentialEvent, CredentialGuard, CredentialId, LeaseEvent};
+use nebula_engine::credential::rotation::{ResourceFanoutDriver, ResourceFanoutIndex};
+use nebula_eventbus::EventBus;
+use nebula_resource::{
+    AcquireOptions, Manager, RegisterOptions, ResidentConfig, Resource, ResourceConfig,
+    ResourceContext, SlotCell, error::Error as ResourceError, resource::ResourceMetadata,
+    topology::resident::Resident,
+};
+use tokio_util::sync::CancellationToken;
+use tracing_subscriber::fmt::MakeWriter;
+use zeroize::Zeroize;
+
+/// Distinctive token planted in the rotated credential material + the
+/// live runtime the hooks borrow. Long + structured so a substring
+/// match cannot false-positive.
+const SECRET: &str = "WIRED-ROTATION-SECRET-7b1e";
+
+// ── CaptureBuf (verbatim shape from the established §4 gate) ─────────
+
+#[derive(Clone, Default)]
+struct CaptureBuf(Arc<Mutex<Vec<u8>>>);
+
+impl CaptureBuf {
+    fn as_string(&self) -> String {
+        let g = self.0.lock().expect("capture buffer poisoned");
+        String::from_utf8_lossy(&g).into_owned()
+    }
+}
+
+impl Write for CaptureBuf {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.0
+            .lock()
+            .expect("capture buffer poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for CaptureBuf {
+    type Writer = CaptureBuf;
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+fn assert_no_secret(haystack: &str, surface: &str) {
+    assert!(
+        !haystack.contains(SECRET),
+        "redaction gate violation: secret {SECRET:?} leaked into {surface} \
+         (case-sensitive):\n---- {surface} ----\n{haystack}\n----"
+    );
+    assert!(
+        !haystack.to_lowercase().contains(&SECRET.to_lowercase()),
+        "redaction gate violation: secret {SECRET:?} leaked into {surface} \
+         (case-insensitive):\n---- {surface} ----\n{haystack}\n----"
+    );
+}
+
+// ── Secret-bearing resident resource ────────────────────────────────
+
+struct SecretCred(String);
+impl Zeroize for SecretCred {
+    fn zeroize(&mut self) {
+        self.0.zeroize();
+    }
+}
+
+#[derive(Debug)]
+struct HookError(&'static str);
+impl std::fmt::Display for HookError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.0)
+    }
+}
+impl std::error::Error for HookError {}
+impl From<HookError> for ResourceError {
+    fn from(e: HookError) -> Self {
+        ResourceError::transient(e.0)
+    }
+}
+
+#[derive(Clone)]
+struct Cfg;
+nebula_schema::impl_empty_has_schema!(Cfg);
+impl ResourceConfig for Cfg {
+    fn validate(&self) -> Result<(), ResourceError> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct SecretRuntime {
+    secret: String,
+}
+
+#[derive(Clone)]
+struct SecretRes {
+    #[allow(
+        dead_code,
+        reason = "models the author-declared resolved SlotCell; the hook borrows the runtime, not this cell — its presence makes the secret reachable through the resolved slot the fan-out rotates"
+    )]
+    db: Arc<SlotCell<CredentialGuard<SecretCred>>>,
+    hook_entered: Arc<AtomicUsize>,
+}
+
+impl Resource for SecretRes {
+    type Config = Cfg;
+    type Runtime = SecretRuntime;
+    type Lease = SecretRuntime;
+    type Error = HookError;
+
+    fn key() -> ResourceKey {
+        resource_key!("wired-redaction-res")
+    }
+
+    async fn create(&self, _c: &Cfg, _x: &ResourceContext) -> Result<SecretRuntime, HookError> {
+        Ok(SecretRuntime {
+            secret: SECRET.to_owned(),
+        })
+    }
+
+    async fn on_credential_refresh(&self, _s: &str, rt: &SecretRuntime) -> Result<(), HookError> {
+        self.hook_entered.fetch_add(1, Ordering::SeqCst);
+        // Genuinely handle the secret-bearing runtime on the rotation
+        // path so redaction is not vacuously true.
+        let _ = rt.secret.len();
+        Ok(())
+    }
+
+    async fn on_credential_revoke(&self, _s: &str, rt: &SecretRuntime) -> Result<(), HookError> {
+        self.hook_entered.fetch_add(1, Ordering::SeqCst);
+        let _ = rt.secret.len();
+        Ok(())
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for SecretRes {
+    fn is_alive_sync(&self, _r: &SecretRuntime) -> bool {
+        true
+    }
+}
+
+// ── The gate ────────────────────────────────────────────────────────
+
+/// Drive BOTH a refresh and a revoke through the wired driver against a
+/// secret-bearing resource, capturing every span/event the spawned
+/// driver + fan-out + resource side produce, then assert the secret
+/// reached none of them — and that the capture is genuinely non-empty
+/// (the driver's own completion event must be present).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wired_rotation_fanout_observability_is_redaction_clean() {
+    // Process-wide capture: the driver runs on a spawned task, so a
+    // thread-local subscriber would miss its spans. `set_global_default`
+    // is fine here — this is a dedicated test binary target.
+    let buf = CaptureBuf::default();
+    let subscriber = tracing_subscriber::fmt()
+        .with_writer(buf.clone())
+        .with_ansi(false)
+        .with_target(true)
+        .with_level(true)
+        .with_max_level(tracing::Level::TRACE)
+        .finish();
+    tracing::subscriber::set_global_default(subscriber).expect("install global capture subscriber");
+
+    let hook_entered = Arc::new(AtomicUsize::new(0));
+    let org = OrgId::new();
+    let scope = ScopeLevel::Organization(org);
+    let mgr = Arc::new(Manager::new());
+    let index = Arc::new(ResourceFanoutIndex::new());
+    let cid = CredentialId::new();
+    let slot_identity: u64 = 0xDEAD_BEEF;
+
+    let slot: SlotCell<CredentialGuard<SecretCred>> = SlotCell::empty();
+    slot.store(Arc::new(CredentialGuard::new(SecretCred(
+        SECRET.to_owned(),
+    ))));
+
+    mgr.register_resident_with(
+        SecretRes {
+            db: Arc::new(slot),
+            hook_entered: Arc::clone(&hook_entered),
+        },
+        Cfg,
+        ResidentConfig::default(),
+        RegisterOptions::default()
+            .with_scope(scope.clone())
+            .with_slot_identity(slot_identity),
+    )
+    .expect("register resolved-credential row");
+
+    let ctx = ResourceContext::minimal(
+        Scope {
+            org_id: Some(org),
+            ..Default::default()
+        },
+        CancellationToken::new(),
+    );
+    let g = mgr
+        .acquire_resident_for::<SecretRes>(&ctx, &AcquireOptions::default(), slot_identity)
+        .await
+        .expect("warm secret-bearing runtime");
+    drop(g);
+
+    index.bind(cid, SecretRes::key(), scope.clone(), "db", slot_identity);
+
+    let cred_bus = Arc::new(EventBus::<CredentialEvent>::new(16));
+    let lease_bus = Arc::new(EventBus::<LeaseEvent>::new(16));
+    let _driver = ResourceFanoutDriver::spawn(
+        Arc::clone(&index),
+        Arc::clone(&mgr),
+        Arc::clone(&cred_bus),
+        Some(Arc::clone(&lease_bus)),
+    );
+
+    // Refresh via the credential bus.
+    cred_bus.emit(CredentialEvent::Refreshed { credential_id: cid });
+    // Revoke via the lease bus (the ADR-0051 → ADR-0067 path).
+    lease_bus.emit(LeaseEvent::LeaseRevoked {
+        credential_id: Some(cid),
+        lease_id: "lease-redaction".to_owned(),
+        provider: std::borrow::Cow::Borrowed("vault"),
+    });
+
+    // Wait until both hooks ran (refresh + revoke) — proof the wired
+    // path handled the secret-bearing runtime on both directions.
+    for _ in 0..3000 {
+        if hook_entered.load(Ordering::SeqCst) >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(1)).await;
+    }
+    assert!(
+        hook_entered.load(Ordering::SeqCst) >= 2,
+        "both rotation + revoke hooks must have run through the wired driver \
+         (handled the secret-bearing runtime), got {}",
+        hook_entered.load(Ordering::SeqCst)
+    );
+
+    // Let the driver flush its credential-data-free completion events.
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(2)).await;
+        tokio::task::yield_now().await;
+    }
+
+    let logs = buf.as_string();
+
+    // Capture-is-real guard: the driver's own completion event target
+    // must be present, so an empty-capture false-clean is impossible.
+    assert!(
+        logs.contains("nebula_engine::credential::rotation"),
+        "expected the wired driver's rotation log target in the capture — \
+         capture-is-real guard, got:\n{logs}"
+    );
+    // And at least one fan-out span (proves the dispatch ran under
+    // capture, not just the driver shell).
+    assert!(
+        logs.contains("nebula.credential.rotation.fanout_refresh")
+            || logs.contains("nebula.credential.rotation.fanout_revoke")
+            || logs.contains("nebula.resource.slot_refresh")
+            || logs.contains("nebula.resource.slot_revoke"),
+        "expected a fan-out / slot rotation span in the capture, got:\n{logs}"
+    );
+
+    // The invariant: no credential material on ANY captured surface
+    // across the fully wired path (driver event + fan-out spans +
+    // resource-side slot spans + any error string).
+    assert_no_secret(&logs, "wired-path captured spans + events");
+}
+
+/// Load-bearing self-check: the absence assertion must actually fire on
+/// a string that obviously contains the token (mirrors the negative
+/// test in the established §4 gates).
+#[test]
+#[should_panic(expected = "redaction gate violation")]
+fn assert_no_secret_is_load_bearing() {
+    assert_no_secret(&format!("leaked: {SECRET}"), "self-check");
+}

--- a/crates/resource/macros/src/field_slots.rs
+++ b/crates/resource/macros/src/field_slots.rs
@@ -243,6 +243,33 @@ pub(crate) fn emit_slot_field_registrations(slots: &[ParsedCredentialSlot]) -> T
     quote! { #(#calls)* }
 }
 
+/// Emit the body of `Resource::credential_slot_epoch` — the `max`
+/// generation across every declared `#[credential]` `SlotCell` field
+/// (ADR-0067 §Deferred create-vs-rotate reconcile).
+///
+/// Derive-generated so a newly-added credential slot is automatically
+/// folded into the epoch — an author cannot forget to include it (the
+/// structural alternative to a "remember to update the epoch" comment).
+/// With no slots the `max` chain is empty and the epoch is `0`
+/// ("never bound"), matching the trait default.
+pub(crate) fn emit_credential_slot_epoch_body(slots: &[ParsedCredentialSlot]) -> TokenStream2 {
+    if slots.is_empty() {
+        return quote! { 0 };
+    }
+    let gens: Vec<TokenStream2> = slots
+        .iter()
+        .map(|slot| {
+            let field = &slot.field_ident;
+            quote! { self.#field.generation() }
+        })
+        .collect();
+    // `max` fold over every slot's generation; a single slot collapses to
+    // just that slot's generation.
+    quote! {
+        [ #(#gens),* ].into_iter().max().unwrap_or(0)
+    }
+}
+
 /// Per slot, emit a read accessor over the author-declared
 /// `SlotCell<CredentialGuard<C>>` field.
 ///

--- a/crates/resource/macros/src/field_slots.rs
+++ b/crates/resource/macros/src/field_slots.rs
@@ -243,15 +243,34 @@ pub(crate) fn emit_slot_field_registrations(slots: &[ParsedCredentialSlot]) -> T
     quote! { #(#calls)* }
 }
 
-/// Emit the body of `Resource::credential_slot_epoch` — the `max`
-/// generation across every declared `#[credential]` `SlotCell` field
-/// (ADR-0067 §Deferred create-vs-rotate reconcile).
+/// Emit the body of `Resource::credential_slot_epoch` — an
+/// **order-sensitive positional fold** over every declared
+/// `#[credential]` `SlotCell` field's generation (ADR-0067 §Deferred
+/// create-vs-rotate reconcile).
 ///
 /// Derive-generated so a newly-added credential slot is automatically
 /// folded into the epoch — an author cannot forget to include it (the
 /// structural alternative to a "remember to update the epoch" comment).
-/// With no slots the `max` chain is empty and the epoch is `0`
-/// ("never bound"), matching the trait default.
+/// With no slots the fold is empty and the epoch is `0` ("never bound"),
+/// matching the trait default.
+///
+/// **Why a positional fold, not `max`.** The epoch's load-bearing
+/// contract (#680) is "the value changes whenever *any* slot's
+/// generation changes" — the resident create-vs-rotate reconcile
+/// compares the epoch a runtime was built against with the live epoch
+/// and only re-delivers the hook when they differ. `max` violates that:
+/// a runtime built at `(slot_a=5, slot_b=10)` then rotated `slot_a→6`
+/// still folds to `max=10`, so the reconcile would miss the stale
+/// runtime entirely and silently report a rotation success while the
+/// runtime keeps serving the pre-rotation credential. A position-weighted
+/// fold `acc = acc * K + gen` (fixed odd `K`) changes on **every** slot
+/// transition regardless of which slot moved or whether another slot's
+/// generation happens to be larger. `wrapping_mul`/`wrapping_add` keep it
+/// total (it is an opaque change-token, never compared by magnitude — the
+/// reconcile only does `built != live`), and the per-slot
+/// [`SlotCell::generation`](crate::SlotCell::generation) is itself
+/// strictly monotone, so no real rotation sequence aliases back to a
+/// prior epoch in practice.
 pub(crate) fn emit_credential_slot_epoch_body(slots: &[ParsedCredentialSlot]) -> TokenStream2 {
     if slots.is_empty() {
         return quote! { 0 };
@@ -263,10 +282,23 @@ pub(crate) fn emit_credential_slot_epoch_body(slots: &[ParsedCredentialSlot]) ->
             quote! { self.#field.generation() }
         })
         .collect();
-    // `max` fold over every slot's generation; a single slot collapses to
-    // just that slot's generation.
+    // Position-weighted fold so EVERY slot transition changes the epoch
+    // (not just the max-bearing one): `acc = acc * K + gen`. `K` is a
+    // fixed odd constant (the 64-bit FNV-1a prime) for good dispersion;
+    // wrapping arithmetic keeps the fold total — the epoch is an opaque
+    // change-token compared only for equality by the create-vs-rotate
+    // reconcile, never by magnitude. A single slot folds to
+    // `0 * K + gen == gen` (unchanged from the prior single-slot
+    // behaviour). Empty slot list returned `0` above ("never bound").
     quote! {
-        [ #(#gens),* ].into_iter().max().unwrap_or(0)
+        {
+            const __NEBULA_SLOT_EPOCH_K: u64 = 0x0000_0100_0000_01b3;
+            [ #(#gens),* ]
+                .into_iter()
+                .fold(0u64, |acc, slot_gen| {
+                    acc.wrapping_mul(__NEBULA_SLOT_EPOCH_K).wrapping_add(slot_gen)
+                })
+        }
     }
 }
 

--- a/crates/resource/macros/src/resource.rs
+++ b/crates/resource/macros/src/resource.rs
@@ -89,8 +89,10 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 }
             }
 
-            // ADR-0067 §Deferred: the `max` `SlotCell` generation across
-            // every declared `#[credential]` field. Derive-emitted so a
+            // ADR-0067 §Deferred: an order-sensitive positional fold over
+            // every declared `#[credential]` `SlotCell` field's
+            // generation (NOT `max` — `max` misses a rotation of a
+            // non-max slot, #690 review / #680). Derive-emitted so a
             // newly-added slot is folded in automatically (no author
             // discipline). Closes the create-vs-rotate lost-update race
             // when paired with the Resident build-epoch reconcile.

--- a/crates/resource/macros/src/resource.rs
+++ b/crates/resource/macros/src/resource.rs
@@ -53,6 +53,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
     let slots = field_slots::parse_credential_slot_fields(fields)?;
     let slot_registrations = field_slots::emit_slot_field_registrations(&slots);
     let slot_accessors = field_slots::emit_slot_accessors(&slots);
+    let credential_slot_epoch_body = field_slots::emit_credential_slot_epoch_body(&slots);
 
     let key_lit = &attrs.key;
     let config_ty = &attrs.config;
@@ -86,6 +87,15 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                         ::std::stringify!(#struct_name),
                     )
                 }
+            }
+
+            // ADR-0067 §Deferred: the `max` `SlotCell` generation across
+            // every declared `#[credential]` field. Derive-emitted so a
+            // newly-added slot is folded in automatically (no author
+            // discipline). Closes the create-vs-rotate lost-update race
+            // when paired with the Resident build-epoch reconcile.
+            fn credential_slot_epoch(&self) -> u64 {
+                #credential_slot_epoch_body
             }
         }
     };

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -23,6 +23,18 @@ use crate::{resource::Resource, topology_tag::TopologyTag};
 /// Callback invoked when a guarded lease is released.
 type GuardedRelease<R> = Box<dyn FnOnce(<R as Resource>::Lease, bool) + Send + Sync>;
 
+/// A drain tracker: an in-flight `(active_count, waiters)` pair. One is the
+/// manager-wide `graceful_shutdown` tracker; another is each
+/// `ManagedResource`'s own counter that `Manager::revoke_slot` drains in
+/// isolation (ADR-0067 §Deferred).
+pub(crate) type DrainTracker = Arc<(AtomicU64, Notify)>;
+
+/// The `(manager_wide, per_resource)` pair an acquire pre-increments and
+/// hands to its [`ResourceGuard`]. Both are decremented + notified on guard
+/// drop: the first unblocks `graceful_shutdown`, the second unblocks the
+/// originating resource's isolated revoke drain.
+pub(crate) type DrainTrackers = (DrainTracker, DrainTracker);
+
 /// A guard over a leased resource.
 ///
 /// Dereferences to `R::Lease` for ergonomic access. On drop, guarded and
@@ -35,8 +47,17 @@ pub struct ResourceGuard<R: Resource> {
     topology_tag: TopologyTag,
     /// When this guard was acquired — used for lifetime tracking and the `Guard` trait.
     acquired_at: Instant,
-    /// Optional drain tracker — decrements on drop, notifies when zero.
-    drain_counter: Option<Arc<(AtomicU64, Notify)>>,
+    /// Optional manager-wide + per-resource drain trackers — each
+    /// decremented on drop, the owning `Notify` woken when it hits zero.
+    ///
+    /// The first element is `Manager::drain_tracker` (`graceful_shutdown`
+    /// drain); the second is the originating `ManagedResource`'s own
+    /// in-flight tracker, which `Manager::revoke_slot` drains in isolation
+    /// (ADR-0067 §Deferred). Both are pre-incremented by `InFlightCounter`
+    /// and handed off here, so a guard handed out for a row reflects in that
+    /// row's revoke drain — closing the revoke-vs-acquire TOCTOU
+    /// (ADR-0044/0036).
+    drain_counters: Option<DrainTrackers>,
 }
 
 enum GuardInner<R: Resource> {
@@ -64,7 +85,7 @@ impl<R: Resource> ResourceGuard<R> {
             resource_key,
             topology_tag,
             acquired_at: Instant::now(),
-            drain_counter: None,
+            drain_counters: None,
         }
     }
 
@@ -112,7 +133,7 @@ impl<R: Resource> ResourceGuard<R> {
             resource_key,
             topology_tag,
             acquired_at: Instant::now(),
-            drain_counter: None,
+            drain_counters: None,
         }
     }
 
@@ -134,29 +155,30 @@ impl<R: Resource> ResourceGuard<R> {
             resource_key,
             topology_tag,
             acquired_at: Instant::now(),
-            drain_counter: None,
+            drain_counters: None,
         }
     }
 
-    /// Attaches a drain tracker for shutdown coordination.
+    /// Attaches the manager-wide + per-resource drain trackers for shutdown
+    /// and revoke coordination.
     ///
-    /// **Caller-owned increment**: this method does NOT increment the counter.
-    /// Callers (i.e. `Manager` acquire paths) must pre-increment the counter
-    /// before any `await` past `lookup()` and hand the *already-counted slot*
-    /// off to the guard via this method. The guard then owns the slot and
-    /// decrements + notifies on Drop.
+    /// **Caller-owned increment**: this method does NOT increment either
+    /// counter. Callers (the `Manager` acquire paths) must pre-increment
+    /// both before any `await` past `lookup()` (via `InFlightCounter`) and
+    /// hand the *already-counted slots* off here. The guard then owns both
+    /// and decrements + notifies each on Drop.
     ///
-    /// This caller-owned ordering is required to close the
-    /// `graceful_shutdown` race where an acquire that passed `lookup()`
-    /// before `cancel.cancel()` could complete *after* `wait_for_drain()`
-    /// observed `0` and the registry was cleared. With pre-increment via
-    /// `Manager::InFlightCounter`, every in-flight acquire is reflected
-    /// in `drain_tracker` from the moment `lookup()` succeeds, so
-    /// `wait_for_drain()` always blocks until the acquire either finishes
-    /// (and the slot transfers to the guard) or fails (and `InFlightCounter`
-    /// decrements on Drop).
-    pub(crate) fn with_drain_tracker(mut self, tracker: Arc<(AtomicU64, Notify)>) -> Self {
-        self.drain_counter = Some(tracker);
+    /// This caller-owned ordering closes two races. (1) The
+    /// `graceful_shutdown` race: an acquire that passed `lookup()` before
+    /// `cancel.cancel()` could otherwise complete *after* `wait_for_drain()`
+    /// observed `0` and the registry was cleared. (2) The revoke-vs-acquire
+    /// TOCTOU (ADR-0044/0036): because the per-resource counter is
+    /// incremented before the post-taint re-check and decremented only when
+    /// this guard drops, `revoke_slot`'s per-resource drain (ADR-0067
+    /// §Deferred) cannot complete while a guard handed out for that row is
+    /// still live.
+    pub(crate) fn with_drain_tracker(mut self, trackers: DrainTrackers) -> Self {
+        self.drain_counters = Some(trackers);
         self
     }
 
@@ -313,11 +335,17 @@ impl<R: Resource> Drop for ResourceGuard<R> {
             },
         }
 
-        // Drain tracking: decrement active count and notify shutdown waiters.
-        if let Some(ref tracker) = self.drain_counter
-            && tracker.0.fetch_sub(1, AtomicOrdering::Release) == 1
-        {
-            tracker.1.notify_waiters();
+        // Drain tracking: decrement BOTH the manager-wide and per-resource
+        // active counts, waking each owning `Notify` on its 1 → 0 edge. The
+        // manager-wide tracker unblocks `graceful_shutdown`; the per-resource
+        // tracker unblocks `revoke_slot`'s isolated per-resource drain
+        // (ADR-0067 §Deferred).
+        if let Some((ref manager, ref per_resource)) = self.drain_counters {
+            for tracker in [manager, per_resource] {
+                if tracker.0.fetch_sub(1, AtomicOrdering::Release) == 1 {
+                    tracker.1.notify_waiters();
+                }
+            }
         }
     }
 }

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -68,7 +68,7 @@ pub use guard::ResourceGuard;
 pub use integration::{AcquireResilience, AcquireRetryConfig};
 pub use manager::{
     DrainTimeoutPolicy, Manager, ManagerConfig, RegisterOptions, ResourceHealthSnapshot,
-    ShutdownConfig, ShutdownError, ShutdownReport, TaintedSlot,
+    RevokeTail, ShutdownConfig, ShutdownError, ShutdownReport, TaintedSlot,
 };
 pub use metrics::{OutcomeCountersSnapshot, ResourceOpsMetrics, ResourceOpsSnapshot};
 pub use nebula_core::{ExecutionId, ResourceKey, ScopeLevel, WorkflowId, resource_key};

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -68,7 +68,7 @@ pub use guard::ResourceGuard;
 pub use integration::{AcquireResilience, AcquireRetryConfig};
 pub use manager::{
     DrainTimeoutPolicy, Manager, ManagerConfig, RegisterOptions, ResourceHealthSnapshot,
-    ShutdownConfig, ShutdownError, ShutdownReport,
+    ShutdownConfig, ShutdownError, ShutdownReport, TaintedSlot,
 };
 pub use metrics::{OutcomeCountersSnapshot, ResourceOpsMetrics, ResourceOpsSnapshot};
 pub use nebula_core::{ExecutionId, ResourceKey, ScopeLevel, WorkflowId, resource_key};

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -62,7 +62,7 @@ use crate::{
 mod execute;
 mod gate;
 pub(crate) mod options;
-mod shutdown;
+pub(crate) mod shutdown;
 
 use execute::{execute_with_resilience, validate_pool_config};
 use gate::{admit_through_gate, settle_gate_admission};
@@ -274,6 +274,7 @@ impl Manager {
             resilience,
             recovery_gate,
             tainted: AtomicBool::new(false),
+            in_flight: Arc::new((AtomicU64::new(0), Notify::new())),
         });
 
         let type_id = std::any::TypeId::of::<ManagedResource<R>>();
@@ -987,13 +988,41 @@ impl Manager {
         managed: Arc<ManagedResource<R>>,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
         if managed.is_tainted() {
-            return Err(Error::revoked(format!(
-                "{}: resource tainted by credential revoke — new acquires rejected",
-                R::key()
-            ))
-            .with_resource_key(R::key()));
+            return Err(Self::tainted_error::<R>());
         }
         Ok(managed)
+    }
+
+    /// Post-`InFlightCounter::new` taint re-check shared by every
+    /// `run_*_acquire` / `try_acquire_*` pipeline.
+    ///
+    /// The acquire-side [`taint_gate`](Self::taint_gate) ran before the
+    /// in-flight counter was constructed, leaving a window where a concurrent
+    /// `revoke_slot` could taint *after* the gate but *before* the increment.
+    /// Re-checking here — once this acquire is reflected in the resource's
+    /// own in-flight counter (the exact counter `revoke_slot` drains,
+    /// ADR-0067 §Deferred) — closes that revoke-vs-acquire TOCTOU so a guard
+    /// is never handed out on a just-revoked credential (ADR-0044/0036).
+    /// Same error/classification as the gate so the caller-facing category
+    /// is unchanged (`Revoked` → `ErrorCategory::Unavailable`).
+    fn reject_if_tainted_post_count<R: Resource>(
+        managed: &Arc<ManagedResource<R>>,
+    ) -> Result<(), Error> {
+        if managed.is_tainted() {
+            return Err(Self::tainted_error::<R>());
+        }
+        Ok(())
+    }
+
+    /// The single typed error both taint checks return — keeps the message
+    /// and `Revoked` (→ `Unavailable`) classification identical at the
+    /// pre-count gate and the post-count re-check.
+    fn tainted_error<R: Resource>() -> Error {
+        Error::revoked(format!(
+            "{}: resource tainted by credential revoke — new acquires rejected",
+            R::key()
+        ))
+        .with_resource_key(R::key())
     }
 
     /// Notifies a registered resource that one of its `#[credential]`
@@ -1126,9 +1155,12 @@ impl Manager {
     /// Sequence (reusing existing primitives, no parallel mechanism):
     ///
     /// 1. **Taint** the [`ManagedResource`] so the `acquire_*` funnel rejects new leases on the
-    ///    revoked credential *immediately* (same flag-gated rejection as `shutting_down`).
-    /// 2. **Drain** in-flight handles via the manager's shared `drain_tracker`
-    ///    (`wait_for_drain`, the exact primitive `graceful_shutdown` uses).
+    ///    revoked credential *immediately* (same flag-gated rejection as `shutting_down`). The
+    ///    acquire pipelines re-check this taint *after* their per-resource in-flight increment, so
+    ///    the taint→increment→re-check ordering closes the revoke-vs-acquire TOCTOU.
+    /// 2. **Drain** only *this resource's* in-flight handles via its own per-resource counter
+    ///    (ADR-0067 §Deferred) — never the manager-wide `drain_tracker`, so a revoke is isolated
+    ///    from in-flight traffic to unrelated resources.
     /// 3. **Dispatch** [`Resource::on_credential_revoke`] against the live runtime per topology.
     /// 4. Emit [`ResourceEvent::SlotRevoked`].
     ///
@@ -1216,29 +1248,38 @@ impl Manager {
         tracing::Span::current().record("topology", managed.topology_tag_erased().as_str());
 
         // 1. Taint first — rejects new acquires before we drain/dispatch.
+        //    The acquire pipelines re-check this taint *after* their
+        //    per-resource in-flight increment, so an acquire that passed the
+        //    taint gate but had not yet incremented cannot slip a guard out
+        //    on the just-revoked credential (ADR-0044/0036 "no authenticated
+        //    traffic on a revoked credential post-revoke").
         managed.taint_erased();
 
-        // 2. Drain in-flight handles via the shared drain tracker (the same
-        //    primitive graceful_shutdown uses). Bounded so a stuck handle
-        //    cannot wedge revoke; the taint already stops new leases.
+        // 2. Drain **only this resource's** in-flight handles (ADR-0067
+        //    §Deferred): a revoke on resource A must not block on in-flight
+        //    traffic to an unrelated resource B, so this awaits the row's
+        //    own per-resource counter — not the manager-wide `drain_tracker`
+        //    (which stays the `graceful_shutdown` primitive). Bounded so a
+        //    stuck handle on *this* resource cannot wedge revoke; the taint
+        //    already stops new leases.
         //
         //    A drain timeout is *terminal* for this dispatch's outcome
         //    metric: it records `TimedOut` and the subsequent hook
         //    success/failure does NOT record a second outcome (one dispatch
         //    = exactly one outcome). The hook still runs and its event /
         //    returned `Result` are unaffected.
-        let drain_result = self
-            .wait_for_drain(std::time::Duration::from_secs(30))
+        let drain_result = managed
+            .wait_for_in_flight_drain_erased(std::time::Duration::from_secs(30))
             .await;
         let drain_timed_out = drain_result.is_err();
-        if let Err(err) = &drain_result {
+        if let Err(outstanding) = &drain_result {
             if let Some(m) = &self.metrics {
                 m.record_slot_revoke_outcome(crate::metrics::SlotDispatchOutcome::TimedOut);
             }
             tracing::warn!(
-                outstanding = err.outstanding,
-                "slot revoke: drain timed out; proceeding to revoke hook \
-                 (resource already tainted, no new leases)"
+                outstanding = *outstanding,
+                "slot revoke: per-resource drain timed out; proceeding to \
+                 revoke hook (resource already tainted, no new leases)"
             );
         }
 
@@ -1429,8 +1470,21 @@ impl Manager {
         // acquire from the moment `lookup()` succeeds. RAII decrements + notifies
         // on every failure / cancel / panic path; on success the slot is handed
         // off to the resulting `ResourceGuard` so the count is held continuously
-        // until the guard drops.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        // until the guard drops. The same counter is the per-resource one
+        // `revoke_slot` drains, which is what the post-taint re-check below
+        // relies on.
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check (ADR-0044/0036 "no authenticated traffic
+        // on a revoked credential post-revoke"): the taint gate ran in
+        // `lookup_for_acquire`, but a revoke could have tainted *after* that
+        // gate yet *before* the in-flight increment above. Re-checking here —
+        // after the per-resource counter is incremented — closes that TOCTOU:
+        // `revoke_slot` taints, then drains this same counter, so either we
+        // observe the taint here or our increment is visible to its drain.
+        // Mirrors the `shutting_down` Defense pattern; same `Revoked`
+        // (→ `Unavailable`) classification as the taint gate.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
         let resilience = managed.resilience.clone();
 
@@ -1548,7 +1602,13 @@ impl Manager {
     {
         let started = Instant::now();
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
+        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // this acquire is reflected in the per-resource counter `revoke_slot`
+        // drains.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
         let resilience = managed.resilience.clone();
 
@@ -1658,7 +1718,13 @@ impl Manager {
     {
         let started = Instant::now();
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
+        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // this acquire is reflected in the per-resource counter `revoke_slot`
+        // drains.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
         let resilience = managed.resilience.clone();
 
@@ -1776,7 +1842,13 @@ impl Manager {
     {
         let started = Instant::now();
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
+        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // this acquire is reflected in the per-resource counter `revoke_slot`
+        // drains.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
         let resilience = managed.resilience.clone();
 
@@ -1898,7 +1970,13 @@ impl Manager {
     {
         let started = Instant::now();
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
+        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // this acquire is reflected in the per-resource counter `revoke_slot`
+        // drains.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
         let resilience = managed.resilience.clone();
 
@@ -1971,7 +2049,13 @@ impl Manager {
         let started = Instant::now();
         let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
-        let in_flight = InFlightCounter::new(self.drain_tracker.clone());
+        let in_flight =
+            InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
+        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // this acquire is reflected in the per-resource counter `revoke_slot`
+        // drains.
+        Self::reject_if_tainted_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
 
         let result = match &managed.topology {
@@ -2343,35 +2427,51 @@ fn resolve_json_templates(
 // has been torn down.
 
 pub(crate) struct InFlightCounter {
-    tracker: Arc<(AtomicU64, Notify)>,
+    /// Manager-wide drain tracker — the `graceful_shutdown` drain primitive.
+    manager: crate::guard::DrainTracker,
+    /// Per-`ManagedResource` in-flight tracker — the *only* counter
+    /// `revoke_slot` drains (ADR-0067 §Deferred), so a revoke on one
+    /// resource never blocks on a sibling's in-flight work.
+    per_resource: crate::guard::DrainTracker,
     armed: bool,
 }
 
 impl InFlightCounter {
-    pub(crate) fn new(tracker: Arc<(AtomicU64, Notify)>) -> Self {
-        tracker.0.fetch_add(1, AtomicOrdering::AcqRel);
+    /// Pre-counts an in-flight acquire against **both** the manager-wide
+    /// drain tracker (shutdown) and the per-resource tracker (revoke drain
+    /// + the taint→increment→re-check TOCTOU close, ADR-0044/0036/0067).
+    pub(crate) fn new(
+        manager: crate::guard::DrainTracker,
+        per_resource: crate::guard::DrainTracker,
+    ) -> Self {
+        manager.0.fetch_add(1, AtomicOrdering::AcqRel);
+        per_resource.0.fetch_add(1, AtomicOrdering::AcqRel);
         Self {
-            tracker,
+            manager,
+            per_resource,
             armed: true,
         }
     }
 
-    /// Hand off the in-flight slot to a `ResourceGuard`. The drain tracker
-    /// remains incremented; the guard's drop will decrement it.
+    /// Hand off the in-flight slot to a `ResourceGuard`. Both trackers stay
+    /// incremented; the guard's drop decrements + notifies both.
     ///
-    /// Disarms this counter so the slot is NOT decremented on drop.
-    pub(crate) fn release_to_guard(mut self) -> Arc<(AtomicU64, Notify)> {
+    /// Disarms this counter so the slot is NOT decremented on drop. Returns
+    /// `(manager_wide, per_resource)` for
+    /// [`ResourceGuard::with_drain_tracker`](crate::guard::ResourceGuard::with_drain_tracker).
+    pub(crate) fn release_to_guard(mut self) -> crate::guard::DrainTrackers {
         self.armed = false;
-        self.tracker.clone()
+        (self.manager.clone(), self.per_resource.clone())
     }
 }
 
 impl Drop for InFlightCounter {
     fn drop(&mut self) {
         if self.armed {
-            let prev = self.tracker.0.fetch_sub(1, AtomicOrdering::AcqRel);
-            if prev == 1 {
-                self.tracker.1.notify_waiters();
+            for tracker in [&self.manager, &self.per_resource] {
+                if tracker.0.fetch_sub(1, AtomicOrdering::AcqRel) == 1 {
+                    tracker.1.notify_waiters();
+                }
             }
         }
     }

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -84,6 +84,54 @@ pub struct ResourceHealthSnapshot {
     pub generation: u64,
 }
 
+/// A resource registry row whose credential slot has been **synchronously
+/// tainted** by [`Manager::taint_slot`](Manager::taint_slot) /
+/// [`Manager::taint_slot_for`](Manager::taint_slot_for) — phase 1 of the
+/// two-phase revoke port (ADR-0067 §Deferred).
+///
+/// Holding one is proof the taint already ran to completion: new acquires on
+/// this row's credential are already rejected. It is consumed by
+/// [`Manager::drain_and_revoke`](Manager::drain_and_revoke) to run the
+/// cancellation-safe drain + revoke-hook tail.
+///
+/// **Why two phases.** The engine rotation fan-out wraps the awaited
+/// drain/hook tail in `tokio::time::timeout`. A Rust `async fn` body is lazy:
+/// if the timeout future is dropped before its first poll, the body never
+/// runs. Splitting the taint into this synchronous phase guarantees the taint
+/// is applied *before and outside* any per-resource timeout — a dropped
+/// `drain_and_revoke` future therefore leaves the row tainted and consistent
+/// (the credential is never silently un-revoked), it only forgoes the
+/// best-effort drain/hook tail.
+///
+/// Opaque by design: the only valid use is to pass it to
+/// [`drain_and_revoke`](Manager::drain_and_revoke). It is **not** `Clone` —
+/// one taint maps to exactly one drain/revoke tail.
+#[must_use = "a TaintedSlot only completes the revoke when passed to Manager::drain_and_revoke"]
+pub struct TaintedSlot {
+    /// Structural key of the tainted resource registry row (span/event
+    /// label only — no credential material).
+    key: ResourceKey,
+    /// The credential slot on that row that was revoked.
+    slot: String,
+    /// The resolved row whose taint flag was already set synchronously.
+    managed: Arc<dyn crate::registry::AnyManagedResource>,
+    /// When the synchronous taint was applied — the drain/revoke duration
+    /// metric spans from here so it covers the whole revoke, not just the
+    /// awaited tail.
+    tainted_at: Instant,
+}
+
+impl std::fmt::Debug for TaintedSlot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Deliberately omits `managed` (not `Debug`, and an internal
+        // erased handle); only the credential-free routing labels.
+        f.debug_struct("TaintedSlot")
+            .field("key", &self.key)
+            .field("slot", &self.slot)
+            .finish_non_exhaustive()
+    }
+}
+
 /// Central registry and lifecycle manager for all resources.
 ///
 /// Owns the [`ReleaseQueue`] internally — callers never need to create,
@@ -1149,61 +1197,34 @@ impl Manager {
         result
     }
 
-    /// Notifies a registered resource that one of its `#[credential]`
-    /// slots was revoked.
+    /// **Phase 1 of the revoke port — synchronous, runs to completion before
+    /// any `.await`.** Resolves the registry row pinned to a resolved
+    /// per-slot credential identity and *taints it immediately* so the
+    /// `acquire_*` funnel rejects new leases on the revoked credential, then
+    /// returns a [`TaintedSlot`] handle the caller passes to
+    /// [`drain_and_revoke`](Self::drain_and_revoke) for the cancellation-safe
+    /// drain + hook tail.
     ///
-    /// Sequence (reusing existing primitives, no parallel mechanism):
+    /// Why this is split off as a non-`async` function: the engine fan-out
+    /// wraps the awaited tail in `tokio::time::timeout`. A Rust `async fn`
+    /// body is *lazy* — if a `timeout` future is dropped before the runtime
+    /// first polls it, the body never runs. Were the taint the first
+    /// statement of an `async` body, a timeout that fired before the first
+    /// poll would drop the future and **skip the taint entirely**, leaving
+    /// new acquires accepted on a credential whose revoke "timed out". This
+    /// function is plain `fn`: the taint is applied eagerly at the call site,
+    /// fully completed before this returns, and therefore *outside* and
+    /// *before* any per-resource timeout (ADR-0067 §Deferred).
     ///
-    /// 1. **Taint** the [`ManagedResource`] so the `acquire_*` funnel rejects new leases on the
-    ///    revoked credential *immediately* (same flag-gated rejection as `shutting_down`). The
-    ///    acquire pipelines re-check this taint *after* their per-resource in-flight increment, so
-    ///    the taint→increment→re-check ordering closes the revoke-vs-acquire TOCTOU.
-    /// 2. **Drain** only *this resource's* in-flight handles via its own per-resource counter
-    ///    (ADR-0067 §Deferred) — never the manager-wide `drain_tracker`, so a revoke is isolated
-    ///    from in-flight traffic to unrelated resources.
-    /// 3. **Dispatch** [`Resource::on_credential_revoke`] against the live runtime per topology.
-    /// 4. Emit [`ResourceEvent::SlotRevoked`].
-    ///
-    /// The drain is best-effort bounded: a long-held handle should not wedge
-    /// revoke forever, so a bounded wait is used and a timeout still
-    /// proceeds to the revoke hook (the taint already stops *new* leases;
-    /// the hook makes the resource stop emitting on the old credential).
-    ///
-    /// # Errors
-    ///
-    /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no resource is registered for
-    ///   `key` at `scope`.
-    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
-    ///   down.
-    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
-    #[tracing::instrument(
-        level = "debug",
-        name = "nebula.resource.slot_revoke",
-        skip(self),
-        fields(key = %key, slot = %slot, topology, duration_ms, op = "revoke")
-    )]
-    pub async fn revoke_slot(
-        &self,
-        key: &ResourceKey,
-        scope: ScopeLevel,
-        slot: &str,
-    ) -> Result<(), Error> {
-        let managed = self.lookup_any_for_slot(key, &scope)?;
-        self.revoke_resolved(key, slot, managed).await
-    }
-
-    /// [`revoke_slot`](Self::revoke_slot) pinned to a resolved per-slot
-    /// credential identity.
-    ///
-    /// Resolves the registry row whose `slot_identity` matches (the same
-    /// unambiguous-by-construction path
-    /// [`get_for`](crate::registry::Registry::get_for) backs), so a
-    /// multi-tenant `(key, scope)` taints/drains/revokes the *specific*
-    /// resolved row instead of failing closed with
+    /// Identity routing: resolves the registry row whose `slot_identity`
+    /// matches via the unambiguous-by-construction
+    /// [`get_for`](crate::registry::Registry::get_for) path, so a
+    /// multi-tenant `(key, scope)` taints the *specific* resolved row
+    /// instead of failing closed with
     /// [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous). This is
     /// the entry point the engine per-slot rotation fan-out drives on a
-    /// lease revoke; identity-agnostic [`revoke_slot`](Self::revoke_slot)
-    /// stays fail-closed for the no-identity caller.
+    /// lease revoke; identity-agnostic [`taint_slot`](Self::taint_slot) stays
+    /// fail-closed for the no-identity caller.
     ///
     /// # Errors
     ///
@@ -1211,57 +1232,143 @@ impl Manager {
     ///   matches `slot_identity`.
     /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
     ///   down.
-    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    ///
+    /// Carries only `key` / `slot` / `slot_identity` / `topology` (no
+    /// credential material) onto the span.
     #[tracing::instrument(
         level = "debug",
-        name = "nebula.resource.slot_revoke",
+        name = "nebula.resource.slot_taint",
         skip(self),
-        fields(key = %key, slot = %slot, slot_identity, topology, duration_ms, op = "revoke")
+        fields(key = %key, slot = %slot, slot_identity, topology, op = "revoke")
     )]
-    pub async fn revoke_slot_for(
+    pub fn taint_slot_for(
         &self,
         key: &ResourceKey,
         scope: ScopeLevel,
         slot: &str,
         slot_identity: u64,
-    ) -> Result<(), Error> {
+    ) -> Result<TaintedSlot, Error> {
         tracing::Span::current().record("slot_identity", slot_identity);
         let managed = self.lookup_any_for_slot_identity(key, &scope, slot_identity)?;
-        self.revoke_resolved(key, slot, managed).await
+        Ok(Self::taint_now(key, slot, managed))
     }
 
-    /// Post-resolution revoke sequence (taint → bounded drain → hook → event)
-    /// shared by [`revoke_slot`](Self::revoke_slot) (identity-agnostic) and
-    /// [`revoke_slot_for`](Self::revoke_slot_for) (slot-identity-pinned).
+    /// [`taint_slot_for`](Self::taint_slot_for) for the slot-identity-agnostic
+    /// caller (the convenience [`revoke_slot`](Self::revoke_slot) path and
+    /// non-fan-out callers/tests).
     ///
-    /// The two public entry points differ only in how they resolve the row;
-    /// the safety-critical taint-before-drain-before-hook ordering and the
-    /// one-outcome-per-dispatch metric (a drain timeout being terminal) are
-    /// identical and live here.
-    async fn revoke_resolved(
+    /// Same eager, pre-`await` taint guarantee as
+    /// [`taint_slot_for`](Self::taint_slot_for); only row resolution differs
+    /// (identity-agnostic, so a multi-tenant `(key, scope)` fails closed with
+    /// [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous) rather
+    /// than tainting an arbitrary tenant's row).
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no resource is registered for
+    ///   `key` at `scope`.
+    /// - [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous) if more than one
+    ///   resolved-credential row exists for `(key, scope)`.
+    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
+    ///   down.
+    #[tracing::instrument(
+        level = "debug",
+        name = "nebula.resource.slot_taint",
+        skip(self),
+        fields(key = %key, slot = %slot, topology, op = "revoke")
+    )]
+    pub fn taint_slot(
         &self,
+        key: &ResourceKey,
+        scope: ScopeLevel,
+        slot: &str,
+    ) -> Result<TaintedSlot, Error> {
+        let managed = self.lookup_any_for_slot(key, &scope)?;
+        Ok(Self::taint_now(key, slot, managed))
+    }
+
+    /// Applies the taint synchronously and packages the [`TaintedSlot`]
+    /// handle. Shared tail of [`taint_slot`](Self::taint_slot) /
+    /// [`taint_slot_for`](Self::taint_slot_for); the safety-critical
+    /// invariant — *taint is fully applied before this returns* — is written
+    /// once here.
+    fn taint_now(
         key: &ResourceKey,
         slot: &str,
         managed: Arc<dyn crate::registry::AnyManagedResource>,
-    ) -> Result<(), Error> {
-        let started = Instant::now();
+    ) -> TaintedSlot {
         tracing::Span::current().record("topology", managed.topology_tag_erased().as_str());
-
-        // 1. Taint first — rejects new acquires before we drain/dispatch.
-        //    The acquire pipelines re-check this taint *after* their
-        //    per-resource in-flight increment, so an acquire that passed the
-        //    taint gate but had not yet incremented cannot slip a guard out
-        //    on the just-revoked credential (ADR-0044/0036 "no authenticated
-        //    traffic on a revoked credential post-revoke").
+        // Taint NOW — synchronously, before any caller `.await`. The acquire
+        // pipelines re-check this taint *after* their per-resource in-flight
+        // increment, so an acquire that passed the taint gate but had not yet
+        // incremented cannot slip a guard out on the just-revoked credential
+        // (ADR-0044/0036 "no authenticated traffic on a revoked credential
+        // post-revoke"). Because this function is not `async`, the store has
+        // *already happened* by the time control returns to the caller — a
+        // subsequently-dropped timeout future on the drain tail cannot
+        // un-apply it.
         managed.taint_erased();
+        TaintedSlot {
+            key: key.clone(),
+            slot: slot.to_owned(),
+            managed,
+            tainted_at: Instant::now(),
+        }
+    }
 
-        // 2. Drain **only this resource's** in-flight handles (ADR-0067
+    /// **Phase 2 of the revoke port — the cancellation-safe awaited tail.**
+    /// Consumes a [`TaintedSlot`] from [`taint_slot`](Self::taint_slot) /
+    /// [`taint_slot_for`](Self::taint_slot_for) (whose taint already ran
+    /// synchronously) and performs the remaining steps:
+    ///
+    /// 1. **Drain** only *this resource's* in-flight handles via its own per-resource counter
+    ///    (ADR-0067 §Deferred) — never the manager-wide `drain_tracker`, so a revoke is isolated
+    ///    from in-flight traffic to unrelated resources.
+    /// 2. **Dispatch** [`Resource::on_credential_revoke`] against the live runtime per topology.
+    /// 3. Emit [`ResourceEvent::SlotRevoked`] / `SlotRevokeFailed`.
+    ///
+    /// **Cancellation-safety.** The taint is *not* in this future — it ran in
+    /// the synchronous [`taint_slot_for`](Self::taint_slot_for) phase. So if
+    /// this future is dropped (e.g. the engine fan-out's
+    /// `tokio::time::timeout` elapses), the row stays tainted and consistent:
+    /// new acquires are still rejected, the credential is never silently
+    /// un-revoked. The drain itself is best-effort bounded — a long-held
+    /// handle should not wedge revoke forever, so a bounded wait is used and
+    /// a timeout still proceeds to the revoke hook (the taint already stops
+    /// *new* leases; the hook makes the resource stop emitting on the old
+    /// credential).
+    ///
+    /// # Errors
+    ///
+    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    #[tracing::instrument(
+        level = "debug",
+        name = "nebula.resource.slot_drain_revoke",
+        skip(self, tainted),
+        fields(
+            key = %tainted.key,
+            slot = %tainted.slot,
+            topology = tainted.managed.topology_tag_erased().as_str(),
+            duration_ms,
+            op = "revoke",
+        )
+    )]
+    pub async fn drain_and_revoke(&self, tainted: TaintedSlot) -> Result<(), Error> {
+        let TaintedSlot {
+            key,
+            slot,
+            managed,
+            tainted_at,
+        } = tainted;
+
+        // 1. Drain **only this resource's** in-flight handles (ADR-0067
         //    §Deferred): a revoke on resource A must not block on in-flight
         //    traffic to an unrelated resource B, so this awaits the row's
         //    own per-resource counter — not the manager-wide `drain_tracker`
         //    (which stays the `graceful_shutdown` primitive). Bounded so a
         //    stuck handle on *this* resource cannot wedge revoke; the taint
-        //    already stops new leases.
+        //    (already applied synchronously in the phase-1 function) already
+        //    stops new leases.
         //
         //    A drain timeout is *terminal* for this dispatch's outcome
         //    metric: it records `TimedOut` and the subsequent hook
@@ -1283,9 +1390,9 @@ impl Manager {
             );
         }
 
-        // 3. Dispatch the revoke hook against the live runtime.
-        let result = managed.dispatch_on_revoke_erased(slot).await;
-        tracing::Span::current().record("duration_ms", started.elapsed().as_millis() as u64);
+        // 2. Dispatch the revoke hook against the live runtime.
+        let result = managed.dispatch_on_revoke_erased(&slot).await;
+        tracing::Span::current().record("duration_ms", tainted_at.elapsed().as_millis() as u64);
 
         match &result {
             Ok(()) => {
@@ -1294,9 +1401,9 @@ impl Manager {
                 if !drain_timed_out && let Some(m) = &self.metrics {
                     m.record_slot_revoke_outcome(crate::metrics::SlotDispatchOutcome::Success);
                 }
-                let _ = self.event_tx.send(ResourceEvent::SlotRevoked {
+                self.emit(ResourceEvent::SlotRevoked {
                     key: key.clone(),
-                    slot: slot.to_owned(),
+                    slot: slot.clone(),
                 });
                 tracing::debug!("slot revoke hook completed");
             },
@@ -1304,15 +1411,77 @@ impl Manager {
                 if !drain_timed_out && let Some(m) = &self.metrics {
                     m.record_slot_revoke_outcome(crate::metrics::SlotDispatchOutcome::Failed);
                 }
-                let _ = self.event_tx.send(ResourceEvent::SlotRevokeFailed {
-                    key: key.clone(),
-                    slot: slot.to_owned(),
+                self.emit(ResourceEvent::SlotRevokeFailed {
+                    key,
+                    slot,
                     error: e.to_string(),
                 });
                 tracing::warn!(error = %e, "slot revoke hook failed");
             },
         }
         result
+    }
+
+    /// Notifies a registered resource that one of its `#[credential]` slots
+    /// was revoked — **thin two-phase convenience** for non-fan-out callers
+    /// and tests.
+    ///
+    /// Equivalent to [`taint_slot`](Self::taint_slot) immediately followed by
+    /// [`drain_and_revoke`](Self::drain_and_revoke). The engine per-slot
+    /// rotation fan-out deliberately does **not** call this: it must run the
+    /// synchronous taint phase *outside* its `tokio::time::timeout` and wrap
+    /// only the awaited drain/hook tail, so a dropped timeout future can
+    /// never skip the taint (ADR-0067 §Deferred). This convenience is for the
+    /// no-timeout caller where the two phases run back-to-back on the same
+    /// task.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no resource is registered for
+    ///   `key` at `scope`.
+    /// - [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous) if more than one
+    ///   resolved-credential row exists for `(key, scope)`.
+    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
+    ///   down.
+    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    pub async fn revoke_slot(
+        &self,
+        key: &ResourceKey,
+        scope: ScopeLevel,
+        slot: &str,
+    ) -> Result<(), Error> {
+        let tainted = self.taint_slot(key, scope, slot)?;
+        self.drain_and_revoke(tainted).await
+    }
+
+    /// [`revoke_slot`](Self::revoke_slot) pinned to a resolved per-slot
+    /// credential identity — the slot-identity-aware two-phase convenience.
+    ///
+    /// Equivalent to [`taint_slot_for`](Self::taint_slot_for) immediately
+    /// followed by [`drain_and_revoke`](Self::drain_and_revoke); a
+    /// multi-tenant `(key, scope)` taints/drains/revokes the *specific*
+    /// resolved row instead of failing closed with
+    /// [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous). Like
+    /// [`revoke_slot`](Self::revoke_slot) this is the back-compat
+    /// back-to-back path; the engine fan-out calls the two phases separately
+    /// (sync taint outside the timeout) per ADR-0067 §Deferred.
+    ///
+    /// # Errors
+    ///
+    /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no row of `key` at `scope`
+    ///   matches `slot_identity`.
+    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
+    ///   down.
+    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    pub async fn revoke_slot_for(
+        &self,
+        key: &ResourceKey,
+        scope: ScopeLevel,
+        slot: &str,
+        slot_identity: u64,
+    ) -> Result<(), Error> {
+        let tainted = self.taint_slot_for(key, scope, slot, slot_identity)?;
+        self.drain_and_revoke(tainted).await
     }
 
     /// Type-erased `(key, scope)` → live `ManagedResource` resolution for
@@ -2351,6 +2520,24 @@ impl Manager {
                     error: e.to_string(),
                 });
             },
+        }
+    }
+
+    /// Broadcasts a [`ResourceEvent`] to current subscribers.
+    ///
+    /// `broadcast::Sender::send` only returns `Err` when there are **zero**
+    /// receivers — an expected, non-error condition (events are a passive
+    /// observability stream, not a delivery guarantee). This helper names
+    /// that contract in one place so the absence of a subscriber is
+    /// explicitly a deliberate no-op rather than a silently discarded
+    /// `Result` at the emit site.
+    fn emit(&self, event: ResourceEvent) {
+        match self.event_tx.send(event) {
+            Ok(_subscribers) => {},
+            // No subscribers attached — the event stream is best-effort
+            // observability, so this is the documented normal case, not a
+            // failure to propagate.
+            Err(broadcast::error::SendError(_dropped)) => {},
         }
     }
 }

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -132,6 +132,60 @@ impl std::fmt::Debug for TaintedSlot {
     }
 }
 
+/// Outcome of the cancellation-safe revoke tail
+/// ([`Manager::drain_and_revoke`]).
+///
+/// The tail has exactly one owner of the per-resource time budget (the
+/// `drain_timeout` argument): the drain wait is bounded by it
+/// (best-effort — a timed-out drain still proceeds to the hook), and the
+/// revoke hook is *separately* bounded by it. There is **no** caller-side
+/// `tokio::time::timeout` wrapping the whole tail — that wrapper used to
+/// be able to drop the future *before the hook ran* when the drain was
+/// slow, contradicting the "hook still runs after a timed-out drain"
+/// contract (ADR-0067 §Deferred). So the three terminal states are
+/// reported here rather than inferred from a dropped outer future:
+///
+/// - [`Done`](Self::Done) — the revoke hook completed `Ok`.
+/// - [`HookFailed`](Self::HookFailed) — the hook returned `Err` (carried
+///   verbatim).
+/// - [`HookTimedOut`](Self::HookTimedOut) — the hook itself did not
+///   complete within the budget. The row stays tainted (the taint ran in
+///   the synchronous phase-1); only a *hung hook* is bounded, never the
+///   taint, and never at the cost of skipping a hook after a slow drain.
+#[derive(Debug)]
+#[must_use = "the revoke tail outcome must be recorded (it is not a silent success)"]
+pub enum RevokeTail {
+    /// Drain + revoke hook completed; the hook returned `Ok`. (A
+    /// best-effort drain timeout that still reached a successful hook is
+    /// still `Done` — the drain timeout is non-fatal.)
+    Done,
+    /// The revoke hook returned an error. The row stays tainted; the
+    /// inner error is preserved for the caller's outcome accounting.
+    HookFailed(Error),
+    /// The revoke hook did not complete within the per-resource budget
+    /// (a wedged `on_credential_revoke`). The row stays tainted; this is
+    /// the only thing the budget bounds.
+    HookTimedOut,
+}
+
+impl RevokeTail {
+    /// Adapts the tail outcome to `Result<(), Error>` for the back-compat
+    /// convenience callers ([`Manager::revoke_slot`] /
+    /// [`Manager::revoke_slot_for`]) that run taint+tail back-to-back and
+    /// only need pass/fail. A hook timeout becomes a retryable transient
+    /// error (the row is tainted; a later retry is meaningful), distinct
+    /// from a hook failure which carries the hook's own error.
+    fn into_result(self) -> Result<(), Error> {
+        match self {
+            RevokeTail::Done => Ok(()),
+            RevokeTail::HookFailed(e) => Err(e),
+            RevokeTail::HookTimedOut => Err(Error::transient(
+                "revoke hook timed out — row stays tainted, no new leases",
+            )),
+        }
+    }
+}
+
 /// Central registry and lifecycle manager for all resources.
 ///
 /// Owns the [`ReleaseQueue`] internally — callers never need to create,
@@ -1316,6 +1370,19 @@ impl Manager {
         }
     }
 
+    /// Default per-resource revoke budget for the back-compat
+    /// back-to-back convenience callers ([`revoke_slot`](Self::revoke_slot)
+    /// / [`revoke_slot_for`](Self::revoke_slot_for)).
+    ///
+    /// 30 s — the same budget the manager-wide `graceful_shutdown` drain
+    /// uses and the value [`drain_and_revoke`](Self::drain_and_revoke)
+    /// previously hard-coded for the drain wait. The engine rotation
+    /// fan-out does **not** use this: it passes its own per-resource
+    /// rotation budget so the timeout has one owner end-to-end (ADR-0067
+    /// §Deferred / #690 review).
+    pub const DEFAULT_REVOKE_DRAIN_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_secs(30);
+
     /// **Phase 2 of the revoke port — the cancellation-safe awaited tail.**
     /// Consumes a [`TaintedSlot`] from [`taint_slot`](Self::taint_slot) /
     /// [`taint_slot_for`](Self::taint_slot_for) (whose taint already ran
@@ -1327,20 +1394,34 @@ impl Manager {
     /// 2. **Dispatch** [`Resource::on_credential_revoke`] against the live runtime per topology.
     /// 3. Emit [`ResourceEvent::SlotRevoked`] / `SlotRevokeFailed`.
     ///
-    /// **Cancellation-safety.** The taint is *not* in this future — it ran in
-    /// the synchronous [`taint_slot_for`](Self::taint_slot_for) phase. So if
-    /// this future is dropped (e.g. the engine fan-out's
-    /// `tokio::time::timeout` elapses), the row stays tainted and consistent:
-    /// new acquires are still rejected, the credential is never silently
-    /// un-revoked. The drain itself is best-effort bounded — a long-held
-    /// handle should not wedge revoke forever, so a bounded wait is used and
-    /// a timeout still proceeds to the revoke hook (the taint already stops
-    /// *new* leases; the hook makes the resource stop emitting on the old
-    /// credential).
+    /// **Single budget owner (ADR-0067 §Deferred / #690 review).** The
+    /// `drain_timeout` argument is the caller's per-resource budget and is
+    /// the *only* timeout governing this tail. It bounds **two** waits
+    /// independently:
     ///
-    /// # Errors
+    /// - the per-resource **drain** — *best-effort*: a drain timeout is
+    ///   non-fatal, it records the `TimedOut` outcome metric and the tail
+    ///   **still proceeds to the revoke hook** (the taint already stops
+    ///   *new* leases; the hook makes the resource stop emitting on the
+    ///   old credential);
+    /// - the **revoke hook** itself — a *wedged* `on_credential_revoke`
+    ///   is the only thing the budget actually cuts short
+    ///   ([`RevokeTail::HookTimedOut`]).
     ///
-    /// - Whatever the resource's `on_credential_revoke` hook maps into [`Error`].
+    /// The caller **must not** wrap this call in its own
+    /// `tokio::time::timeout`. The previous design did, and a slow drain
+    /// could make that outer timeout elapse and **drop the whole future
+    /// before the hook ran** — silently skipping the documented
+    /// "hook still runs after a timed-out drain" guarantee. Bounding both
+    /// waits *inside* this method (one owner, no outer wrapper) means a
+    /// timed-out drain can never skip the hook, and only a hung hook is
+    /// bounded — never the taint.
+    ///
+    /// **Cancellation-safety.** The taint is *not* in this future — it
+    /// ran in the synchronous [`taint_slot_for`](Self::taint_slot_for)
+    /// phase. So if this future *is* dropped anyway (an outer abort, task
+    /// cancel), the row stays tainted and consistent: new acquires are
+    /// still rejected, the credential is never silently un-revoked.
     #[tracing::instrument(
         level = "debug",
         name = "nebula.resource.slot_drain_revoke",
@@ -1353,7 +1434,11 @@ impl Manager {
             op = "revoke",
         )
     )]
-    pub async fn drain_and_revoke(&self, tainted: TaintedSlot) -> Result<(), Error> {
+    pub async fn drain_and_revoke(
+        &self,
+        tainted: TaintedSlot,
+        drain_timeout: std::time::Duration,
+    ) -> RevokeTail {
         let TaintedSlot {
             key,
             slot,
@@ -1365,19 +1450,19 @@ impl Manager {
         //    §Deferred): a revoke on resource A must not block on in-flight
         //    traffic to an unrelated resource B, so this awaits the row's
         //    own per-resource counter — not the manager-wide `drain_tracker`
-        //    (which stays the `graceful_shutdown` primitive). Bounded so a
-        //    stuck handle on *this* resource cannot wedge revoke; the taint
-        //    (already applied synchronously in the phase-1 function) already
-        //    stops new leases.
+        //    (which stays the `graceful_shutdown` primitive). Bounded by the
+        //    caller's per-resource budget so a stuck handle on *this*
+        //    resource cannot wedge revoke; the taint (already applied
+        //    synchronously in the phase-1 function) already stops new
+        //    leases.
         //
         //    A drain timeout is *terminal* for this dispatch's outcome
         //    metric: it records `TimedOut` and the subsequent hook
         //    success/failure does NOT record a second outcome (one dispatch
         //    = exactly one outcome). The hook still runs and its event /
-        //    returned `Result` are unaffected.
-        let drain_result = managed
-            .wait_for_in_flight_drain_erased(std::time::Duration::from_secs(30))
-            .await;
+        //    returned outcome are unaffected — this is the contract the
+        //    removed outer `tokio::time::timeout` wrapper used to break.
+        let drain_result = managed.wait_for_in_flight_drain_erased(drain_timeout).await;
         let drain_timed_out = drain_result.is_err();
         if let Err(outstanding) = &drain_result {
             if let Some(m) = &self.metrics {
@@ -1390,12 +1475,18 @@ impl Manager {
             );
         }
 
-        // 2. Dispatch the revoke hook against the live runtime.
-        let result = managed.dispatch_on_revoke_erased(&slot).await;
+        // 2. Dispatch the revoke hook against the live runtime, bounded by
+        //    the SAME per-resource budget. This is the only place the
+        //    budget can cut the tail short: a wedged `on_credential_revoke`
+        //    must not pin the fan-out row forever. A timed-out drain (above)
+        //    has *already* consumed the metric outcome, so a hook that then
+        //    also times out does not double-record.
+        let hook_outcome =
+            tokio::time::timeout(drain_timeout, managed.dispatch_on_revoke_erased(&slot)).await;
         tracing::Span::current().record("duration_ms", tainted_at.elapsed().as_millis() as u64);
 
-        match &result {
-            Ok(()) => {
+        match hook_outcome {
+            Ok(Ok(())) => {
                 // Only record Success when the drain did not already record
                 // the terminal TimedOut outcome for this dispatch.
                 if !drain_timed_out && let Some(m) = &self.metrics {
@@ -1406,8 +1497,9 @@ impl Manager {
                     slot: slot.clone(),
                 });
                 tracing::debug!("slot revoke hook completed");
+                RevokeTail::Done
             },
-            Err(e) => {
+            Ok(Err(e)) => {
                 if !drain_timed_out && let Some(m) = &self.metrics {
                     m.record_slot_revoke_outcome(crate::metrics::SlotDispatchOutcome::Failed);
                 }
@@ -1417,9 +1509,27 @@ impl Manager {
                     error: e.to_string(),
                 });
                 tracing::warn!(error = %e, "slot revoke hook failed");
+                RevokeTail::HookFailed(e)
+            },
+            Err(_elapsed) => {
+                // The hook itself wedged. The row stays tainted (phase 1).
+                // Record `TimedOut` unless the drain already did (one
+                // dispatch = exactly one outcome).
+                if !drain_timed_out && let Some(m) = &self.metrics {
+                    m.record_slot_revoke_outcome(crate::metrics::SlotDispatchOutcome::TimedOut);
+                }
+                self.emit(ResourceEvent::SlotRevokeFailed {
+                    key,
+                    slot,
+                    error: "revoke hook timed out".to_owned(),
+                });
+                tracing::warn!(
+                    timeout_ms = drain_timeout.as_millis() as u64,
+                    "slot revoke hook timed out (row stays tainted, no new leases)"
+                );
+                RevokeTail::HookTimedOut
             },
         }
-        result
     }
 
     /// Notifies a registered resource that one of its `#[credential]` slots
@@ -1451,7 +1561,9 @@ impl Manager {
         slot: &str,
     ) -> Result<(), Error> {
         let tainted = self.taint_slot(key, scope, slot)?;
-        self.drain_and_revoke(tainted).await
+        self.drain_and_revoke(tainted, Self::DEFAULT_REVOKE_DRAIN_TIMEOUT)
+            .await
+            .into_result()
     }
 
     /// [`revoke_slot`](Self::revoke_slot) pinned to a resolved per-slot
@@ -1481,7 +1593,9 @@ impl Manager {
         slot_identity: u64,
     ) -> Result<(), Error> {
         let tainted = self.taint_slot_for(key, scope, slot, slot_identity)?;
-        self.drain_and_revoke(tainted).await
+        self.drain_and_revoke(tainted, Self::DEFAULT_REVOKE_DRAIN_TIMEOUT)
+            .await
+            .into_result()
     }
 
     /// Type-erased `(key, scope)` → live `ManagedResource` resolution for
@@ -2307,6 +2421,24 @@ impl Manager {
         let config = managed.config();
         match &managed.topology {
             TopologyRuntime::Pool(rt) => {
+                // `warmup` runs `R::create` against the resolved credential
+                // to materialize fresh pool instances — it is acquire-like
+                // and must observe the SAME revoke-vs-acquire TOCTOU close
+                // the `run_*_acquire` pipelines use (#679 / ADR-0044/0036).
+                // The `lookup_for_acquire` taint gate above ran *before*
+                // this in-flight increment, leaving a window where a
+                // concurrent `revoke_slot` could taint after the gate yet
+                // before warmup creates entries. Pre-count this work in the
+                // resource's own in-flight counter (the exact counter
+                // `revoke_slot` drains), then re-check the taint: either we
+                // observe the taint here and reject, or our increment is
+                // visible to the revoke's drain — so no fresh pool entry is
+                // ever created on a just-revoked credential. The counter is
+                // held for the whole `warmup` await (RAII drop on every
+                // exit path).
+                let _in_flight =
+                    InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
+                Self::reject_if_tainted_post_count::<R>(&managed)?;
                 let count = rt.warmup(&managed.resource, &config, ctx).await;
                 Ok(count)
             },

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -12,13 +12,87 @@
 //! silently force-clearing the registry on drain timeout is now opt-in
 //! through [`DrainTimeoutPolicy::Force`](super::DrainTimeoutPolicy::Force).
 
-use std::{sync::atomic::Ordering as AtomicOrdering, time::Duration};
+use std::{
+    sync::{Arc, atomic::Ordering as AtomicOrdering},
+    time::Duration,
+};
+
+use tokio::sync::Notify;
 
 use crate::{
     events::ResourceEvent,
     manager::{DrainTimeoutPolicy, Manager, ShutdownConfig},
     release_queue::ReleaseQueue,
 };
+
+/// Waits until `tracker`'s counter reaches `0` or `timeout` elapses.
+///
+/// Shared by the manager-wide [`Manager::wait_for_drain`] (drains
+/// `Manager::drain_tracker` for `graceful_shutdown`) and the per-resource
+/// drain in `Manager::revoke_resolved` (drains a single
+/// [`ManagedResource`](crate::runtime::managed::ManagedResource)'s own
+/// in-flight tracker). Both must reject a revoked / shutting-down credential
+/// *before* the drained phase, so the subtle lost-wakeup ordering is written
+/// **once** here rather than duplicated per call site (a structural
+/// guarantee, not a discipline one).
+///
+/// The loop uses a `register-then-check` ordering to avoid the classic
+/// `Notify::notify_waiters` lost-wakeup:
+///
+/// 1. Construct + pin + `enable()` a fresh `Notified` future. `enable()`
+///    registers this waiter on the `Notify` queue without an `.await`, so
+///    any subsequent `notify_waiters()` (fired when a handle's `Drop`
+///    decrements the counter from `1 → 0`) reaches us.
+/// 2. Re-check the counter. If it hit `0` between the outer check and our
+///    registration, return now — the wakeup is already consumed.
+/// 3. Only then await the `Notified` future.
+///
+/// Returns `Ok(())` once drained, or `Err(outstanding)` with the snapshot of
+/// the counter at the moment the timer fired.
+pub(crate) async fn wait_for_tracker_drain(
+    tracker: &Arc<(std::sync::atomic::AtomicU64, Notify)>,
+    timeout: Duration,
+) -> Result<(), u64> {
+    let active = tracker.0.load(AtomicOrdering::Acquire);
+    if active == 0 {
+        return Ok(());
+    }
+
+    tracing::debug!(active_handles = active, "waiting for handles to drain");
+    let drained = tokio::time::timeout(timeout, async {
+        loop {
+            // Pre-register this waiter BEFORE re-checking the counter.
+            let notified = tracker.1.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            // Re-check after registration. If the last handle dropped while
+            // we were between the outer check and `enable()`, the counter is
+            // now 0 and we would otherwise wait on a notification that has
+            // already fired.
+            if tracker.0.load(AtomicOrdering::Acquire) == 0 {
+                return;
+            }
+
+            notified.await;
+
+            if tracker.0.load(AtomicOrdering::Acquire) == 0 {
+                return;
+            }
+        }
+    })
+    .await;
+
+    if drained.is_err() {
+        let outstanding = tracker.0.load(AtomicOrdering::Acquire);
+        tracing::warn!(
+            outstanding,
+            "resource manager: drain timeout expired with handles still active"
+        );
+        return Err(outstanding);
+    }
+    Ok(())
+}
 
 /// Structured result of a successful (or forced-through) graceful shutdown.
 #[derive(Debug, Clone)]
@@ -257,66 +331,17 @@ impl Manager {
         }
     }
 
-    /// Waits until all active `ResourceGuard`s are dropped or timeout expires.
+    /// Waits until all active manager-wide `ResourceGuard`s are dropped or
+    /// `timeout` expires (the `graceful_shutdown` drain).
     ///
-    /// The loop uses a `register-then-check` ordering to avoid the classic
-    /// `Notify::notify_waiters` lost-wakeup:
-    ///
-    /// 1. Construct + pin + `enable()` a fresh `Notified` future. Calling `enable()` registers this
-    ///    waiter on the `Notify` queue without requiring a `.await`, so any subsequent
-    ///    `notify_waiters()` (fired when a handle's `Drop` decrements the counter from 1 → 0) will
-    ///    reach us.
-    /// 2. Re-check the counter. If it already hit 0 between the outer initial check and our
-    ///    registration, return now — the wakeup we would otherwise wait for has already been
-    ///    consumed.
-    /// 3. Only then await the `Notified` future.
-    ///
-    /// Without this ordering, a burst of handle drops that completes the
-    /// drain *before* the first `notified().await` poll would leak the
-    /// notification entirely, stalling `graceful_shutdown` for the full
-    /// `drain_timeout` (default 30 s) and risking `SIGKILL` escalation
-    /// under a tight orchestrator shutdown window.
+    /// Thin typed wrapper over [`wait_for_tracker_drain`] against
+    /// `Manager::drain_tracker`; the lost-wakeup-safe ordering and its
+    /// rationale live on that shared helper (the per-resource revoke drain
+    /// reuses the same helper against a single resource's tracker).
     pub(super) async fn wait_for_drain(&self, timeout: Duration) -> Result<(), DrainTimeoutError> {
-        let active = self.drain_tracker.0.load(AtomicOrdering::Acquire);
-        if active == 0 {
-            return Ok(());
-        }
-
-        tracing::debug!(active_handles = active, "waiting for handles to drain");
-        let tracker = &self.drain_tracker;
-        let drained = tokio::time::timeout(timeout, async {
-            loop {
-                // Pre-register this waiter BEFORE re-checking the counter.
-                let notified = tracker.1.notified();
-                tokio::pin!(notified);
-                notified.as_mut().enable();
-
-                // Re-check after registration. If the last handle dropped
-                // while we were between the outer check and `enable()`,
-                // the counter is now 0 and we would otherwise wait on a
-                // notification that has already fired.
-                if tracker.0.load(AtomicOrdering::Acquire) == 0 {
-                    return;
-                }
-
-                notified.await;
-
-                if tracker.0.load(AtomicOrdering::Acquire) == 0 {
-                    return;
-                }
-            }
-        })
-        .await;
-
-        if drained.is_err() {
-            let outstanding = tracker.0.load(AtomicOrdering::Acquire);
-            tracing::warn!(
-                outstanding,
-                "resource manager: drain timeout expired with handles still active"
-            );
-            return Err(DrainTimeoutError { outstanding });
-        }
-        Ok(())
+        wait_for_tracker_drain(&self.drain_tracker, timeout)
+            .await
+            .map_err(|outstanding| DrainTimeoutError { outstanding })
     }
 }
 

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -17,11 +17,38 @@ use crate::{
     error::Error, resource::Resource, runtime::managed::ManagedResource, topology_tag::TopologyTag,
 };
 
+/// Crate-private seal: only `nebula-resource` can name `sealed::Sealed`,
+/// so [`AnyManagedResource`] is **not implementable downstream**.
+///
+/// `AnyManagedResource` is engine-internal: the only purpose is to let
+/// the [`Registry`] store heterogeneous `ManagedResource<R>` behind one
+/// `dyn AnyManagedResource`, and the sole implementor is the blanket
+/// `impl<R: Resource>` below. Sealing makes that a *structural*
+/// guarantee rather than a convention — adding a required method (e.g.
+/// the per-resource-drain hook) can never be a downstream
+/// compile-break, because no downstream impl can exist. The
+/// `LookupOutcome::Found(Arc<dyn AnyManagedResource>)` surface stays
+/// usable (callers only *consume* the trait object); they just cannot
+/// *implement* it.
+mod sealed {
+    /// Sealed marker. Implemented only by the crate-internal blanket
+    /// `impl<R: Resource>` for `ManagedResource<R>`.
+    pub trait Sealed {}
+}
+
 /// Type-erased trait for managed resources stored in the [`Registry`].
 ///
 /// Every `ManagedResource<R>` implements this trait, allowing the registry
 /// to store heterogeneous resource types behind a single `dyn AnyManagedResource`.
-pub trait AnyManagedResource: Send + Sync + 'static {
+///
+/// **Sealed (engine-internal).** This trait has a private `sealed::Sealed`
+/// supertrait, so it can only be implemented inside `nebula-resource` (by
+/// the blanket `impl<R: Resource>`). It is an engine-internal erasure
+/// boundary, **not** a downstream extension point — new required methods
+/// may be added without it being a semver-breaking change for consumers
+/// (they only ever hold `Arc<dyn AnyManagedResource>` via
+/// [`LookupOutcome::Found`], never implement it).
+pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// Returns the resource key for this managed resource.
     fn resource_key(&self) -> ResourceKey;
 
@@ -108,6 +135,11 @@ pub trait AnyManagedResource: Send + Sync + 'static {
         timeout: std::time::Duration,
     ) -> Pin<Box<dyn Future<Output = Result<(), u64>> + Send + 'a>>;
 }
+
+// The one and only `Sealed` impl: every `ManagedResource<R>` (and
+// nothing else, anywhere) — this is what makes `AnyManagedResource`
+// non-implementable downstream.
+impl<R: Resource> sealed::Sealed for ManagedResource<R> {}
 
 impl<R: Resource> AnyManagedResource for ManagedResource<R> {
     fn resource_key(&self) -> ResourceKey {
@@ -496,6 +528,12 @@ mod tests {
 
     struct FakeA;
     struct FakeB;
+
+    // In-crate test doubles: the seal is crate-private, so the test
+    // module can satisfy it directly (an out-of-crate type could not —
+    // that is the point of the seal).
+    impl sealed::Sealed for FakeA {}
+    impl sealed::Sealed for FakeB {}
 
     fn unit_dispatch<'a>() -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
         Box::pin(async { Ok(()) })

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -91,6 +91,22 @@ pub trait AnyManagedResource: Send + Sync + 'static {
         &'a self,
         slot: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>>;
+
+    /// Type-erased bounded drain of **this resource's own** in-flight
+    /// acquires.
+    ///
+    /// `Manager::revoke_slot` takes a `ResourceKey`, not a generic `R`, so
+    /// it drains through the erased view. Forwards to
+    /// `ManagedResource::wait_for_in_flight_drain`, which waits on this
+    /// row's per-resource counter — *not* the manager-wide `drain_tracker`
+    /// — so a revoke is isolated from in-flight traffic to unrelated
+    /// resources (ADR-0067 §Deferred). Boxed for the same `dyn`-safety
+    /// reason as the dispatch hooks. `Err(outstanding)` carries the counter
+    /// snapshot at the moment the timer fired.
+    fn wait_for_in_flight_drain_erased<'a>(
+        &'a self,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<(), u64>> + Send + 'a>>;
 }
 
 impl<R: Resource> AnyManagedResource for ManagedResource<R> {
@@ -138,6 +154,13 @@ impl<R: Resource> AnyManagedResource for ManagedResource<R> {
         slot: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
         Box::pin(self.dispatch_slot_hook(slot, false))
+    }
+
+    fn wait_for_in_flight_drain_erased<'a>(
+        &'a self,
+        timeout: std::time::Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<(), u64>> + Send + 'a>> {
+        Box::pin(self.wait_for_in_flight_drain(timeout))
     }
 }
 
@@ -509,6 +532,12 @@ mod tests {
         ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
             unit_dispatch()
         }
+        fn wait_for_in_flight_drain_erased<'a>(
+            &'a self,
+            _timeout: std::time::Duration,
+        ) -> Pin<Box<dyn Future<Output = Result<(), u64>> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
+        }
     }
 
     impl AnyManagedResource for FakeB {
@@ -541,6 +570,12 @@ mod tests {
             _slot: &'a str,
         ) -> Pin<Box<dyn Future<Output = Result<(), Error>> + Send + 'a>> {
             unit_dispatch()
+        }
+        fn wait_for_in_flight_drain_erased<'a>(
+            &'a self,
+            _timeout: std::time::Duration,
+        ) -> Pin<Box<dyn Future<Output = Result<(), u64>> + Send + 'a>> {
+            Box::pin(async { Ok(()) })
         }
     }
 

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -317,6 +317,35 @@ pub trait Resource: Send + Sync + 'static {
         async { Ok(()) }
     }
 
+    /// The highest `SlotCell` generation across **all** of this resource's
+    /// `#[credential]` slot fields — the resource's current *credential
+    /// epoch*.
+    ///
+    /// `0` means "no credential slot has ever been bound" (also the default
+    /// for resources with no credential slots). Each `SlotCell` transition
+    /// (`store` *or* `take`/clear) strictly advances its generation, so a
+    /// strictly-larger epoch observed after a runtime was built proves a
+    /// credential rotated/was revoked in between.
+    ///
+    /// `#[derive(Resource)]` emits the real implementation (the `max` over
+    /// every declared `#[credential]` field's
+    /// [`SlotCell::generation`](crate::SlotCell::generation)) — it is
+    /// derive-generated, not author-maintained, so a new slot field cannot
+    /// be silently omitted from the epoch. The default `0` keeps
+    /// hand-written impls (and slot-less resources) compiling; for such
+    /// impls the create-vs-rotate reconcile degrades to the
+    /// runtime-presence path only (it never *falsely* reports a stale
+    /// runtime, it just cannot prove staleness by epoch).
+    ///
+    /// Used by the per-slot rotation dispatch and the Resident create slow
+    /// path to close the create-vs-rotate lost-update race (ADR-0067
+    /// §Deferred): the Resident runtime records the epoch it was built
+    /// against and the dispatch reconciles a runtime built against an
+    /// older epoch instead of silently reporting success.
+    fn credential_slot_epoch(&self) -> u64 {
+        0
+    }
+
     /// Health-checks an existing runtime.
     ///
     /// The default implementation always succeeds.

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -317,25 +317,37 @@ pub trait Resource: Send + Sync + 'static {
         async { Ok(()) }
     }
 
-    /// The highest `SlotCell` generation across **all** of this resource's
-    /// `#[credential]` slot fields — the resource's current *credential
-    /// epoch*.
+    /// An opaque change-token over **all** of this resource's
+    /// `#[credential]` slot field generations — the resource's current
+    /// *credential epoch*.
+    ///
+    /// **Contract:** the returned value **changes whenever ANY slot's
+    /// generation changes** — not just the slot with the largest
+    /// generation. It is compared **only for equality** by the
+    /// create-vs-rotate reconcile (built-epoch vs live-epoch), never by
+    /// magnitude, so it is a change-token rather than a monotone counter.
     ///
     /// `0` means "no credential slot has ever been bound" (also the default
     /// for resources with no credential slots). Each `SlotCell` transition
-    /// (`store` *or* `take`/clear) strictly advances its generation, so a
-    /// strictly-larger epoch observed after a runtime was built proves a
-    /// credential rotated/was revoked in between.
+    /// (`store` *or* `take`/clear) strictly advances its per-slot
+    /// generation, so any post-build slot transition yields a different
+    /// epoch — proving a credential rotated/was revoked in between.
     ///
-    /// `#[derive(Resource)]` emits the real implementation (the `max` over
-    /// every declared `#[credential]` field's
-    /// [`SlotCell::generation`](crate::SlotCell::generation)) — it is
-    /// derive-generated, not author-maintained, so a new slot field cannot
-    /// be silently omitted from the epoch. The default `0` keeps
-    /// hand-written impls (and slot-less resources) compiling; for such
-    /// impls the create-vs-rotate reconcile degrades to the
-    /// runtime-presence path only (it never *falsely* reports a stale
-    /// runtime, it just cannot prove staleness by epoch).
+    /// `#[derive(Resource)]` emits the real implementation: an
+    /// order-sensitive positional fold
+    /// (`acc = acc * K + slot.generation()`, fixed odd `K`) over every
+    /// declared `#[credential]` field's
+    /// [`SlotCell::generation`](crate::SlotCell::generation). A plain
+    /// `max` would be wrong here — a runtime built at
+    /// `(slot_a=5, slot_b=10)` then rotated `slot_a→6` still maxes to
+    /// `10`, so the reconcile would miss the now-stale runtime; the
+    /// positional fold changes on every slot transition regardless of
+    /// which slot moved. It is derive-generated, not author-maintained,
+    /// so a new slot field cannot be silently omitted from the epoch. The
+    /// default `0` keeps hand-written impls (and slot-less resources)
+    /// compiling; for such impls the create-vs-rotate reconcile degrades
+    /// to the runtime-presence path only (it never *falsely* reports a
+    /// stale runtime, it just cannot prove staleness by epoch).
     ///
     /// Used by the per-slot rotation dispatch and the Resident create slow
     /// path to close the create-vs-rotate lost-update race (ADR-0067

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -4,12 +4,16 @@
 //! resource. It bundles the resource implementation, hot-swappable config,
 //! topology runtime, release queue, and lifecycle metadata.
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    time::Duration,
 };
 
 use arc_swap::ArcSwap;
+use tokio::sync::Notify;
 
 use super::TopologyRuntime;
 use crate::{
@@ -56,6 +60,20 @@ pub struct ManagedResource<R: Resource> {
     /// and the manager-wide `shutting_down` flag — one shared mechanism,
     /// not a parallel one.
     pub(crate) tainted: AtomicBool,
+    /// Per-resource in-flight acquire counter `(active, notify)`.
+    ///
+    /// Every `acquire_*` against *this* row pre-counts here (alongside the
+    /// manager-wide `Manager::drain_tracker`) and the resulting
+    /// [`ResourceGuard`](crate::guard::ResourceGuard) decrements + notifies
+    /// it on drop. `Manager::revoke_slot` drains **only this** counter
+    /// (ADR-0067 §Deferred): a revoke on resource A must not block on
+    /// in-flight traffic to an unrelated resource B, and the
+    /// taint→increment→post-taint-recheck ordering against this same counter
+    /// is what closes the revoke-vs-acquire TOCTOU that ADR-0044/ADR-0036
+    /// "no authenticated traffic on a revoked credential post-revoke"
+    /// requires. The manager-wide tracker stays the `graceful_shutdown`
+    /// drain primitive and is untouched here.
+    pub(crate) in_flight: Arc<(AtomicU64, Notify)>,
 }
 
 impl<R: Resource> ManagedResource<R> {
@@ -120,6 +138,31 @@ impl<R: Resource> ManagedResource<R> {
     /// Returns `true` if [`taint`](Self::taint) has been called.
     pub(crate) fn is_tainted(&self) -> bool {
         self.tainted.load(Ordering::Acquire)
+    }
+
+    /// Returns a clone of this resource's per-resource in-flight tracker so
+    /// an acquire pipeline can pre-count against it (and hand it to the
+    /// resulting guard). Distinct from the manager-wide `drain_tracker`:
+    /// `Manager::revoke_slot` drains *this* counter only (ADR-0067
+    /// §Deferred), so a revoke never blocks on a sibling resource's
+    /// in-flight work.
+    pub(crate) fn in_flight_tracker(&self) -> Arc<(AtomicU64, Notify)> {
+        Arc::clone(&self.in_flight)
+    }
+
+    /// Drains *this* resource's in-flight acquires (bounded by `timeout`).
+    ///
+    /// The per-resource analogue of `Manager::wait_for_drain`: it waits on
+    /// this row's own counter, not the manager-wide one, so a revoke on this
+    /// resource is isolated from in-flight traffic to unrelated resources
+    /// (ADR-0067 §Deferred). Reuses the exact lost-wakeup-safe ordering of
+    /// the shared shutdown drain helper. Returns `Ok(())` once drained, or
+    /// `Err(outstanding)` with the counter snapshot at the moment the timer
+    /// fired (the caller — `revoke_resolved` — keeps the taint and proceeds
+    /// to the revoke hook regardless; the timeout is best-effort because the
+    /// taint already stops *new* leases).
+    pub(crate) async fn wait_for_in_flight_drain(&self, timeout: Duration) -> Result<(), u64> {
+        crate::manager::shutdown::wait_for_tracker_drain(&self.in_flight, timeout).await
     }
 
     /// Borrows the live runtime(s) for this topology and invokes the

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -173,18 +173,36 @@ impl<R: Resource> ManagedResource<R> {
     /// Exclusive) dispatch once against the shared runtime; Pool dispatches
     /// per idle instance (delegating to
     /// [`PoolRuntime::dispatch_slot_hook_over_idle`](super::pool::PoolRuntime::dispatch_slot_hook_over_idle),
-    /// which carries the same `refresh` selector). Resident before its
-    /// first acquire has no runtime yet — nothing to dispatch, so this is a
-    /// no-op `Ok(())`.
+    /// which carries the same `refresh` selector).
+    ///
+    /// **Topology audit of the `current() == None → Ok(())` stale-skip
+    /// (ADR-0067 §Deferred / #680).** Only **Resident** lazily builds its
+    /// runtime internally via `resource.create()` (under its `create_lock`,
+    /// with a `None`-cell window), so only Resident had the lost-update
+    /// where a rotation racing the first `create` could be recorded as a
+    /// success with the hook never delivered. Its dispatch now goes through
+    /// [`ResidentRuntime::dispatch_resident_hook`](super::resident::ResidentRuntime::dispatch_resident_hook),
+    /// which serialises against `create` on the same lock and reconciles a
+    /// runtime built against an older credential epoch instead of silently
+    /// succeeding. The other arms do **not** share the defect:
+    /// Service / Transport / Exclusive take a caller-supplied runtime at
+    /// register time (no `None` window — the hook is always delivered);
+    /// Pool dispatches over every idle entry and rebuilds fresh instances
+    /// against the current (lock-free) slot, so an empty idle queue masks
+    /// no stale-bound runtime.
     ///
     /// The `refresh` flag selects the hook exactly once per topology arm
     /// (mirroring the pool selector); both directions share identical
     /// per-topology runtime-borrow semantics.
     pub(crate) async fn dispatch_slot_hook(&self, slot: &str, refresh: bool) -> Result<(), Error> {
         match &self.topology {
-            TopologyRuntime::Resident(rt) => match rt.current() {
-                Some(runtime) => self.invoke_slot_hook(slot, refresh, &runtime).await,
-                None => Ok(()),
+            // Reconcile-aware (ADR-0067 §Deferred / #680): serialises
+            // against the resident `create` slow path and re-delivers the
+            // hook to a runtime built against an older credential epoch
+            // rather than skipping with a false success.
+            TopologyRuntime::Resident(rt) => {
+                rt.dispatch_resident_hook(&self.resource, slot, refresh)
+                    .await
             },
             TopologyRuntime::Service(rt) => {
                 self.invoke_slot_hook(slot, refresh, rt.runtime()).await

--- a/crates/resource/src/runtime/resident.rs
+++ b/crates/resource/src/runtime/resident.rs
@@ -4,7 +4,13 @@
 //! runtime. On acquire, the runtime is cloned into an owned handle.
 //! If the runtime is missing or stale, it is (re)created.
 
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::Duration,
+};
 
 use tokio::sync::Mutex;
 use tracing::warn;
@@ -30,8 +36,25 @@ use crate::{
 pub struct ResidentRuntime<R: Resource> {
     cell: Cell<R::Runtime>,
     config: Config,
-    /// Serialises the create / recreate slow path.
+    /// Serialises the create / recreate slow path **and** the per-slot
+    /// rotation hook dispatch (see [`dispatch_resident_hook`]). The
+    /// rotation dispatch holding this same lock is what makes the
+    /// create-vs-rotate reconcile *exactly-once*: a `create` slow path
+    /// and a rotation dispatch can never interleave, so the freshly-built
+    /// runtime's epoch is either reconciled inside `create` (dispatch ran
+    /// first / sees the post-reconcile epoch) or by the dispatch (it sees
+    /// the stored runtime + its recorded epoch) — never both.
+    ///
+    /// [`dispatch_resident_hook`]: Self::dispatch_resident_hook
     create_lock: Mutex<()>,
+    /// The credential epoch ([`Resource::credential_slot_epoch`]) the
+    /// currently-stored runtime was built against. `0` when no runtime has
+    /// been created. Written only under `create_lock`; read under it by
+    /// the rotation dispatch. A stored runtime whose `built_epoch` is
+    /// *older* than the live slot epoch was bound to a pre-rotation
+    /// credential — the lost-update the dispatch must reconcile rather
+    /// than silently report success for (ADR-0067 §Deferred / #680).
+    built_epoch: AtomicU64,
 }
 
 impl<R: Resource> ResidentRuntime<R> {
@@ -41,6 +64,7 @@ impl<R: Resource> ResidentRuntime<R> {
             cell: Cell::new(),
             config,
             create_lock: Mutex::new(()),
+            built_epoch: AtomicU64::new(0),
         }
     }
 
@@ -54,14 +78,112 @@ impl<R: Resource> ResidentRuntime<R> {
         self.cell.is_some()
     }
 
-    /// Snapshots the current shared runtime, if one has been created.
+    /// Per-slot rotation hook dispatch for the Resident topology, with the
+    /// create-vs-rotate reconcile (ADR-0067 §Deferred / #680).
     ///
-    /// Used by the per-slot rotation dispatch to borrow the live runtime
-    /// and hand it to `Resource::on_credential_refresh` /
-    /// `on_credential_revoke`. `None` before the first acquire (nothing to
-    /// rotate yet).
-    pub(crate) fn current(&self) -> Option<Arc<R::Runtime>> {
-        self.cell.load()
+    /// Takes `create_lock` so it is **mutually excluded** with the
+    /// `create` slow path: a rotation dispatch and a first-acquire create
+    /// can never interleave, which is what makes the reconcile
+    /// exactly-once. Under the lock:
+    ///
+    /// - **Runtime present, built epoch ≥ slot epoch** — up to date: deliver
+    ///   the hook normally.
+    /// - **Runtime present, built epoch < slot epoch** — the runtime was
+    ///   bound to a pre-rotation credential (the lost-update): still deliver
+    ///   the hook (the resource's `&self` reaction rebinds against the now
+    ///   current slot) and, on success, advance the recorded epoch. This is
+    ///   the arm that *used to* silently `Ok(())` when `current() == None`
+    ///   raced the build; it is now an explicit, observable reconcile —
+    ///   never a skipped-but-success.
+    /// - **No runtime** — nothing live to refresh. Genuinely a no-op
+    ///   `Ok(())`: a never-created resident has no stale runtime to leave
+    ///   behind, and a create *racing* this dispatch is serialised by
+    ///   `create_lock` — it runs strictly before or after. If it runs
+    ///   after, it reads the post-rotation credential (correct by
+    ///   construction) and records that newer `built_epoch`; if it ran
+    ///   before, its older `built_epoch` makes *this* dispatch's next
+    ///   invocation (or the very acquire that materialised it) take the
+    ///   stale-reconcile arm. "Never created" vs "created against a stale
+    ///   epoch" is exactly the runtime-presence check here.
+    ///
+    /// `refresh = true` selects `on_credential_refresh`, `false`
+    /// `on_credential_revoke`. The revoke direction is symmetric: a runtime
+    /// built against an older epoch is still delivered the revoke hook (it
+    /// must stop emitting on the now-revoked credential); a never-created
+    /// resident has nothing emitting, so the no-op is correct there too.
+    pub(crate) async fn dispatch_resident_hook(
+        &self,
+        resource: &R,
+        slot: &str,
+        refresh: bool,
+    ) -> Result<(), Error> {
+        // Serialise against the create slow path: the reconcile must not
+        // interleave with a runtime being built / its epoch being
+        // published, so delivery is exactly-once.
+        let _guard = self.create_lock.lock().await;
+
+        let Some(runtime) = self.cell.load() else {
+            // No live runtime. Not a stale-skip: nothing is bound to a
+            // credential at all, and a concurrent first create is excluded
+            // by `create_lock` (it runs strictly before/after this and
+            // records its own `built_epoch`). A genuinely never-created,
+            // never-bound resident is a legitimate no-op.
+            tracing::debug!(
+                resource = %R::key(),
+                slot,
+                refresh,
+                "resident slot hook: no live runtime — legitimate no-op \
+                 (never created; not a stale-skip)"
+            );
+            return Ok(());
+        };
+
+        let slot_epoch = resource.credential_slot_epoch();
+        let built = self.built_epoch.load(Ordering::Acquire);
+        let stale = built < slot_epoch;
+        if stale {
+            // The lost-update: the live runtime was built against an older
+            // credential epoch than the slot now holds. This is the arm
+            // that previously could be skipped with a false success when it
+            // raced `current() == None`; it is now an explicit, observable
+            // reconcile — we still deliver the hook so the rotation
+            // actually takes effect. Carries no credential material.
+            tracing::warn!(
+                resource = %R::key(),
+                slot,
+                refresh,
+                built_epoch = built,
+                slot_epoch,
+                "resident slot hook: live runtime is stale (built against an \
+                 older credential epoch) — reconciling by delivering the hook"
+            );
+        }
+
+        let res = if refresh {
+            resource.on_credential_refresh(slot, &runtime).await
+        } else {
+            resource.on_credential_revoke(slot, &runtime).await
+        };
+
+        match res {
+            Ok(()) => {
+                if stale {
+                    // Reconciled: the runtime is now consistent with the
+                    // current slot epoch. Advance so a subsequent dispatch
+                    // does not treat it as stale again.
+                    self.built_epoch.store(slot_epoch, Ordering::Release);
+                }
+                Ok(())
+            },
+            Err(e) => {
+                // On a stale reconcile failure, deliberately do NOT advance
+                // `built_epoch`: the runtime is still bound to the old
+                // credential, so the next dispatch must re-attempt. The
+                // error propagates so the dispatch outcome is recorded as
+                // failed — never a skipped-because-stale success.
+                Err(e.into())
+            },
+        }
     }
 }
 
@@ -136,6 +258,26 @@ where
             }
         }
 
+        // Capture the credential epoch *immediately before* `create`
+        // reads the slot. `create` reads each `#[credential]` slot through
+        // its derive-emitted accessor; if a `SlotCell::store` (engine
+        // rotation fan-out, ADR-0067 D1) lands *after* this read but
+        // *before* we publish the runtime, the runtime is bound to the
+        // pre-rotation credential while a concurrent rotation dispatch
+        // would (pre-fix) see `current() == None`, record a false success,
+        // and the hook would never be delivered (#680 lost-update).
+        //
+        // Recording this epoch as the runtime's `built_epoch` is the
+        // structural reconcile: the rotation dispatch (serialised by the
+        // same `create_lock`) compares it against the live slot epoch and
+        // re-delivers the hook against this runtime if it is older. The
+        // dispatch — not this path — owns hook delivery, so the hook fires
+        // *exactly once* with the real slot name (a `create` reading the
+        // slot strictly after a `store` already builds against the fresh
+        // credential and needs no hook; a `create` reading it strictly
+        // before is detected here via a stale `built_epoch`).
+        let built_epoch = resource.credential_slot_epoch();
+
         // Create a new runtime.
         let runtime = match tokio::time::timeout(
             self.config.create_timeout,
@@ -150,6 +292,11 @@ where
 
         let lease: R::Lease = runtime.clone().into();
         self.cell.store(Arc::new(runtime));
+        // Publish the (runtime, built_epoch) pair. Both writes happen
+        // under `create_lock`; the rotation dispatch reads both under the
+        // same lock, so it never observes a stored runtime with a stale
+        // (un-updated) `built_epoch`.
+        self.built_epoch.store(built_epoch, Ordering::Release);
 
         Ok(ResourceGuard::owned(lease, R::key(), TopologyTag::Resident))
     }

--- a/crates/resource/src/slot.rs
+++ b/crates/resource/src/slot.rs
@@ -5,41 +5,145 @@
 //! rotation the engine swaps a fresh guard in without `&mut` on the
 //! resource (the `&self` refresh-hook model, ADR-0067). Lock-free via
 //! `arc-swap`.
+//!
+//! # Generation / epoch (ADR-0067 §Deferred — create-vs-rotate ordering)
+//!
+//! Every credential-state transition (`store`, `take`) bumps a strictly
+//! monotonically increasing **generation**. `0` is reserved for "never
+//! bound" — the first `store` lands at generation `1`. The generation is
+//! coupled to the stored value inside a single immutable internal entry
+//! published through one `ArcSwapOption` swap, so a reader observes the
+//! generation and the guard it belongs to with **no torn read** (a separate
+//! `AtomicU64` read alongside an `ArcSwap` load could observe a generation
+//! from one transition and a guard from another). A built resource runtime
+//! records the generation it was constructed against; the per-slot rotation
+//! dispatch compares that against the live generation to detect a runtime
+//! left bound to a pre-rotation credential by a create-vs-rotate race
+//! (ADR-0067 §Deferred). See `ResidentRuntime` / `ManagedResource::
+//! dispatch_slot_hook`.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU64, Ordering},
+};
 
 use arc_swap::ArcSwapOption;
-use std::sync::Arc;
+
+/// An immutable (generation, value) pair published as one unit.
+///
+/// Storing the generation *inside* the swapped `Arc` (rather than in a
+/// sibling atomic) is what makes [`SlotCell::load_versioned`] torn-read
+/// free: a single `ArcSwapOption` load yields the guard and the exact
+/// generation it was published at, never a generation from a different
+/// transition.
+#[derive(Debug)]
+struct SlotEntry<S> {
+    /// Strictly monotonically increasing; `>= 1` for any published value.
+    generation: u64,
+    /// The resolved slot value (`CredentialGuard<C>` in production).
+    value: Arc<S>,
+}
 
 /// Lock-free interior-mutable holder for one resolved credential slot.
 ///
-/// Holds `Arc<S>`: a real slot value is `CredentialGuard<C>`, which is
-/// `!Clone` and zeroizes on `Drop`, so the `Arc` indirection lets the engine
-/// swap a rotated guard in with no secret-byte clone.
+/// Holds an `Arc` of an internal generation+value entry: a real slot value
+/// is `CredentialGuard<C>`,
+/// which is `!Clone` and zeroizes on `Drop`, so the `Arc<S>` indirection
+/// inside the entry lets the engine swap a rotated guard in with no
+/// secret-byte clone. Every transition carries a fresh generation so a
+/// runtime built against an older guard is detectable on rotation
+/// (ADR-0067 §Deferred).
 #[derive(Debug)]
 pub struct SlotCell<S> {
-    inner: ArcSwapOption<S>,
+    inner: ArcSwapOption<SlotEntry<S>>,
+    /// Source of strictly increasing generations. `fetch_add` returns the
+    /// *previous* value, so the first transition observes `0` and stamps
+    /// `1` (generation `0` ≡ "never bound").
+    next_generation: AtomicU64,
 }
 
 impl<S> SlotCell<S> {
-    /// An unresolved slot.
+    /// An unresolved slot (generation `0` ≡ "never bound").
     pub fn empty() -> Self {
         Self {
             inner: ArcSwapOption::empty(),
+            next_generation: AtomicU64::new(0),
         }
     }
 
-    /// Install (or replace) the resolved value.
+    /// Returns the next strictly-increasing generation for a transition.
+    fn bump_generation(&self) -> u64 {
+        // `fetch_add` returns the prior value; the first call yields `0`,
+        // so `+ 1` makes the first published generation `1` and every
+        // subsequent transition strictly greater. `Relaxed` is sufficient:
+        // ordering of the generation w.r.t. the stored value is carried by
+        // the single `ArcSwapOption` publish/observe of the `SlotEntry`,
+        // not by this counter's memory order.
+        self.next_generation.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    /// Install (or replace) the resolved value, bumping the generation.
+    ///
+    /// The new generation is published atomically *with* the value inside a
+    /// single internal entry swap, so a concurrent [`load_versioned`] never
+    /// observes the new value paired with an old generation (or vice
+    /// versa).
+    ///
+    /// [`load_versioned`]: Self::load_versioned
     pub fn store(&self, value: Arc<S>) {
-        self.inner.store(Some(value));
+        let generation = self.bump_generation();
+        self.inner
+            .store(Some(Arc::new(SlotEntry { generation, value })));
     }
 
     /// Snapshot the current value, if resolved.
     pub fn load(&self) -> Option<Arc<S>> {
-        self.inner.load_full()
+        self.inner.load_full().map(|entry| Arc::clone(&entry.value))
+    }
+
+    /// Snapshot the current `(generation, value)` together.
+    ///
+    /// The generation and the value come from the *same* internal entry
+    /// (one `ArcSwapOption` load) — there is no window in which they can be
+    /// from different transitions. Returns `None` (and the caller treats
+    /// the epoch as `0`/"never bound") while the slot is unresolved.
+    pub fn load_versioned(&self) -> Option<(u64, Arc<S>)> {
+        self.inner
+            .load_full()
+            .map(|entry| (entry.generation, Arc::clone(&entry.value)))
+    }
+
+    /// The current generation: `0` if never bound, otherwise the
+    /// generation of the latest transition (`store` *or* `take`).
+    ///
+    /// A cleared slot keeps the generation of the `take` that cleared it
+    /// (a clear is itself a credential-state transition — a runtime built
+    /// before a revoke must still see a strictly newer epoch), so this is
+    /// `> 0` after the first transition even when [`load`](Self::load)
+    /// returns `None`.
+    pub fn generation(&self) -> u64 {
+        match self.inner.load_full() {
+            Some(entry) => entry.generation,
+            // No live entry: either never bound (`next_generation == 0`)
+            // or cleared by `take` (the post-take generation we recorded).
+            None => self.next_generation.load(Ordering::Relaxed),
+        }
     }
 
     /// Revoke the slot, returning the previously held value (if any).
+    ///
+    /// A clear is a credential-state transition, so it bumps the
+    /// generation: a runtime built against the pre-clear guard is then
+    /// detectably stale on the next rotation/revoke dispatch (ADR-0067
+    /// §Deferred). The post-clear generation is observable via
+    /// [`generation`](Self::generation) even though [`load`](Self::load)
+    /// is now `None`.
     pub fn take(&self) -> Option<Arc<S>> {
-        self.inner.swap(None)
+        // Bump first so that even if the slot was already empty, the
+        // generation still advances monotonically (a "clear" signal is
+        // meaningful to a rotation observer regardless of prior state).
+        let _post_clear_generation = self.bump_generation();
+        self.inner.swap(None).map(|entry| Arc::clone(&entry.value))
     }
 
     /// Returns `true` if the slot currently holds a resolved value.
@@ -97,5 +201,62 @@ mod tests {
 
         // Second take on now-empty cell returns None.
         assert!(cell.take().is_none());
+    }
+
+    #[test]
+    fn generation_starts_at_zero_and_is_strictly_monotonic() {
+        let cell: SlotCell<FakeGuard> = SlotCell::empty();
+        // Never bound.
+        assert_eq!(cell.generation(), 0, "unbound slot epoch is 0");
+        assert!(cell.load_versioned().is_none());
+
+        // First store -> generation 1, coupled to the value.
+        cell.store(Arc::new(FakeGuard(10)));
+        let (g1, v1) = cell.load_versioned().expect("bound");
+        assert_eq!(g1, 1, "first store is generation 1");
+        assert_eq!(v1.0, 10);
+        assert_eq!(cell.generation(), 1);
+
+        // Second store -> strictly greater generation, new value.
+        cell.store(Arc::new(FakeGuard(20)));
+        let (g2, v2) = cell.load_versioned().expect("bound");
+        assert!(g2 > g1, "store must strictly advance the generation");
+        assert_eq!(v2.0, 20);
+    }
+
+    #[test]
+    fn take_advances_generation_and_is_observable_when_empty() {
+        let cell: SlotCell<FakeGuard> = SlotCell::empty();
+        cell.store(Arc::new(FakeGuard(1)));
+        let g_after_store = cell.generation();
+        assert_eq!(g_after_store, 1);
+
+        // A clear is a credential-state transition: the generation must
+        // advance so a runtime built against the pre-clear guard is
+        // detectably stale, and it stays observable while empty.
+        let _ = cell.take();
+        assert!(cell.load().is_none(), "slot is cleared");
+        let g_after_take = cell.generation();
+        assert!(
+            g_after_take > g_after_store,
+            "take must strictly advance the generation (a clear is a transition)"
+        );
+
+        // Storing again after a clear keeps advancing.
+        cell.store(Arc::new(FakeGuard(2)));
+        assert!(cell.generation() > g_after_take);
+    }
+
+    #[test]
+    fn take_on_never_bound_still_advances_generation() {
+        let cell: SlotCell<FakeGuard> = SlotCell::empty();
+        assert_eq!(cell.generation(), 0);
+        // Even a no-op clear advances the generation: a "clear" signal is
+        // meaningful to a rotation observer regardless of prior state.
+        assert!(cell.take().is_none());
+        assert!(
+            cell.generation() > 0,
+            "take advances generation even when the slot was already empty"
+        );
     }
 }

--- a/crates/resource/tests/credential_slot_epoch_fold.rs
+++ b/crates/resource/tests/credential_slot_epoch_fold.rs
@@ -1,0 +1,325 @@
+//! #690 review (CRITICAL, comment 3255607655 / #680) — the
+//! `credential_slot_epoch` fold must be **order-sensitive**, not `max`.
+//!
+//! The load-bearing contract: the epoch changes whenever *any*
+//! `#[credential]` slot's generation changes — including a slot whose
+//! generation is **not** the largest. A `max` fold violates this: a
+//! runtime built at `(slot_a=5, slot_b=10)` then rotated `slot_a→6` still
+//! maxes to `10`, so the resident create-vs-rotate reconcile would never
+//! see the runtime as stale and would silently report a rotation success
+//! while the runtime keeps serving the pre-rotation credential.
+//!
+//! Two independent proofs:
+//!
+//! 1. **Derive fold** — a real `#[derive(Resource)]` two-slot struct:
+//!    rotating the NON-max slot must change the *derive-emitted*
+//!    `credential_slot_epoch()` (this is the exact macro output #680
+//!    depends on).
+//! 2. **Resident reconcile** — a two-slot resident whose
+//!    `credential_slot_epoch()` uses the same positional fold: rotating
+//!    the NON-max slot under a warm runtime must make the reconcile
+//!    treat the runtime as stale and deliver `on_credential_refresh`
+//!    (the end-to-end #680 invariant).
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, AtomicUsize, Ordering},
+};
+
+use nebula_core::{ResourceKey, ScopeLevel, resource_key, scope::Scope};
+use nebula_credential::{
+    AuthPattern, Credential, CredentialContext, CredentialError, CredentialGuard,
+    CredentialMetadata, ResolveResult, SecretString, SecretToken,
+};
+use nebula_resource::{
+    AcquireOptions, Manager, ResidentConfig, Resource, ResourceConfig, ResourceContext, SlotCell,
+    error::Error, resource::ResourceMetadata, topology::resident::Resident,
+};
+use nebula_schema::FieldValues;
+use tokio_util::sync::CancellationToken;
+use zeroize::Zeroize;
+
+// ── Shared fake credential ──────────────────────────────────────────
+
+/// Static credential fixture. `Zeroize` is a no-op (unit-ish payload);
+/// the `u32` tag is "which credential" the resident test asserts on.
+#[derive(Default)]
+struct FakeCred(u32);
+
+impl Zeroize for FakeCred {
+    fn zeroize(&mut self) {
+        self.0 = 0;
+    }
+}
+
+impl Credential for FakeCred {
+    type Properties = ();
+    type Scheme = SecretToken;
+    type State = SecretToken;
+
+    const KEY: &'static str = "epochfold.fake";
+
+    fn metadata() -> CredentialMetadata {
+        CredentialMetadata::builder()
+            .key(nebula_core::credential_key!("epochfold.fake"))
+            .name("FakeCred")
+            .description("slot-epoch fold fixture")
+            .schema(nebula_credential::schema_of::<Self::Properties>())
+            .pattern(AuthPattern::SecretToken)
+            .build()
+            .expect("FakeCred metadata is valid")
+    }
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(SecretToken::new(
+            SecretString::new("fake-token"),
+        )))
+    }
+}
+
+// ── Part 1: the DERIVE-emitted fold is order-sensitive ──────────────
+
+#[derive(Clone, Default)]
+struct TwoSlotCfg;
+impl nebula_schema::HasSchema for TwoSlotCfg {
+    fn schema() -> nebula_schema::ValidSchema {
+        nebula_schema::ValidSchema::empty()
+    }
+}
+impl ResourceConfig for TwoSlotCfg {}
+
+/// A real derived two-slot resource — `credential_slot_epoch()` here is
+/// the exact token stream `#[derive(Resource)]` emits.
+#[derive(Resource)]
+#[resource(key = "epochfold-derived", topology = "resident", config = TwoSlotCfg)]
+struct TwoSlotDerived {
+    #[credential(key = "slot_a")]
+    slot_a: SlotCell<CredentialGuard<FakeCred>>,
+    #[credential(key = "slot_b")]
+    slot_b: SlotCell<CredentialGuard<FakeCred>>,
+}
+
+#[test]
+fn derived_epoch_changes_when_non_max_slot_rotates() {
+    let r = TwoSlotDerived {
+        slot_a: SlotCell::empty(),
+        slot_b: SlotCell::empty(),
+    };
+
+    // Empty ⇒ 0 ("never bound"), preserved by the fold.
+    assert_eq!(
+        r.credential_slot_epoch(),
+        0,
+        "no slot bound yet — epoch must be 0"
+    );
+
+    // Bind both. slot_b is `store`d more times so its generation is
+    // strictly larger than slot_a's — i.e. slot_a is the NON-max slot.
+    r.slot_a.store(Arc::new(CredentialGuard::new(FakeCred(1))));
+    r.slot_b.store(Arc::new(CredentialGuard::new(FakeCred(2))));
+    r.slot_b.store(Arc::new(CredentialGuard::new(FakeCred(3))));
+    r.slot_b.store(Arc::new(CredentialGuard::new(FakeCred(4))));
+    assert!(
+        r.slot_b.generation() > r.slot_a.generation(),
+        "fixture sanity: slot_b must out-generation slot_a so slot_a is the \
+         NON-max slot (a `max` fold would ignore a slot_a rotation)"
+    );
+
+    let before = r.credential_slot_epoch();
+
+    // Rotate ONLY the non-max slot (slot_a). A `max` fold would NOT
+    // change (slot_b still dominates); the order-sensitive fold MUST.
+    r.slot_a.store(Arc::new(CredentialGuard::new(FakeCred(9))));
+    let after = r.credential_slot_epoch();
+
+    assert_ne!(
+        before, after,
+        "rotating the NON-max slot must change the derive-emitted epoch \
+         (the #680 invariant — `max` would have missed this)"
+    );
+
+    // And clearing the non-max slot (a revoke is also a generation
+    // transition) changes it again.
+    let after2_input = after;
+    r.slot_a.take();
+    assert_ne!(
+        after2_input,
+        r.credential_slot_epoch(),
+        "clearing the non-max slot (revoke) must also change the epoch"
+    );
+}
+
+// ── Part 2: the resident reconcile keys off the order-sensitive epoch ─
+
+#[derive(Debug)]
+struct RaceError(String);
+impl std::fmt::Display for RaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+impl std::error::Error for RaceError {}
+impl From<RaceError> for Error {
+    fn from(e: RaceError) -> Self {
+        Error::transient(e.0)
+    }
+}
+
+#[derive(Clone)]
+struct RaceCfg;
+nebula_schema::impl_empty_has_schema!(RaceCfg);
+impl ResourceConfig for RaceCfg {
+    fn validate(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+struct TwoSlotRuntime {
+    bound_b: Arc<AtomicU32>,
+    refresh_calls: Arc<AtomicUsize>,
+}
+
+/// Hand-written two-slot resident. `credential_slot_epoch()` mirrors the
+/// exact positional fold `#[derive(Resource)]` emits (this fixture is not
+/// derived because the derive's `create` body is `todo!()`); the point is
+/// that the *reconcile* keys off an order-sensitive epoch, so rotating
+/// the non-max slot makes a warm runtime stale.
+#[derive(Clone)]
+struct TwoSlotResident {
+    slot_a: Arc<SlotCell<CredentialGuard<FakeCred>>>,
+    slot_b: Arc<SlotCell<CredentialGuard<FakeCred>>>,
+    refresh_calls: Arc<AtomicUsize>,
+}
+
+impl Resource for TwoSlotResident {
+    type Config = RaceCfg;
+    type Runtime = TwoSlotRuntime;
+    type Lease = TwoSlotRuntime;
+    type Error = RaceError;
+
+    fn key() -> ResourceKey {
+        resource_key!("epochfold-resident")
+    }
+
+    async fn create(
+        &self,
+        _config: &RaceCfg,
+        _ctx: &ResourceContext,
+    ) -> Result<TwoSlotRuntime, RaceError> {
+        // Bind the runtime to slot_b's current credential tag (the
+        // realistic shape — a connection bound to a resolved credential).
+        let b = self
+            .slot_b
+            .load()
+            .map(|g| g.0)
+            .ok_or_else(|| RaceError("slot_b unbound at create".to_owned()))?;
+        Ok(TwoSlotRuntime {
+            bound_b: Arc::new(AtomicU32::new(b)),
+            refresh_calls: self.refresh_calls.clone(),
+        })
+    }
+
+    async fn on_credential_refresh(
+        &self,
+        _slot_name: &str,
+        runtime: &TwoSlotRuntime,
+    ) -> Result<(), RaceError> {
+        if let Some(g) = self.slot_b.load() {
+            runtime.bound_b.store(g.0, Ordering::SeqCst);
+        }
+        runtime.refresh_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    // The exact positional fold the derive emits (FNV-1a 64-bit prime,
+    // wrapping). NOT author discipline for production resources —
+    // `#[derive(Resource)]` generates this; hand-mirrored only because
+    // this fixture cannot be derived (derive `create` is `todo!()`).
+    fn credential_slot_epoch(&self) -> u64 {
+        const K: u64 = 0x0000_0100_0000_01b3;
+        [self.slot_a.generation(), self.slot_b.generation()]
+            .into_iter()
+            .fold(0u64, |acc, slot_gen| {
+                acc.wrapping_mul(K).wrapping_add(slot_gen)
+            })
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for TwoSlotResident {
+    fn is_alive_sync(&self, _runtime: &TwoSlotRuntime) -> bool {
+        true
+    }
+}
+
+/// Rotating the NON-max slot under a warm resident runtime must make the
+/// create-vs-rotate reconcile treat the runtime as **stale** and deliver
+/// `on_credential_refresh` — even though the rotated slot is not the
+/// largest-generation one. A `max` epoch would leave the runtime serving
+/// the pre-rotation credential with a silent false success (#680).
+#[tokio::test]
+async fn resident_reconcile_fires_when_non_max_slot_rotates() {
+    let slot_a: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
+    let slot_b: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
+    // Make slot_b the MAX-generation slot (stored 3×) and slot_a the
+    // non-max slot (stored 1×).
+    slot_a.store(Arc::new(CredentialGuard::new(FakeCred(11))));
+    slot_b.store(Arc::new(CredentialGuard::new(FakeCred(21))));
+    slot_b.store(Arc::new(CredentialGuard::new(FakeCred(22))));
+    slot_b.store(Arc::new(CredentialGuard::new(FakeCred(23))));
+
+    let refresh_calls = Arc::new(AtomicUsize::new(0));
+    let resource = TwoSlotResident {
+        slot_a: Arc::new(slot_a),
+        slot_b: Arc::new(slot_b),
+        refresh_calls: Arc::clone(&refresh_calls),
+    };
+    assert!(
+        resource.slot_b.generation() > resource.slot_a.generation(),
+        "fixture sanity: slot_b must be the max-generation slot"
+    );
+
+    let mgr = Manager::new();
+    mgr.register_resident(resource.clone(), RaceCfg, ResidentConfig::default())
+        .expect("register_resident must succeed");
+
+    // Warm the runtime (records the build epoch against the current
+    // slot generations).
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let guard = mgr
+        .acquire_resident::<TwoSlotResident>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("warm acquire must succeed");
+    assert_eq!(guard.bound_b.load(Ordering::SeqCst), 23);
+
+    // Rotate ONLY the NON-max slot (slot_a). With a `max` epoch the
+    // built epoch would still equal the live epoch (slot_b dominates) and
+    // the reconcile would skip the hook (false success). With the
+    // order-sensitive fold the epoch changes, so the reconcile delivers
+    // the hook.
+    resource
+        .slot_a
+        .store(Arc::new(CredentialGuard::new(FakeCred(99))));
+    mgr.refresh_slot(&TwoSlotResident::key(), ScopeLevel::Global, "slot_a")
+        .await
+        .expect("refresh_slot must succeed (the hook ran — a real success)");
+
+    assert_eq!(
+        refresh_calls.load(Ordering::SeqCst),
+        1,
+        "rotating the NON-max slot must deliver on_credential_refresh \
+         exactly once (order-sensitive epoch → reconcile saw the runtime \
+         as stale; a `max` epoch would have skipped it with a false success)"
+    );
+}

--- a/crates/resource/tests/manager_acquire_for.rs
+++ b/crates/resource/tests/manager_acquire_for.rs
@@ -496,3 +496,56 @@ async fn revoke_slot_for_revokes_only_the_pinned_row() {
         .await
         .expect("tenant B must remain acquirable after tenant A's revoke");
 }
+
+/// #690 review (CodeRabbit, CRITICAL) — `warmup_pool` must NOT create
+/// fresh pool entries on a credential a concurrent revoke tainted after
+/// the pre-lookup gate. `warmup` runs `R::create` against the resolved
+/// credential, so it is acquire-like and must enforce the same
+/// revoke-vs-acquire post-taint re-check the `run_*_acquire` pipelines
+/// got in #679.
+///
+/// Deterministic model of the race: `taint_slot` applies the taint
+/// **synchronously** (phase 1) — exactly the state a concurrent
+/// `revoke_slot` establishes by the time warmup would proceed. With the
+/// resource tainted, `warmup_pool` must reject (Revoked/Unavailable) and
+/// `R::create` must run **zero** times — no fresh pool instance is ever
+/// minted on the revoked credential.
+#[tokio::test]
+async fn warmup_pool_rejected_after_revoke_taint_creates_no_entries() {
+    use nebula_error::{Classify, ErrorCategory};
+
+    let create_counter = Arc::new(AtomicU64::new(0));
+    let manager = Manager::new();
+    manager
+        .register_pooled(
+            PoolRes {
+                create_counter: Arc::clone(&create_counter),
+            },
+            CountingConfig,
+            pool_cfg(),
+        )
+        .expect("register pooled (Global) must succeed");
+
+    // Phase-1 synchronous taint — the exact state a racing `revoke_slot`
+    // leaves the row in before `warmup_pool` could call `rt.warmup`.
+    let _tainted = manager
+        .taint_slot(&PoolRes::key(), ScopeLevel::Global, "db")
+        .expect("taint_slot must resolve the registered pooled row");
+
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let err = manager
+        .warmup_pool::<PoolRes>(&ctx)
+        .await
+        .expect_err("warmup_pool on a revoke-tainted resource must be rejected");
+    assert_eq!(
+        err.category(),
+        ErrorCategory::Unavailable,
+        "tainted warmup must reject with Revoked/Unavailable, got: {err}"
+    );
+    assert_eq!(
+        create_counter.load(Ordering::SeqCst),
+        0,
+        "warmup_pool must create ZERO fresh pool instances on a revoked \
+         credential (post-taint re-check, #679 pattern applied to warmup)"
+    );
+}

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -214,9 +214,55 @@ mod counting {
 
         (mgr, CountingResource::key(), ledger, registry)
     }
+
+    /// Slot identities for the two-tenant isolation fixture. Two distinct
+    /// resolved-credential identities at the same `(key, Global)` occupy two
+    /// distinct registry rows — each its own `ManagedResource` with its own
+    /// per-resource in-flight counter (ADR-0067 §Deferred).
+    pub const SLOT_A: u64 = 0xA;
+    pub const SLOT_B: u64 = 0xB;
+
+    /// Registers `CountingResource` twice as Resident at `SLOT_A` / `SLOT_B`
+    /// so a revoke on one row can be proven isolated from in-flight traffic
+    /// to the other. Returns the manager and per-row ledgers.
+    pub async fn registered_two_tenant() -> (Arc<Manager>, ResourceKey, Ledger, Ledger) {
+        use nebula_resource::RegisterOptions;
+
+        let ledger_a = Ledger::default();
+        let ledger_b = Ledger::default();
+
+        let slot_a: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
+        slot_a.store(Arc::new(CredentialGuard::new(FakeCred(1))));
+        let slot_b: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
+        slot_b.store(Arc::new(CredentialGuard::new(FakeCred(2))));
+
+        let mgr = Manager::new();
+        mgr.register_resident_with(
+            CountingResource {
+                ledger: ledger_a.clone(),
+                db: Arc::new(slot_a),
+            },
+            CountingConfig,
+            ResidentConfig::default(),
+            RegisterOptions::default().with_slot_identity(SLOT_A),
+        )
+        .expect("register_resident_with (A) must succeed");
+        mgr.register_resident_with(
+            CountingResource {
+                ledger: ledger_b.clone(),
+                db: Arc::new(slot_b),
+            },
+            CountingConfig,
+            ResidentConfig::default(),
+            RegisterOptions::default().with_slot_identity(SLOT_B),
+        )
+        .expect("register_resident_with (B) must succeed");
+
+        (Arc::new(mgr), CountingResource::key(), ledger_a, ledger_b)
+    }
 }
 
-use counting::{registered, registered_with_metrics};
+use counting::{registered, registered_two_tenant, registered_with_metrics};
 
 #[tokio::test]
 async fn refresh_slot_invokes_hook_with_runtime() {
@@ -523,4 +569,293 @@ async fn revoke_failure_emits_slot_revoke_failed_not_refresh() {
         saw_revoke_failed,
         "a failed revoke must emit ResourceEvent::SlotRevokeFailed"
     );
+}
+
+/// ADR-0044/0036 "no authenticated traffic on a revoked credential
+/// post-revoke" — the revoke-vs-acquire TOCTOU close.
+///
+/// The acquire-side taint *gate* runs before the in-flight counter is
+/// incremented, so a concurrent revoke that taints in that window would, in
+/// the old code, still let the acquire complete and hand out a live guard on
+/// the just-revoked credential. The fix re-checks the taint *after* the
+/// per-resource in-flight increment (the same counter `revoke_slot` drains).
+///
+/// Deterministic proof of the re-check: a real in-flight guard is held so
+/// `revoke_slot` taints and then parks in the per-resource drain. While it is
+/// parked (taint already set, revoke NOT yet returned) a burst of fresh
+/// acquires is fired — every one passes the gate's predecessor work but MUST
+/// be rejected by the post-count re-check, never returning a guard.
+#[tokio::test]
+async fn revoke_vs_acquire_post_taint_recheck_rejects_late_acquire() {
+    use std::sync::Arc;
+
+    use nebula_core::scope::Scope;
+    use nebula_error::{Classify, ErrorCategory};
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, _ledger) = registered().await;
+    let mgr = Arc::new(mgr);
+
+    // Hold a real in-flight guard so the per-resource drain inside
+    // `revoke_slot` genuinely blocks (counter stays at 1) — this parks the
+    // revoke *after* it has tainted but *before* it returns.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let held = mgr
+        .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("initial acquire must succeed");
+
+    let revoke_handle = {
+        let mgr = Arc::clone(&mgr);
+        let key = key.clone();
+        tokio::spawn(async move { mgr.revoke_slot(&key, ScopeLevel::Global, "db").await })
+    };
+
+    // Let the revoke task reach the taint + per-resource-drain park point.
+    for _ in 0..32 {
+        tokio::task::yield_now().await;
+    }
+    let mut revoke_handle = revoke_handle;
+    // Sanity: the revoke is genuinely still pending (parked on our guard).
+    let pending =
+        tokio::time::timeout(std::time::Duration::from_millis(100), &mut revoke_handle).await;
+    assert!(
+        pending.is_err(),
+        "revoke must still be parked in the per-resource drain while the guard is held"
+    );
+
+    // Burst of acquires that all start *after* the taint but *while the
+    // revoke has not returned*. Every one must be rejected by the post-count
+    // re-check — none may return a live guard on the revoked credential.
+    for i in 0..64 {
+        let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+        let outcome = mgr
+            .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+            .await;
+        let err = outcome.expect_err(&format!(
+            "acquire #{i} during in-flight revoke must be rejected, not return a guard"
+        ));
+        assert_eq!(
+            err.category(),
+            ErrorCategory::Unavailable,
+            "post-taint re-check must reject with Unavailable, got: {err}"
+        );
+    }
+
+    // Release the held guard → per-resource drain completes → revoke returns.
+    drop(held);
+    revoke_handle
+        .await
+        .expect("revoke task must not panic")
+        .expect("revoke_slot must succeed once the held guard drops");
+
+    // And it stays revoked.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let post = mgr
+        .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect_err("acquire after revoke must still be rejected");
+    assert_eq!(post.category(), ErrorCategory::Unavailable);
+}
+
+/// Multi-threaded revoke-vs-acquire stress: many acquire loops race a single
+/// `revoke_slot` on a `multi_thread` runtime. The binding invariant
+/// (ADR-0044/0036): **no acquire may return a live guard once `revoke_slot`
+/// has returned** — a guard handed out on the revoked credential after the
+/// revoke completed is exactly the bug. A per-acquire flag, set the instant
+/// the revoke future resolves, makes "this guard was issued after revoke
+/// completed" observable and is asserted to never happen.
+///
+/// Robustness: the precondition that acquire works *before* the revoke is
+/// proven deterministically by a guard taken on the main task (independent of
+/// worker scheduling). The race window is then established by a bounded
+/// *barrier* — the revoke is issued only once enough workers have each landed
+/// a real successful acquire — rather than a fixed yield budget that starves
+/// under heavy parallel test load.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn revoke_vs_acquire_multithread_no_guard_after_revoke() {
+    use std::{
+        sync::{
+            Arc,
+            atomic::{AtomicBool, AtomicU64, Ordering},
+        },
+        time::Duration,
+    };
+
+    use nebula_core::scope::Scope;
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, _ledger) = registered().await;
+    let mgr = Arc::new(mgr);
+
+    // Deterministic precondition: acquire works on the *unrevoked* resource.
+    // Proven here on the main task so the test never depends on a spawned
+    // worker getting scheduler time before the revoke (the prior flake).
+    {
+        let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+        let g = mgr
+            .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+            .await
+            .expect("acquire on the unrevoked resource must succeed (precondition)");
+        drop(g);
+    }
+
+    let revoke_done = Arc::new(AtomicBool::new(false));
+    let guards_after_revoke = Arc::new(AtomicU64::new(0));
+    let attempts_after_revoke = Arc::new(AtomicU64::new(0));
+    // Per-worker "I have landed ≥1 successful acquire" tally — drives the
+    // pre-revoke barrier without a timing guess.
+    let ok_before_revoke = Arc::new(AtomicU64::new(0));
+    let stop = Arc::new(AtomicBool::new(false));
+
+    const WORKERS: u64 = 8;
+    let mut workers = Vec::new();
+    for _ in 0..WORKERS {
+        let mgr = Arc::clone(&mgr);
+        let revoke_done = Arc::clone(&revoke_done);
+        let guards_after_revoke = Arc::clone(&guards_after_revoke);
+        let attempts_after_revoke = Arc::clone(&attempts_after_revoke);
+        let ok_before_revoke = Arc::clone(&ok_before_revoke);
+        let stop = Arc::clone(&stop);
+        workers.push(tokio::spawn(async move {
+            let mut counted_ok = false;
+            while !stop.load(Ordering::Acquire) {
+                let after = revoke_done.load(Ordering::Acquire);
+                let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+                let outcome = mgr
+                    .acquire_resident::<counting::CountingResource>(
+                        &ctx,
+                        &AcquireOptions::default(),
+                    )
+                    .await;
+                if after {
+                    attempts_after_revoke.fetch_add(1, Ordering::AcqRel);
+                }
+                if let Ok(guard) = outcome {
+                    if !counted_ok {
+                        counted_ok = true;
+                        ok_before_revoke.fetch_add(1, Ordering::AcqRel);
+                    }
+                    // A live guard observed after the revoke future resolved
+                    // is the exact ADR-0044/0036 violation.
+                    if revoke_done.load(Ordering::Acquire) {
+                        guards_after_revoke.fetch_add(1, Ordering::AcqRel);
+                    }
+                    drop(guard);
+                }
+                tokio::task::yield_now().await;
+            }
+        }));
+    }
+
+    // Barrier: issue the revoke only once a majority of workers have each
+    // landed a real successful acquire — a genuine, scheduler-independent
+    // race window. Bounded so a hang fails loudly instead of looping.
+    let barrier = tokio::time::timeout(Duration::from_secs(10), async {
+        while ok_before_revoke.load(Ordering::Acquire) < WORKERS / 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        barrier.is_ok(),
+        "workers failed to establish the pre-revoke acquire window in time"
+    );
+
+    mgr.revoke_slot(&key, ScopeLevel::Global, "db")
+        .await
+        .expect("revoke_slot must succeed");
+    // Mark the boundary the instant the revoke future resolved.
+    revoke_done.store(true, Ordering::Release);
+
+    // Establish a real *post*-revoke window: wait until workers have made a
+    // healthy number of acquire attempts strictly after the boundary (every
+    // one of which must be rejected by the fix), bounded so it fails loudly.
+    let post = tokio::time::timeout(Duration::from_secs(10), async {
+        while attempts_after_revoke.load(Ordering::Acquire) < WORKERS * 4 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await;
+    assert!(
+        post.is_ok(),
+        "workers failed to exercise a post-revoke acquire window in time"
+    );
+
+    stop.store(true, Ordering::Release);
+    for w in workers {
+        w.await.expect("worker must not panic");
+    }
+
+    assert!(
+        ok_before_revoke.load(Ordering::Acquire) >= WORKERS / 2,
+        "sanity: the pre-revoke acquire window must have been real"
+    );
+    assert_eq!(
+        guards_after_revoke.load(Ordering::Acquire),
+        0,
+        "a guard on the revoked credential was handed out AFTER revoke_slot \
+         returned — revoke-vs-acquire TOCTOU is not closed"
+    );
+}
+
+/// ADR-0067 §Deferred: a revoke on one resource must NOT block on in-flight
+/// traffic to an *unrelated* resource. Two tenants (`SLOT_A` / `SLOT_B`) of
+/// the same resource type occupy two distinct registry rows, each with its
+/// own per-resource in-flight counter. With a long-lived lease held on B,
+/// `revoke_slot_for(A)` must drain only A's (empty) counter and return
+/// promptly — *well* under the manager-wide 30 s budget — never parking on
+/// B's held guard. B stays acquirable throughout.
+#[tokio::test]
+async fn revoke_on_one_resource_does_not_block_on_unrelated_resource() {
+    use std::time::{Duration, Instant};
+
+    use nebula_core::scope::Scope;
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, _ledger_a, _ledger_b) = registered_two_tenant().await;
+
+    // Hold a long-lived lease on tenant B. If the revoke on A wrongly drained
+    // the manager-wide tracker, this would wedge A's revoke for the full 30 s.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let b_guard = mgr
+        .acquire_resident_for::<counting::CountingResource>(
+            &ctx,
+            &AcquireOptions::default(),
+            counting::SLOT_B,
+        )
+        .await
+        .expect("acquire on tenant B must succeed");
+
+    // Revoke tenant A while B's lease is still held. A's per-resource counter
+    // is empty, so this must return promptly.
+    let started = Instant::now();
+    tokio::time::timeout(
+        Duration::from_secs(5),
+        mgr.revoke_slot_for(&key, ScopeLevel::Global, "db", counting::SLOT_A),
+    )
+    .await
+    .expect("revoke_slot_for(A) must NOT block on tenant B's held lease (would hit 30s)")
+    .expect("revoke_slot_for(A) must succeed");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "revoke on A must complete promptly with B's lease held (per-resource \
+         drain isolation); took {elapsed:?}"
+    );
+
+    // B's lease was never disturbed and B stays acquirable (only A tainted).
+    drop(b_guard);
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let _b_again = mgr
+        .acquire_resident_for::<counting::CountingResource>(
+            &ctx,
+            &AcquireOptions::default(),
+            counting::SLOT_B,
+        )
+        .await
+        .expect("tenant B must stay acquirable after an unrelated revoke on A");
 }

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -859,3 +859,147 @@ async fn revoke_on_one_resource_does_not_block_on_unrelated_resource() {
         .await
         .expect("tenant B must stay acquirable after an unrelated revoke on A");
 }
+
+/// #681 — phase 1 (`taint_slot`) is **synchronous**: the taint is fully
+/// applied the instant `taint_slot` returns, *before* any `.await`. Proven
+/// by acquiring on the row immediately after `taint_slot` returns and before
+/// `drain_and_revoke` is ever constructed — it must already be rejected.
+/// This is the property a dropped `tokio::time::timeout` future relied on:
+/// because the taint is not inside an async body it cannot be skipped by a
+/// timeout that fires before the first poll.
+#[tokio::test]
+async fn taint_slot_applies_taint_synchronously_before_any_await() {
+    use nebula_core::scope::Scope;
+    use nebula_error::{Classify, ErrorCategory};
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, ledger) = registered().await;
+
+    // Warm the resident runtime (acquire+drop) so the phase-2 revoke hook
+    // has a live `&Runtime` to borrow — `dispatch_slot_hook` is a no-op
+    // `Ok(())` on a Resident whose runtime was never materialized.
+    {
+        let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+        let g = mgr
+            .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+            .await
+            .expect("warm the resident runtime");
+        drop(g);
+    }
+
+    // Phase 1 only — a plain (non-`async`) call. No `.await` has run.
+    let tainted = mgr
+        .taint_slot(&key, ScopeLevel::Global, "db")
+        .expect("taint_slot must resolve the registered row");
+
+    // The row is already tainted: an acquire issued now — before
+    // `drain_and_revoke` is even built, let alone awaited — must be rejected.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let err = mgr
+        .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect_err("acquire after synchronous taint_slot must be rejected");
+    assert_eq!(
+        err.category(),
+        ErrorCategory::Unavailable,
+        "synchronous taint must reject with Revoked/Unavailable, got: {err}"
+    );
+    assert_eq!(
+        ledger.revoke_calls.load(Ordering::SeqCst),
+        0,
+        "phase 1 must NOT have run the revoke hook (that is phase 2's job)"
+    );
+
+    // Completing phase 2 still works and runs the hook exactly once.
+    mgr.drain_and_revoke(tainted)
+        .await
+        .expect("drain_and_revoke (phase 2) must succeed");
+    assert_eq!(
+        ledger.revoke_calls.load(Ordering::SeqCst),
+        1,
+        "phase 2 runs the revoke hook exactly once"
+    );
+}
+
+/// #681 — cancellation-safety: dropping the `drain_and_revoke` future
+/// (phase 2) mid-flight — the exact effect of a `tokio::time::timeout`
+/// elapsing and dropping the wrapped future — must leave the row tainted,
+/// because the taint already ran in the synchronous phase 1. The credential
+/// is never silently un-revoked by a dropped timeout.
+///
+/// The drop is made *genuine*: a real in-flight guard is held so
+/// `drain_and_revoke` actually parks in the per-resource drain (it cannot
+/// complete on the first poll), and the future is then explicitly dropped
+/// while still pending.
+#[tokio::test]
+async fn dropping_drain_and_revoke_future_keeps_row_tainted() {
+    use std::sync::Arc;
+
+    use nebula_core::scope::Scope;
+    use nebula_error::{Classify, ErrorCategory};
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, ledger) = registered().await;
+    let mgr = Arc::new(mgr);
+
+    // Hold a real in-flight guard so phase 2's per-resource drain genuinely
+    // blocks (counter stays at 1) — `drain_and_revoke` parks rather than
+    // completing on its first poll, making the subsequent drop a true
+    // mid-flight cancellation.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let in_flight = mgr
+        .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("initial acquire must succeed");
+
+    // Phase 1: synchronous taint.
+    let tainted = mgr
+        .taint_slot(&key, ScopeLevel::Global, "db")
+        .expect("taint_slot must resolve the registered row");
+
+    // Phase 2 constructed and polled enough to park in the drain, then
+    // explicitly DROPPED while still pending — models the engine fan-out's
+    // `tokio::time::timeout` elapsing and dropping the wrapped future.
+    {
+        let mut fut = Box::pin(mgr.drain_and_revoke(tainted));
+        // A bounded select that loses to a short timer: the drain future is
+        // polled (and parks on the held guard) but never completes, then is
+        // dropped at the end of this block.
+        let parked = tokio::time::timeout(std::time::Duration::from_millis(150), &mut fut).await;
+        assert!(
+            parked.is_err(),
+            "drain_and_revoke must still be parked in the per-resource drain \
+             while the in-flight guard is held"
+        );
+        drop(fut);
+    }
+    assert_eq!(
+        ledger.revoke_calls.load(Ordering::SeqCst),
+        0,
+        "the dropped (never-completed) drain future must not have run the \
+         revoke hook"
+    );
+
+    // The decisive #681 assertion: the taint survived the dropped tail —
+    // every subsequent acquire is still rejected. The taint was applied
+    // synchronously in phase 1, so dropping the phase-2 future cannot roll
+    // it back; the credential is never silently un-revoked.
+    for i in 0..16 {
+        let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+        let err = mgr
+            .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+            .await
+            .expect_err(&format!(
+                "acquire #{i} after a dropped drain future must still be rejected (#681)"
+            ));
+        assert_eq!(
+            err.category(),
+            ErrorCategory::Unavailable,
+            "dropped-tail acquire must still hit the Revoked/Unavailable taint, got: {err}"
+        );
+    }
+
+    drop(in_flight);
+}

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -912,9 +912,14 @@ async fn taint_slot_applies_taint_synchronously_before_any_await() {
     );
 
     // Completing phase 2 still works and runs the hook exactly once.
-    mgr.drain_and_revoke(tainted)
-        .await
-        .expect("drain_and_revoke (phase 2) must succeed");
+    assert!(
+        matches!(
+            mgr.drain_and_revoke(tainted, std::time::Duration::from_secs(5))
+                .await,
+            nebula_resource::RevokeTail::Done
+        ),
+        "drain_and_revoke (phase 2) must complete the revoke hook"
+    );
     assert_eq!(
         ledger.revoke_calls.load(Ordering::SeqCst),
         1,
@@ -923,10 +928,13 @@ async fn taint_slot_applies_taint_synchronously_before_any_await() {
 }
 
 /// #681 — cancellation-safety: dropping the `drain_and_revoke` future
-/// (phase 2) mid-flight — the exact effect of a `tokio::time::timeout`
-/// elapsing and dropping the wrapped future — must leave the row tainted,
-/// because the taint already ran in the synchronous phase 1. The credential
-/// is never silently un-revoked by a dropped timeout.
+/// (phase 2) mid-flight — e.g. a task abort or runtime shutdown
+/// cancelling the awaiting task — must leave the row tainted, because the
+/// taint already ran in the synchronous phase 1. The credential is never
+/// silently un-revoked by a dropped tail. (Post-#690 the engine fan-out
+/// no longer wraps this in an outer `tokio::time::timeout`; the
+/// drop-safety invariant still holds for any other cancellation and is
+/// still load-bearing.)
 ///
 /// The drop is made *genuine*: a real in-flight guard is held so
 /// `drain_and_revoke` actually parks in the per-resource drain (it cannot
@@ -960,10 +968,12 @@ async fn dropping_drain_and_revoke_future_keeps_row_tainted() {
         .expect("taint_slot must resolve the registered row");
 
     // Phase 2 constructed and polled enough to park in the drain, then
-    // explicitly DROPPED while still pending — models the engine fan-out's
-    // `tokio::time::timeout` elapsing and dropping the wrapped future.
+    // explicitly DROPPED while still pending — models a task abort /
+    // runtime shutdown cancelling the awaiting task mid-tail (a generic
+    // cancellation; the engine fan-out no longer wraps this in an outer
+    // timeout post-#690, but the drop-safety invariant is unchanged).
     {
-        let mut fut = Box::pin(mgr.drain_and_revoke(tainted));
+        let mut fut = Box::pin(mgr.drain_and_revoke(tainted, std::time::Duration::from_secs(30)));
         // A bounded select that loses to a short timer: the drain future is
         // polled (and parks on the held guard) but never completes, then is
         // dropped at the end of this block.
@@ -1000,6 +1010,64 @@ async fn dropping_drain_and_revoke_future_keeps_row_tainted() {
             "dropped-tail acquire must still hit the Revoked/Unavailable taint, got: {err}"
         );
     }
+
+    drop(in_flight);
+}
+
+/// #690 review — single-owner budget: a **timed-out drain still runs the
+/// revoke hook**. `drain_and_revoke` is the sole owner of the
+/// per-resource budget — it bounds the drain *best-effort* (a drain
+/// timeout is non-fatal and proceeds to the hook) and there is no outer
+/// `tokio::time::timeout` wrapper that could elapse on the slow drain and
+/// drop the whole future before the hook ran. A real in-flight guard is
+/// held so the per-resource drain genuinely times out against a short
+/// budget; the hook must still fire exactly once and the row stay
+/// tainted. Pre-fix the engine fan-out wrapped the whole call in a 30 s
+/// timeout that, on a slow drain, dropped the future and silently skipped
+/// the hook.
+#[tokio::test]
+async fn drain_timeout_still_runs_revoke_hook_single_budget_owner() {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use nebula_core::scope::Scope;
+    use nebula_resource::AcquireOptions;
+    use tokio_util::sync::CancellationToken;
+
+    let (mgr, key, ledger) = registered().await;
+    let mgr = Arc::new(mgr);
+
+    // Hold a real in-flight guard so the per-resource drain cannot
+    // early-return (counter stays at 1) — with a short budget the drain
+    // genuinely times out.
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let in_flight = mgr
+        .acquire_resident::<counting::CountingResource>(&ctx, &AcquireOptions::default())
+        .await
+        .expect("initial acquire must succeed");
+
+    // Phase 1: synchronous taint.
+    let tainted = mgr
+        .taint_slot(&key, ScopeLevel::Global, "db")
+        .expect("taint_slot must resolve the registered row");
+
+    // Phase 2 with a SHORT per-resource budget: the held guard makes the
+    // drain exceed it. The hook (`CountingResource::on_credential_revoke`
+    // returns immediately) must STILL run — proof the timed-out drain did
+    // not drop the tail before the hook.
+    let tail = mgr
+        .drain_and_revoke(tainted, Duration::from_millis(50))
+        .await;
+    assert!(
+        matches!(tail, nebula_resource::RevokeTail::Done),
+        "a timed-out DRAIN must still complete the revoke hook (single \
+         budget owner; no outer wrapper drops the post-drain hook), got: {tail:?}"
+    );
+    assert_eq!(
+        ledger.revoke_calls.load(Ordering::SeqCst),
+        1,
+        "the revoke hook must run exactly once even though the drain timed out"
+    );
 
     drop(in_flight);
 }

--- a/crates/resource/tests/resident_rotation_race.rs
+++ b/crates/resource/tests/resident_rotation_race.rs
@@ -350,7 +350,10 @@ async fn resident_revoke_during_first_acquire_does_not_serve_revoked_credential(
 
     let revoke_task = {
         let mgr = Arc::clone(&mgr);
-        tokio::spawn(async move { mgr.drain_and_revoke(tainted).await })
+        tokio::spawn(async move {
+            mgr.drain_and_revoke(tainted, std::time::Duration::from_secs(30))
+                .await
+        })
     };
 
     // The drain+revoke tail must be parked while the first build is in
@@ -380,10 +383,11 @@ async fn resident_revoke_during_first_acquire_does_not_serve_revoked_credential(
     let bound_cred = Arc::clone(&guard.bound_cred);
     drop(guard);
 
-    revoke_task
-        .await
-        .expect("revoke task must not panic")
-        .expect("drain_and_revoke must succeed (the revoke hook ran)");
+    let tail = revoke_task.await.expect("revoke task must not panic");
+    assert!(
+        matches!(tail, nebula_resource::RevokeTail::Done),
+        "drain_and_revoke must complete the revoke hook, got: {tail:?}"
+    );
 
     assert_eq!(
         bound_cred.load(Ordering::SeqCst),

--- a/crates/resource/tests/resident_rotation_race.rs
+++ b/crates/resource/tests/resident_rotation_race.rs
@@ -1,0 +1,474 @@
+//! #680 — resident create-vs-rotate lost-update.
+//!
+//! ADR-0067 §Deferred. The Resident arm of `dispatch_slot_hook` used to map
+//! `current() == None` to `Ok(())` (a silent no-op recorded as a rotation
+//! *success*). When a refresh raced the **first** acquire of a Resident
+//! resource, the runtime could be built from the pre-rotation credential
+//! while the fan-out reported success and the `on_credential_refresh` hook
+//! was never delivered — the runtime then served the stale credential
+//! indefinitely.
+//!
+//! These tests drive that exact interleaving deterministically (a gate
+//! inside `create()` parks the first build *after* it has read the slot;
+//! the credential is then rotated and `refresh_slot` dispatched while the
+//! build is parked) and assert the runtime ends up bound to the **new**
+//! credential with the hook delivered exactly once — no sleeps, no
+//! yield-budget guessing; the ordering is enforced by a barrier and the
+//! resident `create_lock`.
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicU32, AtomicUsize, Ordering},
+};
+
+use nebula_core::{ResourceKey, ScopeLevel, resource_key, scope::Scope};
+use nebula_credential::CredentialGuard;
+use nebula_resource::{
+    AcquireOptions, Manager, ResidentConfig, Resource, ResourceConfig, ResourceContext, SlotCell,
+    error::Error, resource::ResourceMetadata, topology::resident::Resident,
+};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+use zeroize::Zeroize;
+
+/// A fake credential secret (`Zeroize` so it can sit inside a
+/// `CredentialGuard`). The `u32` is the "which credential" tag the test
+/// asserts the runtime is bound to.
+#[derive(Default)]
+struct FakeCred(u32);
+
+impl Zeroize for FakeCred {
+    fn zeroize(&mut self) {
+        self.0 = 0;
+    }
+}
+
+#[derive(Debug)]
+struct RaceError(String);
+
+impl std::fmt::Display for RaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for RaceError {}
+
+impl From<RaceError> for Error {
+    fn from(e: RaceError) -> Self {
+        Error::transient(e.0)
+    }
+}
+
+#[derive(Clone)]
+struct RaceConfig;
+
+nebula_schema::impl_empty_has_schema!(RaceConfig);
+
+impl ResourceConfig for RaceConfig {
+    fn validate(&self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+/// Coordinates the deterministic interleaving. Shared between the resource
+/// descriptor and the test body.
+#[derive(Clone, Default)]
+struct RaceGate {
+    /// Fired by `create()` the instant it has read the slot — the test
+    /// waits on this before rotating, so the rotation strictly follows the
+    /// pre-rotation slot read.
+    slot_read: Arc<Notify>,
+    /// `create()` parks on this *after* the slot read until the test
+    /// releases it (the test rotates + dispatches refresh while parked).
+    release_create: Arc<Notify>,
+    /// When `true`, `create()` performs the park; when `false` it returns
+    /// immediately (used for the warm / never-activated fixtures).
+    park_in_create: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// The live runtime. `bound_cred` is the credential tag the runtime is
+/// currently bound to; it is an `Arc<AtomicU32>` so the lease handed to the
+/// caller and the cell-stored runtime share it — a reconcile that mutates
+/// the stored runtime's binding is observable through the caller's guard.
+#[derive(Clone)]
+struct RaceRuntime {
+    bound_cred: Arc<AtomicU32>,
+    refresh_calls: Arc<AtomicUsize>,
+    revoke_calls: Arc<AtomicUsize>,
+}
+
+/// Resident resource whose `create()` *reads its credential slot* (the
+/// realistic shape — a connection bound to the resolved credential) and
+/// whose `on_credential_refresh` re-reads the slot and rebinds the live
+/// runtime via interior mutability (the blue-green `&self` reaction).
+#[derive(Clone)]
+struct RaceResource {
+    db: Arc<SlotCell<CredentialGuard<FakeCred>>>,
+    gate: RaceGate,
+    refresh_calls: Arc<AtomicUsize>,
+    revoke_calls: Arc<AtomicUsize>,
+}
+
+impl Resource for RaceResource {
+    type Config = RaceConfig;
+    type Runtime = RaceRuntime;
+    type Lease = RaceRuntime;
+    type Error = RaceError;
+
+    fn key() -> ResourceKey {
+        resource_key!("race-resident")
+    }
+
+    async fn create(
+        &self,
+        _config: &RaceConfig,
+        _ctx: &ResourceContext,
+    ) -> Result<RaceRuntime, RaceError> {
+        // Read the resolved credential exactly as a real resource would
+        // (bind the runtime to whatever the slot holds *now*).
+        let cred = self
+            .db
+            .load()
+            .map(|g| g.0)
+            .ok_or_else(|| RaceError("slot unbound at create".to_owned()))?;
+        let runtime = RaceRuntime {
+            bound_cred: Arc::new(AtomicU32::new(cred)),
+            refresh_calls: self.refresh_calls.clone(),
+            revoke_calls: self.revoke_calls.clone(),
+        };
+
+        // Signal "I have read the slot", then park (if armed) so the test
+        // can rotate + dispatch refresh while this build is in flight and
+        // still holding the resident `create_lock`.
+        self.gate.slot_read.notify_one();
+        if self.gate.park_in_create.load(Ordering::SeqCst) {
+            self.gate.release_create.notified().await;
+        }
+        Ok(runtime)
+    }
+
+    async fn on_credential_refresh(
+        &self,
+        _slot_name: &str,
+        runtime: &RaceRuntime,
+    ) -> Result<(), RaceError> {
+        // The blue-green `&self` reaction: re-read the (now rotated) slot
+        // and rebind the live runtime to it via interior mutability.
+        if let Some(g) = self.db.load() {
+            runtime.bound_cred.store(g.0, Ordering::SeqCst);
+        }
+        runtime.refresh_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    async fn on_credential_revoke(
+        &self,
+        _slot_name: &str,
+        runtime: &RaceRuntime,
+    ) -> Result<(), RaceError> {
+        // Model "stop serving the revoked credential": clear the binding.
+        runtime.bound_cred.store(0, Ordering::SeqCst);
+        runtime.revoke_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    }
+
+    // Activate the create-vs-rotate epoch reconcile: a hand-written impl
+    // would otherwise inherit the `0` default and never detect staleness.
+    // The derive emits exactly this (the `max` slot generation); we mirror
+    // it by hand because this fixture is not derived. NOT author discipline
+    // for production resources — `#[derive(Resource)]` generates it.
+    fn credential_slot_epoch(&self) -> u64 {
+        self.db.generation()
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for RaceResource {
+    fn is_alive_sync(&self, _runtime: &RaceRuntime) -> bool {
+        true
+    }
+}
+
+/// Pre-rotation / post-rotation credential tags.
+const CRED_OLD: u32 = 7;
+const CRED_NEW: u32 = 99;
+
+fn ctx() -> ResourceContext {
+    ResourceContext::minimal(Scope::default(), CancellationToken::new())
+}
+
+fn build(park: bool) -> (Arc<Manager>, ResourceKey, RaceResource) {
+    let slot: SlotCell<CredentialGuard<FakeCred>> = SlotCell::empty();
+    slot.store(Arc::new(CredentialGuard::new(FakeCred(CRED_OLD))));
+    let resource = RaceResource {
+        db: Arc::new(slot),
+        gate: RaceGate {
+            park_in_create: Arc::new(std::sync::atomic::AtomicBool::new(park)),
+            ..RaceGate::default()
+        },
+        refresh_calls: Arc::new(AtomicUsize::new(0)),
+        revoke_calls: Arc::new(AtomicUsize::new(0)),
+    };
+    let mgr = Manager::new();
+    mgr.register_resident(resource.clone(), RaceConfig, ResidentConfig::default())
+        .expect("register_resident must succeed");
+    (Arc::new(mgr), RaceResource::key(), resource)
+}
+
+/// THE #680 regression. The first acquire's `create()` reads the OLD
+/// credential and parks (still holding `create_lock`). While parked, the
+/// credential is rotated (`slot.store(NEW)`) and `refresh_slot` is
+/// dispatched — the dispatch must block on `create_lock`. When the build is
+/// released, the dispatch observes the freshly-stored runtime as *stale*
+/// (built epoch < slot epoch) and delivers `on_credential_refresh`, so the
+/// runtime the caller holds ends up bound to the NEW credential and the
+/// hook fired exactly once. Pre-fix the dispatch saw `current() == None`,
+/// returned `Ok(())` (false success), and the runtime served `CRED_OLD`
+/// forever.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resident_create_during_rotation_delivers_hook_not_false_success() {
+    let (mgr, key, resource) = build(true);
+
+    // Task A: first acquire. Its `create()` will read the slot then park.
+    let acquire_task = {
+        let mgr = Arc::clone(&mgr);
+        tokio::spawn(async move {
+            mgr.acquire_resident::<RaceResource>(&ctx(), &AcquireOptions::default())
+                .await
+        })
+    };
+
+    // Wait until `create()` has read the OLD credential (deterministic —
+    // the rotation strictly follows the pre-rotation slot read).
+    resource.gate.slot_read.notified().await;
+
+    // Rotate the credential underneath the in-flight build (the engine
+    // fan-out contract: store the new guard into the slot cell, *then*
+    // dispatch the refresh). `store` bumps the slot generation.
+    resource
+        .db
+        .store(Arc::new(CredentialGuard::new(FakeCred(CRED_NEW))));
+
+    // Dispatch the refresh concurrently. It must park on `create_lock`
+    // (task A holds it for the whole parked build), so give it a real
+    // chance to reach that park point, then release the build.
+    let refresh_task = {
+        let mgr = Arc::clone(&mgr);
+        let key = key.clone();
+        tokio::spawn(async move { mgr.refresh_slot(&key, ScopeLevel::Global, "db").await })
+    };
+
+    // The refresh future must still be pending while the build is parked
+    // (it is blocked on `create_lock`). A short bounded timeout that
+    // *expires* is the proof the dispatch is genuinely serialised behind
+    // the in-flight create rather than racing it.
+    let mut refresh_task = refresh_task;
+    let still_pending =
+        tokio::time::timeout(std::time::Duration::from_millis(150), &mut refresh_task).await;
+    assert!(
+        still_pending.is_err(),
+        "refresh_slot must be parked on create_lock while the first build \
+         is in flight (serialised create-vs-rotate)"
+    );
+
+    // Release the parked build → it stores the (OLD-bound) runtime and its
+    // build epoch, releases `create_lock`; the refresh dispatch then runs
+    // and must reconcile.
+    resource.gate.release_create.notify_one();
+
+    let guard = acquire_task
+        .await
+        .expect("acquire task must not panic")
+        .expect("first acquire must succeed");
+    refresh_task
+        .await
+        .expect("refresh task must not panic")
+        .expect("refresh_slot must succeed (the hook ran — a real success)");
+
+    // The decisive assertions: the runtime the caller holds was reconciled
+    // to the NEW credential and the hook fired exactly once. Pre-fix this
+    // would be `CRED_OLD` with `refresh_calls == 0`.
+    assert_eq!(
+        guard.bound_cred.load(Ordering::SeqCst),
+        CRED_NEW,
+        "the resident runtime must be reconciled to the rotated credential \
+         (create-vs-rotate lost-update closed)"
+    );
+    assert_eq!(
+        resource.refresh_calls.load(Ordering::SeqCst),
+        1,
+        "on_credential_refresh must be delivered exactly once (not skipped \
+         with a false success, not double-delivered)"
+    );
+
+    // And a subsequent rotation still reconciles (epoch keeps advancing).
+    resource
+        .db
+        .store(Arc::new(CredentialGuard::new(FakeCred(123))));
+    mgr.refresh_slot(&key, ScopeLevel::Global, "db")
+        .await
+        .expect("second refresh must succeed");
+    assert_eq!(guard.bound_cred.load(Ordering::SeqCst), 123);
+    assert_eq!(resource.refresh_calls.load(Ordering::SeqCst), 2);
+}
+
+/// Revoke inverse: a revoke racing the first resident acquire must not
+/// leave the runtime serving the revoked credential. Same interleaving as
+/// the refresh test but `revoke_slot` (taint + drain + revoke hook) — the
+/// runtime built mid-revoke must still receive `on_credential_revoke`
+/// (here: binding cleared to `0`) rather than continuing to serve
+/// `CRED_OLD`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn resident_revoke_during_first_acquire_does_not_serve_revoked_credential() {
+    let (mgr, key, resource) = build(true);
+
+    let acquire_task = {
+        let mgr = Arc::clone(&mgr);
+        tokio::spawn(async move {
+            mgr.acquire_resident::<RaceResource>(&ctx(), &AcquireOptions::default())
+                .await
+        })
+    };
+
+    resource.gate.slot_read.notified().await;
+
+    // Engine revoke contract: the fan-out runs the *synchronous* taint
+    // first (outside any timeout), then the awaited drain+hook tail. Drive
+    // the same two phases. `taint_slot` is synchronous and must not block
+    // on the in-flight create.
+    let tainted = mgr
+        .taint_slot(&key, ScopeLevel::Global, "db")
+        .expect("taint_slot (phase 1) must resolve the row synchronously");
+
+    // Clear the slot (a revoke is a credential-state transition — bumps the
+    // generation just like `store`).
+    let _ = resource.db.take();
+
+    let revoke_task = {
+        let mgr = Arc::clone(&mgr);
+        tokio::spawn(async move { mgr.drain_and_revoke(tainted).await })
+    };
+
+    // The drain+revoke tail must be parked while the first build is in
+    // flight: it is blocked both on the per-resource drain (task A is an
+    // in-flight acquire) and then on `create_lock`.
+    let mut revoke_task = revoke_task;
+    let pending =
+        tokio::time::timeout(std::time::Duration::from_millis(150), &mut revoke_task).await;
+    assert!(
+        pending.is_err(),
+        "drain_and_revoke must be parked while the first build is in flight \
+         (per-resource drain + create_lock serialisation)"
+    );
+
+    resource.gate.release_create.notify_one();
+
+    let guard = acquire_task
+        .await
+        .expect("acquire task must not panic")
+        .expect("first acquire must succeed");
+    // `bound_cred` is shared (Arc) between the caller's lease and the
+    // cell-stored runtime the revoke hook acts on. Capture it, then drop
+    // the guard so the per-resource drain completes promptly (otherwise the
+    // held in-flight guard wedges the 30 s drain) — the revoke hook then
+    // runs on the still-cell-resident runtime and clears the shared
+    // binding.
+    let bound_cred = Arc::clone(&guard.bound_cred);
+    drop(guard);
+
+    revoke_task
+        .await
+        .expect("revoke task must not panic")
+        .expect("drain_and_revoke must succeed (the revoke hook ran)");
+
+    assert_eq!(
+        bound_cred.load(Ordering::SeqCst),
+        0,
+        "the runtime built mid-revoke must NOT keep serving the revoked \
+         credential — the revoke hook must have cleared the binding"
+    );
+    assert_eq!(
+        resource.revoke_calls.load(Ordering::SeqCst),
+        1,
+        "on_credential_revoke must be delivered exactly once to the \
+         mid-revoke-built runtime"
+    );
+}
+
+/// A genuinely never-activated resident (registered, credential bound, but
+/// **no acquire ever** so no runtime was created): a refresh dispatch is a
+/// *legitimate* no-op success, NOT a false failure and NOT a stale-skip.
+/// This proves the "never created" vs "created against a stale epoch"
+/// distinction — the former is the runtime-presence check returning `None`.
+#[tokio::test]
+async fn never_activated_resident_refresh_is_legitimate_noop() {
+    let (mgr, key, resource) = build(false);
+
+    // No acquire has ever run → no runtime exists. Rotate then refresh.
+    resource
+        .db
+        .store(Arc::new(CredentialGuard::new(FakeCred(CRED_NEW))));
+    mgr.refresh_slot(&key, ScopeLevel::Global, "db")
+        .await
+        .expect("refresh on a never-activated resident must be a legitimate Ok no-op");
+
+    // The hook must NOT have fired (there is no live runtime to refresh) —
+    // this is the legitimate-no-op case, distinct from a stale-skip.
+    assert_eq!(
+        resource.refresh_calls.load(Ordering::SeqCst),
+        0,
+        "no runtime exists — the hook must not fire (legitimate no-op)"
+    );
+
+    // And the first acquire *after* the rotation builds against the NEW
+    // credential (it reads the current slot), needing no hook delivery.
+    let guard = mgr
+        .acquire_resident::<RaceResource>(&ctx(), &AcquireOptions::default())
+        .await
+        .expect("first acquire after rotation must succeed");
+    assert_eq!(
+        guard.bound_cred.load(Ordering::SeqCst),
+        CRED_NEW,
+        "a create that runs strictly after the rotation binds the new \
+         credential directly (no reconcile needed)"
+    );
+    assert_eq!(
+        resource.refresh_calls.load(Ordering::SeqCst),
+        0,
+        "still no hook — the build read the fresh credential itself"
+    );
+}
+
+/// Sanity: with a runtime already warm and *no* intervening rotation, a
+/// refresh still delivers the hook exactly once (idempotent per ADR-0067
+/// D1) and never spuriously reports the runtime stale. Guards against the
+/// epoch compare mis-classifying an up-to-date runtime.
+#[tokio::test]
+async fn warm_resident_no_rotation_refresh_delivers_once_not_stale() {
+    let (mgr, key, resource) = build(false);
+
+    let guard = mgr
+        .acquire_resident::<RaceResource>(&ctx(), &AcquireOptions::default())
+        .await
+        .expect("warm acquire must succeed");
+    assert_eq!(guard.bound_cred.load(Ordering::SeqCst), CRED_OLD);
+
+    // No rotation between build and refresh — built epoch == slot epoch.
+    mgr.refresh_slot(&key, ScopeLevel::Global, "db")
+        .await
+        .expect("refresh on a warm, un-rotated resident must succeed");
+    assert_eq!(
+        resource.refresh_calls.load(Ordering::SeqCst),
+        1,
+        "the hook is still delivered once (idempotent), not skipped"
+    );
+    assert_eq!(
+        guard.bound_cred.load(Ordering::SeqCst),
+        CRED_OLD,
+        "no rotation occurred — the binding is unchanged"
+    );
+}

--- a/docs/adr/0067-engine-owned-rotation-fanout-self-refresh-hook.md
+++ b/docs/adr/0067-engine-owned-rotation-fanout-self-refresh-hook.md
@@ -20,16 +20,30 @@ related:
 
 ## Status
 
-Accepted (2026-05-17) — accepts the **infrastructure** for per-slot
-rotation fan-out and the `&self` refresh hook (the engine-side reverse
+Accepted (2026-05-17). The original infrastructure (engine-side reverse
 index, dispatch port, `RotationOutcome` aggregation, `SlotCell`
-substrate, and the API config-CRUD surface). Production wiring — the
-rotation scheduler (ADR-0030) and lease-revoke (ADR-0051) actually
-invoking the fan-out — is **Deferred** (see [Deferred](#deferred)).
-ROADMAP §M11.5 (per-slot rotation fan-out) and §M12.4 (`nebula-resource`
-frontier→stable) are therefore **not** closed end-to-end yet: they close
-only once that wiring lands and the per-resource-drain correctness items
-in the Deferred section are fixed with it. Amends ADR-0044 (hook
+substrate, API config-CRUD surface) plus, landed 2026-05-17 on
+`feat/engine-resource-rotation-wiring`, the **rotation/lease-revoke
+dispatch wiring and the per-slot-rotation correctness fixes**: an
+engine-owned `ResourceFanoutDriver` subscribes the credential-runtime
+`CredentialEvent::{Refreshed,Revoked}` and `LeaseEvent::LeaseRevoked`
+buses and invokes `dispatch_refresh` / `dispatch_revoke` (proven e2e
+through the real bus path), and the three items that became live with
+it are fixed — per-resource drain + post-taint re-check (#679), a
+two-phase cancellation-safe revoke port so a timed-out/dropped revoke
+still leaves the row tainted (#681), and epoch-reconcile of a rotation
+racing a resident's first acquire (#680). **Still deferred:** the
+*bind-population* producer — populating the reverse index when a
+credential is resolved into a `#[credential]` slot in production —
+depends on the resource-activation path (plugin-driven registrar
+auto-population / a production `ResourceRepo`), which remains deferred
+(see [Deferred](#deferred)); the bind seam (`register_and_bind`) is
+implemented and ready but has no production caller yet. Net: §M11.5's
+rotation **orchestration and correctness** are closed; full end-to-end
+§M11.5 / §M12.4 (`nebula-resource` frontier→stable) closure
+additionally requires that deferred resource-activation bind-population
+— a real rotation/revoke event now fans out correctly to every *bound*
+row, but production binds none until activation lands. Amends ADR-0044 (hook
 signature **and** the credential-slot-field / migration shape — see
 [Supersession](#supersession)); overrides the
 `.ai-factory/PHASE4_BLOCKED.md §1` "re-add rotation orchestration to
@@ -212,7 +226,7 @@ silently drift.
 | # | Abuse | Invariant |
 |---|---|---|
 | 1 | Cross-tenant dedup — `ResourceConfig::fingerprint()` defaults to `0`, collapsing every config of a type to one runtime regardless of resolved credential | **Confirmed bug, fixed structurally at `Manager`**: the dedup key gains a slot-identity component derived from the resolved credential identity per `#[credential]` slot, independent of the author's `fingerprint()`. Not discipline-based — authors cannot regress it by forgetting an override. |
-| 2 | Revoke race on a shared runtime (ADR-0036: zero authenticated traffic post-revoke) | Engine-driven ordering: engine marks the credential `revoking` → `Manager::revoke_slot` taints the runtime (new acquires rejected via the existing `tainted` guard) → drains in-flight guards (`ReleaseQueue` + `drain_tracker`) → reports → engine completes revoke. **Deferred — not yet satisfied end-to-end:** the drain step awaits the *manager-wide* `drain_tracker`, not a per-resource counter, and there is no per-resource post-taint re-check, so a sibling resource's traffic can delay the revoke and the "no acquire after taint observes the revoked credential" guarantee is not provable per-resource. A per-resource drain + post-taint re-check is required before / together with the fan-out wiring (see [Deferred](#deferred)). |
+| 2 | Revoke race on a shared runtime (ADR-0036: zero authenticated traffic post-revoke) | Engine-driven ordering: engine marks the credential `revoking` → `Manager::revoke_slot` taints the runtime (new acquires rejected via the existing `tainted` guard) → drains in-flight guards (`ReleaseQueue` + `drain_tracker`) → reports → engine completes revoke. **Satisfied (2026-05-17):** the drain step awaits a *per-resource* in-flight counter (the manager-wide `drain_tracker` stays only for `graceful_shutdown`) and every `run_*_acquire` re-checks taint after the in-flight increment (#679); the revoke port is two-phase — a synchronous taint is applied before any `.await`, so a timed-out or dropped `drain_and_revoke` still leaves the row tainted (#681). The "no acquire after taint observes the revoked credential" guarantee is now per-resource and tested end-to-end through the wired bus path. |
 | 3 | Secret in config JSON via API (ADR-0028 §7) | `register_from_value(json)` validates against `<R::Config as HasSchema>::schema()`; `ResourceConfig` carries no secrets (slots are credential *references* by key/id, §3.5). API DTOs use ADR-0047 wrappers — zero core/engine/storage types in the wire schema. A regression test rejects secret-shaped config (negative + positive control). |
 | 4 | Type confusion `kind: String → R` in `register_from_value` | `kind → registrar` is a **closed allowlist** (INTEGRATION_MODEL §114-120 closed dependency graph), never reflection. Unknown `kind` ⇒ a typed conflict error, never a silent runtime grab. |
 
@@ -242,31 +256,32 @@ stale Strategy-§6.4 term — the live taxonomy is `frontier`/`stable`).
 Implementation-discovered deferrals (recorded here so they are not lost
 behind the plan):
 
-- **Rotation fan-out is implemented but unwired.** The engine-side
-  reverse index + dispatch port
-  (`ResourceFanoutIndex::{bind,dispatch_refresh,dispatch_revoke}`,
-  `RotationOutcome` aggregation) is fully implemented and unit-tested,
-  but **no production credential-rotation or lease-revoke path invokes
-  it yet** — every current call site is a `#[cfg(test)]` test. The
-  rotation scheduler (ADR-0030) and lease-revoke (ADR-0051) do not yet
-  call `bind` on slot resolution or fan a `dispatch_refresh` /
-  `dispatch_revoke` on a rotation/revoke event; that engine wiring is
-  the remaining work. Consequently the per-resource-drain correctness
-  items below become **live only when that wiring lands** and must be
-  fixed as part of it — they cannot be exercised end-to-end before then.
-  Trigger: the rotation scheduler / lease-revoke handler is wired to
-  call the fan-out port.
-- **Revoke drains the manager-wide tracker, not per-resource.**
-  `Manager::revoke_slot{,_for}` currently taints the target row then
-  awaits the *manager-wide* `drain_tracker` (the same primitive
-  `graceful_shutdown` uses), so an unrelated busy resource can delay a
-  revoke's drain phase and the post-taint re-check is not per-resource.
-  This is **untested in production** (no production caller) and **must
-  be fixed before wiring the fan-out**: draining must move to a
-  **per-resource counter with a post-taint re-check** before or together
-  with the fan-out wiring above — a revoke must not block on traffic to
-  a sibling resource. Trigger: the fan-out wiring lands (same trigger as
-  above; the two are sequenced together).
+- **Rotation fan-out dispatch wired (2026-05-17); bind-population still
+  deferred.** The dispatch path is live and e2e-proven: an
+  engine-owned `ResourceFanoutDriver` subscribes the credential-runtime
+  `CredentialEvent::{Refreshed,Revoked}` and `LeaseEvent::LeaseRevoked`
+  buses and invokes `ResourceFanoutIndex::dispatch_refresh` /
+  `dispatch_revoke` (branch `feat/engine-resource-rotation-wiring`;
+  tested through the real bus path, not by calling `dispatch_*`
+  directly). The remaining unwired piece is **bind-population** —
+  calling `ResourceFanoutIndex::bind` (via the ready `register_and_bind`
+  seam) when a credential is resolved into a `#[credential]` slot in
+  production. No production path resolves credential→slot yet; that
+  producer is the resource-activation path covered by the *Plugin-driven
+  registrar auto-population* / *No production `ResourceRepo`* items
+  below. Until it lands, a real rotation/revoke event fans out
+  correctly to every *bound* row but production binds none. Trigger: a
+  production resource-activation path resolves a credential into a slot
+  and calls `register_and_bind`.
+- **Revoke per-resource drain — resolved (2026-05-17).** `Manager` now
+  drains a *per-resource* in-flight counter for revoke (the manager-wide
+  `drain_tracker` is retained only for `graceful_shutdown`), and every
+  `run_*_acquire` re-checks taint after the in-flight increment (#679).
+  The revoke port is two-phase: a synchronous `taint_slot{,_for}`
+  applied before any `.await`, then `drain_and_revoke` wrapped in the
+  per-resource timeout by the fan-out, so a timed-out/dropped revoke
+  still leaves the row tainted (#681). A revoke no longer blocks on
+  traffic to a sibling resource.
 - **Plugin-driven registrar auto-population.** The engine holds a
   closed `ResourceRegistrarRegistry`, but it is fed by the composition
   root, not auto-populated from `PluginRegistry::resources()`. Wiring a

--- a/docs/superpowers/plans/2026-05-17-resource-rotation-fanout-wiring.md
+++ b/docs/superpowers/plans/2026-05-17-resource-rotation-fanout-wiring.md
@@ -71,10 +71,21 @@ on a runtime built from the OLD credential and the hook is never delivered.
 - New integration tests: rotation event → fan-out → `Manager::refresh_slot_for` → hook;
   `LeaseEvent::LeaseRevoked` → `dispatch_revoke` → taint→drain→revoke hook; redaction gate
   end-to-end through the wired path.
-- Flip the honest claims now true: ADR-0067 §Status → §M11.5/§M12.4 **closed end-to-end**;
-  abuse-case row 2 → satisfied (per-resource drain landed); parent `MATURITY.md`
-  nebula-resource Engine-integration → drop the "fan-out unwired" caveat (save-only,
-  parent tree non-git).
+- Honest close-out (matches the shipped ADR-0067 §Status — **not** a blanket "closed
+  end-to-end"): the rotation/lease-revoke **dispatch path is wired and proven e2e**
+  (engine `ResourceFanoutDriver` subscribes the credential/lease buses → `dispatch_*` →
+  `Manager` slot ports → resource hook) and the three latent items it made live are fixed
+  (#679 per-resource drain + post-taint re-check, #681 two-phase cancellation-safe revoke,
+  #680 epoch-reconcile). **Still deferred:** *bind-population* — populating the
+  reverse-index when a credential resolves into a `#[credential]` slot in production —
+  which depends on the deferred resource-activation path (plugin-driven registrar
+  auto-population / a production `ResourceRepo`); the bind seam (`register_and_bind`) is
+  implemented and ready but has no production caller yet. Net: §M11.5's rotation
+  **orchestration + correctness** are closed; §M12.4 is **NOT** closed and
+  `nebula-resource` stays **`frontier`** in `MATURITY.md` (full §M11.5/§M12.4
+  `frontier→stable` closure additionally requires the deferred bind-population). ADR-0067
+  §Status / abuse-case register / parent `MATURITY.md` reflect exactly this (save-only,
+  parent tree non-git) — no "drop the fan-out caveat" flip.
 - `task dev:check` / per-crate clippy+nextest green for touched crates (resource, engine).
 - Close #679 / #680 / #681 with the landing commit refs.
 

--- a/docs/superpowers/plans/2026-05-17-resource-rotation-fanout-wiring.md
+++ b/docs/superpowers/plans/2026-05-17-resource-rotation-fanout-wiring.md
@@ -1,0 +1,86 @@
+# Plan — wire the resource rotation fan-out (close §M11.5 end-to-end)
+
+> Branch `feat/engine-resource-rotation-wiring` off merged `main` (`7da0174c`, ADR-0067 landed).
+> Authority: **ADR-0067 §Deferred** (binding — read first), ADR-0030 (engine owns rotation
+> orchestration), ADR-0051 (`LeaseEvent` on `EventBus<LeaseEvent>`), ADR-0028 §4 (eventbus≠audit).
+> Closes GitHub issues **#679 / #680 / #681** and de-latents §M11.5.
+
+## Goal
+
+The engine-side `ResourceFanoutIndex` is implemented + unit-tested but **no production path
+invokes it** (every caller is `#[cfg(test)]`). Wire it into the real rotation/lease-revoke
+paths and fix the 3 correctness P1s that become live the moment it is wired. ADR-0067
+sequences them together: **#679 must land before/with the wiring**.
+
+## Non-goals (explicitly deferred, do not pull in)
+
+- Plugin-driven registrar auto-population (cross-crate; separate trigger).
+- `RotationOutcome` → eventbus emission for dashboards (ADR-0028 §4; separate trigger — but
+  the aggregate must still be *returned* and logged here).
+- Production `ResourceRepo` impl + its cross-tenant isolation test gate (#685/#686 area).
+- ADR-0067 §Deferred R-006/R-041/R-042/R-050/R-052.
+
+## Units (sequenced — U1 before U4 per ADR-0067; U2/U3 land with U4)
+
+### U1 — #679: per-resource drain + post-taint re-check (PREREQUISITE)
+`crates/resource/src/manager/` — `revoke_resolved` currently taints the row then awaits the
+**manager-wide** `drain_tracker` (the `graceful_shutdown` primitive); an unrelated busy
+resource delays the revoke and the post-taint re-check is not per-resource.
+- Add a **per-`ManagedResource` in-flight counter**; `revoke_resolved` drains only the
+  revoked row's counter. Keep the manager-wide counter for `graceful_shutdown`.
+- Add a `managed.is_tainted()` **re-check after `InFlightCounter::new`** in every
+  `run_*_acquire` pipeline (mirror the `shutting_down` Defense-B pattern) → `Error::revoked`.
+- Tests: multi-threaded revoke-vs-acquire race; an unrelated resource holding a lease must
+  NOT delay the target revoke's drain.
+
+### U2 — #681: synchronous pre-await taint (cancellation-safe revoke port)
+`crates/resource/src/manager/` + `crates/engine/.../resource_fanout.rs` — a dropped
+`tokio::time::timeout` future must not skip taint. Split the port: a **synchronous
+`taint(key,scope,slot_identity)`** that runs and returns before any `.await`, then an
+awaited drain+hook step the fan-out wraps in the per-resource timeout. The fan-out calls
+the sync taint first, then the bounded awaited phase.
+- Test: a revoke whose awaited phase times out still left the row tainted (new acquires
+  rejected).
+
+### U3 — #680: create-vs-rotate ordering guard (resident lost-update)
+`crates/resource/src/runtime/managed.rs` (Resident arm) + `slot.rs` — `dispatch_slot_hook`
+maps `current()==None` to `Ok(())`, so a refresh racing the first acquire records success
+on a runtime built from the OLD credential and the hook is never delivered.
+- Add an epoch/generation on `SlotCell` (bump on `store`); a runtime records the epoch it
+  was built at; on rotation, if the live runtime's epoch < slot epoch (or `None` race),
+  reconcile (rebuild or re-deliver the hook) instead of silent `Ok`.
+- Tests: create-during-rotation for Resident (and the revoke inverse) — assert the hook is
+  delivered / runtime not left on the stale credential.
+
+### U4 — the wiring (engine; lands with U1–U3)
+`crates/engine/src/credential/` — engine holds `Arc<ResourceFanoutIndex>` + the
+`Arc<nebula_resource::Manager>` it already owns:
+- **`bind`** on credential→slot resolution at the engine register/create path (where a
+  credential is resolved into a `#[credential]` slot); **`unbind`** on resource
+  remove/shutdown.
+- **`dispatch_refresh`** after `RefreshCoordinator::refresh_coalesced` succeeds and the new
+  material is stored into the slot cell — call site in `credential/dispatchers.rs` /
+  `refresh.rs` per ADR-0067 D1, with `per_resource_rotation_timeout`.
+- **`dispatch_revoke`** on `LeaseEvent::LeaseRevoked` (subscribe `EventBus<LeaseEvent>`;
+  `lease/scheduler.rs:551` is the emit site) and on the ADR-0030 scheduler revoke.
+- `RotationOutcome` aggregated + logged (typed, credential-data-free span/log); eventbus
+  emission stays deferred (Non-goal) but the outcome must not be silently dropped.
+- No `nebula-resource → nebula-engine` edge; cross-crate signal via `nebula-eventbus`.
+
+### U5 — end-to-end verification + honest close-out
+- New integration tests: rotation event → fan-out → `Manager::refresh_slot_for` → hook;
+  `LeaseEvent::LeaseRevoked` → `dispatch_revoke` → taint→drain→revoke hook; redaction gate
+  end-to-end through the wired path.
+- Flip the honest claims now true: ADR-0067 §Status → §M11.5/§M12.4 **closed end-to-end**;
+  abuse-case row 2 → satisfied (per-resource drain landed); parent `MATURITY.md`
+  nebula-resource Engine-integration → drop the "fan-out unwired" caveat (save-only,
+  parent tree non-git).
+- `task dev:check` / per-crate clippy+nextest green for touched crates (resource, engine).
+- Close #679 / #680 / #681 with the landing commit refs.
+
+## Discipline
+No plan/task IDs in committed code/comments (cite ADRs). No `unwrap/expect/panic/todo` in
+lib code; `// guard-justified:` above any `#[allow]`/`unreachable!`. Cross-crate via
+eventbus. Subagent-driven: per unit implementer → review → fix loop; reviewers verify
+code not reports; honest escalation over green-washing. U1 commits before U4 (ADR-0067
+sequencing). Squash-merge to `main` via PR.


### PR DESCRIPTION
Wires the engine-side resource rotation fan-out into the real production rotation/lease-revoke paths and fixes the three latent correctness P1s that became live with it. Branch off merged `main` (`7da0174c`, ADR-0067). Follows up the deferred work recorded in ADR-0067 §Deferred.

## What lands (5 commits)
- **#679 — `20ae3521`** per-resource drain + post-taint re-check: revoke drains a *per-resource* in-flight counter (manager-wide `drain_tracker` kept only for `graceful_shutdown`); every `run_*_acquire` re-checks taint after the in-flight increment. A revoke no longer blocks on a sibling resource's traffic; the acquire-after-taint TOCTOU is closed structurally.
- **#681 — `ea344a46`** two-phase cancellation-safe revoke port: synchronous `taint_slot{,_for}` applied before any `.await`, then `drain_and_revoke` wrapped in the per-resource timeout by the fan-out — a timed-out/dropped revoke still leaves the row tainted (no lazy-async-taint skip). Refresh verified to need no split (no pre-await mutation).
- **#680 — `b2803134`** epoch-reconcile rotation-vs-first-acquire: torn-read-free generation on `SlotCell`, derive-generated `credential_slot_epoch()`, `create_lock`-serialized exactly-once reconcile; a refresh racing a resident's first acquire no longer silently records success on a stale-credential runtime. Topology audit: Resident was the only defective arm.
- **U4 — `1d677e9c`** the wiring: an engine-owned `ResourceFanoutDriver` subscribes the credential-runtime `CredentialEvent::{Refreshed,Revoked}` and `LeaseEvent::LeaseRevoked` buses and invokes `dispatch_refresh`/`dispatch_revoke`. `RotationOutcome` is logged credential-data-free (WARN on failed/timed_out; never silently dropped). No `nebula-resource → nebula-engine` edge (`cargo deny` `bans ok`).
- **U5 — `2b59b4c1`** honest doc close-out (below).

## Honest scope — read this
The **rotation/lease-revoke dispatch path is wired and proven end-to-end** (tests emit real bus events, never call `dispatch_*` directly: refresh→hook, lease-revoke→taint+hook, hung-hook→`timed_out` yet row stays tainted, redaction gate through the wired path). The 3 latent P1s are fixed.

**Still deferred (NOT closed here):** *bind-population* — calling `ResourceFanoutIndex::bind` when a credential is resolved into a `#[credential]` slot in production. No production path resolves credential→slot yet; that producer is the resource-activation path (plugin-driven registrar auto-population / a production `ResourceRepo`), which remains explicitly deferred in ADR-0067. The bind seam (`register_and_bind`) is implemented and ready but has no production caller. So a real rotation/revoke event fans out correctly to every *bound* row, but production binds none until activation lands. **§M11.5's rotation orchestration + correctness are closed; full §M11.5/§M12.4 (`nebula-resource` frontier→stable) closure additionally requires the deferred resource-activation bind-population — §M12.4 is NOT claimed and `nebula-resource` stays `frontier`.** ADR-0067 §Status/§Deferred/abuse-row 2 and parent `MATURITY.md` (save-only) updated to state exactly this.

Closes #679
Closes #680
Closes #681

## Verification
Final gate green: `nebula-resource` 280/280, `nebula-engine --features rotation` 504/504 (1 pre-existing chaos-skip), `nebula-engine` 427/427, clippy `-D warnings` clean, `cargo deny bans ok`, rustdoc `-D warnings --no-deps` clean. Pre-push lefthook full gate passed. New e2e wiring + redaction tests exercise the real bus path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Engine now automatically propagates credential refresh and revocation events to bound resources in real-time.

* **Improvements**
  * Credential revocation is now safer with atomic taint-then-drain sequencing, preventing stale resource acquisition.
  * Resources are isolated during rotation, eliminating blocking interference from unrelated credential changes.
  * Added automatic detection of stale runtimes during rotation, ensuring correct credential binding across concurrent operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/690?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->