### PR TITLE
docs(resilience): correct pipeline cancel-safety re rate-limiter quota

### DIFF
--- a/crates/resilience/src/pipeline.rs
+++ b/crates/resilience/src/pipeline.rs
@@ -544,13 +544,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     ///
     /// # Examples
     ///
@@ -602,13 +605,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     pub async fn call_with_context<T, F, Fut>(
         &self,
         cancellation: &CancellationContext,
@@ -641,13 +647,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     pub async fn call_with_policy_context<T, F, Fut>(
         &self,
         context: &PolicyContext,
@@ -761,13 +770,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     ///
     /// # Examples
     ///
@@ -828,13 +840,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     pub async fn call_with_context_and_fallback<T, F, Fut>(
         &self,
         cancellation: &CancellationContext,
@@ -865,13 +880,16 @@ impl<E: Send + 'static> ResiliencePipeline<E> {
     ///
     /// # Cancel safety
     ///
-    /// Cancel-safe with respect to this crate: dropping the returned future
-    /// drops the in-flight operation at its current `.await`. Every pipeline
-    /// step's bookkeeping is stack-local or a drop guard — bulkhead permits
-    /// and circuit-breaker probe slots are released on drop — so no
-    /// crate-owned state is left partially mutated, and the pipeline does
-    /// not detach work via `spawn`. Whether a *partially executed* operation
-    /// is safe to abandon is the supplied operation's own contract.
+    /// Dropping the returned future drops the in-flight operation at its
+    /// current `.await`, and the pipeline does not detach work via `spawn`.
+    /// Most step bookkeeping is stack-local or a drop guard — bulkhead
+    /// permits and circuit-breaker probe slots are released on drop. The
+    /// exception is a rate-limiter step: once its permit is acquired the
+    /// limiter's shared quota is consumed, and dropping the future before
+    /// the operation finishes does *not* refund it — cancellation can still
+    /// burn rate-limit capacity, by design. Whether a *partially executed*
+    /// operation is safe to abandon is the supplied operation's own
+    /// contract.
     pub async fn call_with_policy_context_and_fallback<T, F, Fut>(
         &self,
         context: &PolicyContext,


### PR DESCRIPTION
## What & why

Follow-up to [#710](https://github.com/vanyastaff/nebula/pull/710) (merged). A Codex review on that PR ([comment](https://github.com/vanyastaff/nebula/pull/710#discussion_r3267077864), P2) correctly flagged the pipeline `# Cancel safety` wording as **too broad** — and #710 had already squash-merged before the finding landed, so this is a follow-up correction.

The merged text claimed *"no crate-owned state is left partially mutated"*. But `Step::RateLimiter` awaits the limiter's `acquire()` **before** recursing into the operation, and the built-in limiters mutate shared quota on a successful acquire — `TokenBucket` decrements `state.tokens`, `LeakyBucket` raises `level`, `SlidingWindow` pushes a timestamp. If the pipeline future is dropped after the permit is acquired but before the inner operation finishes, that quota is **intentionally not refunded** — unlike bulkhead permits and circuit-breaker probe slots, which are RAII drop-guards. Callers relying on the rustdoc could wrongly assume cancellation never burns rate-limit capacity.

## Change (doc-only, pipeline.rs, 6 sections)

Rewords the six `ResiliencePipeline` `call*` `# Cancel safety` sections to:

- keep the accurate bulkhead / circuit-breaker drop-guard statement,
- explicitly carve out the rate-limiter step: a consumed permit is **not** refunded on cancellation, so cancellation can still burn rate-limit capacity *by design*,
- keep the "partial-operation abandonment is the caller's contract" line.

Verified against code: `Step::RateLimiter(check)` resolves `check()` (acquire) then `run_operation_with_shells(ctx, idx + 1, f)` — no refund path; `Step::Bulkhead` holds `let _permit` (RAII) across the inner await. The other in-scope files (`retry`/`timeout`/`load_shed`/`deadline`/`context`) compose no rate-limiter and remain accurate — unchanged.

## Verification (branch worktree, atop merged main `45c94da7`)

- `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-resilience --no-deps` — clean
- `cargo clippy -p nebula-resilience --all-targets -- -D warnings` — clean
- `cargo nextest run -p nebula-resilience` — 289 passed
- `cargo test -p nebula-resilience --doc` — 52 passed
- lefthook pre-commit (typos/fmt/clippy) + convco — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
