### PR TITLE
fix(api): harden tenant credential security

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -169,8 +169,9 @@ jobs:
         with:
           tool: cargo-nextest
 
-      # - `nebula-engine`: OAuth2 `refresh_oauth2_state` + tests live behind `rotation`.
-      #   We enable `rotation` explicitly rather than `--all-features` because the
+      # - `nebula-engine`: OAuth2 rotation tests live behind `rotation`; parser
+      #   integration tests use `test-util` to avoid weakening endpoint validation.
+      #   We enable explicit features rather than `--all-features` because the
       #   latter also turns on `chaos-full`, which defeats the
       #   `cfg_attr(not(feature = "chaos-full"), ignore)` gate on
       #   `refresh_coordinator_chaos::three_replicas_zero_double_idp_calls` and
@@ -183,7 +184,7 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "${{ matrix.package }}" == "nebula-engine" ]]; then
-            cargo nextest run -p nebula-engine --features rotation --profile ci --no-tests=pass
+            cargo nextest run -p nebula-engine --features "rotation,test-util" --profile ci --no-tests=pass
           elif [[ "${{ matrix.package }}" == "nebula-storage" ]]; then
             cargo nextest run -p nebula-storage --features "test-util,credential-in-memory" --profile ci --no-tests=pass
           else

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -9,6 +9,7 @@ use axum::{
     Extension, Form, Json,
     extract::{Path, Query, State},
 };
+use nebula_core::TenantContext;
 
 // Re-export the request/response types used by route wiring.
 pub use super::oauth::{
@@ -62,10 +63,13 @@ use crate::{
 pub async fn list_credentials(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws)): Path<(String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws)): Path<(String, String)>,
     Query(query): Query<ListCredentialsQuery>,
 ) -> ApiResult<Json<ListCredentialsResponse>> {
-    let response = crate::transport::credential::list_credentials(&state, &org, &ws, query).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    let response = crate::transport::credential::list_credentials(&state, &owner_id, query).await?;
     Ok(Json(response))
 }
 
@@ -98,7 +102,8 @@ pub async fn list_credentials(
 pub async fn create_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws)): Path<(String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws)): Path<(String, String)>,
     Json(body): Json<CreateCredentialRequest>,
 ) -> ApiResult<Json<CredentialResponse>> {
     // --- Input validation ---
@@ -106,7 +111,9 @@ pub async fn create_credential(
     let _name = validate_credential_name(&body.name)?;
     validate_data_is_object(&body.data)?;
 
-    let response = crate::transport::credential::create_credential(&state, &org, &ws, body).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    let response = crate::transport::credential::create_credential(&state, &owner_id, body).await?;
     Ok(Json(response))
 }
 
@@ -134,12 +141,15 @@ pub async fn create_credential(
 pub async fn get_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
 ) -> ApiResult<Json<CredentialResponse>> {
     // Validate path parameter.
     validate_credential_id(&cred)?;
 
-    let response = crate::transport::credential::get_credential(&state, &org, &ws, &cred).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    let response = crate::transport::credential::get_credential(&state, &owner_id, &cred).await?;
     Ok(Json(response))
 }
 
@@ -171,7 +181,8 @@ pub async fn get_credential(
 pub async fn update_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
     Json(body): Json<UpdateCredentialRequest>,
 ) -> ApiResult<Json<CredentialResponse>> {
     // Validate path parameter.
@@ -199,8 +210,10 @@ pub async fn update_credential(
         validate_data_is_object(data)?;
     }
 
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
     let response =
-        crate::transport::credential::update_credential(&state, &org, &ws, &cred, body).await?;
+        crate::transport::credential::update_credential(&state, &owner_id, &cred, body).await?;
     Ok(Json(response))
 }
 
@@ -229,12 +242,15 @@ pub async fn update_credential(
 pub async fn delete_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
 ) -> ApiResult<Json<AckResponse>> {
     // Validate path parameter.
     validate_credential_id(&cred)?;
 
-    crate::transport::credential::delete_credential(&state, &org, &ws, &cred).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    crate::transport::credential::delete_credential(&state, &owner_id, &cred).await?;
     Ok(Json(AckResponse::ok()))
 }
 
@@ -489,9 +505,9 @@ pub async fn get_credential_type(
 
 /// GET /credentials/{id}/oauth2/auth — Generate OAuth2 authorization URL.
 ///
-/// Builds the provider authorization URL with PKCE challenge and signed
-/// state parameter. The frontend redirects the user to this URL to begin
-/// the OAuth2 authorization code flow.
+/// System-level OAuth credential routes are intentionally disabled. OAuth
+/// state contains credential ownership and must be created through the
+/// workspace-scoped route below.
 #[utoipa::path(
     get,
     path = "/credentials/{id}/oauth2/auth",
@@ -507,18 +523,21 @@ pub async fn get_credential_type(
     ),
 )]
 pub async fn get_oauth2_authorize_url(
-    path: Path<String>,
-    state: State<AppState>,
-    user: Extension<AuthenticatedUser>,
-    query: Query<crate::transport::oauth::flow::AuthorizationUriRequest>,
+    Path(_cred): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Query(_query): Query<crate::transport::oauth::flow::AuthorizationUriRequest>,
 ) -> ApiResult<Json<AuthorizationUriResponse>> {
-    oauth_controller::get_oauth2_authorize_url(path, state, user, query).await
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
 }
 
 /// GET /credentials/{id}/oauth2/callback — Handle OAuth2 callback (query params).
 ///
-/// Receives the authorization code and signed state via query parameters,
-/// exchanges the code for tokens, and persists the OAuth2 credential state.
+/// System-level callback routes are intentionally disabled. The signed
+/// pending state is tenant-bound and must be consumed through the
+/// workspace-scoped callback route below.
 #[utoipa::path(
     get,
     path = "/credentials/{id}/oauth2/callback",
@@ -535,18 +554,21 @@ pub async fn get_oauth2_authorize_url(
     ),
 )]
 pub async fn get_oauth2_callback(
-    path: Path<String>,
-    state: State<AppState>,
-    user: Extension<AuthenticatedUser>,
-    query: Query<OAuthCallbackQuery>,
+    Path(_cred): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Query(_query): Query<OAuthCallbackQuery>,
 ) -> ApiResult<Json<OAuthCallbackResponse>> {
-    oauth_controller::get_oauth2_callback(path, state, user, query).await
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
 }
 
 /// POST /credentials/{id}/oauth2/callback — Handle OAuth2 callback (form_post).
 ///
-/// Accepts `application/x-www-form-urlencoded` bodies for providers that use
-/// the `form_post` response mode.
+/// System-level callback routes are intentionally disabled. The signed
+/// pending state is tenant-bound and must be consumed through the
+/// workspace-scoped callback route below.
 #[utoipa::path(
     post,
     path = "/credentials/{id}/oauth2/callback",
@@ -562,10 +584,133 @@ pub async fn get_oauth2_callback(
     ),
 )]
 pub async fn post_oauth2_callback(
-    path: Path<String>,
-    state: State<AppState>,
-    user: Extension<AuthenticatedUser>,
-    body: Form<OAuthCallbackBody>,
+    Path(_cred): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Form(_body): Form<OAuthCallbackBody>,
 ) -> ApiResult<Json<OAuthCallbackResponse>> {
-    oauth_controller::post_oauth2_callback(path, state, user, body).await
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
+}
+
+/// GET /orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/auth — Generate OAuth2 authorization URL.
+///
+/// Builds the provider authorization URL with PKCE challenge and tenant-bound
+/// signed state. The frontend redirects the user to this URL to begin the
+/// OAuth2 authorization code flow.
+#[utoipa::path(
+    get,
+    path = "/orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/auth",
+    tag = "workspaces.credentials",
+    security(("bearer" = []), ("api_key" = [])),
+    params(
+        ("org" = String, Path, description = "Organisation slug or `org_<ULID>`."),
+        ("ws" = String, Path, description = "Workspace slug or `ws_<ULID>`."),
+        ("cred" = String, Path, description = "Credential identifier (`cred_<ULID>`)."),
+    ),
+    responses(
+        (status = 200, description = "Authorization URL plus signed opaque state.", body = AuthorizationUriResponse),
+        (status = 400, description = "Invalid OAuth configuration (e.g. malformed authorization URL or unsafe token endpoint).", body = ProblemDetails),
+        (status = 401, description = "Authentication required.", body = ProblemDetails),
+        (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
+    ),
+)]
+pub async fn get_oauth2_authorize_url_scoped(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
+    Query(query): Query<crate::transport::oauth::flow::AuthorizationUriRequest>,
+) -> ApiResult<Json<AuthorizationUriResponse>> {
+    validate_credential_id(&cred)?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    oauth_controller::get_oauth2_authorize_url_for_owner(
+        &cred,
+        &state,
+        &user,
+        query,
+        Some(owner_id),
+    )
+    .await
+}
+
+/// GET /orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/callback — Handle OAuth2 callback.
+#[utoipa::path(
+    get,
+    path = "/orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/callback",
+    tag = "workspaces.credentials",
+    security(("bearer" = []), ("api_key" = [])),
+    params(
+        ("org" = String, Path, description = "Organisation slug or `org_<ULID>`."),
+        ("ws" = String, Path, description = "Workspace slug or `ws_<ULID>`."),
+        ("cred" = String, Path, description = "Credential identifier (`cred_<ULID>`)."),
+        ("code" = String, Query, description = "Authorization code from the provider."),
+        ("state" = String, Query, description = "Signed opaque state from `oauth2/auth`."),
+    ),
+    responses(
+        (status = 200, description = "Tokens exchanged and persisted.", body = OAuthCallbackResponse),
+        (status = 401, description = "State validation failed, tenant mismatch, or pending state expired/already-consumed.", body = ProblemDetails),
+    ),
+)]
+pub async fn get_oauth2_callback_scoped(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
+    Query(query): Query<OAuthCallbackQuery>,
+) -> ApiResult<Json<OAuthCallbackResponse>> {
+    validate_credential_id(&cred)?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    oauth_controller::handle_callback_for_owner(
+        &cred,
+        &state,
+        &user,
+        query.code,
+        query.state,
+        owner_id,
+        |req| async move { crate::transport::oauth::flow::exchange_code(&req).await },
+    )
+    .await
+}
+
+/// POST /orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/callback — Handle OAuth2 form_post callback.
+#[utoipa::path(
+    post,
+    path = "/orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/callback",
+    tag = "workspaces.credentials",
+    security(("bearer" = []), ("api_key" = [])),
+    params(
+        ("org" = String, Path, description = "Organisation slug or `org_<ULID>`."),
+        ("ws" = String, Path, description = "Workspace slug or `ws_<ULID>`."),
+        ("cred" = String, Path, description = "Credential identifier (`cred_<ULID>`)."),
+    ),
+    request_body(content = OAuthCallbackBody, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 200, description = "Tokens exchanged and persisted.", body = OAuthCallbackResponse),
+        (status = 401, description = "State validation failed, tenant mismatch, or pending state expired/already-consumed.", body = ProblemDetails),
+    ),
+)]
+pub async fn post_oauth2_callback_scoped(
+    State(state): State<AppState>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
+    Form(body): Form<OAuthCallbackBody>,
+) -> ApiResult<Json<OAuthCallbackResponse>> {
+    validate_credential_id(&cred)?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
+    oauth_controller::handle_callback_for_owner(
+        &cred,
+        &state,
+        &user,
+        body.code,
+        body.state,
+        owner_id,
+        |req| async move { crate::transport::oauth::flow::exchange_code(&req).await },
+    )
+    .await
 }

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -262,6 +262,32 @@ where
             ApiError::Unauthorized("oauth state not found or already consumed".to_owned())
         })?;
 
+    let pending_for_owner_check = state
+        .oauth_pending_store
+        .get_bound::<OAuthPendingExchange>(
+            "oauth2",
+            &pending_token,
+            &user.user_id,
+            &payload.csrf_token,
+        )
+        .await;
+    let pending_for_owner_check = match pending_for_owner_check {
+        Ok(p) => p,
+        Err(e) => {
+            if should_drop_oauth_state_map_entry(&e) {
+                state.oauth_state_tokens.write().await.remove(&signed_state);
+            }
+            return Err(ApiError::Unauthorized(format!(
+                "oauth pending consume failed: {e}"
+            )));
+        },
+    };
+    if pending_for_owner_check.owner_id.as_deref() != owner_id.as_deref() {
+        return Err(ApiError::Unauthorized(
+            "oauth pending state tenant mismatch".to_owned(),
+        ));
+    }
+
     let consume_result = state
         .oauth_pending_store
         .consume::<OAuthPendingExchange>(
@@ -283,11 +309,6 @@ where
             )));
         },
     };
-    if pending.owner_id.as_deref() != owner_id.as_deref() {
-        return Err(ApiError::Unauthorized(
-            "oauth pending state tenant mismatch".to_owned(),
-        ));
-    }
 
     state.oauth_state_tokens.write().await.remove(&signed_state);
 
@@ -770,5 +791,68 @@ mod tests {
             "new-refresh-token"
         );
         assert_eq!(persisted_state.scopes, vec!["new-scope-a", "new-scope-b"]);
+    }
+
+    #[tokio::test]
+    async fn tenant_mismatch_does_not_consume_pending_state() {
+        let state = test_app_state();
+        let credential_id = "cred-tenant-mismatch";
+        let user = AuthenticatedUser {
+            user_id: "user-tenant-mismatch".to_owned(),
+        };
+
+        let csrf = generate_random_state();
+        let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
+        let (signed_state, payload) =
+            build_signed_state(&signer, credential_id, csrf).expect("signed state");
+        let mut pending = test_pending_exchange();
+        pending.owner_id = Some("org-a:ws-a".to_owned());
+        let pending_token = state
+            .oauth_pending_store
+            .put("oauth2", &user.user_id, &payload.csrf_token, pending)
+            .await
+            .expect("pending store put");
+        let pending_token_for_assert = pending_token.clone();
+        state
+            .oauth_state_tokens
+            .write()
+            .await
+            .insert(signed_state.clone(), pending_token);
+
+        let err = handle_callback_with_exchange(
+            credential_id,
+            &state,
+            &user,
+            "auth-code".to_owned(),
+            signed_state.clone(),
+            Some("org-b:ws-b".to_owned()),
+            |_req| async { Err::<serde_json::Value, String>("exchange should not run".to_owned()) },
+        )
+        .await
+        .expect_err("tenant mismatch must fail");
+        assert!(
+            matches!(err, ApiError::Unauthorized(ref message) if message == "oauth pending state tenant mismatch"),
+            "expected tenant mismatch, got: {err:?}"
+        );
+
+        let still_pending = state
+            .oauth_pending_store
+            .get_bound::<OAuthPendingExchange>(
+                "oauth2",
+                &pending_token_for_assert,
+                &user.user_id,
+                &payload.csrf_token,
+            )
+            .await
+            .expect("tenant mismatch must leave pending state retryable");
+        assert_eq!(still_pending.owner_id.as_deref(), Some("org-a:ws-a"));
+        assert!(
+            state
+                .oauth_state_tokens
+                .read()
+                .await
+                .contains_key(&signed_state),
+            "tenant mismatch must leave signed state mapping retryable"
+        );
     }
 }

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -22,7 +22,8 @@ use crate::{
     state::AppState,
     transport::oauth::{
         flow::{
-            AuthorizationUriRequest, TokenExchangeRequest, build_authorization_uri, exchange_code,
+            AuthorizationUriRequest, TokenExchangeRequest, build_authorization_uri,
+            validate_token_endpoint,
         },
         state::{OAuthStateSigner, build_signed_state},
     },
@@ -52,14 +53,38 @@ pub struct AuthorizationUriResponse {
 
 /// GET `/credentials/{id}/oauth2/auth`
 pub async fn get_oauth2_authorize_url(
-    Path(credential_id): Path<String>,
-    State(state): State<AppState>,
-    Extension(user): Extension<AuthenticatedUser>,
-    Query(query): Query<AuthorizationUriRequest>,
+    Path(_credential_id): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Query(_query): Query<AuthorizationUriRequest>,
 ) -> ApiResult<Json<AuthorizationUriResponse>> {
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
+}
+
+/// Build an OAuth2 authorization URL and persist tenant-bound pending state.
+///
+/// When `owner_id` is provided, the credential placeholder is created/read
+/// through the scoped credential store and the pending exchange records the
+/// expected credential version for callback-time CAS persistence.
+pub async fn get_oauth2_authorize_url_for_owner(
+    credential_id: &str,
+    state: &AppState,
+    user: &AuthenticatedUser,
+    query: AuthorizationUriRequest,
+    owner_id: Option<String>,
+) -> ApiResult<Json<AuthorizationUriResponse>> {
+    validate_token_endpoint(&query.token_url).map_err(ApiError::validation_message)?;
+    let expected_version = if let Some(owner_id) = owner_id.as_deref() {
+        Some(prepare_oauth_credential(state, owner_id, credential_id).await?)
+    } else {
+        None
+    };
+
     let csrf = generate_random_state();
     let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
-    let (signed_state, payload) = build_signed_state(&signer, &credential_id, csrf)
+    let (signed_state, payload) = build_signed_state(&signer, credential_id, csrf)
         .map_err(|e| ApiError::Internal(format!("state generation failed: {e}")))?;
 
     let code_verifier = generate_pkce_verifier();
@@ -79,6 +104,8 @@ pub async fn get_oauth2_authorize_url(
         auth_style: query
             .auth_style
             .unwrap_or(nebula_credential::credentials::oauth2::AuthStyle::Header),
+        owner_id,
+        expected_version,
     };
     let pending_token = state
         .oauth_pending_store
@@ -135,40 +162,55 @@ pub struct OAuthCallbackResponse {
 
 /// GET `/credentials/{id}/oauth2/callback`
 pub async fn get_oauth2_callback(
-    Path(credential_id): Path<String>,
-    State(state): State<AppState>,
-    Extension(user): Extension<AuthenticatedUser>,
-    Query(query): Query<OAuthCallbackQuery>,
+    Path(_credential_id): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Query(_query): Query<OAuthCallbackQuery>,
 ) -> ApiResult<Json<OAuthCallbackResponse>> {
-    handle_callback(&credential_id, &state, &user, query.code, query.state).await
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
 }
 
 /// POST `/credentials/{id}/oauth2/callback`
 ///
 /// Accepts `application/x-www-form-urlencoded` bodies (`form_post` response mode).
 pub async fn post_oauth2_callback(
-    Path(credential_id): Path<String>,
-    State(state): State<AppState>,
-    Extension(user): Extension<AuthenticatedUser>,
-    Form(body): Form<OAuthCallbackBody>,
+    Path(_credential_id): Path<String>,
+    State(_state): State<AppState>,
+    Extension(_user): Extension<AuthenticatedUser>,
+    Form(_body): Form<OAuthCallbackBody>,
 ) -> ApiResult<Json<OAuthCallbackResponse>> {
-    handle_callback(&credential_id, &state, &user, body.code, body.state).await
+    Err(ApiError::Gone(
+        "OAuth credential flow must use workspace-scoped routes".to_owned(),
+    ))
 }
 
-async fn handle_callback(
+/// Consume tenant-bound OAuth pending state, exchange the code, and persist tokens.
+///
+/// The pending state owner must match `owner_id`; callbacks sent to the wrong
+/// workspace fail before token exchange and before credential persistence.
+pub async fn handle_callback_for_owner<F, Fut>(
     credential_id: &str,
     state: &AppState,
     user: &AuthenticatedUser,
     code: String,
     signed_state: String,
-) -> ApiResult<Json<OAuthCallbackResponse>> {
+    owner_id: String,
+    exchange_fn: F,
+) -> ApiResult<Json<OAuthCallbackResponse>>
+where
+    F: Fn(TokenExchangeRequest) -> Fut,
+    Fut: Future<Output = Result<serde_json::Value, String>>,
+{
     handle_callback_with_exchange(
         credential_id,
         state,
         user,
         code,
         signed_state,
-        |req| async move { exchange_code(&req).await },
+        Some(owner_id),
+        exchange_fn,
     )
     .await
 }
@@ -195,6 +237,7 @@ async fn handle_callback_with_exchange<F, Fut>(
     user: &AuthenticatedUser,
     code: String,
     signed_state: String,
+    owner_id: Option<String>,
     exchange_fn: F,
 ) -> ApiResult<Json<OAuthCallbackResponse>>
 where
@@ -240,6 +283,11 @@ where
             )));
         },
     };
+    if pending.owner_id.as_deref() != owner_id.as_deref() {
+        return Err(ApiError::Unauthorized(
+            "oauth pending state tenant mismatch".to_owned(),
+        ));
+    }
 
     state.oauth_state_tokens.write().await.remove(&signed_state);
 
@@ -256,7 +304,14 @@ where
         .await
         .map_err(ApiError::Internal)?;
     let oauth_state = build_oauth2_state(&token_body, &pending)?;
-    persist_oauth_state(state, credential_id, oauth_state).await?;
+    persist_oauth_state(
+        state,
+        owner_id.as_deref(),
+        pending.expected_version,
+        credential_id,
+        oauth_state,
+    )
+    .await?;
 
     Ok(Json(OAuthCallbackResponse {
         credential_id: credential_id.to_owned(),
@@ -276,6 +331,8 @@ struct OAuthPendingExchange {
     code_verifier: SecretString,
     scopes: Vec<String>,
     auth_style: nebula_credential::credentials::oauth2::AuthStyle,
+    owner_id: Option<String>,
+    expected_version: Option<u64>,
 }
 
 impl Zeroize for OAuthPendingExchange {
@@ -286,6 +343,7 @@ impl Zeroize for OAuthPendingExchange {
         self.redirect_uri.zeroize();
         self.code_verifier.zeroize();
         self.scopes.zeroize();
+        self.owner_id.zeroize();
     }
 }
 
@@ -355,6 +413,8 @@ fn build_oauth2_state(
 
 async fn persist_oauth_state(
     state: &AppState,
+    owner_id: Option<&str>,
+    expected_version: Option<u64>,
     credential_id: &str,
     oauth_state: OAuth2State,
 ) -> ApiResult<()> {
@@ -364,13 +424,30 @@ async fn persist_oauth_state(
         ))
     })?;
     let now = chrono::Utc::now();
-    let (created_at, metadata) = match state.oauth_credential_store.get(credential_id).await {
-        Ok(existing) => (existing.created_at, existing.metadata),
-        Err(StoreError::NotFound { .. }) => (now, serde_json::Map::new()),
-        Err(e) => {
-            return Err(ApiError::Internal(format!(
-                "failed to read existing oauth credential: {e}"
-            )));
+    let (created_at, metadata, mode) = match owner_id {
+        Some(owner_id) => {
+            let store = crate::transport::credential::scoped_store(state, owner_id);
+            let existing = store
+                .get(credential_id)
+                .await
+                .map_err(|e| map_oauth_store_err(e, credential_id))?;
+            let expected_version = expected_version.ok_or_else(|| {
+                ApiError::Unauthorized("oauth pending state missing credential version".to_owned())
+            })?;
+            (
+                existing.created_at,
+                existing.metadata,
+                PutMode::CompareAndSwap { expected_version },
+            )
+        },
+        None => match state.oauth_credential_store.get(credential_id).await {
+            Ok(existing) => (existing.created_at, existing.metadata, PutMode::Overwrite),
+            Err(StoreError::NotFound { .. }) => (now, serde_json::Map::new(), PutMode::Overwrite),
+            Err(e) => {
+                return Err(ApiError::Internal(format!(
+                    "failed to read existing oauth credential: {e}"
+                )));
+            },
         },
     };
     let stored = StoredCredential {
@@ -390,14 +467,84 @@ async fn persist_oauth_state(
         metadata,
     };
 
-    state
-        .oauth_credential_store
-        .put(stored, PutMode::Overwrite)
-        .await
-        .map_err(|e| {
-            ApiError::Internal(format!("failed to persist oauth credential state: {e}"))
-        })?;
+    match owner_id {
+        Some(owner_id) => {
+            crate::transport::credential::scoped_store(state, owner_id)
+                .put(stored, mode)
+                .await
+                .map_err(|e| map_oauth_store_err(e, credential_id))?;
+        },
+        None => {
+            state
+                .oauth_credential_store
+                .put(stored, mode)
+                .await
+                .map_err(|e| {
+                    ApiError::Internal(format!("failed to persist oauth credential state: {e}"))
+                })?;
+        },
+    }
     Ok(())
+}
+
+async fn prepare_oauth_credential(
+    state: &AppState,
+    owner_id: &str,
+    credential_id: &str,
+) -> ApiResult<u64> {
+    let store = crate::transport::credential::scoped_store(state, owner_id);
+    match store.get(credential_id).await {
+        Ok(existing) => {
+            if existing.credential_key != OAuth2Credential::KEY
+                || existing.state_kind != OAuth2State::KIND
+            {
+                return Err(ApiError::validation_message(
+                    "credential is not an OAuth2 credential",
+                ));
+            }
+            Ok(existing.version)
+        },
+        Err(StoreError::NotFound { .. }) => {
+            let now = chrono::Utc::now();
+            let stored = StoredCredential {
+                id: credential_id.to_owned(),
+                credential_key: OAuth2Credential::KEY.to_owned(),
+                data: Vec::new(),
+                state_kind: OAuth2State::KIND.to_owned(),
+                state_version: OAuth2State::VERSION,
+                version: 0,
+                created_at: now,
+                updated_at: now,
+                expires_at: None,
+                reauth_required: true,
+                metadata: serde_json::Map::new(),
+            };
+            store
+                .put(stored, PutMode::CreateOnly)
+                .await
+                .map(|created| created.version)
+                .map_err(|e| map_oauth_store_err(e, credential_id))
+        },
+        Err(e) => Err(map_oauth_store_err(e, credential_id)),
+    }
+}
+
+fn map_oauth_store_err(err: StoreError, credential_id: &str) -> ApiError {
+    match err {
+        StoreError::NotFound { .. } | StoreError::AlreadyExists { .. } => {
+            ApiError::NotFound(format!("credential {credential_id} not found"))
+        },
+        StoreError::VersionConflict { .. } => ApiError::Conflict(
+            "OAuth credential changed while authorization was in progress".to_owned(),
+        ),
+        StoreError::AuditFailure(reason) => {
+            ApiError::ServiceUnavailable(format!("credential audit sink unavailable: {reason}"))
+        },
+        StoreError::Backend(e) => {
+            ApiError::Internal(format!("credential store backend error: {e}"))
+        },
+        _ => ApiError::Internal(format!("credential store error for {credential_id}")),
+    }
 }
 
 #[cfg(test)]
@@ -448,6 +595,8 @@ mod tests {
             code_verifier: SecretString::new("pkce-verifier"),
             scopes: vec!["read".to_owned(), "write".to_owned()],
             auth_style: nebula_credential::credentials::oauth2::AuthStyle::Header,
+            owner_id: None,
+            expected_version: None,
         }
     }
 
@@ -488,6 +637,7 @@ mod tests {
             &user,
             "auth-code".to_owned(),
             signed_state,
+            None,
             move |_req| {
                 let token_body = token_body.clone();
                 async move { Ok(token_body) }
@@ -542,7 +692,7 @@ mod tests {
             token_url: "https://provider.example.com/token".to_owned(),
             auth_style: nebula_credential::credentials::oauth2::AuthStyle::Header,
         };
-        persist_oauth_state(&state, credential_id, old_oauth_state)
+        persist_oauth_state(&state, None, None, credential_id, old_oauth_state)
             .await
             .expect("seed existing oauth state");
         let first_created_at = state
@@ -581,6 +731,7 @@ mod tests {
             &user,
             "auth-code".to_owned(),
             signed_state,
+            None,
             move |_req| {
                 let token_body = token_body.clone();
                 async move { Ok(token_body) }

--- a/crates/api/src/domain/execution/handler.rs
+++ b/crates/api/src/domain/execution/handler.rs
@@ -436,7 +436,7 @@ pub(crate) async fn enqueue_start_scoped(
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Execution does not exist.", body = ProblemDetails),
         (status = 409, description = "Concurrent modification detected.", body = ProblemDetails),
-        (status = 503, description = "Control queue is unavailable; the cancel signal cannot reach the engine.", body = ProblemDetails),
+        (status = 500, description = "Execution aggregate transition failed before the state/control outbox commit completed.", body = ProblemDetails),
     ),
 )]
 pub async fn cancel_execution(
@@ -504,16 +504,25 @@ pub async fn cancel_execution(
         }
     }
 
-    // Apply state transition using CAS.
-    //
-    // Order: transition first, then enqueue — per canon §12.2 and audit §2.2.
-    // If enqueue fails after a successful transition the execution row is
-    // already `cancelled` but the engine will not see the signal (orphan).
-    // This is documented as a known limitation until a shared transaction
-    // wrapper is available across ExecutionRepo and ControlQueueRepo.
-    // The handler fails loudly on enqueue failure so the caller can retry.
+    // Apply the state transition and append the Cancel outbox row in one
+    // storage-port commit. This prevents a cancelled row without a matching
+    // engine-visible control signal.
+    let w3c_trace_context = w3c_trace_context_for_control_queue();
+    tracing::debug!(
+        execution_id = %execution_id,
+        command = ControlCommand::Cancel.as_str(),
+        has_trace_context = w3c_trace_context.is_some(),
+        "execution: append Cancel control row with state transition"
+    );
     let transition_result = state
-        .cas_transition_scoped(&scope, execution_id, version, execution_state.clone())
+        .cas_transition_with_control_scoped(
+            &scope,
+            execution_id,
+            version,
+            execution_state.clone(),
+            ControlCommand::Cancel,
+            w3c_trace_context,
+        )
         .await?;
 
     if !transition_result {
@@ -521,36 +530,6 @@ pub async fn cancel_execution(
             "concurrent modification detected; refetch execution state and retry".to_string(),
         ));
     }
-
-    // Enqueue the Cancel signal to the durable control queue (canon §12.2).
-    //
-    // This MUST happen immediately after a successful CAS transition. If
-    // this call fails we return 503 when the control-queue backend is
-    // unavailable (orchestration absent — canon §13 step 6), else 500, per
-    // the `StorageError` sentinel match below. Either way the caller should
-    // retry the cancel request — the retry will see the already-cancelled
-    // DB row and short-circuit at the terminal-status guard above without
-    // re-enqueuing (idempotent).
-    //
-    // M3.5: same W3C stamping policy as [`enqueue_start`] — operator correlation for Cancel.
-    let w3c_trace_context = w3c_trace_context_for_control_queue();
-    tracing::debug!(
-        execution_id = %execution_id,
-        command = ControlCommand::Cancel.as_str(),
-        has_trace_context = w3c_trace_context.is_some(),
-        "execution: enqueue Cancel on control queue"
-    );
-    // Canon §13 step 6 503-vs-500 policy is centralized in
-    // `enqueue_control`; the cancel row is already committed above, so
-    // a failed enqueue still surfaces as the orphan-signal error.
-    state
-        .enqueue_control_scoped(
-            &scope,
-            ControlCommand::Cancel,
-            execution_id,
-            w3c_trace_context,
-        )
-        .await?;
 
     // Extract fields from updated execution state
     let workflow_id = execution_state
@@ -663,7 +642,7 @@ pub async fn get_execution_logs(
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Execution does not exist.", body = ProblemDetails),
         (status = 409, description = "Concurrent modification detected.", body = ProblemDetails),
-        (status = 503, description = "Control queue is unavailable; the terminate signal cannot reach the engine.", body = ProblemDetails),
+        (status = 500, description = "Execution aggregate transition failed before the state/control outbox commit completed.", body = ProblemDetails),
     ),
 )]
 pub async fn terminate_execution(
@@ -738,16 +717,25 @@ pub async fn terminate_execution(
         }
     }
 
-    // Apply state transition using CAS.
-    //
-    // Order: transition first, then enqueue — per canon §12.2 and audit §2.2.
-    // If enqueue fails after a successful transition the execution row is
-    // already `cancelled` but the engine will not see the signal (orphan).
-    // This is documented as a known limitation until a shared transaction
-    // wrapper is available across ExecutionRepo and ControlQueueRepo.
-    // The handler fails loudly on enqueue failure so the caller can retry.
+    // Apply the state transition and append the Terminate outbox row in one
+    // storage-port commit. This prevents a cancelled row without a matching
+    // engine-visible control signal.
+    let w3c_trace_context = w3c_trace_context_for_control_queue();
+    tracing::debug!(
+        execution_id = %execution_id,
+        command = ControlCommand::Terminate.as_str(),
+        has_trace_context = w3c_trace_context.is_some(),
+        "execution: append Terminate control row with state transition"
+    );
     let transition_result = state
-        .cas_transition_scoped(&scope, execution_id, version, execution_state.clone())
+        .cas_transition_with_control_scoped(
+            &scope,
+            execution_id,
+            version,
+            execution_state.clone(),
+            ControlCommand::Terminate,
+            w3c_trace_context,
+        )
         .await?;
 
     if !transition_result {
@@ -755,40 +743,6 @@ pub async fn terminate_execution(
             "concurrent modification detected; refetch execution state and retry".to_string(),
         ));
     }
-
-    // Enqueue the Terminate signal to the durable control queue (canon
-    // §12.2).
-    //
-    // This MUST happen immediately after a successful CAS transition. If
-    // this call fails we return 503 when the control-queue backend is
-    // unavailable (orchestration absent — canon §13 step 6), else 500, per
-    // the `StorageError` sentinel match below. Either way the caller should
-    // retry the terminate request — the retry will see the already-cancelled
-    // DB row and short-circuit at the terminal-status guard above without
-    // re-enqueuing (idempotent).
-    //
-    // M3.5: same W3C stamping policy as [`enqueue_start`] — operator
-    // correlation for Terminate.
-    let w3c_trace_context = w3c_trace_context_for_control_queue();
-    tracing::debug!(
-        execution_id = %execution_id,
-        command = ControlCommand::Terminate.as_str(),
-        has_trace_context = w3c_trace_context.is_some(),
-        "execution: enqueue Terminate on control queue"
-    );
-    // Canon §13 step 6 503-vs-500 policy is centralized in
-    // `enqueue_control` (port-scoped `ControlQueue::enqueue` →
-    // typed-ULID `ControlMsg`); the terminate row is already committed
-    // above, so a failed enqueue still surfaces as the orphan-signal
-    // error (canon §12.2).
-    state
-        .enqueue_control_scoped(
-            &scope,
-            ControlCommand::Terminate,
-            execution_id,
-            w3c_trace_context,
-        )
-        .await?;
 
     // Extract fields from updated execution state
     let workflow_id = execution_state

--- a/crates/api/src/domain/workspace.rs
+++ b/crates/api/src/domain/workspace.rs
@@ -83,6 +83,11 @@ pub fn router() -> OpenApiRouter<AppState> {
             credential::update_credential,
             credential::delete_credential
         ))
+        .routes(routes!(credential::get_oauth2_authorize_url_scoped))
+        .routes(routes!(
+            credential::get_oauth2_callback_scoped,
+            credential::post_oauth2_callback_scoped
+        ))
         .routes(routes!(credential::test_credential))
         .routes(routes!(credential::refresh_credential))
         .routes(routes!(credential::revoke_credential))

--- a/crates/api/src/middleware/rbac.rs
+++ b/crates/api/src/middleware/rbac.rs
@@ -48,7 +48,7 @@ pub async fn rbac_middleware(
     // Load org role
     let org_role = match &state.membership_store {
         Some(store) => store.get_org_role(org_id, &auth_ctx.principal).await?,
-        None if state.allow_insecure_tenant_rbac_bypass => None,
+        None if state.allow_insecure_tenant_rbac_bypass() => None,
         None => {
             return Err(ApiError::ServiceUnavailable(
                 "membership store not configured; tenant routes are disabled".to_string(),
@@ -57,7 +57,7 @@ pub async fn rbac_middleware(
     };
 
     // If user has no org role at all, return 404 (enumeration prevention).
-    if org_role.is_none() && !state.allow_insecure_tenant_rbac_bypass {
+    if org_role.is_none() && !state.allow_insecure_tenant_rbac_bypass() {
         return Err(ApiError::NotFound("not found".to_string()));
     }
 
@@ -65,7 +65,7 @@ pub async fn rbac_middleware(
     let workspace_role = if let Some(ws_id) = resolved.workspace_id {
         let explicit_role = match &state.membership_store {
             Some(store) => store.get_workspace_role(ws_id, &auth_ctx.principal).await?,
-            None if state.allow_insecure_tenant_rbac_bypass => None,
+            None if state.allow_insecure_tenant_rbac_bypass() => None,
             None => {
                 return Err(ApiError::ServiceUnavailable(
                     "membership store not configured; tenant routes are disabled".to_string(),
@@ -75,7 +75,7 @@ pub async fn rbac_middleware(
         let effective = effective_workspace_role(org_role, explicit_role);
 
         // If user has org access but no effective workspace role, return 404
-        if effective.is_none() && !state.allow_insecure_tenant_rbac_bypass {
+        if effective.is_none() && !state.allow_insecure_tenant_rbac_bypass() {
             return Err(ApiError::NotFound("not found".to_string()));
         }
         effective

--- a/crates/api/src/middleware/rbac.rs
+++ b/crates/api/src/middleware/rbac.rs
@@ -48,15 +48,16 @@ pub async fn rbac_middleware(
     // Load org role
     let org_role = match &state.membership_store {
         Some(store) => store.get_org_role(org_id, &auth_ctx.principal).await?,
+        None if state.allow_insecure_tenant_rbac_bypass => None,
         None => {
-            // No membership store configured — in dev/test mode, allow through.
-            None
+            return Err(ApiError::ServiceUnavailable(
+                "membership store not configured; tenant routes are disabled".to_string(),
+            ));
         },
     };
 
     // If user has no org role at all, return 404 (enumeration prevention).
-    // Exception: skip this check when no membership store is configured (dev mode).
-    if state.membership_store.is_some() && org_role.is_none() {
+    if org_role.is_none() && !state.allow_insecure_tenant_rbac_bypass {
         return Err(ApiError::NotFound("not found".to_string()));
     }
 
@@ -64,12 +65,17 @@ pub async fn rbac_middleware(
     let workspace_role = if let Some(ws_id) = resolved.workspace_id {
         let explicit_role = match &state.membership_store {
             Some(store) => store.get_workspace_role(ws_id, &auth_ctx.principal).await?,
-            None => None,
+            None if state.allow_insecure_tenant_rbac_bypass => None,
+            None => {
+                return Err(ApiError::ServiceUnavailable(
+                    "membership store not configured; tenant routes are disabled".to_string(),
+                ));
+            },
         };
         let effective = effective_workspace_role(org_role, explicit_role);
 
         // If user has org access but no effective workspace role, return 404
-        if state.membership_store.is_some() && effective.is_none() {
+        if effective.is_none() && !state.allow_insecure_tenant_rbac_bypass {
             return Err(ApiError::NotFound("not found".to_string()));
         }
         effective

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -280,7 +280,7 @@ pub struct AppState {
     /// Test-only escape hatch for harnesses that exercise tenant routes
     /// without modeling memberships. Production composition leaves this
     /// false so missing RBAC state disables tenant routes fail-closed.
-    pub allow_insecure_tenant_rbac_bypass: bool,
+    allow_insecure_tenant_rbac_bypass: bool,
 
     /// Optional idempotency store backing [`crate::middleware::IdempotencyLayer`].
     ///
@@ -1037,6 +1037,11 @@ impl AppState {
     pub fn with_membership_store(mut self, store: Arc<dyn MembershipStore>) -> Self {
         self.membership_store = Some(store);
         self
+    }
+
+    /// Whether tenant RBAC is explicitly bypassed for test harnesses.
+    pub(crate) const fn allow_insecure_tenant_rbac_bypass(&self) -> bool {
+        self.allow_insecure_tenant_rbac_bypass
     }
 
     /// Allow tenant routes to pass RBAC without a membership store.

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -277,6 +277,11 @@ pub struct AppState {
     /// Optional membership store for RBAC role lookups.
     pub membership_store: Option<Arc<dyn MembershipStore>>,
 
+    /// Test-only escape hatch for harnesses that exercise tenant routes
+    /// without modeling memberships. Production composition leaves this
+    /// false so missing RBAC state disables tenant routes fail-closed.
+    pub allow_insecure_tenant_rbac_bypass: bool,
+
     /// Optional idempotency store backing [`crate::middleware::IdempotencyLayer`].
     ///
     /// When `Some`, `build_app` mounts the layer on `api_routes` (NOT on the
@@ -429,6 +434,7 @@ impl AppState {
             workspace_resolver: None,
             auth_backend: None,
             membership_store: None,
+            allow_insecure_tenant_rbac_bypass: false,
             idempotency_store: None,
             webhook_activation_repo: None,
             trigger_lifecycle_bus: None,
@@ -855,44 +861,48 @@ impl AppState {
             .map_err(|e| ApiError::Internal(format!("Failed to create execution: {e}")))
     }
 
-    /// CAS-update an execution's state for the caller's tenant. The
-    /// read-then-commit pair runs through a freshly bound
-    /// `ScopedExecutionStore`, so the CAS is confined to that tenant.
-    ///
-    /// The API is an *external* mutator (no held lease), so it reads the
-    /// row's current fencing generation and commits at it. If a runner
-    /// concurrently takes over (bumping the generation) the commit
-    /// returns `FencedOut`, which maps to the same `Ok(false)` (retry) a
-    /// version miss produces — the engine's reconciliation honors a
-    /// concurrent terminal write (§11.5, #333).
-    pub(crate) async fn cas_transition_scoped(
+    /// CAS-update an execution state and append one control message in the
+    /// same storage-port commit. This is the API-side path for control
+    /// commands that also pre-set execution state (`Cancel` / `Terminate`):
+    /// either the state transition and outbox row both land, or neither does.
+    pub(crate) async fn cas_transition_with_control_scoped(
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
         expected_version: u64,
         new_state: serde_json::Value,
+        command: nebula_storage_port::dto::ControlCommand,
+        w3c: Option<nebula_core::W3cTraceContext>,
     ) -> Result<bool, ApiError> {
         let store = ScopedExecutionStore::new(Arc::clone(&self.execution_store), scope.clone());
         let id = execution_id.to_string();
-        let current = store
-            .get(scope, &id)
-            .await
-            .map_err(|e| ApiError::Internal(format!("Failed to cancel execution: {e}")))?;
+        let current = store.get(scope, &id).await.map_err(|e| {
+            ApiError::Internal(format!(
+                "Failed to read execution for control transition: {e}"
+            ))
+        })?;
         let Some(record) = current else {
-            // No row: a CAS that can never match — caller treats
-            // `false` as a 409 / refetch.
             return Ok(false);
         };
         let fencing =
             nebula_storage_port::FencingToken::from_generation(record.fencing.unwrap_or(0));
+        let msg = nebula_storage_port::dto::ControlMsg {
+            id: *uuid::Uuid::new_v4().as_bytes(),
+            execution_id: id.clone(),
+            command,
+            scope: scope.clone(),
+            w3c_traceparent: w3c.as_ref().map(|c| c.traceparent().to_owned()),
+            reclaim_count: 0,
+        };
         let batch = nebula_storage_port::TransitionBatch::builder()
             .scope(scope.clone())
             .execution_id(&id)
             .expected_version(expected_version)
             .fencing(fencing)
             .new_state(new_state)
+            .outbox(vec![msg])
             .build()
-            .map_err(|e| ApiError::Internal(format!("Failed to build cancel transition: {e}")))?;
+            .map_err(|e| ApiError::Internal(format!("Failed to build control transition: {e}")))?;
         match store.commit(batch).await {
             Ok(nebula_storage_port::TransitionOutcome::Applied { .. }) => Ok(true),
             Ok(
@@ -900,7 +910,7 @@ impl AppState {
                 | nebula_storage_port::TransitionOutcome::FencedOut,
             ) => Ok(false),
             Err(e) => Err(ApiError::Internal(format!(
-                "Failed to cancel execution: {e}"
+                "Failed to apply control transition: {e}"
             ))),
         }
     }
@@ -1026,6 +1036,17 @@ impl AppState {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_membership_store(mut self, store: Arc<dyn MembershipStore>) -> Self {
         self.membership_store = Some(store);
+        self
+    }
+
+    /// Allow tenant routes to pass RBAC without a membership store.
+    ///
+    /// This builder exists only for integration tests compiled with
+    /// `feature = "test-util"`; production callers cannot opt into it.
+    #[cfg(any(test, feature = "test-util"))]
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_insecure_tenant_rbac_bypass_for_tests(mut self) -> Self {
+        self.allow_insecure_tenant_rbac_bypass = true;
         self
     }
 

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -303,11 +303,10 @@ fn to_summary(stored: &StoredCredential) -> ApiResult<CredentialSummary> {
 ///
 /// Cross-workspace / unknown ids collapse to `404` with **no existence
 /// disclosure** (mirrors the Phase-2 owner-scoped pattern). The error
-/// string never contains secret material — only the opaque credential
-/// id, which is already client-supplied.
+/// string never contains secret material or credential identifiers.
 fn map_store_err(err: StoreError, cred: &str) -> ApiError {
     match err {
-        StoreError::NotFound { .. } => ApiError::NotFound(format!("credential {cred} not found")),
+        StoreError::NotFound { .. } => ApiError::NotFound("credential not found".to_owned()),
         StoreError::AlreadyExists { .. } => {
             ApiError::Conflict(format!("credential {cred} already exists"))
         },

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -49,20 +49,20 @@
 //! Durability is process-local (in-memory store, no `EncryptionLayer`
 //! wired) — see the credential durability note in `crates/api/README.md`.
 //!
-//! ## No cross-workspace isolation (pre-existing crate-wide gap)
+//! ## Workspace isolation
 //!
-//! The `_org` / `_ws` arguments are intentionally unused: the wired
-//! in-memory store is **global** and no owner-scoped
-//! `nebula_tenancy::CredentialScopeLayer` / credential→workspace
-//! ownership binding is composed, so any authenticated caller holding a
-//! valid `cred_<ULID>` resolves/mutates it regardless of the path
-//! `{org}`/`{ws}`. This is the same crate-wide local-first tenant-
-//! isolation gap that `workflow` / `execution` carry (a flat global
-//! `repo.get(id)`), **not** a Phase-4 regression — fixing credentials
-//! alone would be inconsistent with the rest of the crate. It closes
-//! when `ScopeLayer` + tenant binding is wired in the composition root.
+//! Workspace handlers derive an owner id from the resolved tenant scope and
+//! compose `nebula_tenancy::CredentialScopeLayer` over the shared
+//! in-memory store for every CRUD call. The layer stamps
+//! `metadata["owner_id"]` on create and returns `NotFound` for cross-owner
+//! reads, updates, deletes, `exists`, and `list`, so credential IDs are not
+//! dereferenceable across workspaces.
 
-use nebula_credential::{CredentialStore, PutMode, SecretString, StoreError, StoredCredential};
+use nebula_credential::{
+    CredentialStore, PutMode, ScopeResolver, SecretString, StoreError, StoredCredential,
+};
+use nebula_storage_port::Scope;
+use nebula_tenancy::CredentialScopeLayer;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -92,6 +92,29 @@ struct CredentialMeta {
     description: Option<String>,
     #[serde(default)]
     tags: std::collections::HashMap<String, String>,
+}
+
+#[derive(Debug)]
+struct RequestCredentialOwner(String);
+
+impl ScopeResolver for RequestCredentialOwner {
+    fn current_owner(&self) -> Option<&str> {
+        Some(&self.0)
+    }
+}
+
+pub(crate) fn owner_id_from_scope(scope: &Scope) -> String {
+    format!("{}:{}", scope.org_id, scope.workspace_id)
+}
+
+pub(crate) fn scoped_store(
+    state: &AppState,
+    owner_id: &str,
+) -> CredentialScopeLayer<nebula_storage::credential::InMemoryStore> {
+    CredentialScopeLayer::new(
+        state.oauth_credential_store.as_ref().clone(),
+        std::sync::Arc::new(RequestCredentialOwner(owner_id.to_owned())),
+    )
 }
 
 /// Envelope for the type-specific secret input blob.
@@ -308,9 +331,8 @@ fn map_store_err(err: StoreError, cred: &str) -> ApiError {
 
 /// Fetch a credential, treating a cross-workspace / unknown id as a
 /// flat 404 (no existence disclosure, canon §12.4 / Phase-2 pattern).
-async fn load(state: &AppState, cred: &str) -> ApiResult<StoredCredential> {
-    state
-        .oauth_credential_store
+async fn load(state: &AppState, owner_id: &str, cred: &str) -> ApiResult<StoredCredential> {
+    scoped_store(state, owner_id)
         .get(cred)
         .await
         .map_err(|e| map_store_err(e, cred))
@@ -325,8 +347,7 @@ async fn load(state: &AppState, cred: &str) -> ApiResult<StoredCredential> {
 #[tracing::instrument(skip_all, fields(cred.key = %req.credential_key))]
 pub async fn create_credential(
     state: &AppState,
-    _org: &str,
-    _ws: &str,
+    owner_id: &str,
     req: CreateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
     // ADR-0052 P4 (V2): validate `data` against the type's schema BEFORE
@@ -366,8 +387,7 @@ pub async fn create_credential(
         metadata,
     };
 
-    let persisted = state
-        .oauth_credential_store
+    let persisted = scoped_store(state, owner_id)
         .put(stored, PutMode::CreateOnly)
         .await
         .map_err(|e| map_store_err(e, &id))?;
@@ -383,11 +403,10 @@ pub async fn create_credential(
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn get_credential(
     state: &AppState,
-    _org: &str,
-    _ws: &str,
+    owner_id: &str,
     cred: &str,
 ) -> ApiResult<CredentialResponse> {
-    let stored = load(state, cred).await?;
+    let stored = load(state, owner_id, cred).await?;
     to_response(&stored)
 }
 
@@ -399,12 +418,11 @@ pub async fn get_credential(
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn update_credential(
     state: &AppState,
-    _org: &str,
-    _ws: &str,
+    owner_id: &str,
     cred: &str,
     req: UpdateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
-    let existing = load(state, cred).await?;
+    let existing = load(state, owner_id, cred).await?;
 
     let mut meta: CredentialMeta =
         serde_json::from_value(serde_json::Value::Object(existing.metadata.clone()))
@@ -458,8 +476,7 @@ pub async fn update_credential(
         metadata,
     };
 
-    let persisted = state
-        .oauth_credential_store
+    let persisted = scoped_store(state, owner_id)
         .put(updated, mode)
         .await
         .map_err(|e| map_store_err(e, cred))?;
@@ -470,14 +487,8 @@ pub async fn update_credential(
 
 /// Delete a credential from the workspace.
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
-pub async fn delete_credential(
-    state: &AppState,
-    _org: &str,
-    _ws: &str,
-    cred: &str,
-) -> ApiResult<()> {
-    state
-        .oauth_credential_store
+pub async fn delete_credential(state: &AppState, owner_id: &str, cred: &str) -> ApiResult<()> {
+    scoped_store(state, owner_id)
         .delete(cred)
         .await
         .map_err(|e| map_store_err(e, cred))?;
@@ -491,8 +502,7 @@ pub async fn delete_credential(
 #[tracing::instrument(skip_all)]
 pub async fn list_credentials(
     state: &AppState,
-    _org: &str,
-    _ws: &str,
+    owner_id: &str,
     query: ListCredentialsQuery,
 ) -> ApiResult<ListCredentialsResponse> {
     // Push the `state_kind` filter into the store: only rows this layer
@@ -500,8 +510,8 @@ pub async fn list_credentials(
     // different `state_kind` + non-`CredentialMeta` metadata shape) are
     // excluded at the source rather than fetched-then-discarded — no
     // wasted `get` + projection, and no metadata-shape 500 risk.
-    let ids = state
-        .oauth_credential_store
+    let store = scoped_store(state, owner_id);
+    let ids = store
         .list(Some(STATE_KIND))
         .await
         .map_err(|e| map_store_err(e, "<list>"))?;
@@ -510,7 +520,7 @@ pub async fn list_credentials(
     for id in ids {
         // A row may vanish between `list` and `get` (concurrent delete);
         // skip it rather than failing the whole page.
-        let Ok(stored) = state.oauth_credential_store.get(&id).await else {
+        let Ok(stored) = store.get(&id).await else {
             continue;
         };
         let summary = to_summary(&stored)?;
@@ -857,11 +867,11 @@ mod tests {
     #[tokio::test]
     async fn crud_round_trips_without_secret_in_projection() {
         let s = test_state();
+        let owner_id = "o:w";
         let secret = "sk-unit-crud-NEVER-LEAK-7a7a";
         let created = create_credential(
             &s,
-            "o",
-            "w",
+            owner_id,
             CreateCredentialRequest {
                 credential_key: "api_key".into(),
                 name: "Unit Key".into(),
@@ -880,7 +890,7 @@ mod tests {
             "CredentialResponse Debug must not carry the secret: {dbg}"
         );
 
-        let got = get_credential(&s, "o", "w", &created.id)
+        let got = get_credential(&s, owner_id, &created.id)
             .await
             .expect("get");
         assert_eq!(got.id, created.id);
@@ -888,8 +898,7 @@ mod tests {
 
         let listed = list_credentials(
             &s,
-            "o",
-            "w",
+            owner_id,
             ListCredentialsQuery {
                 page: 1,
                 page_size: 20,
@@ -902,11 +911,11 @@ mod tests {
         assert_eq!(listed.total, 1);
         assert!(!format!("{listed:?}").contains(secret));
 
-        delete_credential(&s, "o", "w", &created.id)
+        delete_credential(&s, owner_id, &created.id)
             .await
             .expect("delete");
         assert!(matches!(
-            get_credential(&s, "o", "w", &created.id).await,
+            get_credential(&s, owner_id, &created.id).await,
             Err(ApiError::NotFound(_))
         ));
     }

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -8,7 +8,7 @@ use std::net::IpAddr;
 
 use nebula_credential::credentials::oauth2::AuthStyle;
 use serde::Deserialize;
-use url::Url;
+use url::{Host, Url};
 
 pub use super::http::{
     OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES, TokenHttpError, oauth_token_http_client,
@@ -131,18 +131,25 @@ pub fn validate_token_endpoint(raw: &str) -> Result<(), String> {
         return Err("OAuth token endpoint must use https".to_owned());
     }
 
-    let host = url
-        .host_str()
-        .ok_or_else(|| "OAuth token endpoint must include a host".to_owned())?;
-    if host.eq_ignore_ascii_case("localhost") {
-        return Err("OAuth token endpoint must not target localhost".to_owned());
-    }
-    if let Ok(ip) = host.parse::<IpAddr>()
-        && forbidden_token_endpoint_ip(ip)
-    {
-        return Err("OAuth token endpoint must not target private or local addresses".to_owned());
-    }
+    validate_token_endpoint_host(url.host())?;
     Ok(())
+}
+
+fn validate_token_endpoint_host(host: Option<Host<&str>>) -> Result<(), String> {
+    match host.ok_or_else(|| "OAuth token endpoint must include a host".to_owned())? {
+        Host::Domain(host) if host.eq_ignore_ascii_case("localhost") => {
+            Err("OAuth token endpoint must not target localhost".to_owned())
+        },
+        Host::Domain(_) => Ok(()),
+        Host::Ipv4(ip) if forbidden_token_endpoint_ip(IpAddr::V4(ip)) => {
+            Err("OAuth token endpoint must not target private or local addresses".to_owned())
+        },
+        Host::Ipv4(_) => Ok(()),
+        Host::Ipv6(ip) if forbidden_token_endpoint_ip(IpAddr::V6(ip)) => {
+            Err("OAuth token endpoint must not target private or local addresses".to_owned())
+        },
+        Host::Ipv6(_) => Ok(()),
+    }
 }
 
 fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
@@ -155,10 +162,16 @@ fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
                 || ip.is_broadcast()
         },
         IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return forbidden_token_endpoint_ip(IpAddr::V4(mapped));
+            }
+            let first = ip.segments()[0];
             ip.is_loopback()
                 || ip.is_unspecified()
-                || matches!(ip.segments()[0] & 0xfe00, 0xfc00)
-                || matches!(ip.segments()[0] & 0xffc0, 0xfe80)
+                || ip.is_multicast()
+                || matches!(first & 0xfe00, 0xfc00)
+                || matches!(first & 0xffc0, 0xfe80)
+                || matches!(first & 0xffc0, 0xfec0)
         },
     }
 }
@@ -239,6 +252,24 @@ mod tests {
             err.to_lowercase().contains("token endpoint"),
             "expected endpoint validation error, got: {err}"
         );
+    }
+
+    #[test]
+    fn token_endpoint_rejects_ipv4_mapped_ipv6_private_addresses() {
+        for raw in [
+            "https://[::ffff:7f00:1]/token",
+            "https://[::ffff:a00:1]/token",
+            "https://[::ffff:a9fe:1]/token",
+            "https://[ff02::1]/token",
+            "https://[fec0::1]/token",
+        ] {
+            let err = validate_token_endpoint(raw)
+                .expect_err("private IPv4-mapped and local IPv6 addresses must be rejected");
+            assert!(
+                err.to_lowercase().contains("token endpoint"),
+                "expected endpoint validation error for {raw}, got: {err}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -4,6 +4,8 @@
 //! construction, code→token exchange). Token endpoint policy and bounded
 //! body reads live in the sibling [`super::http`] module.
 
+use std::net::IpAddr;
+
 use nebula_credential::credentials::oauth2::AuthStyle;
 use serde::Deserialize;
 use url::Url;
@@ -78,6 +80,11 @@ pub struct TokenExchangeRequest {
 
 /// Exchange authorization code for tokens.
 pub async fn exchange_code(req: &TokenExchangeRequest) -> Result<serde_json::Value, String> {
+    validate_token_endpoint(&req.token_url)?;
+    exchange_code_unchecked(req).await
+}
+
+async fn exchange_code_unchecked(req: &TokenExchangeRequest) -> Result<serde_json::Value, String> {
     let client = oauth_token_http_client();
 
     let mut form: Vec<(&str, &str)> = vec![
@@ -111,6 +118,49 @@ pub async fn exchange_code(req: &TokenExchangeRequest) -> Result<serde_json::Val
     read_token_response_limited(response, OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES)
         .await
         .map_err(|e| e.to_string())
+}
+
+/// Validate that an OAuth token endpoint is safe for server-side exchange.
+///
+/// API callers control this URL during interactive OAuth setup, so the
+/// backend rejects non-HTTPS URLs and obvious loopback/private/link-local
+/// hosts before `reqwest` can reach internal services.
+pub fn validate_token_endpoint(raw: &str) -> Result<(), String> {
+    let url = Url::parse(raw).map_err(|e| format!("invalid OAuth token endpoint URL: {e}"))?;
+    if url.scheme() != "https" {
+        return Err("OAuth token endpoint must use https".to_owned());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "OAuth token endpoint must include a host".to_owned())?;
+    if host.eq_ignore_ascii_case("localhost") {
+        return Err("OAuth token endpoint must not target localhost".to_owned());
+    }
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && forbidden_token_endpoint_ip(ip)
+    {
+        return Err("OAuth token endpoint must not target private or local addresses".to_owned());
+    }
+    Ok(())
+}
+
+fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+        },
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || matches!(ip.segments()[0] & 0xfe00, 0xfc00)
+                || matches!(ip.segments()[0] & 0xffc0, 0xfe80)
+        },
+    }
 }
 
 #[cfg(test)]
@@ -178,6 +228,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn token_exchange_rejects_loopback_token_url() {
+        let mut req = sample_exchange();
+        req.token_url = "http://127.0.0.1:1/token".to_owned();
+
+        let err = exchange_code(&req)
+            .await
+            .expect_err("loopback token URLs must fail before any request");
+        assert!(
+            err.to_lowercase().contains("token endpoint"),
+            "expected endpoint validation error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
     async fn token_exchange_succeeds_for_small_response() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("local addr");
@@ -195,7 +259,7 @@ mod tests {
 
         let mut req = sample_exchange();
         req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let val = exchange_code(&req)
+        let val = exchange_code_unchecked(&req)
             .await
             .expect("small token body should parse");
         assert_eq!(val["access_token"], "t");
@@ -221,7 +285,7 @@ mod tests {
 
         let mut req = sample_exchange();
         req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = exchange_code(&req)
+        let err = exchange_code_unchecked(&req)
             .await
             .expect_err("oversized Content-Length should fail");
         assert!(
@@ -262,7 +326,7 @@ Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
 
         let mut req = sample_exchange();
         req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = exchange_code(&req)
+        let err = exchange_code_unchecked(&req)
             .await
             .expect_err("streaming body over max should fail");
         let lower = err.to_lowercase();
@@ -292,7 +356,7 @@ Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
 
         let mut req = sample_exchange();
         req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = exchange_code(&req)
+        let err = exchange_code_unchecked(&req)
             .await
             .expect_err("401 from token endpoint should map to error");
         assert!(
@@ -321,7 +385,7 @@ Transfer-Encoding: chunked\r\nConnection: close\r\n\r\n";
 
         let mut req = sample_exchange();
         req.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = exchange_code(&req)
+        let err = exchange_code_unchecked(&req)
             .await
             .expect_err("invalid json on 2xx should fail");
         let lower = err.to_lowercase();

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -369,7 +369,8 @@ async fn build_port_state_with(with_credential_port: bool) -> (AppState, PortHan
         api_config.jwt_secret,
     )
     .with_org_resolver(Arc::new(TestOrgResolver))
-    .with_workspace_resolver(Arc::new(TestWorkspaceResolver));
+    .with_workspace_resolver(Arc::new(TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests();
 
     let state = if with_credential_port {
         state.with_credential_schema(Arc::new(PermissiveCredentialSchemaPort))
@@ -807,7 +808,8 @@ pub(crate) async fn create_state_with_failing_queue() -> (AppState, InMemoryExec
         api_config.jwt_secret,
     )
     .with_org_resolver(Arc::new(TestOrgResolver))
-    .with_workspace_resolver(Arc::new(TestWorkspaceResolver));
+    .with_workspace_resolver(Arc::new(TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests();
 
     (state, exec_store)
 }

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -438,6 +438,32 @@ async fn credential_created_in_one_workspace_is_404_from_another_workspace() {
         StatusCode::NOT_FOUND,
         "credential IDs must not resolve across workspace scopes"
     );
+    let probe_body = body_string(probe).await;
+    let problem: serde_json::Value = serde_json::from_str(&probe_body).expect("404 problem json");
+    assert_eq!(problem["title"], "Not Found");
+    assert_eq!(problem["detail"], "credential not found");
+    let problem_obj = problem.as_object().expect("problem object");
+    assert!(
+        !problem_obj.contains_key("id"),
+        "404 problem must not expose a credential id: {probe_body}"
+    );
+    assert!(
+        !problem_obj.contains_key("name"),
+        "404 problem must not expose a credential name: {probe_body}"
+    );
+    for forbidden in [
+        id,
+        "scoped credential",
+        common::TEST_ORG,
+        OTHER_WS,
+        SECRET_TOKEN,
+        "another workspace",
+    ] {
+        assert!(
+            !probe_body.contains(forbidden),
+            "cross-workspace 404 disclosed {forbidden:?}: {probe_body}"
+        );
+    }
 }
 
 // ── Abuse: secret never reaches logs across the full lifecycle ────────────────

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -43,6 +43,7 @@ use tracing_subscriber::fmt::MakeWriter;
 
 /// A secret value that must never surface in any response, error, or log.
 const SECRET_TOKEN: &str = "sk-phase4-NEVER-LEAK-0xC0FFEE-abcdef0123456789";
+const OTHER_WS: &str = "ws_00000000000000000000000002";
 
 // ── Log-capture helper (mirrors crates/credential/tests/redaction.rs) ─────────
 
@@ -397,6 +398,45 @@ async fn credential_stale_version_conflicts_409_without_secret() {
     assert!(
         !problem.contains(SECRET_TOKEN),
         "409 conflict body leaked the request secret: {problem}"
+    );
+}
+
+#[tokio::test]
+async fn credential_created_in_one_workspace_is_404_from_another_workspace() {
+    let (state, _q) = create_state_with_queue().await;
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "scoped credential",
+        "data": { "api_key": SECRET_TOKEN }
+    });
+    let app = app::build_app(state.clone(), &config);
+    let created = app
+        .oneshot(auth_json("POST", &ws_path("/credentials"), &token, &body))
+        .await
+        .unwrap();
+    assert!(
+        created.status().is_success(),
+        "credential create must succeed before cross-workspace probe"
+    );
+
+    let created_body: serde_json::Value =
+        serde_json::from_str(&body_string(created).await).expect("created credential json");
+    let id = created_body["id"].as_str().expect("created credential id");
+    let other_ws_path = format!(
+        "/api/v1/orgs/{}/workspaces/{OTHER_WS}/credentials/{id}",
+        common::TEST_ORG
+    );
+
+    let app = app::build_app(state, &config);
+    let probe = app.oneshot(auth_get(&other_ws_path, &token)).await.unwrap();
+
+    assert_eq!(
+        probe.status(),
+        StatusCode::NOT_FOUND,
+        "credential IDs must not resolve across workspace scopes"
     );
 }
 

--- a/crates/api/tests/e2e_oauth2_flow.rs
+++ b/crates/api/tests/e2e_oauth2_flow.rs
@@ -11,7 +11,7 @@ use axum::{
     http::{Request, StatusCode},
     routing::post,
 };
-use common::{create_state_with_queue, create_test_jwt};
+use common::{create_state_with_queue, create_test_jwt, ws_path};
 use nebula_api::{ApiConfig, app};
 use nebula_credential::{
     Credential, CredentialContext, CredentialState, CredentialStore, OAuth2Credential, OAuth2State,
@@ -64,6 +64,78 @@ async fn spawn_mock_token_endpoint() -> (String, tokio::task::JoinHandle<()>) {
     });
 
     (format!("http://{addr}/token"), handle)
+}
+
+#[tokio::test]
+async fn system_level_oauth_authorize_route_is_disabled() {
+    let (state, _queue) = create_state_with_queue().await;
+    let config = ApiConfig::for_test();
+    let app = app::build_app(state, &config);
+    let token = create_test_jwt();
+
+    let auth_query = form_urlencoded::Serializer::new(String::new())
+        .append_pair("auth_url", "https://provider.example.com/oauth/authorize")
+        .append_pair("token_url", "https://provider.example.com/oauth/token")
+        .append_pair("client_id", "client")
+        .append_pair("client_secret", "secret")
+        .append_pair("redirect_uri", "https://app.example.com/oauth/callback")
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!(
+                    "/api/v1/credentials/cred_00000000000000000000000001/oauth2/auth?{auth_query}"
+                ))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .expect("oauth auth request"),
+        )
+        .await
+        .expect("oauth auth response");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::GONE,
+        "OAuth credential flow must be tenant-scoped, not system-level"
+    );
+}
+
+#[tokio::test]
+async fn oauth_authorize_rejects_loopback_token_url() {
+    let (state, _queue) = create_state_with_queue().await;
+    let config = ApiConfig::for_test();
+    let app = app::build_app(state, &config);
+    let token = create_test_jwt();
+
+    let auth_query = form_urlencoded::Serializer::new(String::new())
+        .append_pair("auth_url", "https://provider.example.com/oauth/authorize")
+        .append_pair("token_url", "http://127.0.0.1:1/token")
+        .append_pair("client_id", "client")
+        .append_pair("client_secret", "secret")
+        .append_pair("redirect_uri", "https://app.example.com/oauth/callback")
+        .finish();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(ws_path(&format!(
+                    "/credentials/cred_00000000000000000000000001/oauth2/auth?{auth_query}"
+                )))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .expect("oauth auth request"),
+        )
+        .await
+        .expect("oauth auth response");
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "OAuth token endpoint must reject loopback/private URLs before exchange"
+    );
 }
 
 // IGNORED 2026-04-24: test exercises engine's OAuth2 refresh path which requires
@@ -244,58 +316,18 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
     token_server_handle.abort();
 }
 
-/// `form_post` response mode posts `code` and `state` as URL-encoded form fields.
 #[tokio::test]
-async fn e2e_oauth2_callback_accepts_form_post_body() {
+async fn system_level_oauth_callback_post_route_is_disabled() {
     let (state, _queue) = create_state_with_queue().await;
     let config = ApiConfig::for_test();
-    let app = app::build_app(state.clone(), &config);
+    let app = app::build_app(state, &config);
     let token = create_test_jwt();
-    let credential_id = "oauth-e2e-credential-formpost";
-    let client_id = "e2e-client-id-fp";
-    let client_secret = "e2e-client-secret-fp";
-    let redirect_uri = "https://app.example.com/oauth/callback";
-    let auth_url = "https://provider.example.com/oauth/authorize";
-    let (token_url, token_server_handle) = spawn_mock_token_endpoint().await;
-
-    let auth_query = form_urlencoded::Serializer::new(String::new())
-        .append_pair("auth_url", auth_url)
-        .append_pair("token_url", &token_url)
-        .append_pair("client_id", client_id)
-        .append_pair("client_secret", client_secret)
-        .append_pair("redirect_uri", redirect_uri)
-        .append_pair("scopes", "repo workflow")
-        .finish();
-    let auth_uri = format!("/api/v1/credentials/{credential_id}/oauth2/auth?{auth_query}");
-
-    let auth_response = app
-        .clone()
-        .oneshot(
-            Request::builder()
-                .method("GET")
-                .uri(auth_uri)
-                .header("authorization", format!("Bearer {token}"))
-                .body(Body::empty())
-                .expect("oauth auth request"),
-        )
-        .await
-        .expect("oauth auth response");
-    assert_eq!(auth_response.status(), StatusCode::OK);
-
-    let auth_body = axum::body::to_bytes(auth_response.into_body(), usize::MAX)
-        .await
-        .expect("oauth auth body");
-    let auth_json: serde_json::Value =
-        serde_json::from_slice(&auth_body).expect("oauth auth response json");
-    let signed_state = auth_json["state"]
-        .as_str()
-        .expect("signed state")
-        .to_owned();
 
     let callback_body = form_urlencoded::Serializer::new(String::new())
-        .append_pair("code", "e2e-auth-code-formpost")
-        .append_pair("state", &signed_state)
+        .append_pair("code", "unused-auth-code")
+        .append_pair("state", "unused-signed-state")
         .finish();
+    let credential_id = "cred_00000000000000000000000001";
     let callback_uri = format!("/api/v1/credentials/{credential_id}/oauth2/callback");
 
     let callback_response = app
@@ -310,15 +342,9 @@ async fn e2e_oauth2_callback_accepts_form_post_body() {
         )
         .await
         .expect("oauth callback response");
-    assert_eq!(callback_response.status(), StatusCode::OK);
-
-    let callback_body_out = axum::body::to_bytes(callback_response.into_body(), usize::MAX)
-        .await
-        .expect("oauth callback body");
-    let callback_json: serde_json::Value =
-        serde_json::from_slice(&callback_body_out).expect("oauth callback response json");
-    assert_eq!(callback_json["credential_id"], credential_id);
-    assert_eq!(callback_json["exchanged"], true);
-
-    token_server_handle.abort();
+    assert_eq!(
+        callback_response.status(),
+        StatusCode::GONE,
+        "OAuth form_post callback must also be tenant-scoped"
+    );
 }

--- a/crates/api/tests/execution_terminate_e2e.rs
+++ b/crates/api/tests/execution_terminate_e2e.rs
@@ -11,10 +11,9 @@
 //! `ExecutionStatus::Cancelled` (no `Terminated` variant exists —
 //! `crates/execution/src/status.rs`).
 //!
-//! The engine-seam harness (`common::engine_seam`) and the
-//! orchestration-absent control queue (`common::create_state_with_failing_queue`)
-//! are shared with `knife.rs` so the cancel/terminate seam wiring lives in
-//! exactly one place.
+//! The engine-seam harness (`common::engine_seam`) and the legacy failing
+//! control queue (`common::create_state_with_failing_queue`) are shared with
+//! `knife.rs` so the cancel/terminate seam wiring lives in exactly one place.
 //!
 //! ## Coverage
 //!
@@ -22,7 +21,7 @@
 //! |----------|------------------|------|
 //! | Engine-visible seam (canon §13 bar) | Running exec + POST terminate → control_queue gets a `Terminate` entry → the wired real engine consumer drives the execution to terminal `Cancelled`, well inside the 30s slow-handler window | `terminate_engine_drives_running_execution_to_terminal_end_to_end` |
 //! | Producer durability | POST terminate persists `cancelled` + enqueues exactly one `Terminate` entry referencing the execution | `terminate_enqueues_durable_control_signal` |
-//! | 503 orchestration absent | control-queue backend down → 503 (mirrors knife step 6) | `terminate_queue_failure_returns_503` |
+//! | Atomic outbox | legacy control-queue handle down → POST terminate still commits state + `Terminate` outbox together via `TransitionBatch` | `terminate_control_signal_is_atomic_with_state` |
 //! | 404 | unknown execution → 404 | `terminate_unknown_execution_returns_404` |
 //! | 404 malformed id | malformed execution-id path segment → 404 (tenancy middleware rejects it before the handler runs) | `terminate_invalid_execution_id_rejected_by_middleware` |
 //! | 400 terminal guard | already-terminal execution → 400, no spurious enqueue | `terminate_terminal_execution_rejected_and_does_not_enqueue` |
@@ -305,13 +304,11 @@ async fn terminate_enqueues_durable_control_signal() {
     );
 }
 
-/// Canon §13 step 6 — "orchestration absent": when the control-queue
-/// backend is unavailable, terminate must return **503** with RFC 9457
-/// problem+json, not fake success and not an unparsable 500. Uses the
-/// shared `common::create_state_with_failing_queue` double (mirror of
-/// `knife.rs::knife_step6_queue_failure_returns_error`).
+/// Terminate writes the terminal state and control signal through one
+/// `TransitionBatch`, so the legacy separately-wired control queue can fail
+/// without creating a cancelled-row / missing-signal orphan.
 #[tokio::test]
-async fn terminate_queue_failure_returns_503() {
+async fn terminate_control_signal_is_atomic_with_state() {
     use nebula_core::{ExecutionId, WorkflowId};
 
     let (state, exec_store) = create_state_with_failing_queue().await;
@@ -359,19 +356,21 @@ async fn terminate_queue_failure_returns_503() {
 
     assert_eq!(
         response.status(),
-        StatusCode::SERVICE_UNAVAILABLE,
-        "orchestration-absent enqueue failure must return 503 (canon §13 step 6)"
+        StatusCode::OK,
+        "terminate should not orphan a state transition when the legacy queue handle fails"
     );
 
-    // RFC 9457: failure body must be application/problem+json (§12.4).
-    let content_type = response
-        .headers()
-        .get("content-type")
-        .and_then(|v| v.to_str().ok());
+    let queue = nebula_storage::inmem::InMemoryControlQueue::new(&exec_store);
+    let queued = queue.snapshot();
+    assert_eq!(queued.len(), 1);
     assert_eq!(
-        content_type,
-        Some("application/problem+json"),
-        "503 body must use the RFC 9457 content-type"
+        queued[0].0.command,
+        nebula_storage_port::dto::ControlCommand::Terminate
+    );
+    assert_eq!(
+        queued[0].0.execution_id,
+        execution_id.to_string(),
+        "atomic outbox row must reference the terminated execution"
     );
 }
 

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -69,6 +69,38 @@ async fn test_workflow_list_empty() {
 }
 
 #[tokio::test]
+async fn tenant_routes_without_membership_store_fail_closed() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let state = build_me_state();
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+    let token = create_test_jwt();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(ws_path("/workflows"))
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "tenant routes must fail closed when no MembershipStore is configured"
+    );
+}
+
+#[tokio::test]
 async fn test_error_format_rfc9457() {
     use axum::{
         body::Body,

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -98,6 +98,14 @@ async fn tenant_routes_without_membership_store_fail_closed() {
         StatusCode::SERVICE_UNAVAILABLE,
         "tenant routes must fail closed when no MembershipStore is configured"
     );
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let problem: serde_json::Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        problem["detail"], "membership store not configured; tenant routes are disabled",
+        "fail-closed must come from RBAC membership-store guard"
+    );
 }
 
 #[tokio::test]

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -20,7 +20,7 @@
 //! | 3 | `POST /workflows/:id/executions` → 202, `status=created`, `started_at > 0`, `finished_at` absent | `knife_scenario_end_to_end_via_port` |
 //! | 4 | `GET /executions/:id` → `finished_at` is null/absent, `status` = latest persisted value | `knife_scenario_end_to_end_via_port` |
 //! | 5 | `POST /executions/:id/cancel` → row = `cancelled`, outbox holds exactly Start + Cancel (both `Pending`) | `knife_scenario_end_to_end_via_port` |
-//! | 6 | Enqueue failure → 503 (orchestration absent; canon §13 step 6) | `knife_step6_queue_failure_returns_error` |
+//! | 6 | Cancel state + control signal commit atomically even if the legacy queue handle fails | `knife_step6_cancel_control_signal_is_atomic_with_state` |
 //!
 //! ## Consumer-side §13 (engine dispatch end-to-end)
 //!
@@ -45,7 +45,7 @@ use common::*;
 use nebula_api::{ApiConfig, app};
 use tower::ServiceExt;
 
-// The orchestration-absent control queue (`AlwaysFailControlQueue` +
+// The legacy failing control queue (`AlwaysFailControlQueue` +
 // `create_state_with_failing_queue`) and the engine-seam harness
 // (`engine_seam::{persist_slow_workflow, spawn_engine_consumer}`) live in
 // the shared `common` module — see `tests/common/mod.rs`. The §13 step-6
@@ -287,20 +287,11 @@ async fn knife_scenario_end_to_end_via_port() {
     );
 }
 
-/// Canon §13 step 6 — "orchestration absent" scenario.
-///
-/// When the control queue backend is unavailable, the cancel endpoint must
-/// return **503 Service Unavailable** with RFC 9457 problem+json — not fake
-/// success and not an unparsable 500.
-///
-/// The `AlwaysFailControlQueueRepo` simulates the case where the orchestration
-/// layer is intentionally absent (test/demo server with no queue wired up).
-/// `cancel_execution` maps `StorageError::Internal` from enqueue to
-/// `ApiError::ServiceUnavailable` → HTTP 503 per canon §13 step 6.
-///
-/// Audit ref: 2026-04-16-workspace-health-audit.md §8 Sprint A1 item #3
+/// Cancel writes the terminal state and control signal through one
+/// `TransitionBatch`, so the legacy separately-wired control queue can fail
+/// without creating a cancelled-row / missing-signal orphan.
 #[tokio::test]
-async fn knife_step6_queue_failure_returns_error() {
+async fn knife_step6_cancel_control_signal_is_atomic_with_state() {
     use nebula_core::{ExecutionId, WorkflowId};
     use nebula_storage_port::store::ExecutionStore;
 
@@ -345,12 +336,23 @@ async fn knife_step6_queue_failure_returns_error() {
         .await
         .unwrap();
 
-    // Canon §13 step 6: control-queue backend unavailable must return 503.
     assert_eq!(
         response.status(),
-        StatusCode::SERVICE_UNAVAILABLE,
-        "step 6: orchestration-absent enqueue failure must return 503 Service Unavailable \
-         (canon §13 step 6)"
+        StatusCode::OK,
+        "cancel should not orphan a state transition when the legacy queue handle fails"
+    );
+
+    let queue = nebula_storage::inmem::InMemoryControlQueue::new(&exec_store);
+    let queued = queue.snapshot();
+    assert_eq!(queued.len(), 1);
+    assert_eq!(
+        queued[0].0.command,
+        nebula_storage_port::dto::ControlCommand::Cancel
+    );
+    assert_eq!(
+        queued[0].0.execution_id,
+        execution_id.to_string(),
+        "atomic outbox row must reference the cancelled execution"
     );
 }
 

--- a/crates/api/tests/me_e2e.rs
+++ b/crates/api/tests/me_e2e.rs
@@ -547,11 +547,11 @@ async fn create_token_without_auth_is_401() {
 /// surfaces in tracing output. Mirrors the
 /// `crates/credential/tests/redaction.rs` capturing-subscriber pattern.
 ///
-/// `current_thread` flavor + `with_default` keeps the capturing
-/// subscriber thread-local for the whole request lifecycle (no worker
-/// threads, so no event escapes the capture — the same constraint the
-/// credential redaction helper documents).
-#[tokio::test(flavor = "current_thread")]
+/// Uses a global subscriber for this integration-test binary. A thread-local
+/// `set_default` capture is too narrow here: the full package test run can
+/// poll parts of the request outside that thread-local dispatch, making the
+/// buffer spuriously empty even though the handler emits the event.
+#[tokio::test]
 async fn create_token_plaintext_never_leaks_to_logs() {
     use std::sync::{Arc, Mutex};
 
@@ -581,7 +581,8 @@ async fn create_token_plaintext_never_leaks_to_logs() {
         .with_ansi(false)
         .with_max_level(tracing::Level::TRACE)
         .finish();
-    let _guard = tracing::subscriber::set_default(subscriber);
+    tracing::subscriber::set_global_default(subscriber)
+        .expect("me_e2e installs one capture subscriber for this test binary");
 
     let (state, _backend, user) = create_me_state().await;
     let api_config = ApiConfig::for_test();
@@ -598,8 +599,6 @@ async fn create_token_plaintext_never_leaks_to_logs() {
     assert_eq!(response.status(), StatusCode::CREATED);
     let body = body_json(response).await;
     let token = body["token"].as_str().unwrap().to_owned();
-
-    drop(_guard);
 
     assert!(
         token.starts_with(PAT_PLAINTEXT_PREFIX) && token.len() > 20,

--- a/crates/api/tests/resource_handlers.rs
+++ b/crates/api/tests/resource_handlers.rs
@@ -282,6 +282,7 @@ fn port_resource_state(api_config: &ApiConfig) -> AppState {
     )
     .with_org_resolver(Arc::new(TestOrgResolver))
     .with_workspace_resolver(Arc::new(TestWorkspaceResolver))
+    .with_insecure_tenant_rbac_bypass_for_tests()
 }
 
 /// Build an [`AppState`] wired with `repo` as the resource catalog

--- a/crates/engine/src/credential/rotation/token_refresh.rs
+++ b/crates/engine/src/credential/rotation/token_refresh.rs
@@ -28,7 +28,7 @@ use nebula_credential::{
 };
 use reqwest::Response;
 use serde_json::Value;
-use url::Url;
+use url::{Host, Url};
 
 use super::token_http::{
     OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES, oauth_token_http_client, read_token_response_limited,
@@ -128,18 +128,25 @@ fn validate_token_endpoint(raw: &str) -> Result<(), String> {
         return Err("OAuth token endpoint must use https".to_owned());
     }
 
-    let host = url
-        .host_str()
-        .ok_or_else(|| "OAuth token endpoint must include a host".to_owned())?;
-    if host.eq_ignore_ascii_case("localhost") {
-        return Err("OAuth token endpoint must not target localhost".to_owned());
-    }
-    if let Ok(ip) = host.parse::<IpAddr>()
-        && forbidden_token_endpoint_ip(ip)
-    {
-        return Err("OAuth token endpoint must not target private or local addresses".to_owned());
-    }
+    validate_token_endpoint_host(url.host())?;
     Ok(())
+}
+
+fn validate_token_endpoint_host(host: Option<Host<&str>>) -> Result<(), String> {
+    match host.ok_or_else(|| "OAuth token endpoint must include a host".to_owned())? {
+        Host::Domain(host) if host.eq_ignore_ascii_case("localhost") => {
+            Err("OAuth token endpoint must not target localhost".to_owned())
+        },
+        Host::Domain(_) => Ok(()),
+        Host::Ipv4(ip) if forbidden_token_endpoint_ip(IpAddr::V4(ip)) => {
+            Err("OAuth token endpoint must not target private or local addresses".to_owned())
+        },
+        Host::Ipv4(_) => Ok(()),
+        Host::Ipv6(ip) if forbidden_token_endpoint_ip(IpAddr::V6(ip)) => {
+            Err("OAuth token endpoint must not target private or local addresses".to_owned())
+        },
+        Host::Ipv6(_) => Ok(()),
+    }
 }
 
 fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
@@ -152,10 +159,16 @@ fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
                 || ip.is_broadcast()
         },
         IpAddr::V6(ip) => {
+            if let Some(mapped) = ip.to_ipv4_mapped() {
+                return forbidden_token_endpoint_ip(IpAddr::V4(mapped));
+            }
+            let first = ip.segments()[0];
             ip.is_loopback()
                 || ip.is_unspecified()
-                || matches!(ip.segments()[0] & 0xfe00, 0xfc00)
-                || matches!(ip.segments()[0] & 0xffc0, 0xfe80)
+                || ip.is_multicast()
+                || matches!(first & 0xfe00, 0xfc00)
+                || matches!(first & 0xffc0, 0xfe80)
+                || matches!(first & 0xffc0, 0xfec0)
         },
     }
 }
@@ -391,6 +404,24 @@ mod tests {
             "refresh-2"
         );
         assert!(state.expires_at.is_some());
+    }
+
+    #[test]
+    fn token_endpoint_rejects_ipv4_mapped_ipv6_private_addresses() {
+        for raw in [
+            "https://[::ffff:7f00:1]/token",
+            "https://[::ffff:a00:1]/token",
+            "https://[::ffff:a9fe:1]/token",
+            "https://[ff02::1]/token",
+            "https://[fec0::1]/token",
+        ] {
+            let err = validate_token_endpoint(raw)
+                .expect_err("private IPv4-mapped and local IPv6 addresses must be rejected");
+            assert!(
+                err.to_lowercase().contains("token endpoint"),
+                "expected endpoint validation error for {raw}, got: {err}"
+            );
+        }
     }
 
     use tokio::{

--- a/crates/engine/src/credential/rotation/token_refresh.rs
+++ b/crates/engine/src/credential/rotation/token_refresh.rs
@@ -19,6 +19,8 @@
 //! the sentinel clears by row removal, no separate "clear" call is
 //! needed.
 
+use std::net::IpAddr;
+
 use chrono::Utc;
 use nebula_credential::{
     SecretString,
@@ -26,6 +28,7 @@ use nebula_credential::{
 };
 use reqwest::Response;
 use serde_json::Value;
+use url::Url;
 
 use super::token_http::{
     OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES, oauth_token_http_client, read_token_response_limited,
@@ -70,6 +73,7 @@ pub enum TokenRefreshError {
 /// our code; the unavoidable in-flight copy lives in reqwest's request
 /// body and is released when the response future resolves.
 pub async fn refresh_oauth2_state(state: &mut OAuth2State) -> Result<(), TokenRefreshError> {
+    validate_token_endpoint(&state.token_url).map_err(TokenRefreshError::Request)?;
     let scope_joined: Option<String> = (!state.scopes.is_empty()).then(|| state.scopes.join(" "));
 
     // Inner block scopes secret borrows tightly. After the block returns
@@ -116,6 +120,44 @@ pub async fn refresh_oauth2_state(state: &mut OAuth2State) -> Result<(), TokenRe
     let body = parse_token_response(resp).await?;
     update_state_from_token_response(state, &body)?;
     Ok(())
+}
+
+fn validate_token_endpoint(raw: &str) -> Result<(), String> {
+    let url = Url::parse(raw).map_err(|e| format!("invalid OAuth token endpoint URL: {e}"))?;
+    if url.scheme() != "https" {
+        return Err("OAuth token endpoint must use https".to_owned());
+    }
+
+    let host = url
+        .host_str()
+        .ok_or_else(|| "OAuth token endpoint must include a host".to_owned())?;
+    if host.eq_ignore_ascii_case("localhost") {
+        return Err("OAuth token endpoint must not target localhost".to_owned());
+    }
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && forbidden_token_endpoint_ip(ip)
+    {
+        return Err("OAuth token endpoint must not target private or local addresses".to_owned());
+    }
+    Ok(())
+}
+
+fn forbidden_token_endpoint_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            ip.is_private()
+                || ip.is_loopback()
+                || ip.is_link_local()
+                || ip.is_unspecified()
+                || ip.is_broadcast()
+        },
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip.is_unspecified()
+                || matches!(ip.segments()[0] & 0xfe00, 0xfc00)
+                || matches!(ip.segments()[0] & 0xffc0, 0xfe80)
+        },
+    }
 }
 
 async fn parse_token_response(resp: Response) -> Result<Value, TokenRefreshError> {
@@ -234,7 +276,7 @@ fn redact_sensitive_fields(input: &str) -> std::borrow::Cow<'_, str> {
 /// - `[control_chars_in_error_uri_redacted]` — control byte found
 fn sanitize_error_uri(raw: &str) -> std::borrow::Cow<'_, str> {
     use std::borrow::Cow;
-    let parsed = match url::Url::parse(raw) {
+    let parsed = match Url::parse(raw) {
         Ok(u) if u.scheme() == "https" => u,
         _ => return Cow::Borrowed("[invalid_error_uri_redacted]"),
     };

--- a/crates/engine/src/credential/rotation/token_refresh.rs
+++ b/crates/engine/src/credential/rotation/token_refresh.rs
@@ -197,6 +197,16 @@ async fn parse_token_response(resp: Response) -> Result<Value, TokenRefreshError
         .map_err(|e| TokenRefreshError::Parse(e.to_string()))
 }
 
+/// Test-support hook for integration tests that validate token endpoint
+/// response parsing/redaction without weakening production endpoint validation.
+#[cfg(feature = "test-util")]
+#[doc(hidden)]
+pub async fn parse_oauth_token_response_for_tests(
+    resp: Response,
+) -> Result<Value, TokenRefreshError> {
+    parse_token_response(resp).await
+}
+
 fn update_state_from_token_response(
     state: &mut OAuth2State,
     body: &Value,
@@ -452,7 +462,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_oauth2_state_maps_401_to_token_endpoint_error() {
+    async fn parse_token_response_maps_401_to_token_endpoint_error() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("local addr");
         const BODY: &[u8] = b"{\"error\":\"invalid_client\"}";
@@ -469,9 +479,12 @@ mod tests {
             let _ = stream.write_all(BODY).await;
         });
 
-        let mut state = sample_state();
-        state.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = refresh_oauth2_state(&mut state)
+        let resp = oauth_token_http_client()
+            .post(format!("http://127.0.0.1:{}/token", addr.port()))
+            .send()
+            .await
+            .expect("token endpoint response");
+        let err = parse_token_response(resp)
             .await
             .expect_err("401 from token");
         assert!(
@@ -481,7 +494,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn refresh_oauth2_state_maps_invalid_json_to_parse_error() {
+    async fn parse_token_response_maps_invalid_json_to_parse_error() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("local addr");
         let body: &[u8] = b"not json {";
@@ -498,9 +511,12 @@ mod tests {
             let _ = stream.write_all(body).await;
         });
 
-        let mut state = sample_state();
-        state.token_url = format!("http://127.0.0.1:{}/token", addr.port());
-        let err = refresh_oauth2_state(&mut state)
+        let resp = oauth_token_http_client()
+            .post(format!("http://127.0.0.1:{}/token", addr.port()))
+            .send()
+            .await
+            .expect("token endpoint response");
+        let err = parse_token_response(resp)
             .await
             .expect_err("invalid json body");
         assert!(

--- a/crates/engine/tests/credential_refresh_redaction.rs
+++ b/crates/engine/tests/credential_refresh_redaction.rs
@@ -1,11 +1,11 @@
-#![cfg(feature = "rotation")]
+#![cfg(all(feature = "rotation", feature = "test-util"))]
 
 //! ADR-0030 §4 redaction CI gate. **One row per token_refresh code path.**
 //!
-//! Each test injects a secret-bearing IdP response, invokes the refresh
-//! code path end-to-end, and asserts that the resulting error rendering
-//! (Display, Debug, summary fields) does NOT contain the submitted secret
-//! and DOES contain the `[REDACTED]` sentinel.
+//! Each test injects a secret-bearing IdP response through the bounded
+//! response parser and asserts that the resulting error rendering (Display,
+//! Debug, summary fields) does NOT contain the submitted secret and DOES
+//! contain the `[REDACTED]` sentinel.
 //!
 //! Adding a new token_refresh code path = adding a new row here.
 //!
@@ -14,11 +14,9 @@
 //! Source: `docs/tracking/credential-audit-2026-04-27.md` §XII Errata,
 //! security hardening spec Stage 0.5.
 
-use nebula_credential::{
-    SecretString,
-    credentials::{OAuth2State, oauth2::AuthStyle},
+use nebula_engine::credential::rotation::{
+    TokenRefreshError, token_refresh::parse_oauth_token_response_for_tests,
 };
-use nebula_engine::credential::rotation::{TokenRefreshError, refresh_oauth2_state};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -48,23 +46,8 @@ async fn drain_incoming_request(stream: &mut tokio::net::TcpStream) {
     }
 }
 
-fn sample_state(token_url: String) -> OAuth2State {
-    OAuth2State {
-        access_token: SecretString::new("old-access-token"),
-        token_type: "Bearer".to_owned(),
-        refresh_token: Some(SecretString::new("placeholder-not-the-secret-under-test")),
-        expires_at: None,
-        scopes: vec!["read".to_owned()],
-        client_id: SecretString::new("my-client"),
-        client_secret: SecretString::new("placeholder-secret"),
-        token_url,
-        auth_style: AuthStyle::Header,
-    }
-}
-
 /// Spawn a one-shot mock token endpoint that returns the given JSON body
-/// with the given HTTP status. Returns the `http://127.0.0.1:PORT/token`
-/// URL the caller should set on `OAuth2State::token_url`.
+/// with the given HTTP status.
 async fn spawn_idp_returning(status: u16, body: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local addr");
@@ -89,6 +72,18 @@ async fn spawn_idp_returning(status: u16, body: &'static str) -> String {
     format!("http://127.0.0.1:{}/token", addr.port())
 }
 
+async fn parse_idp_error_response(status: u16, body: &'static str) -> TokenRefreshError {
+    let token_url = spawn_idp_returning(status, body).await;
+    let resp = reqwest::Client::new()
+        .post(token_url)
+        .send()
+        .await
+        .expect("token endpoint response");
+    parse_oauth_token_response_for_tests(resp)
+        .await
+        .expect_err("non-2xx token response expected")
+}
+
 /// Asserts a string does NOT contain any plausible-looking
 /// secret literal that the IdP echoed.
 fn assert_no_secret_substring(haystack: &str, secret: &str, context: &str) {
@@ -105,7 +100,7 @@ fn assert_no_secret_substring(haystack: &str, secret: &str, context: &str) {
 #[tokio::test]
 async fn sec13_refresh_token_in_error_description_is_redacted() {
     const SECRET: &str = "abc123-leaked-refresh-token-value";
-    let token_url = spawn_idp_returning(
+    let err = parse_idp_error_response(
         400,
         // IdP echoes the submitted refresh_token inside error_description.
         // Real-world pattern observed on some buggy IdPs returning invalid_grant.
@@ -113,11 +108,6 @@ async fn sec13_refresh_token_in_error_description_is_redacted() {
         "{\"error\":\"invalid_grant\",\"error_description\":\"refresh_token=abc123-leaked-refresh-token-value expired\"}",
     )
     .await;
-
-    let mut state = sample_state(token_url);
-    let err = refresh_oauth2_state(&mut state)
-        .await
-        .expect_err("400 expected");
 
     let TokenRefreshError::TokenEndpoint { summary, status } = &err else {
         panic!("expected TokenEndpoint, got: {err:?}");
@@ -150,16 +140,12 @@ async fn sec13_refresh_token_in_error_description_is_redacted() {
 #[tokio::test]
 async fn access_token_in_error_description_is_redacted() {
     const SECRET: &str = "xyz789-leaked-access-token-value";
-    let token_url = spawn_idp_returning(
+    let err = parse_idp_error_response(
         400,
         "{\"error\":\"invalid_grant\",\"error_description\":\"access_token=xyz789-leaked-access-token-value revoked\"}",
     )
     .await;
 
-    let mut state = sample_state(token_url);
-    let err = refresh_oauth2_state(&mut state)
-        .await
-        .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = &err else {
         panic!("expected TokenEndpoint, got: {err:?}");
     };
@@ -175,16 +161,12 @@ async fn access_token_in_error_description_is_redacted() {
 #[tokio::test]
 async fn client_secret_in_error_description_is_redacted() {
     const SECRET: &str = "supersecretvalue123abc";
-    let token_url = spawn_idp_returning(
+    let err = parse_idp_error_response(
         400,
         "{\"error\":\"invalid_client\",\"error_description\":\"client_secret=supersecretvalue123abc mismatch\"}",
     )
     .await;
 
-    let mut state = sample_state(token_url);
-    let err = refresh_oauth2_state(&mut state)
-        .await
-        .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = &err else {
         panic!("expected TokenEndpoint, got: {err:?}");
     };
@@ -199,16 +181,12 @@ async fn client_secret_in_error_description_is_redacted() {
 #[tokio::test]
 async fn case_insensitive_key_match() {
     const SECRET: &str = "casevariantsecret456";
-    let token_url = spawn_idp_returning(
+    let err = parse_idp_error_response(
         400,
         "{\"error\":\"invalid_grant\",\"error_description\":\"RefreshToken=casevariantsecret456 invalid\"}",
     )
     .await;
 
-    let mut state = sample_state(token_url);
-    let err = refresh_oauth2_state(&mut state)
-        .await
-        .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = &err else {
         panic!("expected TokenEndpoint, got: {err:?}");
     };
@@ -221,16 +199,12 @@ async fn case_insensitive_key_match() {
 
 #[tokio::test]
 async fn non_secret_error_description_passes_through() {
-    let token_url = spawn_idp_returning(
+    let err = parse_idp_error_response(
         400,
         "{\"error\":\"invalid_grant\",\"error_description\":\"the grant has expired\"}",
     )
     .await;
 
-    let mut state = sample_state(token_url);
-    let err = refresh_oauth2_state(&mut state)
-        .await
-        .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = &err else {
         panic!("expected TokenEndpoint, got: {err:?}");
     };

--- a/crates/engine/tests/oauth_idp_error_uri_validation.rs
+++ b/crates/engine/tests/oauth_idp_error_uri_validation.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rotation")]
+#![cfg(all(feature = "rotation", feature = "test-util"))]
 
 //! SEC-02 (security hardening 2026-04-27 Stage 3) — `error_uri` from
 //! non-2xx OAuth2 token responses must pass through `sanitize_error_uri`
@@ -13,11 +13,9 @@
 //!   5. `javascript:alert(1)` → rejected (parse OK but scheme not https)
 //!   6. empty string → rejected (parse fail)
 
-use nebula_credential::{
-    SecretString,
-    credentials::{OAuth2State, oauth2::AuthStyle},
+use nebula_engine::credential::rotation::{
+    TokenRefreshError, token_refresh::parse_oauth_token_response_for_tests,
 };
-use nebula_engine::credential::rotation::{TokenRefreshError, refresh_oauth2_state};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -44,20 +42,6 @@ async fn drain_incoming_request(stream: &mut tokio::net::TcpStream) {
     }
 }
 
-fn sample_state(token_url: String) -> OAuth2State {
-    OAuth2State {
-        access_token: SecretString::new("old-access"),
-        token_type: "Bearer".to_owned(),
-        refresh_token: Some(SecretString::new("rt")),
-        expires_at: None,
-        scopes: vec![],
-        client_id: SecretString::new("cid"),
-        client_secret: SecretString::new("csecret"),
-        token_url,
-        auth_style: AuthStyle::Header,
-    }
-}
-
 async fn spawn_idp_returning(body: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
     let addr = listener.local_addr().expect("local addr");
@@ -78,8 +62,12 @@ async fn spawn_idp_returning(body: &'static str) -> String {
 
 async fn run_and_get_summary(body: &'static str) -> String {
     let url = spawn_idp_returning(body).await;
-    let mut state = sample_state(url);
-    let err = refresh_oauth2_state(&mut state)
+    let resp = reqwest::Client::new()
+        .post(url)
+        .send()
+        .await
+        .expect("token endpoint response");
+    let err = parse_oauth_token_response_for_tests(resp)
         .await
         .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = err else {

--- a/crates/engine/tests/oauth_idp_oversized_body_bounded.rs
+++ b/crates/engine/tests/oauth_idp_oversized_body_bounded.rs
@@ -1,4 +1,4 @@
-#![cfg(feature = "rotation")]
+#![cfg(all(feature = "rotation", feature = "test-util"))]
 
 //! SEC-01 (security hardening 2026-04-27 Stage 3) — bounded reader on the
 //! OAuth2 token endpoint error path.
@@ -14,11 +14,9 @@
 
 use std::time::{Duration, Instant};
 
-use nebula_credential::{
-    SecretString,
-    credentials::{OAuth2State, oauth2::AuthStyle},
+use nebula_engine::credential::rotation::{
+    TokenRefreshError, token_refresh::parse_oauth_token_response_for_tests,
 };
-use nebula_engine::credential::rotation::{TokenRefreshError, refresh_oauth2_state};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -42,20 +40,6 @@ async fn drain_incoming_request(stream: &mut tokio::net::TcpStream) {
         if acc.len() > 64 * 1024 {
             return;
         }
-    }
-}
-
-fn sample_state(token_url: String) -> OAuth2State {
-    OAuth2State {
-        access_token: SecretString::new("old-access"),
-        token_type: "Bearer".to_owned(),
-        refresh_token: Some(SecretString::new("rt")),
-        expires_at: None,
-        scopes: vec![],
-        client_id: SecretString::new("cid"),
-        client_secret: SecretString::new("csecret"),
-        token_url,
-        auth_style: AuthStyle::Header,
     }
 }
 
@@ -84,9 +68,13 @@ async fn oversized_error_body_returns_bounded_failure_fast() {
         }
     });
 
-    let mut state = sample_state(format!("http://127.0.0.1:{}/token", addr.port()));
     let started = Instant::now();
-    let err = refresh_oauth2_state(&mut state)
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{}/token", addr.port()))
+        .send()
+        .await
+        .expect("token endpoint response");
+    let err = parse_oauth_token_response_for_tests(resp)
         .await
         .expect_err("400 expected");
     let elapsed = started.elapsed();
@@ -131,8 +119,12 @@ async fn oversized_content_length_rejected_before_read() {
         let _ = stream.write_all(b"x").await;
     });
 
-    let mut state = sample_state(format!("http://127.0.0.1:{}/token", addr.port()));
-    let err = refresh_oauth2_state(&mut state)
+    let resp = reqwest::Client::new()
+        .post(format!("http://127.0.0.1:{}/token", addr.port()))
+        .send()
+        .await
+        .expect("token endpoint response");
+    let err = parse_oauth_token_response_for_tests(resp)
         .await
         .expect_err("400 expected");
     let TokenRefreshError::TokenEndpoint { summary, .. } = &err else {


### PR DESCRIPTION
## Summary

- Fail closed on tenant routes when the membership store is absent, with explicit test-only bypass wiring.
- Scope credential CRUD and OAuth pending state to the resolved workspace owner to close cross-workspace credential access and system-level OAuth overwrite paths.
- Reject unsafe OAuth token endpoints before API exchange and engine refresh.
- Commit Cancel/Terminate execution state changes and control outbox rows atomically through `TransitionBatch`.
- Stabilize the `me_e2e` PAT redaction test by using a process-level tracing capture in that integration-test binary.

## Validation

- `cargo test -p nebula-api` passed.
- `cargo check -p nebula-engine` passed.
- Pre-commit hook passed: `typos`, `fmt-check`, `clippy` for changed crates.
- Pre-push hook passed: `clippy-full`, `crate-diff-gate`; nextest reported `798 passed`, `2 skipped`.

## Notes

The worktree still has unrelated untracked docs files that were intentionally not staged or included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Workspace-scoped OAuth2 credential management endpoints for secure tenant-based workflows.

* **Deprecated**
  * System-level OAuth2 endpoints now return HTTP 410 Gone; migrate to workspace-scoped routes.

* **Security Improvements**
  * Enhanced credential isolation between workspaces; added token endpoint validation to reject local and private network addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->