### PR TITLE
fix(scripts): scope guard turn_base across history rewrites

### DIFF
--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -21,10 +21,10 @@ git_common_dir() { # $1=cwd
   fi
 }
 turn_state_path() { printf '%s/.nebula-guard/turn-%s.json' "$(git_common_dir "${2:-$PWD}")" "${1:-unknown}"; }
-load_state() { # $1=path -> always {impl_files_edited:[...],gate_green:[...],turn_base:".."}
-  local d='{"impl_files_edited":[],"gate_green":[],"turn_base":""}'
+load_state() { # $1=path -> always {impl_files_edited:[...],gate_green:[...],turn_base:"..",turn_base_patch_ids:[...]}
+  local d='{"impl_files_edited":[],"gate_green":[],"turn_base":"","turn_base_patch_ids":[]}'
   if [ -f "$1" ] && have_jq && jq -e . "$1" >/dev/null 2>&1; then
-    jq -c '{impl_files_edited:(if (.impl_files_edited|type)=="array" then .impl_files_edited else [] end),gate_green:(if (.gate_green|type)=="array" then .gate_green else [] end),turn_base:(if (.turn_base|type)=="string" then .turn_base else "" end)}' "$1" 2>/dev/null || printf '%s' "$d"
+    jq -c '{impl_files_edited:(if (.impl_files_edited|type)=="array" then .impl_files_edited else [] end),gate_green:(if (.gate_green|type)=="array" then .gate_green else [] end),turn_base:(if (.turn_base|type)=="string" then .turn_base else "" end),turn_base_patch_ids:(if (.turn_base_patch_ids|type)=="array" then .turn_base_patch_ids else [] end)}' "$1" 2>/dev/null || printf '%s' "$d"
   else printf '%s' "$d"; fi
 }
 save_state() { mkdir -p "$(dirname "$1")" 2>/dev/null && printf '%s' "$2" >"$1" 2>/dev/null || true; }
@@ -36,31 +36,64 @@ save_state() { mkdir -p "$(dirname "$1")" 2>/dev/null && printf '%s' "$2" >"$1" 
 # replayed onto it), that SHA lands on an ABANDONED history line: it is no
 # longer an ancestor of HEAD, so a `turn_base..HEAD` diff spans the ENTIRE
 # old→new base delta — the whole squash-merged upstream PR — and spuriously
-# flags crates this turn never touched. Detect that (merge-base --is-ancestor
-# fails) and repin to the branch's divergence floor from upstream (merge-base
-# with the first of origin/main / main / @{upstream} that resolves); that point
-# is AFTER any squash-merge so the merged work drops out, while commits made on
-# THIS branch are still seen (the no-cheat catch is preserved). When the stored
-# base IS still an ancestor (the common, no-rewrite case) it is returned
-# unchanged — exact prior semantics, zero behavior change. If no upstream ref
-# resolves, "" is emitted: callers skip the diff arm (documented safe
-# degradation — identical to the unborn-branch path; B-union + working-tree
-# ground truth still enforce the green gate). Known narrow residual: a `main`
-# MERGED into the branch mid-turn keeps turn_base an ancestor, so that rarer
-# workflow is out of scope here (the reproduced bug is `rebase --onto`).
-# $1=cwd  $2=stored turn_base  ->  effective base SHA (may be "")
+# flags crates this turn never touched.
+#
+# Recovery order on history rewrite (turn_base not an ancestor of HEAD):
+#   1. If A0 stored patch-ids of pre-turn branch commits, walk the rebased
+#      branch (`upstream-mb..HEAD`, oldest→newest) and find the LAST commit
+#      whose patch-id is in that set. `git patch-id --stable` is invariant
+#      across rebase, so that commit is the rewritten counterpart of the
+#      original turn_base — anything above it is THIS turn. (Codex PR #726
+#      review #3269664222: without this, branches with pre-turn commits get
+#      those older crates re-flagged after a rebase.)
+#   2. Else fall back to upstream merge-base (`origin/main` / `main` /
+#      `@{upstream}`) — that point is AFTER any squash-merge so the merged
+#      work drops out, but pre-turn branch commits would over-report.
+#   3. If no upstream ref resolves, "" — callers skip the diff arm
+#      (documented safe degradation; B-union + working-tree ground truth
+#      still enforce the green gate).
+#
+# When the stored base IS still an ancestor (the common, no-rewrite case) it
+# is returned unchanged — exact prior semantics, zero behavior change.
+# Known narrow residual: `main` MERGED (not rebased) into the branch mid-turn
+# keeps turn_base an ancestor, so that rarer workflow is out of scope here.
+# $1=cwd  $2=stored turn_base
+# stdin   one patch-id per line (turn_base_patch_ids; empty stream = none)
+# stdout  effective base SHA (may be "")
 effective_turn_base() {
-  local cwd="$1" tb="$2" ref mb
+  local cwd="$1" tb="$2" ref candidate mb pid c stored found
+  local -a pids=()
+  # jq -r emits CRLF on git-bash (Windows), so read -r leaves a trailing \r
+  # in pid — the comparison below would silently miss every match. Strip it
+  # defensively (same pattern as stop-gate.sh's _consider path handling).
+  while IFS= read -r pid; do pid="${pid%$'\r'}"; [ -n "$pid" ] && pids+=("$pid"); done
   [ -n "$tb" ] || { printf ''; return 0; }
   if git -C "$cwd" merge-base --is-ancestor "$tb" HEAD 2>/dev/null; then
     printf '%s' "$tb"; return 0          # no rewrite — prior semantics intact
   fi
+  mb=""
   for ref in origin/main main '@{upstream}'; do
     git -C "$cwd" rev-parse --verify -q "$ref" >/dev/null 2>&1 || continue
-    mb="$(git -C "$cwd" merge-base HEAD "$ref" 2>/dev/null)" || continue
-    [ -n "$mb" ] && { printf '%s' "$mb"; return 0; }
+    candidate="$(git -C "$cwd" merge-base HEAD "$ref" 2>/dev/null)"
+    [ -n "$candidate" ] && { mb="$candidate"; break; }
   done
-  printf ''                              # no upstream ref — skip diff arm
+  [ -n "$mb" ] || { printf ''; return 0; } # no upstream ref — skip diff arm
+  if (( ${#pids[@]} > 0 )); then
+    found=""
+    while IFS= read -r c; do
+      c="${c%$'\r'}"; [ -n "$c" ] || continue
+      pid="$(git -C "$cwd" show "$c" 2>/dev/null \
+              | git patch-id --stable 2>/dev/null \
+              | awk 'NF>0{print $1; exit}')"
+      pid="${pid%$'\r'}"
+      [ -n "$pid" ] || continue
+      for stored in "${pids[@]}"; do
+        [ "$pid" = "$stored" ] && { found="$c"; break; }
+      done
+    done < <(git -C "$cwd" rev-list --reverse "${mb}..HEAD" 2>/dev/null | head -n 512)
+    [ -n "$found" ] && { printf '%s' "$found"; return 0; }
+  fi
+  printf '%s' "$mb"                      # fallback: upstream merge-base
 }
 
 crate_of() { # $1=path -> crate name or empty

--- a/.claude/hooks/_lib.sh
+++ b/.claude/hooks/_lib.sh
@@ -29,6 +29,40 @@ load_state() { # $1=path -> always {impl_files_edited:[...],gate_green:[...],tur
 }
 save_state() { mkdir -p "$(dirname "$1")" 2>/dev/null && printf '%s' "$2" >"$1" 2>/dev/null || true; }
 
+# Effective base for the committed-this-turn diff arm (stop-gate.sh §4.C 3rd
+# source, intent-gate.sh turn-diff scope). Stored turn_base = HEAD captured at
+# A0 (turn-reset.sh). When the branch is later rebased / reparented (`git
+# rebase --onto`, or its upstream squash-merged into main and the branch
+# replayed onto it), that SHA lands on an ABANDONED history line: it is no
+# longer an ancestor of HEAD, so a `turn_base..HEAD` diff spans the ENTIRE
+# old→new base delta — the whole squash-merged upstream PR — and spuriously
+# flags crates this turn never touched. Detect that (merge-base --is-ancestor
+# fails) and repin to the branch's divergence floor from upstream (merge-base
+# with the first of origin/main / main / @{upstream} that resolves); that point
+# is AFTER any squash-merge so the merged work drops out, while commits made on
+# THIS branch are still seen (the no-cheat catch is preserved). When the stored
+# base IS still an ancestor (the common, no-rewrite case) it is returned
+# unchanged — exact prior semantics, zero behavior change. If no upstream ref
+# resolves, "" is emitted: callers skip the diff arm (documented safe
+# degradation — identical to the unborn-branch path; B-union + working-tree
+# ground truth still enforce the green gate). Known narrow residual: a `main`
+# MERGED into the branch mid-turn keeps turn_base an ancestor, so that rarer
+# workflow is out of scope here (the reproduced bug is `rebase --onto`).
+# $1=cwd  $2=stored turn_base  ->  effective base SHA (may be "")
+effective_turn_base() {
+  local cwd="$1" tb="$2" ref mb
+  [ -n "$tb" ] || { printf ''; return 0; }
+  if git -C "$cwd" merge-base --is-ancestor "$tb" HEAD 2>/dev/null; then
+    printf '%s' "$tb"; return 0          # no rewrite — prior semantics intact
+  fi
+  for ref in origin/main main '@{upstream}'; do
+    git -C "$cwd" rev-parse --verify -q "$ref" >/dev/null 2>&1 || continue
+    mb="$(git -C "$cwd" merge-base HEAD "$ref" 2>/dev/null)" || continue
+    [ -n "$mb" ] && { printf '%s' "$mb"; return 0; }
+  done
+  printf ''                              # no upstream ref — skip diff arm
+}
+
 crate_of() { # $1=path -> crate name or empty
   local p="${1//\\\\//}"; p="${p//\\//}"
   [[ "$p" =~ (^|/)crates/([^/]+)/ ]] && printf '%s' "${BASH_REMATCH[2]}"

--- a/.claude/hooks/intent-gate.sh
+++ b/.claude/hooks/intent-gate.sh
@@ -52,9 +52,11 @@ fi
 # only view misses them; stop-gate.sh (C) uses the same `git status -u`
 # ground truth. Code files only. effective_turn_base repins a turn_base that a
 # rebase/squash-merge orphaned (else net-LoC / new-file / blob / dup all count
-# the whole rebased-in upstream delta, not just this turn).
+# the whole rebased-in upstream delta AND any pre-turn branch commits that the
+# rebase replayed — patch-ids stored at A0 locate the rewritten turn_base on
+# the new line so the budget stays scoped to THIS turn).
 tb="$(printf '%s' "$st" | jq -r '.turn_base // empty' 2>/dev/null)"
-tb="$(effective_turn_base "$cwd" "$tb")"
+tb="$(printf '%s' "$st" | jq -r '.turn_base_patch_ids[]?' 2>/dev/null | effective_turn_base "$cwd" "$tb")"
 CODE_RE='\.(rs|toml|sh|md)$'
 
 # Unified added-content stream: a `+++ <path>` header per file then each added

--- a/.claude/hooks/intent-gate.sh
+++ b/.claude/hooks/intent-gate.sh
@@ -50,8 +50,11 @@ fi
 # Turn diff scope: committed-this-turn (turn_base..HEAD) + working tree +
 # staged + UNTRACKED. Agents typically leave new files unstaged, so a diff-
 # only view misses them; stop-gate.sh (C) uses the same `git status -u`
-# ground truth. Code files only.
+# ground truth. Code files only. effective_turn_base repins a turn_base that a
+# rebase/squash-merge orphaned (else net-LoC / new-file / blob / dup all count
+# the whole rebased-in upstream delta, not just this turn).
 tb="$(printf '%s' "$st" | jq -r '.turn_base // empty' 2>/dev/null)"
+tb="$(effective_turn_base "$cwd" "$tb")"
 CODE_RE='\.(rs|toml|sh|md)$'
 
 # Unified added-content stream: a `+++ <path>` header per file then each added

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -29,9 +29,11 @@ done < <(git -C "$cwd" status --porcelain -z -u 2>/dev/null)
 # Spec §4.C 3rd source: changes COMMITTED this turn (git status goes clean
 # after a commit; turn-state isn't reset by commit). turn_base = HEAD at A0;
 # effective_turn_base repins it if a rebase/squash-merge orphaned that SHA so
-# the diff stays scoped to THIS turn, not the whole rebased-in upstream delta.
+# the diff stays scoped to THIS turn (not the whole rebased-in delta nor any
+# pre-turn branch commits that the rebase replayed — patch-ids stored at A0
+# locate the rewritten turn_base counterpart on the new line).
 tb="$(printf '%s' "$st" | jq -r '.turn_base // empty' 2>/dev/null)"
-tb="$(effective_turn_base "$cwd" "$tb")"
+tb="$(printf '%s' "$st" | jq -r '.turn_base_patch_ids[]?' 2>/dev/null | effective_turn_base "$cwd" "$tb")"
 if [ -n "$tb" ]; then
   while IFS= read -r -d '' f; do [ -n "$f" ] && _consider "$f"; done \
     < <(git -C "$cwd" diff --name-only -z "$tb"..HEAD 2>/dev/null)

--- a/.claude/hooks/stop-gate.sh
+++ b/.claude/hooks/stop-gate.sh
@@ -27,8 +27,11 @@ while IFS= read -r -d '' rec; do
   esac
 done < <(git -C "$cwd" status --porcelain -z -u 2>/dev/null)
 # Spec §4.C 3rd source: changes COMMITTED this turn (git status goes clean
-# after a commit; turn-state isn't reset by commit). turn_base = HEAD at A0.
+# after a commit; turn-state isn't reset by commit). turn_base = HEAD at A0;
+# effective_turn_base repins it if a rebase/squash-merge orphaned that SHA so
+# the diff stays scoped to THIS turn, not the whole rebased-in upstream delta.
 tb="$(printf '%s' "$st" | jq -r '.turn_base // empty' 2>/dev/null)"
+tb="$(effective_turn_base "$cwd" "$tb")"
 if [ -n "$tb" ]; then
   while IFS= read -r -d '' f; do [ -n "$f" ] && _consider "$f"; done \
     < <(git -C "$cwd" diff --name-only -z "$tb"..HEAD 2>/dev/null)

--- a/.claude/hooks/test/run.sh
+++ b/.claude/hooks/test/run.sh
@@ -42,9 +42,47 @@ mk_rebase_repo() {
   printf '%s|%s' "$d" "$b1"
 }
 
+# Variant covering Codex review #3269664222 (P1): the branch already has a
+# pre-turn commit (`crates/old`) when the turn begins; `git rebase --onto main`
+# replays BOTH `old` and this turn's `new` onto an unrelated upstream. A0
+# stores the patch-id of `old`; effective_turn_base walks the rebased branch
+# and matches that patch-id against the new line, recovering the rewritten
+# `old'` as the effective base so the diff stays scoped to `crates/new` only.
+# Echoes "<dir>|<pre_turn_base_sha>|<patch_id_of_old>|<rewritten_old_sha>".
+# $1=#lines crates/up/src/u.rs   $2=#lines crates/old/src/o.rs (pre-turn)
+# $3=#lines crates/new/src/n.rs (this turn)
+mk_rebase_repo_preturn() {
+  local d up_n="$1" old_n="$2" new_n="$3" root pre_tb pid rewritten i
+  d="$(mktemp -d)"
+  git -C "$d" init -q -b base 2>/dev/null || git -C "$d" init -q
+  git -C "$d" symbolic-ref HEAD refs/heads/base 2>/dev/null || true
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm root --allow-empty
+  root="$(git -C "$d" rev-parse HEAD)"
+  git -C "$d" checkout -q -b feature
+  mkdir -p "$d/crates/old/src"
+  for i in $(seq 1 "$old_n"); do echo "// old $i"; done > "$d/crates/old/src/o.rs"
+  git -C "$d" add -A
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm old
+  pre_tb="$(git -C "$d" rev-parse HEAD)"
+  pid="$(git -C "$d" show "$pre_tb" 2>/dev/null | git patch-id --stable 2>/dev/null | awk 'NF>0{print $1; exit}')"
+  mkdir -p "$d/crates/new/src"
+  for i in $(seq 1 "$new_n"); do echo "// new $i"; done > "$d/crates/new/src/n.rs"
+  git -C "$d" add -A
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm new
+  git -C "$d" checkout -q -b main "$root"
+  mkdir -p "$d/crates/up/src"
+  for i in $(seq 1 "$up_n"); do echo "// up $i"; done > "$d/crates/up/src/u.rs"
+  git -C "$d" add -A
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm squash-unrelated
+  git -C "$d" checkout -q feature
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t rebase --onto main "$root" feature -q >/dev/null 2>&1
+  rewritten="$(git -C "$d" rev-list --reverse main..feature 2>/dev/null | head -n 1)"
+  printf '%s|%s|%s|%s' "$d" "$pre_tb" "$pid" "$rewritten"
+}
+
 # --- _lib unit checks ---
 LS_T="$(mktemp)"; printf '{"impl_files_edited":"oops"}' >"$LS_T"
-chk "load_state normalizes bad shape" '{"impl_files_edited":[],"gate_green":[],"turn_base":""}' "$(load_state "$LS_T")"; rm -f "$LS_T"
+chk "load_state normalizes bad shape" '{"impl_files_edited":[],"gate_green":[],"turn_base":"","turn_base_patch_ids":[]}' "$(load_state "$LS_T")"; rm -f "$LS_T"
 chk "crate_of extracts" engine "$(crate_of 'crates/engine/src/engine.rs')"
 chk "crate_of windows path" engine "$(crate_of 'crates\\engine\\src\\engine.rs')"
 chk "crate_of none" "" "$(crate_of 'README.md')"
@@ -62,16 +100,27 @@ git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit 
 ETB_B1="$(git -C "$ETB_D" rev-parse HEAD)"
 echo x > "$ETB_D/f.txt"; git -C "$ETB_D" add -A
 git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm work
-chk "eff-base ancestor passthrough" "$ETB_B1" "$(effective_turn_base "$ETB_D" "$ETB_B1")"
-chk "eff-base empty stays empty"    ""         "$(effective_turn_base "$ETB_D" "")"
+chk "eff-base ancestor passthrough" "$ETB_B1" "$(effective_turn_base "$ETB_D" "$ETB_B1" </dev/null)"
+chk "eff-base empty stays empty"    ""         "$(effective_turn_base "$ETB_D" "" </dev/null)"
 git -C "$ETB_D" checkout -q -b main "$ETB_ROOT"
 echo y > "$ETB_D/g.txt"; git -C "$ETB_D" add -A
 git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm upstream
 git -C "$ETB_D" checkout -q feature
 git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t rebase --onto main "$ETB_B1" feature -q >/dev/null 2>&1
 ETB_MB="$(git -C "$ETB_D" merge-base HEAD main)"
-chk "eff-base repins stale base"    "$ETB_MB"   "$(effective_turn_base "$ETB_D" "$ETB_B1")"
+chk "eff-base repins stale base"    "$ETB_MB"   "$(effective_turn_base "$ETB_D" "$ETB_B1" </dev/null)"
 rm -rf "$ETB_D"
+# eff-base with stored patch-ids: pre-turn branch commit replayed by rebase.
+# Walking the new line and matching the stored patch-id recovers the rewritten
+# pre-turn commit (NOT just the upstream merge-base), so the diff arm scopes
+# to this turn's `crates/new` and ignores the replayed `crates/old`.
+ETBP="$(mk_rebase_repo_preturn 1 1 1)"
+ETBP_DIR="$(printf '%s' "$ETBP" | awk -F'|' '{print $1}')"
+ETBP_PRE="$(printf '%s' "$ETBP" | awk -F'|' '{print $2}')"
+ETBP_PID="$(printf '%s' "$ETBP" | awk -F'|' '{print $3}')"
+ETBP_REWRITTEN="$(printf '%s' "$ETBP" | awk -F'|' '{print $4}')"
+chk "eff-base patch-id recovers rewritten" "$ETBP_REWRITTEN" "$(printf '%s\n' "$ETBP_PID" | effective_turn_base "$ETBP_DIR" "$ETBP_PRE")"
+rm -rf "$ETBP_DIR"
 
 # A0 turn-reset
 TS_SID="t-a0"; TS_P="$(turn_state_path "$TS_SID" "$PWD")"
@@ -213,6 +262,24 @@ chk "C ignores rebased-in crate" 0 "$(cstop '{"session_id":"'"$RB_SID"'","cwd":"
 printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s"}' "$RB_B1" >"$RB_P"
 chk "C still blocks real post-rebase crate" 2 "$(cstop '{"session_id":"'"$RB_SID"'","cwd":"'"$RB_DIR"'","stop_hook_active":false}')"
 rm -rf "$RB_DIR"
+# P1 (Codex review #3269664222): when the branch already had pre-turn commits
+# before A0, `git rebase --onto` replays them onto the new base. A0 stores the
+# patch-ids of those pre-turn commits; effective_turn_base walks the rebased
+# line, matches the patch-id of `old`, and uses the rewritten `old'` as the
+# effective base — so C ignores the replayed pre-turn crate and only flags
+# this-turn's `crates/new` (which is green here).
+RBP="$(mk_rebase_repo_preturn 1 1 1)"
+RBP_DIR="$(printf '%s' "$RBP" | awk -F'|' '{print $1}')"
+RBP_PRE="$(printf '%s' "$RBP" | awk -F'|' '{print $2}')"
+RBP_PID="$(printf '%s' "$RBP" | awk -F'|' '{print $3}')"
+RBP_SID="c-rebase-pre"; RBP_P="$(turn_state_path "$RBP_SID" "$RBP_DIR")"; mkdir -p "$(dirname "$RBP_P")"
+printf '{"impl_files_edited":[],"gate_green":["new"],"turn_base":"%s","turn_base_patch_ids":["%s"]}' "$RBP_PRE" "$RBP_PID" >"$RBP_P"
+chk "C ignores pre-turn branch commit (P1)" 0 "$(cstop '{"session_id":"'"$RBP_SID"'","cwd":"'"$RBP_DIR"'","stop_hook_active":false}')"
+# Genuine protection survives: same fixture, this-turn crate `new` NOT green
+# -> still blocked (patch-id walk must not over-relax).
+printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s","turn_base_patch_ids":["%s"]}' "$RBP_PRE" "$RBP_PID" >"$RBP_P"
+chk "C still blocks real this-turn crate (P1)" 2 "$(cstop '{"session_id":"'"$RBP_SID"'","cwd":"'"$RBP_DIR"'","stop_hook_active":false}')"
+rm -rf "$RBP_DIR"
 # D fmt (must always exit 0, never block)
 dfmt() { printf '%s' "$1" | bash "$HERE/fmt.sh" >/dev/null 2>&1; echo $?; }
 chk "D exits 0 non-rust"  0 "$(dfmt '{"tool_name":"Write","tool_input":{"file_path":"README.md"},"cwd":"'"$PWD"'"}')"
@@ -336,6 +403,18 @@ ERB_SID="e-rebase"; ERB_P="$(turn_state_path "$ERB_SID" "$ERB_DIR")"; mkdir -p "
 printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s","intent_attempts":0}' "$ERB_B1" >"$ERB_P"
 chk "E ignores rebased-in net-LoC" 0 "$(egate '{"session_id":"'"$ERB_SID"'","cwd":"'"$ERB_DIR"'","stop_hook_active":false}')"
 rm -rf "$ERB_DIR"
+# E P1 (Codex review #3269664222): big pre-turn `crates/old` (450 LoC) +
+# this-turn `crates/new` (1 LoC); after rebase, A0-stored patch-id of `old`
+# locates the rewritten `old'`, so intent-gate counts only the +1 net delta,
+# not the replayed 450 LoC.
+ERBP="$(mk_rebase_repo_preturn 1 450 1)"
+ERBP_DIR="$(printf '%s' "$ERBP" | awk -F'|' '{print $1}')"
+ERBP_PRE="$(printf '%s' "$ERBP" | awk -F'|' '{print $2}')"
+ERBP_PID="$(printf '%s' "$ERBP" | awk -F'|' '{print $3}')"
+ERBP_SID="e-rebase-pre"; ERBP_P="$(turn_state_path "$ERBP_SID" "$ERBP_DIR")"; mkdir -p "$(dirname "$ERBP_P")"
+printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s","turn_base_patch_ids":["%s"],"intent_attempts":0}' "$ERBP_PRE" "$ERBP_PID" >"$ERBP_P"
+chk "E ignores pre-turn branch LoC (P1)" 0 "$(egate '{"session_id":"'"$ERBP_SID"'","cwd":"'"$ERBP_DIR"'","stop_hook_active":false}')"
+rm -rf "$ERBP_DIR"
 
 [ "$fail" -eq 0 ] && echo "ALL GUARD TESTS PASSED" || echo "GUARD TESTS FAILED"
 exit "$fail"

--- a/.claude/hooks/test/run.sh
+++ b/.claude/hooks/test/run.sh
@@ -9,6 +9,39 @@ chk() { # chk "name" expected actual
   else printf 'FAIL - %s (expected[%s] got[%s])\n' "$1" "$2" "$3"; fail=1; fi
 }
 
+# Shared fixture for the rebase/squash-merge regression. Simulates
+# `git rebase --onto <newbase> <old-turn-base> <branch>` after an unrelated PR
+# (crates/up) was squash-merged into the new base, while THIS turn really only
+# touched crates/mine. Echoes "<dir>|<old_turn_base_sha>". root/b1 are empty so
+# only the non-empty `mine` commit is replayed (no rebase empty-commit ambiguity).
+# `-b base` keeps the initial branch distinct from the later `main` branch even
+# when the user's init.defaultBranch is "main".
+# $1=#lines crates/up/src/u.rs (rebased-in, NOT this turn)
+# $2=#lines crates/mine/src/m.rs (this turn's real change)
+mk_rebase_repo() {
+  local d up_n="$1" mine_n="$2" root b1 i
+  d="$(mktemp -d)"
+  git -C "$d" init -q -b base 2>/dev/null || git -C "$d" init -q
+  git -C "$d" symbolic-ref HEAD refs/heads/base 2>/dev/null || true
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm root --allow-empty
+  root="$(git -C "$d" rev-parse HEAD)"
+  git -C "$d" checkout -q -b feature
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm b1 --allow-empty
+  b1="$(git -C "$d" rev-parse HEAD)"
+  mkdir -p "$d/crates/mine/src"
+  for i in $(seq 1 "$mine_n"); do echo "// mine $i"; done > "$d/crates/mine/src/m.rs"
+  git -C "$d" add -A
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm mine
+  git -C "$d" checkout -q -b main "$root"
+  mkdir -p "$d/crates/up/src"
+  for i in $(seq 1 "$up_n"); do echo "// up $i"; done > "$d/crates/up/src/u.rs"
+  git -C "$d" add -A
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm squash-unrelated
+  git -C "$d" checkout -q feature
+  git -C "$d" -c commit.gpgsign=false -c user.email=t@t -c user.name=t rebase --onto main "$b1" feature -q >/dev/null 2>&1
+  printf '%s|%s' "$d" "$b1"
+}
+
 # --- _lib unit checks ---
 LS_T="$(mktemp)"; printf '{"impl_files_edited":"oops"}' >"$LS_T"
 chk "load_state normalizes bad shape" '{"impl_files_edited":[],"gate_green":[],"turn_base":""}' "$(load_state "$LS_T")"; rm -f "$LS_T"
@@ -18,6 +51,27 @@ chk "crate_of none" "" "$(crate_of 'README.md')"
 is_lib_rust 'crates/engine/src/state.rs'        && chk "is_lib_rust src" 0 0 || chk "is_lib_rust src" 0 1
 is_lib_rust 'crates/engine/tests/retry.rs'      && chk "is_lib_rust tests" 1 0 || chk "is_lib_rust tests" 1 1
 is_lib_rust 'crates\\engine\\src\\state.rs'     && chk "is_lib_rust win" 0 0 || chk "is_lib_rust win" 0 1
+# effective_turn_base: ancestor passthrough / empty / repin-on-history-rewrite
+ETB_D="$(mktemp -d)"
+git -C "$ETB_D" init -q -b base 2>/dev/null || git -C "$ETB_D" init -q
+git -C "$ETB_D" symbolic-ref HEAD refs/heads/base 2>/dev/null || true
+git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm root --allow-empty
+ETB_ROOT="$(git -C "$ETB_D" rev-parse HEAD)"
+git -C "$ETB_D" checkout -q -b feature
+git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm b1 --allow-empty
+ETB_B1="$(git -C "$ETB_D" rev-parse HEAD)"
+echo x > "$ETB_D/f.txt"; git -C "$ETB_D" add -A
+git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm work
+chk "eff-base ancestor passthrough" "$ETB_B1" "$(effective_turn_base "$ETB_D" "$ETB_B1")"
+chk "eff-base empty stays empty"    ""         "$(effective_turn_base "$ETB_D" "")"
+git -C "$ETB_D" checkout -q -b main "$ETB_ROOT"
+echo y > "$ETB_D/g.txt"; git -C "$ETB_D" add -A
+git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t commit -qm upstream
+git -C "$ETB_D" checkout -q feature
+git -C "$ETB_D" -c commit.gpgsign=false -c user.email=t@t -c user.name=t rebase --onto main "$ETB_B1" feature -q >/dev/null 2>&1
+ETB_MB="$(git -C "$ETB_D" merge-base HEAD main)"
+chk "eff-base repins stale base"    "$ETB_MB"   "$(effective_turn_base "$ETB_D" "$ETB_B1")"
+rm -rf "$ETB_D"
 
 # A0 turn-reset
 TS_SID="t-a0"; TS_P="$(turn_state_path "$TS_SID" "$PWD")"
@@ -146,6 +200,19 @@ printf '{"session_id":"%s","cwd":"%s"}' "$UB_SID" "$UB_DIR" | bash "$HERE/turn-r
 chk "A0 unborn branch => empty turn_base (§4.C)" '""' "$(jq -c '.turn_base' "$UB_P")"
 rm -rf "$UB_DIR"
 rm -rf "$CG_DIR"
+# Rebase robustness: after `git rebase --onto` reparents the branch onto a base
+# that squash-merged an unrelated PR (crates/up), the stale turn_base must NOT
+# make C flag crates only changed by that already-merged work. crates/mine is
+# this turn's real change.
+RB="$(mk_rebase_repo 1 1)"; RB_DIR="${RB%%|*}"; RB_B1="${RB##*|}"
+RB_SID="c-rebase"; RB_P="$(turn_state_path "$RB_SID" "$RB_DIR")"; mkdir -p "$(dirname "$RB_P")"
+printf '{"impl_files_edited":[],"gate_green":["mine"],"turn_base":"%s"}' "$RB_B1" >"$RB_P"
+chk "C ignores rebased-in crate" 0 "$(cstop '{"session_id":"'"$RB_SID"'","cwd":"'"$RB_DIR"'","stop_hook_active":false}')"
+# Genuine no-cheat protection survives the fix: the crate this turn DID change,
+# with no recorded green gate, is still blocked (repin must not over-relax).
+printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s"}' "$RB_B1" >"$RB_P"
+chk "C still blocks real post-rebase crate" 2 "$(cstop '{"session_id":"'"$RB_SID"'","cwd":"'"$RB_DIR"'","stop_hook_active":false}')"
+rm -rf "$RB_DIR"
 # D fmt (must always exit 0, never block)
 dfmt() { printf '%s' "$1" | bash "$HERE/fmt.sh" >/dev/null 2>&1; echo $?; }
 chk "D exits 0 non-rust"  0 "$(dfmt '{"tool_name":"Write","tool_input":{"file_path":"README.md"},"cwd":"'"$PWD"'"}')"
@@ -261,6 +328,14 @@ EC_SID="e-cap"; EC_P="$(turn_state_path "$EC_SID" "$EC_DIR")"; mkdir -p "$(dirna
 printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"","intent_attempts":0}' >"$EC_P"
 chk "E exactly-5 files allowed" 0 "$(egate '{"session_id":"'"$EC_SID"'","cwd":"'"$EC_DIR"'","stop_hook_active":false}')"
 rm -rf "$EC_DIR"
+# E rebase robustness: a stale turn_base after `git rebase --onto` must not make
+# intent-gate count the squash-merged upstream delta (crates/up = 450 LoC)
+# against this turn's tiny real change (crates/mine = 1 LoC).
+ERB="$(mk_rebase_repo 450 1)"; ERB_DIR="${ERB%%|*}"; ERB_B1="${ERB##*|}"
+ERB_SID="e-rebase"; ERB_P="$(turn_state_path "$ERB_SID" "$ERB_DIR")"; mkdir -p "$(dirname "$ERB_P")"
+printf '{"impl_files_edited":[],"gate_green":[],"turn_base":"%s","intent_attempts":0}' "$ERB_B1" >"$ERB_P"
+chk "E ignores rebased-in net-LoC" 0 "$(egate '{"session_id":"'"$ERB_SID"'","cwd":"'"$ERB_DIR"'","stop_hook_active":false}')"
+rm -rf "$ERB_DIR"
 
 [ "$fail" -eq 0 ] && echo "ALL GUARD TESTS PASSED" || echo "GUARD TESTS FAILED"
 exit "$fail"

--- a/.claude/hooks/turn-reset.sh
+++ b/.claude/hooks/turn-reset.sh
@@ -4,12 +4,52 @@ DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; . "$DIR/_lib.sh"
 read_input
 sid="$(jqg '.session_id')"; cwd="$(jqg '.cwd')"; [ -n "$cwd" ] || cwd="$PWD"
 p="$(turn_state_path "$sid" "$cwd")"
-# Spec §4.C: record base HEAD so C can catch crate changes COMMITTED mid-turn
+# Spec §4.C: record base HEAD so C catches crate changes COMMITTED mid-turn
 # (git status alone goes clean after a commit). --verify -q stays SILENT and
 # exits non-zero on an unborn branch (zero commits): plain `rev-parse HEAD`
-# would print the literal "HEAD" to stdout there, making turn_base non-empty so
-# C runs a vacuous HEAD..HEAD diff. Empty turn_base => C skips the diff arm and
+# would print "HEAD" to stdout there, making turn_base non-empty so C runs a
+# vacuous HEAD..HEAD diff. Empty turn_base => C skips the diff arm and
 # degrades to git-status + B-union (the intended no-commits behavior).
 tb="$(git -C "$cwd" rev-parse --verify -q HEAD 2>/dev/null || true)"
-save_state "$p" "$(printf '{"session":"%s","started_at":"%s","impl_files_edited":[],"gate_green":[],"turn_base":"%s"}' "${sid:-unknown}" "$(date -u +%FT%TZ)" "$tb")"
+# Also snapshot the patch-id of every PRE-TURN branch commit (commits ahead of
+# upstream at A0). `git patch-id --stable` hashes the diff content alone, so a
+# later `git rebase --onto` produces commits with the SAME patch-ids on the new
+# line. effective_turn_base walks the rebased branch and matches against this
+# stored set to recover the rewritten counterpart of turn_base — keeping the
+# committed-this-turn diff arm scoped to THIS turn instead of widening to the
+# whole branch divergence (Codex PR #726 review #3269664222). Empty array =>
+# no pre-turn commits (fresh branch) or no upstream ref => safe degradation
+# (effective_turn_base falls back to upstream merge-base).
+pids_json="[]"
+if [ -n "$tb" ] && have_jq; then
+  mb=""
+  for ref in origin/main main '@{upstream}'; do
+    git -C "$cwd" rev-parse --verify -q "$ref" >/dev/null 2>&1 || continue
+    candidate="$(git -C "$cwd" merge-base HEAD "$ref" 2>/dev/null)"
+    [ -n "$candidate" ] && { mb="$candidate"; break; }
+  done
+  if [ -n "$mb" ] && [ "$mb" != "$tb" ]; then
+    pids_json="$(git -C "$cwd" rev-list --reverse "${mb}..HEAD" 2>/dev/null \
+                  | while IFS= read -r c; do
+                      [ -n "$c" ] || continue
+                      git -C "$cwd" show "$c" 2>/dev/null \
+                        | git patch-id --stable 2>/dev/null \
+                        | awk 'NF>0{print $1; exit}'
+                    done \
+                  | jq -Rsc 'split("\n") | map(rtrimstr("\r")) | map(select(length>0)) | .[0:256]' 2>/dev/null)"
+    [ -z "$pids_json" ] && pids_json="[]"
+  fi
+fi
+if have_jq; then
+  state="$(jq -nc \
+            --arg s "${sid:-unknown}" \
+            --arg t "$(date -u +%FT%TZ)" \
+            --arg tb "$tb" \
+            --argjson pids "$pids_json" \
+            '{session:$s,started_at:$t,impl_files_edited:[],gate_green:[],turn_base:$tb,turn_base_patch_ids:$pids}' 2>/dev/null)"
+fi
+if [ -z "${state:-}" ]; then
+  state="$(printf '{"session":"%s","started_at":"%s","impl_files_edited":[],"gate_green":[],"turn_base":"%s","turn_base_patch_ids":[]}' "${sid:-unknown}" "$(date -u +%FT%TZ)" "$tb")"
+fi
+save_state "$p" "$state"
 allow


### PR DESCRIPTION
## Problem

`stop-gate.sh` and `intent-gate.sh` derive the current turn's touched-crate / touched-file set from `turn_base..HEAD`, where `turn_base` is a fixed commit SHA captured at turn start (`turn-reset.sh` A0).

After the working branch is rebased (`git rebase --onto origin/main <old-base> <branch>`) or its upstream base is squash-merged into `main` and the branch is reparented, `turn_base` points at a commit on an **abandoned history line**. The `turn_base..HEAD` diff (and the working-tree/staged/untracked union both hooks build) then spans the **entire delta between the old and new base** — i.e. the whole squash-merged upstream PR — so crates that were only changed by that already-merged work are reported as "changed this turn". The Stop-gate then demands a fresh `cargo clippy -p <crate> -- -D warnings` + `cargo nextest run -p <crate>` for each (minutes per crate), training the operator to treat the guard as noise. `intent-gate.sh` showed the identical stale-base churn (spurious net-LoC / new-file / blob counting).

## Fix

New `effective_turn_base()` in `_lib.sh`, called by both hooks before the committed-this-turn diff arm:

- **`turn_base` still an ancestor of `HEAD`** (the common, no-rewrite case) → returned unchanged. **Zero behavior change.**
- **Not an ancestor** (`git merge-base --is-ancestor` fails ⇒ history rewrite) → repin to the branch's `merge-base` with the first of `origin/main` / `main` / `@{upstream}` that resolves. That point is **after** any squash-merge, so the merged upstream work drops out, while commits made on *this* branch are still seen.
- **No upstream ref resolves** → `""`; callers skip the diff arm — documented safe degradation, identical to the unborn-branch path. B-union (`impl_files_edited`) + working-tree `git status` ground truth still enforce the green gate.

Only the touched-set **scoping** changes. The D10 no-cheat guarantee (edit-guard B + clean-gate recorder A2 + Stop-gate C + lefthook/CI) is untouched — `record.sh` / `edit-guard.sh` unmodified; the `// budget-justified:` / escape semantics of `intent-gate.sh` are preserved.

### Options considered

| # | Option | Verdict |
|---|--------|---------|
| 1 | Always `origin/main...HEAD` | Rejected — regresses the common multi-turn case (re-demands every prior turn's committed crates; `gate_green` is reset per turn) |
| **2** | **Repin when `turn_base` no longer ancestor of HEAD** | **Chosen — exact prior semantics in the no-rewrite case, graceful recovery on rewrite, minimal** |
| 3 | Date-window commits + content-equality vs `origin/main` | Rejected — rebase rewrites commit-dates; per-file blob compare is complex, violates "minimal" |
| 4 | Memoize A2 green per crate by tree hash | Rejected — does not fix root cause (a rebased crate's tree *does* change → memo misses); also mutates the A2 core |

## Verification

- `task hooks:test` → `ALL GUARD TESTS PASSED` (exit 0). New regression cases, all green:
  - `effective_turn_base` unit: ancestor passthrough / empty / repins-stale-base
  - **`C ignores rebased-in crate`** — the reproduced false positive (RED → GREEN)
  - **`C still blocks real post-rebase crate`** — genuine no-cheat block still fires when the real this-turn crate has no recorded green gate
  - **`E ignores rebased-in net-LoC`** — intent-gate no longer counts the rebased-in upstream delta
- Manual rebased fixture: `effective_turn_base` repins ≠ stale base; `stop-gate.sh` / `intent-gate.sh` exit `0` on a 600-LoC rebased-in upstream, `stop-gate.sh` exits `2` when the real crate is ungreen.
- TDD: tests written first, watched fail with the predicted reason, then implemented, watched pass.
- lefthook pre-commit (typos + convco) and pre-push (full workspace gate) passed; no hooks bypassed.

## Scope

`.claude/hooks/_lib.sh` (+34), `stop-gate.sh` (+4/-1), `intent-gate.sh` (+4/-1), `test/run.sh` (+75 regression). No unrelated hooks changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved state tracking for code changes during branch operations

* **Improvements**
  * Enhanced handling of rebased and squash-merged branches
  * Better recovery and baseline computation during complex git operations

* **Tests**
  * Added test coverage for rebase and upstream merge scenarios
  * Extended regression testing for state management edge cases

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->