### PR TITLE
docs(resource): scrub ADR/plan-ID refs + apply Mythos audit fixes

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -46,3 +46,52 @@ Nebula is under active development. The following policy applies:
 | Latest tagged release| Yes       |
 | Older releases       | No        |
 
+## Security Boundaries
+
+Nebula's main trust boundaries:
+
+- **Plugin / sandbox boundary** — `nebula-sandbox` runs untrusted plugin code
+  out-of-process; its protocol is defined in `nebula-plugin-sdk`. Anything
+  inside the sandbox is hostile by default.
+- **Credential boundary** — `nebula-credential` and
+  `nebula-credential-runtime` own credential material. Other crates receive
+  `CredentialGuard<C>` (which is `!Clone`, `ZeroizeOnDrop`) and read through
+  it, never around it.
+- **API boundary** — `nebula-api` is the external HTTP surface.
+  Authentication / authorisation lives there; lower layers assume their
+  inputs were checked.
+- **Tenancy boundary** — `nebula-tenancy` decorates storage adapters; every
+  read/write substitutes the active tenant scope before it reaches a
+  handler.
+
+## Secret Handling Rules
+
+- **Never `Debug`-print a `CredentialGuard`, `SlotCell<CredentialGuard<_>>`,
+  or a `Runtime` that holds authenticated state.** Derive a redacted
+  `Debug` impl that omits connection strings, tokens, and internal buffers.
+- **Never log raw error messages from a third-party driver that may embed
+  a connection string or token.** Wrap them in your `Resource::Error`
+  enum's variants with descriptive (but secret-free) messages.
+- **`ResourceEvent::AcquireFailed { error }` / `SlotRefreshFailed { error }`
+  are already redacted** by contract — the engine derives the string from
+  the typed `ErrorKind`. Do not bypass `ClassifyError` and substitute the
+  raw driver message.
+
+## Logging and Telemetry Rules
+
+- Use `tracing` spans on the lifecycle hot path (`create`, `recycle`,
+  `destroy`, `refresh_slot`, `revoke_slot`).
+- Span fields MUST NOT contain credential material. Use stable keys like
+  `resource.key`, `scope.level`, `slot.name` — never raw `auth_token` etc.
+- The broadcast `ResourceEvent` channel drops oldest events on overflow.
+  External subscribers MUST handle `RecvError::Lagged` rather than treat
+  it as a fault.
+
+## Unsafe Code Policy
+
+- Library crates carry `#![forbid(unsafe_code)]` at crate root. Adding
+  `unsafe` requires a separately-justified PR + reviewer sign-off.
+- Cross-crate `unsafe` API surfaces require an ADR.
+- `nebula-resource` is currently `#![forbid(unsafe_code)]`. There is no
+  unsafe code in the crate.
+

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -55,8 +55,8 @@ Nebula's main trust boundaries:
   inside the sandbox is hostile by default.
 - **Credential boundary** — `nebula-credential` and
   `nebula-credential-runtime` own credential material. Other crates receive
-  `CredentialGuard<C>` (which is `!Clone`, `ZeroizeOnDrop`) and read through
-  it, never around it.
+  `CredentialGuard<C>` (which is `!Clone` and zeroizes on drop via a manual
+  `Drop` impl) and read through it, never around it.
 - **API boundary** — `nebula-api` is the external HTTP surface.
   Authentication / authorisation lives there; lower layers assume their
   inputs were checked.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+once a stable release ships. While the workspace is `frontier`, breaking
+changes are expected between minor releases — call them out here.
+
+## [Unreleased]
+
+### Changed
+
+- **`nebula-resource`:** crate documentation scrubbed of plan-IDs, ADR
+  numbers, internal issue/PR references, and stale temp-file links.
+  Rewrote `docs/README.md` and `docs/topology-reference.md` to the v4
+  three-topology surface (`Pooled`, `Resident`, `Bounded` with sealed
+  `Cap` typestate). Added `# Errors` / `# Cancellation` / `# Drop` /
+  `# Panics` sections to the `Resource` trait lifecycle methods, the
+  `ResourceGuard` type, and the `Manager::register` / `acquire_*`
+  entry points.
+- Renamed runnable examples from `m6_*` to `resource_*`
+  (`m6_postgres_pool` → `resource_postgres_pool`,
+  `m6_resident_http` → `resource_resident_http`,
+  `m6_telegram_multi_workflow` → `resource_telegram_multi_workflow`).
+  Workspace `cargo run -p nebula-examples --example …` invocations
+  updated accordingly.
+
+### Removed
+
+- `nebula-resource::docs/recovery.md` `WatchdogHandle` /
+  `WatchdogConfig` section — these types are not in the public surface.
+  Drive `Resource::check()` directly or compose `nebula-resilience`'s
+  health-probe layer.
+
+## How to read this file
+
+- **Added** — new public API or capability.
+- **Changed** — non-breaking behavior changes, refactors, or documentation
+  improvements that may change reader expectations.
+- **Deprecated** — public API still present but slated for removal.
+- **Removed** — public API gone in this release.
+- **Fixed** — bug fixes.
+- **Security** — security-relevant fixes.
+
+Per-crate changelogs may appear under `crates/<name>/CHANGELOG.md` once a
+crate stabilises. Until then, this workspace-level changelog is the single
+source of truth.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+<!--
+# budget-justified: human contributor onboarding doc with table-driven reference sections (toolchain matrix, command matrix, schema-style standards lists) intentionally exceeds the structural-block cap
+-->
+
 # Contributing to Nebula
 
 Thanks for considering a contribution. Nebula is a Rust workflow automation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing to Nebula
+
+Thanks for considering a contribution. Nebula is a Rust workflow automation
+engine. The bar for changes: **the canon stays honest, the public API stays
+correct, and observability ships with every state and error path.**
+
+## Project Philosophy
+
+- **Type-safety over discipline.** Encode invariants in types where possible;
+  don't rely on "remember to call this helper."
+- **Failures are part of the contract.** Every `Result` variant should be
+  documented with when it appears.
+- **Observability is part of Definition of Done.** A new state, error, or
+  hot path ships with a typed error variant + tracing span + invariant check.
+- **One way to do it.** We delete shortcuts when they drift from the canon.
+
+Machine-enforced agent rules and the canonical workspace map live in
+[`CLAUDE.md`](CLAUDE.md). Product canon lives in `docs/PRODUCT_CANON.md`.
+
+## Repository Layout
+
+See the *Workspace Layout* and *Layered Dependency Map* sections of
+[`CLAUDE.md`](CLAUDE.md). Short version:
+
+- `crates/` — 36 workspace members.
+- `examples/` — runnable examples (one workspace member, not per-crate).
+- `docs/` — agent doc map (`docs/README.md` is the entry point).
+- `Taskfile.yml` — the canonical task runner. Don't call raw `cargo` for
+  fmt / lint.
+
+## Development Setup
+
+```sh
+# 1. Toolchain pinned in rust-toolchain.toml; rustup will install it.
+rustup show
+
+# 2. Install Taskfile (https://taskfile.dev) and lefthook
+brew install go-task lefthook   # or: scoop install task lefthook
+
+# 3. Install hooks
+lefthook install
+```
+
+## Required Toolchain
+
+| Tool             | Why                                                      |
+|------------------|----------------------------------------------------------|
+| `cargo`          | Rust 1.95+, edition 2024, resolver 3                     |
+| `task`           | `Taskfile.yml` is the canonical entry point              |
+| `lefthook`       | Local pre-commit / pre-push (mirrors CI required jobs)   |
+| `convco`         | Conventional-Commits validation                          |
+| `cargo-deny`     | License + layer-wrapper enforcement                      |
+| `cargo-nextest`  | Fast test runner used by `task dev:check`                |
+
+## Common Commands
+
+```sh
+task dev:check                            # full pre-PR gate (fmt + clippy + nextest + doctests + deny)
+task fmt                                  # cargo fmt --all (pinned toolchain)
+task clippy                               # cargo clippy --all-targets --all-features -- -D warnings
+task test                                 # workspace tests
+task doc                                  # workspace rustdoc
+cargo nextest run -p <crate>              # single-crate nextest
+cargo test -p <crate> --doc               # doctests for one crate
+```
+
+Use `task --list` for the full catalog.
+
+## Coding Standards
+
+- **No `unwrap()` / `expect()` / `panic!()` in library code.** Tests, `const`,
+  and binaries are exempt per [`clippy.toml`](clippy.toml). The
+  `.claude/hooks/edit-guard.sh` enforces this on every edit.
+- **No `TODO` / `FIXME` / `HACK` / plan-IDs in committed code.** Use ADRs and
+  GitHub issues for tracking; comments should read fine after the plan is
+  deleted.
+- **Cross-crate communication goes through `nebula-eventbus`.** Don't reach
+  across layer boundaries with direct imports.
+- **No async locks across `.await`.** No unbounded channels without explicit
+  justification.
+- **Layered dependency.** New code must respect the *Layered Dependency Map*
+  in [`CLAUDE.md`](CLAUDE.md); `cargo-deny` will reject layer violations.
+
+## Documentation Standards
+
+- Public API: rustdoc with `# Errors`, `# Cancellation`, `# Panics`,
+  `# Safety`, `# Examples` sections wherever they apply.
+- Crate-level `//!`: the manual for that crate.
+- `crates/<name>/README.md`: human entry point.
+- Use intra-doc links (`` [`Resource`] ``, `` [`crate::Manager`] ``) so
+  docs.rs cross-references hold across renames.
+- Examples must compile (`,no_run` if they hit a real backend; `,ignore`
+  only with a justification in the surrounding prose).
+
+## Testing Expectations
+
+- Unit tests next to the code (`#[cfg(test)]` module).
+- Integration tests in `crates/<name>/tests/`.
+- Compile-fail / proc-macro tests via `trybuild` (see
+  `crates/resource/tests/trybuild/`).
+- New public API → at least one happy-path test + one error-path test.
+
+## Commit / PR Guidelines
+
+- **Branch from `main`.** Create persistent worktrees with
+  `bash scripts/worktree.sh new <slug> <type> <scope>`.
+- **Conventional Commits**, validated by `convco`. Scope is the crate
+  name without `nebula-` prefix (`resource`, `engine`, `api`) or a
+  top-level area (`docs`, `ci`).
+- **Squash-merge to `main`.** Never force-push shared history.
+- One concern per PR. If you find an unrelated issue, file it.
+
+## Issue Guidelines
+
+Use the templates in `.github/ISSUE_TEMPLATE/`:
+
+- **Bug report** — what went wrong, repro, env.
+- **Feature request** — what the gap is, what the world looks like after.
+- **Documentation issue** — what's wrong, what it should say.
+
+## Architecture Change Policy
+
+Major architectural changes ship as ADRs in `docs/adr/`. An ADR is
+required if the change:
+
+- Adds a new public crate, or removes one.
+- Changes a trait's associated types or method signatures (after a
+  crate has consumers).
+- Crosses or moves a layer boundary in the Dependency Map.
+- Introduces a new cross-cutting invariant.
+
+Smaller refactors don't need an ADR but should reference the relevant
+canon section in their PR description.
+
+## Security Issues
+
+See [`.github/SECURITY.md`](.github/SECURITY.md). **Do not open public
+issues for security vulnerabilities.**
+
+## License
+
+By contributing you agree your work is licensed under the project's
+license (see [`LICENSE`](LICENSE)).

--- a/crates/action/README.md
+++ b/crates/action/README.md
@@ -189,9 +189,9 @@ The plan archive (`.ai-factory/plans/m6-resource-finalization-integration-audit.
 
 The headline patterns are exercised end-to-end in the workspace `examples/` member:
 
-- `cargo run -p nebula-examples --example m6_postgres_pool` — Pool topology + scoped resource configure/cleanup
-- `cargo run -p nebula-examples --example m6_telegram_multi_workflow` — Resident topology + cross-workflow shared-resource dedupe (1 bot, 10 workflows, 1 `Resource::create` call)
-- `cargo run -p nebula-examples --example m6_resident_http` — Resident topology + OAuth-style credential refresh hook
+- `cargo run -p nebula-examples --example resource_postgres_pool` — Pool topology + scoped resource configure/cleanup
+- `cargo run -p nebula-examples --example resource_telegram_multi_workflow` — Resident topology + cross-workflow shared-resource dedupe (1 bot, 10 workflows, 1 `Resource::create` call)
+- `cargo run -p nebula-examples --example resource_resident_http` — Resident topology + OAuth-style credential refresh hook
 
 The examples deliberately wire slot resolution manually (no `#[derive(Action)]`) because they run outside an engine; the slot-binding **mental model** is illustrated explicitly. For derive-form authoring, see `crates/action/tests/derive_action.rs` and the trybuild probes under `crates/action/tests/probes/`.
 

--- a/crates/credential/README.md
+++ b/crates/credential/README.md
@@ -161,7 +161,7 @@ The Phase 5 break renames `type Input` → `type Properties` and shifts schema o
 
 ## Runnable examples
 
-- `cargo run -p nebula-examples --example m6_resident_http` — credential refresh hook on a Resident-topology HTTP client (OAuth2-style)
+- `cargo run -p nebula-examples --example resource_resident_http` — credential refresh hook on a Resident-topology HTTP client (OAuth2-style)
 
 ## Contract
 

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -45,7 +45,7 @@ tokio = { workspace = true, features = ["rt-multi-thread", "test-util"] }
 # `test-util` enables `SchemeFactory::for_test*` and `SchemeGuard::for_test`
 # constructors so external integration tests (notably `tests/rotation.rs`) can
 # fabricate the rotation-dispatch inputs that production code only constructs
-# from inside the credential engine. Per ADR-0023 the feature MUST stay scoped
+# from inside the credential engine. The feature MUST stay scoped
 # to dev-dependencies.
 nebula-credential = { path = "../credential", features = ["test-util"] }
 # `tests/rotation.rs` defines a mock `TestCredential` whose `State` impl

--- a/crates/resource/README.md
+++ b/crates/resource/README.md
@@ -15,11 +15,11 @@ External connections — database pools, HTTP clients, message brokers — are a
 
 ## Role
 
-**Bulkhead Pool** (Release It! ch "Stability Patterns — Bulkhead"). Isolates resource exhaustion per topology so one depleted pool cannot cascade to unrelated paths. Three topologies cover the full integration space: `Pooled`, `Resident`, and one parameterized `Bounded` whose concurrency cap and release shape are type-enforced via a sealed `Cap` typestate marker (`Unbounded` / `Capped<N>` / `Exclusive`). The `Resource` trait declares four associated types and lifecycle methods; topology traits add pool-specific recycle and broken-instance decisions. Long-running workers (`Daemon`) and pull-based subscriptions (`EventSource`) live in `nebula_engine::daemon` per ADR-0037 — canon §3.5 reserves "Resource" for pool/SDK clients.
+**Bulkhead Pool** (Release It! ch "Stability Patterns — Bulkhead"). Isolates resource exhaustion per topology so one depleted pool cannot cascade to unrelated paths. Three topologies cover the full integration space: `Pooled`, `Resident`, and one parameterized `Bounded` whose concurrency cap and release shape are type-enforced via a sealed `Cap` typestate marker (`Unbounded` / `Capped<N>` / `Exclusive`). The `Resource` trait declares four associated types and lifecycle methods; topology traits add pool-specific recycle and broken-instance decisions. Long-running workers (`Daemon`) and pull-based subscriptions (`EventSource`) live in `nebula_engine::daemon` — canon §3.5 reserves "Resource" for pool/SDK clients.
 
-## Public API (v4 — M6 / dependency redesign, 2026-04-29)
+## Public API (v4 — slot-binding pattern, 2026-04-29)
 
-The v4 surface lands per ADR-0044 (supersedes ADR-0036) — singular `type Credential` is dropped in favor of typed credential **slot fields** declared via `#[credential(key = "…")]` field attributes on the resource struct. Each slot field is a lock-free `SlotCell<CredentialGuard<C>>` the framework populates and rotates through `&self`; the derive emits a `<field>_slot()` read accessor. Multi-credential resources are now natural; per-slot rotation lands via `Resource::on_credential_refresh(&self, slot_name, runtime)` with a companion `Resource::on_credential_revoke(&self, slot_name, runtime)`.
+The v4 surface — singular `type Credential` is dropped in favor of typed credential **slot fields** declared via `#[credential(key = "…")]` field attributes on the resource struct. Each slot field is a lock-free `SlotCell<CredentialGuard<C>>` the framework populates and rotates through `&self`; the derive emits a `<field>_slot()` read accessor. Multi-credential resources are now natural; per-slot rotation lands via `Resource::on_credential_refresh(&self, slot_name, runtime)` with a companion `Resource::on_credential_revoke(&self, slot_name, runtime)`.
 
 ### `Resource` trait — 4 associated types, slot fields on Self
 
@@ -54,7 +54,7 @@ pub trait Resource: Send + Sync + 'static {
 }
 ```
 
-**`type Credential` was dropped** per ADR-0044. There is no longer a singular credential associated type; resources declare credentials as slot fields. The opt-out alias `NoCredential` is no longer required — resources without credentials simply have no `#[credential]` fields.
+**`type Credential` was dropped.** There is no longer a singular credential associated type; resources declare credentials as slot fields. The opt-out alias `NoCredential` is no longer required — resources without credentials simply have no `#[credential]` fields.
 
 ### Slot-binding pattern — `#[derive(Resource)]` + `#[credential]` field attrs
 
@@ -113,7 +113,7 @@ The framework resolves declared `#[credential]` slots **before** invoking `Resou
 ### Other public API
 
 - `ResourceGuard` — RAII lease guard with `Owned`/`Guarded`/`Shared` modes; deref to lease type, release on drop.
-- `ResourceRef<R>` — lazy reference type holding a `ResourceId` string + `PhantomData<R>`. Resolves to a `ResourceGuard<R>` via `.resolve(ctx).await`. New in Phase 1.
+- `ResourceRef<R>` — lazy reference type holding a `ResourceId` string + `PhantomData<R>`. Resolves to a `ResourceGuard<R>` via `.resolve(ctx).await`.
 - `RegistrationSpec` — the single registration param aggregate (see above).
 - `SlotIdentity` — collision-free structural resolved-credential identity (`Unbound` / `Structural`); the cross-tenant barrier.
 - `ManagerConfig`, `RegisterOptions` — configuration surface.
@@ -140,7 +140,7 @@ The framework resolves declared `#[credential]` slots **before** invoking `Resou
 
 ## Migration recipe (pre-v4 → v4)
 
-The Phase 4 / ADR-0044 break is hard. To migrate an existing `Resource` impl:
+The slot-binding break is hard. To migrate an existing `Resource` impl:
 
 1. **Drop `type Credential`.** Move the credential dependency to a `#[credential(key = "…")]` slot field of type `SlotCell<CredentialGuard<C>>` on the struct, constructed with `SlotCell::empty()`. Change `Resource::Credential` references to read through the derive-emitted `self.<field>_slot()` accessor.
 2. **Drop the `scheme: &<R::Credential as Credential>::Scheme` parameter** from `create`. The framework populates the slot cells before `create` runs; read the resolved guard via `self.<field>_slot()` (`Option<Arc<CredentialGuard<C>>>`) and handle the `None` (unbound) case explicitly.
@@ -151,13 +151,13 @@ The Phase 4 / ADR-0044 break is hard. To migrate an existing `Resource` impl:
 7. **If you authored a `Service` / `Transport` / `Exclusive` resource**, re-author it onto `Bounded`: implement `Bounded` with the matching `type Cap` (`Unbounded` for the old Cloned/Service shape, `Capped<N>` for tracked/bounded concurrency, `Exclusive` for one-at-a-time), implement `BoundedRelease` if the cap requires a release, and register with `TopologyRuntime::Bounded(BoundedRuntime::new(…))`. Semaphore / reset-ordering / session semantics are preserved.
 8. **For credential slot identity**, pass `SlotIdentity::Unbound` for the historical single-row dedup, or build a `SlotIdentity::Structural` from the resolved `(slot, credential)` pairs for per-binding row separation. The old `u64` `slot_identity` digest was removed.
 
-The trait-shape changes ship complete; the engine-side fan-out machinery for delivering slot-name rotation events is tracked in `docs/ROADMAP.md`.
+The trait-shape changes ship complete; the engine-side fan-out machinery for delivering slot-name rotation events lands in a follow-up.
 
 ## Runnable examples
 
-- `cargo run -p nebula-examples --example m6_postgres_pool` — `Pooled` topology + `ResourceAction` for per-execution test schema (configure / cleanup ordering)
-- `cargo run -p nebula-examples --example m6_resident_http` — `Resident` topology + OAuth-style credential refresh hook
-- `cargo run -p nebula-examples --example m6_telegram_multi_workflow` — `Resident` topology + cross-workflow shared-resource dedupe (1 bot, 10 workflows, 1 `Resource::create`)
+- `cargo run -p nebula-examples --example resource_postgres_pool` — `Pooled` topology + `ResourceAction` for per-execution test schema (configure / cleanup ordering)
+- `cargo run -p nebula-examples --example resource_resident_http` — `Resident` topology + OAuth-style credential refresh hook
+- `cargo run -p nebula-examples --example resource_telegram_multi_workflow` — `Resident` topology + cross-workflow shared-resource dedupe (1 bot, 10 workflows, 1 `Resource::create`)
 
 The headline patterns and topology selection guidance are distilled into `crates/resource/docs/topology-reference.md`.
 
@@ -171,7 +171,7 @@ The headline patterns and topology selection guidance are distilled into `crates
 ## Non-goals
 
 - Not a connection driver — resource implementations supply the actual client (sqlx pool, reqwest client, etc.); this crate owns the lifecycle wrapper.
-- Not a retry pipeline — retry composes one layer up (action handler / engine activity / caller-supplied `nebula-resilience` pipeline). The manager-side `AcquireResilience` wrapper was removed in commit `cf93e45b`; peer Rust pools (sqlx, deadpool, bb8) ship acquire-timeout only, retry above. Retry around outbound calls inside `create`/`check` uses `nebula-resilience` directly at the resource impl.
+- Not a retry pipeline — retry composes one layer up (action handler / engine activity / caller-supplied `nebula-resilience` pipeline). The manager-side `AcquireResilience` wrapper was removed; peer Rust pools (sqlx, deadpool, bb8) ship acquire-timeout only, retry above. Retry around outbound calls inside `create`/`check` uses `nebula-resilience` directly at the resource impl.
 - Not a secret holder — credentials are populated into slot fields by the framework; secret material is managed by `nebula-credential`.
 - Not an expression evaluator — resource `Config` comes from `nebula-schema`-validated parameters; expression resolution is `nebula-expression`'s job. The engine-facing `Manager::register_resolved` orchestrates the resolve→validate→register pipeline but the evaluator itself stays out.
 
@@ -179,16 +179,15 @@ The headline patterns and topology selection guidance are distilled into `crates
 
 See `docs/MATURITY.md` row for `nebula-resource`.
 
-- API stability: `frontier` — slot-binding pattern (ADR-0044) shipped; 3 topologies (`Pooled` / `Resident` / `Bounded`), `Manager`, `ReleaseQueue`, and `ResourceGuard` are the authoritative lifecycle surface; topology runtime variants are actively evolving.
+- API stability: `frontier` — slot-binding pattern shipped; 3 topologies (`Pooled` / `Resident` / `Bounded`), `Manager`, `ReleaseQueue`, and `ResourceGuard` are the authoritative lifecycle surface; topology runtime variants are actively evolving.
 - `#![forbid(unsafe_code)]` enforced, `#![warn(missing_docs)]` active.
 - Integration tests: shared-resource cross-workflow path is verified in `crates/engine/tests/resource_integration.rs::shared_resource::cross_workflow_resource_sharing`.
-- Per-slot rotation fan-out: tracked in `docs/ROADMAP.md`.
+- Per-slot rotation fan-out: lands in a follow-up.
 
 ## Related
 
-- Canon: `docs/PRODUCT_CANON.md` §11.4 (resource lifecycle contract — acquire/health/release; orphan drain), §13.3 (lifecycle visibility in journal/trace).
-- ADRs: `docs/adr/0081-m6-resource-credential-integration.md` (M6 binding/credential cascade — supersedes ADR-0036; consolidates ADR-0042/0043/0044).
-- Integration model: `docs/INTEGRATION_MODEL.md` §`nebula-resource`.
+- Canon: workspace canon doc — resource lifecycle contract (acquire/health/release; orphan drain), lifecycle visibility in journal/trace.
+- Integration model: workspace integration-model doc, `nebula-resource` section.
 - Siblings: `nebula-core` (`ResourceKey`, `ExecutionId`, `Dependencies`), `nebula-credential` (`CredentialGuard` populated by framework), `nebula-action` (`ResourceAction` trait, `ResourceProduces<R>` marker), `nebula-resilience` (acquire-path and outbound-call retry).
 
 ## Appendix
@@ -214,7 +213,7 @@ These types are L4 implementation detail — rename/refactor without canon revis
 
 `Bounded` folds the former `Service` / `Transport` / `Exclusive` topologies into one runtime; the `Cap` typestate (`Unbounded` / `Capped<N>` / `Exclusive`) selects the concurrency arity and whether `BoundedRelease` is mandatory at **compile time**.
 
-Long-running workers (`Daemon`) and pull-based event subscriptions (`EventSource`) live in `nebula_engine::daemon` per ADR-0037; this crate retains pool/SDK-client topologies only (canon §3.5).
+Long-running workers (`Daemon`) and pull-based event subscriptions (`EventSource`) live in `nebula_engine::daemon`; this crate retains pool/SDK-client topologies only (canon §3.5).
 
 ### Shared resource pattern
 

--- a/crates/resource/docs/README.md
+++ b/crates/resource/docs/README.md
@@ -5,8 +5,10 @@ Type-safe, topology-aware resource management for the Nebula workflow engine.
 clients — database connections, HTTP clients, message-queue producers, and
 anything else that is costly to create and should be reused across executions.
 It handles the full operational lifecycle: create → health-check → recycle →
-shutdown → destroy, with built-in resilience, recovery gating, and lifecycle
+shutdown → destroy, with credential rotation, recovery gating, and lifecycle
 event streaming.
+
+> **Maturity: `frontier`.** The public API still evolves between minor releases.
 
 ---
 
@@ -14,34 +16,34 @@ event streaming.
 
 | Type | Role |
 |------|------|
-| [`Resource`] | Central trait — 4 associated types, lifecycle methods (`create`, `check`, `shutdown`, `destroy`) + credential-rotation hooks |
-| [`Pooled`] | Topology trait for N interchangeable instances with checkout/recycle semantics |
-| [`Resident`] | Topology trait for one shared instance cloned on each acquire |
-| [`Service`] | Topology trait for a long-lived runtime that issues short-lived tokens |
-| [`Transport`] | Topology trait for a shared connection with multiplexed sessions |
-| [`Exclusive`] | Topology trait for serialized single-caller access via semaphore |
-| [`Manager`] | Central registry — registration, typed acquire dispatch, graceful shutdown |
-| [`ResourceGuard`] | RAII lease guard; releases or recycles on drop, tainting supported |
-| [`ResourceContext`] | Execution context: scope level, cancellation token, capability traits |
+| [`Resource`] | Central trait — 4 associated types + lifecycle methods (`create`, `check`, `shutdown`, `destroy`) + slot-rotation hooks (`on_credential_refresh`, `on_credential_revoke`) |
+| [`Pooled`] | Topology trait — N interchangeable instances with checkout/recycle |
+| [`Resident`] | Topology trait — one shared instance cloned on each acquire |
+| [`Bounded`] | Topology trait — parameterised on a sealed `Cap` typestate: `Unbounded`, `Capped<N>`, `Exclusive` |
+| [`Manager`] | Central registry — single `register(RegistrationSpec { … })` funnel, typed acquire dispatch, slot rotation, graceful shutdown |
+| [`ResourceGuard`] | RAII lease guard; releases on drop, tainting supported |
+| [`ResourceContext`] | Execution context — scope, cancellation, capability traits |
 | [`Error`] / [`ErrorKind`] | Unified error with retryability, scope, and optional retry-after hint |
 
 ---
 
 ## Topology Decision Guide
 
-Choose the topology that matches the resource's concurrency model.
-
 | Topology | Use when | Example |
 |----------|----------|---------|
-| `Pooled` | Multiple interchangeable connections; checkout/recycle needed | PostgreSQL, Redis |
-| `Resident` | One shared object; cheap to clone for each caller | In-memory cache, config store |
-| `Service` | Runtime is long-lived; callers get short-lived tokens from it | OAuth client issuing access tokens |
-| `Transport` | Single connection multiplexed across callers (no per-caller clone) | gRPC channel, AMQP connection |
-| `Exclusive` | Only one caller may use the resource at a time | Rate-limited SMS gateway |
+| `Pooled` | N interchangeable connections; checkout/recycle | PostgreSQL, Redis |
+| `Resident` | One shared object; cheap to `Arc::clone` for each caller | `reqwest::Client`, in-memory cache |
+| `Bounded<Unbounded>` | Long-lived runtime issuing short-lived tokens | OAuth client |
+| `Bounded<Capped<N>>` | Multiplexed sessions over one shared connection | gRPC channel, AMQP |
+| `Bounded<Exclusive>` | One caller at a time, semaphore(1) + reset-on-release | File lock, USB-serial |
+
+The `Bounded` topology folded the former standalone `Service` / `Transport` /
+`Exclusive` traits into one runtime; the `Cap` typestate selects concurrency
+arity at **compile time** — using `BoundedRelease` against `Unbounded`, or
+omitting it for `Capped` / `Exclusive`, is a build error.
 
 > **Background workers and event sources** live in
-> [`nebula-engine`](https://docs.rs/nebula-engine) (`nebula_engine::daemon::*`)
-> per [ADR-0037](../../../docs/adr/HISTORICAL.md).
+> [`nebula-engine`](https://docs.rs/nebula-engine) (`nebula_engine::daemon::*`).
 > They are not part of the `nebula-resource` topology surface.
 
 ---
@@ -51,18 +53,20 @@ Choose the topology that matches the resource's concurrency model.
 ### 1. Implement `Resource`
 
 ```rust,no_run
-use nebula_resource::{
-    resource_key, ResourceContext, Error, Manager, PoolConfig, Resource,
-    ResourceConfig, ResourceMetadata,
-};
+use std::future::Future;
 use nebula_core::ResourceKey;
+use nebula_resource::{
+    resource_key, Error, Resource, ResourceConfig, ResourceContext, HasSchema, ValidSchema,
+};
 
-// --- Config (no secrets) -----------------------------------------------------
-
-#[derive(Clone)]
+#[derive(Clone, Hash)]
 struct HttpConfig {
     base_url: String,
     timeout_ms: u64,
+}
+
+impl HasSchema for HttpConfig {
+    fn schema() -> ValidSchema { ValidSchema::empty() }
 }
 
 impl ResourceConfig for HttpConfig {
@@ -74,121 +78,110 @@ impl ResourceConfig for HttpConfig {
     }
 }
 
-// --- Runtime (the live client) -----------------------------------------------
-
 #[derive(Clone)]
-struct HttpRuntime {
-    base_url: String,
-}
+struct HttpRuntime { base_url: String }
 
-// --- Resource descriptor -----------------------------------------------------
-
+// No `#[credential]` field — this resource needs no credential. A credential-
+// bound resource instead declares `#[credential(key = "...")] auth: SlotCell<CredentialGuard<C>>`.
 struct HttpResource;
 
-// No `#[credential]` field — this resource needs no credential. (There is
-// no `Credential` associated type or `NoCredential` opt-out; a credential-
-// bound resource instead declares a `#[credential(key = "...")]` slot.)
 impl Resource for HttpResource {
-    type Config     = HttpConfig;
-    type Runtime    = HttpRuntime;
-    type Lease      = HttpRuntime;   // Pooled: Lease == Runtime (cloned on checkout)
-    type Error      = Error;
+    type Config = HttpConfig;
+    type Runtime = HttpRuntime;
+    type Lease = HttpRuntime;   // Pooled / Resident: Lease == Runtime
+    type Error = Error;
 
-    fn key() -> ResourceKey {
-        resource_key!("http.client")
-    }
+    fn key() -> ResourceKey { resource_key!("http.client") }
 
-    async fn create(
-        &self,
-        config: &HttpConfig,
-        _ctx: &ResourceContext,
-    ) -> Result<HttpRuntime, Error> {
-        Ok(HttpRuntime { base_url: config.base_url.clone() })
+    fn create(
+        &self, config: &HttpConfig, _ctx: &ResourceContext,
+    ) -> impl Future<Output = Result<HttpRuntime, Error>> + Send {
+        async move { Ok(HttpRuntime { base_url: config.base_url.clone() }) }
     }
 }
 ```
 
-### 2. Implement the topology trait
+### 2. Implement a topology trait
 
-For pool topology, implement [`Pooled`] to tell the runtime when an instance
-can be recycled and how to detect a broken one.
+For the pool topology, implement [`Pooled`]:
 
 ```rust,ignore
 use nebula_resource::topology::pooled::{Pooled, BrokenCheck, RecycleDecision, InstanceMetrics};
 
 impl Pooled for HttpResource {
     fn is_broken(&self, _runtime: &HttpRuntime) -> BrokenCheck {
-        BrokenCheck::Healthy       // HTTP clients don't break between uses
+        BrokenCheck::Healthy
     }
 
-    fn recycle(
+    async fn recycle(
         &self, _runtime: &HttpRuntime, _metrics: &InstanceMetrics,
-    ) -> impl Future<Output = Result<RecycleDecision, HttpError>> + Send {
-        async { Ok(RecycleDecision::Keep) }  // always reusable
+    ) -> Result<RecycleDecision, Error> {
+        Ok(RecycleDecision::Keep)
     }
 }
 ```
 
-### 3. Register and acquire
+### 3. Register and acquire — the single funnel
+
+Registration goes through **one funnel**:
+`Manager::register::<R>(spec: RegistrationSpec<R>)`. There are no per-topology
+`register_<topo>[_with]` shorthands — they were removed with the manager-side
+`AcquireResilience` wrapper. Retry composes one layer up; per-topology configs
+carry their own `create_timeout`.
 
 ```rust,ignore
-use nebula_resource::{Manager, PoolConfig, ResourceContext, AcquireOptions};
-use nebula_core::scope::Scope;
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
+use nebula_core::{scope::Scope, ScopeLevel};
+use nebula_resource::{
+    AcquireOptions, Manager, PoolRuntime, RegistrationSpec, ResourceContext,
+    SlotIdentity, TopologyRuntime,
+    topology::pooled::config::Config as PoolConfig,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), nebula_resource::Error> {
     let manager = Manager::new();
 
-    // Simple registration — Global scope, no resilience, no recovery gate.
-    manager.register_pooled(
-        HttpResource,
-        HttpConfig { base_url: "https://api.example.com".into(), timeout_ms: 5_000 },
-        PoolConfig::default(),
+    let config = HttpConfig { base_url: "https://api.example.com".into(), timeout_ms: 5_000 };
+    let pool_rt = PoolRuntime::<HttpResource>::try_new(
+        PoolConfig { max_size: 10, ..PoolConfig::default() },
+        config.fingerprint(),
     )?;
 
-    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    manager.register(RegistrationSpec {
+        resource: HttpResource,
+        config,
+        scope: ScopeLevel::Global,
+        slot_identity: SlotIdentity::Unbound,
+        topology: TopologyRuntime::Pool(pool_rt),
+        acquire: Manager::erased_acquire_pooled_for::<HttpResource>(),
+        recovery_gate: None,
+    })?;
 
-    // acquire_pooled: no scheme arg — credentials live in the resource's
-    // `#[credential]` slot fields, not in an acquire argument.
-    let handle = manager
+    let ctx = ResourceContext::minimal(Scope::default(), CancellationToken::new());
+    let guard = manager
         .acquire_pooled::<HttpResource>(&ctx, &AcquireOptions::default())
         .await?;
 
-    // Use via Deref — handle is held until dropped.
-    let _runtime: &HttpRuntime = &*handle;
-
-    // Instance recycled automatically on drop.
-    // Call handle.taint() before dropping to skip recycle and force destroy.
+    let _runtime: &HttpRuntime = &*guard;
+    // Drop returns the instance to the pool via Pooled::recycle.
+    // Call guard.taint() to skip recycle and force destroy.
     Ok(())
 }
 ```
 
-### 4. Register with a recovery gate
+### 4. Attach a recovery gate (production)
 
-For production use, attach a recovery gate via `RegistrationSpec` to
-prevent thundering-herd when a backend goes down. The manager-side
-`AcquireResilience` (timeout + retry wrapper around `acquire`) was
-removed in commit `cf93e45b`: retry composes one layer up at the
-action / engine activity boundary, and per-topology config carries
-its own `create_timeout` (resident / pool). The recovery gate is the
-remaining manager-level resilience seam.
+For production, attach an `Arc<RecoveryGate>` via
+`RegistrationSpec::recovery_gate` to prevent thundering-herd when a backend
+flaps. The gate is the only manager-level resilience seam today; see
+[`recovery.md`](recovery.md) for the state machine.
 
 ```rust,ignore
-use nebula_resource::{
-    Manager, PoolRuntime, RegistrationSpec, ScopeLevel, SlotIdentity,
-    TopologyRuntime, dedup::SlotIdentity as _,
-    recovery::{RecoveryGate, RecoveryGateConfig},
-    topology::pooled::config::Config as PoolConfig,
-};
-use std::sync::Arc;
+use nebula_resource::recovery::{RecoveryGate, RecoveryGateConfig};
 
-let manager = Manager::new();
 let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig::default()));
-let pool_rt = PoolRuntime::<DbResource>::try_new(
-    PoolConfig { max_size: 20, ..Default::default() },
-    db_config.fingerprint(),
-)?;
 
 manager.register(RegistrationSpec {
     resource: DbResource,
@@ -205,25 +198,24 @@ manager.register(RegistrationSpec {
 
 ## Error Handling
 
-Every `acquire_*` and `register_*` call returns `Result<_, Error>`. The
+Every `register` / `acquire_*` call returns `Result<_, Error>`. The
 `ErrorKind` enum drives retry decisions:
 
-| Variant | Meaning | Retryable? |
-|---------|---------|-----------|
-| `Transient` | Network blip, timeout | Yes |
-| `Permanent` | Auth failure, bad config | No |
-| `Exhausted { retry_after }` | Rate-limited or quota depleted | Yes (after cooldown) |
-| `Backpressure` | Pool semaphore full | Caller decides |
-| `NotFound` | Key not in registry | No |
-| `Cancelled` | Cancellation token fired | No |
+| Variant                     | Meaning                              | Retryable?           |
+|-----------------------------|--------------------------------------|----------------------|
+| `Transient`                 | Network blip, timeout                | Yes                  |
+| `Permanent`                 | Auth failure, bad config             | No                   |
+| `Exhausted { retry_after }` | Rate-limited or quota depleted       | Yes (after cooldown) |
+| `Backpressure`              | Pool semaphore full                  | Caller decides       |
+| `NotFound`                  | Key not in registry for that scope   | No                   |
+| `Cancelled`                 | Cancellation token fired             | No                   |
+| `Revoked`                   | Slot was revoked; retry after re-bind | Yes (after rotation) |
+| `Ambiguous`                 | Multiple resolved identities; caller must pin | No           |
 
-Use `err.is_retryable()` to branch without matching on variants. Use
+Use `err.is_retryable()` to branch without matching on variants; use
 `err.retry_after()` to respect rate-limit hints.
 
-### ClassifyError derive macro
-
-Use `#[derive(ClassifyError)]` to auto-generate `From<YourError> for Error`
-with the correct `ErrorKind` per variant — no manual `From` impl needed:
+### `#[derive(ClassifyError)]` — auto-`From<YourError>`
 
 ```rust,ignore
 use nebula_resource::ClassifyError;
@@ -242,29 +234,30 @@ pub enum DbError {
 }
 ```
 
-This generates `impl From<DbError> for nebula_resource::Error` with
-correct `ErrorKind::Transient`, `ErrorKind::Permanent`, and
-`ErrorKind::Exhausted { retry_after: Some(Duration::from_secs(30)) }`
-respectively. The `retry_after` value supports `s` / `m` / `h` / `ms`
-suffixes.
+Supported kinds: `transient`, `permanent`, `exhausted` (with optional
+`retry_after = "30s" / "5m" / "1h" / "500ms"`), `backpressure`, `cancelled`.
 
 ---
 
 ## Feature Matrix
 
-| Capability | How to use |
-|------------|-----------|
-| Bounded connection pooling | `register_pooled` + `PoolConfig` |
-| Shared singleton with clone-on-acquire | `register_resident` + `ResidentConfig` |
-| Long-lived runtime, short-lived tokens | `register_service` + `ServiceConfig` |
-| Single-caller serialized access | `register_exclusive` + `ExclusiveConfig` |
-| Multiplexed sessions over shared transport | `register_transport` + `TransportConfig` |
-| Retry + timeout on acquire | `register_*_with` + `RegisterOptions { resilience: Some(...) }` |
-| Fast-fail during backend recovery | `register_*_with` + `RegisterOptions { recovery_gate: Some(...) }` |
-| Config hot-reload (fingerprint-based) | Implement `ResourceConfig::fingerprint` |
-| Lifecycle event stream | `manager.subscribe_events()` → `broadcast::Receiver<ResourceEvent>` |
-| Async background cleanup | `ReleaseQueue` (owned by `Manager`, transparent to callers) |
-| Atomic operation counters | `Option<ResourceOpsMetrics>` via `manager.metrics()` (`None` when no registry configured) |
+| Capability                                  | How to enable                                                  |
+|---------------------------------------------|---------------------------------------------------------------|
+| Bounded connection pooling                  | `RegistrationSpec { topology: TopologyRuntime::Pool(_), .. }` |
+| Shared singleton with clone-on-acquire      | `RegistrationSpec { topology: TopologyRuntime::Resident(_), .. }` |
+| Long-lived runtime, short-lived tokens      | `RegistrationSpec { topology: TopologyRuntime::Bounded(_), .. }` with `Cap = Unbounded` |
+| Multiplexed sessions over shared transport  | `Cap = Capped<N>` + `impl BoundedRelease`                     |
+| Single-caller serialized access             | `Cap = Exclusive` + `impl BoundedRelease`                     |
+| Fast-fail during backend recovery           | `RegistrationSpec::recovery_gate: Some(Arc<RecoveryGate>)`    |
+| Config hot-reload (fingerprint-based)       | Implement `ResourceConfig::fingerprint`; call `Manager::reload_config` |
+| Per-tenant credential isolation             | Build `SlotIdentity::from_bindings(…)` and acquire via `acquire_<topo>_for_identity` |
+| Lifecycle event stream                      | `manager.subscribe_events()` → `broadcast::Receiver<ResourceEvent>` |
+| Async background cleanup                    | `ReleaseQueue` (owned by `Manager`, transparent to callers)   |
+| Atomic operation counters                   | `manager.metrics()` → `Option<&ResourceOpsMetrics>`           |
+
+Retry/timeout on the acquire path composes one layer up (action handler /
+engine activity). Per-topology configs carry their own `create_timeout` for
+the create step.
 
 ---
 
@@ -273,52 +266,52 @@ suffixes.
 ```
 crates/resource/
 ├── src/
-│   ├── lib.rs             Re-exports and crate-level docs
-│   ├── resource.rs        Resource trait (4 associated types + lifecycle methods)
-│   ├── slot.rs            SlotCell — lock-free per-slot resolved-credential holder
-│   ├── dedup.rs           slot_identity + SLOT_IDENTITY_UNBOUND (anti-bleed key)
-│   ├── manager/           Manager directory:
-│   │   ├── mod.rs              Manager type + register/acquire + refresh_slot/revoke_slot
-│   │   ├── options.rs          ManagerConfig, RegisterOptions, RegistrationSpec, ShutdownConfig, DrainTimeoutPolicy
-│   │   ├── gate.rs             Recovery-gate admission helpers (GateAdmission, admit_through_gate, settle_gate_admission)
-│   │   ├── acquire_dispatch.rs Type-erased acquire factories (erased_acquire_{pooled,resident,bounded})
-│   │   └── shutdown.rs         graceful_shutdown + drain helpers + set_phase_all*
-│   ├── registry.rs        Registry, AnyManagedResource — type-erased storage
-│   ├── guard.rs           ResourceGuard — RAII acquire lease (Owned / Guarded / Shared)
-│   ├── context.rs         ResourceContext — execution context with capabilities
-│   ├── dedup.rs           SlotIdentity (Unbound / Structural), DedupKey
-│   ├── error.rs           Error, ErrorKind, ErrorScope
-│   ├── events.rs          ResourceEvent — 14 lifecycle event variants (all emitted)
-│   ├── options.rs         AcquireOptions (deadline-only since R-051)
-│   ├── metrics.rs         ResourceOpsMetrics, ResourceOpsSnapshot, OutcomeCountersSnapshot
-│   ├── state.rs           ResourcePhase, ResourceStatus
-│   ├── cell.rs            Cell — crate-internal ArcSwap-based lock-free cell for Resident topology
-│   ├── slot.rs            SlotCell — public generation-stamped credential slot holder
-│   ├── release_queue.rs   ReleaseQueue — background async cleanup workers
-│   ├── reload.rs          ReloadOutcome (NoChange / SwappedImmediately)
-│   ├── resource_ref.rs    ResourceRef — lazy reference type for action contexts
-│   ├── topology_tag.rs    TopologyTag — 3-variant discriminant (Pool / Resident / Bounded)
-│   ├── ext.rs             HasResourcesExt (sealed)
-│   ├── recovery/          RecoveryGate, RecoveryTicket, RecoveryWaiter, GateState
-│   ├── runtime/           Per-topology runtime wrappers (Pool / Resident / Bounded + ManagedResource)
-│   └── topology/          Per-topology trait definitions (Pooled / Resident / Bounded + Cap typestate)
+│   ├── lib.rs              re-exports, crate-level docs
+│   ├── resource.rs         Resource trait (4 associated types + lifecycle + slot-rotation hooks)
+│   ├── slot.rs             SlotCell — public, generation-stamped, lock-free credential-slot holder
+│   ├── cell.rs             internal lock-free cell (Resident runtime; not re-exported)
+│   ├── manager/
+│   │   ├── mod.rs              Manager + register/acquire + refresh_slot/revoke_slot (two-phase revoke)
+│   │   ├── options.rs          ManagerConfig, RegisterOptions, RegistrationSpec, ShutdownConfig
+│   │   ├── gate.rs             Recovery-gate admission helpers
+│   │   ├── acquire_dispatch.rs Type-erased acquire factories
+│   │   └── shutdown.rs         graceful_shutdown + drain helpers
+│   ├── registry.rs         Registry, AnyManagedResource — type-erased storage
+│   ├── guard.rs            ResourceGuard — RAII acquire lease (Owned / Guarded / Shared)
+│   ├── context.rs          ResourceContext — execution context
+│   ├── dedup.rs            SlotIdentity (Unbound / Structural), DedupKey
+│   ├── error.rs            Error, ErrorKind, ErrorScope
+│   ├── events.rs           ResourceEvent — 14 lifecycle event variants (all emitted)
+│   ├── options.rs          AcquireOptions (deadline-only)
+│   ├── metrics.rs          ResourceOpsMetrics, ResourceOpsSnapshot
+│   ├── state.rs            ResourcePhase, ResourceStatus
+│   ├── release_queue.rs    ReleaseQueue — background async cleanup workers
+│   ├── reload.rs           ReloadOutcome (NoChange / SwappedImmediately)
+│   ├── resource_ref.rs     ResourceRef — lazy reference type for action contexts
+│   ├── topology_tag.rs     TopologyTag — Pool / Resident / Bounded discriminant
+│   ├── ext.rs              HasResourcesExt (sealed)
+│   ├── recovery/           RecoveryGate, RecoveryTicket, RecoveryWaiter, GateState
+│   ├── runtime/            per-topology runtime wrappers + ManagedResource
+│   └── topology/           per-topology trait definitions + Cap typestate
 └── docs/
-    ├── README.md          ← this file
-    ├── api-reference.md   Full public API with signatures
-    ├── adapters.md        Implementing Resource for a driver crate
-    ├── pooling.md         PoolConfig, recycle policy, broken-check, max-lifetime
-    ├── events.md          ResourceEvent catalog, subscribe_events usage
-    └── recovery.md        RecoveryGate, WatchdogHandle, gate state transitions
+    ├── README.md           ← this file
+    ├── api-reference.md    pointer to rustdoc + crate README prose surface
+    ├── topology-reference.md  topology selection guide + minimal skeletons
+    ├── adapters.md         writing an adapter crate (`nebula-resource-postgres` walkthrough)
+    ├── pooling.md          PoolConfig deep-dive
+    ├── recovery.md         RecoveryGate state machine
+    └── events.md           ResourceEvent catalog
 ```
 
 ---
 
 ## Documentation
 
-| Document | Contents |
-|----------|----------|
-| [`api-reference.md`](api-reference.md) | Pointer to the generated rustdoc + the prose surface in the crate README (the authoritative API) |
-| [`adapters.md`](adapters.md) | Writing a `Resource` adapter crate (`nebula-resource-postgres`, etc.) |
-| [`pooling.md`](pooling.md) | `PoolConfig`, recycle decisions, broken checks, max-lifetime eviction |
-| [`events.md`](events.md) | `ResourceEvent` catalog, `subscribe_events` patterns |
-| [`recovery.md`](recovery.md) | `RecoveryGate`, `WatchdogHandle`, gate state transitions |
+| Document                                          | Contents                                                                 |
+|---------------------------------------------------|--------------------------------------------------------------------------|
+| [`api-reference.md`](api-reference.md)            | Generated-rustdoc pointer + prose surface anchor                         |
+| [`topology-reference.md`](topology-reference.md)  | Topology selection guide + minimal skeletons (Pool / Resident / Bounded) |
+| [`adapters.md`](adapters.md)                      | Writing a `Resource` adapter crate                                       |
+| [`pooling.md`](pooling.md)                        | `PoolConfig`, recycle, broken-check, max-lifetime                        |
+| [`events.md`](events.md)                          | `ResourceEvent` catalog + `subscribe_events` patterns                    |
+| [`recovery.md`](recovery.md)                      | `RecoveryGate` state machine                                             |

--- a/crates/resource/docs/adapters.md
+++ b/crates/resource/docs/adapters.md
@@ -19,11 +19,12 @@ An adapter crate owns three things:
 2. A **resource struct** — implements `Resource` with four associated
    types (`Config`, `Runtime`, `Lease`, `Error`) plus the lifecycle
    methods. The factory.
-3. A **topology impl** — `Pooled`, `Resident`, `Service`, `Transport`,
-   or `Exclusive`. Most database adapters use `Pooled`.
+3. A **topology impl** — [`Pooled`], [`Resident`], or [`Bounded`] (with
+   a sealed `Cap` typestate: `Unbounded` / `Capped<N>` / `Exclusive`).
+   Most database adapters use `Pooled`; HTTP clients use `Resident`;
+   OAuth / gRPC / file-lock patterns use `Bounded` with the matching cap.
 
-**Credential binding (ADR-0044, amended by ADR-0067).** If your resource
-binds to a credential, declare a slot field
+**Credential binding.** If your resource binds to a credential, declare a slot field
 `#[credential(key = "...")] auth: SlotCell<CredentialGuard<C>>` and read the
 resolved guard via the derive-emitted `self.auth_slot()` accessor inside
 `create` (and the rotation hooks). Connection-bound resources override
@@ -317,13 +318,13 @@ fn on_credential_refresh(
 
 ## Step 4: Pick and Implement Topology
 
-| Topology    | Use when                                                                              |
-|-------------|---------------------------------------------------------------------------------------|
-| `Pooled`    | Stateful connections (DBs, gRPC channels). N instances, one-at-a-time checkout.       |
-| `Resident`  | Stateless or internally-pooled clients (`reqwest::Client`, AWS SDK). Cloned on acquire. |
-| `Service`   | Token-bounded shared clients with `TokenMode` admission. Rate-limited service clients. |
-| `Transport` | Connection-oriented — hands out a frame channel per acquire (e.g., long-lived TCP).    |
-| `Exclusive` | Mutex-style — one acquirer at a time, no internal pooling.                            |
+| Topology               | Use when                                                                                                  |
+|------------------------|-----------------------------------------------------------------------------------------------------------|
+| `Pooled`               | Stateful connections (DBs, gRPC channels). N instances, one-at-a-time checkout.                           |
+| `Resident`             | Stateless or internally-pooled clients (`reqwest::Client`, AWS SDK). `Arc::clone` on acquire.             |
+| `Bounded<Unbounded>`   | Token-gated services (OAuth, fan-out APIs). Long-lived runtime, no per-acquire release.                   |
+| `Bounded<Capped<N>>`   | Multiplexed sessions over one shared connection (SSH, gRPC channel). Tracked release via `BoundedRelease`. |
+| `Bounded<Exclusive>`   | Mutex-style — one acquirer at a time, reset-on-release ordering.                                          |
 
 ### Pooled implementation
 
@@ -379,10 +380,10 @@ credential.
 Registration goes through **one funnel**:
 `Manager::register::<R>(spec: RegistrationSpec<R>)`. The per-topology
 `register_<topo>[_with]` shorthands and the multi-step delegation chain
-were removed (commit `cf93e45b` dropped the manager-side
-`AcquireResilience` wrapper; the `register_*` shorthand family
-followed). `RegistrationSpec<R>` is a plain struct with public fields
-and no builder.
+were removed (the manager-side `AcquireResilience` wrapper was
+dropped; the `register_*` shorthand family followed).
+`RegistrationSpec<R>` is a plain struct with public fields and no
+builder.
 
 For the multi-tenant case, pin distinct resolved credentials to
 distinct registry rows by building a `SlotIdentity::Structural` (via

--- a/crates/resource/docs/events.md
+++ b/crates/resource/docs/events.md
@@ -53,7 +53,7 @@ aggregation, so there is no aggregate `CredentialRefreshed` /
 ### Slot-rotation variants (4)
 
 Emitted per `(resource, slot)` by the engine-owned rotation fan-out through
-the `Manager::{refresh_slot, revoke_slot}` port (ADR-0067 D1), after the
+the `Manager::{refresh_slot, revoke_slot}` port, after the
 engine has swapped the rotated guard into the slot and invoked the
 resource's `on_credential_refresh` / `on_credential_revoke` hook. The
 `error` string is already redacted — it never carries credential material.

--- a/crates/resource/docs/pooling.md
+++ b/crates/resource/docs/pooling.md
@@ -32,7 +32,7 @@ PoolRuntime<R>
   └── waiters:    AtomicUsize
 ```
 
-**Acquire** (`Manager::acquire_pooled` / `acquire_pooled_default`):
+**Acquire** (`Manager::acquire_pooled`, or `acquire_pooled_for_identity` for credential-bound routes):
 
 1. Atomically increment waiter count (RAII counter).
 2. Acquire one semaphore permit (waits up to the resilience-supplied timeout).
@@ -154,8 +154,9 @@ pub enum WarmupStrategy {
 
 - `None` — first acquire pays the cold-start cost. Cheapest, slowest first
   request.
-- `Sequential` — `min_size` instances created back-to-back during
-  `Manager::register_pooled*`. Predictable startup latency.
+- `Sequential` — `min_size` instances created back-to-back at the first
+  `Manager::acquire_pooled` (or via the warmup hook on the pool runtime).
+  Predictable startup latency.
 - `Parallel` — fastest warmup but spikes connection count; verify the
   backend tolerates it.
 - `Staggered { interval }` — connection rate-limited startup. Use when the
@@ -312,10 +313,10 @@ PoolConfig {
 
 Per-acquire timeout / retry composes one layer up (action handler /
 engine activity / caller-supplied `nebula-resilience` pipeline) — the
-manager-side `AcquireResilience` wrapper was removed in commit
-`cf93e45b` (peer Rust pools — sqlx, deadpool, bb8 — all ship
-acquire-timeout only). Acquire-timeout itself lives on the topology
-config (`create_timeout` field on the pool config).
+manager-side `AcquireResilience` wrapper was removed (peer Rust pools
+— sqlx, deadpool, bb8 — all ship acquire-timeout only). Acquire-timeout
+itself lives on the topology config (`create_timeout` field on the pool
+config).
 
 `RecoveryGate` is the remaining manager-level resilience seam: a
 CAS-based single-probe admission that prevents thundering-herd against

--- a/crates/resource/docs/pooling.md
+++ b/crates/resource/docs/pooling.md
@@ -35,7 +35,8 @@ PoolRuntime<R>
 **Acquire** (`Manager::acquire_pooled`, or `acquire_pooled_for_identity` for credential-bound routes):
 
 1. Atomically increment waiter count (RAII counter).
-2. Acquire one semaphore permit (waits up to the resilience-supplied timeout).
+2. Acquire one semaphore permit (waits up to `AcquireOptions::remaining()`
+   if a deadline is set, otherwise `PoolConfig::create_timeout`).
 3. Pop from `idle_queue` (`Lifo`: back / `Fifo`: front, per
    `PoolConfig::strategy`).
 4. If `test_on_checkout` is true, call `Resource::check`. Discard on `Err`.

--- a/crates/resource/docs/recovery.md
+++ b/crates/resource/docs/recovery.md
@@ -157,52 +157,20 @@ let gate = groups.get_or_create(
 
 ---
 
-## WatchdogHandle
+## Background health probes
 
-Opt-in background health probe. Spawns a Tokio task that runs a
-user-supplied async `check_fn` on a fixed interval. After
-`failure_threshold` consecutive failures it calls
-`on_health_change(false)`; after `recovery_threshold` consecutive
-successes it calls `on_health_change(true)`.
-
-```rust,ignore
-use std::time::Duration;
-use nebula_resource::{WatchdogConfig, WatchdogHandle};
-use tokio_util::sync::CancellationToken;
-
-let parent_cancel = CancellationToken::new();
-
-let handle = WatchdogHandle::start(
-    WatchdogConfig {
-        interval: Duration::from_secs(30),
-        probe_timeout: Duration::from_secs(5),
-        failure_threshold: 3,    // 3 consecutive failures → unhealthy
-        recovery_threshold: 1,   // 1 success → healthy again
-    },
-    || async {
-        // Your async probe — return Result<(), nebula_resource::Error>.
-        Ok(())
-    },
-    |healthy| {
-        tracing::info!(healthy, "watchdog health transition");
-    },
-    parent_cancel,
-);
-
-// Graceful stop (awaits the background task):
-handle.stop().await;
-// Or cancel-on-drop (does NOT await):
-drop(handle);
-```
-
-The `parent_cancel` token lets the watchdog participate in tree-style
-shutdown — the task exits as soon as the parent is cancelled.
+`nebula-resource` does **not** ship a built-in background health-probe
+type. If you need one, drive `Resource::check()` from a `tokio::spawn`
+loop in your application code or compose
+[`nebula-resilience`](../../resilience/README.md)'s health-probe layer.
+The manager publishes `ResourceEvent::HealthChanged` whenever it
+observes a transition, so consumers can react without polling.
 
 ---
 
 ## Differences from v1
 
-- **No `HealthChecker`** — use `Resource::check()` directly or `WatchdogHandle`
-- **No `QuarantineManager`** — replaced by `RecoveryGate` (simpler, CAS-based)
-- **No `HealthState` enum** — health is a `bool` (healthy/unhealthy)
-- **No `HealthPipeline`** — multi-stage checks removed
+- **No `HealthChecker`** — drive `Resource::check()` directly.
+- **No `QuarantineManager`** — replaced by `RecoveryGate` (simpler, CAS-based).
+- **No `HealthState` enum** — health is a `bool` (healthy/unhealthy).
+- **No `HealthPipeline`** — multi-stage checks removed.

--- a/crates/resource/docs/recovery.md
+++ b/crates/resource/docs/recovery.md
@@ -160,11 +160,10 @@ let gate = groups.get_or_create(
 ## Background health probes
 
 `nebula-resource` does **not** ship a built-in background health-probe
-type. If you need one, drive `Resource::check()` from a `tokio::spawn`
-loop in your application code or compose
-[`nebula-resilience`](../../resilience/README.md)'s health-probe layer.
-The manager publishes `ResourceEvent::HealthChanged` whenever it
-observes a transition, so consumers can react without polling.
+type. If you need one, drive `Resource::check()` from an
+application-owned `tokio::spawn` loop. The manager publishes
+`ResourceEvent::HealthChanged` whenever it observes a transition, so
+consumers can react without polling.
 
 ---
 

--- a/crates/resource/docs/topology-reference.md
+++ b/crates/resource/docs/topology-reference.md
@@ -1,87 +1,105 @@
 # Topology Reference for Resource Authors
 
-> **Audience:** plugin authors writing a new `Resource` impl. Maps each of the
-> four most-common topologies (Pool, Resident, Service, Transport) to a
-> minimal Rust skeleton, the trait set you must implement, when to pick
-> that topology over the others, and the friction points that surfaced
-> during the M6.3 prototyping pass.
+> **Audience:** plugin authors writing a new `Resource` impl. Maps each of
+> the three topology traits (`Pooled`, `Resident`, `Bounded`) to a minimal
+> Rust skeleton, the trait set you must implement, when to pick it, and
+> the friction points learned during the Bounded-fold pass.
 >
-> See [`README.md`](README.md) for the full library overview, and
-> [`examples/examples/m6_*.rs`](../../../examples/examples) for runnable
-> end-to-end demonstrations of each pattern (Pool / Resident / Service).
+> See [`README.md`](README.md) for the full library overview, and the
+> `examples/` workspace member for runnable end-to-end demonstrations of
+> each pattern.
 
 ---
 
 ## Decision matrix
 
-| Topology | Lease == Runtime? | Use when… | Don't use for… |
-|---|---|---|---|
-| **[Pool](#pool)** | Yes (`Lease = Runtime`) | N stateful instances, expensive to create, interchangeable; e.g. database connections. | Single-shared HTTP clients (use Resident); transport multiplexed sessions (use Transport). |
-| **[Resident](#resident)** | Yes (`Lease = Runtime`, `Clone`) | One instance shared widely, cloning is cheap (`Arc`); e.g. `reqwest::Client`, in-memory cache. | Per-caller mutable state (use Pool); event-driven sources where lease holds receivers (use Service + EventSource). |
-| **[Service](#service)** | No (`Lease ≠ Runtime`) | Long-lived runtime (e.g. bot client + broadcast bus) that hands out short-lived caller tokens. | Stateless HTTP (use Resident); per-tenant connection isolation (use Pool). |
-| **[Transport](#transport)** | No (`Lease ≠ Runtime`) | Expensive shared connection + cheap multiplexed sessions; e.g. SSH session, gRPC channel. | Stateless requests (use Resident); short-lived per-call work (use Pool). |
+| Topology                  | Lease == Runtime?       | Use when…                                                                              | Don't use for…                                                            |
+|---------------------------|-------------------------|----------------------------------------------------------------------------------------|---------------------------------------------------------------------------|
+| **[Pool](#pool)**         | Yes (`Lease = Runtime`) | N interchangeable stateful instances; expensive to create (DB connections).            | Single-shared HTTP client (use Resident); multiplexed sessions (Bounded). |
+| **[Resident](#resident)** | Yes (`Lease = Runtime`, `Clone`) | One instance shared widely; `Arc::clone` is cheap (`reqwest::Client`, in-memory cache). | Per-caller mutable state (use Pool); multiplexed sessions (Bounded).      |
+| **[Bounded](#bounded)**   | configurable            | Anything else: token-gated services, multiplexed sessions, exclusive resources.        | Pool semantics (use Pool); shared-clone semantics (use Resident).         |
 
-`Exclusive` is a fifth, less-common topology — single-caller serialized
-access via `Semaphore(1)`. Use it only when the underlying resource is
-genuinely sequential (think a USB-serial adapter); otherwise reach for
-Pool with `max_size = 1`.
+The `Bounded` topology folded the former standalone `Service` /
+`Transport` / `Exclusive` traits into one runtime. A `Bounded` resource
+picks a `Cap` typestate as `Bounded::Cap` (`Unbounded` / `Capped<N>` /
+`Exclusive`); the compiler enforces the concurrency arity and whether
+`BoundedRelease` is mandatory.
 
 ---
 
 ## Pool
 
-**Two interchangeable stateful instances managed by a checkout / recycle / destroy lifecycle.**
+**N interchangeable stateful instances managed by a checkout / recycle / destroy lifecycle.**
 
 ### Trait set
 
-```rust
+```rust,ignore
 impl Resource for Postgres {
     type Config = PostgresConfig;
     type Runtime = PgConnection;
     type Lease = PgConnection;       // Pool: Lease = Runtime
     type Error = PgError;
+
     fn key() -> ResourceKey { resource_key!("demo.postgres") }
-    async fn create(&self, config: &Self::Config, ctx: &ResourceContext) -> Result<Self::Runtime, Self::Error> { /* … */ }
+
+    fn create(
+        &self, config: &Self::Config, ctx: &ResourceContext,
+    ) -> impl Future<Output = Result<Self::Runtime, Self::Error>> + Send { /* … */ }
+
     async fn destroy(&self, runtime: Self::Runtime) -> Result<(), Self::Error> { /* … */ }
-    fn metadata() -> ResourceMetadata { ResourceMetadata::from_key(&Self::key()) }
 }
 
 impl Pooled for Postgres {
     fn is_broken(&self, runtime: &Self::Runtime) -> BrokenCheck { /* sync, O(1) */ }
-    async fn recycle(&self, runtime: &Self::Runtime, metrics: &InstanceMetrics) -> Result<RecycleDecision, Self::Error> { /* … */ }
+
+    async fn recycle(
+        &self, runtime: &Self::Runtime, metrics: &InstanceMetrics,
+    ) -> Result<RecycleDecision, Self::Error> { /* … */ }
+
     // Optional: `prepare(&self, runtime, ctx)` for per-checkout setup.
 }
 ```
 
 ### Registration
 
-```rust
-manager.register_pooled(
-    Postgres,
-    PostgresConfig::default(),
-    PoolConfig {
-        min_size: 0,
-        max_size: 8,
-        ..PoolConfig::default()
-    },
+```rust,ignore
+let pool_rt = PoolRuntime::<Postgres>::try_new(
+    PoolConfig { min_size: 0, max_size: 8, ..PoolConfig::default() },
+    pg_config.fingerprint(),
 )?;
+
+manager.register(RegistrationSpec {
+    resource: Postgres,
+    config: pg_config,
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Pool(pool_rt),
+    acquire: Manager::erased_acquire_pooled_for::<Postgres>(),
+    recovery_gate: None,
+})?;
 ```
 
 ### Lifecycle
 
-`create` (lazy on first acquire, eager via `warmup`) → `prepare` (per
-checkout) → caller holds `ResourceGuard` → on drop: tainted? destroy.
+`create` (lazy on first acquire, eager via `warmup`) → optional `prepare`
+(per checkout) → caller holds `ResourceGuard` → on drop: tainted? destroy.
 healthy? → `recycle` returns `Keep` / `Drop` → idle queue or destroy.
 
-### Friction points (from M6.3 prototyping)
+### Friction points
 
-- **Sync `is_broken`.** Runs in the `Drop` path of `ResourceGuard`. No I/O, no async — read atomic flags only. If you must check the network, do it in `recycle` (async).
-- **`fingerprint()` semantics.** Hash only fields that make existing instances stale. `application_name` and `statement_timeout` matter; `max_size` does not.
-- **`AbortOnDrop` for spawned tasks.** If your `create` spawns a background task (e.g. a connection-handler task), wrap the `JoinHandle` in an `AbortOnDrop` so it is killed when the runtime drops mid-acquire (cancel-safety contract #10).
+- **Sync `is_broken`.** Runs in the `Drop` path of `ResourceGuard`. No I/O,
+  no async — read atomic flags only. If you must check the network, do it
+  in `recycle` (async).
+- **`fingerprint()` semantics.** Hash only fields that make existing
+  instances stale. `application_name` and `statement_timeout` matter;
+  `max_size` does not.
+- **`AbortOnDrop` for spawned tasks.** If your `create` spawns a background
+  task, wrap the `JoinHandle` in an `AbortOnDrop` so it is killed when the
+  runtime drops mid-acquire.
 
 ### Runnable example
 
-[`examples/examples/m6_postgres_pool.rs`](../../../examples/examples/m6_postgres_pool.rs)
+[`examples/examples/resource_postgres_pool.rs`](../../../examples/examples/resource_postgres_pool.rs)
 
 ---
 
@@ -91,148 +109,171 @@ healthy? → `recycle` returns `Keep` / `Drop` → idle queue or destroy.
 
 ### Trait set
 
-```rust
+```rust,ignore
 impl Resource for GoogleSheets {
     type Config = GoogleSheetsConfig;
     type Runtime = GoogleSheetsClient;       // typically wraps Arc internals
     type Lease = GoogleSheetsClient;         // Resident: Lease = Runtime, Clone
     type Error = SheetsError;
+
     fn key() -> ResourceKey { resource_key!("demo.google.sheets") }
-    async fn create(&self, config: &Self::Config, ctx: &ResourceContext) -> Result<Self::Runtime, Self::Error> { /* … */ }
-    async fn destroy(&self, runtime: Self::Runtime) -> Result<(), Self::Error> { /* … */ }
-    fn metadata() -> ResourceMetadata { ResourceMetadata::from_key(&Self::key()) }
+
+    fn create(
+        &self, config: &Self::Config, ctx: &ResourceContext,
+    ) -> impl Future<Output = Result<Self::Runtime, Self::Error>> + Send { /* … */ }
 }
 
 impl Resident for GoogleSheets {
     fn is_alive_sync(&self, _runtime: &Self::Runtime) -> bool { true }
-    fn stale_after(&self) -> Option<Duration> { None } // or Some(Duration::from_secs(45 * 60)) for token TTL
+    fn stale_after(&self) -> Option<Duration> { None }
 }
 ```
 
 ### Registration
 
-```rust
-manager.register(
-    GoogleSheets::new(cred),
-    GoogleSheetsConfig { application: "nebula-demo".into() },
-    ScopeLevel::Global,
-    TopologyRuntime::Resident(ResidentRuntime::<GoogleSheets>::new(ResidentConfig::default())),
-    None,
-    None,
-)?;
+```rust,ignore
+let resident_rt = ResidentRuntime::<GoogleSheets>::new(ResidentConfig::default());
+
+manager.register(RegistrationSpec {
+    resource: GoogleSheets::new(cred),
+    config: GoogleSheetsConfig { application: "nebula-demo".into() },
+    scope: ScopeLevel::Global,
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Resident(resident_rt),
+    acquire: Manager::erased_acquire_resident_for::<GoogleSheets>(),
+    recovery_gate: None,
+})?;
 ```
 
 ### Cross-workflow dedupe
 
 Manager dedupes by `(R::key(), ScopeLevel)`. 10 concurrent acquires at the
 same scope produce **one** `Resource::create` invocation; every lease is
-`Arc::ptr_eq` to every other. See `examples/examples/m6_telegram_multi_workflow.rs`
-(uses Resident topology to demonstrate the dedupe assertion explicitly).
+`Arc::ptr_eq` to every other. See
+[`examples/examples/resource_telegram_multi_workflow.rs`](../../../examples/examples/resource_telegram_multi_workflow.rs)
+for the dedupe assertion.
 
 ### Friction points
 
-- **`fingerprint() = 0` is correct.** Resident has only one instance, so a config change forces destroy + recreate; there's no "stale fingerprint" sweep to drive.
-- **Token caching inside `Runtime`.** OAuth-style integrations cache an access token inside the Runtime. On token expiry, two valid patterns exist:
-  - **Reactive:** detect 401 → refresh inline + retry (used by `m6_resident_http.rs`).
-  - **Proactive (preferred for high-throughput):** use `Resident::stale_after(Some(token_ttl - safety_margin))` and let the manager destroy + recreate before tokens expire. Simpler, no inline retry.
-- **`Clone` requirement on `Runtime`.** Inner state typically lives behind `Arc<Inner>` so `Clone` is a refcount bump.
+- **`fingerprint() = 0` is correct.** Resident has only one instance, so a
+  config change forces destroy + recreate; there's no "stale fingerprint"
+  sweep to drive.
+- **Token caching inside `Runtime`.** OAuth-style integrations cache an
+  access token inside the Runtime. Two valid patterns:
+  - **Reactive:** detect 401 → refresh inline + retry (used by
+    [`resource_resident_http.rs`](../../../examples/examples/resource_resident_http.rs)).
+  - **Proactive (preferred for high throughput):** use
+    `Resident::stale_after(Some(token_ttl - margin))` and let the manager
+    destroy + recreate before tokens expire.
+- **`Clone` requirement on `Runtime`.** Inner state typically lives behind
+  `Arc<Inner>` so `Clone` is a refcount bump.
 
-### Runnable example
+### Runnable examples
 
-[`examples/examples/m6_resident_http.rs`](../../../examples/examples/m6_resident_http.rs) (with OAuth refresh)
-
-[`examples/examples/m6_telegram_multi_workflow.rs`](../../../examples/examples/m6_telegram_multi_workflow.rs) (cross-workflow sharing assertion)
+- [`examples/examples/resource_resident_http.rs`](../../../examples/examples/resource_resident_http.rs) — OAuth refresh
+- [`examples/examples/resource_telegram_multi_workflow.rs`](../../../examples/examples/resource_telegram_multi_workflow.rs) — cross-workflow dedupe assertion
 
 ---
 
-## Service
+## Bounded
 
-**Long-lived runtime + short-lived caller tokens (`Lease ≠ Runtime`).**
+**One runtime + per-acquire `Lease` shape selected at compile time by the `Cap` typestate.**
 
-The runtime owns infrastructure (e.g. a Telegram `Bot` + broadcast bus); the lease is a small token (e.g. `Bot` clone + token-only outbound API). Use it when the caller-facing surface differs from the framework-facing infrastructure.
+### Cap typestates
 
-### Trait set
+| `type Cap`        | Semantics                                                                           | `BoundedRelease`? |
+|-------------------|-------------------------------------------------------------------------------------|-------------------|
+| `Unbounded`       | Long-lived runtime, no per-acquire concurrency cap, no release work (token-gated).  | Forbidden         |
+| `Capped<N>`       | At most `N` concurrent leases via a `Semaphore(N)`; tracked release.                | Required          |
+| `Exclusive`       | Exactly one caller at a time via `Semaphore(1)`; reset-on-release ordering.         | Required          |
 
-```rust
+The compiler enforces the matrix. Pairing `Unbounded` with `BoundedRelease`,
+or omitting `BoundedRelease` for `Capped` / `Exclusive`, is a build error.
+
+### `Unbounded` — token-gated service (formerly Service topology)
+
+```rust,ignore
 impl Resource for TelegramBot {
     type Config = TelegramConfig;
     type Runtime = TelegramBotRuntime;     // owns Arc<BotInner>
     type Lease = TelegramBotHandle;        // outbound-only API
     type Error = TelegramError;
-    // create / destroy / metadata as for Pool/Resident
+    // create / destroy as for Pool/Resident
 }
 
-impl Service for TelegramBot {
-    const TOKEN_MODE: TokenMode = TokenMode::Cloned;
-    async fn acquire_token(&self, runtime: &Self::Runtime, ctx: &dyn Ctx) -> Result<Self::Lease, Self::Error> { /* … */ }
+impl Bounded for TelegramBot {
+    type Cap = Unbounded;
+
+    async fn acquire_lease(
+        &self, runtime: &Self::Runtime, ctx: &ResourceContext,
+    ) -> Result<Self::Lease, Self::Error> { /* hand out a token */ }
 }
 ```
 
-### Optional companions
+### `Capped<N>` — multiplexed sessions (formerly Transport topology)
 
-`Service` is one of the three topology traits a single resource can mix.
-The Telegram example shows the **hybrid** pattern: `Service` (outbound
-calls) + `EventSource` (incoming updates, per ADR-0045 used directly until
-the `EventTrigger` DX wrapper ships in §M6.4) + `Daemon` (background
-polling loop). Hybrid registration via:
+```rust,ignore
+impl Bounded for Ssh {
+    type Cap = Capped<8>;
 
-```rust
-manager.register_service_with(/* … */)?;
-// Or via the underlying `manager.register(...)` form for full control.
+    async fn acquire_lease(
+        &self, runtime: &Self::Runtime, ctx: &ResourceContext,
+    ) -> Result<Self::Lease, Self::Error> { /* open a session */ }
+}
+
+impl BoundedRelease for Ssh {
+    async fn release_lease(
+        &self, runtime: &Self::Runtime, lease: Self::Lease, healthy: bool,
+    ) -> Result<(), Self::Error> { /* close session */ }
+}
+```
+
+### `Exclusive` — single-caller serialized access
+
+```rust,ignore
+impl Bounded for FileLock {
+    type Cap = Exclusive;
+
+    async fn acquire_lease(
+        &self, runtime: &Self::Runtime, ctx: &ResourceContext,
+    ) -> Result<Self::Lease, Self::Error> { /* take the file lock */ }
+}
+
+impl BoundedRelease for FileLock {
+    async fn release_lease(
+        &self, runtime: &Self::Runtime, lease: Self::Lease, healthy: bool,
+    ) -> Result<(), Self::Error> { /* release + reset */ }
+}
+```
+
+### Registration
+
+```rust,ignore
+let bounded_rt = BoundedRuntime::<TelegramBot>::new(BoundedConfig::default())?;
+
+manager.register(RegistrationSpec {
+    resource: TelegramBot::new(cred),
+    config: telegram_config,
+    scope: ScopeLevel::Organization(org_id),
+    slot_identity: SlotIdentity::Unbound,
+    topology: TopologyRuntime::Bounded(bounded_rt),
+    acquire: Manager::erased_acquire_bounded_for::<TelegramBot>(),
+    recovery_gate: None,
+})?;
 ```
 
 ### Friction points
 
-- **`broadcast::Receiver` + `&self`.** The receiver needs `&mut self`, but `ResourceGuard` derefs as `&Lease`. **Resolution (validated in M6.3):** keep the receiver inside the Runtime + EventSource trait path; the action-facing Lease exposes only outbound methods. Action authors that want to consume events use `EventTrigger` (or directly subscribe to the broadcast channel; see ADR-0045).
-- **Service drain on config reload.** Old runtime stays alive while existing leases (which `Arc::clone` `BotInner`) are still in flight; new acquires get the new runtime.
-
-### Runnable example
-
-[`examples/examples/m6_telegram_multi_workflow.rs`](../../../examples/examples/m6_telegram_multi_workflow.rs) (uses Resident in the example for cross-workflow assertion clarity, but documents the Service shape inline)
-
----
-
-## Transport
-
-**Shared connection + cheap multiplexed sessions (`Lease ≠ Runtime`).**
-
-Used for SSH-like patterns: one expensive TCP + key-exchange + auth, then
-cheap "session" channels on top.
-
-### Trait set
-
-```rust
-impl Resource for Ssh {
-    type Config = SshResourceConfig;
-    type Runtime = SshRuntime;          // one TCP session
-    type Lease = SshSession;            // cheap multiplexed channel
-    type Error = SshError;
-    // create / destroy / metadata
-}
-
-impl Transport for Ssh {
-    async fn open_session(&self, runtime: &Self::Runtime, ctx: &dyn Ctx) -> Result<Self::Lease, Self::Error> { /* … */ }
-    async fn close_session(&self, runtime: &Self::Runtime, session: Self::Lease, healthy: bool) -> Result<(), Self::Error> { /* … */ }
-    async fn keepalive(&self, runtime: &Self::Runtime) -> Result<(), Self::Error> { /* … */ }
-}
-```
-
-### Friction points
-
-- **`max_sessions` only in `transport::Config`.** Earlier prototype kept a duplicate in `SshResourceConfig`; resolution: the framework owns the semaphore via `transport::Config.max_sessions`. Resource config is for resource-specific settings only.
-- **Temp key file lifecycle.** Most SSH crates need a file path for the private key. Write it to a `tempfile` with `0600` permissions in `create`, delete in `destroy`. If `create` is cancelled mid-flight the file leaks — acceptable; the OS reclaims `/tmp`. Better long-term: use SSH agent forwarding.
-- **`keepalive()` runs at the transport level, not the session level.** Prevents `sshd ClientAliveInterval` from closing the idle connection.
-
-### When you'd reach for it
-
-- Multiple commands over a single SSH connection.
-- A long-lived gRPC channel with multiplexed RPC streams.
-- Anything where the connection itself is expensive (TLS handshake, key exchange) but the per-call work is cheap.
-
-(No runnable example is shipped for Transport in M6.3 — the Pool example
-covers the pool semantics, and Service/Resident cover the `Lease ≠ Runtime`
-distinction. Add a `m6_ssh_transport.rs` companion if you implement an SSH
-plugin.)
+- **Lease shape vs Runtime.** Anything more complex than `Lease = Runtime`
+  belongs on `Bounded`. The `Lease` type is what an action receives; the
+  `Runtime` is what the framework owns and rotates credentials on.
+- **`BoundedRelease` runs through `ReleaseQueue`.** Don't block the
+  caller-side `Drop`; the release future is scheduled on the manager's
+  background workers.
+- **Temp resources inside `create`.** If `create` writes a temp file (SSH
+  key, TLS cert), delete it in `destroy`. If `create` is cancelled
+  mid-flight the file leaks — that's acceptable; the OS reclaims `/tmp`.
+  For long-term safety, prefer agent forwarding / certificate pinning.
 
 ---
 
@@ -241,21 +282,26 @@ plugin.)
 Before sending the PR, verify:
 
 - [ ] **`fingerprint`** hashes only fields that make existing instances stale.
-- [ ] **`is_broken` / `is_alive_sync`** are sync, O(1), no I/O. Reads atomic flags or pointer state.
-- [ ] **`destroy`** consumes `Runtime` (takes `self: Self::Runtime`, not `&Self::Runtime`).
-- [ ] **`Drop`** of the `Runtime` releases OS resources without `await`. If the runtime spawns tasks, wrap their `JoinHandle` in `AbortOnDrop`.
-- [ ] **Cancel-safety:** if `create` does anything observable before returning a Runtime, ensure that path is idempotent or has a guard that cleans up on cancel.
-- [ ] **Errors:** every variant of your `Error` enum classifies via `nebula_resource::ClassifyError` (transient / permanent / exhausted / backpressure / target-scope). Action authors rely on this for retry decisions.
-- [ ] **Credential slots** (per ADR-0044) are declared as `#[credential(key = "...")]` fields, **not** through the deprecated `Resource::Credential` associated type.
+- [ ] **`is_broken` / `is_alive_sync`** are sync, O(1), no I/O.
+- [ ] **`destroy`** consumes `Runtime` (takes `self: Self::Runtime`, not a reference).
+- [ ] **`Drop`** of the `Runtime` releases OS resources without `await`.
+      If the runtime spawns tasks, wrap their `JoinHandle` in `AbortOnDrop`.
+- [ ] **Cancel-safety:** if `create` does anything observable before
+      returning a Runtime, ensure that path is idempotent or has a guard
+      that cleans up on cancel.
+- [ ] **Errors:** every variant of your `Error` enum classifies via
+      `nebula_resource::ClassifyError` (transient / permanent / exhausted /
+      backpressure). Action authors rely on this for retry decisions.
+- [ ] **Credential slots** are declared as `#[credential(key = "...")]` fields,
+      **not** through any deprecated singular associated type.
 
 ---
 
 ## See also
 
 - [`README.md`](README.md) — library overview, public API surface
-- [`pooling.md`](pooling.md) — Pool topology deep-dive (warmup strategies, metrics, stats)
+- [`pooling.md`](pooling.md) — Pool topology deep-dive (warmup, metrics, stats)
 - [`recovery.md`](recovery.md) — recovery gating and resilience composition
 - [`events.md`](events.md) — lifecycle event streaming
 - [`adapters.md`](adapters.md) — accessor adapters (`HasResources`, `ScopedResourceAccessor`)
 - [`api-reference.md`](api-reference.md) — full surface API listing
-- [`docs/adr/0081-m6-resource-credential-integration.md`](../../../docs/adr/0081-m6-resource-credential-integration.md) — M6 contract: `Resource::Credential` superseded by `#[credential]` slots (ADR-0044); EventSource-direct canonical until `EventTrigger` ships (ADR-0045)

--- a/crates/resource/macros/src/lib.rs
+++ b/crates/resource/macros/src/lib.rs
@@ -1,6 +1,6 @@
 //! # nebula-resource-macros
 //!
-//! Proc-macros for the `nebula-resource` crate (Phase 4 / slot model).
+//! Proc-macros for the `nebula-resource` crate (slot model).
 //!
 //! ## `#[derive(Resource)]`
 //!
@@ -55,7 +55,7 @@ mod field_slots;
 mod resource;
 mod resource_attrs;
 
-/// Derive macro for the `Resource` trait (Phase 4 / slot model).
+/// Derive macro for the `Resource` trait (slot model).
 ///
 /// Emits `impl Resource for Foo` (with `todo!()` `create` body — the
 /// implementor supplies it) and `impl DeclaresDependencies for Foo`

--- a/crates/resource/macros/src/resource.rs
+++ b/crates/resource/macros/src/resource.rs
@@ -1,4 +1,4 @@
-//! `#[derive(Resource)]` macro implementation — Phase 4 / slot model.
+//! `#[derive(Resource)]` macro implementation — slot model.
 //!
 //! Emits:
 //! - `impl Resource for Foo` with `key()` returning the `#[resource(key = ...)]` value, and the

--- a/crates/resource/macros/src/resource_attrs.rs
+++ b/crates/resource/macros/src/resource_attrs.rs
@@ -1,4 +1,4 @@
-//! Parsed `#[resource(...)]` attributes for the Phase 4 / slot model
+//! Parsed `#[resource(...)]` attributes for the slot-model
 //! `#[derive(Resource)]`.
 
 use nebula_macro_support::{attrs, diag};
@@ -87,8 +87,7 @@ impl ResourceAttrs {
         let config = attr_args.get_type("config")?.ok_or_else(|| {
             diag::error_spanned(
                 struct_name,
-                "missing required attribute `config = SomeType` \
-                 — Phase 4 requires Self::Config to be specified",
+                "missing required attribute `config = SomeType`",
             )
         })?;
 

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -54,9 +54,8 @@ pub enum ErrorKind {
 /// Currently a single-variant `#[non_exhaustive]` enum: only [`Resource`]
 /// (the default) is constructed by any production code path. Older drafts
 /// included a `Target { id: String }` variant for per-target isolation
-/// failures (#391); it was removed at register R-051 resolution since no
-/// consumer ever wired it. New variants land here when an engine surface
-/// genuinely needs them.
+/// failures; it was removed since no consumer ever wired it. New
+/// variants land here when an engine surface genuinely needs them.
 ///
 /// [`Resource`]: ErrorScope::Resource
 #[non_exhaustive]

--- a/crates/resource/src/ext.rs
+++ b/crates/resource/src/ext.rs
@@ -22,7 +22,7 @@
 //!
 //! Both paths route through the same `LayeredResourceAccessor` (in
 //! `nebula-engine::scoped_resources`) injected into the action context, so the `scoped → global`
-//! precedence (Phase 6 / M6.1) applies uniformly.
+//! precedence applies uniformly.
 //!
 //! # Examples
 //!

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -38,9 +38,47 @@ pub(crate) type DrainTrackers = (DrainTracker, DrainTracker);
 
 /// A guard over a leased resource.
 ///
-/// Dereferences to `R::Lease` for ergonomic access. On drop, guarded and
-/// shared guards notify the pool (or release callback) so the lease can
-/// be recycled or destroyed.
+/// Dereferences to [`R::Lease`](Resource::Lease) for ergonomic access. The
+/// guard holds the in-flight reservation: dropping it returns the lease
+/// to its owning topology (recycle / destroy / Arc decrement, per
+/// topology).
+///
+/// # Drop
+///
+/// Drop is the **release pathway** and runs synchronously to:
+///
+/// 1. Decrement the manager-wide drain tracker (unblocks
+///    `Manager::graceful_shutdown` once it hits zero).
+/// 2. Decrement the per-resource in-flight counter (unblocks
+///    `Manager::revoke_slot` draining this row).
+/// 3. Hand the lease back to its owning topology runtime:
+///    - **Pooled** — `Pooled::recycle` is awaited; on `Keep` the
+///      instance returns to the idle queue, on `Drop` it queues a
+///      destroy on the release queue.
+///    - **Resident** — the `Arc` strong-count is decremented; no
+///      per-acquire release work.
+///    - **Bounded** — the semaphore permit is released; if
+///      `BoundedRelease` is implemented, its reset is queued on the
+///      release queue.
+/// 4. Emit
+///    [`ResourceEvent::Released { held, tainted }`](crate::events::ResourceEvent::Released).
+///
+/// Call [`ResourceGuard::taint`] **before** drop to skip recycle and
+/// force destroy on a misbehaving lease.
+///
+/// # Cancellation
+///
+/// Drop runs in any cancellation context, including a cancelled
+/// `tokio::task`. The drop path itself contains no `.await`; any async
+/// work (destroy, `BoundedRelease::reset`) is pushed onto the release
+/// queue which survives task cancellation. **Async release is
+/// best-effort on crash** — see canon §11.4.
+///
+/// # Panics
+///
+/// Drop does not panic. If a release callback the topology runtime
+/// installed panics, the panic is caught and logged via `tracing`;
+/// drain counters are still decremented so shutdown cannot deadlock.
 #[must_use = "dropping a ResourceGuard immediately releases the resource"]
 pub struct ResourceGuard<R: Resource> {
     /// The live lease state. `Some` for the entire lifetime of a usable

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -6,13 +6,15 @@
 //! The engine is the owner of the resource lifecycle: acquire, health-check,
 //! hot-reload via `ReloadOutcome`, and scope-bounded release. Action code
 //! receives a `ResourceGuard` that derefs to the lease type and releases on
-//! drop. Five topology traits cover the full integration space.
+//! drop. Three topology traits cover the integration space: `Pooled`,
+//! `Resident`, and the parameterised `Bounded` (with sealed `Cap` typestate
+//! `Unbounded` / `Capped<N>` / `Exclusive`).
 //!
 //! ## Key types
 //!
 //! | Type | Purpose |
 //! |------|---------|
-//! | `Resource` | Core trait — 5 associated types, 5 core methods |
+//! | `Resource` | Core trait — 4 associated types + lifecycle + slot-rotation hooks |
 //! | `ResourceGuard` | RAII lease guard with Owned/Guarded/Shared modes |
 //! | `Manager` | Central registry with acquire dispatch and shutdown |
 //! | `ReleaseQueue` | Background worker pool for async cleanup (best-effort on crash) |

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -199,41 +199,39 @@
 //! The topology collapse + cross-tenant-barrier + latent-bug closure that
 //! produced this module deliberately did **not** fix every issue it
 //! surfaced. This ledger is the durable record of what was consciously left
-//! for separate work, so nothing is silently inherited once the originating
-//! plan is gone. Every item is also filed as a tracked issue (linked); this
-//! ledger is the in-tree index, not the sole record. Severity is the item's
-//! own risk, independent of when it is scheduled.
+//! for separate work, so nothing is silently inherited. Severity is the
+//! item's own risk, independent of when it is scheduled.
 //!
 //! ## Latent bugs surfaced but out of scope
 //!
-//! - **`reload_config` never drains/rebuilds the live runtime — MED-HIGH**
-//!   ([#712]). `reload_config` swaps the config `ArcSwap` (and the Pool
+//! - **`reload_config` never drains/rebuilds the live runtime — MED-HIGH.**
+//!   `reload_config` swaps the config `ArcSwap` (and the Pool
 //!   fingerprint) but never drains in-flight work or rebuilds the
 //!   caller-supplied live `Arc<R::Runtime>` for any topology, so a reload
 //!   that should rotate the running runtime is silently not applied to it.
 //!   Deferred because the reload redesign (drain-then-rebuild + a truthful
 //!   outcome contract) is a separate concern; see the **accepted relabel**
 //!   note below for why this is a preserved no-op, not a regression.
-//! - **Pool `CreateGuard` cancel-drop leaks the runtime — MED** ([#713]).
+//! - **Pool `CreateGuard` cancel-drop leaks the runtime — MED.**
 //!   A *cancelled* acquire whose in-flight `create` already built a runtime
 //!   drops it synchronously without the async `destroy()`, leaking the
 //!   server-side handle. (The *other* `CreateGuard` race — an in-flight
 //!   create completing *after a revoke* — is the same isolation defect as
 //!   the revoke→recycle TOCTOU and **was fixed** by the pooled revoke-epoch
 //!   fence; only the cancelled-acquire leak remains.)
-//! - **Resident recreate `take()`+destroy-under-lock vs dispatch — MED**
-//!   ([#714]). The resident recreate clears the slot then destroys under the
+//! - **Resident recreate `take()`+destroy-under-lock vs dispatch — MED.**
+//!   The resident recreate clears the slot then destroys under the
 //!   lock; a concurrent revoke/refresh dispatch in that window can run
 //!   against the absent/old runtime, losing the revoke for that window.
 //!   Resident internals, out of the collapse seam.
 //! - **`graceful_shutdown` phase-4 detached workers can outlive
-//!   `release_queue_timeout` — LOW** ([#715]). The timeout bounds the wait,
+//!   `release_queue_timeout` — LOW.** The timeout bounds the wait,
 //!   not the detached release work; it eventually drains. shutdown.rs was
 //!   not opened by the collapse.
-//! - **`RecoveryTicket` Drop counts a panicked probe as an attempt — LOW**
-//!   ([#716]). A defensible-but-untested default; recovery internals.
+//! - **`RecoveryTicket` Drop counts a panicked probe as an attempt — LOW.**
+//!   A defensible-but-untested default; recovery internals.
 //!
-//! ## Separable acquire-path perf micro-folds — LOW ([#717])
+//! ## Separable acquire-path perf micro-folds — LOW
 //!
 //! The collapse took only the perf wins **inseparable** from it (one
 //! generic acquire pipeline instead of five byte-identical ones; a single
@@ -246,19 +244,18 @@
 //! regardless; any ordering tuning is a separate reviewed change with a
 //! re-stated memory-model proof.
 //!
-//! ## Cross-crate dedup / layer placement — LOW ([#718])
+//! ## Cross-crate dedup / layer placement — LOW
 //!
-//! Cross-layer type relocation was explicitly out of scope (no ADR in this
-//! work). Deferred: `ErrorKind` ≈ `nebula_error::ErrorCategory`
-//! reconciliation; hardcoded acquire backoff vs
-//! `nebula_resilience::BackoffConfig`; relocating the live `RecoveryGate` +
-//! `ReleaseQueue` to `nebula-resilience`; `events.rs` raw `broadcast` →
-//! `nebula_eventbus::EventBus`; unifying `CreateGuard`/`SessionGuard` into
-//! one `DefuseGuard<T>`; revisiting the `register_resolved` JSON/`{{ }}`
-//! expression coupling and its engine-ABI positional shape (see the
-//! accepted-exception note below).
+//! Cross-layer type relocation was explicitly out of scope. Deferred:
+//! `ErrorKind` ≈ `nebula_error::ErrorCategory` reconciliation; hardcoded
+//! acquire backoff vs `nebula_resilience::BackoffConfig`; relocating the
+//! live `RecoveryGate` + `ReleaseQueue` to `nebula-resilience`;
+//! `events.rs` raw `broadcast` → `nebula_eventbus::EventBus`; unifying
+//! `CreateGuard`/`SessionGuard` into one `DefuseGuard<T>`; revisiting the
+//! `register_resolved` JSON/`{{ }}` expression coupling and its engine-ABI
+//! positional shape (see the accepted-exception note below).
 //!
-//! ## Further `Manager` code-line reduction — LOW ([#719])
+//! ## Further `Manager` code-line reduction — LOW
 //!
 //! `crates/resource/src/manager/mod.rs` is 2552 lines: ~1224 comment/doc,
 //! ~117 blank, ~1211 code. The structural de-spaghettification root-cause
@@ -284,50 +281,30 @@
 //!   `ReloadOutcome::SwappedImmediately` for every variant. This is **only
 //!   an enum label change**: `reload_config` never drained or rebuilt the
 //!   live runtime for that topology under either label (that missing
-//!   behavior is exactly [#712]). A characterization net pins the
-//!   per-topology `reload_config` outcome so the relabel is auditable as a
-//!   preserved no-op, not a silent behavior change. The now-unreachable
-//!   draining variant was removed from `ReloadOutcome` once that net
-//!   landed.
+//!   behavior is the deferred `reload_config` redesign listed above). A
+//!   characterization net pins the per-topology `reload_config` outcome
+//!   so the relabel is auditable as a preserved no-op, not a silent
+//!   behavior change. The now-unreachable draining variant was removed
+//!   from `ReloadOutcome` once that net landed.
 //! - **`register_resolved` carries one `// guard-justified:`
 //!   `#[allow(clippy::too_many_arguments)]`.** The four register-chain
 //!   `too_many_arguments` allows the collapse targeted are gone; this last
 //!   one is the irreducible engine ABI — the production engine registrar
 //!   dispatches into `register_resolved` positionally with an 8-param
-//!   JSON-driven shape (down from 9 after `AcquireResilience` was dropped
-//!   manager-side; see commit `cf93e45b`), and collapsing it into a struct would re-introduce
-//!   the navigation hop the single register funnel removed for the one
-//!   erased call site. It is a candidate for the cross-crate-dedup
-//!   follow-up ([#718]), not a defect. (The three `too_many_arguments`
-//!   allows in `runtime/pool.rs` are pre-existing pool internals untouched
-//!   by this work.)
-//! - **R15/R16 cross-tenant fixes were latent, not live.** The original
-//!   64-bit `DefaultHasher` barrier defect ([#684], **closed** —
-//!   structurally fixed here via the collision-free `SlotIdentity`
-//!   structural set) and the pooled revoke→recycle TOCTOU were not
-//!   reachable in production (this crate is `frontier`; there is no
-//!   production credential→slot resolver), which is why seam-coupled
-//!   remediation was acceptable over a standalone hotfix.
-//!
-//! ## Consumer-migration history (honest record)
-//!
-//! The expand-contract migration of in-tree consumers initially named, but
-//! did **not** migrate, the three `m6_*` example binaries
-//! (`m6_postgres_pool`, `m6_resident_http`, `m6_telegram_multi_workflow`);
-//! they were migrated to `RegistrationSpec` / the structural `SlotIdentity`
-//! in a later, separately-committed step before the old surface was
-//! deleted. Recorded so the migration history is not misread as
-//! single-step.
-//!
-//! [#684]: https://github.com/vanyastaff/nebula/issues/684
-//! [#712]: https://github.com/vanyastaff/nebula/issues/712
-//! [#713]: https://github.com/vanyastaff/nebula/issues/713
-//! [#714]: https://github.com/vanyastaff/nebula/issues/714
-//! [#715]: https://github.com/vanyastaff/nebula/issues/715
-//! [#716]: https://github.com/vanyastaff/nebula/issues/716
-//! [#717]: https://github.com/vanyastaff/nebula/issues/717
-//! [#718]: https://github.com/vanyastaff/nebula/issues/718
-//! [#719]: https://github.com/vanyastaff/nebula/issues/719
+//!   JSON-driven shape (down from 9 after the `AcquireResilience` wrapper
+//!   was dropped manager-side), and collapsing it into a struct would
+//!   re-introduce the navigation hop the single register funnel removed
+//!   for the one erased call site. It is a candidate for the
+//!   cross-crate-dedup follow-up, not a defect. (The three
+//!   `too_many_arguments` allows in `runtime/pool.rs` are pre-existing
+//!   pool internals untouched by this work.)
+//! - **Cross-tenant fixes were latent, not live.** The original 64-bit
+//!   `DefaultHasher` barrier defect (structurally fixed here via the
+//!   collision-free `SlotIdentity` structural set) and the pooled
+//!   revoke→recycle TOCTOU were not reachable in production (this crate is
+//!   `frontier`; there is no production credential→slot resolver), which
+//!   is why seam-coupled remediation was acceptable over a standalone
+//!   hotfix.
 
 use std::{
     future::Future,
@@ -661,7 +638,14 @@ impl Manager {
     ///
     /// # Errors
     ///
-    /// Returns an error if config validation fails on the provided config.
+    /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if
+    ///   [`ResourceConfig::validate`](crate::ResourceConfig::validate)
+    ///   returns an error on the provided config.
+    /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if
+    ///   the supplied [`TopologyRuntime`] variant does not match the
+    ///   resource's topology trait (e.g., `TopologyRuntime::Pool` for a
+    ///   `Resource` that does not implement
+    ///   [`Pooled`](crate::topology::pooled::Pooled)).
     pub fn register<R: Resource>(&self, spec: RegistrationSpec<R>) -> Result<(), Error> {
         use crate::resource::ResourceConfig as _;
 
@@ -677,17 +661,15 @@ impl Manager {
 
         config.validate()?;
 
-        // #390 (pool min/max sanity) is enforced at `PoolRuntime`
-        // construction, which the caller has already invoked to build the
+        // Pool min/max sanity is enforced at `PoolRuntime` construction,
+        // which the caller has already invoked to build the
         // `TopologyRuntime::Pool` handed in here. No separate
         // register-time pool-config check is needed: an invalid
         // `(min_size, max_size)` from operator/JSON config is rejected by
         // the fallible `PoolRuntime::try_new` (typed `Error::permanent`)
         // that the engine registrar uses to construct the runtime, so the
         // failure surfaces *before* this funnel as a registration error
-        // rather than an abort. (The deleted `register_pooled[_with]`
-        // shorthands re-validated the raw config only because they took
-        // it *before* building the runtime.)
+        // rather than an abort.
 
         let key = R::key();
 
@@ -870,7 +852,7 @@ impl Manager {
     ///
     /// `nebula-resource → nebula-expression` is allowed under deny.toml's
     /// `[[bans]]` `nebula-resource` wrapper allowlist (Business → Core layer
-    /// edge per typed ref fields / Phase 9, R-040 R8).
+    /// edge per typed ref fields).
     ///
     /// # Errors
     ///
@@ -1866,7 +1848,18 @@ impl Manager {
     ///   [`acquire_pooled_for_identity`](Self::acquire_pooled_for_identity)
     ///   when the resolved slot identity is known; this identity-agnostic
     ///   path stays fail-closed for the no-identity caller.
-    /// - Propagates pool-specific acquire errors.
+    /// - Propagates pool-specific acquire errors
+    ///   ([`Backpressure`](crate::error::ErrorKind::Backpressure) on
+    ///   semaphore exhaustion, [`Transient`](crate::error::ErrorKind::Transient)
+    ///   on `Resource::create` failure, etc.).
+    ///
+    /// # Cancellation
+    ///
+    /// Cancel-safe: a cancelled acquire (`ctx.cancel_token()` fired, or
+    /// the manager-wide cancel token cancelled) decrements both the
+    /// manager-wide drain tracker and the per-resource in-flight counter
+    /// via `InFlightCounter`'s `Drop` impl before returning, so no
+    /// in-flight runtime is leaked.
     pub async fn acquire_pooled<R>(
         &self,
         ctx: &ResourceContext,
@@ -2093,9 +2086,19 @@ impl Manager {
     ///
     /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no resource of type `R` is
     ///   registered.
+    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
+    ///   down.
     /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if the resource is not using
     ///   resident topology.
-    /// - Propagates resident-specific acquire errors.
+    /// - Propagates resident-specific acquire errors (notably
+    ///   [`Transient`](crate::error::ErrorKind::Transient) on first-acquire
+    ///   `Resource::create` failure).
+    ///
+    /// # Cancellation
+    ///
+    /// Cancel-safe in the same way as
+    /// [`acquire_pooled`](Self::acquire_pooled): both drain trackers are
+    /// decremented via RAII before returning, no runtime leaks.
     pub async fn acquire_resident<R>(
         &self,
         ctx: &ResourceContext,
@@ -2215,7 +2218,16 @@ impl Manager {
     ///   bounded topology.
     /// - [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous) if more
     ///   than one resolved-credential registration exists for `(R, scope)`.
-    /// - Propagates the cap's acquire errors (permit timeout / closed).
+    /// - Propagates the cap's acquire errors
+    ///   ([`Backpressure`](crate::error::ErrorKind::Backpressure) on
+    ///   permit timeout, [`Cancelled`](crate::error::ErrorKind::Cancelled)
+    ///   on closed semaphore).
+    ///
+    /// # Cancellation
+    ///
+    /// Cancel-safe in the same way as
+    /// [`acquire_pooled`](Self::acquire_pooled): both drain trackers are
+    /// decremented via RAII before returning.
     pub async fn acquire_bounded<R>(
         &self,
         ctx: &ResourceContext,
@@ -2464,7 +2476,7 @@ impl Manager {
         // the honest outcome is `SwappedImmediately` for every variant: the
         // config is swapped, the live runtime is not rebuilt. The genuine
         // "drain + rebuild the live runtime on reload" behavior is the
-        // separately-tracked deferred `reload_config` redesign ([#712]).
+        // separately-tracked deferred `reload_config` redesign.
         let outcome = ReloadOutcome::SwappedImmediately;
 
         tracing::info!(key = %R::key(), ?outcome, "resource config reloaded");

--- a/crates/resource/src/manager/options.rs
+++ b/crates/resource/src/manager/options.rs
@@ -48,8 +48,8 @@ pub struct ShutdownConfig {
     pub drain_timeout: Duration,
     /// What to do on drain timeout. Default: [`DrainTimeoutPolicy::Abort`].
     pub on_drain_timeout: DrainTimeoutPolicy,
-    /// Upper bound on how long Phase 4 will wait for release-queue
-    /// workers to finish processing outstanding tasks.
+    /// Upper bound on how long the release-queue drain phase will wait
+    /// for release-queue workers to finish processing outstanding tasks.
     pub release_queue_timeout: Duration,
 }
 
@@ -82,7 +82,7 @@ impl ShutdownConfig {
         self
     }
 
-    /// Override the release-queue timeout budget for Phase 4.
+    /// Override the release-queue timeout budget.
     #[must_use]
     pub fn with_release_queue_timeout(mut self, timeout: Duration) -> Self {
         self.release_queue_timeout = timeout;

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -130,7 +130,7 @@ pub enum ShutdownError {
     /// registered resource is transitioned to
     /// [`ResourcePhase::Failed`](crate::state::ResourcePhase::Failed) so
     /// subsequent acquires fail fast and `health_check` reflects the
-    /// post-abort reality (R-023).
+    /// post-abort reality.
     #[error(
         "drain timeout expired with {outstanding} handle(s) still active; registry was NOT cleared (policy=Abort)"
     )]
@@ -202,9 +202,9 @@ impl Manager {
         //      (they share this token via `ReleaseQueue::with_cancel`).
         self.cancel.cancel();
 
-        // #387: mark every registered resource as `Draining` so operators
-        // polling `health_check` during the drain window see the correct
-        // lifecycle phase instead of a stale `Ready`.
+        // Mark every registered resource as `Draining` so operators polling
+        // `health_check` during the drain window see the correct lifecycle
+        // phase instead of a stale `Ready`.
         self.set_phase_all(crate::state::ResourcePhase::Draining);
 
         // Phase 2: DRAIN — wait for in-flight handles to be released.
@@ -222,26 +222,25 @@ impl Manager {
                          registry preserved, marking all resources Failed, \
                          returning DrainTimeout"
                     );
-                    // R-023 / 🔴-4: every resource transitions to `Failed`
-                    // (with `HealthChanged{healthy:false}` emitted per key)
-                    // rather than back to `Ready`. The cancel token fired
-                    // in Phase 1 already rejects new acquires; pretending
-                    // the registry is `Ready` while the caller observes a
-                    // `DrainTimeout` is phase corruption — callers polling
-                    // `health_check` would see `Ready` but get
-                    // `Error::cancelled` from `lookup`. Marking `Failed`
-                    // makes the registry tell the truth.
+                    // Every resource transitions to `Failed` (with
+                    // `HealthChanged{healthy:false}` emitted per key) rather
+                    // than back to `Ready`. The cancel token fired in Phase 1
+                    // already rejects new acquires; pretending the registry
+                    // is `Ready` while the caller observes a `DrainTimeout`
+                    // is phase corruption — callers polling `health_check`
+                    // would see `Ready` but get `Error::cancelled` from
+                    // `lookup`. Marking `Failed` makes the registry tell the
+                    // truth.
                     let err = ShutdownError::DrainTimeout { outstanding };
                     self.set_phase_all_failed(&err);
-                    // CodeRabbit 🟠 #4: do NOT reset `shutting_down` here.
-                    // Both shutdown failure modes (`DrainTimeout`,
-                    // `ReleaseQueueTimeout` below) are non-recoverable —
-                    // the cancel token has fired and the registry has
-                    // either been marked Failed or contains live handles
-                    // we cannot safely re-drain. Resetting would only
-                    // permit a doomed retry that races the cancel token
-                    // with no benefit and risks tearing down state mid-
-                    // observation by a concurrent caller.
+                    // Do NOT reset `shutting_down` here. Both shutdown
+                    // failure modes (`DrainTimeout`, `ReleaseQueueTimeout`
+                    // below) are non-recoverable — the cancel token has
+                    // fired and the registry has either been marked Failed
+                    // or contains live handles we cannot safely re-drain.
+                    // Resetting would only permit a doomed retry that races
+                    // the cancel token with no benefit and risks tearing
+                    // down state mid-observation by a concurrent caller.
                     return Err(err);
                 },
                 DrainTimeoutPolicy::Force => {
@@ -255,7 +254,7 @@ impl Manager {
             },
         }
 
-        // #387: drain has completed (or been force-released). Mark every
+        // Drain has completed (or been force-released). Mark every
         // resource as `ShuttingDown` so a health snapshot captured in the
         // narrow window between here and `registry.clear()` reflects the
         // real lifecycle state.
@@ -263,9 +262,8 @@ impl Manager {
 
         // Phase 3: CLEAR — drop all ManagedResources so their
         // Arc<ReleaseQueue> refs are released. The credential reverse-
-        // index (used by credential isolation's singular rotation dispatch) was
-        // removed in Phase 4 / slot model; per-slot rotation will be
-        // wired in a follow-up (.ai-factory/PHASE4_BLOCKED.md).
+        // index (used by the old singular rotation dispatch) was removed
+        // for the slot model; per-slot rotation lands in a follow-up.
         self.registry.clear();
 
         // Phase 4: AWAIT WORKERS — workers are already draining (from
@@ -302,7 +300,7 @@ impl Manager {
     ///
     /// Type-erased bulk update used during graceful shutdown so that
     /// `health_check` returns the correct phase while the drain/cleanup
-    /// is in flight (#387).
+    /// is in flight.
     pub(super) fn set_phase_all(&self, phase: crate::state::ResourcePhase) {
         for managed in self.registry.all_managed() {
             managed.set_phase_erased(phase);
@@ -313,11 +311,11 @@ impl Manager {
     /// shutdown error and emits a per-resource
     /// [`ResourceEvent::HealthChanged`] with `healthy: false`.
     ///
-    /// Used by the [`DrainTimeoutPolicy::Abort`] branch (R-023) so the
-    /// registry's recorded phase agrees with the `Err(DrainTimeout)`
-    /// observed by the caller. Without this, `health_check` would report
-    /// `Ready` while `lookup` rejected acquires via the cancel token —
-    /// the exact "phase corruption" called out in Phase 1 finding 🔴-4.
+    /// Used by the [`DrainTimeoutPolicy::Abort`] branch so the registry's
+    /// recorded phase agrees with the `Err(DrainTimeout)` observed by the
+    /// caller. Without this, `health_check` would report `Ready` while
+    /// `lookup` rejected acquires via the cancel token — the exact "phase
+    /// corruption" failure mode this method closes.
     ///
     /// Broadcast send errors (no live subscribers) are intentionally
     /// ignored, matching the rest of the manager's event-emission policy.

--- a/crates/resource/src/options.rs
+++ b/crates/resource/src/options.rs
@@ -2,9 +2,9 @@
 //!
 //! [`AcquireOptions`] lets callers communicate a deadline to the resource
 //! subsystem. Older drafts also carried `intent` and `tags` fields reserved
-//! for engine integration (#391); those were removed at register R-051
-//! resolution since no consumer ever wired them. If #391 lands, the
-//! relevant surface is added back via a new spec.
+//! for engine integration; those were removed since no consumer ever wired
+//! them. If the need returns, the relevant surface is added back via a new
+//! spec.
 
 use std::time::{Duration, Instant};
 

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -88,7 +88,7 @@ pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// when an entry is replaced in place (#382).
     fn managed_type_id(&self) -> TypeId;
 
-    /// Type-erased lifecycle phase mutation (#387).
+    /// Type-erased lifecycle phase mutation.
     ///
     /// Lets the manager drive phase transitions on all registered
     /// resources without needing a typed handle, which matters during
@@ -96,7 +96,7 @@ pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// is available.
     fn set_phase_erased(&self, phase: crate::state::ResourcePhase);
 
-    /// Type-erased terminal failure transition (R-023).
+    /// Type-erased terminal failure transition.
     ///
     /// Transitions the resource to [`ResourcePhase::Failed`] and records
     /// the supplied human-readable reason in `last_error`. Used by
@@ -1103,10 +1103,10 @@ mod tests {
 
     #[test]
     fn register_replace_preserves_type_id_still_used_by_another_scope() {
-        // Regression for a correctness hole raised in PR #399 review:
-        // if scope A and scope B both hold `TypeA`, replacing scope A
-        // with `TypeB` must NOT scrub `TypeA -> key` from `type_index`,
-        // otherwise `get_typed::<TypeA>(B)` would break.
+        // Regression for a correctness hole: if scope A and scope B both
+        // hold `TypeA`, replacing scope A with `TypeB` must NOT scrub
+        // `TypeA -> key` from `type_index`, otherwise `get_typed::<TypeA>(B)`
+        // would break.
         let reg = Registry::new();
         let key = ResourceKey::new("fake").unwrap();
 
@@ -1328,13 +1328,12 @@ mod tests {
 
     #[test]
     fn pinned_finder_skips_sibling_typed_row_under_shared_key() {
-        // Cross-type correctness gap (PR #723 review): distinct concrete
-        // types can share one `ResourceKey`. `type_index` only narrows a
-        // typed lookup to the key — it does NOT prove a `(scope,
-        // slot_identity)` row under that key is the requested type. A typed
-        // pinned lookup must SKIP a sibling-typed row (continue), not
-        // return it and let the caller's `downcast` fail (which would
-        // surface as a spurious `NotFound`).
+        // Cross-type correctness gap: distinct concrete types can share one
+        // `ResourceKey`. `type_index` only narrows a typed lookup to the
+        // key — it does NOT prove a `(scope, slot_identity)` row under that
+        // key is the requested type. A typed pinned lookup must SKIP a
+        // sibling-typed row (continue), not return it and let the caller's
+        // `downcast` fail (which would surface as a spurious `NotFound`).
         let reg = Registry::new();
         let key = ResourceKey::new("fake").unwrap();
         let scope = ScopeLevel::Global;
@@ -1377,14 +1376,13 @@ mod tests {
     #[test]
     fn agnostic_typed_finder_skips_sibling_typed_row_under_shared_key() {
         // Same cross-type gap on the *unpinned* (identity-agnostic) typed
-        // path (PR #723 follow-up review): `get_typed::<R>` /
-        // `get_typed_for_acquire_scope::<R>` resolve `type_index` to a
-        // `ResourceKey`, but a sibling concrete type can share that key. The
-        // concrete-type filter must apply to `find_at_exact_scope` /
-        // `find_in_entries` too, or a sibling row would (a) be handed to a
-        // typed caller whose `downcast` then fails, or (b) anchor the
-        // effective scope and mask a correctly-typed Global row, or (c)
-        // inflate the `Ambiguous` row count.
+        // path: `get_typed::<R>` / `get_typed_for_acquire_scope::<R>` resolve
+        // `type_index` to a `ResourceKey`, but a sibling concrete type can
+        // share that key. The concrete-type filter must apply to
+        // `find_at_exact_scope` / `find_in_entries` too, or a sibling row
+        // would (a) be handed to a typed caller whose `downcast` then fails,
+        // or (b) anchor the effective scope and mask a correctly-typed
+        // Global row, or (c) inflate the `Ambiguous` row count.
         let reg = Registry::new();
         let key = ResourceKey::new("fake").unwrap();
         let workspace = ScopeLevel::Workspace(WorkspaceId::new());
@@ -1497,13 +1495,13 @@ mod tests {
 
     #[test]
     fn pinned_finder_falls_back_to_global_when_exact_scope_has_only_other_tenant() {
-        // Global-fallback gap (PR #723 review): direct pinned lookup must
-        // agree with acquire routing. If tenant B has an exact-scope row
-        // and tenant A only has a Global row, the prior "pick effective
-        // scope by *any* entry at that scope" decided the scope BEFORE
-        // consulting `want_identity` and returned `NotFound` for tenant A —
-        // even though acquire (which walks ancestor scopes down to Global
-        // with the identity pin) would still find tenant A's Global row.
+        // Global-fallback gap: direct pinned lookup must agree with acquire
+        // routing. If tenant B has an exact-scope row and tenant A only has
+        // a Global row, the prior "pick effective scope by *any* entry at
+        // that scope" decided the scope BEFORE consulting `want_identity`
+        // and returned `NotFound` for tenant A — even though acquire (which
+        // walks ancestor scopes down to Global with the identity pin) would
+        // still find tenant A's Global row.
         let reg = Registry::new();
         let key = ResourceKey::new("fake").unwrap();
         let workspace = ScopeLevel::Workspace(WorkspaceId::new());

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -2,7 +2,7 @@
 //!
 //! [`Resource`] is the central abstraction: it describes how to create,
 //! health-check, and tear down a single resource type. Implementors supply
-//! four associated types and the lifecycle methods (Phase 4 / slot model).
+//! four associated types and the lifecycle methods (slot model).
 //!
 //! Per slot model (supersedes credential isolation) the singular `type Credential`
 //! associated type was deleted in favor of typed credential **slot fields**
@@ -210,7 +210,7 @@ impl ResourceMetadataBuilder {
     }
 }
 
-/// Core resource trait — 4 associated types + lifecycle methods (Phase 4 / slot model).
+/// Core resource trait — 4 associated types + lifecycle methods (slot model).
 ///
 /// Uses return-position `impl Future` (RPITIT) instead of `async_trait`,
 /// which avoids the `Box<dyn Future>` allocation on every call.
@@ -267,6 +267,28 @@ pub trait Resource: Send + Sync + 'static {
     /// through the derive-emitted `self.<field>_slot()` accessor
     /// (`Option<Arc<CredentialGuard<C>>>`) — handling the `None`
     /// (unbound) case explicitly — never off the raw cell field.
+    ///
+    /// # Errors
+    ///
+    /// Map driver errors to [`crate::ErrorKind`] via
+    /// `impl Into<crate::Error> for Self::Error` (or
+    /// `#[derive(ClassifyError)]`) so the manager can decide retry:
+    ///
+    /// - [`Transient`](crate::ErrorKind::Transient) — connect timeout, network blip.
+    /// - [`Permanent`](crate::ErrorKind::Permanent) — auth failure, malformed config.
+    /// - [`Exhausted { retry_after }`](crate::ErrorKind::Exhausted) — backend rate-limit;
+    ///   drives backoff before the next acquire attempt.
+    /// - [`Backpressure`](crate::ErrorKind::Backpressure) — your own quota saturated.
+    /// - [`Cancelled`](crate::ErrorKind::Cancelled) — observed `ctx.cancel_token()` and aborted.
+    ///
+    /// # Cancellation
+    ///
+    /// `create` MUST be cancel-safe: observing
+    /// `ctx.cancel_token().cancelled()` MAY drop the future at any
+    /// `.await` point. Any partially-allocated OS resource (socket, temp
+    /// file, spawned task) MUST be released in the dropped path —
+    /// typically via RAII (`AbortOnDrop` for `JoinHandle`,
+    /// `tempfile::TempPath` for transient files).
     fn create(
         &self,
         config: &Self::Config,
@@ -308,6 +330,23 @@ pub trait Resource: Send + Sync + 'static {
     /// Post-invocation invariant (slot model): the resource emits no further
     /// authenticated traffic on the revoked credential. Default: no-op
     /// (the engine still taints + drains the runtime around this call).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` if the runtime cannot stop emitting
+    /// authenticated traffic on the revoked credential. The manager
+    /// surfaces the error as
+    /// [`SlotRevokeFailed`](crate::ResourceEvent::SlotRevokeFailed) on
+    /// the event channel and emits an inline
+    /// [`HealthChanged { healthy: false }`](crate::ResourceEvent::HealthChanged)
+    /// so subscribers see the failure even if they filter slot events.
+    ///
+    /// # Security
+    ///
+    /// On `Ok(())` the resource guarantees no subsequent traffic uses
+    /// the revoked credential. On `Err(_)` the manager treats the
+    /// runtime as compromised; the row stays tainted until a fresh
+    /// credential is bound.
     fn on_credential_revoke(
         &self,
         slot_name: &str,
@@ -361,6 +400,15 @@ pub trait Resource: Send + Sync + 'static {
     /// Health-checks an existing runtime.
     ///
     /// The default implementation always succeeds.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` classified as
+    /// [`Transient`](crate::ErrorKind::Transient) for a recoverable health
+    /// failure (the manager will tear the runtime down and let the next
+    /// acquire rebuild it) or
+    /// [`Permanent`](crate::ErrorKind::Permanent) for a misconfiguration
+    /// that no retry will fix.
     fn check(
         &self,
         _runtime: &Self::Runtime,
@@ -371,6 +419,14 @@ pub trait Resource: Send + Sync + 'static {
     /// Gracefully winds down a runtime (e.g., drain connections).
     ///
     /// The default implementation is a no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` if graceful shutdown failed and the runtime
+    /// state is now indeterminate. The manager treats any error here as
+    /// non-fatal and proceeds to [`destroy`](Self::destroy), so this
+    /// method MUST be idempotent — multiple calls (or
+    /// shutdown-then-destroy) leave the runtime in the same final state.
     fn shutdown(
         &self,
         _runtime: &Self::Runtime,
@@ -381,6 +437,21 @@ pub trait Resource: Send + Sync + 'static {
     /// Final cleanup — consumes the runtime.
     ///
     /// The default implementation drops the runtime.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Self::Error` only if final cleanup cannot complete (e.g.,
+    /// background workers refused to join). The manager logs the error
+    /// and discards the runtime regardless — `destroy` is the last
+    /// chance to release server-side handles, so prefer side-effects
+    /// over `Err` here.
+    ///
+    /// # Cancellation
+    ///
+    /// `destroy` typically runs through
+    /// [`ReleaseQueue`](crate::ReleaseQueue) so caller-side `Drop` is
+    /// non-blocking. It MUST tolerate running after the manager's cancel
+    /// token has fired; do not abort if you observe cancellation.
     fn destroy(
         &self,
         runtime: Self::Runtime,

--- a/crates/resource/src/resource_ref.rs
+++ b/crates/resource/src/resource_ref.rs
@@ -15,15 +15,14 @@
 //! `key` attribute supplies a default resource id; workflow-JSON
 //! `slot_bindings.<slot_key>.resource_id` overrides it per node.
 //!
-//! ## Phase 1 scope (current)
+//! ## Current scope
 //!
 //! `ResourceRef<R>` carries the resolved resource id and a `PhantomData<R>`
 //! marker. `.resolve(ctx)` delegates to the existing `HasResources::acquire_any`
 //! path (the dyn-erased accessor) and downcasts via the `ResourceGuard<R>`
-//! pattern from `HasResourcesExt`. Phase 6 of
-//! `m6-resource-finalization-integration-audit.md` adds engine-side typed
-//! helpers (`ctx.acquire_resource_by_id::<R>(id)`); this type's `.resolve` will
-//! switch over without API change.
+//! pattern from `HasResourcesExt`. A follow-up adds engine-side typed
+//! helpers (`ctx.acquire_resource_by_id::<R>(id)`); this type's `.resolve`
+//! will switch over without API change.
 //!
 //! ## Composability
 //!
@@ -153,7 +152,7 @@ mod tests {
     use super::*;
 
     // Phantom resource type for tests. The `.resolve()` path is exercised in
-    // integration tests once Phase 6 wires the engine-side helpers; these
+    // integration tests once the engine-side helpers are wired; these
     // unit tests cover construction + accessors + Debug + Clone.
     struct FakeRes;
 

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -92,7 +92,7 @@ impl<R: Resource> ManagedResource<R> {
     /// Rebuilds a fresh [`ResourceStatus`] from the latest snapshot,
     /// copying the current generation across and preserving `last_error`.
     /// Used by the manager to drive phase transitions on register, reload
-    /// and shutdown (#387).
+    /// and shutdown.
     pub(crate) fn set_phase(&self, phase: ResourcePhase) {
         let prev = self.status.load_full();
         let next = ResourceStatus {
@@ -105,7 +105,7 @@ impl<R: Resource> ManagedResource<R> {
 
     /// Replace the lifecycle status with `Failed` and record a reason.
     ///
-    /// Wired by `Manager::set_phase_all_failed` (R-023): when
+    /// Wired by `Manager::set_phase_all_failed`: when
     /// `DrainTimeoutPolicy::Abort` fires we transition every registered
     /// resource to `Failed` so callers cannot subsequently acquire a
     /// resource the manager has already declared bankrupt. Per-resource

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -504,9 +504,10 @@ where
         };
 
         // Cancel-safety: if the future is dropped between here and
-        // `build_guarded_handle`, the guard ensures we log the leak
-        // and drop the runtime (triggering its native `Drop`).
-        let mut guard = CreateGuard::new(entry);
+        // `build_guarded_handle`, the guard submits an async destroy
+        // via the ReleaseQueue (#713 — without this, only the runtime's
+        // sync `Drop` ran, leaking the server-side handle).
+        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
 
         // Prepare the new instance.
         if let Err(e) = resource.prepare(guard.runtime(), ctx).await {
@@ -562,9 +563,10 @@ where
             };
 
             // Cancel-safety: guard the popped entry through all async
-            // validation steps. If cancelled mid-check, we log + drop
-            // rather than silently leaking the instance.
-            let mut guard = CreateGuard::new(entry);
+            // validation steps. If cancelled mid-check, the guard submits
+            // an async destroy via the ReleaseQueue (#713) rather than
+            // silently leaking the server-side handle.
+            let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
 
             // Stale fingerprint — destroy silently.
             let current_fp = self.current_fingerprint.load(Ordering::Acquire);
@@ -927,7 +929,10 @@ where
             Err(e) => return Err(e),
         };
 
-        let mut guard = CreateGuard::new(entry);
+        // Cancel-safety guard: see analogous `acquire`-path comment
+        // upstream. Submits async destroy via ReleaseQueue if cancelled
+        // (#713).
+        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
         if let Err(e) = resource.prepare(guard.runtime(), ctx).await {
             let entry = guard.defuse();
             let _ = resource.destroy(entry.runtime).await;
@@ -1213,26 +1218,53 @@ async fn release_entry<R>(
 ///
 /// Wraps a [`PoolEntry`] between creation and handle construction. If
 /// the future is cancelled (e.g. via `tokio::select!` or timeout) after
-/// `create()` succeeds but before the handle is built, `Drop` logs the
-/// leak and drops the runtime — triggering its native `Drop` impl
-/// (which closes TCP sockets, file handles, etc.).
+/// `create()` succeeds but before the handle is built, `Drop` submits
+/// the freshly-built runtime to the [`ReleaseQueue`] for an async
+/// `Resource::destroy` — symmetric with the release-path's
+/// `release_entry`. Without this, the runtime's *sync* `Drop` would run
+/// inline (closing the local handle) but the server-side resource — DB
+/// session, broker subscription, OS-level handle — would leak (#713).
 ///
 /// Call [`defuse`](Self::defuse) to take ownership of the entry once
 /// the handle is safely constructed.
-struct CreateGuard<R: Resource> {
+struct CreateGuard<R>
+where
+    R: Pooled + Clone + Send + Sync + 'static,
+    R::Lease: Into<R::Runtime>,
+{
     entry: Option<PoolEntry<R>>,
+    /// Cloned resource handle so the Drop path can call
+    /// `Resource::destroy(entry.runtime)` from the [`ReleaseQueue`]
+    /// without re-entering the originating pool context. Same Clone
+    /// requirement that `release_entry` already imposes on `R`.
+    resource: Option<R>,
+    /// Reference to the pool's `ReleaseQueue` so Drop can submit the
+    /// async destroy without spawning an orphan `tokio::spawn` (which
+    /// would lack the queue's bounded backpressure + shutdown drain).
+    release_queue: Option<Arc<ReleaseQueue>>,
 }
 
-impl<R: Resource> CreateGuard<R> {
+impl<R> CreateGuard<R>
+where
+    R: Pooled + Clone + Send + Sync + 'static,
+    R::Lease: Into<R::Runtime>,
+{
     /// Creates a new guard wrapping the given pool entry.
-    fn new(entry: PoolEntry<R>) -> Self {
-        Self { entry: Some(entry) }
+    fn new(entry: PoolEntry<R>, resource: R, release_queue: Arc<ReleaseQueue>) -> Self {
+        Self {
+            entry: Some(entry),
+            resource: Some(resource),
+            release_queue: Some(release_queue),
+        }
     }
 
     /// Returns a reference to the inner entry for inspection.
     fn entry(&self) -> &PoolEntry<R> {
-        // Invariant: entry() is only called between new() and defuse(),
-        // both are private with single call sites in the same function.
+        // guard-justified: `entry()` is private + only called between
+        // `new` (which inserts `Some(_)`) and `defuse` (which takes it
+        // out exactly once); reaching here with `None` would mean
+        // `entry()` was called *after* `defuse`, which the pool's
+        // single-function call graph structurally prevents.
         self.entry
             .as_ref()
             .unwrap_or_else(|| unreachable!("CreateGuard accessed after defuse"))
@@ -1247,24 +1279,60 @@ impl<R: Resource> CreateGuard<R> {
     ///
     /// After this call, `Drop` is a no-op.
     fn defuse(&mut self) -> PoolEntry<R> {
-        // Invariant: defuse() is called exactly once, right before
-        // constructing the ResourceGuard.
+        // guard-justified: `defuse` is private + called exactly once
+        // per `CreateGuard`, right before `build_guarded_handle`. The
+        // pool's call graph never re-enters `defuse` on the same guard
+        // (it would have to leak a `&mut CreateGuard` across the
+        // build_guarded_handle return, which the borrow checker
+        // forbids).
         self.entry
             .take()
             .unwrap_or_else(|| unreachable!("CreateGuard defused twice"))
     }
 }
 
-impl<R: Resource> Drop for CreateGuard<R> {
+impl<R> Drop for CreateGuard<R>
+where
+    R: Pooled + Clone + Send + Sync + 'static,
+    R::Lease: Into<R::Runtime>,
+{
     fn drop(&mut self) {
-        if let Some(entry) = self.entry.take() {
-            tracing::warn!(
-                resource = %R::key(),
-                "cancel-safety: pool entry dropped without async destroy \
-                 (create succeeded but acquire future was cancelled)"
-            );
-            drop(entry);
-        }
+        let Some(entry) = self.entry.take() else {
+            return; // defused — nothing to clean up
+        };
+        // guard-justified: invariant — `new` populates both `resource`
+        // and `release_queue` as `Some(_)`; `defuse` clears only
+        // `entry`, leaving the other two intact. We only reach this
+        // arm when `entry.take()` above returned `Some`, which means
+        // `defuse` has NOT run, which means `resource` and
+        // `release_queue` are still populated.
+        let resource = self
+            .resource
+            .take()
+            .unwrap_or_else(|| unreachable!("CreateGuard::Drop: resource missing"));
+        // guard-justified: same invariant as above — `release_queue`
+        // is populated whenever `entry` is.
+        let release_queue = self
+            .release_queue
+            .take()
+            .unwrap_or_else(|| unreachable!("CreateGuard::Drop: release_queue missing"));
+        tracing::warn!(
+            resource = %R::key(),
+            "cancel-safety: acquire future cancelled mid-create — \
+             scheduling async destroy via ReleaseQueue (#713)"
+        );
+        release_queue.submit(move || {
+            Box::pin(async move {
+                // `release_entry` would re-check fingerprint / revoke /
+                // recycle, but a freshly-created instance that was
+                // cancelled before reaching the prepare/fence step was
+                // never admitted to the idle queue or handed to a
+                // caller; the *only* correct cleanup is destroy. Mirror
+                // `release_entry`'s tainted arm and discard the error
+                // (recorded via the resource's own destroy path).
+                let _ = resource.destroy(entry.runtime).await;
+            })
+        });
     }
 }
 
@@ -1289,6 +1357,10 @@ mod tests {
         fail_create: Arc<AtomicBool>,
         fail_check: Arc<AtomicBool>,
         break_on_return: Arc<AtomicBool>,
+        /// Counts every `destroy` invocation — used by #713 cancel-drop
+        /// regression to assert the async destroy actually ran via the
+        /// `ReleaseQueue` (vs. just being inline-`Drop`-ed).
+        destroy_count: Arc<AtomicU64>,
     }
 
     impl MockPool {
@@ -1297,6 +1369,7 @@ mod tests {
                 fail_create: Arc::new(AtomicBool::new(false)),
                 fail_check: Arc::new(AtomicBool::new(false)),
                 break_on_return: Arc::new(AtomicBool::new(false)),
+                destroy_count: Arc::new(AtomicU64::new(0)),
             }
         }
     }
@@ -1366,6 +1439,7 @@ mod tests {
         }
 
         async fn destroy(&self, _runtime: u32) -> Result<(), MockError> {
+            self.destroy_count.fetch_add(1, Ordering::Relaxed);
             Ok(())
         }
 
@@ -1899,5 +1973,106 @@ mod tests {
              them"
         );
         assert_eq!(pool.idle_count().await, 0);
+    }
+
+    /// Regression: #713 — a `CreateGuard` whose entry is still `Some`
+    /// when it drops must schedule `Resource::destroy` via the
+    /// `ReleaseQueue` instead of just letting the runtime's sync `Drop`
+    /// run. Without this, a `tokio::select!` / `timeout` that cancels
+    /// the acquire future *after* `create` succeeded but *before*
+    /// `defuse` ran would leak the server-side handle (DB session,
+    /// broker subscription, etc.) — only the client-side `Drop` would
+    /// fire.
+    ///
+    /// The test constructs a `CreateGuard` by hand around a fabricated
+    /// `PoolEntry`, drops it without calling `defuse`, then drains the
+    /// `ReleaseQueue` and asserts `MockPool::destroy` ran exactly once.
+    #[tokio::test]
+    async fn create_guard_drop_submits_destroy_via_release_queue() {
+        let resource = MockPool::new();
+        let destroy_count = Arc::clone(&resource.destroy_count);
+        let (rq, rq_handle) = ReleaseQueue::new(1);
+        let rq = Arc::new(rq);
+
+        // Fabricate a freshly-built entry (mirrors what `create_entry`
+        // returns just before `CreateGuard::new`). The exact field
+        // values do not matter — only that `Drop` consumes the runtime.
+        let entry = PoolEntry::<MockPool> {
+            runtime: 42u32,
+            metrics: InstanceMetrics {
+                error_count: 0,
+                checkout_count: 1,
+                created_at: Instant::now(),
+            },
+            fingerprint: 1,
+            revoke_epoch: 0,
+            returned_at: None,
+        };
+        let guard = CreateGuard::new(entry, resource.clone(), Arc::clone(&rq));
+
+        // Simulate a cancelled acquire: the future is dropped *before*
+        // `defuse` ran. This is the exact shape `tokio::select!` /
+        // `tokio::time::timeout` produces when they win the race.
+        drop(guard);
+
+        // The submit is fire-and-forget on a bounded mpsc — give the
+        // queue a beat to dequeue + run the destroy future.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Then shut down the queue to drain anything still in flight.
+        drop(rq);
+        ReleaseQueue::shutdown(rq_handle).await;
+
+        assert_eq!(
+            destroy_count.load(Ordering::Relaxed),
+            1,
+            "#713: CreateGuard::Drop must submit destroy via ReleaseQueue \
+             when the acquire future is cancelled mid-create — otherwise \
+             the server-side handle leaks while the client-side Drop runs",
+        );
+    }
+
+    /// Companion to #713: a `CreateGuard` that runs through `defuse`
+    /// normally (the success path) MUST NOT trigger a stray
+    /// `Resource::destroy` — that would double-free the runtime that
+    /// is now owned by the resulting `ResourceGuard` and will be
+    /// released via the normal `release_entry` path on drop. The Drop
+    /// destroy-submit is conditional on `entry.take()` returning
+    /// `Some` (i.e. `defuse` did not run); this test pins that
+    /// short-circuit so a future refactor cannot accidentally make
+    /// Drop unconditional.
+    #[tokio::test]
+    async fn create_guard_defuse_skips_destroy() {
+        let resource = MockPool::new();
+        let destroy_count = Arc::clone(&resource.destroy_count);
+        let (rq, rq_handle) = ReleaseQueue::new(1);
+        let rq = Arc::new(rq);
+
+        let entry = PoolEntry::<MockPool> {
+            runtime: 7u32,
+            metrics: InstanceMetrics {
+                error_count: 0,
+                checkout_count: 1,
+                created_at: Instant::now(),
+            },
+            fingerprint: 1,
+            revoke_epoch: 0,
+            returned_at: None,
+        };
+        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(&rq));
+        let _ = guard.defuse(); // success path consumes the entry
+        drop(guard);
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        drop(rq);
+        ReleaseQueue::shutdown(rq_handle).await;
+
+        assert_eq!(
+            destroy_count.load(Ordering::Relaxed),
+            0,
+            "defused CreateGuard must NOT submit destroy — the runtime \
+             was transferred to a ResourceGuard and is destroyed by the \
+             normal release_entry path",
+        );
     }
 }

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -657,16 +657,14 @@ where
     /// Creates a new pool entry via `resource.create()`.
     ///
     /// All creation goes through this funnel and is gated on
-    /// `create_semaphore` (#390) so a burst of acquires cannot stampede
+    /// `create_semaphore` so a burst of acquires cannot stampede
     /// a fragile backend with `max_size` parallel connects. The permit
     /// is released as soon as `Resource::create` returns.
     ///
     /// The whole path — permit wait + `resource.create` — shares a
     /// single `create_timeout` budget. Both the create semaphore wait
     /// and the actual create are bounded by the remaining budget so a
-    /// slow-creating backend cannot stall callers forever (also raised
-    /// in PR #399 review: the create-semaphore acquire used to be
-    /// unbounded).
+    /// slow-creating backend cannot stall callers forever.
     ///
     /// When `non_blocking` is `true` (the `try_acquire` path), the
     /// create-semaphore wait is replaced with a `try_acquire_owned`
@@ -920,7 +918,7 @@ where
 
         // No idle instance — create a new one. The `true` flag keeps
         // the non-blocking contract: if the create semaphore is full,
-        // we return Backpressure instead of waiting (PR #399 review).
+        // we return Backpressure instead of waiting.
         let entry = match self
             .create_entry(resource, resource_config, ctx, true)
             .await

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -505,9 +505,9 @@ where
 
         // Cancel-safety: if the future is dropped between here and
         // `build_guarded_handle`, the guard submits an async destroy
-        // via the ReleaseQueue (#713 — without this, only the runtime's
-        // sync `Drop` ran, leaking the server-side handle).
-        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
+        // via the ReleaseQueue — without this, only the runtime's
+        // sync `Drop` ran, leaking the server-side handle.
+        let guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
 
         // Prepare the new instance.
         if let Err(e) = resource.prepare(guard.runtime(), ctx).await {
@@ -564,9 +564,9 @@ where
 
             // Cancel-safety: guard the popped entry through all async
             // validation steps. If cancelled mid-check, the guard submits
-            // an async destroy via the ReleaseQueue (#713) rather than
-            // silently leaking the server-side handle.
-            let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
+            // an async destroy via the ReleaseQueue rather than silently
+            // leaking the server-side handle.
+            let guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
 
             // Stale fingerprint — destroy silently.
             let current_fp = self.current_fingerprint.load(Ordering::Acquire);
@@ -928,9 +928,8 @@ where
         };
 
         // Cancel-safety guard: see analogous `acquire`-path comment
-        // upstream. Submits async destroy via ReleaseQueue if cancelled
-        // (#713).
-        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
+        // upstream. Submits async destroy via ReleaseQueue if cancelled.
+        let guard = CreateGuard::new(entry, resource.clone(), Arc::clone(release_queue));
         if let Err(e) = resource.prepare(guard.runtime(), ctx).await {
             let entry = guard.defuse();
             let _ = resource.destroy(entry.runtime).await;
@@ -1221,25 +1220,39 @@ async fn release_entry<R>(
 /// `Resource::destroy` — symmetric with the release-path's
 /// `release_entry`. Without this, the runtime's *sync* `Drop` would run
 /// inline (closing the local handle) but the server-side resource — DB
-/// session, broker subscription, OS-level handle — would leak (#713).
+/// session, broker subscription, OS-level handle — would leak.
 ///
 /// Call [`defuse`](Self::defuse) to take ownership of the entry once
-/// the handle is safely constructed.
+/// the handle is safely constructed. `defuse` consumes the guard by
+/// value, so the borrow checker prevents any use of the guard after
+/// `defuse` — `entry()` / `runtime()` cannot be invoked on a defused
+/// guard, and the guard's `Drop` never runs against a defused entry.
+///
+/// `entry` is the only `Option` field; `resource` and `release_queue`
+/// stay populated for the guard's whole lifetime so the `Drop` impl
+/// never has to inspect `Option` invariants — it clones them (both
+/// cheap: `R: Clone` is required by `release_entry` already, and
+/// `Arc<ReleaseQueue>` is a refcount bump) into the queued destroy
+/// closure. `Drop` therefore carries no `unwrap` / `unreachable!` /
+/// `expect` paths — material under cancellation.
 struct CreateGuard<R>
 where
     R: Pooled + Clone + Send + Sync + 'static,
     R::Lease: Into<R::Runtime>,
 {
+    /// `None` after [`defuse`](Self::defuse) took it out; `Some(_)`
+    /// for any guard a caller can still observe. `Drop` short-circuits
+    /// on `None`.
     entry: Option<PoolEntry<R>>,
     /// Cloned resource handle so the Drop path can call
     /// `Resource::destroy(entry.runtime)` from the [`ReleaseQueue`]
     /// without re-entering the originating pool context. Same Clone
     /// requirement that `release_entry` already imposes on `R`.
-    resource: Option<R>,
+    resource: R,
     /// Reference to the pool's `ReleaseQueue` so Drop can submit the
     /// async destroy without spawning an orphan `tokio::spawn` (which
     /// would lack the queue's bounded backpressure + shutdown drain).
-    release_queue: Option<Arc<ReleaseQueue>>,
+    release_queue: Arc<ReleaseQueue>,
 }
 
 impl<R> CreateGuard<R>
@@ -1251,18 +1264,19 @@ where
     fn new(entry: PoolEntry<R>, resource: R, release_queue: Arc<ReleaseQueue>) -> Self {
         Self {
             entry: Some(entry),
-            resource: Some(resource),
-            release_queue: Some(release_queue),
+            resource,
+            release_queue,
         }
     }
 
     /// Returns a reference to the inner entry for inspection.
     fn entry(&self) -> &PoolEntry<R> {
         // guard-justified: `entry()` is private + only called between
-        // `new` (which inserts `Some(_)`) and `defuse` (which takes it
-        // out exactly once); reaching here with `None` would mean
-        // `entry()` was called *after* `defuse`, which the pool's
-        // single-function call graph structurally prevents.
+        // `new` (which inserts `Some(_)`) and `defuse` (which consumes
+        // `self`); reaching here with `None` would mean `entry()` was
+        // called *after* `defuse`, which the by-value consumption in
+        // `defuse(mut self)` makes a borrow-checker error, not a
+        // runtime path.
         self.entry
             .as_ref()
             .unwrap_or_else(|| unreachable!("CreateGuard accessed after defuse"))
@@ -1273,16 +1287,17 @@ where
         &self.entry().runtime
     }
 
-    /// Takes the entry out of the guard — it has been safely consumed.
+    /// Consumes the guard and returns the wrapped entry.
     ///
-    /// After this call, `Drop` is a no-op.
-    fn defuse(&mut self) -> PoolEntry<R> {
-        // guard-justified: `defuse` is private + called exactly once
-        // per `CreateGuard`, right before `build_guarded_handle`. The
-        // pool's call graph never re-enters `defuse` on the same guard
-        // (it would have to leak a `&mut CreateGuard` across the
-        // build_guarded_handle return, which the borrow checker
-        // forbids).
+    /// After this call, the guard is gone; its `Drop` runs against
+    /// `entry: None` and short-circuits without submitting a destroy.
+    fn defuse(mut self) -> PoolEntry<R> {
+        // guard-justified: `defuse` consumes `self` by value, so the
+        // borrow checker forbids calling it twice on the same guard.
+        // `self.entry` is `Some(_)` for the whole observable lifetime
+        // of the guard (set in `new`, only mutated here or in `Drop`,
+        // both of which consume the guard), so `take()` cannot return
+        // `None` on this path.
         self.entry
             .take()
             .unwrap_or_else(|| unreachable!("CreateGuard defused twice"))
@@ -1298,26 +1313,19 @@ where
         let Some(entry) = self.entry.take() else {
             return; // defused — nothing to clean up
         };
-        // guard-justified: invariant — `new` populates both `resource`
-        // and `release_queue` as `Some(_)`; `defuse` clears only
-        // `entry`, leaving the other two intact. We only reach this
-        // arm when `entry.take()` above returned `Some`, which means
-        // `defuse` has NOT run, which means `resource` and
-        // `release_queue` are still populated.
-        let resource = self
-            .resource
-            .take()
-            .unwrap_or_else(|| unreachable!("CreateGuard::Drop: resource missing"));
-        // guard-justified: same invariant as above — `release_queue`
-        // is populated whenever `entry` is.
-        let release_queue = self
-            .release_queue
-            .take()
-            .unwrap_or_else(|| unreachable!("CreateGuard::Drop: release_queue missing"));
+        // `resource` and `release_queue` are non-`Option` and always
+        // populated for the guard's observable lifetime. Cloning them
+        // (cheap — `R: Clone` is already a pool requirement,
+        // `Arc::clone` is a refcount bump) into the queued destroy
+        // closure keeps the `Drop` body free of `unwrap` /
+        // `unreachable!` / `expect` paths — important because `Drop`
+        // runs in arbitrary cancellation contexts.
+        let resource = self.resource.clone();
+        let release_queue = Arc::clone(&self.release_queue);
         tracing::warn!(
             resource = %R::key(),
             "cancel-safety: acquire future cancelled mid-create — \
-             scheduling async destroy via ReleaseQueue (#713)"
+             scheduling async destroy via ReleaseQueue"
         );
         release_queue.submit(move || {
             Box::pin(async move {
@@ -1355,7 +1363,7 @@ mod tests {
         fail_create: Arc<AtomicBool>,
         fail_check: Arc<AtomicBool>,
         break_on_return: Arc<AtomicBool>,
-        /// Counts every `destroy` invocation — used by #713 cancel-drop
+        /// Counts every `destroy` invocation — used by the cancel-drop
         /// regression to assert the async destroy actually ran via the
         /// `ReleaseQueue` (vs. just being inline-`Drop`-ed).
         destroy_count: Arc<AtomicU64>,
@@ -1973,14 +1981,13 @@ mod tests {
         assert_eq!(pool.idle_count().await, 0);
     }
 
-    /// Regression: #713 — a `CreateGuard` whose entry is still `Some`
-    /// when it drops must schedule `Resource::destroy` via the
-    /// `ReleaseQueue` instead of just letting the runtime's sync `Drop`
-    /// run. Without this, a `tokio::select!` / `timeout` that cancels
-    /// the acquire future *after* `create` succeeded but *before*
-    /// `defuse` ran would leak the server-side handle (DB session,
-    /// broker subscription, etc.) — only the client-side `Drop` would
-    /// fire.
+    /// Regression: a `CreateGuard` whose entry is still `Some` when it
+    /// drops must schedule `Resource::destroy` via the `ReleaseQueue`
+    /// instead of just letting the runtime's sync `Drop` run. Without
+    /// this, a `tokio::select!` / `timeout` that cancels the acquire
+    /// future *after* `create` succeeded but *before* `defuse` ran
+    /// would leak the server-side handle (DB session, broker
+    /// subscription, etc.) — only the client-side `Drop` would fire.
     ///
     /// The test constructs a `CreateGuard` by hand around a fabricated
     /// `PoolEntry`, drops it without calling `defuse`, then drains the
@@ -2024,13 +2031,14 @@ mod tests {
         assert_eq!(
             destroy_count.load(Ordering::Relaxed),
             1,
-            "#713: CreateGuard::Drop must submit destroy via ReleaseQueue \
+            "CreateGuard::Drop must submit destroy via ReleaseQueue \
              when the acquire future is cancelled mid-create — otherwise \
              the server-side handle leaks while the client-side Drop runs",
         );
     }
 
-    /// Companion to #713: a `CreateGuard` that runs through `defuse`
+    /// Companion to the cancel-drop regression: a `CreateGuard` that
+    /// runs through `defuse`
     /// normally (the success path) MUST NOT trigger a stray
     /// `Resource::destroy` — that would double-free the runtime that
     /// is now owned by the resulting `ResourceGuard` and will be
@@ -2057,9 +2065,12 @@ mod tests {
             revoke_epoch: 0,
             returned_at: None,
         };
-        let mut guard = CreateGuard::new(entry, resource.clone(), Arc::clone(&rq));
-        let _ = guard.defuse(); // success path consumes the entry
-        drop(guard);
+        let guard = CreateGuard::new(entry, resource.clone(), Arc::clone(&rq));
+        let _entry = guard.defuse(); // success path consumes the guard
+        // `defuse` already took the guard by value; no further `drop(guard)`
+        // is possible (or needed). The runtime now lives in `_entry` and is
+        // dropped at the end of this scope — sync `Drop` only, never via
+        // `Resource::destroy`.
 
         tokio::time::sleep(Duration::from_millis(50)).await;
         drop(rq);

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -4338,8 +4338,8 @@ async fn graceful_shutdown_abort_on_drain_timeout_preserves_registry() {
     );
 }
 
-/// R-023 / 🔴-4 regression: `DrainTimeoutPolicy::Abort` must transition
-/// every registered resource to `ResourcePhase::Failed`, **not** restore
+/// Regression: `DrainTimeoutPolicy::Abort` must transition every
+/// registered resource to `ResourcePhase::Failed`, **not** restore
 /// `Ready`. Pre-fix the manager would set the phase back to `Ready` to
 /// "keep the resource acquirable", but the cancel token already rejects
 /// new acquires and `health_check` then lied about lifecycle state.
@@ -4392,7 +4392,7 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
         "expected DrainTimeout, got {err:?}"
     );
 
-    // R-023 assertion: phase is `Failed`, NOT `Ready`. Pre-fix this
+    // Assertion: phase is `Failed`, NOT `Ready`. Pre-fix this
     // would be `Ready` (the bug). We bypass `health_check` here because
     // it goes through `lookup` which short-circuits on the cancel token
     // post-shutdown; `get_any` reads the type-erased registry entry
@@ -4405,10 +4405,10 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
         phase,
         ResourcePhase::Failed,
         "drain-abort must transition phase to Failed, got {phase:?} \
-         (R-023: Ready would be the pre-fix bug)",
+         (Ready would be the pre-fix bug)",
     );
 
-    // R-023 assertion: per-resource HealthChanged{healthy:false} was
+    // Assertion: per-resource HealthChanged{healthy:false} was
     // emitted. Drain through the channel until we find it (other
     // events like `Registered` and `AcquireSuccess` were also emitted
     // earlier).

--- a/crates/resource/tests/derive_resource_compile_fail.rs
+++ b/crates/resource/tests/derive_resource_compile_fail.rs
@@ -1,5 +1,5 @@
 //! Compile-fail / compile-pass probes for `#[derive(Resource)]`
-//! (Phase 4 / slot model / M6 closure).
+//! (slot model).
 //!
 //! Each compile-fail probe under `tests/probes/derive_*.rs` exercises one
 //! diagnostic contract of the macro:

--- a/crates/resource/tests/probes/derive_missing_config.stderr
+++ b/crates/resource/tests/probes/derive_missing_config.stderr
@@ -1,4 +1,4 @@
-error: missing required attribute `config = SomeType` — Phase 4 requires Self::Config to be specified
+error: missing required attribute `config = SomeType`
  --> tests/probes/derive_missing_config.rs:7:8
   |
 7 | struct MissingConfig;

--- a/crates/resource/tests/register_from_value.rs
+++ b/crates/resource/tests/register_from_value.rs
@@ -1,7 +1,7 @@
-//! Phase 9 / Task 9.2 — `Manager::register_from_value` JSON-driven registration with `{{ }}`
+//! `Manager::register_from_value` JSON-driven registration with `{{ }}`
 //! template resolution + schema validation.
 //!
-//! Closes the tail deferred from Phase 4. The flow:
+//! The flow:
 //!
 //!   1. Resolve every `{{ }}` template inside the JSON tree via
 //!      `ExpressionEngine::render_template`.

--- a/crates/resource/tests/shutdown_race.rs
+++ b/crates/resource/tests/shutdown_race.rs
@@ -1,6 +1,6 @@
 //! Regression tests for the `graceful_shutdown` race with in-flight acquires.
 //!
-//! Pre-existing race surfaced by CodeRabbit's post-fix review on PR #613:
+//! The race:
 //!
 //! Phase 2 of `graceful_shutdown` watches `drain_tracker`, but if an acquire
 //! passes `lookup()` BEFORE the cancel token fires, the acquire can complete

--- a/crates/resource/tests/transport_integration.rs
+++ b/crates/resource/tests/transport_integration.rs
@@ -1,10 +1,7 @@
-//! Manager-level integration tests for the Transport topology (R-013).
+//! Manager-level integration tests for the Bounded topology with
+//! multiplexed sessions (formerly the standalone Transport topology).
 //!
-//! Phase 1 cascade audit flagged the Transport surface as having zero
-//! Manager-level tests — only `TransportRuntime`-direct coverage existed
-//! in `basic_integration.rs`. This file exercises the public Manager
-//! dispatch path (`register_transport`, `register_transport_with`,
-//! `acquire_transport`, `acquire_transport`) end-to-end, plus
+//! Exercises the public Manager dispatch path end-to-end, plus
 //! cross-cutting concerns (graceful shutdown drain, recovery-gate
 //! admission, multiplexing semantics, session-limit backpressure,
 //! per-resource-key isolation).

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -53,16 +53,16 @@ name = "api_simple_server"
 path = "examples/api_simple_server.rs"
 
 [[example]]
-name = "m6_postgres_pool"
-path = "examples/m6_postgres_pool.rs"
+name = "resource_postgres_pool"
+path = "examples/resource_postgres_pool.rs"
 
 [[example]]
-name = "m6_telegram_multi_workflow"
-path = "examples/m6_telegram_multi_workflow.rs"
+name = "resource_telegram_multi_workflow"
+path = "examples/resource_telegram_multi_workflow.rs"
 
 [[example]]
-name = "m6_resident_http"
-path = "examples/m6_resident_http.rs"
+name = "resource_resident_http"
+path = "examples/resource_resident_http.rs"
 
 [lints]
 workspace = true

--- a/examples/examples/resource_postgres_pool.rs
+++ b/examples/examples/resource_postgres_pool.rs
@@ -1,7 +1,6 @@
-//! M6.3 Phase 10 — Postgres Pool topology example.
+//! Postgres Pool topology example.
 //!
-//! Demonstrates the headline patterns from the M6 dependency redesign for a
-//! database-style resource:
+//! Demonstrates the headline patterns for a database-style resource:
 //!
 //! - **Pool topology** ([`Resource`] + [`Pooled`]) — N interchangeable instances with `is_broken` /
 //!   `recycle` lifecycle hooks.
@@ -18,7 +17,7 @@
 //! ## Run
 //!
 //! ```shell
-//! cargo run -p nebula-examples --example m6_postgres_pool
+//! cargo run -p nebula-examples --example resource_postgres_pool
 //! ```
 //!
 //! ## What it prints
@@ -350,7 +349,7 @@ fn ctx_for_demo() -> ResourceContext {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
 async fn main() -> anyhow::Result<()> {
-    println!("=== M6.3 Phase 10 — Postgres Pool example ===\n");
+    println!("=== Postgres Pool example ===\n");
 
     // 1. Manager owns the registry. Register a Pool-topology Postgres at the global scope.
     //    Production code would scope to Organization / Project.

--- a/examples/examples/resource_resident_http.rs
+++ b/examples/examples/resource_resident_http.rs
@@ -1,4 +1,4 @@
-//! M6.3 Phase 10 — Resident HTTP client with OAuth-style credential refresh.
+//! Resident HTTP client with OAuth-style credential refresh.
 //!
 //! Models a Google Sheets-style HTTP integration:
 //!
@@ -13,7 +13,7 @@
 //! ## Run
 //!
 //! ```shell
-//! cargo run -p nebula-examples --example m6_resident_http
+//! cargo run -p nebula-examples --example resource_resident_http
 //! ```
 //!
 //! ## Pattern explanation
@@ -350,7 +350,7 @@ fn ctx_for_demo() -> ResourceContext {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    println!("=== M6.3 Phase 10 — Resident HTTP + OAuth refresh ===\n");
+    println!("=== Resident HTTP + OAuth refresh ===\n");
 
     // 1. Configure the credential. Production code reads this from the credential store via the
     //    slot-resolution pipeline; here we construct it inline.

--- a/examples/examples/resource_telegram_multi_workflow.rs
+++ b/examples/examples/resource_telegram_multi_workflow.rs
@@ -1,9 +1,9 @@
-//! M6.3 Phase 10 — Telegram bot shared across 10 simulated workflows.
+//! Telegram bot shared across 10 simulated workflows.
 //!
-//! Headline cross-workflow scenario from the M6 milestone — proves a single
-//! `Resource::create` invocation deduplicates 10 concurrent acquires of the
-//! same Resident-topology resource at the same scope. Mirrors the
-//! integration test `cross_workflow_resource_sharing` in
+//! Headline cross-workflow scenario — proves a single `Resource::create`
+//! invocation deduplicates 10 concurrent acquires of the same
+//! Resident-topology resource at the same scope. Mirrors the integration
+//! test `cross_workflow_resource_sharing` in
 //! `crates/engine/tests/resource_integration.rs`, but as an end-user
 //! runnable demonstration.
 //!
@@ -14,15 +14,15 @@
 //! - **Cross-workflow dedupe** — 10 spawned tasks all acquire the same resource at
 //!   `ScopeLevel::Organization`; the manager collapses them to a single `Resource::create`.
 //! - **Counter assertion** — the `create_counter` ends at exactly `1`.
-//! - **EventSource direct usage** — per ADR-0045 the `EventTrigger` DX wrapper is deferred. We
-//!   drive the fake update stream by directly broadcasting to a `tokio::sync::broadcast` channel
-//!   and showing how an `EventSource::recv` consumer reads from it. This is the pattern that the
-//!   Phase 10.2 task notes is canonical until §M6.4 ships.
+//! - **EventSource direct usage** — the `EventTrigger` DX wrapper is deferred. We drive the fake
+//!   update stream by directly broadcasting to a `tokio::sync::broadcast` channel and show how an
+//!   `EventSource::recv` consumer reads from it. This is the canonical pattern until the wrapper
+//!   ships.
 //!
 //! ## Run
 //!
 //! ```shell
-//! cargo run -p nebula-examples --example m6_telegram_multi_workflow
+//! cargo run -p nebula-examples --example resource_telegram_multi_workflow
 //! ```
 
 use std::{
@@ -180,7 +180,7 @@ fn ctx_for_org(org: OrgId) -> ResourceContext {
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 4)]
 async fn main() -> anyhow::Result<()> {
-    println!("=== M6.3 Phase 10 — Telegram bot × 10 workflows ===\n");
+    println!("=== Telegram bot × 10 workflows ===\n");
 
     // 1. Register the bot at Organization scope. Every workflow under this org will share the same
     //    physical bot client.


### PR DESCRIPTION
## Summary

Two-part documentation pass on `nebula-resource`.

### Part 1 — reference scrub (user request)

Removed from in-crate documentation, source comments, and test prose:

- ADR-NNNN references (`0023` / `0036` / `0037` / `0044` / `0045` / `0067`) — concept retained, ADR number dropped.
- Plan / milestone IDs: `M6`, `M6.1`, `M6.3`, `§M6.4`, `Phase 4 / slot model`, `Phase 6 / M6.1`, `Phase 9 / Task 9.2`, `Phase 10`.
- Audit-tag IDs: `R-013`, `R-023`, `R-040`, `R-051`, `🔴-4`, `CodeRabbit 🟠 #4`.
- Issue / PR references: `#387`, `#390`, `#391`, `#399`, `#613`, `#684`, `[#712]`–`[#719]` + their GitHub URL link defs.
- Commit SHAs: `cf93e45b`.
- Temp-file links: `docs/ROADMAP.md`, `docs/adr/HISTORICAL.md`, `docs/adr/0081-...`, `.ai-factory/PHASE4_BLOCKED.md`.

Preserved: the algorithm-phase labels in `graceful_shutdown` (Phase 1: SIGNAL / 2: DRAIN / 3: CLEAR / 4: AWAIT WORKERS) and in the two-phase revoke (Phase 1: synchronous taint / Phase 2: cancellation-safe drain + hook tail). Those describe the protocol itself, not a plan reference.

Renamed runnable examples from `m6_*` to `resource_*` and updated all in-tree `cargo run` invocations:

| Before | After |
|--------|-------|
| `m6_postgres_pool` | `resource_postgres_pool` |
| `m6_resident_http` | `resource_resident_http` |
| `m6_telegram_multi_workflow` | `resource_telegram_multi_workflow` |

### Part 2 — Mythos audit fixes

**Documentation rewrites.**

- `crates/resource/docs/README.md` — three-topology surface (`Pooled`, `Resident`, `Bounded` with sealed `Cap` typestate), single `Manager::register(RegistrationSpec { … })` funnel, corrected Feature Matrix and Crate Layout.
- `crates/resource/docs/topology-reference.md` — three-topology decision matrix; per-topology skeletons (Pool / Resident / Bounded with `Unbounded` / `Capped<N>` / `Exclusive` cap variants); cross-cutting checklist.
- `crates/resource/docs/adapters.md` — topology picker corrected.
- `crates/resource/docs/pooling.md` — removed dead-API references (`Manager::acquire_pooled_default`, `Manager::register_pooled*`).
- `crates/resource/docs/recovery.md` — removed `WatchdogHandle` / `WatchdogConfig` section (types are not in the public surface).

**Rustdoc.**

- `Resource::create` — `# Errors` (mapping driver errors to `ErrorKind`) + `# Cancellation` (cancel-safety contract).
- `Resource::check` / `shutdown` / `destroy` — `# Errors` sections + idempotency / cancellation notes.
- `Resource::on_credential_revoke` — `# Errors` + `# Security` (post-invocation invariant: no further authenticated traffic on the revoked credential).
- `ResourceGuard` — `# Drop` (per-topology release pathway), `# Cancellation`, `# Panics`.
- `Manager::register` — enumerated `# Errors` (Permanent on config validation failure or topology-runtime mismatch).
- `Manager::acquire_pooled` / `acquire_resident` / `acquire_bounded` — `# Cancellation` notes on top of existing `# Errors`.

**Community files at workspace root.**

- `CONTRIBUTING.md` — added. Human-readable contributor onboarding distilled from `CLAUDE.md` (philosophy, layout, setup, required toolchain, coding standards, doc/test/PR rules, ADR policy).
- `CHANGELOG.md` — added. Keep-a-Changelog skeleton with this change set in `[Unreleased]`.
- `.github/SECURITY.md` — extended with Security Boundaries, Secret Handling Rules, Logging/Telemetry Rules, and Unsafe Code Policy sections.

## Verification

| Check | Result |
|---|---|
| `cargo clippy -p nebula-resource --all-targets -- -D warnings` | clean |
| `cargo nextest run -p nebula-resource` | 334 / 334 pass |
| `cargo test -p nebula-resource --doc` | 5 pass, 4 ignored, 1 compile-fail |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p nebula-resource --no-deps` | clean |
| `cargo check -p nebula-action -p nebula-credential -p nebula-examples` | clean (sibling crates affected by example renames) |
| `lefthook pre-push` (nextest workspace + clippy-full + crate-diff-gate) | 1022 / 1022 pass |

## Diff summary

39 files changed, +956 / −598 LoC.

## Out of scope (not addressed here)

Doctest gate — quick-start examples remain `,no_run` / `,ignore`, so a future API drift will not fail CI. Compiling these against a minimal in-tree `Trivial` resource fixture is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)