### PR TITLE
fix(github): correct stale ADR example in rfc issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/rfc.yml
+++ b/.github/ISSUE_TEMPLATE/rfc.yml
@@ -103,7 +103,7 @@ body:
       label: Related Issues, ADRs, or Canon Sections
       description: Link to anything that provides relevant prior context.
       placeholder: |
-        ADR: docs/adr/0012-execution-context-design.md
+        ADR: docs/adr/0081-m6-resource-credential-integration.md (or docs/adr/HISTORICAL.md for pre-0042 decisions)
         Related: #234 (original `ExecutionContext` PR), #456 (Core-layer test pain)
 
   - type: checkboxes


### PR DESCRIPTION
## Summary

The RFC issue template's "Related Issues, ADRs, or Canon Sections" placeholder cited `docs/adr/0012-execution-context-design.md` — a filename that never existed (real ADR-0012 was `0012-checkpoint-recovery.md`, now git-history-only after the 0001–0041 eviction). A filer copying the example would reference a non-existent file. The placeholder now points at a live ADR plus `docs/adr/HISTORICAL.md` for pre-0042 decisions.

Pre-existing placeholder bug, independent of #704 (the ADR-eviction PR did not introduce it; it was flagged and deferred there as out-of-scope).

Form-template YAML re-parsed clean after the edit (9 body items intact).

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.7_%281M%29-D97757?logo=claude&logoColor=white)