### PR TITLE
feat(engine): wire resource acquire through acquire_erased lease pipeline

### DIFF
--- a/crates/action/src/error.rs
+++ b/crates/action/src/error.rs
@@ -327,6 +327,24 @@ impl From<nebula_core::CoreError> for ActionError {
                 capability,
                 action_id,
             },
+            nebula_core::CoreError::ResourceUnavailable {
+                key,
+                detail,
+                retryable: true,
+                retry_after: Some(backoff),
+            } => ActionError::retryable_with_backoff(format!("{key}: {detail}"), backoff),
+            nebula_core::CoreError::ResourceUnavailable {
+                key,
+                detail,
+                retryable: true,
+                retry_after: None,
+            } => ActionError::retryable(format!("{key}: {detail}")),
+            nebula_core::CoreError::ResourceUnavailable {
+                key,
+                detail,
+                retryable: false,
+                ..
+            } => ActionError::fatal(format!("{key}: {detail}")),
             other => ActionError::fatal_from(other),
         }
     }
@@ -880,6 +898,19 @@ mod tests {
     }
 
     // ── ValidationReason + structured Validation (L7) ──────────────────────
+
+    #[test]
+    fn core_resource_unavailable_retryable_becomes_action_retryable() {
+        let core = nebula_core::CoreError::resource_unavailable(
+            "postgres",
+            "pool exhausted",
+            true,
+            Some(Duration::from_millis(50)),
+        );
+        let action: ActionError = core.into();
+        assert!(matches!(action, ActionError::Retryable { .. }));
+        assert_eq!(action.backoff_hint(), Some(Duration::from_millis(50)));
+    }
 
     #[test]
     fn validation_reason_as_str_stable() {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,5 +1,7 @@
 //! Core error types for nebula-core operations.
 
+use std::time::Duration;
+
 use thiserror::Error;
 
 /// Core error -- only errors that core vocabulary operations produce.
@@ -73,6 +75,22 @@ pub enum CoreError {
         /// The action that attempted access.
         action_id: String,
     },
+
+    /// Resource lease/acquire failed (surfaced through the shared accessor seam).
+    ///
+    /// Actions reach this via [`ResourceAccessor`](crate::accessor::ResourceAccessor);
+    /// retryable variants are converted to retryable action errors at the action boundary.
+    #[error("resource unavailable: {key}: {detail}")]
+    ResourceUnavailable {
+        /// Resource key label for observability.
+        key: String,
+        /// Human-readable failure detail (no secret bytes).
+        detail: String,
+        /// When true, the action runtime may retry with backoff.
+        retryable: bool,
+        /// Optional retry delay hint from the resource layer.
+        retry_after: Option<Duration>,
+    },
 }
 
 impl CoreError {
@@ -109,6 +127,21 @@ impl CoreError {
     pub fn dependency_missing(name: &'static str, required_by: &'static str) -> Self {
         Self::DependencyMissing { name, required_by }
     }
+
+    /// Create a resource-acquire failure surfaced through the accessor seam.
+    pub fn resource_unavailable(
+        key: impl Into<String>,
+        detail: impl Into<String>,
+        retryable: bool,
+        retry_after: Option<Duration>,
+    ) -> Self {
+        Self::ResourceUnavailable {
+            key: key.into(),
+            detail: detail.into(),
+            retryable,
+            retry_after,
+        }
+    }
 }
 
 /// Result type for core operations.
@@ -128,6 +161,12 @@ impl nebula_error::Classify for CoreError {
                 nebula_error::ErrorCategory::NotFound
             },
             Self::CredentialAccessDenied { .. } => nebula_error::ErrorCategory::Authorization,
+            Self::ResourceUnavailable {
+                retryable: true, ..
+            } => nebula_error::ErrorCategory::Unavailable,
+            Self::ResourceUnavailable {
+                retryable: false, ..
+            } => nebula_error::ErrorCategory::Cancelled,
         }
     }
 
@@ -141,11 +180,29 @@ impl nebula_error::Classify for CoreError {
             Self::CredentialNotConfigured(_) => "CORE:CREDENTIAL_NOT_CONFIGURED",
             Self::CredentialNotFound { .. } => "CORE:CREDENTIAL_NOT_FOUND",
             Self::CredentialAccessDenied { .. } => "CORE:CREDENTIAL_ACCESS_DENIED",
+            Self::ResourceUnavailable { .. } => "CORE:RESOURCE_UNAVAILABLE",
         })
     }
 
     fn is_retryable(&self) -> bool {
-        false
+        matches!(
+            self,
+            Self::ResourceUnavailable {
+                retryable: true,
+                ..
+            }
+        )
+    }
+
+    fn retry_hint(&self) -> Option<nebula_error::RetryHint> {
+        match self {
+            Self::ResourceUnavailable {
+                retry_after: Some(d),
+                retryable: true,
+                ..
+            } => Some(nebula_error::RetryHint::after(*d)),
+            _ => None,
+        }
     }
 }
 

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -11,7 +11,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        Arc,
+        Arc, RwLock,
         atomic::{AtomicU64, Ordering},
     },
     time::{Duration, Instant},
@@ -21,7 +21,7 @@ use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use nebula_action::{ActionError, ActionResult, capability::default_resource_accessor};
 use nebula_core::{
-    ActionKey, NodeKey,
+    ActionKey, NodeKey, ResourceKey,
     accessor::{CredentialAccessor, ResourceAccessor},
     id::{ExecutionId, InstanceId, WorkflowId},
     node_key,
@@ -203,6 +203,12 @@ pub struct WorkflowEngine {
     resolver: ParamResolver,
     /// Optional resource manager for providing resources to actions.
     resource_manager: Option<Arc<nebula_resource::Manager>>,
+    /// Extra scope fields merged into each node's resource acquire context
+    /// (`org_id`, `workspace_id`) when resources are registered above execution
+    /// scope.
+    resource_acquire_scope: Option<nebula_core::scope::Scope>,
+    /// Per-resource resolved slot identities recorded at activation.
+    resource_slot_identities: RwLock<HashMap<ResourceKey, u64>>,
     /// Optional spec-16 port bundle (execution-state / lease / journal /
     /// node-result / idempotency / checkpoint). `None` puts the engine in
     /// single-process library mode (no coordination seam, no lease).
@@ -366,6 +372,8 @@ impl WorkflowEngine {
             resource_fanout_spawned: std::sync::atomic::AtomicBool::new(false),
             resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
+            resource_acquire_scope: None,
+            resource_slot_identities: RwLock::new(HashMap::new()),
             stores: None,
             workflow_stores: None,
             credential_resolver: None,
@@ -574,6 +582,45 @@ impl WorkflowEngine {
     pub fn with_resource_manager(mut self, manager: Arc<nebula_resource::Manager>) -> Self {
         self.resource_manager = Some(manager);
         self
+    }
+
+    /// Merge `org_id` / `workspace_id` into the scope used for resource acquire.
+    #[must_use]
+    pub fn with_resource_acquire_scope(mut self, scope: nebula_core::scope::Scope) -> Self {
+        self.resource_acquire_scope = Some(scope);
+        self
+    }
+
+    /// Record a resolved slot identity for a resource key (activation-time).
+    pub fn record_resource_slot_identity(&self, key: ResourceKey, slot_identity: u64) {
+        self.resource_slot_identities
+            .write()
+            .expect("resource_slot_identities lock poisoned")
+            .insert(key, slot_identity);
+    }
+
+    /// Live-register a resource kind and record its slot identity for acquire.
+    ///
+    /// Callers should prefer this over
+    /// [`ResourceRegistrarRegistry::register`](crate::ResourceRegistrarRegistry::register)
+    /// alone so action-time `acquire_any` uses the same `slot_identity` as the
+    /// manager registry row.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`ResourceRegistrarRegistry::register`].
+    pub async fn register_resource(
+        &self,
+        kind: &str,
+        manager: &nebula_resource::Manager,
+        request: crate::RegisterRequest<'_>,
+    ) -> Result<(), crate::RegistrarError> {
+        let outcome = self
+            .resource_registrars
+            .register(kind, manager, request)
+            .await?;
+        self.record_resource_slot_identity(outcome.resource_key, outcome.slot_identity);
+        Ok(())
     }
 
     /// Thread in the closed `kind → typed registrar` allowlist.
@@ -3153,8 +3200,23 @@ impl WorkflowEngine {
         // layered accessor transparently — `scoped → global`, closest
         // ancestor wins.
         let resources: Arc<dyn ResourceAccessor> = if let Some(manager) = &self.resource_manager {
-            let global: Arc<dyn ResourceAccessor> =
-                Arc::new(EngineResourceAccessor::new(Arc::clone(manager)));
+            let extra = self.resource_acquire_scope.clone().unwrap_or_default();
+            let scope = nebula_core::scope::Scope {
+                execution_id: Some(execution_id),
+                workflow_id: Some(workflow_id),
+                org_id: extra.org_id,
+                workspace_id: extra.workspace_id,
+                ..Default::default()
+            };
+            let slot_identities = self
+                .resource_slot_identities
+                .read()
+                .expect("resource_slot_identities lock poisoned")
+                .clone();
+            let global: Arc<dyn ResourceAccessor> = Arc::new(
+                EngineResourceAccessor::new(Arc::clone(manager), scope, cancel_token.clone())
+                    .with_slot_identities(slot_identities),
+            );
             Arc::new(LayeredResourceAccessor::global_only(global))
         } else {
             default_resource_accessor()

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -207,8 +207,12 @@ pub struct WorkflowEngine {
     /// (`org_id`, `workspace_id`) when resources are registered above execution
     /// scope.
     resource_acquire_scope: Option<nebula_core::scope::Scope>,
-    /// Per-resource resolved slot identities recorded at activation.
+    /// Per-execution acquire scope (`org_id` / `workspace_id` for this run).
+    execution_acquire_scopes: DashMap<ExecutionId, nebula_core::scope::Scope>,
+    /// Per-resource resolved slot identities recorded at activation (pre-run).
     resource_slot_identities: RwLock<HashMap<ResourceKey, u64>>,
+    /// Frozen slot-identity map per execution (snapshot at run start).
+    resource_slot_identities_by_execution: DashMap<ExecutionId, Arc<HashMap<ResourceKey, u64>>>,
     /// Optional spec-16 port bundle (execution-state / lease / journal /
     /// node-result / idempotency / checkpoint). `None` puts the engine in
     /// single-process library mode (no coordination seam, no lease).
@@ -373,7 +377,9 @@ impl WorkflowEngine {
             resolver: ParamResolver::new(expression_engine),
             resource_manager: None,
             resource_acquire_scope: None,
+            execution_acquire_scopes: DashMap::new(),
             resource_slot_identities: RwLock::new(HashMap::new()),
+            resource_slot_identities_by_execution: DashMap::new(),
             stores: None,
             workflow_stores: None,
             credential_resolver: None,
@@ -585,18 +591,70 @@ impl WorkflowEngine {
     }
 
     /// Merge `org_id` / `workspace_id` into the scope used for resource acquire.
+    ///
+    /// Prefer [`execute_workflow_with_acquire_scope`](Self::execute_workflow_with_acquire_scope)
+    /// when each run carries its own tenant; this builder sets the engine default.
     #[must_use]
     pub fn with_resource_acquire_scope(mut self, scope: nebula_core::scope::Scope) -> Self {
         self.resource_acquire_scope = Some(scope);
         self
     }
 
+    /// Merges engine-default and per-run tenant fields for resource acquire.
+    fn merged_acquire_scope(
+        engine_default: &Option<nebula_core::scope::Scope>,
+        run_scope: Option<&nebula_core::scope::Scope>,
+    ) -> nebula_core::scope::Scope {
+        let pick = run_scope.or(engine_default.as_ref());
+        nebula_core::scope::Scope {
+            org_id: pick.and_then(|s| s.org_id),
+            workspace_id: pick.and_then(|s| s.workspace_id),
+            ..Default::default()
+        }
+    }
+
+    fn install_execution_resource_context(
+        &self,
+        execution_id: ExecutionId,
+        run_acquire_scope: Option<nebula_core::scope::Scope>,
+    ) {
+        let slot_snap = self
+            .resource_slot_identities
+            .read()
+            .map(|ids| Arc::new(ids.clone()))
+            .unwrap_or_else(|err| {
+                tracing::error!(
+                    target: "nebula_engine",
+                    ?err,
+                    "resource_slot_identities lock poisoned; empty slot map for execution"
+                );
+                Arc::new(HashMap::new())
+            });
+        self.resource_slot_identities_by_execution
+            .insert(execution_id, slot_snap);
+
+        let acquire_scope =
+            Self::merged_acquire_scope(&self.resource_acquire_scope, run_acquire_scope.as_ref());
+        self.execution_acquire_scopes
+            .insert(execution_id, acquire_scope);
+    }
+
     /// Record a resolved slot identity for a resource key (activation-time).
     pub fn record_resource_slot_identity(&self, key: ResourceKey, slot_identity: u64) {
-        self.resource_slot_identities
-            .write()
-            .expect("resource_slot_identities lock poisoned")
-            .insert(key, slot_identity);
+        match self.resource_slot_identities.write() {
+            Ok(mut ids) => {
+                ids.insert(key, slot_identity);
+            },
+            Err(err) => {
+                tracing::error!(
+                    target: "nebula_engine",
+                    ?err,
+                    %key,
+                    slot_identity,
+                    "resource_slot_identities lock poisoned; slot identity not recorded"
+                );
+            },
+        }
     }
 
     /// Live-register a resource kind and record its slot identity for acquire.
@@ -618,6 +676,27 @@ impl WorkflowEngine {
         let outcome = self
             .resource_registrars
             .register(kind, manager, request)
+            .await?;
+        self.record_resource_slot_identity(outcome.resource_key, outcome.slot_identity);
+        Ok(())
+    }
+
+    /// Live-register under `rotation`, bind the fan-out index, and record slot identity.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`ResourceRegistrarRegistry::register_and_bind`].
+    #[cfg(feature = "rotation")]
+    pub async fn register_resource_and_bind(
+        &self,
+        kind: &str,
+        manager: &nebula_resource::Manager,
+        request: crate::RegisterRequest<'_>,
+        fanout_index: Option<&crate::credential::rotation::ResourceFanoutIndex>,
+    ) -> Result<(), crate::RegistrarError> {
+        let outcome = self
+            .resource_registrars
+            .register_and_bind(kind, manager, request, fanout_index)
             .await?;
         self.record_resource_slot_identity(outcome.resource_key, outcome.slot_identity);
         Ok(())
@@ -1297,12 +1376,36 @@ impl WorkflowEngine {
         input: serde_json::Value,
         budget: ExecutionBudget,
     ) -> Result<ExecutionResult, EngineError> {
+        self.execute_workflow_with_acquire_scope(workflow, input, budget, None)
+            .await
+    }
+
+    /// Like [`execute_workflow`](Self::execute_workflow) with per-run tenant scope.
+    ///
+    /// `run_acquire_scope` supplies `org_id` / `workspace_id` for this execution.
+    /// Fields set here override the engine default from
+    /// [`with_resource_acquire_scope`](Self::with_resource_acquire_scope).
+    pub async fn execute_workflow_with_acquire_scope(
+        &self,
+        workflow: &WorkflowDefinition,
+        input: serde_json::Value,
+        budget: ExecutionBudget,
+        run_acquire_scope: Option<nebula_core::scope::Scope>,
+    ) -> Result<ExecutionResult, EngineError> {
         budget
             .validate_for_execution()
             .map_err(|msg| EngineError::PlanningFailed(msg.to_string()))?;
 
         let execution_id = ExecutionId::new();
         let started = Instant::now();
+
+        self.install_execution_resource_context(execution_id, run_acquire_scope);
+        let slot_by_exec = &self.resource_slot_identities_by_execution;
+        let acquire_by_exec = &self.execution_acquire_scopes;
+        let _execution_resource_guard = scopeguard::guard(execution_id, move |id| {
+            slot_by_exec.remove(&id);
+            acquire_by_exec.remove(&id);
+        });
 
         // 1. Validate workflow (reuse ExecutionPlan for validation)
         let _plan = ExecutionPlan::from_workflow(execution_id, workflow, budget.clone())
@@ -3200,7 +3303,11 @@ impl WorkflowEngine {
         // layered accessor transparently — `scoped → global`, closest
         // ancestor wins.
         let resources: Arc<dyn ResourceAccessor> = if let Some(manager) = &self.resource_manager {
-            let extra = self.resource_acquire_scope.clone().unwrap_or_default();
+            let extra = self
+                .execution_acquire_scopes
+                .get(&execution_id)
+                .map(|entry| entry.value().clone())
+                .unwrap_or_default();
             let scope = nebula_core::scope::Scope {
                 execution_id: Some(execution_id),
                 workflow_id: Some(workflow_id),
@@ -3209,13 +3316,13 @@ impl WorkflowEngine {
                 ..Default::default()
             };
             let slot_identities = self
-                .resource_slot_identities
-                .read()
-                .expect("resource_slot_identities lock poisoned")
-                .clone();
+                .resource_slot_identities_by_execution
+                .get(&execution_id)
+                .map(|entry| Arc::clone(entry.value()))
+                .unwrap_or_else(|| Arc::new(HashMap::new()));
             let global: Arc<dyn ResourceAccessor> = Arc::new(
                 EngineResourceAccessor::new(Arc::clone(manager), scope, cancel_token.clone())
-                    .with_slot_identities(slot_identities),
+                    .with_slot_identities_arc(slot_identities),
             );
             Arc::new(LayeredResourceAccessor::global_only(global))
         } else {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -601,14 +601,22 @@ impl WorkflowEngine {
     }
 
     /// Merges engine-default and per-run tenant fields for resource acquire.
+    ///
+    /// Per-run values override the engine default field-by-field; unset run
+    /// fields fall back to the engine default.
     fn merged_acquire_scope(
         engine_default: &Option<nebula_core::scope::Scope>,
         run_scope: Option<&nebula_core::scope::Scope>,
     ) -> nebula_core::scope::Scope {
-        let pick = run_scope.or(engine_default.as_ref());
+        let default = engine_default.as_ref();
+        let run = run_scope;
         nebula_core::scope::Scope {
-            org_id: pick.and_then(|s| s.org_id),
-            workspace_id: pick.and_then(|s| s.workspace_id),
+            org_id: run
+                .and_then(|s| s.org_id)
+                .or_else(|| default.and_then(|s| s.org_id)),
+            workspace_id: run
+                .and_then(|s| s.workspace_id)
+                .or_else(|| default.and_then(|s| s.workspace_id)),
             ..Default::default()
         }
     }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -103,7 +103,7 @@ pub use nebula_plugin::{Plugin, PluginKey, PluginManifest, PluginRegistry, Resol
 pub use node_output::NodeOutput;
 pub use resource::{
     ErasedResourceRegistrar, RegisterRequest, RegistrarError, ResourceRegistrarRegistry,
-    TypedResourceRegistrar,
+    ResourceRegistrationOutcome, TypedResourceRegistrar,
 };
 pub use resource_accessor::EngineResourceAccessor;
 pub use resource_status::{

--- a/crates/engine/src/resource/mod.rs
+++ b/crates/engine/src/resource/mod.rs
@@ -13,5 +13,5 @@ pub mod registrar;
 
 pub use registrar::{
     ErasedResourceRegistrar, RegisterRequest, RegistrarError, ResourceRegistrarRegistry,
-    TypedResourceRegistrar,
+    ResourceRegistrationOutcome, TypedResourceRegistrar,
 };

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -583,8 +583,6 @@ impl ResourceRegistrarRegistry {
         // reverse-index binding so a later rotation / lease-revoke fans
         // to this exact resolved row.
         if let Some((idx, scope, slot_bindings, credential_ids)) = bind_plan {
-            let resource_key = outcome.resource_key;
-            let slot_identity = outcome.slot_identity;
             for (slot_name, cred_id) in &credential_ids {
                 // Only bind slots the resource actually declared (those
                 // present in `slot_bindings`): a stray `credential_ids`
@@ -593,10 +591,10 @@ impl ResourceRegistrarRegistry {
                 if slot_bindings.contains_key(slot_name) {
                     idx.bind(
                         *cred_id,
-                        resource_key.clone(),
+                        outcome.resource_key.clone(),
                         scope.clone(),
                         slot_name.clone(),
-                        slot_identity,
+                        outcome.slot_identity,
                     );
                 }
             }

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -562,7 +562,7 @@ impl ResourceRegistrarRegistry {
         manager: &Manager,
         request: RegisterRequest<'_>,
         fanout_index: Option<&crate::credential::rotation::ResourceFanoutIndex>,
-    ) -> Result<(), RegistrarError> {
+    ) -> Result<ResourceRegistrationOutcome, RegistrarError> {
         // Snapshot the bind inputs before `request` is moved into the
         // typed `register` call. Cheap clones (a small slot map + scope);
         // the resource key comes from the erased registrar so the
@@ -601,7 +601,7 @@ impl ResourceRegistrarRegistry {
                 }
             }
         }
-        Ok(())
+        Ok(outcome)
     }
 
     /// Resolves `kind` through the closed allowlist and validates

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -164,6 +164,17 @@ impl nebula_error::Classify for RegistrarError {
     }
 }
 
+/// Metadata returned after a successful live registration through the
+/// closed allowlist.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceRegistrationOutcome {
+    /// Catalog key the row was registered under.
+    pub resource_key: nebula_core::ResourceKey,
+    /// Structural slot identity hashed from `slot_bindings` (matches the
+    /// manager registry row and must be recorded on the engine for acquire).
+    pub slot_identity: u64,
+}
+
 /// Type-agnostic inputs the *caller* (the engine registration loop)
 /// threads into a typed registration.
 ///
@@ -291,23 +302,26 @@ pub trait ErasedResourceRegistrar: Send + Sync {
 /// `TopologyRuntime<R>` by value, and a registrar may be invoked more
 /// than once (re-activation, multiple scopes), so both are *factories*
 /// rather than stored values.
-pub struct TypedResourceRegistrar<R, FRes, FTopo>
+pub struct TypedResourceRegistrar<R, FRes, FTopo, FAcq>
 where
     R: Resource + nebula_core::DeclaresDependencies,
     R::Config: serde::de::DeserializeOwned,
     FRes: Fn() -> R + Send + Sync,
     FTopo: Fn() -> TopologyRuntime<R> + Send + Sync,
+    FAcq: Fn(u64) -> nebula_resource::ErasedAcquireFn + Send + Sync,
 {
     resource_factory: FRes,
     topology_factory: FTopo,
+    acquire_for_slot: FAcq,
 }
 
-impl<R, FRes, FTopo> TypedResourceRegistrar<R, FRes, FTopo>
+impl<R, FRes, FTopo, FAcq> TypedResourceRegistrar<R, FRes, FTopo, FAcq>
 where
     R: Resource + nebula_core::DeclaresDependencies,
     R::Config: serde::de::DeserializeOwned,
     FRes: Fn() -> R + Send + Sync,
     FTopo: Fn() -> TopologyRuntime<R> + Send + Sync,
+    FAcq: Fn(u64) -> nebula_resource::ErasedAcquireFn + Send + Sync,
 {
     /// Builds a typed registrar for resource type `R`.
     ///
@@ -315,20 +329,24 @@ where
     /// already resolved by the engine per );
     /// `topology_factory` yields the `TopologyRuntime<R>` declared for
     /// this kind. Both are invoked once per registration call.
-    pub fn new(resource_factory: FRes, topology_factory: FTopo) -> Self {
+    /// `acquire_for_slot` builds the erased acquire hook for a resolved
+    /// per-slot credential identity (see [`Manager::erased_acquire_*`]).
+    pub fn new(resource_factory: FRes, topology_factory: FTopo, acquire_for_slot: FAcq) -> Self {
         Self {
             resource_factory,
             topology_factory,
+            acquire_for_slot,
         }
     }
 }
 
-impl<R, FRes, FTopo> ErasedResourceRegistrar for TypedResourceRegistrar<R, FRes, FTopo>
+impl<R, FRes, FTopo, FAcq> ErasedResourceRegistrar for TypedResourceRegistrar<R, FRes, FTopo, FAcq>
 where
     R: Resource + nebula_core::DeclaresDependencies,
     R::Config: serde::de::DeserializeOwned,
     FRes: Fn() -> R + Send + Sync,
     FTopo: Fn() -> TopologyRuntime<R> + Send + Sync,
+    FAcq: Fn(u64) -> nebula_resource::ErasedAcquireFn + Send + Sync,
 {
     fn register<'a>(
         &'a self,
@@ -337,6 +355,7 @@ where
     ) -> BoxFut<'a, Result<(), nebula_resource::Error>> {
         let resource = (self.resource_factory)();
         let topology = (self.topology_factory)();
+        let acquire_for_slot = &self.acquire_for_slot;
         Box::pin(async move {
             manager
                 .register_from_value::<R>(
@@ -346,6 +365,7 @@ where
                     resource,
                     request.scope,
                     topology,
+                    acquire_for_slot,
                     request.resilience,
                     request.recovery_gate,
                 )
@@ -446,18 +466,29 @@ impl ResourceRegistrarRegistry {
         kind: &str,
         manager: &Manager,
         request: RegisterRequest<'_>,
-    ) -> Result<(), RegistrarError> {
+    ) -> Result<ResourceRegistrationOutcome, RegistrarError> {
         let registrar = self
             .registrars
             .get(kind)
             .ok_or_else(|| RegistrarError::UnknownKind(kind.to_owned()))?;
+        let resource_key = registrar.resource_key();
+        let slot_identity = nebula_resource::slot_identity(
+            request
+                .slot_bindings
+                .iter()
+                .map(|(slot, key)| (slot.as_str(), key.as_str())),
+        );
         registrar
             .register(manager, request)
             .await
             .map_err(|source| RegistrarError::Register {
                 kind: kind.to_owned(),
                 source,
-            })
+            })?;
+        Ok(ResourceRegistrationOutcome {
+            resource_key,
+            slot_identity,
+        })
     }
 
     /// Resolves `kind` through the closed allowlist, dispatches into its
@@ -545,14 +576,13 @@ impl ResourceRegistrarRegistry {
         let bind_plan = fanout_index.map(|idx| {
             (
                 idx,
-                registrar.resource_key(),
                 request.scope.clone(),
                 request.slot_bindings.clone(),
                 request.credential_ids.clone(),
             )
         });
 
-        registrar
+        let outcome = registrar
             .register(manager, request)
             .await
             .map_err(|source| RegistrarError::Register {
@@ -563,18 +593,9 @@ impl ResourceRegistrarRegistry {
         // Registration succeeded — the registry row exists. Record the
         // reverse-index binding so a later rotation / lease-revoke fans
         // to this exact resolved row.
-        if let Some((idx, resource_key, scope, slot_bindings, credential_ids)) = bind_plan {
-            // Recompute the structural slot identity EXACTLY as
-            // `Manager::register_from_value` does (a stable hash over the
-            // `(slot_key, CredentialKey)` pairs) so the reverse-index row
-            // and the manager registry row share one identity. Mismatch
-            // here would route a rotation to a non-existent row
-            // (`Ambiguous` / silent miss).
-            let slot_identity = nebula_resource::slot_identity(
-                slot_bindings
-                    .iter()
-                    .map(|(slot, key)| (slot.as_str(), key.as_str())),
-            );
+        if let Some((idx, scope, slot_bindings, credential_ids)) = bind_plan {
+            let resource_key = outcome.resource_key;
+            let slot_identity = outcome.slot_identity;
             for (slot_name, cred_id) in &credential_ids {
                 // Only bind slots the resource actually declared (those
                 // present in `slot_bindings`): a stray `credential_ids`
@@ -652,7 +673,7 @@ mod tests {
         error::Error as ResourceError,
         resource::{Resource, ResourceConfig, ResourceMetadata},
         runtime::{TopologyRuntime, resident::ResidentRuntime},
-        topology::resident,
+        topology::resident::{self, Resident},
     };
 
     use super::*;
@@ -751,14 +772,21 @@ mod tests {
     // `DeclaresDependencies` (empty) impl is correct.
     impl nebula_core::DeclaresDependencies for TestRes {}
 
+    impl Resident for TestRes {
+        fn is_alive_sync(&self, runtime: &Arc<AtomicU64>) -> bool {
+            runtime.load(Ordering::Relaxed) < u64::MAX
+        }
+    }
+
     fn test_registrar(create_counter: Arc<AtomicU64>) -> Arc<dyn ErasedResourceRegistrar> {
-        Arc::new(TypedResourceRegistrar::<TestRes, _, _>::new(
+        Arc::new(TypedResourceRegistrar::<TestRes, _, _, _>::new(
             move || TestRes::new(create_counter.clone()),
             || {
                 TopologyRuntime::Resident(ResidentRuntime::<TestRes>::new(
                     resident::config::Config::default(),
                 ))
             },
+            |slot| Manager::erased_acquire_resident::<TestRes>(slot),
         ))
     }
 

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -326,11 +326,12 @@ where
     /// Builds a typed registrar for resource type `R`.
     ///
     /// `resource_factory` yields the `R` value (with credential slots
-    /// already resolved by the engine per );
+    /// already resolved by the engine per registration scope).
     /// `topology_factory` yields the `TopologyRuntime<R>` declared for
     /// this kind. Both are invoked once per registration call.
     /// `acquire_for_slot` builds the erased acquire hook for a resolved
-    /// per-slot credential identity (see [`Manager::erased_acquire_*`]).
+    /// per-slot credential identity (for example
+    /// [`Manager::erased_acquire_resident`](nebula_resource::manager::Manager::erased_acquire_resident)).
     pub fn new(resource_factory: FRes, topology_factory: FTopo, acquire_for_slot: FAcq) -> Self {
         Self {
             resource_factory,

--- a/crates/engine/src/resource/registrar.rs
+++ b/crates/engine/src/resource/registrar.rs
@@ -563,11 +563,6 @@ impl ResourceRegistrarRegistry {
         request: RegisterRequest<'_>,
         fanout_index: Option<&crate::credential::rotation::ResourceFanoutIndex>,
     ) -> Result<(), RegistrarError> {
-        let registrar = self
-            .registrars
-            .get(kind)
-            .ok_or_else(|| RegistrarError::UnknownKind(kind.to_owned()))?;
-
         // Snapshot the bind inputs before `request` is moved into the
         // typed `register` call. Cheap clones (a small slot map + scope);
         // the resource key comes from the erased registrar so the
@@ -582,13 +577,7 @@ impl ResourceRegistrarRegistry {
             )
         });
 
-        let outcome = registrar
-            .register(manager, request)
-            .await
-            .map_err(|source| RegistrarError::Register {
-                kind: kind.to_owned(),
-                source,
-            })?;
+        let outcome = self.register(kind, manager, request).await?;
 
         // Registration succeeded — the registry row exists. Record the
         // reverse-index binding so a later rotation / lease-revoke fans

--- a/crates/engine/src/resource_accessor.rs
+++ b/crates/engine/src/resource_accessor.rs
@@ -1,55 +1,71 @@
 //! Engine-side [`ResourceAccessor`] implementation.
 //!
 //! [`EngineResourceAccessor`] bridges the engine's resource manager to the
-//! [`ResourceAccessor`] capability trait consumed by actions. It delegates
-//! key-based lookups directly to the [`nebula_resource::Manager`].
-//!
-//! # Design
-//!
-//! The `ResourceAccessor` trait operates on string keys (`&str`), while the
-//! resource manager uses typed [`ResourceKey`] values. The accessor parses
-//! the string key at call time and returns a fatal `ActionError` if the
-//! key is not a valid resource key format.
-//!
-//! Acquire returns the underlying `Arc<dyn AnyManagedResource>` boxed as
-//! `Box<dyn Any + Send + Sync>`. Action code can downcast to the concrete
-//! `Arc<ManagedResource<R>>` to access the resource's typed state, or use
-//! the accessor only as an existence check before performing a typed acquire
-//! via the manager directly.
-//!
-//! No allowlist is enforced — unlike credentials, resources are identified
-//! by their registered key and any registered key may be acquired.
+//! [`ResourceAccessor`] capability trait consumed by actions. Acquire runs
+//! the full manager lease pipeline (slot-identity-pinned, scope-aware) and
+//! returns a boxed [`nebula_resource::ResourceGuard`] for downcast by action
+//! code — not a raw `ManagedResource` handle.
 
-use std::{any::Any, fmt, future::Future, pin::Pin, sync::Arc};
+use std::{any::Any, collections::HashMap, fmt, future::Future, pin::Pin, sync::Arc};
 
-use nebula_core::{CoreError, ResourceKey, accessor::ResourceAccessor};
+use nebula_core::{CoreError, ResourceKey, accessor::ResourceAccessor, scope::Scope};
+use nebula_resource::{
+    AcquireOptions, ErrorKind, Manager, ResourceContext, SLOT_IDENTITY_UNBOUND,
+    dedup::slot_identity,
+};
+use tokio_util::sync::CancellationToken;
 
 type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
 
 /// Engine-side implementation of [`ResourceAccessor`].
 ///
-/// Wraps an [`Arc<nebula_resource::Manager>`] and delegates `acquire` and
-/// `exists` calls to it via key-based lookup.
-///
-/// # Examples
-///
-/// ```rust,ignore
-/// use std::sync::Arc;
-/// use nebula_engine::resource_accessor::EngineResourceAccessor;
-/// use nebula_resource::Manager;
-///
-/// let manager = Arc::new(Manager::new());
-/// let accessor = EngineResourceAccessor::new(manager);
-/// ```
+/// Wraps an [`Arc<nebula_resource::Manager>`] and dispatches `acquire_any` /
+/// `try_acquire_any` through [`Manager::acquire_erased`] using the execution
+/// scope and optional per-key slot identities recorded at activation.
 pub struct EngineResourceAccessor {
-    manager: Arc<nebula_resource::Manager>,
+    manager: Arc<Manager>,
+    scope: Scope,
+    cancel: CancellationToken,
+    slot_identities: Arc<HashMap<ResourceKey, u64>>,
 }
 
 impl EngineResourceAccessor {
     /// Creates a new accessor backed by the given resource manager.
     #[must_use]
-    pub fn new(manager: Arc<nebula_resource::Manager>) -> Self {
-        Self { manager }
+    pub fn new(manager: Arc<Manager>, scope: Scope, cancel: CancellationToken) -> Self {
+        Self {
+            manager,
+            scope,
+            cancel,
+            slot_identities: Arc::new(HashMap::new()),
+        }
+    }
+
+    /// Overrides the default slot-identity map (key → resolved credential hash).
+    #[must_use]
+    pub fn with_slot_identities(mut self, slot_identities: HashMap<ResourceKey, u64>) -> Self {
+        self.slot_identities = Arc::new(slot_identities);
+        self
+    }
+
+    fn slot_identity_for(&self, key: &ResourceKey) -> u64 {
+        self.slot_identities
+            .get(key)
+            .copied()
+            .unwrap_or(SLOT_IDENTITY_UNBOUND)
+    }
+
+    fn resource_ctx(&self) -> ResourceContext {
+        ResourceContext::minimal(self.scope.clone(), self.cancel.clone())
+    }
+
+    fn map_err(key: &ResourceKey, err: nebula_resource::Error) -> CoreError {
+        let detail = format!("{}: {err}", key.as_str());
+        match err.kind() {
+            ErrorKind::NotFound => CoreError::CredentialNotFound { key: detail },
+            ErrorKind::Ambiguous => CoreError::scope_violation(key.as_str(), detail),
+            _ => CoreError::CredentialNotConfigured(detail),
+        }
     }
 }
 
@@ -57,6 +73,7 @@ impl fmt::Debug for EngineResourceAccessor {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("EngineResourceAccessor")
             .field("manager", &"<Manager>")
+            .field("scope", &self.scope)
             .finish()
     }
 }
@@ -64,23 +81,22 @@ impl fmt::Debug for EngineResourceAccessor {
 impl ResourceAccessor for EngineResourceAccessor {
     fn has(&self, key: &ResourceKey) -> bool {
         self.manager
-            .get_any(key, &nebula_resource::ScopeLevel::Global)
-            .is_some()
+            .has_registered_for_scope(key, &self.scope, self.slot_identity_for(key))
     }
 
     fn acquire_any(
         &self,
         key: &ResourceKey,
     ) -> BoxFut<'_, Result<Box<dyn Any + Send + Sync>, CoreError>> {
-        let any_managed = self
-            .manager
-            .get_any(key, &nebula_resource::ScopeLevel::Global);
-        let key_str = key.as_str().to_owned();
+        let manager = Arc::clone(&self.manager);
+        let key = key.clone();
+        let ctx = self.resource_ctx();
+        let slot_identity = self.slot_identity_for(&key);
+        let options = AcquireOptions::default();
         Box::pin(async move {
-            match any_managed {
-                Some(m) => Ok(Box::new(m.as_any_arc()) as Box<dyn Any + Send + Sync>),
-                None => Err(CoreError::CredentialNotFound { key: key_str }),
-            }
+            Manager::acquire_erased(manager, &key, &ctx, &options, slot_identity)
+                .await
+                .map_err(|e| Self::map_err(&key, e))
         })
     }
 
@@ -88,25 +104,108 @@ impl ResourceAccessor for EngineResourceAccessor {
         &self,
         key: &ResourceKey,
     ) -> BoxFut<'_, Result<Option<Box<dyn Any + Send + Sync>>, CoreError>> {
-        let any_managed = self
-            .manager
-            .get_any(key, &nebula_resource::ScopeLevel::Global);
+        let fut = self.acquire_any(key);
         Box::pin(async move {
-            Ok(any_managed.map(|m| Box::new(m.as_any_arc()) as Box<dyn Any + Send + Sync>))
+            match fut.await {
+                Ok(value) => Ok(Some(value)),
+                Err(CoreError::CredentialNotFound { .. }) => Ok(None),
+                Err(err) => Err(err),
+            }
         })
     }
 }
 
+/// Build slot identities for activation from resolved `(slot, credential)` pairs.
+#[must_use]
+pub fn slot_identities_for_key(
+    key: ResourceKey,
+    pairs: &[(&str, &str)],
+) -> HashMap<ResourceKey, u64> {
+    let id = slot_identity(pairs.iter().copied());
+    let mut map = HashMap::new();
+    map.insert(key, id);
+    map
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{
+        fmt,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+    };
 
-    use nebula_resource::Manager;
+    use nebula_resource::{
+        Manager, ResidentConfig, ResourceContext, ScopeLevel,
+        dedup::SLOT_IDENTITY_UNBOUND,
+        error::Error,
+        resource::{Resource, ResourceConfig, ResourceMetadata},
+        runtime::{TopologyRuntime, resident::ResidentRuntime},
+        topology::resident::Resident,
+    };
 
     use super::*;
 
-    fn make_accessor() -> EngineResourceAccessor {
-        EngineResourceAccessor::new(Arc::new(Manager::new()))
+    #[derive(Debug, Clone)]
+    struct AccError(String);
+
+    impl fmt::Display for AccError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.write_str(&self.0)
+        }
+    }
+
+    impl std::error::Error for AccError {}
+
+    impl From<AccError> for Error {
+        fn from(e: AccError) -> Self {
+            Error::permanent(e.0)
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct AccConfig;
+
+    nebula_schema::impl_empty_has_schema!(AccConfig);
+
+    impl ResourceConfig for AccConfig {}
+
+    #[derive(Clone)]
+    struct AccResource;
+
+    impl Resource for AccResource {
+        type Config = AccConfig;
+        type Runtime = Arc<AtomicU64>;
+        type Lease = Arc<AtomicU64>;
+        type Error = AccError;
+
+        fn key() -> ResourceKey {
+            ResourceKey::new("test.engine_accessor.acc").expect("valid resource key in test")
+        }
+
+        async fn create(
+            &self,
+            _config: &AccConfig,
+            _ctx: &ResourceContext,
+        ) -> Result<Arc<AtomicU64>, AccError> {
+            Ok(Arc::new(AtomicU64::new(42)))
+        }
+
+        fn metadata() -> ResourceMetadata {
+            ResourceMetadata::from_key(&Self::key())
+        }
+    }
+
+    impl Resident for AccResource {
+        fn is_alive_sync(&self, _runtime: &Arc<AtomicU64>) -> bool {
+            true
+        }
+    }
+
+    fn make_accessor(manager: Arc<Manager>) -> EngineResourceAccessor {
+        EngineResourceAccessor::new(manager, Scope::default(), CancellationToken::new())
     }
 
     fn rk(key: &str) -> ResourceKey {
@@ -115,13 +214,13 @@ mod tests {
 
     #[tokio::test]
     async fn has_returns_false_for_unregistered_key() {
-        let accessor = make_accessor();
+        let accessor = make_accessor(Arc::new(Manager::new()));
         assert!(!accessor.has(&rk("postgres")));
     }
 
     #[tokio::test]
     async fn acquire_any_returns_err_for_unregistered_key() {
-        let accessor = make_accessor();
+        let accessor = make_accessor(Arc::new(Manager::new()));
         let result = accessor.acquire_any(&rk("postgres")).await;
         assert!(
             matches!(result, Err(CoreError::CredentialNotFound { .. })),
@@ -131,16 +230,43 @@ mod tests {
 
     #[tokio::test]
     async fn try_acquire_any_returns_none_for_unregistered_key() {
-        let accessor = make_accessor();
+        let accessor = make_accessor(Arc::new(Manager::new()));
         let result = accessor.try_acquire_any(&rk("postgres")).await;
         assert!(matches!(result, Ok(None)));
     }
 
     #[tokio::test]
+    async fn acquire_any_returns_guard_for_registered_resource() {
+        let manager = Arc::new(Manager::new());
+        manager
+            .register(
+                AccResource,
+                AccConfig,
+                ScopeLevel::Global,
+                TopologyRuntime::Resident(ResidentRuntime::<AccResource>::new(
+                    ResidentConfig::default(),
+                )),
+                Manager::erased_acquire_resident::<AccResource>(SLOT_IDENTITY_UNBOUND),
+                None,
+                None,
+            )
+            .expect("register");
+
+        let accessor = make_accessor(Arc::clone(&manager));
+        let key = AccResource::key();
+        let boxed = accessor
+            .acquire_any(&key)
+            .await
+            .expect("acquire through accessor");
+        let guard = boxed
+            .downcast::<nebula_resource::ResourceGuard<AccResource>>()
+            .expect("ResourceGuard downcast");
+        assert_eq!(guard.load(Ordering::Relaxed), 42);
+    }
+
+    #[tokio::test]
     async fn debug_redacts_manager() {
-        // `Manager::new()` spawns a release queue worker that needs a Tokio
-        // runtime — keep the assertion but run under #[tokio::test].
-        let accessor = make_accessor();
+        let accessor = make_accessor(Arc::new(Manager::new()));
         let debug = format!("{accessor:?}");
         assert!(debug.contains("<Manager>"));
     }

--- a/crates/engine/src/resource_accessor.rs
+++ b/crates/engine/src/resource_accessor.rs
@@ -48,6 +48,17 @@ impl EngineResourceAccessor {
         self
     }
 
+    /// Like [`with_slot_identities`](Self::with_slot_identities) but shares an
+    /// existing `Arc` (per-execution snapshot on the engine).
+    #[must_use]
+    pub fn with_slot_identities_arc(
+        mut self,
+        slot_identities: Arc<HashMap<ResourceKey, u64>>,
+    ) -> Self {
+        self.slot_identities = slot_identities;
+        self
+    }
+
     fn slot_identity_for(&self, key: &ResourceKey) -> u64 {
         self.slot_identities
             .get(key)
@@ -59,13 +70,8 @@ impl EngineResourceAccessor {
         ResourceContext::minimal(self.scope.clone(), self.cancel.clone())
     }
 
-    fn map_err(key: &ResourceKey, err: nebula_resource::Error) -> CoreError {
-        let detail = format!("{}: {err}", key.as_str());
-        match err.kind() {
-            ErrorKind::NotFound => CoreError::CredentialNotFound { key: detail },
-            ErrorKind::Ambiguous => CoreError::scope_violation(key.as_str(), detail),
-            _ => CoreError::CredentialNotConfigured(detail),
-        }
+    fn map_err(_key: &ResourceKey, err: nebula_resource::Error) -> CoreError {
+        err.to_core_error()
     }
 }
 
@@ -104,12 +110,18 @@ impl ResourceAccessor for EngineResourceAccessor {
         &self,
         key: &ResourceKey,
     ) -> BoxFut<'_, Result<Option<Box<dyn Any + Send + Sync>>, CoreError>> {
-        let fut = self.acquire_any(key);
+        let manager = Arc::clone(&self.manager);
+        let key = key.clone();
+        let ctx = self.resource_ctx();
+        let slot_identity = self.slot_identity_for(&key);
+        let options = AcquireOptions::default();
         Box::pin(async move {
-            match fut.await {
+            match Manager::acquire_erased(manager, &key, &ctx, &options, slot_identity).await {
                 Ok(value) => Ok(Some(value)),
-                Err(CoreError::CredentialNotFound { .. }) => Ok(None),
-                Err(err) => Err(err),
+                Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::Cancelled) => {
+                    Ok(None)
+                },
+                Err(e) => Err(Self::map_err(&key, e)),
             }
         })
     }
@@ -139,7 +151,7 @@ mod tests {
 
     use nebula_resource::{
         Manager, ResidentConfig, ResourceContext, ScopeLevel,
-        dedup::SLOT_IDENTITY_UNBOUND,
+        dedup::{SLOT_IDENTITY_UNBOUND, slot_identity},
         error::Error,
         resource::{Resource, ResourceConfig, ResourceMetadata},
         runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -269,5 +281,50 @@ mod tests {
         let accessor = make_accessor(Arc::new(Manager::new()));
         let debug = format!("{accessor:?}");
         assert!(debug.contains("<Manager>"));
+    }
+
+    #[tokio::test]
+    async fn acquire_any_uses_recorded_slot_identity_not_unbound() {
+        let manager = Arc::new(Manager::new());
+        let key = AccResource::key();
+        let bound = slot_identity([("slot", "cred-a")]);
+
+        manager
+            .register_with_identity(
+                AccResource,
+                AccConfig,
+                ScopeLevel::Global,
+                bound,
+                TopologyRuntime::Resident(ResidentRuntime::<AccResource>::new(
+                    ResidentConfig::default(),
+                )),
+                Manager::erased_acquire_resident::<AccResource>(bound),
+                None,
+                None,
+            )
+            .expect("register cred-bound row");
+
+        let accessor = make_accessor(Arc::clone(&manager))
+            .with_slot_identities(HashMap::from([(key.clone(), bound)]));
+        assert!(accessor.has(&key));
+
+        let boxed = accessor
+            .acquire_any(&key)
+            .await
+            .expect("acquire with matching slot identity");
+        let _guard = boxed
+            .downcast::<nebula_resource::ResourceGuard<AccResource>>()
+            .expect("ResourceGuard downcast");
+
+        let wrong = make_accessor(manager).with_slot_identities(HashMap::from([(
+            key.clone(),
+            slot_identity([("slot", "other")]),
+        )]));
+        assert!(
+            !wrong.has(&key),
+            "has must not see cred-bound row under a different slot identity"
+        );
+        let missing = wrong.try_acquire_any(&key).await.expect("try_acquire");
+        assert!(missing.is_none());
     }
 }

--- a/crates/engine/src/resource_accessor.rs
+++ b/crates/engine/src/resource_accessor.rs
@@ -118,9 +118,7 @@ impl ResourceAccessor for EngineResourceAccessor {
         Box::pin(async move {
             match Manager::acquire_erased(manager, &key, &ctx, &options, slot_identity).await {
                 Ok(value) => Ok(Some(value)),
-                Err(e) if matches!(e.kind(), ErrorKind::NotFound | ErrorKind::Cancelled) => {
-                    Ok(None)
-                },
+                Err(e) if matches!(e.kind(), ErrorKind::NotFound) => Ok(None),
                 Err(e) => Err(Self::map_err(&key, e)),
             }
         })

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -47,6 +47,7 @@ use nebula_execution::context::ExecutionBudget;
 use nebula_metrics::MetricsRegistry;
 use nebula_resource::{
     Manager, ResidentConfig, ResourceContext,
+    dedup::SLOT_IDENTITY_UNBOUND,
     error::Error as ResourceError,
     resource::{Resource, ResourceConfig, ResourceMetadata},
     runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -353,6 +354,7 @@ async fn pipeline_with_resource_manager_resolves_and_executes() {
             TopologyRuntime::Resident(ResidentRuntime::<WitnessResource>::new(
                 ResidentConfig::default(),
             )),
+            Manager::erased_acquire_resident::<WitnessResource>(SLOT_IDENTITY_UNBOUND),
             None,
             None,
         )

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -9,7 +9,10 @@
 
 use std::{
     collections::HashMap,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 use nebula_action::{
@@ -17,13 +20,21 @@ use nebula_action::{
     stateless::StatelessAction,
 };
 use nebula_core::{ActionKey, Dependencies, action_key, id::WorkflowId, node_key};
+use nebula_core::{OrgId, ResourceKey, ScopeLevel, resource_key};
 use nebula_engine::{
     ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessSandbox,
     WorkflowEngine,
 };
 use nebula_execution::context::ExecutionBudget;
 use nebula_metrics::MetricsRegistry;
-use nebula_resource::Manager;
+use nebula_resource::{
+    Manager, ResidentConfig, ResourceContext,
+    dedup::SLOT_IDENTITY_UNBOUND,
+    error::Error as ResourceError,
+    resource::{Resource, ResourceConfig, ResourceMetadata},
+    runtime::{TopologyRuntime, resident::ResidentRuntime},
+    topology::resident::Resident,
+};
 use nebula_workflow::{NodeDefinition, Version, WorkflowConfig, WorkflowDefinition};
 
 // ---------------------------------------------------------------------------
@@ -269,6 +280,176 @@ async fn full_resource_lifecycle_with_shutdown() {
     assert!(manager.is_shutdown());
 }
 
+// ---------------------------------------------------------------------------
+// Engine integration — real acquire through EngineResourceAccessor
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct IntegrationProbeError(String);
+
+impl std::fmt::Display for IntegrationProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for IntegrationProbeError {}
+
+impl From<IntegrationProbeError> for ResourceError {
+    fn from(e: IntegrationProbeError) -> Self {
+        ResourceError::permanent(e.0)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct IntegrationProbeConfig;
+
+nebula_schema::impl_empty_has_schema!(IntegrationProbeConfig);
+
+impl ResourceConfig for IntegrationProbeConfig {}
+
+#[derive(Clone)]
+struct IntegrationProbeResource;
+
+impl Resource for IntegrationProbeResource {
+    type Config = IntegrationProbeConfig;
+    type Runtime = Arc<AtomicU64>;
+    type Lease = Arc<AtomicU64>;
+    type Error = IntegrationProbeError;
+
+    fn key() -> ResourceKey {
+        resource_key!("test.engine_integration.probe")
+    }
+
+    async fn create(
+        &self,
+        _config: &IntegrationProbeConfig,
+        _ctx: &ResourceContext,
+    ) -> Result<Arc<AtomicU64>, IntegrationProbeError> {
+        Ok(Arc::new(AtomicU64::new(7)))
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for IntegrationProbeResource {
+    fn is_alive_sync(&self, runtime: &Arc<AtomicU64>) -> bool {
+        runtime.load(Ordering::Relaxed) > 0
+    }
+}
+
+struct IntegrationAcquireHandler;
+
+impl Action for IntegrationAcquireHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    fn metadata() -> &'static ActionMetadata {
+        static M: OnceLock<ActionMetadata> = OnceLock::new();
+        M.get_or_init(|| {
+            ActionMetadata::new(
+                action_key!("test.engine_integration.acquire"),
+                "IntegrationAcquire",
+                "static",
+            )
+        })
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl StatelessAction for IntegrationAcquireHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        let key = IntegrationProbeResource::key();
+        let boxed = ctx
+            .resources()
+            .acquire_any(&key)
+            .await
+            .map_err(ActionError::from)?;
+        let guard = boxed
+            .downcast::<nebula_resource::ResourceGuard<IntegrationProbeResource>>()
+            .map_err(|_| ActionError::fatal("expected ResourceGuard downcast"))?;
+        let value = guard.load(Ordering::Relaxed);
+        Ok(ActionResult::success(serde_json::json!({ "lease": value })))
+    }
+}
+
+/// Org-scoped registration + execution-scoped acquire + slot identity on engine.
+#[tokio::test]
+async fn engine_acquires_org_scoped_resource_through_accessor() {
+    let manager = Arc::new(Manager::new());
+    let org = OrgId::new();
+
+    manager
+        .register(
+            IntegrationProbeResource,
+            IntegrationProbeConfig,
+            ScopeLevel::Organization(org),
+            TopologyRuntime::Resident(ResidentRuntime::<IntegrationProbeResource>::new(
+                ResidentConfig::default(),
+            )),
+            Manager::erased_acquire_resident::<IntegrationProbeResource>(SLOT_IDENTITY_UNBOUND),
+            None,
+            None,
+        )
+        .expect("register org-scoped resource");
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.legacy_register_stateless_with_metadata(
+        meta(action_key!("engine-integration-acquire")),
+        IntegrationAcquireHandler,
+    );
+
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let sandbox = Arc::new(InProcessSandbox::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            sandbox,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+
+    let engine = WorkflowEngine::new(runtime, metrics)
+        .unwrap()
+        .with_resource_manager(Arc::clone(&manager))
+        .with_resource_acquire_scope(nebula_core::scope::Scope {
+            org_id: Some(org),
+            ..Default::default()
+        });
+    engine.record_resource_slot_identity(IntegrationProbeResource::key(), SLOT_IDENTITY_UNBOUND);
+
+    let node = node_key!("probe");
+    let wf = make_workflow(vec![
+        NodeDefinition::new(node.clone(), "A", "engine-integration-acquire").unwrap(),
+    ]);
+
+    let result = engine
+        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .await
+        .expect("workflow execution");
+
+    assert!(result.is_success(), "workflow should succeed");
+    let output = result.node_output(&node).expect("node output");
+    assert_eq!(
+        output.get("lease").and_then(serde_json::Value::as_u64),
+        Some(7)
+    );
+}
+
 /// Verify that `ctx.resource()` returns a fatal error when no resource
 /// manager is attached to the engine.
 ///
@@ -346,6 +527,7 @@ mod shared_resource {
     use nebula_core::{ExecutionId, OrgId, ResourceKey, ScopeLevel, resource_key, scope::Scope};
     use nebula_resource::{
         AcquireOptions, Manager, ResidentConfig, ResourceContext,
+        dedup::SLOT_IDENTITY_UNBOUND,
         error::Error,
         resource::{Resource, ResourceConfig, ResourceMetadata},
         runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -581,6 +763,7 @@ mod shared_resource {
                 test_config(),
                 ScopeLevel::Organization(org),
                 TopologyRuntime::Resident(resident_rt),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -657,6 +840,7 @@ mod shared_resource {
                 TopologyRuntime::Resident(ResidentRuntime::<TelegramBot>::new(
                     ResidentConfig::default(),
                 )),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -669,6 +853,7 @@ mod shared_resource {
                 TopologyRuntime::Resident(ResidentRuntime::<AlternateBot>::new(
                     ResidentConfig::default(),
                 )),
+                Manager::erased_acquire_resident::<AlternateBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -731,6 +916,7 @@ mod shared_resource {
                 TopologyRuntime::Resident(ResidentRuntime::<TelegramBot>::new(
                     ResidentConfig::default(),
                 )),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -743,6 +929,7 @@ mod shared_resource {
                 TopologyRuntime::Resident(ResidentRuntime::<TelegramBot>::new(
                     ResidentConfig::default(),
                 )),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -803,6 +990,7 @@ mod shared_resource {
                 test_config(),
                 scope.clone(),
                 TopologyRuntime::Resident(resident_rt),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )
@@ -880,6 +1068,7 @@ mod shared_resource {
                 test_config(),
                 ScopeLevel::Global,
                 TopologyRuntime::Resident(resident_rt),
+                Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
                 None,
                 None,
             )

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -54,7 +54,7 @@ use nebula_engine::{
 };
 use nebula_metrics::MetricsRegistry;
 use nebula_resource::{
-    AnyResource, ScopeLevel,
+    AnyResource, Manager, ScopeLevel,
     error::Error as ResourceError,
     resource::{Resource, ResourceConfig, ResourceMetadata},
     runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -152,6 +152,12 @@ impl Resource for DemoResource {
 
 impl nebula_core::DeclaresDependencies for DemoResource {}
 
+impl resident::Resident for DemoResource {
+    fn is_alive_sync(&self, runtime: &Arc<AtomicU64>) -> bool {
+        runtime.load(Ordering::Relaxed) < u64::MAX
+    }
+}
+
 /// `AnyResource` is the type-erased shape `Plugin::resources()` returns —
 /// metadata-only. This impl mirrors what `#[derive(Resource)]` would emit
 /// for the erased view (key + metadata); it deliberately exposes **no**
@@ -215,13 +221,14 @@ fn demo_registrars(plugins: &PluginRegistry) -> ResourceRegistrarRegistry {
 
     registrars.insert(
         kind.as_str().to_owned(),
-        Arc::new(TypedResourceRegistrar::<DemoResource, _, _>::new(
+        Arc::new(TypedResourceRegistrar::<DemoResource, _, _, _>::new(
             DemoResource::new,
             || {
                 TopologyRuntime::Resident(ResidentRuntime::<DemoResource>::new(
                     resident::config::Config::default(),
                 ))
             },
+            |slot| Manager::erased_acquire_resident::<DemoResource>(slot),
         )),
     );
     registrars
@@ -328,8 +335,7 @@ async fn wired_registrar_performs_typed_registration() {
     let expr = ExpressionEngine::with_cache_size(16);
 
     engine
-        .resource_registrars()
-        .register(
+        .register_resource(
             "demo.widget",
             &manager,
             RegisterRequest {

--- a/crates/engine/tests/resource_registrar_validate.rs
+++ b/crates/engine/tests/resource_registrar_validate.rs
@@ -30,11 +30,12 @@ use std::sync::Arc;
 use nebula_core::{ResourceKey, resource_key};
 use nebula_engine::{RegistrarError, ResourceRegistrarRegistry, TypedResourceRegistrar};
 use nebula_resource::{
-    ScopeLevel,
+    Manager, ScopeLevel,
     error::Error as ResourceError,
     resource::{Resource, ResourceConfig, ResourceMetadata},
     runtime::{TopologyRuntime, resident::ResidentRuntime},
     topology::resident,
+    topology::resident::Resident,
 };
 use nebula_schema::{HasSchema, Schema};
 use serde::Deserialize;
@@ -112,17 +113,24 @@ impl Resource for HttpPool {
 
 impl nebula_core::DeclaresDependencies for HttpPool {}
 
+impl Resident for HttpPool {
+    fn is_alive_sync(&self, _runtime: &()) -> bool {
+        true
+    }
+}
+
 fn registry_with_http_pool() -> ResourceRegistrarRegistry {
     let mut registry = ResourceRegistrarRegistry::new();
     registry.insert(
         "http_pool",
-        Arc::new(TypedResourceRegistrar::<HttpPool, _, _>::new(
+        Arc::new(TypedResourceRegistrar::<HttpPool, _, _, _>::new(
             || HttpPool,
             || {
                 TopologyRuntime::Resident(ResidentRuntime::<HttpPool>::new(
                     resident::config::Config::default(),
                 ))
             },
+            |slot| Manager::erased_acquire_resident::<HttpPool>(slot),
         )),
     );
     registry
@@ -150,7 +158,7 @@ async fn known_kind_schema_valid_config_is_ok_and_no_manager_mutation() {
     // nothing registered, proving validation never reached registration.
     // (`Manager::new` spawns a release-queue reactor task, hence the
     // Tokio context.)
-    let manager = nebula_resource::Manager::new();
+    let manager = Manager::new();
     assert!(
         manager
             .get_any(&<HttpPool as Resource>::key(), &ScopeLevel::Global)

--- a/crates/resource/src/context.rs
+++ b/crates/resource/src/context.rs
@@ -152,6 +152,11 @@ impl ResourceContext {
     pub fn execution_id(&self) -> Option<nebula_core::ExecutionId> {
         self.scope().execution_id
     }
+
+    /// Copies scope + cancellation for type-erased acquire dispatch (no accessor clone).
+    pub fn clone_for_acquire(&self) -> Self {
+        Self::minimal(self.scope().clone(), self.cancellation().clone())
+    }
 }
 
 impl std::fmt::Debug for ResourceContext {
@@ -205,7 +210,7 @@ impl HasCredentials for ResourceContext {
 // ---------------------------------------------------------------------------
 
 /// Converts a [`Scope`] bag to the most specific [`ScopeLevel`].
-fn scope_to_level(scope: &Scope) -> ScopeLevel {
+pub fn scope_to_level(scope: &Scope) -> ScopeLevel {
     if let Some(id) = scope.execution_id {
         ScopeLevel::Execution(id)
     } else if let Some(id) = scope.workflow_id {
@@ -217,6 +222,42 @@ fn scope_to_level(scope: &Scope) -> ScopeLevel {
     } else {
         ScopeLevel::Global
     }
+}
+
+/// Scope levels to probe for acquire/lookup, most specific first.
+///
+/// When an execution-scoped context carries `org_id` / `workspace_id`, registry
+/// rows registered at those levels remain reachable without falling through to
+/// an unrelated Global row.
+pub fn scope_levels_for_acquire(scope: &Scope) -> Vec<ScopeLevel> {
+    let mut levels = Vec::with_capacity(5);
+    if let Some(id) = scope.execution_id {
+        levels.push(ScopeLevel::Execution(id));
+    }
+    if let Some(id) = scope.workflow_id {
+        levels.push(ScopeLevel::Workflow(id));
+    }
+    if let Some(id) = scope.workspace_id {
+        levels.push(ScopeLevel::Workspace(id));
+    }
+    if let Some(id) = scope.org_id {
+        levels.push(ScopeLevel::Organization(id));
+    }
+    levels.push(ScopeLevel::Global);
+    levels
+}
+
+/// Builds a minimal [`Scope`] bag containing only the given level's id field.
+pub fn minimal_scope_for_level(level: &ScopeLevel) -> Scope {
+    let mut scope = Scope::default();
+    match level {
+        ScopeLevel::Global => {},
+        ScopeLevel::Organization(id) => scope.org_id = Some(*id),
+        ScopeLevel::Workspace(id) => scope.workspace_id = Some(*id),
+        ScopeLevel::Workflow(id) => scope.workflow_id = Some(*id),
+        ScopeLevel::Execution(id) => scope.execution_id = Some(*id),
+    }
+    scope
 }
 
 #[cfg(test)]
@@ -252,6 +293,21 @@ mod tests {
         };
         let ctx = ResourceContext::minimal(scope, CancellationToken::new());
         assert_eq!(ctx.scope_level(), ScopeLevel::Execution(eid));
+    }
+
+    #[test]
+    fn scope_levels_for_acquire_includes_ancestors() {
+        let org = nebula_core::OrgId::new();
+        let eid = ExecutionId::new();
+        let scope = Scope {
+            execution_id: Some(eid),
+            org_id: Some(org),
+            ..Default::default()
+        };
+        let levels = scope_levels_for_acquire(&scope);
+        assert_eq!(levels[0], ScopeLevel::Execution(eid));
+        assert_eq!(levels[1], ScopeLevel::Organization(org));
+        assert_eq!(levels.last(), Some(&ScopeLevel::Global));
     }
 
     #[test]

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -235,12 +235,9 @@ impl Error {
             ErrorKind::Cancelled => {
                 nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)
             },
-            ErrorKind::Permanent => nebula_core::CoreError::resource_unavailable(
-                key_label,
-                detail,
-                false,
-                None,
-            ),
+            ErrorKind::Permanent => {
+                nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)
+            },
             ErrorKind::Transient
             | ErrorKind::Exhausted { .. }
             | ErrorKind::Backpressure

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -221,8 +221,7 @@ impl Error {
         .with_resource_key(key)
     }
 
-    /// Maps this error into the credential-shaped [`CoreError`] surface used by
-    /// [`ResourceAccessor`](nebula_core::accessor::ResourceAccessor).
+    /// Maps this error into the accessor [`nebula_core::CoreError`] surface.
     #[must_use]
     pub fn to_core_error(&self) -> nebula_core::CoreError {
         let key_label = self
@@ -236,7 +235,12 @@ impl Error {
             ErrorKind::Cancelled => {
                 nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)
             },
-            ErrorKind::Permanent => nebula_core::CoreError::CredentialNotConfigured(detail),
+            ErrorKind::Permanent => nebula_core::CoreError::resource_unavailable(
+                key_label,
+                detail,
+                false,
+                None,
+            ),
             ErrorKind::Transient
             | ErrorKind::Exhausted { .. }
             | ErrorKind::Backpressure

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -220,6 +220,34 @@ impl Error {
         ))
         .with_resource_key(key)
     }
+
+    /// Maps this error into the credential-shaped [`CoreError`] surface used by
+    /// [`ResourceAccessor`](nebula_core::accessor::ResourceAccessor).
+    #[must_use]
+    pub fn to_core_error(&self) -> nebula_core::CoreError {
+        let key_label = self
+            .resource_key()
+            .map(|k| k.as_str().to_owned())
+            .unwrap_or_else(|| "resource".to_owned());
+        let detail = self.to_string();
+        match self.kind() {
+            ErrorKind::NotFound => nebula_core::CoreError::CredentialNotFound { key: detail },
+            ErrorKind::Ambiguous => nebula_core::CoreError::scope_violation(key_label, detail),
+            ErrorKind::Cancelled => {
+                nebula_core::CoreError::resource_unavailable(key_label, detail, false, None)
+            },
+            ErrorKind::Permanent => nebula_core::CoreError::CredentialNotConfigured(detail),
+            ErrorKind::Transient
+            | ErrorKind::Exhausted { .. }
+            | ErrorKind::Backpressure
+            | ErrorKind::Revoked => nebula_core::CoreError::resource_unavailable(
+                key_label,
+                detail,
+                true,
+                self.retry_after(),
+            ),
+        }
+    }
 }
 
 impl fmt::Display for Error {
@@ -316,6 +344,32 @@ mod tests {
         let err = Error::exhausted("quota depleted", None);
         assert!(err.is_retryable());
         assert_eq!(err.retry_after(), None);
+    }
+
+    #[test]
+    fn to_core_error_maps_retryable_transient() {
+        use nebula_error::Classify as _;
+        let key = nebula_core::resource_key!("postgres");
+        let err = Error::transient("upstream timeout").with_resource_key(key);
+        let core = err.to_core_error();
+        assert!(matches!(
+            core,
+            nebula_core::CoreError::ResourceUnavailable {
+                retryable: true,
+                ..
+            }
+        ));
+        assert!(core.is_retryable());
+    }
+
+    #[test]
+    fn to_core_error_maps_not_found_to_credential_not_found() {
+        let key = nebula_core::resource_key!("postgres");
+        let err = Error::not_found(&key);
+        assert!(matches!(
+            err.to_core_error(),
+            nebula_core::CoreError::CredentialNotFound { .. }
+        ));
     }
 
     #[test]

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -59,7 +59,9 @@ pub mod topology;
 pub mod topology_tag;
 
 pub use cell::Cell;
-pub use context::ResourceContext;
+pub use context::{
+    ResourceContext, minimal_scope_for_level, scope_levels_for_acquire, scope_to_level,
+};
 pub use dedup::{DedupKey, SLOT_IDENTITY_UNBOUND, slot_identity};
 pub use error::{Error, ErrorKind, ErrorScope};
 pub use events::ResourceEvent;
@@ -67,8 +69,8 @@ pub use ext::HasResourcesExt;
 pub use guard::ResourceGuard;
 pub use integration::{AcquireResilience, AcquireRetryConfig};
 pub use manager::{
-    DrainTimeoutPolicy, Manager, ManagerConfig, RegisterOptions, ResourceHealthSnapshot,
-    RevokeTail, ShutdownConfig, ShutdownError, ShutdownReport, TaintedSlot,
+    DrainTimeoutPolicy, ErasedAcquireFn, Manager, ManagerConfig, RegisterOptions,
+    ResourceHealthSnapshot, RevokeTail, ShutdownConfig, ShutdownError, ShutdownReport, TaintedSlot,
 };
 pub use metrics::{OutcomeCountersSnapshot, ResourceOpsMetrics, ResourceOpsSnapshot};
 pub use nebula_core::{ExecutionId, ResourceKey, ScopeLevel, WorkflowId, resource_key};

--- a/crates/resource/src/manager/acquire_dispatch.rs
+++ b/crates/resource/src/manager/acquire_dispatch.rs
@@ -15,7 +15,7 @@ use crate::error::Error;
 #[cfg(test)]
 #[must_use]
 pub(crate) fn noop_erased_acquire() -> ErasedAcquireFn {
-    Arc::new(|_mgr, _ctx, _opts| {
+    Arc::new(|_mgr, _ctx, _opts, _scope| {
         Box::pin(async {
             Err(Error::permanent(
                 "acquire dispatch not configured for this registry test entry",
@@ -30,10 +30,10 @@ where
     R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
     R::Lease: Clone + Send + 'static,
 {
-    Arc::new(move |mgr, ctx, opts| {
+    Arc::new(move |mgr, ctx, opts, matched_scope| {
         Box::pin(async move {
             let guard = mgr
-                .acquire_resident_for::<R>(&ctx, &opts, slot_identity)
+                .acquire_resident_at_scope::<R>(&ctx, &opts, slot_identity, matched_scope)
                 .await?;
             Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
         })
@@ -46,10 +46,10 @@ where
     R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
     R::Lease: Into<R::Runtime> + Send + 'static,
 {
-    Arc::new(move |mgr, ctx, opts| {
+    Arc::new(move |mgr, ctx, opts, matched_scope| {
         Box::pin(async move {
             let guard = mgr
-                .acquire_pooled_for::<R>(&ctx, &opts, slot_identity)
+                .acquire_pooled_at_scope::<R>(&ctx, &opts, slot_identity, matched_scope)
                 .await?;
             Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
         })
@@ -62,10 +62,10 @@ where
     R::Runtime: Send + Sync + 'static,
     R::Lease: Send + 'static,
 {
-    Arc::new(move |mgr, ctx, opts| {
+    Arc::new(move |mgr, ctx, opts, matched_scope| {
         Box::pin(async move {
             let guard = mgr
-                .acquire_service_for::<R>(&ctx, &opts, slot_identity)
+                .acquire_service_at_scope::<R>(&ctx, &opts, slot_identity, matched_scope)
                 .await?;
             Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
         })
@@ -78,10 +78,10 @@ where
     R::Runtime: Send + Sync + 'static,
     R::Lease: Send + 'static,
 {
-    Arc::new(move |mgr, ctx, opts| {
+    Arc::new(move |mgr, ctx, opts, matched_scope| {
         Box::pin(async move {
             let guard = mgr
-                .acquire_transport_for::<R>(&ctx, &opts, slot_identity)
+                .acquire_transport_at_scope::<R>(&ctx, &opts, slot_identity, matched_scope)
                 .await?;
             Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
         })
@@ -94,10 +94,10 @@ where
     R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
     R::Lease: Send + 'static,
 {
-    Arc::new(move |mgr, ctx, opts| {
+    Arc::new(move |mgr, ctx, opts, matched_scope| {
         Box::pin(async move {
             let guard = mgr
-                .acquire_exclusive_for::<R>(&ctx, &opts, slot_identity)
+                .acquire_exclusive_at_scope::<R>(&ctx, &opts, slot_identity, matched_scope)
                 .await?;
             Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
         })

--- a/crates/resource/src/manager/acquire_dispatch.rs
+++ b/crates/resource/src/manager/acquire_dispatch.rs
@@ -1,0 +1,155 @@
+//! Type-erased acquire dispatch stored at registration time.
+//!
+//! [`Manager::register_with_identity`] captures a topology-specific
+//! `acquire_*_for` closure so callers that only know a [`ResourceKey`]
+//! (engine / action accessor) can still run the full lease pipeline.
+
+use std::{any::Any, sync::Arc};
+
+use crate::registry::ErasedAcquireFn;
+
+#[cfg(test)]
+use crate::error::Error;
+
+/// No-op acquire used by registry unit tests that only exercise lookup.
+#[cfg(test)]
+#[must_use]
+pub(crate) fn noop_erased_acquire() -> ErasedAcquireFn {
+    Arc::new(|_mgr, _ctx, _opts| {
+        Box::pin(async {
+            Err(Error::permanent(
+                "acquire dispatch not configured for this registry test entry",
+            ))
+        })
+    })
+}
+
+fn arc_acquire_resident<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::resident::Resident + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Clone + Send + 'static,
+{
+    Arc::new(move |mgr, ctx, opts| {
+        Box::pin(async move {
+            let guard = mgr
+                .acquire_resident_for::<R>(&ctx, &opts, slot_identity)
+                .await?;
+            Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
+        })
+    })
+}
+
+fn arc_acquire_pooled<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::pooled::Pooled + Clone + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Into<R::Runtime> + Send + 'static,
+{
+    Arc::new(move |mgr, ctx, opts| {
+        Box::pin(async move {
+            let guard = mgr
+                .acquire_pooled_for::<R>(&ctx, &opts, slot_identity)
+                .await?;
+            Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
+        })
+    })
+}
+
+fn arc_acquire_service<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::service::Service + Clone + Send + Sync + 'static,
+    R::Runtime: Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    Arc::new(move |mgr, ctx, opts| {
+        Box::pin(async move {
+            let guard = mgr
+                .acquire_service_for::<R>(&ctx, &opts, slot_identity)
+                .await?;
+            Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
+        })
+    })
+}
+
+fn arc_acquire_transport<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::transport::Transport + Clone + Send + Sync + 'static,
+    R::Runtime: Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    Arc::new(move |mgr, ctx, opts| {
+        Box::pin(async move {
+            let guard = mgr
+                .acquire_transport_for::<R>(&ctx, &opts, slot_identity)
+                .await?;
+            Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
+        })
+    })
+}
+
+fn arc_acquire_exclusive<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::exclusive::Exclusive + Clone + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    Arc::new(move |mgr, ctx, opts| {
+        Box::pin(async move {
+            let guard = mgr
+                .acquire_exclusive_for::<R>(&ctx, &opts, slot_identity)
+                .await?;
+            Ok(Box::new(guard) as Box<dyn Any + Send + Sync>)
+        })
+    })
+}
+
+/// Erased acquire hook for a resident topology row.
+pub(crate) fn erased_acquire_resident<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::resident::Resident + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Clone + Send + 'static,
+{
+    arc_acquire_resident::<R>(slot_identity)
+}
+
+/// Erased acquire hook for a pooled topology row.
+pub(crate) fn erased_acquire_pooled<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::pooled::Pooled + Clone + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Into<R::Runtime> + Send + 'static,
+{
+    arc_acquire_pooled::<R>(slot_identity)
+}
+
+/// Erased acquire hook for a service topology row.
+pub(crate) fn erased_acquire_service<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::service::Service + Clone + Send + Sync + 'static,
+    R::Runtime: Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    arc_acquire_service::<R>(slot_identity)
+}
+
+/// Erased acquire hook for a transport topology row.
+pub(crate) fn erased_acquire_transport<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::transport::Transport + Clone + Send + Sync + 'static,
+    R::Runtime: Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    arc_acquire_transport::<R>(slot_identity)
+}
+
+/// Erased acquire hook for an exclusive topology row.
+pub(crate) fn erased_acquire_exclusive<R>(slot_identity: u64) -> ErasedAcquireFn
+where
+    R: crate::topology::exclusive::Exclusive + Clone + Send + Sync + 'static,
+    R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+    R::Lease: Send + 'static,
+{
+    arc_acquire_exclusive::<R>(slot_identity)
+}

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -1183,27 +1183,8 @@ impl Manager {
         }
     }
 
-    /// [`lookup`](Self::lookup) plus the resource-level taint check.
-    ///
-    /// Every `acquire_*` path funnels through here so a single check
-    /// rejects new leases once `revoke_slot` has tainted the resource —
-    /// the same single-funnel discipline `lookup` uses for the
-    /// `shutting_down` race. Diagnostic paths (`health_check`,
-    /// `pool_stats`, `reload_config`) intentionally use the plain
-    /// `lookup` so they keep working on a tainted resource.
-    ///
-    /// `warmup_pool` is intentionally routed through here (taint-gated),
-    /// **not** the plain `lookup`: it runs `R::create` to materialize new
-    /// instances against the credential, so it is acquire-like and must
-    /// be blocked once the resource is tainted by a revoke.
-    ///
-    /// A tainted resource is rejected with
-    /// [`ErrorKind::Revoked`](crate::error::ErrorKind::Revoked) — a
-    /// non-terminal, retryable classification (the taint clears when the
-    /// credential is re-registered), distinct from the
-    /// [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) that
-    /// the `shutting_down` funnel raises.
-    /// Acquire-side lookup walking the scope bag from most specific to Global.
+    /// Typed acquire lookup walking [`scope_levels_for_acquire`](crate::context::scope_levels_for_acquire)
+    /// on the context scope bag, then [`taint_gate`](Self::taint_gate).
     fn lookup_for_acquire_scope<R: Resource>(
         &self,
         ctx: &ResourceContext,
@@ -1244,6 +1225,18 @@ impl Manager {
     }
 
     /// Shared taint check tail for the acquire-side lookups.
+    ///
+    /// Every `acquire_*` path funnels through here so a single check
+    /// rejects new leases once `revoke_slot` has tainted the resource.
+    /// Diagnostic paths (`health_check`, `pool_stats`, `reload_config`) use
+    /// the plain `lookup` so they keep working on a tainted resource.
+    ///
+    /// `warmup_pool` is routed through the acquire funnel (taint-gated) because
+    /// it materializes instances via `R::create`.
+    ///
+    /// Taint rejects with [`ErrorKind::Revoked`](crate::error::ErrorKind::Revoked),
+    /// distinct from [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled)
+    /// raised by [`Self::shutdown_guard`].
     fn taint_gate<R: Resource>(
         managed: Arc<ManagedResource<R>>,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
@@ -1787,20 +1780,7 @@ impl Manager {
         }
     }
 
-    /// [`lookup_any_for_slot`](Self::lookup_any_for_slot) pinned to a
-    /// resolved per-slot credential identity.
-    ///
-    /// Resolves through [`Registry::get_for`](crate::registry::Registry::get_for),
-    /// which selects the single row whose `(scope, slot_identity)` matches
-    /// and is therefore **unambiguous by construction** — a resolved
-    /// credential pins exactly one row, so the
-    /// [`LookupOutcome::Ambiguous`](crate::registry::LookupOutcome) arm
-    /// cannot occur here (no fail-closed path is bypassed: the engine
-    /// fan-out supplies the resolved identity it recorded at register time).
-    /// A `slot_identity` that was never registered is
-    /// [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound), never an
-    /// accidental alias to another tenant's row.
-    /// Acquires a [`ResourceGuard`] through the registry row's erased dispatch
+    /// Acquires a [`crate::guard::ResourceGuard`] through the registry row's erased dispatch
     /// hook (key + scope + resolved slot identity).
     ///
     /// This is the object-safe entry point used by the engine/action accessor
@@ -1896,6 +1876,8 @@ impl Manager {
         self.has_registered_for_scope(key, &scope_bag, slot_identity)
     }
 
+    /// [`lookup_any_for_slot`](Self::lookup_any_for_slot) pinned to a resolved
+    /// per-slot credential identity via [`Registry::get_for`](crate::registry::Registry::get_for).
     fn lookup_any_for_slot_identity(
         &self,
         key: &ResourceKey,

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -37,7 +37,7 @@ use std::{
     time::Instant,
 };
 
-use nebula_core::{LayerLifecycle, ResourceKey, ScopeLevel};
+use nebula_core::{Context, LayerLifecycle, ResourceKey, ScopeLevel};
 use tokio::sync::{Notify, broadcast};
 use tokio_util::sync::CancellationToken;
 
@@ -59,11 +59,13 @@ use crate::{
     runtime::{TopologyRuntime, managed::ManagedResource},
 };
 
+pub(crate) mod acquire_dispatch;
 mod execute;
 mod gate;
 pub(crate) mod options;
 pub(crate) mod shutdown;
 
+pub use crate::registry::ErasedAcquireFn;
 use execute::{execute_with_resilience, validate_pool_config};
 use gate::{admit_through_gate, settle_gate_admission};
 pub use options::{DrainTimeoutPolicy, ManagerConfig, RegisterOptions, ShutdownConfig};
@@ -287,6 +289,61 @@ impl Manager {
         self.event_tx.subscribe()
     }
 
+    /// Erased acquire hook for [`register`](Self::register) on a pooled resource.
+    #[must_use]
+    pub fn erased_acquire_pooled<R>(slot_identity: u64) -> ErasedAcquireFn
+    where
+        R: crate::topology::pooled::Pooled + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Into<R::Runtime> + Send + 'static,
+    {
+        acquire_dispatch::erased_acquire_pooled::<R>(slot_identity)
+    }
+
+    /// Erased acquire hook for [`register`](Self::register) on a resident resource.
+    #[must_use]
+    pub fn erased_acquire_resident<R>(slot_identity: u64) -> ErasedAcquireFn
+    where
+        R: crate::topology::resident::Resident + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Clone + Send + 'static,
+    {
+        acquire_dispatch::erased_acquire_resident::<R>(slot_identity)
+    }
+
+    /// Erased acquire hook for [`register`](Self::register) on a service resource.
+    #[must_use]
+    pub fn erased_acquire_service<R>(slot_identity: u64) -> ErasedAcquireFn
+    where
+        R: crate::topology::service::Service + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        acquire_dispatch::erased_acquire_service::<R>(slot_identity)
+    }
+
+    /// Erased acquire hook for [`register`](Self::register) on a transport resource.
+    #[must_use]
+    pub fn erased_acquire_transport<R>(slot_identity: u64) -> ErasedAcquireFn
+    where
+        R: crate::topology::transport::Transport + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        acquire_dispatch::erased_acquire_transport::<R>(slot_identity)
+    }
+
+    /// Erased acquire hook for [`register`](Self::register) on an exclusive resource.
+    #[must_use]
+    pub fn erased_acquire_exclusive<R>(slot_identity: u64) -> ErasedAcquireFn
+    where
+        R: crate::topology::exclusive::Exclusive + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        acquire_dispatch::erased_acquire_exclusive::<R>(slot_identity)
+    }
+
     /// Registers a resource with its config, scope, topology, and optional
     /// resilience / recovery gate configuration.
     ///
@@ -307,12 +364,17 @@ impl Manager {
     /// # Errors
     ///
     /// Returns an error if config validation fails on the provided config.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "mirrors register_with_identity minus slot_identity; arity grows when acquire hook is required at registration"
+    )]
     pub fn register<R: Resource>(
         &self,
         resource: R,
         config: R::Config,
         scope: ScopeLevel,
         topology: TopologyRuntime<R>,
+        acquire: ErasedAcquireFn,
         resilience: Option<AcquireResilience>,
         recovery_gate: Option<Arc<RecoveryGate>>,
     ) -> Result<(), Error> {
@@ -322,6 +384,7 @@ impl Manager {
             scope,
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             topology,
+            acquire,
             resilience,
             recovery_gate,
         )
@@ -358,6 +421,7 @@ impl Manager {
         scope: ScopeLevel,
         slot_identity: u64,
         topology: TopologyRuntime<R>,
+        acquire: ErasedAcquireFn,
         resilience: Option<AcquireResilience>,
         recovery_gate: Option<Arc<RecoveryGate>>,
     ) -> Result<(), Error> {
@@ -365,7 +429,35 @@ impl Manager {
         config.validate()?;
 
         let key = R::key();
+        self.register_row_with_acquire(
+            key,
+            resource,
+            config,
+            scope,
+            slot_identity,
+            topology,
+            acquire,
+            resilience,
+            recovery_gate,
+        )
+    }
 
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "internal row builder shared by register_with_identity; same arity as the public register path"
+    )]
+    fn register_row_with_acquire<R: Resource>(
+        &self,
+        key: ResourceKey,
+        resource: R,
+        config: R::Config,
+        scope: ScopeLevel,
+        slot_identity: u64,
+        topology: TopologyRuntime<R>,
+        acquire: ErasedAcquireFn,
+        resilience: Option<AcquireResilience>,
+        recovery_gate: Option<Arc<RecoveryGate>>,
+    ) -> Result<(), Error> {
         let managed = Arc::new(ManagedResource {
             resource,
             config: arc_swap::ArcSwap::from_pointee(config),
@@ -380,8 +472,14 @@ impl Manager {
         });
 
         let type_id = std::any::TypeId::of::<ManagedResource<R>>();
-        self.registry
-            .register(key.clone(), type_id, scope, slot_identity, managed.clone());
+        self.registry.register(
+            key.clone(),
+            type_id,
+            scope,
+            slot_identity,
+            managed.clone(),
+            acquire,
+        );
 
         // #387: everything below `register()` is a single funnel — the
         // resource is installed, so advance its phase from `Initializing`
@@ -417,13 +515,16 @@ impl Manager {
         pool_config: crate::topology::pooled::config::Config,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::pooled::Pooled + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Into<R::Runtime> + Send + 'static,
     {
         use crate::resource::ResourceConfig as _;
 
         validate_pool_config(&pool_config)?;
 
         let fingerprint = config.fingerprint();
+        let slot_identity = crate::dedup::SLOT_IDENTITY_UNBOUND;
         self.register(
             resource,
             config,
@@ -432,6 +533,7 @@ impl Manager {
                 pool_config,
                 fingerprint,
             )),
+            acquire_dispatch::erased_acquire_pooled::<R>(slot_identity),
             None,
             None,
         )
@@ -452,8 +554,11 @@ impl Manager {
         resident_config: crate::topology::resident::config::Config,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::resident::Resident + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Clone + Send + 'static,
     {
+        let slot_identity = crate::dedup::SLOT_IDENTITY_UNBOUND;
         self.register(
             resource,
             config,
@@ -461,6 +566,7 @@ impl Manager {
             TopologyRuntime::Resident(crate::runtime::resident::ResidentRuntime::<R>::new(
                 resident_config,
             )),
+            acquire_dispatch::erased_acquire_resident::<R>(slot_identity),
             None,
             None,
         )
@@ -482,8 +588,11 @@ impl Manager {
         service_config: crate::topology::service::config::Config,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::service::Service + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
+        let slot_identity = crate::dedup::SLOT_IDENTITY_UNBOUND;
         self.register(
             resource,
             config,
@@ -492,6 +601,7 @@ impl Manager {
                 runtime,
                 service_config,
             )),
+            acquire_dispatch::erased_acquire_service::<R>(slot_identity),
             None,
             None,
         )
@@ -513,8 +623,11 @@ impl Manager {
         exclusive_config: crate::topology::exclusive::config::Config,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::exclusive::Exclusive + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
+        let slot_identity = crate::dedup::SLOT_IDENTITY_UNBOUND;
         self.register(
             resource,
             config,
@@ -523,6 +636,7 @@ impl Manager {
                 runtime,
                 exclusive_config,
             )),
+            acquire_dispatch::erased_acquire_exclusive::<R>(slot_identity),
             None,
             None,
         )
@@ -544,8 +658,11 @@ impl Manager {
         transport_config: crate::topology::transport::config::Config,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::transport::Transport + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
+        let slot_identity = crate::dedup::SLOT_IDENTITY_UNBOUND;
         self.register(
             resource,
             config,
@@ -554,6 +671,7 @@ impl Manager {
                 runtime,
                 transport_config,
             )),
+            acquire_dispatch::erased_acquire_transport::<R>(slot_identity),
             None,
             None,
         )
@@ -575,7 +693,9 @@ impl Manager {
         options: RegisterOptions,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::pooled::Pooled + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Into<R::Runtime> + Send + 'static,
     {
         use crate::resource::ResourceConfig as _;
 
@@ -591,6 +711,7 @@ impl Manager {
                 pool_config,
                 fingerprint,
             )),
+            acquire_dispatch::erased_acquire_pooled::<R>(options.slot_identity),
             options.resilience,
             options.recovery_gate,
         )
@@ -612,7 +733,9 @@ impl Manager {
         options: RegisterOptions,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::resident::Resident + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Clone + Send + 'static,
     {
         self.register_with_identity(
             resource,
@@ -622,6 +745,7 @@ impl Manager {
             TopologyRuntime::Resident(crate::runtime::resident::ResidentRuntime::<R>::new(
                 resident_config,
             )),
+            acquire_dispatch::erased_acquire_resident::<R>(options.slot_identity),
             options.resilience,
             options.recovery_gate,
         )
@@ -644,7 +768,9 @@ impl Manager {
         options: RegisterOptions,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::service::Service + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
         self.register_with_identity(
             resource,
@@ -655,6 +781,7 @@ impl Manager {
                 runtime,
                 service_config,
             )),
+            acquire_dispatch::erased_acquire_service::<R>(options.slot_identity),
             options.resilience,
             options.recovery_gate,
         )
@@ -677,7 +804,9 @@ impl Manager {
         options: RegisterOptions,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::transport::Transport + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
         self.register_with_identity(
             resource,
@@ -688,6 +817,7 @@ impl Manager {
                 runtime,
                 transport_config,
             )),
+            acquire_dispatch::erased_acquire_transport::<R>(options.slot_identity),
             options.resilience,
             options.recovery_gate,
         )
@@ -710,7 +840,9 @@ impl Manager {
         options: RegisterOptions,
     ) -> Result<(), Error>
     where
-        R: Resource,
+        R: crate::topology::exclusive::Exclusive + Clone + Resource + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Send + 'static,
     {
         self.register_with_identity(
             resource,
@@ -721,6 +853,7 @@ impl Manager {
                 runtime,
                 exclusive_config,
             )),
+            acquire_dispatch::erased_acquire_exclusive::<R>(options.slot_identity),
             options.resilience,
             options.recovery_gate,
         )
@@ -888,6 +1021,7 @@ impl Manager {
         resource: R,
         scope: ScopeLevel,
         topology: TopologyRuntime<R>,
+        acquire_for_slot: &(dyn Fn(u64) -> ErasedAcquireFn + Send + Sync),
         resilience: Option<AcquireResilience>,
         recovery_gate: Option<Arc<RecoveryGate>>,
     ) -> Result<(), Error>
@@ -957,6 +1091,7 @@ impl Manager {
             scope,
             slot_id,
             topology,
+            acquire_for_slot(slot_id),
             resilience,
             recovery_gate,
         )
@@ -1068,21 +1203,38 @@ impl Manager {
     /// credential is re-registered), distinct from the
     /// [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) that
     /// the `shutting_down` funnel raises.
-    fn lookup_for_acquire<R: Resource>(
+    /// Acquire-side lookup walking the scope bag from most specific to Global.
+    fn lookup_for_acquire_scope<R: Resource>(
         &self,
-        scope: &ScopeLevel,
+        ctx: &ResourceContext,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
-        Self::taint_gate::<R>(self.lookup::<R>(scope)?)
+        self.shutdown_guard()?;
+        for level in crate::context::scope_levels_for_acquire(ctx.scope()) {
+            match self.lookup::<R>(&level) {
+                Ok(managed) => return Self::taint_gate::<R>(managed),
+                Err(e) if matches!(e.kind(), crate::error::ErrorKind::NotFound) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(Error::not_found(&R::key()))
     }
 
-    /// [`lookup_for_acquire`](Self::lookup_for_acquire) pinned to a resolved
-    /// per-slot credential identity (the unambiguous acquire path).
-    fn lookup_for_acquire_with<R: Resource>(
+    /// [`lookup_for_acquire_scope`](Self::lookup_for_acquire_scope) pinned to
+    /// a resolved per-slot credential identity.
+    fn lookup_for_acquire_with_scope<R: Resource>(
         &self,
-        scope: &ScopeLevel,
+        ctx: &ResourceContext,
         slot_identity: u64,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
-        Self::taint_gate::<R>(self.lookup_for::<R>(scope, slot_identity)?)
+        self.shutdown_guard()?;
+        for level in crate::context::scope_levels_for_acquire(ctx.scope()) {
+            match self.lookup_for::<R>(&level, slot_identity) {
+                Ok(managed) => return Self::taint_gate::<R>(managed),
+                Err(e) if matches!(e.kind(), crate::error::ErrorKind::NotFound) => continue,
+                Err(e) => return Err(e),
+            }
+        }
+        Err(Error::not_found(&R::key()))
     }
 
     /// Shared taint check tail for the acquire-side lookups.
@@ -1642,6 +1794,74 @@ impl Manager {
     /// A `slot_identity` that was never registered is
     /// [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound), never an
     /// accidental alias to another tenant's row.
+    /// Acquires a [`ResourceGuard`] through the registry row's erased dispatch
+    /// hook (key + scope + resolved slot identity).
+    ///
+    /// This is the object-safe entry point used by the engine/action accessor
+    /// when the concrete resource type `R` is not known at compile time.
+    ///
+    /// # Errors
+    ///
+    /// Same as the typed `acquire_*_for` family: not found, ambiguous (when
+    /// `slot_identity` does not match a row), shutdown, taint, topology, and
+    /// acquire-time failures.
+    pub async fn acquire_erased(
+        manager: Arc<Self>,
+        key: &ResourceKey,
+        ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+    ) -> Result<Box<dyn std::any::Any + Send + Sync>, Error> {
+        use crate::registry::AcquireLookupOutcome;
+
+        manager.shutdown_guard()?;
+        let acquire = match manager
+            .registry
+            .get_acquire_for(key, ctx.scope(), slot_identity)
+        {
+            AcquireLookupOutcome::Found(f) => f,
+            AcquireLookupOutcome::NotFound => return Err(Error::not_found(key)),
+            AcquireLookupOutcome::Ambiguous { rows } => {
+                return Err(Error::ambiguous(format!(
+                    "{key}: {rows} resolved-credential registrations exist at this scope; \
+                     acquire must target a resolved row via slot identity"
+                ))
+                .with_resource_key(key.clone()));
+            },
+        };
+        acquire(manager, ctx.clone_for_acquire(), options.clone()).await
+    }
+
+    /// Returns whether a registry row exists for `(key, scope bag, slot_identity)`.
+    #[must_use]
+    pub fn has_registered_for_scope(
+        &self,
+        key: &ResourceKey,
+        scope: &nebula_core::Scope,
+        slot_identity: u64,
+    ) -> bool {
+        use crate::registry::AcquireLookupOutcome;
+        matches!(
+            self.registry.get_acquire_for(key, scope, slot_identity),
+            AcquireLookupOutcome::Found(_)
+        )
+    }
+
+    /// Returns whether a registry row exists for `(key, scope level, slot_identity)`.
+    ///
+    /// Prefer [`has_registered_for_scope`](Self::has_registered_for_scope) when
+    /// the full scope bag is available (execution + org/workspace).
+    #[must_use]
+    pub fn has_registered_for(
+        &self,
+        key: &ResourceKey,
+        scope: &ScopeLevel,
+        slot_identity: u64,
+    ) -> bool {
+        let scope_bag = crate::context::minimal_scope_for_level(scope);
+        self.has_registered_for_scope(key, &scope_bag, slot_identity)
+    }
+
     fn lookup_any_for_slot_identity(
         &self,
         key: &ResourceKey,
@@ -1696,7 +1916,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Into<R::Runtime> + Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         self.run_pooled_acquire(managed, ctx, options).await
     }
 
@@ -1728,7 +1948,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Into<R::Runtime> + Send + 'static,
     {
-        let managed = self.lookup_for_acquire_with::<R>(&ctx.scope_level(), slot_identity)?;
+        let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
         self.run_pooled_acquire(managed, ctx, options).await
     }
 
@@ -1831,7 +2051,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Clone + Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         self.run_resident_acquire(managed, ctx, options).await
     }
 
@@ -1863,7 +2083,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Clone + Send + 'static,
     {
-        let managed = self.lookup_for_acquire_with::<R>(&ctx.scope_level(), slot_identity)?;
+        let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
         self.run_resident_acquire(managed, ctx, options).await
     }
 
@@ -1947,7 +2167,7 @@ impl Manager {
         R::Runtime: Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         self.run_service_acquire(managed, ctx, options).await
     }
 
@@ -1979,7 +2199,7 @@ impl Manager {
         R::Runtime: Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire_with::<R>(&ctx.scope_level(), slot_identity)?;
+        let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
         self.run_service_acquire(managed, ctx, options).await
     }
 
@@ -2071,7 +2291,7 @@ impl Manager {
         R::Runtime: Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         self.run_transport_acquire(managed, ctx, options).await
     }
 
@@ -2103,7 +2323,7 @@ impl Manager {
         R::Runtime: Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire_with::<R>(&ctx.scope_level(), slot_identity)?;
+        let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
         self.run_transport_acquire(managed, ctx, options).await
     }
 
@@ -2195,7 +2415,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         self.run_exclusive_acquire(managed, options).await
     }
 
@@ -2227,7 +2447,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Send + 'static,
     {
-        let managed = self.lookup_for_acquire_with::<R>(&ctx.scope_level(), slot_identity)?;
+        let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
         self.run_exclusive_acquire(managed, options).await
     }
 
@@ -2330,7 +2550,7 @@ impl Manager {
         R::Lease: Into<R::Runtime> + Send + 'static,
     {
         let started = Instant::now();
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         // Defense B against the `graceful_shutdown` race — see `acquire_pooled`.
         let in_flight =
             InFlightCounter::new(self.drain_tracker.clone(), managed.in_flight_tracker());
@@ -2417,7 +2637,7 @@ impl Manager {
         R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
         R::Lease: Into<R::Runtime> + Send + 'static,
     {
-        let managed = self.lookup_for_acquire::<R>(&ctx.scope_level())?;
+        let managed = self.lookup_for_acquire_scope::<R>(ctx)?;
         let config = managed.config();
         match &managed.topology {
             TopologyRuntime::Pool(rt) => {

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -1209,14 +1209,9 @@ impl Manager {
         ctx: &ResourceContext,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
         self.shutdown_guard()?;
-        for level in crate::context::scope_levels_for_acquire(ctx.scope()) {
-            match self.lookup::<R>(&level) {
-                Ok(managed) => return Self::taint_gate::<R>(managed),
-                Err(e) if matches!(e.kind(), crate::error::ErrorKind::NotFound) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-        Err(Error::not_found(&R::key()))
+        let managed =
+            Self::resolve_typed::<R>(self.registry.get_typed_for_acquire_scope::<R>(ctx.scope()))?;
+        Self::taint_gate::<R>(managed)
     }
 
     /// [`lookup_for_acquire_scope`](Self::lookup_for_acquire_scope) pinned to
@@ -1227,14 +1222,25 @@ impl Manager {
         slot_identity: u64,
     ) -> Result<Arc<ManagedResource<R>>, Error> {
         self.shutdown_guard()?;
-        for level in crate::context::scope_levels_for_acquire(ctx.scope()) {
-            match self.lookup_for::<R>(&level, slot_identity) {
-                Ok(managed) => return Self::taint_gate::<R>(managed),
-                Err(e) if matches!(e.kind(), crate::error::ErrorKind::NotFound) => continue,
-                Err(e) => return Err(e),
-            }
-        }
-        Err(Error::not_found(&R::key()))
+        let managed = Self::resolve_typed::<R>(
+            self.registry
+                .get_typed_for_acquire::<R>(ctx.scope(), slot_identity),
+        )?;
+        Self::taint_gate::<R>(managed)
+    }
+
+    /// Typed acquire lookup at a scope level already chosen by [`Registry::get_acquire_for`].
+    fn lookup_typed_at_acquire_scope<R: Resource>(
+        &self,
+        matched_scope: ScopeLevel,
+        slot_identity: u64,
+    ) -> Result<Arc<ManagedResource<R>>, Error> {
+        self.shutdown_guard()?;
+        let managed = Self::resolve_typed::<R>(
+            self.registry
+                .get_typed_at_acquire_scope::<R>(matched_scope, slot_identity),
+        )?;
+        Self::taint_gate::<R>(managed)
     }
 
     /// Shared taint check tail for the acquire-side lookups.
@@ -1815,21 +1821,46 @@ impl Manager {
         use crate::registry::AcquireLookupOutcome;
 
         manager.shutdown_guard()?;
-        let acquire = match manager
+        tracing::debug!(
+            target: "nebula.resource",
+            %key,
+            slot_identity,
+            "acquire_erased: resolving registry hook"
+        );
+        match manager
             .registry
             .get_acquire_for(key, ctx.scope(), slot_identity)
         {
-            AcquireLookupOutcome::Found(f) => f,
-            AcquireLookupOutcome::NotFound => return Err(Error::not_found(key)),
+            AcquireLookupOutcome::Found {
+                acquire,
+                matched_scope,
+            } => {
+                acquire(
+                    manager,
+                    ctx.clone_for_acquire(),
+                    options.clone(),
+                    matched_scope,
+                )
+                .await
+            },
+            AcquireLookupOutcome::NotFound => {
+                tracing::debug!(target: "nebula.resource", %key, "acquire_erased: not found");
+                Err(Error::not_found(key))
+            },
             AcquireLookupOutcome::Ambiguous { rows } => {
-                return Err(Error::ambiguous(format!(
+                tracing::warn!(
+                    target: "nebula.resource",
+                    %key,
+                    rows,
+                    "acquire_erased: ambiguous scope/slot identity"
+                );
+                Err(Error::ambiguous(format!(
                     "{key}: {rows} resolved-credential registrations exist at this scope; \
                      acquire must target a resolved row via slot identity"
                 ))
-                .with_resource_key(key.clone()));
+                .with_resource_key(key.clone()))
             },
-        };
-        acquire(manager, ctx.clone_for_acquire(), options.clone()).await
+        }
     }
 
     /// Returns whether a registry row exists for `(key, scope bag, slot_identity)`.
@@ -1841,9 +1872,12 @@ impl Manager {
         slot_identity: u64,
     ) -> bool {
         use crate::registry::AcquireLookupOutcome;
+        if self.shutdown_guard().is_err() {
+            return false;
+        }
         matches!(
             self.registry.get_acquire_for(key, scope, slot_identity),
-            AcquireLookupOutcome::Found(_)
+            AcquireLookupOutcome::Found { .. }
         )
     }
 
@@ -1949,6 +1983,23 @@ impl Manager {
         R::Lease: Into<R::Runtime> + Send + 'static,
     {
         let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
+        self.run_pooled_acquire(managed, ctx, options).await
+    }
+
+    /// [`acquire_pooled_for`](Self::acquire_pooled_for) with a pre-resolved scope level.
+    pub(crate) async fn acquire_pooled_at_scope<R>(
+        &self,
+        ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+        matched_scope: ScopeLevel,
+    ) -> Result<crate::guard::ResourceGuard<R>, Error>
+    where
+        R: crate::topology::pooled::Pooled + Clone + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Into<R::Runtime> + Send + 'static,
+    {
+        let managed = self.lookup_typed_at_acquire_scope::<R>(matched_scope, slot_identity)?;
         self.run_pooled_acquire(managed, ctx, options).await
     }
 
@@ -2087,6 +2138,23 @@ impl Manager {
         self.run_resident_acquire(managed, ctx, options).await
     }
 
+    /// [`acquire_resident_for`](Self::acquire_resident_for) with a pre-resolved scope level.
+    pub(crate) async fn acquire_resident_at_scope<R>(
+        &self,
+        ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+        matched_scope: ScopeLevel,
+    ) -> Result<crate::guard::ResourceGuard<R>, Error>
+    where
+        R: crate::topology::resident::Resident + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Clone + Send + 'static,
+    {
+        let managed = self.lookup_typed_at_acquire_scope::<R>(matched_scope, slot_identity)?;
+        self.run_resident_acquire(managed, ctx, options).await
+    }
+
     /// Shared resident acquire pipeline (resilience + gate + drain
     /// bookkeeping) over an already-resolved [`ManagedResource`]. The two
     /// public resident-acquire entry points differ only in how they resolve
@@ -2200,6 +2268,23 @@ impl Manager {
         R::Lease: Send + 'static,
     {
         let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
+        self.run_service_acquire(managed, ctx, options).await
+    }
+
+    /// [`acquire_service_for`](Self::acquire_service_for) with a pre-resolved scope level.
+    pub(crate) async fn acquire_service_at_scope<R>(
+        &self,
+        ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+        matched_scope: ScopeLevel,
+    ) -> Result<crate::guard::ResourceGuard<R>, Error>
+    where
+        R: crate::topology::service::Service + Clone + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        let managed = self.lookup_typed_at_acquire_scope::<R>(matched_scope, slot_identity)?;
         self.run_service_acquire(managed, ctx, options).await
     }
 
@@ -2327,6 +2412,23 @@ impl Manager {
         self.run_transport_acquire(managed, ctx, options).await
     }
 
+    /// [`acquire_transport_for`](Self::acquire_transport_for) with a pre-resolved scope level.
+    pub(crate) async fn acquire_transport_at_scope<R>(
+        &self,
+        ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+        matched_scope: ScopeLevel,
+    ) -> Result<crate::guard::ResourceGuard<R>, Error>
+    where
+        R: crate::topology::transport::Transport + Clone + Send + Sync + 'static,
+        R::Runtime: Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        let managed = self.lookup_typed_at_acquire_scope::<R>(matched_scope, slot_identity)?;
+        self.run_transport_acquire(managed, ctx, options).await
+    }
+
     /// Shared transport acquire pipeline (resilience + gate + drain
     /// bookkeeping) over an already-resolved [`ManagedResource`]. The two
     /// public transport-acquire entry points differ only in how they resolve
@@ -2448,6 +2550,23 @@ impl Manager {
         R::Lease: Send + 'static,
     {
         let managed = self.lookup_for_acquire_with_scope::<R>(ctx, slot_identity)?;
+        self.run_exclusive_acquire(managed, options).await
+    }
+
+    /// [`acquire_exclusive_for`](Self::acquire_exclusive_for) with a pre-resolved scope level.
+    pub(crate) async fn acquire_exclusive_at_scope<R>(
+        &self,
+        _ctx: &ResourceContext,
+        options: &AcquireOptions,
+        slot_identity: u64,
+        matched_scope: ScopeLevel,
+    ) -> Result<crate::guard::ResourceGuard<R>, Error>
+    where
+        R: crate::topology::exclusive::Exclusive + Clone + Send + Sync + 'static,
+        R::Runtime: Clone + Into<R::Lease> + Send + Sync + 'static,
+        R::Lease: Send + 'static,
+    {
+        let managed = self.lookup_typed_at_acquire_scope::<R>(matched_scope, slot_identity)?;
         self.run_exclusive_acquire(managed, options).await
     }
 

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -11,11 +11,28 @@ use std::{
 };
 
 use dashmap::DashMap;
-use nebula_core::{ResourceKey, ScopeLevel};
+use nebula_core::{ResourceKey, Scope, ScopeLevel};
 
 use crate::{
-    error::Error, resource::Resource, runtime::managed::ManagedResource, topology_tag::TopologyTag,
+    context::{ResourceContext, scope_levels_for_acquire},
+    error::Error,
+    options::AcquireOptions,
+    resource::Resource,
+    runtime::managed::ManagedResource,
+    topology_tag::TopologyTag,
 };
+
+/// Erased acquire hook installed on each registry row at registration.
+pub type ErasedAcquireFn = Arc<
+    dyn Fn(
+            Arc<crate::Manager>,
+            ResourceContext,
+            AcquireOptions,
+        )
+            -> Pin<Box<dyn Future<Output = Result<Box<dyn Any + Send + Sync>, Error>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// Crate-private seal: only `nebula-resource` can name `sealed::Sealed`,
 /// so [`AnyManagedResource`] is **not implementable downstream**.
@@ -217,6 +234,19 @@ pub enum LookupOutcome {
     },
 }
 
+/// Outcome of a registry acquire-hook lookup (same semantics as [`LookupOutcome`]).
+pub(crate) enum AcquireLookupOutcome {
+    /// Exactly one row matched — here is its erased acquire hook.
+    Found(ErasedAcquireFn),
+    /// No row matched the key/scope/identity.
+    NotFound,
+    /// More than one row at the resolved scope without a slot identity pin.
+    Ambiguous {
+        /// How many distinct credential rows competed.
+        rows: usize,
+    },
+}
+
 /// A single entry in the registry, associating a `(scope, slot_identity)`
 /// row with a managed resource.
 ///
@@ -229,6 +259,18 @@ struct RegistryEntry {
     scope: ScopeLevel,
     slot_identity: u64,
     managed: Arc<dyn AnyManagedResource>,
+    acquire: ErasedAcquireFn,
+}
+
+enum ScopeFind {
+    Hit {
+        managed: Arc<dyn AnyManagedResource>,
+        acquire: ErasedAcquireFn,
+    },
+    NotFound,
+    Ambiguous {
+        rows: usize,
+    },
 }
 
 /// Type-erased storage for all registered resources.
@@ -271,6 +313,7 @@ impl Registry {
         scope: ScopeLevel,
         slot_identity: u64,
         managed: Arc<dyn AnyManagedResource>,
+        acquire: ErasedAcquireFn,
     ) {
         // Lock order is **strictly one-way**: `entries → (release) → type_index`.
         //
@@ -308,6 +351,7 @@ impl Registry {
                     scope,
                     slot_identity,
                     managed,
+                    acquire,
                 };
 
                 if prev_type_id != type_id
@@ -324,6 +368,7 @@ impl Registry {
                     scope,
                     slot_identity,
                     managed,
+                    acquire,
                 });
                 None
             }
@@ -350,7 +395,36 @@ impl Registry {
         let Some(entries) = self.entries.get(key) else {
             return LookupOutcome::NotFound;
         };
-        Self::find_by_scope(&entries, scope, None)
+        match Self::find_in_entries(&entries, scope, None) {
+            ScopeFind::Hit { managed, .. } => LookupOutcome::Found(managed),
+            ScopeFind::NotFound => LookupOutcome::NotFound,
+            ScopeFind::Ambiguous { rows } => LookupOutcome::Ambiguous { rows },
+        }
+    }
+
+    /// Looks up the erased acquire hook for `(key, scope bag, slot_identity)`.
+    ///
+    /// Walks [`scope_levels_for_acquire`] from most specific to Global so
+    /// org/workspace rows remain visible under execution-scoped contexts.
+    pub(crate) fn get_acquire_for(
+        &self,
+        key: &ResourceKey,
+        scope: &Scope,
+        slot_identity: u64,
+    ) -> AcquireLookupOutcome {
+        let Some(entries) = self.entries.get(key) else {
+            return AcquireLookupOutcome::NotFound;
+        };
+        for level in scope_levels_for_acquire(scope) {
+            match Self::find_at_exact_scope(&entries, &level, Some(slot_identity)) {
+                ScopeFind::Hit { acquire, .. } => return AcquireLookupOutcome::Found(acquire),
+                ScopeFind::Ambiguous { rows } => {
+                    return AcquireLookupOutcome::Ambiguous { rows };
+                },
+                ScopeFind::NotFound => continue,
+            }
+        }
+        AcquireLookupOutcome::NotFound
     }
 
     /// Looks up a managed resource by key, scope, and a resolved slot
@@ -369,7 +443,11 @@ impl Registry {
         let Some(entries) = self.entries.get(key) else {
             return LookupOutcome::NotFound;
         };
-        Self::find_by_scope(&entries, scope, Some(slot_identity))
+        match Self::find_in_entries(&entries, scope, Some(slot_identity)) {
+            ScopeFind::Hit { managed, .. } => LookupOutcome::Found(managed),
+            ScopeFind::NotFound => LookupOutcome::NotFound,
+            ScopeFind::Ambiguous { rows } => LookupOutcome::Ambiguous { rows },
+        }
     }
 
     /// Typed lookup: finds the resource for type `R` and downcasts to
@@ -443,6 +521,38 @@ impl Registry {
         self.type_index.clear();
     }
 
+    /// Lookup at an exact [`ScopeLevel`] only (no ancestor or Global fallback).
+    fn find_at_exact_scope(
+        entries: &[RegistryEntry],
+        scope: &ScopeLevel,
+        want_identity: Option<u64>,
+    ) -> ScopeFind {
+        let mut at_scope = entries.iter().filter(|e| e.scope == *scope);
+
+        if let Some(id) = want_identity {
+            return match at_scope.find(|e| e.slot_identity == id) {
+                Some(entry) => ScopeFind::Hit {
+                    managed: Arc::clone(&entry.managed),
+                    acquire: Arc::clone(&entry.acquire),
+                },
+                None => ScopeFind::NotFound,
+            };
+        }
+
+        let Some(first) = at_scope.next() else {
+            return ScopeFind::NotFound;
+        };
+        let extra = at_scope.count();
+        if extra == 0 {
+            ScopeFind::Hit {
+                managed: Arc::clone(&first.managed),
+                acquire: Arc::clone(&first.acquire),
+            }
+        } else {
+            ScopeFind::Ambiguous { rows: 1 + extra }
+        }
+    }
+
     /// Scope-aware, slot-identity-aware lookup within a list of entries.
     ///
     /// Resolves the effective scope first (exact match, else
@@ -461,11 +571,11 @@ impl Registry {
     /// to silently alias one tenant's runtime to another. (`rows` is the
     /// count of entries at that scope, not of distinct `slot_identity`
     /// values.)
-    fn find_by_scope(
+    fn find_in_entries(
         entries: &[RegistryEntry],
         scope: &ScopeLevel,
         want_identity: Option<u64>,
-    ) -> LookupOutcome {
+    ) -> ScopeFind {
         // Resolve the effective scope: exact match wins; otherwise fall
         // back to Global. Scope precedence is decided BEFORE slot identity.
         let effective_scope = if entries.iter().any(|e| e.scope == *scope) {
@@ -475,30 +585,10 @@ impl Registry {
         {
             ScopeLevel::Global
         } else {
-            return LookupOutcome::NotFound;
+            return ScopeFind::NotFound;
         };
 
-        let mut at_scope = entries.iter().filter(|e| e.scope == effective_scope);
-
-        if let Some(id) = want_identity {
-            return match at_scope.find(|e| e.slot_identity == id) {
-                Some(entry) => LookupOutcome::Found(Arc::clone(&entry.managed)),
-                None => LookupOutcome::NotFound,
-            };
-        }
-
-        // Identity-agnostic: exactly one row → Found; two or more distinct
-        // credential rows → fail closed (`Ambiguous`) rather than picking
-        // one and bleeding one tenant's runtime to another.
-        let Some(first) = at_scope.next() else {
-            return LookupOutcome::NotFound;
-        };
-        let extra = at_scope.count();
-        if extra == 0 {
-            LookupOutcome::Found(Arc::clone(&first.managed))
-        } else {
-            LookupOutcome::Ambiguous { rows: 1 + extra }
-        }
+        Self::find_at_exact_scope(entries, &effective_scope, want_identity)
     }
 }
 
@@ -525,6 +615,10 @@ mod tests {
     use nebula_core::WorkspaceId;
 
     use super::*;
+
+    fn test_acquire() -> ErasedAcquireFn {
+        crate::manager::acquire_dispatch::noop_erased_acquire()
+    }
 
     struct FakeA;
     struct FakeB;
@@ -632,6 +726,7 @@ mod tests {
             ScopeLevel::Global,
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeA),
+            test_acquire(),
         );
         reg.register(
             key.clone(),
@@ -639,6 +734,7 @@ mod tests {
             ScopeLevel::Workspace(WorkspaceId::new()),
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeA),
+            test_acquire(),
         );
 
         // Replace only the Global entry with FakeB. Workflow still
@@ -649,6 +745,7 @@ mod tests {
             ScopeLevel::Global,
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeB),
+            test_acquire(),
         );
 
         assert!(
@@ -670,6 +767,7 @@ mod tests {
             scope.clone(),
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeA),
+            test_acquire(),
         );
         assert!(reg.type_index.contains_key(&TypeId::of::<FakeA>()));
 
@@ -681,6 +779,7 @@ mod tests {
             scope,
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeB),
+            test_acquire(),
         );
 
         // The stale TypeId row for FakeA must be gone (#382).
@@ -706,6 +805,7 @@ mod tests {
             scope.clone(),
             0xAAAA,
             Arc::new(FakeA),
+            test_acquire(),
         );
         reg.register(
             key.clone(),
@@ -713,6 +813,7 @@ mod tests {
             scope.clone(),
             0xBBBB,
             Arc::new(FakeA),
+            test_acquire(),
         );
 
         // Each resolved identity pins its own row.
@@ -747,6 +848,7 @@ mod tests {
             scope.clone(),
             0xAAAA,
             Arc::new(FakeA),
+            test_acquire(),
         );
         reg.register(
             key.clone(),
@@ -754,6 +856,7 @@ mod tests {
             scope.clone(),
             0xBBBB,
             Arc::new(FakeA),
+            test_acquire(),
         );
 
         match reg.get(&key, &scope) {
@@ -776,6 +879,7 @@ mod tests {
             scope.clone(),
             crate::dedup::SLOT_IDENTITY_UNBOUND,
             Arc::new(FakeA),
+            test_acquire(),
         );
 
         assert!(matches!(reg.get(&key, &scope), LookupOutcome::Found(_)));

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -28,6 +28,7 @@ pub type ErasedAcquireFn = Arc<
             Arc<crate::Manager>,
             ResourceContext,
             AcquireOptions,
+            ScopeLevel,
         )
             -> Pin<Box<dyn Future<Output = Result<Box<dyn Any + Send + Sync>, Error>> + Send>>
         + Send
@@ -236,8 +237,13 @@ pub enum LookupOutcome {
 
 /// Outcome of a registry acquire-hook lookup (same semantics as [`LookupOutcome`]).
 pub(crate) enum AcquireLookupOutcome {
-    /// Exactly one row matched — here is its erased acquire hook.
-    Found(ErasedAcquireFn),
+    /// Exactly one row matched — hook plus the scope level that won the walk.
+    Found {
+        /// Erased topology dispatch for this row.
+        acquire: ErasedAcquireFn,
+        /// Scope level selected by the acquire scope walk (avoids a second walk).
+        matched_scope: ScopeLevel,
+    },
     /// No row matched the key/scope/identity.
     NotFound,
     /// More than one row at the resolved scope without a slot identity pin.
@@ -417,14 +423,109 @@ impl Registry {
         };
         for level in scope_levels_for_acquire(scope) {
             match Self::find_at_exact_scope(&entries, &level, Some(slot_identity)) {
-                ScopeFind::Hit { acquire, .. } => return AcquireLookupOutcome::Found(acquire),
+                ScopeFind::Hit { acquire, .. } => {
+                    return AcquireLookupOutcome::Found {
+                        acquire,
+                        matched_scope: level,
+                    };
+                },
                 ScopeFind::Ambiguous { rows } => {
                     return AcquireLookupOutcome::Ambiguous { rows };
                 },
-                ScopeFind::NotFound => continue,
+                ScopeFind::NotFound => {
+                    if slot_identity == crate::dedup::SLOT_IDENTITY_UNBOUND
+                        && Self::scope_has_cred_bound_rows_without_unbound(&entries, &level)
+                    {
+                        return AcquireLookupOutcome::NotFound;
+                    }
+                    continue;
+                },
             }
         }
         AcquireLookupOutcome::NotFound
+    }
+
+    /// Typed managed-resource lookup for acquire paths.
+    ///
+    /// Walks [`scope_levels_for_acquire`] with [`find_at_exact_scope`] at each
+    /// level (no within-level Global fallback). Matches
+    /// [`get_acquire_for`](Self::get_acquire_for) so the erased hook and typed
+    /// row cannot diverge when Global and ancestor-scoped rows coexist.
+    pub(crate) fn get_typed_for_acquire<R: Resource>(
+        &self,
+        scope: &Scope,
+        slot_identity: u64,
+    ) -> LookupOutcome {
+        self.get_typed_walking_acquire_scope::<R>(scope, Some(slot_identity))
+    }
+
+    /// Typed lookup at an exact scope level (no ancestor walk).
+    ///
+    /// Used by the erased acquire path after [`get_acquire_for`](Self::get_acquire_for)
+    /// has already selected the winning scope level.
+    pub(crate) fn get_typed_at_acquire_scope<R: Resource>(
+        &self,
+        level: ScopeLevel,
+        slot_identity: u64,
+    ) -> LookupOutcome {
+        let type_id = TypeId::of::<ManagedResource<R>>();
+        let Some(key) = self.type_index.get(&type_id) else {
+            return LookupOutcome::NotFound;
+        };
+        let Some(entries) = self.entries.get(&*key) else {
+            return LookupOutcome::NotFound;
+        };
+        match Self::find_at_exact_scope(&entries, &level, Some(slot_identity)) {
+            ScopeFind::Hit { managed, .. } => LookupOutcome::Found(managed),
+            ScopeFind::Ambiguous { rows } => LookupOutcome::Ambiguous { rows },
+            ScopeFind::NotFound => LookupOutcome::NotFound,
+        }
+    }
+
+    /// [`get_typed_for_acquire`](Self::get_typed_for_acquire) without a
+    /// resolved slot identity (fail-closed on ambiguity at each level).
+    pub(crate) fn get_typed_for_acquire_scope<R: Resource>(&self, scope: &Scope) -> LookupOutcome {
+        self.get_typed_walking_acquire_scope::<R>(scope, None)
+    }
+
+    fn get_typed_walking_acquire_scope<R: Resource>(
+        &self,
+        scope: &Scope,
+        slot_identity: Option<u64>,
+    ) -> LookupOutcome {
+        let type_id = TypeId::of::<ManagedResource<R>>();
+        let Some(key) = self.type_index.get(&type_id) else {
+            return LookupOutcome::NotFound;
+        };
+        let Some(entries) = self.entries.get(&*key) else {
+            return LookupOutcome::NotFound;
+        };
+        for level in scope_levels_for_acquire(scope) {
+            match Self::find_at_exact_scope(&entries, &level, slot_identity) {
+                ScopeFind::Hit { managed, .. } => return LookupOutcome::Found(managed),
+                ScopeFind::Ambiguous { rows } => return LookupOutcome::Ambiguous { rows },
+                ScopeFind::NotFound => {
+                    if slot_identity == Some(crate::dedup::SLOT_IDENTITY_UNBOUND)
+                        && Self::scope_has_cred_bound_rows_without_unbound(&entries, &level)
+                    {
+                        return LookupOutcome::NotFound;
+                    }
+                    continue;
+                },
+            }
+        }
+        LookupOutcome::NotFound
+    }
+
+    /// At `level`, cred-bound rows exist but the caller asked for
+    /// [`SLOT_IDENTITY_UNBOUND`](crate::dedup::SLOT_IDENTITY_UNBOUND).
+    fn scope_has_cred_bound_rows_without_unbound(
+        entries: &[RegistryEntry],
+        level: &ScopeLevel,
+    ) -> bool {
+        entries
+            .iter()
+            .any(|e| e.scope == *level && e.slot_identity != crate::dedup::SLOT_IDENTITY_UNBOUND)
     }
 
     /// Looks up a managed resource by key, scope, and a resolved slot

--- a/crates/resource/tests/acquire_erased_dispatch.rs
+++ b/crates/resource/tests/acquire_erased_dispatch.rs
@@ -166,7 +166,7 @@ async fn acquire_erased_finds_org_scoped_row_from_execution_scope_bag() {
 
     let ctx = ResourceContext::minimal(scope, CancellationToken::new());
 
-    Manager::acquire_erased(
+    let boxed = Manager::acquire_erased(
         Arc::clone(&manager),
         &ProbeResource::key(),
         &ctx,
@@ -175,4 +175,94 @@ async fn acquire_erased_finds_org_scoped_row_from_execution_scope_bag() {
     )
     .await
     .expect("execution-scoped acquire must reach org-scoped row");
+
+    let lease = *boxed
+        .downcast::<nebula_resource::ResourceGuard<ProbeResource>>()
+        .expect("downcast to ResourceGuard from org-scoped row");
+    assert_eq!(lease.load(Ordering::Relaxed), 1);
+}
+
+/// Global + Organization rows at the same `slot_identity` must not let typed
+/// acquire bind Global while walking an execution+org scope bag.
+#[tokio::test]
+async fn acquire_erased_and_typed_pick_org_not_global_fallback() {
+    let manager = Arc::new(Manager::new());
+    let org = OrgId::new();
+    let global_resource = ProbeResource::new();
+    let global_count = Arc::clone(&global_resource.create_count);
+    let org_resource = ProbeResource::new();
+    let org_count = Arc::clone(&org_resource.create_count);
+
+    manager
+        .register(
+            global_resource,
+            ProbeConfig,
+            ScopeLevel::Global,
+            TopologyRuntime::Resident(ResidentRuntime::<ProbeResource>::new(
+                resident::config::Config::default(),
+            )),
+            Manager::erased_acquire_resident::<ProbeResource>(SLOT_IDENTITY_UNBOUND),
+            None,
+            None,
+        )
+        .expect("register global row");
+
+    manager
+        .register(
+            org_resource,
+            ProbeConfig,
+            ScopeLevel::Organization(org),
+            TopologyRuntime::Resident(ResidentRuntime::<ProbeResource>::new(
+                resident::config::Config::default(),
+            )),
+            Manager::erased_acquire_resident::<ProbeResource>(SLOT_IDENTITY_UNBOUND),
+            None,
+            None,
+        )
+        .expect("register org row");
+
+    let scope = Scope {
+        execution_id: Some(ExecutionId::new()),
+        org_id: Some(org),
+        ..Default::default()
+    };
+    let ctx = ResourceContext::minimal(scope, CancellationToken::new());
+    let key = ProbeResource::key();
+
+    let boxed = Manager::acquire_erased(
+        Arc::clone(&manager),
+        &key,
+        &ctx,
+        &AcquireOptions::default(),
+        SLOT_IDENTITY_UNBOUND,
+    )
+    .await
+    .expect("acquire_erased");
+
+    let lease = *boxed
+        .downcast::<nebula_resource::ResourceGuard<ProbeResource>>()
+        .expect("downcast");
+    assert_eq!(lease.load(Ordering::Relaxed), 1);
+    assert_eq!(org_count.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        global_count.load(Ordering::Relaxed),
+        0,
+        "must not create via Global row when org row matches scope bag"
+    );
+
+    let guard = manager
+        .acquire_resident_for::<ProbeResource>(
+            &ctx,
+            &AcquireOptions::default(),
+            SLOT_IDENTITY_UNBOUND,
+        )
+        .await
+        .expect("typed acquire_resident_for");
+    assert_eq!(guard.load(Ordering::Relaxed), 1);
+    assert_eq!(
+        org_count.load(Ordering::Relaxed),
+        1,
+        "typed acquire must reuse the org row without a second create"
+    );
+    assert_eq!(global_count.load(Ordering::Relaxed), 0);
 }

--- a/crates/resource/tests/acquire_erased_dispatch.rs
+++ b/crates/resource/tests/acquire_erased_dispatch.rs
@@ -1,0 +1,178 @@
+//! `Manager::acquire_erased` exercises the registry-stored `ErasedAcquireFn` hook.
+
+use std::{
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+};
+
+use nebula_core::{ExecutionId, OrgId, ResourceKey, scope::Scope};
+use nebula_resource::{
+    AcquireOptions, Manager, ResourceContext, ScopeLevel,
+    dedup::SLOT_IDENTITY_UNBOUND,
+    error::Error,
+    resource::{Resource, ResourceConfig, ResourceMetadata},
+    runtime::{TopologyRuntime, resident::ResidentRuntime},
+    topology::resident::{self, Resident},
+};
+use tokio_util::sync::CancellationToken;
+
+#[derive(Debug, Clone)]
+struct ProbeError(String);
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl std::error::Error for ProbeError {}
+
+impl From<ProbeError> for Error {
+    fn from(e: ProbeError) -> Self {
+        Error::permanent(e.0)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct ProbeConfig;
+
+nebula_schema::impl_empty_has_schema!(ProbeConfig);
+
+impl ResourceConfig for ProbeConfig {}
+
+#[derive(Clone)]
+struct ProbeResource {
+    create_count: Arc<AtomicU64>,
+}
+
+impl ProbeResource {
+    fn new() -> Self {
+        Self {
+            create_count: Arc::new(AtomicU64::new(0)),
+        }
+    }
+}
+
+impl Resource for ProbeResource {
+    type Config = ProbeConfig;
+    type Runtime = Arc<AtomicU64>;
+    type Lease = Arc<AtomicU64>;
+    type Error = ProbeError;
+
+    fn key() -> ResourceKey {
+        nebula_core::resource_key!("test.acquire_erased.probe")
+    }
+
+    fn create(
+        &self,
+        _config: &ProbeConfig,
+        _ctx: &ResourceContext,
+    ) -> impl Future<Output = Result<Arc<AtomicU64>, ProbeError>> + Send {
+        let counter = self.create_count.clone();
+        async move {
+            counter.fetch_add(1, Ordering::Relaxed);
+            Ok(counter)
+        }
+    }
+
+    fn metadata() -> ResourceMetadata {
+        ResourceMetadata::from_key(&Self::key())
+    }
+}
+
+impl Resident for ProbeResource {
+    fn is_alive_sync(&self, _runtime: &Arc<AtomicU64>) -> bool {
+        true
+    }
+}
+
+#[tokio::test]
+async fn acquire_erased_returns_guard_and_runs_create_once() {
+    let manager = Arc::new(Manager::new());
+    let resource = ProbeResource::new();
+    let create_count = Arc::clone(&resource.create_count);
+
+    manager
+        .register(
+            resource,
+            ProbeConfig,
+            ScopeLevel::Global,
+            TopologyRuntime::Resident(ResidentRuntime::<ProbeResource>::new(
+                resident::config::Config::default(),
+            )),
+            Manager::erased_acquire_resident::<ProbeResource>(SLOT_IDENTITY_UNBOUND),
+            None,
+            None,
+        )
+        .expect("register");
+
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let key = ProbeResource::key();
+    let boxed = Manager::acquire_erased(
+        Arc::clone(&manager),
+        &key,
+        &ctx,
+        &AcquireOptions::default(),
+        SLOT_IDENTITY_UNBOUND,
+    )
+    .await
+    .expect("acquire_erased");
+
+    let lease = *boxed
+        .downcast::<nebula_resource::ResourceGuard<ProbeResource>>()
+        .expect("downcast to ResourceGuard");
+    assert_eq!(lease.load(Ordering::Relaxed), 1);
+    assert_eq!(create_count.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn acquire_erased_finds_org_scoped_row_from_execution_scope_bag() {
+    let manager = Arc::new(Manager::new());
+    let org = OrgId::new();
+    let resource = ProbeResource::new();
+
+    manager
+        .register(
+            resource,
+            ProbeConfig,
+            ScopeLevel::Organization(org),
+            TopologyRuntime::Resident(ResidentRuntime::<ProbeResource>::new(
+                resident::config::Config::default(),
+            )),
+            Manager::erased_acquire_resident::<ProbeResource>(SLOT_IDENTITY_UNBOUND),
+            None,
+            None,
+        )
+        .expect("register at org scope");
+
+    let key = ProbeResource::key();
+    assert!(
+        manager.has_registered_for(&key, &ScopeLevel::Organization(org), SLOT_IDENTITY_UNBOUND),
+        "row must exist at org scope before acquire"
+    );
+
+    let scope = Scope {
+        execution_id: Some(ExecutionId::new()),
+        org_id: Some(org),
+        ..Default::default()
+    };
+    assert!(
+        manager.has_registered_for_scope(&key, &scope, SLOT_IDENTITY_UNBOUND),
+        "scope-chain lookup must find org row"
+    );
+
+    let ctx = ResourceContext::minimal(scope, CancellationToken::new());
+
+    Manager::acquire_erased(
+        Arc::clone(&manager),
+        &ProbeResource::key(),
+        &ctx,
+        &AcquireOptions::default(),
+        SLOT_IDENTITY_UNBOUND,
+    )
+    .await
+    .expect("execution-scoped acquire must reach org-scoped row");
+}

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -445,6 +445,9 @@ async fn manager_register_and_acquire_pooled() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -484,6 +487,9 @@ async fn manager_register_and_acquire_resident() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -515,6 +521,9 @@ async fn manager_shutdown_rejects_acquire() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -695,6 +704,9 @@ async fn register_transitions_phase_to_ready() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -720,6 +732,9 @@ async fn reload_config_bumps_status_generation() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -757,6 +772,9 @@ async fn graceful_shutdown_report_marks_registry_cleared() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -913,6 +931,9 @@ async fn register_emits_registered_event() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -938,6 +959,9 @@ async fn remove_emits_removed_event() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -967,6 +991,9 @@ async fn acquire_emits_success_event() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1114,6 +1141,9 @@ async fn manager_scope_exact_match() {
             test_config(),
             scope.clone(),
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1152,6 +1182,9 @@ async fn manager_scope_fallback_to_global() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1192,6 +1225,9 @@ async fn manager_scope_mismatch_not_found() {
             test_config(),
             ScopeLevel::Organization(org_id),
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1240,6 +1276,9 @@ async fn metrics_track_acquire_release_create_destroy() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1292,6 +1331,9 @@ async fn manager_multiple_resources_coexist() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1308,6 +1350,9 @@ async fn manager_multiple_resources_coexist() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -1746,6 +1791,9 @@ async fn service_acquire_via_manager() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Service(svc_rt),
+            Manager::erased_acquire_service::<ServiceTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2275,6 +2323,9 @@ async fn registry_backed_metrics_record_operations() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2290,6 +2341,9 @@ async fn registry_backed_metrics_record_operations() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2355,6 +2409,9 @@ async fn graceful_shutdown_stops_new_acquires() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2396,6 +2453,9 @@ async fn graceful_shutdown_clears_registry() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2583,6 +2643,9 @@ async fn acquire_retries_on_transient_failure() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             Some(resilience),
             None,
         )
@@ -2624,6 +2687,9 @@ async fn acquire_no_retry_on_permanent_failure() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             Some(resilience),
             None,
         )
@@ -2656,6 +2722,9 @@ async fn acquire_succeeds_without_resilience() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2696,6 +2765,9 @@ async fn acquire_timeout_fires() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             Some(resilience),
             None,
         )
@@ -2729,6 +2801,9 @@ async fn graceful_shutdown_second_call_errors_already_shutting_down() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2778,6 +2853,9 @@ async fn topology_mismatch_returns_permanent_error() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -2829,6 +2907,9 @@ async fn retry_exhaustion_returns_last_transient_error() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             Some(resilience),
             None,
         )
@@ -2879,6 +2960,9 @@ async fn acquire_failure_passively_triggers_recovery_gate() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(gate.clone()),
         )
@@ -3369,6 +3453,9 @@ async fn recovery_gate_blocks_acquire_when_permanently_failed() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(Arc::new(gate)),
         )
@@ -3404,6 +3491,9 @@ async fn recovery_gate_blocks_acquire_when_in_progress() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(Arc::new(gate)),
         )
@@ -3437,6 +3527,9 @@ async fn recovery_gate_allows_acquire_when_idle() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(Arc::new(gate)),
         )
@@ -3471,6 +3564,9 @@ async fn recovery_gate_allows_acquire_after_backoff_expires() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(Arc::new(gate)),
         )
@@ -3498,6 +3594,9 @@ async fn recovery_gate_none_does_not_affect_acquire() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3617,6 +3716,9 @@ async fn reload_config_swaps_config_and_bumps_generation() {
             ReloadConfig::new(1),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3654,6 +3756,9 @@ async fn reload_config_rejects_invalid_config() {
             ReloadConfig::new(1),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3698,6 +3803,9 @@ async fn reload_config_emits_event() {
             ReloadConfig::new(1),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3733,6 +3841,9 @@ async fn reload_config_evicts_stale_pool_instances() {
             ReloadConfig::new(1),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3798,6 +3909,9 @@ async fn reload_config_rejected_when_shutdown() {
             ReloadConfig::new(1),
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<PoolTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3833,6 +3947,9 @@ async fn graceful_shutdown_abort_on_drain_timeout_preserves_registry() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3893,6 +4010,9 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -3978,6 +4098,9 @@ async fn graceful_shutdown_force_clears_registry_on_timeout() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -4024,6 +4147,9 @@ async fn graceful_shutdown_happy_path_returns_zero_outstanding() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -4076,6 +4202,9 @@ async fn probe_boundary_serializes_callers_under_herd() {
             test_config(),
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ResidentTestResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             Some(gate.clone()),
         )

--- a/crates/resource/tests/dx_audit.rs
+++ b/crates/resource/tests/dx_audit.rs
@@ -226,6 +226,9 @@ async fn use_case_1_http_client_pool() {
             },
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<HttpClientResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None, // resilience
             None,
         )
@@ -357,6 +360,9 @@ async fn use_case_2_resident_config_store() {
             },
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<ConfigStoreResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -497,6 +503,7 @@ async fn use_case_3_db_pool_with_resilience_and_shutdown() {
             },
             ScopeLevel::Global,
             TopologyRuntime::Pool(pool_rt),
+            Manager::erased_acquire_pooled::<DbResource>(nebula_resource::SLOT_IDENTITY_UNBOUND),
             Some(resilience),
             None,
         )

--- a/crates/resource/tests/dx_evaluation.rs
+++ b/crates/resource/tests/dx_evaluation.rs
@@ -403,6 +403,7 @@ async fn use_case_3_db_with_resilience_and_shutdown() {
             config,
             ScopeLevel::Global, // scope
             TopologyRuntime::Pool(PoolRuntime::<DbResource>::new(pool_config, fingerprint)),
+            Manager::erased_acquire_pooled::<DbResource>(nebula_resource::SLOT_IDENTITY_UNBOUND),
             Some(AcquireResilience::standard()), // resilience
             None,
         )

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -113,6 +113,10 @@ impl DeclaresDependencies for Postgres {
     }
 }
 
+fn postgres_acquire_for_slot(slot: u64) -> nebula_resource::ErasedAcquireFn {
+    Manager::erased_acquire_resident::<Postgres>(slot)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -136,6 +140,7 @@ async fn register_from_value_resolves_template_and_registers() {
             Postgres,
             ScopeLevel::Global,
             TopologyRuntime::Resident(ResidentRuntime::<Postgres>::new(ResidentConfig::default())),
+            &postgres_acquire_for_slot,
             None,
             None,
         )
@@ -169,6 +174,7 @@ async fn register_from_value_validates_schema_failure() {
             Postgres,
             ScopeLevel::Global,
             TopologyRuntime::Resident(ResidentRuntime::<Postgres>::new(ResidentConfig::default())),
+            &postgres_acquire_for_slot,
             None,
             None,
         )
@@ -201,6 +207,7 @@ async fn register_from_value_resourceconfig_validate_fires() {
             Postgres,
             ScopeLevel::Global,
             TopologyRuntime::Resident(ResidentRuntime::<Postgres>::new(ResidentConfig::default())),
+            &postgres_acquire_for_slot,
             None,
             None,
         )
@@ -232,6 +239,7 @@ async fn register_from_value_unknown_slot_binding_rejected() {
             Postgres,
             ScopeLevel::Global,
             TopologyRuntime::Resident(ResidentRuntime::<Postgres>::new(ResidentConfig::default())),
+            &postgres_acquire_for_slot,
             None,
             None,
         )
@@ -264,6 +272,7 @@ async fn register_from_value_passthrough_no_templates() {
             Postgres,
             ScopeLevel::Global,
             TopologyRuntime::Resident(ResidentRuntime::<Postgres>::new(ResidentConfig::default())),
+            &postgres_acquire_for_slot,
             None,
             None,
         )

--- a/crates/resource/tests/register_from_value_rejects_secret.rs
+++ b/crates/resource/tests/register_from_value_rejects_secret.rs
@@ -153,6 +153,7 @@ async fn register_from_value_rejects_inline_secret_field() {
         "password": secret,
     });
 
+    let acquire_for_slot = |slot: u64| Manager::erased_acquire_resident::<Db>(slot);
     let err = manager
         .register_from_value::<Db>(
             config_json,
@@ -161,6 +162,7 @@ async fn register_from_value_rejects_inline_secret_field() {
             Db,
             ScopeLevel::Global,
             topology(),
+            &acquire_for_slot,
             None,
             None,
         )
@@ -206,6 +208,7 @@ async fn register_from_value_accepts_clean_config_same_resource() {
         "port": 5432,
     });
 
+    let acquire_for_slot = |slot: u64| Manager::erased_acquire_resident::<Db>(slot);
     manager
         .register_from_value::<Db>(
             config_json,
@@ -214,6 +217,7 @@ async fn register_from_value_accepts_clean_config_same_resource() {
             Db,
             ScopeLevel::Global,
             topology(),
+            &acquire_for_slot,
             None,
             None,
         )

--- a/crates/resource/tests/shutdown_race.rs
+++ b/crates/resource/tests/shutdown_race.rs
@@ -158,6 +158,9 @@ async fn graceful_shutdown_blocks_in_flight_acquire() {
             SlowConfig,
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<SlowCreateResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )
@@ -270,6 +273,9 @@ async fn lookup_rejects_acquire_after_shutdown_starts() {
             SlowConfig,
             ScopeLevel::Global,
             TopologyRuntime::Resident(resident_rt),
+            Manager::erased_acquire_resident::<SlowCreateResource>(
+                nebula_resource::SLOT_IDENTITY_UNBOUND,
+            ),
             None,
             None,
         )

--- a/examples/examples/m6_resident_http.rs
+++ b/examples/examples/m6_resident_http.rs
@@ -38,6 +38,7 @@ use std::{
 use nebula_core::{ResourceKey, ScopeLevel, resource_key, scope::Scope};
 use nebula_resource::{
     AcquireOptions, Manager, ResidentConfig, ResourceContext,
+    dedup::SLOT_IDENTITY_UNBOUND,
     error::Error as ResourceError,
     resource::{Resource, ResourceConfig, ResourceMetadata},
     runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -373,6 +374,7 @@ async fn main() -> anyhow::Result<()> {
         },
         ScopeLevel::Global,
         TopologyRuntime::Resident(resident_runtime),
+        Manager::erased_acquire_resident::<GoogleSheets>(SLOT_IDENTITY_UNBOUND),
         None,
         None,
     )?;

--- a/examples/examples/m6_telegram_multi_workflow.rs
+++ b/examples/examples/m6_telegram_multi_workflow.rs
@@ -36,6 +36,7 @@ use std::{
 use nebula_core::{OrgId, ResourceKey, ScopeLevel, resource_key, scope::Scope};
 use nebula_resource::{
     AcquireOptions, Manager, ResidentConfig, ResourceContext,
+    dedup::SLOT_IDENTITY_UNBOUND,
     error::Error as ResourceError,
     resource::{Resource, ResourceConfig, ResourceMetadata},
     runtime::{TopologyRuntime, resident::ResidentRuntime},
@@ -196,6 +197,7 @@ async fn main() -> anyhow::Result<()> {
         },
         ScopeLevel::Organization(org),
         TopologyRuntime::Resident(resident_runtime),
+        Manager::erased_acquire_resident::<TelegramBot>(SLOT_IDENTITY_UNBOUND),
         None,
         None,
     )?;


### PR DESCRIPTION
## Summary

- Route engine \ResourceAccessor\ through \Manager::acquire_erased\ with execution scope bag and per-key slot identities recorded at activation, instead of unscoped \get_any\ without leases.
- Store \ErasedAcquireFn\ on registry rows; align typed and erased scope walks with fail-closed \UNBOUND\ when cred-bound rows exist without an unbound row.
- Per-run tenant scope via \xecute_workflow_with_acquire_scope\; per-execution slot-identity snapshots; \egister_resource\ / \egister_and_bind\ record slot identity.
- \cquire_erased\ reuses the matched scope level from the first walk (no second scope-chain lookup).
- Map resource errors to \CoreError::ResourceUnavailable\ so transient acquire failures become retryable \ActionError\s.

## Commits

1. \eat(engine): wire accessor through acquire_erased and scope chain\
2. \ix(engine): use ResourceRegistrationOutcome in register_and_bind\
3. \ix(engine): address resource acquire code-review follow-ups\
4. \ix(engine): repair register_and_bind move and example acquire hooks\

## Test plan

- [x] \cargo nextest run -p nebula-resource -p nebula-engine\ (pre-push: 1202 passed)
- [x] lefthook pre-push clippy + crate-diff-gate
- [ ] \	ask dev:check\ on CI
- [ ] Review org-scoped + slot-identity tests in \cquire_erased_dispatch\ and engine accessor unit tests


Made with [Cursor](https://cursor.com)