### PR TITLE
feat(api): add access kernel for PAT scopes

### DIFF
--- a/crates/api/src/access/grant.rs
+++ b/crates/api/src/access/grant.rs
@@ -1,0 +1,85 @@
+//! API access grant model.
+
+use std::collections::BTreeSet;
+
+use nebula_core::Permission;
+use thiserror::Error;
+
+/// Effective API access granted to an authenticated caller.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Grant {
+    /// A first-party identity whose permissions are resolved outside PAT scopes.
+    UnrestrictedIdentity,
+    /// A personal access token with complete API access.
+    PatFullAccess,
+    /// A personal access token restricted to a fixed permission set.
+    PatScoped(BTreeSet<Permission>),
+    /// Internal system access for trusted platform calls.
+    SystemInternal,
+}
+
+impl Grant {
+    /// Require `permission` for this grant.
+    ///
+    /// Unrestricted identity, full-access PAT, and system grants allow every
+    /// permission. Scoped PATs allow only permissions present in their set.
+    pub fn require(&self, permission: Permission) -> Result<(), AccessDenied> {
+        match self {
+            Self::UnrestrictedIdentity | Self::PatFullAccess | Self::SystemInternal => Ok(()),
+            Self::PatScoped(permissions) if permissions.contains(&permission) => Ok(()),
+            Self::PatScoped(_) => Err(AccessDenied::new(permission)),
+        }
+    }
+}
+
+/// Error returned when an access grant does not allow a required permission.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("access denied for permission {permission:?}")]
+pub struct AccessDenied {
+    permission: Permission,
+}
+
+impl AccessDenied {
+    /// Create an access-denied error for `permission`.
+    #[must_use]
+    pub const fn new(permission: Permission) -> Self {
+        Self { permission }
+    }
+
+    /// Permission that was denied.
+    #[must_use]
+    pub const fn permission(&self) -> Permission {
+        self.permission
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use nebula_core::Permission;
+
+    use super::{AccessDenied, Grant};
+
+    #[test]
+    fn unrestricted_grants_allow_required_permission() {
+        for grant in [
+            Grant::UnrestrictedIdentity,
+            Grant::PatFullAccess,
+            Grant::SystemInternal,
+        ] {
+            assert_eq!(grant.require(Permission::WorkflowDelete), Ok(()));
+        }
+    }
+
+    #[test]
+    fn scoped_pat_allows_only_included_permissions() {
+        let grant = Grant::PatScoped(BTreeSet::from([Permission::WorkflowRead]));
+
+        assert_eq!(grant.require(Permission::WorkflowRead), Ok(()));
+        assert_eq!(
+            grant.require(Permission::WorkflowWrite),
+            Err(AccessDenied::new(Permission::WorkflowWrite))
+        );
+    }
+}

--- a/crates/api/src/access/layer.rs
+++ b/crates/api/src/access/layer.rs
@@ -2,6 +2,7 @@
 
 use axum::{extract::Request, middleware::Next, response::Response};
 use nebula_core::{Permission, TenantContext};
+use tracing::Instrument;
 
 use crate::{error::ApiError, middleware::auth::AuthContext};
 
@@ -11,23 +12,58 @@ pub async fn require_permission(
     request: Request,
     next: Next,
 ) -> Result<Response, ApiError> {
-    {
-        let auth = request
-            .extensions()
-            .get::<AuthContext>()
-            .ok_or_else(|| ApiError::Unauthorized("not authenticated".to_string()))?;
-        let tenant = request
-            .extensions()
-            .get::<TenantContext>()
-            .ok_or_else(|| ApiError::Internal("tenant context not available".to_string()))?;
+    let span = tracing::info_span!(
+        "access.require_permission",
+        permission = ?permission,
+        auth.method = tracing::field::Empty,
+        tenant.org_id = tracing::field::Empty,
+        tenant.workspace_id = tracing::field::Empty,
+        outcome = tracing::field::Empty,
+    );
 
-        tenant.require(permission)?;
-        auth.grant
-            .require(permission)
-            .map_err(|err| ApiError::Forbidden(err.to_string()))?;
+    async move {
+        {
+            let current_span = tracing::Span::current();
+            let Some(auth) = request.extensions().get::<AuthContext>() else {
+                current_span.record("outcome", "missing_auth_context");
+                tracing::warn!("access denied: missing auth context");
+                return Err(ApiError::Unauthorized("not authenticated".to_string()));
+            };
+            current_span.record("auth.method", tracing::field::debug(auth.auth_method));
+
+            let Some(tenant) = request.extensions().get::<TenantContext>() else {
+                current_span.record("outcome", "missing_tenant_context");
+                tracing::error!("access invariant failed: tenant context not available");
+                return Err(ApiError::Internal(
+                    "tenant context not available".to_string(),
+                ));
+            };
+            current_span.record("tenant.org_id", tracing::field::debug(&tenant.org_id));
+            current_span.record(
+                "tenant.workspace_id",
+                tracing::field::debug(&tenant.workspace_id),
+            );
+
+            if let Err(err) = tenant.require(permission) {
+                current_span.record("outcome", "tenant_denied");
+                tracing::warn!(error = %err, "access denied by tenant role");
+                return Err(err.into());
+            }
+
+            if let Err(err) = auth.grant.require(permission) {
+                current_span.record("outcome", "grant_denied");
+                tracing::warn!(error = %err, "access denied by auth grant");
+                return Err(ApiError::Forbidden(err.to_string()));
+            }
+
+            current_span.record("outcome", "granted");
+            tracing::debug!("access granted");
+        }
+
+        Ok(next.run(request).await)
     }
-
-    Ok(next.run(request).await)
+    .instrument(span)
+    .await
 }
 
 #[cfg(test)]
@@ -60,11 +96,15 @@ mod tests {
             }))
     }
 
-    fn request(auth: AuthContext, tenant: TenantContext) -> Request<Body> {
-        let mut request = Request::builder()
+    fn bare_request() -> Request<Body> {
+        Request::builder()
             .uri("/")
             .body(Body::empty())
-            .expect("test request must be valid");
+            .expect("test request must be valid")
+    }
+
+    fn request(auth: AuthContext, tenant: TenantContext) -> Request<Body> {
+        let mut request = bare_request();
         request.extensions_mut().insert(auth);
         request.extensions_mut().insert(tenant);
         request
@@ -125,5 +165,39 @@ mod tests {
             .expect("router must respond");
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn guard_denies_request_when_missing_auth_context() {
+        let mut request = bare_request();
+        request
+            .extensions_mut()
+            .insert(tenant_with_workspace_role(Some(
+                WorkspaceRole::WorkspaceViewer,
+            )));
+
+        let response = protected_router(Permission::WorkflowRead)
+            .oneshot(request)
+            .await
+            .expect("router must respond");
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn guard_errors_when_missing_tenant_context() {
+        let mut request = bare_request();
+        request
+            .extensions_mut()
+            .insert(auth_with_grant(Grant::PatScoped(BTreeSet::from([
+                Permission::WorkflowRead,
+            ]))));
+
+        let response = protected_router(Permission::WorkflowRead)
+            .oneshot(request)
+            .await
+            .expect("router must respond");
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/api/src/access/layer.rs
+++ b/crates/api/src/access/layer.rs
@@ -1,0 +1,129 @@
+//! Runtime access guard for tenant-scoped routes.
+
+use axum::{extract::Request, middleware::Next, response::Response};
+use nebula_core::{Permission, TenantContext};
+
+use crate::{error::ApiError, middleware::auth::AuthContext};
+
+/// Require `permission` before allowing a protected route to run.
+pub async fn require_permission(
+    permission: Permission,
+    request: Request,
+    next: Next,
+) -> Result<Response, ApiError> {
+    {
+        let auth = request
+            .extensions()
+            .get::<AuthContext>()
+            .ok_or_else(|| ApiError::Unauthorized("not authenticated".to_string()))?;
+        let tenant = request
+            .extensions()
+            .get::<TenantContext>()
+            .ok_or_else(|| ApiError::Internal("tenant context not available".to_string()))?;
+
+        tenant.require(permission)?;
+        auth.grant
+            .require(permission)
+            .map_err(|err| ApiError::Forbidden(err.to_string()))?;
+    }
+
+    Ok(next.run(request).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use axum::{
+        Router,
+        body::Body,
+        http::{Request, StatusCode},
+        middleware,
+        routing::get,
+    };
+    use nebula_core::{
+        OrgId, OrgRole, Permission, Principal, TenantContext, WorkspaceId, WorkspaceRole,
+    };
+    use tower::ServiceExt;
+
+    use super::require_permission;
+    use crate::{
+        access::Grant,
+        middleware::auth::{AuthContext, AuthMethod},
+    };
+
+    fn protected_router(permission: Permission) -> Router {
+        Router::new()
+            .route("/", get(|| async { StatusCode::NO_CONTENT }))
+            .layer(middleware::from_fn(move |request, next| {
+                require_permission(permission, request, next)
+            }))
+    }
+
+    fn request(auth: AuthContext, tenant: TenantContext) -> Request<Body> {
+        let mut request = Request::builder()
+            .uri("/")
+            .body(Body::empty())
+            .expect("test request must be valid");
+        request.extensions_mut().insert(auth);
+        request.extensions_mut().insert(tenant);
+        request
+    }
+
+    fn auth_with_grant(grant: Grant) -> AuthContext {
+        AuthContext {
+            principal: Principal::System,
+            auth_method: AuthMethod::ApiKey,
+            grant,
+        }
+    }
+
+    fn tenant_with_workspace_role(workspace_role: Option<WorkspaceRole>) -> TenantContext {
+        TenantContext {
+            org_id: OrgId::new(),
+            workspace_id: Some(WorkspaceId::new()),
+            principal: Principal::System,
+            org_role: Some(OrgRole::OrgMember),
+            workspace_role,
+        }
+    }
+
+    #[tokio::test]
+    async fn guard_allows_request_when_tenant_role_and_grant_allow_permission() {
+        let response = protected_router(Permission::WorkflowRead)
+            .oneshot(request(
+                auth_with_grant(Grant::PatScoped(BTreeSet::from([Permission::WorkflowRead]))),
+                tenant_with_workspace_role(Some(WorkspaceRole::WorkspaceViewer)),
+            ))
+            .await
+            .expect("router must respond");
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn guard_denies_request_when_grant_lacks_permission() {
+        let response = protected_router(Permission::WorkflowRead)
+            .oneshot(request(
+                auth_with_grant(Grant::PatScoped(BTreeSet::new())),
+                tenant_with_workspace_role(Some(WorkspaceRole::WorkspaceViewer)),
+            ))
+            .await
+            .expect("router must respond");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn guard_denies_request_when_tenant_role_lacks_permission() {
+        let response = protected_router(Permission::WorkflowRead)
+            .oneshot(request(
+                auth_with_grant(Grant::PatScoped(BTreeSet::from([Permission::WorkflowRead]))),
+                tenant_with_workspace_role(None),
+            ))
+            .await
+            .expect("router must respond");
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/api/src/access/mod.rs
+++ b/crates/api/src/access/mod.rs
@@ -1,0 +1,16 @@
+//! First-party API access grants and scope parsing.
+
+pub mod grant;
+pub mod layer;
+pub mod route;
+pub mod scope;
+
+pub use grant::{AccessDenied, Grant};
+pub use layer::require_permission;
+pub use route::{
+    AccessCoverageError, REQUIRED_PERMISSION_EXTENSION, assert_tenant_access_coverage, protected,
+};
+pub use scope::{
+    FULL_ACCESS_SCOPE, ScopeParseError, UNSUPPORTED_PERMISSION_SCOPE, parse_pat_grant,
+    permission_from_scope, permission_scope, validate_new_pat_scopes,
+};

--- a/crates/api/src/access/route.rs
+++ b/crates/api/src/access/route.rs
@@ -11,7 +11,10 @@ use utoipa::openapi::{
 };
 use utoipa_axum::router::UtoipaMethodRouter;
 
-use crate::access::{UNSUPPORTED_PERMISSION_SCOPE, layer::require_permission, permission_scope};
+use crate::access::{
+    UNSUPPORTED_PERMISSION_SCOPE, layer::require_permission, permission_from_scope,
+    permission_scope,
+};
 
 /// OpenAPI operation extension containing the required Access Kernel scope.
 pub const REQUIRED_PERMISSION_EXTENSION: &str = "x-required-permission";
@@ -61,7 +64,9 @@ pub fn assert_tenant_access_coverage(openapi: &OpenApi) -> Result<(), AccessCove
 
         for (method, operation) in operations(item) {
             match required_permission_extension(operation) {
-                Some(Value::String(scope)) if scope != UNSUPPORTED_PERMISSION_SCOPE => {},
+                Some(Value::String(scope))
+                    if scope != UNSUPPORTED_PERMISSION_SCOPE
+                        && permission_from_scope(scope).is_ok() => {},
                 Some(Value::String(scope)) => failures.push(format!(
                     "{path} {method} has unsupported {REQUIRED_PERMISSION_EXTENSION} value {scope}"
                 )),
@@ -224,6 +229,21 @@ mod tests {
         let message = err.to_string();
         assert!(message.contains("/api/v1/orgs/{org} GET"));
         assert!(message.contains(UNSUPPORTED_PERMISSION_SCOPE));
+    }
+
+    #[test]
+    fn unknown_required_permission_extension_fails_coverage() {
+        let openapi = openapi_with_path(
+            "/api/v1/orgs/{org}",
+            operation_with_extension(json!("workflows:reed")),
+        );
+
+        let err =
+            assert_tenant_access_coverage(&openapi).expect_err("unknown access scope must fail");
+
+        let message = err.to_string();
+        assert!(message.contains("/api/v1/orgs/{org} GET"));
+        assert!(message.contains("workflows:reed"));
     }
 
     #[test]

--- a/crates/api/src/access/route.rs
+++ b/crates/api/src/access/route.rs
@@ -1,0 +1,339 @@
+//! Route and OpenAPI helpers for Access Kernel protected routes.
+
+use std::fmt;
+
+use nebula_core::Permission;
+use serde_json::{Value, json};
+use utoipa::openapi::{
+    OpenApi,
+    extensions::Extensions,
+    path::{Operation, PathItem},
+};
+use utoipa_axum::router::UtoipaMethodRouter;
+
+use crate::access::{UNSUPPORTED_PERMISSION_SCOPE, layer::require_permission, permission_scope};
+
+/// OpenAPI operation extension containing the required Access Kernel scope.
+pub const REQUIRED_PERMISSION_EXTENSION: &str = "x-required-permission";
+
+/// Attach runtime and OpenAPI access metadata to a method router.
+pub fn protected<S>(permission: Permission, routes: UtoipaMethodRouter<S>) -> UtoipaMethodRouter<S>
+where
+    S: Send + Sync + Clone + 'static,
+{
+    let scope = permission_scope(permission);
+    assert_ne!(
+        scope, UNSUPPORTED_PERMISSION_SCOPE,
+        "unsupported permission {permission:?} cannot protect a public route"
+    );
+
+    let (schemas, mut paths, method_router) = routes;
+    annotate_paths(&mut paths, scope);
+    let method_router = method_router.layer(axum::middleware::from_fn(move |request, next| {
+        require_permission(permission, request, next)
+    }));
+
+    (schemas, paths, method_router)
+}
+
+/// Access coverage failures found in tenant-scoped OpenAPI operations.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AccessCoverageError {
+    failures: Vec<String>,
+}
+
+impl fmt::Display for AccessCoverageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.failures.join("; "))
+    }
+}
+
+impl std::error::Error for AccessCoverageError {}
+
+/// Assert that every tenant-scoped OpenAPI operation declares access metadata.
+pub fn assert_tenant_access_coverage(openapi: &OpenApi) -> Result<(), AccessCoverageError> {
+    let mut failures = Vec::new();
+
+    for (path, item) in &openapi.paths.paths {
+        if !is_tenant_scoped_path(path) {
+            continue;
+        }
+
+        for (method, operation) in operations(item) {
+            match required_permission_extension(operation) {
+                Some(Value::String(scope)) if scope != UNSUPPORTED_PERMISSION_SCOPE => {},
+                Some(Value::String(scope)) => failures.push(format!(
+                    "{path} {method} has unsupported {REQUIRED_PERMISSION_EXTENSION} value {scope}"
+                )),
+                Some(_) => failures.push(format!(
+                    "{path} {method} {REQUIRED_PERMISSION_EXTENSION} must be a string"
+                )),
+                None => failures.push(format!(
+                    "{path} {method} is missing string {REQUIRED_PERMISSION_EXTENSION}"
+                )),
+            }
+        }
+    }
+
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        Err(AccessCoverageError { failures })
+    }
+}
+
+fn annotate_paths(paths: &mut utoipa::openapi::path::Paths, scope: &str) {
+    for item in paths.paths.values_mut() {
+        for operation in operations_mut(item) {
+            operation
+                .extensions
+                .get_or_insert_with(Extensions::default)
+                .insert(REQUIRED_PERMISSION_EXTENSION.to_string(), json!(scope));
+        }
+    }
+}
+
+fn is_tenant_scoped_path(path: &str) -> bool {
+    path.starts_with("/api/v1/orgs/{org}")
+}
+
+fn required_permission_extension(operation: &Operation) -> Option<&Value> {
+    operation
+        .extensions
+        .as_ref()
+        .and_then(|extensions| extensions.get(REQUIRED_PERMISSION_EXTENSION))
+}
+
+fn operations(item: &PathItem) -> impl Iterator<Item = (&'static str, &Operation)> {
+    [
+        ("GET", item.get.as_ref()),
+        ("PUT", item.put.as_ref()),
+        ("POST", item.post.as_ref()),
+        ("DELETE", item.delete.as_ref()),
+        ("OPTIONS", item.options.as_ref()),
+        ("HEAD", item.head.as_ref()),
+        ("PATCH", item.patch.as_ref()),
+        ("TRACE", item.trace.as_ref()),
+    ]
+    .into_iter()
+    .filter_map(|(method, operation)| operation.map(|operation| (method, operation)))
+}
+
+fn operations_mut(item: &mut PathItem) -> impl Iterator<Item = &mut Operation> {
+    [
+        item.get.as_mut(),
+        item.put.as_mut(),
+        item.post.as_mut(),
+        item.delete.as_mut(),
+        item.options.as_mut(),
+        item.head.as_mut(),
+        item.patch.as_mut(),
+        item.trace.as_mut(),
+    ]
+    .into_iter()
+    .flatten()
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::routing::MethodRouter;
+    use nebula_core::Permission;
+    use serde_json::{Value, json};
+    use utoipa::openapi::{
+        OpenApiBuilder, RefOr,
+        extensions::Extensions,
+        path::{HttpMethod, Operation, OperationBuilder, PathItem, PathsBuilder},
+        schema::{Ref, Schema},
+    };
+    use utoipa_axum::{
+        router::{OpenApiRouter, UtoipaMethodRouter},
+        routes,
+    };
+
+    use super::{REQUIRED_PERMISSION_EXTENSION, assert_tenant_access_coverage, protected};
+    use crate::access::{UNSUPPORTED_PERMISSION_SCOPE, permission_scope};
+
+    fn openapi_with_path(path: &str, operation: Operation) -> utoipa::openapi::OpenApi {
+        OpenApiBuilder::new()
+            .paths(
+                PathsBuilder::new()
+                    .path(path, PathItem::new(HttpMethod::Get, operation))
+                    .build(),
+            )
+            .build()
+    }
+
+    fn operation_with_extension(value: Value) -> Operation {
+        OperationBuilder::new()
+            .extensions(Some(Extensions::from_iter([(
+                REQUIRED_PERMISSION_EXTENSION.to_string(),
+                value,
+            )])))
+            .build()
+    }
+
+    #[utoipa::path(
+        get,
+        path = "/orgs/{org}/things",
+        responses((status = 200, description = "ok"))
+    )]
+    async fn dummy_tenant_route() {}
+
+    #[test]
+    fn tenant_path_without_required_permission_extension_fails_coverage() {
+        let openapi = openapi_with_path(
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows",
+            Operation::new(),
+        );
+
+        let err = assert_tenant_access_coverage(&openapi)
+            .expect_err("tenant operation without extension must fail");
+
+        let message = err.to_string();
+        assert!(message.contains("/api/v1/orgs/{org}/workspaces/{ws}/workflows GET"));
+        assert!(message.contains(REQUIRED_PERMISSION_EXTENSION));
+    }
+
+    #[test]
+    fn tenant_path_with_required_permission_extension_passes_coverage() {
+        let openapi = openapi_with_path(
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows",
+            operation_with_extension(json!("workflows:read")),
+        );
+
+        assert_eq!(assert_tenant_access_coverage(&openapi), Ok(()));
+    }
+
+    #[test]
+    fn non_tenant_path_is_ignored_by_coverage() {
+        let openapi = openapi_with_path("/api/v1/me", Operation::new());
+
+        assert_eq!(assert_tenant_access_coverage(&openapi), Ok(()));
+    }
+
+    #[test]
+    fn unsupported_required_permission_extension_fails_coverage() {
+        let openapi = openapi_with_path(
+            "/api/v1/orgs/{org}",
+            operation_with_extension(json!(UNSUPPORTED_PERMISSION_SCOPE)),
+        );
+
+        let err = assert_tenant_access_coverage(&openapi)
+            .expect_err("unsupported access extension must fail");
+
+        let message = err.to_string();
+        assert!(message.contains("/api/v1/orgs/{org} GET"));
+        assert!(message.contains(UNSUPPORTED_PERMISSION_SCOPE));
+    }
+
+    #[test]
+    fn non_string_required_permission_extension_fails_coverage() {
+        let openapi = openapi_with_path(
+            "/api/v1/orgs/{org}",
+            operation_with_extension(json!(["orgs:read"])),
+        );
+
+        let err = assert_tenant_access_coverage(&openapi)
+            .expect_err("non-string access extension must fail");
+
+        assert!(err.to_string().contains("must be a string"));
+    }
+
+    #[test]
+    fn protected_annotates_every_operation_with_required_permission() {
+        let paths = PathsBuilder::new()
+            .path(
+                "/workflows",
+                PathItem::new(HttpMethod::Get, Operation::new()),
+            )
+            .path(
+                "/workflows/{workflow}",
+                PathItem::from_http_methods(
+                    [HttpMethod::Get, HttpMethod::Delete],
+                    Operation::new(),
+                ),
+            )
+            .build();
+        let permission = Permission::WorkflowRead;
+
+        let (_, annotated_paths, _) =
+            protected(permission, (Vec::new(), paths, MethodRouter::<()>::new()));
+
+        for item in annotated_paths.paths.values() {
+            for operation in [item.get.as_ref(), item.delete.as_ref()]
+                .into_iter()
+                .flatten()
+            {
+                let extension = operation
+                    .extensions
+                    .as_ref()
+                    .and_then(|extensions| extensions.get(REQUIRED_PERMISSION_EXTENSION));
+                assert_eq!(extension, Some(&json!(permission_scope(permission))));
+            }
+        }
+    }
+
+    #[test]
+    fn protected_preserves_schemas_while_annotating_paths() {
+        let schemas = vec![(
+            "ProtectedSchema".to_string(),
+            RefOr::Ref(Ref::from_schema_name("ProtectedSchema")),
+        )];
+        let paths = PathsBuilder::new()
+            .path(
+                "/workflows",
+                PathItem::new(HttpMethod::Get, Operation::new()),
+            )
+            .build();
+        let routes: UtoipaMethodRouter<()> = (schemas.clone(), paths, MethodRouter::<()>::new());
+
+        let (protected_schemas, protected_paths, _) = protected(Permission::WorkflowRead, routes);
+
+        assert!(protected_schemas == schemas);
+        assert_eq!(
+            protected_paths
+                .get_path_operation("/workflows", HttpMethod::Get)
+                .and_then(|operation| operation.extensions.as_ref())
+                .and_then(|extensions| extensions.get(REQUIRED_PERMISSION_EXTENSION)),
+            Some(&json!("workflows:read"))
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "unsupported permission")]
+    fn protected_panics_for_permission_without_pat_scope_mapping() {
+        assert_eq!(
+            permission_scope(Permission::WorkspaceMemberRead),
+            UNSUPPORTED_PERMISSION_SCOPE
+        );
+
+        let routes: UtoipaMethodRouter<()> = (
+            Vec::<(String, RefOr<Schema>)>::new(),
+            PathsBuilder::new()
+                .path("/members", PathItem::new(HttpMethod::Get, Operation::new()))
+                .build(),
+            MethodRouter::<()>::new(),
+        );
+
+        let _ = protected(Permission::WorkspaceMemberRead, routes);
+    }
+
+    #[test]
+    fn coverage_passes_after_openapi_router_nesting_adds_api_v1_prefix() {
+        let openapi = OpenApiRouter::<()>::new()
+            .nest(
+                "/api/v1",
+                OpenApiRouter::new()
+                    .routes(protected(Permission::OrgRead, routes!(dummy_tenant_route))),
+            )
+            .into_openapi();
+
+        assert!(
+            openapi
+                .paths
+                .get_path_operation("/api/v1/orgs/{org}/things", HttpMethod::Get)
+                .is_some()
+        );
+        assert_eq!(assert_tenant_access_coverage(&openapi), Ok(()));
+    }
+}

--- a/crates/api/src/access/scope.rs
+++ b/crates/api/src/access/scope.rs
@@ -1,0 +1,225 @@
+//! PAT scope vocabulary and parsing.
+
+use std::collections::BTreeSet;
+
+use nebula_core::Permission;
+use thiserror::Error;
+
+use crate::access::Grant;
+
+/// Scope string that grants complete API access to a PAT.
+pub const FULL_ACCESS_SCOPE: &str = "full_access";
+
+/// Placeholder scope for core permissions that are not part of this API scope vocabulary.
+pub const UNSUPPORTED_PERMISSION_SCOPE: &str = "__unsupported_permission__";
+
+/// Error returned when parsing API access scopes.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ScopeParseError {
+    /// No scopes were supplied.
+    #[error("at least one scope is required")]
+    Empty,
+    /// The scope is not in the supported API vocabulary.
+    #[error("unknown scope {0}")]
+    Unknown(String),
+    /// `full_access` cannot be combined with any other scope.
+    #[error("{FULL_ACCESS_SCOPE} cannot be combined with other scopes")]
+    FullAccessMixed,
+}
+
+/// Return the canonical API scope string for `permission`.
+///
+/// Permissions not included in the PAT scope vocabulary map to
+/// [`UNSUPPORTED_PERMISSION_SCOPE`].
+#[must_use]
+pub fn permission_scope(permission: Permission) -> &'static str {
+    match permission {
+        Permission::WorkflowRead => "workflows:read",
+        Permission::WorkflowWrite => "workflows:write",
+        Permission::WorkflowDelete => "workflows:delete",
+        Permission::WorkflowExecute => "workflows:execute",
+        Permission::ExecutionRead => "executions:read",
+        Permission::ExecutionCancel => "executions:cancel",
+        Permission::ExecutionTerminate => "executions:terminate",
+        Permission::ExecutionRestart => "executions:restart",
+        Permission::CredentialRead => "credentials:read",
+        Permission::CredentialWrite => "credentials:write",
+        Permission::CredentialDelete => "credentials:delete",
+        Permission::ResourceRead => "resources:read",
+        Permission::ResourceWrite => "resources:write",
+        Permission::ResourceDelete => "resources:delete",
+        Permission::MemberRead => "members:read",
+        Permission::MemberInvite => "members:invite",
+        Permission::MemberRemove => "members:remove",
+        Permission::OrgRead => "orgs:read",
+        Permission::OrgUpdate => "orgs:update",
+        Permission::OrgDelete => "orgs:delete",
+        Permission::ServiceAccountManage => "service_accounts:manage",
+        _ => UNSUPPORTED_PERMISSION_SCOPE,
+    }
+}
+
+/// Parse a canonical API scope string into a core permission.
+pub fn permission_from_scope(scope: &str) -> Result<Permission, ScopeParseError> {
+    match scope {
+        "workflows:read" => Ok(Permission::WorkflowRead),
+        "workflows:write" => Ok(Permission::WorkflowWrite),
+        "workflows:delete" => Ok(Permission::WorkflowDelete),
+        "workflows:execute" => Ok(Permission::WorkflowExecute),
+        "executions:read" => Ok(Permission::ExecutionRead),
+        "executions:cancel" => Ok(Permission::ExecutionCancel),
+        "executions:terminate" => Ok(Permission::ExecutionTerminate),
+        "executions:restart" => Ok(Permission::ExecutionRestart),
+        "credentials:read" => Ok(Permission::CredentialRead),
+        "credentials:write" => Ok(Permission::CredentialWrite),
+        "credentials:delete" => Ok(Permission::CredentialDelete),
+        "resources:read" => Ok(Permission::ResourceRead),
+        "resources:write" => Ok(Permission::ResourceWrite),
+        "resources:delete" => Ok(Permission::ResourceDelete),
+        "members:read" => Ok(Permission::MemberRead),
+        "members:invite" => Ok(Permission::MemberInvite),
+        "members:remove" => Ok(Permission::MemberRemove),
+        "orgs:read" => Ok(Permission::OrgRead),
+        "orgs:update" => Ok(Permission::OrgUpdate),
+        "orgs:delete" => Ok(Permission::OrgDelete),
+        "service_accounts:manage" => Ok(Permission::ServiceAccountManage),
+        unknown => Err(ScopeParseError::Unknown(unknown.to_owned())),
+    }
+}
+
+/// Parse PAT scope strings into an effective API access grant.
+pub fn parse_pat_grant(scopes: &[String]) -> Result<Grant, ScopeParseError> {
+    if scopes.is_empty() {
+        return Err(ScopeParseError::Empty);
+    }
+
+    let has_full_access = scopes.iter().any(|scope| scope == FULL_ACCESS_SCOPE);
+    if has_full_access {
+        return if scopes.len() == 1 {
+            Ok(Grant::PatFullAccess)
+        } else {
+            Err(ScopeParseError::FullAccessMixed)
+        };
+    }
+
+    scopes
+        .iter()
+        .map(|scope| permission_from_scope(scope))
+        .collect::<Result<BTreeSet<_>, _>>()
+        .map(Grant::PatScoped)
+}
+
+/// Validate PAT scope strings for a new token request.
+pub fn validate_new_pat_scopes(scopes: &[String]) -> Result<(), ScopeParseError> {
+    parse_pat_grant(scopes).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+
+    use nebula_core::Permission;
+
+    use super::{
+        FULL_ACCESS_SCOPE, ScopeParseError, UNSUPPORTED_PERMISSION_SCOPE, parse_pat_grant,
+        permission_from_scope, permission_scope, validate_new_pat_scopes,
+    };
+    use crate::access::Grant;
+
+    #[test]
+    fn parses_pat_grant_from_permission_scopes() {
+        assert_eq!(
+            parse_pat_grant(&[
+                "workflows:read".to_string(),
+                "executions:cancel".to_string(),
+                "resources:write".to_string(),
+                "members:read".to_string(),
+            ]),
+            Ok(Grant::PatScoped(BTreeSet::from([
+                Permission::WorkflowRead,
+                Permission::ExecutionCancel,
+                Permission::ResourceWrite,
+                Permission::MemberRead,
+            ])))
+        );
+    }
+
+    #[test]
+    fn full_access_scope_alone_grants_full_pat_access() {
+        assert_eq!(
+            parse_pat_grant(&[FULL_ACCESS_SCOPE.to_string()]),
+            Ok(Grant::PatFullAccess)
+        );
+    }
+
+    #[test]
+    fn duplicate_scopes_collapse() {
+        assert_eq!(
+            parse_pat_grant(&["workflows:read".to_string(), "workflows:read".to_string(),]),
+            Ok(Grant::PatScoped(BTreeSet::from([Permission::WorkflowRead])))
+        );
+    }
+
+    #[test]
+    fn rejects_empty_unknown_and_mixed_full_access_scopes() {
+        assert_eq!(parse_pat_grant(&[]), Err(ScopeParseError::Empty));
+        assert_eq!(
+            parse_pat_grant(&["bogus".to_string()]),
+            Err(ScopeParseError::Unknown("bogus".to_string()))
+        );
+        assert_eq!(
+            parse_pat_grant(&[FULL_ACCESS_SCOPE.to_string(), "workflows:read".to_string(),]),
+            Err(ScopeParseError::FullAccessMixed)
+        );
+    }
+
+    #[test]
+    fn validation_matches_parser_errors_without_returning_grant() {
+        assert_eq!(validate_new_pat_scopes(&["orgs:read".to_string()]), Ok(()));
+        assert_eq!(validate_new_pat_scopes(&[]), Err(ScopeParseError::Empty));
+    }
+
+    #[test]
+    fn maps_representative_permissions_to_scope_strings() {
+        assert_eq!(
+            permission_scope(Permission::WorkflowExecute),
+            "workflows:execute"
+        );
+        assert_eq!(
+            permission_scope(Permission::CredentialDelete),
+            "credentials:delete"
+        );
+        assert_eq!(
+            permission_scope(Permission::ResourceDelete),
+            "resources:delete"
+        );
+        assert_eq!(
+            permission_scope(Permission::ServiceAccountManage),
+            "service_accounts:manage"
+        );
+        assert_eq!(
+            permission_scope(Permission::WorkspaceMemberRead),
+            UNSUPPORTED_PERMISSION_SCOPE
+        );
+    }
+
+    #[test]
+    fn maps_scope_strings_to_permissions() {
+        assert_eq!(
+            permission_from_scope("workflows:write"),
+            Ok(Permission::WorkflowWrite)
+        );
+        assert_eq!(
+            permission_from_scope("executions:terminate"),
+            Ok(Permission::ExecutionTerminate)
+        );
+        assert_eq!(
+            permission_from_scope("members:remove"),
+            Ok(Permission::MemberRemove)
+        );
+        assert_eq!(
+            permission_from_scope(FULL_ACCESS_SCOPE),
+            Err(ScopeParseError::Unknown(FULL_ACCESS_SCOPE.to_string()))
+        );
+    }
+}

--- a/crates/api/src/domain/auth/backend/pat.rs
+++ b/crates/api/src/domain/auth/backend/pat.rs
@@ -44,7 +44,8 @@ pub struct PatRecord {
     pub prefix: String,
     /// SHA-256 of the *full* plaintext token.
     pub hash: [u8; 32],
-    /// Allowed scopes — `[]` means full access.
+    /// Allowed scopes. Use `full_access` for complete access; empty scopes
+    /// are invalid at the API auth boundary.
     pub scopes: Vec<String>,
     /// When the PAT was created.
     pub created_at: DateTime<Utc>,

--- a/crates/api/src/domain/auth/backend/provider.rs
+++ b/crates/api/src/domain/auth/backend/provider.rs
@@ -39,7 +39,8 @@ pub struct ProfilePatch {
 pub struct CreatePatParams {
     /// Caller-chosen friendly name.
     pub name: String,
-    /// Granted scopes (`[]` = full access).
+    /// Granted scopes. Use `full_access` for complete access; empty scopes
+    /// are invalid at the API auth boundary.
     pub scopes: Vec<String>,
     /// Optional time-to-live in seconds; `None` = non-expiring.
     pub ttl_seconds: Option<u64>,

--- a/crates/api/src/domain/me/dto.rs
+++ b/crates/api/src/domain/me/dto.rs
@@ -89,7 +89,8 @@ pub struct TokenSummary {
     pub id: String,
     /// Caller-chosen friendly name.
     pub name: String,
-    /// Granted scopes (e.g. `["workflows:read"]`).
+    /// Granted scopes (e.g. `["workflows:read"]`). Use exactly
+    /// `["full_access"]` for complete API access.
     pub scopes: Vec<String>,
     /// ISO 8601 creation timestamp.
     pub created_at: String,
@@ -113,7 +114,8 @@ pub struct MyTokensResponse {
 pub struct CreateTokenRequest {
     /// Caller-chosen friendly name.
     pub name: String,
-    /// Granted scopes.
+    /// Granted scopes. Must contain at least one supported scope; use exactly
+    /// `["full_access"]` for complete API access.
     pub scopes: Vec<String>,
     /// Optional time-to-live in seconds. Omit for non-expiring tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/crates/api/src/domain/me/handler.rs
+++ b/crates/api/src/domain/me/handler.rs
@@ -37,6 +37,7 @@ use nebula_core::Principal;
 use zeroize::Zeroize;
 
 use crate::{
+    access::validate_new_pat_scopes,
     domain::{
         auth::backend::{AuthBackend, CreatePatParams, PatRecord, ProfilePatch},
         me::dto::{
@@ -46,7 +47,7 @@ use crate::{
         shared::{AckResponse, OrgRoleDto},
     },
     error::{ApiError, ApiResult, ProblemDetails},
-    middleware::auth::AuthContext,
+    middleware::auth::{AuthContext, AuthMethod},
     state::AppState,
 };
 
@@ -311,6 +312,7 @@ pub async fn list_my_tokens(
         (status = 201, description = "Token created; `token` carries the plaintext once.", body = CreateTokenResponse),
         (status = 400, description = "Validation error.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
+        (status = 403, description = "PAT-authenticated callers cannot create PATs.", body = ProblemDetails),
         (status = 404, description = "Authenticated user no longer exists.", body = ProblemDetails),
         (status = 503, description = "Authentication backend not configured.", body = ProblemDetails),
     ),
@@ -321,6 +323,12 @@ pub async fn create_token(
     Json(body): Json<CreateTokenRequest>,
 ) -> ApiResult<(StatusCode, Json<CreateTokenResponse>)> {
     let user_id = require_user_id(&auth)?;
+    if auth.auth_method == AuthMethod::Pat {
+        return Err(ApiError::Forbidden(
+            "personal access tokens cannot create new personal access tokens".to_owned(),
+        ));
+    }
+
     let backend = auth_backend_or_503(&state)?;
 
     // Request-level validation → 400.
@@ -330,6 +338,8 @@ pub async fn create_token(
             "token name must be 1..=128 non-blank characters",
         ));
     }
+    validate_new_pat_scopes(&body.scopes)
+        .map_err(|err| ApiError::validation_message(format!("invalid token scopes: {err}")))?;
 
     let params = CreatePatParams {
         name: name.to_owned(),

--- a/crates/api/src/domain/mod.rs
+++ b/crates/api/src/domain/mod.rs
@@ -62,6 +62,8 @@ use crate::{
 pub fn create_routes(state: AppState, _config: &ApiConfig) -> (Router, OpenApi) {
     let api_router = build_openapi_router(&state);
     let (router, openapi) = api_router.split_for_parts();
+    crate::access::assert_tenant_access_coverage(&openapi)
+        .expect("tenant routes must declare access permissions");
     let router = router.with_state(state);
     (router, openapi)
 }

--- a/crates/api/src/domain/org/routes.rs
+++ b/crates/api/src/domain/org/routes.rs
@@ -10,24 +10,45 @@
 //! non-deprecated member handlers are unaffected by the allow.
 #![allow(deprecated)]
 
+use nebula_core::Permission;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::handler;
-use crate::state::AppState;
+use crate::{access, state::AppState};
 
 /// Organization routes under `/api/v1/orgs/{org}/*`.
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
-        .routes(routes!(
-            handler::get_org,
-            handler::update_org,
-            handler::delete_org
+        .routes(access::protected(
+            Permission::OrgRead,
+            routes!(handler::get_org),
         ))
-        .routes(routes!(handler::list_members, handler::add_member))
-        .routes(routes!(handler::remove_member))
-        .routes(routes!(
-            handler::list_service_accounts,
-            handler::create_service_account
+        .routes(access::protected(
+            Permission::OrgUpdate,
+            routes!(handler::update_org),
         ))
-        .routes(routes!(handler::delete_service_account))
+        .routes(access::protected(
+            Permission::OrgDelete,
+            routes!(handler::delete_org),
+        ))
+        .routes(access::protected(
+            Permission::MemberRead,
+            routes!(handler::list_members),
+        ))
+        .routes(access::protected(
+            Permission::MemberInvite,
+            routes!(handler::add_member),
+        ))
+        .routes(access::protected(
+            Permission::MemberRemove,
+            routes!(handler::remove_member),
+        ))
+        .routes(access::protected(
+            Permission::ServiceAccountManage,
+            routes!(
+                handler::list_service_accounts,
+                handler::create_service_account,
+                handler::delete_service_account
+            ),
+        ))
 }

--- a/crates/api/src/domain/workspace.rs
+++ b/crates/api/src/domain/workspace.rs
@@ -19,9 +19,11 @@
 //! table stays in sync with the published spec.
 #![allow(deprecated)]
 
+use nebula_core::Permission;
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use crate::{
+    access,
     domain::{
         credential::handler as credential, execution::handler as execution,
         resource::handler as resource, workflow::handler as workflow,
@@ -33,62 +35,148 @@ use crate::{
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
         // Workflows
-        .routes(routes!(
-            workflow::list_workflows,
-            workflow::create_workflow
+        .routes(access::protected(
+            Permission::WorkflowRead,
+            routes!(workflow::list_workflows),
         ))
-        .routes(routes!(
-            workflow::get_workflow,
-            workflow::update_workflow,
-            workflow::delete_workflow
+        .routes(access::protected(
+            Permission::WorkflowRead,
+            routes!(workflow::get_workflow),
         ))
-        .routes(routes!(workflow::activate_workflow))
-        .routes(routes!(workflow::execute_workflow))
-        .routes(routes!(workflow::validate_workflow_handler))
+        .routes(access::protected(
+            Permission::WorkflowWrite,
+            routes!(workflow::create_workflow),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowWrite,
+            routes!(workflow::update_workflow),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowWrite,
+            routes!(workflow::activate_workflow),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowWrite,
+            routes!(workflow::validate_workflow_handler),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowDelete,
+            routes!(workflow::delete_workflow),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowExecute,
+            routes!(workflow::execute_workflow),
+        ))
         // Executions
-        .routes(routes!(
-            execution::list_executions_for_workflow,
-            execution::start_execution
+        .routes(access::protected(
+            Permission::ExecutionRead,
+            routes!(execution::list_executions_for_workflow),
         ))
-        .routes(routes!(execution::list_executions))
-        .routes(routes!(
-            execution::get_execution,
-            execution::cancel_execution
+        .routes(access::protected(
+            Permission::ExecutionRead,
+            routes!(execution::list_executions),
         ))
-        .routes(routes!(execution::terminate_execution))
-        .routes(routes!(execution::restart_execution))
+        .routes(access::protected(
+            Permission::ExecutionRead,
+            routes!(execution::get_execution),
+        ))
+        .routes(access::protected(
+            Permission::WorkflowExecute,
+            routes!(execution::start_execution),
+        ))
+        .routes(access::protected(
+            Permission::ExecutionCancel,
+            routes!(execution::cancel_execution),
+        ))
+        .routes(access::protected(
+            Permission::ExecutionTerminate,
+            routes!(execution::terminate_execution),
+        ))
+        .routes(access::protected(
+            Permission::ExecutionRestart,
+            routes!(execution::restart_execution),
+        ))
         // Resources. Config-CRUD collection + by-id, then the READ-ONLY
         // runtime-status projection. Resource lifecycle
         // (acquire/release/drain/reload) is engine-owned and deliberately
         // NOT exposed over HTTP (INTEGRATION_MODEL integration seam.1): `{res}/status`
         // is the ONLY `{res}/...` sub-route, and it is a GET only — there
         // is intentionally no acquire/release/drain route.
-        .routes(routes!(resource::list_resources, resource::create_resource))
-        .routes(routes!(
-            resource::get_resource,
-            resource::update_resource,
-            resource::delete_resource
+        .routes(access::protected(
+            Permission::ResourceRead,
+            routes!(resource::list_resources),
         ))
-        .routes(routes!(resource::get_resource_status))
+        .routes(access::protected(
+            Permission::ResourceRead,
+            routes!(resource::get_resource),
+        ))
+        .routes(access::protected(
+            Permission::ResourceRead,
+            routes!(resource::get_resource_status),
+        ))
+        .routes(access::protected(
+            Permission::ResourceWrite,
+            routes!(resource::create_resource),
+        ))
+        .routes(access::protected(
+            Permission::ResourceWrite,
+            routes!(resource::update_resource),
+        ))
+        .routes(access::protected(
+            Permission::ResourceDelete,
+            routes!(resource::delete_resource),
+        ))
         // Credentials (Plane B — API-owned OAuth flow). Literal paths first, then
         // collection, then parameterized `{cred}`, then sub-resources.
-        .routes(routes!(credential::resolve_credential))
-        .routes(routes!(credential::continue_resolve_credential))
-        .routes(routes!(
-            credential::list_credentials,
-            credential::create_credential
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::resolve_credential),
         ))
-        .routes(routes!(
-            credential::get_credential,
-            credential::update_credential,
-            credential::delete_credential
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::continue_resolve_credential),
         ))
-        .routes(routes!(credential::get_oauth2_authorize_url_scoped))
-        .routes(routes!(
-            credential::get_oauth2_callback_scoped,
-            credential::post_oauth2_callback_scoped
+        .routes(access::protected(
+            Permission::CredentialRead,
+            routes!(credential::list_credentials),
         ))
-        .routes(routes!(credential::test_credential))
-        .routes(routes!(credential::refresh_credential))
-        .routes(routes!(credential::revoke_credential))
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::create_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialRead,
+            routes!(credential::get_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::update_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialDelete,
+            routes!(credential::delete_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::get_oauth2_authorize_url_scoped),
+        ))
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(
+                credential::get_oauth2_callback_scoped,
+                credential::post_oauth2_callback_scoped
+            ),
+        ))
+        .routes(access::protected(
+            Permission::CredentialRead,
+            routes!(credential::test_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialWrite,
+            routes!(credential::refresh_credential),
+        ))
+        .routes(access::protected(
+            Permission::CredentialDelete,
+            routes!(credential::revoke_credential),
+        ))
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -64,6 +64,7 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 
+pub mod access;
 pub mod app;
 pub mod config;
 pub mod domain;

--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -19,7 +19,11 @@ use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode};
 use nebula_core::UserId;
 use serde::{Deserialize, Serialize};
 
-use crate::{domain::auth::backend::PAT_PREFIX as AUTH_PAT_PREFIX, state::AppState};
+use crate::{
+    access::{Grant, parse_pat_grant},
+    domain::auth::backend::PAT_PREFIX as AUTH_PAT_PREFIX,
+    state::AppState,
+};
 
 /// The canonical prefix for Nebula API keys.
 pub const API_KEY_PREFIX: &str = "nbl_sk_";
@@ -70,6 +74,8 @@ pub struct AuthContext {
     pub principal: nebula_core::Principal,
     /// Which authentication method was used.
     pub auth_method: AuthMethod,
+    /// Effective API access granted to the authenticated caller.
+    pub grant: Grant,
 }
 
 /// The authentication mechanism that was used for the current request.
@@ -119,6 +125,7 @@ pub async fn auth_middleware(
                 request.extensions_mut().insert(AuthContext {
                     principal,
                     auth_method: AuthMethod::Session,
+                    grant: Grant::UnrestrictedIdentity,
                 });
                 return Ok(next.run(request).await);
             },
@@ -148,6 +155,7 @@ pub async fn auth_middleware(
             .map_err(|_| StatusCode::UNAUTHORIZED)?
             .ok_or(StatusCode::UNAUTHORIZED)?;
 
+        let grant = parse_pat_grant(&record.scopes).map_err(|_| StatusCode::UNAUTHORIZED)?;
         let principal = nebula_core::Principal::User(record.user_id);
         request.extensions_mut().insert(AuthenticatedUser {
             user_id: record.user_id.to_string(),
@@ -155,6 +163,7 @@ pub async fn auth_middleware(
         request.extensions_mut().insert(AuthContext {
             principal,
             auth_method: AuthMethod::Pat,
+            grant,
         });
         return Ok(next.run(request).await);
     }
@@ -184,6 +193,7 @@ pub async fn auth_middleware(
         request.extensions_mut().insert(AuthContext {
             principal: nebula_core::Principal::System,
             auth_method: AuthMethod::ApiKey,
+            grant: Grant::SystemInternal,
         });
         return Ok(next.run(request).await);
     }
@@ -212,6 +222,7 @@ pub async fn auth_middleware(
     request.extensions_mut().insert(AuthContext {
         principal,
         auth_method: AuthMethod::Jwt,
+        grant: Grant::UnrestrictedIdentity,
     });
 
     Ok(next.run(request).await)

--- a/crates/api/src/middleware/rbac.rs
+++ b/crates/api/src/middleware/rbac.rs
@@ -11,7 +11,9 @@ use axum::{
     middleware::Next,
     response::Response,
 };
-use nebula_core::{ResolvedIds, TenantContext, role::effective_workspace_role};
+use nebula_core::{
+    OrgRole, ResolvedIds, TenantContext, WorkspaceRole, role::effective_workspace_role,
+};
 
 use crate::{error::ApiError, middleware::auth::AuthContext, state::AppState};
 
@@ -45,10 +47,13 @@ pub async fn rbac_middleware(
         .org_id
         .ok_or(ApiError::Internal("org_id not resolved".to_string()))?;
 
+    let insecure_bypass_without_store =
+        state.allow_insecure_tenant_rbac_bypass() && state.membership_store.is_none();
+
     // Load org role
     let org_role = match &state.membership_store {
         Some(store) => store.get_org_role(org_id, &auth_ctx.principal).await?,
-        None if state.allow_insecure_tenant_rbac_bypass() => None,
+        None if insecure_bypass_without_store => Some(OrgRole::OrgOwner),
         None => {
             return Err(ApiError::ServiceUnavailable(
                 "membership store not configured; tenant routes are disabled".to_string(),
@@ -57,7 +62,7 @@ pub async fn rbac_middleware(
     };
 
     // If user has no org role at all, return 404 (enumeration prevention).
-    if org_role.is_none() && !state.allow_insecure_tenant_rbac_bypass() {
+    if org_role.is_none() {
         return Err(ApiError::NotFound("not found".to_string()));
     }
 
@@ -65,7 +70,7 @@ pub async fn rbac_middleware(
     let workspace_role = if let Some(ws_id) = resolved.workspace_id {
         let explicit_role = match &state.membership_store {
             Some(store) => store.get_workspace_role(ws_id, &auth_ctx.principal).await?,
-            None if state.allow_insecure_tenant_rbac_bypass() => None,
+            None if insecure_bypass_without_store => Some(WorkspaceRole::WorkspaceAdmin),
             None => {
                 return Err(ApiError::ServiceUnavailable(
                     "membership store not configured; tenant routes are disabled".to_string(),
@@ -75,7 +80,7 @@ pub async fn rbac_middleware(
         let effective = effective_workspace_role(org_role, explicit_role);
 
         // If user has org access but no effective workspace role, return 404
-        if effective.is_none() && !state.allow_insecure_tenant_rbac_bypass() {
+        if effective.is_none() {
             return Err(ApiError::NotFound("not found".to_string()));
         }
         effective

--- a/crates/api/tests/access_e2e.rs
+++ b/crates/api/tests/access_e2e.rs
@@ -1,0 +1,285 @@
+//! Runtime access-control E2E tests.
+//!
+//! These tests prove tenant RBAC and PAT grants are both enforced at request
+//! time. The route metadata/OpenAPI coverage tests live elsewhere; this file
+//! drives real HTTP requests through the app router.
+
+mod common;
+
+use std::{str::FromStr, sync::Arc};
+
+use axum::{
+    body::Body,
+    http::{Request, Response, StatusCode},
+};
+use nebula_api::{
+    ApiConfig, AppState, app,
+    domain::auth::backend::{
+        AuthBackend, CreatePatParams, InMemoryAuthBackend, SignupRequest, dto::SecretString,
+    },
+    error::ApiError,
+    state::{AddMemberOutcome, MembershipStore, OrgMember, RemoveMemberOutcome},
+};
+use nebula_core::{OrgId, OrgRole, Principal, UserId, WorkspaceId, WorkspaceRole};
+use tower::ServiceExt;
+
+use common::{
+    TEST_ORG, TEST_WS, build_me_state, create_state_with_queue, me_support::jwt_for, ws_path,
+};
+
+#[derive(Clone)]
+struct FixedMembershipStore {
+    principal: Principal,
+    org_role: OrgRole,
+    workspace_role: WorkspaceRole,
+}
+
+#[async_trait::async_trait]
+impl MembershipStore for FixedMembershipStore {
+    async fn get_org_role(
+        &self,
+        org_id: OrgId,
+        principal: &Principal,
+    ) -> Result<Option<OrgRole>, ApiError> {
+        if org_id == test_org_id() && principal == &self.principal {
+            Ok(Some(self.org_role))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn get_workspace_role(
+        &self,
+        workspace_id: WorkspaceId,
+        principal: &Principal,
+    ) -> Result<Option<WorkspaceRole>, ApiError> {
+        if workspace_id == test_ws_id() && principal == &self.principal {
+            Ok(Some(self.workspace_role))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn list_members(&self, org_id: OrgId) -> Result<Vec<OrgMember>, ApiError> {
+        if org_id == test_org_id() {
+            Ok(vec![OrgMember {
+                principal: self.principal.clone(),
+                role: self.org_role,
+            }])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+
+    async fn add_member(
+        &self,
+        _org_id: OrgId,
+        _principal: &Principal,
+        _role: OrgRole,
+    ) -> Result<(), ApiError> {
+        Ok(())
+    }
+
+    async fn remove_member(
+        &self,
+        _org_id: OrgId,
+        _principal: &Principal,
+    ) -> Result<bool, ApiError> {
+        Ok(false)
+    }
+
+    async fn add_member_guarded(
+        &self,
+        _org_id: OrgId,
+        _principal: &Principal,
+        _role: OrgRole,
+    ) -> Result<AddMemberOutcome, ApiError> {
+        Ok(AddMemberOutcome::Added)
+    }
+
+    async fn remove_member_guarded(
+        &self,
+        _org_id: OrgId,
+        _principal: &Principal,
+    ) -> Result<RemoveMemberOutcome, ApiError> {
+        Ok(RemoveMemberOutcome::NotFound)
+    }
+
+    async fn list_orgs_for_principal(
+        &self,
+        principal: &Principal,
+    ) -> Result<Vec<(OrgId, OrgRole)>, ApiError> {
+        if principal == &self.principal {
+            Ok(vec![(test_org_id(), self.org_role)])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+}
+
+fn test_org_id() -> OrgId {
+    TEST_ORG.parse().expect("TEST_ORG must be a valid OrgId")
+}
+
+fn test_ws_id() -> WorkspaceId {
+    TEST_WS
+        .parse()
+        .expect("TEST_WS must be a valid WorkspaceId")
+}
+
+async fn state_with_pat_and_workspace_role(
+    scopes: Vec<&str>,
+    workspace_role: WorkspaceRole,
+) -> (AppState, String) {
+    let backend = Arc::new(InMemoryAuthBackend::new());
+    let profile = backend
+        .register_user(SignupRequest {
+            email: "access-e2e@nebula.dev".to_owned(),
+            password: SecretString::new("hunter22".to_owned()),
+            display_name: "Access E2E".to_owned(),
+        })
+        .await
+        .expect("register access e2e user");
+    let user_id = UserId::from_str(&profile.user_id).expect("registered user id parses");
+    let minted = backend
+        .create_pat(
+            &profile.user_id,
+            CreatePatParams {
+                name: "access-e2e".to_owned(),
+                scopes: scopes.into_iter().map(str::to_owned).collect(),
+                ttl_seconds: None,
+            },
+        )
+        .await
+        .expect("mint access e2e PAT");
+
+    let backend_dyn: Arc<dyn AuthBackend> = backend;
+    let membership_dyn: Arc<dyn MembershipStore> = Arc::new(FixedMembershipStore {
+        principal: Principal::User(user_id),
+        org_role: OrgRole::OrgMember,
+        workspace_role,
+    });
+    let state = build_me_state()
+        .with_auth_backend(backend_dyn)
+        .with_membership_store(membership_dyn);
+
+    (state, minted.plaintext)
+}
+
+async fn post_workflows_with_pat(state: AppState, pat: &str) -> Response<Body> {
+    let app = app::build_app(state, &ApiConfig::for_test());
+    let create_request = serde_json::json!({
+        "name": "Access E2E Workflow",
+        "description": "Created by access runtime test",
+        "definition": {
+            "nodes": [],
+            "edges": []
+        }
+    });
+
+    app.oneshot(
+        Request::builder()
+            .method("POST")
+            .uri(ws_path("/workflows"))
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {pat}"))
+            .body(Body::from(serde_json::to_string(&create_request).unwrap()))
+            .unwrap(),
+    )
+    .await
+    .expect("app must respond")
+}
+
+#[tokio::test]
+async fn editor_pat_without_write_scope_cannot_create_workflow() {
+    let (state, pat) =
+        state_with_pat_and_workspace_role(vec!["workflows:read"], WorkspaceRole::WorkspaceEditor)
+            .await;
+
+    let response = post_workflows_with_pat(state, &pat).await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn viewer_full_access_pat_cannot_create_workflow() {
+    let (state, pat) =
+        state_with_pat_and_workspace_role(vec!["full_access"], WorkspaceRole::WorkspaceViewer)
+            .await;
+
+    let response = post_workflows_with_pat(state, &pat).await;
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn editor_full_access_pat_can_create_workflow() {
+    let (state, pat) =
+        state_with_pat_and_workspace_role(vec!["full_access"], WorkspaceRole::WorkspaceEditor)
+            .await;
+
+    let response = post_workflows_with_pat(state, &pat).await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn editor_pat_with_write_scope_reaches_workflow_handler() {
+    let (state, pat) =
+        state_with_pat_and_workspace_role(vec!["workflows:write"], WorkspaceRole::WorkspaceEditor)
+            .await;
+
+    let response = post_workflows_with_pat(state, &pat).await;
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+}
+
+#[tokio::test]
+async fn jwt_bypass_harness_without_membership_store_can_still_list_workflows() {
+    let (state, _queue) = create_state_with_queue().await;
+    let jwt = jwt_for(&UserId::new().to_string());
+    let app = app::build_app(state, &ApiConfig::for_test());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(ws_path("/workflows"))
+                .header("authorization", format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn configured_membership_store_with_no_roles_denies_tenant_access() {
+    let request_user_id = UserId::new();
+    let seeded_other_user_id = UserId::new();
+    let membership_dyn: Arc<dyn MembershipStore> = Arc::new(FixedMembershipStore {
+        principal: Principal::User(seeded_other_user_id),
+        org_role: OrgRole::OrgMember,
+        workspace_role: WorkspaceRole::WorkspaceViewer,
+    });
+    let (state, _queue) = create_state_with_queue().await;
+    let state = state.with_membership_store(membership_dyn);
+    let app = app::build_app(state, &ApiConfig::for_test());
+    let jwt = jwt_for(&request_user_id.to_string());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(ws_path("/workflows"))
+                .header("authorization", format!("Bearer {jwt}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}

--- a/crates/api/tests/me_e2e.rs
+++ b/crates/api/tests/me_e2e.rs
@@ -650,17 +650,12 @@ async fn pat_authenticated_request_cannot_create_token() {
 
     let app = app::build_app(state, &api_config);
     let response = app
-        .oneshot(
-            Request::builder()
-                .method("POST")
-                .uri("/api/v1/me/tokens")
-                .header("authorization", format!("Bearer {}", minted.plaintext))
-                .header("content-type", "application/json")
-                .body(Body::from(
-                    r#"{"name":"nested-pat","scopes":["full_access"]}"#,
-                ))
-                .unwrap(),
-        )
+        .oneshot(mutating(
+            "POST",
+            "/api/v1/me/tokens",
+            &minted.plaintext,
+            Some(r#"{"name":"nested-pat","scopes":["full_access"]}"#),
+        ))
         .await
         .unwrap();
 

--- a/crates/api/tests/me_e2e.rs
+++ b/crates/api/tests/me_e2e.rs
@@ -105,7 +105,7 @@ async fn get_me_returns_profile_with_real_token_count() {
             &user.user_id,
             nebula_api::domain::auth::backend::CreatePatParams {
                 name: "cli".to_owned(),
-                scopes: vec![],
+                scopes: vec!["workflows:read".to_owned()],
                 ttl_seconds: Some(3600),
             },
         )
@@ -211,6 +211,38 @@ async fn get_me_with_non_user_principal_is_401() {
         ct,
         "non-user-principal 401 must come from the handler (RFC 9457 problem+json)"
     );
+}
+
+#[tokio::test]
+async fn pat_with_legacy_empty_scopes_is_rejected_at_auth() {
+    let (state, backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+    let minted = backend
+        .create_pat(
+            &user.user_id,
+            nebula_api::domain::auth::backend::CreatePatParams {
+                name: "legacy-empty-scopes".to_owned(),
+                scopes: vec![],
+                ttl_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/api/v1/me")
+                .header("authorization", format!("Bearer {}", minted.plaintext))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
 }
 
 // Helper: a 401 emitted by the handler carries application/problem+json;
@@ -408,7 +440,7 @@ async fn list_my_tokens_returns_metadata_only() {
             &user.user_id,
             nebula_api::domain::auth::backend::CreatePatParams {
                 name: "list-me".to_owned(),
-                scopes: vec!["a".to_owned()],
+                scopes: vec!["workflows:read".to_owned()],
                 ttl_seconds: None,
             },
         )
@@ -432,7 +464,7 @@ async fn list_my_tokens_returns_metadata_only() {
     let tokens = body["tokens"].as_array().expect("tokens array");
     assert_eq!(tokens.len(), 1);
     assert_eq!(tokens[0]["name"], "list-me");
-    assert_eq!(tokens[0]["scopes"][0], "a");
+    assert_eq!(tokens[0]["scopes"][0], "workflows:read");
     assert!(tokens[0]["id"].as_str().unwrap().starts_with("pat_"));
     assert!(
         !raw.contains(&plaintext),
@@ -473,7 +505,7 @@ async fn create_token_returns_plaintext_once_and_201() {
             "POST",
             "/api/v1/me/tokens",
             &user.jwt,
-            Some(r#"{"name":"deploy-bot","scopes":["workflows:read","workflows:run"],"ttl_seconds":7200}"#),
+            Some(r#"{"name":"deploy-bot","scopes":["workflows:read","workflows:execute"],"ttl_seconds":7200}"#),
         ))
         .await
         .unwrap();
@@ -513,12 +545,131 @@ async fn create_token_blank_name_is_400() {
             "POST",
             "/api/v1/me/tokens",
             &user.jwt,
-            Some(r#"{"name":"","scopes":[]}"#),
+            Some(r#"{"name":"","scopes":["full_access"]}"#),
         ))
         .await
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_token_empty_scopes_is_400() {
+    let (state, _backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let response = app
+        .oneshot(mutating(
+            "POST",
+            "/api/v1/me/tokens",
+            &user.jwt,
+            Some(r#"{"name":"empty-scope","scopes":[]}"#),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_token_unknown_scope_is_400() {
+    let (state, _backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let response = app
+        .oneshot(mutating(
+            "POST",
+            "/api/v1/me/tokens",
+            &user.jwt,
+            Some(r#"{"name":"unknown-scope","scopes":["workflows:run"]}"#),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_token_full_access_mixed_scope_is_400() {
+    let (state, _backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let response = app
+        .oneshot(mutating(
+            "POST",
+            "/api/v1/me/tokens",
+            &user.jwt,
+            Some(r#"{"name":"mixed-scope","scopes":["full_access","workflows:read"]}"#),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_token_full_access_scope_is_201() {
+    let (state, _backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+    let app = app::build_app(state, &api_config);
+
+    let response = app
+        .oneshot(mutating(
+            "POST",
+            "/api/v1/me/tokens",
+            &user.jwt,
+            Some(r#"{"name":"full-access","scopes":["full_access"]}"#),
+        ))
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = body_json(response).await;
+    assert_eq!(body["summary"]["scopes"][0], "full_access");
+}
+
+#[tokio::test]
+async fn pat_authenticated_request_cannot_create_token() {
+    let (state, backend, user) = create_me_state().await;
+    let api_config = ApiConfig::for_test();
+
+    let minted = backend
+        .create_pat(
+            &user.user_id,
+            nebula_api::domain::auth::backend::CreatePatParams {
+                name: "bootstrap-pat".to_owned(),
+                scopes: vec!["full_access".to_owned()],
+                ttl_seconds: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/me/tokens")
+                .header("authorization", format!("Bearer {}", minted.plaintext))
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    r#"{"name":"nested-pat","scopes":["full_access"]}"#,
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(
+        backend.list_pats(&user.user_id).await.unwrap().len(),
+        1,
+        "PAT-authenticated creation attempt must not mint an additional PAT"
+    );
 }
 
 #[tokio::test]
@@ -533,7 +684,7 @@ async fn create_token_without_auth_is_401() {
                 .method("POST")
                 .uri("/api/v1/me/tokens")
                 .header("content-type", "application/json")
-                .body(Body::from(r#"{"name":"x","scopes":[]}"#))
+                .body(Body::from(r#"{"name":"x","scopes":["full_access"]}"#))
                 .unwrap(),
         )
         .await
@@ -592,7 +743,7 @@ async fn create_token_plaintext_never_leaks_to_logs() {
             "POST",
             "/api/v1/me/tokens",
             &user.jwt,
-            Some(r#"{"name":"secret-probe","scopes":[]}"#),
+            Some(r#"{"name":"secret-probe","scopes":["full_access"]}"#),
         ))
         .await
         .unwrap();
@@ -628,7 +779,7 @@ async fn delete_token_revokes_and_is_idempotent() {
             &user.user_id,
             nebula_api::domain::auth::backend::CreatePatParams {
                 name: "to-revoke".to_owned(),
-                scopes: vec![],
+                scopes: vec!["workflows:read".to_owned()],
                 ttl_seconds: None,
             },
         )
@@ -710,7 +861,7 @@ async fn delete_token_owned_by_another_user_is_404() {
             &user_a.user_id,
             nebula_api::domain::auth::backend::CreatePatParams {
                 name: "user-a-token".to_owned(),
-                scopes: vec![],
+                scopes: vec!["workflows:read".to_owned()],
                 ttl_seconds: None,
             },
         )

--- a/crates/api/tests/openapi_spec.rs
+++ b/crates/api/tests/openapi_spec.rs
@@ -22,7 +22,11 @@ mod common;
 use std::collections::HashSet;
 
 use axum::{body::Body, http::Request};
-use nebula_api::{ApiConfig, build_app};
+use nebula_api::{
+    ApiConfig,
+    access::{REQUIRED_PERMISSION_EXTENSION, UNSUPPORTED_PERMISSION_SCOPE},
+    build_app,
+};
 use serde_json::Value;
 use tower::ServiceExt;
 
@@ -31,8 +35,6 @@ use crate::common::create_state_with_queue;
 const HTTP_METHODS: &[&str] = &[
     "get", "post", "put", "patch", "delete", "options", "head", "trace",
 ];
-const REQUIRED_PERMISSION_EXTENSION: &str = "x-required-permission";
-const UNSUPPORTED_PERMISSION: &str = "__unsupported_permission__";
 
 async fn fetch_spec_json() -> Value {
     let (state, _queue) = create_state_with_queue().await;
@@ -181,7 +183,7 @@ async fn tenant_operations_declare_required_permission() {
                 "operation {method} {path} must not declare an empty `{REQUIRED_PERMISSION_EXTENSION}`"
             );
             assert_ne!(
-                permission, UNSUPPORTED_PERMISSION,
+                permission, UNSUPPORTED_PERMISSION_SCOPE,
                 "operation {method} {path} must not publish unsupported permission placeholder"
             );
         }

--- a/crates/api/tests/openapi_spec.rs
+++ b/crates/api/tests/openapi_spec.rs
@@ -31,6 +31,8 @@ use crate::common::create_state_with_queue;
 const HTTP_METHODS: &[&str] = &[
     "get", "post", "put", "patch", "delete", "options", "head", "trace",
 ];
+const REQUIRED_PERMISSION_EXTENSION: &str = "x-required-permission";
+const UNSUPPORTED_PERMISSION: &str = "__unsupported_permission__";
 
 async fn fetch_spec_json() -> Value {
     let (state, _queue) = create_state_with_queue().await;
@@ -143,6 +145,224 @@ fn walk_refs(value: &Value, schemas: &HashSet<String>, unresolved: &mut Vec<Stri
         },
         _ => {},
     }
+}
+
+#[tokio::test]
+async fn tenant_operations_declare_required_permission() {
+    let spec = fetch_spec_json().await;
+    let paths = spec
+        .get("paths")
+        .and_then(Value::as_object)
+        .expect("spec.paths must be present");
+
+    let mut checked = 0usize;
+    for (path, item) in paths {
+        if !path.starts_with("/api/v1/orgs/{org}") {
+            continue;
+        }
+
+        let item = item.as_object().expect("each path entry must be an object");
+        for method in HTTP_METHODS {
+            let Some(operation) = item.get(*method) else {
+                continue;
+            };
+            checked += 1;
+
+            let permission = operation
+                .get(REQUIRED_PERMISSION_EXTENSION)
+                .and_then(Value::as_str)
+                .unwrap_or_else(|| {
+                    panic!(
+                        "operation {method} {path} must declare string `{REQUIRED_PERMISSION_EXTENSION}`"
+                    )
+                });
+            assert!(
+                !permission.is_empty(),
+                "operation {method} {path} must not declare an empty `{REQUIRED_PERMISSION_EXTENSION}`"
+            );
+            assert_ne!(
+                permission, UNSUPPORTED_PERMISSION,
+                "operation {method} {path} must not publish unsupported permission placeholder"
+            );
+        }
+    }
+
+    assert!(
+        checked > 0,
+        "spec must contain at least one tenant operation under /api/v1/orgs/{{org}}"
+    );
+}
+
+#[tokio::test]
+async fn selected_operations_publish_expected_permissions() {
+    let spec = fetch_spec_json().await;
+
+    for (method, path, expected) in [
+        // Org
+        ("get", "/api/v1/orgs/{org}", "orgs:read"),
+        ("patch", "/api/v1/orgs/{org}", "orgs:update"),
+        ("delete", "/api/v1/orgs/{org}", "orgs:delete"),
+        ("get", "/api/v1/orgs/{org}/members", "members:read"),
+        ("post", "/api/v1/orgs/{org}/members", "members:invite"),
+        (
+            "delete",
+            "/api/v1/orgs/{org}/members/{principal}",
+            "members:remove",
+        ),
+        // Workspace/workflow
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows",
+            "workflows:read",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows",
+            "workflows:write",
+        ),
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows/{wf}",
+            "workflows:read",
+        ),
+        (
+            "put",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows/{wf}",
+            "workflows:write",
+        ),
+        (
+            "delete",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows/{wf}",
+            "workflows:delete",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows/{wf}/execute",
+            "workflows:execute",
+        ),
+        // Executions
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/executions",
+            "executions:read",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/workflows/{wf}/executions",
+            "workflows:execute",
+        ),
+        (
+            "delete",
+            "/api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}",
+            "executions:cancel",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}/terminate",
+            "executions:terminate",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}/restart",
+            "executions:restart",
+        ),
+        // Resources
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources",
+            "resources:read",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources",
+            "resources:write",
+        ),
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources/{res}",
+            "resources:read",
+        ),
+        (
+            "put",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources/{res}",
+            "resources:write",
+        ),
+        (
+            "delete",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources/{res}",
+            "resources:delete",
+        ),
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/resources/{res}/status",
+            "resources:read",
+        ),
+        // Credentials
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials",
+            "credentials:read",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials",
+            "credentials:write",
+        ),
+        (
+            "get",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}",
+            "credentials:read",
+        ),
+        (
+            "put",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}",
+            "credentials:write",
+        ),
+        (
+            "delete",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}",
+            "credentials:delete",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve",
+            "credentials:write",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/test",
+            "credentials:read",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/refresh",
+            "credentials:write",
+        ),
+        (
+            "post",
+            "/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/revoke",
+            "credentials:delete",
+        ),
+    ] {
+        assert_eq!(
+            required_permission_for(&spec, path, method),
+            expected,
+            "{method} {path} must publish `{expected}` as `{REQUIRED_PERMISSION_EXTENSION}`"
+        );
+    }
+}
+
+fn required_permission_for<'a>(spec: &'a Value, path: &str, method: &str) -> &'a str {
+    spec.get("paths")
+        .and_then(|paths| paths.get(path))
+        .and_then(|item| item.get(method))
+        .and_then(|operation| operation.get(REQUIRED_PERMISSION_EXTENSION))
+        .and_then(Value::as_str)
+        .unwrap_or_else(|| {
+            panic!(
+                "operation {method} {path} must exist and declare string `{REQUIRED_PERMISSION_EXTENSION}`"
+            )
+        })
 }
 
 #[tokio::test]

--- a/crates/core/src/permission.rs
+++ b/crates/core/src/permission.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::role::WorkspaceRole;
 
 /// Granular permission that can be checked against a workspace role.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[non_exhaustive]
 pub enum Permission {
     // Workflow
@@ -25,6 +25,8 @@ pub enum Permission {
 
     // Resource
     ResourceRead,
+    ResourceWrite,
+    ResourceDelete,
 
     // Workspace membership
     WorkspaceMemberRead,
@@ -34,6 +36,7 @@ pub enum Permission {
     OrgRead,
     OrgUpdate,
     OrgDelete,
+    MemberRead,
     MemberInvite,
     MemberRemove,
     ServiceAccountManage,
@@ -62,6 +65,8 @@ impl Permission {
             | Self::WorkflowDelete
             | Self::CredentialWrite
             | Self::CredentialDelete
+            | Self::ResourceWrite
+            | Self::ResourceDelete
             | Self::ExecutionTerminate => Some(WorkspaceRole::WorkspaceEditor),
 
             // Admin can manage members
@@ -71,9 +76,36 @@ impl Permission {
             Self::OrgRead
             | Self::OrgUpdate
             | Self::OrgDelete
+            | Self::MemberRead
             | Self::MemberInvite
             | Self::MemberRemove
             | Self::ServiceAccountManage => None,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_mutation_permissions_require_workspace_editor() {
+        assert_eq!(
+            Permission::ResourceRead.required_workspace_role(),
+            Some(WorkspaceRole::WorkspaceViewer)
+        );
+        assert_eq!(
+            Permission::ResourceWrite.required_workspace_role(),
+            Some(WorkspaceRole::WorkspaceEditor)
+        );
+        assert_eq!(
+            Permission::ResourceDelete.required_workspace_role(),
+            Some(WorkspaceRole::WorkspaceEditor)
+        );
+    }
+
+    #[test]
+    fn member_read_is_org_level_permission() {
+        assert_eq!(Permission::MemberRead.required_workspace_role(), None);
     }
 }

--- a/crates/core/src/tenancy.rs
+++ b/crates/core/src/tenancy.rs
@@ -43,13 +43,28 @@ impl TenantContext {
             // Org-level permission — check org_role
             // OrgAdmin+ can do most org ops; OrgOwner for destructive ops
             let required = match permission {
-                Permission::OrgRead => OrgRole::OrgMember,
+                Permission::OrgRead | Permission::MemberRead => OrgRole::OrgMember,
                 Permission::OrgUpdate
                 | Permission::MemberInvite
                 | Permission::MemberRemove
                 | Permission::ServiceAccountManage => OrgRole::OrgAdmin,
                 Permission::OrgDelete => OrgRole::OrgOwner,
-                _ => OrgRole::OrgAdmin,
+                Permission::WorkflowRead
+                | Permission::WorkflowWrite
+                | Permission::WorkflowDelete
+                | Permission::WorkflowExecute
+                | Permission::ExecutionRead
+                | Permission::ExecutionCancel
+                | Permission::ExecutionTerminate
+                | Permission::ExecutionRestart
+                | Permission::CredentialRead
+                | Permission::CredentialWrite
+                | Permission::CredentialDelete
+                | Permission::ResourceRead
+                | Permission::ResourceWrite
+                | Permission::ResourceDelete
+                | Permission::WorkspaceMemberRead
+                | Permission::WorkspaceMemberManage => OrgRole::OrgAdmin,
             };
             match self.org_role {
                 Some(actual) if actual >= required => Ok(()),
@@ -105,4 +120,63 @@ pub struct ResolvedIds {
     pub credential_id: Option<CredentialId>,
     pub trigger_id: Option<TriggerId>,
     pub service_account_id: Option<ServiceAccountId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::id::UserId;
+
+    fn context_with_org_role(org_role: Option<OrgRole>) -> TenantContext {
+        TenantContext {
+            org_id: OrgId::new(),
+            workspace_id: None,
+            principal: Principal::User(UserId::new()),
+            org_role,
+            workspace_role: None,
+        }
+    }
+
+    #[test]
+    fn org_member_can_read_org_and_members() {
+        let ctx = context_with_org_role(Some(OrgRole::OrgMember));
+
+        assert!(ctx.require(Permission::OrgRead).is_ok());
+        assert!(ctx.require(Permission::MemberRead).is_ok());
+    }
+
+    #[test]
+    fn org_member_cannot_manage_org_members_or_service_accounts() {
+        let ctx = context_with_org_role(Some(OrgRole::OrgMember));
+
+        for permission in [
+            Permission::OrgUpdate,
+            Permission::MemberInvite,
+            Permission::MemberRemove,
+            Permission::ServiceAccountManage,
+        ] {
+            assert_eq!(
+                ctx.require(permission)
+                    .map_err(|err| (err.required_role, err.current_role)),
+                Err((
+                    OrgRole::OrgAdmin.to_string(),
+                    OrgRole::OrgMember.to_string()
+                ))
+            );
+        }
+    }
+
+    #[test]
+    fn only_org_owner_can_delete_org() {
+        let admin = context_with_org_role(Some(OrgRole::OrgAdmin));
+        let owner = context_with_org_role(Some(OrgRole::OrgOwner));
+
+        assert_eq!(
+            admin
+                .require(Permission::OrgDelete)
+                .map_err(|err| (err.required_role, err.current_role)),
+            Err((OrgRole::OrgOwner.to_string(), OrgRole::OrgAdmin.to_string()))
+        );
+        assert!(owner.require(Permission::OrgDelete).is_ok());
+    }
 }


### PR DESCRIPTION
## Summary
- Add an API access kernel for PAT grants, scope parsing, and tenant-route permission guards.
- Extend core permissions/RBAC for resources and member reads, then enforce RBAC ∩ PAT grant at runtime.
- Wire tenant routes through `access::protected` and publish `x-required-permission` OpenAPI metadata.
- Validate new PAT scopes, require explicit `full_access`, reject legacy empty PAT scopes at auth, and forbid PAT-authenticated PAT minting.

## Why
PAT scopes previously had no reliable runtime authorization model. Tenant routes also had no uniform route-level permission declaration, so OpenAPI and handler protection could drift quietly.

## Validation
- `cargo test -p nebula-api`
- `cargo test -p nebula-core`
- `cargo check -p nebula-api`
- `rustfmt --edition 2024 --check <touched files>`
- `git diff --check HEAD`
- pre-commit hooks: `typos`, `fmt-check`, `clippy`, `convco`
- pre-push hooks: `clippy-full`, `crate-diff-gate` / nextest 466 passed

## Notes
- `cargo fmt --check` across the whole workspace on Windows hit `os error 206` due to command length, so touched files were checked directly with `rustfmt`.
- PR is draft for review of the authorization model and route permission matrix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced permission-based access control for API endpoints with role-based scoping
  * Personal access tokens now support granular permission scopes (e.g., workflows:read, workflows:write) and a "full_access" option

* **Breaking Changes**
  * Personal access tokens now require at least one scope; empty scopes are rejected at authentication
  * Tokens created with personal access tokens are no longer supported

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->