### PR TITLE
refactor(resource)!: post-audit cleanup — seal HasResourcesExt, drop ReloadOutcome::Restarting, sweep stale docs

### DIFF
--- a/crates/resource/README.md
+++ b/crates/resource/README.md
@@ -102,7 +102,6 @@ manager.register(RegistrationSpec {
     slot_identity: SlotIdentity::Unbound,      // structural anti-bleed identity (see below)
     topology: TopologyRuntime::Resident(resident_runtime),
     acquire: Manager::erased_acquire_resident_for::<R>(),
-    resilience: None,                          // Option<AcquireResilience>
     recovery_gate: None,                       // Option<Arc<RecoveryGate>>
 })?;
 ```
@@ -129,10 +128,9 @@ The framework resolves declared `#[credential]` slots **before** invoking `Resou
 - `ResourceContext` — execution context with cancellation and capability traits (`HasResources`, `HasCredentials`).
 - `ScopeLevel` — re-exported from `nebula_core::ScopeLevel`.
 - `ResourcePhase`, `ResourceStatus` — lifecycle phase tracking for observability.
-- `ResourceEvent` — lifecycle events (`Acquired`, `Released`, `HealthCheck`, `Recycled`, `ConfigReloaded`, …).
+- `ResourceEvent` — lifecycle events (`Registered`, `Removed`, `AcquireSuccess`, `AcquireFailed`, `Released`, `HealthChanged`, `ConfigReloaded`, `RetryAttempt`, `BackpressureDetected`, `RecoveryGateChanged`, `SlotRefreshed`, `SlotRevoked`, `SlotRefreshFailed`, `SlotRevokeFailed`).
 - `ResourceOpsMetrics`, `ResourceOpsSnapshot` — registry-backed operation counters.
 - `RecoveryGate`, `RecoveryGateConfig`, `RecoveryTicket`, `RecoveryWaiter`, `GateState` — thundering-herd recovery gate.
-- `AcquireResilience`, `AcquireRetryConfig` — resilience configuration for acquire paths.
 - `TopologyRuntime` — enum dispatching to the 3 topology runtime variants (`Pool` / `Resident` / `Bounded`).
 - Topology traits: `Pooled`, `Resident`, `Bounded` (+ `BoundedRelease`, the `CapMarker` typestates `Unbounded` / `Capped<N>` / `Exclusive`).
 - Topology runtimes: `PoolRuntime`, `ResidentRuntime`, `BoundedRuntime`.
@@ -173,7 +171,7 @@ The headline patterns and topology selection guidance are distilled into `crates
 ## Non-goals
 
 - Not a connection driver — resource implementations supply the actual client (sqlx pool, reqwest client, etc.); this crate owns the lifecycle wrapper.
-- Not a retry pipeline — retry around outbound calls inside `create`/`check` uses `nebula-resilience` directly. The `AcquireResilience` type configures the acquire-path retry only.
+- Not a retry pipeline — retry composes one layer up (action handler / engine activity / caller-supplied `nebula-resilience` pipeline). The manager-side `AcquireResilience` wrapper was removed in commit `cf93e45b`; peer Rust pools (sqlx, deadpool, bb8) ship acquire-timeout only, retry above. Retry around outbound calls inside `create`/`check` uses `nebula-resilience` directly at the resource impl.
 - Not a secret holder — credentials are populated into slot fields by the framework; secret material is managed by `nebula-credential`.
 - Not an expression evaluator — resource `Config` comes from `nebula-schema`-validated parameters; expression resolution is `nebula-expression`'s job. The engine-facing `Manager::register_resolved` orchestrates the resolve→validate→register pipeline but the evaluator itself stays out.
 

--- a/crates/resource/docs/README.md
+++ b/crates/resource/docs/README.md
@@ -164,29 +164,41 @@ async fn main() -> Result<(), nebula_resource::Error> {
 }
 ```
 
-### 4. Register with resilience
+### 4. Register with a recovery gate
 
-For production use, add timeout + retry + recovery gate via `RegisterOptions`:
+For production use, attach a recovery gate via `RegistrationSpec` to
+prevent thundering-herd when a backend goes down. The manager-side
+`AcquireResilience` (timeout + retry wrapper around `acquire`) was
+removed in commit `cf93e45b`: retry composes one layer up at the
+action / engine activity boundary, and per-topology config carries
+its own `create_timeout` (resident / pool). The recovery gate is the
+remaining manager-level resilience seam.
 
 ```rust,ignore
 use nebula_resource::{
-    Manager, PoolConfig, RegisterOptions, AcquireResilience, RecoveryGate, RecoveryGateConfig,
+    Manager, PoolRuntime, RegistrationSpec, ScopeLevel, SlotIdentity,
+    TopologyRuntime, dedup::SlotIdentity as _,
+    recovery::{RecoveryGate, RecoveryGateConfig},
+    topology::pooled::config::Config as PoolConfig,
 };
 use std::sync::Arc;
 
 let manager = Manager::new();
 let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig::default()));
-
-manager.register_pooled_with(
-    DbResource,
-    db_config,
+let pool_rt = PoolRuntime::<DbResource>::try_new(
     PoolConfig { max_size: 20, ..Default::default() },
-    RegisterOptions {
-        resilience: Some(AcquireResilience::standard()),
-        recovery_gate: Some(gate),
-        ..Default::default()
-    },
+    db_config.fingerprint(),
 )?;
+
+manager.register(RegistrationSpec {
+    resource: DbResource,
+    config: db_config,
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Pool(pool_rt),
+    acquire: Manager::erased_acquire_pooled_for::<DbResource>(),
+    recovery_gate: Some(gate),
+})?;
 ```
 
 ---
@@ -267,27 +279,29 @@ crates/resource/
 │   ├── dedup.rs           slot_identity + SLOT_IDENTITY_UNBOUND (anti-bleed key)
 │   ├── manager/           Manager directory:
 │   │   ├── mod.rs              Manager type + register/acquire + refresh_slot/revoke_slot
-│   │   ├── options.rs          ManagerConfig, RegisterOptions, ShutdownConfig, DrainTimeoutPolicy
-│   │   ├── gate.rs             Recovery-gate admission helpers
-│   │   ├── execute.rs          Resilience pipeline + register-time pool config validation
+│   │   ├── options.rs          ManagerConfig, RegisterOptions, RegistrationSpec, ShutdownConfig, DrainTimeoutPolicy
+│   │   ├── gate.rs             Recovery-gate admission helpers (GateAdmission, admit_through_gate, settle_gate_admission)
+│   │   ├── acquire_dispatch.rs Type-erased acquire factories (erased_acquire_{pooled,resident,bounded})
 │   │   └── shutdown.rs         graceful_shutdown + drain helpers + set_phase_all*
 │   ├── registry.rs        Registry, AnyManagedResource — type-erased storage
 │   ├── guard.rs           ResourceGuard — RAII acquire lease (Owned / Guarded / Shared)
 │   ├── context.rs         ResourceContext — execution context with capabilities
+│   ├── dedup.rs           SlotIdentity (Unbound / Structural), DedupKey
 │   ├── error.rs           Error, ErrorKind, ErrorScope
-│   ├── events.rs          ResourceEvent — 14 lifecycle event variants
+│   ├── events.rs          ResourceEvent — 14 lifecycle event variants (all emitted)
 │   ├── options.rs         AcquireOptions (deadline-only since R-051)
 │   ├── metrics.rs         ResourceOpsMetrics, ResourceOpsSnapshot, OutcomeCountersSnapshot
 │   ├── state.rs           ResourcePhase, ResourceStatus
-│   ├── cell.rs            Cell — ArcSwap-based lock-free cell for Resident topology
+│   ├── cell.rs            Cell — crate-internal ArcSwap-based lock-free cell for Resident topology
+│   ├── slot.rs            SlotCell — public generation-stamped credential slot holder
 │   ├── release_queue.rs   ReleaseQueue — background async cleanup workers
-│   ├── reload.rs          ReloadOutcome
-│   ├── topology_tag.rs    TopologyTag — 5-variant discriminant (post-ADR-0037)
-│   ├── integration.rs     AcquireResilience, AcquireRetryConfig
-│   ├── ext.rs             HasResourcesExt
-│   ├── recovery/          RecoveryGate, RecoveryGroupRegistry, WatchdogHandle
-│   ├── runtime/           Per-topology runtime wrappers (5 topologies)
-│   └── topology/          Per-topology trait definitions (Pooled / Resident / Service / Transport / Exclusive)
+│   ├── reload.rs          ReloadOutcome (NoChange / SwappedImmediately)
+│   ├── resource_ref.rs    ResourceRef — lazy reference type for action contexts
+│   ├── topology_tag.rs    TopologyTag — 3-variant discriminant (Pool / Resident / Bounded)
+│   ├── ext.rs             HasResourcesExt (sealed)
+│   ├── recovery/          RecoveryGate, RecoveryTicket, RecoveryWaiter, GateState
+│   ├── runtime/           Per-topology runtime wrappers (Pool / Resident / Bounded + ManagedResource)
+│   └── topology/          Per-topology trait definitions (Pooled / Resident / Bounded + Cap typestate)
 └── docs/
     ├── README.md          ← this file
     ├── api-reference.md   Full public API with signatures

--- a/crates/resource/docs/adapters.md
+++ b/crates/resource/docs/adapters.md
@@ -376,55 +376,55 @@ argument; a credential-bound resource carries its resolved guard in its
 register/acquire surface is identical whether or not the resource binds a
 credential.
 
-1. **`register_pooled` + `acquire_pooled`** — zero-boilerplate. `Global`
-   scope, no resilience, no recovery gate.
-2. **`register_pooled_with` + `acquire_pooled`** — pass `RegisterOptions`
-   for a non-default `scope`, an `AcquireResilience` profile, or a
-   `RecoveryGate`.
-3. **`Manager::register` + `acquire_pooled`** — full positional path when
-   you need to build the `TopologyRuntime::Pool(PoolRuntime::<R>::new(...))`
-   yourself. For the multi-tenant case, pin distinct resolved credentials to
-   distinct registry rows with `register_with_identity` (or
-   `RegisterOptions::with_slot_identity`) and acquire via
-   `acquire_pooled_for`.
+Registration goes through **one funnel**:
+`Manager::register::<R>(spec: RegistrationSpec<R>)`. The per-topology
+`register_<topo>[_with]` shorthands and the multi-step delegation chain
+were removed (commit `cf93e45b` dropped the manager-side
+`AcquireResilience` wrapper; the `register_*` shorthand family
+followed). `RegistrationSpec<R>` is a plain struct with public fields
+and no builder.
+
+For the multi-tenant case, pin distinct resolved credentials to
+distinct registry rows by building a `SlotIdentity::Structural` (via
+`SlotIdentity::from_bindings`) and acquire through
+`acquire_pooled_for_identity`.
 
 ```rust,ignore
-// path 1: simplest
-use nebula_resource::{Manager, PoolConfig};
+use nebula_resource::{
+    AcquireOptions, Manager, PoolRuntime, RegistrationSpec, ScopeLevel,
+    TopologyRuntime, dedup::SlotIdentity,
+    topology::pooled::config::Config as PoolConfig,
+};
 use nebula_resource_postgres::{PostgresConfig, PostgresResource};
 
 let manager = Manager::new();
-manager.register_pooled(
-    PostgresResource,
-    PostgresConfig { host: "db.example.com".into(), port: 5432,
-                     database: "myapp".into(), connect_timeout_secs: 10 },
-    PoolConfig { max_size: 10, ..PoolConfig::default() },
-)?;
-```
-
-```rust,ignore
-// path 2: with options.
-use nebula_resource::{
-    AcquireResilience, AcquireRetryConfig, PoolConfig, RegisterOptions,
+let pg_config = PostgresConfig {
+    host: "db.example.com".into(),
+    port: 5432,
+    database: "myapp".into(),
+    connect_timeout_secs: 10,
 };
-
-let opts = RegisterOptions::default()  // scope = Global
-    .with_resilience(AcquireResilience {
-        timeout: Some(std::time::Duration::from_secs(5)),
-        retry: Some(AcquireRetryConfig::default()),
-    });
-
-manager.register_pooled_with(
-    PostgresResource, PostgresConfig::default(), PoolConfig::default(), opts,
+let pool_rt = PoolRuntime::<PostgresResource>::try_new(
+    PoolConfig { max_size: 10, ..PoolConfig::default() },
+    pg_config.fingerprint(),
 )?;
+
+manager.register(RegistrationSpec {
+    resource: PostgresResource,
+    config: pg_config,
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Pool(pool_rt),
+    acquire: Manager::erased_acquire_pooled_for::<PostgresResource>(),
+    recovery_gate: None,  // attach an Arc<RecoveryGate> for thundering-herd protection
+})?;
 ```
 
 To acquire:
 
 ```rust,ignore
 use nebula_core::scope::Scope;
-use nebula_resource::AcquireOptions;
-use nebula_resource::context::ResourceContext;
+use nebula_resource::{AcquireOptions, context::ResourceContext};
 use tokio_util::sync::CancellationToken;
 
 let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
@@ -433,6 +433,12 @@ let handle = manager
     .await?;
 let conn: &PgConnection = &*handle;  // RAII — returns to the pool on drop.
 ```
+
+Retry / timeout composition lives one layer up (action handler / engine
+activity) — peer Rust pools (sqlx, deadpool, bb8) all ship
+acquire-timeout only, and per-topology configs carry their own
+`create_timeout`. Add a `RecoveryGate` only when you need thundering-
+herd protection on a flapping backend.
 
 ---
 
@@ -443,19 +449,32 @@ Tests should not require a real database — use a mock `PgConnection`.
 ```rust,ignore
 // tests/integration.rs
 use nebula_core::scope::Scope;
-use nebula_resource::{AcquireOptions, Manager, PoolConfig, TopologyTag};
-use nebula_resource::context::ResourceContext;
+use nebula_resource::{
+    AcquireOptions, Manager, PoolRuntime, RegistrationSpec, ScopeLevel,
+    TopologyRuntime, TopologyTag, context::ResourceContext, dedup::SlotIdentity,
+    topology::pooled::config::Config as PoolConfig,
+};
 use nebula_resource_postgres::{PostgresConfig, PostgresResource};
 use tokio_util::sync::CancellationToken;
 
 #[tokio::test]
 async fn register_and_acquire() {
     let manager = Manager::new();
-    manager.register_pooled(
-        PostgresResource,
-        PostgresConfig::default(),
+    let pg_config = PostgresConfig::default();
+    let pool_rt = PoolRuntime::<PostgresResource>::try_new(
         PoolConfig::default(),
-    ).expect("valid config must register");
+        pg_config.fingerprint(),
+    ).expect("valid pool config");
+
+    manager.register(RegistrationSpec {
+        resource: PostgresResource,
+        config: pg_config,
+        scope: ScopeLevel::Global,
+        slot_identity: SlotIdentity::Unbound,
+        topology: TopologyRuntime::Pool(pool_rt),
+        acquire: Manager::erased_acquire_pooled_for::<PostgresResource>(),
+        recovery_gate: None,
+    }).expect("valid config must register");
 
     let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
     let handle = manager

--- a/crates/resource/docs/pooling.md
+++ b/crates/resource/docs/pooling.md
@@ -106,8 +106,9 @@ pub struct PoolConfig {
 `max_size`/`max_lifetime` against your backend's connection-budget and TTL.
 
 `PoolConfig::validate()` enforces `min_size <= max_size` and non-zero
-`max_size`. `Manager::register_pooled` / `register_pooled_with` call this
-implicitly.
+`max_size`. `PoolRuntime::try_new` calls it implicitly, so an invalid
+config surfaces as a typed error at runtime construction — before
+`Manager::register` ever sees the `TopologyRuntime::Pool(...)` value.
 
 ---
 
@@ -309,29 +310,43 @@ PoolConfig {
 
 ## Integration with Resilience
 
-Per-acquire timeout, retry policy, and recovery-gate admission belong on
-`AcquireResilience` / `RecoveryGate`, not on `PoolConfig`. Wire them in
-via `RegisterOptions`:
+Per-acquire timeout / retry composes one layer up (action handler /
+engine activity / caller-supplied `nebula-resilience` pipeline) — the
+manager-side `AcquireResilience` wrapper was removed in commit
+`cf93e45b` (peer Rust pools — sqlx, deadpool, bb8 — all ship
+acquire-timeout only). Acquire-timeout itself lives on the topology
+config (`create_timeout` field on the pool config).
+
+`RecoveryGate` is the remaining manager-level resilience seam: a
+CAS-based single-probe admission that prevents thundering-herd against
+a flapping backend. Wire it through `RegistrationSpec::recovery_gate`:
 
 ```rust,ignore
 use std::sync::Arc;
 use nebula_resource::{
-    AcquireResilience, RecoveryGate, RecoveryGateConfig, RegisterOptions,
+    Manager, PoolRuntime, RegistrationSpec, ScopeLevel, TopologyRuntime,
+    dedup::SlotIdentity,
+    recovery::{RecoveryGate, RecoveryGateConfig},
+    topology::pooled::config::Config as PoolConfig,
 };
 
 let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig::default()));
-
-manager.register_pooled_with(
-    PostgresResource,
-    pg_config,
+let pool_rt = PoolRuntime::<PostgresResource>::try_new(
     PoolConfig::default(),
-    RegisterOptions {
-        resilience:    Some(AcquireResilience::standard()),
-        recovery_gate: Some(gate),
-        ..RegisterOptions::default()
-    },
+    pg_config.fingerprint(),
 )?;
+
+manager.register(RegistrationSpec {
+    resource: PostgresResource,
+    config: pg_config,
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Pool(pool_rt),
+    acquire: Manager::erased_acquire_pooled_for::<PostgresResource>(),
+    recovery_gate: Some(gate),
+})?;
 ```
 
-See [`api-reference.md`](api-reference.md) for `RegisterOptions` field
-semantics and [`recovery.md`](recovery.md) for `RecoveryGate` behavior.
+See [`api-reference.md`](api-reference.md) for the `RegistrationSpec`
+public fields and [`recovery.md`](recovery.md) for `RecoveryGate`
+behaviour (state machine + thundering-herd admission semantics).

--- a/crates/resource/docs/recovery.md
+++ b/crates/resource/docs/recovery.md
@@ -100,25 +100,33 @@ When registering a resource, pass an optional `RecoveryGate`:
 ```rust,ignore
 use std::sync::Arc;
 use nebula_resource::{
-    PoolConfig, RecoveryGate, RecoveryGateConfig, RegisterOptions,
+    Manager, PoolRuntime, RegistrationSpec, ScopeLevel, TopologyRuntime,
+    dedup::SlotIdentity,
+    recovery::{RecoveryGate, RecoveryGateConfig},
+    topology::pooled::config::Config as PoolConfig,
 };
 
 let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig::default()));
-
-manager.register_pooled_with(
-    PostgresResource,
-    pg_config,
+let pool_rt = PoolRuntime::<PostgresResource>::try_new(
     PoolConfig::default(),
-    RegisterOptions {
-        recovery_gate: Some(gate.clone()),
-        ..RegisterOptions::default()
-    },
+    pg_config.fingerprint(),
 )?;
+
+manager.register(RegistrationSpec {
+    resource: PostgresResource,
+    config: pg_config,
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Pool(pool_rt),
+    acquire: Manager::erased_acquire_pooled_for::<PostgresResource>(),
+    recovery_gate: Some(gate.clone()),
+})?;
 ```
 
-For credential-bound resources, also pass `credential_id: Some(...)` in
-`RegisterOptions`. Use `Manager::register` (positional) for full control
-over scope and topology.
+For credential-bound resources, declare `#[credential(key = "...")]`
+fields on the resource struct — the framework resolves them before
+`Resource::create` runs. Per-tenant routing uses
+`SlotIdentity::from_bindings(...)` plus `acquire_pooled_for_identity`.
 
 The Manager automatically:
 1. **Checks the gate** before each acquire (admission helper in

--- a/crates/resource/src/ext.rs
+++ b/crates/resource/src/ext.rs
@@ -68,6 +68,20 @@ use crate::{
     error::{Error, ErrorKind},
 };
 
+/// Sealing module — keeps [`HasResourcesExt`] closed to external impls.
+///
+/// `HasResourcesExt` adds a method *over* every `HasResources` via a
+/// blanket impl. Without sealing, a downstream crate could write its
+/// own `impl HasResourcesExt for SomeOtherType` and collide with the
+/// blanket — a published-library semver hazard (rust-intel §C1). The
+/// sealed supertrait makes external impls a compile error; the blanket
+/// impl below is the sole impl path, and adding methods to
+/// `HasResourcesExt` is therefore non-breaking.
+mod sealed {
+    pub trait Sealed {}
+    impl<C: super::HasResources + ?Sized> Sealed for C {}
+}
+
 /// Typed resource access for any context implementing `HasResources`.
 ///
 /// Ad-hoc form: looks up by `R::key()` only. For per-node slot binding,
@@ -75,6 +89,11 @@ use crate::{
 /// derive-emitted `FromWorkflowNode` factory call
 /// `ActionContextExt::acquire_resource_by_id` instead — slot binding is
 /// the preferred path for production code (see crate-level docs).
+///
+/// **Sealed.** External crates cannot implement this trait; the sole
+/// impl is the crate-internal blanket `impl<C: HasResources + ?Sized>
+/// HasResourcesExt for C`. New methods can be added here without
+/// breaking downstream code.
 ///
 /// # Examples
 ///
@@ -84,7 +103,7 @@ use crate::{
 /// let pool = ctx.resource::<PostgresResource>().await?;
 /// let cache = ctx.try_resource::<RedisResource>().await?;
 /// ```
-pub trait HasResourcesExt: HasResources {
+pub trait HasResourcesExt: HasResources + sealed::Sealed {
     /// Acquire a typed resource guard. Returns error if not found or acquisition fails.
     fn resource<R: Resource>(&self) -> impl Future<Output = Result<ResourceGuard<R>, Error>> + Send
     where

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -293,8 +293,9 @@
 //!   `#[allow(clippy::too_many_arguments)]`.** The four register-chain
 //!   `too_many_arguments` allows the collapse targeted are gone; this last
 //!   one is the irreducible engine ABI — the production engine registrar
-//!   dispatches into `register_resolved` positionally with a 9-param
-//!   JSON-driven shape, and collapsing it into a struct would re-introduce
+//!   dispatches into `register_resolved` positionally with an 8-param
+//!   JSON-driven shape (down from 9 after `AcquireResilience` was dropped
+//!   manager-side; see commit `cf93e45b`), and collapsing it into a struct would re-introduce
 //!   the navigation hop the single register funnel removed for the one
 //!   erased call site. It is a candidate for the cross-crate-dedup
 //!   follow-up ([#718]), not a defect. (The three `too_many_arguments`

--- a/crates/resource/src/reload.rs
+++ b/crates/resource/src/reload.rs
@@ -5,13 +5,19 @@
 /// Used by [`Manager`](crate::manager::Manager) for both config changes
 /// and credential rotation. Each variant maps to one of the possible
 /// outcomes when a reload is dispatched to a topology runtime.
+///
+/// The historical `Restarting` variant was reachable only from the
+/// pre-collapse `Service` topology (a former engine-side daemon row);
+/// post topology collapse (3 runtimes) it is structurally unreachable
+/// and was removed. The two surviving outcomes — `NoChange` (fingerprint
+/// identical) and `SwappedImmediately` (config/credential swapped in
+/// place) — cover every live registry row. See the
+/// [`manager`](crate::manager) module docs for the relabel rationale.
+#[non_exhaustive]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ReloadOutcome {
     /// Applied immediately. Next acquire gets fresh config/credential.
     SwappedImmediately,
-    /// Engine-side daemon (per engine daemon topology, lives in `nebula_engine::daemon`)
-    /// cancelled and restarting after a reload.
-    Restarting,
     /// Fingerprint identical — no change needed.
     NoChange,
 }


### PR DESCRIPTION
## Why

Follow-up to PR #728 (mythos audit). Three items the audit flagged as
in-scope but deliberately separated from #728 to keep that PR focused
on the dormant-event wiring. All three touch only `nebula-resource`
and none of them depend on the open latent-ledger items
(#712–#716), so they fit in one PR.

## What

### `ReloadOutcome::Restarting` — removed

* The variant was reachable only from the pre-collapse `Service`
  topology. Post topology collapse (3 runtimes — Pool / Resident /
  Bounded) it is structurally unreachable.
* `manager/mod.rs` "accepted carve-outs" doc claimed the variant
  "was removed once the characterization net landed", but the removal
  never happened — the doc was lying.
* This commit makes the doc factual: variant deleted, enum is now
  `#[non_exhaustive]`, surviving two variants (`NoChange`,
  `SwappedImmediately`) cover every live registry row.
* Also fixes the same module-doc claim about `register_resolved`
  being a 9-positional-arg ABI — `cf93e45b` dropped it to 8.

### `HasResourcesExt` — sealed

* Was `pub trait HasResourcesExt: HasResources` with an open
  blanket impl — a rust-intel §C1 semver hazard.
* Fix: add `sealed::Sealed` crate-private supertrait + blanket
  `impl Sealed`. Downstream crates keep using the trait (methods
  reachable via the blanket) but cannot conflict with it. New
  methods on `HasResourcesExt` are now additive.

### Stale-doc sweep — `AcquireResilience` / `register_*_with` family

`cf93e45b` dropped the manager-side resilience surface and the
`register_<topo>[_with]` shorthand family but did not sweep the doc
tree. Stale references confused fresh contributors and risked LLM
agents generating code against dead API (rust-intel §A1 API
hallucination triage).

| File | What changed |
|---|---|
| `crates/resource/README.md` | Registration example drops `resilience: None,`; "Other public API" list no longer names `AcquireResilience` / `AcquireRetryConfig`, enumerates current `ResourceEvent` variants; Non-goals reworded to "retry composes one layer up" + `cf93e45b` pointer. |
| `crates/resource/docs/README.md` | "Register with resilience" → "Register with a recovery gate", rewritten around `RegistrationSpec`. Source-tree map updated for the post-collapse layout. |
| `crates/resource/docs/adapters.md` | 3-path register table folded into the single `RegistrationSpec` funnel; integration-test sample updated. |
| `crates/resource/docs/pooling.md` | "Integration with Resilience" rewritten around `RecoveryGate`; `PoolConfig::validate()` retargeted to `PoolRuntime::try_new`. |
| `crates/resource/docs/recovery.md` | Manager integration example uses `RegistrationSpec`; cred-id paragraph updated for the slot-binding model. |

## Breaking change

The `!` is for the `ReloadOutcome::Restarting` removal. No downstream
consumer in the workspace matched on it (`cargo check --workspace
--all-targets` passes), but external consumers with exhaustive
`match` arms over the (previously non-`non_exhaustive`) enum would
fail to compile.

`HasResourcesExt` sealing is **not** breaking: the trait is still
usable as before — only future external `impl` blocks become a
compile error, and no such impls exist (the blanket already covered
every `HasResources`).

## Out of scope (still deferred)

* `Noop{Resource,Credential}Accessor` cross-crate dup
  (`action` / `credential` / `resource`).
* Latent ledger #712–#716 — separate PR each.

## Verification

* `cargo check -p nebula-resource --tests` ✓
* `cargo clippy -p nebula-resource --tests -- -D warnings` ✓
* `cargo nextest run -p nebula-resource` — 332 / 332 ✓
* `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-resource --no-deps` ✓
* `cargo check --workspace --all-targets` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)