### PR TITLE
docs(resilience): annotate cancel-safety on public async fns

### DIFF
--- a/crates/resilience/src/context.rs
+++ b/crates/resilience/src/context.rs
@@ -119,6 +119,16 @@ impl PolicyContext {
         })
     }
 
+    /// Run `future` under this context's cancellation and deadline.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the wrapped future at its current `.await` (the `select!` arms
+    /// hold only stack-local state) — no crate-owned state is left partially
+    /// mutated, and no work is detached via `spawn`. Whether a *partially
+    /// executed* operation is safe to abandon is the wrapped future's own
+    /// contract.
     pub(crate) async fn run_result<T, E, Fut>(&self, future: Fut) -> Result<T, CallError<E>>
     where
         Fut: Future<Output = Result<T, CallError<E>>> + Send,

--- a/crates/resilience/src/deadline.rs
+++ b/crates/resilience/src/deadline.rs
@@ -66,6 +66,15 @@ impl Deadline {
     ///
     /// Returns `CallError::Timeout` if the deadline is already expired or the
     /// future does not complete within the remaining budget.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: `Deadline` is a `Copy` value
+    /// with no shared state, so dropping the returned future drops the
+    /// in-flight future at its current `.await` and leaves nothing partially
+    /// mutated; no work is detached via `spawn`. Whether a *partially
+    /// executed* operation is safe to abandon is the wrapped future's own
+    /// contract.
     pub async fn timeout<T, E, Fut>(self, future: Fut) -> Result<T, CallError<E>>
     where
         Fut: Future<Output = T> + Send,
@@ -82,6 +91,14 @@ impl Deadline {
     ///
     /// Returns `CallError::Timeout` if the deadline is already expired or `delay`
     /// is longer than the remaining budget.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: `Deadline` is a `Copy` value
+    /// with no shared state, so dropping the returned future drops the
+    /// in-flight sleep at its current `.await` and leaves nothing partially
+    /// mutated; no work is detached via `spawn`. The wrapped sleep has no
+    /// side effects, so abandoning it part-way is always safe.
     pub async fn sleep<E>(self, delay: Duration) -> Result<(), CallError<E>> {
         if delay.is_zero() {
             return Ok(());

--- a/crates/resilience/src/load_shed.rs
+++ b/crates/resilience/src/load_shed.rs
@@ -17,6 +17,15 @@ use crate::{
 /// Returns `Err(CallError::LoadShed)` when the shed predicate fires,
 /// or `Err(CallError::Operation)` if the operation itself fails.
 ///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` — the shed
+/// predicate and bookkeeping are stack-local, so no crate-owned state is
+/// left partially mutated, and no work is detached via `spawn`. Whether a
+/// *partially executed* operation is safe to abandon is the supplied
+/// operation's own contract.
+///
 /// # Examples
 ///
 /// ```rust,no_run
@@ -51,6 +60,15 @@ where
 ///
 /// Returns `Err(CallError::LoadShed)` when the shed predicate fires,
 /// or `Err(CallError::Operation)` if the operation itself fails.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` — the shed
+/// predicate and bookkeeping are stack-local, so no crate-owned state is
+/// left partially mutated, and no work is detached via `spawn`. Whether a
+/// *partially executed* operation is safe to abandon is the supplied
+/// operation's own contract.
 pub async fn load_shed_with_sink<T, E, S, Fut, F>(
     should_shed: S,
     f: F,
@@ -80,6 +98,15 @@ where
 /// `Err(CallError::Timeout)` when the context deadline expires,
 /// `Err(CallError::LoadShed)` when the shed predicate fires, or
 /// `Err(CallError::Operation)` if the operation itself fails.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` — the shed
+/// predicate and bookkeeping are stack-local, so no crate-owned state is
+/// left partially mutated, and no work is detached via `spawn`. Whether a
+/// *partially executed* operation is safe to abandon is the supplied
+/// operation's own contract.
 pub async fn load_shed_with_policy_context<T, E, S, Fut, F>(
     context: &PolicyContext,
     should_shed: S,
@@ -103,6 +130,15 @@ where
 /// `Err(CallError::Timeout)` when the context deadline expires,
 /// `Err(CallError::LoadShed)` when the shed predicate fires, or
 /// `Err(CallError::Operation)` if the operation itself fails.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` — the shed
+/// predicate and bookkeeping are stack-local, so no crate-owned state is
+/// left partially mutated, and no work is detached via `spawn`. Whether a
+/// *partially executed* operation is safe to abandon is the supplied
+/// operation's own contract.
 pub async fn load_shed_with_policy_context_and_sink<T, E, S, Fut, F>(
     context: &PolicyContext,
     should_shed: S,

--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -542,6 +542,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     /// Returns the appropriate `CallError` variant depending on which pipeline
     /// step fails (timeout, retry exhaustion, circuit open, bulkhead full, or operation error).
     ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
+    ///
     /// # Examples
     ///
     /// ```rust,no_run
@@ -589,6 +599,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// Returns `Err(CallError::Cancelled)` if cancellation fires before the pipeline
     /// completes, or the normal pipeline error otherwise.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
     pub async fn call_with_context<T, F, Fut>(
         &self,
         cancellation: &CancellationContext,
@@ -618,6 +638,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     /// Returns `Err(CallError::Cancelled)` if the context is cancelled,
     /// `Err(CallError::Timeout)` if the context deadline expires, or the normal
     /// pipeline error otherwise.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
     pub async fn call_with_policy_context<T, F, Fut>(
         &self,
         context: &PolicyContext,
@@ -729,6 +759,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// Returns the fallback's error if both the pipeline and fallback fail.
     ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
+    ///
     /// # Examples
     ///
     /// ```rust,no_run
@@ -785,6 +825,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     /// Returns `Err(CallError::Cancelled)` if cancellation fires before the
     /// pipeline/fallback completes, or the normal pipeline/fallback error
     /// otherwise.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
     pub async fn call_with_context_and_fallback<T, F, Fut>(
         &self,
         cancellation: &CancellationContext,
@@ -812,6 +862,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     /// Returns `Err(CallError::Cancelled)` if the context is cancelled,
     /// `Err(CallError::Timeout)` if the context deadline expires, or the normal
     /// pipeline/fallback error otherwise.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await`. Every pipeline
+    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
+    /// and circuit-breaker probe slots are released on drop — so no
+    /// crate-owned state is left partially mutated, and the pipeline does
+    /// not detach work via `spawn`. Whether a *partially executed* operation
+    /// is safe to abandon is the supplied operation's own contract.
     pub async fn call_with_policy_context_and_fallback<T, F, Fut>(
         &self,
         context: &PolicyContext,

--- a/crates/resilience/src/retry.rs
+++ b/crates/resilience/src/retry.rs
@@ -436,6 +436,15 @@ impl<E: 'static> RetryConfig<E> {
 /// Returns `Err(CallError::RetriesExhausted)` when all attempts are exhausted,
 /// or `Err(CallError::Operation)` if the error is not retryable.
 ///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight attempt at its current `.await` and discards all
+/// retry bookkeeping (attempt counter, last error, backoff delay) — no
+/// crate-owned state is left partially mutated, and no work is detached
+/// via `spawn`. Whether a *partially executed* attempt is safe to abandon
+/// is the supplied operation's own contract.
+///
 /// # Examples
 ///
 /// ```rust
@@ -586,6 +595,15 @@ where
 ///
 /// Returns `Err(CallError::RetriesExhausted)` when all `n` attempts are exhausted,
 /// or `Err(CallError::Operation)` if the error is not retryable.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight attempt at its current `.await` and discards all
+/// retry bookkeeping (attempt counter, last error, backoff delay) — no
+/// crate-owned state is left partially mutated, and no work is detached
+/// via `spawn`. Whether a *partially executed* attempt is safe to abandon
+/// is the supplied operation's own contract.
 ///
 /// # Examples
 ///

--- a/crates/resilience/src/timeout.rs
+++ b/crates/resilience/src/timeout.rs
@@ -19,6 +19,14 @@ use crate::{
 ///
 /// Returns `Err(CallError::Timeout)` on timeout or `Err(CallError::Operation)` on operation error.
 ///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` and discards the
+/// timeout bookkeeping — no crate-owned state is left partially mutated,
+/// and no work is detached via `spawn`. Whether a *partially executed*
+/// operation is safe to abandon is the supplied operation's own contract.
+///
 /// # Examples
 ///
 /// ```rust,no_run
@@ -46,6 +54,14 @@ where
 /// # Errors
 ///
 /// Returns `Err(CallError::Timeout)` on timeout or `Err(CallError::Operation)` on operation error.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` and discards the
+/// timeout bookkeeping — no crate-owned state is left partially mutated,
+/// and no work is detached via `spawn`. Whether a *partially executed*
+/// operation is safe to abandon is the supplied operation's own contract.
 pub async fn timeout_with_sink<T, E, F>(
     duration: Duration,
     future: F,
@@ -79,6 +95,14 @@ where
 /// Returns `Err(CallError::Cancelled)` when the context is cancelled,
 /// `Err(CallError::Timeout)` when either deadline expires, or
 /// `Err(CallError::Operation)` if the operation itself fails.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` and discards the
+/// timeout bookkeeping — no crate-owned state is left partially mutated,
+/// and no work is detached via `spawn`. Whether a *partially executed*
+/// operation is safe to abandon is the supplied operation's own contract.
 pub async fn timeout_with_policy_context<T, E, F>(
     context: &PolicyContext,
     duration: Duration,
@@ -102,6 +126,14 @@ where
 /// Returns `Err(CallError::Cancelled)` when the context is cancelled,
 /// `Err(CallError::Timeout)` when either deadline expires, or
 /// `Err(CallError::Operation)` if the operation itself fails.
+///
+/// # Cancel safety
+///
+/// Cancel-safe with respect to this crate: dropping the returned future
+/// drops the in-flight operation at its current `.await` and discards the
+/// timeout bookkeeping — no crate-owned state is left partially mutated,
+/// and no work is detached via `spawn`. Whether a *partially executed*
+/// operation is safe to abandon is the supplied operation's own contract.
 pub async fn timeout_with_policy_context_and_sink<T, E, F>(
     context: &PolicyContext,
     duration: Duration,
@@ -207,6 +239,14 @@ impl TimeoutExecutor {
     ///
     /// Returns `Err(CallError::Timeout)` on timeout or `Err(CallError::Operation)` on operation
     /// error.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await` and discards the
+    /// timeout bookkeeping — no crate-owned state is left partially mutated,
+    /// and no work is detached via `spawn`. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own contract.
     pub async fn call<T, E, F>(&self, future: F) -> Result<T, CallError<E>>
     where
         F: Future<Output = Result<T, E>>,
@@ -221,6 +261,14 @@ impl TimeoutExecutor {
     /// Returns `Err(CallError::Cancelled)` when the context is cancelled,
     /// `Err(CallError::Timeout)` when either deadline expires, or
     /// `Err(CallError::Operation)` if the operation itself fails.
+    ///
+    /// # Cancel safety
+    ///
+    /// Cancel-safe with respect to this crate: dropping the returned future
+    /// drops the in-flight operation at its current `.await` and discards the
+    /// timeout bookkeeping — no crate-owned state is left partially mutated,
+    /// and no work is detached via `spawn`. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own contract.
     pub async fn call_with_policy_context<T, E, F>(
         &self,
         context: &PolicyContext,


### PR DESCRIPTION
## What & why

The vendored **rust-intel** skill (`.claude/skills/rust-intel/SKILL.md`, merged in [#709](https://github.com/vanyastaff/nebula/pull/709)) makes a `# Cancel safety` rustdoc section **mandatory for every public `async fn`** — taxonomy category **§B3** plus operating-mode rule 5. A `/rust-cc-audit` of `crates/resilience/src/**` found **0 correctness defects** but one taxonomy deviation: several public async fns lacked the `# Cancel safety` section. `hedge.rs` and `circuit_breaker.rs` already had a correct one; this PR brings the rest of the audited surface to §B3 parity, matching their exact rustdoc style (no intra-doc link brackets, so `rustdoc -D warnings` stays clean).

## Annotated fns (doc-only, 6 files, +189 lines, 0 code/signature/behavior change)

| File | Public async fns |
|------|------------------|
| `retry.rs` | `retry_with`, `retry` |
| `timeout.rs` | `timeout`, `timeout_with_sink`, `timeout_with_policy_context`, `timeout_with_policy_context_and_sink`, `TimeoutExecutor::call`, `TimeoutExecutor::call_with_policy_context` |
| `load_shed.rs` | `load_shed`, `load_shed_with_sink`, `load_shed_with_policy_context`, `load_shed_with_policy_context_and_sink` |
| `deadline.rs` | `Deadline::timeout`, `Deadline::sleep` |
| `context.rs` | `PolicyContext::run_result` (pub(crate)) |
| `pipeline.rs` | the six public `ResiliencePipeline` `call*` entry points |

Each named file is brought to **full §B3 compliance** (every `pub`/`pub(crate)` async fn), not only the audit's approximate line list, so a half-annotated file can't regress the next audit. Private/inner helpers (`retry_loop`, `sleep_with_deadline`, `call_inner`, `run_with_policy_deadline`, `call_with_fallback_inner`, `execute_pipeline`, `run_retry_step`) and the `#[doc(hidden)]` `retry_with_inner` are intentionally excluded — not part of the rendered public surface. Files outside the audit scope (`fallback.rs`, `bulkhead.rs`, `cancellation.rs`, `rate_limiter.rs`, `gate.rs`) are untouched.

## The cancel-safety verdict is audit-proven, not re-derived

The rust-intel skill warns ~50% of LLM cancel-safety judgements are confidently wrong, so the content encodes the verdict the audit already proved by enumerating each `.await`:

- **Cancel-safe with respect to this crate's own state.** All retry/timeout bookkeeping (`last_err`, attempt counters, delays) is stack-local and discarded on drop. `Deadline` is a `Copy` value. `context.rs` `select!` arms hold only stack-local state. In `pipeline.rs`, every step's bookkeeping is stack-local or a **RAII drop-guard** — bulkhead permits and circuit-breaker probe slots are released on drop — so no crate-owned state is left partially mutated.
- **No detached work.** A `spawn`/`JoinSet` sweep confirms the only production detachment in the crate is `hedge.rs` (already documented, out of scope). `execute_pipeline` → `run_operation_with_shells` uses `select!` / `tokio::time::timeout` / recursive `Box::pin` with **no spawn**; every other `spawn`/`JoinSet` hit is `#[cfg(test)]`.
- **Operation-level abandonment is the caller's contract.** Each section explicitly states that whether a *partially executed* operation is safe to abandon is the supplied operation's own contract — not something these wrappers can guarantee or annotate.

No fn's actual `.await` structure contradicted this verdict, so no false "cancel-safe" claim was written and no correctness finding is raised.

## Verification (verified on the branch worktree where the change lives)

- `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-resilience --no-deps` — clean (the lefthook pre-push does **not** mirror the CI Documentation job, so rustdoc was checked explicitly)
- `cargo clippy -p nebula-resilience --all-targets -- -D warnings` — clean
- `cargo nextest run -p nebula-resilience` — 289 passed, 0 skipped (unchanged)
- `cargo test -p nebula-resilience --doc` — 52 passed
- lefthook pre-push (clippy-full + nextest agent profile + crate-diff-gate) — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
