### PR TITLE
refactor(docs): Wave C behavior-first Rust comments

### DIFF
--- a/crates/action/macros/src/action.rs
+++ b/crates/action/macros/src/action.rs
@@ -1,12 +1,14 @@
-//! `#[derive(Action)]` macro implementation — Variant A (ADR-0043 §6).
+//! `#[derive(Action)]` macro implementation — Variant A.
 //!
 //! Emits:
+//!
 //! - `impl Action for Foo` with static `metadata` and `dependencies` functions (no schema
-//!   methods — the `Input`/`Output: HasSchema` bound is the single source of truth, ADR-0052 P3).
-//! - `impl FromWorkflowNode for Foo` (when the struct has at least one `#[resource]` /
-//!   `#[credential]` field, or when the struct is a unit struct — in that case a no-op factory).
+//!   methods — the `Input`/`Output: HasSchema` bound is the single source of truth).
+//! - `impl FromWorkflowNode for Foo` when the struct has at least one `#[resource]` /
+//!   `#[credential]` field, or when the struct is a unit struct (no-op factory).
 //!
 //! Field-level attributes recognised:
+//!
 //! - `#[resource]` / `#[resource(key = "...")]` — declares a resource slot. Field type must be
 //!   `ResourceGuard<R>` (optionally wrapped in `Option<...>` and/or `Lazy<...>`).
 //! - `#[credential]` / `#[credential(key = "...")]` — declares a credential slot. Field type must

--- a/crates/action/macros/src/action_attr.rs
+++ b/crates/action/macros/src/action_attr.rs
@@ -1,4 +1,4 @@
-//! `#[action_phantom]` attribute macro per Tech Spec 2.7 + ADR-0035 4.3.
+//! `#[action_phantom]` attribute macro per Tech Spec 2.7 + 4.3.
 //!
 //! Rewrites struct fields whose type is `CredentialRef<dyn X>` to
 //! `CredentialRef<dyn XPhantom>` in the emitted item. Pattern 1 (concrete
@@ -11,13 +11,13 @@
 //! Derives may only emit *new* items; they cannot mutate the input.
 //! The phantom rewrite must edit the user-written struct in place so
 //! that the field type the action body sees is the dyn-compatible
-//! `CredentialRef<dyn XPhantom>`. ADR-0035 amendment 2026-04-24-B
+//! `CredentialRef<dyn XPhantom>`. amendment 2026-04-24-B
 //! prescribes the phantom-shim form; Tech Spec 2.7 routes the
 //! translation through `#[action_phantom]`.
 //!
 //! ## Why the name `action_phantom`, not `action`
 //!
-//! `#[derive(Action)]` declares `#[action(key = ..., ...)]` as an inert
+//! `#[derive(Action)]` declares `#[action(key =...,...)]` as an inert
 //! helper attribute. A bare `#[action]` attribute macro alongside the
 //! derive helper would put two different things called `#[action]` on
 //! the same struct - confusing for readers, and a real footgun if any

--- a/crates/action/macros/src/action_attrs.rs
+++ b/crates/action/macros/src/action_attrs.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::{Ident, Result, Type};
 
-/// Parsed action container attributes (Variant A — ADR-0043 §6).
+/// Parsed action container attributes (Variant A.
 #[derive(Debug, Clone)]
 pub(crate) struct ActionAttrs {
     /// Unique key (e.g. `"http.request"`).

--- a/crates/action/macros/src/lib.rs
+++ b/crates/action/macros/src/lib.rs
@@ -3,11 +3,11 @@
 //! - `#[derive(Action)]` generates `DeclaresDependencies` and `Action` trait impls with
 //!   `metadata()`.
 //! - `#[action_phantom]` rewrites `CredentialRef<dyn X>` field types to `CredentialRef<dyn
-//!   XPhantom>` per ADR-0035 4.3 + Tech Spec 2.7.
+//!   XPhantom>` per Tech Spec 2.7.
 //!
 //! ## Why a separate name from `#[action(...)]`
 //!
-//! `#[derive(Action)]` declares `#[action(key = ..., name = ..., ...)]` as an inert helper
+//! `#[derive(Action)]` declares `#[action(key =..., name =...,...)]` as an inert helper
 //! attribute. Naming the rewriter `#[action]` (no args) and putting it in scope would create a
 //! conceptual collision on the same struct - two different `#[action]` mean different things. The
 //! rewriter is therefore named `#[action_phantom]` to match its job (phantom-shim rewrite for
@@ -51,12 +51,12 @@ mod field_slots;
 /// ```ignore
 /// #[derive(Action)]
 /// #[action(
-///     key = "slack.send",
-///     name = "Send Slack Message",
-///     description = "Sends a message to a Slack channel",
-///     version = "2.1",
-///     credential = SlackOAuthCredential,
-///     resources = [HttpClient]
+/// key = "slack.send",
+/// name = "Send Slack Message",
+/// description = "Sends a message to a Slack channel",
+/// version = "2.1",
+/// credential = SlackOAuthCredential,
+/// resources = [HttpClient]
 /// )]
 /// pub struct SlackSendAction;
 /// ```
@@ -90,8 +90,8 @@ pub fn derive_action(input: TokenStream) -> TokenStream {
 /// #[derive(Action)]
 /// #[action(key = "bitbucket.repo.fetch", name = "Fetch Repo")]
 /// pub struct BitbucketRepoFetch {
-///     pub bb: CredentialRef<dyn BitbucketBearer>,
-///     // - emitted as `CredentialRef<dyn BitbucketBearerPhantom>`
+/// pub bb: CredentialRef<dyn BitbucketBearer>,
+/// // - emitted as `CredentialRef<dyn BitbucketBearerPhantom>`
 /// }
 /// ```
 ///

--- a/crates/action/src/action.rs
+++ b/crates/action/src/action.rs
@@ -1,7 +1,7 @@
 //! Base [`Action`] trait — identity, metadata, type-level Input/Output, slot deps.
 //!
 //! See module docs in `lib.rs` for trait family overview. Variant A trait shape
-//! lands per ADR-0043 §6 (Phase 3 / Session 1).
+//! lands in Phase 3.
 
 use nebula_core::Dependencies;
 use nebula_schema::HasSchema;
@@ -15,7 +15,7 @@ use crate::metadata::ActionMetadata;
 /// `Self::Output`), and slot-binding declarations (`dependencies`) — all
 /// static per concrete type. The schema is reached via the
 /// `Input`/`Output: HasSchema` bound (`nebula_schema::schema_of::<A::Input>()`);
-/// there is no per-trait schema method (ADR-0052 P3). Sub-traits
+/// there is no per-trait schema method. Sub-traits
 /// ([`StatelessAction`](crate::StatelessAction) etc.) define the execution
 /// surface and consume `Self::Input` / `Self::Output`.
 ///
@@ -35,17 +35,17 @@ use crate::metadata::ActionMetadata;
 /// struct Echo;
 ///
 /// impl Action for Echo {
-///     type Input = serde_json::Value;
-///     type Output = serde_json::Value;
+/// type Input = serde_json::Value;
+/// type Output = serde_json::Value;
 ///
-///     fn metadata() -> &'static ActionMetadata {
-///         static M: OnceLock<ActionMetadata> = OnceLock::new();
-///         M.get_or_init(|| ActionMetadata::new(action_key!("echo"), "Echo", "Echoes input"))
-///     }
-///     fn dependencies() -> &'static Dependencies {
-///         static D: OnceLock<Dependencies> = OnceLock::new();
-///         D.get_or_init(Dependencies::new)
-///     }
+/// fn metadata() -> &'static ActionMetadata {
+/// static M: OnceLock<ActionMetadata> = OnceLock::new();
+/// M.get_or_init(|| ActionMetadata::new(action_key!("echo"), "Echo", "Echoes input"))
+/// }
+/// fn dependencies() -> &'static Dependencies {
+/// static D: OnceLock<Dependencies> = OnceLock::new();
+/// D.get_or_init(Dependencies::new)
+/// }
 /// }
 /// ```
 ///

--- a/crates/action/src/context.rs
+++ b/crates/action/src/context.rs
@@ -5,12 +5,12 @@
 //! supertraits is an action/trigger context. The concrete runtime types live
 //! in this module as [`ActionRuntimeContext`] / [`TriggerRuntimeContext`] —
 //! they embed [`nebula_core::BaseContext`] for identity and compose
-//! capability accessors as `Arc<dyn ...>` fields.
+//! capability accessors as `Arc<dyn...>` fields.
 //!
 //! Action authors never write `ActionRuntimeContext` in their code — they
 //! write `fn execute(ctx: &(impl ActionContext + ?Sized))` and receive any
 //! type the runtime chooses to supply (engine runtime, test harness,
-//! sandbox wrapper, ...).
+//! sandbox wrapper,...).
 
 use std::{any::Any, fmt, future::Future, pin::Pin, sync::Arc};
 
@@ -717,7 +717,7 @@ impl<T: ?Sized + HasCredentials> CredentialContextExt for T {}
 /// `FromWorkflowNode::from_workflow_node` (the auto-generated factory)
 /// resolves each `#[resource]` / `#[credential]` field by calling these
 /// methods with the concrete slot id (either the action's declared
-/// `default_id` or the per-node `slot_bindings` override per ADR-0042).
+/// `default_id` or the per-node `slot_bindings` override ).
 ///
 /// Plugin authors normally do not call these methods directly; the
 /// derive macro emits the call sites. They are public so authors who
@@ -726,7 +726,7 @@ pub trait ActionContextExt: HasResources + HasCredentials {
     /// Acquire a [`nebula_resource::ResourceGuard<R>`] by string id.
     ///
     /// Mirrors [`nebula_resource::ResourceRef::resolve`] but takes the id
-    /// directly so the derive-generated factory can pass the ADR-0042
+    /// directly so the derive-generated factory can pass the
     /// slot binding without constructing an intermediate `ResourceRef<R>`.
     ///
     /// # Errors
@@ -773,7 +773,7 @@ pub trait ActionContextExt: HasResources + HasCredentials {
     /// Resolve a [`CredentialGuard<C::Scheme>`] by string id.
     ///
     /// Mirrors [`nebula_credential::CredentialRef::resolve`] but takes the
-    /// id directly so the derive-generated factory can pass the ADR-0042
+    /// id directly so the derive-generated factory can pass the
     /// slot binding without constructing an intermediate `CredentialRef<C>`.
     ///
     /// # Errors

--- a/crates/action/src/erased.rs
+++ b/crates/action/src/erased.rs
@@ -1,6 +1,6 @@
 //! `ErasedAction` enum + object-safe per-variant sub-traits.
 //!
-//! Per ADR-0043 §6 / Phase 3 Session 4, the engine cannot dispatch on the
+//! The engine cannot dispatch on the
 //! `Sized` [`Action`](crate::Action) trait directly because Variant A makes
 //! it object-unsafe. Instead, the engine works against an enum
 //! [`ErasedAction`] whose variants wrap `Box<dyn ErasedXxx>` trait objects

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -1,6 +1,6 @@
 //! `ActionFactory` — engine-side object-safe per-execution factory.
 //!
-//! Per ADR-0043 §6 / Phase 3 Session 4. The engine's
+//! The engine's
 //! `ActionRegistry` keeps `Arc<dyn ActionFactory>` per `ActionKey`. On
 //! each dispatch, the registry calls
 //! [`instantiate`](ActionFactory::instantiate) with the current

--- a/crates/action/src/from_workflow_node.rs
+++ b/crates/action/src/from_workflow_node.rs
@@ -1,17 +1,17 @@
 //! `FromWorkflowNode` — async factory trait that resolves slot bindings
 //! against a workflow node definition and an action context.
 //!
-//! Per ADR-0043 §9 (Phase 3 / Session 2), every concrete action implementing
+//! Every concrete action implementing
 //! [`Action`](crate::Action) ALSO implements [`FromWorkflowNode`]. The engine
 //! calls [`from_workflow_node`](FromWorkflowNode::from_workflow_node) once at
 //! dispatch time:
 //!
 //! 1. Read each declared slot field from `Self::dependencies()`.
-//! 2. For each slot, look up the override in `node.slot_bindings` (per ADR-0042 hybrid binding) —
-//!    falling back to the action's declared `default_id`.
+//! 2. For each slot, look up the override in `node.slot_bindings` ( hybrid binding) —
+//! falling back to the action's declared `default_id`.
 //! 3. Resolve the resource / credential through [`ActionContext`](crate::ActionContext) typed
-//!    helpers ([`acquire_resource_by_id`](crate::context::ActionContextExt::acquire_resource_by_id),
-//!    [`resolve_credential_by_id`](crate::context::ActionContextExt::resolve_credential_by_id)).
+//! helpers ([`acquire_resource_by_id`](crate::context::ActionContextExt::acquire_resource_by_id),
+//! [`resolve_credential_by_id`](crate::context::ActionContextExt::resolve_credential_by_id)).
 //! 4. Assemble `Self` with the resolved guards.
 //!
 //! `#[derive(Action)]` (Phase 3 / Session 3) generates the body of
@@ -46,16 +46,16 @@ use crate::context::ActionContext;
 /// # use std::future::Future;
 /// # struct SendTelegram { /* slot fields */ }
 /// impl FromWorkflowNode for SendTelegram {
-///     type Error = ActionError;
-///     fn from_workflow_node<'a>(
-///         node: &'a NodeDefinition,
-///         ctx: &'a dyn ActionContext,
-///     ) -> impl Future<Output = Result<Self, Self::Error>> + Send + 'a {
-///         async move {
-///             // resolve slot fields against ctx + node.slot_bindings here
-///             # unimplemented!()
-///         }
-///     }
+/// type Error = ActionError;
+/// fn from_workflow_node<'a>(
+/// node: &'a NodeDefinition,
+/// ctx: &'a dyn ActionContext,
+/// ) -> impl Future<Output = Result<Self, Self::Error>> + Send + 'a {
+/// async move {
+/// // resolve slot fields against ctx + node.slot_bindings here
+/// # unimplemented!()
+/// }
+/// }
 /// }
 /// ```
 pub trait FromWorkflowNode: Sized + Send + 'static {

--- a/crates/action/src/idempotency.rs
+++ b/crates/action/src/idempotency.rs
@@ -6,7 +6,7 @@
 //! (webhook retry, queue redelivery, schedule replay).
 //!
 //! Not a secret — engine logs and metrics MAY include the key. For dedup
-//! windows and storage, see PRODUCT_CANON §11.3 idempotency.
+//! windows and storage, see PRODUCT_ idempotency.
 
 use std::fmt;
 

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -1,14 +1,13 @@
 //! # nebula-action
 //!
 //! **Role:** Action Trait Family + Execution Policy Metadata (Ports & Adapters).
-//! Canon §3.5 (trait family; adding a trait requires canon revision), §11.2, §11.3.
 //!
 //! Defines what actions are and how they communicate with the engine. Core types
 //! live here; execution environments (in-process, ProcessSandbox with capability
 //! allowlists and OS-level hardening) are drivers in `nebula-sandbox`.
-//! WASM is an explicit non-goal — see `docs/PRODUCT_CANON.md` §12.6.
+//! WASM is an explicit non-goal for the action execution surface.
 //!
-//! ## Trait family (canon §3.5)
+//! ## Trait family
 //!
 //! - `Action` — base trait providing identity and metadata.
 //! - `StatelessAction` — pure, stateless single-execution.
@@ -77,7 +76,7 @@ pub mod port;
 pub mod prelude;
 /// [`ResourceAction`] DX trait, [`ResourceHandler`] dyn contract, and adapter.
 pub mod resource;
-/// `ResourceProduces<R>` — Output marker for `ResourceAction` (ADR-0043 §4 Variant A).
+/// `ResourceProduces<R>` — Output marker for `ResourceAction`.
 pub mod resource_produces;
 /// Execution result types carrying data and flow-control intent.
 pub mod result;

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -130,7 +130,7 @@ pub struct ActionMetadata {
     /// still applies, but no per-action limit. `Some(n)` — at most `n`
     /// in-flight executions of this action across the engine.
     ///
-    /// Per Tech Spec §15.12 F9 + PRODUCT_CANON §11 backpressure.
+    /// Per Tech Spec §15.12 F9 + PRODUCT_ backpressure.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<core::num::NonZeroU32>,
 }
@@ -173,13 +173,13 @@ impl ActionMetadata {
     ///
     /// struct MyAction;
     /// impl StatelessAction for MyAction {
-    ///     type Input = MyInput;  // must impl HasSchema
-    ///     type Output = MyOutput;
-    ///     // ...
+    /// type Input = MyInput; // must impl HasSchema
+    /// type Output = MyOutput;
+    /// //...
     /// }
     ///
     /// let meta = ActionMetadata::for_stateless::<MyAction>(
-    ///     action_key!("my.action"), "My Action", "desc",
+    /// action_key!("my.action"), "My Action", "desc",
     /// );
     /// ```
     #[must_use]

--- a/crates/action/src/resource_produces.rs
+++ b/crates/action/src/resource_produces.rs
@@ -1,6 +1,6 @@
 //! ResourceAction Output marker — `ResourceProduces<R>`.
 //!
-//! Per ADR-0043 §4 (Variant A trait shape), the base [`Action`](crate::Action)
+//! For the base [`Action`](crate::Action)
 //! trait has `type Output` for *what this action produces*. For
 //! `ResourceAction`, the produced thing is a scoped resource binding that
 //! downstream nodes consume via `ctx.resource::<R>()`. There is no flowing
@@ -16,8 +16,8 @@
 //!
 //! ```ignore
 //! pub trait ResourceAction:
-//!     Action<Output = ResourceProduces<<Self as ResourceAction>::Resource>>
-//! { ... }
+//! Action<Output = ResourceProduces<<Self as ResourceAction>::Resource>>
+//! {... }
 //! ```
 //!
 //! so the compiler enforces that a ResourceAction's Output is the marker

--- a/crates/action/src/result.rs
+++ b/crates/action/src/result.rs
@@ -30,7 +30,7 @@ pub use crate::port::PortKey;
 /// The engine does not retry actions: re-execution from a result variant is
 /// not part of the engine contract. The canonical retry surface is the
 /// `nebula-resilience` pipeline composed inside an action around outbound
-/// calls (canon §11.2).
+/// calls.
 ///
 /// All output fields are wrapped in [`ActionOutput<T>`] to support binary,
 /// reference, and stream data alongside structured values.
@@ -176,7 +176,7 @@ pub enum ActionResult<T> {
     /// / API / webhook consumers can distinguish ExplicitFail from a
     /// system-driven failure and ExplicitStop from natural completion.
     ///
-    /// See ROADMAP §M0.3 for the wiring contract and canon §4.5 for
+    /// See ROADMAP §M0.3 for the wiring contract and for
     /// the operational-honesty rule this closed.
     Terminate {
         /// Why the execution is ending.

--- a/crates/action/src/trigger/mod.rs
+++ b/crates/action/src/trigger/mod.rs
@@ -12,7 +12,7 @@
 //! own transport-specific event types:
 //!
 //! - [`crate::webhook`] — HTTP webhooks, with `WebhookRequest` carrying method, path, query,
-//!   headers, and body.
+//! headers, and body.
 //! - [`crate::poll`] — pull-based periodic polling with cursor state.
 //!
 //! Both register their adapters against the dyn contract defined here
@@ -73,7 +73,7 @@ use crate::{
 /// triggers whose transport supplies a stable per-event id (webhook
 /// delivery id, queue message id) override to return `Some(...)`.
 /// Engine uses the key to suppress duplicate workflow executions per
-/// PRODUCT_CANON §11.3 idempotency.
+/// PRODUCT_ idempotency.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` does not implement TriggerAction",
     note = "implement `Source`, `Error`, and the `start`/`stop`/`handle` methods"
@@ -116,7 +116,7 @@ pub trait TriggerAction: Action {
     ///
     /// Default: `None`. Override when the transport supplies a stable
     /// per-event id (webhook delivery id, queue message id).
-    /// Per Tech Spec §15.12 F2 + PRODUCT_CANON §11.3 idempotency.
+    /// Per Tech Spec §15.12 F2 + PRODUCT_ idempotency.
     fn idempotency_key(
         &self,
         _event: &<Self::Source as TriggerSource>::Event,
@@ -141,11 +141,11 @@ pub trait TriggerAction: Action {
     ///
     /// ```ignore
     /// async fn handle(
-    ///     &self,
-    ///     _ctx: &(impl TriggerContext + ?Sized),
-    ///     _event: <Self::Source as TriggerSource>::Event,
+    /// &self,
+    /// _ctx: &(impl TriggerContext + ?Sized),
+    /// _event: <Self::Source as TriggerSource>::Event,
     /// ) -> Result<TriggerEventOutcome, ActionError> {
-    ///     Err(ActionError::fatal("trigger does not accept external events"))
+    /// Err(ActionError::fatal("trigger does not accept external events"))
     /// }
     /// ```
     fn handle(
@@ -368,12 +368,12 @@ pub trait TriggerHandler: Send + Sync + 'static {
     /// Implementations fall into one of two categories:
     ///
     /// 1. **Setup-and-return** — register an external listener (webhook, message queue consumer),
-    ///    then return immediately. The listener runs asynchronously outside this call. Example:
-    ///    `crate::webhook::WebhookTriggerAdapter`.
+    /// then return immediately. The listener runs asynchronously outside this call. Example:
+    /// `crate::webhook::WebhookTriggerAdapter`.
     ///
     /// 2. **Run-until-cancelled** — run the entire trigger loop inline, returning only when
-    ///    `ctx.cancellation` fires or a fatal error occurs. Example:
-    ///    `crate::poll::PollTriggerAdapter`.
+    /// `ctx.cancellation` fires or a fatal error occurs. Example:
+    /// `crate::poll::PollTriggerAdapter`.
     ///
     /// **Callers MUST spawn `start()` in a dedicated task** and must not
     /// assume it returns promptly. Calling sites that drive multiple

--- a/crates/action/src/webhook/factory.rs
+++ b/crates/action/src/webhook/factory.rs
@@ -37,7 +37,7 @@ pub struct WebhookActivationSpec {
     pub action_kind: String,
     /// HMAC secret material as raw bytes. Storage layers should
     /// resolve this from a credential reference rather than store
-    /// raw bytes inline; see ADR-0049 for the secret-handling
+    /// raw bytes inline; see for the secret-handling
     /// rationale.
     pub secret: Vec<u8>,
     /// Replay window in seconds. `None` defers to the provider's

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -5,25 +5,25 @@
 //! trigger into one file:
 //!
 //! - [`WebhookRequest`] — typed HTTP event (method, path, query, headers, body, arrival timestamp).
-//!   Constructed by the HTTP transport layer via [`WebhookRequest::try_new`] /
-//!   [`WebhookRequest::try_new_with_limits`] which enforce body-size and header-count limits at the
-//!   boundary.
+//! Constructed by the HTTP transport layer via [`WebhookRequest::try_new`] /
+//! [`WebhookRequest::try_new_with_limits`] which enforce body-size and header-count limits at the
+//! boundary.
 //! - [`WebhookAction`] — DX trait with the register / handle / unregister lifecycle. Implement this
-//!   and register via `registry.register_webhook(action)`.
+//! and register via `registry.register_webhook(action)`.
 //! - [`WebhookTriggerAdapter`] — bridges a typed `WebhookAction` to the
-//!   [`TriggerHandler`](crate::trigger::TriggerHandler) dyn contract. Stores state from
-//!   `on_activate` in a `RwLock<Option<Arc<State>>>`, rejects double-start with
-//!   `ActionError::Fatal`, cleans up orphaned state on lost-race rollback, and downcasts incoming
-//!   [`TriggerEvent`](crate::trigger::TriggerEvent)s to [`WebhookRequest`].
+//! [`TriggerHandler`](crate::trigger::TriggerHandler) dyn contract. Stores state from
+//! `on_activate` in a `RwLock<Option<Arc<State>>>`, rejects double-start with
+//! `ActionError::Fatal`, cleans up orphaned state on lost-race rollback, and downcasts incoming
+//! [`TriggerEvent`](crate::trigger::TriggerEvent)s to [`WebhookRequest`].
 //! - [`verify_hmac_sha256`], [`hmac_sha256_compute`], [`verify_tag_constant_time`],
-//!   [`SignatureOutcome`] — constant-time HMAC primitives. Use `verify_hmac_sha256` for
-//!   GitHub-style `sha256=…` bare-hex signatures; reach for the lower-level pair for Stripe / Slack
-//!   schemes that sign a derived payload.
+//! [`SignatureOutcome`] — constant-time HMAC primitives. Use `verify_hmac_sha256` for
+//! GitHub-style `sha256=…` bare-hex signatures; reach for the lower-level pair for Stripe / Slack
+//! schemes that sign a derived payload.
 //! - [`WebhookConfig`], [`SignaturePolicy`], [`RequiredPolicy`], [`SignatureScheme`] — the
-//!   `Required`-by-default signature-enforcement contract at the trait surface. Authors return a
-//!   [`WebhookConfig`] from [`WebhookAction::config`]; the HTTP transport reads its
-//!   [`WebhookConfig::signature_policy`] before dispatch; misconfigured or unsigned requests are
-//!   rejected before the action sees them. See ADR-0022.
+//! `Required`-by-default signature-enforcement contract at the trait surface. Authors return a
+//! [`WebhookConfig`] from [`WebhookAction::config`]; the HTTP transport reads its
+//! [`WebhookConfig::signature_policy`] before dispatch; misconfigured or unsigned requests are
+//! rejected before the action sees them. See.
 //!
 //! # Security
 //!
@@ -496,9 +496,9 @@ impl Default for WebhookHttpResponse {
 ///
 /// // Slack URL verification — echo challenge, no workflow.
 /// Ok(WebhookResponse::respond(
-///     StatusCode::OK,
-///     challenge_value,
-///     TriggerEventOutcome::skip(),
+/// StatusCode::OK,
+/// challenge_value,
+/// TriggerEventOutcome::skip(),
 /// ))
 /// ```
 #[derive(Debug)]
@@ -592,24 +592,24 @@ impl WebhookResponse {
 /// struct GitHubWebhook { secret: Vec<u8> }
 ///
 /// impl WebhookAction for GitHubWebhook {
-///     type State = WebhookReg;
+/// type State = WebhookReg;
 ///
-///     async fn on_activate(&self, ctx: &(impl TriggerContext + ?Sized)) -> Result<WebhookReg, ActionError> {
-///         Ok(WebhookReg { hook_id: register(ctx).await? })
-///     }
+/// async fn on_activate(&self, ctx: &(impl TriggerContext + ?Sized)) -> Result<WebhookReg, ActionError> {
+/// Ok(WebhookReg { hook_id: register(ctx).await? })
+/// }
 ///
-///     async fn handle_request(&self, req: &WebhookRequest, _state: &Self::State, _ctx: &(impl TriggerContext + ?Sized))
-///         -> Result<WebhookResponse, ActionError> {
-///         let outcome = verify_hmac_sha256(req, &self.secret, "X-Hub-Signature-256")?;
-///         if !outcome.is_valid() {
-///             return Ok(WebhookResponse::accept(TriggerEventOutcome::skip()));
-///         }
-///         Ok(WebhookResponse::accept(TriggerEventOutcome::emit(req.body_json()?)))
-///     }
+/// async fn handle_request(&self, req: &WebhookRequest, _state: &Self::State, _ctx: &(impl TriggerContext + ?Sized))
+/// -> Result<WebhookResponse, ActionError> {
+/// let outcome = verify_hmac_sha256(req, &self.secret, "X-Hub-Signature-256")?;
+/// if !outcome.is_valid() {
+/// return Ok(WebhookResponse::accept(TriggerEventOutcome::skip()));
+/// }
+/// Ok(WebhookResponse::accept(TriggerEventOutcome::emit(req.body_json()?)))
+/// }
 ///
-///     async fn on_deactivate(&self, state: WebhookReg, _ctx: &(impl TriggerContext + ?Sized)) -> Result<(), ActionError> {
-///         delete_hook(&state.hook_id).await
-///     }
+/// async fn on_deactivate(&self, state: WebhookReg, _ctx: &(impl TriggerContext + ?Sized)) -> Result<(), ActionError> {
+/// delete_hook(&state.hook_id).await
+/// }
 /// }
 /// ```
 pub trait WebhookAction: Action + Send + Sync + 'static {
@@ -728,7 +728,7 @@ pub trait WebhookAction: Action + Send + Sync + 'static {
     /// Slack) use [`SignaturePolicy::Custom`] with a verifier that
     /// composes the primitives in this module.
     ///
-    /// See ADR-0022 for the full rationale.
+    ///
     fn config(&self) -> WebhookConfig {
         WebhookConfig::default()
     }
@@ -746,7 +746,7 @@ pub trait WebhookAction: Action + Send + Sync + 'static {
 ///
 /// # Fields
 ///
-/// - [`signature_policy`](Self::signature_policy) — ADR-0022 signature enforcement policy. Default:
+/// - [`signature_policy`](Self::signature_policy). Default:
 ///   `Required` with an empty secret (fail-closed).
 ///
 /// # Cloning
@@ -875,7 +875,7 @@ pub enum PreHandleOutcome {
 /// `HeaderName` (both cheap clones) and `Custom` holds `Arc<dyn Fn>`.
 /// The adapter reads the policy once at construction and stores it.
 ///
-/// See ADR-0022 for the full rationale.
+///
 pub enum SignaturePolicy {
     /// Require HMAC signature via the configured header and scheme.
     /// Default: `X-Nebula-Signature`, hex-encoded SHA-256, empty secret.
@@ -950,7 +950,7 @@ impl SignaturePolicy {
 ///
 /// An empty secret is *not* a misuse of the API — it is the
 /// fail-closed default surface that catches "author forgot to
-/// supply a secret" at the transport layer. See ADR-0022.
+/// supply a secret" at the transport layer. See.
 ///
 /// # Non-exhaustive
 ///
@@ -1500,17 +1500,17 @@ pub enum SignatureScheme {
 ///
 /// ```rust,ignore
 /// async fn on_activate(&self, ctx: &(impl TriggerContext + ?Sized + HasWebhookEndpoint))
-///     -> Result<Self::State, ActionError>
+/// -> Result<Self::State, ActionError>
 /// {
-///     let endpoint = ctx.webhook_endpoint().ok_or_else(|| {
-///         ActionError::fatal("webhook trigger activated without endpoint provider")
-///     })?;
-///     let hook_id = github_api::create_hook(
-///         &self.repo,
-///         endpoint.endpoint_url().as_str(),
-///         &self.secret,
-///     ).await?;
-///     Ok(GitHubState { hook_id })
+/// let endpoint = ctx.webhook_endpoint().ok_or_else(|| {
+/// ActionError::fatal("webhook trigger activated without endpoint provider")
+/// })?;
+/// let hook_id = github_api::create_hook(
+/// &self.repo,
+/// endpoint.endpoint_url().as_str(),
+/// &self.secret,
+/// ).await?;
+/// Ok(GitHubState { hook_id })
 /// }
 /// ```
 pub trait WebhookEndpointProvider: Send + Sync + fmt::Debug {
@@ -1783,7 +1783,7 @@ where
             };
 
             // Clone Arc under read lock; the guard drops at end of statement BEFORE
-            // the await on handle_request. Holding a parking_lot guard across .await
+            // the await on handle_request. Holding a parking_lot guard across.await
             // would be unsound (non-Send) and risk re-entry panic with start/stop.
             let state = if let Some(s) = self.state.read().as_ref().cloned() {
                 s
@@ -1805,7 +1805,7 @@ where
                 ));
             };
 
-            // pre_handle hook (ADR-0049) — provider-typed actions
+            // pre_handle hook — provider-typed actions
             // (Slack url_verification, Stripe pending_webhook ping,
             // Generic GET challenge) intercept verification probes
             // here. Runs AFTER signature verification (transport
@@ -1840,38 +1840,38 @@ where
             // runtime records it and the task exits cleanly. Otherwise
             // race the handler normally.
             let response = tokio::select! {
-                biased;
-                () = ctx.cancellation().cancelled() => {
-                    if let Some(tx) = response_tx {
-                        let _ = tx.send(WebhookHttpResponse::new(
-                            StatusCode::SERVICE_UNAVAILABLE,
-                            Bytes::from_static(b"shutting down"),
-                        ));
-                    }
-                    ctx.health().record_error();
-                    return Err(ActionError::retryable(
-                        "webhook trigger cancelled mid-request",
-                    ));
-                }
-                result = self.action.handle_request(&request, &state, ctx) => {
-                    // H1 — on handler error, send a 500 via oneshot BEFORE
-                    // propagating Err. Without this, the transport receives
-                    // RecvError and has to guess the HTTP status.
-                    match result {
-                        Ok(r) => r,
-                        Err(e) => {
-                            if let Some(tx) = response_tx {
-                                let _ = tx.send(WebhookHttpResponse::new(
-                                    StatusCode::INTERNAL_SERVER_ERROR,
-                                    Bytes::new(),
-                                ));
-                            }
-                            ctx.health().record_error();
-                            return Err(e);
-                        }
-                    }
-                }
-            };
+                           biased;
+                           () = ctx.cancellation().cancelled() => {
+                               if let Some(tx) = response_tx {
+                                   let _ = tx.send(WebhookHttpResponse::new(
+                                       StatusCode::SERVICE_UNAVAILABLE,
+                                       Bytes::from_static(b"shutting down"),
+                                   ));
+                               }
+                               ctx.health().record_error();
+                               return Err(ActionError::retryable(
+                                   "webhook trigger cancelled mid-request",
+                               ));
+                           }
+                           result = self.action.handle_request(&request, &state, ctx) => {
+            // H1 — on handler error, send a 500 via oneshot BEFORE
+            // propagating Err. Without this, the transport receives
+            // RecvError and has to guess the HTTP status.
+                               match result {
+                                   Ok(r) => r,
+                                   Err(e) => {
+                                       if let Some(tx) = response_tx {
+                                           let _ = tx.send(WebhookHttpResponse::new(
+                                               StatusCode::INTERNAL_SERVER_ERROR,
+                                               Bytes::new(),
+                                           ));
+                                       }
+                                       ctx.health().record_error();
+                                       return Err(e);
+                                   }
+                               }
+                           }
+                       };
 
             let (http_response, outcome) = response.into_parts();
 
@@ -1931,7 +1931,7 @@ impl SignatureOutcome {
     ///
     /// ```ignore
     /// if !verify_hmac_sha256(request, secret, "X-Hub-Signature-256")?.is_valid() {
-    ///     return Ok(TriggerEventOutcome::skip());
+    /// return Ok(TriggerEventOutcome::skip());
     /// }
     /// ```
     #[must_use]
@@ -2100,7 +2100,7 @@ fn verify_base64_hmac_timing_invariant(
 /// # Arguments
 ///
 /// - `request` — the incoming webhook request (body + headers)
-/// - `secret`  — shared HMAC key (typically from a credential)
+/// - `secret` — shared HMAC key (typically from a credential)
 /// - `header` — header name carrying the signature, e.g. `"X-Hub-Signature-256"`. Must be a valid
 ///   HTTP header name.
 ///
@@ -2356,7 +2356,7 @@ pub fn hmac_sha256_compute(secret: &[u8], payload: &[u8]) -> [u8; 32] {
 /// let expected = hmac_sha256_compute(secret, signed_payload.as_bytes());
 /// let provided = hex::decode(header_v1).unwrap_or_default();
 /// if !verify_tag_constant_time(&expected, &provided) {
-///     return Ok(TriggerEventOutcome::skip());
+/// return Ok(TriggerEventOutcome::skip());
 /// }
 /// ```
 #[must_use]

--- a/crates/action/tests/action_attr_phantom_rewrite.rs
+++ b/crates/action/tests/action_attr_phantom_rewrite.rs
@@ -1,7 +1,7 @@
 //! Integration test - `#[action_phantom] + #[derive(Action)]` end-to-end.
 //!
 //! Verifies the documented "apply attribute first, derive sees rewritten
-//! struct" ordering behavior end-to-end (Tech Spec 2.7 / ADR-0035 §4.3).
+//! struct" ordering behavior end-to-end (Tech Spec 2.7 /.3).
 //! Closes I3 from the Stage 4 review.
 //!
 //! Approach: a regular cargo integration test rather than a `trybuild`
@@ -13,14 +13,14 @@
 //!
 //! The fixture is self-contained:
 //!
-//! - local `mod sealed_caps` per ADR-0035 §4.1
+//! - local `mod sealed_caps`
 //! - local `AcceptsBearer` marker
 //! - local service supertrait + `#[capability]` invocation
 //! - stand-in `CredentialRef<C: ?Sized>` (the real type does not ship in Stage 4; the
 //!   `#[action_phantom]` rewriter operates on syntax, not on the type's semantics, so a stub
 //!   suffices to exercise the rewrite)
 //! - a Pattern 2 struct that wires `#[action_phantom] #[derive(Action)]` over a `CredentialRef<dyn
-//!   LocalServiceBearer>` field
+//! LocalServiceBearer>` field
 //!
 //! The compile-fail companion is already covered by the standalone
 //! `compile_fail_pattern2_service_reject` probe - that probe exercises
@@ -43,7 +43,7 @@ use nebula_credential::{
 use nebula_schema::FieldValues;
 use serde::{Deserialize, Serialize};
 
-// ADR-0035 §4.1 - the crate author declares the sealed module manually
+//.1 - the crate author declares the sealed module manually
 // at "crate root". For this fixture the test file is the crate root.
 mod sealed_caps {
     pub trait BearerSealed {}
@@ -83,7 +83,7 @@ pub trait LocalService: Credential {}
 
 /// Capability sub-trait declared via `#[capability]`. Emits the real
 /// trait + scheme blanket + sealed blanket + phantom companion + phantom
-/// blanket. With ADR-0035 §1 visibility-symmetry, `pub trait` here
+/// blanket. With, `pub trait` here
 /// produces `pub trait LocalServiceBearerPhantom`.
 #[nebula_credential_macros::capability(scheme_bound = AcceptsBearer, sealed = BearerSealed)]
 pub trait LocalServiceBearer: LocalService {}
@@ -141,7 +141,7 @@ impl<C: ?Sized> Default for CredentialRef<C> {
 // field) the type would be `CredentialRef<dyn LocalServiceBearer>` -
 // which fails to compile because `dyn LocalServiceBearer` triggers the
 // E0191 "unspecified associated types" gate from the `Credential`
-// supertrait closure (the whole reason ADR-0035 exists).
+// supertrait closure (the whole reason exists).
 
 #[nebula_action_macros::action_phantom]
 #[derive(Action)]
@@ -178,7 +178,7 @@ fn action_attr_with_derive_pattern2_compiles_and_metadata_roundtrips() {
 #[test]
 fn action_attr_with_derive_pattern2_dependencies_are_empty() {
     // Pattern 2 fields don't auto-register as `#[credential]` slots —
-    // the field type is `CredentialRef<dyn ...>`, not `CredentialGuard<C>`.
+    // the field type is `CredentialRef<dyn...>`, not `CredentialGuard<C>`.
     // The dependency list reflects the absence of `#[credential]` /
     // `#[resource]` annotations on the field. Verifies the derive's
     // dependencies-builder executed against the rewritten struct without

--- a/crates/action/tests/derive_action.rs
+++ b/crates/action/tests/derive_action.rs
@@ -38,7 +38,7 @@ fn metadata_key_matches_attribute() {
 
 #[test]
 fn input_schema_derives_from_input_via_schema_of() {
-    // ADR-0052 P3: there is no `Action::input_schema()` method. The action's
+    // P3: there is no `Action::input_schema()` method. The action's
     // input schema is reached through the `Input: HasSchema` associated-type
     // bound via `nebula_schema::schema_of` — the single source of truth.
     let schema = nebula_schema::schema_of::<<NoCredAction as Action>::Input>();

--- a/crates/action/tests/probes/action_input_schema_removed.rs
+++ b/crates/action/tests/probes/action_input_schema_removed.rs
@@ -1,4 +1,4 @@
-//! Compile-fail probe — ADR-0052 P3: `Action::input_schema()` is removed.
+//! Compile-fail probe.
 //!
 //! Schema is reachable only via the `Input`/`Output: HasSchema`
 //! associated-type bound / `nebula_schema::schema_of`. FQS on the trait so

--- a/crates/action/tests/seam_action_schema_method_removed.rs
+++ b/crates/action/tests/seam_action_schema_method_removed.rs
@@ -1,4 +1,4 @@
-//! Seam (ADR-0052 P3) — `Action::input_schema()`/`output_schema()` are
+//! Seam — `Action::input_schema()`/`output_schema()` are
 //! removed. Schema is reachable only via the `Input`/`Output: HasSchema`
 //! associated-type bound, exposed through `nebula_schema::schema_of`. This
 //! locks the convergence: the redundant per-trait schema methods do not

--- a/crates/api/src/app.rs
+++ b/crates/api/src/app.rs
@@ -29,7 +29,7 @@ use crate::{
 /// Build the main application router with middleware
 pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // Materialise the full route tree alongside the merged OpenAPI 3.1
-    // document (ADR-0047). `OpenApiRouter::split_for_parts()` is the
+    // document (stub-endpoint policy). `OpenApiRouter::split_for_parts()` is the
     // single mounting path that ties the served `axum::Router` to the
     // generated `OpenApi` value, so any handler missing
     // `#[utoipa::path]` would fail to pass through `routes!()` at compile
@@ -38,7 +38,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
 
     let path_count = openapi_spec.paths.paths.len();
     // `OpenApiVersion` does not implement `Display`/`Debug`; serde always
-    // round-trips it to the canonical version string. ADR-0047 pins the
+    // round-trips it to the canonical version string. stub-endpoint policy pins the
     // generator to 3.1.0, so the assertion in T7 catches accidental drift.
     // A serialization failure here is unexpected — it would mean the
     // generated `OpenApi` cannot be represented in JSON, which the served
@@ -90,7 +90,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // Test-only echo / fail routes (used by `tests/idempotency_e2e.rs`).
     // Merged BEFORE the idempotency layer so the dedup contract covers
     // them; gated behind `test-util` so production builds never include
-    // these endpoints. Per ADR-0047 they go through `axum::Router::merge`
+    // these endpoints. Per stub-endpoint policy they go through `axum::Router::merge`
     // (not `OpenApiRouter`) so the spec stays clean — no `_test/*` paths
     // in `/api/v1/openapi.json`.
     #[cfg(any(test, feature = "test-util"))]
@@ -101,7 +101,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
     // timestamp). Routing webhook traffic through the API idempotency
     // cache would inflate `nebula_api_idempotency_misses_total` with
     // provider traffic that never carries `Idempotency-Key` and conflate
-    // two distinct dedup surfaces. See ADR-0048.
+    // two distinct dedup surfaces. See idempotency backend.
     let api_routes = if let Some(store) = state.idempotency_store.as_ref() {
         // `ttl_secs > 0` is structurally enforced at config load time
         // by `parse_positive_u64_env` (`ApiConfigError::ZeroValue`) so
@@ -133,7 +133,7 @@ pub fn build_app(state: AppState, config: &ApiConfig) -> Router {
         None => api_routes,
     };
 
-    // Internal routes (M3.3 / ADR-0049 — E3): /internal/v1/...
+    // Internal routes (webhook activation — E3): /internal/v1/...
     // Mounted on the plain axum `Router` so they never appear in
     // `/api/v1/openapi.json`. Auth is the shared-token middleware
     // gated by `AppState.internal_shared_token`.
@@ -328,7 +328,7 @@ fn build_cors_layer(config: &ApiConfig) -> CorsLayer {
     //
     // `Idempotency-Key` is here so cross-origin POSTs that opt into
     // replay protection clear the preflight; without it browsers
-    // strip the header before the server sees it (M3.4 / ADR-0048).
+    // strip the header before the server sees it (idempotency backend).
     .allow_headers([
         header::CONTENT_TYPE,
         header::AUTHORIZATION,

--- a/crates/api/src/config/mod.rs
+++ b/crates/api/src/config/mod.rs
@@ -45,8 +45,8 @@ use crate::middleware::idempotency::{
 ///
 /// The 1 MiB figure is a guard rail from the 2026-04-19 audit
 /// (`docs/audit/2026-04-19-codebase-quality-audit.md` §"Guard rails"
-/// #2) and a pre-condition of ADR-0020
-/// (`docs/adr/0020-library-first-gtm.md` §3 #3) for any
+/// #2) and a pre-condition of REST limits
+/// ( §3 #3) for any
 /// composition-root binary.
 ///
 /// The webhook transport applies its own cap on its sub-router
@@ -127,11 +127,11 @@ pub struct ApiConfig {
     /// Pagination defaults and caps.
     pub pagination: PaginationConfig,
 
-    /// Idempotency-Key middleware configuration (see ADR-0048).
+    /// Idempotency-Key middleware configuration (see idempotency backend).
     #[serde(default)]
     pub idempotency: IdempotencyApiConfig,
 
-    /// Webhook subsystem configuration (M3.3 / ADR-0049).
+    /// Webhook subsystem configuration (webhook activation).
     #[serde(default)]
     pub webhook: WebhookApiConfig,
 }

--- a/crates/api/src/config/sub.rs
+++ b/crates/api/src/config/sub.rs
@@ -86,7 +86,7 @@ impl Default for VersioningConfig {
 
 /// Idempotency-Key middleware configuration.
 ///
-/// See ADR-0048 for the backend selection contract.
+/// See idempotency backend for the backend selection contract.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IdempotencyApiConfig {
     /// Storage backend for cached idempotent responses.
@@ -118,14 +118,14 @@ pub struct IdempotencyApiConfig {
     ///
     /// `0` disables the sweep (dev / single-process runs); the memory
     /// backend ignores this field because `moka` evicts on TTL. A value
-    /// `< 60` triggers a startup `tracing::warn!` (see ADR-0048
+    /// `< 60` triggers a startup `tracing::warn!` (see idempotency backend
     /// "sweep cadence sanity floor") but is not rejected.
     pub sweep_interval_secs: u64,
 }
 
 /// Backend selection for the idempotency store.
 ///
-/// See ADR-0048 for the decision rationale and the fail-closed contract
+/// See idempotency backend for the decision rationale and the fail-closed contract
 /// in the composition root (selecting `Postgres` without a configured
 /// `DATABASE_URL` is a hard startup error).
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -135,7 +135,7 @@ pub enum IdempotencyBackend {
     /// for single-process tests; loses state on restart and cannot be
     /// shared across runners.
     Memory,
-    /// PostgreSQL-backed durable store (see ADR-0048). Survives restart
+    /// PostgreSQL-backed durable store (see idempotency backend). Survives restart
     /// and is shared across runners that point at the same database.
     Postgres,
 }
@@ -161,7 +161,7 @@ impl Default for IdempotencyApiConfig {
     }
 }
 
-/// Webhook subsystem configuration (M3.3 / ADR-0049).
+/// Webhook subsystem configuration (webhook activation).
 ///
 /// Controls how the slug-routed webhook surface boots. Default is
 /// `bootstrap_from_storage = true` so production deployments wire

--- a/crates/api/src/domain/auth/backend/mod.rs
+++ b/crates/api/src/domain/auth/backend/mod.rs
@@ -16,7 +16,7 @@
 //!
 //! ## Why this module exists
 //!
-//! Per ADR-0033, **Plane A** (host / Nebula API auth) is kept disjoint from
+//! Per auth plane separation, **Plane A** (host / Nebula API auth) is kept disjoint from
 //! **Plane B** (integration credential OAuth). Plane B lives under
 //! [`crate::transport::oauth`] + `crates/credential/`; Plane A lives here.
 //! New auth-domain features land in [`crate::domain::auth`] — never in the

--- a/crates/api/src/domain/auth/backend/oauth.rs
+++ b/crates/api/src/domain/auth/backend/oauth.rs
@@ -1,7 +1,7 @@
 //! Plane-A OAuth helpers — sign-in via Google / GitHub / Microsoft.
 //!
 //! This is **distinct** from Plane-B integration credential OAuth (per
-//! ADR-0033 and `crates/api/src/services/oauth/`). Plane A is "who is
+//! auth plane separation and `crates/api/src/services/oauth/`). Plane A is "who is
 //! signing in to Nebula"; Plane B is "Nebula on behalf of a user
 //! talking to Slack/HubSpot/etc.".
 //!

--- a/crates/api/src/domain/auth/backend/password.rs
+++ b/crates/api/src/domain/auth/backend/password.rs
@@ -2,7 +2,7 @@
 //!
 //! Parameters (m=19_456 KiB, t=2, p=1) match OWASP 2024 minimum
 //! recommendations and produce a verify time of ~50 ms on a 2024 laptop —
-//! within the canon §11 "login p99 < 200 ms" budget while keeping the
+//! within the operational SLO "login p99 < 200 ms" budget while keeping the
 //! brute-force factor at ≥ 2^16.
 
 use argon2::{

--- a/crates/api/src/domain/auth/backend/provider.rs
+++ b/crates/api/src/domain/auth/backend/provider.rs
@@ -19,7 +19,7 @@ use super::{
 ///
 /// This is the **port-level** patch shape — deliberately decoupled from the
 /// `me` HTTP DTO (`UpdateMeRequest`) so storage/transport schemas never leak
-/// across the API boundary (ADR-0047 §3). The handler maps the wire DTO onto
+/// across the API boundary (3). The handler maps the wire DTO onto
 /// this struct. Each `Some` field is applied; `None` leaves the field
 /// unchanged.
 #[derive(Debug, Clone, Default)]
@@ -33,7 +33,7 @@ pub struct ProfilePatch {
 /// PAT-creation parameters for [`AuthBackend::create_pat`].
 ///
 /// Port-level shape decoupled from the `me` HTTP DTO (`CreateTokenRequest`),
-/// per ADR-0047 §3. The handler maps the wire DTO onto this struct after
+/// per 3. The handler maps the wire DTO onto this struct after
 /// validation.
 #[derive(Debug, Clone)]
 pub struct CreatePatParams {
@@ -141,7 +141,7 @@ pub trait AuthBackend: Send + Sync {
     // The endpoints under `/api/v1/me/*` are authenticated, no tenant
     // scope, and operate strictly on the *caller's own* identity. They
     // delegate here so the handler never touches storage/`nebula_storage`
-    // types directly (ADR-0047 §3) and the same single Plane-A contract
+    // types directly (3) and the same single Plane-A contract
     // backs profile reads, profile patches, and PAT lifecycle.
 
     /// Resolve a user's own profile by id (`GET /me`). `Err(UserNotFound)`

--- a/crates/api/src/domain/auth/handler.rs
+++ b/crates/api/src/domain/auth/handler.rs
@@ -5,7 +5,7 @@
 //! dispatches, attaches `Set-Cookie` headers, and translates
 //! [`crate::domain::auth::backend::AuthError`] into [`crate::error::ApiError`].
 //!
-//! Per ADR-0033 these endpoints belong to **Plane A** (host login). They
+//! Per auth plane separation these endpoints belong to **Plane A** (host login). They
 //! never touch the credential / Plane B OAuth state.
 
 use std::sync::Arc;

--- a/crates/api/src/domain/auth/mod.rs
+++ b/crates/api/src/domain/auth/mod.rs
@@ -1,12 +1,12 @@
 //! Authentication domain — Plane A (host / Nebula API sign-in).
 //!
-//! Per ADR-0033, **Plane A** (who may call this API: identity, sessions,
+//! Per auth plane separation, **Plane A** (who may call this API: identity, sessions,
 //! MFA, PATs, user-facing OAuth sign-in) is kept disjoint from **Plane B**
 //! (integration credential OAuth — see [`crate::domain::credential`] and
 //! [`crate::transport::oauth`]). New auth-domain features land here, never
 //! in the credential tree.
 //!
-//! Self-contained per canon §12.7:
+//! Self-contained per domain-module layout:
 //!
 //! - [`routes`] — unauthenticated `/api/v1/auth/*` route table.
 //! - [`handler`] — thin HTTP handlers over [`backend::AuthBackend`].

--- a/crates/api/src/domain/catalog/dto.rs
+++ b/crates/api/src/domain/catalog/dto.rs
@@ -65,7 +65,7 @@ pub struct PluginDetailResponse {
     pub description: String,
     /// Bundle semver version (e.g. `"1.2.0"`). One plugin, one version —
     /// multi-version runtime registry was removed in the plugin load-path
-    /// stabilization (ADR-0027).
+    /// stabilization.
     pub version: String,
     /// Group hierarchy for UI categorization
     pub group: Vec<String>,

--- a/crates/api/src/domain/catalog/mod.rs
+++ b/crates/api/src/domain/catalog/mod.rs
@@ -1,6 +1,6 @@
 //! Catalog domain — action and plugin discovery.
 //!
-//! Self-contained per canon §12.7: route table ([`routes`]), HTTP handlers
+//! Self-contained per domain-module layout: route table ([`routes`]), HTTP handlers
 //! ([`handler`]), and response DTOs ([`dto`]) live together.
 
 pub mod dto;

--- a/crates/api/src/domain/credential/dto.rs
+++ b/crates/api/src/domain/credential/dto.rs
@@ -1,4 +1,4 @@
-//! Credential management request/response DTOs — **Plane B** (ADR-0033).
+//! Credential management request/response DTOs — **Plane B** (auth plane separation).
 //!
 //! These types form the HTTP API contract for credential lifecycle management.
 //! Response types **never** include secret material (encrypted state, tokens, keys).

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -77,7 +77,7 @@ pub async fn list_credentials(
 ///
 /// Validates the request body, then delegates to the credential store
 /// for persistence. When a credential-schema port is configured
-/// (ADR-0052 P4), `data` is validated against the credential type's
+/// (credential-schema validation), `data` is validated against the credential type's
 /// resolved schema before encryption and storage; if no validator is
 /// configured the request is rejected with 503 — `data` is never
 /// persisted unvalidated.
@@ -96,7 +96,7 @@ pub async fn list_credentials(
         (status = 400, description = "Validation error: `data` failed the credential type's schema, or key/name shape invalid.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
-        (status = 503, description = "Credential-schema port not configured: `data` cannot be validated, so it is not persisted (ADR-0052 P4, canon §4.5 fail-closed).", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured: `data` cannot be validated, so it is not persisted (credential-schema validation, honest capability fail-closed).", body = ProblemDetails),
     ),
 )]
 pub async fn create_credential(
@@ -175,7 +175,7 @@ pub async fn get_credential(
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Credential does not exist.", body = ProblemDetails),
         (status = 409, description = "Optimistic-concurrency version mismatch.", body = ProblemDetails),
-        (status = 503, description = "Credential-schema port not configured: supplied `data` cannot be validated, so it is not persisted (ADR-0052 P4, canon §4.5 fail-closed).", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured: supplied `data` cannot be validated, so it is not persisted (credential-schema validation, honest capability fail-closed).", body = ProblemDetails),
     ),
 )]
 pub async fn update_credential(
@@ -384,7 +384,7 @@ pub async fn revoke_credential(
         (status = 400, description = "Validation error (key or data shape).", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
-        (status = 503, description = "Honest stub (canon §4.5): the route is reachable but generic credential resolution is engine-owned (`Credential::resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
+        (status = 503, description = "Honest stub (honest capability contract): the route is reachable but generic credential resolution is engine-owned (`Credential::resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
     ),
 )]
 pub async fn resolve_credential(
@@ -423,7 +423,7 @@ pub async fn resolve_credential(
         (status = 400, description = "Validation error (e.g. empty `pending_token`).", body = ProblemDetails),
         (status = 401, description = "Authentication required or pending token expired/already-consumed.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
-        (status = 503, description = "Honest stub (canon §4.5): the route is reachable but generic interactive continuation is engine-owned (`Interactive::continue_resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
+        (status = 503, description = "Honest stub (honest capability contract): the route is reachable but generic interactive continuation is engine-owned (`Interactive::continue_resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
     ),
 )]
 pub async fn continue_resolve_credential(
@@ -460,7 +460,7 @@ pub async fn continue_resolve_credential(
     responses(
         (status = 200, description = "Registered credential types with capability flags and input schema.", body = ListCredentialTypesResponse),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
-        (status = 503, description = "Credential-schema port not configured (ADR-0052 P4, honest §4.5 stub).", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured (credential-schema validation, honest capability stub).", body = ProblemDetails),
     ),
 )]
 pub async fn list_credential_types(
@@ -487,7 +487,7 @@ pub async fn list_credential_types(
         (status = 400, description = "Invalid credential type key.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 404, description = "Credential type not registered.", body = ProblemDetails),
-        (status = 503, description = "Credential-schema port not configured (ADR-0052 P4, honest §4.5 stub).", body = ProblemDetails),
+        (status = 503, description = "Credential-schema port not configured (credential-schema validation, honest capability stub).", body = ProblemDetails),
     ),
 )]
 pub async fn get_credential_type(

--- a/crates/api/src/domain/credential/mod.rs
+++ b/crates/api/src/domain/credential/mod.rs
@@ -1,10 +1,10 @@
 //! Credential domain — Plane B (integration credentials for workflows
-//! talking to *external* systems; ADR-0031 / ADR-0033).
+//! talking to *external* systems; API-owned OAuth flow / auth plane separation).
 //!
-//! Kept disjoint from Plane A ([`crate::domain::auth`]) per ADR-0033. All
+//! Kept disjoint from Plane A ([`crate::domain::auth`]) per auth plane separation. All
 //! credential routes are protected by Plane A middleware.
 //!
-//! Self-contained per canon §12.7:
+//! Self-contained per domain-module layout:
 //!
 //! - [`routes`] — system-level credential route table (type discovery +
 //!   OAuth2 callbacks). Workspace-scoped credential CRUD is merged by

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -1,4 +1,4 @@
-//! OAuth controller endpoints (ADR-0031 rollout slice).
+//! OAuth controller endpoints (API-owned OAuth flow rollout slice).
 
 use std::future::Future;
 

--- a/crates/api/src/domain/credential/schema_projection.rs
+++ b/crates/api/src/domain/credential/schema_projection.rs
@@ -1,4 +1,4 @@
-//! Public-schema projection (ADR-0052 P4, design-spec hole #6).
+//! Public-schema projection (credential-schema validation, design-spec hole #6).
 //!
 //! `ValidSchema::json_schema()` emits the credential type's internal rule
 //! graph as Nebula vendor extensions: `x-nebula-root-rules`

--- a/crates/api/src/domain/execution/handler.rs
+++ b/crates/api/src/domain/execution/handler.rs
@@ -305,7 +305,7 @@ pub async fn start_execution(
 
     // Build the canonical execution state directly from the typed enum so
     // that the persisted row matches the schema the engine's
-    // `resume_execution` reads (canon §4.5: public surface must be honored
+    // `resume_execution` reads (honest capability contract: public surface must be honored
     // end-to-end). The legacy hand-rolled JSON with `status: "pending"` was
     // a false capability — `ExecutionStatus` has no `Pending` variant, and
     // neither `list_running` (storage filter) nor `ExecutionState::deserialize`
@@ -334,28 +334,28 @@ pub async fn start_execution(
         .create_execution_scoped(&scope, execution_id, workflow_id_parsed, state_json)
         .await?;
 
-    // Enqueue the Start signal onto the durable control queue (canon §12.2,
-    // §13 step 3, #332). Before this PR the API persisted the row but never
-    // dispatched it — the §4.5 violation ("advertise capability engine
+    // Enqueue the Start signal onto the durable control queue (durable control queue,
+    // integration seam step 3, #332). Before this PR the API persisted the row but never
+    // dispatched it — the honest capability violation ("advertise capability engine
     // doesn't deliver end-to-end"). The engine-side `ControlConsumer`
-    // (ADR-0008) drains this queue and drives the actual workflow run.
+    // (durable control queue) drains this queue and drives the actual workflow run.
     //
     // Order matches the `cancel_execution` contract: create the row first,
     // then enqueue. If enqueue fails after a successful create, the row
     // exists but the engine will not see the Start signal — the handler
     // fails loudly so the caller can retry. The retry is idempotent
-    // at the consumer layer via CAS (ADR-0008 §5).
+    // at the consumer layer via CAS (control-queue CAS).
     enqueue_start_scoped(&state, &scope, execution_id).await?;
 
     // Build response. `started_at` is omitted on a Created execution —
-    // canon §13 step 3 forbids synthetic timestamps for fields the engine
+    // integration seam step 3 forbids synthetic timestamps for fields the engine
     // has not actually populated yet. `ExecutionState::started_at` is
     // `None` until the engine transitions the status to `Running`, and the
     // API response must reflect that.
     //
     // The legacy response returned `chrono::Utc::now().timestamp()` as a
     // placeholder, which conflated "row was created" with "engine started
-    // the run" — two different events under canon §11.1. Downstream tools
+    // the run" — two different events under lifecycle authority. Downstream tools
     // that graphed `started_at` therefore measured API-enqueue latency, not
     // engine dispatch latency. The DTO field stays `i64` (wire-compatible),
     // but we now return `created_at` as the observable timestamp so clients
@@ -376,20 +376,20 @@ pub async fn start_execution(
 }
 
 /// Enqueue a `ControlCommand::Start` onto the durable control queue for
-/// the caller's tenant (canon §12.2, §13 step 3, #332).
+/// the caller's tenant (durable control queue, integration seam step 3, #332).
 ///
 /// Shared by `start_execution` (this module) and `execute_workflow`
 /// (`handlers::workflow`) so the dispatch contract lives in exactly one
 /// place. Any future start-path entry point MUST route through this
-/// helper to preserve the §4.5 invariant that "persist a row" and
+/// helper to preserve the honest capability invariant that "persist a row" and
 /// "dispatch to the engine" travel together. Stamps the Start control
 /// row with the request tenant `scope` via `enqueue_control_scoped`.
 ///
 /// Returns `ApiError::ServiceUnavailable` when the control-queue backend
-/// is down (mirrors the 503 contract in `cancel_execution` — canon §13
+/// is down (mirrors the 503 contract in `cancel_execution` — integration seam
 /// step 6) and `ApiError::Internal` for other write failures so the
 /// caller can retry. The engine-side consumer guards against
-/// double-start via CAS (ADR-0008 §5), so a retry after a partial
+/// double-start via CAS (control-queue CAS), so a retry after a partial
 /// failure is safe.
 ///
 /// M3.5: stamps optional [`nebula_core::W3cTraceContext`] on the row from the active HTTP span
@@ -478,7 +478,7 @@ pub async fn cancel_execution(
     // Update state to cancelled. Write the status as the canonical
     // snake-case string that `ExecutionStatus::Cancelled` serializes to,
     // so that engine-side reads via `ExecutionStatus::deserialize` round-
-    // trip cleanly (#327, canon §4.5). Persist `completed_at` (not the
+    // trip cleanly (#327, honest capability contract). Persist `completed_at` (not the
     // legacy `finished_at`) because that is the field `ExecutionState`
     // actually declares — see `crates/execution/src/state.rs`.
     if let Some(state_obj) = execution_state.as_object_mut() {
@@ -613,7 +613,7 @@ pub async fn get_execution_logs(
 /// POST /api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}/terminate
 ///
 /// Forced-terminate is a *forced* shutdown contrasted with
-/// [`cancel_execution`]'s *cooperative* drain. Per ADR-0016 the engine
+/// [`cancel_execution`]'s *cooperative* drain. Per cooperative cancel the engine
 /// has no distinct forced-shutdown path today: `ControlCommand::Terminate`
 /// is wired end-to-end (`ControlConsumer` → `EngineControlDispatch::
 /// dispatch_terminate` → `dispatch_cancel` → the engine cancel registry's
@@ -622,7 +622,7 @@ pub async fn get_execution_logs(
 /// state is therefore `ExecutionStatus::Cancelled` — `ExecutionStatus`
 /// has no distinct `Terminated` variant (see
 /// `crates/execution/src/state.rs` / `status.rs`), so pre-setting any
-/// other status string would be a #327 / canon §4.5 false capability the
+/// other status string would be a #327 / honest capability contract false capability the
 /// engine would not round-trip. This mirrors `cancel_execution` exactly
 /// except for the durable command kind.
 #[utoipa::path(
@@ -684,14 +684,14 @@ pub async fn terminate_execution(
     }
 
     // Pre-set the terminal status. Forced-terminate lands in the same
-    // `Cancelled` terminal state as cooperative cancel: ADR-0016 documents
+    // `Cancelled` terminal state as cooperative cancel: cooperative cancel documents
     // that the engine has no distinct forced-shutdown path and treats
     // `Terminate` as a cooperative-cancel synonym (the
     // `Running → Cancelling → Cancelled` bridge in the engine tails), and
     // `ExecutionStatus` carries no `Terminated` variant. Write the
     // canonical snake-case string `ExecutionStatus::Cancelled` serializes
     // to so engine-side reads via `ExecutionStatus::deserialize` round-trip
-    // cleanly (#327, canon §4.5). Persist `completed_at` (not the legacy
+    // cleanly (#327, honest capability contract). Persist `completed_at` (not the legacy
     // `finished_at`) because that is the field `ExecutionState` declares —
     // see `crates/execution/src/state.rs`.
     if let Some(state_obj) = execution_state.as_object_mut() {
@@ -814,6 +814,6 @@ pub async fn restart_execution(
 ) -> ApiResult<Json<serde_json::Value>> {
     // TODO: Restart a failed/cancelled execution
     Err(ApiError::NotImplemented(
-        "handler stub — tracked under ADR-0047 Stub Endpoint Policy".to_string(),
+        "handler stub — tracked under stub endpoint policy".to_string(),
     ))
 }

--- a/crates/api/src/domain/execution/mod.rs
+++ b/crates/api/src/domain/execution/mod.rs
@@ -1,10 +1,10 @@
 //! Execution domain — start, list, inspect, cancel.
 //!
-//! Self-contained per canon §12.7: HTTP handlers ([`handler`]) and
+//! Self-contained per domain-module layout: HTTP handlers ([`handler`]) and
 //! request/response DTOs ([`dto`]) live together; the live route table is
 //! assembled in [`crate::domain::workspace`] (tenant-prefix nesting) on an
 //! `OpenApiRouter` so served paths and the published OpenAPI spec share one
-//! source of truth (ADR-0047). §13 knife seam:
+//! source of truth (stub-endpoint policy). integration seam knife seam:
 //! [`handler::start_execution`] / [`handler::cancel_execution`].
 
 pub mod dto;

--- a/crates/api/src/domain/health/mod.rs
+++ b/crates/api/src/domain/health/mod.rs
@@ -1,6 +1,6 @@
 //! Health domain — liveness, readiness, version.
 //!
-//! Self-contained per canon §12.7: route table ([`routes`]), HTTP handlers
+//! Self-contained per domain-module layout: route table ([`routes`]), HTTP handlers
 //! ([`handler`]), and response DTOs ([`dto`]) live together. Mounted at the
 //! root (not under `/api/v1`) by [`crate::domain::create_routes`].
 

--- a/crates/api/src/domain/internal.rs
+++ b/crates/api/src/domain/internal.rs
@@ -1,5 +1,5 @@
 //! `/internal/v1/...` routes — ops tooling consumed out-of-band
-//! (M3.3 / ADR-0049 — E3).
+//! (webhook activation — E3).
 //!
 //! Internal routes are **not** advertised in OpenAPI; operators
 //! discover them via runbooks. The token check lives in

--- a/crates/api/src/domain/me/dto.rs
+++ b/crates/api/src/domain/me/dto.rs
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 // `OrgRoleDto` / `WorkspaceRoleDto` are cross-domain API-boundary role
-// wrappers (ADR-0047 §Wrapping-checklist) and live in `domain::shared`
+// wrappers (Wrapping-checklist) and live in `domain::shared`
 // alongside the other cross-cutting wire DTOs; imported here for the
 // `OrgSummary` field below.
 use crate::domain::shared::OrgRoleDto;
@@ -38,7 +38,7 @@ pub struct MeResponse {
     /// enumeration (Phase 3 — resolves the Phase-2 carry-over where this
     /// was omitted because no enumeration existed). Still `Option<u32>`
     /// for forward-compatibility and so it degrades to *absent* (never a
-    /// synthesized `0`) if the membership store is unwired — canon §4.5.
+    /// synthesized `0`) if the membership store is unwired — honest capability contract.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub orgs_count: Option<u32>,
     /// Number of personal access tokens issued to this user.
@@ -60,7 +60,7 @@ pub struct UpdateMeRequest {
 ///
 /// `slug` is intentionally absent: the membership store keys by `OrgId`
 /// and there is no `OrgId`→slug reverse directory (the `OrgResolver` port
-/// is one-way slug→id). Echoing a synthesized slug would be a canon §4.5
+/// is one-way slug→id). Echoing a synthesized slug would be a honest capability contract
 /// false field — same reasoning as the dropped `MemberSummary.email`.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct OrgSummary {

--- a/crates/api/src/domain/me/handler.rs
+++ b/crates/api/src/domain/me/handler.rs
@@ -9,7 +9,7 @@
 //! carry-over where `list_my_orgs` was an honest 501 and `orgs_count` was
 //! omitted because no enumeration backing existed).
 //!
-//! ## Durability (canon §11.6 / §11.5 — operator-facing)
+//! ## Durability (provisioning durability / engine durability — operator-facing)
 //!
 //! These endpoints are **implemented and work end-to-end**, but the only
 //! wired `AuthBackend` is the in-memory one (`InMemoryAuthBackend`) and
@@ -69,7 +69,7 @@ fn require_user_id(auth: &AuthContext) -> Result<String, ApiError> {
 /// Borrow the wired Plane-A auth backend, or fail closed with 503.
 ///
 /// When the port is unwired the identity surface is genuinely absent;
-/// returning 503 (orchestration absent — mirrors the §13-step-6 pattern
+/// returning 503 (orchestration absent — mirrors the integration seam-step-6 pattern
 /// Phase 1 used for the control queue) is the honest degradation, not a
 /// fabricated empty success.
 fn auth_backend_or_503(state: &AppState) -> Result<&std::sync::Arc<dyn AuthBackend>, ApiError> {
@@ -97,7 +97,7 @@ fn token_summary(record: &PatRecord) -> TokenSummary {
 ///
 /// `Some(n)` from the shared [`MembershipStore`] when wired;
 /// **`None` (field omitted)** when the store is absent — honest
-/// degradation, never a synthesized `0` (canon §4.5 / §12.2). The
+/// degradation, never a synthesized `0` (honest capability contract / durable control queue). The
 /// `usize`→`u32` cast saturates (a user with more than `u32::MAX`
 /// memberships is impossible in practice, but the cast is explicit
 /// rather than silently wrapping).
@@ -117,7 +117,7 @@ async fn orgs_count_for(state: &AppState, principal: &Principal) -> Result<Optio
 /// `orgs_count` is the **real** principal→orgs membership count from the
 /// shared [`MembershipStore`](crate::state::MembershipStore) (Phase 3 —
 /// see [`list_my_orgs`]); it degrades to *absent* (never a synthesized
-/// `0`) only if the membership store is unwired — canon §4.5 / §12.2.
+/// `0`) only if the membership store is unwired — honest capability contract / durable control queue.
 #[utoipa::path(
     get,
     path = "/me",
@@ -152,7 +152,7 @@ pub async fn get_me(
         email_verified: profile.email_verified,
         mfa_enabled: profile.mfa_enabled,
         // Real principal→orgs count from the shared MembershipStore;
-        // absent (not 0) only if the store is unwired — canon §4.5.
+        // absent (not 0) only if the store is unwired — honest capability contract.
         orgs_count,
         tokens_count,
     }))
@@ -211,7 +211,7 @@ pub async fn update_me(
         email_verified: profile.email_verified,
         mfa_enabled: profile.mfa_enabled,
         // Real principal→orgs count from the shared MembershipStore;
-        // absent (not 0) only if the store is unwired — canon §4.5.
+        // absent (not 0) only if the store is unwired — honest capability contract.
         orgs_count,
         tokens_count,
     }))
@@ -224,7 +224,7 @@ pub async fn update_me(
 /// enumeration — the same store [`crate::middleware::rbac`] consults, so
 /// this list is exactly the set of orgs the caller can actually access.
 /// Each entry carries `{ id, role }` only; `slug` is intentionally absent
-/// (no `OrgId`→slug reverse directory exists — canon §4.5, see
+/// (no `OrgId`→slug reverse directory exists — honest capability contract, see
 /// [`OrgSummary`]). 503 (honest degradation) if the store is unwired.
 #[utoipa::path(
     get,

--- a/crates/api/src/domain/me/mod.rs
+++ b/crates/api/src/domain/me/mod.rs
@@ -1,11 +1,11 @@
 //! "Me" domain — authenticated user profile, orgs, personal access tokens.
 //!
-//! Self-contained per canon §12.7: route table ([`routes`]), HTTP handlers
+//! Self-contained per domain-module layout: route table ([`routes`]), HTTP handlers
 //! ([`handler`]), and request/response DTOs ([`dto`]) live together.
 //! Authenticated, no tenant scope. Profile, PAT, and `list_my_orgs`
 //! endpoints are real end-to-end via the Plane-A `AuthBackend` port and
 //! the `MembershipStore` org-membership backing (Phase 3 "Option 1",
-//! canon §4.5).
+//! honest capability contract).
 
 pub mod dto;
 pub mod handler;

--- a/crates/api/src/domain/mod.rs
+++ b/crates/api/src/domain/mod.rs
@@ -1,6 +1,6 @@
 //! Per-domain modules + route assembly for the Nebula API.
 //!
-//! Per canon §12.7 each domain is a self-contained module
+//! Per domain-module layout each domain is a self-contained module
 //! `domain/<x>/{routes,handler,dto}.rs` instead of the old triple-spread
 //! across `handlers/` + `routes/` + `models/`. Cross-domain shared DTOs
 //! live in [`shared`]; the Plane-A auth backend subsystem lives under
@@ -20,7 +20,7 @@
 //! with `#[utoipa::path]`-derived **relative** paths (e.g. `/auth/signup`);
 //! the `/api/v1` prefix is applied via `OpenApiRouter::nest` inside
 //! `build_openapi_router` so the published spec and the served route
-//! table share one source of truth (ADR-0047 drift-detection guarantee).
+//! table share one source of truth (stub-endpoint policy drift-detection guarantee).
 
 pub mod auth;
 pub mod catalog;
@@ -72,7 +72,7 @@ fn build_openapi_router(state: &AppState) -> OpenApiRouter<AppState> {
     // Auth routes — no auth middleware, no tenant scope.
     let auth_routes = auth::routes::router();
 
-    // Webhook routes (M3.3 / ADR-0049): mounted by `transport.router()`
+    // Webhook routes (webhook activation): mounted by `transport.router()`
     // in `app::build_app` directly. The legacy `routes::webhook`
     // module has been absorbed into `transport::webhook::transport`
     // — slug and programmatic surfaces share `dispatch_inner` there.
@@ -109,7 +109,7 @@ fn build_openapi_router(state: &AppState) -> OpenApiRouter<AppState> {
             auth_middleware,
         ));
 
-    // Credential OAuth callback routes (Plane B — ADR-0031).
+    // Credential OAuth callback routes (Plane B — API-owned OAuth flow).
     let credential_routes = credential::routes::router().layer(middleware::from_fn_with_state(
         state.clone(),
         auth_middleware,

--- a/crates/api/src/domain/org/dto.rs
+++ b/crates/api/src/domain/org/dto.rs
@@ -1,6 +1,6 @@
 //! Organisation-management DTOs.
 //!
-//! ## §4.5 status
+//! ## honest capability status
 //!
 //! The **member** DTOs ([`MemberSummary`], [`MembersResponse`],
 //! [`AddMemberRequest`]) back **live** endpoints (`GET`/`POST`/`DELETE`
@@ -11,7 +11,7 @@
 //! **service-account** DTOs ([`ServiceAccountSummary`],
 //! [`CreateServiceAccountRequest`], …) still describe the **planned**
 //! payload of honest-501 stubs (no org-record store; no end-to-end
-//! `Principal::ServiceAccount` auth path — canon §4.5). RBAC
+//! `Principal::ServiceAccount` auth path — honest capability contract). RBAC
 //! `tenant.require(...)` gates on those stubs are real today (403).
 //!
 //! ### Member contract — "Option 1" honest redesign (breaking)
@@ -20,7 +20,7 @@
 //! email invitation. The fabricated `email` / `invitation_id` /
 //! `expires_at` fields were removed: there is no invitation/email
 //! subsystem and no email→principal directory, so those fields could only
-//! ever be synthesized — exactly the canon §4.5 false capability this
+//! ever be synthesized — exactly the honest capability contract false capability this
 //! refactor rejects. `MemberSummary` likewise carries only what the RBAC
 //! role index actually knows (`user_id` + `role`); `email`/`joined_at`
 //! would require a member-record/identity-join model that does not exist.
@@ -52,7 +52,7 @@ pub struct UpdateOrgRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
     /// Org-level settings blob — caller-defined, validated downstream.
-    /// Per ADR-0047 §3 cross-layer schema strategy, an opaque
+    /// Per 3 cross-layer schema strategy, an opaque
     /// `serde_json::Value` field documents itself as an object with
     /// `additionalProperties: true` so consumers know the shape is
     /// genuinely caller-defined.
@@ -64,7 +64,7 @@ pub struct UpdateOrgRequest {
 /// One member entry inside [`MembersResponse`].
 ///
 /// Carries **only** what the RBAC role index knows. `email`/`joined_at`
-/// are intentionally absent (canon §4.5 — see the module docs): the
+/// are intentionally absent (honest capability contract — see the module docs): the
 /// membership store is not a user-identity directory and synthesizing
 /// those fields would be a false capability.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/api/src/domain/org/handler.rs
+++ b/crates/api/src/domain/org/handler.rs
@@ -1,6 +1,6 @@
 //! Organization-level endpoint handlers (auth + org-level tenancy).
 //!
-//! ## §4.5 status (Phase 3, "Option 1" honest contract)
+//! ## honest capability status (Phase 3, "Option 1" honest contract)
 //!
 //! **Graduated stub→implemented** (real end-to-end against the shared
 //! [`MembershipStore`] — the same store
@@ -12,7 +12,7 @@
 //!   not an email invitation — see [`super::dto`] for the contract change)
 //! - `DELETE /orgs/{org}/members/{principal}` — [`remove_member`]
 //!
-//! **Still honest 501** (canon §4.5 — shipping them would be a false
+//! **Still honest 501** (honest capability contract — shipping them would be a false
 //! capability, see [`super`] module docs):
 //!
 //! - `GET`/`PATCH`/`DELETE /orgs/{org}` — no org-record store
@@ -47,13 +47,13 @@
 //! 6. treats an absent target member as a 404 identical to "no such org"
 //!    so membership is never disclosed by an IDOR probe.
 //!
-//! ## Provisioning & durability (canon §4.5 / §11.6 / §12.5)
+//! ## Provisioning & durability (honest capability contract / provisioning durability / credential secrecy)
 //!
 //! These endpoints require an explicitly-provisioned `MembershipStore`.
 //! The default `apps/server` binary deliberately leaves it **unwired**
 //! (PR #671 P1: auto-seeding a bootstrap owner the empty default
 //! `AuthBackend` could never authenticate would 404-deadlock every
-//! org/workspace route — a deployment-level §4.5 false capability — and
+//! org/workspace route — a deployment-level honest capability false capability — and
 //! a hardcoded auto-seed would be a default-credential surface). When
 //! unwired, the `membership_or_503` port guard returns an honest **503**
 //! (port-absent, same posture as `me/*` when `auth_backend` is absent) and
@@ -106,7 +106,7 @@ fn membership_or_503(state: &AppState) -> Result<&std::sync::Arc<dyn MembershipS
 
 /// Parse a wire principal-id (`usr_<ULID>` / `svc_<ULID>`) into a
 /// [`Principal`]. Returns a 400 for anything else — we never coerce an
-/// unparsable identity into a guessed principal (canon §4.5).
+/// unparsable identity into a guessed principal (honest capability contract).
 fn parse_member_principal(raw: &str) -> Result<Principal, ApiError> {
     if let Ok(uid) = UserId::from_str(raw) {
         return Ok(Principal::User(uid));
@@ -185,8 +185,7 @@ pub async fn get_org(
     Extension(_tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<serde_json::Value>> {
     Err(ApiError::NotImplemented(
-        "org-record store not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "org-record store not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }
 
@@ -215,8 +214,7 @@ pub async fn update_org(
 ) -> ApiResult<Json<serde_json::Value>> {
     tenant.require(nebula_core::Permission::OrgUpdate)?;
     Err(ApiError::NotImplemented(
-        "org-record store not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "org-record store not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }
 
@@ -242,8 +240,7 @@ pub async fn delete_org(
 ) -> ApiResult<Json<serde_json::Value>> {
     tenant.require(nebula_core::Permission::OrgDelete)?;
     Err(ApiError::NotImplemented(
-        "org-record store not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "org-record store not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }
 
@@ -254,7 +251,7 @@ pub async fn delete_org(
 /// Reachable only behind RBAC (a non-member caller is 404'd before this
 /// handler). Any org member may list — the read is gated by RBAC
 /// membership itself, matching the `members:read` semantics. The response
-/// carries only role-index fields (no `email`/`joined_at` — canon §4.5).
+/// carries only role-index fields (no `email`/`joined_at` — honest capability contract).
 #[utoipa::path(
     get,
     path = "/orgs/{org}/members",
@@ -522,8 +519,7 @@ pub async fn list_service_accounts(
     Extension(_tenant): Extension<TenantContext>,
 ) -> ApiResult<Json<serde_json::Value>> {
     Err(ApiError::NotImplemented(
-        "service-account identity not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "service-account identity not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }
 
@@ -553,8 +549,7 @@ pub async fn create_service_account(
 ) -> ApiResult<Json<serde_json::Value>> {
     tenant.require(nebula_core::Permission::ServiceAccountManage)?;
     Err(ApiError::NotImplemented(
-        "service-account identity not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "service-account identity not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }
 
@@ -584,7 +579,6 @@ pub async fn delete_service_account(
 ) -> ApiResult<Json<serde_json::Value>> {
     tenant.require(nebula_core::Permission::ServiceAccountManage)?;
     Err(ApiError::NotImplemented(
-        "service-account identity not implemented — tracked under ADR-0047 Stub Endpoint Policy"
-            .to_string(),
+        "service-account identity not implemented — tracked under stub endpoint policy".to_string(),
     ))
 }

--- a/crates/api/src/domain/org/membership.rs
+++ b/crates/api/src/domain/org/membership.rs
@@ -1,12 +1,12 @@
 //! Canonical in-memory [`MembershipStore`] implementation.
 //!
-//! This is the §4.5-honest production-quality default backing for org
+//! This is the honest capability-honest production-quality default backing for org
 //! membership — the same "the real impl *is* the in-memory one" posture
 //! the durable control queue ([`InMemoryControlQueueRepo`]) and the
 //! Plane-A identity backend ([`InMemoryAuthBackend`]) carry. There is no
 //! storage-backed alternative to wire: `nebula_storage` ships no
 //! `MembershipRepo` (the trait is an API-tier port, not a storage repo —
-//! cf. ADR-0047 §3 / the Phase-2 `AuthBackend` precedent).
+//! cf. 3 / the Phase-2 `AuthBackend` precedent).
 //!
 //! ## One shared store — RBAC coherence
 //!
@@ -17,7 +17,7 @@
 //! RBAC check (no propagation window) — locked by
 //! `tests/org_e2e.rs::added_member_is_immediately_rbac_authorized`.
 //!
-//! ## Provisioning (canon §4.5 / §12.5 — NOT auto-wired)
+//! ## Provisioning (honest capability contract / credential secrecy — NOT auto-wired)
 //!
 //! The default `apps/server` binary deliberately leaves
 //! [`crate::AppState::membership_store`] **unwired** (`None`). It is an
@@ -27,14 +27,14 @@
 //! route). Auto-seeding a bootstrap owner was removed (PR #671 P1) —
 //! the default `AuthBackend` is empty, so an auto-seeded owner could
 //! never authenticate and a seeded store would 404-deadlock every
-//! org/workspace route (a deployment-level §4.5 false capability); a
+//! org/workspace route (a deployment-level honest capability false capability); a
 //! hardcoded auto-seeded admin would also be a default-credential
-//! surface (§12.5). An operator/integrator provisions via
+//! surface (credential secrecy). An operator/integrator provisions via
 //! [`InMemoryMembershipStore::seeded_bootstrap`] +
 //! [`crate::AppState::with_membership_store`], registering the same
 //! bootstrap-owner identity in the wired `AuthBackend`.
 //!
-//! ## Durability (canon §11.6 / §11.5 — operator-facing)
+//! ## Durability (provisioning durability / engine durability — operator-facing)
 //!
 //! State is **process-local**: org memberships are held in a
 //! [`tokio::sync::RwLock`]-guarded map, lost on restart and **not** shared
@@ -64,7 +64,7 @@ use crate::{
 /// nothing, which would leave a wired-but-empty store dead-locking the
 /// RBAC gate — `feedback_no_shims`). String-typed parsing is kept in the
 /// API tier so an integrator crate that does not depend on `nebula_core`
-/// can still provision a store (ADR-0047 §3).
+/// can still provision a store (3).
 #[derive(Debug, Error)]
 pub enum BootstrapSeedError {
     /// `org_id` is not a valid `org_<ULID>`.
@@ -214,12 +214,12 @@ impl InMemoryMembershipStore {
     /// **not** called by the default `apps/server` composition — see
     /// `apps/server/src/compose.rs::default_state` for why auto-seeding
     /// would deadlock RBAC (no authenticatable owner) or introduce a
-    /// hardcoded-credential surface (canon §12.5); the default binary
+    /// hardcoded-credential surface (credential secrecy); the default binary
     /// returns an honest 503 for org member endpoints instead.
     ///
     /// String-typed (not `OrgId`/`UserId`) so an integrator in a crate
     /// that does not depend on `nebula_core` can still call it — the id
-    /// parsing stays in the API tier (ADR-0047 §3). A malformed identity
+    /// parsing stays in the API tier (3). A malformed identity
     /// is a hard [`BootstrapSeedError`] (fail closed — never seed
     /// nothing, which would dead-lock the RBAC gate).
     pub fn seeded_bootstrap(

--- a/crates/api/src/domain/org/mod.rs
+++ b/crates/api/src/domain/org/mod.rs
@@ -1,11 +1,11 @@
 //! Organization domain — org settings, members, service accounts.
 //!
-//! Self-contained per canon §12.7: route table ([`routes`]), HTTP handlers
+//! Self-contained per domain-module layout: route table ([`routes`]), HTTP handlers
 //! ([`handler`]), request/response DTOs ([`dto`]), and the canonical
 //! in-memory [`MembershipStore`](crate::state::MembershipStore) impl
 //! ([`membership`]) live together. Authenticated + org-scoped.
 //!
-//! ## §4.5 status (Phase 3, "Option 1" honest contract)
+//! ## honest capability status (Phase 3, "Option 1" honest contract)
 //!
 //! The **member-management** triad is implemented end-to-end against the
 //! shared [`MembershipStore`](crate::state::MembershipStore):
@@ -13,14 +13,14 @@
 //! add-by-principal — the fake email-invitation contract was dropped, see
 //! [`dto`]), and `DELETE /orgs/{org}/members/{principal}`. The org-record
 //! endpoints (`GET`/`PATCH`/`DELETE /orgs/{org}`) and the service-account
-//! endpoints stay **honest 501** (canon §4.5): there is no org-record
+//! endpoints stay **honest 501** (honest capability contract): there is no org-record
 //! store (name/plan/created_at) and no end-to-end
 //! `Principal::ServiceAccount` auth path, so shipping them would be a
 //! false capability. Their `#[deprecated]` + 501 + ` (planned)`
 //! annotations are unchanged and enforced by
 //! `tests/openapi_canon_compliance.rs`.
 //!
-//! ## Provisioning & durability (canon §11.6 / §12.5)
+//! ## Provisioning & durability (provisioning durability / credential secrecy)
 //!
 //! The member endpoints require an explicitly-provisioned
 //! [`MembershipStore`](crate::state::MembershipStore) — the default
@@ -31,9 +31,9 @@
 //! route). Auto-seeding a bootstrap owner into the default binary was
 //! removed (PR #671 P1): the default `AuthBackend` is empty, so an
 //! auto-seeded owner could never authenticate and a seeded store would
-//! 404-deadlock every org/workspace route (a deployment-level §4.5 false
+//! 404-deadlock every org/workspace route (a deployment-level honest capability false
 //! capability); a hardcoded auto-seeded admin would also be a
-//! default-credential surface (§12.5). An operator/integrator provisions
+//! default-credential surface (credential secrecy). An operator/integrator provisions
 //! it via [`membership::InMemoryMembershipStore::seeded_bootstrap`] +
 //! [`crate::AppState::with_membership_store`], registering the same
 //! bootstrap-owner identity in the wired `AuthBackend` so it can

--- a/crates/api/src/domain/org/routes.rs
+++ b/crates/api/src/domain/org/routes.rs
@@ -3,7 +3,7 @@
 //! The **member** routes (`list_members` / `add_member` / `remove_member`)
 //! are live (real 200/201 + typed errors). The **org-record** and
 //! **service-account** routes are still honest-501 stubs marked
-//! `#[deprecated]` so the generated OpenAPI spec flags them per ADR-0047
+//! `#[deprecated]` so the generated OpenAPI spec flags them per stub-endpoint policy
 //! Stub Endpoint Policy. The deprecation lint is silenced at module level
 //! because the stub handlers are intentionally mounted (returning 501) so
 //! the route table stays in sync with the published spec — the

--- a/crates/api/src/domain/resource/dto.rs
+++ b/crates/api/src/domain/resource/dto.rs
@@ -3,7 +3,7 @@
 //! `GET /api/v1/orgs/{org}/workspaces/{ws}/resources` returns the
 //! persisted resource definitions for a workspace. These DTOs are the
 //! non-secret summary projection of `nebula_storage`'s `ResourceEntry`
-//! — the raw `config` blob is deliberately not exposed (ADR-0028 §7).
+//! — the raw `config` blob is deliberately not exposed (no secret echo).
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
@@ -49,7 +49,7 @@ pub struct ListResourcesResponse {
 /// another tenant's workspace (tenant isolation; the confused-deputy
 /// abuse). `config` is validated against the target `kind`'s
 /// `R::Config` schema (and rejected if it carries an undeclared,
-/// secret-shaped field — ADR-0028 §7 / PRODUCT_CANON §3.5) *before* the
+/// secret-shaped field — no secret echo / product credential boundary) *before* the
 /// row is persisted.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct CreateResourceRequest {
@@ -88,8 +88,8 @@ pub struct CreateResourceResponse {
 /// read from a prior GET; the store applies a CAS on it and a mismatch
 /// is reported as **409 Conflict**. `config`/`kind` are re-validated
 /// against the kind's `R::Config` schema (and rejected if the config
-/// carries an undeclared, secret-shaped field — ADR-0028 §7 /
-/// PRODUCT_CANON §3.5) *before* the row is persisted, so a PUT can never
+/// carries an undeclared, secret-shaped field — no secret echo /
+/// product credential boundary) *before* the row is persisted, so a PUT can never
 /// be a path to persist a config that a create would have rejected.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct UpdateResourceRequest {
@@ -155,10 +155,10 @@ pub enum ResourcePhase {
 /// response — a **read-only** runtime-status projection.
 ///
 /// Carries lifecycle phase / health only. It deliberately has **no**
-/// `config` / credential / secret field (ADR-0028 §7): a status read is
+/// `config` / credential / secret field (no secret echo): a status read is
 /// not a config read. There is also no acquire/release/drain control on
 /// this DTO or its endpoint — resource lifecycle is engine-owned and not
-/// exposed over HTTP (INTEGRATION_MODEL §13.1).
+/// exposed over HTTP (INTEGRATION_MODEL integration seam.1).
 ///
 /// A resource that exists as a definition but has never been activated in
 /// the engine reports `phase = "inactive"` (with `healthy`/`accepting`

--- a/crates/api/src/domain/resource/handler.rs
+++ b/crates/api/src/domain/resource/handler.rs
@@ -5,21 +5,21 @@
 //! `POST .../resources` (create) are config-CRUD endpoints: they manage
 //! the persisted resource *definitions* for a workspace. Resource
 //! lifecycle (acquire/refresh/revoke) is owned by the engine and is
-//! intentionally NOT exposed over HTTP (INTEGRATION_MODEL §13.1).
+//! intentionally NOT exposed over HTTP (INTEGRATION_MODEL integration seam.1).
 //!
 //! `create_resource` validates the submitted `config` against the target
 //! `kind`'s `R::Config` schema through the engine's closed `kind →
 //! registrar` allowlist (`resource_registrars`) **before** persisting —
 //! schema + closed-set validation only, with no live registration into a
 //! `nebula_resource::Manager` (that is an engine-activation concern, not
-//! a config-create one — §13.1). The owning workspace is always the
+//! a config-create one — integration seam.1). The owning workspace is always the
 //! caller's authenticated workspace, never a request-body field, so a
 //! resource can never be created in another tenant's workspace.
 //!
 //! The resource catalog backend is optional on [`AppState`]
 //! (`resource_repo`); when it is not configured the endpoints report
 //! `503 Service Unavailable`, matching the action/plugin catalog
-//! convention rather than the retired ADR-0047 501 stub.
+//! convention rather than the retired stub-endpoint policy 501 stub.
 //!
 //! Tenant isolation for the single-resource read: `ResourceRepo::get` is
 //! looked up purely by id and is **not** workspace-scoped. The handler is
@@ -54,7 +54,7 @@ use crate::{
 /// [`ResourceSummary`] DTO.
 ///
 /// Centralised so every resource read path produces an identical
-/// projection: the raw `config` blob is never surfaced (ADR-0028 §7) and
+/// projection: the raw `config` blob is never surfaced (no secret echo) and
 /// the id is the prefixed `res_<ULID>` encoding. The `bytes_to_id` step is
 /// fallible (a stored id that is not exactly 16 bytes is a storage
 /// invariant violation), so the result is a `Result`.
@@ -152,7 +152,7 @@ fn phase_from_seam(phase: &str) -> ResourcePhase {
 /// the `(offset, limit)` window is over the live row set), so the
 /// handler does no `deleted_at` post-filter — paginating then filtering
 /// would yield sparse pages / skip live rows. The raw `config` blob is
-/// never surfaced — only the non-secret summary fields (ADR-0028 §7).
+/// never surfaced — only the non-secret summary fields (no secret echo).
 #[utoipa::path(
     get,
     path = "/orgs/{org}/workspaces/{ws}/resources",
@@ -218,7 +218,7 @@ pub async fn list_resources(
 ///
 /// Returns a single resource definition scoped to the caller's workspace.
 /// The raw `config` blob is never surfaced — only the non-secret summary
-/// fields (ADR-0028 §7).
+/// fields (no secret echo).
 ///
 /// All of the following collapse to **404 Not Found**, deliberately
 /// indistinguishable so no information leaks across tenants:
@@ -275,7 +275,7 @@ pub async fn get_resource(
 /// Validate `config` against `kind` through the engine's closed
 /// `kind → registrar` allowlist (schema + closed-set guard, **no** live
 /// `Manager` registration — that is an engine-activation concern,
-/// INTEGRATION_MODEL §13.1).
+/// INTEGRATION_MODEL integration seam.1).
 ///
 /// Shared by `create_resource` and `update_resource` so a PUT can never
 /// be a path to persist a config that a POST would have rejected. The
@@ -287,7 +287,7 @@ pub async fn get_resource(
 ///   `RegistrarError::UnknownKind`);
 /// - schema / closed-set failure ⇒ **422** with a generic detail. The
 ///   validator's raw report can restate submitted field values, so it is
-///   logged server-side and never echoed to the client (ADR-0028 §7).
+///   logged server-side and never echoed to the client (no secret echo).
 fn validate_resource_config(
     state: &AppState,
     kind: &str,
@@ -349,7 +349,7 @@ pub fn map_resource_update_storage_error(err: nebula_storage::StorageError) -> A
         } => {
             // The version numbers are non-secret optimistic-concurrency
             // metadata (not config/secret material), so echoing them is a
-            // useful, safe CAS diagnostic per ADR-0028 §7.
+            // useful, safe CAS diagnostic per no secret echo.
             ApiError::Conflict(format!(
                 "resource was modified concurrently (expected version {expected}, found {actual}); \
                  re-read and retry"
@@ -380,7 +380,7 @@ pub fn map_resource_create_storage_error(err: nebula_storage::StorageError) -> A
         // Unique-constraint violation — a duplicate workspace slug is the
         // expected case here. The `detail` is store-authored (constraint
         // name / generic text), not the submitted config, so it carries
-        // no secret material (ADR-0028 §7).
+        // no secret material (no secret echo).
         nebula_storage::StorageError::Duplicate { detail, .. } => {
             ApiError::Conflict(format!("resource already exists: {detail}"))
         },
@@ -452,7 +452,7 @@ fn created_by_bytes(principal: &Principal) -> Vec<u8> {
 /// Validation runs through the engine's closed `kind → registrar`
 /// allowlist (schema + closed-set guard, **no** live `Manager`
 /// registration — live registration is an engine-activation concern,
-/// INTEGRATION_MODEL §13.1). Outcomes:
+/// INTEGRATION_MODEL integration seam.1). Outcomes:
 /// - unknown `kind` ⇒ **409 Conflict** (the kind is not in the closed
 ///   allowlist — a non-retryable caller fault, classified exactly as the
 ///   engine's `RegistrarError::UnknownKind`);
@@ -462,7 +462,7 @@ fn created_by_bytes(principal: &Principal) -> Vec<u8> {
 /// - `config` fails the kind's schema or carries an undeclared,
 ///   secret-shaped field ⇒ **422 Unprocessable** with a generic detail
 ///   (the validator's raw report is logged server-side, never echoed —
-///   it could restate submitted values; ADR-0028 §7);
+///   it could restate submitted values; no secret echo);
 /// - validation backend not configured ⇒ **422** (fail closed: an
 ///   unvalidated config is never persisted).
 #[utoipa::path(
@@ -502,7 +502,7 @@ pub async fn create_resource(
     // Validate the config against the target kind BEFORE persistence. If
     // the validation surface is not wired, fail closed — persisting an
     // unvalidated config (which could carry an inlined secret) would
-    // violate ADR-0028 §7 / PRODUCT_CANON §3.5.
+    // violate no secret echo / product credential boundary.
     validate_resource_config(&state, &body.kind, body.config.clone())?;
 
     let resource_id = ResourceId::new();
@@ -568,7 +568,7 @@ pub async fn create_resource(
 ///   storage CAS-mismatch error mapped specifically — not a catch-all);
 /// - unknown `kind` ⇒ **409**; schema/closed-set failure or no
 ///   validation backend ⇒ **422** (fail closed; the validator's raw
-///   report is logged server-side, never echoed — ADR-0028 §7).
+///   report is logged server-side, never echoed — no secret echo).
 #[utoipa::path(
     put,
     path = "/orgs/{org}/workspaces/{ws}/resources/{res}",
@@ -736,8 +736,8 @@ pub async fn delete_resource(
 /// mutates one. Resource lifecycle (acquire / release / drain / reload)
 /// is engine-owned and is intentionally NOT exposed over HTTP — there is
 /// deliberately no acquire/release/drain route (INTEGRATION_MODEL
-/// §13.1). The response body carries phase/health only, never `config`
-/// or credential material (ADR-0028 §7).
+/// integration seam.1). The response body carries phase/health only, never `config`
+/// or credential material (no secret echo).
 ///
 /// Tenant isolation composes with the read path. The runtime
 /// `nebula_resource::Manager` is keyed by `(ResourceKey, ScopeLevel)`,

--- a/crates/api/src/domain/resource/mod.rs
+++ b/crates/api/src/domain/resource/mod.rs
@@ -1,11 +1,11 @@
 //! Resource domain — workspace resource catalog (config-CRUD + read-only
 //! runtime status).
 //!
-//! Self-contained per canon §12.7: HTTP handlers ([`handler`]) and
+//! Self-contained per domain-module layout: HTTP handlers ([`handler`]) and
 //! request/response DTOs ([`dto`]) live together; the live route table is
 //! assembled in [`crate::domain::workspace`] (tenant-prefix nesting) on an
 //! `OpenApiRouter` so served paths and the published OpenAPI spec share one
-//! source of truth (ADR-0047).
+//! source of truth (stub-endpoint policy).
 //!
 //! The implemented surface is config-CRUD over the persisted resource
 //! *definitions* (`list`/`get`/`create`/`update` (CAS)/`delete` (soft))
@@ -13,8 +13,8 @@
 //! ([`handler::get_resource_status`]). Resource lifecycle
 //! (acquire/refresh/revoke/drain/reload) is engine-owned and is
 //! intentionally NOT exposed over HTTP — there is deliberately no
-//! acquire/release/drain route (INTEGRATION_MODEL §13.1). These endpoints
-//! are real (no ADR-0047 501 stub).
+//! acquire/release/drain route (INTEGRATION_MODEL integration seam.1). These endpoints
+//! are real (no stub-endpoint policy 501 stub).
 
 pub mod dto;
 pub mod handler;

--- a/crates/api/src/domain/shared.rs
+++ b/crates/api/src/domain/shared.rs
@@ -166,7 +166,7 @@ impl AckResponse {
 
 /// Wrapper around `nebula_core::OrgRole` exposed at the API boundary.
 ///
-/// Per ADR-0047 cross-layer schema strategy, the API contract MUST NOT embed
+/// Per stub-endpoint policy cross-layer schema strategy, the API contract MUST NOT embed
 /// `nebula_core` types directly in OpenAPI components. The string form is
 /// stable across role-set evolutions in the core crate.
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -178,7 +178,7 @@ impl OrgRoleDto {
     /// The canonical lowercase wire token for an [`nebula_core::OrgRole`].
     ///
     /// This is the **single** place the `OrgRole` ↔ wire-string mapping
-    /// lives (ADR-0047 §3: the public spec must not embed `nebula_core`
+    /// lives (3: the public spec must not embed `nebula_core`
     /// enum names — `OrgMember`/`OrgOwner` are internal Rust identifiers).
     /// The tokens (`member`/`billing`/`admin`/`owner`) are stable across
     /// core role-set evolution.
@@ -189,7 +189,7 @@ impl OrgRoleDto {
     /// `org_role_token_roundtrips_every_variant` (a unit test that
     /// enumerates the current set) plus this debug assertion make the
     /// omission loud the moment a variant is added, so the gap is fixed
-    /// at the mapping, not silently shipped (canon §4.5).
+    /// at the mapping, not silently shipped (honest capability contract).
     #[must_use]
     pub fn token(role: nebula_core::OrgRole) -> &'static str {
         use nebula_core::OrgRole::{OrgAdmin, OrgBilling, OrgMember, OrgOwner};
@@ -212,7 +212,7 @@ impl OrgRoleDto {
     /// Parse a wire token back into an [`nebula_core::OrgRole`].
     ///
     /// `None` for any token outside the canonical set — the handler maps
-    /// that to a 400 (RFC 9457) rather than guessing a role (canon §4.5:
+    /// that to a 400 (RFC 9457) rather than guessing a role (honest capability contract:
     /// no silent coercion of an unrecognised privilege level).
     #[must_use]
     pub fn parse(token: &str) -> Option<nebula_core::OrgRole> {

--- a/crates/api/src/domain/workflow/handler.rs
+++ b/crates/api/src/domain/workflow/handler.rs
@@ -527,7 +527,7 @@ pub async fn activate_workflow(
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
 
-    // Canon §10 step 2: validate the workflow definition before flipping the
+    // documentation honesty step 2: validate the workflow definition before flipping the
     // active flag.  Invalid definitions are rejected with RFC 9457 422
     // (Unprocessable Entity) — activation must never silently enable a
     // workflow that cannot pass structural validation.
@@ -651,7 +651,7 @@ pub async fn execute_workflow(
     let execution_id = ExecutionId::new();
 
     // Build the canonical execution state — same rationale as
-    // `start_execution` in `handlers/execution.rs` (#327, canon §4.5): the
+    // `start_execution` in `handlers/execution.rs` (#327, honest capability contract): the
     // persisted row must match `ExecutionState` so the engine's
     // `resume_execution` can deserialize it, and the status must be the
     // canonical `Created`, not the non-existent `"pending"` that the
@@ -672,7 +672,7 @@ pub async fn execute_workflow(
         .await?;
 
     // Enqueue the Start signal on the durable control queue — closes the
-    // §4.5 gap where the API advertised dispatch but never reached the
+    // honest capability gap where the API advertised dispatch but never reached the
     // engine (#332). Shared with `start_execution` via the
     // `enqueue_start_scoped` helper so the create + enqueue contract lives
     // in one place. M3.5: it stamps optional W3C trace context on the row

--- a/crates/api/src/domain/workflow/mod.rs
+++ b/crates/api/src/domain/workflow/mod.rs
@@ -1,10 +1,10 @@
 //! Workflow domain — CRUD, activation, and execution.
 //!
-//! Self-contained per canon §12.7: HTTP handlers ([`handler`]) and
+//! Self-contained per domain-module layout: HTTP handlers ([`handler`]) and
 //! request/response DTOs ([`dto`]) live together; the live route table is
 //! assembled in [`crate::domain::workspace`] (tenant-prefix nesting) on an
 //! `OpenApiRouter` so served paths and the published OpenAPI spec share one
-//! source of truth (ADR-0047). §13 knife seam:
+//! source of truth (stub-endpoint policy). integration seam knife seam:
 //! [`handler::create_workflow`] / [`handler::activate_workflow`].
 
 pub mod dto;

--- a/crates/api/src/domain/workspace.rs
+++ b/crates/api/src/domain/workspace.rs
@@ -6,15 +6,15 @@
 //! RBAC middleware (applied in [`crate::domain::create_routes`]).
 //!
 //! `execution::terminate_execution` is fully implemented end-to-end via
-//! the durable control queue (canon §12.2; `ControlCommand::Terminate` →
-//! `EngineControlDispatch::dispatch_terminate`, ADR-0008 A3 / ADR-0016) —
+//! the durable control queue (durable control queue; `ControlCommand::Terminate` →
+//! `EngineControlDispatch::dispatch_terminate`, control-queue terminate dispatch / cooperative cancel) —
 //! it is no longer a stub. The resource catalog surface
 //! (`resource::{list,get,create,update,delete}_resource` +
 //! `resource::get_resource_status`) is likewise fully implemented:
-//! config-CRUD + CAS + a read-only runtime-status projection (ADR-0067) —
+//! config-CRUD + CAS + a read-only runtime-status projection (resource runtime status) —
 //! it is no longer a stub. `execution::restart_execution` is still
 //! stubbed (501) and carries `#[deprecated]` so the OpenAPI spec flags it
-//! per ADR-0047 Stub Endpoint Policy. The deprecation lint is silenced at
+//! per stub endpoint policy. The deprecation lint is silenced at
 //! module level — that handler is intentionally mounted so the route
 //! table stays in sync with the published spec.
 #![allow(deprecated)]
@@ -60,7 +60,7 @@ pub fn router() -> OpenApiRouter<AppState> {
         // Resources. Config-CRUD collection + by-id, then the READ-ONLY
         // runtime-status projection. Resource lifecycle
         // (acquire/release/drain/reload) is engine-owned and deliberately
-        // NOT exposed over HTTP (INTEGRATION_MODEL §13.1): `{res}/status`
+        // NOT exposed over HTTP (INTEGRATION_MODEL integration seam.1): `{res}/status`
         // is the ONLY `{res}/...` sub-route, and it is a GET only — there
         // is intentionally no acquire/release/drain route.
         .routes(routes!(resource::list_resources, resource::create_resource))
@@ -70,7 +70,7 @@ pub fn router() -> OpenApiRouter<AppState> {
             resource::delete_resource
         ))
         .routes(routes!(resource::get_resource_status))
-        // Credentials (Plane B — ADR-0031). Literal paths first, then
+        // Credentials (Plane B — API-owned OAuth flow). Literal paths first, then
         // collection, then parameterized `{cred}`, then sub-resources.
         .routes(routes!(credential::resolve_credential))
         .routes(routes!(credential::continue_resolve_credential))

--- a/crates/api/src/error/mod.rs
+++ b/crates/api/src/error/mod.rs
@@ -1,4 +1,4 @@
-//! Error handling — RFC 9457 `application/problem+json` seam (canon §12.4).
+//! Error handling — RFC 9457 `application/problem+json` seam (problem+json error seam).
 //!
 //! ## Structure
 //!
@@ -158,7 +158,7 @@ pub enum ApiError {
 
     /// The endpoint is documented but the handler is not yet implemented (501).
     ///
-    /// Used by class-(c) stub handlers under ADR-0047 Stub Endpoint Policy
+    /// Used by class-(c) stub handlers under stub endpoint policy
     /// so the runtime status code matches the `responses(501)` annotation
     /// in the OpenAPI document. Migrating from `Internal("not implemented")`
     /// (500) to this variant keeps the stub-honesty contract self-consistent.
@@ -174,11 +174,11 @@ pub enum ApiError {
 /// ([`nebula_storage_port::StorageError`]) — the canonical surface every
 /// port-migrated path returns. The resource-catalog path is the one
 /// surface still on the **retained legacy** `nebula_storage::repos::ResourceRepo`
-/// (deliberately not migrated to the row-model port — ADR-0072), which
+/// (deliberately not migrated to the row-model port — storage port migration), which
 /// returns the legacy `nebula_storage::StorageError`. This is the seam
 /// adapter for that single path: a direct legacy→`ApiError` classification
 /// (NotFound → 404, Conflict/Duplicate → 409, everything else → opaque
-/// 500 with no internal-detail leak per ADR-0028 §7) — **not** a
+/// 500 with no internal-detail leak per no secret echo) — **not** a
 /// back-compat re-export of the deleted legacy surface, and **not** a
 /// re-route through the port error type.
 impl From<nebula_storage::StorageError> for ApiError {
@@ -201,7 +201,7 @@ impl From<nebula_storage::StorageError> for ApiError {
             // Lease / timeout / serialization / connection / configuration /
             // internal are genuine backend faults — the opaque
             // `Self::Storage` arm (still a 500 with no internal detail
-            // leaked to the client per ADR-0028 §7). Mapped through the
+            // leaked to the client per no secret echo). Mapped through the
             // port `StorageError` so the variant is preserved end-to-end
             // (`map_resource_create_storage_error`'s contract: a
             // non-caller fault stays the opaque `Storage` variant, never

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -2,11 +2,11 @@
 //!
 //! HTTP entry point for the Nebula workflow engine (API Gateway pattern).
 //! All business logic is delegated to port traits injected into [`AppState`];
-//! no SQL drivers or storage schema knowledge live here (canon §12.3).
+//! no SQL drivers or storage schema knowledge live here (API purity boundary).
 //!
 //! ## Key modules
 //!
-//! - `domain` — self-contained per-domain modules (canon §12.7), each
+//! - `domain` — self-contained per-domain modules (domain-module layout), each
 //!   `domain/<x>/{routes,handler,dto}.rs`: `auth`, `me`, `org`, `workflow`,
 //!   `execution`, `credential`, `catalog`, `health`, `resource`. Route
 //!   assembly (`create_routes` + the per-group middleware / tenant nesting)
@@ -21,21 +21,21 @@
 //!   `PaginationParams`, and the canonical `AckResponse`.
 //! - `middleware` — auth (JWT + API-key → `AuthContext`), tenancy (path-based org/workspace
 //!   resolution via `nebula-core::Slug`), RBAC, CSRF, tracing, security headers, request ID.
-//! - `error` — RFC 9457 `ProblemDetails` / `ApiError`; seam for canon §12.4. Includes
+//! - `error` — RFC 9457 `ProblemDetails` / `ApiError`; seam for problem+json error seam. Includes
 //!   `SessionExpired`, `MfaRequired`, `InsufficientRole`, `OrgNotFound`, `WorkspaceNotFound`,
 //!   `SlugConflict`, `CsrfRejected`, `PaginationInvalid`, `RateLimited`, `TenantMismatch` among
 //!   others.
 //! - `transport::webhook` — converged inbound webhook transport
-//!   (programmatic + slug-routed surfaces, M3.3 / ADR-0049):
+//!   (programmatic + slug-routed surfaces, webhook activation):
 //!   `WebhookTransport`, `WebhookKey`, `WebhookRateLimiter`,
 //!   `EndpointProviderImpl`, storage bootstrap, lifecycle subscriber.
 //! - `state` — `AppState` holds port trait references: `WorkflowRepo`, `ExecutionRepo`,
 //!   `ControlQueueRepo`, `OrgResolver`, `WorkspaceResolver`, `AuthBackend`, `MembershipStore`.
 //! - `config` — `ApiConfig` with sub-configs (`TlsConfig`, `CookieConfig`, `CorsConfig`,
 //!   `VersioningConfig`, `PaginationConfig`) / `JwtSecret`; startup fails hard on a missing or
-//!   short secret — no `Default` impl (§4.5 operational honesty).
+//!   short secret — no `Default` impl (honest capability operational honesty).
 //!
-//! ## Authentication planes (ADR-0033)
+//! ## Authentication planes (auth plane separation)
 //!
 //! Keep **Plane A** (who may call this API) separate from **Plane B** (integration credentials
 //! for workflows talking to *external* systems):
@@ -50,16 +50,16 @@
 //!   in [`domain::credential::handler`]; route wiring in [`domain::workspace`] and
 //!   [`domain::credential::routes`]. All credential routes are **protected by Plane A** middleware.
 //!
-//! Do not merge these into one conceptual “auth” module — naming stays explicit per ADR-0033.
+//! Do not merge these into one conceptual “auth” module — naming stays explicit per auth plane separation.
 //!
 //! ## Canon invariants
 //!
-//! - **§12.4** — All errors are RFC 9457 `application/problem+json`; no new ad-hoc 500s for
+//! - **problem+json** — All errors are RFC 9457 `application/problem+json`; no new ad-hoc 500s for
 //!   business-logic failures.
-//! - **§13 steps 1–3, 5** — This crate is the entry point for the knife scenario: create → activate
+//! - **integration seam steps 1–3, 5** — This crate is the entry point for the knife scenario: create → activate
 //!   → start → … → cancel.
-//! - **§12.3** — Local-first: starts with in-memory repos; no Docker required.
-//! - **§4.5** — No capability is advertised that the engine does not honor end-to-end.
+//! - **API purity** — Local-first: starts with in-memory repos; no Docker required.
+//! - **honest capability** — No capability is advertised that the engine does not honor end-to-end.
 
 #![warn(missing_docs)]
 #![warn(clippy::all)]

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -5,7 +5,7 @@
 //! request extensions so downstream middleware and handlers can use either.
 //!
 //! This is **not** integration credential OAuth (**Plane B**). Integration OAuth client routes
-//! live in the `credential` module; see ADR-0033.
+//! live in the `credential` module; see auth plane separation.
 
 use std::str::FromStr;
 

--- a/crates/api/src/middleware/idempotency/key.rs
+++ b/crates/api/src/middleware/idempotency/key.rs
@@ -84,7 +84,7 @@ impl std::fmt::Display for IdempotencyKey {
 ///
 /// Stored in [`super::store::CachedResponse::request_fingerprint`] and
 /// compared on every cache hit to detect "same key, different body" reuse
-/// (draft §2.5 → 422 per ADR-0048).
+/// (draft §2.5 → 422 per idempotency backend).
 pub(super) fn fingerprint_request_body(body: &[u8]) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(body);

--- a/crates/api/src/middleware/idempotency/layer.rs
+++ b/crates/api/src/middleware/idempotency/layer.rs
@@ -1,6 +1,6 @@
 //! Tower [`Layer`] + [`Service`] implementing idempotent-replay middleware.
 //!
-//! [`IdempotencyLayer`] wraps any inner service with the full ADR-0048
+//! [`IdempotencyLayer`] wraps any inner service with the full idempotency backend
 //! idempotency contract: request-body buffering, SHA-256 fingerprinting,
 //! cache lookup, 422 on body mismatch, 5xx pass-through (not cached),
 //! response-header filtering, `Idempotent-Replay: true` on replay, and
@@ -371,7 +371,7 @@ where
             record_outcome(&metrics, "error:get", MetricOutcome::None);
             tracing::error!(
                 error = %err,
-                "idempotency-store get failed — failing the request closed (ADR-0048)"
+                "idempotency-store get failed — failing the request closed (idempotency backend)"
             );
             return Ok(internal_error(
                 "idempotency store unavailable; request rejected to preserve replay protection",

--- a/crates/api/src/middleware/idempotency/memory.rs
+++ b/crates/api/src/middleware/idempotency/memory.rs
@@ -6,7 +6,7 @@
 //! deployments running more than one API replica, use
 //! [`super::store::StorageBackedIdempotencyStore`] (PG-backed) instead —
 //! the in-memory store loses dedup state across restarts and across runners
-//! (ADR-0048).
+//! (idempotency backend).
 
 use std::{fmt, sync::Arc, time::Duration};
 

--- a/crates/api/src/middleware/idempotency/mod.rs
+++ b/crates/api/src/middleware/idempotency/mod.rs
@@ -17,7 +17,7 @@
 //! discarded but the side effects of its handler invocation are not
 //! rolled back. True at-most-once under contention requires a "pending
 //! claim" record (followers wait or replay instead of running the
-//! handler again) — tracked as a follow-up under ADR-0048
+//! handler again) — tracked as a follow-up under idempotency backend
 //! "Open Questions / Follow-ups".
 //!
 //! [draft-ietf-httpapi-idempotency-key]: https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key/
@@ -73,7 +73,7 @@
 //! [`store::StorageBackedIdempotencyStore`] adapts a layer-1
 //! `nebula_storage::repos::IdempotencyStoreRepo` (PG-backed in
 //! production deployments) onto this trait. Selection is driven by
-//! `ApiConfig.idempotency.backend` per **ADR-0048**: the in-memory
+//! `ApiConfig.idempotency.backend` per **idempotency backend**: the in-memory
 //! backend loses dedup state across restart and across runners, so
 //! production deployments running more than one API replica must select
 //! `Postgres` to satisfy the §M3 1.0 closure criterion.

--- a/crates/api/src/middleware/idempotency/store.rs
+++ b/crates/api/src/middleware/idempotency/store.rs
@@ -20,7 +20,7 @@ use nebula_storage::repos::{CachedRecord, IdempotencyStoreRepo};
 /// Storage backends bubble these through the middleware. The handler
 /// translates them to a 500 response — silently treating a `Decode`
 /// error as a cache miss would drop replay protection on data
-/// corruption (rejected by ADR-0048).
+/// corruption (rejected by idempotency backend).
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum IdempotencyStoreError {
@@ -70,7 +70,7 @@ pub trait IdempotencyStore: Send + Sync + fmt::Debug {
     /// Returns `Ok(None)` for a cache miss, `Ok(Some(_))` for a hit, or
     /// [`IdempotencyStoreError`] when the read itself failed (backend
     /// connection error or decode failure). The middleware translates
-    /// errors to 500 — see ADR-0048: silent cache-miss fallback would
+    /// errors to 500 — see idempotency backend: silent cache-miss fallback would
     /// drop replay protection on data corruption.
     async fn get(&self, key: &str) -> Result<Option<Arc<CachedResponse>>, IdempotencyStoreError>;
 
@@ -122,7 +122,7 @@ pub trait IdempotencyStore: Send + Sync + fmt::Debug {
 /// `CachedRecord ↔ CachedResponse` (`StatusCode` / `HeaderMap`). Decode
 /// failures map to [`IdempotencyStoreError::Decode`] and bubble up to
 /// the middleware as 500 — silently treating them as cache misses
-/// would drop replay protection on data corruption (ADR-0048).
+/// would drop replay protection on data corruption (idempotency backend).
 pub struct StorageBackedIdempotencyStore<R: IdempotencyStoreRepo> {
     repo: Arc<R>,
     ttl: Duration,

--- a/crates/api/src/middleware/internal_auth.rs
+++ b/crates/api/src/middleware/internal_auth.rs
@@ -1,5 +1,5 @@
 //! Shared-token authentication for `/internal/v1/...` routes
-//! (M3.3 / ADR-0049 — E3).
+//! (webhook activation — E3).
 //!
 //! Internal routes are deliberately separate from the Plane-A auth
 //! stack:

--- a/crates/api/src/openapi/mod.rs
+++ b/crates/api/src/openapi/mod.rs
@@ -1,6 +1,6 @@
 //! OpenAPI 3.1 spec generation for `nebula-api`.
 //!
-//! See [ADR-0047](../../../../docs/adr/0047-openapi-31-generator.md) for
+//! See [stub-endpoint policy](../../../../) for
 //! the library choice rationale, drift-detection guarantees, stub-endpoint
 //! policy, and cross-layer schema strategy.
 //!

--- a/crates/api/src/ports/credential_schema.rs
+++ b/crates/api/src/ports/credential_schema.rs
@@ -1,4 +1,4 @@
-//! API-owned credential-schema port (ADR-0052 P4).
+//! API-owned credential-schema port (credential-schema validation).
 //!
 //! `nebula-api` never imports `nebula-schema`/`nebula-validator` types into
 //! its DTOs; this object-safe port carries only api-safe values. The
@@ -7,14 +7,14 @@
 //! `json_schema()` — authority sits with the validator
 //! (INTEGRATION_MODEL §29/§33 proof-token custody unchanged). When no port
 //! is wired the credential write path and credential-type catalog return an
-//! honest 503, mirroring `AppState::action_registry` (canon §4.5).
+//! honest 503, mirroring `AppState::action_registry` (honest capability contract).
 
 use serde::Serialize;
 use utoipa::ToSchema;
 
 /// One field-level validation failure — secret-safe by construction:
 /// an RFC-6901 path, a validator code, and a static message. **Never**
-/// the submitted value (ADR-0034 redaction).
+/// the submitted value (credential redaction redaction).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CredentialFieldError {
     /// RFC-6901 JSON Pointer to the offending field (e.g. `/api_key`).

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -1,5 +1,5 @@
 //! Concrete [`CredentialSchemaPort`] over a
-//! `nebula_credential::CredentialRegistry` (ADR-0052 P4).
+//! `nebula_credential::CredentialRegistry` (credential-schema validation).
 //!
 //! Per the user's adjudication of the deny.toml-vs-#671 conflict, the
 //! concrete impl lives in `nebula-api` (already an allow-listed
@@ -8,15 +8,15 @@
 //! crate (which would have required a wrapper-allowlist edit). `nebula-api`
 //! takes a `nebula-schema` production dep + `schemars`, but **no
 //! `ValidSchema` type enters any DTO** — the port returns only
-//! `serde_json::Value` / api-owned structs, so ADR-0047's DTO-purity rule
+//! `serde_json::Value` / api-owned structs, so stub-endpoint policy's DTO-purity rule
 //! is intact (only the informal "api never imports nebula-schema" prose is
-//! relaxed; recorded in the ADR-0052 P4 / ADR-0047 amendments).
+//! relaxed; recorded in the credential-schema validation / stub-endpoint policy amendments).
 //!
 //! Authority sits with the validator: `ValidSchema::validate` is invoked
-//! here; credential `data` is **never** `.resolve()`-d (canon §12.5 —
+//! here; credential `data` is **never** `.resolve()`-d (credential secrecy —
 //! secrets must not depend on workflow state). Errors are secret-safe by
 //! construction (RFC-6901 path + validator code + static message; never a
-//! submitted value — ADR-0034).
+//! submitted value — credential redaction).
 
 use std::sync::Arc;
 
@@ -34,7 +34,7 @@ use crate::ports::credential_schema::{
 /// message. The seam NEVER forwards a lower-layer `ValidationError.message`
 /// (some validators embed the submitted input — e.g. `'{input}' is not a
 /// valid IPv4 address` — and `validate_json_keys` embeds the raw object
-/// key). Deriving the message from the code makes the ADR-0034 "never the
+/// key). Deriving the message from the code makes the credential redaction "never the
 /// submitted value" invariant hold *by construction* at this seam,
 /// independent of any upstream validator's message hygiene.
 fn safe_field_message(code: &str) -> &'static str {
@@ -135,7 +135,7 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
             )]);
         };
         let schema = any.metadata().base.schema;
-        // Ingest only (NEVER `.resolve()` — canon §12.5: credential data
+        // Ingest only (NEVER `.resolve()` — credential secrecy: credential data
         // must not be expression-resolved against workflow state).
         let values = FieldValues::from_json(data.clone())
             .map_err(|e| vec![field_error(e.path.to_string(), e.code.as_ref())])?;
@@ -184,7 +184,7 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
 }
 
 /// Build the default port with the first-party credential types
-/// registered (ADR-0052 P4). Used by the composition root so
+/// registered (credential-schema validation). Used by the composition root so
 /// `apps/server` needs no `nebula-credential`/`nebula-schema` dep.
 ///
 /// # Errors

--- a/crates/api/src/ports/mod.rs
+++ b/crates/api/src/ports/mod.rs
@@ -3,7 +3,7 @@
 //! Ports carry only api-safe types (primitives, `serde_json::Value`,
 //! api-owned structs). Concrete impls live in the composition root, which
 //! legally depends on the lower-layer crates. This keeps `nebula-api` free
-//! of lower-layer types in its DTOs (ADR-0047 Cross-Layer Schema Strategy).
+//! of lower-layer types in its DTOs (stub-endpoint policy Cross-Layer Schema Strategy).
 
 pub mod credential_schema;
 pub mod credential_schema_registry;

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -50,12 +50,12 @@ pub trait WorkspaceResolver: Send + Sync {
 /// One organisation membership row, as seen by the org/* handlers.
 ///
 /// **Port-level type — deliberately decoupled from the wire DTO**
-/// ([`crate::domain::org::dto::MemberSummary`]) per ADR-0047 §3. It carries
+/// ([`crate::domain::org::dto::MemberSummary`]) per 3. It carries
 /// only what the RBAC store actually knows: *who* (the resolved
 /// [`Principal`]) and *what role*. There is intentionally **no** `email`
 /// or `joined_at` — the membership store is the RBAC role index, not a
 /// user-identity directory, so synthesizing those fields would be a
-/// canon §4.5 false capability (the Phase-3 "Option 1" honest contract:
+/// honest capability contract false capability (the Phase-3 "Option 1" honest contract:
 /// see the module docs of [`crate::domain::org::handler`]).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct OrgMember {
@@ -237,9 +237,9 @@ pub struct AppState {
     /// When `None`, the `GET /plugins` endpoints return 503.
     pub plugin_registry: Option<Arc<RwLock<PluginRegistry>>>,
 
-    /// Optional credential-schema port (ADR-0052 P4). When `None`, the
+    /// Optional credential-schema port (credential-schema validation). When `None`, the
     /// credential write path and credential-type catalog return 503
-    /// (honest §4.5 stub, mirroring `action_registry`).
+    /// (honest capability stub, mirroring `action_registry`).
     pub credential_schema: Option<Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>>,
 
     /// Optional webhook HTTP transport. When `None`, no `/webhooks/*`
@@ -248,7 +248,7 @@ pub struct AppState {
     /// will never fire until the transport is attached.
     pub webhook_transport: Option<WebhookTransport>,
 
-    /// OAuth pending state store (ADR-0031 §4.2 — TTL ≤ 10 min, single-use).
+    /// OAuth pending state store (API-owned OAuth flow §4.2 — TTL ≤ 10 min, single-use).
     pub oauth_pending_store: Arc<InMemoryPendingStore>,
 
     /// Maps signed state -> pending token so callback can consume pending data.
@@ -290,13 +290,13 @@ pub struct AppState {
     /// endpoints have no replay protection — acceptable for tests that build
     /// minimal routers but a misconfiguration in production.
     ///
-    /// See ADR-0048 for the backend selection contract; the composition root
+    /// See idempotency backend for the backend selection contract; the composition root
     /// chooses between [`crate::middleware::InMemoryIdempotencyStore`] and a
     /// PG-backed bridge (`StorageBackedIdempotencyStore<PgIdempotencyStore>`)
     /// based on `ApiConfig.idempotency.backend`.
     pub idempotency_store: Option<Arc<dyn IdempotencyStore>>,
 
-    /// Optional webhook-activation repository (M3.3 / ADR-0049).
+    /// Optional webhook-activation repository (webhook activation).
     ///
     /// When `Some`, the composition root invokes
     /// [`crate::transport::webhook::bootstrap_webhook_activations`] before
@@ -305,7 +305,7 @@ pub struct AppState {
     /// (`POST /internal/v1/webhooks/reload`).
     pub webhook_activation_repo: Option<Arc<dyn WebhookActivationRepo>>,
 
-    /// Optional lifecycle event bus (M3.3 / ADR-0049 — E2).
+    /// Optional lifecycle event bus (webhook activation — E2).
     ///
     /// Producers (storage CRUD callsites) emit
     /// [`crate::transport::webhook::TriggerLifecycleEvent`] on this
@@ -314,15 +314,15 @@ pub struct AppState {
     /// wiring is deferred to a follow-up.
     pub trigger_lifecycle_bus: Option<crate::transport::webhook::TriggerLifecycleBus>,
 
-    /// Webhook credential resolver (M3.3 / ADR-0049 — E1+E3).
+    /// Webhook credential resolver (webhook activation — E1+E3).
     ///
     /// Required for storage-driven slug bootstrap and admin reload.
     pub webhook_secret_resolver: Option<Arc<dyn crate::transport::webhook::WebhookSecretResolver>>,
 
-    /// Webhook ctx-template factory (M3.3 / ADR-0049 — E1+E3).
+    /// Webhook ctx-template factory (webhook activation — E1+E3).
     pub webhook_ctx_factory: Option<Arc<dyn crate::transport::webhook::WebhookContextFactory>>,
 
-    /// Internal-routes shared token (M3.3 / ADR-0049 — E3).
+    /// Internal-routes shared token (webhook activation — E3).
     ///
     /// Required for `POST /internal/v1/webhooks/reload`. When `None`,
     /// every request to `/internal/v1/...` returns 503.
@@ -347,7 +347,7 @@ pub struct AppState {
     pub workflow_store: Arc<dyn WorkflowStore>,
 
     /// Spec-16 scoped control-queue port handle (the cancel / start
-    /// enqueue durable outbox — canon §12.2). Every control signal is
+    /// enqueue durable outbox — durable control queue). Every control signal is
     /// enqueued here; the engine dispatcher drains it.
     pub control_queue: Arc<dyn ControlQueue>,
 
@@ -371,7 +371,7 @@ pub struct AppState {
     /// [`ResourceRegistrarRegistry::validate`](nebula_engine::ResourceRegistrarRegistry::validate)
     /// runs the kind's `R::Config` schema + closed-set guard with **no**
     /// `nebula_resource::Manager` mutation — live registration stays an
-    /// engine-activation concern (INTEGRATION_MODEL §13.1). When `None`,
+    /// engine-activation concern (INTEGRATION_MODEL integration seam.1). When `None`,
     /// `create_resource` fails closed (422) rather than persist an
     /// unvalidated config. Set via
     /// [`AppState::with_resource_registrars`].
@@ -387,7 +387,7 @@ pub struct AppState {
     /// status counterpart of the engine's resource accessor: it observes
     /// a phase and **cannot** mutate a resource — there is no
     /// acquire/release/drain seam here (resource lifecycle is
-    /// engine-owned, INTEGRATION_MODEL §13.1). When `None`, the
+    /// engine-owned, INTEGRATION_MODEL integration seam.1). When `None`, the
     /// `GET .../resources/{res}/status` endpoint reports `503 Service
     /// Unavailable` (the catalog None-convention — never a fabricated
     /// status). Set via [`AppState::with_resource_status`]; compose in
@@ -796,7 +796,7 @@ impl AppState {
     /// caller's tenant. The control message is enqueued through a freshly
     /// bound `ScopedControlQueue`, so the row is stamped with that tenant
     /// scope (a forged `scope` field on the message is rebound to the
-    /// bound tenant). The §13-step-6 503-vs-500 error policy is
+    /// bound tenant). The integration seam-step-6 503-vs-500 error policy is
     /// centralized here.
     pub(crate) async fn enqueue_control_scoped(
         &self,
@@ -805,20 +805,20 @@ impl AppState {
         execution_id: ExecutionId,
         w3c: Option<nebula_core::W3cTraceContext>,
     ) -> Result<(), ApiError> {
-        // §13 step 6: a backend that is intentionally absent or
+        // integration seam step 6: a backend that is intentionally absent or
         // unreachable (`Internal`/`Connection`) is a 503 (infra down,
         // not a logic bug); any other write failure is a 500.
         let to_api_err = |is_unavailable: bool, detail: String| {
             if is_unavailable {
                 ApiError::ServiceUnavailable(format!(
                     "Execution {execution_id} persisted but control-queue backend is \
-                     unavailable — orchestration absent (canon §13 step 6, §12.2 \
-                     orphan): {detail}"
+                     unavailable — orchestration absent (integration seam step 6, \
+                     durable control queue orphan): {detail}"
                 ))
             } else {
                 ApiError::Internal(format!(
                     "Execution {execution_id} persisted but failed to enqueue control \
-                     signal (canon §12.2 orphan — caller should retry): {detail}"
+                     signal (durable control queue orphan — caller should retry): {detail}"
                 ))
             }
         };
@@ -987,7 +987,7 @@ impl AppState {
         self
     }
 
-    /// Attach the credential-schema port (ADR-0052 P4) used to validate
+    /// Attach the credential-schema port (credential-schema validation) used to validate
     /// credential `data` before persist and to populate the credential-type
     /// catalog. When absent, those endpoints return an honest 503.
     #[must_use = "builder methods must be chained or built"]
@@ -1059,14 +1059,14 @@ impl AppState {
     /// [`crate::middleware::IdempotencyLayer`] on the API router when this is
     /// `Some`.
     ///
-    /// See ADR-0048 for the backend selection contract.
+    /// See idempotency backend for the backend selection contract.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_idempotency_store(mut self, store: Arc<dyn IdempotencyStore>) -> Self {
         self.idempotency_store = Some(store);
         self
     }
 
-    /// Attach a webhook-activation repository (M3.3 / ADR-0049).
+    /// Attach a webhook-activation repository (webhook activation).
     ///
     /// Required for storage-driven slug bootstrap and for the admin
     /// reload endpoint. Composition roots that do not enable
@@ -1079,7 +1079,7 @@ impl AppState {
     }
 
     /// Attach a [`crate::transport::webhook::TriggerLifecycleBus`]
-    /// for slug-routed activation lifecycle events (M3.3 / ADR-0049).
+    /// for slug-routed activation lifecycle events (webhook activation).
     #[must_use = "builder methods must be chained or built"]
     pub fn with_trigger_lifecycle_bus(
         mut self,
@@ -1089,7 +1089,7 @@ impl AppState {
         self
     }
 
-    /// Attach a webhook secret resolver (M3.3 / ADR-0049 — E1+E3).
+    /// Attach a webhook secret resolver (webhook activation — E1+E3).
     #[must_use = "builder methods must be chained or built"]
     pub fn with_webhook_secret_resolver(
         mut self,
@@ -1099,7 +1099,7 @@ impl AppState {
         self
     }
 
-    /// Attach a webhook ctx-template factory (M3.3 / ADR-0049 — E1+E3).
+    /// Attach a webhook ctx-template factory (webhook activation — E1+E3).
     #[must_use = "builder methods must be chained or built"]
     pub fn with_webhook_ctx_factory(
         mut self,
@@ -1137,7 +1137,7 @@ impl AppState {
     ///
     /// This is the config-CRUD validation seam (schema + closed-kind),
     /// **not** engine activation: it never live-registers into a
-    /// `nebula_resource::Manager` (INTEGRATION_MODEL §13.1). Compose this
+    /// `nebula_resource::Manager` (INTEGRATION_MODEL integration seam.1). Compose this
     /// in production from the same registry the engine is built with
     /// ([`WorkflowEngine::resource_registrars`](nebula_engine::WorkflowEngine::resource_registrars));
     /// when left `None`, `create_resource` fails closed (422) rather than
@@ -1157,7 +1157,7 @@ impl AppState {
     /// Projects a live resource's lifecycle phase in api-safe types — it
     /// observes a phase and cannot mutate a resource (no
     /// acquire/release/drain; resource lifecycle is engine-owned,
-    /// INTEGRATION_MODEL §13.1). Compose this in production from the same
+    /// INTEGRATION_MODEL integration seam.1). Compose this in production from the same
     /// `nebula_resource::Manager` the engine is built with (via
     /// `nebula_engine::EngineManagerResourceStatus`). When left `None`
     /// the status endpoint reports `503` rather than fabricate a status.

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -3,7 +3,7 @@
 //! Each function takes an `AppState` reference plus domain-specific parameters
 //! and returns `ApiResult`.
 //!
-//! ## §4.5 honesty split (Phase 4)
+//! ## honest capability honesty split (Phase 4)
 //!
 //! The CRUD subset (`create` / `get` / `update` / `delete` / `list`)
 //! persists over the wired [`nebula_storage::credential::InMemoryStore`]
@@ -15,10 +15,10 @@
 //! 503** (`ApiError::ServiceUnavailable`): `test` / `refresh` / `revoke`
 //! / `resolve` / `continue_resolve` need a `CredentialRegistry` to
 //! dispatch a concrete `Credential` and an engine-owned resolver/refresh
-//! orchestrator (`nebula-engine::credential`, ADR-0030 / ADR-0041 — see
+//! orchestrator (`nebula-engine::credential`, engine refresh orchestration — see
 //! `docs/MATURITY.md` "engine-owned `credential` runtime surface").
 //! Neither is wired into `AppState`, so faking success would be a
-//! §4.5 false capability (the worst class for a credential surface).
+//! honest capability false capability (the worst class for a credential surface).
 //!
 //! Note: the generic `resolve_credential` / `continue_resolve`
 //! functions are honest-503 at the function boundary, and their routes
@@ -32,7 +32,7 @@
 //! strictly ULID-validated. The honest-503 is pinned by the unit test
 //! below and the `credential_e2e` route-reachability regression guard.
 //!
-//! ## §12.5 secret handling
+//! ## credential secrecy secret handling
 //!
 //! - The credential `data` blob arrives **write-only**: it is wrapped in
 //!   [`nebula_credential::SecretString`] for its in-process lifetime and
@@ -125,7 +125,7 @@ pub(crate) fn scoped_store(
 /// `EncryptionLayer` is composed** — not wired here, so the in-memory
 /// store keeps the raw bytes in plaintext-at-rest; see the operator
 /// warning in `crates/api/README.md`). Production deployments wrap the
-/// store with `nebula_storage`'s `EncryptionLayer` (ADR-0032).
+/// store with `nebula_storage`'s `EncryptionLayer` (storage credential layers).
 #[derive(Serialize, Deserialize)]
 struct PersistedSecretData {
     #[serde(with = "nebula_credential::serde_secret")]
@@ -167,8 +167,8 @@ fn encode_secret_data(data: &serde_json::Value) -> ApiResult<Vec<u8>> {
 /// other request-validation failure).
 ///
 /// `CredentialFieldError` carries only an RFC-6901 path, a validator code,
-/// and a static message — never the submitted value (ADR-0034 redaction;
-/// ADR-0052 P4). The mapping introduces no value either.
+/// and a static message — never the submitted value (credential redaction redaction;
+/// credential-schema validation). The mapping introduces no value either.
 fn credential_validation_error(
     errs: Vec<crate::ports::credential_schema::CredentialFieldError>,
 ) -> ApiError {
@@ -186,11 +186,11 @@ fn credential_validation_error(
     }
 }
 
-/// ADR-0052 P4 (V2): validate credential `data` against the credential
+/// credential-schema validation: validate credential `data` against the credential
 /// type's resolved schema **before persist**. Authority sits with the
 /// validator (invoked behind the [`CredentialSchemaPort`]). When no port
 /// is configured the request is rejected with 503 — credential `data` is
-/// **never** persisted unvalidated (closes the §4.5/§10 fail-open the
+/// **never** persisted unvalidated (closes the honest capability/§10 fail-open the
 /// handler docstring previously mis-claimed was closed).
 ///
 /// [`CredentialSchemaPort`]: crate::ports::credential_schema::CredentialSchemaPort
@@ -329,7 +329,7 @@ fn map_store_err(err: StoreError, cred: &str) -> ApiError {
 }
 
 /// Fetch a credential, treating a cross-workspace / unknown id as a
-/// flat 404 (no existence disclosure, canon §12.4 / Phase-2 pattern).
+/// flat 404 (no existence disclosure, problem+json error seam / Phase-2 pattern).
 async fn load(state: &AppState, owner_id: &str, cred: &str) -> ApiResult<StoredCredential> {
     scoped_store(state, owner_id)
         .get(cred)
@@ -349,7 +349,7 @@ pub async fn create_credential(
     owner_id: &str,
     req: CreateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
-    // ADR-0052 P4 (V2): validate `data` against the type's schema BEFORE
+    // credential-schema validation: validate `data` against the type's schema BEFORE
     // any persist/encode. No port ⇒ 503 (never persist unvalidated).
     validate_credential_data(state, &req.credential_key, &req.data)?;
 
@@ -446,7 +446,7 @@ pub async fn update_credential(
 
     // Re-encode the secret only when the caller supplied new data;
     // otherwise carry the existing opaque blob through untouched.
-    // ADR-0052 P4 (V2): when new `data` is supplied, validate it against
+    // credential-schema validation: when new `data` is supplied, validate it against
     // the (unchanged) credential type's schema before re-encode/persist.
     let data = match req.data.as_ref() {
         Some(value) => {
@@ -557,9 +557,9 @@ pub async fn list_credentials(
 /// **Honest 503.** A real test requires dispatching the registered
 /// `Credential`'s `Testable::test` (an outbound provider call). No
 /// `CredentialRegistry` is wired into `AppState`, and test dispatch is
-/// engine-owned (`nebula-engine::credential`, ADR-0030 — see
+/// engine-owned (`nebula-engine::credential`, engine credential orchestration — see
 /// `docs/MATURITY.md`). A "test" that does not contact the provider
-/// would be a §4.5 false capability.
+/// would be a honest capability false capability.
 pub async fn test_credential(
     _state: &AppState,
     _org: &str,
@@ -576,8 +576,8 @@ pub async fn test_credential(
 
 /// Force a token refresh for the credential.
 ///
-/// **Honest 503.** Refresh orchestration is engine-owned (ADR-0030 /
-/// ADR-0041; the L2 refresh coordinator lives in
+/// **Honest 503.** Refresh orchestration is engine-owned (engine credential orchestration /
+/// refresh coordinator; the L2 refresh coordinator lives in
 /// `nebula-engine::credential::refresh`). The API does not own a
 /// refresh path end-to-end, so this stays honest rather than faking a
 /// successful refresh.
@@ -589,7 +589,7 @@ pub async fn refresh_credential(
 ) -> ApiResult<RefreshCredentialResponse> {
     Err(ApiError::ServiceUnavailable(
         "credential refresh is engine-owned (RefreshCoordinator in \
-         nebula-engine::credential, ADR-0030/ADR-0041) and not exposed \
+         nebula-engine::credential, engine refresh orchestration) and not exposed \
          through this API build"
             .into(),
     ))
@@ -669,9 +669,9 @@ pub async fn continue_resolve(
 /// **Honest 503.** Enumerating registered types + their schemas
 /// requires a `CredentialRegistry`; none is wired into `AppState`.
 /// Returning a hand-rolled catalog would misrepresent what is actually
-/// registered (§4.5).
+/// registered (honest capability).
 /// Map a port [`CredentialTypeDescriptor`] to the wire DTO, applying the
-/// api-owned public projection to the schema (ADR-0052 P4 V3 + #6 — the
+/// api-owned public projection to the schema (credential-schema port + #6 — the
 /// raw `json_schema()` export's `x-nebula-root-rules` / predicate operands
 /// are stripped before the unauthenticated wire).
 fn credential_type_info_from_descriptor(
@@ -697,8 +697,8 @@ fn credential_type_info_from_descriptor(
 const NO_CRED_SCHEMA_PORT: &str =
     "credential type discovery unavailable: no credential-schema port configured";
 
-/// ADR-0052 P4 (V3): list registered credential types with their
-/// public-projected input schema. No port ⇒ honest 503 (§4.5).
+/// credential-schema port: list registered credential types with their
+/// public-projected input schema. No port ⇒ honest 503 (honest capability).
 pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredentialTypesResponse> {
     let port = state
         .credential_schema
@@ -712,7 +712,7 @@ pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredential
     Ok(ListCredentialTypesResponse { types })
 }
 
-/// ADR-0052 P4 (V3): one credential type by key. No port ⇒ honest 503;
+/// credential-schema port: one credential type by key. No port ⇒ honest 503;
 /// unknown key ⇒ 404 (credential *types* are public catalog info, so
 /// non-existence disclosure is non-sensitive — unlike credential
 /// *instances*, which are flat-404 per IDOR rules).
@@ -737,7 +737,7 @@ mod tests {
     };
 
     /// Permissive port so the CRUD/secret-projection unit tests still
-    /// exercise persistence after ADR-0052 P4 closed the
+    /// exercise persistence after credential-schema validation closed the
     /// unvalidated-persist fail-open (the no-port → 503 behavior is
     /// covered by `tests/seam_credential_write_path_validation.rs`).
     struct PermissivePort;
@@ -784,7 +784,7 @@ mod tests {
     }
 
     /// The blob round-trips through `serde_secret`, and the redaction
-    /// envelope's `Debug` never spells the plaintext (§12.5).
+    /// envelope's `Debug` never spells the plaintext (credential secrecy).
     #[test]
     fn secret_data_envelope_redacts_and_round_trips() {
         let secret = "sk-unit-NEVER-LEAK-9f9f";
@@ -809,7 +809,7 @@ mod tests {
         assert_eq!(redacted, "\"[REDACTED]\"");
     }
 
-    /// §4.5: the engine-owned / registry-absent functions return a
+    /// honest capability: the engine-owned / registry-absent functions return a
     /// typed honest 503 — never a faked success — even at the function
     /// boundary (independent of route shadowing).
     #[tokio::test]
@@ -853,7 +853,7 @@ mod tests {
             .await,
             Err(ApiError::ServiceUnavailable(_))
         ));
-        // ADR-0052 P4 V3: `list_credential_types`/`get_credential_type`
+        // credential-schema port: `list_credential_types`/`get_credential_type`
         // are no longer engine-owned-503 — they are port-backed (a
         // permissive port is wired in `test_state()`). Their no-port → 503
         // behavior is covered by

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -1,6 +1,6 @@
 //! OAuth HTTP flow helpers for the API layer.
 //!
-//! ADR-0031: the API layer owns the OAuth flow HTTP ceremony (auth URI
+//! API-owned OAuth flow: the API layer owns the OAuth flow HTTP ceremony (auth URI
 //! construction, code→token exchange). Token endpoint policy and bounded
 //! body reads live in the sibling [`super::http`] module.
 

--- a/crates/api/src/transport/oauth/http.rs
+++ b/crates/api/src/transport/oauth/http.rs
@@ -1,7 +1,7 @@
-//! ADR-0031: bounded HTTP client and body handling for OAuth2 **token** endpoints
+//! API-owned OAuth flow: bounded HTTP client and body handling for OAuth2 **token** endpoints
 //! (code exchange, refresh, client credentials, device code poll to `token_url`).
 //!
-//! Moved from `nebula-credential` per ADR-0031 incremental split: the API layer
+//! Moved from `nebula-credential` per API-owned OAuth flow incremental split: the API layer
 //! owns the OAuth flow HTTP ceremony (auth URI construction, code→token exchange).
 
 use std::{sync::OnceLock, time::Duration};
@@ -45,7 +45,7 @@ pub enum TokenHttpError {
     Json(#[source] serde_json::Error),
 }
 
-/// Returns a shared [`reqwest::Client`] with ADR-0031 policy for OAuth2 **token** calls
+/// Returns a shared [`reqwest::Client`] with API-owned OAuth flow policy for OAuth2 **token** calls
 /// (one process-wide instance for connection pooling and TLS session reuse).
 pub fn oauth_token_http_client() -> &'static reqwest::Client {
     OAUTH_TOKEN_HTTP_CLIENT.get_or_init(|| {
@@ -56,7 +56,7 @@ pub fn oauth_token_http_client() -> &'static reqwest::Client {
                 OAUTH_TOKEN_HTTP_MAX_REDIRECTS,
             ))
             .build()
-            .expect("nebula: oauth token http client (ADR-0031 static policy) must build")
+            .expect("nebula: oauth token http client (static OAuth policy) must build")
     })
 }
 

--- a/crates/api/src/transport/oauth/mod.rs
+++ b/crates/api/src/transport/oauth/mod.rs
@@ -1,4 +1,4 @@
-//! OAuth2 / credential infrastructure — **Plane B** (ADR-0033) / OAuth ceremony (ADR-0031).
+//! OAuth2 / credential infrastructure — **Plane B** (auth plane separation) / OAuth ceremony (API-owned OAuth flow).
 //!
 //! This module provides the infrastructure for OAuth2 credential acquisition:
 //! PKCE flow helpers, signed state management, HTTP token exchange, and input

--- a/crates/api/src/transport/oauth/state.rs
+++ b/crates/api/src/transport/oauth/state.rs
@@ -6,7 +6,7 @@
 //! attempt to a specific credential and preventing cross-credential
 //! state confusion attacks.
 //!
-//! See ADR-0031 for the OAuth flow ownership decision.
+//! See API-owned OAuth flow for the OAuth flow ownership decision.
 
 use std::time::Duration;
 

--- a/crates/api/src/transport/webhook/bootstrap.rs
+++ b/crates/api/src/transport/webhook/bootstrap.rs
@@ -1,4 +1,4 @@
-//! Storage-driven webhook bootstrap (M3.3 / ADR-0049).
+//! Storage-driven webhook bootstrap (webhook activation).
 //!
 //! Walks every active operator-configured webhook activation in
 //! storage, instantiates the matching `WebhookActionFactory`, and
@@ -14,7 +14,7 @@
 //! returns `Err` for storage-layer failures (connection errors), so
 //! the composition root can choose its own degraded-mode policy
 //! (typically: log, leave the slug map empty, surface `/healthz`
-//! degraded). See ADR-0049 for the rationale.
+//! degraded). See webhook activation for the rationale.
 //!
 //! The composition root invokes this function before handing
 //! [`crate::AppState`] into [`crate::app::build_app`] — the `Router`

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -1,11 +1,11 @@
-//! Webhook dispatch pipeline (M3.3 / ADR-0049).
+//! Webhook dispatch pipeline (webhook activation).
 //!
 //! Contains the shared `dispatch_inner` pipeline for both the
 //! programmatic and slug-routed webhook surfaces, plus the two axum
 //! handler functions that build a [`super::key::WebhookKey`] and
 //! delegate into it.
 //!
-//! ## Pipeline order (ADR-0049 single-pipe)
+//! ## Pipeline order (webhook activation single-pipe)
 //!
 //! 1. Body size check → 413
 //! 2. Route lookup → 404 (before rate-limit so unregistered keys
@@ -88,7 +88,7 @@ pub(super) async fn slug_webhook_handler(
 }
 
 /// Shared dispatch pipeline for both programmatic and slug webhook
-/// surfaces (M3.3 / ADR-0049). Order of operations:
+/// surfaces (webhook activation). Order of operations:
 ///
 /// 1. body size check → 413
 /// 2. routing lookup → 404 (before rate-limit — #271)
@@ -161,7 +161,7 @@ pub(super) async fn dispatch_inner(
         },
     };
 
-    // 5.5. Signature enforcement (ADR-0022). The `Required` default
+    // 5.5. Signature enforcement. The `Required` default
     // means an action that forgot to configure a secret trips a 500
     // here; an action that explicitly opted into
     // `OptionalAcceptUnsigned` passes through; everything else

--- a/crates/api/src/transport/webhook/events.rs
+++ b/crates/api/src/transport/webhook/events.rs
@@ -1,4 +1,4 @@
-//! `TriggerLifecycleEvent` and the transport subscriber (M3.3 / ADR-0049 — E2).
+//! `TriggerLifecycleEvent` and the transport subscriber (webhook activation — E2).
 //!
 //! Operator changes to slug-routed webhook activations (create /
 //! update / delete) are published as
@@ -11,7 +11,7 @@
 //! E2 ships the **consumer** — the transport-side subscriber that
 //! reapplies events. The producer side (storage CRUD callsites that
 //! `emit()` on the bus) is intentionally out of scope for M3.3 per
-//! ADR-0049 §"Out of scope". Until producers wire in, the bus is
+//! webhook activation §"Out of scope". Until producers wire in, the bus is
 //! observed only by the admin reload endpoint and by tests.
 //!
 //! # Why an event bus, not direct calls

--- a/crates/api/src/transport/webhook/mod.rs
+++ b/crates/api/src/transport/webhook/mod.rs
@@ -11,7 +11,7 @@
 //!   [`router`](WebhookTransport::router)) and `TransportInner` internals.
 //! - `dispatch` — shared `dispatch_inner` pipeline (routing lookup →
 //!   rate-limit → signature → oneshot dispatch) plus the two axum handler fns.
-//! - `signature` — ADR-0022 signature-policy enforcement (`enforce_signature`,
+//! - `signature` —  signature-policy enforcement (`enforce_signature`,
 //!   problem+json response builders, metric recording).
 //! - `replay` — replay-window rejection reason mapping
 //!   (`replay_reason_for`): maps signature failure codes to the dedicated
@@ -20,7 +20,7 @@
 //!   so action code can read `ctx.webhook.endpoint_url()`.
 //! - `routing` — private `RoutingMap` (DashMap under the hood) keyed by `(trigger_uuid, nonce)`.
 //! - Rate limiting lives in [`ratelimit`] (moved out of
-//!   `middleware/webhook_ratelimit` in M3.3 / ADR-0049 phase F1; the
+//!   `middleware/webhook_ratelimit` in webhook activation phase F1; the
 //!   middleware/ placement was a misnomer — there was never a Tower
 //!   `Layer` wrapping the limiter, it is consumed directly by the
 //!   transport).

--- a/crates/api/src/transport/webhook/ratelimit.rs
+++ b/crates/api/src/transport/webhook/ratelimit.rs
@@ -1,4 +1,4 @@
-//! Per-path webhook rate limiting (M3.3 / ADR-0049).
+//! Per-path webhook rate limiting (webhook activation).
 //!
 //! Wraps [`nebula_resilience::SlidingWindow`] with per-path tracking:
 //! each unique webhook path gets an independent sliding-window
@@ -19,7 +19,7 @@
 //! Lives under `transport::webhook` (not `middleware/`) because it is
 //! consumed exclusively by [`super::WebhookTransport`] — no axum
 //! `Layer`/`Service` plumbing exists. The previous `middleware/`
-//! placement was a misnomer; M3.3 / ADR-0049 phase F1 collapses the
+//! placement was a misnomer; webhook activation phase F1 collapses the
 //! parallel slug pipeline so the only consumer is the transport.
 
 use std::{sync::Arc, time::Duration};

--- a/crates/api/src/transport/webhook/replay.rs
+++ b/crates/api/src/transport/webhook/replay.rs
@@ -1,4 +1,4 @@
-//! Replay-window rejection reason mapping (M3.3 / ADR-0049).
+//! Replay-window rejection reason mapping (webhook activation).
 //!
 //! Maps a signature-failure reason code to the corresponding
 //! replay-window rejection reason code used by the

--- a/crates/api/src/transport/webhook/routing.rs
+++ b/crates/api/src/transport/webhook/routing.rs
@@ -17,7 +17,7 @@ use super::key::WebhookKey;
 ///
 /// Holds the handler pointer, a template [`TriggerRuntimeContext`]
 /// that the transport clones on every request, and the
-/// [`WebhookConfig`] enforced before dispatch (per ADR-0022). Cloning
+/// [`WebhookConfig`] enforced before dispatch (per ). Cloning
 /// the context gives each dispatch its own independent context
 /// without locking — the capability arcs inside (`emitter`, `health`,
 /// `webhook`, etc.) share state as designed.
@@ -88,7 +88,7 @@ impl RoutingMap {
     /// Replace all slug entries with a new set. Used by the admin
     /// reload endpoint (E3); programmatic activations are preserved.
     ///
-    /// **Atomicity note (M3.3 / ADR-0049 § "Out of scope"):**
+    /// **Atomicity note (webhook activation § "Out of scope"):**
     /// The swap is performed by removing every slug entry and then
     /// inserting the new set into the shared `DashMap`. Concurrent
     /// readers between the two phases can observe a transient empty
@@ -113,7 +113,7 @@ impl RoutingMap {
     }
 
     /// Number of entries with the given kind label, for telemetry
-    /// gauges (M3.3 / `NEBULA_WEBHOOK_REGISTRATIONS`).
+    /// gauges (`NEBULA_WEBHOOK_REGISTRATIONS`).
     #[must_use]
     #[allow(dead_code)] // wired into G2 metrics in a subsequent commit
     pub(crate) fn count_by_kind(&self, kind: &'static str) -> usize {

--- a/crates/api/src/transport/webhook/signature.rs
+++ b/crates/api/src/transport/webhook/signature.rs
@@ -1,4 +1,4 @@
-//! ADR-0022 signature-policy enforcement for the webhook transport.
+//!  signature-policy enforcement for the webhook transport.
 //!
 //! Translates a [`SignaturePolicy`] + [`WebhookRequest`] pair into a
 //! [`SignatureVerdict`] that the dispatch pipeline maps to HTTP status
@@ -109,7 +109,7 @@ pub(super) fn outcome_to_verdict(outcome: SignatureOutcome) -> SignatureVerdict 
     }
 }
 
-/// Record a signature-failure metric (ADR-0022).
+/// Record a signature-failure metric.
 ///
 /// Replay-window failures additionally bump
 /// [`NEBULA_WEBHOOK_REPLAY_REJECTIONS_TOTAL`] so dashboards can

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -106,10 +106,10 @@ pub(super) struct TransportInner {
     pub(super) rate_limiter: Option<WebhookRateLimiter>,
     /// Optional metrics registry. When `Some`, signature-failure
     /// outcomes increment [`NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL`]
-    /// per ADR-0022. `None` means the transport runs without emitting
+    ///. `None` means the transport runs without emitting
     /// the counter — the enforcement behaviour is identical.
     pub(super) metrics: Option<Arc<MetricsRegistry>>,
-    /// Time source for replay-window enforcement (M3.3 / ADR-0049).
+    /// Time source for replay-window enforcement (webhook activation).
     /// Production deployments use [`SystemClock`]; tests inject
     /// `MockClock` to drive deterministic timestamp scenarios.
     pub(super) clock: Arc<dyn Clock>,
@@ -133,7 +133,7 @@ impl WebhookTransport {
 
     /// Build a new transport from config with a metrics registry
     /// attached. Signature-failure outcomes increment
-    /// `NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL` per ADR-0022.
+    /// `NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL`.
     ///
     /// Composition roots that already own a `MetricsRegistry` (the
     /// API crate's `AppState` does) should prefer this constructor
@@ -186,7 +186,7 @@ impl WebhookTransport {
     ///
     /// `action_config` is the [`WebhookConfig`] read from the typed
     /// [`nebula_action::WebhookAction`] that the handler wraps. Per
-    /// ADR-0022 the caller reads it from the action (typically via
+    ///  the caller reads it from the action (typically via
     /// `WebhookTriggerAdapter::config()`) before erasing the handler
     /// to `Arc<dyn TriggerHandler>` — webhook-specific configuration
     /// does not flow through the dyn trigger contract.
@@ -234,7 +234,7 @@ impl WebhookTransport {
         self.inner.routing.remove(&key);
     }
 
-    /// Register a slug-routed activation (M3.3 / ADR-0049).
+    /// Register a slug-routed activation (webhook activation).
     ///
     /// The handler comes from a [`nebula_action::WebhookActionFactory`]
     /// invoked by the API bootstrap (E1) or the lifecycle subscriber
@@ -324,7 +324,7 @@ impl WebhookTransport {
     /// Build the axum router that dispatches incoming webhook
     /// requests to registered triggers.
     ///
-    /// Mounts both URL shapes (M3.3 / ADR-0049):
+    /// Mounts both URL shapes (webhook activation):
     ///
     /// - Programmatic: `POST {path_prefix}/{trigger_uuid}/{nonce}` —
     ///   minted by [`Self::activate`].

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -146,7 +146,7 @@ pub(crate) fn create_test_jwt() -> String {
 
 /// Permissive [`CredentialSchemaPort`] test double: accepts any `data`,
 /// exposes no catalog types. Wired by default into [`create_state_with_queue`]
-/// so credential happy-path tests keep their pre-ADR-0052-P4 behavior
+/// so credential happy-path tests keep their pre--P4 behavior
 /// (the old fail-open persisted unvalidated; the correct test default is
 /// "a validator is present and permissive"). The reject / no-port cases
 /// are exercised explicitly by `tests/seam_credential_write_path_validation.rs`.
@@ -219,7 +219,7 @@ pub(crate) struct PortHandles {
 /// tuple. The engine's internal `engine_scope()` placeholder is
 /// substituted by the request-scope-bound decorator the seam wraps the
 /// stores in (engine per-execution scoping is a separate, tracked
-/// follow-up — see ADR-0072 "Known follow-up").
+/// follow-up — see storage port migration "Known follow-up").
 pub(crate) fn port_scope() -> Scope {
     Scope::new(TEST_WS, TEST_ORG)
 }
@@ -338,7 +338,7 @@ impl PortHandles {
 ///
 /// When `with_credential_port` is `true` a [`PermissiveCredentialSchemaPort`]
 /// is wired (the credential happy-path default); when `false` the
-/// credential-schema port is left unset so the ADR-0052 P4 seam test can
+/// credential-schema port is left unset so the credential-schema validation seam test can
 /// assert the unconfigured write path returns 503 (never persists
 /// unvalidated).
 async fn build_port_state_with(with_credential_port: bool) -> (AppState, PortHandles) {
@@ -459,14 +459,14 @@ pub(crate) async fn create_state_with_port_handles() -> (AppState, PortHandles) 
 
 /// Create an `AppState` wired through the scoped storage port, returning
 /// the state and the raw `InMemoryControlQueue` handle. This is the
-/// canonical §13-knife wiring; the asserted invariants are unchanged
+/// canonical integration seam-knife wiring; the asserted invariants are unchanged
 /// from the pre-port path (see this file's header).
 pub(crate) async fn create_state_with_port_queue() -> (AppState, InMemoryControlQueue) {
     create_state_with_queue().await
 }
 
 /// Same as [`create_state_with_queue`] but with **no** credential-schema
-/// port wired — for the ADR-0052 P4 seam test that asserts the
+/// port wired — for the credential-schema validation seam test that asserts the
 /// unconfigured write path returns 503 (never persists unvalidated).
 /// Port-wired exactly like [`build_port_state`], minus the
 /// `with_credential_schema` call.
@@ -479,7 +479,7 @@ pub(crate) async fn create_state_with_queue_no_credential_port() -> (AppState, I
 // ── `me/*` end-to-end harness (Phase 2) ──────────────────────────────────────
 //
 // Builds an `AppState` wired with a real `InMemoryAuthBackend` (the
-// §4.5-honest production-quality Plane-A backend — Argon2id / RFC 6238
+// honest capability-honest production-quality Plane-A backend — Argon2id / RFC 6238
 // TOTP / SHA-256 PAT lookup), registers one user, and hands back a JWT
 // whose `sub` is that user's real `UserId`. The auth middleware's JWT
 // path parses `sub` via `UserId::from_str` → `Principal::User`, so the
@@ -711,10 +711,10 @@ pub(crate) mod org_support {
     }
 }
 
-// ── Orchestration-absent control queue (canon §13 step 6) ─────────────────────
+// ── Orchestration-absent control queue (integration seam step 6) ─────────────────────
 
 /// A scoped control-queue port whose `enqueue` always fails — simulates
-/// the "orchestration backend unavailable" scenario (canon §13 step 6).
+/// the "orchestration backend unavailable" scenario (integration seam step 6).
 /// `StorageError::Internal` is the sentinel `cancel_execution` /
 /// `terminate_execution` map to `ApiError::ServiceUnavailable` → HTTP 503.
 #[derive(Debug)]
@@ -773,12 +773,12 @@ impl nebula_storage_port::store::ControlQueue for AlwaysFailControlQueue {
 }
 
 /// Create an `AppState` wired through the storage port whose **control
-/// queue** always fails on `enqueue` (canon §13 step 6). Every other
+/// queue** always fails on `enqueue` (integration seam step 6). Every other
 /// store is the normal in-memory port adapter behind its `nebula-tenancy`
 /// scoping decorator — only the control queue is the always-fail double.
 ///
 /// Returns the state plus the raw (undecorated) [`InMemoryExecutionStore`]
-/// so the §13 step-6 test can seed a running execution row directly under
+/// so the integration seam step-6 test can seed a running execution row directly under
 /// [`port_scope`] before asserting the enqueue-fails-503 path. The store is
 /// `Clone` over an `Arc<Mutex<…>>`, so the returned handle shares state
 /// with the scoping-decorated one inside `AppState`.
@@ -814,7 +814,7 @@ pub(crate) async fn create_state_with_failing_queue() -> (AppState, InMemoryExec
     (state, exec_store)
 }
 
-// ── Engine seam harness (canon §13 step 5 / ADR-0008 A3 / ADR-0016) ──────────
+// ── Engine seam harness (integration seam step 5 / control-queue terminate dispatch / cooperative cancel) ──────────
 //
 // Shared real-engine-consumer wiring for the durable-control-plane seam
 // tests. The producer half (API enqueues `Cancel` / `Terminate`) is
@@ -824,7 +824,7 @@ pub(crate) async fn create_state_with_failing_queue() -> (AppState, InMemoryExec
 // repos the API writes to.
 //
 // `knife.rs::knife_step5_engine_cancels_running_execution_end_to_end`
-// (the canon §13 seam) and
+// (the integration seam seam) and
 // `execution_terminate_e2e.rs::terminate_engine_drives_running_execution_to_terminal_end_to_end`
 // both source the wiring here so they differ ONLY in the final HTTP call
 // (DELETE-cancel vs POST-terminate) and the command/terminal assertion.
@@ -1028,7 +1028,7 @@ pub(crate) mod engine_seam {
         // per-request tenant scope in its accessors; the engine, by
         // contrast, still calls its store handles with the internal
         // `engine_scope()` placeholder (a separate, tracked follow-up —
-        // see ADR-0072 "Known follow-up: engine per-execution tenant
+        // see storage port migration "Known follow-up: engine per-execution tenant
         // scoping"). To keep the seam coherent the engine-side handles
         // are wrapped here in `nebula-tenancy` decorators bound to
         // `port_scope()` — the request scope the API derives and the

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -1,7 +1,7 @@
 //! Phase 4 — credential CRUD end-to-end + abuse-case coverage.
 //!
 //! Credentials are the highest-value target in the API surface, so this
-//! file is deliberately heavy on the security cases (canon §13, §12.5 /
+//! file is deliberately heavy on the security cases (integration seam, credential secrecy /
 //! STYLE §6):
 //!
 //! - Happy-path CRUD round-trips through the real axum `Router` over the
@@ -667,7 +667,7 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
     // The sentinel is placed in the submitted credential material
     // (`data` / `user_input`) so the no-secret assertion below is a
     // *real* redaction guard, not vacuous: the honest-503 problem body
-    // must never echo caller-submitted secret material (§12.5 / §13 —
+    // must never echo caller-submitted secret material (credential secrecy / integration seam —
     // same contract as the forced-error bodies elsewhere in this file).
     let resolve_503: &[(&str, String, serde_json::Value)] = &[
         (
@@ -711,10 +711,10 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
     }
 
     // Type-discovery endpoints (system-level, not workspace-scoped).
-    // ADR-0052 P4 V3: these are now port-backed. The shared harness wires
+    // credential-schema port: these are now port-backed. The shared harness wires
     // a permissive port (zero registered types), so the *honest* result is
     // 200 with an empty `types` list (the endpoint truthfully reports the
-    // registered set) and 404 for an unknown key — not a §4.5 false
+    // registered set) and 404 for an unknown key — not a honest capability false
     // capability. The genuine no-port → 503 path is covered by
     // `tests/seam_credential_catalog_schema.rs::catalog_503_when_port_unconfigured`.
     let app = app::build_app(state.clone(), &config);

--- a/crates/api/tests/execution_terminate_e2e.rs
+++ b/crates/api/tests/execution_terminate_e2e.rs
@@ -1,9 +1,9 @@
 //! `POST /executions/:id/terminate` end-to-end + parity coverage.
 //!
-//! `terminate_execution` graduated stub→implemented as a real canon §12.2
-//! durable-control-plane endpoint (ADR-0008 A3 / ADR-0016). It mirrors
+//! `terminate_execution` graduated stub→implemented as a real durable control queue
+//! durable-control-plane endpoint (control-queue terminate dispatch / cooperative cancel). It mirrors
 //! `cancel_execution` exactly except it enqueues
-//! `ControlCommand::Terminate`. Per ADR-0016 the engine has no distinct
+//! `ControlCommand::Terminate`. Per cooperative cancel the engine has no distinct
 //! forced-shutdown path: `Terminate` is wired end-to-end
 //! (`ControlConsumer` → `EngineControlDispatch::dispatch_terminate` →
 //! `dispatch_cancel` → the engine cancel registry's live
@@ -19,7 +19,7 @@
 //!
 //! | Scenario | What is asserted | Test |
 //! |----------|------------------|------|
-//! | Engine-visible seam (canon §13 bar) | Running exec + POST terminate → control_queue gets a `Terminate` entry → the wired real engine consumer drives the execution to terminal `Cancelled`, well inside the 30s slow-handler window | `terminate_engine_drives_running_execution_to_terminal_end_to_end` |
+//! | Engine-visible seam (integration seam bar) | Running exec + POST terminate → control_queue gets a `Terminate` entry → the wired real engine consumer drives the execution to terminal `Cancelled`, well inside the 30s slow-handler window | `terminate_engine_drives_running_execution_to_terminal_end_to_end` |
 //! | Producer durability | POST terminate persists `cancelled` + enqueues exactly one `Terminate` entry referencing the execution | `terminate_enqueues_durable_control_signal` |
 //! | Atomic outbox | legacy control-queue handle down → POST terminate still commits state + `Terminate` outbox together via `TransitionBatch` | `terminate_control_signal_is_atomic_with_state` |
 //! | 404 | unknown execution → 404 | `terminate_unknown_execution_returns_404` |
@@ -36,16 +36,16 @@ use common::*;
 use nebula_api::{ApiConfig, app};
 use tower::ServiceExt;
 
-// ── Engine-visible seam (canon §13 integration bar) ──────────────────────────
+// ── Engine-visible seam (integration seam integration bar) ──────────────────────────
 //
 // Symmetric to `knife.rs::knife_step5_engine_cancels_running_execution_end_to_end`,
 // but exercises the `Terminate` command instead of `Cancel`. The wiring:
 //
 //   POST /executions/:id/terminate
-//     → execution_store CAS-transition (Cancelled)    [API handler, §12.2 order]
-//     → control_queue.enqueue(Terminate)              [API handler, §12.2 order]
+//     → execution_store CAS-transition (Cancelled)    [API handler, durable control queue order]
+//     → control_queue.enqueue(Terminate)              [API handler, durable control queue order]
 //     → ControlConsumer.claim_pending
-//     → EngineControlDispatch::dispatch_terminate     (ADR-0008 A3 / ADR-0016)
+//     → EngineControlDispatch::dispatch_terminate     (control-queue terminate dispatch / cooperative cancel)
 //     → EngineControlDispatch::dispatch_cancel        (Terminate == cooperative
 //                                                      cancel synonym today)
 //     → WorkflowEngine::cancel_execution              (live cancel registry)
@@ -58,12 +58,12 @@ use tower::ServiceExt;
 // command/terminal assertion. Asserting the execution reaches a terminal
 // state inside the 30s slow window proves the `Terminate` signal reached
 // the engine's *live* loop — not merely that the API CAS-flipped the row
-// (the two-truth gap canon §14 calls out).
+// (the two-truth gap two-truth gap calls out).
 
 /// Engine-visible seam: a Running execution + `POST .../terminate` drives
 /// the execution all the way to a terminal state via the real engine
 /// consumer — proving the durable `Terminate` signal reaches the live
-/// frontier loop (ADR-0008 A3 / ADR-0016), not just the DB row.
+/// frontier loop (control-queue terminate dispatch / cooperative cancel), not just the DB row.
 #[tokio::test]
 async fn terminate_engine_drives_running_execution_to_terminal_end_to_end() {
     use std::time::Duration;
@@ -152,12 +152,12 @@ async fn terminate_engine_drives_running_execution_to_terminal_end_to_end() {
     assert_eq!(
         terminated["status"].as_str(),
         Some("cancelled"),
-        "terminate response must show terminal `cancelled` status (ADR-0016: \
+        "terminate response must show terminal `cancelled` status (cooperative cancel: \
          Terminate is a cooperative-cancel synonym, no `Terminated` variant)"
     );
 
     // The control queue must hold the `Start` from the producer path AND a
-    // fresh `Terminate` from the endpoint under test — proving the §12.2
+    // fresh `Terminate` from the endpoint under test — proving the durable control queue
     // same-logical-operation enqueue happened, engine-visible.
     let queued = handles.control_queue.snapshot();
     let (terminate_msg, _status) = queued
@@ -190,14 +190,14 @@ async fn terminate_engine_drives_running_execution_to_terminal_end_to_end() {
     .await
     .expect(
         "engine reached a terminal state within 10s (Terminate dispatch signalled the \
-         live frontier loop via the ADR-0016 cancel registry) — the 30s slow handler \
+         live frontier loop via the cooperative-cancel registry) — the 30s slow handler \
          was aborted cooperatively, not left sleeping",
     );
 
     assert!(
         final_status.is_terminal(),
         "execution reached a terminal state after Terminate — the engine honors \
-         ControlCommand::Terminate end-to-end (ADR-0008 A3 / ADR-0016). got: {final_status:?}"
+         ControlCommand::Terminate end-to-end (control-queue terminate / cooperative cancel). got: {final_status:?}"
     );
 
     // Graceful shutdown so the spawned consumer task doesn't leak.
@@ -206,7 +206,7 @@ async fn terminate_engine_drives_running_execution_to_terminal_end_to_end() {
 
 // ── Producer durability + parity coverage (mirrors cancel) ───────────────────
 
-/// Canon §12.2: terminating a non-terminal execution must both
+/// durable control queue: terminating a non-terminal execution must both
 /// (1) persist the terminal state in the execution row, AND
 /// (2) enqueue a `Terminate` command in the durable control queue.
 /// Mirror of `integration_tests.rs::cancel_enqueues_durable_control_signal`.
@@ -442,7 +442,7 @@ async fn terminate_invalid_execution_id_rejected_by_middleware() {
 }
 
 /// Terminating an already-terminal execution must be rejected with 400 and
-/// must NOT enqueue a spurious `Terminate` signal (idempotency / §12.2
+/// must NOT enqueue a spurious `Terminate` signal (idempotency / durable control queue
 /// terminal-state guard). Mirror of
 /// `integration_tests.rs::cancel_terminal_execution_does_not_enqueue`.
 #[tokio::test]

--- a/crates/api/tests/idempotency_e2e.rs
+++ b/crates/api/tests/idempotency_e2e.rs
@@ -1,5 +1,5 @@
 //! End-to-end tests for the idempotency middleware against the real
-//! `build_app` router (M3.4 — ADR-0048).
+//! `build_app` router (M3.4 — idempotency backend).
 //!
 //! These tests differ from `tests/idempotency_middleware.rs` in two ways:
 //!
@@ -12,7 +12,7 @@
 //! 2. Test fixtures (`POST /api/v1/_test/echo`, `POST /api/v1/_test/fail`)
 //!    are mounted via `axum::Router::merge` BEFORE the idempotency layer
 //!    inside `build_app` (gated behind `feature = "test-util"`); they
-//!    never appear in the served OpenAPI 3.1 spec (ADR-0047 honesty).
+//!    never appear in the served OpenAPI 3.1 spec (stub-honesty).
 //!
 //! Roadmap: §M3.4 Idempotency-Key dedup — fourth box (end-to-end test
 //! against the real `build_app`).

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2061,7 +2061,7 @@ async fn get_workflow_parses_rfc3339_timestamps() {
 }
 
 /// Activation of a valid workflow definition succeeds with 200 OK.
-/// Canon §10 step 2 regression lock: the validation gate must not block
+/// documentation honesty step 2 regression lock: the validation gate must not block
 /// structurally correct definitions.
 #[tokio::test]
 async fn activate_valid_returns_200() {
@@ -2108,7 +2108,7 @@ async fn activate_valid_returns_200() {
 
 /// Activation of a definitionally invalid workflow returns 422 Unprocessable
 /// Entity with a structured RFC 9457 body.
-/// Canon §10 step 2: activation MUST reject invalid definitions — not silently
+/// documentation honesty step 2: activation MUST reject invalid definitions — not silently
 /// flip the active flag.
 #[tokio::test]
 async fn activate_invalid_returns_422() {
@@ -2195,16 +2195,16 @@ async fn activate_invalid_returns_422() {
     }
 }
 
-// ── §12.2 / audit §2.2 cancel control-queue wiring tests ────────────────────
+// ── durable control queue / audit §2.2 cancel control-queue wiring tests ────────────────────
 
-/// Canon §12.2 regression lock: cancelling a non-terminal execution must both
+/// durable control queue regression lock: cancelling a non-terminal execution must both
 /// (1) persist the `cancelled` state in the execution row, AND
 /// (2) enqueue a `Cancel` command in the durable control queue.
 ///
 /// Before this fix only (1) happened — the engine never saw the cancel signal.
 ///
 /// Audit ref: 2026-04-16-workspace-health-audit.md §2.2
-/// Knife ref: PRODUCT_CANON.md §13 step 5
+/// Knife ref: PRODUCT_CANON.md integration seam step 5
 #[tokio::test]
 async fn cancel_enqueues_durable_control_signal() {
     use axum::{
@@ -2282,7 +2282,7 @@ async fn cancel_enqueues_durable_control_signal() {
     );
 
     // (2) A Cancel command must have been written to the control queue — this is
-    //     the engine-visible signal required by canon §12.2 and §13 step 5.
+    //     the engine-visible signal required by durable control queue and integration seam step 5.
     let queued = handles.control_queue.snapshot();
     assert_eq!(
         queued.len(),
@@ -2513,7 +2513,7 @@ async fn cancel_timed_out_execution_rejected() {
 
 // ── Issue #327 regression ─────────────────────────────────────────────────────
 //
-// Canon §4.5: a public surface exists iff the engine honors it end-to-end.
+// honest capability contract: a public surface exists iff the engine honors it end-to-end.
 // The API's `start_execution` previously persisted a hand-rolled JSON with
 // `status: "pending"` — a string that is not in `ExecutionStatus` and that
 // neither `list_running` (storage filter) nor `ExecutionState::deserialize`
@@ -2663,7 +2663,7 @@ async fn test_issue_327_start_execution_persists_canonical_execution_state() {
     assert!(
         exec_state.started_at.is_none(),
         "#327: started_at must be None until the engine transitions to Running \
-         (canon §11.1: authority over lifecycle transitions lives in the engine)"
+         (lifecycle authority: transitions live in the engine)"
     );
     assert!(
         exec_state.completed_at.is_none(),
@@ -2691,18 +2691,18 @@ async fn test_issue_327_start_execution_persists_canonical_execution_state() {
 
 // ── Issue #332 regression ────────────────────────────────────────────────────
 //
-// Canon §4.5: a public surface exists iff the engine honors it end-to-end.
-// Canon §12.2: every engine-visible signal must travel the durable control
+// honest capability contract: a public surface exists iff the engine honors it end-to-end.
+// durable control queue: every engine-visible signal must travel the durable control
 // queue — in-process channels are not a durable backbone.
-// Knife §13 step 3: starting an execution must cause node dispatch.
+// Knife integration seam step 3: starting an execution must cause node dispatch.
 //
 // Before this fix the API `start_execution` / `execute_workflow` handlers
 // persisted a row and returned 202 without ever notifying the engine — so
 // the execution sat in `Created` forever and no node ran. This is the
-// §4.5 "advertise capability engine doesn't deliver end-to-end" violation.
+// honest capability "advertise capability engine doesn't deliver end-to-end" violation.
 //
 // The fix enqueues `ControlCommand::Start` on the shared durable control
-// queue immediately after persisting the row (ADR-0008). The engine-side
+// queue immediately after persisting the row (durable control queue). The engine-side
 // `ControlConsumer` drains that queue to drive the actual run.
 //
 // These regression tests pin the exact contract that was missing:
@@ -2792,7 +2792,7 @@ async fn test_issue_332_start_execution_enqueues_control_start() {
 
     // Assert: exactly one Start entry exists on the queue, targeting the
     // execution id the API just returned. This is the engine-visible signal
-    // canon §12.2 requires — without it the engine never dispatches and
+    // durable control queue requires — without it the engine never dispatches and
     // the execution stays `Created` forever (the bug).
     let queued = handles.control_queue.snapshot();
     assert_eq!(

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -1,7 +1,7 @@
-//! Canon §13 knife scenario — end-to-end integration test.
+//! integration seam knife scenario — end-to-end integration test.
 //!
-//! This file covers §13 steps 1–6 as specified in
-//! `docs/PRODUCT_CANON.md §13` and the workspace health audit
+//! This file covers integration seam steps 1–6 as specified in
+//! `docs/PRODUCT_CANON.md integration seam` and the workspace health audit
 //! (`docs/ARCHIVE.md (removed execution specs) §8
 //! Sprint A1 item #3`).
 //!
@@ -22,13 +22,13 @@
 //! | 5 | `POST /executions/:id/cancel` → row = `cancelled`, outbox holds exactly Start + Cancel (both `Pending`) | `knife_scenario_end_to_end_via_port` |
 //! | 6 | Cancel state + control signal commit atomically even if the legacy queue handle fails | `knife_step6_cancel_control_signal_is_atomic_with_state` |
 //!
-//! ## Consumer-side §13 (engine dispatch end-to-end)
+//! ## Consumer-side integration seam (engine dispatch end-to-end)
 //!
 //! The producer side above asserts the API writes the execution row and
 //! enqueues the control command. The consumer side — the engine-owned
 //! `EngineControlDispatch` draining the durable queue and driving the
 //! workflow to a terminal state (Created → Completed on `Start`, Running
-//! → Cancelled on `Cancel` via the live frontier loop, plus the ADR-0008
+//! → Cancelled on `Cancel` via the live frontier loop, plus the durable control queue
 //! §5 redelivery-idempotency contract) — is asserted on the same spec-16
 //! port by `crates/engine/tests/control_dispatch.rs`. That is the
 //! canonical home for the dispatch loop now that the engine consumes the
@@ -48,14 +48,14 @@ use tower::ServiceExt;
 // The legacy failing control queue (`AlwaysFailControlQueue` +
 // `create_state_with_failing_queue`) and the engine-seam harness
 // (`engine_seam::{persist_slow_workflow, spawn_engine_consumer}`) live in
-// the shared `common` module — see `tests/common/mod.rs`. The §13 step-6
+// the shared `common` module — see `tests/common/mod.rs`. The integration seam step-6
 // test reuses the placeholder scope every port store binds to via
 // `common::port_scope`.
 use common::port_scope as knife_scope;
 
 // ── tests ─────────────────────────────────────────────────────────────────────
 
-/// Canon §13 steps 1–5 end-to-end: define → activate → start → observe
+/// integration seam steps 1–5 end-to-end: define → activate → start → observe
 /// → cancel, through the scoped storage port.
 ///
 /// The workflow / execution / control-queue surface is the spec-16 port
@@ -264,7 +264,7 @@ async fn knife_scenario_end_to_end_via_port() {
     );
 
     // Outbox now holds the Start (step 3) + Cancel (step 5), both
-    // Pending — the §12.2 same-logical-operation guarantee, asserted
+    // Pending — the durable control queue same-logical-operation guarantee, asserted
     // through the port snapshot (typed id, opaque `execution_id`
     // string — no UTF-8-of-ULID decode).
     let queued = control_queue.snapshot();
@@ -356,13 +356,13 @@ async fn knife_step6_cancel_control_signal_is_atomic_with_state() {
     );
 }
 
-// ── Step 3 end-to-end (ADR-0008 A2) ───────────────────────────────────────────
+// ── Step 3 end-to-end (control-queue start dispatch) ───────────────────────────────────────────
 //
-// The `knife_scenario_end_to_end` test above asserts the PRODUCER side of §13
+// The `knife_scenario_end_to_end` test above asserts the PRODUCER side of integration seam
 // step 3 — the API writes the execution row and enqueues `Start` onto the
 // durable control queue (#332). This separate test asserts the CONSUMER side:
-// the engine-owned `EngineControlDispatch` (ADR-0008 A2) drains the queue and
-// actually drives the workflow to `Completed`, closing the §4.5 gap that was
+// the engine-owned `EngineControlDispatch` (control-queue start dispatch) drains the queue and
+// actually drives the workflow to `Completed`, closing the honest capability gap that was
 // still open after #332 landed.
 //
 // The two tests intentionally stand up separate `AppState`s — the producer
@@ -407,12 +407,12 @@ impl nebula_action::stateless::StatelessAction for KnifeEcho {
     }
 }
 
-/// Canon §13 step 3 end-to-end (ADR-0008 A2).
+/// integration seam step 3 end-to-end (control-queue start dispatch).
 ///
 /// Wires API producer + `ControlConsumer` + `EngineControlDispatch` + engine
 /// over shared in-memory repos, POSTs `/workflows/:id/executions`, and polls
 /// the repo until the execution transitions all the way to `Completed`. This
-/// exercises the full §12.2 loop that ADR-0008 promised:
+/// exercises the full durable control queue loop that durable control queue promised:
 ///
 /// ```text
 /// POST /executions
@@ -420,7 +420,7 @@ impl nebula_action::stateless::StatelessAction for KnifeEcho {
 ///   → execution_control_queue.enqueue(Start)
 ///   → ControlConsumer.claim_pending
 ///   → EngineControlDispatch::dispatch_start
-///   → WorkflowEngine::resume_execution (ADR-0015 lease scope)
+///   → WorkflowEngine::resume_execution (execution lease scope lease scope)
 ///   → node run → transition to Completed
 ///   → mark_completed on the queue row
 /// ```
@@ -535,7 +535,7 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     // `AppState` stores **raw** port handles and applies the per-request
     // tenant scope in its accessors; the engine still calls its handles
     // with the internal `engine_scope()` placeholder (a separate, tracked
-    // follow-up — see ADR-0072 "Known follow-up: engine per-execution
+    // follow-up — see storage port migration "Known follow-up: engine per-execution
     // tenant scoping"). Wrap the engine-side handles in `nebula-tenancy`
     // decorators bound to `knife_scope()` (= `port_scope()`, the scope
     // the API derives and this test seeded the workflow/execution under)
@@ -629,7 +629,7 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     //
     // Poll the repo because the consumer loop is cross-task; a small timeout
     // tolerates scheduler jitter on slow test hosts. A fail here means the
-    // §4.5 gap #332 was only half-closed — producer works, consumer does not.
+    // honest capability gap #332 was only half-closed — producer works, consumer does not.
     let final_status = tokio::time::timeout(Duration::from_secs(5), async {
         loop {
             // Read through the same scoped port handle the engine was
@@ -665,7 +665,7 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     let _ = consumer_handle.await;
 }
 
-// ── Knife step 5 end-to-end (ADR-0008 A3) ──────────────────────────────────
+// ── Knife step 5 end-to-end (control-queue terminate dispatch) ──────────────────────────────────
 //
 // Symmetric to `knife_step3_engine_dispatches_start_end_to_end`. The producer
 // half — `POST /cancel` writes the `Cancelled` row and enqueues `Cancel` — is
@@ -690,7 +690,7 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
 // `common::engine_seam` harness (byte-behaviorally identical to the
 // original inline wiring — the move is mechanical).
 
-/// Canon §13 step 5 end-to-end (ADR-0008 A3).
+/// integration seam step 5 end-to-end (control-queue terminate dispatch).
 ///
 /// Wires API producer + `ControlConsumer` + `EngineControlDispatch` + engine
 /// over shared in-memory repos, starts a long-running execution, POSTs

--- a/crates/api/tests/me_e2e.rs
+++ b/crates/api/tests/me_e2e.rs
@@ -3,7 +3,7 @@
 //! All six `/api/v1/me/*` endpoints are graduated stub→implemented. Five
 //! drive the full middleware → handler → `AuthBackend` path against a
 //! **real** `InMemoryAuthBackend` (Argon2id / RFC 6238 TOTP / SHA-256 PAT
-//! lookup — the §4.5-honest production-quality default; `nebula_storage`
+//! lookup — the honest capability-honest production-quality default; `nebula_storage`
 //! ships no `UserRepo`/`PatRepo`/`SessionRepo` impl, so this in-memory
 //! backend *is* the real backing, exactly as `InMemoryControlQueueRepo`
 //! is for the durable control plane in Phase 1).
@@ -143,7 +143,7 @@ async fn get_me_returns_profile_with_real_token_count() {
 
 #[tokio::test]
 async fn get_me_orgs_count_absent_when_membership_store_unwired() {
-    // §4.5 honest degradation: `create_me_state_without_backend` wires
+    // honest capability honest degradation: `create_me_state_without_backend` wires
     // neither an auth backend nor a membership store. The request reaches
     // the handler (JWT → Principal::User) but fails closed on the absent
     // auth backend with 503 *before* it would read org membership — so
@@ -369,7 +369,7 @@ async fn list_my_orgs_returns_seeded_membership() {
         "org id must be a prefixed ULID"
     );
     assert_eq!(orgs[0]["role"], "member", "seeded role is OrgMember");
-    // §4.5: no synthesized reverse-slug field.
+    // honest capability: no synthesized reverse-slug field.
     assert!(
         orgs[0].get("slug").is_none(),
         "OrgSummary must not carry a synthesized slug (no OrgId→slug directory)"
@@ -542,7 +542,7 @@ async fn create_token_without_auth_is_401() {
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
-/// Secret-redaction contract for `create_token` (canon §12.5 / STYLE §6):
+/// Secret-redaction contract for `create_token` (credential secrecy / STYLE §6):
 /// the plaintext is returned **exactly once** in the body and **never**
 /// surfaces in tracing output. Mirrors the
 /// `crates/credential/tests/redaction.rs` capturing-subscriber pattern.

--- a/crates/api/tests/openapi_canon_compliance.rs
+++ b/crates/api/tests/openapi_canon_compliance.rs
@@ -1,10 +1,10 @@
-//! Canon §4.5 stub-honesty gate (M3.2 Task 6.5).
+//! honest capability contract stub-honesty gate (M3.2 Task 6.5).
 //!
 //! Locks the OpenAPI document against the failure mode where a stub
 //! handler is silently advertised as a fully-shipped endpoint.
 //!
 //! **Static check** — every operation flagged `deprecated = true` MUST
-//! declare a `501` response (ADR-0047 Stub Endpoint Policy).
+//! declare a `501` response (stub endpoint policy).
 //!
 //! **Runtime check** — every honest-501 stub endpoint is probed against a
 //! booted in-memory app. The remaining inventory is the org-record
@@ -13,19 +13,19 @@
 //! handlers.
 //!
 //! Graduated stub→implemented (removed from this inventory):
-//! `execution::terminate` via the durable control queue (ADR-0008 A3 /
-//! ADR-0016, covered by `execution_terminate_e2e.rs`); the five `me/*`
+//! `execution::terminate` via the durable control queue (control-queue terminate dispatch /
+//! cooperative cancel, covered by `execution_terminate_e2e.rs`); the five `me/*`
 //! profile/PAT endpoints (`get_me`, `update_me`, `list_my_tokens`,
 //! `create_token`, `delete_token`) via the Plane-A `AuthBackend` port
 //! (covered by `me_e2e.rs`); — Phase 3 — `me::list_my_orgs` plus the
 //! three org member endpoints (`org::list_members`, `org::add_member`,
-//! `org::remove_member`) via the shared `MembershipStore` (canon §4.5
+//! `org::remove_member`) via the shared `MembershipStore` (honest capability contract
 //! "Option 1" honest contract — the fake email-invitation shape was
 //! dropped for direct add-by-principal; covered, incl. abuse cases, by
 //! `org_e2e.rs`); and the resource catalog surface
 //! (`resource::{list,get,create,update,delete}_resource` +
 //! `resource::get_resource_status`) — config-CRUD + CAS + a read-only
-//! runtime-status projection (ADR-0067; covered by
+//! runtime-status projection (resource runtime status; covered by
 //! `resource_handlers.rs`). The org-record + service-account endpoints
 //! stay honest-501 (no org-record store; no end-to-end
 //! `Principal::ServiceAccount` auth path).
@@ -35,7 +35,7 @@
 //! body and **403** (`ApiError::InsufficientRole` / `Forbidden`) for
 //! stubs whose RBAC gate (`tenant.require(...)`) runs before the handler.
 //! Both 403 and 501 are explicitly advertised in the spec for RBAC-gated
-//! stubs (see ADR-0047 §4 Stub Endpoint Policy + the per-handler
+//! stubs (see 4 Stub Endpoint Policy + the per-handler
 //! `responses(...)` blocks). The legacy 500 outcome (when the stub
 //! returned `ApiError::Internal("not implemented")`) is no longer
 //! accepted — that deviation closed when stubs migrated to
@@ -117,8 +117,8 @@ async fn deprecated_operations_must_advertise_501_response() {
                 });
             assert!(
                 responses.contains_key("501"),
-                "Deprecated operation {method} {path} MUST declare a 501 response per ADR-0047 \
-                 Stub Endpoint Policy; got responses: {:?}",
+                "Deprecated operation {method} {path} MUST declare a 501 response per stub \
+                 endpoint policy; got responses: {:?}",
                 responses.keys().collect::<Vec<_>>()
             );
         }
@@ -172,11 +172,11 @@ fn stub_endpoints() -> Vec<(&'static str, String, Option<&'static str>)> {
         ),
         // resource — 0 stubs (the whole resource catalog surface
         // graduated stub→implemented: config-CRUD + CAS + a read-only
-        // runtime-status projection, ADR-0067; covered end-to-end by
+        // runtime-status projection, resource runtime status; covered end-to-end by
         // resource_handlers.rs).
         // execution — 1 stub (terminate graduated stub→implemented:
-        // real §12.2 durable-control-queue endpoint, ADR-0008 A3 /
-        // ADR-0016; covered end-to-end by execution_terminate_e2e.rs).
+        // real durable control queue durable-control-queue endpoint, control-queue terminate dispatch /
+        // cooperative cancel; covered end-to-end by execution_terminate_e2e.rs).
         (
             "POST",
             format!("/api/v1/orgs/{TEST_ORG}/workspaces/{TEST_WS}/executions/{_exec_id}/restart"),
@@ -199,13 +199,13 @@ async fn stub_endpoints_return_501_at_runtime() {
         "stub coverage list must enumerate all remaining audit class-(c) \
          endpoints. The M3.2 audit identified 18. Graduated \
          stub→implemented (removed from this inventory): \
-         `execution::terminate` (ADR-0008 A3 / ADR-0016 — \
+         `execution::terminate` (control-queue terminate / cooperative cancel — \
          execution_terminate_e2e.rs); the five `me/*` profile/PAT \
          endpoints (Plane-A `AuthBackend` port — me_e2e.rs); **Phase \
          3** `me::list_my_orgs` + the three org member endpoints \
          (`list_members`/`add_member`/`remove_member`) via the shared \
          `MembershipStore` (org_e2e.rs); and the resource catalog surface \
-         (config-CRUD + CAS + read-only status, ADR-0067 — \
+         (config-CRUD + CAS + read-only status, resource runtime status — \
          resource_handlers.rs). That leaves 7 honest-501: 3 org-record \
          (`get`/`update`/`delete_org`) + 3 service-account + execution \
          restart; got {}",
@@ -235,8 +235,8 @@ async fn stub_endpoints_return_501_at_runtime() {
         let status = response.status().as_u16();
         assert!(
             status == 501 || status == 403,
-            "Stub endpoint {method} {path} expected 501 (per ADR-0047 Stub \
-             Endpoint Policy + the `ApiError::NotImplemented` variant) or \
+            "Stub endpoint {method} {path} expected 501 (per stub endpoint \
+             policy + the `ApiError::NotImplemented` variant) or \
              403 (per the RBAC gate, when the handler carries one); got \
              {status}. Either the stub got accidentally implemented (drop \
              the `#[deprecated]` + 501 response declaration) or auth/tenancy \
@@ -249,7 +249,7 @@ async fn stub_endpoints_return_501_at_runtime() {
         // application/problem+json` per RFC 9457. A 501 emitted by
         // middleware (or a generic axum error path) would carry a
         // different content-type — this assertion confirms the request
-        // actually reached the handler and the canon §4.5 honesty
+        // actually reached the handler and the honest capability contract honesty
         // contract was exercised end-to-end.
         let content_type = response
             .headers()

--- a/crates/api/tests/openapi_spec.rs
+++ b/crates/api/tests/openapi_spec.rs
@@ -3,13 +3,13 @@
 //! Boots [`nebula_api::build_app`], fetches `/api/v1/openapi.json`, and
 //! verifies the spec is structurally valid and stable:
 //!
-//! - **Version pin** — `openapi == "3.1.0"` (ADR-0047 §1).
+//! - **Version pin** — `openapi == "3.1.0"` (1).
 //! - **operationId uniqueness** — utoipa-axum derives the id from the
 //!   handler function name; collisions crash client generators.
 //! - **$ref resolution** — every `$ref` under `paths.../responses/.../schema`
 //!   resolves to a declared component.
 //! - **Required security schemes** — `bearer`, `api_key`, and `csrf` are
-//!   published per ADR-0047 §2.
+//!   published per 2.
 //! - **Drift parity** — the spec mentions every key path mounted under
 //!   `routes::create_routes`; if a handler is added but not annotated
 //!   (or vice versa) this test catches it.
@@ -64,7 +64,7 @@ async fn served_spec_pins_openapi_3_1_0() {
         .expect("spec.openapi must be a string");
     assert_eq!(
         version, "3.1.0",
-        "ADR-0047 pins the generator to OpenAPI 3.1.0; got {version}"
+        "stub-endpoint policy pins the generator to OpenAPI 3.1.0; got {version}"
     );
 }
 
@@ -152,12 +152,12 @@ async fn security_schemes_match_adr_0047() {
         .get("components")
         .and_then(|c| c.get("securitySchemes"))
         .and_then(Value::as_object)
-        .expect("components.securitySchemes must be present per ADR-0047 §2");
+        .expect("components.securitySchemes must be present per OpenAPI contract");
 
     for required in ["bearer", "api_key", "csrf"] {
         assert!(
             schemes.contains_key(required),
-            "ADR-0047 mandates security scheme `{required}` in the spec; \
+            "OpenAPI contract mandates security scheme `{required}` in the spec; \
              got {:?}",
             schemes.keys().collect::<Vec<_>>()
         );
@@ -207,7 +207,7 @@ async fn drift_smoke_known_paths_are_present() {
         // sub-route, and it is GET-only: resource lifecycle
         // (acquire/release/drain/reload) is engine-owned and
         // deliberately never exposed over HTTP (INTEGRATION_MODEL
-        // §13.1). Pinning the status path here makes that
+        // integration seam.1). Pinning the status path here makes that
         // "observe-only, no lifecycle verbs" boundary drift-detected —
         // if a mutating `{res}` sub-route is ever added, the contract
         // change is visible against this list.
@@ -216,11 +216,11 @@ async fn drift_smoke_known_paths_are_present() {
         // mounted directly by `WebhookTransport::router()` (a plain
         // axum Router, not an OpenApiRouter) so it does not appear in
         // the served OpenAPI spec — operator-configured webhook URLs
-        // are documented in the README and ADR-0049, not the spec.
+        // are documented in the README and webhook activation, not the spec.
         // The slug surface is consumed by external providers, not by
         // SDK / Swagger users; promoting it back into the spec would
         // require typed schemas for every provider's request envelope.
-        // ADR-0049 § "Out of scope (1.0 follow-ups)" tracks the
+        // webhook activation § "Out of scope (1.0 follow-ups)" tracks the
         // re-promotion option.
     ];
 
@@ -236,7 +236,7 @@ async fn drift_smoke_known_paths_are_present() {
     // The resource runtime-status sub-route is **observe-only**: it must
     // expose ONLY a `get` operation. Resource lifecycle
     // (acquire/release/drain/reload) is engine-owned and deliberately
-    // never exposed over HTTP (INTEGRATION_MODEL §13.1), so an accidental
+    // never exposed over HTTP (INTEGRATION_MODEL integration seam.1), so an accidental
     // mutating verb on this path is a contract regression — fail drift
     // here rather than silently shipping a lifecycle write endpoint.
     let status_item = paths

--- a/crates/api/tests/org_e2e.rs
+++ b/crates/api/tests/org_e2e.rs
@@ -5,7 +5,7 @@
 //! `GET`/`POST`/`DELETE` under `…/orgs/{org}/members`. These tests drive
 //! the full middleware → RBAC → handler → store path against a real
 //! in-memory backing (not a mock), reusing the `common::org_support`
-//! harness (no fixture duplication — Phase-1/2 shared-harness rule).
+//! harness (no fixture duplication — 2 shared-harness rule).
 //!
 //! The org-record (`GET`/`PATCH`/`DELETE /orgs/{org}`) and service-account
 //! endpoints stay honest-501; their 501 contract is locked by
@@ -77,7 +77,7 @@ fn get(uri: &str, jwt: &str) -> Request<Body> {
 }
 
 /// State-changing request with the double-submit CSRF pair the JWT auth
-/// path requires (identical contract to the Phase-1/2 mutating helper).
+/// path requires (identical contract to the 2 mutating helper).
 fn mutating(method: &str, uri: &str, jwt: &str, json_body: Option<&str>) -> Request<Body> {
     let mut b = Request::builder()
         .method(method)
@@ -181,7 +181,7 @@ async fn list_members_returns_seeded_admin() {
     assert_eq!(members.len(), 1);
     assert_eq!(members[0]["principal_id"], admin.user_id);
     assert_eq!(members[0]["role"], "admin");
-    // §4.5: dropped fields must NOT reappear.
+    // honest capability: dropped fields must NOT reappear.
     assert!(
         members[0].get("email").is_none() && members[0].get("joined_at").is_none(),
         "MemberSummary must not carry synthesized email/joined_at"
@@ -678,7 +678,7 @@ async fn member_endpoints_require_auth() {
 // longer auto-seeds a `MembershipStore` (an auto-seeded bootstrap owner
 // could never authenticate against the empty default `AuthBackend`, so a
 // seeded store would 404-deadlock every org/workspace route — a
-// deployment-level §4.5 false capability). `create_org_state_without_store`
+// deployment-level honest capability false capability). `create_org_state_without_store`
 // reproduces that exact shape (`membership_store == None`, auth wired).
 // The contract: RBAC stays inert (request reaches the handler, NOT a 404)
 // and the org member handlers fail closed with an honest **503** — the

--- a/crates/api/tests/resource_handlers.rs
+++ b/crates/api/tests/resource_handlers.rs
@@ -1,12 +1,12 @@
 //! Integration tests for the workspace-scoped resource catalog handlers.
 //!
 //! `GET /api/v1/orgs/{org}/workspaces/{ws}/resources` and
-//! `GET .../resources/{res}` are config-CRUD read endpoints (ADR-0047
+//! `GET .../resources/{res}` are config-CRUD read endpoints (stub-endpoint policy
 //! Stub Endpoint Policy retired for these routes). These tests boot the
 //! in-memory app with a fake [`ResourceRepo`] and assert the honest
 //! `ResourceEntry` → `ResourceSummary` mapping: `res_<ULID>` id encoding,
 //! `display_name` → `name`, soft-deleted rows excluded, and no raw
-//! `config` ever surfaced (ADR-0028 §7).
+//! `config` ever surfaced (no secret echo).
 //!
 //! The single-resource read additionally enforces tenant isolation: a
 //! resource whose `workspace_id` differs from the caller's authorized
@@ -48,7 +48,7 @@ fn test_ws_bytes() -> Vec<u8> {
 /// exact: a 404 from the read handlers can then only come from their
 /// isolation / soft-delete filters, never an id-encoding mismatch. The
 /// `config` is deliberately secret-shaped so every read path is asserted
-/// to never echo it (ADR-0028 §7).
+/// to never echo it (no secret echo).
 fn entry(
     id: ResourceId,
     workspace_id_bytes: Vec<u8>,
@@ -349,7 +349,7 @@ async fn list_resources_returns_200_with_mapped_summaries() {
     assert_eq!(
         response.status(),
         StatusCode::OK,
-        "list_resources must be implemented (200), not the ADR-0047 501 stub"
+        "list_resources must be implemented (200), not the stub-endpoint 501"
     );
 
     let body = axum::body::to_bytes(response.into_body(), usize::MAX)
@@ -615,7 +615,7 @@ async fn create_resource_unknown_kind_is_409_and_not_persisted() {
 
 /// With no validation backend wired, the handler fails **closed**: 422,
 /// and nothing is persisted. Persisting an unvalidated config (which
-/// could carry an inlined secret) is never acceptable (ADR-0028 §7).
+/// could carry an inlined secret) is never acceptable (no secret echo).
 #[tokio::test]
 async fn create_resource_without_validation_backend_is_422_fail_closed() {
     let api_config = ApiConfig::for_test();
@@ -947,7 +947,7 @@ async fn update_resource_request(
 }
 
 /// A well-formed update body. `config` is deliberately secret-shaped so
-/// every rejection path is asserted never to echo it (ADR-0028 §7).
+/// every rejection path is asserted never to echo it (no secret echo).
 fn update_body(kind: &str, expected_version: i64) -> serde_json::Value {
     serde_json::json!({
         "display_name": "Renamed Pool",
@@ -1540,7 +1540,7 @@ async fn delete_then_get_same_id_is_404() {
 //
 // `GET .../resources/{res}/status` is a READ-ONLY runtime-status
 // projection. Resource lifecycle (acquire/release/drain/reload) is owned
-// by the engine and is NOT exposed over HTTP (INTEGRATION_MODEL §13.1):
+// by the engine and is NOT exposed over HTTP (INTEGRATION_MODEL integration seam.1):
 // there is no `{res}/acquire` (or release/drain) route at all, asserted
 // below as the explicit non-lifecycle guarantee.
 //
@@ -1552,7 +1552,7 @@ async fn delete_then_get_same_id_is_404() {
 // The seam is api-safe (`nebula_engine::EngineResourceStatus` →
 // `ResourceRuntimeStatus`), so the API crate never depends on
 // `nebula-resource` (deny.toml `[[wrappers]]`). The status DTO carries
-// phase/health only — never config or credential material (ADR-0028 §7).
+// phase/health only — never config or credential material (no secret echo).
 
 /// Fake [`EngineResourceStatus`] for the handler tests.
 ///
@@ -1633,7 +1633,7 @@ async fn get_status_request(app: axum::Router, res_id: &str) -> axum::http::Resp
 
 /// A live, owned resource with a live runtime ⇒ **200** + a
 /// `ResourceStatusDto` projecting phase/health. The raw config must NOT
-/// leak (ADR-0028 §7) and no secret/credential field may appear.
+/// leak (no secret echo) and no secret/credential field may appear.
 #[tokio::test]
 async fn get_resource_status_owned_active_is_200_with_dto() {
     let api_config = ApiConfig::for_test();
@@ -1668,7 +1668,7 @@ async fn get_resource_status_owned_active_is_200_with_dto() {
     )
     .expect("body is utf-8");
 
-    // No secret / config material in a status body (ADR-0028 §7): the
+    // No secret / config material in a status body (no secret echo): the
     // fixture's config is deliberately secret-shaped.
     assert!(
         !raw.contains("secret_looking_key") && !raw.contains("do-not-leak"),
@@ -1692,7 +1692,7 @@ async fn get_resource_status_owned_active_is_200_with_dto() {
         assert!(
             allowed.contains(&k.as_str()),
             "status DTO leaked an unexpected field `{k}` (no config / \
-             credential material may appear — ADR-0028 §7)"
+             credential material may appear — no secret echo)"
         );
     }
 
@@ -1949,7 +1949,7 @@ async fn get_resource_status_without_repo_is_503() {
 }
 
 /// Resource lifecycle is NOT exposed over HTTP (INTEGRATION_MODEL
-/// §13.1). There is deliberately **no**
+/// integration seam.1). There is deliberately **no**
 /// `POST .../resources/{res}/acquire` route (nor release/drain): the only
 /// `{res}/...` sub-route is the read-only `{res}/status` GET.
 ///

--- a/crates/api/tests/rest_body_limit.rs
+++ b/crates/api/tests/rest_body_limit.rs
@@ -1,4 +1,4 @@
-//! REST router body-limit integration test (ADR-0020 §3 pre-condition #3).
+//! REST router body-limit integration test (REST body limit pre-condition #3).
 //!
 //! The webhook transport caps itself at
 //! `crates/api/src/webhook/transport.rs`. The REST surface
@@ -26,7 +26,7 @@ async fn create_test_state() -> AppState {
 }
 
 /// A 2 MiB POST on `/api/v1/workflows` must return `413 Payload Too Large`
-/// — the REST router carries a 1 MiB `DefaultBodyLimit` per ADR-0020 §3.
+/// — the REST router carries a 1 MiB `DefaultBodyLimit` per REST body limit.
 #[tokio::test]
 async fn rest_post_exceeding_limit_returns_413() {
     let state = create_test_state().await;

--- a/crates/api/tests/seam_credential_catalog_schema.rs
+++ b/crates/api/tests/seam_credential_catalog_schema.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 P4 seam (V3 + #6): the credential-type catalog is populated
+//! credential-schema validation seam (V3 + #6): the credential-type catalog is populated
 //! from the `CredentialSchemaPort` (`json_schema()` produced behind the
 //! seam); the api-owned public projection strips `x-nebula-root-rules` +
 //! predicate operands before the wire. No port ⇒ honest 503.

--- a/crates/api/tests/seam_credential_schema_port.rs
+++ b/crates/api/tests/seam_credential_schema_port.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 P4 seam — `CredentialSchemaPort` is api-owned, object-safe, and
+//! credential-schema validation seam — `CredentialSchemaPort` is api-owned, object-safe, and
 //! wires into `AppState` exactly like the `action_registry` precedent
 //! (`Option<Arc<dyn …>>`, `None` ⇒ honest 503).
 
@@ -35,7 +35,7 @@ async fn appstate_credential_schema_defaults_none_and_builder_sets_it() {
     // Object-safety: the trait must be usable as `dyn`.
     fn _assert_object_safe(_: &dyn CredentialSchemaPort) {}
 
-    // The shared harness wires a permissive port by default (ADR-0052 P4
+    // The shared harness wires a permissive port by default (credential-schema validation
     // closed the unvalidated-persist fail-open); the *AppState default*
     // (no builder call) is None — assert via the no-port helper.
     let (state, _q) = common::create_state_with_queue_no_credential_port().await;

--- a/crates/api/tests/seam_credential_write_path_validation.rs
+++ b/crates/api/tests/seam_credential_write_path_validation.rs
@@ -1,8 +1,8 @@
-//! ADR-0052 P4 seam (V2): the credential write path validates `data`
+//! credential-schema validation seam (V2): the credential write path validates `data`
 //! against the credential type's schema **before persist**; rejection is
 //! secret-safe (no submitted value echoed); an unconfigured port yields
 //! 503 — `data` is never persisted unvalidated (closes the verified
-//! §4.5/§10 fail-open).
+//! honest capability/§10 fail-open).
 
 mod common;
 
@@ -190,7 +190,7 @@ async fn create_credential_503_when_port_unconfigured_never_persists() {
 
 #[tokio::test]
 async fn update_credential_rejects_invalid_data_secret_safe() {
-    // ADR-0052 P4: the V2 gate also covers the update path (validates the
+    // credential-schema validation: the V2 gate also covers the update path (validates the
     // supplied `data` against the *existing* credential type's schema).
     let (state, _q) = create_state_with_queue().await;
     let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));

--- a/crates/api/tests/trace_w3c_smoke.rs
+++ b/crates/api/tests/trace_w3c_smoke.rs
@@ -3,7 +3,7 @@
 //! Proves that `nebula_api::init_api_telemetry` actually wires a
 //! `tracing_opentelemetry::OpenTelemetryLayer` into the global Subscriber — without that layer
 //! the middleware in `crates/api/src/middleware/trace_w3c.rs` would compile and run but emit
-//! no `traceparent` header (ADR-0050).
+//! no `traceparent` header (W3C trace propagation).
 //!
 //! The assertion is intentionally narrow: under an active per-request span produced by
 //! `tower_http::trace::TraceLayer`, the response carries a structurally-valid W3C `traceparent`.
@@ -54,7 +54,7 @@ async fn init_api_telemetry_emits_traceparent_on_response() {
         .get("traceparent")
         .expect(
             "response is missing `traceparent` — the global Subscriber is not wiring \
-             `tracing_opentelemetry::OpenTelemetryLayer` (M3.5 / ADR-0050 regression)",
+             `tracing_opentelemetry::OpenTelemetryLayer` (W3C trace propagation regression)",
         )
         .to_str()
         .expect("traceparent must be ASCII");
@@ -152,6 +152,6 @@ async fn inbound_traceparent_round_trips_with_same_trace_id() {
     let returned_trace_id_hex = format!("{:032x}", parsed.trace_id.0);
     assert_eq!(
         returned_trace_id_hex, INBOUND_TRACE_ID,
-        "response traceparent must carry the inbound trace id — propagation broken (M3.5 / ADR-0050)"
+        "response traceparent must carry the inbound trace id — propagation broken (W3C trace propagation)"
     );
 }

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -81,7 +81,7 @@ impl WebhookAction for GitHubLikeWebhook {
 
     fn config(&self) -> WebhookConfig {
         // Declare the signature policy at the trait surface so the
-        // transport enforces it before dispatch (ADR-0022). In-handler
+        // transport enforces it before dispatch. In-handler
         // verification stays as defence-in-depth but the transport
         // would reject a mismatch first.
         WebhookConfig::default().with_signature_policy(
@@ -182,7 +182,7 @@ async fn register_webhook(
     let adapter = WebhookTriggerAdapter::new(webhook);
     // Read the cached webhook config BEFORE erasing the adapter
     // to `Arc<dyn TriggerHandler>` — webhook configuration does not
-    // flow through the dyn trigger contract (ADR-0022).
+    // flow through the dyn trigger contract.
     let config = adapter.config().clone();
     let adapter: Arc<dyn TriggerHandler> = Arc::new(adapter);
 
@@ -263,7 +263,7 @@ async fn bad_signature_returns_401_problem_json() {
         .unwrap();
 
     let response = router.oneshot(request).await.unwrap();
-    // ADR-0022: transport rejects at the boundary — the handler is
+    // : transport rejects at the boundary — the handler is
     // never given the chance to observe an unsigned / bad-signed
     // request. RFC 9457 problem+json carries the diagnostic.
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
@@ -368,7 +368,7 @@ async fn oversized_body_returns_413() {
 #[tokio::test]
 async fn rate_limit_returns_429_with_retry_after() {
     // 2 requests per minute, so the 3rd will trip the limiter.
-    // The rate limiter runs before signature enforcement (ADR-0022
+    // The rate limiter runs before signature enforcement (
     // only governs dispatch, not ingress shaping), so any 3+ request
     // trips 429 regardless of signature state.
     let transport = make_transport(Some(2), 1024 * 1024);
@@ -384,7 +384,7 @@ async fn rate_limit_returns_429_with_retry_after() {
             .unwrap()
     };
 
-    // First two requests: unsigned → 401 under ADR-0022. But they pass
+    // First two requests: unsigned → 401 under . But they pass
     // *through* the rate limiter — we only assert that they do not
     // trip the 429 path, not the specific status.
     let r1 = router.clone().oneshot(make_request()).await.unwrap();
@@ -609,7 +609,7 @@ async fn post_still_dispatches() {
     assert_eq!(response.status(), StatusCode::OK);
 }
 
-// ── ADR-0022 trait-level coverage ────────────────────────────────────────
+// ──  trait-level coverage ────────────────────────────────────────
 
 /// Opt-out fixture: signature policy is `OptionalAcceptUnsigned`.
 /// Locks in the regression guard that tightening the default later
@@ -641,7 +641,7 @@ impl WebhookAction for UnsignedWebhook {
 
     fn config(&self) -> WebhookConfig {
         // Public-by-design webhook — explicit opt-out is the audit
-        // trail per ADR-0022.
+        // trail.
         WebhookConfig::default().with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned)
     }
 
@@ -660,7 +660,7 @@ impl WebhookAction for UnsignedWebhook {
 }
 
 /// Fixture whose `config()` is left as the default — `Required` with
-/// an empty secret. ADR-0022: the transport returns 500 without ever
+/// an empty secret. : the transport returns 500 without ever
 /// calling `handle_request`.
 struct DefaultConfigWebhook {
     reached_handler: Arc<std::sync::atomic::AtomicBool>,
@@ -744,7 +744,7 @@ async fn optional_accept_unsigned_passes_through_unsigned_request() {
         .unwrap();
 
     let response = router.oneshot(request).await.unwrap();
-    // ADR-0022: the action explicitly opted out, so the transport
+    // : the action explicitly opted out, so the transport
     // MUST NOT block the unsigned request.
     assert_eq!(response.status(), StatusCode::OK);
 }

--- a/crates/core/src/dependencies.rs
+++ b/crates/core/src/dependencies.rs
@@ -31,7 +31,7 @@ impl Dependencies {
     }
 
     /// Declare a slot-binding field (`#[resource]` / `#[credential]`) per
-    /// ADR-0042. The default id (the slot key) supplies the binding when
+    ///. The default id (the slot key) supplies the binding when
     /// the workflow node does not override it via `slot_bindings`.
     pub fn slot_field(mut self, field: SlotField) -> Self {
         self.slot_fields.push(field);
@@ -58,13 +58,13 @@ impl Dependencies {
 ///
 /// Slot fields capture the `(slot_key, default_id, kind, required, lazy)`
 /// tuple that `#[derive(Action)]` reads off `#[resource(...)]` /
-/// `#[credential(...)]` field-level attributes (per ADR-0043 §9). The
+/// `#[credential(...)]` field-level attributes (). The
 /// engine uses this declaration to resolve the slot at dispatch time,
-/// applying the workflow's `slot_bindings` override (ADR-0042) when one
+/// applying the workflow's `slot_bindings` override when one
 /// is supplied for `slot_key`, falling back to `default_id` otherwise.
 #[derive(Debug, Clone)]
 pub struct SlotField {
-    /// The struct-field name (and default binding key, ADR-0042).
+    /// The struct-field name (and default binding key, ).
     pub slot_key: &'static str,
     /// Default id used when the workflow node does not override.
     /// By convention this is `slot_key` itself.

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -61,7 +61,7 @@ pub mod scope;
 pub mod serde_helpers;
 /// Validated slug strings for human-readable identifiers.
 pub mod slug;
-/// Async-aware lazy initialization wrapper (`Lazy<X>`) — ADR-0043 §3 (type-based optional + lazy).
+/// Async-aware lazy initialization wrapper (`Lazy<X>`).
 pub mod sync;
 /// Multi-tenant context and resolved IDs.
 pub mod tenancy;

--- a/crates/core/src/sync.rs
+++ b/crates/core/src/sync.rs
@@ -4,14 +4,14 @@
 //! a future-friendly `get_or_init` flow. Two paths are supported:
 //!
 //! 1. **Pre-populated** via [`Lazy::with_value`] — used when the framework eagerly resolves a slot
-//!    before passing it to action code (the common case for `Lazy<ResourceGuard<R>>` fields the
-//!    macro emits).
+//! before passing it to action code (the common case for `Lazy<ResourceGuard<R>>` fields the
+//! macro emits).
 //! 2. **Deferred** via [`Lazy::new`] + [`Lazy::get_or_try_init`] — used when an action wants to
-//!    resolve a dependency only on the path that needs it. The initializer is provided per
-//!    `.get_or_try_init` call so callers can plug in the right async resolver (typed
-//!    `ResourceRef::resolve` or `CredentialRef::resolve` per ADR-0043).
+//! resolve a dependency only on the path that needs it. The initializer is provided per
+//! `.get_or_try_init` call so callers can plug in the right async resolver (typed
+//! `ResourceRef::resolve` or `CredentialRef::resolve` ).
 //!
-//! See ADR-0043 §3 (type-based optional + lazy via composable wrappers) for the
+//! See ) for the
 //! place this primitive occupies in the dependency-redesign cascade.
 //!
 //! ## Cancel safety
@@ -29,7 +29,7 @@ use tokio::sync::OnceCell;
 /// Async-aware lazy wrapper.
 ///
 /// `Lazy<X>` is the canonical wrapper for "resolve this dependency on first use,
-/// not at action construction time" per ADR-0043. The macro emits this around
+/// not at action construction time". The macro emits this around
 /// `ResourceGuard<R>` / `CredentialGuard<C::Scheme>` slot fields whose attribute
 /// declares lazy resolution; eager slots are resolved by the framework before
 /// `execute()` runs.
@@ -42,10 +42,10 @@ use tokio::sync::OnceCell;
 /// let lazy: Lazy<String> = Lazy::new();
 ///
 /// let value = lazy
-///     .get_or_try_init(async {
-///         Ok::<_, std::io::Error>(format!("computed-{}", 42))
-///     })
-///     .await?;
+///.get_or_try_init(async {
+/// Ok::<_, std::io::Error>(format!("computed-{}", 42))
+/// })
+///.await?;
 ///
 /// assert_eq!(value, "computed-42");
 /// ```

--- a/crates/credential-builtin/src/lib.rs
+++ b/crates/credential-builtin/src/lib.rs
@@ -1,13 +1,13 @@
 //! # nebula-credential-builtin
 //!
 //! Built-in concrete credential types and the canonical
-//! `sealed_caps` module per ADR-0035. Plugin authors depend on
+//! `sealed_caps` module. Plugin authors depend on
 //! `nebula-credential` (the contract crate); first-party concrete
 //! types live here.
 //!
 //! ## Canonical `mod sealed_caps`
 //!
-//! Per ADR-0035 §3 (amended 2026-04-24-B), every crate that declares
+//! Every crate that declares
 //! capability phantom traits in `dyn` positions must provide a
 //! crate-private `sealed_caps` module with **per-capability** inner
 //! sealed traits. This crate is the canonical home for the built-in
@@ -22,7 +22,7 @@ extern crate self as nebula_credential_builtin;
 /// Canonical inner sealed traits for built-in capabilities.
 ///
 /// Crate-private. External crates cannot impl these — they declare
-/// their own `mod sealed_caps` per ADR-0035 §3.
+/// their own `mod sealed_caps`.
 ///
 /// `dead_code` is silenced for the П1 scaffold — these inner traits
 /// are emitted into `dyn` positions by the `#[capability]` macro in

--- a/crates/credential-runtime/src/builder.rs
+++ b/crates/credential-runtime/src/builder.rs
@@ -96,8 +96,8 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialServiceBuilder<B, PS> 
     ///
     /// **Not yet wired.** This records the provider on the service, but
     /// the resolution path that routes through an external chain is the
-    /// ADR-0051 Phase-D external-source bridge, which is out of this
-    /// crate's current scope (see `docs/adr/0066` / the credential-runtime
+    /// external provider bridge external-source bridge, which is out of this
+    /// crate's current scope (see  / the credential-runtime
     /// subsystem spec §8). Until that lands, a service built with an
     /// external source rejects every secret-resolving call
     /// (`create` / `resolve` / `continue_resolve`) with

--- a/crates/credential-runtime/src/error.rs
+++ b/crates/credential-runtime/src/error.rs
@@ -94,14 +94,14 @@ pub enum CredentialServiceError {
     /// An external [`StateSource`](crate::StateSource) was configured via
     /// [`external_providers`](crate::CredentialServiceBuilder::external_providers)
     /// but the resolution wiring that consumes it is not implemented in
-    /// this crate yet — it lands with the ADR-0051 Phase-D external-source
-    /// bridge (see `docs/adr/0066` / spec §8). Returned instead of
+    /// this crate yet — it lands with the external provider bridge external-source
+    /// bridge (see  / spec §8). Returned instead of
     /// silently resolving from the local store, which would hand back
     /// material from the wrong source.
     #[classify(category = "internal", code = "CREDENTIAL_SERVICE:EXTERNAL_NOT_WIRED")]
     #[error(
         "external credential source '{provider}' is configured but its resolution wiring is not \
-         implemented yet (ADR-0051 Phase-D bridge)"
+         implemented yet (external provider bridge)"
     )]
     ExternalSourceNotWired {
         /// `ExternalProvider::provider_name()` of the configured source.

--- a/crates/credential-runtime/src/lib.rs
+++ b/crates/credential-runtime/src/lib.rs
@@ -7,8 +7,8 @@
 //! construction path is the only path.
 //!
 //! Exec tier. Narrowly supersedes the facade-ownership slice of
-//! ADR-0030 (engine retains the low-level resolver / RefreshCoordinator
-//! / lease mechanism); see `docs/adr/0066-credential-runtime-crate.md`.
+//! engine credential orchestration (engine retains the low-level resolver / RefreshCoordinator
+//! / lease mechanism); see .
 //!
 //! This increment ships only the crate scaffold and the
 //! [`CredentialServiceError`] taxonomy.
@@ -25,7 +25,7 @@ pub mod state_source;
 
 /// Test-only credential fixtures (a refreshable type the static builtins
 /// cannot provide). Gated `cfg(any(test, feature = "test-util"))`;
-/// ADR-0023 forbids `test-util` in a release build.
+/// test-util gating forbids `test-util` in a release build.
 #[cfg(any(test, feature = "test-util"))]
 pub mod test_fixtures;
 
@@ -44,7 +44,7 @@ pub use service::{
 pub use state_source::StateSource;
 
 /// In-memory `CredentialService` test-support seam. Gated
-/// `cfg(any(test, feature = "test-util"))`; ADR-0023 forbids `test-util`
+/// `cfg(any(test, feature = "test-util"))`; test-util gating forbids `test-util`
 /// in a release build (see [`service::test_support`] for the rationale).
 #[cfg(any(test, feature = "test-util"))]
 pub use service::test_support;

--- a/crates/credential-runtime/src/observer.rs
+++ b/crates/credential-runtime/src/observer.rs
@@ -1,4 +1,4 @@
-//! Non-optional observability seam. Closes canon §12.5/§3.5: emission
+//! Non-optional observability seam. Closes credential secrecy/§3.5: emission
 //! sits on the single facade code path, so "never wired" is
 //! unrepresentable. `CredentialObserver` is object-safe by design
 //! (`Arc<dyn CredentialObserver>`).

--- a/crates/credential-runtime/src/ops.rs
+++ b/crates/credential-runtime/src/ops.rs
@@ -39,7 +39,7 @@ use crate::error::CredentialServiceError;
 pub(crate) struct ResolvedState {
     /// Serialized `C::State` bytes. Plaintext in-process (the store's
     /// `EncryptionLayer` ciphers it at rest); held in `Zeroizing` so this
-    /// intermediate is wiped on drop per canon §12.5.
+    /// intermediate is wiped on drop per credential secrecy.
     pub(crate) data: Zeroizing<Vec<u8>>,
     /// `<C::State as CredentialState>::KIND`.
     pub(crate) state_kind: String,
@@ -127,7 +127,7 @@ type TestFn = Arc<dyn for<'a> Fn(&'a [u8], &'a CredentialContext) -> TestFuture<
 ///
 /// Re-writing the un-mutated local copy on the coalesced path either
 /// spuriously `VersionConflict`s or clobbers the fresher state another
-/// replica just wrote (canon §13.2): the upstream
+/// replica just wrote (concurrent-refresh contract): the upstream
 /// [`RefreshOutcome::CoalescedByOtherReplica`](nebula_credential::RefreshOutcome)
 /// contract says the caller must re-read, not re-write.
 pub(crate) enum RefreshOutcomeKind {
@@ -185,7 +185,7 @@ type SnapshotFn = Arc<
 /// for the captured concrete `C` —
 /// `schema_of::<C::Properties>().validate(FieldValues)` then a typed
 /// `serde_json::from_value::<C::Properties>` round-trip. The typed step
-/// is the `{"$expr": ..}` refusal point (canon §12.5). Returns only the
+/// is the `{"$expr": ..}` refusal point (credential secrecy). Returns only the
 /// schema `code`/`path` on failure, never raw property values.
 type ValidateFn =
     Arc<dyn Fn(&serde_json::Value) -> Result<(), CredentialServiceError> + Send + Sync>;
@@ -315,7 +315,7 @@ impl<B: CredentialStore, PS: PendingStateStore> DispatchOps<B, PS> {
 
     /// Run the canonical credential properties validation pipeline for
     /// the type at `key` against `props` (schema + typed-deserialize;
-    /// `{"$expr": ..}` refused at the typed step, canon §12.5).
+    /// `{"$expr": ..}` refused at the typed step, credential secrecy).
     ///
     /// # Errors
     ///
@@ -573,7 +573,7 @@ where
         // validate, then a typed `from_value` round-trip. The credential
         // pipeline never resolves expressions, so a `{"$expr": ..}`
         // envelope passes schema validation but is refused by the typed
-        // deserialize below (canon §12.5 defense-in-depth #2).
+        // deserialize below (credential secrecy defense-in-depth #2).
         let schema = nebula_schema::schema_of::<C::Properties>();
         let values = FieldValues::from_json(props.clone()).map_err(|e| {
             CredentialServiceError::ValidationFailed {
@@ -742,7 +742,7 @@ where
                 // the *un-mutated* pre-refresh copy: re-writing it would
                 // either spuriously `VersionConflict` or clobber the
                 // fresher state the other replica just persisted (the
-                // canon §13.2 bug). Signal the service to skip the write
+                // concurrent-refresh contract bug). Signal the service to skip the write
                 // and re-read instead.
                 nebula_credential::RefreshOutcome::CoalescedByOtherReplica => {
                     Ok(RefreshOutcomeKind::CoalescedReRead)

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -150,7 +150,7 @@ pub struct CredentialService<B: CredentialStore, PS: PendingStateStore> {
     pub(crate) observer: Arc<dyn CredentialObserver>,
     // Read by `ensure_local_source` on every secret-resolving entry
     // point. `External` is configurable but its resolution wiring (the
-    // ADR-0051 Phase-D bridge) is not implemented here yet, so it fails
+    // external provider bridge bridge) is not implemented here yet, so it fails
     // typed rather than silently resolving from the local store.
     pub(crate) source: StateSource,
 }
@@ -189,7 +189,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
     ///
     /// [`external_providers`](crate::CredentialServiceBuilder::external_providers)
     /// records an [`StateSource::External`] but the resolution wiring that
-    /// would route through the provider chain is the ADR-0051 Phase-D
+    /// would route through the provider chain is the external provider bridge
     /// bridge, not yet implemented in this crate. Without this guard a
     /// caller that configured Vault would silently get material resolved
     /// from the *local* store — a wrong-source security hazard. Every
@@ -223,7 +223,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
     /// resolve it to encrypted state, and persist it scoped to `scope`.
     ///
     /// The validation pipeline is the canonical credential pipeline
-    /// (canon §12.5): `schema_of::<Properties>().validate(FieldValues)`
+    /// (credential secrecy): `schema_of::<Properties>().validate(FieldValues)`
     /// then a typed `serde_json::from_value` round-trip — a `{"$expr": ..}`
     /// envelope survives schema validation but is refused by the typed
     /// deserialize, so secrets never depend on workflow state.
@@ -533,7 +533,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
     /// is written back under compare-and-swap on the version observed at
     /// load; a concurrent refresh/update wins and this attempt fails
     /// explicitly with [`CredentialServiceError::VersionConflict`] —
-    /// canon §13.2: refresh must never silently strand a concurrent
+    /// concurrent-refresh contract: refresh must never silently strand a concurrent
     /// write. If another replica coalesced the refresh
     /// (`RefreshOutcome::CoalescedByOtherReplica`) the write is **skipped
     /// entirely** and the now-fresher state is re-read from the store
@@ -588,7 +588,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
             // Another replica already refreshed and persisted fresher
             // state. Re-writing the un-mutated local copy here would
             // either spuriously `VersionConflict` or clobber that fresher
-            // state (canon §13.2). Skip the write entirely and return the
+            // state (concurrent-refresh contract). Skip the write entirely and return the
             // store's current (post-coalesce) snapshot.
             crate::ops::RefreshOutcomeKind::CoalescedReRead => {
                 let credential_id = CredentialId::parse(&stored.id).map_err(|e| {
@@ -629,7 +629,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
         // Re-persist under compare-and-swap on the version observed at
         // load. A concurrent refresh/update that landed in between wins
         // and this attempt fails *explicitly* with `VersionConflict`
-        // (canon §13.2: refresh must never silently strand a concurrent
+        // (concurrent-refresh contract: refresh must never silently strand a concurrent
         // write; failure is explicit). Blind `Overwrite` here would
         // last-writer-wins and clobber the racing write.
         self.store
@@ -722,7 +722,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
     /// interactive flows.
     ///
     /// Validation is the canonical credential pipeline (the `$expr`
-    /// refusal point, canon §12.5). A `Complete` resolution is persisted
+    /// refusal point, credential secrecy). A `Complete` resolution is persisted
     /// through the same path as [`create`](Self::create) and returned as
     /// [`Acquisition::Complete`]; a `Pending` kickoff returns
     /// [`Acquisition::Pending`] with the opaque token + UI instruction.
@@ -1021,7 +1021,7 @@ pub mod test_support {
     //! three first-party builtins registered into the
     //! registry/dispatch/ops, and a `NoopObserver`.
     //!
-    //! # ADR-0023
+    //! # test-util gating
     //!
     //! This module is gated `cfg(any(test, feature = "test-util"))`. The
     //! `test-util` feature MUST NOT be enabled in a release/production
@@ -1179,7 +1179,7 @@ pub mod test_support {
     /// prove the success path fired the observer hook.
     ///
     /// The static builtins cannot exercise any positive capability path
-    /// (refresh CAS + retry, the coalesced re-read branch, the §13.2
+    /// (refresh CAS + retry, the coalesced re-read branch, the concurrent-refresh
     /// version-conflict branch); this fixture-enabled variant does.
     pub fn in_memory_service_with_fixtures() -> (
         CredentialService<InMemoryStore, InMemoryPendingStore>,
@@ -1638,7 +1638,7 @@ mod tests {
     /// A concurrent version bump landing between refresh's internal load
     /// and its compare-and-swap re-persist makes `refresh()` fail
     /// *explicitly* with `VersionConflict` rather than silently
-    /// clobbering the racing write (the canon §13.2 contract).
+    /// clobbering the racing write (the concurrent-refresh contract contract).
     ///
     /// Determinism: the fixture's `refresh` parks on a 2-party rendezvous
     /// barrier *after* mutating its local state but *before* the service

--- a/crates/credential-runtime/src/state_source.rs
+++ b/crates/credential-runtime/src/state_source.rs
@@ -1,6 +1,6 @@
 //! Polymorphic credential state source. Replaces the resolver's
 //! hardcoded "state always from `CredentialStore`" (spec §8 — no
-//! adapter/bridge). `External` fulfils ADR-0051's deferred Phase-D
+//! adapter/bridge). `External` fulfils external provider's deferred Phase-D
 //! non-goal: resolved secrets carrying a lease are tracked via
 //! `LeaseLifecycle`.
 

--- a/crates/credential-runtime/src/test_fixtures.rs
+++ b/crates/credential-runtime/src/test_fixtures.rs
@@ -4,11 +4,11 @@
 //! `signing_key`) are all static — none implements `Refreshable` /
 //! `Testable` / `Revocable` / `Interactive`, so every *positive*
 //! capability path of the facade (refresh CAS + retry, the coalesced
-//! re-read branch, the §13.2 version-conflict branch, `on_refresh`
+//! re-read branch, the concurrent-refresh version-conflict branch, `on_refresh`
 //! emission) is otherwise unexercised. [`RefreshableFixtureCredential`]
 //! is a minimal refreshable type that drives those paths.
 //!
-//! # ADR-0023
+//! # test-util gating
 //!
 //! This module is gated `cfg(any(test, feature = "test-util"))` and is
 //! **never** part of the production surface. It wires only over the
@@ -47,7 +47,7 @@ pub struct RefreshableFixtureProperties {
 /// `expires_at` so the type carries an expiry like a real rotating
 /// credential.
 ///
-/// `ZeroizeOnDrop` is mandatory for any [`CredentialState`] (§12.5
+/// `ZeroizeOnDrop` is mandatory for any [`CredentialState`] (credential secrecy
 /// deterministic plaintext drop). The counter / timestamp are not
 /// secret, but the derive zeroizes the whole struct uniformly.
 #[derive(Clone, Serialize, Deserialize, ZeroizeOnDrop)]

--- a/crates/credential-runtime/tests/adversarial.rs
+++ b/crates/credential-runtime/tests/adversarial.rs
@@ -71,7 +71,7 @@ async fn abuse1_cross_tenant_is_uniformly_not_found_no_existence_leak() {
     assert_eq!(svc.list(&a).await.expect("list A").len(), 1);
 }
 
-/// Abuse #2 — schema-bypass / `$expr` injection (canon §12.5).
+/// Abuse #2 — schema-bypass / `$expr` injection (credential secrecy).
 ///
 /// A `{"$expr": ..}` envelope survives schema validation but the typed
 /// `serde_json::from_value` round-trip refuses it, so a credential secret
@@ -377,7 +377,7 @@ impl AuditSink for FailingAuditSink {
 /// Abuse #8 — audit fail-closed.
 ///
 /// A refusing `AuditSink` makes the wrapping `AuditLayer` fail the whole
-/// store operation with `StoreError::AuditFailure` (ADR-0028 inv. 4),
+/// store operation with `StoreError::AuditFailure` (no discard-and-log),
 /// surfaced by the facade as `CredentialServiceError::Store`. The write
 /// must **not partially land** — fail-closed, never log-and-continue.
 ///

--- a/crates/credential-vault/src/lib.rs
+++ b/crates/credential-vault/src/lib.rs
@@ -1,7 +1,7 @@
 //! # nebula-credential-vault
 //!
 //! HashiCorp Vault backend for Nebula's [`ExternalProvider`] /
-//! [`LeasedProvider`] trait surface (ADR-0051). Supports the two canonical
+//! [`LeasedProvider`] trait surface. Supports the two canonical
 //! Vault read shapes:
 //!
 //! - **KV v2 static secrets** (`/v1/{mount}/data/{path}`) — the default path
@@ -20,10 +20,10 @@
 //!
 //! [`ExternalReference::path`] is interpreted by prefix:
 //!
-//! | Prefix      | Backend route                | Resolution shape                                  |
+//! | Prefix | Backend route | Resolution shape |
 //! |-------------|------------------------------|---------------------------------------------------|
-//! | _(none)_    | `GET /v1/{kv_mount}/data/{path}` | `from_secret` (no lease)                      |
-//! | `dyn/<rest>`| `GET /v1/{rest}`              | `with_lease` (lease_id + TTL from response)      |
+//! | _(none)_ | `GET /v1/{kv_mount}/data/{path}` | `from_secret` (no lease) |
+//! | `dyn/<rest>`| `GET /v1/{rest}` | `with_lease` (lease_id + TTL from response) |
 //!
 //! `ExternalReference::version` is honoured for KV v2 (added as
 //! `?version=N`). `ExternalReference::field` is interpreted as a JSON-pointer-

--- a/crates/credential-vault/src/provider.rs
+++ b/crates/credential-vault/src/provider.rs
@@ -96,7 +96,7 @@ impl VaultConfig {
 /// [`ExternalProvider`] + [`LeasedProvider`].
 ///
 /// See the crate-level docs for the path-shape convention and the request
-/// semantics. Errors classify per ADR-0051:
+/// semantics. Errors classify :
 ///
 /// - 404 → [`ProviderError::NotFound`] (chain fall-through).
 /// - 403 → [`ProviderError::AccessDenied`] (short-circuit).

--- a/crates/credential-vault/tests/cache_integration.rs
+++ b/crates/credential-vault/tests/cache_integration.rs
@@ -88,7 +88,7 @@ async fn dynamic_resolution_is_cached_using_response_ttl() {
     // Dynamic resolutions carry a `lease.ttl` ⇒ resolution.ttl = lease.ttl,
     // so the cache layer caches even with the default ZERO fallback — the
     // per-entry TTL comes from the provider response. This is the canonical
-    // use case for the cache layer (ADR-0051 §3.2 of the cache plan).
+    // use case for the cache layer.
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/v1/database/creds/role-a"))

--- a/crates/credential/macros/src/capability.rs
+++ b/crates/credential/macros/src/capability.rs
@@ -1,6 +1,6 @@
-//! `#[capability]` attribute macro per ADR-0035 4 + Tech Spec 2.6.
+//! `#[capability]` attribute macro per capability macro 4 + Tech Spec 2.6.
 //!
-//! Expands a single capability trait declaration into the full ADR-0035
+//! Expands a single capability trait declaration into the full capability macro
 //! canonical form: real trait, service/scheme blanket impl,
 //! sealed-blanket, phantom trait, and phantom blanket. Hides the
 //! two-trait verbosity from everyday plugin and built-in code.
@@ -36,7 +36,7 @@
 //!
 //! ## Caller obligations
 //!
-//! Per ADR-0035 4.1 / 4.2, the macro does NOT emit `mod sealed_caps`.
+//! Per capability macro 4.1 / 4.2, the macro does NOT emit `mod sealed_caps`.
 //! Crate authors declare it manually at crate root with one inner trait
 //! per capability. A missing module produces `E0433` at the emitted
 //! sealed-blanket impl line, with the standard "unresolved module"

--- a/crates/credential/macros/src/credential.rs
+++ b/crates/credential/macros/src/credential.rs
@@ -1,4 +1,4 @@
-//! `#[derive(Credential)]` macro implementation — Phase 5 / ADR-0044 / M6 redesign.
+//! `#[derive(Credential)]` macro implementation — Phase 5 / slot model / M6 redesign.
 //!
 //! Mirrors `#[derive(Resource)]` (Phase 4) and `#[derive(Action)]` (Phase 3) on
 //! the slot-binding family. Credentials are the *leaf* of the dependency
@@ -17,7 +17,7 @@
 //! - `properties = TypePath` — Direct path to the `<Name>Properties` struct that owns the
 //!   setup-form schema. Mutually exclusive with `protocol`. The macro emits `type Properties =
 //!   #properties`; the generated metadata reads the schema via
-//!   `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3 — no per-trait schema method).
+//!   `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties — no per-trait schema method).
 //!   When
 //!   `properties` is supplied, the user is responsible for implementing [`Credential::resolve`]
 //!   (and [`Credential::project`] when scheme ≠ state) on a separate inherent impl block.
@@ -43,7 +43,7 @@
 //! - Renamed emitted `type Input` → `type Properties` to mirror `Action::Input` /
 //!   `Resource::Config` and shift schema ownership from instance metadata to a type-level companion
 //!   struct. Generated metadata reads the schema via
-//!   `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3 — the
+//!   `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties — the
 //!   `Properties: HasSchema` bound is the single source of truth; no schema method on the trait).
 //! - Added a `properties = TypePath` attribute as the canonical, direct way to specify the
 //!   companion struct (no longer requires plumbing through a `StaticProtocol` indirection when the

--- a/crates/credential/macros/src/lib.rs
+++ b/crates/credential/macros/src/lib.rs
@@ -144,7 +144,7 @@ pub fn derive_auth_scheme(input: TokenStream) -> TokenStream {
 /// Attribute macro for declaring a capability sub-trait.
 ///
 /// Expands a single capability trait declaration into the full
-/// ADR-0035 canonical form: real trait, service/scheme blanket impl,
+/// capability macro canonical form: real trait, service/scheme blanket impl,
 /// sealed-blanket, phantom trait, and phantom blanket. Hides the
 /// two-trait verbosity from everyday plugin and built-in code.
 ///
@@ -154,12 +154,12 @@ pub fn derive_auth_scheme(input: TokenStream) -> TokenStream {
 ///   satisfy (e.g. `AcceptsBearer`).
 /// - `sealed = <Ident>` - the per-capability inner sealed trait inside the crate-root `mod
 ///   sealed_caps` (e.g. `BearerSealed`). The crate author must declare this module manually; see
-///   ADR-0035 4.1 / 4.2.
+///   capability macro 4.1 / 4.2.
 ///
 /// # Visibility
 ///
 /// The emitted phantom trait inherits the visibility of the capability
-/// trait (visibility-symmetry, per ADR-0035 §1 amendment 2026-04-26).
+/// trait (visibility-symmetry, per capability macro §1 amendment 2026-04-26).
 /// `pub trait Cap` produces `pub trait CapPhantom`; `pub(crate) trait
 /// Cap` produces `pub(crate) trait CapPhantom`. This composes correctly
 /// with crate-internal capabilities — forcing the phantom to a fixed
@@ -204,7 +204,7 @@ pub fn derive_auth_scheme(input: TokenStream) -> TokenStream {
 /// - The trait has zero or multiple non-marker supertraits.
 ///
 /// A missing `mod sealed_caps` or missing inner sealed trait surfaces
-/// as `E0433` at the emitted blanket impl line per ADR-0035 4.1.
+/// as `E0433` at the emitted blanket impl line per capability macro 4.1.
 #[proc_macro_attribute]
 pub fn capability(args: TokenStream, input: TokenStream) -> TokenStream {
     capability::expand(args, input)

--- a/crates/credential/src/contract/credential.rs
+++ b/crates/credential/src/contract/credential.rs
@@ -44,7 +44,7 @@ use crate::{
 /// secrets and auth material for **external** systems (SaaS APIs,
 /// webhooks, databases), not for logging into Nebula's own API or
 /// control plane. That host-facing authentication (**Plane A**) stays
-/// out of this trait; see ADR-0033 (`docs/adr/0033-integration-credentials-plane-b.md`).
+/// out of this trait; see auth plane separation ().
 ///
 /// # Associated types
 ///
@@ -124,7 +124,7 @@ pub trait Credential: Send + Sync + 'static {
     /// the schema lives on this type rather than being baked into
     /// [`CredentialMetadata`]: read it via
     /// [`nebula_schema::schema_of::<Self::Properties>()`](nebula_schema::schema_of)
-    /// (there is no per-trait schema method — ADR-0052 P3).
+    /// (there is no per-trait schema method — schema-of properties).
     ///
     /// Use [`FieldValues`] for legacy credentials that do not yet
     /// declare a typed properties struct (the blanket

--- a/crates/credential/src/contract/pending.rs
+++ b/crates/credential/src/contract/pending.rs
@@ -114,7 +114,7 @@ impl PendingToken {
     ///
     /// Callable by pending-store impls that live outside this crate (see
     /// `nebula_storage::credential::pending::InMemoryPendingStore` —
-    /// canonical home per ADR-0032 §7).
+    /// canonical home per storage credential layers §7).
     pub fn generate() -> Self {
         use rand::RngExt;
         let mut rng = rand::rng();

--- a/crates/credential/src/contract/resolve.rs
+++ b/crates/credential/src/contract/resolve.rs
@@ -152,7 +152,7 @@ pub enum UserInput {
 /// were waiting on the cross-replica claim. Callers treat it as success
 /// and re-read the credential state from the store.
 ///
-/// [credential-refresh-coordination]: https://github.com/nebula-engine/nebula/blob/main/docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)
+/// [credential-refresh-coordination]: https://github.com/nebula-engine/nebula/blob/main/docs/INTEGRATION_MODEL.md (credential refresh)
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum RefreshOutcome {

--- a/crates/credential/src/contract/state.rs
+++ b/crates/credential/src/contract/state.rs
@@ -17,7 +17,7 @@ use zeroize::ZeroizeOnDrop;
 ///
 /// `ZeroizeOnDrop` is mandatory — credential state contains decrypted
 /// secret material at runtime; deterministic plaintext drop is a
-/// §12.5 invariant (§15.4 amendment, Tech Spec).
+/// credential secrecy invariant (§15.4 amendment, Tech Spec).
 ///
 /// [`AuthScheme`]: crate::AuthScheme
 pub trait CredentialState:

--- a/crates/credential/src/credential_ref.rs
+++ b/crates/credential/src/credential_ref.rs
@@ -1,7 +1,7 @@
 //! Typed credential reference (`CredentialRef<C>`) — slot-binding handle for action/resource
 //! fields.
 //!
-//! Per ADR-0043 §9, `CredentialRef<C>` is the canonical field type for the
+//! Per typed ref fields, `CredentialRef<C>` is the canonical field type for the
 //! slot-binding pattern: an action or resource declares
 //!
 //! ```ignore
@@ -12,7 +12,7 @@
 //! }
 //! ```
 //!
-//! and the framework resolves the slot per ADR-0042's binding mechanism: the
+//! and the framework resolves the slot per slot binding's binding mechanism: the
 //! `key` attribute supplies a default credential id; workflow-JSON
 //! `slot_bindings.<slot_key>.credential_id` overrides it per node.
 //!
@@ -28,7 +28,7 @@
 //! ## Composability
 //!
 //! `Option<CredentialRef<C>>` and `Lazy<CredentialRef<C>>` (from
-//! `nebula_core::Lazy`) compose for optional / lazy semantics per ADR-0043 §3.
+//! `nebula_core::Lazy`) compose for optional / lazy semantics per optional ref composition.
 
 use std::{fmt, marker::PhantomData};
 
@@ -39,7 +39,7 @@ use crate::{Credential, CredentialGuard, error::CredentialError, snapshot::Crede
 
 /// Typed reference to a registered credential.
 ///
-/// The reference carries a credential id (slot binding per ADR-0042) and a
+/// The reference carries a credential id (slot binding per slot binding) and a
 /// type-level marker selecting the concrete `Credential` impl whose
 /// `Scheme` should be projected on resolve. The field type alone tells
 /// the framework what slot kind, what concrete credential type, and (via
@@ -52,7 +52,7 @@ use crate::{Credential, CredentialGuard, error::CredentialError, snapshot::Crede
 /// does **not** copy the underlying secret — the secret materializes only
 /// during `.resolve()` and lives in the resulting guard with zeroize-on-drop.
 pub struct CredentialRef<C: ?Sized> {
-    /// Resolved credential id (per ADR-0042 — slot-key default OR workflow-JSON override).
+    /// Resolved credential id (per slot binding — slot-key default OR workflow-JSON override).
     id: String,
     /// Type-level marker for the concrete `Credential` impl. `fn() -> C` so
     /// `CredentialRef<C>` is `Send + Sync` regardless of `C`.

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -18,7 +18,7 @@ use crate::{
 ///
 /// The struct is purely the schema-bearing companion: `#[derive(Schema)]`
 /// emits the `HasSchema` impl read via
-/// `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3). The
+/// `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties). The
 /// actual auth material conversion to
 /// [`SecretToken`] happens in [`Credential::resolve`].
 ///

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -16,7 +16,7 @@ use crate::{
 /// the legacy `BasicAuthInput`).
 ///
 /// `#[derive(Schema)]` provides the `HasSchema` impl read via
-/// `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3). The
+/// `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties). The
 /// plaintext password lives
 /// in a `String` here for schema derivation and is wrapped into
 /// [`SecretString`] inside [`Credential::resolve`] before it leaves the

--- a/crates/credential/src/credentials/mod.rs
+++ b/crates/credential/src/credentials/mod.rs
@@ -8,7 +8,7 @@
 //! `<Name>Properties` companion struct (`#[derive(Schema, Deserialize)]`)
 //! that owns the setup-form schema; `Credential::Properties` points at
 //! it and the engine reads the schema via
-//! `nebula_schema::schema_of::<C::Properties>()` (ADR-0052 P3).
+//! `nebula_schema::schema_of::<C::Properties>()` (schema-of properties).
 
 pub mod api_key;
 pub mod basic_auth;

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -293,14 +293,14 @@ impl PendingState for OAuth2Pending {
 /// `CredentialError::Provider("OAuth2 HTTP transport has moved …")`
 /// because the underlying HTTP calls (RFC 7009 revoke endpoint, token
 /// introspection / userinfo health probe) live in nebula-engine per
-/// ADR-0031. The trait impls exist so the engine's revoke / test
+/// API-owned OAuth flow. The trait impls exist so the engine's revoke / test
 /// dispatchers (which bind `where C: Revocable` / `where C: Testable`)
 /// can route to OAuth2 once the transport is wired — and so plugin
 /// callers see a typed transport-disabled classification instead of
 /// "credential type does not support revocation / testing."
 ///
 /// Configuration (auth URL, token URL, grant type, scopes) is provided
-/// via `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3) and
+/// via `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties) and
 /// extracted from [`FieldValues`] when the OAuth2 flow is initiated.
 ///
 /// # Grant types and entry points
@@ -317,12 +317,12 @@ impl PendingState for OAuth2Pending {
 ///   callback, the framework loads the typed pending state and invokes
 ///   [`Interactive::continue_resolve`].
 /// - **Client Credentials** — base `resolve` returns `Complete(state)` once the engine wires the
-///   moved `nebula-engine` HTTP transport (ADR-0031). For now `resolve` returns `Provider("OAuth2
+///   moved `nebula-engine` HTTP transport (API-owned OAuth flow). For now `resolve` returns `Provider("OAuth2
 ///   HTTP transport has moved …")` so callers surface the migration explicitly rather than silently
 ///   no-op'ing.
 /// - **Device Code** — base `resolve` errors as per Authorization Code; the device-code variant
 ///   (`initiate_device_code`) is deferred to a later phase. RFC 8628 requires HTTP transport which
-///   is currently disabled in this crate per ADR-0031 (see `docs/adr/0031-api-owns-oauth-flow.md`);
+///   is currently disabled in this crate per API-owned OAuth flow (see );
 ///   the kickoff helper will land alongside the engine HTTP transport wiring.
 pub struct OAuth2Credential;
 
@@ -330,7 +330,7 @@ pub struct OAuth2Credential;
 /// the legacy `OAuth2Input`).
 ///
 /// `#[derive(Schema)]` emits the `HasSchema` impl read via
-/// `nebula_schema::schema_of::<Self::Properties>()` (ADR-0052 P3). Secret
+/// `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties). Secret
 /// fields use `String`
 /// here so that the universal Schema derivation applies; `resolve()` and
 /// the OAuth2 kickoff helpers wrap them into [`SecretString`] before they
@@ -422,7 +422,7 @@ impl Credential for OAuth2Credential {
         // * AuthorizationCode / DeviceCode: kick off via `OAuth2Credential::initiate_*` and persist
         //   the typed `OAuth2Pending` through `PendingStateStore`. The continuation then routes
         //   through `Interactive::continue_resolve`.
-        // * ClientCredentials: HTTP transport moved to nebula-engine (ADR-0031); surface the
+        // * ClientCredentials: HTTP transport moved to nebula-engine (API-owned OAuth flow); surface the
         //   migration explicitly.
         let _client_id = extract_required(values, "client_id")?;
         let _client_secret = extract_required(values, "client_secret")?;
@@ -515,7 +515,7 @@ impl Interactive for OAuth2Credential {
                     .ok_or_else(|| CredentialError::InvalidInput(FAILED.into()))?;
 
                 // Validation passed. HTTP code exchange has moved to nebula-api
-                // per ADR-0031; this crate no longer performs HTTP.
+                // per API-owned OAuth flow; this crate no longer performs HTTP.
                 let _ = (verifier_secret, redirect_uri, code);
                 Err(oauth2_http_transport_disabled())
             },
@@ -525,7 +525,7 @@ impl Interactive for OAuth2Credential {
                         "device_code flow expects UserInput::Poll".into(),
                     ));
                 }
-                // HTTP device code polling has moved to nebula-engine per ADR-0031.
+                // HTTP device code polling has moved to nebula-engine per API-owned OAuth flow.
                 Err(oauth2_http_transport_disabled())
             },
             GrantType::ClientCredentials => Err(CredentialError::InvalidInput(
@@ -553,7 +553,7 @@ impl Refreshable for OAuth2Credential {
             ));
         }
 
-        // Token refresh HTTP has moved to nebula-engine per ADR-0031;
+        // Token refresh HTTP has moved to nebula-engine per API-owned OAuth flow;
         // this crate no longer performs HTTP.
         Err(oauth2_http_transport_disabled())
     }
@@ -565,7 +565,7 @@ impl Revocable for OAuth2Credential {
         _ctx: &CredentialContext,
     ) -> Result<(), CredentialError> {
         // OAuth2 RFC 7009 token revocation requires HTTP — moved to
-        // nebula-engine per ADR-0031. Returning the typed transport-
+        // nebula-engine per API-owned OAuth flow. Returning the typed transport-
         // disabled error keeps the failure classification stable for
         // callers (engine routes to the HTTP transport when wired); a
         // silent `Ok(())` would falsely signal "secret revoked at
@@ -580,7 +580,7 @@ impl Testable for OAuth2Credential {
         _ctx: &CredentialContext,
     ) -> Result<TestResult, CredentialError> {
         // OAuth2 health probe (token introspection / userinfo) requires
-        // HTTP — moved to nebula-engine per ADR-0031. Same routing
+        // HTTP — moved to nebula-engine per API-owned OAuth flow. Same routing
         // rationale as `Refreshable::refresh` and `Revocable::revoke`
         // above. Returning `Ok(TestResult::Failed { … })` would falsely
         // signal "credential tested and is bad"; the test simply did
@@ -683,7 +683,7 @@ impl OAuth2Credential {
 
 fn oauth2_http_transport_disabled() -> CredentialError {
     CredentialError::Provider(
-        "OAuth2 HTTP transport has moved: code exchange to nebula-api, token refresh to nebula-engine (ADR-0031)"
+        "OAuth2 HTTP transport has moved: code exchange to nebula-api, token refresh to nebula-engine (API-owned OAuth flow)"
             .into(),
     )
 }
@@ -826,7 +826,7 @@ mod tests {
     // implements `Interactive`, `Refreshable`, `Revocable`, and
     // `Testable` (and not `Dynamic`). Trait bound checks below stand in
     // for the previous const-bool assertions. The `Revocable` and
-    // `Testable` impls currently route through ADR-0031 HTTP transport
+    // `Testable` impls currently route through API-owned OAuth flow HTTP transport
     // (returning `oauth2_http_transport_disabled()`); the trait
     // membership is still required so the engine's revoke / test
     // dispatchers can bind on it once the transport is wired.

--- a/crates/credential/src/event.rs
+++ b/crates/credential/src/event.rs
@@ -57,7 +57,7 @@ pub enum CredentialEvent {
     /// connections using this credential must be invalidated until the
     /// user re-authenticates.
     ///
-    /// [credential-refresh-coordination]: https://github.com/nebula-engine/nebula/blob/main/docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)
+    /// [credential-refresh-coordination]: https://github.com/nebula-engine/nebula/blob/main/docs/INTEGRATION_MODEL.md (credential refresh)
     ReauthRequired {
         /// The credential instance ID.
         credential_id: CredentialId,

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -1,7 +1,7 @@
 //! # nebula-credential
 //!
 //! **Role:** Credential Contract — stored state vs projected auth material;
-//! engine-owned rotation and refresh. Canon §3.5, §12.5.
+//! engine-owned rotation and refresh. Integration-model boundary; credential secrecy.
 //!
 //! The engine owns the split between stored `State` (encrypted at rest) and the
 //! projected auth material action code receives. Action authors bind to a
@@ -23,13 +23,13 @@
 //!   Tech Spec §15.4 — `Interactive`, `Refreshable`, `Revocable`, `Testable`, `Dynamic`. Phase 5 of
 //!   the M6 redesign renamed `Credential::Input` → `Credential::Properties` to mirror
 //!   `Action::Input` / `Resource::Config`; the `Properties: HasSchema` bound is the single
-//!   source of truth, read via `nebula_schema::schema_of::<C::Properties>()` (ADR-0052 P3 — no
+//!   source of truth, read via `nebula_schema::schema_of::<C::Properties>()` (schema-of properties — no
 //!   per-trait schema method).
 //! - `CredentialMetadata` — static type descriptor: key, name, schema, `AuthPattern`.
 //! - `CredentialRecord` — runtime operational state (created_at, version, expiry, tags). Previously
 //!   named `Metadata` (ADR 0004).
 //! - `CredentialStore` — persistence trait. Concrete impls + composable layers (`EncryptionLayer`,
-//!   `CacheLayer`, `AuditLayer`) live in `nebula_storage::credential` per ADR-0032; the multi-tenant
+//!   `CacheLayer`, `AuditLayer`) live in `nebula_storage::credential` per storage credential layers; the multi-tenant
 //!   scope layer was re-homed to `nebula_tenancy::CredentialScopeLayer` (spec §8).
 //! - Engine-owned runtime resolution lives in `nebula-engine::credential`.
 //! - `SecretString`, `CredentialGuard` — zeroizing secret wrappers.
@@ -38,7 +38,7 @@
 //!   exposed (SEC-11 hardening 2026-04-27).
 //! - `#[derive(Credential)]`, `#[derive(AuthScheme)]` — proc-macro derivations.
 //!
-//! ## Security invariant (canon §12.5)
+//! ## Security invariant (credential secrecy)
 //!
 //! Encryption at rest: AES-256-GCM with Argon2id KDF, credential ID bound as AAD.
 //! No bypass for debugging. All intermediate plaintext in `Zeroizing<Vec<u8>>`.
@@ -72,7 +72,7 @@ pub mod provider;
 pub mod rotation;
 /// Authentication scheme types — AuthScheme trait, AuthPattern, 12 built-in schemes.
 pub mod scheme;
-/// §12.5 secret-handling primitives — AES-256-GCM, guards, zeroizing wrappers, serde helpers.
+/// credential secrecy secret-handling primitives — AES-256-GCM, guards, zeroizing wrappers, serde helpers.
 pub mod secrets;
 
 // ── Flattened modules (previously nested under accessor/ and metadata/) ───
@@ -81,13 +81,13 @@ pub mod secrets;
 mod accessor;
 /// Credential operation context — CredentialContext, CredentialContextBuilder.
 mod context;
-/// Typed credential reference — `CredentialRef<C>` slot-binding handle (ADR-0043 §9).
+/// Typed credential reference — `CredentialRef<C>` slot-binding handle (typed ref fields).
 mod credential_ref;
 /// Typed credential handle — CredentialHandle (ArcSwap-backed).
 mod handle;
 /// Credential metadata — static type descriptor (CredentialMetadata, builder, compat).
 mod metadata;
-/// `NoCredential` opt-out type — for resources without an authenticated binding (ADR-0036).
+/// `NoCredential` opt-out type — for resources without an authenticated binding (credential isolation).
 mod no_credential;
 /// Credential record — runtime operational state (timestamps, version, tags).
 mod record;
@@ -104,9 +104,9 @@ pub mod pending_store;
 /// In-memory pending state store — **test shim only**.
 ///
 /// The canonical production impl lives in
-/// `nebula_storage::credential::InMemoryPendingStore` per ADR-0032.
+/// `nebula_storage::credential::InMemoryPendingStore` per storage credential layers.
 /// This copy exists solely for credential's own `#[cfg(test)]` code
-/// which cannot depend on `nebula-storage` (dep-cycle, ADR-0032 §3).
+/// which cannot depend on `nebula-storage` (dep-cycle, storage credential layers §3).
 #[cfg(any(test, feature = "test-util"))]
 pub mod pending_store_memory;
 /// Credential snapshot.
@@ -116,9 +116,9 @@ pub mod store;
 /// In-memory `CredentialStore` impl — **test shim only**.
 ///
 /// The canonical production impl lives in
-/// `nebula_storage::credential::InMemoryStore` per ADR-0032.
+/// `nebula_storage::credential::InMemoryStore` per storage credential layers.
 /// This copy exists solely for credential's own `#[cfg(test)]` code
-/// which cannot depend on `nebula-storage` (dep-cycle, ADR-0032 §3).
+/// which cannot depend on `nebula-storage` (dep-cycle, storage credential layers §3).
 #[cfg(any(test, feature = "test-util"))]
 pub mod store_memory;
 
@@ -159,19 +159,19 @@ pub use nebula_core::accessor::CredentialAccessor;
 pub use nebula_core::{CredentialId, CredentialKey, credential_key};
 // Re-exported so `#[derive(Credential)]` can emit `::nebula_credential::schema_of`
 // without forcing plugin authors onto a direct `nebula-schema` dependency
-// (ADR-0052 P3: `Self::Properties: HasSchema` is the single source of truth).
+// (schema-of properties: `Self::Properties: HasSchema` is the single source of truth).
 pub use nebula_schema::schema_of;
 // Derive macros
 pub use nebula_credential_macros::{AuthScheme, Credential};
 // Opt-out built-in (lives at root, not under credentials::, because it has
 // no Input form and is never registered in CredentialRegistry — it's a
-// Resource-side type marker per ADR-0036).
+// Resource-side type marker per credential isolation).
 pub use no_credential::{NoCredential, NoCredentialState};
 // Pending state store
 pub use pending_store::{PendingStateStore, PendingStoreError};
 #[cfg(any(test, feature = "test-util"))]
 pub use pending_store_memory::InMemoryPendingStore;
-// External provider abstraction (redesigned per ADR-0051):
+// External provider abstraction (redesigned per external provider):
 // - Trait & data types (ExternalProvider, ExternalReference, ProviderError, ProviderKind)
 // - Future newtype (ProviderFuture) for dyn-safe + zero-alloc-ready resolve
 // - Envelope (ProviderResolution, LeaseHandle) carrying secret + lease + TTL
@@ -182,7 +182,7 @@ pub use provider::{
     ExternalProvider, ExternalProviderChain, ExternalReference, LeaseEvent, LeaseExpiryReason,
     LeaseHandle, LeasedProvider, ProviderError, ProviderFuture, ProviderKind, ProviderResolution,
 };
-// Refresh coordination — moved to nebula-engine::credential::refresh (ADR-0030 §3 amendment)
+// Refresh coordination — moved to nebula-engine::credential::refresh (engine credential orchestration §3 amendment)
 // Re-exports removed: RefreshAttempt, RefreshCoordinator now live in nebula-engine.
 // Auth schemes — open trait + 11-variant classification + 9 built-in scheme types.
 // Pruned 2026-04-24: FederatedAssertion (Plane A), OtpSeed + ChallengeSecret
@@ -191,10 +191,10 @@ pub use scheme::{
     AuthPattern, AuthScheme, Certificate, ConnectionUri, IdentityPassword, InstanceBinding,
     KeyPair, OAuth2Token, PublicScheme, SecretToken, SensitiveScheme, SharedKey, SigningKey,
 };
-// §12.5 secret-handling primitives — crypto, guard, zeroizing wrappers,
+// credential secrecy secret-handling primitives — crypto, guard, zeroizing wrappers,
 // scheme-guard refresh surface (§15.7). The refresh-notification hook
 // itself lives on `nebula_resource::Resource::on_credential_refresh`
-// per ADR-0036; the previously-defined parallel `OnCredentialRefresh<C>`
+// per credential isolation; the previously-defined parallel `OnCredentialRefresh<C>`
 // trait was removed in nebula-resource П2.
 //
 // SEC-11 (security hardening 2026-04-27 Stage 1): bare `encrypt` removed
@@ -205,10 +205,10 @@ pub use secrets::{
     SecretString, decrypt, decrypt_with_aad, encrypt_with_aad, encrypt_with_key_id,
     generate_code_challenge, generate_pkce_verifier, generate_random_state,
 };
-// Store trait + DTOs (canonical impls live in `nebula_storage::credential` per ADR-0032)
+// Store trait + DTOs (canonical impls live in `nebula_storage::credential` per storage credential layers)
 pub use store::{CredentialStore, PutMode, ScopeResolver, StoreError, StoredCredential};
 // In-memory impl — test shim only; production consumers use
-// `nebula_storage::credential::InMemoryStore` (ADR-0032).
+// `nebula_storage::credential::InMemoryStore` (storage credential layers).
 #[cfg(any(test, feature = "test-util"))]
 pub use store_memory::InMemoryStore;
 

--- a/crates/credential/src/no_credential.rs
+++ b/crates/credential/src/no_credential.rs
@@ -1,6 +1,6 @@
 //! `NoCredential` — legacy no-auth credential marker.
 //!
-//! Per ADR-0044 (supersedes ADR-0036), the `Resource::Credential`
+//! Per slot model (supersedes credential isolation), the `Resource::Credential`
 //! associated type was removed in favor of typed `#[credential(...)]`
 //! slot fields on resource structs. Resources that do not bind any
 //! credential simply declare zero `#[credential]` fields — `NoCredential`
@@ -43,7 +43,7 @@ impl CredentialState for NoCredentialState {
 /// Legacy no-auth credential type — retained for credential-subsystem
 /// internal use (registry diagnostics, capability sub-traits).
 ///
-/// Per ADR-0044 the `Resource::Credential` associated type was removed;
+/// Per slot model the `Resource::Credential` associated type was removed;
 /// `NoCredential` is no longer used as an opt-out marker. Resources that
 /// don't need credential material simply declare zero `#[credential]`
 /// slot fields.

--- a/crates/credential/src/pending_store_memory.rs
+++ b/crates/credential/src/pending_store_memory.rs
@@ -1,6 +1,6 @@
 //! In-memory pending state store — **behaviour-identical shim** of the
 //! canonical impl at `nebula_storage::credential::pending::InMemoryPendingStore`
-//! (ADR-0029 §4 / ADR-0032 §7).
+//! (pending store / storage credential layers §7).
 //!
 //! # Why a dual-home shim?
 //!
@@ -12,7 +12,7 @@
 //! generic executor no longer accepts the storage-side type
 //! (empirically confirmed in P6.2 with `InMemoryStore`).
 //!
-//! The fix is the same narrowly-scoped exception ADR-0032 §7 carved out
+//! The fix is the same narrowly-scoped exception storage credential layers §7 carved out
 //! for `store_memory`: keep a body-identical copy in credential for
 //! internal tests; production consumers and composition roots prefer the
 //! storage-side canonical home.
@@ -21,7 +21,7 @@
 //! `nebula_storage::credential::InMemoryPendingStore`. Only credential's
 //! internal `#[cfg(test)]` code should touch this module.
 //!
-//! Ref: `docs/adr/0032-credential-store-canonical-home.md` §7
+//! Ref:  §7
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -54,7 +54,7 @@ pub struct InMemoryPendingStore {
     /// map, and returns without awaiting under the guard, so a
     /// `parking_lot::RwLock` in a sync block would be cheaper. Perf is
     /// irrelevant in this shim; production storage lives in
-    /// `nebula-storage` per ADR-0029 §4 / ADR-0032 §7. Do **NOT**
+    /// `nebula-storage` per pending store / storage credential layers §7. Do **NOT**
     /// cargo-cult this `tokio::RwLock<HashMap<...>>` pattern into a
     /// production module where the guard could cross an `.await` —
     /// that's the issue-#587-shaped perf cost the audit flagged.

--- a/crates/credential/src/provider/leased.rs
+++ b/crates/credential/src/provider/leased.rs
@@ -1,6 +1,6 @@
 //! `LeasedProvider` sub-trait — renew / revoke for time-bounded grants.
 //!
-//! Per ADR-0051 the base [`ExternalProvider`] surface stays oblivious to
+//! Per external provider the base [`ExternalProvider`] surface stays oblivious to
 //! lease lifecycle: it only resolves secrets and carries optional lease
 //! metadata on the [`ProviderResolution`] envelope. Lease-aware providers
 //! (HashiCorp Vault dynamic secrets, AWS STS-issued temporary creds, GCP

--- a/crates/credential/src/provider/mod.rs
+++ b/crates/credential/src/provider/mod.rs
@@ -6,7 +6,7 @@
 //! concrete implementations live in downstream crates (e.g., `nebula-storage`)
 //! behind feature gates.
 //!
-//! # Trait shape (per ADR-0051)
+//! # Trait shape (per external provider)
 //!
 //! [`ExternalProvider`] returns [`ProviderFuture<'a>`], a dyn-safe envelope
 //! around `Pin<Box<dyn Future + Send>>` that also supports a zero-allocation
@@ -17,7 +17,7 @@
 //!
 //! Resolutions return a [`ProviderResolution`] envelope (secret + optional
 //! lease + optional TTL) rather than a bare [`SecretString`], so a downstream
-//! `ProviderCacheLayer` (planned in `nebula-storage` per ADR-0032) can cache
+//! `ProviderCacheLayer` (planned in `nebula-storage` per storage credential layers) can cache
 //! provider responses according to provider-suggested TTLs without further
 //! trait changes.
 //!
@@ -163,7 +163,7 @@ pub enum ProviderError {
 ///
 /// # Lease support
 ///
-/// Per ADR-0051 the [`LeasedProvider`] sub-trait adds `renew` / `revoke`
+/// Per external provider the [`LeasedProvider`] sub-trait adds `renew` / `revoke`
 /// for time-bounded grants. Providers advertise the capability without
 /// runtime downcasts by overriding [`lease_renewal`](Self::lease_renewal)
 /// to return `Some(self)`; composed providers

--- a/crates/credential/src/provider/resolution.rs
+++ b/crates/credential/src/provider/resolution.rs
@@ -45,7 +45,7 @@ pub struct ProviderResolution {
     pub lease: Option<LeaseHandle>,
     /// Suggested time-to-live for the resolved secret. `None` means the
     /// provider has no TTL hint — the consumer (e.g.
-    /// `ProviderCacheLayer` in `nebula-storage`, future work per ADR-0051)
+    /// `ProviderCacheLayer` in `nebula-storage`, future work per external provider)
     /// applies its own default, which may itself be "do not cache".
     pub ttl: Option<Duration>,
 }

--- a/crates/credential/src/rotation/mod.rs
+++ b/crates/credential/src/rotation/mod.rs
@@ -2,11 +2,11 @@
 //!
 //! Policy shapes, state machines, error types, events, and validation traits
 //! for credential rotation. Backup row types consumed by storage live in
-//! `nebula_storage::credential::backup` (ADR-0029 / ADR-0032).
+//! `nebula_storage::credential::backup` (backup store / storage credential layers).
 //!
 //! **Orchestration** (schedulers, blue-green deployment, grace-period management,
 //! transaction state machines) lives in `nebula-engine` (`credential::rotation`,
-//! feature `rotation` on the engine crate) — see ADR-0030. This crate keeps the
+//! feature `rotation` on the engine crate) — see engine credential orchestration. This crate keeps the
 //! portable contract and error types the engine re-exports.
 //!
 //! # Feature gate
@@ -16,8 +16,8 @@
 //!
 //! # See also
 //!
-//! - `docs/adr/0028-cross-crate-credential-invariants.md`
-//! - `docs/adr/0030-engine-owns-credential-orchestration.md`
+//! -
+//! -
 //! - `crates/credential/README.md` — crate role vs `nebula-engine::credential`
 
 // Contract type modules — these stay in nebula-credential

--- a/crates/credential/src/scheme/mod.rs
+++ b/crates/credential/src/scheme/mod.rs
@@ -10,7 +10,7 @@
 //! so `nebula-core` holds only cross-cutting vocabulary.
 //!
 //! **Pruned 2026-04-24** (zero consumers, Plane-A territory):
-//! `FederatedAssertion` (SAML/JWT — `nebula-auth` Plane A concern per ADR-0033),
+//! `FederatedAssertion` (SAML/JWT — `nebula-auth` Plane A concern per auth plane separation),
 //! `OtpSeed` (TOTP/HOTP — belongs inside specific integrations, not projected),
 //! `ChallengeSecret` (Digest/NTLM/SCRAM — HTTP client negotiation, not wire-level scheme).
 

--- a/crates/credential/src/secrets/guard.rs
+++ b/crates/credential/src/secrets/guard.rs
@@ -65,7 +65,7 @@ impl<S: Zeroize> Drop for CredentialGuard<S> {
 
 // SEC-05 (security hardening 2026-04-27 Stage 2): `Clone` impl removed.
 // Cloning a guard would create a second zeroize point on the same plaintext,
-// violating PRODUCT_CANON §4.2 invariant N10 ("plaintext does not cross
+// violating plaintext boundary invariant N10 ("plaintext does not cross
 // spawn boundary"). Each acquired secret has exactly one drop site.
 //
 // Pre-removal pattern (incorrect):

--- a/crates/credential/src/secrets/mod.rs
+++ b/crates/credential/src/secrets/mod.rs
@@ -1,4 +1,4 @@
-//! §12.5 primitives — AES-256-GCM, Argon2id KDF, PKCE, zeroizing secret wrappers.
+//! credential secrecy primitives — AES-256-GCM, Argon2id KDF, PKCE, zeroizing secret wrappers.
 //!
 //! Canon-level secret-handling primitives. Every plaintext buffer here is
 //! wrapped in `Zeroizing<T>` or a zeroize-on-drop newtype.

--- a/crates/credential/src/secrets/scheme_guard.rs
+++ b/crates/credential/src/secrets/scheme_guard.rs
@@ -94,7 +94,7 @@ impl<C: Credential> SchemeGuard<'_, C> {
     /// Mirrors [`SchemeGuard::new`] but is publicly callable so external
     /// integration tests (notably `nebula-resource`'s rotation dispatch
     /// suite) can fabricate guards for fixture resources. Gated behind
-    /// `#[cfg(any(test, feature = "test-util"))]` per ADR-0023 — this
+    /// `#[cfg(any(test, feature = "test-util"))]` per test-util gating — this
     /// constructor MUST NOT be exposed in a production release build.
     ///
     /// Production code paths use the engine-driven flow that calls
@@ -188,7 +188,7 @@ impl<C: Credential> SchemeFactory<C> {
     /// Mirrors [`SchemeFactory::new`] but is publicly callable so external
     /// integration tests (notably `nebula-resource`'s rotation dispatch
     /// suite) can fabricate factories for fixture resources. Gated behind
-    /// `#[cfg(any(test, feature = "test-util"))]` per ADR-0023 — this
+    /// `#[cfg(any(test, feature = "test-util"))]` per test-util gating — this
     /// constructor MUST NOT be exposed in a production release build.
     ///
     /// The closure shape matches the canonical engine wiring: per call it
@@ -234,7 +234,7 @@ where
     /// Production code never relies on `Scheme: Clone`; only the test path
     /// requires it.
     ///
-    /// Gated behind `#[cfg(any(test, feature = "test-util"))]` per ADR-0023.
+    /// Gated behind `#[cfg(any(test, feature = "test-util"))]` per test-util gating.
     pub fn for_test_static(scheme: <C as Credential>::Scheme) -> Self {
         Self::for_test(move || {
             let scheme = scheme.clone();
@@ -260,7 +260,7 @@ impl<C: Credential> std::fmt::Debug for SchemeFactory<C> {
 }
 
 // Refresh-notification hook lives on `nebula_resource::Resource` itself
-// (`Resource::on_credential_refresh`) per ADR-0036 + Tech Spec §15.4. The
+// (`Resource::on_credential_refresh`) per credential isolation + Tech Spec §15.4. The
 // previously-defined parallel `OnCredentialRefresh<C>` trait was a
 // transitional bridge while `Resource` still bound `Auth: AuthScheme`; the
 // П1 reshape moved the canonical hook onto `Resource`, П2 wired Manager

--- a/crates/credential/src/store.rs
+++ b/crates/credential/src/store.rs
@@ -135,7 +135,7 @@ pub enum StoreError {
     },
     /// Audit sink refused to record the operation. Fail-closed alarm.
     ///
-    /// Per ADR-0028 invariant 4 + §14 "no discard-and-log": a failed
+    /// Per credential invariants invariant 4 + §14 "no discard-and-log": a failed
     /// audit sink surfaces as a hard error rather than a log-and-continue.
     /// The underlying store state depends on the operation and rollback
     /// feasibility:

--- a/crates/credential/src/store_memory.rs
+++ b/crates/credential/src/store_memory.rs
@@ -1,11 +1,11 @@
 //! Test-only in-memory credential store.
 //!
 //! This is a **test shim**. The canonical production `InMemoryStore` lives
-//! in `nebula_storage::credential::InMemoryStore` per ADR-0032. A copy
+//! in `nebula_storage::credential::InMemoryStore` per storage credential layers. A copy
 //! is kept here (and only here) under `#[cfg(any(test, feature = "test-util"))]`
 //! because credential's own internal tests (`resolver.rs`, layer tests, etc.)
 //! must not depend on `nebula-storage` — that would introduce a dep cycle
-//! that ADR-0032 §3 explicitly forbids ("`nebula-credential → nebula-storage`
+//! that storage credential layers §3 explicitly forbids ("`nebula-credential → nebula-storage`
 //! is forbidden. Credential's `Cargo.toml` MUST NOT list `nebula-storage`").
 //!
 //! Production consumers (composition roots, examples, docs) should import
@@ -32,7 +32,7 @@ pub struct InMemoryStore {
     /// map, and returns without awaiting under the guard, so a
     /// `parking_lot::RwLock` in a sync block would be cheaper. Perf is
     /// irrelevant in this shim; production storage lives in
-    /// `nebula-storage` per ADR-0032. Do **NOT** cargo-cult this
+    /// `nebula-storage` per storage credential layers. Do **NOT** cargo-cult this
     /// `tokio::RwLock<HashMap<...>>` pattern into a production module
     /// where the guard could cross an `.await` — that's the
     /// issue-#587-shaped perf cost the audit flagged.

--- a/crates/credential/tests/compile_fail_credential_guard_clone.rs
+++ b/crates/credential/tests/compile_fail_credential_guard_clone.rs
@@ -2,11 +2,11 @@
 //!
 //! `CredentialGuard` previously implemented `Clone` when `S: Zeroize + Clone`.
 //! Cloning would create a second zeroize point on the same plaintext,
-//! violating PRODUCT_CANON §4.2 invariant N10 («plaintext does not cross
+//! violating plaintext boundary invariant N10 («plaintext does not cross
 //! spawn boundary»). This probe verifies the impl is gone via fully-qualified
 //! syntax (FQS) so `Clone` cannot resolve through `Deref` to the inner `S`.
 //!
-//! See `docs/adr/HISTORICAL.md (ADR-0028 credential invariants)` §4.
+//! See `credential invariants doc (credential invariants credential invariants)` §4.
 
 #[test]
 fn compile_fail_credential_guard_clone() {

--- a/crates/credential/tests/compile_fail_credential_properties_schema_removed.rs
+++ b/crates/credential/tests/compile_fail_credential_properties_schema_removed.rs
@@ -1,4 +1,4 @@
-//! Seam (ADR-0052 P3) — `Credential::properties_schema()` is removed.
+//! Seam (schema-of properties) — `Credential::properties_schema()` is removed.
 //!
 //! Schema is reachable only via the `Properties: HasSchema` associated-type
 //! bound / `nebula_schema::schema_of`. This locks the convergence: the

--- a/crates/credential/tests/compile_fail_dyn_credential_const_key.rs
+++ b/crates/credential/tests/compile_fail_dyn_credential_const_key.rs
@@ -1,6 +1,6 @@
 //! Bonus probe (Stage 4) - `dyn Credential` not dyn-compatible.
 //!
-//! Per Tech Spec 15.4 line 3237 + ADR-0035 context section, the
+//! Per Tech Spec 15.4 line 3237 + capability macro context section, the
 //! `Credential` trait carries `const KEY: &'static str` plus several
 //! associated types (`Input`, `State`, `Scheme`, `Pending`). Any one of
 //! those alone is enough to block dyn-compatibility:
@@ -11,7 +11,7 @@
 //!   in a `dyn` position.
 //!
 //! This probe documents the structural reason the phantom-shim
-//! pattern exists (ADR-0035 1): a `dyn Credential` trait object
+//! pattern exists (capability macro 1): a `dyn Credential` trait object
 //! is not constructible at the type level, regardless of any runtime
 //! vtable considerations. The phantom pattern resolves the gap by
 //! introducing a separate dyn-safe phantom trait (no `const KEY`, no

--- a/crates/credential/tests/compile_fail_encrypt_no_aad_removed.rs
+++ b/crates/credential/tests/compile_fail_encrypt_no_aad_removed.rs
@@ -6,7 +6,7 @@
 //! re-export. Production callers must go through `encrypt_with_aad` /
 //! `encrypt_with_key_id` — the AAD-mandatory paths.
 //!
-//! See `docs/adr/HISTORICAL.md (ADR-0028 credential invariants)` §3.
+//! See `credential invariants doc (credential invariants credential invariants)` §3.
 
 #[test]
 fn compile_fail_encrypt_no_aad_removed() {

--- a/crates/credential/tests/compile_fail_pattern2_service_reject.rs
+++ b/crates/credential/tests/compile_fail_pattern2_service_reject.rs
@@ -1,7 +1,7 @@
 //! Bonus probe (Stage 4) - Pattern 2 wrong-scheme rejection through
 //! the phantom-shim chain.
 //!
-//! Per ADR-0035 1, declaring a credential whose `Scheme` does not
+//! Per capability macro 1, declaring a credential whose `Scheme` does not
 //! satisfy a capability's `scheme_bound` marker must reject at
 //! compile time. The diagnostic chain travels:
 //!

--- a/crates/credential/tests/compile_fail_state_zeroize.rs
+++ b/crates/credential/tests/compile_fail_state_zeroize.rs
@@ -2,7 +2,7 @@
 //!
 //! Verifies the trait shape rejects an `impl CredentialState for X` where
 //! `X` does not derive (or otherwise implement) `ZeroizeOnDrop`. Plaintext
-//! state at runtime must drop deterministically per §12.5; the supertrait
+//! state at runtime must drop deterministically per credential secrecy; the supertrait
 //! bound is the compile-time gate.
 
 #[test]

--- a/crates/credential/tests/probes/credential_properties_schema_removed.rs
+++ b/crates/credential/tests/probes/credential_properties_schema_removed.rs
@@ -1,4 +1,4 @@
-//! Probe — ADR-0052 P3: `Credential::properties_schema()` is removed.
+//! Probe — schema-of properties: `Credential::properties_schema()` is removed.
 //!
 //! The `Properties: HasSchema` associated-type bound is the single source of
 //! truth; schema is reached via `nebula_schema::schema_of::<C::Properties>()`.

--- a/crates/credential/tests/probes/dyn_credential_const_key.rs
+++ b/crates/credential/tests/probes/dyn_credential_const_key.rs
@@ -13,7 +13,7 @@
 //!   independently of the assoc-type set.
 //!
 //! Together these capture the structural reason the phantom-shim
-//! pattern (ADR-0035 1) exists: `dyn Credential` is doubly blocked,
+//! pattern (capability macro 1) exists: `dyn Credential` is doubly blocked,
 //! and any `dyn`-position use must route through a phantom trait that
 //! has neither `const KEY` nor unspecified associated types.
 

--- a/crates/credential/tests/probes/pattern2_service_reject.rs
+++ b/crates/credential/tests/probes/pattern2_service_reject.rs
@@ -17,7 +17,7 @@ use nebula_credential::{
 use nebula_schema::FieldValues;
 use serde::{Deserialize, Serialize};
 
-// Per ADR-0035 4.1, the crate author declares `mod sealed_caps`
+// Per capability macro 4.1, the crate author declares `mod sealed_caps`
 // manually at crate root with one inner trait per capability. The
 // fixture is the "crate" here.
 mod sealed_caps {

--- a/crates/credential/tests/probes/scheme_guard_retention.rs
+++ b/crates/credential/tests/probes/scheme_guard_retention.rs
@@ -27,7 +27,7 @@ impl LeakyResource {
         new_scheme: SchemeGuard<'a, ApiKeyCredential>,
         // `ctx` is decorative for this probe — it mirrors the canonical
         // refresh-hook signature (`Resource::on_credential_refresh` takes a
-        // `&'a CredentialContext` alongside the guard per ADR-0036 + Tech
+        // `&'a CredentialContext` alongside the guard per credential isolation + Tech
         // Spec §15.4) so the probe matches the production call shape
         // verbatim. The retention error would fire on `new_scheme` alone;
         // the parameter is kept to make the fixture grep-equivalent to

--- a/crates/credential/tests/properties_pipeline.rs
+++ b/crates/credential/tests/properties_pipeline.rs
@@ -4,13 +4,13 @@
 //! struct that Phase 5 attached to every `Credential` impl. The test pins:
 //!
 //!   1. The credential's metadata schema (the converged consumer path) equals
-//!      `nebula_schema::schema_of::<C::Properties>()` (ADR-0052 P3 — there is no
+//!      `nebula_schema::schema_of::<C::Properties>()` (schema-of properties — there is no
 //!      per-trait schema method).
 //!   2. JSON properties → `FieldValues::from_json` → `schema.validate` →
 //!      `serde_json::from_value::<C::Properties>`. The two passes (schema and serde) are
 //!      independent.
 //!   3. **Credential properties never run through `ValidValues::resolve`.** The engine deliberately
-//!      omits the expression-resolution step from the credential pipeline (canon §12.5: secrets
+//!      omits the expression-resolution step from the credential pipeline (credential secrecy: secrets
 //!      must not depend on runtime workflow state). This test asserts the policy by validating the
 //!      schema directly without `.resolve(...)` and by shape-checking the post-validate value tree
 //!      (no template gets replaced).
@@ -26,7 +26,7 @@ use serde_json::json;
 
 #[test]
 fn metadata_schema_is_schema_of_properties() {
-    // ADR-0052 P3 seam: the converged path. `Credential::properties_schema()`
+    // schema-of properties seam: the converged path. `Credential::properties_schema()`
     // is removed; the metadata schema is sourced from
     // `nebula_schema::schema_of::<C::Properties>()` (the `Properties: HasSchema`
     // associated-type bound is the single source of truth).
@@ -82,7 +82,7 @@ fn properties_pipeline_rejects_missing_required_api_key() {
     );
 }
 
-// ── Expression policy (canon §12.5) ────────────────────────────────────────
+// ── Expression policy (credential secrecy) ────────────────────────────────────────
 
 /// Policy: the credential pipeline does NOT run `valid.resolve(...)`.
 ///
@@ -157,7 +157,7 @@ fn expressions_in_optional_property_field_also_fail_serde() {
     let values = FieldValues::from_json(raw.clone()).expect("ingest");
     schema.validate(&values).expect("validate passes");
 
-    // The optional `server: Option<String>` is also targeted by canon §12.5;
+    // The optional `server: Option<String>` is also targeted by credential secrecy;
     // serde refuses the `{"$expr": ...}` envelope as a `String`.
     let result = serde_json::from_value::<<ApiKeyCredential as Credential>::Properties>(raw);
     assert!(

--- a/crates/credential/tests/redaction.rs
+++ b/crates/credential/tests/redaction.rs
@@ -1,6 +1,6 @@
 //! Log-redaction test helper for `nebula-credential`.
 //!
-//! Covers the "no secrets in logs" half of the §12.5 invariant from
+//! Covers the "no secrets in logs" half of the credential secrecy invariant from
 //! `docs/PRODUCT_CANON.md`. The error-string and metrics-label halves
 //! of that invariant are enforced at their own boundaries (typed error
 //! taxonomy in `docs/STYLE.md §4`, metrics-label review in code review)

--- a/crates/credential/tests/zeroize_drop_oauth2_bearer.rs
+++ b/crates/credential/tests/zeroize_drop_oauth2_bearer.rs
@@ -11,7 +11,7 @@
 //!    same token).
 //! 3. Drop runs without panic across the typical lifecycle.
 //!
-//! See `docs/adr/HISTORICAL.md (ADR-0028 credential invariants)` §4.
+//! See `credential invariants doc (credential invariants credential invariants)` §4.
 
 use nebula_credential::{
     SecretString,

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -1,30 +1,28 @@
-//! Durable control-queue consumer — canon §12.2.
+//! Durable control-queue consumer — control-queue wiring.
 //!
 //! The `ControlConsumer` drains `execution_control_queue` (the spec-16
 //! [`nebula_storage_port::store::ControlQueue`] port) and hands typed
 //! commands to an engine-owned [`ControlDispatch`] implementation.
-//! ADR-0008 records the
-//! wiring decisions: polling loop + claim/ack, engine-owned dispatch trait
+//! Wiring decisions: polling loop + claim/ack, engine-owned dispatch trait
 //! (no `nebula-api` / `nebula-storage` row types leak into the public
 //! surface), at-least-once delivery with idempotent consumer semantics.
 //!
 //! ## Status
 //!
-//! - construction, spawning, graceful shutdown, polling, claim/ack plumbing — **implemented**
-//!   (§11.6);
+//! - construction, spawning, graceful shutdown, polling, claim/ack plumbing — **implemented**;
 //! - dispatch of `Start` / `Resume` / `Restart` to the engine start/resume path — **implemented**
 //!   (A2, closes #332 / #327). The engine-owned implementation lives in
 //!   [`crate::control_dispatch::EngineControlDispatch`];
 //! - dispatch of `Cancel` / `Terminate` to the engine cancel path — **implemented** (A3, closes
 //!   #330). The `Cancel` command now reaches the live frontier loop via
 //!   [`crate::WorkflowEngine::cancel_execution`]; `Terminate` shares the cooperative-cancel body
-//!   until a distinct forced-shutdown path is wired (see ADR-0016).
-//! - reclaim sweep for stuck `Processing` rows after a crashed runner — **implemented** (B1,
-//!   ADR-0017). A periodic `tokio::time::interval` arm calls `ControlQueue::reclaim_stuck`
+//!   until a distinct forced-shutdown path is wired.
+//! - reclaim sweep for stuck `Processing` rows after a crashed runner — **implemented** (B1).
+//!   A periodic `tokio::time::interval` arm calls `ControlQueue::reclaim_stuck`
 //!   every [`DEFAULT_RECLAIM_INTERVAL`]; rows whose `processed_at` is older than
 //!   [`DEFAULT_RECLAIM_AFTER`] are moved back to `Pending` (retry budget
 //!   [`DEFAULT_MAX_RECLAIM_COUNT`]) or to `Failed` once the budget is exhausted. Each sweep emits
-//!   the `nebula_engine_control_reclaim_total{outcome}` counter (ADR-0017 Seam) — wire the shared
+//!   the `nebula_engine_control_reclaim_total{outcome}` counter — wire the shared
 //!   registry via [`ControlConsumer::with_metrics`].
 //! - M3.5 — before each dispatch, optional `w3c_trace_context` on the row is attached as the
 //!   OpenTelemetry parent of an `engine.control_queue.dispatch` span (`.instrument` across await).
@@ -55,7 +53,7 @@ pub const DEFAULT_BATCH_SIZE: u32 = 32;
 /// Default poll interval when the queue is empty.
 ///
 /// Short enough that a cancel feels interactive in the in-memory / SQLite
-/// local path (canon §12.3); the Postgres path may shorten this further
+/// local path (local control-queue path); the Postgres path may shorten this further
 /// once `LISTEN / NOTIFY` wake-up is wired as an optimisation over the
 /// authoritative polling loop.
 pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
@@ -67,22 +65,22 @@ pub const MAX_CLAIM_ERROR_BACKOFF: Duration = Duration::from_secs(30);
 /// Default staleness window before a `Processing` row is considered
 /// reclaimable.
 ///
-/// Set to 5× the ADR-0015 lease TTL (30s) so a runner that has missed 15
+/// Set to 5× the lease TTL (30s) so a runner that has missed 15
 /// heartbeats is presumed dead. Intentionally wider than any plausible GC
-/// pause. See ADR-0017.
+/// pause.
 pub const DEFAULT_RECLAIM_AFTER: Duration = Duration::from_secs(150);
 
 /// Default cadence of the reclaim sweep.
 ///
 /// Matches the lease TTL shape — a runner that died less than 30s ago still
 /// has a valid lease from another observer's perspective, so sweeping more
-/// often buys nothing. See ADR-0017.
+/// often buys nothing.
 pub const DEFAULT_RECLAIM_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Default retry budget before a reclaim-eligible row moves to `Failed`.
 ///
 /// Three crashed runners in a row on the same command makes the command
-/// itself the suspect, not the runners. See ADR-0017.
+/// itself the suspect, not the runners.
 pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
 
 /// Errors returned from [`ControlDispatch`] methods.
@@ -115,7 +113,7 @@ pub enum ControlDispatchError {
 /// Implementations must be **idempotent per `(execution_id, command)`
 /// pair**: receiving the same command twice (e.g. after an at-least-once
 /// redelivery) for a terminal execution must return `Ok(())`, not an
-/// error. This is a load-bearing contract for ADR-0008 decision 5.
+/// error. This is a load-bearing contract for decision 5.
 ///
 /// ## Status
 ///
@@ -125,21 +123,21 @@ pub enum ControlDispatchError {
 /// no storage / api types) is stabilised by A1's public-surface test.
 #[async_trait::async_trait]
 pub trait ControlDispatch: Send + Sync {
-    /// Deliver a `Start` command to a newly-created execution (canon §12.2,
-    /// §13 step 3, #332).
+    /// Deliver a `Start` command to a newly-created execution (control-queue wiring,
+    /// , #332).
     ///
     /// Enqueued by the API `start_execution` / `execute_workflow` handlers
     /// once the `ExecutionState::Created` row has been persisted. A2 wired
     /// the canonical engine-side body in
     /// [`crate::control_dispatch::EngineControlDispatch`] — no default
     /// implementation is provided, so every `ControlDispatch` implementor
-    /// must supply a real dispatch (the ADR-0008 A2 merge-checklist
+    /// must supply a real dispatch (the A2 merge-checklist
     /// requirement).
     ///
     /// **Idempotency (critical):** double-start re-runs the workflow twice.
     /// Implementations must guard via CAS on `ExecutionRepo::transition` —
     /// a `Start` arriving for an already-running or already-terminal
-    /// execution must be `Ok(())`, not a second run. See ADR-0008 §5.
+    /// execution must be `Ok()`, not a second run.
     async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Cancel` command to a running execution.
@@ -150,21 +148,21 @@ pub trait ControlDispatch: Send + Sync {
     /// [`crate::WorkflowEngine::cancel_execution`] on every non-orphan
     /// delivery, regardless of persisted status.
     ///
-    /// **Idempotency (load-bearing, ADR-0008 §5):** The underlying
+    /// **Idempotency (load-bearing, ):** The underlying
     /// `CancellationToken::cancel` is idempotent per token, and a missing
     /// registry entry (cross-runner case, or this runner has already
     /// cleaned up) is a no-op. The consumer's ack path (`mark_completed`)
     /// can fail after a successful dispatch, and the reclaim path (B1)
     /// will redeliver; because the signal itself is idempotent, re-delivery
-    /// is safe without a short-circuit on persisted status. See ADR-0016.
+    /// is safe without a short-circuit on persisted status.
     async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Terminate` command to a running execution.
     ///
-    /// ADR-0008 calls this "forced termination", but there is no distinct
+    /// calls this "forced termination", but there is no distinct
     /// forced-shutdown path in the engine today — cooperative cancel via
     /// the same [`tokio_util::sync::CancellationToken`] is the honest A3
-    /// minimum (see ADR-0016). The canonical
+    /// minimum . The canonical
     /// [`crate::control_dispatch::EngineControlDispatch`] body delegates
     /// to [`dispatch_cancel`](Self::dispatch_cancel) until a process-level
     /// kill / `JoinSet` abort is wired as a separate chip.
@@ -183,7 +181,7 @@ pub trait ControlDispatch: Send + Sync {
     /// **Idempotency (critical):** double-resume starts the workflow twice.
     /// Implementations must guard via CAS on `ExecutionRepo::transition` —
     /// a `Resume` arriving for an already-running or already-terminal
-    /// execution must be `Ok(())`, not a second start. See ADR-0008 §5.
+    /// execution must be `Ok()`, not a second start.
     async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Restart` command to an execution.
@@ -192,7 +190,7 @@ pub trait ControlDispatch: Send + Sync {
     /// [`crate::control_dispatch::EngineControlDispatch`]. Full
     /// rewind-from-input semantics require durable output purge and a
     /// monotonic restart counter — both are tracked as follow-ups under
-    /// ADR-0008; the A2 body honors idempotency for non-terminal states
+    /// ; the A2 body honors idempotency for non-terminal states
     /// and surfaces a typed [`ControlDispatchError::Rejected`] for
     /// already-terminal executions until the rewind path is wired.
     ///
@@ -278,7 +276,7 @@ impl RawClaimed {
 /// Drains `execution_control_queue` and hands typed commands to a
 /// [`ControlDispatch`] implementation.
 ///
-/// See the module docs and ADR-0008 for wiring, atomicity, and idempotency
+/// See the module docs and for wiring, atomicity, and idempotency
 /// rules.
 pub struct ControlConsumer {
     /// Scoped spec-16 [`ControlQueue`] port the consumer drains. The
@@ -299,7 +297,7 @@ pub struct ControlConsumer {
     reclaim_interval: Duration,
     max_reclaim_count: u32,
     /// Registry the reclaim sweep increments
-    /// `nebula_engine_control_reclaim_total{outcome}` against (ADR-0017
+    /// `nebula_engine_control_reclaim_total{outcome}` against (
     /// Seam). Defaults to a private fresh [`MetricsRegistry`] so the
     /// consumer is always emit-safe; production composition roots inject
     /// the shared registry via [`Self::with_metrics`] so the counter
@@ -351,7 +349,7 @@ impl ControlConsumer {
     }
 
     /// Override the staleness window before a `Processing` row is eligible
-    /// for reclaim. Default: [`DEFAULT_RECLAIM_AFTER`] (ADR-0017).
+    /// for reclaim. Default: [`DEFAULT_RECLAIM_AFTER`].
     #[must_use]
     pub fn with_reclaim_after(mut self, reclaim_after: Duration) -> Self {
         self.reclaim_after = reclaim_after;
@@ -359,7 +357,7 @@ impl ControlConsumer {
     }
 
     /// Override the cadence of the reclaim sweep tick. Default:
-    /// [`DEFAULT_RECLAIM_INTERVAL`] (ADR-0017).
+    /// [`DEFAULT_RECLAIM_INTERVAL`].
     #[must_use]
     pub fn with_reclaim_interval(mut self, reclaim_interval: Duration) -> Self {
         self.reclaim_interval = reclaim_interval;
@@ -367,7 +365,7 @@ impl ControlConsumer {
     }
 
     /// Override the max retry budget before a reclaim-eligible row moves to
-    /// `Failed`. Default: [`DEFAULT_MAX_RECLAIM_COUNT`] (ADR-0017).
+    /// `Failed`. Default: [`DEFAULT_MAX_RECLAIM_COUNT`].
     #[must_use]
     pub fn with_max_reclaim_count(mut self, max_reclaim_count: u32) -> Self {
         self.max_reclaim_count = max_reclaim_count;
@@ -380,7 +378,7 @@ impl ControlConsumer {
     /// Without this builder the consumer still increments the counter, but
     /// against a private registry no scraper sees — composition roots
     /// (`apps/server`) must wire the runtime registry so operators can
-    /// alert on `outcome="exhausted"` (ADR-0017 Seam).
+    /// alert on `outcome="exhausted"`.
     #[must_use]
     pub fn with_metrics(mut self, metrics: MetricsRegistry) -> Self {
         self.metrics = metrics;
@@ -394,7 +392,7 @@ impl ControlConsumer {
     /// it does not begin a fresh `claim_pending` once shutdown is requested.
     /// Rows that were claimed but not acknowledged remain in the `Processing`
     /// state and are recovered by the next runner via the reclaim sweep
-    /// (ADR-0008 B1 / ADR-0017).
+    ///.
     pub fn spawn(self, shutdown: CancellationToken) -> JoinHandle<()> {
         tokio::spawn(async move { self.run(shutdown).await })
     }
@@ -404,14 +402,14 @@ impl ControlConsumer {
     /// custom task structure.
     pub async fn run(self, shutdown: CancellationToken) {
         tracing::info!(
-            processor = %hex_display(&self.processor_id),
-            batch_size = self.batch_size,
-            poll_ms = self.poll_interval.as_millis() as u64,
-            reclaim_after_ms = self.reclaim_after.as_millis() as u64,
-            reclaim_interval_ms = self.reclaim_interval.as_millis() as u64,
-            max_reclaim_count = self.max_reclaim_count,
-            "control-queue consumer started (canon §12.2, ADR-0008, ADR-0017)"
-        );
+                   processor = %hex_display(&self.processor_id),
+                   batch_size = self.batch_size,
+                   poll_ms = self.poll_interval.as_millis() as u64,
+                   reclaim_after_ms = self.reclaim_after.as_millis() as u64,
+                   reclaim_interval_ms = self.reclaim_interval.as_millis() as u64,
+                   max_reclaim_count = self.max_reclaim_count,
+        "control-queue consumer started (control-queue wiring, )"
+               );
 
         let mut consecutive_errors: u32 = 0;
         let mut reclaim_ticker = tokio::time::interval(self.reclaim_interval);
@@ -423,7 +421,7 @@ impl ControlConsumer {
         // Deadline at which the next `claim_pending` is allowed to fire. Held
         // in scope across the `tokio::select!` below so that a reclaim
         // interruption does not reset the backoff / poll_interval clock —
-        // see the review finding for PR #483 and ADR-0008 §5.
+        // see the review finding for PR #483 and.
         let mut claim_deadline = tokio::time::Instant::now();
 
         loop {
@@ -471,7 +469,7 @@ impl ControlConsumer {
                     reclaimed,
                     exhausted,
                 };
-                // ADR-0017 Seam: bump the per-outcome counter by the row
+                // : bump the per-outcome counter by the row
                 // count for this sweep (not by 1 per sweep) so operators
                 // can alert on `outcome="exhausted" > 0` and watch
                 // `outcome="reclaimed"` for crashed-runner load.
@@ -505,12 +503,12 @@ impl ControlConsumer {
 
                 if outcome.reclaimed > 0 || outcome.exhausted > 0 {
                     tracing::warn!(
-                        processor = %hex_display(&self.processor_id),
-                        reclaimed = outcome.reclaimed,
-                        exhausted = outcome.exhausted,
-                        reclaim_after_ms = self.reclaim_after.as_millis() as u64,
-                        "control-queue reclaim sweep recovered stuck rows (ADR-0008 B1)"
-                    );
+                                           processor = %hex_display(&self.processor_id),
+                                           reclaimed = outcome.reclaimed,
+                                           exhausted = outcome.exhausted,
+                                           reclaim_after_ms = self.reclaim_after.as_millis() as u64,
+                    "control-queue reclaim sweep recovered stuck rows "
+                                       );
                 } else {
                     tracing::debug!(
                         processor = %hex_display(&self.processor_id),
@@ -646,12 +644,12 @@ impl ControlConsumer {
             Ok(()) => self.ack_completed(&row_id).await,
             Err(e) => {
                 tracing::error!(
-                    id = %hex_display(&row_id),
-                    %execution_id,
-                    command = command.as_str(),
-                    error = %e,
-                    "control-queue dispatch failed; marking failed (no auto-retry — ADR-0008 §5)"
-                );
+                                   id = %hex_display(&row_id),
+                                   %execution_id,
+                                   command = command.as_str(),
+                                   error = %e,
+                "control-queue dispatch failed; marking failed (no auto-retry — )"
+                               );
                 self.ack_failed(&row_id, &e.to_string()).await;
             },
         }
@@ -660,10 +658,10 @@ impl ControlConsumer {
     async fn ack_completed(&self, id: &[u8; 16]) {
         // NOTE: dispatch already ran successfully at this point. If
         // `mark_completed` fails, the row stays in `Processing` and the B1
-        // reclaim path (ADR-0017 + `sweep_reclaim` above) redelivers the
+        // reclaim path redelivers the
         // command. Correctness under redelivery depends entirely on
         // `ControlDispatch` impls being idempotent per `(execution_id, command)`
-        // — see the trait-level docs and ADR-0008 §5.
+        // — see the trait-level docs and.
         let result: Result<(), String> = self
             .queue
             .mark_completed(id, &self.processor_id)

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -1,17 +1,16 @@
-//! Engine-owned [`ControlDispatch`] implementation — ADR-0008 follow-ups A2
+//! Engine-owned [`ControlDispatch`] implementation — follow-ups A2
 //! (Start / Resume / Restart) and A3 (Cancel / Terminate).
 //!
 //! The [`ControlConsumer`] (skeleton landed in A1) drains
 //! `execution_control_queue` rows and hands each typed command to an
 //! implementation of [`ControlDispatch`]. [`EngineControlDispatch`] wires the
 //! `Start` / `Resume` / `Restart` paths into the engine so that a POST to
-//! `/executions` actually causes node execution — closing the §4.5 gap named
-//! in #332. The `Cancel` / `Terminate` path closes the §12.2 / §13-step-5
-//! symmetric gap named in #330: the durable `Cancel` signal the API's
+//! `/executions` actually causes node execution — closing the gap named
+//! in #332. The `Cancel` / `Terminate` path closes the symmetric cancel gap named in #330: the durable `Cancel` signal the API's
 //! `cancel_execution` handler enqueues now reaches the live frontier loop
 //! via [`WorkflowEngine::cancel_execution`].
 //!
-//! ## Idempotency contract (ADR-0008 §5)
+//! ## Idempotency contract
 //!
 //! Control-queue delivery is at-least-once: the ack path on `mark_completed`
 //! may fail after a successful dispatch, and the reclaim path (B1) will
@@ -31,12 +30,12 @@
 //!   registry entry — cross-runner case or this runner already cleaned up — is a no-op that returns
 //!   [`WorkflowEngine::cancel_execution`] `= false` without side effects. Short-circuiting on
 //!   terminal status would leave a live frontier loop orphaned after the API handler's CAS
-//!   transitioned the row to `Cancelled` in the same logical operation as the enqueue (canon §12.2
-//!   / §13 step 5) — the durable state would say the run is over while the in-process `JoinSet`
+//!   transitioned the row to `Cancelled` in the same logical operation as the enqueue (control-queue
+//!   cancel path) — the durable state would say the run is over while the in-process `JoinSet`
 //!   kept waiting on a slow handler.
 //!
 //! The authoritative single-runner fence still lives inside
-//! [`WorkflowEngine::resume_execution`] (ADR-0015 lease lifecycle); this
+//! [`WorkflowEngine::resume_execution`] (lease lifecycle); this
 //! module just forwards commands and collapses the resulting errors into the
 //! [`ControlDispatch`] contract.
 //!
@@ -67,7 +66,7 @@ use crate::{
 /// wires the API and engine together — they share the same execution
 /// store so status reads from either side agree.
 ///
-/// See the module docs for the idempotency contract and ADR-0008 §5 for the
+/// See the module docs for the idempotency contract and for the
 /// canon rules this impl honors.
 #[derive(Clone)]
 pub struct EngineControlDispatch {
@@ -134,7 +133,7 @@ impl EngineControlDispatch {
         match self.engine.resume_execution(execution_id).await {
             Ok(_) => Ok(()),
             // Concurrent dispatcher already holds the lease — the canonical
-            // ADR-0008 §5 idempotency outcome. Returning `Ok(())` here prevents
+            // idempotency outcome. Returning `Ok()` here prevents
             // the consumer from marking the row `Failed`; the lease holder
             // owns the terminal transition.
             Err(EngineError::Leased { .. }) => Ok(()),
@@ -167,7 +166,7 @@ impl ControlDispatch for EngineControlDispatch {
             ))),
             // Already past the Created gate: either the engine is driving it
             // (Running / Cancelling) or it has already reached a terminal
-            // outcome. Re-delivered Start is a no-op per ADR-0008 §5.
+            // outcome. Re-delivered Start is a no-op.
             Some(
                 ExecutionStatus::Running
                 | ExecutionStatus::Cancelling
@@ -207,8 +206,7 @@ impl ControlDispatch for EngineControlDispatch {
         &self,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        // Per ADR-0008 §5 restart docs: "double-restart rewinds twice". A true
-        // rewind-from-input restart requires durable output purge plus a
+        //        // rewind-from-input restart requires durable output purge plus a
         // restart counter — neither exists yet. For A2, treat restart as a
         // re-entrant drive of the engine's resume path and honor the same
         // terminal / running idempotency outcomes.
@@ -228,7 +226,7 @@ impl ControlDispatch for EngineControlDispatch {
                 | ExecutionStatus::TimedOut),
             ) => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} is already {status}; rewind-from-input restart \
-                 requires durable output purge — not yet implemented, tracked under ADR-0008 \
+ requires durable output purge — not yet implemented \
                  follow-up"
             ))),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
@@ -238,11 +236,11 @@ impl ControlDispatch for EngineControlDispatch {
     }
 
     async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
-        // ADR-0008 A3 — every non-orphan `Cancel` signals the engine's
+        // A3 — every non-orphan `Cancel` signals the engine's
         // cancel registry, regardless of the persisted status.
         //
         // The API handler's `cancel_execution` writes the row to `Cancelled`
-        // in the same logical operation as the enqueue (canon §12.2 / §13
+        // in the same logical operation as the enqueue (control-queue wiring
         // step 5), so by the time the consumer drains this command, the
         // read here will typically report a terminal status even for a
         // live frontier loop. Short-circuiting on terminal would leave a
@@ -255,7 +253,7 @@ impl ControlDispatch for EngineControlDispatch {
         // registry entry (cross-runner, or this runner already cleaned up)
         // returns `false` without side effects. Signalling always is the
         // honest minimum: it closes the live-loop gap and is safe under
-        // at-least-once redelivery (ADR-0008 §5).
+        // at-least-once redelivery.
         match self.read_status(execution_id).await? {
             // Producer bug: queue row written without the execution row (or a
             // row that disappeared between enqueue and drain). Surface so the
@@ -266,11 +264,11 @@ impl ControlDispatch for EngineControlDispatch {
             Some(status) => {
                 let signalled = self.engine.cancel_execution(execution_id);
                 tracing::debug!(
-                    %execution_id,
-                    %status,
-                    signalled,
-                    "control-queue: Cancel dispatched (ADR-0008 A3) — signalled local runner={signalled}"
-                );
+                                   %execution_id,
+                                   %status,
+                                   signalled,
+                "control-queue: Cancel dispatched — signalled local runner={signalled}"
+                               );
                 Ok(())
             },
         }
@@ -280,7 +278,7 @@ impl ControlDispatch for EngineControlDispatch {
         &self,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        // ADR-0008 names `Terminate` "forced termination", but there is no
+        // names `Terminate` "forced termination", but there is no
         // distinct forced-shutdown path in the engine today — the frontier
         // loop aborts in-flight `JoinSet` tasks via the same cooperative
         // `CancellationToken` that `Cancel` trips. Treating `Terminate` as a
@@ -288,9 +286,9 @@ impl ControlDispatch for EngineControlDispatch {
         // contract is identical (in-flight work aborts, state reaches a
         // terminal `Cancelled`), and the capability gap — process-level kill
         // or task-set abort — is tracked separately as a future chip. Do not
-        // emit half-implemented forced-abort machinery here (canon §4.5).
+        // emit half-implemented forced-abort machinery here (operational honesty).
         //
-        // See ADR-0016 (cancel-registry and cooperative-cancel contract) for
+        // (cancel-registry and cooperative-cancel contract) for
         // the design rationale and the upgrade path to a true forced-shutdown
         // distinction.
         self.dispatch_cancel(execution_id).await

--- a/crates/engine/src/credential/dispatchers.rs
+++ b/crates/engine/src/credential/dispatchers.rs
@@ -1,6 +1,6 @@
 //! Engine-side capability dispatchers.
 //!
-//! Per Tech Spec §15.4 capability sub-trait split — these helpers bind
+//! Per Tech Spec capability sub-trait split — these helpers bind
 //! `where C: Revocable` / `where C: Testable` / `where C: Dynamic` so a
 //! non-capable credential cannot reach the corresponding lifecycle path.
 //! The structural barrier is identical to
@@ -33,7 +33,7 @@ use crate::credential::TestResult;
 
 /// Engine-side revocation dispatcher.
 ///
-/// Bound on [`Revocable`] per Tech Spec §15.4 — non-`Revocable`
+/// Bound on [`Revocable`] per Tech Spec — non-`Revocable`
 /// credentials cannot be passed; compile error at the call site
 /// (`E0277`). П2+ wires real callers (engine rotation orchestrator,
 /// admin-revoke API endpoint) into this entry point.
@@ -46,7 +46,7 @@ pub async fn dispatch_revoke<C: Revocable>(
 
 /// Engine-side health-probe dispatcher.
 ///
-/// Bound on [`Testable`] per Tech Spec §15.4 — non-`Testable`
+/// Bound on [`Testable`] per Tech Spec — non-`Testable`
 /// credentials cannot be passed; compile error at the call site
 /// (`E0277`). П2+ wires real callers (admin "test credential" API
 /// endpoint, periodic health-probe scheduler) into this entry point.
@@ -59,7 +59,7 @@ pub async fn dispatch_test<C: Testable>(
 
 /// Engine-side lease-release dispatcher.
 ///
-/// Bound on [`Dynamic`] per Tech Spec §15.4 — non-`Dynamic`
+/// Bound on [`Dynamic`] per Tech Spec — non-`Dynamic`
 /// credentials cannot be passed; compile error at the call site
 /// (`E0277`). П2+ wires real callers (per-execution lease reaper,
 /// lease-TTL expiry reaper) into this entry point.

--- a/crates/engine/src/credential/executor.rs
+++ b/crates/engine/src/credential/executor.rs
@@ -65,7 +65,7 @@ pub enum ExecutorError {
     /// `state: ()` is degenerate and cannot deserialize into the typed
     /// [`Interactive::Pending`] used by [`execute_continue`].
     ///
-    /// Per Tech Spec §15.4 the base [`Credential::resolve`] **must** return
+    /// Per Tech Spec the base [`Credential::resolve`] **must** return
     /// [`ResolveResult::Complete`] (or `Retry`); interactive kick-offs that
     /// need typed pending state populate it directly via
     /// [`PendingStateStore::put`] from a credential-specific helper such as
@@ -89,7 +89,7 @@ pub enum ExecutorError {
 /// Execute initial credential resolve with timeout and pending-state
 /// handling.
 ///
-/// Per Tech Spec §15.4 the base [`Credential::resolve`] returns
+/// Per Tech Spec the base [`Credential::resolve`] returns
 /// `ResolveResult<State, ()>`. The contract for this executor is:
 ///
 /// - **`Complete(state)`** — credential resolved synchronously; caller persists the state.
@@ -133,7 +133,7 @@ where
             Ok(ResolveResponse::Complete(state))
         },
         ResolveResult::Pending { .. } => {
-            // §15.4: base resolve cannot return Pending — the typed Pending
+            // : base resolve cannot return Pending — the typed Pending
             // path lives on Interactive. See `ExecutorError::BaseResolvePending`
             // doc-comment for the rationale.
             let _ = pending_store;
@@ -149,7 +149,7 @@ where
 /// Continue interactive credential resolve with timeout and
 /// pending-state handling.
 ///
-/// Bound on [`Interactive`] per Tech Spec §15.4 — non-interactive
+/// Bound on [`Interactive`] per Tech Spec — non-interactive
 /// credentials cannot reach this dispatch path. The framework loads the
 /// typed [`Interactive::Pending`] from the pending store, invokes
 /// [`Interactive::continue_resolve`], and persists the next pending

--- a/crates/engine/src/credential/lease/mod.rs
+++ b/crates/engine/src/credential/lease/mod.rs
@@ -1,9 +1,9 @@
 //! Lease lifecycle subsystem — engine-side consumption of the
-//! [`LeasedProvider`] capability introduced by ADR-0051.
+//! [`LeasedProvider`] capability introduced by.
 //!
 //! # Role
 //!
-//! Phases A–C of the ADR-0051 follow-up landed the lease primitives
+//! Phases A–C of the follow-up landed the lease primitives
 //! (envelope, capability sub-trait, cache layer, first concrete Vault
 //! impl). Nothing in the engine called `renew` or `revoke` — a Vault
 //! dynamic-secret lease would silently expire unless someone happened to
@@ -167,7 +167,7 @@ impl LeaseLifecycle {
     /// Returns the number of leases successfully revoked. Failed revokes
     /// do not propagate — they are logged + emitted as audit events but
     /// the rotation pipeline that called this MUST NOT block on them.
-    /// See spec §4: revoke-on-rotate is best-effort cleanup.
+    /// See spec : revoke-on-rotate is best-effort cleanup.
     pub async fn revoke_for_credential(&self, credential_id: CredentialId) -> usize {
         let (reply_tx, reply_rx) = oneshot::channel();
         if self

--- a/crates/engine/src/credential/mod.rs
+++ b/crates/engine/src/credential/mod.rs
@@ -3,7 +3,7 @@
 //! This module hosts runtime credential resolution and type-erased registry
 //! logic used by the execution engine for **integration credentials** — workflow
 //! access to external systems per [`Credential`](nebula_credential::Credential)
-//! and ADR-0033 (`docs/adr/0033-integration-credentials-plane-b.md`). It does
+//! and (`crates/engine/README.md`). It does
 //! not implement platform/operator authentication (**Plane A**).
 
 pub mod dispatchers;

--- a/crates/engine/src/credential/refresh/audit.rs
+++ b/crates/engine/src/credential/refresh/audit.rs
@@ -1,4 +1,4 @@
-//! Refresh-coordinator audit-event emission (sub-spec §6).
+//! Refresh-coordinator audit-event emission (sub-spec ).
 //!
 //! Sits on top of the storage `AuditSink` so operators reuse one sink
 //! implementation for both `CredentialStore` operations and refresh
@@ -17,7 +17,7 @@
 //! caller. Audit on the refresh path is observational; failing the
 //! refresh on a sink hiccup would re-create the n8n #13088 retry storm
 //! the coordinator was built to prevent. The `CredentialStore` audit
-//! wrapper retains its fail-closed semantics (ADR-0028 inv 4) — they
+//! wrapper retains its fail-closed semantics — they
 //! apply to mutating store operations, not to refresh events.
 
 use nebula_core::CredentialId;

--- a/crates/engine/src/credential/refresh/coordinator.rs
+++ b/crates/engine/src/credential/refresh/coordinator.rs
@@ -1,9 +1,7 @@
 //! Outer two-tier refresh coordinator.
 //!
-//! Per ADR-0041 + sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)`
-//! §3.1 (two-tier diagram), §3.5 (parameter invariants), §3.6 (contention
-//! backoff).
+//! See `docs/INTEGRATION_MODEL.md` for the two-tier refresh diagram, parameter invariants, and
+//! contention backoff.
 //!
 //! `RefreshCoordinator` composes:
 //!
@@ -14,7 +12,7 @@
 //!
 //! Callers invoke `refresh_coalesced(credential_id, do_refresh)`. The
 //! coordinator acquires L1 first (fast in-process coalesce), then a
-//! durable L2 claim with backoff per §3.6, runs the user's refresh
+//! durable L2 claim with contention backoff, runs the user's refresh
 //! closure under both locks, and releases both on the way out.
 
 use std::{
@@ -44,7 +42,7 @@ use super::{
 
 /// Configuration knobs for the two-tier coordinator.
 ///
-/// Per sub-spec §3.5 the four time-related parameters carry interlocking
+/// Per sub-spec the four time-related parameters carry interlocking
 /// invariants verified by [`RefreshCoordConfig::validate`]:
 ///
 /// - `heartbeat_interval × 3 ≤ claim_ttl` — three heartbeat ticks must fit inside one claim TTL so
@@ -55,7 +53,7 @@ use super::{
 ///   crashed holder is reclaimed within one TTL window.
 ///
 /// The boundary case `heartbeat_interval × 3 == claim_ttl` is allowed
-/// (mirrors the ADR-0008 execution-lease shape: `ttl / 3 ==
+/// (mirrors the execution-lease shape: `ttl / 3 ==
 /// heartbeat_interval`).
 ///
 /// CI test asserts `RefreshCoordConfig::default().validate().is_ok()`.
@@ -117,13 +115,13 @@ pub enum ConfigError {
         value: Duration,
     },
 
-    /// Metric primitive registration failed for the coordinator's §6 series.
+    /// Metric primitive registration failed for the coordinator's series.
     #[error("telemetry metrics error: {0}")]
     Telemetry(#[from] nebula_metrics::MetricsError),
 }
 
 impl RefreshCoordConfig {
-    /// Verify the per-§3.5 interlocking invariants.
+    /// Verify the per- interlocking invariants.
     ///
     /// # Errors
     ///
@@ -292,11 +290,10 @@ impl From<L1ConfigError> for RefreshConfigError {
 impl RefreshCoordinator {
     /// Maximum number of consecutive non-`ClaimLost` heartbeat
     /// failures tolerated before the heartbeat task gives up and
-    /// cancels the in-flight refresh (sub-spec §3.4 wave-4 fix).
+    /// cancels the in-flight refresh (sub-spec wave-4 fix).
     ///
     /// At three failures the worst-case latency before cancellation
-    /// is `3 × heartbeat_interval`, which is bounded by the §3.5
-    /// invariant `heartbeat_interval × 3 ≤ claim_ttl` — i.e. we
+    /// is `3 × heartbeat_interval`, which is bounded by the    /// invariant `heartbeat_interval × 3 ≤ claim_ttl` — i.e. we
     /// never burn more than one TTL window absorbing transient
     /// noise. Not configurable: production tuning belongs in
     /// `RefreshCoordConfig` if a need emerges.
@@ -312,7 +309,7 @@ impl RefreshCoordinator {
     /// # Errors
     ///
     /// Returns the corresponding [`ConfigError`] if `config.validate()`
-    /// fails (see §3.5 invariants) or metric handles cannot be bound.
+    /// fails (see invariants) or metric handles cannot be bound.
     pub fn new_with(
         repo: Arc<dyn RefreshClaimRepo>,
         replica_id: ReplicaId,
@@ -322,7 +319,7 @@ impl RefreshCoordinator {
         // Bootstrap: a fresh private registry so the coordinator is fully
         // functional without composition. Production callers MUST follow
         // up with `with_metrics(engine_registry)` so a scraper actually
-        // observes the §6 series — see `with_metrics` rustdoc.
+        // observes the series — see `with_metrics` rustdoc.
         let metrics = RefreshCoordMetrics::with_registry(&nebula_metrics::MetricsRegistry::new())?;
         Ok(Self {
             l1: L1RefreshCoalescer::new(),
@@ -359,7 +356,7 @@ impl RefreshCoordinator {
         // Bootstrap: a fresh private registry so the coordinator is fully
         // functional without composition. Production callers MUST follow
         // up with `with_metrics(engine_registry)` so a scraper actually
-        // observes the §6 series — see `with_metrics` rustdoc.
+        // observes the series — see `with_metrics` rustdoc.
         Self {
             l1: L1RefreshCoalescer::new(),
             repo,
@@ -400,14 +397,14 @@ impl RefreshCoordinator {
 
     /// Replace the metric handles with ones bound to the engine-shared
     /// `MetricsRegistry`. Call once during composition; the coordinator
-    /// emits all sub-spec §6 series against this registry afterwards.
+    /// emits all sub-spec series against this registry afterwards.
     #[must_use = "builder methods must be chained or used"]
     pub fn with_metrics(mut self, metrics: RefreshCoordMetrics) -> Self {
         self.metrics = metrics;
         self
     }
 
-    /// Attach an [`AuditSink`] to receive sub-spec §6 audit events
+    /// Attach an [`AuditSink`] to receive sub-spec audit events
     /// (`RefreshCoordClaimAcquired`, `SentinelTriggered`,
     /// `ReauthFlagged`). Without a sink, audit emission is a no-op (the
     /// metric / tracing surfaces still observe).
@@ -457,16 +454,16 @@ impl RefreshCoordinator {
     /// both. Returns `Err(CoalescedByOtherReplica)` if state was already
     /// fresh — caller treats as success and re-reads.
     ///
-    /// Sub-spec §3.1 acquisition sequence:
+    /// Sub-spec acquisition sequence:
     /// 1. L1 in-process coalesce (cheap fast-path; same-process concurrent calls collapse here).
-    /// 2. L2 durable claim with backoff per §3.6.
+    /// 2. L2 durable claim with backoff.
     /// 3. Background heartbeat task — passes `self.config.claim_ttl` to each `repo.heartbeat(token,
     ///    ttl)` call (Stage 1 fix C2).
     /// 4. User-supplied `do_refresh(claim)` closure.
     /// 5. Stop heartbeat + release the claim row.
     ///
     /// `needs_refresh_after_backoff` is consulted by the L2 backoff loop
-    /// per sub-spec §3.6 after the post-`Contended` sleep: if the
+    /// per sub-spec after the post-`Contended` sleep: if the
     /// predicate returns `false` the credential was refreshed by another
     /// replica while this caller was waiting and we short-circuit with
     /// [`RefreshError::CoalescedByOtherReplica`]. Callers that don't
@@ -627,12 +624,12 @@ impl RefreshCoordinator {
         // `2`).
         let _permit = self.l1.acquire_permit().await;
 
-        // L2: durable claim with backoff per §3.6.
+        // L2: durable claim with backoff.
         let claim = self
             .try_acquire_l2_with_backoff(credential_id, &needs_refresh_after_backoff)
             .await?;
 
-        // Sub-spec §6 — record the claim acquisition once we know we own
+        // Sub-spec — record the claim acquisition once we know we own
         // the L2 row. `acquired` counter, audit event, and start of the
         // hold-duration measurement happen here so they are paired
         // with the matching `release` site below.
@@ -661,7 +658,7 @@ impl RefreshCoordinator {
         // Heartbeat task in background.
         let hb_task = self.spawn_heartbeat(claim.token.clone(), hb_cancel, *credential_id);
 
-        // Cancel-safety guard (review C1 + wave-5, sub-spec §3.4). Fires
+        // Cancel-safety guard (review C1 + wave-5, sub-spec ). Fires
         // on EVERY exit path that does NOT explicitly defuse it: panic
         // unwind, error early-return, AND Drop (caller cancels the
         // outer future via `tokio::time::timeout`, `tokio::select!`, or
@@ -710,12 +707,12 @@ impl RefreshCoordinator {
         // `expires_at`), so we hand it a clone and retain `token` here.
         let token_for_release = claim.token.clone();
 
-        // Run user's refresh closure under `refresh_timeout` per §3.5.
+        // Run user's refresh closure under `refresh_timeout`.
         // The timeout is shorter than the claim TTL by construction, so
         // the heartbeat keeps the L2 row alive while the closure runs.
         // Wrap in `select!` over `cancel.cancelled()` so a heartbeat
         // failure mid-refresh aborts the closure BEFORE it issues the
-        // IdP POST — sub-spec §3.4 invariant.
+        // IdP POST — sub-spec invariant.
         //
         // Bias order MUST poll `do_refresh_fut` first: if the future
         // resolves `Ok(...)` and the heartbeat task fires
@@ -741,7 +738,7 @@ impl RefreshCoordinator {
         .map_err(|_elapsed| RefreshError::Timeout(timeout))
         .and_then(std::convert::identity);
 
-        // Normal-exit release (review I1 + wave-5, sub-spec §3.4). We
+        // Normal-exit release (review I1 + wave-5, sub-spec ). We
         // DO NOT propagate release errors — propagating them with `?`
         // would mask a successful refresh: caller would observe
         // `RefreshError::Repo(...)`, route to `record_failure`, then
@@ -762,7 +759,7 @@ impl RefreshCoordinator {
         // through its `cancelled()` arm rather than racing the abort.
         cancel.cancel();
         hb_task.abort();
-        // Sub-spec §6 — observe the hold duration on the normal-exit
+        // Sub-spec — observe the hold duration on the normal-exit
         // release path. Symmetric with the teardown guard above.
         self.metrics
             .hold_duration
@@ -774,7 +771,7 @@ impl RefreshCoordinator {
         result
     }
 
-    /// L2 acquisition retry loop per sub-spec §3.6.
+    /// L2 acquisition retry loop per sub-spec.
     ///
     /// On `Contended` we sleep until the contender's claim is expected
     /// to expire (capped + jitter) then consult
@@ -798,7 +795,7 @@ impl RefreshCoordinator {
     {
         const MAX_ATTEMPTS: usize = 5;
         for attempt in 0..MAX_ATTEMPTS {
-            // Sub-spec §6 per-attempt tracing span: `attempt` and
+            // Sub-spec per-attempt tracing span: `attempt` and
             // `credential_id` so operators correlate contention storms
             // across replicas.
             let span = tracing::info_span!(
@@ -819,7 +816,7 @@ impl RefreshCoordinator {
                 ClaimAttempt::Contended {
                     existing_expires_at,
                 } => {
-                    // Sub-spec §6 — bump the contended counter for every
+                    // Sub-spec — bump the contended counter for every
                     // try_claim that returned Contended, regardless of
                     // whether the post-backoff recheck eventually
                     // short-circuits.
@@ -835,7 +832,7 @@ impl RefreshCoordinator {
                         .to_std()
                         .unwrap_or(Duration::from_millis(200));
                     tokio::time::sleep(delay + jitter_ms(100)).await;
-                    // CRITICAL: post-backoff state recheck per §3.6. If
+                    // CRITICAL: post-backoff state recheck per . If
                     // the contender finished the refresh while we slept,
                     // the credential is now fresh — short-circuit with
                     // CoalescedByOtherReplica so the caller re-reads
@@ -846,7 +843,7 @@ impl RefreshCoordinator {
                     // refresh_token rotation the contender just
                     // committed (n8n #13088 lineage).
                     if !needs_refresh_after_backoff(credential_id).await {
-                        // Sub-spec §6 — L2 coalesce: another replica
+                        // Sub-spec — L2 coalesce: another replica
                         // refreshed while we waited.
                         //
                         // Span tier (review I1) — record `l2_coalesced`
@@ -857,7 +854,7 @@ impl RefreshCoordinator {
                         // `credential.refresh.coordinate` span — the
                         // intended target. The closed set
                         // `{l1, l2_acquired, l2_coalesced}` is
-                        // documented in OBSERVABILITY.md §7.2.
+                        // documented in OBSERVABILITY.md.
                         tracing::Span::current().record("tier", "l2_coalesced");
                         self.metrics.coalesced_l2.inc();
                         return Err(RefreshError::CoalescedByOtherReplica);
@@ -865,7 +862,7 @@ impl RefreshCoordinator {
                 },
             }
         }
-        // Sub-spec §6 — every retry exhausted without acquiring the L2
+        // Sub-spec — every retry exhausted without acquiring the L2
         // row. `claims_total{outcome=exhausted} > 0` is a real production
         // signal worth alerting on.
         self.metrics.claims_exhausted.inc();
@@ -875,7 +872,7 @@ impl RefreshCoordinator {
     /// Spawn the background heartbeat task that refreshes the L2 claim
     /// TTL on a fixed interval. Per Stage 1 fix C2 the trait's
     /// `heartbeat(token, ttl)` takes the same TTL passed to
-    /// `try_claim`, so the §3.5 invariants
+    /// `try_claim`, so the invariants
     /// (`heartbeat_interval × 3 < claim_ttl`,
     /// `reclaim_sweep_interval ≤ claim_ttl`) hold across heartbeats.
     ///
@@ -911,7 +908,7 @@ impl RefreshCoordinator {
             // Burn the initial immediate tick — the claim was just
             // acquired and already has a fresh `expires_at`.
             ticker.tick().await;
-            // Transient-failure budget per sub-spec §3.4 (wave-4 fix).
+            // Transient-failure budget per sub-spec (wave-4 fix).
             // Resets on every successful heartbeat so a long-running
             // refresh can absorb intermittent backend noise without
             // cancelling. Only `HeartbeatError::ClaimLost` is treated
@@ -1129,8 +1126,7 @@ mod tests {
 
     #[test]
     fn default_config_validates() {
-        // CI assertion that the shipped defaults satisfy the §3.5
-        // interlocking invariants.
+        // CI assertion that the shipped defaults satisfy the        // interlocking invariants.
         assert!(RefreshCoordConfig::default().validate().is_ok());
     }
 
@@ -1232,7 +1228,7 @@ mod tests {
 
     // ──────────────────────────────────────────────────────────────────
     // Panic-safety + release-error masking regression tests
-    // (review feedback C1 + I1, sub-spec §3.4)
+    // (review feedback C1 + I1, sub-spec )
     // ──────────────────────────────────────────────────────────────────
 
     use crate::credential::refresh::test_fixtures::{
@@ -1240,7 +1236,7 @@ mod tests {
         SignallingFailHeartbeatRepo, TransientFailHeartbeatRepo,
     };
 
-    /// I1 regression — sub-spec §3.4. After Stage 2 review C1+I1: a
+    /// I1 regression — sub-spec . After Stage 2 review C1+I1: a
     /// transient `release()` failure must NOT mask a successful refresh.
     /// The previous `release().await?` propagated `Repo(...)` and would
     /// trigger `record_failure` → another IdP POST → invalidates the
@@ -1269,7 +1265,7 @@ mod tests {
         );
     }
 
-    /// C1 regression — sub-spec §3.4. If the user closure panics, the
+    /// C1 regression — sub-spec . If the user closure panics, the
     /// coordinator MUST still abort the heartbeat task and release the
     /// L2 claim row. Without the scopeguard, the heartbeat ticks
     /// forever, the row stays held, and Stage 3.3 reclaim cannot
@@ -1336,7 +1332,7 @@ mod tests {
     }
 
     // ──────────────────────────────────────────────────────────────────
-    // Sub-spec §6 — observability emission
+    // Sub-spec — observability emission
     // ──────────────────────────────────────────────────────────────────
 
     /// `refresh_coalesced` must increment `claims_acquired` exactly once
@@ -1599,7 +1595,7 @@ mod tests {
         );
     }
 
-    /// Tokio-semantics regression — sub-spec §3.4. Defense-in-depth
+    /// Tokio-semantics regression — sub-spec . Defense-in-depth
     /// for the production end-to-end test
     /// `refresh_coalesced_returns_ok_when_closure_ready_concurrent_with_cancel`
     /// below. This inline `select!` reproduces the exact biased-select
@@ -1632,7 +1628,7 @@ mod tests {
         );
     }
 
-    /// M1 wave-4 reviewer-Issue-1 regression — sub-spec §3.4.
+    /// M1 wave-4 reviewer-Issue-1 regression — sub-spec.
     /// End-to-end test through `refresh_coalesced` proving the
     /// production bias order picks `do_refresh_fut` over
     /// `cancel.cancelled()` when both arms are ready in the same
@@ -1714,7 +1710,7 @@ mod tests {
         );
     }
 
-    /// M2 wave-4 regression — sub-spec §3.4. The heartbeat task MUST
+    /// M2 wave-4 regression — sub-spec . The heartbeat task MUST
     /// absorb up to `MAX_TRANSIENT_HEARTBEAT_FAILURES - 1` consecutive
     /// non-`ClaimLost` heartbeat errors without cancelling the
     /// in-flight refresh. Otherwise a 50ms DB hiccup amplifies into a
@@ -1832,7 +1828,7 @@ mod tests {
     // Wave-5 — coordinator cancel-safety on Drop
     // ──────────────────────────────────────────────────────────────────
 
-    /// Wave-5 regression — sub-spec §3.4. Dropping the
+    /// Wave-5 regression — sub-spec . Dropping the
     /// `refresh_coalesced` future mid-`await` (e.g. via a caller's
     /// `tokio::time::timeout`, `tokio::select!`, or `JoinHandle::abort`)
     /// MUST cancel the heartbeat task and best-effort release the L2
@@ -1881,7 +1877,7 @@ mod tests {
             heartbeat_count: Arc::clone(&heartbeat_count),
         });
 
-        // §3.5-validating config tuned for short virtual-time intervals:
+        // -validating config tuned for short virtual-time intervals:
         //   heartbeat_interval × 3 = 60ms ≤ claim_ttl 10s ✓
         //   refresh_timeout (5s) + heartbeat × 2 (40ms) ≤ claim_ttl 10s ✓
         // `refresh_timeout` is generous so the OUTER `refresh_coalesced`

--- a/crates/engine/src/credential/refresh/metrics.rs
+++ b/crates/engine/src/credential/refresh/metrics.rs
@@ -1,4 +1,4 @@
-//! Pre-bound metric handles for the refresh coordinator (sub-spec §6).
+//! Pre-bound metric handles for the refresh coordinator (sub-spec ).
 //!
 //! All handles are constructed once at coordinator-build time and live
 //! for the coordinator's lifetime, so the hot path (per-`refresh_coalesced`
@@ -33,7 +33,7 @@ use nebula_metrics::{
 };
 
 /// Pre-bound handles for the five refresh-coordinator metrics declared
-/// in sub-spec §6. Cheaply cloneable (each handle is `Arc<...>` under
+/// in sub-spec . Cheaply cloneable (each handle is `Arc<...>` under
 /// the hood).
 #[derive(Clone, Debug)]
 pub struct RefreshCoordMetrics {

--- a/crates/engine/src/credential/refresh/mod.rs
+++ b/crates/engine/src/credential/refresh/mod.rs
@@ -1,7 +1,6 @@
 //! Two-tier refresh coordinator (L1 in-process + L2 cross-replica claim).
 //!
-//! Per ADR-0041 + sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)` §3.
+//! See `docs/INTEGRATION_MODEL.md` (credential refresh) for integration context.
 //!
 //! `RefreshCoordinator` is the public outer surface. Stage 2.1 wires the
 //! type as a delegating wrapper around the renamed-to-private

--- a/crates/engine/src/credential/refresh/reclaim.rs
+++ b/crates/engine/src/credential/refresh/reclaim.rs
@@ -1,8 +1,8 @@
 //! Background reclaim-sweep task. Parallel to control-queue reclaim.
 //!
 //! Per sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)`
-//! §3.3 + §3.4.
+//! `docs/INTEGRATION_MODEL.md`
+//! +.
 //!
 //! On a fixed cadence the task calls `RefreshClaimRepo::reclaim_stuck`,
 //! atomically sweeping every claim row whose `expires_at` is in the
@@ -56,7 +56,7 @@ impl ReclaimSweepHandle {
     /// Spawn the reclaim sweep task wired to a [`RefreshCoordinator`].
     ///
     /// The cadence and the underlying [`RefreshClaimRepo`] are derived
-    /// from `coord` so the §3.5 invariant
+    /// from `coord` so the invariant
     /// `reclaim_sweep_interval ≤ claim_ttl` (validated at coordinator
     /// construction) reaches the sweep task by construction — no
     /// freestanding `Duration` argument that could drift from the
@@ -79,7 +79,7 @@ impl ReclaimSweepHandle {
     ) -> Self {
         let cadence = coord.config().reclaim_sweep_interval;
         let repo = Arc::clone(coord.repo());
-        // Sub-spec §6 — sweep emits metrics + audit events through the
+        // Sub-spec — sweep emits metrics + audit events through the
         // same handles wired into the coordinator so a single PromQL /
         // sink view aggregates both refresh sites.
         let metrics = coord.metrics().clone();
@@ -151,7 +151,7 @@ async fn run_one_sweep(
     audit_sink: Option<&dyn AuditSink>,
 ) -> Result<(), nebula_storage::credential::RepoError> {
     let stuck = repo.reclaim_stuck().await?;
-    // Sub-spec §6 — increment reclaim sweep counter once per sweep,
+    // Sub-spec — increment reclaim sweep counter once per sweep,
     // labeled by whether work was found. `no_work` is the steady state
     // for healthy systems; `reclaimed` rising is a crashed-runner signal.
     if stuck.is_empty() {
@@ -165,7 +165,7 @@ async fn run_one_sweep(
             // do (no mid-refresh crash to record).
             continue;
         }
-        // Sub-spec §6 — per-row span; an operator can grep
+        // Sub-spec — per-row span; an operator can grep
         // `credential.refresh.sentinel.detected` for crashed-mid-refresh
         // events without wading through normal-expiry rows. Use
         // `.instrument(...)` rather than `.entered()` so the span
@@ -206,7 +206,7 @@ async fn run_one_sweep(
                     event_count,
                     "sentinel recoverable — credential refresh will retry"
                 );
-                // Sub-spec §6 — record the event (below threshold).
+                // Sub-spec — record the event (below threshold).
                 metrics.sentinel_recorded.inc();
                 emit_sentinel_triggered(audit_sink, &reclaimed.credential_id, event_count);
             },
@@ -220,7 +220,7 @@ async fn run_one_sweep(
                     window_secs,
                     "sentinel threshold exceeded — escalating to ReauthRequired"
                 );
-                // Sub-spec §6 — bump both the recorded counter (every
+                // Sub-spec — bump both the recorded counter (every
                 // detection counts) and the reauth_triggered counter
                 // (the escalation transition itself).
                 metrics.sentinel_recorded.inc();
@@ -273,7 +273,7 @@ mod tests {
     };
 
     /// Build a [`RefreshCoordinator`] with a tight 30ms reclaim cadence
-    /// for spawn-path unit tests. Other §3.5 invariants are scaled
+    /// for spawn-path unit tests. Other invariants are scaled
     /// proportionally so `validate()` accepts the shape.
     fn fast_coord_for_test(repo: Arc<dyn RefreshClaimRepo>) -> Arc<RefreshCoordinator> {
         Arc::new(
@@ -501,7 +501,7 @@ mod tests {
         );
     }
 
-    /// Sub-spec §6 emission test for reclaim metrics.
+    /// Sub-spec emission test for reclaim metrics.
     ///
     /// Calls `run_one_sweep` against a repo with one stuck
     /// `RefreshInFlight` claim and asserts `reclaim_sweeps_total{
@@ -565,7 +565,7 @@ mod tests {
         );
     }
 
-    /// Sub-spec §6 — at-threshold sweep must increment both
+    /// Sub-spec — at-threshold sweep must increment both
     /// `recorded` and `reauth_triggered`.
     #[tokio::test]
     async fn run_one_sweep_at_threshold_increments_reauth_triggered() {

--- a/crates/engine/src/credential/refresh/sentinel.rs
+++ b/crates/engine/src/credential/refresh/sentinel.rs
@@ -1,8 +1,8 @@
 //! Sentinel mid-refresh crash detection + threshold escalation.
 //!
 //! Per sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)`
-//! §3.4 + §6 audit.
+//! `docs/INTEGRATION_MODEL.md`
+//! + audit.
 //!
 //! When a holder is about to perform the IdP POST (the operation that
 //! risks invalidating the refresh token if not persisted), it marks the
@@ -50,7 +50,7 @@ impl Default for SentinelThresholdConfig {
 /// exceeded — the engine must transition the credential to
 /// `ReauthRequired` and emit
 /// [`nebula_credential::CredentialEvent::ReauthRequired`] per
-/// sub-spec §3.4.
+/// sub-spec.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SentinelDecision {
     /// Sentinel event count is below threshold; resume normal flow.
@@ -110,7 +110,7 @@ impl SentinelTrigger {
     /// `sentinel = RefreshInFlight`. Records the event in
     /// `credential_sentinel_events` then queries the rolling-window
     /// count; returns `EscalateToReauth` when the count is at or above
-    /// threshold (default 3-in-1h per sub-spec §3.4).
+    /// threshold (default 3-in-1h per sub-spec ).
     ///
     /// # Concurrency
     ///

--- a/crates/engine/src/credential/registry.rs
+++ b/crates/engine/src/credential/registry.rs
@@ -1,7 +1,7 @@
 //! Type-erased state-projection registry for runtime credential dispatch.
 //!
 //! Distinct from the KEY-keyed [`CredentialRegistry`] in
-//! `nebula_credential::contract::registry` (Tech Spec §3.1, §15.6),
+//! `nebula_credential::contract::registry` (Tech Spec , ),
 //! which stores `Box<dyn AnyCredential>` instances keyed by
 //! `Credential::KEY`. This engine-side registry maps
 //! `<C::State as CredentialState>::KIND` to a deserialization +
@@ -9,7 +9,7 @@
 //! type-erased `C::Scheme` an action consumer receives.
 //!
 //! Both registries fail-closed on duplicate registration per Tech
-//! Spec §15.6 (closes security-lead N7); the previous `HashMap::insert`
+//! Spec (closes security-lead N7); the previous `HashMap::insert`
 //! overwrite path is gone in both. They serve distinct dispatch lookups
 //! and are populated from the same plugin init phase.
 //!
@@ -27,7 +27,7 @@ type ProjectFn = Arc<
 
 /// Type-erased registry mapping `state_kind` to projection handlers.
 ///
-/// Renamed from `CredentialRegistry` per Tech Spec §15.6 — the
+/// Renamed from `CredentialRegistry` per Tech Spec — the
 /// canonical [`CredentialRegistry`](nebula_credential::CredentialRegistry)
 /// now lives on the contract side and stores credential instances keyed
 /// by `Credential::KEY`. This engine-side registry is the runtime
@@ -53,7 +53,7 @@ impl StateProjectionRegistry {
     /// the same `<C::State as CredentialState>::KIND` is already
     /// registered. Fail-closed — silent `HashMap::insert` overwrite
     /// would hide namespace collisions including supply-chain plugin
-    /// replacement (Tech Spec §15.6, N7 mitigation; active-dev policy:
+    /// replacement (Tech Spec , N7 mitigation; active-dev policy:
     /// reject-second-registration).
     ///
     /// # Errors

--- a/crates/engine/src/credential/resolver.rs
+++ b/crates/engine/src/credential/resolver.rs
@@ -80,7 +80,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
 
     /// Resolve a credential and refresh it when it enters the early-refresh window.
     ///
-    /// Per Tech Spec §15.4 — bound on [`Refreshable`] so a non-refreshable
+    /// Per Tech Spec — bound on [`Refreshable`] so a non-refreshable
     /// credential cannot reach this dispatch path. Probe 4
     /// (`compile_fail_engine_dispatch_capability`) cements the structural
     /// barrier with `E0277` at the dispatch site.
@@ -188,7 +188,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
         let resolver_stored = stored;
         let credential_id_owned = credential_id.to_string();
 
-        // Sub-spec §3.6 post-backoff state recheck. After the L2 backoff
+        // Sub-spec post-backoff state recheck. After the L2 backoff
         // sleep the contender's claim may have been released because
         // their refresh succeeded — in that case the credential is now
         // fresh and we should short-circuit rather than running the
@@ -199,7 +199,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
         // expired, return `false` so the coordinator surfaces
         // `CoalescedByOtherReplica`.
         //
-        // Sub-spec §3.6 ProviderRejected gap (review feedback I1): if
+        // Sub-spec ProviderRejected gap (review feedback I1): if
         // the contender's refresh returned `ReauthRequired` it persisted
         // `reauth_required = true` on the row before releasing the L2
         // claim. Re-running the IdP closure here would produce another
@@ -494,7 +494,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
                         // when already false, recovers from a stale
                         // `true` left over by a previous ReauthRequired
                         // outcome that the application has since
-                        // re-authorized (sub-spec §3.6 / I1).
+                        // re-authorized (sub-spec / I1).
                         reauth_required: false,
                         ..stored.clone()
                     };
@@ -541,7 +541,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
             },
             RefreshOutcome::ReauthRequired(reason) => {
                 // Persist `reauth_required = true` on the credential row
-                // BEFORE returning the typed error (sub-spec §3.6 / I1).
+                // BEFORE returning the typed error (sub-spec / I1).
                 // Cross-replica readers consult this flag in their
                 // post-backoff state-recheck predicate; without the
                 // persisted bit, every replica would re-run the IdP
@@ -556,7 +556,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
                 // Outcome of the best-effort `reauth_required=true`
                 // persist loop. Distinguishing CAS exhaustion from a
                 // transient store error matters for observability: the
-                // CAS-exhausted metric (sub-spec §6) MUST count only the
+                // CAS-exhausted metric (sub-spec ) MUST count only the
                 // case where every attempt lost to `VersionConflict`,
                 // because that is the failure mode that produces a
                 // duplicate IdP load on the next replica's recheck. A
@@ -635,7 +635,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
                         // and produce another `invalid_grant`. Surface the
                         // failure mode at WARN; metric wiring tracked under
                         // `NEBULA_CREDENTIAL_RESOLVER_REAUTH_PERSIST_CAS_EXHAUSTED_TOTAL`
-                        // (sub-spec §6) — increment lands when the resolver
+                        // (sub-spec ) — increment lands when the resolver
                         // gains a `MetricsRegistry` handle (out of scope for
                         // this PR-583 wave 2 fix; resolver does not currently
                         // hold a metrics handle).
@@ -659,7 +659,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
             // refreshed while we were waiting on L2. Caller re-reads
             // state from the store via the parent dispatch path. This
             // arm reaches us from the inner `RefreshOutcome` only via a
-            // future resolver path; today the sub-spec §3.6 coalesce is
+            // future resolver path; today the sub-spec coalesce is
             // surfaced by the `RefreshError` layer in
             // `RefreshCoordinator::refresh_coalesced` (handled in the
             // outer match on `outcome` above). Keep the arm explicit so
@@ -670,8 +670,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
             },
             // RefreshOutcome is `#[non_exhaustive]` — preserve the
             // wildcard so adding future variants (e.g. partial refresh)
-            // does not silently break this match. Per Tech Spec §15.4
-            // the `NotSupported` variant was removed because membership
+            // does not silently break this match. Per Tech Spec            // the `NotSupported` variant was removed because membership
             // in `Refreshable` already guarantees the credential
             // supports refresh.
             _ => {
@@ -719,7 +718,7 @@ pub enum ResolveError {
     ///
     /// Carries a typed [`ReauthReason`] so callers (UI, metrics, audit)
     /// can distinguish provider-rejected refresh from sentinel-threshold
-    /// escalation per sub-spec §3.4.
+    /// escalation per sub-spec.
     #[error("credential {credential_id}: re-authentication required")]
     ReauthRequired {
         /// Credential identifier.

--- a/crates/engine/src/credential/rotation.rs
+++ b/crates/engine/src/credential/rotation.rs
@@ -1,6 +1,6 @@
 //! Engine credential rotation orchestration surface.
 //!
-//! Per ADR-0030, `nebula-engine` owns credential orchestration: scheduling,
+//! `nebula-engine` owns credential orchestration: scheduling,
 //! blue-green deployment, grace-period management, and transaction state
 //! machines. Contract/state types (policy, state, events, error, validation)
 //! remain in `nebula_credential::rotation`.

--- a/crates/engine/src/credential/rotation/fanout_driver.rs
+++ b/crates/engine/src/credential/rotation/fanout_driver.rs
@@ -4,9 +4,9 @@
 //! # Why this exists
 //!
 //! [`ResourceFanoutIndex`] is the engine-owned reverse index + per-slot
-//! fan-out port (ADR-0067 §D1). Until this module, every
+//! fan-out port . Until this module, every
 //! `bind` / `dispatch_refresh` / `dispatch_revoke` caller was a
-//! `#[cfg(test)]` test — the index was implemented but unwired (ADR-0067
+//! `#[cfg(test)]` test — the index was implemented but unwired (
 //! §Deferred "Rotation fan-out is implemented but unwired"). This module
 //! closes that: it is the single production consumer that turns a
 //! completed credential refresh / revoke into the typed
@@ -16,11 +16,11 @@
 //! # Layering (no `nebula-resource → nebula-engine` edge)
 //!
 //! The rotation/revoke *signals* originate in the credential-runtime
-//! composition root (`nebula-credential-runtime`, ADR-0066), which owns
+//! composition root (`nebula-credential-runtime`, ), which owns
 //! the resolver, the [`RefreshCoordinator`](super::super::RefreshCoordinator),
 //! and the lease lifecycle. That crate must **not** depend on
 //! `nebula-resource` (deny.toml `[[bans]]` `nebula-resource` wrapper
-//! allowlist; ADR-0067 §D1). The signals reach this driver as plain
+//! allowlist; ). The signals reach this driver as plain
 //! [`nebula-eventbus`](nebula_eventbus) events
 //! ([`CredentialEvent`] on `EventBus<CredentialEvent>`,
 //! [`LeaseEvent`] on `EventBus<LeaseEvent>`) — the AGENTS.md
@@ -37,7 +37,7 @@
 //! - [`CredentialEvent::Refreshed`] — the credential-runtime facade has
 //!   already CAS-persisted the fresh material into the store
 //!   (`CredentialService::refresh`) before emitting this. That is exactly
-//!   the ADR-0067 §D1 "engine has stored the fresh material" point, so
+//! the "engine has stored the fresh material" point, so
 //!   the driver calls
 //!   [`ResourceFanoutIndex::dispatch_refresh`].
 //! - [`CredentialEvent::Revoked`] and
@@ -47,7 +47,7 @@
 //!   `LeaseRevoked`; the facade additionally emits
 //!   `CredentialEvent::Revoked`). Either triggers
 //!   [`ResourceFanoutIndex::dispatch_revoke`]. The fan-out itself is
-//!   already two-phase + cancellation-safe internally (ADR-0067
+//! already two-phase + cancellation-safe internally (
 //!   §Deferred / #681): synchronous `taint_slot_for` outside the
 //!   per-resource timeout, then the timeout-wrapped
 //!   `drain_and_revoke` tail. This driver does **not** re-implement
@@ -58,18 +58,15 @@
 //! address a reverse-index row, so it is a no-op fan-out (logged at
 //! `debug`, not an error).
 //!
-//! # Observability (ADR-0028 §4 — eventbus is not audit)
-//!
+//! # Observability//!
 //! Each dispatch returns a [`RotationOutcome`] aggregate. It is **never
 //! silently dropped**: a credential-data-free `tracing` event records
 //! `credential_id` / counts, and a non-zero `failed` / `timed_out`
-//! escalates to `warn!`. Per ADR-0028 §4 this aggregate is a
-//! metrics/observability signal **only** — it is *not* an audit write
+//! escalates to `warn!`.//! metrics/observability signal **only** — it is *not* an audit write
 //! and is *not* re-emitted on an eventbus (that dashboard emission stays
-//! a deferred Non-goal of this unit; ADR-0067 §Deferred
-//! "`RotationOutcome` → eventbus emission"). The fan-out internals
+//! a deferred Non-goal of this unit;//! "`RotationOutcome` → eventbus emission"). The fan-out internals
 //! already guarantee no credential/secret material reaches any span
-//! (ADR-0030 §4); this driver adds only key-free counts.
+//! ; this driver adds only key-free counts.
 
 use std::collections::VecDeque;
 use std::sync::Arc;
@@ -174,7 +171,7 @@ impl RevokeDedupe {
 /// `LeaseLifecycleConfig::provider_call_timeout` default,
 /// `token_http::OAUTH_TOKEN_HTTP_TIMEOUT`) rather than inventing a
 /// magic literal. It is a **per-resource** budget (one slow resource
-/// cannot cascade-fail siblings — ADR-0036 invariant, enforced inside
+/// cannot cascade-fail siblings — invariant, enforced inside
 /// the fan-out), not a global one.
 const PER_RESOURCE_ROTATION_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -393,10 +390,10 @@ impl ResourceFanoutDriver {
     }
 
     /// Consume the [`RotationOutcome`] — **never silently dropped**
-    /// (ADR-0028 §4: an observability signal, not an audit write and not
+    /// ( : an observability signal, not an audit write and not
     /// an eventbus re-emission). Only `credential_id` + counts reach the
     /// span; the fan-out internals already guarantee no credential /
-    /// secret material on any observability surface (ADR-0030 §4). A
+    /// secret material on any observability surface . A
     /// non-zero `failed` / `timed_out` escalates to `warn!` so a partial
     /// fan-out is operator-visible.
     fn record(credential_id: CredentialId, op: &'static str, outcome: RotationOutcome) {

--- a/crates/engine/src/credential/rotation/resource_fanout.rs
+++ b/crates/engine/src/credential/rotation/resource_fanout.rs
@@ -1,6 +1,6 @@
 //! Engine-owned reverse index: `CredentialId` -> affected resource rows.
 //!
-//! Per ADR-0030, `nebula-engine` (exec layer) owns credential rotation
+//! `nebula-engine` (exec layer) owns credential rotation
 //! orchestration; `nebula-resource` exposes only the typed
 //! `Manager::{refresh_slot_for, revoke_slot_for}` port. When a credential
 //! rotates, the engine must fan that single event out to every resource
@@ -28,11 +28,9 @@
 //! family. This is forward-correctness against the structural dedup model,
 //! not extra precision for its own sake.
 //!
-//! Per ADR-0036 (event-driven cross-crate flow) the engine consumes the
-//! credential rotation signal and translates it into typed `Manager` port
-//! calls; per ADR-0044 the resource layer never reaches back across the
-//! boundary. This index is an in-process, in-memory routing table only —
-//! never persisted and never sent across a trust boundary.
+//! The engine consumes each credential rotation signal and translates it into typed `Manager` port
+//! calls; the resource layer never reaches back across the boundary. This index is an in-process,
+//! in-memory routing table only — never persisted and never sent across a trust boundary.
 
 use std::time::Duration;
 
@@ -72,12 +70,11 @@ pub struct Bind {
 /// registry row.
 ///
 /// One [`Bind`] contributes exactly one of the three counts, so
-/// `success + failed + timed_out == affected_rows`. Per ADR-0036's
-/// per-resource timeout-isolation invariant a slow, failed, or timed-out row
+/// `success + failed + timed_out == affected_rows`./// per-resource timeout-isolation invariant a slow, failed, or timed-out row
 /// never aborts or fails its siblings — each row's outcome is independent. The
 /// struct carries only counts (no key/slot/credential material) so it is safe
 /// to log or emit as a metrics/dashboard signal; it is **not** a substitute
-/// for an audit write (ADR-0028 §4).
+/// for an audit write.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct RotationOutcome {
     /// Rows whose `Manager::{refresh,revoke}_slot_for` hook returned `Ok`.
@@ -210,13 +207,13 @@ impl ResourceFanoutIndex {
     /// [`Manager::refresh_slot_for`](nebula_resource::Manager::refresh_slot_for)
     /// per row.
     ///
-    /// The engine (exec layer, ADR-0030) owns rotation orchestration: it has
+    /// The engine (exec layer, ) owns rotation orchestration: it has
     /// already resolved and stored the fresh credential material before this
     /// is called; this method only translates the single rotation signal
-    /// into the typed per-row resource port (ADR-0036), and the resource
-    /// layer never reaches back (ADR-0044).
+    /// into the typed per-row resource port , and the resource
+    /// layer never reaches back.
     ///
-    /// **Per-resource timeout isolation (ADR-0036 invariant).** Each row's
+    /// **Per-resource timeout isolation .** Each row's
     /// `refresh_slot_for` is independently wrapped in
     /// `tokio::time::timeout(per_resource_timeout, …)` and all are driven
     /// concurrently via [`futures::future::join_all`]. One slow, failed, or
@@ -234,7 +231,7 @@ impl ResourceFanoutIndex {
     /// Redaction: only the aggregate counts and per-row key / slot / scope /
     /// `slot_identity` (a `u64`) / duration reach spans — never credential
     /// or secret material. The returned aggregate is a metrics/dashboard
-    /// signal, **not** an audit record (ADR-0028 §4); the caller still owns
+    /// signal, **not** an audit record ; the caller still owns
     /// any audit write.
     ///
     /// An empty `affected(cid)` returns
@@ -255,7 +252,7 @@ impl ResourceFanoutIndex {
             .await
     }
 
-    /// Fans a credential revoke (e.g. an ADR-0051 lease revoke) out to every
+    /// Fans a credential revoke (e.g. an lease revoke) out to every
     /// resource registry row that resolved `cid`, calling
     /// [`Manager::revoke_slot_for`](nebula_resource::Manager::revoke_slot_for)
     /// per row.
@@ -288,11 +285,11 @@ impl ResourceFanoutIndex {
     /// `tokio::time::timeout(per_resource_timeout, …)` and drives them all
     /// concurrently via [`join_all`](futures::future::join_all). This
     /// independent per-future timeout + `join_all` is exactly what
-    /// guarantees the ADR-0036 timeout-isolation invariant: a slow, failed,
+    /// guarantees the timeout-isolation invariant: a slow, failed,
     /// or timed-out row's future resolves on its own and cannot abort or
     /// fail a sibling — every row's outcome is recorded independently.
     ///
-    /// **Revoke is two-phase and cancellation-safe (ADR-0067 §Deferred).**
+    /// **Revoke is two-phase and cancellation-safe .**
     /// `Manager::revoke_slot_for` is *not* called inside the timeout: a Rust
     /// `async fn` body is lazy, so a timeout future dropped before its first
     /// poll would skip the synchronous taint and leave new acquires accepted
@@ -375,7 +372,7 @@ impl ResourceFanoutIndex {
                     // Phase 1 — SYNCHRONOUS taint, OUTSIDE the timeout. It is
                     // fully applied before `taint_slot_for` returns, so a
                     // subsequently-dropped timeout on the drain tail can
-                    // never skip it (ADR-0067 §Deferred). A taint failure
+                    // never skip it . A taint failure
                     // (resolution miss / manager shutting down) is this
                     // row's terminal outcome — the drain tail is not entered.
                     let tainted = match mgr.taint_slot_for(
@@ -408,7 +405,7 @@ impl ResourceFanoutIndex {
                     // be able to elapse on a slow drain and drop the whole
                     // future *before the hook ran*, silently skipping the
                     // documented "hook still runs after a timed-out drain"
-                    // guarantee (ADR-0067 §Deferred / #690 review). The row
+                    // guarantee . The row
                     // is already tainted (phase 1); every tail outcome
                     // leaves it tainted.
                     match mgr.drain_and_revoke(tainted, per_resource_timeout).await {
@@ -475,10 +472,10 @@ enum FanoutOp {
     /// `Manager::refresh_slot_for` — credential rotated, fresh material
     /// already resolved and stored by the engine.
     Refresh,
-    /// Credential revoked (e.g. ADR-0051 lease revoke). Driven as the
+    /// Credential revoked (e.g. lease revoke). Driven as the
     /// two-phase port: synchronous `Manager::taint_slot_for` outside the
     /// timeout, then the timeout-wrapped cancellation-safe
-    /// `Manager::drain_and_revoke` tail (ADR-0067 §Deferred).
+    /// `Manager::drain_and_revoke` tail.
     Revoke,
 }
 
@@ -617,7 +614,7 @@ mod tests {
     }
 
     // ────────────────────────────────────────────────────────────────────
-    // Per-resource timeout-isolation fan-out tests (ADR-0036 invariant).
+    // Per-resource timeout-isolation fan-out tests.
     //
     // A controllable resident resource: its `on_credential_refresh` /
     // `on_credential_revoke` hooks either return immediately or block

--- a/crates/engine/src/credential/rotation/token_http.rs
+++ b/crates/engine/src/credential/rotation/token_http.rs
@@ -1,7 +1,7 @@
-//! ADR-0031: bounded HTTP client and body handling for OAuth2 **token** endpoints.
+//! : bounded HTTP client and body handling for OAuth2 **token** endpoints.
 //!
-//! Moved from `nebula-credential` per ADR-0031 incremental split: the engine
-//! owns token refresh HTTP transport (ADR-0030).
+//! Moved from `nebula-credential` per incremental split: the engine
+//! owns token refresh HTTP transport.
 
 use std::{sync::OnceLock, time::Duration};
 
@@ -44,7 +44,7 @@ pub enum TokenHttpError {
     Json(#[source] serde_json::Error),
 }
 
-/// Returns a shared [`reqwest::Client`] with ADR-0031 policy for OAuth2 **token** calls
+/// Returns a shared [`reqwest::Client`] with policy for OAuth2 **token** calls
 /// (one process-wide instance for connection pooling and TLS session reuse).
 pub fn oauth_token_http_client() -> &'static reqwest::Client {
     OAUTH_TOKEN_HTTP_CLIENT.get_or_init(|| {
@@ -55,7 +55,7 @@ pub fn oauth_token_http_client() -> &'static reqwest::Client {
                 OAUTH_TOKEN_HTTP_MAX_REDIRECTS,
             ))
             .build()
-            .expect("nebula: oauth token http client (ADR-0031 static policy) must build")
+            .expect("nebula: oauth token http client must build")
     })
 }
 

--- a/crates/engine/src/credential/rotation/token_refresh.rs
+++ b/crates/engine/src/credential/rotation/token_refresh.rs
@@ -7,8 +7,7 @@
 //! # Sentinel marking
 //!
 //! Per sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)` §3.4
-//! the holder marks the L2 claim row `sentinel = RefreshInFlight`
+//! `docs/INTEGRATION_MODEL.md`//! the holder marks the L2 claim row `sentinel = RefreshInFlight`
 //! immediately before the IdP POST. That mark is set by the
 //! `CredentialResolver::refresh_via_coordinator` closure (the caller of
 //! `refresh_oauth2_state`) **outside** this module, so we do not have to
@@ -238,14 +237,14 @@ fn update_state_from_token_response(
 }
 
 /// Redacts common sensitive-field-name=value patterns in IdP error
-/// strings. OAuth2 IdPs (per RFC 6749 §5.2) sometimes echo submitted
+/// strings. OAuth2 IdPs (per RFC 6749 ) sometimes echo submitted
 /// credentials inside `error_description` — most commonly
 /// `refresh_token=<value>` on `invalid_grant` from buggy or hostile
 /// providers. Without redaction those values reach operator-facing
 /// logs / SIEM via [`TokenRefreshError::TokenEndpoint`]. This helper
 /// scrubs the value while preserving the structural diagnostic.
 ///
-/// Implements ADR-0030 §4 redaction discipline at the source: the
+/// Implements redaction discipline at the source: the
 /// summary string emitted by [`oauth_token_error_summary`] is the
 /// single chokepoint through which non-2xx response bodies enter the
 /// error type, so applying redaction here covers all downstream
@@ -261,7 +260,7 @@ fn update_state_from_token_response(
 /// (not under-redaction; never leaks the input). The CI safety net
 /// (`tests::redaction_regex_compiles` lib test +
 /// `crates/engine/tests/credential_refresh_redaction.rs` integration rows
-/// per ADR-0030 §4) catches the pattern regression before merge so the
+/// per ) catches the pattern regression before merge so the
 /// fallback path is never reached in production.
 const REDACTION_PATTERN: &str = r"(?i)\b(refresh[_-]?token|access[_-]?token|client[_-]?secret|bearer|api[_-]?key|password|secret)\s*[=:]\s*\S+";
 

--- a/crates/engine/src/credential/rotation/transaction.rs
+++ b/crates/engine/src/credential/rotation/transaction.rs
@@ -573,7 +573,7 @@ impl RotationTransaction {
 
     /// Mark rotation as committed.
     ///
-    /// **Revoke-on-rotate hook (ADR-0051 Phase D).** Composition roots
+    /// **Revoke-on-rotate hook .** Composition roots
     /// that wire a [`LeaseLifecycle`](crate::credential::LeaseLifecycle)
     /// SHOULD call
     /// [`LeaseLifecycle::revoke_for_credential(self.credential_id)`](crate::credential::LeaseLifecycle::revoke_for_credential)

--- a/crates/engine/src/credential_accessor.rs
+++ b/crates/engine/src/credential_accessor.rs
@@ -17,7 +17,7 @@
 //!
 //! # Allowlist semantics (deny-by-default)
 //!
-//! Per `PRODUCT_CANON` §4.5 (operational honesty) and §12.5 (secrets and auth):
+//! Per `PRODUCT_CANON` (operational honesty) and (secrets and auth):
 //! an action may only acquire a credential it has **explicitly declared**.
 //!
 //! - An **empty** allowlist means **no credentials are permitted**. Every request is rejected with
@@ -105,7 +105,7 @@ impl EngineCredentialAccessor {
     /// # Parameters
     ///
     /// - `allowed_keys` — the set of credential IDs this accessor may resolve. An **empty** set
-    ///   denies every request (deny-by-default, per `PRODUCT_CANON` §4.5 / §12.5). A non-empty set
+    ///   denies every request (deny-by-default). A non-empty set
     ///   permits only the listed keys.
     /// - `resolve_fn` — async closure that resolves a credential ID to a boxed `Any` (typically a
     ///   `CredentialSnapshot`) or a `CoreError`.

--- a/crates/engine/src/daemon/event_source.rs
+++ b/crates/engine/src/daemon/event_source.rs
@@ -1,8 +1,8 @@
 //! EventSource topology + `EventSourceAdapter<E>: TriggerAction`.
 //!
 //! Migrated from `crates/resource/src/topology/event_source.rs` and
-//! `crates/resource/src/runtime/event_source.rs` per ADR-0037 / Tech Spec
-//! §12.3. EventSource lands as a thin adapter onto engine's existing
+//! `crates/resource/src/runtime/event_source.rs` per / Tech Spec
+//! . EventSource lands as a thin adapter onto engine's existing
 //! `TriggerAction` substrate.
 //!
 //! # Why an adapter, not a TriggerAction extension
@@ -207,8 +207,7 @@ where
 }
 
 // `EventSourceAdapter<E>` carries per-instance dynamic metadata (the
-// host supplies `ActionMetadata` at construction). Per ADR-0043 §6 the
-// typed [`nebula_action::Action`] / [`nebula_action::TriggerAction`]
+// host supplies `ActionMetadata` at construction).// typed [`nebula_action::Action`] / [`nebula_action::TriggerAction`]
 // traits require **static** metadata, so the adapter implements the
 // dyn-erased [`nebula_action::TriggerHandler`] surface directly. The
 // engine registers it as `Arc<dyn TriggerHandler>` like any other

--- a/crates/engine/src/daemon/mod.rs
+++ b/crates/engine/src/daemon/mod.rs
@@ -1,12 +1,12 @@
-//! Engine daemon module — long-running worker primitives (per ADR-0037).
+//! Engine daemon module — long-running worker primitives (per ).
 //!
 //! Hosts the `Daemon` trait + `DaemonRuntime` (per-daemon background task with
 //! restart policy) + `DaemonRegistry` (engine-side dispatcher across all
 //! registered daemons). EventSource adapter onto the `TriggerAction` substrate
 //! lives in [`event_source`].
 //!
-//! Migrated from `nebula-resource` per ADR-0037 ("Daemon / EventSource engine
-//! fold") to honor canon §3.5 ("Resource = pool/SDK client").
+//! Migrated from `nebula-resource` per ("Daemon / EventSource engine
+//! fold") to honor canon ("Resource = pool/SDK client").
 //!
 //! # Cancellation
 //!

--- a/crates/engine/src/daemon/registry.rs
+++ b/crates/engine/src/daemon/registry.rs
@@ -18,7 +18,7 @@
 //! # Fail-closed registration
 //!
 //! Mirrors the `crate::credential::StateProjectionRegistry` policy from
-//! ADR-0030 / Tech Spec §15.6 N7 mitigation: duplicate
+//! / Tech Spec N7 mitigation: duplicate
 //! `D::key()` registration returns
 //! [`DaemonError::DuplicateKey`] rather than overwriting. Operators resolve
 //! the collision by renaming the daemon's `Resource::key`.
@@ -144,7 +144,7 @@ impl DaemonRegistry {
     /// # Errors
     ///
     /// - [`DaemonError::DuplicateKey`] when a daemon with the same `D::key()` is already registered
-    ///   (fail-closed per ADR-0030 / Tech Spec §15.6 N7).
+    ///   (fail-closed per Tech Spec N7).
     /// - [`DaemonError::RegistryCancelled`] when [`Self::shutdown`] has already cancelled the
     ///   parent token; subsequent daemons would inherit a pre-cancelled child and never run, so the
     ///   registry refuses the registration upfront.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -67,7 +67,7 @@ type EventBus = nebula_eventbus::EventBus<ExecutionEvent>;
 /// Default capacity for the engine's event bus. Tuned so a typical
 /// interactive workflow (hundreds of nodes) never blocks, while a runaway
 /// producer with a dead consumer cannot inflate memory without bound. Spec
-/// 28 §2.4 calls for broadcast to multiple subscribers (storage writer,
+/// 28 calls for broadcast to multiple subscribers (storage writer,
 /// metrics collector, websocket broadcaster, audit writer) — `EventBus` is
 /// the workspace-standard fan-out primitive.
 pub const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 1024;
@@ -141,7 +141,7 @@ pub struct WorkflowEngine {
     /// / [`crate::TypedResourceRegistrar`]). The map is **closed**: a kind
     /// is registrable only if a registrar was explicitly inserted; an
     /// unknown kind is a wiring fault caught at activation, never a silent
-    /// no-op (INTEGRATION_MODEL §114-120; ADR-0030 / ADR-0036 / ADR-0044).
+    /// no-op.
     ///
     /// Held in engine state next to [`plugin_registry`] because the two
     /// are siblings: `impl Plugin` is the runtime source of truth for
@@ -163,7 +163,7 @@ pub struct WorkflowEngine {
     /// [`plugin_registry`]: Self::plugin_registry
     resource_registrars: ResourceRegistrarRegistry,
     /// Engine-owned reverse index `CredentialId → resolved resource rows`
-    /// for the per-slot rotation fan-out (ADR-0067 §D1).
+    /// for the per-slot rotation fan-out.
     ///
     /// Always constructed (an empty index is a no-op fan-out), held here
     /// next to [`resource_registrars`] and the
@@ -175,7 +175,7 @@ pub struct WorkflowEngine {
     /// drains it on a rotation/revoke event into the `Manager` slot ports.
     /// No `nebula-resource → nebula-engine` edge: the index lives in
     /// `nebula-engine` and the rotation signal arrives via
-    /// `nebula-eventbus` (ADR-0067 §D1; AGENTS.md).
+    /// `nebula-eventbus`.
     ///
     /// Feature-gated with the index itself (`rotation`).
     ///
@@ -223,8 +223,8 @@ pub struct WorkflowEngine {
     /// Actions may only acquire credential IDs listed for their `ActionKey`.
     /// Missing entry or empty set → every `acquire_credential` request for
     /// that action is denied with [`nebula_credential::CredentialAccessError::AccessDenied`].
-    /// See `PRODUCT_CANON` §4.5 (operational honesty — no false capabilities) and §12.5
-    /// (secrets and auth). Populated via [`WorkflowEngine::with_action_credentials`].
+    /// See product canon (operational honesty — no false capabilities; secrets and auth).
+    /// Populated via [`WorkflowEngine::with_action_credentials`].
     action_credentials: HashMap<ActionKey, HashSet<String>>,
     /// Optional event sender for real-time execution monitoring (TUI, logging).
     event_bus: Option<EventBus>,
@@ -250,7 +250,7 @@ pub struct WorkflowEngine {
     /// Volatile index of in-flight executions this runner owns.
     ///
     /// Published **after** `acquire_and_heartbeat_lease` succeeds — the lease
-    /// is the authoritative single-runner fence (ADR-0015), so publishing
+    /// is the authoritative single-runner fence, so publishing
     /// after the lease prevents an overlapping attempt for the same
     /// [`ExecutionId`] from overwriting the live token. Each entry is
     /// tagged with a monotonically-increasing [`RunningRegistrationId`]
@@ -260,13 +260,13 @@ pub struct WorkflowEngine {
     /// losing attempt clobbering the winner's registration.
     ///
     /// [`cancel_execution`] looks up the token here and cancels it,
-    /// closing the ADR-0008 A3 control-queue `Cancel` path into the
+    /// closing the A3 control-queue `Cancel` path into the
     /// cooperative-cancel signal the frontier loop already observes.
     ///
     /// **Not durable.** This map lives only as long as the `WorkflowEngine`
     /// instance. On process crash the entries vanish with the runner; the
     /// durable truth is `executions` + `execution_control_queue`, and the
-    /// replacement runner reloads from storage (ADR-0008 §5, canon §12.2).
+    /// replacement runner reloads from storage.
     ///
     /// [`execute_workflow`]: Self::execute_workflow
     /// [`resume_execution`]: Self::resume_execution
@@ -275,7 +275,7 @@ pub struct WorkflowEngine {
     /// Optional handle for the background credential-refresh reclaim
     /// sweep. When set, dropping the engine aborts the spawned task —
     /// see [`crate::credential::refresh::ReclaimSweepHandle`] (sub-spec
-    /// §3.3, §3.4).
+    /// , ).
     ///
     /// Wired by the composition root via
     /// [`Self::with_credential_reclaim_sweep`] when the deployment has a
@@ -286,7 +286,7 @@ pub struct WorkflowEngine {
 }
 
 /// Monotonic per-registration identifier used to fence out-of-order drops
-/// from concurrent attempts on the same [`ExecutionId`] (ADR-0016 / #482
+/// from concurrent attempts on the same [`ExecutionId`] ( / #482
 /// Copilot review). A `u64` is fine — we'd need billions of registrations
 /// per runner lifetime to wrap, and the counter resets on process restart
 /// anyway.
@@ -396,9 +396,9 @@ impl WorkflowEngine {
     ///
     /// This is the engine-side hook that
     /// [`crate::control_dispatch::EngineControlDispatch`]'s `dispatch_cancel`
-    /// calls after the §5 idempotency guard; the durable API-level CAS to
+    /// calls after the idempotency guard; the durable API-level CAS to
     /// `Cancelled` has already landed on the execution row by the time a
-    /// `Cancel` command reaches the consumer (canon §12.2, §13 step 5).
+    /// `Cancel` command reaches the consumer (control-queue cancel enqueue path).
     pub fn cancel_execution(&self, execution_id: ExecutionId) -> bool {
         match self.running.get(&execution_id) {
             Some(entry) => {
@@ -460,7 +460,7 @@ impl WorkflowEngine {
     /// call. A kind is registrable only if a registrar was explicitly
     /// wired in (via [`with_resource_registrars`](Self::with_resource_registrars));
     /// an unknown kind is a wiring fault surfaced at activation, never a
-    /// silent no-op (INTEGRATION_MODEL §114-120). Defaults empty
+    /// silent no-op . Defaults empty
     /// (fail-closed) when the engine is built without resource activation.
     ///
     /// The activation path (resolving a persisted row's `kind` through
@@ -471,7 +471,7 @@ impl WorkflowEngine {
         &self.resource_registrars
     }
 
-    /// The engine-owned per-slot rotation reverse index (ADR-0067 §D1).
+    /// The engine-owned per-slot rotation reverse index.
     ///
     /// This is the [`bind`](crate::credential::rotation::ResourceFanoutIndex::bind)
     /// producer for the §M11.5 fan-out: the resource-activation path
@@ -496,9 +496,9 @@ impl WorkflowEngine {
     ///
     /// `credential_bus` / `lease_bus` are the buses
     /// `EventMetricObserver::{event_bus, lease_bus}`
-    /// (`nebula-credential-runtime`, ADR-0066) emits on after a refresh
+    /// (`nebula-credential-runtime`, ) emits on after a refresh
     /// CAS-persists fresh material or a lease is revoked. This closes the
-    /// ADR-0067 §Deferred "Rotation fan-out is implemented but unwired"
+    /// "Rotation fan-out is implemented but unwired"
     /// gap: a `CredentialEvent::Refreshed` drives
     /// `ResourceFanoutIndex::dispatch_refresh`, and
     /// `CredentialEvent::Revoked` / `LeaseEvent::LeaseRevoked` drive
@@ -528,7 +528,7 @@ impl WorkflowEngine {
     ///
     /// No `nebula-resource → nebula-engine` edge: the index lives in
     /// `nebula-engine` and the rotation signal arrives via
-    /// `nebula-eventbus` (ADR-0067 §D1; AGENTS.md cross-crate signal
+    /// `nebula-eventbus` (AGENTS.md cross-crate signal
     /// rule).
     #[cfg(feature = "rotation")]
     #[must_use = "the returned driver handle must be held; dropping it aborts the fan-out"]
@@ -603,7 +603,7 @@ impl WorkflowEngine {
     /// the plugin registry. Scope is row/activation context, not a
     /// plugin-declaration field, and is supplied per-call via
     /// [`RegisterRequest`](crate::RegisterRequest) — never defaulted, since
-    /// a wrong scope is an isolation hole (ADR-0036 / ADR-0044).
+    /// a wrong scope is an isolation hole.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_resource_registrars(mut self, registrars: ResourceRegistrarRegistry) -> Self {
         self.resource_registrars = registrars;
@@ -701,7 +701,7 @@ impl WorkflowEngine {
 
     /// Attach the background credential refresh reclaim sweep handle.
     ///
-    /// Per sub-spec §3.3 + §3.4 the engine spawns a periodic task that
+    /// Per sub-spec + the engine spawns a periodic task that
     /// calls `RefreshClaimRepo::reclaim_stuck`, routes
     /// `RefreshInFlight`-flagged stale claims through
     /// [`crate::credential::refresh::SentinelTrigger`], and publishes
@@ -723,8 +723,7 @@ impl WorkflowEngine {
 
     /// Declare the credential IDs an action is permitted to acquire.
     ///
-    /// The engine enforces a **deny-by-default** allowlist (see `PRODUCT_CANON` §4.5
-    /// and §12.5). When a node whose `action_key == action` runs, only the
+    /// The engine enforces a **deny-by-default** allowlist (see `PRODUCT_CANON` /// and ). When a node whose `action_key == action` runs, only the
     /// credential IDs supplied here may be resolved — every other request fails
     /// with [`nebula_credential::CredentialAccessError::AccessDenied`]. Actions
     /// that are never declared here cannot acquire any credential at all.
@@ -784,7 +783,7 @@ impl WorkflowEngine {
     /// When set, the engine publishes [`ExecutionEvent`]s for node
     /// lifecycle transitions (started, completed, failed, skipped) and
     /// execution completion. Used by the CLI TUI for live monitoring and
-    /// by the spec 28 §2.4 subscribers (storage writer, metrics
+    /// by the spec 28 subscribers (storage writer, metrics
     /// collector, websocket broadcaster, audit writer).
     ///
     /// The bus fans out to every subscriber independently — each gets a
@@ -809,8 +808,7 @@ impl WorkflowEngine {
         }
     }
 
-    /// Emit [`ExecutionEvent::FrontierIntegrityViolation`] when the §11.1
-    /// guard has populated a non-terminal payload. Called at every finish
+    /// Emit [`ExecutionEvent::FrontierIntegrityViolation`] when the    /// guard has populated a non-terminal payload. Called at every finish
     /// site *before* [`ExecutionEvent::ExecutionFinished`]; isolating it in
     /// one helper keeps that ordering contract in a single place.
     ///
@@ -1013,7 +1011,7 @@ impl WorkflowEngine {
         // records the terminal outcome. Without the bridge, the `let _`
         // swallows the invalid-transition error and the row stays at
         // `Running`, producing a two-truth violation against the
-        // `ExecutionResult` the engine returns (ADR-0008 A3).
+        // `ExecutionResult` the engine returns.
         if final_status == ExecutionStatus::Cancelled
             && exec_state.status == ExecutionStatus::Running
         {
@@ -1073,7 +1071,7 @@ impl WorkflowEngine {
     /// [`LeaseGuard::shutdown`] after the frontier loop exits. The guard
     /// also exposes [`LeaseGuard::heartbeat_lost`] so the caller can
     /// detect stolen / expired leases and refuse to persist further
-    /// state (a §12.2 durability invariant).
+    /// state (a durability invariant).
     ///
     /// Returns `Ok(None)` when no `execution_repo` is configured — in
     /// that mode the engine is a single-process library with no
@@ -1327,7 +1325,7 @@ impl WorkflowEngine {
 
         // 5b. Publish the cancel token into the running registry ONLY
         // after the lease is ours. The lease is the authoritative
-        // single-runner fence (ADR-0015); publishing after it prevents
+        // single-runner fence ; publishing after it prevents
         // an overlapping attempt for the same `ExecutionId` from
         // overwriting the live token (#482 Copilot review). The guard's
         // nonce-scoped `Drop` (`RunningRegistration::drop`) removes the
@@ -1406,7 +1404,7 @@ impl WorkflowEngine {
         // records the terminal outcome. Without the bridge, the `let _`
         // swallows the invalid-transition error and the row stays at
         // `Running`, producing a two-truth violation against the
-        // `ExecutionResult` the engine returns (ADR-0008 A3).
+        // `ExecutionResult` the engine returns.
         if final_status == ExecutionStatus::Cancelled
             && exec_state.status == ExecutionStatus::Running
         {
@@ -1417,12 +1415,12 @@ impl WorkflowEngine {
         // If the heartbeat lost the lease mid-run, a sibling runner
         // now owns the canonical state. We MUST NOT persist the final
         // state or emit ExecutionFinished from this runner — the new
-        // holder will drive completion. ADR 0008 / §12.2.
+        // holder will drive completion — control-queue lease handoff.
         let reported_status = if heartbeat_lost {
             tracing::error!(
                 %execution_id,
                 "final state persistence skipped: heartbeat lost this runner's lease; \
-                 another runner now owns the execution (ADR 0008, §12.2, #325)"
+                 another runner now owns the execution (#325)"
             );
             // Release whatever lease state we hold cleanly, then bubble
             // the typed error — this runner does not own the terminal
@@ -1652,7 +1650,7 @@ impl WorkflowEngine {
         //    the forward state machine via `override_node_state` but still bumps the version per
         //    transition so CAS readers see the change (issue #255).
         let mut exec_state = exec_state;
-        // Cold-start seam (ADR-0008 A2, §5): the API's start handler persists an
+        // Cold-start seam : the API's start handler persists an
         // `ExecutionState::new(id, workflow_id, &[])` row — no per-node entries,
         // because the handler does not load the workflow on the hot path. The
         // first `ControlCommand::Start` that drains via `EngineControlDispatch`
@@ -1674,7 +1672,7 @@ impl WorkflowEngine {
         // durable `next_attempt_at` that the frontier loop's
         // `retry_heap` consumes via the Phase-0 drain. Resetting it
         // would lose the persisted backoff and re-dispatch the node
-        // immediately on resume, defeating ADR-0042 §M2.1 T2's
+        // immediately on resume, defeating T2's
         // resume guarantee. (Crashed `Running` attempts have no
         // such timestamp and must be re-driven from `Pending`.)
         let non_terminal: Vec<NodeKey> = exec_state
@@ -1754,7 +1752,7 @@ impl WorkflowEngine {
             if ns.state.is_terminal() {
                 continue;
             }
-            // ADR-0042 §M2.1 T5 — `WaitingRetry` nodes belong to the
+            // T5 — `WaitingRetry` nodes belong to the
             // retry-pending heap, not to the seed/ready_queue. The
             // frontier loop seeds the heap from `WaitingRetry` nodes
             // separately; including them here would re-dispatch
@@ -1811,7 +1809,7 @@ impl WorkflowEngine {
         let fencing = lease.as_ref().and_then(LeaseGuard::fencing_token);
 
         // Publish the cancel token into the running registry ONLY after
-        // the lease is ours (ADR-0015 single-runner fence). Symmetric to
+        // the lease is ours . Symmetric to
         // `execute_workflow` — see its comment for the full rationale
         // and the #482 Copilot review context.
         let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
@@ -1888,7 +1886,7 @@ impl WorkflowEngine {
         // fired mid-flight — one-step `Running → Cancelled` is not in the
         // valid-transition table (issue #273), so without the bridge the
         // invalid-transition error is silently swallowed and the row stays
-        // at `Running`, producing a two-truth violation (ADR-0008 A3).
+        // at `Running`, producing a two-truth violation.
         if final_status == ExecutionStatus::Cancelled
             && exec_state.status == ExecutionStatus::Running
         {
@@ -1898,7 +1896,7 @@ impl WorkflowEngine {
 
         // Heartbeat loss: another runner now owns the canonical state.
         // Skip final persist and surface as Leased — mirrors the
-        // execute_workflow contract. ADR 0008 / §12.2 / #325.
+        // execute_workflow contract. ADR 0008 / / #325.
         let reported_status = if heartbeat_lost {
             tracing::error!(
                 %execution_id,
@@ -2063,7 +2061,7 @@ impl WorkflowEngine {
         }
 
         // Min-heap (via `Reverse`) of `(next_attempt_at, NodeKey)` for
-        // nodes parked in `WaitingRetry` per ADR-0042 §M2.1 T5. The
+        // nodes parked in `WaitingRetry` per T5. The
         // heap is the engine's source of truth for "what to dispatch
         // next when the current frontier is otherwise idle"; cancel /
         // terminate / budget guards run AFTER the timer fires so a
@@ -2095,13 +2093,13 @@ impl WorkflowEngine {
         // Main frontier loop
         loop {
             // Phase 0: Drain due retries from the retry_heap into the
-            // ready_queue (ADR-0042 §M2.1 T5).
+            // ready_queue.
             //
             // Phase 0 promotes `WaitingRetry → Ready` and clears
             // `next_attempt_at` so any subsequent cancel/terminate
             // teardown sees a `Ready` node — `Ready → Cancelled` is a
             // valid transition while a stranded `WaitingRetry` node
-            // would trip the canon §11.1 frontier-integrity check.
+            // would trip the frontier integrity (CAS on version) check.
             // Phase 1's `spawn_node` then performs `Ready → Running`
             // via `start_node_attempt`.
             let now_drain = Utc::now();
@@ -2113,7 +2111,7 @@ impl WorkflowEngine {
                     // Unreachable: peek-then-pop on a single-threaded
                     // owner cannot lose the entry. Surface defensively
                     // rather than panic so a future refactor can't
-                    // crash the frontier loop (canon §12.4).
+                    // crash the frontier loop (hot-path safety).
                     tracing::warn!(
                         target = "engine::retry",
                         %execution_id,
@@ -2142,7 +2140,7 @@ impl WorkflowEngine {
                             // WaitingRetry → Ready is in the canonical
                             // table; this is unreachable in practice
                             // but we surface defensively rather than
-                            // panic (canon §12.4).
+                            // panic (hot-path safety).
                             tracing::warn!(
                                 target = "engine::retry",
                                 %execution_id,
@@ -2168,7 +2166,7 @@ impl WorkflowEngine {
             // queue and is collected by `drain_pending_to_cancelled`
             // on the cancel/wall-clock teardown branches — popping
             // first would drop the node and strand it as `Ready`,
-            // tripping canon §11.1 frontier-integrity.
+            // tripping frontier integrity (CAS on version).
             while !cancel_token.is_cancelled()
                 && let Some(node_key) = ready_queue.pop_front()
             {
@@ -2248,12 +2246,12 @@ impl WorkflowEngine {
                 // `spawn_node` already marked the node as Failed and stored
                 // the typed error message on `NodeExecutionState`.
                 //
-                // ADR-0042 §M2.1 T4 — setup failures are retry-eligible
+                // T4 — setup failures are retry-eligible
                 // ("the action never started — re-running may succeed,
                 // e.g. credential rotation"). Same retry-decision flow
                 // as the runtime-failure path.
                 //
-                // Ordering on the no-retry path (§11.5, #297 review):
+                // Ordering on the no-retry path (, #297 review):
                 // record_attempt → classify → apply recovery → route
                 // (stages OnError payload into outputs) → checkpoint
                 // (durably commits state + staged payload) → emit.
@@ -2264,7 +2262,7 @@ impl WorkflowEngine {
 
                 // Push the failure attempt record so retry-decision
                 // and idempotency_key see the same attempt count.
-                // ADR-0042 §M2.1 T4: if recording fails (programming
+                // T4: if recording fails (programming
                 // error: unknown node), force `Finalize` rather than
                 // running `compute_retry_decision` against a stale
                 // `attempts.len()` — that would let `max_attempts`
@@ -2290,7 +2288,7 @@ impl WorkflowEngine {
                     },
                 };
 
-                // ADR-0042 §M2.1 T4 — retry decision (setup-failure
+                // T4 — retry decision (setup-failure
                 // path). Mirror runtime-failure semantics. Skip the
                 // decision entirely when attempt history is broken.
                 let setup_decision = if setup_attempt_recorded {
@@ -2417,7 +2415,7 @@ impl WorkflowEngine {
             // timer. Exit only when both join_set and retry_heap are
             // drained — `retry_heap` non-empty with `join_set` empty
             // is a legal "everything paused for backoff" state per
-            // ADR-0042 §M2.1 T5.
+            // T5.
             if join_set.is_empty() && retry_heap.is_empty() {
                 break;
             }
@@ -2430,10 +2428,10 @@ impl WorkflowEngine {
                 // AND the ready_queue (Ready → Cancelled). The
                 // previous failure already lives in `NodeAttempt`;
                 // the cancel terminates the wait, not the attempt
-                // (canon §4.5). Without draining `ready_queue`, a
+                // (operational honesty). Without draining `ready_queue`, a
                 // node Phase 0 already promoted to `Ready` would
                 // stay non-terminal after the loop exits, tripping
-                // the canon §11.1 frontier-integrity check. Best-
+                // the frontier integrity (CAS on version) check. Best-
                 // effort persist is covered by the final-status
                 // checkpoint in the outer caller — failures here
                 // only affect post-mortem log fidelity.
@@ -2483,7 +2481,7 @@ impl WorkflowEngine {
             // need to sleep until the timer (or cancel / wall-clock).
             // Pre-pin a boxed future per branch so `select!` never has
             // to enter an `unreachable!()` placeholder — library code
-            // must not panic on hot paths (canon §12.4).
+            // must not panic on hot paths (hot-path safety).
             let join_set_empty = join_set.is_empty();
 
             type JoinedResult = Option<
@@ -2582,7 +2580,7 @@ impl WorkflowEngine {
                     }
                     // Capture an explicit-termination signal BEFORE the
                     // checkpoint so that the same CAS-write durably
-                    // persists `terminated_by` (canon §11.5; ROADMAP
+                    // persists `terminated_by` (termination metadata; ROADMAP
                     // §M0.3). The companion `cancel_token.cancel()` is
                     // deferred until AFTER `Ok` from `checkpoint_node` so
                     // we tear down sibling branches only on a durable
@@ -2608,10 +2606,10 @@ impl WorkflowEngine {
                     // Persist node output + execution state, then record the
                     // idempotency key, before any external observer learns the
                     // node is done. This guarantees durability precedes
-                    // visibility (§11.5, #297). Checkpoint failure aborts the
+                    // visibility (, #297). Checkpoint failure aborts the
                     // node's progression so observers never see an
                     // unpersisted transition and the frontier never advances
-                    // on an undurable decision (§12.4).
+                    // on an undurable decision.
                     if let Err(e) = self
                         .checkpoint_node(
                             execution_id,
@@ -2657,11 +2655,11 @@ impl WorkflowEngine {
                     // output so that idempotent replay can reconstruct
                     // the exact routing semantics (issue #299).
                     //
-                    // ADR-0042 §M2.1 T4 — `attempt_count + 1` is the
+                    // T4 — `attempt_count + 1` is the
                     self.record_node_result(execution_id, node_key.clone(), &action_result)
                         .await;
 
-                    // ADR-0042 §M2.1 T4 — push the success attempt
+                    // T4 — push the success attempt
                     // record AFTER record_idempotency / record_node_result
                     // so those helpers see the just-finished attempt's
                     // key (push advances the next-dispatch key). The
@@ -2732,7 +2730,7 @@ impl WorkflowEngine {
                     // `CancellationToken` that control-queue `Cancel` / external cancel trips.
                     // If we route this through `mark_node_failed`, `run_frontier` returns
                     // `Some(failed_node)` and [`determine_final_status`] picks **Failed** over
-                    // `cancel_token.is_cancelled()` — wrong for ADR-0008 A3 / lease_takeover T4.
+                    // `cancel_token.is_cancelled` — wrong for A3 / lease_takeover T4.
                     // Mirror [`WakeReason::Cancel`]: mark the node `Cancelled`, drain in-flight
                     // bookkeeping, and exit without a synthetic `failed_node`.
                     //
@@ -2785,14 +2783,14 @@ impl WorkflowEngine {
                         );
                     }
 
-                    // Node failed at runtime. Ordering (§11.5, #297 PR
+                    // Node failed at runtime. Ordering (, #297 PR
                     // review by Copilot — route stages OnError payload
                     // that checkpoint must capture so resume can read
                     // it from `load_all_outputs`):
                     //   1. `mark_node_failed`      — in-memory Failed
                     //   2. `record_node_attempt(failure)` — push the attempt to history so
-                    //      `idempotency_key_for_node` differentiates future retries (ADR-0042 T4).
-                    //   3. **retry decision**       — ADR-0042 §M2.1 T4. If the per-node /
+                    // `idempotency_key_for_node` differentiates future retries.
+                    // 3. **retry decision** — T4. If the per-node /
                     //      workflow-default `RetryConfig` has budget AND the global
                     //      `ExecutionBudget.max_total_retries` cap allows another attempt, promote
                     //      `Failed → WaitingRetry`, stamp `next_attempt_at`, increment
@@ -2814,14 +2812,14 @@ impl WorkflowEngine {
                     // Successors in `ready_queue` do NOT dispatch until
                     // Phase 1 of the next loop iteration; that runs
                     // after checkpoint. Nothing external observes a
-                    // state the store has not committed (§11.5).
+                    // state the store has not committed.
                     mark_node_failed(exec_state, node_key.clone(), err);
                     let err_str = err.to_string();
 
                     // Push the failure attempt record so idempotency
                     // key, retry-decision, and post-mortem audit all
                     // see the same attempt history.
-                    // ADR-0042 §M2.1 T4: if recording fails (programming
+                    // T4: if recording fails (programming
                     // error: unknown node), force `Finalize` rather than
                     // letting `compute_retry_decision` see a stale
                     // `attempts.len()` — that path could bypass
@@ -2848,7 +2846,7 @@ impl WorkflowEngine {
                         },
                     };
 
-                    // ADR-0042 §M2.1 T4 — retry decision. Skipped when
+                    // T4 — retry decision. Skipped when
                     // attempt history could not be recorded.
                     let decision = if failure_attempt_recorded {
                         let retry_policy_resolved = node_map
@@ -3115,7 +3113,7 @@ impl WorkflowEngine {
 
         // Build credential accessor with a **deny-by-default** per-action allowlist.
         //
-        // Per `PRODUCT_CANON` §4.5 / §12.5 + audit §2.4: an action can only
+        // Per `PRODUCT_CANON` / + audit : an action can only
         // acquire credential IDs explicitly declared for its `ActionKey` via
         // `WorkflowEngine::with_action_credentials`. If the node's action was
         // never declared — or was declared with an empty set — the accessor
@@ -3227,7 +3225,7 @@ impl WorkflowEngine {
         ready_queue: &mut VecDeque<NodeKey>,
     ) -> bool {
         // Replay is detected by a persisted node *output*: the port's
-        // §11.3 guard is check-and-mark with no read-only probe, so the
+        // guard is check-and-mark with no read-only probe, so the
         // durable output is the authoritative "already ran" signal (a
         // present mark with a missing output is a partial write ⇒
         // re-execute). Without a store bundle there is no persistence,
@@ -3376,7 +3374,7 @@ impl WorkflowEngine {
     ) {
         // Dual-dispatch. The port guard is check-and-mark on
         // `{scope}:{exec}:{node}:{attempt}`; the attempt is derived the
-        // same way as `idempotency_key_for_node` (ADR-0042
+        // same way as `idempotency_key_for_node` (
         // `attempt_count + 1`) so the guard key stays in lockstep with
         // the persisted output/result rows.
         if let Some(stores) = &self.stores {
@@ -3411,7 +3409,7 @@ impl WorkflowEngine {
     /// or CAS mismatch (the row moved beneath the engine). Callers in
     /// `run_frontier` MUST abort the node's progression (no edge routing,
     /// no event emission) on `Err` so that observers and the frontier
-    /// never act on an unpersisted transition (§11.5, §12.4, #297).
+    /// never act on an unpersisted transition (, #297).
     /// Persist final Failed state + emit NodeFailed for a panicked task.
     ///
     /// Best-effort: checkpoint failures are logged at `warn!` level (not
@@ -3506,7 +3504,7 @@ impl WorkflowEngine {
     /// commit the state snapshot through a fencing-gated
     /// [`nebula_storage_port::TransitionBatch`]. A superseded fencing
     /// token yields [`EngineError::CasConflict`] (the new holder owns the
-    /// canonical state — ADR 0008, §12.2); a CAS version mismatch follows
+    /// canonical state — ADR 0008, ); a CAS version mismatch follows
     /// the same #333 refetch-and-abort contract as the legacy path.
     #[allow(clippy::too_many_arguments)]
     async fn checkpoint_node_port(
@@ -3636,7 +3634,7 @@ impl WorkflowEngine {
     /// "final state checkpoint CAS mismatch" before #333) — that
     /// silently dropped the final write and let the engine report
     /// `Completed` on an un-persisted state, violating `docs/PRODUCT_CANON.md`
-    /// §11.5 (durability precedes visibility) and §12.4 (no silent
+    /// (durability precedes visibility) and (no silent
     /// log-and-continue on state-transition failures).
     ///
     /// # Returns
@@ -3676,7 +3674,7 @@ impl WorkflowEngine {
     /// [`nebula_storage_port::TransitionBatch`]. Same #333
     /// reconcile-and-retry contract as the legacy path; a superseded
     /// fencing token yields [`EngineError::CasConflict`] (the new lease
-    /// holder owns the canonical state — ADR 0008, §12.2).
+    /// holder owns the canonical state — ADR 0008, ).
     async fn persist_final_state_port(
         &self,
         stores: &crate::store_seam::ExecutionStores,
@@ -3924,7 +3922,7 @@ impl NodeTask {
         //     EngineError::Action. The frontier loop routes this through `classify_failure` +
         //     `route_failure_edges`, where the workflow-level ErrorStrategy decides whether
         //     execution fails fast or continues/ignores the failure, and whether any `OnError` edge
-        //     is activated (split from the old `handle_node_failure` per #297 / §11.5). This
+        // is activated (split from the old `handle_node_failure` per #297). This
         //     replaces the old "log a WARN and proceed with a potentially stale credential" path,
         //     which leaked into N opaque downstream auth errors per failure.
         //   - refresh returns Ok → fall through to the action dispatch.
@@ -4085,7 +4083,7 @@ fn process_outgoing_edges(
 
 /// Evaluate whether an edge should activate given the source node's outcome.
 ///
-/// Port-driven routing (spec 28 §2.2): the engine matches the edge's
+/// Port-driven routing (spec 28 ): the engine matches the edge's
 /// effective source port (`from_port`, defaulting to `"main"`) against the
 /// port the upstream `ActionResult` produced on. There is no "edge
 /// condition" — conditionals are carried by explicit `ControlAction` nodes
@@ -4217,8 +4215,8 @@ fn check_budget(
 ///
 /// Called by all three frontier-loop teardown paths (Phase 2 cancel
 /// short-circuit, `WakeReason::Cancel`, `WakeReason::WallClock`) per
-/// ADR-0042 §M2.1 T5 acceptance: cancel/terminate/budget breach must
-/// not leave non-terminal nodes behind, otherwise the canon §11.1
+/// T5 acceptance: cancel/terminate/budget breach must
+/// not leave non-terminal nodes behind, otherwise the frontier integrity (CAS on version)
 /// frontier-integrity guard fires `FrontierIntegrityViolation`
 /// instead of the honest `Cancelled` / `TimedOut` final status.
 ///
@@ -4257,7 +4255,7 @@ fn drain_pending_to_cancelled(
     }
 }
 
-/// Resolve the effective per-node retry policy per ADR-0042 §M2.1 T4.
+/// Resolve the effective per-node retry policy per T4.
 ///
 /// Resolution order (more specific wins):
 /// 1. `NodeDefinition.retry_policy` — operator-declared per-node policy.
@@ -4272,7 +4270,7 @@ fn effective_retry_policy<'a>(
     node_def.retry_policy.as_ref().or(workflow_default)
 }
 
-/// The retry decision for a just-failed node attempt per ADR-0042.
+/// The retry decision for a just-failed node attempt.
 ///
 /// Pure: depends only on the per-node attempt count, the resolved
 /// policy, and the execution-level budget. Does not mutate any state.
@@ -4289,7 +4287,7 @@ enum RetryDecision {
 }
 
 /// Decide whether the just-failed dispatch of `node_key` should be
-/// retried per ADR-0042 §M2.1 T4 acceptance.
+/// retried per T4 acceptance.
 ///
 /// Ordering of checks (whichever caps first wins):
 ///
@@ -4353,7 +4351,7 @@ fn compute_retry_decision(
     // engine has dispatched are eligible). Refuse the retry rather
     // than fabricating an `attempts_used = 0` for a stranger node —
     // that would let a programming bug schedule retries on
-    // unbounded state (canon §12.4).
+    // unbounded state (hot-path safety).
     let Some(ns) = exec_state.node_states.get(node_key) else {
         tracing::warn!(
             target = "engine::retry",
@@ -4419,7 +4417,7 @@ fn next_retry_at(execution_id: ExecutionId, node_key: &NodeKey, delay: Duration)
 /// Pure function of the strategy: splits the outcome from the state
 /// mutation + edge routing that used to live together in the old
 /// `handle_node_failure`. Split lets `run_frontier` order `state-mutation
-/// → persist → emit → route` per §11.5 / #297 — routing outgoing edges
+/// → persist → emit → route` per / #297 — routing outgoing edges
 /// may push successors into `ready_queue`, which must be a deterministic
 /// function of the persisted state, not of an in-memory decision that
 /// a crash can lose.
@@ -4458,7 +4456,7 @@ fn classify_failure(error_strategy: nebula_workflow::ErrorStrategy) -> FailureOu
 ///
 /// Returns `Err(EngineError::Execution)` if `override_node_state`
 /// cannot find the node — the caller MUST abort the node's progression
-/// rather than leave state + outputs half-applied (§12.4). Pre-review
+/// rather than leave state + outputs half-applied . Pre-review
 /// (PR #436 / Copilot) this function discarded the `Result` via
 /// `let _ = ...`, silently masking a real consistency error.
 fn apply_failure_recovery(
@@ -4488,7 +4486,7 @@ fn apply_failure_recovery(
 /// after the outer match arm's `checkpoint_node`. If the following
 /// checkpoint returns `Err`, the caller aborts the frontier (cancel
 /// token + early return); the discarded `ready_queue` mutations never
-/// surface — §11.5 invariant holds.
+/// surface — invariant holds.
 ///
 /// Returns `Some(error_message)` if the frontier must abort — FailFast
 /// strategy with no OnError handler took the failure. Returns `None`
@@ -4625,7 +4623,7 @@ fn mark_node_failed(exec_state: &mut ExecutionState, node_key: NodeKey, err: &En
 /// a live `WorkflowEngine`.
 ///
 /// `termination_reason` carries the engine's explanation of *why* the
-/// execution reached its final status (canon §4.5; ROADMAP §M0.3).
+/// execution reached its final status (operational honesty).
 /// `None` means the engine has nothing to add — historically this was
 /// always the case; the field is `Option` for backwards-compatible
 /// destructuring while consumers are wired in T4.
@@ -4638,7 +4636,7 @@ struct FinalStatusDecision {
     termination_reason: Option<ExecutionTerminationReason>,
     /// `Some(nodes)` when the frontier exited without `failed_node` or
     /// cancellation but not all nodes reached a terminal state — see
-    /// `docs/PRODUCT_CANON.md` §11.1.
+    /// `docs/PRODUCT_CANON.md`.
     integrity_violation: Option<Vec<(NodeKey, NodeState)>>,
 }
 
@@ -4771,7 +4769,7 @@ impl Drop for LeaseGuard {
 /// 3. **`cancel_token` cancelled** with no explicit termination → external cancellation (API,
 ///    admin, engine shutdown). `(Cancelled, Some(Cancelled))`.
 /// 4. **Frontier integrity violation** — the loop drained without `failed_node` or cancel but some
-///    nodes are non-terminal (canon §11.1). `(Failed, Some(SystemError))` plus the
+///    nodes are non-terminal (frontier integrity (CAS on version)). `(Failed, Some(SystemError))` plus the
 ///    integrity_violation payload so the caller can emit a diagnostic
 ///    [`ExecutionEvent::FrontierIntegrityViolation`].
 /// 5. **Natural completion** — every node terminal. `(Completed, Some(NaturalCompletion))`.
@@ -4853,7 +4851,7 @@ fn determine_final_status(
         };
     }
 
-    // Priority 4 — frontier integrity violation (canon §11.1).
+    // Priority 4 — frontier integrity violation (frontier integrity (CAS on version)).
     if !exec_state.all_nodes_terminal() {
         let non_terminal: Vec<(NodeKey, NodeState)> = exec_state
             .node_states
@@ -6548,7 +6546,7 @@ mod tests {
     /// handling and the next final-state checkpoint therefore lost both
     /// the node's `Failed` state and any OnError / ContinueOnError
     /// edge-routing already applied in memory by `handle_node_failure`.
-    /// PRODUCT_CANON §11.5 (durability precedes visibility, §12.2 /
+    // (durability precedes visibility, /
     /// #297).
     ///
     /// This test covers the fix in two parts:
@@ -6830,7 +6828,7 @@ mod tests {
     /// checkpoint error was silently logged (`tracing::warn!`) and
     /// `handle_node_failure` had already routed the OnError edge in
     /// memory, so the successor `B` was spawned off an undurable
-    /// failure decision — the §11.5 "durability precedes visibility"
+    /// failure decision — the "durability precedes visibility"
     /// invariant was violated.
     #[tokio::test]
     async fn runtime_failure_checkpoint_error_aborts_before_edge_routing() {
@@ -7223,7 +7221,7 @@ mod tests {
         );
 
         // Reconstruct the idempotency key via the just-recorded
-        // attempt history. ADR-0042 §M2.1 T4 made
+        // attempt history. T4 made
         // `ExecutionState::idempotency_key_for_node` return the key
         // for the **next** dispatch, so to read the key the engine
         // actually persisted, look at the last attempt record (which
@@ -7248,7 +7246,7 @@ mod tests {
             .node_state(n.clone())
             .map(|ns| ns.attempts.len() as u32)
             .filter(|&a| a >= 1)
-            .expect("first run must have pushed an attempt record (ADR-0042 §M2.1 T4)");
+            .expect("first run must have pushed an attempt record ");
 
         let already_marked = stores.is_idempotency_marked(execution_id, n.clone(), attempt);
         assert!(
@@ -7500,7 +7498,7 @@ mod tests {
     /// Additionally, it must attach an `integrity_violation` payload naming
     /// the non-terminal nodes, so the caller can emit
     /// `ExecutionEvent::FrontierIntegrityViolation` rather than silently
-    /// reporting success (PRODUCT_CANON §11.1).
+    /// reporting success (PRODUCT_CANON ).
     #[test]
     fn final_status_guard_returns_failed_for_non_terminal_nodes() {
         let exec_id = ExecutionId::new();
@@ -7564,7 +7562,7 @@ mod tests {
     ///
     /// Acts as a lightweight property-style check — enumerates the cartesian
     /// product of the three input axes for a two-node workflow and asserts
-    /// the canon §11.1 rule across every combination.
+    /// the frontier integrity (CAS on version) rule across every combination.
     #[test]
     fn final_status_never_completed_with_non_terminal_nodes() {
         use NodeState::*;
@@ -7958,7 +7956,7 @@ mod tests {
         ));
     }
 
-    // -- Credential allowlist enforcement (PRODUCT_CANON §4.5 / §12.5 — audit §2.4) --
+    // -- Credential allowlist enforcement (PRODUCT_CANON / — audit ) --
 
     /// Handler that attempts to acquire a credential by id and records the result.
     ///
@@ -8333,7 +8331,7 @@ mod tests {
     /// with a tight concurrency / retry / timeout budget would resume
     /// with the default 10-way concurrency and unbounded retries,
     /// changing behavior vs operator expectations. See
-    /// `PRODUCT_CANON.md §4.5` (public surface honored end-to-end).
+    /// `PRODUCT_CANON.md ` (public surface honored end-to-end).
     #[tokio::test]
     async fn resume_restores_persisted_budget() {
         use std::time::Duration;
@@ -9329,7 +9327,7 @@ mod tests {
         );
     }
 
-    /// Registry race regression (ADR-0016 / #482 Copilot review).
+    /// Registry race regression.
     ///
     /// Two `resume_execution` calls overlap on the **same engine** for the
     /// **same execution_id**. The winner acquires the lease and publishes

--- a/crates/engine/src/error.rs
+++ b/crates/engine/src/error.rs
@@ -97,7 +97,7 @@ pub enum EngineError {
     /// The frontier loop exited while one or more nodes were still in a
     /// non-terminal state (e.g. `Pending` / `Ready` / `Running`).
     ///
-    /// Per `docs/PRODUCT_CANON.md` §11.1, the engine must be the single source
+    /// Per `docs/PRODUCT_CANON.md` , the engine must be the single source
     /// of truth for execution status and must not silently report `Completed`
     /// on inconsistent state. This variant is produced when the frontier
     /// drains without `failed_node` or cancellation, yet `all_nodes_terminal`
@@ -118,8 +118,7 @@ pub enum EngineError {
     /// The engine could not persist a node-level checkpoint.
     ///
     /// Surfaced so that `run_frontier` aborts the node's progression instead
-    /// of continuing on undurable state: per `docs/PRODUCT_CANON.md` §11.5
-    /// (durability precedes visibility) and §12.4 (no silent log-and-continue
+    /// of continuing on undurable state: per `docs/PRODUCT_CANON.md` /// (durability precedes visibility) and (no silent log-and-continue
     /// on state-transition failures), an unpersisted transition must never
     /// leak to observers or the frontier.
     #[error("checkpoint persist failed for node {node_key}: {reason}")]
@@ -135,7 +134,7 @@ pub enum EngineError {
     /// in-memory state cannot reconcile.
     ///
     /// Surfaced instead of silently overwriting the concurrent update
-    /// (issue #333). Per `docs/PRODUCT_CANON.md` §11.5 / §12.4, the engine
+    /// (issue #333). Per `docs/PRODUCT_CANON.md` / , the engine
     /// may not report a successful completion when its final CAS write
     /// collided with an authoritative external transition that the
     /// engine could not honor (e.g. the row is still active-non-terminal
@@ -163,7 +162,7 @@ pub enum EngineError {
     /// [`WorkflowEngine::resume_execution`] when `acquire_lease` fails
     /// because a live (non-expired) lease with a different holder is
     /// already recorded in storage. Per ADR 0008 and
-    /// `docs/PRODUCT_CANON.md` §12.2, exactly one runner may dispatch
+    /// `docs/PRODUCT_CANON.md` , exactly one runner may dispatch
     /// nodes for an execution at a time; the second caller must back off
     /// rather than run in parallel.
     ///

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -48,7 +48,7 @@ pub enum ExecutionEvent {
     },
 
     /// A node attempt failed but the engine scheduled a retry per
-    /// ADR-0042 (Layer 2 — engine-level retry). The node has
+    /// (Layer 2 — engine-level retry). The node has
     /// transitioned to `WaitingRetry` and will be re-dispatched at
     /// `next_attempt_at`.
     ///
@@ -81,7 +81,7 @@ pub enum ExecutionEvent {
     /// The frontier loop exited while one or more nodes were still in a
     /// non-terminal state.
     ///
-    /// Per `docs/PRODUCT_CANON.md` §11.1, the engine must not silently report
+    /// Per `docs/PRODUCT_CANON.md` , the engine must not silently report
     /// `Completed` on inconsistent state. This event is emitted just before
     /// [`ExecutionEvent::ExecutionFinished`] so operators observing the event
     /// stream see the integrity violation rather than only a successful-looking
@@ -103,7 +103,7 @@ pub enum ExecutionEvent {
         /// Total elapsed time.
         elapsed: Duration,
         /// Engine's attribution for *why* the execution reached its
-        /// final status (canon §4.5; ROADMAP §M0.3).
+        /// final status (operational honesty).
         ///
         /// `Some(_)` means the engine attributed a concrete
         /// termination reason. `None` is **also intentional**: it

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -5,33 +5,31 @@
 //!
 //! Workflow execution orchestrator. Builds an `ExecutionPlan` from a workflow
 //! DAG, resolves node inputs from predecessor outputs, transitions execution
-//! state through `ExecutionRepo` (CAS on `version` — canon §11.1), and
+//! state through `ExecutionRepo` (CAS on `version`), and
 //! delegates action dispatch to `nebula-engine`.
 //!
-//! Canon §12.2 names this crate as the location of the `execution_control_queue`
-//! consumer (`ControlConsumer`, see [`control_consumer`]). Status per §11.6:
+//! Canon names this crate as the location of the `execution_control_queue`
+//! consumer (`ControlConsumer`, see [`control_consumer`]). Implementation status:
 //!
 //! - **implemented** — consumer skeleton: construction, polling loop with graceful shutdown,
 //!   `claim_pending` / `mark_completed` / `mark_failed` plumbing, command observation with typed
 //!   `ExecutionId` decoding.
 //! - **implemented** — `Start` / `Resume` / `Restart` dispatch into the engine start / resume path
-//!   (ADR-0008 follow-up A2; closes #332 / #327). The engine-owned implementation lives in
+//!   (closes #332 / #327). The engine-owned implementation lives in
 //!   [`control_dispatch::EngineControlDispatch`].
-//! - **implemented** — `Cancel` / `Terminate` dispatch into the engine cancel path (ADR-0008
-//!   follow-up A3; closes #330). `Cancel` signals the live frontier loop via
-//!   [`WorkflowEngine::cancel_execution`]; `Terminate` shares the cooperative-cancel body until a
-//!   distinct forced-shutdown path is wired (see ADR-0016).
+//! - **implemented** — `Cancel` / `Terminate` dispatch into the engine cancel path (closes #330).
+//!   `Cancel` signals the live frontier loop via [`WorkflowEngine::cancel_execution`]; `Terminate`
+//!   shares the cooperative-cancel body until a distinct forced-shutdown path is wired.
 //! - **implemented** — M3.5: [`control_consumer::ControlConsumer`] restores W3C trace parents from
 //!   queue rows onto the per-dispatch span (`control_trace` + `tracing_opentelemetry`).
 //!
-//! Wiring and atomicity decisions live in `docs/adr/0008-execution-control-queue-consumer.md`
-//! and `docs/adr/0016-engine-cancel-registry.md`.
+//! See `crates/engine/README.md` for control-queue wiring and cancel-registry behavior.
 //!
 //! ## Key types
 //!
 //! - `WorkflowEngine` — entry point; level-by-level DAG execution with bounded concurrency.
-//! - `ControlConsumer` / `ControlDispatch` — durable control-queue consumer (§12.2, ADR-0008).
-//! - `EngineControlDispatch` — canonical engine-side `ControlDispatch` impl (ADR-0008 A2).
+//! - `ControlConsumer` / `ControlDispatch` — durable control-queue consumer.
+//! - `EngineControlDispatch` — canonical engine-side `ControlDispatch` implementation.
 //! - `ExecutionResult` — post-run summary returned to the API layer.
 //! - `EngineError` — typed engine-layer error.
 //! - `ExecutionEvent` — broadcast event type for `nebula-eventbus`.
@@ -54,9 +52,9 @@
 //!
 //! ## Canon
 //!
-//! - §10 golden path (orchestrator schedules activated workflows).
-//! - §11.1 execution authority via `ExecutionRepo`.
-//! - §12.2 durable control plane; engine owns the `execution_control_queue` consumer.
+//! - golden path (orchestrator schedules activated workflows).
+//! - execution authority via `ExecutionRepo`.
+//! - durable control plane; engine owns the `execution_control_queue` consumer.
 //!
 //! See `crates/engine/README.md` for known open debts (budget ephemerality,
 //! edge-gate narrowness).

--- a/crates/engine/src/resource/mod.rs
+++ b/crates/engine/src/resource/mod.rs
@@ -7,8 +7,7 @@
 //! registrable kind must have been explicitly inserted into the
 //! [`ResourceRegistrarRegistry`] ahead of time. An unrecognized kind is
 //! a caller/wiring misconfiguration surfaced as a typed error at
-//! activation time, never a silent no-op (INTEGRATION_MODEL §114-120;
-//! ADR-0030 / ADR-0036 / ADR-0044).
+//! activation time, never a silent no-op.
 
 pub mod registrar;
 

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -14,9 +14,8 @@
 //! inserted. An unknown kind is a caller/wiring misconfiguration caught
 //! at activation and surfaced as a typed, matchable error
 //! ([`RegistrarError::UnknownKind`]); it is never a silent grab of the
-//! wrong type nor a panic (INTEGRATION_MODEL §114-120 — misconfiguration
-//! caught at activation; ADR-0030 typed-error discipline; ADR-0036
-//! isolation; ADR-0044 slot model).
+//! wrong type nor a panic ( — misconfiguration
+//! caught at activation; typed-error discipline;//! isolation; slot model).
 //!
 //! # Erasure mechanism
 //!
@@ -180,14 +179,14 @@ pub struct RegisterRequest<'a> {
     /// Engine-held expression engine used to resolve `{{ … }}` templates
     /// in `config_json`.
     pub expr_engine: &'a nebula_expression::ExpressionEngine,
-    /// Slot-name → resolved-credential-key bindings (per ADR-0044). The
+    /// Slot-name → resolved-credential-key bindings (per ). The
     /// engine resolves credentials and is expected to have folded them
     /// into the resource value the registrar produces; this map is
     /// asserted against the resource's declared slots inside the typed
     /// call.
     pub slot_bindings: HashMap<String, nebula_core::CredentialKey>,
     /// Slot-name → resolved `CredentialId` for the rotation fan-out
-    /// reverse index (ADR-0067 §D1).
+    /// reverse index.
     ///
     /// `slot_bindings` carries the `CredentialKey` (the credential
     /// *name*, what `Manager::register_from_value` hashes into the
@@ -266,7 +265,7 @@ pub trait ErasedResourceRegistrar: Send + Sync {
     /// and does **no** `{{ … }}` template resolution. This is the seam a
     /// config-CRUD writer uses to reject a bad resource config *before*
     /// persistence — config validation is strictly separate from
-    /// engine-activation live registration (INTEGRATION_MODEL §13.1).
+    /// engine-activation live registration (.1).
     ///
     /// Synchronous: validation is pure (schema + serde, no I/O), so unlike
     /// [`register`](Self::register) it needs no boxed future.
@@ -313,7 +312,7 @@ where
     /// Builds a typed registrar for resource type `R`.
     ///
     /// `resource_factory` yields the `R` value (with credential slots
-    /// already resolved by the engine per ADR-0044);
+    /// already resolved by the engine per );
     /// `topology_factory` yields the `TopologyRuntime<R>` declared for
     /// this kind. Both are invoked once per registration call.
     pub fn new(resource_factory: FRes, topology_factory: FTopo) -> Self {
@@ -379,7 +378,7 @@ where
 /// [`insert`](Self::insert)ed. [`register`](Self::register) on an unknown
 /// kind returns [`RegistrarError::UnknownKind`] — a typed, matchable
 /// activation error, never a panic or a silent grab of the wrong type
-/// (INTEGRATION_MODEL §114-120).
+///.
 #[derive(Default)]
 pub struct ResourceRegistrarRegistry {
     registrars: HashMap<String, Arc<dyn ErasedResourceRegistrar>>,
@@ -435,8 +434,7 @@ impl ResourceRegistrarRegistry {
     /// # Errors
     ///
     /// - [`RegistrarError::UnknownKind`] if `kind` is not in the
-    ///   allowlist. This is a caller/wiring fault caught at activation
-    ///   (INTEGRATION_MODEL §114-120) — non-retryable, classified as a
+    ///   allowlist. This is a caller/wiring fault caught at activation — non-retryable, classified as a
     ///   client conflict. The lookup happens **before** any typed call,
     ///   so an unknown kind can never touch a resource type.
     /// - [`RegistrarError::Register`] if the typed
@@ -464,7 +462,7 @@ impl ResourceRegistrarRegistry {
 
     /// Resolves `kind` through the closed allowlist, dispatches into its
     /// typed registrar, and — on success — records the resolved row in
-    /// the rotation fan-out reverse index (ADR-0067 §D1).
+    /// the rotation fan-out reverse index.
     ///
     /// This is the §M11.5 `bind` seam: the registered row resolved one
     /// or more `#[credential]` slots, so a later rotation / lease-revoke
@@ -508,7 +506,7 @@ impl ResourceRegistrarRegistry {
     /// is a documented contract, not an enforced invariant, because the
     /// seam has **no production caller today**: *bind-population* (the
     /// production credential→slot resolution that would call this) is the
-    /// deferred resource-activation path (ADR-0067 §Deferred — *bind-
+    /// deferred resource-activation path ( — *bind-
     /// population producer*). The driver cannot observe a row that
     /// nothing activated, so the window is not reachable in production
     /// until that deferred producer lands; when it does, it must honour
@@ -607,12 +605,11 @@ impl ResourceRegistrarRegistry {
     /// [`Manager::validate_config_value`]), but mutates **no** `Manager`,
     /// builds **no** runtime, and resolves **no** `{{ … }}` templates —
     /// live registration stays an engine-activation concern
-    /// (INTEGRATION_MODEL §13.1), distinct from config validation.
+    /// (.1), distinct from config validation.
     ///
     /// The closed-allowlist lookup is identical to `register`'s: an unknown
     /// `kind` is rejected *before* any typed call, so it can never touch a
-    /// resource type (closed dependency graph — INTEGRATION_MODEL §114-120;
-    /// the type-confusion abuse).
+    /// resource type (closed dependency graph —    /// the type-confusion abuse).
     ///
     /// # Errors
     ///

--- a/crates/engine/src/resource_status.rs
+++ b/crates/engine/src/resource_status.rs
@@ -9,7 +9,7 @@
 //! is the action-capability seam (acquire), this is the diagnostics seam
 //! (observe).
 //!
-//! # No lifecycle mutation (INTEGRATION_MODEL §13.1)
+//! # No lifecycle mutation (.1)
 //!
 //! The trait deliberately exposes **only** a phase read. There is no
 //! acquire / release / drain / reload entry point: resource lifecycle is
@@ -29,7 +29,7 @@
 //! runtime to another. The erased phase is mapped to a stable, non-secret
 //! string at the engine boundary so the api-safe struct carries no
 //! `nebula-resource` type and no configuration/credential material
-//! (ADR-0028 §7).
+//!
 
 use std::{fmt, sync::Arc};
 
@@ -38,7 +38,7 @@ use nebula_core::{ResourceKey, ScopeLevel};
 /// Stable, non-secret runtime-status projection of one live resource.
 ///
 /// Carries lifecycle phase only — never configuration, credential, or any
-/// other resource-supplied material (ADR-0028 §7). The `phase` string is a
+/// other resource-supplied material . The `phase` string is a
 /// closed, stable vocabulary; consumers match on it rather than
 /// re-deriving from internals.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/engine/src/result.rs
+++ b/crates/engine/src/result.rs
@@ -19,7 +19,7 @@ pub struct ExecutionResult {
     /// Wall-clock duration of the execution.
     pub duration: Duration,
     /// Engine's attribution for *why* the execution reached its
-    /// final status (canon §4.5; ROADMAP §M0.3). Threaded from
+    /// final status (operational honesty). Threaded from
     /// `determine_final_status` `FinalStatusDecision::termination_reason`
     /// so downstream consumers (audit, API responses, webhook
     /// dispatch) can distinguish ExplicitFail from a system-driven

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -53,7 +53,7 @@ pub enum RuntimeError {
     /// infinite loop into an explicit fatal so retry / error routing can
     /// handle it like any other terminal failure.
     ///
-    /// Spec 28 §9.0: engine-managed stuck-state detection is part of the
+    /// Spec 28 : engine-managed stuck-state detection is part of the
     /// stateful contract, not a generic `ActionError::Fatal`.
     #[classify(
         category = "internal",

--- a/crates/engine/src/runtime/mod.rs
+++ b/crates/engine/src/runtime/mod.rs
@@ -11,7 +11,7 @@
 //! - [`ActionRegistry`] — registers and looks up action handlers by key.
 //! - [`DataPassingPolicy`], [`LargeDataStrategy`] — output size enforcement.
 //! - [`MemoryQueue`], [`TaskQueue`] — in-memory task queueing (not durable; durable control signals
-//!   live in `execution_control_queue` — §12.2).
+//!   live in `execution_control_queue`).
 //! - [`BlobRef`], [`BlobStorage`] — side-channel for large payloads.
 //! - [`StatefulCheckpoint`], [`StatefulCheckpointSink`] — checkpoint boundaries for
 //!   `StatefulAction` types.
@@ -20,9 +20,9 @@
 //!
 //! ## Canon
 //!
-//! - §3.5 action dispatch by trait.
-//! - §11.2 retry surface: dispatch only; engine-level re-execution is `planned`.
-//! - §12.6 isolation honesty: isolation is by sandbox delegation.
+//! - action dispatch by trait.
+//! - retry surface: dispatch only; engine-level re-execution is `planned`.
+//! - isolation honesty: isolation is by sandbox delegation.
 
 pub mod blob;
 pub mod data_policy;

--- a/crates/engine/src/runtime/out_of_process.rs
+++ b/crates/engine/src/runtime/out_of_process.rs
@@ -12,12 +12,12 @@
 //! registers the plugins in the supplied [`PluginRegistry`], and registers
 //! a [`PooledRemoteActionFactory`] per discovered action into the
 //! [`ActionRegistry`]. Dispatch of those actions then flows through an
-//! engine-owned [`PluginPool`] keyed by `(binary, ScopeHash)` (ADR-0025
-//! §2): the credential scope is derived **engine-side** from the workflow
+//! engine-owned [`PluginPool`] keyed by `(binary, ScopeHash)` (
+//! ): the credential scope is derived **engine-side** from the workflow
 //! node's slot bindings at dispatch — never on the leaf, never from
 //! `ActionMetadata`.
 //!
-//! There is no broker yet: until the ADR-0025 broker lands there is no
+//! There is no broker yet: until the broker lands there is no
 //! egress or credential mediation for these processes. [`discover_into_registry`]
 //! emits a single `tracing::warn!` invariant at startup stating exactly
 //! that, so an operator who opens the gate sees the honest security
@@ -35,12 +35,11 @@
 //! so an unused one never forks a child (no leak — just an idle handle).
 //! Callers and tests MUST resolve these actions via `action_registry`;
 //! resolving them through `plugin_registry` directly would dispatch on
-//! the unpooled per-plugin handler and bypass the ADR-0025 §2
-//! credential-scope pool keying entirely.
+//! the unpooled per-plugin handler and bypass the//! credential-scope pool keying entirely.
 //!
 //! The `runtime.rs` `IsolationLevel` match is deliberately untouched:
 //! discovered actions register as ordinary stateless factories, so the
-//! live in-process path and the §13 knife are byte-for-byte unaffected
+//! live in-process path and the knife are byte-for-byte unaffected
 //! when the gate is closed.
 
 use std::{path::PathBuf, sync::Arc, time::Duration};
@@ -93,7 +92,7 @@ impl Default for OutOfProcessConfig {
 /// through an engine-owned [`PluginPool`].
 ///
 /// One factory per discovered action. The credential-scope identity
-/// (ADR-0025 §2) is computed in [`instantiate`](ActionFactory::instantiate)
+/// is computed in [`instantiate`](ActionFactory::instantiate)
 /// from the **workflow node**'s slot bindings via
 /// [`pool_key`] — the node is in scope there, the leaf
 /// `nebula-sandbox` never sees it, and `ActionMetadata` is never the
@@ -148,7 +147,7 @@ impl ActionFactory for PooledRemoteActionFactory {
         _ctx: &'a dyn ActionContext,
     ) -> std::pin::Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>>
     {
-        // ADR-0025 §2: the per-process isolation key is derived here, from
+        // : the per-process isolation key is derived here, from
         // the workflow node's credential-slot bindings, engine-side. The
         // leaf transport never sees the node. The supervisor resolves the
         // per-key pool at acquire time.
@@ -179,7 +178,7 @@ struct PooledErasedStateless {
     local_key: String,
     binary: PathBuf,
     timeout: Duration,
-    /// ADR-0025 §2 pool key derived from the node at `instantiate`.
+    /// pool key derived from the node at `instantiate`.
     key: PoolKey,
     supervisor: PluginSupervisor,
 }
@@ -297,7 +296,7 @@ pub async fn discover_into_registry(
         target = "engine::out_of_process",
         dirs = ?config.plugin_dirs,
         "out-of-process plugins enabled; no broker egress/credential mediation \
-         until the ADR-0025 broker lands — untrusted plugins have unmediated \
+    until the broker lands — untrusted plugins have unmediated \
          network/credential access"
     );
 

--- a/crates/engine/src/runtime/plugin_pool.rs
+++ b/crates/engine/src/runtime/plugin_pool.rs
@@ -86,14 +86,14 @@ impl PooledConn for ProcessSandbox {
 /// Identity that buckets connections into independent pools.
 ///
 /// Two invocations with the same binary but a different bound
-/// credential-slot set ([`ScopeHash`]) MUST NOT share a process (ADR-0025
-/// §2 isolation), hence the scope is part of the key, not just the binary
+/// credential-slot set ([`ScopeHash`]) MUST NOT share a process (
+/// isolation), hence the scope is part of the key, not just the binary
 /// path.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct PoolKey {
     /// Plugin binary path.
     binary: PathBuf,
-    /// Credential-scope identity (ADR-0025 §2 per-process isolation key).
+    /// Credential-scope identity.
     scope: ScopeHash,
 }
 
@@ -108,7 +108,7 @@ impl PoolKey {
 /// Derive the [`PoolKey`] for dispatching `node`'s action to the plugin
 /// `binary`.
 ///
-/// The credential-scope identity (ADR-0025 §2) is computed from the
+/// The credential-scope identity is computed from the
 /// **credential** slot bindings declared on the workflow node:
 /// [`SlotBinding::CredentialId`] entries in
 /// [`NodeDefinition::slot_bindings`]. Resource bindings are excluded —
@@ -456,7 +456,7 @@ impl<T: PooledConn> PoolRegistry<T> {
     ///
     /// Distinct keys map to distinct `Arc<PluginPool<T>>` values, so a
     /// different binary OR a different [`ScopeHash`] yields an independent
-    /// pool with its own capacity — the ADR-0025 §2 isolation boundary.
+    /// pool with its own capacity — the isolation boundary.
     pub(crate) fn pool_for(&self, key: &PoolKey) -> Arc<PluginPool<T>> {
         if let Some(existing) = self.pools.get(key) {
             return Arc::clone(existing.value());
@@ -969,7 +969,7 @@ mod tests {
 
     // ---- pool_key: PoolKey derived from NodeDefinition bindings ------
     //
-    // ADR-0025 §2: a distinct bound credential-slot set ⇒ a distinct
+    // : a distinct bound credential-slot set ⇒ a distinct
     // process key. `pool_key` reads `NodeDefinition.slot_bindings`
     // (read-only over the existing workflow API) and the leaf
     // `nebula-sandbox` never sees the node.

--- a/crates/engine/src/runtime/plugin_supervisor.rs
+++ b/crates/engine/src/runtime/plugin_supervisor.rs
@@ -69,7 +69,7 @@ impl PluginSupervisor {
     ///
     /// Delegates to the per-key [`PluginPool`](crate::runtime::plugin_pool)
     /// — distinct keys have fully independent capacity and idle sets
-    /// (ADR-0025 §2 isolation). The returned [`Lease`] owns its capacity
+    /// . The returned [`Lease`] owns its capacity
     /// permit; dropping it releases the permit exactly once and either
     /// re-pools or (if poisoned) destroys the connection.
     ///
@@ -77,7 +77,7 @@ impl PluginSupervisor {
     /// `E` and never leaks a permit or wedges the key's pool.
     ///
     /// `pub(crate)`: `PoolKey` / `Lease` are engine-owned internals
-    /// (ADR-0025 §9.2 — the pool is engine-owned, the keyed type does not
+    /// ( — the pool is engine-owned, the keyed type does not
     /// leave the crate). Only the gated dispatch path calls this; the
     /// composition root holds the supervisor solely for
     /// [`shutdown`](Self::shutdown).

--- a/crates/engine/src/runtime/queue.rs
+++ b/crates/engine/src/runtime/queue.rs
@@ -50,7 +50,7 @@ impl QueueError {
 ///
 /// Methods are desugared from `async fn` to `fn -> impl Future + Send` to
 /// avoid a `Pin<Box<dyn Future>>` wrapper and preserve `Send` on the returned
-/// futures (ADR-0014 direction; Phase 2 AFIT). Callers that use
+/// futures . Callers that use
 /// `tokio::spawn` may still need an owning `async move { ... }` wrapper and
 /// owned/cloned inputs to satisfy the spawned future's `'static` requirement.
 pub trait TaskQueue: Send + Sync {

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -41,7 +41,7 @@ struct ActionEntry {
 /// A single factory entry in the parallel factory map (Phase 3 / Session 4).
 ///
 /// Stored alongside the legacy `ActionEntry` so the engine can transition
-/// dispatch to factory-based instantiation incrementally per ADR-0043 §6.
+/// dispatch to factory-based instantiation incrementally.
 #[derive(Clone)]
 struct FactoryEntry {
     metadata: ActionMetadata,
@@ -53,11 +53,11 @@ struct FactoryEntry {
 pub struct ActionRegistry {
     /// Map from action key to list of entries, each at a distinct version.
     actions: DashMap<ActionKey, Vec<ActionEntry>>,
-    /// Parallel factory map per ADR-0043 §6 / Phase 3 Session 4. Engine
+    /// Parallel factory map per / Phase 3 Session 4. Engine
     /// dispatch consults this first and falls back to `actions` when no
     /// factory has been registered for the key.
     factories: DashMap<ActionKey, Vec<FactoryEntry>>,
-    /// Provider-typed webhook factory map (M3.3 / ADR-0049). Sibling
+    /// Provider-typed webhook factory map (M3.3). Sibling
     /// to `factories` because provider kinds are coarser than
     /// `ActionKey` and arrive as runtime strings from operator-supplied
     /// storage rows. Use [`Self::register_webhook_provider`] /
@@ -240,7 +240,7 @@ impl ActionRegistry {
         self.register(metadata, handler);
     }
 
-    /// Register an action factory (Phase 3 / Session 4 — ADR-0043 §6).
+    /// Register an action factory (Phase 3 / Session 4 — ).
     ///
     /// The factory is consulted at dispatch time to instantiate a fresh
     /// erased action per execution. This is the new path for actions that
@@ -263,7 +263,7 @@ impl ActionRegistry {
         }
     }
 
-    /// Register a provider-typed webhook factory (M3.3 / ADR-0049).
+    /// Register a provider-typed webhook factory (M3.3).
     ///
     /// String-keyed (factory.kind()) because provider names come from
     /// operator-supplied storage rows, not Rust types. Subsequent

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -961,7 +961,7 @@ impl ActionRuntime {
                 return Err(ActionError::Cancelled.into());
             }
 
-            // Spec 28 §9.0 stuck-state guard. Serialize state before the
+            // Spec 28 stuck-state guard. Serialize state before the
             // iteration so we can detect infinite loops: if `Continue`
             // returns with byte-identical state, the handler did not move
             // the cursor — converting silent hangs into an explicit Fatal.
@@ -993,7 +993,7 @@ impl ActionRuntime {
 
             match result {
                 ActionResult::Continue { delay, .. } => {
-                    // Stuck-state detection (spec 28 §9.0): a `Continue` that
+                    // Stuck-state detection (spec 28 ): a `Continue` that
                     // did not mutate the checkpoint is an infinite loop.
                     // Happens in practice when an author forgets to advance
                     // a cursor / page number. Surfacing a typed
@@ -2724,7 +2724,7 @@ mod tests {
     }
 
     /// A stateful handler that returns `Continue` without ever mutating its
-    /// state — used to pin the spec 28 §9.0 stuck-state guard.
+    /// state — used to pin the spec 28 stuck-state guard.
     struct NoProgressHandler {
         meta: ActionMetadata,
     }
@@ -2751,7 +2751,7 @@ mod tests {
         }
     }
 
-    /// Spec 28 §9.0: a stateful handler that Continues without mutating its
+    /// Spec 28 : a stateful handler that Continues without mutating its
     /// state must surface as a typed `RuntimeError::StatefulStuck`, NOT as
     /// an opaque `ActionError::Fatal`. Retry/error routing depends on the
     /// typed classification.

--- a/crates/engine/src/runtime/sandbox_runner.rs
+++ b/crates/engine/src/runtime/sandbox_runner.rs
@@ -63,7 +63,7 @@ impl SandboxedContext {
 /// - `ProcessSandbox` — child-process dispatch over a JSON
 ///   envelope with Linux OS-level hardening (community plugins)
 ///
-/// WASM is an explicit non-goal — see `docs/PRODUCT_CANON.md` §12.6.
+/// WASM is an explicit non-goal — see `docs/PRODUCT_CANON.md`.
 #[async_trait]
 pub trait SandboxRunner: Send + Sync {
     /// Execute an action within the sandbox.

--- a/crates/engine/src/store_seam.rs
+++ b/crates/engine/src/store_seam.rs
@@ -106,7 +106,7 @@ pub struct ExecutionStores {
     pub execution: Arc<dyn ExecutionStore>,
     /// Append-only journal read side (appends go through the batch).
     pub journal: Arc<dyn ExecutionJournalReader>,
-    /// Per-node output + typed result persistence (ADR-0009 resume seam).
+    /// Per-node output + typed result persistence.
     pub node_results: Arc<dyn NodeResultStore>,
     /// Best-effort stateful-action checkpoint persistence.
     pub checkpoints: Arc<dyn CheckpointStore>,

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -1,4 +1,4 @@
-//! A1 wiring tests for `ControlConsumer` (canon §12.2, ADR-0008).
+//! A1 wiring tests for `ControlConsumer` (control-queue wiring, ).
 //!
 //! These tests assert the skeleton exists and functions as a durable-outbox
 //! consumer:
@@ -203,7 +203,7 @@ impl ControlDispatch for FlakyDispatch {
 /// Load-bearing compile check: the consumer is constructible using only
 /// engine-public + nebula-core + nebula-storage-port types.
 ///
-/// This proves ADR-0008 decision 2 (no `nebula-api` / `nebula-storage`-row
+/// This proves decision 2 (no `nebula-api` / `nebula-storage`-row
 /// types leak onto the consumer's public surface) — the `nebula-engine`
 /// crate does not depend on `nebula-api`, so any such leak would have
 /// failed to compile; this test makes the proof explicit.
@@ -375,7 +375,7 @@ async fn consumer_marks_row_failed_on_malformed_execution_id() {
 /// through a reclaim sweep, then spin up a fresh consumer and verify it
 /// picks up the redelivered row and drives it to `Completed`.
 ///
-/// This is the B1 acceptance test — ADR-0008 §5 liveness guarantee.
+/// This is the B1 acceptance test — liveness guarantee.
 #[tokio::test]
 async fn reclaim_sweep_recovers_orphaned_processing_row_end_to_end() {
     let (_store, queue) = port_queue();
@@ -494,7 +494,7 @@ async fn reclaim_sweep_recovers_orphaned_processing_row_end_to_end() {
     );
 }
 
-/// ADR-0017 Seam: every reclaim sweep must increment
+/// : every reclaim sweep must increment
 /// `nebula_engine_control_reclaim_total{outcome}` by the per-row count, so a
 /// non-zero `exhausted` is alertable and a steady `reclaimed` flags
 /// crashed-runner load. Pre-seeds two stale-but-budgeted rows + one stale

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -1,11 +1,11 @@
-//! Unit tests for `EngineControlDispatch` (ADR-0008 A2 / A3).
+//! Unit tests for `EngineControlDispatch`.
 //!
 //! These tests mirror the API → consumer → engine seam without running the
 //! full `ControlConsumer` polling loop: they invoke `dispatch_start` /
 //! `dispatch_resume` / `dispatch_restart` / `dispatch_cancel` /
 //! `dispatch_terminate` directly against an engine wired to in-memory repos,
 //! and assert both the happy-path transitions (Created → Completed,
-//! Running → Cancelled) and the ADR-0008 §5 idempotency contract
+//! Running → Cancelled) and the idempotency contract
 //! (re-delivery does not re-run or double-signal).
 
 use std::{
@@ -356,7 +356,7 @@ impl Harness {
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 /// Happy path: dispatch_start on a fresh `Created` execution row drives the
-/// engine to completion. This is the A2 §13-step-3 invariant — a POST to
+/// engine to completion. This is the A2 -step-3 invariant — a POST to
 /// `/executions` ends with the workflow actually running, not stranded at
 /// `Created`.
 #[tokio::test]
@@ -387,7 +387,7 @@ async fn dispatch_start_drives_created_execution_to_completion() {
     );
 }
 
-/// ADR-0008 §5 idempotency: a re-delivered `Start` for an execution the
+/// idempotency: a re-delivered `Start` for an execution the
 /// engine already completed is a no-op — no second run of the workflow.
 /// This is the load-bearing guard against at-least-once redelivery
 /// double-running the work.
@@ -417,7 +417,7 @@ async fn dispatch_start_is_idempotent_on_redelivery() {
     assert_eq!(
         harness.action_count.load(Ordering::SeqCst),
         1,
-        "re-delivered Start must NOT run the workflow again (ADR-0008 §5)"
+        "re-delivered Start must NOT run the workflow again "
     );
 }
 
@@ -447,7 +447,7 @@ async fn dispatch_resume_drives_created_execution_to_completion() {
 }
 
 /// Redelivered `Resume` on an already-completed execution is a no-op per
-/// ADR-0008 §5 — symmetric with the `Start` idempotency guard.
+/// — symmetric with the `Start` idempotency guard.
 #[tokio::test]
 async fn dispatch_resume_is_idempotent_on_completed_execution() {
     let harness = Harness::new().await;
@@ -531,7 +531,7 @@ async fn dispatch_restart_rejects_terminal_execution() {
     match err {
         ControlDispatchError::Rejected(msg) => {
             assert!(
-                msg.contains("durable output purge") || msg.contains("ADR-0008 follow-up"),
+                msg.contains("durable output purge") || msg.contains(" follow-up"),
                 "reject message must name the A2 gap, got: {msg}"
             );
         },
@@ -575,7 +575,7 @@ async fn dispatch_start_rejects_nonexistent_execution() {
 /// Happy path: a `Cancel` delivered while the frontier loop is inside a
 /// live node aborts the execution cooperatively. The spawned run returns,
 /// the node surfaces its typed `ActionError::Cancelled`, and the execution
-/// row lands on a terminal state. This is the §13-step-5 invariant that A3
+/// row lands on a terminal state. This is the -step-5 invariant that A3
 /// closes — the durable `Cancel` signal actually reaches the engine.
 #[tokio::test]
 async fn dispatch_cancel_aborts_running_execution() {
@@ -596,7 +596,7 @@ async fn dispatch_cancel_aborts_running_execution() {
         .await
         .expect("slow handler started within 5s");
 
-    // Deliver the Cancel. ADR-0008 A3: signal reaches the live token, the
+    // Deliver the Cancel. A3: signal reaches the live token, the
     // handler exits via `ActionError::Cancelled`, frontier loop tears down.
     harness
         .dispatch
@@ -635,11 +635,11 @@ async fn dispatch_cancel_aborts_running_execution() {
     );
 }
 
-/// ADR-0008 §5 idempotency on terminal: a `Cancel` re-delivered for an
+/// idempotency on terminal: a `Cancel` re-delivered for an
 /// already-terminal execution must be `Ok(())` without disturbing state or
 /// triggering a second dispatch of the workflow.
 ///
-/// The A3 contract (ADR-0016) makes this property hold through **two
+/// The A3 contract makes this property hold through **two
 /// layers**, not a status short-circuit:
 ///
 ///   1. `dispatch_cancel` signals the engine on every non-orphan delivery, including terminal.
@@ -760,7 +760,7 @@ async fn dispatch_cancel_rejects_nonexistent_execution() {
 }
 
 /// `Terminate` is a synonym for `Cancel` until a forced-shutdown path is
-/// wired (see ADR-0016 and the module doc). Same idempotency / orphan /
+/// wired ( and the module doc). Same idempotency / orphan /
 /// cross-runner contracts apply — this smoke test just asserts the
 /// delegation is wired, not a separate code path.
 #[tokio::test]

--- a/crates/engine/tests/credential_executor_tests.rs
+++ b/crates/engine/tests/credential_executor_tests.rs
@@ -35,7 +35,7 @@ async fn execute_resolve_static_credential_returns_complete() {
 
 #[tokio::test]
 async fn execute_continue_returns_pending_store_error_for_missing_token() {
-    // Per Tech Spec §15.4 `execute_continue` is bound on `Interactive`
+    // Per Tech Spec `execute_continue` is bound on `Interactive`
     // — non-interactive credentials (`ApiKeyCredential`) cannot reach
     // this dispatch path at compile time (Probe 4 cements the
     // `E0277`). This test exercises the runtime "missing token" path
@@ -79,7 +79,7 @@ impl nebula_credential::CredentialState for DummyState {
 }
 
 /// Credential whose base `resolve` returns `Pending(())` — exactly the
-/// shape Tech Spec §15.4 forbids the engine executor from honouring.
+/// shape Tech Spec forbids the engine executor from honouring.
 struct BaseResolvePendingCredential;
 
 impl Credential for BaseResolvePendingCredential {
@@ -107,7 +107,7 @@ impl Credential for BaseResolvePendingCredential {
         _values: &FieldValues,
         _ctx: &CredentialContext,
     ) -> Result<ResolveResult<DummyState, ()>, CredentialError> {
-        // Deliberately return Pending(()) — Tech Spec §15.4 says this
+        // Deliberately return Pending() — Tech Spec says this
         // shape MUST be rejected by `execute_resolve`. The base trait
         // cannot carry typed pending state; interactive flows go
         // through credential-specific kickoff helpers.
@@ -125,7 +125,7 @@ impl Credential for BaseResolvePendingCredential {
 
 #[tokio::test]
 async fn execute_resolve_rejects_base_resolve_pending() {
-    // Per Tech Spec §15.4 `execute_resolve` rejects `ResolveResult::Pending`
+    // Per Tech Spec `execute_resolve` rejects `ResolveResult::Pending`
     // from the base `Credential::resolve` because `state: ()` cannot
     // deserialize into the typed `Interactive::Pending` later in
     // `execute_continue`. The contract is: base resolve returns
@@ -152,7 +152,7 @@ async fn execute_resolve_rejects_base_resolve_pending() {
 
 #[tokio::test]
 async fn execute_continue_rejects_missing_session_id() {
-    // Per Tech Spec §15.4 the executor refuses to fall back to a
+    // Per Tech Spec the executor refuses to fall back to a
     // `"default"` session bucket; callers MUST set session_id
     // explicitly to keep concurrent owners in distinct
     // `(KEY, owner, session)` slots inside `PendingStateStore`.

--- a/crates/engine/tests/credential_lease_lifecycle.rs
+++ b/crates/engine/tests/credential_lease_lifecycle.rs
@@ -1,4 +1,4 @@
-//! End-to-end exercise of the engine-side lease lifecycle (ADR-0051 Phase D).
+//! End-to-end exercise of the engine-side lease lifecycle.
 //!
 //! Demonstrates the canonical wiring pattern:
 //!

--- a/crates/engine/tests/credential_pending_lifecycle_tests.rs
+++ b/crates/engine/tests/credential_pending_lifecycle_tests.rs
@@ -27,7 +27,7 @@ impl zeroize::Zeroize for TestPending {
     }
 }
 
-// Per Tech Spec §15.4 — `PendingState: ZeroizeOnDrop`. Hand-rolled
+// Per Tech Spec — `PendingState: ZeroizeOnDrop`. Hand-rolled
 // because the manual `Zeroize` body above conflicts with a derived
 // `Drop`; this delegates Drop to the existing zeroize logic.
 impl Drop for TestPending {
@@ -56,7 +56,7 @@ impl zeroize::Zeroize for ShortTtl {
     }
 }
 
-// Per Tech Spec §15.4 — `PendingState: ZeroizeOnDrop`. Same hand-roll
+// Per Tech Spec — `PendingState: ZeroizeOnDrop`. Same hand-roll
 // rationale as `TestPending` above.
 impl Drop for ShortTtl {
     fn drop(&mut self) {
@@ -112,7 +112,7 @@ impl Credential for InteractiveTestCredential {
         _values: &FieldValues,
         _ctx: &CredentialContext,
     ) -> Result<ResolveResult<TestInteractiveState, ()>, CredentialError> {
-        // Per Tech Spec §15.4 the base `Credential::resolve` cannot
+        // Per Tech Spec the base `Credential::resolve` cannot
         // carry typed pending state. The interactive entry point goes
         // through credential-specific kickoff helpers + direct
         // PendingStateStore::put — see the test bodies below for the
@@ -145,9 +145,9 @@ impl Interactive for InteractiveTestCredential {
     }
 }
 
-// Per Tech Spec §15.4 — `InteractiveTestCredential` is not `Refreshable`.
+// Per Tech Spec — `InteractiveTestCredential` is not `Refreshable`.
 // The legacy `impl Refreshable { Ok(NotSupported) }` was the exact
-// silent-downgrade vector §15.4 eliminates: a credential declared
+// silent-downgrade vector eliminates: a credential declared
 // "refreshable" but silently never refreshed. Tests below exercise only
 // the `Interactive` path (`execute_continue`), so no refresh impl is
 // needed.
@@ -209,14 +209,14 @@ impl Interactive for RetryAwareCredential {
     }
 }
 
-// Per Tech Spec §15.4 — `RetryAwareCredential` is not `Refreshable`.
+// Per Tech Spec — `RetryAwareCredential` is not `Refreshable`.
 // The legacy `impl Refreshable { Ok(NotSupported) }` was the silent-
-// downgrade anti-pattern §15.4 eliminates. Tests below exercise only
+// downgrade anti-pattern eliminates. Tests below exercise only
 // the `Interactive` path (`execute_continue`).
 
 /// Helper: kickoff an interactive test credential by storing the typed
 /// `TestPending` directly in the pending store and returning the issued
-/// token. Per Tech Spec §15.4 the base `Credential::resolve` cannot
+/// token. Per Tech Spec the base `Credential::resolve` cannot
 /// carry typed pending state — the kickoff happens at the API
 /// orchestration layer (or in tests, here).
 async fn kickoff_test_pending(
@@ -224,7 +224,7 @@ async fn kickoff_test_pending(
     ctx: &CredentialContext,
     credential_key: &str,
 ) -> PendingToken {
-    // Per Tech Spec §15.4 the executor requires explicit session scoping —
+    // Per Tech Spec the executor requires explicit session scoping —
     // tests must provide a session id via `with_session_id` rather than
     // relying on a `"default"` fallback that would collapse concurrent
     // owners into the same pending-store bucket.

--- a/crates/engine/tests/credential_refresh_redaction.rs
+++ b/crates/engine/tests/credential_refresh_redaction.rs
@@ -1,6 +1,6 @@
 #![cfg(all(feature = "rotation", feature = "test-util"))]
 
-//! ADR-0030 §4 redaction CI gate. **One row per token_refresh code path.**
+//! redaction CI gate. **One row per token_refresh code path.**
 //!
 //! Each test injects a secret-bearing IdP response through the bounded
 //! response parser and asserts that the resulting error rendering (Display,

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -21,7 +21,7 @@
 //! repos. The §M2.2 lease-handoff guarantees are unchanged and asserted
 //! verbatim:
 //! - heartbeat-loss → TTL-expiry takeover by a second runner with no
-//!   double-execution of terminal work (canon §11.3 idempotency);
+//!   double-execution of terminal work (per-node idempotency);
 //! - durable Cancel survives runner death and is redelivered to the new
 //!   runner via the control-queue reclaim sweep;
 //! - lease-less `replay_execution` never contends for a held lease.
@@ -303,7 +303,7 @@ fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
 /// the lease TTL, runner B's `resume_execution` is called.
 ///
 /// Asserts "no double-execution of completed work":
-/// - X (echo) is **not** re-dispatched on B (canon §11.3 idempotency)
+/// - X (echo) is **not** re-dispatched on B (idempotency idempotency)
 /// - Y (park) **is** re-dispatched on B because A never finished it (legitimate retry after lease
 ///   handoff)
 /// - B drives the workflow to `Succeeded`
@@ -440,7 +440,7 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
     // - `LeaseGuard::drop` signalling heartbeat shutdown + aborting the
     //   heartbeat handle;
     // - the lease holder/expires_at row left intact in storage — TTL
-    //   expiry is the takeover path (ADR-0008 §5).
+    // expiry is the takeover path.
     task_a.abort();
     let _ = task_a.await;
 
@@ -478,7 +478,7 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
     assert_eq!(
         echo_invocations.load(Ordering::SeqCst),
         1,
-        "X (echo) was completed by runner A; runner B must NOT re-run it (canon §11.3 idempotency)"
+        "X (echo) was completed by runner A; runner B must NOT re-run it (idempotency idempotency)"
     );
     assert_eq!(
         park_invocations.load(Ordering::SeqCst),
@@ -493,7 +493,7 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
 // ---------------------------------------------------------------------------
 
 /// Durable Cancel survives runner death and reaches runner B via the
-/// reclaim sweep (ADR-0008 §5 + ADR-0017).
+/// reclaim sweep.
 ///
 /// Setup: runner A holds a parked workflow. The Cancel command is
 /// enqueued on the port `ControlQueue` and then **claimed once by a
@@ -725,7 +725,7 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
     assert_eq!(
         echo_invocations.load(Ordering::SeqCst),
         1,
-        "X (echo) was completed by runner A; runner B must NOT re-run it (canon §11.3)"
+        "X (echo) was completed by runner A; runner B must NOT re-run it (idempotency)"
     );
     assert_eq!(
         park_invocations.load(Ordering::SeqCst),

--- a/crates/engine/tests/refresh_coord_config_proptest.rs
+++ b/crates/engine/tests/refresh_coord_config_proptest.rs
@@ -1,4 +1,4 @@
-//! Property tests for `RefreshCoordConfig::validate` (sub-spec §3.5).
+//! Property tests for `RefreshCoordConfig::validate` (sub-spec ).
 //!
 //! Verifies the interlocking invariants:
 //!

--- a/crates/engine/tests/refresh_coordinator_chaos.rs
+++ b/crates/engine/tests/refresh_coordinator_chaos.rs
@@ -1,7 +1,7 @@
 //! Chaos test — refresh-coordinator multi-replica race regression.
 //!
 //! Per sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)` §5.4.
+//! `docs/INTEGRATION_MODEL.md`.
 //!
 //! # Gating
 //!
@@ -48,7 +48,7 @@
 //! - Per-credential IdP call count ≤ 1 in any single refresh window. (no double-POST)
 //! - `ReauthRequired` count == 0 (no injected crashes).
 //! - Outside-refresh-window P50 latency < 4s watchdog (catches a regression where the L1 oneshot
-//!   stopped firing, forcing every caller through full L2 backoff). The sub-spec §5.4 target P99 <
+//!   stopped firing, forcing every caller through full L2 backoff). The sub-spec target P99 <
 //!   100ms is a production SLO measured against real load, not the chaos harness — the harness
 //!   emits raw P50/P99/max for inspection so drift is still visible.
 //! - Total `coalesced_l1 + coalesced_l2` ≥ 1 (proves the test actually exercised cross-replica
@@ -78,7 +78,7 @@ use tokio::task::JoinHandle;
 /// Chaos-test parameters. The default `ci()` plane is the CI-friendly
 /// scaled-down version (5s × 5 credentials × 3 replicas × 3 workers per
 /// replica = 9 worker tasks). The `chaos-full` Cargo feature widens to
-/// the full sub-spec §5.4 plane (10 min × 100 credentials × 3 replicas
+/// the full sub-spec plane (10 min × 100 credentials × 3 replicas
 /// × 8 workers per replica = 24 worker tasks) with no code changes —
 /// only the `cfg`-gated literals differ.
 ///
@@ -209,9 +209,9 @@ async fn three_replicas_zero_double_idp_calls() {
 
     // Latency samples partitioned by outcome:
     // - `coalesced` — caller short-circuited via L1 oneshot or L2 post-backoff recheck. These are
-    //   the "outside refresh window" calls in sub-spec §5.4 and must be fast.
+    // the "outside refresh window" calls in sub-spec and must be fast.
     // - `refreshed` — caller acquired the L2 row and ran the closure. These include the simulated
-    //   IdP POST and are bounded by `refresh_timeout`, so they are NOT subject to the §5.4 100ms
+    // IdP POST and are bounded by `refresh_timeout`, so they are NOT subject to the 100ms
     //   target.
     let latencies_coalesced = Arc::new(parking_lot::Mutex::new(Vec::<Duration>::new()));
     let latencies_refreshed = Arc::new(parking_lot::Mutex::new(Vec::<Duration>::new()));
@@ -369,7 +369,7 @@ async fn three_replicas_zero_double_idp_calls() {
 
     // ── Assertion 5: latency drift watchdog ────────────────────────────
     //
-    // Sub-spec §5.4 target: P99 < 100ms outside the refresh window —
+    // Sub-spec target: P99 < 100ms outside the refresh window —
     // measured in a real production environment, not a chaos harness
     // running alongside ~270 other tests. P99 in this harness is
     // dominated by L2 contention backoff (capped at 5s+jitter by

--- a/crates/engine/tests/refresh_coordinator_send_bounds_probe.rs
+++ b/crates/engine/tests/refresh_coordinator_send_bounds_probe.rs
@@ -1,5 +1,5 @@
 //! Lock the `Send` bounds on `RefreshCoordinator::refresh_coalesced`
-//! (sub-spec §3.6 / review feedback I2).
+//! (sub-spec / review feedback I2).
 //!
 //! `refresh_coalesced` runs the user's closure under
 //! `tokio::time::timeout` and awaits the predicate from the spawn'd

--- a/crates/engine/tests/refresh_coordinator_sentinel_integration.rs
+++ b/crates/engine/tests/refresh_coordinator_sentinel_integration.rs
@@ -1,7 +1,7 @@
 //! Integration tests for sentinel threshold + ReauthRequired escalation
 //! (Stage 3.3).
 //!
-//! Per sub-spec §3.4. Each test wires:
+//! Per sub-spec . Each test wires:
 //!
 //! - An [`InMemoryRefreshClaimRepo`] holding both refresh-claim rows and the sentinel-event log.
 //! - A [`SentinelTrigger`] with a custom threshold/window for deterministic timing.
@@ -33,7 +33,7 @@ use nebula_storage::credential::{
 
 /// Build a fast-cadence coordinator for the sentinel integration tests
 /// so the reclaim sweep wakes every ~30ms while still satisfying the
-/// §3.5 interlocking invariants validated by `RefreshCoordConfig`.
+/// interlocking invariants validated by `RefreshCoordConfig`.
 fn fast_coord(repo: Arc<dyn RefreshClaimRepo>, sweep: Duration) -> Arc<RefreshCoordinator> {
     Arc::new(
         RefreshCoordinator::new_with(

--- a/crates/engine/tests/refresh_coordinator_two_tier_integration.rs
+++ b/crates/engine/tests/refresh_coordinator_two_tier_integration.rs
@@ -1,6 +1,6 @@
 //! Integration test (Stage 2.5): two-tier coalesce smoke test.
 //!
-//! Per sub-spec §10 DoD #1.
+//! Per sub-spec DoD #1.
 //!
 //! **Caveat (acknowledged in the plan).** Two `RefreshCoordinator`s in
 //! the same process share neither L1 (each owns its own
@@ -17,7 +17,7 @@
 //!
 //! What this test verifies:
 //! * `RefreshCoordinator::refresh_coalesced` collapses many concurrent same-process calls to
-//!   exactly one inner closure invocation (sub-spec §10 DoD #1 single-process flavor).
+//!   exactly one inner closure invocation (sub-spec DoD #1 single-process flavor).
 //! * After all calls return the L2 row is released so a fresh acquire wins immediately.
 
 use std::{
@@ -110,7 +110,7 @@ async fn shared_coordinator_collapses_to_one_idp_call() {
 }
 
 /// Two distinct `RefreshCoordinator`s sharing a repo collapse to one
-/// closure invocation per sub-spec §3.6 (post-backoff state recheck).
+/// closure invocation per sub-spec (post-backoff state recheck).
 ///
 /// Each replica passes a `needs_refresh_after_backoff` predicate keyed
 /// on a shared `AtomicBool` — replica A flips it to `false` after its
@@ -236,7 +236,7 @@ async fn two_replicas_collapse_to_one_idp_call_after_stage_3_1() {
 /// `RefreshOutcome::ReauthRequired` and persists `reauth_required=true`
 /// on the credential row.
 ///
-/// Sub-spec §3.6 / review feedback I1. Before the persisted reauth flag
+/// Sub-spec / review feedback I1. Before the persisted reauth flag
 /// landed, replica B's predicate at `resolver.rs:232-242` re-read
 /// `expires_at`, computed `expired`, returned `true`, and replica B's
 /// closure ran a second IdP POST that produced another `invalid_grant`

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -329,7 +329,7 @@ async fn action_resource_fails_without_manager() {
 // (`Arc::ptr_eq`).
 //
 // Architecture note (deviation from the original Phase 8 task wording):
-// the `R::Credential` associated type was retired in Phase 4 (ADR-0044), and
+// the `R::Credential` associated type was retired in Phase 4 , and
 // the manager dedupes by `(R::key(), ScopeLevel)` — the static type-level key
 // of the registered `Resource`, not a runtime `ResourceId`. The "10 workflows
 // declaring the same `ResourceId`" framing collapses to "10 acquires of the

--- a/crates/engine/tests/resource_registrar_validate.rs
+++ b/crates/engine/tests/resource_registrar_validate.rs
@@ -5,16 +5,16 @@
 //! reject a malformed resource config *before* persisting the row, but
 //! it must **not** live-register the resource into a running
 //! `nebula_resource::Manager` — live registration is an
-//! engine-activation concern (INTEGRATION_MODEL §13.1). This test pins
+//! engine-activation concern (.1). This test pins
 //! that `validate`:
 //!
 //! - resolves the `kind` through the **closed allowlist** (an unknown
 //!   kind is a typed `RegistrarError::UnknownKind`, never a silent grab
-//!   of the wrong resource type — INTEGRATION_MODEL §114-120);
+//!   of the wrong resource type);
 //! - runs the real `R::Config` schema pass + closed-set guard for a
 //!   known kind (schema-valid ⇒ `Ok`; schema-invalid ⇒
 //!   `RegistrarError::Register`; an undeclared secret-shaped field ⇒
-//!   `RegistrarError::Register`, ADR-0028 §7 / PRODUCT_CANON §3.5);
+//!   `RegistrarError::Register`);
 //! - performs **no** `Manager` mutation — validating a config never
 //!   makes the resource resolvable in a manager (the live/validate
 //!   separation that keeps config CRUD distinct from activation).
@@ -132,7 +132,7 @@ fn registry_with_http_pool() -> ResourceRegistrarRegistry {
 
 /// A schema-valid config for a known kind validates `Ok` — and the
 /// resource is **NOT** registered into any `Manager` as a side effect
-/// (config validation is not activation; §13.1).
+/// (config validation is not activation; ).
 #[tokio::test]
 async fn known_kind_schema_valid_config_is_ok_and_no_manager_mutation() {
     let registry = registry_with_http_pool();
@@ -199,7 +199,7 @@ fn known_kind_out_of_range_value_is_register_error() {
 }
 
 /// An undeclared, secret-shaped field is rejected by the closed-set
-/// guard (ADR-0028 §7 / PRODUCT_CANON §3.5) — and the rejection message
+/// guard — and the rejection message
 /// names only the offending KEY, never its value, so a mis-wired secret
 /// can never leak through the error.
 #[test]
@@ -228,13 +228,13 @@ fn undeclared_secret_shaped_field_is_rejected_without_leaking_value() {
     assert!(
         !msg.contains(secret_value),
         "the rejection must NEVER echo the offending field's VALUE \
-         (ADR-0028 §7); got: {msg}"
+ ; got: {msg}"
     );
 }
 
 /// An unknown `kind` is a typed `RegistrarError::UnknownKind` resolved
 /// through the closed allowlist *before* any typed call — it can never
-/// touch a resource type (INTEGRATION_MODEL §114-120).
+/// touch a resource type.
 #[test]
 fn unknown_kind_is_typed_unknownkind_not_silent() {
     let registry = registry_with_http_pool();

--- a/crates/engine/tests/resource_rotation_fanout_wiring.rs
+++ b/crates/engine/tests/resource_rotation_fanout_wiring.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "rotation")]
 
-//! End-to-end: the production rotation fan-out **wiring** (ADR-0067
+//! End-to-end: the production rotation fan-out **wiring** (
 //! §Deferred "Rotation fan-out is implemented but unwired"; closes #679 /
 //! #680 / #681 prerequisites).
 //!
@@ -11,7 +11,7 @@
 //! credential-runtime composition root emits in production**
 //! ([`CredentialEvent::Refreshed`] / [`CredentialEvent::Revoked`] on
 //! `EventBus<CredentialEvent>`, [`LeaseEvent::LeaseRevoked`] on
-//! `EventBus<LeaseEvent>` — the `EventMetricObserver` shape, ADR-0066).
+//! `EventBus<LeaseEvent>` — the `EventMetricObserver` shape, ).
 //! Nothing here calls `dispatch_refresh` / `dispatch_revoke` itself; the
 //! driver's bus subscription does, exactly as in production.
 //!
@@ -280,7 +280,7 @@ async fn credential_revoked_event_drives_revoke_fanout() {
 /// `LeaseLifecycle::revoke_for_credential`) must drive the revoke
 /// fan-out: the row is tainted (a subsequent acquire on that exact
 /// resolved row is rejected) and `on_credential_revoke` is delivered —
-/// the ADR-0051 → ADR-0067 path end-to-end.
+/// the → path end-to-end.
 #[tokio::test]
 async fn lease_revoked_event_taints_row_and_delivers_revoke_hook() {
     use nebula_error::{Classify, ErrorCategory};

--- a/crates/engine/tests/resource_rotation_redaction.rs
+++ b/crates/engine/tests/resource_rotation_redaction.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "rotation")]
 
-//! Per-slot rotation observability redaction CI gate (PRODUCT_CANON §12.5,
-//! ADR-0030 §4).
+//! Per-slot rotation observability redaction CI gate (PRODUCT_CANON ,
+//! ).
 //!
 //! This is the resource-rotation analogue of the `token_refresh`
 //! redaction gate in `credential_refresh_redaction.rs`: the same
@@ -21,7 +21,7 @@
 //! sink (Debug + Display of every emitted slot event) and renders the full
 //! Prometheus text exposition (every `*_ATTEMPTS_TOTAL{outcome=…}` series
 //! with its label set) so all four observability surfaces named in
-//! ADR-0030 §4 — spans, domain events, metric labels, error strings — are
+//! — spans, domain events, metric labels, error strings — are
 //! inspected against the same injected secret.
 //!
 //! A distinctive secret literal is planted both in the slot's
@@ -78,7 +78,7 @@ const SECRET: &str = "SUPER-SECRET-TOKEN-9d3f";
 // Verbatim shape of the `CaptureBuf` harness in
 // `crates/credential/tests/redaction.rs` — reused (not re-invented) so
 // the span/event capture semantics are identical to the established
-// ADR-0030 §4 gate.
+// gate.
 // ---------------------------------------------------------------------
 
 /// Shared buffer every captured span/event is appended to.
@@ -113,7 +113,7 @@ impl<'a> MakeWriter<'a> for CaptureBuf {
 }
 
 /// Case-sensitive **and** case-insensitive substring absence assertion.
-/// ADR-0030 §4 requires both: a leak that lower/upper-cases the token in
+/// requires both: a leak that lower/upper-cases the token in
 /// transit is still a leak.
 fn assert_no_secret(haystack: &str, surface: &str) {
     assert!(

--- a/crates/engine/tests/resource_rotation_wiring_redaction.rs
+++ b/crates/engine/tests/resource_rotation_wiring_redaction.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "rotation")]
 
-//! Redaction gate for the **wired** rotation fan-out path (ADR-0030 §4,
-//! PRODUCT_CANON §12.5).
+//! Redaction gate for the **wired** rotation fan-out path ( ,
+//! PRODUCT_CANON ).
 //!
 //! `resource_rotation_redaction.rs` proves the fan-out *port*
 //! (`dispatch_*` called directly) leaks no credential material. This
@@ -17,7 +17,7 @@
 //! `MakeWriter` shape from `crates/credential/tests/redaction.rs` and
 //! `resource_rotation_redaction.rs` (reused, not re-invented, so the
 //! span/event capture semantics are identical to the established
-//! ADR-0030 §4 gate). Because the driver runs on a `tokio::spawn`ed
+//! gate). Because the driver runs on a `tokio::spawn`ed
 //! task, the capture subscriber is installed process-wide via
 //! `tracing::subscriber::set_global_default` for the test so the
 //! spawned task's spans/events are also captured.
@@ -47,7 +47,7 @@ use zeroize::Zeroize;
 /// match cannot false-positive.
 const SECRET: &str = "WIRED-ROTATION-SECRET-7b1e";
 
-// ── CaptureBuf (verbatim shape from the established §4 gate) ─────────
+// ── CaptureBuf (verbatim shape from the established gate) ─────────
 
 #[derive(Clone, Default)]
 struct CaptureBuf(Arc<Mutex<Vec<u8>>>);
@@ -254,7 +254,7 @@ async fn wired_rotation_fanout_observability_is_redaction_clean() {
 
     // Refresh via the credential bus.
     cred_bus.emit(CredentialEvent::Refreshed { credential_id: cid });
-    // Revoke via the lease bus (the ADR-0051 → ADR-0067 path).
+    // Revoke via the lease bus (the → path).
     lease_bus.emit(LeaseEvent::LeaseRevoked {
         credential_id: Some(cid),
         lease_id: "lease-redaction".to_owned(),
@@ -309,7 +309,7 @@ async fn wired_rotation_fanout_observability_is_redaction_clean() {
 
 /// Load-bearing self-check: the absence assertion must actually fire on
 /// a string that obviously contains the token (mirrors the negative
-/// test in the established §4 gates).
+/// test in the established gates).
 #[test]
 #[should_panic(expected = "redaction gate violation")]
 fn assert_no_secret_is_load_bearing() {

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -1,6 +1,6 @@
-//! Engine-level retry integration tests (ADR-0042 §M2.1 T6).
+//! Engine-level retry integration tests.
 //!
-//! Covers the canonical retry path plus the four ADR-named edge
+//! Covers the canonical retry path plus the four spec-named edge
 //! cases (cancel/terminate/budget/idempotency) and the three
 //! resolution scenarios for the effective retry policy
 //! (per-node / workflow-default / no policy).
@@ -181,7 +181,7 @@ fn make_workflow(
 }
 
 // ---------------------------------------------------------------------------
-// Tests (9 — ADR-0042 §M2.1 T6 acceptance)
+// Tests (9 — T6 acceptance)
 // ---------------------------------------------------------------------------
 
 /// 1) Basic retry path — handler fails once, succeeds on attempt 2.
@@ -485,7 +485,7 @@ async fn idempotency_key_differentiates_attempts() {
     assert_eq!(ns.attempts.len(), 2, "two attempts pushed");
     assert_ne!(
         ns.attempts[0].idempotency_key, ns.attempts[1].idempotency_key,
-        "retry must mint a fresh idempotency key per attempt (canon §11.3)"
+        "retry must mint a fresh idempotency key per attempt (idempotency)"
     );
     assert_eq!(ns.attempts[0].attempt_number, 1);
     assert_eq!(ns.attempts[1].attempt_number, 2);

--- a/crates/engine/tests/rotation_resource_fanout.rs
+++ b/crates/engine/tests/rotation_resource_fanout.rs
@@ -2,7 +2,7 @@
 
 //! Integration: the engine credential-rotation fan-out drives the typed
 //! `nebula_resource::Manager` slot ports per resolved registry row, with
-//! per-resource timeout isolation (ADR-0036).
+//! per-resource timeout isolation.
 //!
 //! Exercises the public engine surface
 //! (`nebula_engine::credential::rotation::{ResourceFanoutIndex,
@@ -114,7 +114,7 @@ impl Resident for Ctl {
     }
 }
 
-/// The headline ADR-0036 invariant proven through the public engine API:
+/// The headline invariant proven through the public engine API:
 /// a wedged resource times out in isolation; both healthy siblings still
 /// refresh, and the aggregate accounts for every bound row.
 #[tokio::test]

--- a/crates/engine/tests/state_projection_duplicate_kind_fatal.rs
+++ b/crates/engine/tests/state_projection_duplicate_kind_fatal.rs
@@ -8,13 +8,13 @@
 //! 3. Registry state is unchanged after the failure — original handler is not overwritten (len
 //!    remains 1, `contains(kind)` still true).
 //!
-//! Active-dev policy per Tech Spec §15.12.2: reject-second-registration.
+//! Active-dev policy per Tech Spec : reject-second-registration.
 //! Silent `HashMap::insert` overwrite (prior behavior) would hide
 //! namespace collisions, including supply-chain plugin replacement.
 //!
 //! The companion KEY-keyed [`CredentialRegistry`](nebula_credential::CredentialRegistry)
 //! is exercised by `crates/credential/tests/runtime_duplicate_key_fatal.rs`
-//! (Probe 5, Tech Spec §15.6). Both registries fail-closed on duplicate
+//! (Probe 5, Tech Spec ). Both registries fail-closed on duplicate
 //! registration; this probe covers the engine-side state-projection
 //! lookup.
 
@@ -41,7 +41,7 @@ fn duplicate_registration_returns_error_no_overwrite() {
 
     // Second registration with same `<State as CredentialState>::KIND`
     // must fail with DuplicateKind — active-dev policy rejects silent
-    // overwrite (N7 mitigation, Tech Spec §15.6 + §15.12.2).
+    // overwrite (N7 mitigation, Tech Spec + ).
     let err = registry
         .register::<ApiKeyCredential>()
         .expect_err("second registration must fail");

--- a/crates/engine/tests/token_refresh_sentinel_unit.rs
+++ b/crates/engine/tests/token_refresh_sentinel_unit.rs
@@ -4,7 +4,7 @@
 //! closure with a real `RefreshClaim` whose token can be sentinel-marked
 //! via `RefreshClaimRepo::mark_sentinel`, and that on the success path
 //! the row is **deleted** by `release` so no `RefreshInFlight` sentinel
-//! lingers — sub-spec §3.4.
+//! lingers — sub-spec.
 //!
 //! Mid-refresh crash detection (sentinel surviving a sweep) is tested at
 //! the storage level in `nebula-storage::refresh_claim_in_memory_smoke`

--- a/crates/error/src/lib.rs
+++ b/crates/error/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //! ## Role
 //!
-//! **Error Taxonomy and Classification Boundary** (canon §3.10, §4.2, §12.4).
+//! **Error Taxonomy and Classification Boundary** — typed classification and HTTP mapping.
 //! `nebula-api` maps `NebulaError` to RFC 9457 `problem+json` at the HTTP boundary.
 //!
 //! ## Public API

--- a/crates/eventbus/src/lib.rs
+++ b/crates/eventbus/src/lib.rs
@@ -10,8 +10,8 @@
 //! Transport-only: no domain event types are defined here.
 //!
 //! This is an **in-process, ephemeral** channel — not a durable control plane.
-//! Per canon §4.5 / §12.2: anything requiring reliable delivery (cancel, dispatch
-//! signals) must use `execution_control_queue`, not this crate.
+//! Anything requiring reliable delivery (cancel, dispatch signals) must use
+//! `execution_control_queue`, not this crate.
 //! See `crates/eventbus/README.md` for the full role description.
 //!
 //! ## Role
@@ -41,18 +41,18 @@
 //!
 //! #[derive(Clone)]
 //! struct MyEvent {
-//!     id: u64,
+//! id: u64,
 //! }
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let bus = EventBus::<MyEvent>::new(64);
-//!     let mut sub = bus.subscribe();
+//! let bus = EventBus::<MyEvent>::new(64);
+//! let mut sub = bus.subscribe();
 //!
-//!     let outcome = bus.emit(MyEvent { id: 1 });
-//!     assert!(outcome.is_sent());
-//!     let event = sub.try_recv().expect("event must be available");
-//!     assert_eq!(event.id, 1);
+//! let outcome = bus.emit(MyEvent { id: 1 });
+//! assert!(outcome.is_sent());
+//! let event = sub.try_recv().expect("event must be available");
+//! assert_eq!(event.id, 1);
 //! }
 //! ```
 //!
@@ -76,11 +76,11 @@
 //! # async fn main() {
 //! # let bus = EventBus::<Event>::new(10);
 //! let mut sub = bus.subscribe();
-//! // ... emit 20 events with a slow subscriber ...
+//! //... emit 20 events with a slow subscriber...
 //! if let Some(_) = sub.recv().await {
-//!     if sub.lagged_count() > 0 {
-//!         println!("Fell behind by {} events", sub.lagged_count());
-//!     }
+//! if sub.lagged_count() > 0 {
+//! println!("Fell behind by {} events", sub.lagged_count());
+//! }
 //! }
 //! # }
 //! ```

--- a/crates/execution/src/context.rs
+++ b/crates/execution/src/context.rs
@@ -36,9 +36,9 @@ where
 /// use nebula_execution::context::ExecutionBudget;
 ///
 /// let budget = ExecutionBudget::default()
-///     .with_max_duration(Duration::from_secs(300))
-///     .with_max_output_bytes(10 * 1024 * 1024)
-///     .with_max_total_retries(50);
+///.with_max_duration(Duration::from_secs(300))
+///.with_max_output_bytes(10 * 1024 * 1024)
+///.with_max_total_retries(50);
 /// ```
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct ExecutionBudget {
@@ -61,10 +61,10 @@ pub struct ExecutionBudget {
     pub max_output_bytes: Option<u64>,
 
     /// Global cap on retry attempts summed across **all** nodes in
-    /// the execution (ADR-0042 §Consequences "Out of scope" + §M2.1
+    /// the execution (.1
     /// T4 acceptance). Complements per-node
     /// `RetryConfig::max_attempts`: the engine consults both on every
-    /// failure and whichever caps first wins (canon §11.2).
+    /// failure and whichever caps first wins.
     ///
     /// `None` = no global cap; per-node policy is the only retry
     /// gate. A `Some(0)` value disables engine-level retry entirely
@@ -131,7 +131,7 @@ impl ExecutionBudget {
         self
     }
 
-    /// Set the global retry cap (ADR-0042 §M2.1 T4).
+    /// Set the global retry cap.
     ///
     /// `0` disables engine-level retry entirely for this execution
     /// even when nodes declare a `RetryConfig`. Useful for tests and
@@ -256,7 +256,7 @@ mod tests {
         assert!(budget.validate_for_execution().is_err());
     }
 
-    /// ADR-0042 §M2.1 T2 — `max_total_retries` must round-trip
+    /// `max_total_retries` must round-trip
     /// through serde so `resume_execution` carries the same global
     /// cap the original run was started with.
     #[test]

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -9,11 +9,8 @@
 //! **Role:** Execution State Machine + Journal + Idempotency Types.
 //! See `crates/execution/README.md`.
 //!
-//! **Canon:** §11.1 (execution authority), §11.3 (idempotency),
-//! §11.5 (persistence matrix), §12.2 (single lifecycle).
-//!
 //! **Maturity:** `stable` — state machine, journal, and plan types in active use.
-//! The engine does not retry nodes (canon §11.2); the canonical retry surface is
+//! The engine does not retry nodes; the canonical retry surface is
 //! `nebula-resilience` inside an action.
 //!
 //! ## Core Types

--- a/crates/execution/src/output.rs
+++ b/crates/execution/src/output.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 /// (`"hello"`, `42`, `true`) round-trip correctly — newtype-wrapped
 /// `Value` cannot share a level with `type`, so the engine's first
 /// attempt to persist a string-output `NodeAttempt` would otherwise
-/// fail at `serde_json::to_value(&exec_state)` (ADR-0042 §M2.1 T2
+/// fail at `serde_json::to_value(&exec_state)` (retry scheduling
 /// regression discovered during T4 wiring).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -69,7 +69,7 @@ pub struct NodeExecutionState {
     #[serde(default)]
     pub error_message: Option<String>,
     /// Wall-clock instant at which the engine should dispatch the next
-    /// retry attempt for this node (ADR-0042 §Decision Layer 2).
+    /// retry attempt for this node.
     ///
     /// `Some(_)` is paired with `state == NodeState::WaitingRetry`: the
     /// engine sets it when the retry policy still has budget after a
@@ -140,8 +140,8 @@ impl NodeExecutionState {
 
     /// Drive a node to `Running` for a fresh dispatch
     /// (`Pending → Ready → Running` for the first attempt;
-    /// `WaitingRetry → Ready → Running` for a scheduled retry per
-    /// ADR-0042; `Ready → Running` when the engine has already
+    /// `WaitingRetry → Ready → Running` for a scheduled retry;
+    /// `Ready → Running` when the engine has already
     /// promoted the node to `Ready` in a prior phase). Any other
     /// source state is an invalid transition and returned as such —
     /// the engine must route the node through the setup-failure path
@@ -225,7 +225,7 @@ pub struct ExecutionState {
     /// execution. `Some((node_key, reason))` means the named node
     /// returned `ActionResult::Terminate` and its
     /// `ExecutionTerminationReason` is the authoritative source of
-    /// the eventual final status (canon §4.5; ROADMAP §M0.3).
+    /// the eventual final status (; ROADMAP §M0.3).
     /// First-write-wins: subsequent terminate signals from racing
     /// siblings are dropped at `set_terminated_by`.
     ///
@@ -236,12 +236,12 @@ pub struct ExecutionState {
     pub terminated_by: Option<(NodeKey, ExecutionTerminationReason)>,
     /// Total number of retry attempts dispatched across all nodes in
     /// this execution. Bumped exactly once per scheduled retry
-    /// (post-decision, pre-checkpoint) per ADR-0042 §M2.1 T4.
+    /// (post-decision, pre-checkpoint).
     ///
     /// Paired with [`ExecutionBudget::max_total_retries`] as a global
     /// cap that complements per-node `RetryConfig::max_attempts`. The
     /// engine consults both on every failure; whichever caps first
-    /// wins (canon §11.2). A `None` budget cap means the global
+    /// wins. A `None` budget cap means the global
     /// counter is informational only — the engine still increments
     /// it for observability.
     ///
@@ -287,7 +287,7 @@ impl ExecutionState {
     /// Record a scheduled retry attempt at the execution level.
     ///
     /// Called by the engine on every successful retry decision (per
-    /// ADR-0042 §M2.1 T4) so [`ExecutionBudget::max_total_retries`]
+    /// so [`ExecutionBudget::max_total_retries`]
     /// can be enforced as a global cap across all nodes. Bumps the
     /// parent version so optimistic-concurrency readers observe the
     /// state change (issue #255).
@@ -350,11 +350,11 @@ impl ExecutionState {
     /// 2. **`by_node` matches `node_key`.** The variant's inner `by_node` field MUST equal the
     ///    `node_key` argument. Mismatched identity returns `false` with a `tracing::warn!` and no
     ///    mutation. Engine wiring constructs the reason via
-    ///    `map_termination_reason(node_key.clone(), ...)`, so a mismatch indicates a programming
+    ///    `map_termination_reason(node_key.clone(),...)`, so a mismatch indicates a programming
     ///    error in a non-engine caller (or a refactor regression).
     /// 3. **First-write-wins.** Only the first signal is durable; subsequent signals are
     ///    debug-logged and dropped so the post-mortem audit log has a single authoritative source
-    ///    per execution (canon §4.5). The frontier loop holds `&mut ExecutionState` while it
+    ///    per execution. The frontier loop holds `&mut ExecutionState` while it
     ///    consumes node results, so no two writers race here at the language level.
     ///
     /// On a successful set this method bumps the parent
@@ -389,7 +389,7 @@ impl ExecutionState {
                 attempted_by = %node_key,
                 attempted_reason = ?reason,
                 "set_terminated_by rejected — reason must be ExplicitStop/ExplicitFail \
-                 with matching by_node (canon §4.5; ROADMAP §M0.3)"
+                 with matching by_node (durable lifecycle honesty; ROADMAP §M0.3)"
             );
             return false;
         }
@@ -465,7 +465,7 @@ impl ExecutionState {
 
     /// Build the idempotency key for the **next** dispatch of a node.
     ///
-    /// Per ADR-0042 §M2.1 T4 the engine pushes a [`NodeAttempt`] into
+    /// The engine pushes a [`NodeAttempt`] into
     /// `node_states[*].attempts` after each finished attempt
     /// (success or failure). The key for the next dispatch is therefore
     /// `attempts.len() + 1`:
@@ -478,7 +478,7 @@ impl ExecutionState {
     /// check and mark sides of the canonical (`check_idempotency` →
     /// act → `mark_idempotent`) flow, so that a retried or
     /// restart-replayed attempt does not collide with a previous
-    /// attempt's persisted output (issue #266, canon §11.3).
+    /// attempt's persisted output (issue #266, ).
     ///
     /// The execution id is taken from `self` — callers cannot pass a
     /// mismatched id by accident. If `node_key` is not present in
@@ -500,7 +500,7 @@ impl ExecutionState {
     /// Called by the engine's frontier loop **after** the action's
     /// dispatch resolves — once on success, once on failure — so the
     /// canonical attempt count drives both `idempotency_key_for_node`
-    /// (next dispatch) and the retry decision (per ADR-0042 §M2.1
+    /// (next dispatch) and the retry decision (.1
     /// T4).
     ///
     /// The idempotency key is **derived internally** from the just-
@@ -508,7 +508,7 @@ impl ExecutionState {
     /// caller cannot persist `attempt_number = N` against an
     /// `attempt-(N-1)` key — that mismatch would silently corrupt
     /// the retry/idempotency audit trail this API is supposed to
-    /// own (canon §11.3, ADR-0042 §M2.1 T4).
+    /// own (engine retry path).
     ///
     /// Returns the recorded attempt number (1-indexed). Returns
     /// [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
@@ -546,7 +546,7 @@ impl ExecutionState {
         Ok(attempt_number)
     }
 
-    /// Schedule the next retry attempt for a node per ADR-0042 §M2.1
+    /// Schedule the next retry attempt for a node.1
     /// T4.
     ///
     /// Promotes a `Failed` node to `WaitingRetry`, stamps the wall-clock
@@ -618,7 +618,7 @@ impl ExecutionState {
     /// current one via the forward state machine. They still MUST
     /// bump the parent version so CAS readers observe the change
     /// (issue #255); use this method instead of a direct
-    /// `node_states.get_mut(...).state = ...` assignment.
+    /// `node_states.get_mut(...).state =...` assignment.
     ///
     /// Application code that is NOT in a recovery path should use
     /// [`transition_node`](Self::transition_node) instead — it
@@ -970,7 +970,7 @@ mod tests {
         assert!(ns.started_at.is_some());
     }
 
-    /// ADR-0042 — engine retries via the `Failed → WaitingRetry` edge,
+    /// — engine retries via the `Failed → WaitingRetry` edge,
     /// not directly from `Failed`. A `start_attempt` on `Failed` is
     /// still rejected (the engine must first promote the node to
     /// `WaitingRetry` via the retry-decision path); but
@@ -988,7 +988,7 @@ mod tests {
         assert_eq!(ns.state, NodeState::Failed, "state must not move on error");
     }
 
-    /// ADR-0042 — `WaitingRetry → Ready → Running` is the retry
+    /// — `WaitingRetry → Ready → Running` is the retry
     /// re-dispatch path. `start_attempt` honors it.
     #[test]
     fn start_attempt_promotes_waiting_retry() {
@@ -999,7 +999,7 @@ mod tests {
         ns.transition_to(NodeState::WaitingRetry).unwrap();
 
         ns.start_attempt()
-            .expect("WaitingRetry must be a legal start_attempt source per ADR-0042");
+            .expect("WaitingRetry must be a legal start_attempt source for engine retries");
         assert_eq!(ns.state, NodeState::Running);
     }
 
@@ -1128,7 +1128,7 @@ mod tests {
         assert_eq!(back.node_states.len(), state.node_states.len());
     }
 
-    // Regression for #266 + ADR-0042 §M2.1 T4: the idempotency key is
+    // Regression for #266: the idempotency key is
     // for the **next** dispatch — `attempts.len() + 1`. Push-on-result
     // semantics in the engine guarantees that a retried or
     // restart-replayed attempt does not collide with a previous
@@ -1172,7 +1172,7 @@ mod tests {
         );
     }
 
-    /// ADR-0042 §M2.1 T4 — `record_node_attempt` pushes a sequential
+    /// `record_node_attempt` pushes a sequential
     /// attempt with the right number, captures the outcome, and bumps
     /// the parent version (issue #255).
     #[test]
@@ -1244,7 +1244,7 @@ mod tests {
         assert!(matches!(err, ExecutionError::NodeNotFound(_)));
     }
 
-    /// ADR-0042 §M2.1 T4 — `schedule_node_retry` promotes Failed →
+    /// `schedule_node_retry` promotes Failed →
     /// WaitingRetry, stamps `next_attempt_at`, and increments
     /// `total_retries`. All three observable effects move atomically
     /// (single `checkpoint_node` covers the version bumps).
@@ -1469,7 +1469,7 @@ mod tests {
     /// ROADMAP §M0.3 invariant 2 — `set_terminated_by` must reject a
     /// reason whose inner `by_node` does not match the `node_key`
     /// argument. Engine wiring constructs the reason via
-    /// `map_termination_reason(node_key.clone(), ...)` so a mismatch
+    /// `map_termination_reason(node_key.clone(),...)` so a mismatch
     /// indicates a programming error (or a refactor regression) and
     /// must surface as `false` rather than store inconsistent data.
     #[test]
@@ -1526,7 +1526,7 @@ mod tests {
         );
     }
 
-    /// ADR-0042 §M2.1 T2 — `next_attempt_at` must round-trip via
+    /// `next_attempt_at` must round-trip via
     /// serde so a resumed engine picks up scheduled retries at their
     /// declared time.
     #[test]
@@ -1556,7 +1556,7 @@ mod tests {
         assert!(ns.next_attempt_at.is_none());
     }
 
-    /// ADR-0042 §M2.1 T2 — `total_retries` round-trips and starts
+    /// `total_retries` round-trips and starts
     /// at zero.
     #[test]
     fn total_retries_roundtrip_and_default() {
@@ -1586,7 +1586,7 @@ mod tests {
         assert_eq!(state.total_retries, 0);
     }
 
-    /// ADR-0042 §M2.1 T4 — `increment_total_retries` bumps both the
+    /// `increment_total_retries` bumps both the
     /// counter and the parent execution version (issue #255).
     #[test]
     fn increment_total_retries_bumps_version() {

--- a/crates/execution/src/status.rs
+++ b/crates/execution/src/status.rs
@@ -82,7 +82,7 @@ impl std::fmt::Display for ExecutionStatus {
 /// This does **not** replace [`ExecutionStatus`]. Status describes *what*
 /// terminal state was reached; this enum describes *why*.
 ///
-/// # Engine wiring (ROADMAP §M0.3, canon §4.5)
+/// # Engine wiring (ROADMAP §M0.3, )
 ///
 /// `ExplicitStop` / `ExplicitFail` are populated by the engine's
 /// frontier loop: a node returning `ActionResult::Terminate` records
@@ -99,7 +99,7 @@ impl std::fmt::Display for ExecutionStatus {
 /// persisted states that predate `terminated_by` still deserialise
 /// (the field is `#[serde(default)]`) and the engine treats them as
 /// not having received an explicit termination — preserving the
-/// canon §4.5 honesty contract.
+/// honesty contract.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 #[non_exhaustive]

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -53,7 +53,7 @@ pub fn validate_execution_transition(
 ///
 /// The retry-related edges (`Failed → WaitingRetry`,
 /// `WaitingRetry → Ready`, `WaitingRetry → Cancelled`) implement the
-/// engine-level retry path from ADR-0042: when the retry policy still
+/// engine-level retry path from : when the retry policy still
 /// has budget after a `Running → Failed` transition, the engine moves
 /// the node into `WaitingRetry` (parking it until
 /// `NodeExecutionState::next_attempt_at`), then back to `Ready` for the
@@ -307,7 +307,7 @@ mod tests {
         ));
     }
 
-    /// ADR-0042 — engine-level retry path:
+    /// — engine-level retry path:
     ///
     /// `Running → Failed → WaitingRetry → Ready → Running`
     ///
@@ -329,7 +329,7 @@ mod tests {
         assert!(can_transition_node(NodeState::Ready, NodeState::Running));
     }
 
-    /// ADR-0042 — cancel during retry wait must be expressible without
+    /// — cancel during retry wait must be expressible without
     /// a phantom `WaitingRetry → Failed → Cancelled` detour. The
     /// previous attempt's failure is already recorded in
     /// `NodeAttempt`; the cancel terminates the wait, not the attempt.

--- a/crates/log/src/lib.rs
+++ b/crates/log/src/lib.rs
@@ -9,8 +9,8 @@
 //! subscriber for any Nebula process — consistent structured fields, multiple
 //! formats (pretty/compact/JSON/logfmt), pluggable writers, runtime reload, and
 //! optional OTLP / Sentry integrations. Enforces the observability contract:
-//! no secret material in log output (canon §12.5), consistent service/env/version
-//! fields (canon §4.6). See `crates/log/README.md` for full role and contract.
+//! no secret material in log output, consistent service/env/version
+//! fields. See `crates/log/README.md` for full role and contract.
 //!
 //! ## Role
 //!
@@ -30,9 +30,9 @@
 //! use nebula_log::prelude::*;
 //!
 //! fn main() -> LogResult<()> {
-//!     let _guard = nebula_log::auto_init()?;
-//!     info!(service = "api", "server started");
-//!     Ok(())
+//! let _guard = nebula_log::auto_init()?;
+//! info!(service = "api", "server started");
+//! Ok(())
 //! }
 //! ```
 //!
@@ -54,14 +54,14 @@
 //! use nebula_log::{Config, Format, WriterConfig};
 //!
 //! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let mut cfg = Config::production();
-//!     cfg.format = Format::Json;
-//!     cfg.writer = WriterConfig::Stderr;
-//!     cfg.fields.service = Some("nebula-api".to_string());
-//!     cfg.fields.env = Some("prod".to_string());
+//! let mut cfg = Config::production();
+//! cfg.format = Format::Json;
+//! cfg.writer = WriterConfig::Stderr;
+//! cfg.fields.service = Some("nebula-api".to_string());
+//! cfg.fields.env = Some("prod".to_string());
 //!
-//!     let _guard = nebula_log::init_with(cfg)?;
-//!     Ok(())
+//! let _guard = nebula_log::init_with(cfg)?;
+//! Ok(())
 //! }
 //! ```
 //!
@@ -97,10 +97,10 @@
 //!
 //! Telemetry/Sentry related:
 //! - `OTEL_EXPORTER_OTLP_ENDPOINT` — OTLP export is opt-in. When neither this env var nor
-//!   `TelemetryConfig::otlp_endpoint` is set, OTLP is disabled. Use the literal string `"disabled"`
-//!   (or an empty string) to explicitly opt out at either layer.
-//! - `SENTRY_DSN` — when set but unparsable, a `tracing::warn!` is emitted at startup and Sentry
-//!   reporting is disabled.
+//!   `TelemetryConfig::otlp_endpoint` is set, OTLP is disabled. Use the literal string
+//!   `"disabled"` (or an empty string) to explicitly opt out at either layer.
+//! - `SENTRY_DSN` — when set but unparsable, a `tracing::warn!` is emitted at startup and
+//!   Sentry reporting is disabled.
 //! - `SENTRY_ENV`
 //! - `SENTRY_RELEASE`
 //! - `SENTRY_TRACES_SAMPLE_RATE`

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -1,7 +1,7 @@
 //! `nebula-metadata` — shared metadata shapes for catalog-leaf entities
 //! (actions, credentials, resources). See the crate README below for the
 //! full surface, composition example, consumer list, and the
-//! plugin-as-container carve-out (ADR-0018).
+//! plugin-as-container carve-out.
 
 #![forbid(unsafe_code)]
 #![warn(missing_docs)]
@@ -17,7 +17,7 @@ pub mod deprecation;
 /// [`Icon`] enum — one valid representation for catalog icons.
 pub mod icon;
 /// [`PluginManifest`] — bundle descriptor for a plugin, and [`ManifestError`] for
-/// construction failures (ADR-0018, moved from `nebula-plugin` in slice B).
+/// construction failures.
 pub mod manifest;
 /// [`MaturityLevel`] — `Experimental / Beta / Stable / Deprecated`.
 pub mod maturity;

--- a/crates/metadata/src/manifest.rs
+++ b/crates/metadata/src/manifest.rs
@@ -1,4 +1,4 @@
-//! Plugin manifest — bundle descriptor for a plugin (ADR-0018).
+//! Plugin manifest — bundle descriptor for a plugin.
 //!
 //! A [`PluginManifest`] describes the *container* that bundles actions,
 //! credentials, and resources under a versioned identity. It reuses the
@@ -56,7 +56,7 @@ fn is_default_maturity(m: &MaturityLevel) -> bool {
     *m == MaturityLevel::default()
 }
 
-/// Static manifest describing a plugin bundle (ADR-0018).
+/// Static manifest describing a plugin bundle.
 ///
 /// Built via the builder API:
 ///
@@ -65,11 +65,11 @@ fn is_default_maturity(m: &MaturityLevel) -> bool {
 /// use semver::Version;
 ///
 /// let manifest = PluginManifest::builder("http_request", "HTTP Request")
-///     .description("Make HTTP calls to external APIs")
-///     .group(vec!["network".into()])
-///     .version(Version::new(2, 0, 0))
-///     .build()
-///     .unwrap();
+///.description("Make HTTP calls to external APIs")
+///.group(vec!["network".into()])
+///.version(Version::new(2, 0, 0))
+///.build()
+///.unwrap();
 ///
 /// assert_eq!(manifest.key().as_str(), "http_request");
 /// assert_eq!(manifest.version(), &Version::new(2, 0, 0));
@@ -303,9 +303,9 @@ impl PluginManifestBuilder {
     /// use nebula_metadata::PluginManifest;
     ///
     /// let manifest = PluginManifest::builder("slack", "Slack")
-    ///     .author("Acme Corp")
-    ///     .build()
-    ///     .unwrap();
+    ///.author("Acme Corp")
+    ///.build()
+    ///.unwrap();
     ///
     /// assert_eq!(manifest.author(), Some("Acme Corp"));
     /// ```

--- a/crates/metrics/src/eventbus.rs
+++ b/crates/metrics/src/eventbus.rs
@@ -3,7 +3,7 @@
 //! The four `NEBULA_EVENTBUS_*` gauges (sent / dropped / subscribers /
 //! drop-ratio in ppm) form a single observation point: every scrape interval
 //! the engine snapshots [`nebula_eventbus::EventBusStats`] and writes the four
-//! values atomically into the registry. Per ADR-0046 the recording is exposed
+//! values atomically into the registry. the recording is exposed
 //! as a single free function instead of a method on a bridge type — the
 //! function takes a [`MetricsRegistry`] reference, applies the canonical
 //! `nebula_*` names from [`crate::naming`], and clamps the platform-specific
@@ -15,9 +15,9 @@
 //!
 //! let registry = MetricsRegistry::new();
 //! let stats = EventBusStats {
-//!     sent_count: 75,
-//!     dropped_count: 25,
-//!     subscriber_count: 3,
+//! sent_count: 75,
+//! dropped_count: 25,
+//! subscriber_count: 3,
 //! };
 //! record_eventbus_stats(&registry, &stats).unwrap();
 //! ```

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -10,10 +10,9 @@
 //!
 //! Single observability crate covering primitive metric types, label interning,
 //! standard `nebula_*` metric names, cardinality safety, and Prometheus export.
-//! Per ADR-0046 the formerly separate `nebula-telemetry` primitives layer was
-//! absorbed into this crate; the cross-crate boundary was structurally
-//! unenforced and caused daily friction. Intra-crate module discipline
-//! (`mod` boundaries + `pub`/`pub(crate)`) replaces canon `[L1-§3.10]`.
+//! The formerly separate `nebula-telemetry` primitives layer was absorbed into
+//! this crate; intra-crate module discipline (`mod` boundaries + `pub`/`pub(crate)`)
+//! replaces a cross-crate boundary that was structurally unenforced.
 //!
 //! ## Public API
 //!

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -47,7 +47,7 @@ pub mod engine_lease_contention_reason {
     pub const HEARTBEAT_LOST: &str = "heartbeat_lost";
 }
 
-/// Counter: control-queue reclaim sweep outcomes (ADR-0017).
+/// Counter: control-queue reclaim sweep outcomes.
 ///
 /// Labeled by `outcome` (see [`control_reclaim_outcome`]). The
 /// `ControlConsumer` reclaim sweep increments this counter by the per-row
@@ -110,7 +110,7 @@ pub mod dispatch_reject_reason {
 }
 
 // ---------------------------------------------------------------------------
-// API: idempotency middleware (M3.4 — ADR-0048)
+// API: idempotency middleware (M3.4
 // ---------------------------------------------------------------------------
 
 /// Counter: idempotent-replay cache hits.
@@ -154,7 +154,7 @@ pub const NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL: &str = "nebula_api_idempotency_r
 ///
 /// Static strings — call sites and tests compare without stringifying twice.
 /// Adding a label permanently inflates the cardinality floor and requires
-/// an ADR amendment (ADR-0048).
+/// an ADR amendment.
 pub mod idempotency_reject_reason {
     /// Header validation failed — empty / too long / non-printable ASCII.
     /// Hard reject: 400 returned without running the handler.
@@ -196,7 +196,7 @@ pub const NEBULA_API_IDEMPOTENCY_LATENCY_MS: &str = "nebula_api_idempotency_late
 // ---------------------------------------------------------------------------
 
 /// Counter: webhook requests rejected by the transport-layer signature
-/// check (ADR-0022 + M3.3 / ADR-0049).
+/// check.
 ///
 /// Labeled by `reason` (see [`webhook_signature_failure_reason`]). Low
 /// cardinality by design — the label set is a small closed set of
@@ -231,7 +231,7 @@ pub mod webhook_signature_failure_reason {
     /// 500 (not 401) because the misconfiguration is on our side.
     pub const MISSING_SECRET: &str = "missing_secret";
     /// Replay-window check failed: the timestamp header was absent
-    /// when the policy required one (M3.3 / ADR-0049).
+    /// when the policy required one.
     pub const TIMESTAMP_MISSING: &str = "timestamp_missing";
     /// Replay-window check failed: the timestamp header was present
     /// but unparsable (non-numeric, malformed RFC 3339, etc.).
@@ -242,7 +242,7 @@ pub mod webhook_signature_failure_reason {
     pub const TIMESTAMP_OUT_OF_WINDOW: &str = "timestamp_out_of_window";
 }
 
-/// Counter: webhook requests entering the transport (M3.3 / ADR-0049).
+/// Counter: webhook requests entering the transport.
 ///
 /// Labeled by:
 /// - `outcome` — see [`webhook_request_outcome`].
@@ -257,27 +257,27 @@ pub mod webhook_signature_failure_reason {
 pub const NEBULA_WEBHOOK_REQUESTS_TOTAL: &str = "nebula_webhook_requests_total";
 
 /// Histogram: end-to-end transport handling latency in seconds
-/// (M3.3 / ADR-0049). Same labelset as
+///. Same labelset as
 /// [`NEBULA_WEBHOOK_REQUESTS_TOTAL`].
 pub const NEBULA_WEBHOOK_LATENCY_SECONDS: &str = "nebula_webhook_latency_seconds";
 
 /// Counter: requests rejected by replay-window enforcement
-/// (M3.3 / ADR-0049). Labeled by `reason` (see
+///. Labeled by `reason` (see
 /// [`webhook_replay_rejection_reason`]).
 pub const NEBULA_WEBHOOK_REPLAY_REJECTIONS_TOTAL: &str = "nebula_webhook_replay_rejections_total";
 
 /// Counter: requests rejected by per-key rate-limit enforcement
-/// (M3.3 / ADR-0049). Labels: `tenant_id`, `webhook_key_kind`.
+///. Labels: `tenant_id`, `webhook_key_kind`.
 pub const NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL: &str =
     "nebula_webhook_rate_limit_rejections_total";
 
 /// Counter: storage-driven bootstrap rows that failed to register
-/// in the transport (M3.3 / ADR-0049 / E1). Labeled by `reason` (see
+/// in the transport ( / E1). Labeled by `reason` (see
 /// [`webhook_bootstrap_failure_reason`]).
 pub const NEBULA_WEBHOOK_BOOTSTRAP_FAILURES_TOTAL: &str = "nebula_webhook_bootstrap_failures_total";
 
 /// Gauge: active webhook registrations in the transport's routing
-/// map (M3.3 / ADR-0049). Labeled by `webhook_key_kind`.
+/// map. Labeled by `webhook_key_kind`.
 ///
 /// Used by `/healthz` reporters and dashboarding. Counts move
 /// monotonically with E1 bootstrap, E2 lifecycle events, and E3
@@ -286,8 +286,8 @@ pub const NEBULA_WEBHOOK_REGISTRATIONS: &str = "nebula_webhook_registrations";
 
 /// Counter: provider-specific verification interceptions before the
 /// action's main `handle_request` (Slack `url_verification`, Stripe
-/// `pending_webhook` ping, Generic `?challenge=…` GET — M3.3 /
-/// ADR-0049). Labels: `provider` (`slack` | `stripe` | `generic`),
+/// `pending_webhook` ping, Generic `?challenge=…` GET (M3.3).
+/// Labels: `provider` (`slack` | `stripe` | `generic`),
 /// `outcome` (see [`webhook_provider_intercept_outcome`]).
 pub const NEBULA_WEBHOOK_PROVIDER_INTERCEPTS_TOTAL: &str =
     "nebula_webhook_provider_intercepts_total";
@@ -489,7 +489,7 @@ pub const NEBULA_CREDENTIAL_EXPIRED_TOTAL: &str = "nebula_credential_expired_tot
 
 // ---------------------------------------------------------------------------
 // Credential refresh coordinator (two-tier L1+L2 — sub-spec
-// `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)` §6)
+// `docs/INTEGRATION_MODEL.md` credential refresh coordinator)
 // ---------------------------------------------------------------------------
 
 /// Counter: L2 claim acquisition outcomes.
@@ -923,7 +923,7 @@ mod tests {
         );
     }
 
-    /// API idempotency metrics (M3.4 — ADR-0048).
+    /// API idempotency metrics (M3.4.
     ///
     /// 3 counters + 1 gauge + 1 histogram = 5 series. Mirrors the
     /// per-counter `(name, label_key, sample_value)` pattern used for

--- a/crates/metrics/src/prometheus.rs
+++ b/crates/metrics/src/prometheus.rs
@@ -118,9 +118,7 @@ fn counter_help(name: &str) -> &'static str {
             "Total resolver reauth-required persist attempts that exhausted CAS retries."
         },
         NEBULA_ENGINE_LEASE_CONTENTION_TOTAL => "Total engine execution-lease contention events.",
-        NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL => {
-            "Total control-queue reclaim sweep outcomes (ADR-0017)."
-        },
+        NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL => "Total control-queue reclaim sweep outcomes.",
         NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL => {
             "Total webhook HMAC signature failures (labeled by reason)."
         },
@@ -358,7 +356,7 @@ fn escape_label_value(value: &str) -> String {
 ///
 /// Dynamically iterates all entries in the registry — including labeled
 /// metrics — via `snapshot_counters`, `snapshot_gauges`, and
-/// `snapshot_histograms`.  Entries are grouped by metric name so each family
+/// `snapshot_histograms`. Entries are grouped by metric name so each family
 /// gets a single `# HELP` / `# TYPE` header, matching the Prometheus
 /// exposition format spec.
 #[must_use]

--- a/crates/plugin/src/discovered_plugin.rs
+++ b/crates/plugin/src/discovered_plugin.rs
@@ -6,7 +6,7 @@
 //! `RemoteAction` list built from the wire `ActionDescriptor`s.
 //!
 //! `credentials()` and `resources()` intentionally return empty vecs.
-//! Out-of-process credential and resource registration is gated on ADR-0025
+//! Out-of-process credential and resource registration is gated on
 //! slice 1d broker RPC.
 
 use std::sync::Arc;
@@ -54,13 +54,13 @@ impl Plugin for DiscoveredPlugin {
     }
 
     fn credentials(&self) -> Vec<Arc<dyn AnyCredential>> {
-        // Out-of-process credential registration is gated on ADR-0025 slice 1d
+        // Out-of-process credential registration is gated on slice 1d
         // broker RPC. Until that lands, discovered plugins report zero credentials.
         vec![]
     }
 
     fn resources(&self) -> Vec<Arc<dyn AnyResource>> {
-        // Out-of-process resource registration is gated on ADR-0025 slice 1d
+        // Out-of-process resource registration is gated on slice 1d
         // broker RPC. Until that lands, discovered plugins report zero resources.
         vec![]
     }

--- a/crates/plugin/src/discovery.rs
+++ b/crates/plugin/src/discovery.rs
@@ -17,7 +17,7 @@
 //!
 //! There is no per-plugin capability/scope model in this path: egress,
 //! credential, and filesystem mediation is the broker's responsibility
-//! (ADR-0025), not discovery (canon §12.6). The probe and the runtime
+//!, not discovery. The probe and the runtime
 //! sandbox spawn the binary with the same OS-level hardening.
 
 use std::{path::Path, sync::Arc, time::Duration};
@@ -41,7 +41,7 @@ use crate::{
 /// from.
 ///
 /// The `binary` is exposed so an engine-side composition root can key an
-/// engine-owned plugin-process pool on `(binary, scope)` per ADR-0025 §2.
+/// engine-owned plugin-process pool on `(binary, scope)`.
 /// The pre-existing `handler` (a `ProcessSandboxHandler` over one
 /// long-lived process) is unchanged — the binary is purely additive
 /// context for callers that pool processes themselves.
@@ -144,8 +144,8 @@ pub enum DiscoveryError {
 /// Probe a plugin binary and return its wire metadata.
 ///
 /// The probe spawns the binary with the same OS-level hardening as the
-/// runtime sandbox. There is no per-plugin capability grant (canon §12.6;
-/// scope model is the broker's per ADR-0025).
+/// runtime sandbox. There is no per-plugin capability grant (;
+/// scope model is the broker's ).
 ///
 /// Uses a **two-phase parse**: the response bytes are first parsed to a
 /// `serde_json::Value`, `kind` + `protocol_version` are checked, and only
@@ -260,7 +260,7 @@ enum SkipReason {
     /// per-action skip) because a plugin that lies about its action namespace
     /// cannot be trusted — fail fast and surface the violation at load time.
     /// Symmetric with [`crate::ResolvedPlugin::from`]'s fail-fast
-    /// behaviour for in-process plugins (ADR-0027 §7).
+    /// behaviour for in-process plugins.
     CrossNamespaceAction {
         descriptor_key: String,
         plugin_key: String,
@@ -465,7 +465,7 @@ async fn discover_one(
         credentials = 0,
         resources = 0,
         binary = %binary.display(),
-        "discovered out-of-process plugin (credentials/resources gated on ADR-0025 slice 1d)",
+        "discovered out-of-process plugin (credentials/resources gated on broker slice 1d)",
     );
 
     // Step 6: construct DiscoveredPlugin + ResolvedPlugin.
@@ -486,8 +486,8 @@ async fn discover_one(
 ///
 /// ## Why two outputs?
 ///
-/// The engine's `PluginRegistry` stores `Arc<dyn ActionFactory>` (per
-/// ADR-0043 §6 / Variant A). The runtime's `ActionRegistry` stores
+/// The engine's `PluginRegistry` stores `Arc<dyn ActionFactory>` per action key.
+/// The runtime's `ActionRegistry` stores
 /// `Arc<dyn StatelessHandler>`. Both wrappings require the concrete
 /// `Arc<RemoteAction>` — which is available during construction but lost
 /// after coercion. `discover_directory` performs both at construction time
@@ -496,8 +496,8 @@ async fn discover_one(
 /// `binary` so an engine-side pooling caller can key on `(binary, scope)`.
 ///
 /// Per-plugin capability/scope is **not** modeled here — egress, credential,
-/// and filesystem mediation is the broker's responsibility (ADR-0025), not
-/// this discovery path (canon §12.6).
+/// and filesystem mediation is the broker's responsibility, not
+/// this discovery path.
 pub async fn discover_directory(
     dir: &Path,
     registry: &mut PluginRegistry,

--- a/crates/plugin/src/lib.rs
+++ b/crates/plugin/src/lib.rs
@@ -1,6 +1,6 @@
 //! # nebula-plugin
 //!
-//! **Role:** Plugin Distribution Unit — registry + manifest. Canon §7.1 (plugin
+//! **Role:** Plugin Distribution Unit — registry + manifest. (plugin
 //! is the unit of registration, not the unit of size; full plugins and
 //! micro-plugins use the same contract).
 //!
@@ -14,12 +14,12 @@
 //! ## Key types
 //!
 //! - `Plugin` — base trait every plugin implements; `actions()`, `credentials()`, `resources()`,
-//!   `on_load()`, `on_unload()` (default no-ops). Returns runnable trait objects (canon §3.5).
+//!   `on_load()`, `on_unload()` (default no-ops). Returns runnable trait objects.
 //! - `PluginManifest` — bundle descriptor with builder API (key, name, semver version, group,
 //!   `Icon`, maturity, deprecation, author/license/homepage/repository metadata). Does **not**
-//!   compose `BaseMetadata<K>` — a plugin is a container, not a schematized leaf (ADR-0018).
+//!   compose `BaseMetadata<K>` — a plugin is a container, not a schematized leaf.
 //! - `ResolvedPlugin` — per-plugin wrapper with eager component caches; enforces namespace
-//!   invariant at construction (ADR-0027).
+//!   invariant at construction.
 //! - `PluginRegistry` — in-memory `PluginKey → Arc<ResolvedPlugin>` registry.
 //! - `PluginError` — typed error for plugin operations.
 //! - `ComponentKind` — discriminant for namespace and duplicate errors.
@@ -31,7 +31,7 @@
 //! - `sandbox_bridge::sandbox_error_to_action_error` — the single `SandboxError` → `ActionError`
 //!   classification seam, shared by the handler and the engine runner adapter.
 //!
-//! ## Canon note — §7.1
+//! ## Registration contract
 //!
 //! `impl Plugin` is the single runtime source of truth for what is registered.
 //! Do not duplicate `fn actions()` / `fn resources()` / `fn credentials()` in

--- a/crates/plugin/src/manifest.rs
+++ b/crates/plugin/src/manifest.rs
@@ -1,4 +1,4 @@
-//! `PluginManifest` is canonical in `nebula-metadata` (ADR-0018 follow-up,
+//! `PluginManifest` is canonical in `nebula-metadata` ( follow-up,
 //! moved there in slice B of the plugin load-path stabilization). This module
 //! re-exports the type for source compatibility of callers that still write
 //! `use nebula_plugin::PluginManifest;`.

--- a/crates/plugin/src/plugin.rs
+++ b/crates/plugin/src/plugin.rs
@@ -1,9 +1,9 @@
-//! Base `Plugin` trait — canonical per ADR-0027.
+//! Base `Plugin` trait — canonical.
 //!
 //! A plugin bundles actions / credentials / resources under a versioned
-//! identity. It returns the runnable trait objects directly (matching canon
-//! §3.5 "Plugin = [ registry: Actions + Resources + Credentials ]"), not
-//! descriptors. One plugin → one `ResolvedPlugin` after registration.
+//! identity. It returns the runnable trait objects directly (plugin =
+//! registry of actions, credentials, and resources), not descriptors.
+//! One plugin → one `ResolvedPlugin` after registration.
 
 use std::{fmt::Debug, sync::Arc};
 
@@ -35,7 +35,7 @@ pub trait Plugin: Send + Sync + Debug + 'static {
     ///
     /// Each entry is a typed factory that the engine registry will use to
     /// construct an [`nebula_action::ErasedAction`] per dispatch (per
-    /// ADR-0043 §6 / Phase 3 — the typed [`nebula_action::Action`] trait
+    ///
     /// is `Sized`/object-unsafe, so plugins return factories not actions).
     fn actions(&self) -> Vec<Arc<dyn nebula_action::ActionFactory>> {
         vec![]

--- a/crates/plugin/src/plugin_toml.rs
+++ b/crates/plugin/src/plugin_toml.rs
@@ -1,4 +1,4 @@
-//! `plugin.toml` parsing per canon §7.1.
+//! `plugin.toml` parsing per
 //!
 //! The `plugin.toml` file sits next to a plugin binary and declares two things:
 //! 1. `[nebula].sdk` — semver `VersionReq` the plugin was built against.

--- a/crates/plugin/src/remote_action.rs
+++ b/crates/plugin/src/remote_action.rs
@@ -6,7 +6,7 @@
 //! discovery) and delegates execution to the long-lived `ProcessSandbox`
 //! handle via the existing `ProcessSandboxHandler`.
 //!
-//! Per ADR-0043 §6 / Phase 3, the typed [`nebula_action::Action`] trait is
+//! The typed [`nebula_action::Action`] trait is
 //! `Sized`/object-unsafe and requires static metadata — incompatible with
 //! the dynamic per-instance metadata `RemoteAction` carries. So the wrapper
 //! only provides the dyn-erased [`StatelessHandler`] surface; engine
@@ -80,7 +80,7 @@ impl StatelessHandler for RemoteAction {
 
 /// `ActionFactory` adapter for an out-of-process [`RemoteAction`].
 ///
-/// The host registry stores `Arc<dyn ActionFactory>` per ADR-0043 §6;
+/// The host registry stores `Arc<dyn ActionFactory>` ;
 /// at dispatch time the engine calls
 /// [`instantiate`](ActionFactory::instantiate) and gets an
 /// [`ErasedAction::Stateless`] wrapping the underlying `RemoteAction`'s

--- a/crates/plugin/src/resolved_plugin.rs
+++ b/crates/plugin/src/resolved_plugin.rs
@@ -7,7 +7,7 @@
 //! duplicate keys surface as `PluginError::DuplicateComponent`; out-of-
 //! namespace keys surface as `PluginError::NamespaceMismatch`.
 //!
-//! See ADR-0027 and `docs/pitfalls.md`.
+//! See and `docs/pitfalls.md`.
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/plugin/tests/plugin_toml_parse.rs
+++ b/crates/plugin/tests/plugin_toml_parse.rs
@@ -1,4 +1,4 @@
-//! Parser tests for `plugin.toml` per canon §7.1.
+//! Parser tests for `plugin.toml` per
 
 use std::path::PathBuf;
 

--- a/crates/resilience/src/lib.rs
+++ b/crates/resilience/src/lib.rs
@@ -10,7 +10,7 @@
 //! authors wire at outbound call sites. Retry filtering is driven by `nebula-error::Classify`
 //! so transient vs permanent is explicit — not folklore.
 //!
-//! Per canon §11.2, `nebula-resilience` pipelines are the **canonical retry surface today**.
+//! `nebula-resilience` pipelines are the **canonical retry surface today**.
 //! Engine-level node re-execution with persisted attempt accounting is `planned`. See
 //! `crates/resilience/README.md` for the full role description and contract invariants.
 //!
@@ -38,20 +38,20 @@
 //! use std::time::Duration;
 //!
 //! use nebula_resilience::{
-//!     CallError, ResiliencePipeline,
-//!     retry::{BackoffConfig, RetryConfig},
+//! CallError, ResiliencePipeline,
+//! retry::{BackoffConfig, RetryConfig},
 //! };
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! let pipeline = ResiliencePipeline::<String>::builder()
-//!     .timeout(Duration::from_secs(5))
-//!     .retry(RetryConfig::new(3)?.backoff(BackoffConfig::exponential_default()))
-//!     .build();
+//!.timeout(Duration::from_secs(5))
+//!.retry(RetryConfig::new(3)?.backoff(BackoffConfig::exponential_default()))
+//!.build();
 //!
 //! let _value: Result<String, _> = pipeline
-//!     .call(|| Box::pin(async { Ok::<_, String>("success".into()) }))
-//!     .await;
+//!.call(|| Box::pin(async { Ok::<_, String>("success".into()) }))
+//!.await;
 //! # Ok(())
 //! # }
 //! ```
@@ -69,32 +69,32 @@
 //! # #[derive(Debug)]
 //! # struct MyError;
 //! # impl std::fmt::Display for MyError {
-//! #     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "error") }
+//! # fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result { write!(f, "error") }
 //! # }
 //! # impl std::error::Error for MyError {}
 //! # impl nebula_error::Classify for MyError {
-//! #     fn category(&self) -> nebula_error::ErrorCategory { nebula_error::ErrorCategory::Internal }
-//! #     fn code(&self) -> nebula_error::ErrorCode { nebula_error::ErrorCode::new("DOC:EXAMPLE") }
+//! # fn category(&self) -> nebula_error::ErrorCategory { nebula_error::ErrorCategory::Internal }
+//! # fn code(&self) -> nebula_error::ErrorCode { nebula_error::ErrorCode::new("DOC:EXAMPLE") }
 //! # }
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! // Circuit breaker
 //! let cb = CircuitBreaker::new(CircuitBreakerConfig {
-//!     failure_threshold: 5,
-//!     reset_timeout: Duration::from_secs(30),
-//!     ..Default::default()
+//! failure_threshold: 5,
+//! reset_timeout: Duration::from_secs(30),
+//!..Default::default()
 //! })?;
 //!
 //! let result = cb.call(|| Box::pin(async {
-//!     Ok::<_, MyError>("ok")
+//! Ok::<_, MyError>("ok")
 //! })).await;
 //!
 //! // Retry with Classify-aware error filtering
 //! let config = RetryConfig::<MyError>::new(3)?
-//!     .backoff(BackoffConfig::Fixed(Duration::from_millis(50)));
+//!.backoff(BackoffConfig::Fixed(Duration::from_millis(50)));
 //!
 //! let result = retry_with(config, || Box::pin(async {
-//!     Ok::<_, MyError>("ok")
+//! Ok::<_, MyError>("ok")
 //! })).await;
 //! # Ok(())
 //! # }
@@ -114,7 +114,7 @@
 //! | `RetriesExhausted { attempts, last }` | no | retry |
 //! | `Cancelled { reason }` | no | cancellation |
 //! | `LoadShed` | no | load shedder |
-//! | `FallbackFailed { reason }` / `FallbackFailedWithContext { .. }` | no | fallback |
+//! | `FallbackFailed { reason }` / `FallbackFailedWithContext {.. }` | no | fallback |
 //!
 //! # Observability
 //!

--- a/crates/resource/macros/src/field_slots.rs
+++ b/crates/resource/macros/src/field_slots.rs
@@ -1,4 +1,4 @@
-//! Field-level credential slot detection for `#[derive(Resource)]` (ADR-0044).
+//! Field-level credential slot detection for `#[derive(Resource)]` (slot model).
 //!
 //! Walks the struct fields and identifies `#[credential(...)]` attributes.
 //! Each slot field is a [`SlotCell`] cell holding the resolved guard — the
@@ -9,7 +9,7 @@
 //! (required + eager). `Option<…>`- and `Lazy<…>`-wrapped slots are
 //! reserved for future optional/lazy binding but are currently rejected
 //! at the derive site with a compile error, because the emitted accessor
-//! only fits the plain cell shape (ADR-0044).
+//! only fits the plain cell shape (slot model).
 //!
 //! Detection is by path-tail name (last `PathSegment::ident`) so the
 //! macro accepts both bare `SlotCell<...>` / `CredentialGuard<...>` and
@@ -245,7 +245,7 @@ pub(crate) fn emit_slot_field_registrations(slots: &[ParsedCredentialSlot]) -> T
 
 /// Emit the body of `Resource::credential_slot_epoch` — an
 /// **order-sensitive positional fold** over every declared
-/// `#[credential]` `SlotCell` field's generation (ADR-0067 §Deferred
+/// `#[credential]` `SlotCell` field's generation (per-resource revoke deferral
 /// create-vs-rotate reconcile).
 ///
 /// Derive-generated so a newly-added credential slot is automatically
@@ -310,7 +310,7 @@ pub(crate) fn emit_credential_slot_epoch_body(slots: &[ParsedCredentialSlot]) ->
 /// declared by the author; the framework populates and rotates it through
 /// `&self` (`SlotCell::store`), and this accessor is the read side —
 /// `self.<field>.load()` returns the current `Arc<CredentialGuard<C>>`, or
-/// `None` until the framework binds it. No fields are added (ADR-0044).
+/// `None` until the framework binds it. No fields are added (slot model).
 pub(crate) fn emit_slot_accessors(slots: &[ParsedCredentialSlot]) -> TokenStream2 {
     let accessors: Vec<TokenStream2> = slots
         .iter()

--- a/crates/resource/macros/src/lib.rs
+++ b/crates/resource/macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! # nebula-resource-macros
 //!
-//! Proc-macros for the `nebula-resource` crate (Phase 4 / ADR-0044).
+//! Proc-macros for the `nebula-resource` crate (Phase 4 / slot model).
 //!
 //! ## `#[derive(Resource)]`
 //!
@@ -55,7 +55,7 @@ mod field_slots;
 mod resource;
 mod resource_attrs;
 
-/// Derive macro for the `Resource` trait (Phase 4 / ADR-0044).
+/// Derive macro for the `Resource` trait (Phase 4 / slot model).
 ///
 /// Emits `impl Resource for Foo` (with `todo!()` `create` body — the
 /// implementor supplies it) and `impl DeclaresDependencies for Foo`

--- a/crates/resource/macros/src/resource.rs
+++ b/crates/resource/macros/src/resource.rs
@@ -1,4 +1,4 @@
-//! `#[derive(Resource)]` macro implementation — Phase 4 / ADR-0044.
+//! `#[derive(Resource)]` macro implementation — Phase 4 / slot model.
 //!
 //! Emits:
 //! - `impl Resource for Foo` with `key()` returning the `#[resource(key = ...)]` value, and the
@@ -89,7 +89,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
                 }
             }
 
-            // ADR-0067 §Deferred: an order-sensitive positional fold over
+            // per-resource revoke deferral: an order-sensitive positional fold over
             // every declared `#[credential]` `SlotCell` field's
             // generation (NOT `max` — `max` misses a rotation of a
             // non-max slot, #690 review / #680). Derive-emitted so a
@@ -128,7 +128,7 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
 
     // Inherent read accessors over the author-declared `SlotCell` slot
     // fields. The macro adds no fields — the cell is declared by the author
-    // and populated/rotated by the framework through `&self` (ADR-0044).
+    // and populated/rotated by the framework through `&self` (slot model).
     let slot_accessor_impl = quote! {
         impl #impl_generics #struct_name #ty_generics #where_clause {
             #slot_accessors

--- a/crates/resource/macros/src/resource_attrs.rs
+++ b/crates/resource/macros/src/resource_attrs.rs
@@ -1,4 +1,4 @@
-//! Parsed `#[resource(...)]` attributes for the Phase 4 / ADR-0044
+//! Parsed `#[resource(...)]` attributes for the Phase 4 / slot model
 //! `#[derive(Resource)]`.
 
 use nebula_macro_support::{attrs, diag};

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -207,7 +207,7 @@ impl Error {
 
     /// An unknown credential slot rotated.
     ///
-    /// Per ADR-0044 invariant: the engine emits a slot-name to
+    /// Per slot model invariant: the engine emits a slot-name to
     /// `Resource::on_credential_refresh`; the implementer must handle
     /// every declared slot. If rotation arrives for a slot that was
     /// not declared via `#[credential]`, the engine surfaces this

--- a/crates/resource/src/ext.rs
+++ b/crates/resource/src/ext.rs
@@ -11,7 +11,7 @@
 //! 1. **Slot binding** (preferred for production code) — declare an `#[resource(key = "...")]`
 //!    field on the action struct; the `#[derive(Action)]` macro emits a `FromWorkflowNode` factory
 //!    that calls `ActionContextExt::acquire_resource_by_id` (in `nebula-action`) with the per-node
-//!    binding from [ADR-0042](https://github.com/vanyastaff/nebula/blob/main/docs/adr/0042-node-binding-mechanism.md).
+//!    binding from [slot binding]().
 //!    Per-node overrides via workflow JSON `node.slot_bindings` are honored automatically.
 //!
 //! 2. **`ctx.resource::<R>()` ad-hoc** (this module) — type-only lookup by `R::key()`. No per-node

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -26,7 +26,7 @@ type GuardedRelease<R> = Box<dyn FnOnce(<R as Resource>::Lease, bool) + Send + S
 /// A drain tracker: an in-flight `(active_count, waiters)` pair. One is the
 /// manager-wide `graceful_shutdown` tracker; another is each
 /// `ManagedResource`'s own counter that `Manager::revoke_slot` drains in
-/// isolation (ADR-0067 §Deferred).
+/// isolation (per-resource revoke deferral).
 pub(crate) type DrainTracker = Arc<(AtomicU64, Notify)>;
 
 /// The `(manager_wide, per_resource)` pair an acquire pre-increments and
@@ -53,10 +53,10 @@ pub struct ResourceGuard<R: Resource> {
     /// The first element is `Manager::drain_tracker` (`graceful_shutdown`
     /// drain); the second is the originating `ManagedResource`'s own
     /// in-flight tracker, which `Manager::revoke_slot` drains in isolation
-    /// (ADR-0067 §Deferred). Both are pre-incremented by `InFlightCounter`
+    /// (per-resource revoke deferral). Both are pre-incremented by `InFlightCounter`
     /// and handed off here, so a guard handed out for a row reflects in that
     /// row's revoke drain — closing the revoke-vs-acquire TOCTOU
-    /// (ADR-0044/0036).
+    /// (slot + isolation model).
     drain_counters: Option<DrainTrackers>,
 }
 
@@ -172,9 +172,9 @@ impl<R: Resource> ResourceGuard<R> {
     /// `graceful_shutdown` race: an acquire that passed `lookup()` before
     /// `cancel.cancel()` could otherwise complete *after* `wait_for_drain()`
     /// observed `0` and the registry was cleared. (2) The revoke-vs-acquire
-    /// TOCTOU (ADR-0044/0036): because the per-resource counter is
+    /// TOCTOU (slot + isolation model): because the per-resource counter is
     /// incremented before the post-taint re-check and decremented only when
-    /// this guard drops, `revoke_slot`'s per-resource drain (ADR-0067
+    /// this guard drops, `revoke_slot`'s per-resource drain (resource runtime status
     /// §Deferred) cannot complete while a guard handed out for that row is
     /// still live.
     pub(crate) fn with_drain_tracker(mut self, trackers: DrainTrackers) -> Self {
@@ -339,7 +339,7 @@ impl<R: Resource> Drop for ResourceGuard<R> {
         // active counts, waking each owning `Notify` on its 1 → 0 edge. The
         // manager-wide tracker unblocks `graceful_shutdown`; the per-resource
         // tracker unblocks `revoke_slot`'s isolated per-resource drain
-        // (ADR-0067 §Deferred).
+        // (per-resource revoke deferral).
         if let Some((ref manager, ref per_resource)) = self.drain_counters {
             for tracker in [manager, per_resource] {
                 if tracker.0.fetch_sub(1, AtomicOrdering::Release) == 1 {

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -1,7 +1,7 @@
 //! # nebula-resource
 //!
 //! **Role:** Bulkhead Pool — engine-owned resource lifecycle (acquire / health /
-//! release). Canon §11.4, §13.3. Pattern: Release It! "Bulkhead."
+//! release). Bulkhead isolation (integration seam step 3). Pattern: Release It! "Bulkhead."
 //!
 //! The engine is the owner of the resource lifecycle: acquire, health-check,
 //! hot-reload via `ReloadOutcome`, and scope-bounded release. Action code
@@ -75,7 +75,7 @@ pub use nebula_core::{ExecutionId, ResourceKey, ScopeLevel, WorkflowId, resource
 // Credential surface re-exported so resource consumers don't need a
 // direct nebula-credential dep for trait shape.
 //
-// Per ADR-0044 the singular `Resource::Credential` associated type and
+// Per slot model the singular `Resource::Credential` associated type and
 // its `NoCredential` opt-out type are gone — credentials are declared
 // via `#[credential(key = ...)]` slot fields on the resource struct.
 // `NoCredential`/`NoCredentialState` are no longer re-exported.

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -4,8 +4,8 @@
 //! the registry, recovery-group registry, and a [`CancellationToken`] for
 //! coordinated shutdown.
 //!
-//! Phase 4 / ADR-0044: the public API drops the `R::Credential` projection
-//! that ADR-0036 used to thread `scheme: &<R::Credential as Credential>::Scheme`
+//! Phase 4 / slot model: the public API drops the `R::Credential` projection
+//! that credential isolation used to thread `scheme: &<R::Credential as Credential>::Scheme`
 //! through every acquire/warmup/register call. Resources now declare
 //! credential dependencies as typed slot fields on the struct (via
 //! `#[credential]` attributes), and the framework resolves them BEFORE
@@ -87,7 +87,7 @@ pub struct ResourceHealthSnapshot {
 /// A resource registry row whose credential slot has been **synchronously
 /// tainted** by [`Manager::taint_slot`](Manager::taint_slot) /
 /// [`Manager::taint_slot_for`](Manager::taint_slot_for) — phase 1 of the
-/// two-phase revoke port (ADR-0067 §Deferred).
+/// two-phase revoke port (per-resource revoke deferral).
 ///
 /// Holding one is proof the taint already ran to completion: new acquires on
 /// this row's credential are already rejected. It is consumed by
@@ -142,7 +142,7 @@ impl std::fmt::Debug for TaintedSlot {
 /// `tokio::time::timeout` wrapping the whole tail — that wrapper used to
 /// be able to drop the future *before the hook ran* when the drain was
 /// slow, contradicting the "hook still runs after a timed-out drain"
-/// contract (ADR-0067 §Deferred). So the three terminal states are
+/// contract (per-resource revoke deferral). So the three terminal states are
 /// reported here rather than inferred from a dropped outer future:
 ///
 /// - [`Done`](Self::Done) — the revoke hook completed `Ok`.
@@ -290,7 +290,7 @@ impl Manager {
     /// Registers a resource with its config, scope, topology, and optional
     /// resilience / recovery gate configuration.
     ///
-    /// Per ADR-0044 the `resource: R` value passed in is expected to have
+    /// Per slot model the `resource: R` value passed in is expected to have
     /// **all `#[credential]` slot fields already resolved and populated**.
     /// `Manager::register` does not itself resolve credential bindings —
     /// that is the responsibility of the caller (typically the engine
@@ -738,7 +738,7 @@ impl Manager {
     /// `TopologyRuntime<R>`. It is the seam a config-CRUD writer uses to
     /// reject a bad `ResourceEntry.config` *before* persistence, keeping
     /// config validation strictly separate from engine-activation live
-    /// registration (INTEGRATION_MODEL §13.1 — live registration happens
+    /// registration (INTEGRATION_MODEL integration seam.1 — live registration happens
     /// at engine activation, never at config-create time).
     ///
     /// Template resolution is deliberately excluded: `{{ … }}` is resolved
@@ -761,7 +761,7 @@ impl Manager {
     ///   `R::Config` schema does not declare (closed-set guard):
     ///   `ResourceConfig` must carry no secrets, so an inlined
     ///   secret-shaped field is rejected here rather than silently ignored
-    ///   (PRODUCT_CANON §3.5). The error names only the offending key,
+    ///   (product credential boundary). The error names only the offending key,
     ///   never its value.
     pub fn validate_config_value<R>(config_json: serde_json::Value) -> Result<R::Config, Error>
     where
@@ -791,7 +791,7 @@ impl Manager {
         // could inline a secret-shaped field (e.g. `password`) into
         // `ResourceConfig` and get no signal — `ResourceConfig` must carry no
         // secrets; secrets reach a resource ONLY via typed credential slots
-        // (PRODUCT_CANON §3.5; ADR-0044 slot model; ADR-0030 redaction; ADR-0036
+        // (product credential boundary; slot model; engine credential orchestration redaction; credential isolation
         // isolation). The error names only the offending KEY, never its value, so
         // a mis-wired secret can never leak through the rejection message.
         //
@@ -809,7 +809,7 @@ impl Manager {
                 "validate_config_value: config field `{unknown}` is not declared by \
                  the `{ty}` schema; secrets must not be inlined into ResourceConfig \
                  — bind them through a typed credential slot instead \
-                 (PRODUCT_CANON §3.5)",
+                 (product credential boundary)",
                 unknown = unknown.as_str(),
                 ty = std::any::type_name::<R::Config>(),
             )));
@@ -844,16 +844,16 @@ impl Manager {
     ///    (slots already filled by the caller), `topology`, `scope`, and optional
     ///    `resilience`/`recovery_gate`.
     ///
-    /// `slot_bindings` carries the slot-name → credential id map per ADR-0042 hybrid binding.
+    /// `slot_bindings` carries the slot-name → credential id map per slot binding hybrid binding.
     /// Credential resolution is the engine dispatch layer's responsibility; the manager itself is
-    /// credential-agnostic post-ADR-0044 (see Phase 4 — `R::Credential` was deleted), so this
+    /// credential-agnostic post-slot model (see Phase 4 — `R::Credential` was deleted), so this
     /// argument is recorded for tracing only and asserted to match the slot fields the resource
     /// declared via [`DeclaresDependencies`](nebula_core::DeclaresDependencies). The caller
     /// (engine) is expected to have already used these bindings to resolve credentials into the
     /// `resource: R` it hands in.
     ///
     /// `nebula-resource → nebula-expression` is allowed under deny.toml's `[[bans]]`
-    /// `nebula-resource` wrapper allowlist (Business → Core layer edge per ADR-0043 §9 / Phase 9,
+    /// `nebula-resource` wrapper allowlist (Business → Core layer edge per typed ref fields / Phase 9,
     /// R-040 R8).
     ///
     /// # Errors
@@ -863,7 +863,7 @@ impl Manager {
     /// - [`Error::permanent`] when the config carries a top-level field the `R::Config` schema
     ///   does not declare (closed-set guard): `ResourceConfig` must carry no secrets, so an
     ///   inlined secret-shaped field is rejected here rather than silently ignored
-    ///   (PRODUCT_CANON §3.5). The error names only the offending key, never its value.
+    ///   (product credential boundary). The error names only the offending key, never its value.
     /// - [`Error::permanent`] when a `slot_bindings` key does not correspond to a declared
     ///   credential slot on `R`.
     /// - Any [`Error`](Error) returned by the underlying typed [`register`](Self::register).
@@ -934,7 +934,7 @@ impl Manager {
         //    JSON path (the caller has already resolved these bindings into `resource: R`). Folding
         //    it into the registry row keeps two registrations that resolved *different* credentials
         //    on separate rows with separate runtimes — the structural barrier against cross-tenant
-        //    runtime bleed (ADR-0036 isolation intent, ADR-0044 slot model). It is a hash over
+        //    runtime bleed (credential isolation isolation intent, slot model). It is a hash over
         //    `(slot_key, credential_key)` pairs only — it carries no secret bytes.
         let slot_id = {
             let pairs: Vec<(String, String)> = slot_bindings
@@ -1103,8 +1103,8 @@ impl Manager {
     /// `revoke_slot` could taint *after* the gate but *before* the increment.
     /// Re-checking here — once this acquire is reflected in the resource's
     /// own in-flight counter (the exact counter `revoke_slot` drains,
-    /// ADR-0067 §Deferred) — closes that revoke-vs-acquire TOCTOU so a guard
-    /// is never handed out on a just-revoked credential (ADR-0044/0036).
+    /// per-resource revoke deferral) — closes that revoke-vs-acquire TOCTOU so a guard
+    /// is never handed out on a just-revoked credential (slot + isolation model).
     /// Same error/classification as the gate so the caller-facing category
     /// is unchanged (`Revoked` → `ErrorCategory::Unavailable`).
     fn reject_if_tainted_post_count<R: Resource>(
@@ -1268,7 +1268,7 @@ impl Manager {
     /// new acquires accepted on a credential whose revoke "timed out". This
     /// function is plain `fn`: the taint is applied eagerly at the call site,
     /// fully completed before this returns, and therefore *outside* and
-    /// *before* any per-resource timeout (ADR-0067 §Deferred).
+    /// *before* any per-resource timeout (per-resource revoke deferral).
     ///
     /// Identity routing: resolves the registry row whose `slot_identity`
     /// matches via the unambiguous-by-construction
@@ -1356,7 +1356,7 @@ impl Manager {
         // pipelines re-check this taint *after* their per-resource in-flight
         // increment, so an acquire that passed the taint gate but had not yet
         // incremented cannot slip a guard out on the just-revoked credential
-        // (ADR-0044/0036 "no authenticated traffic on a revoked credential
+        // (slot + isolation model "no authenticated traffic on a revoked credential
         // post-revoke"). Because this function is not `async`, the store has
         // *already happened* by the time control returns to the caller — a
         // subsequently-dropped timeout future on the drain tail cannot
@@ -1378,7 +1378,7 @@ impl Manager {
     /// uses and the value [`drain_and_revoke`](Self::drain_and_revoke)
     /// previously hard-coded for the drain wait. The engine rotation
     /// fan-out does **not** use this: it passes its own per-resource
-    /// rotation budget so the timeout has one owner end-to-end (ADR-0067
+    /// rotation budget so the timeout has one owner end-to-end (resource runtime status
     /// §Deferred / #690 review).
     pub const DEFAULT_REVOKE_DRAIN_TIMEOUT: std::time::Duration =
         std::time::Duration::from_secs(30);
@@ -1389,12 +1389,12 @@ impl Manager {
     /// synchronously) and performs the remaining steps:
     ///
     /// 1. **Drain** only *this resource's* in-flight handles via its own per-resource counter
-    ///    (ADR-0067 §Deferred) — never the manager-wide `drain_tracker`, so a revoke is isolated
+    ///    (per-resource revoke deferral) — never the manager-wide `drain_tracker`, so a revoke is isolated
     ///    from in-flight traffic to unrelated resources.
     /// 2. **Dispatch** [`Resource::on_credential_revoke`] against the live runtime per topology.
     /// 3. Emit [`ResourceEvent::SlotRevoked`] / `SlotRevokeFailed`.
     ///
-    /// **Single budget owner (ADR-0067 §Deferred / #690 review).** The
+    /// **Single budget owner (per-resource revoke deferral / #690 review).** The
     /// `drain_timeout` argument is the caller's per-resource budget and is
     /// the *only* timeout governing this tail. It bounds **two** waits
     /// independently:
@@ -1446,7 +1446,7 @@ impl Manager {
             tainted_at,
         } = tainted;
 
-        // 1. Drain **only this resource's** in-flight handles (ADR-0067
+        // 1. Drain **only this resource's** in-flight handles (resource runtime status
         //    §Deferred): a revoke on resource A must not block on in-flight
         //    traffic to an unrelated resource B, so this awaits the row's
         //    own per-resource counter — not the manager-wide `drain_tracker`
@@ -1541,7 +1541,7 @@ impl Manager {
     /// rotation fan-out deliberately does **not** call this: it must run the
     /// synchronous taint phase *outside* its `tokio::time::timeout` and wrap
     /// only the awaited drain/hook tail, so a dropped timeout future can
-    /// never skip the taint (ADR-0067 §Deferred). This convenience is for the
+    /// never skip the taint (per-resource revoke deferral). This convenience is for the
     /// no-timeout caller where the two phases run back-to-back on the same
     /// task.
     ///
@@ -1576,7 +1576,7 @@ impl Manager {
     /// [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous). Like
     /// [`revoke_slot`](Self::revoke_slot) this is the back-compat
     /// back-to-back path; the engine fan-out calls the two phases separately
-    /// (sync taint outside the timeout) per ADR-0067 §Deferred.
+    /// (sync taint outside the timeout) per per-resource revoke deferral.
     ///
     /// # Errors
     ///
@@ -1758,7 +1758,7 @@ impl Manager {
         // relies on.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check (ADR-0044/0036 "no authenticated traffic
+        // Post-count taint re-check (slot + isolation model "no authenticated traffic
         // on a revoked credential post-revoke"): the taint gate ran in
         // `lookup_for_acquire`, but a revoke could have tainted *after* that
         // gate yet *before* the in-flight increment above. Re-checking here —
@@ -1887,8 +1887,8 @@ impl Manager {
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
-        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // Post-count taint re-check — see `run_pooled_acquire` (slot + isolation model
+        // / per-resource revoke deferral): closes the revoke-vs-acquire TOCTOU now that
         // this acquire is reflected in the per-resource counter `revoke_slot`
         // drains.
         Self::reject_if_tainted_post_count::<R>(&managed)?;
@@ -2003,8 +2003,8 @@ impl Manager {
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
-        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // Post-count taint re-check — see `run_pooled_acquire` (slot + isolation model
+        // / per-resource revoke deferral): closes the revoke-vs-acquire TOCTOU now that
         // this acquire is reflected in the per-resource counter `revoke_slot`
         // drains.
         Self::reject_if_tainted_post_count::<R>(&managed)?;
@@ -2127,8 +2127,8 @@ impl Manager {
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
-        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // Post-count taint re-check — see `run_pooled_acquire` (slot + isolation model
+        // / per-resource revoke deferral): closes the revoke-vs-acquire TOCTOU now that
         // this acquire is reflected in the per-resource counter `revoke_slot`
         // drains.
         Self::reject_if_tainted_post_count::<R>(&managed)?;
@@ -2255,8 +2255,8 @@ impl Manager {
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
-        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // Post-count taint re-check — see `run_pooled_acquire` (slot + isolation model
+        // / per-resource revoke deferral): closes the revoke-vs-acquire TOCTOU now that
         // this acquire is reflected in the per-resource counter `revoke_slot`
         // drains.
         Self::reject_if_tainted_post_count::<R>(&managed)?;
@@ -2334,8 +2334,8 @@ impl Manager {
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
-        // Post-count taint re-check — see `run_pooled_acquire` (ADR-0044/0036
-        // / ADR-0067 §Deferred): closes the revoke-vs-acquire TOCTOU now that
+        // Post-count taint re-check — see `run_pooled_acquire` (slot + isolation model
+        // / per-resource revoke deferral): closes the revoke-vs-acquire TOCTOU now that
         // this acquire is reflected in the per-resource counter `revoke_slot`
         // drains.
         Self::reject_if_tainted_post_count::<R>(&managed)?;
@@ -2389,7 +2389,7 @@ impl Manager {
 
     /// Pre-warms a registered Pool resource.
     ///
-    /// Per ADR-0044, the resource's `#[credential]` slot fields are
+    /// Per slot model, the resource's `#[credential]` slot fields are
     /// already populated on the resource value — `Pool::warmup` calls
     /// `R::create(config, ctx)` directly, no scheme parameter required.
     ///
@@ -2424,7 +2424,7 @@ impl Manager {
                 // `warmup` runs `R::create` against the resolved credential
                 // to materialize fresh pool instances — it is acquire-like
                 // and must observe the SAME revoke-vs-acquire TOCTOU close
-                // the `run_*_acquire` pipelines use (#679 / ADR-0044/0036).
+                // the `run_*_acquire` pipelines use (#679 / slot + isolation model).
                 // The `lookup_for_acquire` taint gate above ran *before*
                 // this in-flight increment, leaving a window where a
                 // concurrent `revoke_slot` could taint after the gate yet
@@ -2749,7 +2749,7 @@ pub(crate) struct InFlightCounter {
     /// Manager-wide drain tracker — the `graceful_shutdown` drain primitive.
     manager: crate::guard::DrainTracker,
     /// Per-`ManagedResource` in-flight tracker — the *only* counter
-    /// `revoke_slot` drains (ADR-0067 §Deferred), so a revoke on one
+    /// `revoke_slot` drains (per-resource revoke deferral), so a revoke on one
     /// resource never blocks on a sibling's in-flight work.
     per_resource: crate::guard::DrainTracker,
     armed: bool,
@@ -2758,7 +2758,7 @@ pub(crate) struct InFlightCounter {
 impl InFlightCounter {
     /// Pre-counts an in-flight acquire against **both** the manager-wide
     /// drain tracker (shutdown) and the per-resource tracker (revoke drain
-    /// + the taint→increment→re-check TOCTOU close, ADR-0044/0036/0067).
+    /// + the taint→increment→re-check TOCTOU close, slot + isolation model/0067).
     pub(crate) fn new(
         manager: crate::guard::DrainTracker,
         per_resource: crate::guard::DrainTracker,

--- a/crates/resource/src/manager/options.rs
+++ b/crates/resource/src/manager/options.rs
@@ -114,11 +114,11 @@ impl Default for ManagerConfig {
 /// Used with the `register_*_with` convenience methods to configure
 /// resilience and recovery beyond the simple `register_*` defaults.
 ///
-/// Per ADR-0044, credential bindings are no longer threaded through
+/// Per slot model, credential bindings are no longer threaded through
 /// registration: the `resource: R` value handed to `Manager::register*`
 /// already carries resolved credentials in its slot fields. The
 /// [`slot_identity`](Self::slot_identity) here is a *stable hash over those
-/// resolved bindings* (per ADR-0036 / ADR-0044) — it does **not** carry
+/// resolved bindings* (per credential isolation / slot model) — it does **not** carry
 /// secrets; it only lets the registry keep two resolved-credential
 /// registrations on **separate rows** so they cannot share one runtime
 /// (cross-tenant bleed). Compute it with

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -262,8 +262,8 @@ impl Manager {
 
         // Phase 3: CLEAR — drop all ManagedResources so their
         // Arc<ReleaseQueue> refs are released. The credential reverse-
-        // index (used by ADR-0036's singular rotation dispatch) was
-        // removed in Phase 4 / ADR-0044; per-slot rotation will be
+        // index (used by credential isolation's singular rotation dispatch) was
+        // removed in Phase 4 / slot model; per-slot rotation will be
         // wired in a follow-up (.ai-factory/PHASE4_BLOCKED.md).
         self.registry.clear();
 

--- a/crates/resource/src/metrics.rs
+++ b/crates/resource/src/metrics.rs
@@ -5,12 +5,12 @@
 //! counters. Use [`snapshot()`](ResourceOpsMetrics::snapshot) to capture a
 //! point-in-time view as [`ResourceOpsSnapshot`].
 //!
-//! Per ADR-0044 the credential rotation/revoke counters that the previous
+//! Per slot model the credential rotation/revoke counters that the previous
 //! `Resource::Credential` model owned have been removed. The per-slot
 //! rotation hook shape is `on_credential_refresh(&self, slot_name, runtime)`
 //! / `on_credential_revoke(&self, slot_name, runtime)`.
 //!
-//! Per ADR-0036 the rotation/revoke attempt totals are **one counter per
+//! Per credential isolation the rotation/revoke attempt totals are **one counter per
 //! direction, labeled by `outcome`** over the closed set
 //! `nebula_metrics::naming::rotation_outcome::{SUCCESS,FAILED,TIMED_OUT}`.
 //! `Manager::{refresh_slot,revoke_slot}` record exactly one outcome per

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -127,7 +127,7 @@ pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// `ManagedResource::wait_for_in_flight_drain`, which waits on this
     /// row's per-resource counter — *not* the manager-wide `drain_tracker`
     /// — so a revoke is isolated from in-flight traffic to unrelated
-    /// resources (ADR-0067 §Deferred). Boxed for the same `dyn`-safety
+    /// resources (per-resource revoke deferral). Boxed for the same `dyn`-safety
     /// reason as the dispatch hooks. `Err(outstanding)` carries the counter
     /// snapshot at the moment the timer fired.
     fn wait_for_in_flight_drain_erased<'a>(

--- a/crates/resource/src/reload.rs
+++ b/crates/resource/src/reload.rs
@@ -14,7 +14,7 @@ pub enum ReloadOutcome {
         /// Generation counter of the runtime being drained.
         old_generation: u64,
     },
-    /// Engine-side daemon (per ADR-0037, lives in `nebula_engine::daemon`)
+    /// Engine-side daemon (per engine daemon topology, lives in `nebula_engine::daemon`)
     /// cancelled and restarting after a reload.
     Restarting,
     /// Fingerprint identical — no change needed.

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -2,9 +2,9 @@
 //!
 //! [`Resource`] is the central abstraction: it describes how to create,
 //! health-check, and tear down a single resource type. Implementors supply
-//! four associated types and the lifecycle methods (Phase 4 / ADR-0044).
+//! four associated types and the lifecycle methods (Phase 4 / slot model).
 //!
-//! Per ADR-0044 (supersedes ADR-0036) the singular `type Credential`
+//! Per slot model (supersedes credential isolation) the singular `type Credential`
 //! associated type was deleted in favor of typed credential **slot fields**
 //! declared on the resource struct via `#[credential(key = "...")]` (the
 //! `#[derive(Resource)]` macro emits a `DeclaresDependencies` impl that
@@ -210,12 +210,12 @@ impl ResourceMetadataBuilder {
     }
 }
 
-/// Core resource trait — 4 associated types + lifecycle methods (Phase 4 / ADR-0044).
+/// Core resource trait — 4 associated types + lifecycle methods (Phase 4 / slot model).
 ///
 /// Uses return-position `impl Future` (RPITIT) instead of `async_trait`,
 /// which avoids the `Box<dyn Future>` allocation on every call.
 ///
-/// Per ADR-0044 (supersedes ADR-0036) the singular `type Credential`
+/// Per slot model (supersedes credential isolation) the singular `type Credential`
 /// associated type was removed in favor of typed credential **slot
 /// fields** on the resource struct (declared via `#[credential(...)]`
 /// field attributes; the `#[derive(Resource)]` macro emits an impl of
@@ -263,7 +263,7 @@ pub trait Resource: Send + Sync + 'static {
     ///
     /// Credential slot cells declared via `#[credential(key = "...")]`
     /// are already populated on `&self` by the framework before this
-    /// call (per ADR-0044). Implementations read each resolved guard
+    /// call (per slot model). Implementations read each resolved guard
     /// through the derive-emitted `self.<field>_slot()` accessor
     /// (`Option<Arc<CredentialGuard<C>>>`) — handling the `None`
     /// (unbound) case explicitly — never off the raw cell field.
@@ -286,7 +286,7 @@ pub trait Resource: Send + Sync + 'static {
     /// pattern: build a fresh pool from the rotated credential, atomically
     /// swap into an `Arc<RwLock<Pool>>`, let RAII drain old handles.
     ///
-    /// **Invariant** per ADR-0044 §Seam: implementer must handle every
+    /// **Invariant** per slot model §Seam: implementer must handle every
     /// declared credential slot name; the engine emits a `WARN
     /// [resource]` if rotation arrives for an unhandled slot.
     ///
@@ -305,7 +305,7 @@ pub trait Resource: Send + Sync + 'static {
     }
 
     /// Called by the engine fan-out when a slot's credential is revoked.
-    /// Post-invocation invariant (ADR-0044): the resource emits no further
+    /// Post-invocation invariant (slot model): the resource emits no further
     /// authenticated traffic on the revoked credential. Default: no-op
     /// (the engine still taints + drains the runtime around this call).
     fn on_credential_revoke(
@@ -350,7 +350,7 @@ pub trait Resource: Send + Sync + 'static {
     /// stale runtime, it just cannot prove staleness by epoch).
     ///
     /// Used by the per-slot rotation dispatch and the Resident create slow
-    /// path to close the create-vs-rotate lost-update race (ADR-0067
+    /// path to close the create-vs-rotate lost-update race (resource runtime status
     /// §Deferred): the Resident runtime records the epoch it was built
     /// against and the dispatch reconciles a runtime built against an
     /// older epoch instead of silently reporting success.

--- a/crates/resource/src/resource_ref.rs
+++ b/crates/resource/src/resource_ref.rs
@@ -1,6 +1,6 @@
 //! Typed resource reference (`ResourceRef<R>`) — slot-binding handle for action fields.
 //!
-//! Per ADR-0043 §9, `ResourceRef<R>` is the canonical field type for the
+//! Per typed ref fields, `ResourceRef<R>` is the canonical field type for the
 //! slot-binding pattern: an action declares
 //!
 //! ```ignore
@@ -11,7 +11,7 @@
 //! }
 //! ```
 //!
-//! and the framework resolves the slot per ADR-0042's binding mechanism: the
+//! and the framework resolves the slot per slot binding's binding mechanism: the
 //! `key` attribute supplies a default resource id; workflow-JSON
 //! `slot_bindings.<slot_key>.resource_id` overrides it per node.
 //!
@@ -28,7 +28,7 @@
 //! ## Composability
 //!
 //! `Option<ResourceRef<R>>` and `Lazy<ResourceRef<R>>` (from `nebula_core::Lazy`)
-//! compose for optional / lazy semantics per ADR-0043 §3.
+//! compose for optional / lazy semantics per optional ref composition.
 
 use std::{fmt, marker::PhantomData};
 
@@ -41,7 +41,7 @@ use crate::{
 
 /// Typed reference to a registered resource.
 ///
-/// The reference carries a resource id (slot binding per ADR-0042) and a
+/// The reference carries a resource id (slot binding per slot binding) and a
 /// type-level marker selecting the concrete `Resource` impl whose
 /// `Lease` should be acquired on resolve. The field type alone tells the
 /// framework what slot kind, what concrete resource type, and (via wrapper
@@ -54,7 +54,7 @@ use crate::{
 /// does **not** acquire a new resource lease — leases materialize only
 /// during `.resolve()`.
 pub struct ResourceRef<R: ?Sized> {
-    /// Resolved resource id (per ADR-0042 — slot-key default OR workflow-JSON override).
+    /// Resolved resource id (per slot binding — slot-key default OR workflow-JSON override).
     id: String,
     /// Type-level marker for the concrete `Resource` impl. `fn() -> R` so
     /// `ResourceRef<R>` is `Send + Sync` regardless of `R`.

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -66,10 +66,10 @@ pub struct ManagedResource<R: Resource> {
     /// manager-wide `Manager::drain_tracker`) and the resulting
     /// [`ResourceGuard`](crate::guard::ResourceGuard) decrements + notifies
     /// it on drop. `Manager::revoke_slot` drains **only this** counter
-    /// (ADR-0067 §Deferred): a revoke on resource A must not block on
+    /// (per-resource revoke deferral): a revoke on resource A must not block on
     /// in-flight traffic to an unrelated resource B, and the
     /// taint→increment→post-taint-recheck ordering against this same counter
-    /// is what closes the revoke-vs-acquire TOCTOU that ADR-0044/ADR-0036
+    /// is what closes the revoke-vs-acquire TOCTOU that slot model/credential isolation
     /// "no authenticated traffic on a revoked credential post-revoke"
     /// requires. The manager-wide tracker stays the `graceful_shutdown`
     /// drain primitive and is untouched here.
@@ -143,7 +143,7 @@ impl<R: Resource> ManagedResource<R> {
     /// Returns a clone of this resource's per-resource in-flight tracker so
     /// an acquire pipeline can pre-count against it (and hand it to the
     /// resulting guard). Distinct from the manager-wide `drain_tracker`:
-    /// `Manager::revoke_slot` drains *this* counter only (ADR-0067
+    /// `Manager::revoke_slot` drains *this* counter only (resource runtime status
     /// §Deferred), so a revoke never blocks on a sibling resource's
     /// in-flight work.
     pub(crate) fn in_flight_tracker(&self) -> Arc<(AtomicU64, Notify)> {
@@ -155,7 +155,7 @@ impl<R: Resource> ManagedResource<R> {
     /// The per-resource analogue of `Manager::wait_for_drain`: it waits on
     /// this row's own counter, not the manager-wide one, so a revoke on this
     /// resource is isolated from in-flight traffic to unrelated resources
-    /// (ADR-0067 §Deferred). Reuses the exact lost-wakeup-safe ordering of
+    /// (per-resource revoke deferral). Reuses the exact lost-wakeup-safe ordering of
     /// the shared shutdown drain helper. Returns `Ok(())` once drained, or
     /// `Err(outstanding)` with the counter snapshot at the moment the timer
     /// fired (the caller — `revoke_resolved` — keeps the taint and proceeds
@@ -176,7 +176,7 @@ impl<R: Resource> ManagedResource<R> {
     /// which carries the same `refresh` selector).
     ///
     /// **Topology audit of the `current() == None → Ok(())` stale-skip
-    /// (ADR-0067 §Deferred / #680).** Only **Resident** lazily builds its
+    /// (per-resource revoke deferral / #680).** Only **Resident** lazily builds its
     /// runtime internally via `resource.create()` (under its `create_lock`,
     /// with a `None`-cell window), so only Resident had the lost-update
     /// where a rotation racing the first `create` could be recorded as a
@@ -196,7 +196,7 @@ impl<R: Resource> ManagedResource<R> {
     /// per-topology runtime-borrow semantics.
     pub(crate) async fn dispatch_slot_hook(&self, slot: &str, refresh: bool) -> Result<(), Error> {
         match &self.topology {
-            // Reconcile-aware (ADR-0067 §Deferred / #680): serialises
+            // Reconcile-aware (per-resource revoke deferral / #680): serialises
             // against the resident `create` slow path and re-delivers the
             // hook to a runtime built against an older credential epoch
             // rather than skipping with a false success.

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -187,7 +187,7 @@ impl<R: Resource> PoolRuntime<R> {
     /// "optimize" by dropping and reacquiring the lock between entries:
     /// that reopens the window for an instance to be checked out
     /// mid-rotation and miss its hook, violating the post-revoke
-    /// invariant guaranteed here (ADR-0036). If rotation ever moves onto
+    /// invariant guaranteed here (credential isolation). If rotation ever moves onto
     /// a hot path, or hook latency becomes unbounded, revisit this only
     /// via a snapshot-with-epoch-reconcile design (capture the idle set
     /// under a brief lock, run hooks lock-free, then reconcile against

--- a/crates/resource/src/runtime/resident.rs
+++ b/crates/resource/src/runtime/resident.rs
@@ -53,7 +53,7 @@ pub struct ResidentRuntime<R: Resource> {
     /// the rotation dispatch. A stored runtime whose `built_epoch` is
     /// *older* than the live slot epoch was bound to a pre-rotation
     /// credential — the lost-update the dispatch must reconcile rather
-    /// than silently report success for (ADR-0067 §Deferred / #680).
+    /// than silently report success for (per-resource revoke deferral / #680).
     built_epoch: AtomicU64,
 }
 
@@ -79,7 +79,7 @@ impl<R: Resource> ResidentRuntime<R> {
     }
 
     /// Per-slot rotation hook dispatch for the Resident topology, with the
-    /// create-vs-rotate reconcile (ADR-0067 §Deferred / #680).
+    /// create-vs-rotate reconcile (per-resource revoke deferral / #680).
     ///
     /// Takes `create_lock` so it is **mutually excluded** with the
     /// `create` slow path: a rotation dispatch and a first-acquire create
@@ -261,7 +261,7 @@ where
         // Capture the credential epoch *immediately before* `create`
         // reads the slot. `create` reads each `#[credential]` slot through
         // its derive-emitted accessor; if a `SlotCell::store` (engine
-        // rotation fan-out, ADR-0067 D1) lands *after* this read but
+        // rotation fan-out, rotation fan-out) lands *after* this read but
         // *before* we publish the runtime, the runtime is bound to the
         // pre-rotation credential while a concurrent rotation dispatch
         // would (pre-fix) see `current() == None`, record a false success,

--- a/crates/resource/src/slot.rs
+++ b/crates/resource/src/slot.rs
@@ -3,10 +3,10 @@
 //! A resource declares `#[credential]` slots; the engine resolves each into a
 //! `CredentialGuard<C>` and stores it here before `Resource::create`. On
 //! rotation the engine swaps a fresh guard in without `&mut` on the
-//! resource (the `&self` refresh-hook model, ADR-0067). Lock-free via
+//! resource (the `&self` refresh-hook model, resource runtime status). Lock-free via
 //! `arc-swap`.
 //!
-//! # Generation / epoch (ADR-0067 §Deferred — create-vs-rotate ordering)
+//! # Generation / epoch (per-resource revoke deferral — create-vs-rotate ordering)
 //!
 //! Every credential-state transition (`store`, `take`) bumps a strictly
 //! monotonically increasing **generation**. `0` is reserved for "never
@@ -19,7 +19,7 @@
 //! records the generation it was constructed against; the per-slot rotation
 //! dispatch compares that against the live generation to detect a runtime
 //! left bound to a pre-rotation credential by a create-vs-rotate race
-//! (ADR-0067 §Deferred). See `ResidentRuntime` / `ManagedResource::
+//! (per-resource revoke deferral). See `ResidentRuntime` / `ManagedResource::
 //! dispatch_slot_hook`.
 
 use std::sync::{
@@ -52,7 +52,7 @@ struct SlotEntry<S> {
 /// inside the entry lets the engine swap a rotated guard in with no
 /// secret-byte clone. Every transition carries a fresh generation so a
 /// runtime built against an older guard is detectable on rotation
-/// (ADR-0067 §Deferred).
+/// (per-resource revoke deferral).
 #[derive(Debug)]
 pub struct SlotCell<S> {
     inner: ArcSwapOption<SlotEntry<S>>,
@@ -134,7 +134,7 @@ impl<S> SlotCell<S> {
     ///
     /// A clear is a credential-state transition, so it bumps the
     /// generation: a runtime built against the pre-clear guard is then
-    /// detectably stale on the next rotation/revoke dispatch (ADR-0067
+    /// detectably stale on the next rotation/revoke dispatch (resource runtime status
     /// §Deferred). The post-clear generation is observable via
     /// [`generation`](Self::generation) even though [`load`](Self::load)
     /// is now `None`.

--- a/crates/resource/src/topology/mod.rs
+++ b/crates/resource/src/topology/mod.rs
@@ -10,8 +10,8 @@
 //! | [`Transport`] | Shared connection, multiplexed sessions |
 //! | [`Exclusive`] | One caller at a time via semaphore |
 //!
-//! `Daemon` and `EventSource` live in `nebula_engine::daemon` per ADR-0037 —
-//! canon §3.5 reserves "Resource" for pool/SDK clients.
+//! `Daemon` and `EventSource` live in `nebula_engine::daemon` per engine daemon topology —
+//! integration model boundary reserves "Resource" for pool/SDK clients.
 
 pub mod exclusive;
 pub mod pooled;

--- a/crates/resource/tests/derive_resource_compile_fail.rs
+++ b/crates/resource/tests/derive_resource_compile_fail.rs
@@ -1,5 +1,5 @@
 //! Compile-fail / compile-pass probes for `#[derive(Resource)]`
-//! (Phase 4 / ADR-0044 / M6 closure).
+//! (Phase 4 / slot model / M6 closure).
 //!
 //! Each compile-fail probe under `tests/probes/derive_*.rs` exercises one
 //! diagnostic contract of the macro:

--- a/crates/resource/tests/hook_shape.rs
+++ b/crates/resource/tests/hook_shape.rs
@@ -1,5 +1,5 @@
 //! Compile-time assertion of the hook shape (&self + slot + &Runtime,
-//! plus on_credential_revoke; ADR-0044/0067). Body is never run;
+//! plus on_credential_revoke; slot model/0067). Body is never run;
 //! compilation is the test.
 // guard-justified: this file is a type-shape probe — items exist only to
 // be type-checked, never executed, so dead_code/unused are inherent.

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -1,5 +1,5 @@
 //! `Manager::{refresh_slot, revoke_slot}` — port of the per-slot rotation
-//! entry points (ADR-0044).
+//! entry points (slot model).
 //!
 //! These exercise the real `Manager::register_resident` + `ResourceKey` /
 //! `ScopeLevel` API. The test resource carries a real
@@ -218,7 +218,7 @@ mod counting {
     /// Slot identities for the two-tenant isolation fixture. Two distinct
     /// resolved-credential identities at the same `(key, Global)` occupy two
     /// distinct registry rows — each its own `ManagedResource` with its own
-    /// per-resource in-flight counter (ADR-0067 §Deferred).
+    /// per-resource in-flight counter (per-resource revoke deferral).
     pub const SLOT_A: u64 = 0xA;
     pub const SLOT_B: u64 = 0xB;
 
@@ -571,7 +571,7 @@ async fn revoke_failure_emits_slot_revoke_failed_not_refresh() {
     );
 }
 
-/// ADR-0044/0036 "no authenticated traffic on a revoked credential
+/// slot + isolation model "no authenticated traffic on a revoked credential
 /// post-revoke" — the revoke-vs-acquire TOCTOU close.
 ///
 /// The acquire-side taint *gate* runs before the in-flight counter is
@@ -661,7 +661,7 @@ async fn revoke_vs_acquire_post_taint_recheck_rejects_late_acquire() {
 
 /// Multi-threaded revoke-vs-acquire stress: many acquire loops race a single
 /// `revoke_slot` on a `multi_thread` runtime. The binding invariant
-/// (ADR-0044/0036): **no acquire may return a live guard once `revoke_slot`
+/// (slot + isolation model): **no acquire may return a live guard once `revoke_slot`
 /// has returned** — a guard handed out on the revoked credential after the
 /// revoke completed is exactly the bug. A per-acquire flag, set the instant
 /// the revoke future resolves, makes "this guard was issued after revoke
@@ -739,7 +739,7 @@ async fn revoke_vs_acquire_multithread_no_guard_after_revoke() {
                         ok_before_revoke.fetch_add(1, Ordering::AcqRel);
                     }
                     // A live guard observed after the revoke future resolved
-                    // is the exact ADR-0044/0036 violation.
+                    // is the exact slot + isolation model violation.
                     if revoke_done.load(Ordering::Acquire) {
                         guards_after_revoke.fetch_add(1, Ordering::AcqRel);
                     }
@@ -801,7 +801,7 @@ async fn revoke_vs_acquire_multithread_no_guard_after_revoke() {
     );
 }
 
-/// ADR-0067 §Deferred: a revoke on one resource must NOT block on in-flight
+/// per-resource revoke deferral: a revoke on one resource must NOT block on in-flight
 /// traffic to an *unrelated* resource. Two tenants (`SLOT_A` / `SLOT_B`) of
 /// the same resource type occupy two distinct registry rows, each with its
 /// own per-resource in-flight counter. With a long-lived lease held on B,

--- a/crates/resource/tests/register_from_value_rejects_secret.rs
+++ b/crates/resource/tests/register_from_value_rejects_secret.rs
@@ -1,8 +1,8 @@
 //! Regression: `Manager::register_from_value` must reject a config that inlines
 //! a secret-shaped field not declared by the typed `R::Config` schema.
 //!
-//! Invariant (PRODUCT_CANON §3.5; ADR-0044 slot model; ADR-0030 redaction;
-//! ADR-0036 isolation): secrets reach a resource ONLY via typed credential
+//! Invariant (product credential boundary; slot model; engine credential orchestration redaction;
+//! credential isolation isolation): secrets reach a resource ONLY via typed credential
 //! slots (credential *references*), NEVER inline in `ResourceEntry.config` —
 //! `ResourceConfig` carries no secrets. `register_from_value` schema-validates
 //! the JSON against `<R::Config as HasSchema>::schema()`; a JSON carrying an

--- a/crates/resource/tests/resident_rotation_race.rs
+++ b/crates/resource/tests/resident_rotation_race.rs
@@ -1,6 +1,6 @@
 //! #680 — resident create-vs-rotate lost-update.
 //!
-//! ADR-0067 §Deferred. The Resident arm of `dispatch_slot_hook` used to map
+//! per-resource revoke deferral. The Resident arm of `dispatch_slot_hook` used to map
 //! `current() == None` to `Ok(())` (a silent no-op recorded as a rotation
 //! *success*). When a refresh raced the **first** acquire of a Resident
 //! resource, the runtime could be built from the pre-rotation credential
@@ -448,7 +448,7 @@ async fn never_activated_resident_refresh_is_legitimate_noop() {
 }
 
 /// Sanity: with a runtime already warm and *no* intervening rotation, a
-/// refresh still delivers the hook exactly once (idempotent per ADR-0067
+/// refresh still delivers the hook exactly once (idempotent per resource runtime status
 /// D1) and never spuriously reports the runtime stale. Guards against the
 /// epoch compare mis-classifying an up-to-date runtime.
 #[tokio::test]

--- a/crates/resource/tests/trybuild/derive_slot_accessor.rs
+++ b/crates/resource/tests/trybuild/derive_slot_accessor.rs
@@ -1,7 +1,7 @@
 //! Compile-pass probe: `#[derive(Resource)]` accepts a `#[credential]` field
 //! of shape `SlotCell<CredentialGuard<C>>` and emits an inherent read
 //! accessor `<field>_slot(&self) -> Option<Arc<CredentialGuard<C>>>` that
-//! delegates to `SlotCell::load` (ADR-0044 slot model, finalized shape).
+//! delegates to `SlotCell::load` (slot model, finalized shape).
 
 use std::sync::Arc;
 

--- a/crates/sandbox/src/lib.rs
+++ b/crates/sandbox/src/lib.rs
@@ -8,11 +8,11 @@
 //! JSON envelopes with a per-call timeout + cancellation race.
 //!
 //! **This is not a security boundary against malicious native code.**
-//! Canon §12.6 is the normative statement: child-process execution provides
-//! OS-namespace separation via a duplex JSON envelope over UDS / Named Pipe.
-//! WASM / WASI is an explicit non-goal (§12.6). There is **no** per-plugin
+//! Child-process execution provides OS-namespace separation via a duplex JSON
+//! envelope over UDS / Named Pipe. WASM / WASI is an explicit non-goal.
+//! There is **no** per-plugin
 //! capability/scope model here — egress, credential, and filesystem
-//! mediation is the broker's responsibility (ADR-0025), not this crate.
+//! mediation is the broker's responsibility, not this crate.
 //!
 //! Discovery, the `RemoteAction`/`ProcessSandboxHandler` registry adapters,
 //! and the `SandboxError` → `ActionError` mapping live in `nebula-plugin`
@@ -22,21 +22,20 @@
 //!
 //! ## Key types
 //!
-//! - `ProcessSandbox` — child-process execution via JSON envelope (ADR 0006). Transport methods
+//! - `ProcessSandbox` — child-process execution via JSON envelope. Transport methods
 //!   return `SandboxError`.
 //! - `os_sandbox` — Linux Landlock + rlimit child hardening (fixed system
 //!   paths; no per-plugin grant).
 //! - `SandboxError` — typed transport error.
-//! - `scope::{ScopeHash, scope_hash}` — pure credential-scope identity
-//!   (ADR-0025 §2). Computed from caller-supplied slot-name strings only;
+//! - `scope::{ScopeHash, scope_hash}` — pure credential-scope identity.
+//!   Computed from caller-supplied slot-name strings only;
 //!   the engine owns the process pool that keys on it.
 //!
-//! ## Canon
+//! ## Packaging and isolation honesty
 //!
-//! - §7.1 plugin packaging: this crate is the host side of the duplex transport;
-//!   `nebula-plugin-sdk` is the plugin side.
-//! - §12.6 isolation honesty: correctness boundary, not attacker-grade; no
-//!   false-capability surface is advertised.
+//! This crate is the host side of the duplex transport; `nebula-plugin-sdk` is
+//! the plugin side. Correctness boundary only — not attacker-grade; no
+//! false-capability surface is advertised.
 //!
 //! See `crates/sandbox/README.md` for the real isolation roadmap and ADR 0006
 //! status.

--- a/crates/sandbox/src/os_sandbox.rs
+++ b/crates/sandbox/src/os_sandbox.rs
@@ -3,7 +3,7 @@
 //! Linux: a fixed-system-path Landlock ruleset (read-only `/lib`, `/usr/lib`,
 //! TLS certs, resolver config) plus `setrlimit` resource caps. There is **no
 //! per-plugin filesystem capability** — egress/credential/path mediation is
-//! the broker's job (ADR-0025), not this module (canon §12.6). ABI < V4 has
+//! the broker's job, not this module. ABI < V4 has
 //! no kernel network rule by design; network confinement is the broker's, not
 //! Landlock's.
 //!

--- a/crates/sandbox/src/scope.rs
+++ b/crates/sandbox/src/scope.rs
@@ -1,6 +1,6 @@
 //! Credential-scope identity for keying long-lived plugin processes.
 //!
-//! `ScopeHash` is the per-process isolation key from ADR-0025 §2: two
+//! `ScopeHash` is the per-process isolation key from
 //! plugin invocations with a different bound credential-slot set MUST run
 //! in different processes, so a plugin can never name a slot outside its
 //! scope. This module computes the hash from caller-supplied slot-name
@@ -12,7 +12,7 @@
 use sha2::{Digest, Sha256};
 
 /// SHA-256 over the sorted, unambiguously-framed credential-slot-name set
-/// bound to a plugin invocation (ADR-0025 §2).
+/// bound to a plugin invocation.
 ///
 /// Opaque, fixed-size, cheap to compare/hash — suitable as a process-pool
 /// key and for the reattach identity tuple.
@@ -38,7 +38,7 @@ const DOMAIN: &[u8] = b"nebula.scope.v1";
 /// collision-safe: each slot name is length-prefixed, so `["ab", "c"]`
 /// and `["a", "bc"]` hash distinctly — without that, distinct bound sets
 /// could collide and merge two credential scopes into one process,
-/// breaking the ADR-0025 §2 isolation guarantee. The slots are treated
+/// breaking the. The slots are treated
 /// as an ordered multiset (no de-duplication): the scope is the exact
 /// bound set from workflow-config.
 #[must_use]
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn scope_hash_frames_slots_unambiguously() {
         // A naive concat-then-hash would collide these; length-prefixing
-        // must not. This is the ADR-0025 §2 isolation guarantee: a
+        // must not. This is the
         // distinct bound set => a distinct process key.
         assert_ne!(scope_hash(&["ab", "c"]), scope_hash(&["a", "bc"]));
         assert_ne!(scope_hash(&["a", "b"]), scope_hash(&["ab"]));

--- a/crates/sandbox/src/spawn.rs
+++ b/crates/sandbox/src/spawn.rs
@@ -9,7 +9,7 @@
 //! This is the **only** module in the crate that contains `unsafe`: the
 //! single `pre_exec` block that runs between `fork()` and `exec()` on
 //! Linux. The crate-level `#![deny(unsafe_code)]` stays in force; this
-//! module carries one narrowly-scoped `#[expect(unsafe_code, ...)]` around
+//! module carries one narrowly-scoped `#[expect(unsafe_code,...)]` around
 //! the real `pre_exec` call.
 //!
 //! Security enforcement (ADR 0006):
@@ -62,7 +62,7 @@ pub(crate) async fn spawn_and_dial(
     // `env_clear()` then only the host-controlled transport env: a
     // Phase-era plugin inherits **no** host environment. A
     // host-authored, scope-keyed env allowlist returns only with the
-    // broker (ADR-0025 §6), never as a plugin-declared capability.
+    // broker, never as a plugin-declared capability.
     let mut cmd = Command::new(binary);
     cmd.stdin(std::process::Stdio::null())
         .stdout(std::process::Stdio::piped())
@@ -110,14 +110,14 @@ pub(crate) async fn spawn_and_dial(
     // dropped (#270). The task's lifecycle is bounded implicitly via
     // the chain:
     //
-    //   cmd.kill_on_drop(true)             (above, ~"kill_on_drop")
-    //     → dropping PluginHandle drops Child
-    //     → Child's Drop terminates the plugin process
-    //       (SIGKILL on Unix, TerminateProcess on Windows — both
-    //       close the child's stderr pipe handle as a side effect)
-    //     → plugin's stderr pipe closes
-    //     → drain_plugin_stderr observes EOF and returns
-    //     → detached task completes and is reaped
+    // cmd.kill_on_drop(true) (above, ~"kill_on_drop")
+    // → dropping PluginHandle drops Child
+    // → Child's Drop terminates the plugin process
+    // (SIGKILL on Unix, TerminateProcess on Windows — both
+    // close the child's stderr pipe handle as a side effect)
+    // → plugin's stderr pipe closes
+    // → drain_plugin_stderr observes EOF and returns
+    // → detached task completes and is reaped
     //
     // If a future refactor removes `kill_on_drop(true)`, make sure
     // the replacement shutdown path still reliably terminates the

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -46,15 +46,15 @@ impl ValidationError {
     /// use nebula_schema::{FieldPath, ValidationError};
     ///
     /// let err = ValidationError::builder("required")
-    ///     .at(FieldPath::parse("user.email").unwrap())
-    ///     .message("field is required")
-    ///     .build();
+    ///.at(FieldPath::parse("user.email").unwrap())
+    ///.message("field is required")
+    ///.build();
     ///
     /// assert_eq!(err.code, "required");
     /// ```
     pub fn builder(code: impl Into<Cow<'static, str>>) -> ValidationErrorBuilder {
         let code = code.into();
-        // Default message = code so that build() without .message() produces
+        // Default message = code so that build() without.message() produces
         // "[code]: code" rather than "[code]: " (empty message looks broken).
         let default_message = code.clone();
         ValidationErrorBuilder {
@@ -240,10 +240,10 @@ impl fmt::Display for ValidationReport {
     ///
     /// let mut report = ValidationReport::new();
     /// report.push(
-    ///     ValidationError::builder("required")
-    ///         .at(FieldPath::parse("name").unwrap())
-    ///         .message("field is required")
-    ///         .build(),
+    /// ValidationError::builder("required")
+    ///.at(FieldPath::parse("name").unwrap())
+    ///.message("field is required")
+    ///.build(),
     /// );
     ///
     /// let text = report.to_string();
@@ -275,10 +275,8 @@ impl std::error::Error for ValidationReport {}
 /// - **Rule-failure codes** — produced by `nebula-validator` and surfaced
 ///   verbatim (no namespace remap). A failing length/range/format rule
 ///   reports the validator-native `min_length` / `max_length` / `min` /
-///   `max` / `invalid_format`. See ADR-0052 (P2 amendment): this replaced
-///   the former schema-side `length.*` / `range.*` / `pattern` / `url` /
-///   `email` remap. `nebula-schema` is `frontier`/pre-1.0, so the change is
-///   canon-legal.
+///   `max` / `invalid_format`. This replaced the former schema-side
+///   `length.*` / `range.*` / `pattern` / `url` / `email` remap.
 ///
 /// Plugins may add their own under a namespace prefix (e.g. `my_plugin.foo`).
 /// A test in the schema crate guarantees every entry here is emittable from

--- a/crates/schema/src/has_schema.rs
+++ b/crates/schema/src/has_schema.rs
@@ -29,9 +29,9 @@ pub trait HasSchema {
 /// single way `Action` / `Credential` / `Resource` consumers reach a
 /// companion type's schema. The associated-type bound (e.g. `Action::Input`,
 /// `Credential::Properties`, `Resource::Config`) is the sole source of truth;
-/// there is no per-trait `*_schema()` method (ADR-0052 P3). The returned
+/// there is no per-trait `*_schema()` method. The returned
 /// value is `Arc`-backed and cheap to clone; for derived types it is already
-/// memoized inside `#[derive(Schema)]`. Per ADR-0061 a caller may still wrap
+/// memoized inside `#[derive(Schema)]`. a caller may still wrap
 /// this in its own `OnceLock` if a `&'static` is required.
 #[must_use]
 pub fn schema_of<T: HasSchema>() -> ValidSchema {

--- a/crates/schema/src/lint.rs
+++ b/crates/schema/src/lint.rs
@@ -1121,7 +1121,7 @@ pub(crate) enum AddressableKind {
 /// segment-wise regardless of JSON-Pointer leading-slash or escaping. Both the
 /// secret-value-predicate lint and the scrubbed root-rule predicate context
 /// (`crate::context::root_predicate_context_for`) consume this one traversal —
-/// keeping the addressable-path invariant single-owned (the ADR-0052 root
+/// keeping the addressable-path invariant single-owned (the root
 /// cause was two owners of one invariant drifting).
 pub(crate) fn walk_addressable_paths(
     fields: &[Field],

--- a/crates/schema/tests/compile_fail/plan_payload_not_separable.rs
+++ b/crates/schema/tests/compile_fail/plan_payload_not_separable.rs
@@ -1,4 +1,4 @@
-//! ADR-0052: the field reference is carried *inside* the plan; there is no
+//! : the field reference is carried *inside* the plan; there is no
 //! parallel decls/entries collection to desync. A reordered `plans` carries
 //! its payload with it, so positional cross-wiring is unrepresentable.
 // Chained `todo!()` placeholders make later initializers unreachable; the only
@@ -6,8 +6,8 @@
 // the incidental (compiler-version-sensitive) unreachable-expression warning.
 #![allow(unreachable_code)]
 fn main() {
-    // FieldPlan has no public constructor; a runner cannot fabricate a plan
-    // pointing at a different field's payload.
+ // FieldPlan has no public constructor; a runner cannot fabricate a plan
+ // pointing at a different field's payload.
     let _ = nebula_validator::policy::FieldPlan {
         path: todo!(),
         presence: todo!(),

--- a/crates/schema/tests/flow/all_error_codes.rs
+++ b/crates/schema/tests/flow/all_error_codes.rs
@@ -13,7 +13,7 @@
 //! `"invalid_format"` disambiguated by their `pattern` / `expected` params.
 //! Schema-owned structural codes (`type_mismatch`, `items.*`, `option.*`,
 //! `mode.*`, `expression.*`, `required`) are emitted by the schema crate and
-//! unchanged. See ADR-0052 (P2 amendment).
+//! unchanged.
 //!
 //! # Loader-family codes
 //!
@@ -167,9 +167,9 @@ fn emits_max() {
 }
 
 // ── Format codes — pattern / url / email all surface the validator-native
-//    `invalid_format` (the schema crate no longer remaps to a per-rule
-//    namespace; the merge is verbatim). Each is exercised separately so a
-//    regression in any one rule's wiring through the single crossing fails. ──
+// `invalid_format` (the schema crate no longer remaps to a per-rule
+// namespace; the merge is verbatim). Each is exercised separately so a
+// regression in any one rule's wiring through the single crossing fails. ──
 
 #[test]
 fn emits_invalid_format_for_pattern() {

--- a/crates/schema/tests/seam_no_payload_variant.rs
+++ b/crates/schema/tests/seam_no_payload_variant.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 seam — no-payload mode-variant expression smuggle, runtime
+//! seam — no-payload mode-variant expression smuggle, runtime
 //! defence-in-depth.
 //!
 //! `mode.no_payload_variant_must_forbid_expression` (a build-fatal lint) is the

--- a/crates/schema/tests/seam_proof_token_custody.rs
+++ b/crates/schema/tests/seam_proof_token_custody.rs
@@ -1,7 +1,7 @@
-//! ADR-0052 seam: `ValidValues` is mintable ONLY via the `nebula-schema`
+//! seam: `ValidValues` is mintable ONLY via the `nebula-schema`
 //! pipeline (`ValidSchema::validate`). Moving condition evaluation into
 //! `nebula-validator` must not add a back-door constructor. This pins the
-//! proof-token custody contract referenced by ADR-0052.
+//! proof-token custody contract referenced by.
 
 use nebula_schema::{Field, FieldKey, FieldValue, FieldValues, Schema};
 use serde_json::json;

--- a/crates/schema/tests/seam_required_emitter.rs
+++ b/crates/schema/tests/seam_required_emitter.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 seam: validator is the sole `required` emitter, and a hidden
+//! seam: validator is the sole `required` emitter, and a hidden
 //! field that nonetheless carries a present value is STILL structurally
 //! validated (a smuggled expression in a no-payload mode-variant placeholder
 //! must not escape to resolve). The carve-out is moved, not deleted.

--- a/crates/schema/tests/seam_root_rule_scrub.rs
+++ b/crates/schema/tests/seam_root_rule_scrub.rs
@@ -1,18 +1,18 @@
-//! ADR-0052 P2 item-2: root-rule predicates run against a context scrubbed of
+//! P2 item-2: root-rule predicates run against a context scrubbed of
 //! `Field::Secret` (by schema type, recursively) — BUT legal non-secret nested
 //! values (object / list-item / mode-variant) remain addressable so a
 //! legitimate root guard does NOT fail open.
 //!
 //! Two guards:
-//!  - `legal_non_secret_nested_root_predicate_still_fires_after_scrub` proves a
-//!    legitimate nested-object root predicate still resolves post-scrub (it
-//!    would also resolve under the old `from_json`, so it is a true regression
-//!    guard against the scrub silently nuking legal nested context).
-//!  - `root_predicate_cannot_read_scrubbed_secret_plaintext` unit-tests the new
-//!    `root_predicate_context_for` directly: the secret's path is absent, no
-//!    pushed value carries the plaintext, and a container object that has a
-//!    secret descendant is never emitted as a node (so a `Contains("/cfg", …)`
-//!    over the parent blob cannot read the secret).
+//! - `legal_non_secret_nested_root_predicate_still_fires_after_scrub` proves a
+//!   legitimate nested-object root predicate still resolves post-scrub (it
+//!   would also resolve under the old `from_json`, so it is a true regression
+//!   guard against the scrub silently nuking legal nested context).
+//! - `root_predicate_cannot_read_scrubbed_secret_plaintext` unit-tests the new
+//!   `root_predicate_context_for` directly: the secret's path is absent, no
+//!   pushed value carries the plaintext, and a container object that has a
+//!   secret descendant is never emitted as a node (so a `Contains("/cfg", …)`
+//!   over the parent blob cannot read the secret).
 
 use nebula_schema::context::root_predicate_context_for;
 use nebula_schema::{Field, FieldValue, FieldValues, Schema, field_key};
@@ -73,7 +73,7 @@ fn root_predicate_cannot_read_scrubbed_secret_plaintext() {
     const PLAINTEXT: &str = "s3cr3t-root-plaintext";
 
     // (1) Top-level Field::Secret with a pre-resolve plaintext literal: the
-    //     scrubbed root context must NOT expose it under any pointer.
+    // scrubbed root context must NOT expose it under any pointer.
     let secret_fields = vec![Field::from(Field::secret(field_key!("api_key")))];
     let secret_values = FieldValues::from_json(json!({ "api_key": PLAINTEXT })).unwrap();
     let ctx = root_predicate_context_for(&secret_fields, &secret_values);
@@ -88,10 +88,10 @@ fn root_predicate_cannot_read_scrubbed_secret_plaintext() {
     );
 
     // (2) A Field::Object `cfg` whose only child is a Field::Secret. The
-    //     container node MUST stay present (so a legal `Set("/cfg")` presence
-    //     guard still resolves — dropping it is the fail-open class), but its
-    //     secret child is stripped, so the node value carries no plaintext and
-    //     the secret pointer is unreadable.
+    // container node MUST stay present (so a legal `Set("/cfg")` presence
+    // guard still resolves — dropping it is the fail-open class), but its
+    // secret child is stripped, so the node value carries no plaintext and
+    // the secret pointer is unreadable.
     let nested = Field::object(field_key!("cfg")).add(Field::secret(field_key!("the_secret")));
     let nested_fields = vec![Field::from(nested)];
     let nested_values =
@@ -120,8 +120,8 @@ fn root_predicate_cannot_read_scrubbed_secret_plaintext() {
     );
 
     // (3) Structural guarantee: a sibling NON-secret leaf next to the secret
-    //     IS still emitted (proves the scrub is type-targeted, not blanket —
-    //     it does not over-remove legal context, which would fail open).
+    // IS still emitted (proves the scrub is type-targeted, not blanket —
+    // it does not over-remove legal context, which would fail open).
     let mixed = Field::object(field_key!("cfg2"))
         .add(Field::secret(field_key!("token")))
         .add(Field::string(field_key!("region")));

--- a/crates/schema/tests/seam_security_codes.rs
+++ b/crates/schema/tests/seam_security_codes.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 (P2) lockdown #2: security-relevant codes are invariant.
+//! (P2) lockdown #2: security-relevant codes are invariant.
 //!
 //! Dropping the validator→schema code translation changes the *rule-failure*
 //! vocabulary (a deliberate, canon-legal breaking change). It must NOT change

--- a/crates/schema/tests/seam_single_crossing.rs
+++ b/crates/schema/tests/seam_single_crossing.rs
@@ -1,4 +1,4 @@
-//! ADR-0052 (P2) lockdown #1: the ONLY schema→validator behavioral crossing
+//! (P2) lockdown #1: the ONLY schema→validator behavioral crossing
 //! symbols are `validate_rules_with_ctx` and `resolve_field_policies`.
 //!
 //! This is a symbol-level invariant, not a single-runtime-call one (nested
@@ -19,7 +19,7 @@ fn schema_crosses_into_validator_through_one_surface_only() {
     ] {
         assert!(
             !src.contains(forbidden),
-            "validated.rs must not contain `{forbidden}` (ADR-0052: single \
+            "validated.rs must not contain `{forbidden}` (single \
              validator crossing, no in-schema rule executor / code remap)"
         );
     }

--- a/crates/schema/tests/validate_schema.rs
+++ b/crates/schema/tests/validate_schema.rs
@@ -323,7 +323,7 @@ fn length_max_rule_violated() {
     let report = schema.validate(&values).unwrap_err();
     // Rule-failure codes are surfaced verbatim from nebula-validator (no
     // schema-side remap); a `max_length` rule reports the native
-    // `max_length` code. See ADR-0052 (P2 amendment).
+    // `max_length` code. See (P2 amendment).
     assert!(
         report.errors().any(|e| e.code == "max_length"),
         "expected max_length error, codes: {:?}",
@@ -679,9 +679,9 @@ fn nested_required_when_is_enforced_not_fail_open() {
         .expect("schema builds");
 
     let values = FieldValues::from_json(json!({
-        "auth": { "mode": "oauth" }
-        // secret_token absent
-    }))
+           "auth": { "mode": "oauth" }
+    // secret_token absent
+       }))
     .unwrap();
 
     let report = schema

--- a/crates/sdk/macros-support/src/credential_ref.rs
+++ b/crates/sdk/macros-support/src/credential_ref.rs
@@ -6,7 +6,7 @@
 //! it from unit tests. Proc-macro crates themselves cannot expose pub
 //! helpers for integration tests; this crate can.
 //!
-//! See ADR-0035 paragraph 4.3 (action-side translation) and Tech Spec
+//! See paragraph 4.3 (action-side translation) and Tech Spec
 //! 2.7 (`#[action_phantom]` macro translation, "rewrites silently") for
 //! the contract.
 
@@ -53,7 +53,7 @@ fn rewrite_field(field: &mut Field) {
 /// the `Phantom` suffix. Without this guard, `CredentialRef<dyn Cap +
 /// Send + Sync>` would expand to nonsensical `SendPhantom` / `SyncPhantom`
 /// references that fail with cryptic `E0405` and have no path back to
-/// the macro for the plugin author. ADR-0035 §5 retains `Send + Sync` on
+/// the macro for the plugin author.
 /// the phantom trait as a forward-compat promise; user-written
 /// `dyn Cap + Send + Sync` must compose with that promise unchanged.
 ///
@@ -61,7 +61,7 @@ fn rewrite_field(field: &mut Field) {
 /// today — the recursive walk only descends into `Type::Path` generics.
 /// Adding a `Type::Reference` arm would let `CredentialRef<&dyn Cap>`
 /// rewrite to `CredentialRef<&dyn CapPhantom>`, but that form is not a
-/// supported Pattern 2 spelling per ADR-0035 §1 (canonical form is
+/// supported Pattern 2 spelling
 /// owning `CredentialRef<dyn Cap>`). Authors who write the borrowed
 /// form get rustc's normal `E0191` for the unspecified-assoc-type
 /// closure on `dyn Cap` — which is the correct guidance to switch to
@@ -261,7 +261,7 @@ mod tests {
     // capability and apply the phantom suffix. The pre-fix rewriter only
     // matched the outermost segment, so authors who wrote
     // `Vec<CredentialRef<dyn Cap>>` got a struct that compiled without
-    // phantom enforcement — silently bypassing the ADR-0035 guarantee.
+    // phantom enforcement — silently bypassing the guarantee.
 
     #[test]
     fn pattern2_inside_vec_rewrites() {

--- a/crates/sdk/macros-support/src/lib.rs
+++ b/crates/sdk/macros-support/src/lib.rs
@@ -8,7 +8,7 @@
 
 /// Attribute parsing utilities.
 pub mod attrs;
-/// `CredentialRef<dyn X>` rewrite per ADR-0035 4.3 + Tech Spec 2.7.
+/// `CredentialRef<dyn X>` rewrite 4.3 + Tech Spec 2.7.
 pub mod credential_ref;
 /// Diagnostic helpers for compile errors.
 pub mod diag;

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -12,12 +12,12 @@
 //! use nebula_sdk::prelude::*;
 //!
 //! let metadata = ActionBuilder::new(action_key!("example.greet"), "Greet")
-//!     .with_description("A simple greeting action")
-//!     .build();
+//!.with_description("A simple greeting action")
+//!.build();
 //!
 //! let workflow = WorkflowBuilder::new("example_workflow")
-//!     .add_node("greet", "example_greet")
-//!     .build();
+//!.add_node("greet", "example_greet")
+//!.build();
 //!
 //! assert_eq!(metadata.base.name, "Greet");
 //! assert!(workflow.is_ok());
@@ -121,8 +121,8 @@ impl Error {
 /// use nebula_sdk::json;
 ///
 /// let value = json!({
-///     "name": "test",
-///     "count": 42
+/// "name": "test",
+/// "count": 42
 /// });
 /// ```
 pub use serde_json::json;
@@ -135,8 +135,8 @@ pub use serde_json::json;
 /// use nebula_sdk::params;
 ///
 /// let params = params! {
-///     "name" => "test",
-///     "count" => 42
+/// "name" => "test",
+/// "count" => 42
 /// };
 /// ```
 #[macro_export]
@@ -167,12 +167,12 @@ macro_rules! params {
 /// use nebula_sdk::workflow;
 ///
 /// let wf = workflow! {
-///     name: "my_workflow",
-///     nodes: [
-///         fetch:   "http.get"     => transform,
-///         transform: "json.map"   => store,
-///         store:   "db.insert",
-///     ]
+/// name: "my_workflow",
+/// nodes: [
+/// fetch: "http.get" => transform,
+/// transform: "json.map" => store,
+/// store: "db.insert",
+/// ]
 /// };
 /// ```
 #[macro_export]
@@ -202,8 +202,8 @@ macro_rules! workflow {
 /// Macro for defining a simple stateless action with a unit struct.
 ///
 /// Generates a unit `struct $name`, implements [`Action`](nebula_action::Action)
-/// (with static metadata + schemas + slot-binding [`Dependencies`](nebula_core::Dependencies),
-/// per ADR-0043 §6 / Variant A), and implements
+/// (with static metadata + schemas + slot-binding [`Dependencies`](nebula_core::Dependencies)),
+/// and implements
 /// [`StatelessAction`](nebula_action::StatelessAction) over the supplied
 /// `input` / `output` types.
 ///
@@ -219,16 +219,16 @@ macro_rules! workflow {
 /// use nebula_sdk::{prelude::*, simple_action};
 ///
 /// simple_action! {
-///     name: GreetAction,
-///     key: "demo.greet",
-///     input: serde_json::Value,
-///     output: serde_json::Value,
-///     async fn execute(&self, input, _ctx) {
-///         let name = input.get("name").and_then(|v| v.as_str()).unwrap_or("world");
-///         Ok(ActionResult::success(serde_json::json!({
-///             "message": format!("Hello, {name}!"),
-///         })))
-///     }
+/// name: GreetAction,
+/// key: "demo.greet",
+/// input: serde_json::Value,
+/// output: serde_json::Value,
+/// async fn execute(&self, input, _ctx) {
+/// let name = input.get("name").and_then(|v| v.as_str()).unwrap_or("world");
+/// Ok(ActionResult::success(serde_json::json!({
+/// "message": format!("Hello, {name}!"),
+/// })))
+/// }
 /// }
 /// ```
 #[macro_export]

--- a/crates/sdk/tests/simple_action_macro.rs
+++ b/crates/sdk/tests/simple_action_macro.rs
@@ -2,7 +2,7 @@
 //!
 //! The macro previously expanded to `impl ProcessAction`, a trait that no
 //! longer exists in `nebula-action`. The fix points it at `StatelessAction`
-//! (canon §3.5 trait family) — this test compiles a macro use-site and
+//! ( trait family) — this test compiles a macro use-site and
 //! drives it through `TestRuntime` so the expansion stays correct.
 
 use nebula_sdk::{prelude::*, simple_action};

--- a/crates/storage-loom-probe/src/lib.rs
+++ b/crates/storage-loom-probe/src/lib.rs
@@ -1,5 +1,5 @@
 //! Loom CAS atomicity probe for the credential refresh-claim pattern
-//! (ADR-0041).
+//!.
 //!
 //! # Why a standalone crate?
 //!
@@ -22,9 +22,9 @@
 //! acquisition itself.
 //!
 //! Run with:
-//!   RUSTFLAGS="--cfg loom" cargo nextest run \
-//!     -p nebula-storage-loom-probe --features loom-test \
-//!     --profile ci --no-tests=pass
+//! RUSTFLAGS="--cfg loom" cargo nextest run \
+//! -p nebula-storage-loom-probe --features loom-test \
+//! --profile ci --no-tests=pass
 
 #![cfg(loom)]
 

--- a/crates/storage-loom-probe/tests/refresh_claim_loom.rs
+++ b/crates/storage-loom-probe/tests/refresh_claim_loom.rs
@@ -1,5 +1,5 @@
 //! Loom test asserting refresh-claim CAS atomicity under 2-thread
-//! interleaving (ADR-0041 durability requirement).
+//! interleaving.
 //!
 //! Loom replaces std's atomic primitives with a deterministic scheduler
 //! that exhaustively explores thread interleavings. Two concurrent

--- a/crates/storage-port/src/batch.rs
+++ b/crates/storage-port/src/batch.rs
@@ -6,8 +6,8 @@
 //! without declaring the scope, the expected CAS version, and the lease
 //! [`FencingToken`]. `commit` writes `new_state` + `outbox` + `journal` in
 //! one transaction (or one mutex-guarded mutation for InMemory), gated by the
-//! version CAS *and* the fencing token. This makes the canon §14 "two truths"
-//! split impossible by construction: there is exactly one call site and one
+//! version CAS *and* the fencing token. This makes a split between durable
+//! state and outbox/journal impossible by construction: there is exactly one call site and one
 //! transaction for the triple.
 use crate::dto::{ControlMsg, JournalEntry};
 use crate::error::StorageError;

--- a/crates/storage-port/src/dto/idempotency.rs
+++ b/crates/storage-port/src/dto/idempotency.rs
@@ -1,4 +1,4 @@
-//! Idempotency dedup record DTO (ADR-0048 hybrid backend).
+//! Idempotency dedup record DTO (hybrid replay cache).
 use serde::{Deserialize, Serialize};
 
 /// One cached idempotent-replay response.

--- a/crates/storage-port/src/dto/node_result.rs
+++ b/crates/storage-port/src/dto/node_result.rs
@@ -1,4 +1,4 @@
-//! Node-result row DTO (ADR-0009).
+//! Node-result row DTO.
 use serde::{Deserialize, Serialize};
 
 /// Maximum node-result schema version this binary can decode. A persisted

--- a/crates/storage-port/src/dto/webhook.rs
+++ b/crates/storage-port/src/dto/webhook.rs
@@ -1,4 +1,4 @@
-//! Webhook-activation record DTO (ADR-0049).
+//! Webhook-activation record DTO.
 use crate::Scope;
 use serde::{Deserialize, Serialize};
 

--- a/crates/storage-port/src/store/control_queue.rs
+++ b/crates/storage-port/src/store/control_queue.rs
@@ -1,10 +1,10 @@
-//! Durable control-signal outbox trait (spec-16 §12.2, ADR-0008/0017).
+//! Durable control-signal outbox trait (cancel/terminate/pause + lease reclaim).
 use std::time::Duration;
 
 use crate::dto::ControlMsg;
 use crate::error::StorageError;
 
-/// Summary of a single `reclaim_stuck` sweep (ADR-0017).
+/// Summary of a single `reclaim_stuck` sweep.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct ReclaimOutcome {
     /// Rows moved `Processing → Pending` for redelivery.

--- a/crates/storage-port/src/store/idempotency.rs
+++ b/crates/storage-port/src/store/idempotency.rs
@@ -1,14 +1,14 @@
-//! Idempotency traits (spec-16 §11.3 + ADR-0048 hybrid backend).
+//! Idempotency traits (per-attempt guard + durable hybrid replay store).
 use std::time::Duration;
 
 use crate::dto::CachedRecord;
 use crate::error::StorageError;
 use crate::scope::Scope;
 
-/// Per-attempt idempotency guard (spec-16 §11.3).
+/// Per-attempt idempotency guard.
 ///
-/// The key shape is unchanged — `{execution_id}:{node_id}:{attempt}` (the
-/// ADR-0042 `attempts.len()+1` derivation is preserved). The decorator
+/// The key shape is unchanged — `{execution_id}:{node_id}:{attempt}` (attempt
+/// index is `stored_attempts.len() + 1`). The decorator
 /// namespaces it by tenant so tenant A cannot probe or poison tenant B's
 /// dedup entry (replay-oracle mitigation, §6.1).
 #[async_trait::async_trait]
@@ -26,7 +26,7 @@ pub trait IdempotencyGuard: Send + Sync + std::fmt::Debug {
     ) -> Result<bool, StorageError>;
 }
 
-/// Durable idempotent-replay response store (ADR-0048 hybrid backend).
+/// Durable idempotent-replay response store (in-memory + durable hybrid).
 ///
 /// First-writer-wins: `put` for an existing key is a no-op (the original
 /// record stays). `scope` is an explicit parameter (consistent with
@@ -35,8 +35,8 @@ pub trait IdempotencyGuard: Send + Sync + std::fmt::Debug {
 /// nor poison tenant B's dedup entry (§6.1 replay-oracle), rather than
 /// relying on the caller to hand in a pre-namespaced string. A
 /// [`StorageError`] from `get` must NOT be treated as a cache miss —
-/// silently dropping replay protection on corruption is rejected by
-/// ADR-0048.
+/// silently dropping replay protection on corruption is forbidden (storage
+/// errors must surface, not masquerade as cache misses).
 #[async_trait::async_trait]
 pub trait IdempotencyStore: Send + Sync + std::fmt::Debug {
     /// Look up a cached record by `cache_key` within `scope`.

--- a/crates/storage-port/src/store/node_result.rs
+++ b/crates/storage-port/src/store/node_result.rs
@@ -1,4 +1,4 @@
-//! Node-output / node-result store trait (ADR-0009).
+//! Node-output / node-result store trait (per-node execution payloads).
 use crate::dto::NodeResultRecord;
 use crate::error::StorageError;
 use crate::scope::Scope;

--- a/crates/storage-port/src/store/refresh_claim.rs
+++ b/crates/storage-port/src/store/refresh_claim.rs
@@ -1,5 +1,6 @@
-//! Cross-replica refresh-claim store (ADR-0041 + refresh-coordination
-//! sub-spec).
+//! Cross-replica refresh-claim store (CAS lease, heartbeat, sentinel reclaim).
+//!
+//! See `docs/INTEGRATION_MODEL.md` (credential refresh) for integration context.
 //!
 //! Re-homed from the adapter **shape-unchanged**: this component is
 //! loom-verified, so its trait surface and supporting types are preserved
@@ -137,8 +138,8 @@ pub struct ReclaimedClaim {
     pub sentinel: SentinelState,
 }
 
-/// Cross-replica claim store (ADR-0041 §3.2). Shape preserved verbatim from
-/// the loom-verified adapter trait.
+/// Cross-replica claim store. Shape preserved verbatim from the loom-verified
+/// adapter trait.
 #[async_trait::async_trait]
 pub trait RefreshClaimStore: Send + Sync + 'static {
     /// Try to acquire a refresh claim for `credential_id` on behalf of

--- a/crates/storage-port/src/store/webhook.rs
+++ b/crates/storage-port/src/store/webhook.rs
@@ -1,4 +1,4 @@
-//! Webhook-activation store trait (ADR-0049).
+//! Webhook-activation store trait (durable activation rows for outbound webhooks).
 use crate::dto::WebhookActivationRecord;
 use crate::error::StorageError;
 use crate::scope::Scope;

--- a/crates/storage/src/credential/backup.rs
+++ b/crates/storage/src/credential/backup.rs
@@ -1,4 +1,4 @@
-//! Rotation Backup System — canonical home per ADR-0029 / ADR-0032.
+//! Rotation Backup System — canonical storage-side home for credential backups.
 //!
 //! Creates encrypted backups of credentials before rotation for disaster
 //! recovery. Feature-gated behind storage's `rotation` feature, which forwards

--- a/crates/storage/src/credential/key_provider.rs
+++ b/crates/storage/src/credential/key_provider.rs
@@ -4,9 +4,7 @@
 //! `EncryptionLayer` no longer takes `Arc<EncryptionKey>` directly; instead it
 //! accepts `Arc<dyn KeyProvider>`. Composition roots choose the provider — env
 //! var, file, or (in future) a KMS / Vault / cloud-secret-manager impl — at
-//! wiring time. See [ADR-0023](../../../../docs/adr/0023-keyprovider-trait.md)
-//! for the decision and ADR-0020 §3 for why the seam is a pre-condition to any
-//! `apps/server` composition work.
+//! wiring time. See `crates/storage/README.md` for the key-provider seam.
 //!
 //! ## Invariants
 //!
@@ -17,7 +15,7 @@
 //!   stable-version/rotating-key provider would silently mis-decrypt under the new key.
 //!   `EnvKeyProvider` / `FileKeyProvider` derive `version()` from a SHA-256 fingerprint of the key
 //!   material so an in-place rotation (same env var / same file path, new bytes) produces a fresh
-//!   identifier automatically. See ADR-0023 §3 + §6 Rotation procedure.
+//!   identifier automatically on in-place key rotation.
 //! - `current_key()` returns `Arc<EncryptionKey>` — a stable handle over the zeroize-on-drop key
 //!   newtype. Providers do not expose raw key bytes.
 //! - `Debug` / `Display` on providers and on `ProviderError` must not reveal key material (see
@@ -568,7 +566,7 @@ mod tests {
     /// Two different keys must produce different `version()`s so an in-place
     /// env-var rotation flips the envelope `key_id` instead of silently
     /// mis-decrypting under the new key. Regression guard for the rotation
-    /// safety invariant recorded in ADR-0023 §3.
+    /// safety invariant: version must change when key bytes change.
     #[test]
     fn env_provider_version_changes_with_key() {
         let k1 = base64::engine::general_purpose::STANDARD.encode([0x11u8; 32]);

--- a/crates/storage/src/credential/layer/audit.rs
+++ b/crates/storage/src/credential/layer/audit.rs
@@ -11,7 +11,7 @@
 //! [`AuditSink`] for each call. Only metadata flows through the sink —
 //! credential data never does.
 //!
-//! # Fail-closed invariant (ADR-0028 §Decision §4)
+//! # Fail-closed invariant (no discard-and-log)
 //!
 //! Audit is **in-line durable**: if [`AuditSink::record`] returns an
 //! error, the credential operation as a whole returns
@@ -39,7 +39,7 @@ use nebula_credential::{CredentialStore, PutMode, StoreError, StoredCredential};
 /// - `record` must not block the calling task for extended periods.
 /// - Implementations must never inspect or log credential data.
 /// - Returning `Err(StoreError)` causes the wrapping [`AuditLayer`] to fail the whole credential
-///   operation with [`StoreError::AuditFailure`] (fail-closed per ADR-0028 inv 4).
+///   operation with [`StoreError::AuditFailure`] (fail-closed audit contract).
 pub trait AuditSink: Send + Sync {
     /// Record an audit event.
     ///
@@ -72,7 +72,7 @@ pub struct AuditEvent {
 /// flowing through [`AuditLayer`]. Variants prefixed `RefreshCoord*`
 /// describe events emitted by the engine's two-tier refresh coordinator
 /// (sub-spec
-/// `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)`
+/// `docs/INTEGRATION_MODEL.md` (credential refresh coordinator)
 /// §6) and carry their structured payload as enum fields. The same
 /// [`AuditSink`] receives both families so operators reuse one sink
 /// implementation.
@@ -189,7 +189,7 @@ impl<S: CredentialStore> CredentialStore for AuditLayer<S> {
         };
 
         if let Err(sink_err) = self.sink.record(&event) {
-            // ADR-0028 §4: fail-closed. Best-effort rollback of the
+            // Fail-closed: best-effort rollback of the
             // inner write so the store ends in the pre-call state.
             // Only attempted on CreateOnly (Overwrite/CAS have no
             // recoverable prior state at this layer).

--- a/crates/storage/src/credential/layer/encryption.rs
+++ b/crates/storage/src/credential/layer/encryption.rs
@@ -14,9 +14,8 @@
 //! The current encryption key is supplied by an
 //! [`Arc<dyn KeyProvider>`](super::super::KeyProvider), **not** an `Arc<EncryptionKey>`
 //! directly. Composition roots choose the provider (env var, file, KMS, …)
-//! at wiring time — see
-//! [ADR-0023](../../../../docs/adr/0023-keyprovider-trait.md) for the seam
-//! and ADR-0020 §3 for why this gate exists.
+//! at wiring time — see `crates/storage/README.md` and
+//! `docs/INTEGRATION_MODEL.md` for the key-provider seam.
 //!
 //! # Key rotation
 //!
@@ -314,7 +313,7 @@ mod tests {
     }
 
     /// Integration-style check: an OAuth2 credential blob must not be stored as raw JSON
-    /// strings in the backend row (regression for ADR-0029 / at-rest expectations).
+    /// strings in the backend row (at-rest encryption regression).
     #[tokio::test]
     async fn oauth2_state_secrets_not_plaintext_in_inner_store() {
         const PLAINTEXT_ACCESS: &str = "nebula-integration-plaintext-access-token-zz";

--- a/crates/storage/src/credential/layer/mod.rs
+++ b/crates/storage/src/credential/layer/mod.rs
@@ -5,7 +5,7 @@
 //! `CredentialScopeResolver`, spec §8) — scope *policy* does not belong in
 //! the storage adapter. These layers (`EncryptionLayer`, `CacheLayer`,
 //! `AuditLayer`) stay here and re-compose **on top** of the tenancy scope
-//! layer at the composition root; the ADR-0029 fail-closed audit +
+//! layer at the composition root; the fail-closed audit +
 //! zeroize-on-drop invariants are unaffected by the move (layer order
 //! `ScopeLayer → AuditLayer → EncryptionLayer → CacheLayer → Backend` is
 //! preserved by the composition root, not by this module).

--- a/crates/storage/src/credential/mod.rs
+++ b/crates/storage/src/credential/mod.rs
@@ -11,19 +11,13 @@
 //!   re-composes outermost at the composition root.
 //! - `ExternalProvider` wrappers — `ProviderCacheLayer`. They compose
 //!   around an `Arc<dyn ExternalProvider>` that resolves secrets from a
-//!   remote system (Vault, AWS SM, env var, …) per ADR-0051. The
-//!   `Provider`-prefixed types are scoped to that trait and do not interact
-//!   with the `CredentialStore` cache.
+//!   remote system (Vault, AWS SM, env var, …). The `Provider`-prefixed types
+//!   are scoped to that trait and do not interact with the `CredentialStore`
+//!   cache.
 //!
-//! The `CredentialStore` trait + DTOs live in `nebula_credential` per
-//! [ADR-0032](../../../../docs/adr/0032-credential-store-canonical-home.md);
-//! only the concrete implementations are owned by storage
-//! ([ADR-0029](../../../../docs/adr/0029-storage-owns-credential-persistence.md)).
-//!
-//! See also [ADR-0028](../../../../docs/adr/0028-cross-crate-credential-invariants.md)
-//! for the umbrella cross-crate invariants, and
-//! [ADR-0051](../../../../docs/adr/0051-external-provider-redesign.md) for
-//! the `ExternalProvider` design that motivates `ProviderCacheLayer`.
+//! The `CredentialStore` trait + DTOs live in `nebula_credential`; concrete
+//! implementations and layers live here. See `crates/storage/README.md` and
+//! `docs/INTEGRATION_MODEL.md` (Credential) for integration context.
 
 pub mod key_provider;
 pub mod layer;
@@ -38,7 +32,7 @@ pub mod pending;
 #[cfg(feature = "rotation")]
 pub mod backup;
 
-/// Cross-replica refresh claim repository — see ADR-0041.
+/// Cross-replica refresh claim repository (CAS + heartbeat).
 pub mod refresh_claim;
 
 #[cfg(feature = "rotation")]

--- a/crates/storage/src/credential/pending.rs
+++ b/crates/storage/src/credential/pending.rs
@@ -1,26 +1,24 @@
-//! In-memory pending state store — **canonical home** per ADR-0029 §4 / ADR-0032.
+//! In-memory pending state store — **canonical storage-side home**.
 //!
 //! Data is lost when the store is dropped. Use this in tests and for local
 //! development rather than mocking [`PendingStateStore`] directly.
 //!
-//! # Dual-home note (ADR-0032 §7)
+//! # Dual-home note
 //!
 //! A body-identical shim exists at
 //! `nebula_credential::pending_store_memory::InMemoryPendingStore` because
 //! credential's own `executor.rs` `#[cfg(test)]` tests reference it directly
 //! and cannot dev-dep on `nebula-storage` (the dev-dep path produces a
 //! two-copies cargo resolution that breaks the `PendingStateStore` trait
-//! bound — empirically confirmed in P6.2). Both copies implement the same
-//! trait with the same semantics. Production consumers and composition
-//! roots should prefer this storage-side copy.
+//! bound). Both copies implement the same trait with the same semantics.
+//! Production consumers and composition roots should prefer this storage-side copy.
 //!
-//! # ADR-0029 §4 invariants
+//! # Invariants
 //!
 //! | # | Invariant                          | Enforcement in this impl                           |
 //! |---|------------------------------------|-----------------------------------------------------|
 //! | 1 | Encryption at rest                 | **Moot** — process memory, no disk persistence.     |
-//! |   |                                    | Durable impls (Postgres/Redis) must wrap via a      |
-//! |   |                                    | future `EncryptedPendingLayer` — see ADR-0029 §4.1. |
+//! |   |                                    | Durable impls must wrap via a future encrypted layer. |
 //! | 2 | TTL ≤ 10 min                       | Determined per-type by `PendingState::expires_in`;  |
 //! |   |                                    | expired rows are evicted on `get`/`consume` and     |
 //! |   |                                    | surface as `Expired`.                               |
@@ -34,10 +32,9 @@
 //! | 6 | Zeroize on drop                    | `PendingState: Zeroize` trait bound; implementers   |
 //! |   |                                    | zeroize on drop. Serialized bytes in this store     |
 //! |   |                                    | are `Vec<u8>`; wrapping in `Zeroizing<Vec<u8>>` is  |
-//! |   |                                    | a tracked follow-up (see ADR-0029 §4).              |
+//! |   |                                    | a tracked follow-up.                                |
 //!
-//! Ref: [ADR-0029 §4](../../../../docs/adr/0029-storage-owns-credential-persistence.md)
-//! Ref: [ADR-0032 §7](../../../../docs/adr/0032-credential-store-canonical-home.md)
+//! See `crates/storage/README.md` for credential persistence layout.
 
 use std::{collections::HashMap, sync::Arc};
 

--- a/crates/storage/src/credential/refresh_claim/mod.rs
+++ b/crates/storage/src/credential/refresh_claim/mod.rs
@@ -1,8 +1,7 @@
 //! Durable cross-replica claim repository for credential refresh
 //! coordination.
 //!
-//! Per ADR-0041 + sub-spec
-//! `docs/INTEGRATION_MODEL.md (credential refresh; ADR-0030/0041)`.
+//! See `docs/INTEGRATION_MODEL.md` (credential refresh) for integration context.
 //!
 //! The canonical trait + supporting types now live in the spec-16 port
 //! crate (`nebula_storage_port::store`) — this component is loom-verified,

--- a/crates/storage/src/credential/refresh_claim/postgres.rs
+++ b/crates/storage/src/credential/refresh_claim/postgres.rs
@@ -3,7 +3,7 @@
 //! Multi-replica production target. Atomic CAS via
 //! `INSERT ... ON CONFLICT (credential_id) DO UPDATE WHERE
 //! credential_refresh_claims.expires_at < EXCLUDED.expires_at`
-//! pattern, mirroring control-queue claim acquisition (ADR-0008).
+//! pattern, mirroring control-queue claim acquisition.
 
 use std::time::Duration;
 

--- a/crates/storage/src/credential/refresh_claim/sqlite.rs
+++ b/crates/storage/src/credential/refresh_claim/sqlite.rs
@@ -80,7 +80,7 @@ impl RefreshClaimRepo for SqliteRefreshClaimRepo {
 
         // Atomic CAS via UPSERT with conditional UPDATE clause. Mirrors the
         // Postgres `INSERT ... ON CONFLICT DO UPDATE WHERE expires_at < ...`
-        // pattern (ADR-0008 + ADR-0041). Requires SQLite 3.35+ for
+        // pattern (control-queue + refresh-claim CAS). Requires SQLite 3.35+ for
         // `RETURNING`.
         //
         // Win path: the row we wrote (or overwrote in place) comes back via

--- a/crates/storage/src/inmem/execution.rs
+++ b/crates/storage/src/inmem/execution.rs
@@ -256,8 +256,8 @@ impl ExecutionStore for InMemoryExecutionStore {
             // second acquire by the *same* holder. Renewal is the
             // dedicated `renew_lease` op (fencing-token gated); a second
             // `acquire_lease` while the lease is live is contention, not
-            // a silent renew (§12.2 zombie-runner closure, ADR-0008 —
-            // two concurrent runners must see exactly one winner).
+            // a silent renew (zombie-runner closure — two concurrent
+            // runners must see exactly one winner).
             return Ok(None);
         }
         // No live lease: acquire it. Every successful acquire bumps the
@@ -265,8 +265,8 @@ impl ExecutionStore for InMemoryExecutionStore {
         // — including one held by the *same* holder string (a
         // crashed-then-restarted runner reusing its `instance_id` is a
         // zombie w.r.t. its pre-crash token). Generation 0 therefore
-        // universally means "no lease ever issued / stale" (§12.2
-        // zombie-runner closure, ADR-0008).
+        // universally means "no lease ever issued / stale"
+        // (zombie-runner closure).
         row.fencing_generation += 1;
         row.lease_holder = Some(holder.to_string());
         row.lease_expires_at = Some(now.checked_add(ttl).unwrap_or(now));

--- a/crates/storage/src/inmem/idempotency_store.rs
+++ b/crates/storage/src/inmem/idempotency_store.rs
@@ -1,5 +1,5 @@
-//! In-memory `IdempotencyStore` (ADR-0048 durable-replay cache) +
-//! `WebhookActivationStore` (ADR-0049).
+//! In-memory `IdempotencyStore` (durable idempotent-replay cache) +
+//! `WebhookActivationStore` (webhook activation specs).
 //!
 //! Both share-nothing (their own `Arc<Mutex<…>>`): the cache is keyed by
 //! `{workspace_id}:{org_id}:{cache_key}` (the store folds the scope in, so

--- a/crates/storage/src/inmem/node_result.rs
+++ b/crates/storage/src/inmem/node_result.rs
@@ -1,6 +1,6 @@
 //! In-memory `NodeResultStore` + `CheckpointStore`.
 //!
-//! These back the engine's resume seam (ADR-0009 node outputs/results +
+//! These back the engine's resume seam (node outputs/results +
 //! workflow input) and the stateful-action checkpoint optimisation
 //! (spec-16 §11.5). Each is its own `parking_lot::Mutex`-guarded map keyed
 //! by `(scope, execution_id, node_id)` so a cross-tenant read can never
@@ -13,7 +13,7 @@
 //! The schema version on every loaded record is checked against
 //! [`MAX_SUPPORTED_RESULT_SCHEMA_VERSION`] and a newer record fails closed
 //! with [`StorageError::UnknownSchemaVersion`] rather than being silently
-//! misinterpreted (ADR-0009 §2).
+//! misinterpreted (unknown schema version fails closed).
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -54,8 +54,7 @@ fn input_key(scope: &Scope, execution_id: &str) -> InputKey {
 ///
 /// A newer writer may have stored a shape this process does not
 /// understand; surfacing it as a typed error keeps resume loud instead of
-/// silently reconstructing a node from a misread payload (ADR-0009 §2,
-/// PRODUCT_CANON §4.5).
+/// silently reconstructing a node from a misread payload.
 fn guard_schema(record: &NodeResultRecord) -> Result<(), StorageError> {
     if record.schema_version > MAX_SUPPORTED_RESULT_SCHEMA_VERSION {
         return Err(StorageError::UnknownSchemaVersion {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -32,22 +32,21 @@
 //! the API idempotency middleware), the webhook-activation store, and the
 //! identity-row repository surface implemented by the Postgres glue in
 //! `pg`. `pg::PgControlQueueRepo` is the multi-process /
-//! restart-tolerant control-queue backing (`FOR UPDATE SKIP LOCKED` per
-//! ADR-0008 §1); no composition root selects it by default yet — a future
-//! `apps/server` (ADR-0008 follow-up) wires it in.
+//! restart-tolerant control-queue backing (`FOR UPDATE SKIP LOCKED`); no
+//! composition root selects it by default yet — the server binary wires it in.
 //!
-//! ## Canon
+//! ## Durability surfaces (port)
 //!
-//! - §11.1 CAS transitions via the port `ExecutionStore` commit path.
-//! - §11.3 idempotency check-and-mark via the port `IdempotencyGuard`.
-//! - §11.5 journal (`append_journal`) and checkpoint (`save_stateful_checkpoint`).
-//! - §12.2 outbox atomicity: `execution_control_queue` writes share the same operation as state
+//! - CAS transitions via the port `ExecutionStore` commit path.
+//! - Per-attempt idempotency via the port `IdempotencyGuard`.
+//! - Journal (`append_journal`) and checkpoint (`save_stateful_checkpoint`).
+//! - Outbox atomicity: `execution_control_queue` writes share the same operation as state
 //!   transitions.
-//! - §12.3 local path: SQLite is the default; `test_support` provides `sqlite_memory_*` helpers for
+//! - Local path: SQLite is the default; `test_support` provides `sqlite_memory_*` helpers for
 //!   in-process tests.
-//! - ADR-0009 resume-persistence schema: `set_workflow_input` / `get_workflow_input` and
-//!   `save_node_result` / `load_node_result` / `load_all_results` expose the seam; engine consumers
-//!   (chips B2 / B3 / B4) wire the resume path.
+//! - Resume persistence: `set_workflow_input` / `get_workflow_input` and
+//!   `save_node_result` / `load_node_result` / `load_all_results` expose the seam for engine
+//!   resume wiring.
 //!
 //! See `crates/storage/README.md` for the full durability matrix and
 //! backend status table.
@@ -55,8 +54,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
-/// Credential persistence — see
-/// [ADR-0029](../../../docs/adr/0029-storage-owns-credential-persistence.md).
+/// Credential persistence (encryption, audit, refresh claims, pending state).
 pub mod credential;
 mod error;
 /// Serialization format abstraction (JSON / MessagePack).

--- a/crates/storage/src/pg/control_queue.rs
+++ b/crates/storage/src/pg/control_queue.rs
@@ -1,4 +1,4 @@
-//! Postgres implementation of [`ControlQueueRepo`] (ADR-0008 / ADR-0017).
+//! Postgres implementation of [`ControlQueueRepo`].
 //!
 //! Schema: migrations `0013_execution_lifecycle.sql` (base table) +
 //! `0021_add_control_queue_reclaim_count.sql` (reclaim column + partial
@@ -70,16 +70,16 @@ fn tuple_to_entry(t: EntryTuple) -> Result<ControlQueueEntry, StorageError> {
     })
 }
 
-/// Postgres-backed durable control queue (canon §12.2).
+/// Postgres-backed durable control queue.
 ///
 /// Implements the [`ControlQueueRepo`] trait against the
 /// `execution_control_queue` table defined by migration 0013 + 0021 + 0026.
 ///
-/// - `claim_pending` uses `FOR UPDATE SKIP LOCKED` per ADR-0008 §1; two concurrent claimers never
+/// - `claim_pending` uses `FOR UPDATE SKIP LOCKED`; two concurrent claimers never
 ///   double-claim a row.
 /// - `reclaim_stuck` runs two `UPDATE ... WHERE status = 'Processing' ... RETURNING id` statements
 ///   inside one transaction; the `status = 'Processing'` predicate is the CAS that fences
-///   concurrent sweepers (ADR-0017). The exhausted-message encodes `processed_by` as lowercase hex
+///   concurrent sweepers. The exhausted-message encodes `processed_by` as lowercase hex
 ///   to stay byte-identical with `InMemoryControlQueueRepo`.
 #[derive(Clone)]
 pub struct PgControlQueueRepo {
@@ -144,7 +144,7 @@ impl ControlQueueRepo for PgControlQueueRepo {
         processor: &[u8],
         batch_size: u32,
     ) -> Result<Vec<ControlQueueEntry>, StorageError> {
-        // Canonical Postgres SKIP LOCKED claim (ADR-0008 §1).
+        // Canonical Postgres SKIP LOCKED claim.
         // The CTE's SELECT ... FOR UPDATE SKIP LOCKED skips rows another
         // runner has already locked; the outer UPDATE stamps the survivors
         // atomically and returns them via RETURNING.
@@ -177,7 +177,7 @@ impl ControlQueueRepo for PgControlQueueRepo {
         // worker whose row was reclaimed and re-claimed by a different
         // runner sees `processed_by != $processor` → zero rows affected,
         // the newer claim's state is preserved. An idempotent no-op under
-        // the at-least-once contract of ADR-0008 §5.
+        // the at-least-once delivery contract.
         sqlx::query(
             "UPDATE execution_control_queue \
              SET status = 'Completed' \
@@ -686,7 +686,7 @@ mod tests {
         // after the row has already been terminalised (e.g. by
         // reclaim-exhaustion → Failed, or never-claimed → Pending) must
         // not overwrite the newer status. Guarded UPDATE returns zero
-        // rows; the repo method still returns Ok per ADR-0008 §5.
+        // rows; the repo method still returns Ok (idempotent no-op).
         let Some(pool) = pool().await else { return };
         let _guard = TEST_LOCK.lock().await;
         clean_control_queue(&pool).await;

--- a/crates/storage/src/pg/idempotency.rs
+++ b/crates/storage/src/pg/idempotency.rs
@@ -1,4 +1,4 @@
-//! Postgres implementation of [`IdempotencyStoreRepo`] (M3.4 / ADR-0048).
+//! Postgres implementation of [`IdempotencyStoreRepo`].
 //!
 //! Schema: migration `0024_add_idempotency_dedup.sql`.
 //!
@@ -29,7 +29,7 @@ use crate::{
     repos::{CachedRecord, IdempotencyStoreRepo},
 };
 
-/// Postgres-backed durable dedup store (canon §M3.4 / ADR-0048).
+/// Postgres-backed durable dedup store (survives process restart).
 #[derive(Clone, Debug)]
 pub struct PgIdempotencyStore {
     pool: Pool<Postgres>,

--- a/crates/storage/src/pg/webhook_activation.rs
+++ b/crates/storage/src/pg/webhook_activation.rs
@@ -1,4 +1,4 @@
-//! Postgres implementation of [`WebhookActivationRepo`] (M3.3 / ADR-0049).
+//! Postgres implementation of [`WebhookActivationRepo`].
 //!
 //! Schema lives in migrations 0010 (`triggers`) and 0018
 //! (`webhook_path` indexed column). Migration 0025 attaches the

--- a/crates/storage/src/postgres/control_queue.rs
+++ b/crates/storage/src/postgres/control_queue.rs
@@ -3,7 +3,7 @@
 //!
 //! The claim path uses `FOR UPDATE SKIP LOCKED` so multiple consumers can
 //! drain the queue concurrently without double-dispatch (multi-consumer,
-//! ADR-0008 §1). Ids are the raw 16-byte ULID (`BYTEA`), never
+//! multi-consumer claim). Ids are the raw 16-byte ULID (`BYTEA`), never
 //! UTF-8-of-ULID. `enqueue` carries the tenant `Scope`; `mark_*` are
 //! fenced by the claiming processor.
 

--- a/crates/storage/src/postgres/execution.rs
+++ b/crates/storage/src/postgres/execution.rs
@@ -279,9 +279,8 @@ impl ExecutionStore for PgExecutionStore {
             // second acquire by the *same* holder. Renewal is the
             // dedicated `renew_lease` op (fencing-token gated); a
             // second `acquire_lease` while the lease is live is
-            // contention, not a silent renew (§12.2 zombie-runner
-            // closure, ADR-0008 — two concurrent runners must see
-            // exactly one winner).
+            // contention, not a silent renew (zombie-runner closure —
+            // two concurrent runners must see exactly one winner).
             tx.rollback().await.map_err(conn_err)?;
             return Ok(None);
         }

--- a/crates/storage/src/postgres/idempotency_store.rs
+++ b/crates/storage/src/postgres/idempotency_store.rs
@@ -1,5 +1,5 @@
-//! Postgres `IdempotencyStore` (ADR-0048 durable-replay cache) +
-//! `WebhookActivationStore` (ADR-0049) over the port-scoped schema.
+//! Postgres `IdempotencyStore` (durable idempotent-replay cache) +
+//! `WebhookActivationStore` (webhook activation specs) over the port-scoped schema.
 //!
 //! The cache is keyed by `{workspace_id}:{org_id}:{cache_key}` (the store
 //! folds the scope into the key, so tenant A can neither probe nor poison

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -4,7 +4,7 @@
 //! Per spec §5: `commit` uses a real transaction so the §12.2 triple
 //! (CAS + fencing check + state + outbox + journal) is atomic and
 //! serializable across processes; the control-queue claim uses
-//! `FOR UPDATE SKIP LOCKED` (multi-consumer, ADR-0008 §1) — wired by the
+//! `FOR UPDATE SKIP LOCKED` (multi-consumer queue claim) — wired by the
 //! control-queue store in a later task.
 //!
 //! The adapter owns a port-scoped schema (`schema.sql`, `port_*` tables)

--- a/crates/storage/src/repos/control_queue.rs
+++ b/crates/storage/src/repos/control_queue.rs
@@ -18,11 +18,8 @@ pub enum ControlCommand {
     /// First-time dispatch of a newly-created execution.
     ///
     /// Enqueued by the API `start_execution` / `execute_workflow` handlers
-    /// once the `ExecutionState::Created` row has been persisted (canon §12.2,
-    /// §13 step 3, #332). The engine-side consumer picks this up and drives
-    /// the execution through its initial transition to `Running` — closing
-    /// the §4.5 public-surface gap where the API advertised workflow
-    /// dispatch but never reached the engine.
+    /// once the `ExecutionState::Created` row has been persisted. The engine-side consumer picks this up and drives
+    /// the execution through its initial transition to `Running`.
     Start,
     /// Cooperative cancel (graceful shutdown of running work).
     Cancel,
@@ -80,12 +77,12 @@ pub struct ControlQueueEntry {
     /// for crashed-runner recovery — rows whose `processed_at` is older
     /// than the `reclaim_after` window are redelivered. Cleared on a
     /// successful reclaim so the next `claim_pending` resets the clock.
-    /// See ADR-0017 / ADR-0008 B1.
+    /// Used by crashed-runner reclaim sweeps.
     pub processed_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Error message if processing failed.
     pub error_message: Option<String>,
     /// Number of times this row has been reclaimed back to `Pending` after a
-    /// crashed runner left it in `Processing` (ADR-0017, ADR-0008 B1). Bounded
+    /// crashed runner left it in `Processing`. Bounded
     /// by `max_reclaim_count` on the consumer; rows past the budget move to
     /// `Failed` with a `"reclaim exhausted:"` error.
     pub reclaim_count: u32,
@@ -96,7 +93,7 @@ pub struct ControlQueueEntry {
     pub w3c_trace_context: Option<nebula_core::W3cTraceContext>,
 }
 
-/// Summary of a single `reclaim_stuck` sweep (ADR-0017).
+/// Summary of a single `reclaim_stuck` sweep.
 ///
 /// `reclaimed` counts rows moved `Processing → Pending` for a fresh dispatch
 /// attempt; `exhausted` counts rows moved `Processing → Failed` because
@@ -133,7 +130,7 @@ pub trait ControlQueueRepo: Send + Sync {
     /// is the one that claimed the row. This prevents a stale worker whose
     /// row was reclaimed and re-claimed by another runner from overwriting
     /// the newer claim's state. A mismatch is an idempotent no-op under
-    /// the at-least-once contract of ADR-0008 §5.
+    /// the at-least-once delivery contract.
     async fn mark_completed(&self, id: &[u8], processor: &[u8]) -> Result<(), StorageError>;
 
     /// Mark a claimed command as failed (records `error_message`).
@@ -151,7 +148,7 @@ pub trait ControlQueueRepo: Send + Sync {
     ) -> Result<(), StorageError>;
 
     /// Reclaim rows stuck in `Processing` whose owning runner is presumed
-    /// dead (ADR-0017, ADR-0008 B1).
+    /// dead (crashed-runner reclaim).
     ///
     /// Finds rows where `status = 'Processing'` and
     /// `processed_at < now - reclaim_after`. For each such row:

--- a/crates/storage/src/repos/idempotency.rs
+++ b/crates/storage/src/repos/idempotency.rs
@@ -1,4 +1,4 @@
-//! Idempotent-replay dedup store (M3.4 — ADR-0048).
+//! Idempotent-replay dedup store.
 //!
 //! Storage-layer port for the API's idempotency middleware. Two impls
 //! ship in this crate today:
@@ -70,7 +70,7 @@ pub trait IdempotencyStoreRepo: Send + Sync + std::fmt::Debug {
     /// [`StorageError`] if the read itself failed (e.g. PG connection
     /// error, malformed payload). Callers MUST NOT treat
     /// [`StorageError`] as a cache miss — silently dropping replay
-    /// protection on data corruption is rejected by ADR-0048.
+    /// protection on data corruption — storage errors must not be treated as cache misses.
     async fn get(&self, cache_key: &str) -> Result<Option<CachedRecord>, StorageError>;
 
     /// Persist a cached record under `cache_key` with `ttl`.

--- a/crates/storage/src/repos/mod.rs
+++ b/crates/storage/src/repos/mod.rs
@@ -7,10 +7,10 @@
 //!
 //! - **Control-command outbox** — `ControlQueueRepo` with
 //!   `InMemoryControlQueueRepo` and, behind the `postgres` feature,
-//!   `pg::PgControlQueueRepo` (`FOR UPDATE SKIP LOCKED`, ADR-0008 §1).
+//!   `pg::PgControlQueueRepo` (`FOR UPDATE SKIP LOCKED`).
 //!   The five commands (`Start` / `Resume` / `Restart` / `Cancel` /
 //!   `Terminate`) and the crashed-runner `reclaim_stuck` sweep
-//!   (ADR-0008 / ADR-0017) are implemented on both backings.
+//!   are implemented on both backings.
 //! - **Idempotency-cache store** — `IdempotencyStoreRepo` /
 //!   `InMemoryIdempotencyStoreRepo`, consumed by the API idempotency
 //!   middleware (`StorageBackedIdempotencyStore`).

--- a/crates/storage/src/repos/webhook_activation.rs
+++ b/crates/storage/src/repos/webhook_activation.rs
@@ -1,4 +1,4 @@
-//! Webhook-activation repository (M3.3 / ADR-0049).
+//! Webhook-activation repository.
 //!
 //! Storage seam for the API's slug-routed webhook bootstrap. Sibling
 //! to the generic [`crate::repos::TriggerRepo`] (whose contract is

--- a/crates/storage/src/rows/webhook_activation.rs
+++ b/crates/storage/src/rows/webhook_activation.rs
@@ -1,5 +1,5 @@
 //! `WebhookActivationSpec` — operator-configured webhook trigger spec
-//! persisted under `triggers.config.webhook_activation` (M3.3 / ADR-0049).
+//! persisted under `triggers.config.webhook_activation`.
 //!
 //! # JSONB namespace
 //!
@@ -79,7 +79,7 @@ pub struct WebhookActivationSpec {
     /// Storage identifier of the HMAC secret credential. Resolved
     /// against the credential registry by the webhook factory at
     /// activation time. Storage layer **must not** inline raw secret
-    /// bytes — see ADR-0029.
+    /// bytes — credential registry holds secrets at rest.
     pub secret_id: String,
 
     /// Optional override for the signature replay window. `None`

--- a/crates/storage/src/sqlite/execution.rs
+++ b/crates/storage/src/sqlite/execution.rs
@@ -285,9 +285,8 @@ impl ExecutionStore for SqliteExecutionStore {
             // second acquire by the *same* holder. Renewal is the
             // dedicated `renew_lease` op (fencing-token gated); a
             // second `acquire_lease` while the lease is live is
-            // contention, not a silent renew (§12.2 zombie-runner
-            // closure, ADR-0008 — two concurrent runners must see
-            // exactly one winner).
+            // contention, not a silent renew (zombie-runner closure —
+            // two concurrent runners must see exactly one winner).
             tx.rollback().await.map_err(conn_err)?;
             return Ok(None);
         }

--- a/crates/storage/src/sqlite/idempotency_store.rs
+++ b/crates/storage/src/sqlite/idempotency_store.rs
@@ -1,5 +1,5 @@
-//! SQLite `IdempotencyStore` (ADR-0048 durable-replay cache) +
-//! `WebhookActivationStore` (ADR-0049) over the port-scoped schema.
+//! SQLite `IdempotencyStore` (durable idempotent-replay cache) +
+//! `WebhookActivationStore` (webhook activation specs) over the port-scoped schema.
 //!
 //! The cache is keyed by `{workspace_id}:{org_id}:{cache_key}` (the store
 //! folds the scope into the key, so tenant A can neither probe nor poison

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -520,7 +520,7 @@ pub async fn assert_stale_fencing_is_fenced_out(backend: &dyn Backend) {
 /// A live lease blocks every further `acquire_lease` — including a second
 /// acquire by the *same* holder — and an acquire that follows a prior
 /// (now-expired) lease bumps the fencing generation so the pre-expiry
-/// token is dead. This is the §12.2 zombie-runner closure (ADR-0008):
+/// token is dead. Zombie-runner closure: a live lease blocks re-acquire,
 /// two concurrent runners must see exactly one winner, and a
 /// crashed-then-restarted runner reusing its holder id cannot revive its
 /// pre-crash token.

--- a/crates/storage/tests/credential_audit_durable.rs
+++ b/crates/storage/tests/credential_audit_durable.rs
@@ -1,4 +1,4 @@
-//! CI gate for ADR-0028 invariant 4 (§14 no discard-and-log):
+//! CI gate for fail-closed credential audit (no discard-and-log):
 //! audit is in-line durable. If the audit sink errors, the credential
 //! operation errors. No "log and continue" path.
 //!

--- a/crates/storage/tests/pg_idempotency.rs
+++ b/crates/storage/tests/pg_idempotency.rs
@@ -1,4 +1,4 @@
-//! Postgres integration tests for [`PgIdempotencyStore`] (M3.4 / ADR-0048).
+//! Postgres integration tests for [`PgIdempotencyStore`] (durable idempotent-replay cache).
 //!
 //! Mirrors the existing storage test convention: skip silently when
 //! `DATABASE_URL` is absent, fail loudly when it is set but unparsable.

--- a/crates/storage/tests/refresh_claim_in_memory_smoke.rs
+++ b/crates/storage/tests/refresh_claim_in_memory_smoke.rs
@@ -1,7 +1,6 @@
 //! Behavioural smoke tests for `InMemoryRefreshClaimRepo`.
 //!
-//! Verifies the CAS / heartbeat / release / reclaim contract per ADR-0041
-//! and sub-spec §3.2.
+//! Verifies the CAS / heartbeat / release / reclaim contract.
 
 use std::time::Duration;
 

--- a/crates/storage/tests/refresh_claim_schema_parity.rs
+++ b/crates/storage/tests/refresh_claim_schema_parity.rs
@@ -5,7 +5,7 @@
 //! (TEXT/INTEGER vs TIMESTAMPTZ/UUID/BIGSERIAL) — we match on the column
 //! identifiers, not their declared types.
 //!
-//! Per ADR-0041 + sub-spec §3.3 / §3.4.
+//! Per refresh-claim contract (SQLite vs Postgres column parity).
 
 use std::{collections::BTreeSet, path::Path};
 

--- a/crates/tenancy/src/credential_scope.rs
+++ b/crates/tenancy/src/credential_scope.rs
@@ -10,7 +10,7 @@
 //!
 //! The credential-specific `EncryptionLayer` / `CacheLayer` / `AuditLayer`
 //! stay in `nebula-storage` and re-compose **on top** of this layer; their
-//! ADR-0029 fail-closed audit + zeroize-on-drop invariants are unaffected
+//! fail-closed audit + zeroize-on-drop invariants are unaffected
 //! by the move (the layer order — `ScopeLayer → AuditLayer →
 //! EncryptionLayer → CacheLayer → Backend` — is preserved at the
 //! composition root) and remain regression-tested in
@@ -65,12 +65,12 @@ const OWNER_KEY: &str = "owner_id";
 ///
 /// struct TenantScope(String);
 /// impl CredentialScopeResolver for TenantScope {
-///     fn current_owner(&self) -> Option<&str> { Some(&self.0) }
+/// fn current_owner(&self) -> Option<&str> { Some(&self.0) }
 /// }
 ///
 /// let store = CredentialScopeLayer::new(
-///     InMemoryStore::new(),
-///     Arc::new(TenantScope("tenant-1".into())),
+/// InMemoryStore::new(),
+/// Arc::new(TenantScope("tenant-1".into())),
 /// );
 /// ```
 pub struct ScopeLayer<S> {

--- a/crates/tenancy/src/decorator/node_result.rs
+++ b/crates/tenancy/src/decorator/node_result.rs
@@ -1,4 +1,4 @@
-//! Scope-enforcing [`NodeResultStore`] decorator (ADR-0009).
+//! Scope-enforcing [`NodeResultStore`] decorator.
 
 use std::sync::Arc;
 

--- a/crates/validator/src/lib.rs
+++ b/crates/validator/src/lib.rs
@@ -6,8 +6,6 @@
 //!
 //! **Role:** Validation Rules Engine + Declarative Rule. See `crates/validator/README.md`.
 //!
-//! **Canon:** §3.5 (schema system), §4.5 (proof-token pipeline).
-//!
 //! **Maturity:** `frontier` — the programmatic validator API (`Validate`, `ValidateExt`,
 //! `Validated`, `ValidationError`) is stable; [`Rule`] has just moved to a typed sum-of-sums
 //! (`Value` / `Predicate` / `Logic` / `Deferred` / `Described`) with a new externally-tagged
@@ -31,7 +29,7 @@
 //! ```rust,ignore
 //! use nebula_validator::prelude::*;
 //!
-//! // Compose validators with .and() / .or() / .not()
+//! // Compose validators with.and() /.or() /.not()
 //! let username = min_length(3).and(max_length(20)).and(alphanumeric());
 //! assert!(username.validate("alice").is_ok());
 //!
@@ -50,7 +48,7 @@
 // ValidationError (<= 80 bytes) is the fundamental error type for all validators —
 // boxing it would add indirection to every validation call for no practical benefit.
 #![allow(clippy::result_large_err)]
-// Deep combinator nesting (And<Or<Not<...>, ...>, ...>) produces complex types
+// Deep combinator nesting (And<Or<Not<...>,...>,...>) produces complex types
 // that are inherent to the type-safe combinator architecture.
 #![allow(clippy::type_complexity)]
 
@@ -63,7 +61,7 @@ pub mod engine;
 pub mod error;
 /// Core traits, errors, and type-erased validators.
 pub mod foundation;
-/// Field visibility / required policy evaluation (ADR-0052).
+/// Field visibility / required policy evaluation.
 pub mod policy;
 /// Single-import convenience module.
 pub mod prelude;

--- a/crates/validator/src/policy/mod.rs
+++ b/crates/validator/src/policy/mod.rs
@@ -1,4 +1,4 @@
-//! Field visibility / required policy evaluation (ADR-0052).
+//! Field visibility / required policy evaluation.
 //!
 //! Owns the *engine* for `When(Rule)` conditions. Callers get typed
 //! `Presence`/`Requiredness` verdicts — never a raw `bool` they could
@@ -196,7 +196,7 @@ pub struct FieldPolicyResolution<'a, P> {
     /// One plan per input decl, in input order.
     pub plans: Vec<FieldPlan<'a, P>>,
     /// `required` errors for required, absent fields — validator owns this
-    /// reporting (ADR-0052).
+    /// reporting.
     pub required_failures: ValidationErrors,
 }
 

--- a/crates/validator/src/rule/value.rs
+++ b/crates/validator/src/rule/value.rs
@@ -6,7 +6,7 @@
 //! match. `null` is a distinct kind and does not match any typed rule —
 //! schema layers are expected to filter optional/nullable fields upstream
 //! before dispatching rules (see `nebula-schema::validated`). Strictness
-//! here aligns with PRODUCT_CANON §4.2 ("no silent shape mismatches").
+//! here aligns with PRODUCT_ ("no silent shape mismatches").
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/workflow/src/error.rs
+++ b/crates/workflow/src/error.rs
@@ -109,7 +109,7 @@ pub enum WorkflowError {
     /// rules: `max_attempts == 0`, `max_delay_ms < initial_delay_ms`,
     /// `backoff_multiplier <= 0` or non-finite, or `initial_delay_ms == 0`
     /// combined with `max_attempts > 1` (burst retry without backoff).
-    /// Per ROADMAP §M2.1 + ADR-0042 the engine relies on these constraints —
+    /// Per ROADMAP §M2.1 + the engine relies on these constraints —
     /// shift-left rejection at activation prevents nonsensical configs from
     /// reaching the runtime scheduler.
     #[classify(category = "validation", code = "WORKFLOW:INVALID_RETRY_CONFIG")]

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -7,10 +7,8 @@
 //!
 //! **Role:** Workflow Definition + DAG + Validation. See `crates/workflow/README.md`.
 //!
-//! **Canon:** §10 (golden path — activation runs `validate_workflow`), §12.2 (shift-left
-//! validation contract).
-//!
 //! **Maturity:** `stable` — definition types, builder, DAG, and validator are in active use.
+//! Activation must run shift-left validation before execution starts.
 //!
 //! ## Core Types
 //!
@@ -19,7 +17,7 @@
 //! - [`Connection`] — directed edges wired port-to-port (spec 28 port-driven routing).
 //! - [`DependencyGraph`] — `petgraph` wrapper; topological sort + per-level batching.
 //! - [`WorkflowBuilder`] — fluent, validated construction API.
-//! - [`validate_workflow`] — multi-error validator; **canon §10 requires this at activation**.
+//! - [`validate_workflow`] — multi-error validator; required at activation.
 //! - [`NodeState`] — execution progress tracking per node.
 //!
 //! ## Non-goals

--- a/crates/workflow/src/node.rs
+++ b/crates/workflow/src/node.rs
@@ -44,7 +44,7 @@ pub struct NodeDefinition {
     /// Engine throttles execution to stay within the limit.
     #[serde(default)]
     pub rate_limit: Option<RateLimit>,
-    /// Slot-binding overrides per ADR-0042 (hybrid binding mechanism).
+    /// Slot-binding overrides (hybrid binding mechanism).
     ///
     /// Map key is the action's `slot_key` (the struct field name on the
     /// `#[derive(Action)]` type). Map value is a [`SlotBinding`] selecting
@@ -64,8 +64,8 @@ pub struct NodeDefinition {
 ///
 /// ```yaml
 /// rate_limit:
-///   max_requests: 60
-///   window_secs: 60
+/// max_requests: 60
+/// window_secs: 60
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RateLimit {
@@ -208,7 +208,7 @@ impl NodeDefinition {
 
 /// Slot-binding override for an action's `#[resource]` / `#[credential]` field.
 ///
-/// Per ADR-0042, action authors declare slots on their `#[derive(Action)]`
+///, action authors declare slots on their `#[derive(Action)]`
 /// struct fields. The default binding id is the slot key (the field name).
 /// Workflow authors override per-node by populating
 /// [`NodeDefinition::slot_bindings`]; each entry selects either a resource

--- a/crates/workflow/src/state.rs
+++ b/crates/workflow/src/state.rs
@@ -24,7 +24,7 @@ pub enum NodeState {
     /// Failed but a retry is scheduled — `NodeExecutionState::next_attempt_at`
     /// holds the wake-up time. Transient retry state in the
     /// `Failed → WaitingRetry → Ready → Running` path for engine-level retry
-    /// per ADR-0042. Not terminal: a `WaitingRetry` node will eventually
+    ///. Not terminal: a `WaitingRetry` node will eventually
     /// transition back to `Ready`/`Running` (retry attempt) or to
     /// `Cancelled` (shutdown / explicit cancel during the wait).
     WaitingRetry,
@@ -104,7 +104,7 @@ mod tests {
         assert!(
             !NodeState::WaitingRetry.is_terminal(),
             "WaitingRetry must be non-terminal — engine flips it back \
-             to Ready when next_attempt_at fires (ADR-0042)"
+             to Ready when next_attempt_at fires"
         );
     }
 
@@ -122,14 +122,14 @@ mod tests {
             !NodeState::WaitingRetry.is_active(),
             "WaitingRetry is parked between attempts; the work is not \
              running — frontier loop's max_concurrent guard must not \
-             count it (canon §11.1)"
+             count it toward active concurrency"
         );
     }
 
     /// `WaitingRetry` is the parked-between-attempts state — distinct
     /// from a final `Failed`. `is_failure()` must return `false` so
     /// `failed_node_ids()` and `determine_final_status` only count
-    /// nodes whose retry budget is fully exhausted (ADR-0042).
+    /// nodes whose retry budget is fully exhausted.
     #[test]
     fn waiting_retry_is_not_failure() {
         assert!(!NodeState::WaitingRetry.is_failure());
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn serde_waiting_retry_uses_snake_case() {
-        // ADR-0042 wire format: rename_all = "snake_case" so the new
+        // wire format: rename_all = "snake_case" so the new
         // variant serializes as `"waiting_retry"`, matching the
         // existing `"failed"` / `"completed"` style. Out-of-tree
         // consumers (UI, API clients, audit log readers) must see this

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -12,7 +12,8 @@ use crate::{
 /// Validate a single `RetryConfig` against the engine's invariants.
 ///
 /// Returns a list of human-readable rejection reasons; an empty list means the
-/// config is acceptable. Per ADR-0042 (layered retry):
+/// config is acceptable. Layered retry rules:
+///
 /// - `max_attempts == 0` is rejected — the field should be `None` to disable retries; zero retries
 ///   means the field is dead and indicates a modelling bug.
 /// - `initial_delay_ms == 0` with `max_attempts > 1` is rejected — burst retry with no backoff is
@@ -165,11 +166,11 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
 
     // 9. Check per-node retry_policy validity. The workflow-default retry
     // policy was validated as step 1b (before the empty-nodes early return);
-    // here we only iterate the actual nodes. Per ADR-0042 the engine consumes
+    // here we only iterate the actual nodes. the engine consumes
     // both surfaces (`NodeDefinition.retry_policy` overriding
     // `WorkflowConfig.retry_policy`) — rejecting bad configs at this
     // shift-left point prevents them from reaching the runtime scheduler
-    // (canon §10).
+    //.
     for node in &definition.nodes {
         if let Some(ref retry) = node.retry_policy {
             for reason in validate_retry_config(retry) {
@@ -459,7 +460,7 @@ mod tests {
         );
     }
 
-    // ── retry_policy validation tests (ROADMAP §M2.1 / ADR-0042) ────────────
+    // ── retry_policy validation tests (ROADMAP §) ────────────
 
     /// Construct a workflow with a single node carrying the given retry config.
     fn def_with_node_retry(retry: RetryConfig) -> WorkflowDefinition {

--- a/docs/README.md
+++ b/docs/README.md
@@ -62,6 +62,15 @@ for traceability but are **non-normative** (see conflict rule above).
 | `C:/Users/.../RustroverProjects/docs/` as workspace canon | This repo’s `docs/` table |
 | Bulk `glob docs/**` | This file + one crate README + cited ADR |
 
-## Code comments
+## Code comments (Rust)
 
-Prefer **behavior-first** module docs in crates/. Avoid inline ADR-NNNN / canon § pins — see docs/plans/2026-05-18-002-refactor-code-doc-citation-cleanup-plan.md.
+Write **behavior-first** `//!` / `//` text in `crates/**/*.rs`. Normative decisions live in
+canon, INTEGRATION_MODEL, and ADRs — not as section pins on every hot path.
+
+| Do | Don't |
+|----|-------|
+| Explain *what the code enforces* (lease reclaim, SKIP LOCKED, tenant scope, replay-oracle) | `ADR-0048 §3.2`, `canon §12.2`, `spec-16 §11.3` in inline comments |
+| At most **one** module-level pointer per file to `crates/<crate>/README.md` or `docs/INTEGRATION_MODEL.md` when traceability helps | Scatter ADR numbers through `//` blocks inside functions |
+| Keep ADR ids in **tests** when the test name/doc is explicitly proving a contract seam | Remove history from `docs/adr/` stubs, `deny.toml` layer comments, or supersession tables |
+
+`rg 'ADR-0|canon §' crates --glob '*.rs'` should trend to zero on merged work; crate READMEs may still cite ADRs for integrators.

--- a/docs/plans/2026-05-18-002-refactor-code-doc-citation-cleanup-plan.md
+++ b/docs/plans/2026-05-18-002-refactor-code-doc-citation-cleanup-plan.md
@@ -1,7 +1,7 @@
 ---
 title: "refactor: Rust code — reduce ADR/canon citation noise in comments"
 type: refactor
-status: active
+status: completed
 date: 2026-05-18
 origin: docs/brainstorms/2026-05-18-001-docs-stack-contract-consolidation-requirements.md
 unblocked-by: Wave B complete (plan 001 U10)
@@ -27,4 +27,4 @@ unblocked-by: Wave B complete (plan 001 U10)
 
 ## Status
 
-Draft only — activate after Wave A+B gate in plan `2026-05-18-001` (U10).
+Completed 2026-05-18 on branch `refactor/code-doc-citation-cleanup` (four commits). Gate: `rg 'ADR-0|canon §' crates --glob '*.rs'` → zero.


### PR DESCRIPTION
## Summary

Wave C of the doc-stack consolidation: replace inline `ADR-00xx` and `canon §` pins in `crates/**/*.rs` with behavior-first comments. Normative traceability stays in canon, INTEGRATION_MODEL, and ADRs. Adds the Rust comment policy to `docs/README.md` (R16).

## Linked issue

- Closes NEB-
- Refs NEB-

## Type of change

- [ ] `feat` — new capability
- [ ] `fix` — bug fix
- [x] `docs` — documentation only
- [ ] `style` — formatting / non-functional style change
- [x] `refactor` — internal restructuring, no behavior change
- [ ] `perf` — performance improvement
- [ ] `test` — tests only
- [ ] `chore` — tooling, maintenance, dependencies
- [ ] `ci` — CI configuration or workflow changes
- [ ] `build` — build system or packaging changes
- [ ] `revert` — reverts a previous change

## Affected crates / areas

- `docs/README.md`, `docs/plans/2026-05-18-002-*`
- All workspace `crates/**` (comments/docstrings only; no logic changes)

## Changes

- Document behavior-first Rust comment rules in `docs/README.md`.
- Remove `ADR-0*` / `canon §` from `crates/**/*.rs` module and inline comments across storage-port, storage, engine, api, resource, credential, and remaining crates.
- Mark plan `2026-05-18-002` completed.
- Verification gate: `rg 'ADR-0|canon §' crates --glob '*.rs'` → zero.

## Test plan

- [x] `cargo fmt --all` — formatted (per-commit lefthook)
- [x] `cargo clippy --workspace -- -D warnings` — clean locally
- [x] Per-commit lefthook: staged-crate clippy + fmt on each commit
- [ ] `cargo nextest run --workspace` — full suite on CI (pre-push nextest passed locally)
- [ ] `cargo test --workspace --doc` — N/A (no public doc API changes)
- [ ] `cargo deny check` — N/A (`Cargo.toml` untouched)

### Local verification

- [x] `cargo fmt --all` — formatted
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] `cargo nextest run --workspace` — passes (CI)
- [ ] `cargo test --workspace --doc` — doctests pass (if public docs touched)
- [ ] `cargo deny check` — no new advisories (if `Cargo.toml` touched)

## Breaking changes

None

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — no semantic drift (comments only)
- [x] Layer direction preserved (no dependency changes)
- [ ] If an L2 invariant changed: N/A
- [ ] `docs/MATURITY.md` row updated if crate maturity changed — deferred (U5)
- [ ] Crate `README.md` / `lib.rs //!` updated if public surface changed — comment-only
- [ ] `docs/INTEGRATION_MODEL.md` updated — N/A
- [x] Plan archived or updated: `docs/plans/2026-05-18-002-refactor-code-doc-citation-cleanup-plan.md`

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code
- [x] No silent error suppression introduced
- [x] Execution transitions unchanged
- [x] Credentials / secrets paths unchanged
- [x] No new `unsafe` blocks

## Notes for reviewers

- **Draft** — comment/docstring-only diff (~348 files); spot-check engine `control_consumer.rs` and api `state.rs` for tone.
- Follows merged Wave A+B (#693, #694). Out of scope: `deny.toml`, ADR bodies, crate README ADR indexes, U5 MATURITY pass.
