### PR TITLE
fix(ci): make intent-gate escape hatch reliable under pipefail

### DIFF
--- a/.claude/hooks/intent-gate.sh
+++ b/.claude/hooks/intent-gate.sh
@@ -73,9 +73,22 @@ ig_added_lines() {
             | grep -E "$CODE_RE" || true)
 }
 
+# Materialize the added-content stream ONCE. Every consumer below reads it via
+# a here-string (`<<<"$IG_ADDED"`), never `ig_added_lines | …`. Two reasons:
+# (1) Correctness. A short-circuiting reader (`grep -q` in budget_justified)
+#     closes the pipe on its first match while ig_added_lines is still
+#     producing; the producer takes SIGPIPE (exit 141) and `set -o pipefail`
+#     adopts 141 as the pipeline status. A PRESENT, regex-matching
+#     `// budget-justified:` token would then read as ABSENT and the deny
+#     fires anyway. A here-string has no upstream process, so the pipeline's
+#     only exit status is the reader's own.
+# (2) Speed. The git+sed pipeline previously re-ran 4× (net / budget / dup /
+#     blob); it now runs exactly once.
+IG_ADDED="$(ig_added_lines)"
+
 # net = added − deleted. added = stream added lines minus `+++ ` headers;
 # deleted = numstat deletions on tracked changes (untracked delete nothing).
-added="$(ig_added_lines | awk '/^\+\+\+ /{next} /^\+/{c++} END{print c+0}')"
+added="$(awk '/^\+\+\+ /{next} /^\+/{c++} END{print c+0}' <<<"$IG_ADDED")"
 deleted=0
 while read -r _a d _; do
   [[ "$d" =~ ^[0-9]+$ ]] && deleted=$((deleted + d))
@@ -88,8 +101,11 @@ net=$((added - deleted))
 # Net-negative (cleanup / deletion) is always allowed — positive constraint.
 if [ "$net" -lt 0 ]; then ig_log allow "net-negative"; allow; fi
 
-# Escape token: `// budget-justified:` on any added line this turn.
-budget_justified() { ig_added_lines | grep -qE '//[[:space:]]*budget-justified:'; }
+# Escape token: `// budget-justified:` on any added line this turn. Reads the
+# pre-captured stream via here-string — never `ig_added_lines | grep -q`,
+# whose grep short-circuits on first match and SIGPIPEs the producer (=> 141
+# under pipefail => a present token silently misread as absent).
+budget_justified() { grep -qE '//[[:space:]]*budget-justified:' <<<"$IG_ADDED"; }
 
 # Duplicate public-symbol heuristic: a NEW `pub fn|struct|trait NAME` whose
 # NAME already exists (same kind) elsewhere in crates/*/src — the "47 date
@@ -102,7 +118,7 @@ budget_justified() { ig_added_lines | grep -qE '//[[:space:]]*budget-justified:'
 # the false-positive surface this skiplist exists to contain.
 dup_symbol() {
   local added kind name hit
-  added="$(ig_added_lines | grep -E '^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' || true)"
+  added="$(grep -E '^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait)[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' <<<"$IG_ADDED" || true)"
   [ -n "$added" ] || return 1
   while IFS= read -r line; do
     kind="$(printf '%s' "$line" | sed -E 's/^\+[[:space:]]*pub[[:space:]]+(fn|struct|trait).*/\1/')"
@@ -129,11 +145,11 @@ fi
 # header reset — uniform with the net-LoC / dup-symbol consumers).
 BLOB_CAP=100
 longest_added_run() {
-  ig_added_lines | awk '
+  awk '
       /^\+\+\+ /      { run=0; next }
       /^\+/           { run++; if (run>max) max=run; next }
       { run=0 }
-      END             { print max+0 }'
+      END             { print max+0 }' <<<"$IG_ADDED"
 }
 blob="$(longest_added_run)"
 if [ "${blob:-0}" -gt "$BLOB_CAP" ] && ! budget_justified; then

--- a/.claude/hooks/test/run.sh
+++ b/.claude/hooks/test/run.sh
@@ -204,6 +204,25 @@ EBT_SID="e-bud-trk"; EBT_P="$(turn_state_path "$EBT_SID" "$EBT_DIR")"; mkdir -p 
 printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"","intent_attempts":0}' >"$EBT_P"
 chk "E counts +-prefixed tracked" 2 "$(egate '{"session_id":"'"$EBT_SID"'","cwd":"'"$EBT_DIR"'","stop_hook_active":false}')"
 rm -rf "$EBT_DIR"
+# Regression: a `// budget-justified:` token that appears EARLY in a LARGE
+# ig_added_lines stream must still suppress an over-budget deny. The pre-fix
+# `budget_justified() { ig_added_lines | grep -qE ...; }` short-circuited on
+# the first match, SIGPIPE'd the still-producing ig_added_lines, and
+# `set -o pipefail` adopted 141 as the pipeline status => a PRESENT,
+# regex-matching token was misread as ABSENT => the deny fired anyway. Two
+# untracked files: the sorted-first one carries the token on its first line
+# (stream position ~2); the second is large enough that grep -q exits long
+# before the producer drains. The existing "budget-justified escapes" case
+# can't catch this — its token is the LAST stream line, so grep -q reads to
+# EOF and the producer finishes naturally (no SIGPIPE).
+EBJ_DIR="$(mktemp -d)"
+( cd "$EBJ_DIR" && git init -q && git -c user.email=t@t -c user.name=t commit -qm init --allow-empty \
+  && { echo '<!-- // budget-justified: regression -->'; for i in $(seq 1 200); do echo "filler $i"; done; } > a_just.md \
+  && { for i in $(seq 1 450); do echo "filler $i"; done; } > z_big.md )
+EBJ_SID="e-bud-sigpipe"; EBJ_P="$(turn_state_path "$EBJ_SID" "$EBJ_DIR")"; mkdir -p "$(dirname "$EBJ_P")"
+printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"","intent_attempts":0}' >"$EBJ_P"
+chk "E budget-justified suppresses over large stream (SIGPIPE regr)" 0 "$(egate '{"session_id":"'"$EBJ_SID"'","cwd":"'"$EBJ_DIR"'","stop_hook_active":false}')"
+rm -rf "$EBJ_DIR"
 
 # E new-file budget (cap 5)
 EF_DIR="$(mktemp -d)"


### PR DESCRIPTION
## Summary

`.claude/hooks/intent-gate.sh` (ADR-0083 Layer-2 structural-budget gate) had a shell bug that made the documented `// budget-justified:` escape hatch unreliable: `budget_justified()` ran `ig_added_lines | grep -qE …`. `grep -q` exits 0 on its first match and closes the pipe while `ig_added_lines` is still producing; the producer takes SIGPIPE (exit 141) and `set -o pipefail` adopts 141 as the pipeline status. A **present, regex-matching** `// budget-justified:` token therefore read as **absent**, so the net-LoC / blob / new-file / dup-symbol denies fired even when the turn correctly carried the escape token — reliably reproducible once the added-lines stream is a few hundred lines (grep -q short-circuits before the producer drains).

## Linked issue

No Linear/GitHub issue — Refs ADR-0083 (`docs/adr/0083-agent-intent-honesty-gate.md`).

## Type of change

- [x] `fix` — bug fix
- [x] `ci` — CI / enforced-discipline tooling

## Affected crates / areas

- `.claude/hooks/intent-gate.sh` (Layer-2 structural-budget gate)
- `.claude/hooks/test/run.sh` (guard-hook test harness)

## Changes

- Materialize the added-content stream once into `IG_ADDED` immediately after `ig_added_lines()` is defined.
- Rewrite all four consumers — net-LoC count, `budget_justified`, `dup_symbol`, `longest_added_run` — to read it via a here-string (`<<<"$IG_ADDED"`) instead of `ig_added_lines | …`. No upstream producer ⇒ the pipeline's only exit status is the reader's own ⇒ no SIGPIPE/141 under `pipefail`.
- Side effect: the git+sed pipeline now runs **once** per invocation instead of 4×.
- Add a regression case (`E budget-justified suppresses over large stream (SIGPIPE regr)`): two untracked files, the sorted-first carrying the token on line 1 and the second large enough that `grep -q` exits ~stream-line 2, long before the producer drains. The pre-existing "budget-justified escapes" case can't catch this — its token is the last stream line, so `grep -q` reads to EOF and the producer finishes naturally.

No budget threshold (`NET_CAP` 400 / `NF_CAP` 5 / `BLOB_CAP` 100 / loop-bound 2) changed. The D10 no-cheat guarantee is **unaffected** — this only makes the documented escape hatch behave as specified; it removes/softens no gate.

## Test plan

- **RED proven**: with the bug present, the new regression case failed `expected[0] got[2]` (deny fired through a present token).
- **Mechanism isolated**: `producer | grep -q` under `pipefail` → exit `141`; `grep -q <<<"$var"` → exit `0`.
- **GREEN**: post-fix `task hooks:test` → `ALL GUARD TESTS PASSED`; the pre-existing token-last `E budget-justified escapes` case and all `+`-prefix / net / blob / new-file / dup cases still pass (zero regressions).

### Local verification

Shell-only change — no Rust touched, so the cargo rows below do not apply:

- [x] `task hooks:test` (= `bash .claude/hooks/test/run.sh`) — `ALL GUARD TESTS PASSED`
- [x] `convco` (lefthook pre-commit) — commit message valid
- [x] lefthook pre-push — passed
- [ ] ~~`cargo fmt --all` / `clippy` / `nextest` / `doc` / `deny`~~ — N/A (no `.rs`/`Cargo.toml`)

## Breaking changes

None.

## Safety / security impact

- D10 structural no-cheat guarantee unaffected — fix is escape-hatch-detection + a compute-once refactor; no threshold removed or softened, `stop-gate.sh` still runs first.
- Rust-specific rows (unwrap/expect/panic, `transition_node()`, `unsafe`) — N/A (shell only, no library code touched).

## Notes for reviewers

Focus: the here-string conversion is the correctness fix; verify no remaining `ig_added_lines | …` consumer exists (only the func def + the single `IG_ADDED="$(ig_added_lines)"` capture should reference it). Docs checklist omitted per template (pure tooling bug fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of budget-justified logic by streamlining internal processing operations to eliminate potential pipeline failures and ensure consistent behavior across cost calculations.

* **Tests**
  * Added regression test to verify correct handling of budget-justified markers in edge cases involving multiple added files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/708?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->