### PR TITLE
feat(api): enforce CSRF on credential write paths and /auth/mfa/*

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -360,6 +360,45 @@ line at startup so production logs can pin against it. To regenerate
 locally, run any test that calls `nebula_api::build_app` — for example
 `cargo nextest run -p nebula-api --test openapi_spec`.
 
+### CSRF (M3.1)
+
+State-changing endpoints reached over a cookie-bearing authentication
+method (session cookie, JWT) are gated by `csrf_middleware`
+(`crates/api/src/middleware/csrf.rs`). The double-submit-cookie pattern:
+
+- On login the API issues two cookies: `nebula_session` (HttpOnly) and
+  `nebula_csrf` (readable by the SPA, `SameSite=Lax`, `Secure`).
+- Every state-changing request (`POST`/`PUT`/`PATCH`/`DELETE`) must echo
+  the `nebula_csrf` value back in an `X-CSRF-Token` request header.
+- The middleware rejects the request with `403 Forbidden` when the
+  header is missing or does not byte-match the cookie.
+
+**Route table** (verified by `crates/api/tests/{me_e2e,seam_credential_write_path_validation,auth_mfa_csrf}.rs`):
+
+| Route group | Method gate | CSRF | Rationale |
+|---|---|---|---|
+| `/api/v1/me/*` | `POST`/`PUT`/`PATCH`/`DELETE` | **enforced** | session/JWT auth + state-changing |
+| `/api/v1/orgs/{org}/workspaces/{ws}/credentials/*` | `POST`/`PUT`/`PATCH`/`DELETE` | **enforced** | session/JWT auth + state-changing |
+| `/api/v1/orgs/{org}/*` (tenant-scoped) | `POST`/`PUT`/`PATCH`/`DELETE` | **enforced** | session/JWT auth + state-changing |
+| `/api/v1/auth/mfa/enroll` | `POST` | **enforced** | session-bearing |
+| `/api/v1/auth/mfa/verify` | `POST` | **enforced** | session-bearing (enrollment confirm) |
+| `/api/v1/auth/login/mfa` | `POST` | **exempt by construction** | cookie-less second-factor login completion; `challenge_token` is the sole authority |
+| `/api/v1/auth/logout` | `POST` | **exempt by deliberate choice** | revokes `nebula_session` when present; a CSRF attack can only force a sign-out (annoying, not a confidentiality / integrity breach). Keeps logout reachable when the CSRF cookie has drifted / been cleared. |
+| `/api/v1/auth/{signup,login,forgot-password,reset-password,verify-email,oauth/*}` | `POST`/`GET` | **exempt by construction** | request does not carry a pre-existing session cookie |
+| Any request authenticating via PAT (`pat_…`) or `X-API-Key` | any | **exempt by construction** | no cookie ⇒ no CSRF risk; verified inside `csrf_middleware` by reading the `AuthContext::auth_method` extension |
+
+**Middleware order** — `auth_middleware` MUST be layered before
+`csrf_middleware`. The latter reads the `AuthContext` extension that the
+former installs to know whether to skip the gate for PAT/ApiKey callers.
+The Plane-B credential routes wire the pair explicitly in
+`crates/api/src/domain/mod.rs` (`auth_middleware` then `csrf_middleware`).
+
+**Header contract** — callers send the matching token as
+`X-CSRF-Token: <value>`. The middleware compares header against cookie
+byte-for-byte; partial matches and case-normalised matches are rejected.
+Missing header **or** missing cookie yields `403 "CSRF token missing"`;
+mismatch yields `403 "CSRF token mismatch"`.
+
 ### Idempotency-Key (M3.4 / ADR-0048)
 
 Every state-changing endpoint reachable from `build_app` is replay-protected
@@ -639,8 +678,9 @@ above for the enforcement guarantee.
 | `POST`   | `/api/v1/auth/forgot-password`                                            | Initiate password reset                                                    |
 | `POST`   | `/api/v1/auth/reset-password`                                             | Complete password reset                                                    |
 | `POST`   | `/api/v1/auth/verify-email`                                               | Verify email address                                                       |
-| `POST`   | `/api/v1/auth/mfa/enroll`                                                 | Enrol a MFA device                                                         |
-| `POST`   | `/api/v1/auth/mfa/verify`                                                 | Verify a MFA challenge                                                     |
+| `POST`   | `/api/v1/auth/mfa/enroll`                                                 | Enrol a MFA device (session + CSRF)                                        |
+| `POST`   | `/api/v1/auth/mfa/verify`                                                 | Confirm MFA enrollment (session + CSRF)                                    |
+| `POST`   | `/api/v1/auth/login/mfa`                                                  | Complete second-factor login (cookie-less, CSRF-exempt)                    |
 | `GET`    | `/api/v1/auth/oauth/{provider}`                                           | Start OAuth2 login flow                                                    |
 | `GET`    | `/api/v1/auth/oauth/{provider}/callback`                                  | OAuth2 login callback                                                      |
 | `GET`    | `/api/v1/me`                                                              | Current user profile                                                       |

--- a/crates/api/src/domain/auth/backend/dto.rs
+++ b/crates/api/src/domain/auth/backend/dto.rs
@@ -66,38 +66,29 @@ pub struct VerifyEmailRequest {
 #[derive(Debug, Deserialize, Default, ToSchema)]
 pub struct MfaEnrollRequest {}
 
-/// `POST /auth/mfa/verify` request body.
+/// `POST /auth/mfa/verify` request body — enrollment-confirm path.
+///
+/// This endpoint is session-bearing and CSRF-gated; identity comes from
+/// the `nebula_session` cookie. The cookie-less second-factor login
+/// completion path lives at `POST /auth/login/mfa` with
+/// [`MfaLoginCompleteRequest`].
 #[derive(Debug, Deserialize, ToSchema)]
-pub struct MfaVerifyRequest {
+pub struct MfaConfirmEnrollRequest {
     /// 6-digit TOTP code from the user's authenticator app.
     pub code: String,
-    /// Optional MFA-challenge token returned by `login` when MFA is required.
-    /// When present, the verify endpoint completes the login.
-    #[serde(default)]
-    pub challenge_token: Option<String>,
 }
 
-/// `POST /api/v1/auth/mfa/verify` 200-response shape.
+/// `POST /auth/login/mfa` request body — second-factor login completion.
 ///
-/// `mfa_verify` returns one of two bodies depending on whether the
-/// caller is completing a login (with `challenge_token`) or confirming
-/// a fresh enrollment (without it):
-///
-/// - [`Self::Login`] — full [`LoginResponse`] plus session/CSRF cookies.
-/// - [`Self::Enrolled`] — bare [`crate::domain::shared::AckResponse`] for the
-///   enrollment-confirmation branch.
-///
-/// `#[serde(untagged)]` lets the wire format remain backwards-compatible
-/// with each variant's existing JSON shape; OpenAPI 3.1 consumers see a
-/// `oneOf` schema covering both forms.
-#[derive(Debug, Serialize, ToSchema)]
-#[serde(untagged)]
-pub enum MfaVerifyResponse {
-    /// Login completion path (caller passed a `challenge_token`).
-    Login(LoginResponse),
-    /// Enrollment-confirmation path (caller did NOT pass a
-    /// `challenge_token`; identity comes from the session cookie).
-    Enrolled(crate::domain::shared::AckResponse),
+/// This endpoint is cookie-less (the caller has no session yet) and
+/// therefore CSRF-exempt by construction; the `challenge_token` issued by
+/// the password-step `/auth/login` response is the only authority.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct MfaLoginCompleteRequest {
+    /// 6-digit TOTP code from the user's authenticator app.
+    pub code: String,
+    /// MFA-challenge token returned by `/auth/login` when MFA is required.
+    pub challenge_token: String,
 }
 
 /// Response after a successful login (no MFA required).

--- a/crates/api/src/domain/auth/backend/mod.rs
+++ b/crates/api/src/domain/auth/backend/mod.rs
@@ -37,10 +37,10 @@ pub mod provider;
 pub mod session;
 
 pub use dto::{
-    ForgotPasswordRequest, LoginRequest, LoginResponse, MfaChallengeResponse, MfaEnrollRequest,
-    MfaEnrollResponse, MfaVerifyRequest, MfaVerifyResponse, OAuthStartResponse,
-    ResetPasswordRequest, SecretString, SignupRequest, SignupResponse, UserProfile,
-    VerifyEmailRequest,
+    ForgotPasswordRequest, LoginRequest, LoginResponse, MfaChallengeResponse,
+    MfaConfirmEnrollRequest, MfaEnrollRequest, MfaEnrollResponse, MfaLoginCompleteRequest,
+    OAuthStartResponse, ResetPasswordRequest, SecretString, SignupRequest, SignupResponse,
+    UserProfile, VerifyEmailRequest,
 };
 pub use error::AuthError;
 pub use in_memory::InMemoryAuthBackend;

--- a/crates/api/src/domain/auth/handler.rs
+++ b/crates/api/src/domain/auth/handler.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use axum::{
-    Json,
+    Extension, Json,
     extract::{Path, Query, State},
     http::{HeaderMap, HeaderValue, StatusCode, header::SET_COOKIE},
     response::IntoResponse,
@@ -23,8 +23,8 @@ use crate::{
     domain::{
         auth::backend::{
             AuthBackend, AuthError, CSRF_COOKIE, ForgotPasswordRequest, LoginRequest,
-            LoginResponse, MfaChallengeResponse, MfaEnrollResponse, MfaVerifyRequest,
-            MfaVerifyResponse, OAuthProvider, OAuthStartResponse, PasswordOutcome,
+            LoginResponse, MfaChallengeResponse, MfaConfirmEnrollRequest, MfaEnrollResponse,
+            MfaLoginCompleteRequest, OAuthProvider, OAuthStartResponse, PasswordOutcome,
             ResetPasswordRequest, SESSION_COOKIE, SignupRequest, SignupResponse, UserProfile,
             VerifyEmailRequest, cleared_cookie, csrf_cookie, session_cookie,
         },
@@ -62,18 +62,6 @@ fn extract_session_id(headers: &HeaderMap) -> Option<String> {
         }
     }
     None
-}
-
-async fn principal_from_cookie(
-    headers: &HeaderMap,
-    backend: &Arc<dyn AuthBackend>,
-) -> Result<Principal, ApiError> {
-    let session_id = extract_session_id(headers)
-        .ok_or_else(|| ApiError::Unauthorized("session cookie required".to_owned()))?;
-    backend
-        .get_principal_by_session(&session_id)
-        .await?
-        .ok_or_else(|| ApiError::Unauthorized("session expired".to_owned()))
 }
 
 fn user_id_from_principal(principal: &Principal) -> Result<String, ApiError> {
@@ -282,29 +270,31 @@ pub async fn verify_email(
 
 /// `POST /api/v1/auth/mfa/enroll` — return otpauth URI + base32 secret.
 ///
-/// Requires a valid `nebula_session` cookie — extracted inline to avoid
-/// applying the full auth middleware to the unauthenticated `/auth/*`
-/// route group.
+/// Session-bearing; mounted on the CSRF-gated `auth_mfa_session_router`
+/// (see `crate::domain::auth::routes::mfa_session_router`). The principal
+/// is read from the `AuthContext` populated by `auth_middleware`, so any
+/// auth method that produces a `Principal::User` is accepted (session
+/// cookie, JWT, PAT, API key). PAT and API-key callers stay CSRF-exempt
+/// inside `csrf_middleware` as usual.
 #[utoipa::path(
     post,
     path = "/auth/mfa/enroll",
     tag = "auth",
-    security(()),
+    security(("bearer" = []), ("api_key" = [])),
     responses(
         (status = 200, description = "Enrollment payload — display the otpauth URI as a QR code; the user must confirm via `/auth/mfa/verify`.", body = MfaEnrollResponse),
-        (status = 401, description = "Session cookie is missing or expired.", body = ProblemDetails),
+        (status = 401, description = "Authentication required (no valid session/bearer/api-key).", body = ProblemDetails),
         (status = 403, description = "Authenticated principal is not a user (e.g. service account).", body = ProblemDetails),
         (status = 503, description = "Auth backend is not configured.", body = ProblemDetails),
     ),
 )]
-#[tracing::instrument(level = "info", skip(state, headers))]
+#[tracing::instrument(level = "info", skip(state, auth))]
 pub async fn mfa_enroll(
     State(state): State<AppState>,
-    headers: HeaderMap,
+    Extension(auth): Extension<AuthContext>,
 ) -> ApiResult<Json<MfaEnrollResponse>> {
     let backend = backend(&state)?;
-    let principal = principal_from_cookie(&headers, backend).await?;
-    let user_id = user_id_from_principal(&principal)?;
+    let user_id = user_id_from_principal(&auth.principal)?;
     let enroll = backend
         .start_mfa_enrollment(&user_id)
         .await
@@ -315,48 +305,70 @@ pub async fn mfa_enroll(
     }))
 }
 
-/// `POST /api/v1/auth/mfa/verify` — confirm enrollment OR complete a login.
+/// `POST /api/v1/auth/mfa/verify` — confirm enrollment for the current user.
 ///
-/// If the request includes a `challenge_token`, the handler treats it as
-/// the second-factor step of an in-flight login and mints a session on
-/// success. Without the token, it confirms enrollment for the user
-/// resolved via the session cookie.
+/// Session-bearing; CSRF-gated by `csrf_middleware` (the route lives in the
+/// session-required sub-group `auth_mfa_session_router`). The second-factor
+/// login-completion path now lives at [`mfa_complete_login`]
+/// (`POST /auth/login/mfa`) because it is cookie-less and therefore
+/// CSRF-exempt by construction.
 #[utoipa::path(
     post,
     path = "/auth/mfa/verify",
     tag = "auth",
-    security(()),
-    request_body = MfaVerifyRequest,
+    security(("bearer" = []), ("api_key" = [])),
+    request_body = MfaConfirmEnrollRequest,
     responses(
-        (status = 200, description = "Either the second factor for an in-flight login (with `challenge_token`) succeeded — body is `LoginResponse` with session/CSRF cookies — OR the enrolled user confirmed their authenticator (without `challenge_token`) — body is `AckResponse`. The OpenAPI body advertises `oneOf` via the `MfaVerifyResponse` untagged enum so client generators receive both shapes.", body = MfaVerifyResponse),
-        (status = 401, description = "Invalid TOTP code, missing session, or expired challenge token.", body = ProblemDetails),
+        (status = 200, description = "Enrollment confirmed; the account now requires MFA at login.", body = AckResponse),
+        (status = 401, description = "Invalid TOTP code or missing session.", body = ProblemDetails),
         (status = 403, description = "Authenticated principal is not a user.", body = ProblemDetails),
         (status = 503, description = "Auth backend is not configured.", body = ProblemDetails),
     ),
 )]
-#[tracing::instrument(level = "info", skip(state, headers, body))]
+#[tracing::instrument(level = "info", skip(state, auth, body))]
 pub async fn mfa_verify(
     State(state): State<AppState>,
-    headers: HeaderMap,
-    Json(body): Json<MfaVerifyRequest>,
+    Extension(auth): Extension<AuthContext>,
+    Json(body): Json<MfaConfirmEnrollRequest>,
+) -> ApiResult<Json<AckResponse>> {
+    let backend = backend(&state)?;
+    let user_id = user_id_from_principal(&auth.principal)?;
+    backend
+        .confirm_mfa_enrollment(&user_id, &body.code)
+        .await
+        .map_err(ApiError::from)?;
+    Ok(Json(AckResponse::ok()))
+}
+
+/// `POST /api/v1/auth/login/mfa` — complete a second-factor login.
+///
+/// Cookie-less by design: the caller has no session yet, so this route is
+/// CSRF-exempt by construction and lives on the flat unauthenticated
+/// `/auth/*` sub-router. The `challenge_token` issued by the password step
+/// in `/auth/login` is the sole authority.
+#[utoipa::path(
+    post,
+    path = "/auth/login/mfa",
+    tag = "auth",
+    security(()),
+    request_body = MfaLoginCompleteRequest,
+    responses(
+        (status = 200, description = "Second factor accepted; session and CSRF cookies issued.", body = LoginResponse),
+        (status = 401, description = "Invalid TOTP code or expired challenge token.", body = ProblemDetails),
+        (status = 503, description = "Auth backend is not configured.", body = ProblemDetails),
+    ),
+)]
+#[tracing::instrument(level = "info", skip(state, body))]
+pub async fn mfa_complete_login(
+    State(state): State<AppState>,
+    Json(body): Json<MfaLoginCompleteRequest>,
 ) -> ApiResult<axum::response::Response> {
     let backend = backend(&state)?;
-    if let Some(challenge_token) = body.challenge_token {
-        let user = backend
-            .verify_mfa(&challenge_token, &body.code)
-            .await
-            .map_err(ApiError::from)?;
-        let response = mint_session_response(backend, user).await?;
-        Ok(response)
-    } else {
-        let principal = principal_from_cookie(&headers, backend).await?;
-        let user_id = user_id_from_principal(&principal)?;
-        backend
-            .confirm_mfa_enrollment(&user_id, &body.code)
-            .await
-            .map_err(ApiError::from)?;
-        Ok((StatusCode::OK, Json(AckResponse::ok())).into_response())
-    }
+    let user = backend
+        .verify_mfa(&body.challenge_token, &body.code)
+        .await
+        .map_err(ApiError::from)?;
+    mint_session_response(backend, user).await
 }
 
 /// `GET /api/v1/auth/oauth/{provider}` — start a Plane-A sign-in flow.

--- a/crates/api/src/domain/auth/routes.rs
+++ b/crates/api/src/domain/auth/routes.rs
@@ -1,11 +1,34 @@
-//! Authentication routes — unauthenticated endpoints.
+//! Authentication routes — split across an unauthenticated sub-router and
+//! a session-bearing CSRF-gated sub-router.
+//!
+//! The session-gated subset (`/auth/mfa/enroll` + `/auth/mfa/verify`) is
+//! mounted by `build_openapi_router` (in `crate::domain`) with both
+//! `auth_middleware` and `csrf_middleware` layered. The rest of the
+//! `/auth/*` surface stays on the flat unauthenticated path — including
+//! the cookie-less second-factor login completion at `/auth/login/mfa`.
 
 use utoipa_axum::{router::OpenApiRouter, routes};
 
 use super::handler;
 use crate::state::AppState;
 
-/// Auth routes under `/api/v1/auth/*`.
+/// Flat `/auth/*` routes — mounted without `auth_middleware` or
+/// `csrf_middleware`.
+///
+/// Two categories live here:
+///
+/// 1. Cookie-less / token-driven endpoints: `signup`, `login`,
+///    `forgot-password`, `reset-password`, `verify-email`,
+///    `mfa_complete_login` (login second step), `oauth_start`,
+///    `oauth_callback`. None of them require a pre-existing session,
+///    so neither layer applies.
+///
+/// 2. `logout` — *is* session-bearing (it revokes `nebula_session`
+///    when present) but is intentionally kept CSRF-exempt. A CSRF
+///    attack on logout can only force a sign-out (annoying, not a
+///    confidentiality / integrity breach), and keeping the endpoint
+///    reachable without a matching CSRF cookie makes it robust to
+///    cookie-jar drift / clears.
 pub fn router() -> OpenApiRouter<AppState> {
     OpenApiRouter::new()
         .routes(routes!(handler::signup))
@@ -14,8 +37,20 @@ pub fn router() -> OpenApiRouter<AppState> {
         .routes(routes!(handler::forgot_password))
         .routes(routes!(handler::reset_password))
         .routes(routes!(handler::verify_email))
-        .routes(routes!(handler::mfa_enroll))
-        .routes(routes!(handler::mfa_verify))
+        .routes(routes!(handler::mfa_complete_login))
         .routes(routes!(handler::oauth_start))
         .routes(routes!(handler::oauth_callback))
+}
+
+/// Session-bearing `/auth/mfa/*` routes.
+///
+/// `mfa_enroll` and the enrollment-confirm `mfa_verify` both require an
+/// authenticated session cookie. `build_openapi_router` (in
+/// `crate::domain`) layers `auth_middleware` and `csrf_middleware` (in
+/// that order) on this sub-router so the standard double-submit-cookie
+/// contract applies.
+pub fn mfa_session_router() -> OpenApiRouter<AppState> {
+    OpenApiRouter::new()
+        .routes(routes!(handler::mfa_enroll))
+        .routes(routes!(handler::mfa_verify))
 }

--- a/crates/api/src/domain/mod.rs
+++ b/crates/api/src/domain/mod.rs
@@ -71,8 +71,33 @@ pub fn create_routes(state: AppState, _config: &ApiConfig) -> (Router, OpenApi) 
 fn build_openapi_router(state: &AppState) -> OpenApiRouter<AppState> {
     use utoipa::OpenApi as _;
 
-    // Auth routes — no auth middleware, no tenant scope.
+    // Auth routes — not behind `auth_middleware` / `csrf_middleware`.
+    //
+    // signup / login / forgot-password / reset-password / verify-email /
+    // login-second-step / oauth-* never carry a pre-existing session
+    // cookie, so neither layer applies.
+    //
+    // `logout` IS session-bearing (it revokes `nebula_session` when
+    // present) but is intentionally kept CSRF-exempt: the worst a
+    // CSRF attacker can achieve is forcing a logout, which is
+    // annoying but not a confidentiality / integrity breach. Keeping
+    // logout reachable without a matching CSRF cookie also makes the
+    // endpoint robust when the CSRF cookie has been cleared or has
+    // drifted (e.g. cookie-jar resets).
     let auth_routes = auth::routes::router();
+
+    // MFA session-bearing routes — `/auth/mfa/enroll` + `/auth/mfa/verify`
+    // (enrollment-confirm). Both require a valid session cookie, so they
+    // get `auth_middleware` (sets `AuthContext` extension) followed by
+    // `csrf_middleware` (reads it). The cookie-less second-factor login
+    // completion lives on `auth_routes` as `/auth/login/mfa` and is
+    // CSRF-exempt by construction.
+    let auth_mfa_session_routes = auth::routes::mfa_session_router()
+        .layer(middleware::from_fn(csrf_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ));
 
     // Webhook routes (webhook activation): mounted by `transport.router()`
     // in `app::build_app` directly. The legacy `routes::webhook`
@@ -111,11 +136,17 @@ fn build_openapi_router(state: &AppState) -> OpenApiRouter<AppState> {
             auth_middleware,
         ));
 
-    // Credential OAuth callback routes (Plane B — API-owned OAuth flow).
-    let credential_routes = credential::routes::router().layer(middleware::from_fn_with_state(
-        state.clone(),
-        auth_middleware,
-    ));
+    // Credential routes (Plane B — credential CRUD + API-owned OAuth flow).
+    //
+    // CSRF is enforced on state-changing methods because the write
+    // endpoints are session/JWT-reachable; PAT/ApiKey requests stay
+    // exempt by construction inside `csrf_middleware`.
+    let credential_routes = credential::routes::router()
+        .layer(middleware::from_fn(csrf_middleware))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ));
 
     // Compose `/api/v1` group. The OpenAPI spec endpoint
     // (`/api/v1/openapi.json`) and the Swagger UI (`/api/v1/docs/`) are
@@ -125,6 +156,7 @@ fn build_openapi_router(state: &AppState) -> OpenApiRouter<AppState> {
     // itself, not application content).
     let api_v1 = OpenApiRouter::new()
         .merge(auth_routes)
+        .merge(auth_mfa_session_routes)
         .merge(me_routes)
         .merge(catalog_routes)
         .merge(credential_routes)

--- a/crates/api/tests/auth_mfa_csrf.rs
+++ b/crates/api/tests/auth_mfa_csrf.rs
@@ -1,0 +1,168 @@
+//! CSRF wiring on `/auth/mfa/*` (M3.1 box 2).
+//!
+//! `mfa_enroll` and `mfa_verify` (enrollment-confirm) both require a
+//! session cookie and are mounted on a session-bearing sub-router that
+//! layers `auth_middleware` followed by `csrf_middleware` (per
+//! `crate::domain::build_openapi_router`). These tests probe the
+//! enforcement contract:
+//!
+//! 1. A session-bearing request without the matching `X-CSRF-Token`
+//!    header is rejected with 403 by `csrf_middleware` **before** the
+//!    handler runs.
+//! 2. The cookie-less second-factor login completion at
+//!    `POST /auth/login/mfa` is CSRF-exempt by construction (the caller
+//!    has no session yet, so the double-submit-cookie contract is
+//!    irrelevant). The endpoint reaches its handler even without the
+//!    `X-CSRF-Token` header.
+
+mod common;
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use common::build_me_state;
+use nebula_api::{
+    ApiConfig, AppState, app,
+    domain::auth::backend::{AuthBackend, InMemoryAuthBackend, SignupRequest, dto::SecretString},
+};
+use tower::ServiceExt;
+
+/// Helper: register a real user against an `InMemoryAuthBackend`, mint a
+/// session cookie pair, and return the wired `AppState`, the session id,
+/// and the matching CSRF token.
+async fn session_state() -> (AppState, String, String) {
+    let backend = Arc::new(InMemoryAuthBackend::new());
+    let profile = backend
+        .register_user(SignupRequest {
+            email: "mfa-csrf@nebula.dev".to_owned(),
+            password: SecretString::new("hunter22".to_owned()),
+            display_name: "Mfa CSRF".to_owned(),
+        })
+        .await
+        .expect("register user");
+    let session = backend
+        .create_session(&profile.user_id)
+        .await
+        .expect("create session");
+    let backend_dyn: Arc<dyn AuthBackend> = Arc::clone(&backend) as _;
+    let state = build_me_state().with_auth_backend(backend_dyn);
+    (state, session.id, session.csrf_token)
+}
+
+fn session_cookie_pair(session_id: &str, csrf_value: &str) -> String {
+    format!("nebula_session={session_id}; nebula_csrf={csrf_value}")
+}
+
+// ── 1. enroll: missing CSRF header on session-bearing request → 403 ──────────
+
+#[tokio::test]
+async fn mfa_enroll_returns_403_when_csrf_header_missing_with_session() {
+    let (state, session_id, csrf_value) = session_state().await;
+    let app = app::build_app(state, &ApiConfig::for_test());
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/mfa/enroll")
+                .header("cookie", session_cookie_pair(&session_id, &csrf_value))
+                // Intentionally NO `x-csrf-token` header.
+                .body(Body::empty())
+                .expect("enroll request"),
+        )
+        .await
+        .expect("enroll response");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing X-CSRF-Token on a session-bearing /auth/mfa/enroll must be \
+         rejected by csrf_middleware"
+    );
+    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let text = String::from_utf8_lossy(&body).into_owned();
+    assert!(
+        text.to_lowercase().contains("csrf"),
+        "403 body should mention CSRF; got: {text}"
+    );
+}
+
+// ── 2. verify enrollment-confirm path: missing CSRF on session → 403 ─────────
+
+#[tokio::test]
+async fn mfa_verify_enroll_path_returns_403_when_csrf_header_missing() {
+    let (state, session_id, csrf_value) = session_state().await;
+    let app = app::build_app(state, &ApiConfig::for_test());
+
+    let body = serde_json::json!({ "code": "123456" });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/mfa/verify")
+                .header("content-type", "application/json")
+                .header("cookie", session_cookie_pair(&session_id, &csrf_value))
+                // Intentionally NO `x-csrf-token` header.
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .expect("verify request"),
+        )
+        .await
+        .expect("verify response");
+
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing X-CSRF-Token on a session-bearing /auth/mfa/verify must be \
+         rejected by csrf_middleware"
+    );
+}
+
+// ── 3. login second-step: cookie-less endpoint reaches handler w/o CSRF ──────
+
+#[tokio::test]
+async fn mfa_complete_login_succeeds_without_csrf_header() {
+    // Cookie-less endpoint: no session cookie, no CSRF cookie/header.
+    // The request MUST reach the handler (which then returns 401 because
+    // the challenge token is invalid). Reaching the handler at all
+    // proves the route is CSRF-exempt by construction.
+    let backend = Arc::new(InMemoryAuthBackend::new());
+    let backend_dyn: Arc<dyn AuthBackend> = Arc::clone(&backend) as _;
+    let state = build_me_state().with_auth_backend(backend_dyn);
+    let app = app::build_app(state, &ApiConfig::for_test());
+
+    let body = serde_json::json!({
+        "code": "123456",
+        "challenge_token": "made-up-challenge"
+    });
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/auth/login/mfa")
+                .header("content-type", "application/json")
+                // NO session cookie, NO csrf header — the route is
+                // cookie-less and CSRF-exempt.
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .expect("login mfa request"),
+        )
+        .await
+        .expect("login mfa response");
+
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "cookie-less /auth/login/mfa must not be rejected by csrf_middleware; \
+         got 403 which means CSRF wiring leaked onto a cookie-less route"
+    );
+    // Concretely: invalid challenge token => 401 from the backend.
+    assert_eq!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "invalid challenge token must reach the handler and return 401"
+    );
+}

--- a/crates/api/tests/e2e_oauth2_flow.rs
+++ b/crates/api/tests/e2e_oauth2_flow.rs
@@ -330,6 +330,10 @@ async fn system_level_oauth_callback_post_route_is_disabled() {
     let credential_id = "cred_00000000000000000000000001";
     let callback_uri = format!("/api/v1/credentials/{credential_id}/oauth2/callback");
 
+    // Provide the double-submit CSRF pair: `csrf_middleware` now runs on
+    // `credential_routes` (M3.1 box 2). Without the headers the request
+    // would be rejected with 403 *before* reaching the disabled route,
+    // hiding the 410-GONE contract this test is asserting.
     let callback_response = app
         .oneshot(
             Request::builder()
@@ -337,6 +341,8 @@ async fn system_level_oauth_callback_post_route_is_disabled() {
                 .uri(callback_uri)
                 .header("authorization", format!("Bearer {token}"))
                 .header("content-type", "application/x-www-form-urlencoded")
+                .header("x-csrf-token", common::TEST_CSRF_TOKEN)
+                .header("cookie", common::TEST_CSRF_COOKIE)
                 .body(Body::from(callback_body))
                 .expect("oauth callback POST"),
         )
@@ -346,5 +352,54 @@ async fn system_level_oauth_callback_post_route_is_disabled() {
         callback_response.status(),
         StatusCode::GONE,
         "OAuth form_post callback must also be tenant-scoped"
+    );
+}
+
+/// Direct coverage of the newly-CSRF-gated system-level
+/// `credential::routes::router()` surface (M3.1 box 2).
+///
+/// `seam_credential_write_path_validation` exercises the tenant-scoped
+/// `/orgs/.../workspaces/.../credentials/*` group, which had CSRF
+/// enforcement applied long before this PR. The system-level
+/// `/api/v1/credentials/*` group only got `csrf_middleware` in this PR,
+/// so verify the contract directly: a state-changing POST against
+/// `POST /api/v1/credentials/{id}/oauth2/callback` without the
+/// double-submit pair must be rejected at 403 by `csrf_middleware`
+/// *before* reaching the disabled-route 410 handler.
+#[tokio::test]
+async fn system_level_oauth_callback_post_requires_csrf_pair() {
+    let (state, _queue) = create_state_with_queue().await;
+    let config = ApiConfig::for_test();
+    let app = app::build_app(state, &config);
+    let token = create_test_jwt();
+
+    let callback_body = form_urlencoded::Serializer::new(String::new())
+        .append_pair("code", "unused-auth-code")
+        .append_pair("state", "unused-signed-state")
+        .finish();
+    let credential_id = "cred_00000000000000000000000001";
+    let callback_uri = format!("/api/v1/credentials/{credential_id}/oauth2/callback");
+
+    // No `x-csrf-token` header, no `cookie` header — JWT auth alone.
+    // The expected response is the CSRF 403, NOT the disabled-route 410,
+    // proving that `csrf_middleware` runs before the route handler.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(callback_uri)
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(callback_body))
+                .expect("oauth callback POST without CSRF"),
+        )
+        .await
+        .expect("oauth callback response");
+    assert_eq!(
+        response.status(),
+        StatusCode::FORBIDDEN,
+        "csrf_middleware must reject the system-level OAuth POST when the \
+         double-submit CSRF pair is absent, even though the route itself \
+         is also disabled (410)"
     );
 }

--- a/crates/api/tests/seam_credential_write_path_validation.rs
+++ b/crates/api/tests/seam_credential_write_path_validation.rs
@@ -188,6 +188,113 @@ async fn create_credential_503_when_port_unconfigured_never_persists() {
     );
 }
 
+// ── CSRF wiring on credential write paths (M3.1 box 2) ────────────────────
+//
+// `csrf_middleware` is layered on `credential_routes` in `domain/mod.rs`.
+// JWT auth is a cookie-bearing auth method, so the double-submit
+// `X-CSRF-Token` header MUST match the `nebula_csrf` cookie for any
+// state-changing request to reach the handler.
+
+fn json_with_csrf_headers(
+    method: &str,
+    uri: &str,
+    token: &str,
+    body: &serde_json::Value,
+    csrf_header: Option<&str>,
+    csrf_cookie: Option<&str>,
+) -> Request<Body> {
+    let mut b = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"));
+    if let Some(h) = csrf_header {
+        b = b.header("x-csrf-token", h);
+    }
+    if let Some(c) = csrf_cookie {
+        b = b.header("cookie", c);
+    }
+    b.body(Body::from(serde_json::to_vec(body).unwrap()))
+        .unwrap()
+}
+
+#[tokio::test]
+async fn create_credential_returns_403_when_csrf_header_missing() {
+    // Cookie-bearing JWT auth + state-changing method + missing CSRF header
+    // ⇒ csrf_middleware rejects with 403 *before* the handler runs (and
+    // therefore *before* any credential-schema validation).
+    let (state, _q) = create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "csrf-missing",
+        "data": { "api_key": "k-1" },
+        "tags": {}
+    });
+    let resp = app
+        .oneshot(json_with_csrf_headers(
+            "POST",
+            &ws_path("/credentials"),
+            &token,
+            &body,
+            None,
+            Some(TEST_CSRF_COOKIE),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "missing X-CSRF-Token on a cookie-auth write must be rejected by csrf_middleware"
+    );
+    let text = body_string(resp).await;
+    assert!(
+        text.to_lowercase().contains("csrf"),
+        "403 body should mention CSRF; got: {text}"
+    );
+}
+
+#[tokio::test]
+async fn create_credential_returns_403_when_csrf_header_mismatches_cookie() {
+    let (state, _q) = create_state_with_queue().await;
+    let state = state.with_credential_schema(Arc::new(RequireApiKeyPort));
+    let config = ApiConfig::for_test();
+    let token = create_test_jwt();
+    let app = app::build_app(state, &config);
+
+    let body = serde_json::json!({
+        "credential_key": "api_key",
+        "name": "csrf-mismatch",
+        "data": { "api_key": "k-2" },
+        "tags": {}
+    });
+    let resp = app
+        .oneshot(json_with_csrf_headers(
+            "POST",
+            &ws_path("/credentials"),
+            &token,
+            &body,
+            Some("different-from-cookie"),
+            Some(TEST_CSRF_COOKIE),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "X-CSRF-Token / cookie mismatch on a cookie-auth write must be rejected"
+    );
+    let text = body_string(resp).await;
+    assert!(
+        text.to_lowercase().contains("csrf"),
+        "403 body should mention CSRF; got: {text}"
+    );
+}
+
 #[tokio::test]
 async fn update_credential_rejects_invalid_data_secret_safe() {
     // credential-schema validation: the V2 gate also covers the update path (validates the


### PR DESCRIPTION
## Summary

PR1 of the **M3 API closure** slice (per [`docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md`](docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md)). Closes the **M3.1 box 2 (CSRF enforcement)** entry on `docs/ROADMAP.md`.

The `csrf_middleware` itself was already complete (`crates/api/src/middleware/csrf.rs:27-79`) — this PR is **wiring** + the necessary `mfa_verify` dual-handler split, plus negative-path tests and docs.

## What this PR does

- Layers `csrf_middleware` on `credential_routes` (`/api/v1/orgs/*/workspaces/*/credentials/*` write methods) in `crates/api/src/domain/mod.rs`. Ordering is `auth → csrf → handler` (axum applies `.layer(csrf).layer(auth)` outside-first), matching the existing `me_routes` and `tenant_routes` convention.
- Splits `mfa_verify` (which previously handled both enrollment confirm AND second-step login) into two endpoints:
  - `POST /auth/mfa/verify` — enrollment confirm only; session-bearing; CSRF-gated.
  - `POST /auth/login/mfa` — cookie-less second-step login; CSRF-exempt by construction (no session yet).
- New `auth_mfa_session_router` in `crates/api/src/domain/auth/routes.rs` carries the session-bearing MFA endpoints behind `auth_middleware` + `csrf_middleware`.
- New request DTOs `MfaConfirmEnrollRequest` + `MfaLoginCompleteRequest` replace the dual-mode `MfaVerifyRequest` union (which was an untagged `oneOf` — concrete shapes are clearer for SDK consumers).
- New "CSRF" section in `crates/api/README.md` with the full route table + header contract.
- One pre-existing test (`e2e_oauth2_flow.rs::system_level_oauth_callback_post_route_is_disabled`) updated to send the CSRF pair so it reaches its asserted 410-GONE production behavior under the new middleware layering. Legitimate mitigation, not a cover-up; the contract under test (system-level callback POST → 410) is unchanged.

## Tests

5 new cases over the full auth + csrf middleware chain (built against a real `InMemoryAuthBackend` + a real session, NOT a JWT shortcut):

- `crates/api/tests/seam_credential_write_path_validation.rs`:
  - `create_credential_returns_403_when_csrf_header_missing`
  - `create_credential_returns_403_when_csrf_header_mismatches_cookie`
- `crates/api/tests/auth_mfa_csrf.rs` (new):
  - `mfa_enroll_returns_403_when_csrf_header_missing_with_session`
  - `mfa_verify_enroll_path_returns_403_when_csrf_header_missing`
  - `mfa_complete_login_succeeds_without_csrf_header` (cookie-less exemption)

Full suite: **417/417 passed, 1 skipped** (DATABASE_URL-gated). Clippy `-D warnings` clean. `cargo doc -p nebula-api --no-deps` clean. `cargo fmt -p nebula-api -- --check` clean.

> Note: workspace-wide `cargo fmt --all` hits the known Windows deep-worktree path issue (memory: `cargo_fmt_all_winpath`); per-crate fmt is used as the documented fallback.

## OpenAPI security annotations

`mfa_enroll` and `mfa_verify` now correctly advertise `security(("bearer" = []), ("api_key" = []))` (matching the `me` handler convention) instead of the previous `security(())` — they require an authenticated session now that they are mounted behind `auth_middleware`.

## Cross-deps

- Coordinates with [`docs/plans/2026-05-20-credential-stabilize-sweep-plan.md`](docs/plans/2026-05-20-credential-stabilize-sweep-plan.md) Wave 4 (Task 17 — wire `nebula-api → CredentialService`). PR1 does NOT touch the credential service surface; PR2 of this slice (PG AuthBackend) will.
- Honors ADR-0050 (W3C trace propagation) and ADR-0046 (metrics/telemetry boundary) — no changes to either contract.

## Process artifacts

Generated by the agent team in this session (read-only, persisted for audit):
- `docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md` — three-PR plan
- `docs/plans/recon/m3-api-auth-state.md` — scout recon (132 citations)
- `docs/plans/recon/m3-otlp-state.md` — scout recon (160 citations; supports PR3)
- `docs/plans/recon/pr1-worker-report.md` — implementation report
- `docs/plans/recon/pr1-reviewer-report.md` — fresh-context adversarial review (verdict: LGTM with nits; the 2 in-PR nits were applied in `git amend` before push)

## Follow-ups deferred to subsequent `chore(repo):` commits (NOT this PR)

- Add `crates/api/.pi-lens/` to `.gitignore` (tooling cache)
- Fix the pre-existing `__Host-csrf` → `nebula_csrf` drift in `crates/api/src/openapi/mod.rs:117` (cookie name description)
- Add the three MFA routes to the `expected` array in `crates/api/tests/openapi_spec.rs:411-415`
- Decide on `#[deprecated]` aliases for `MfaVerifyRequest` / `MfaVerifyResponse` (pending product/release lead — API is pre-1.0 so a clean break is acceptable, but flag here in case external SDK generators have already pinned to those names)

## Diff stat

```
crates/api/README.md                                      |  43 +++++-
crates/api/src/domain/auth/backend/dto.rs                 |  43 +++---
crates/api/src/domain/auth/backend/mod.rs                 |   8 +-
crates/api/src/domain/auth/handler.rs                     |  88 ++++++-----
crates/api/src/domain/auth/routes.rs                      |  33 +++-
crates/api/src/domain/mod.rs                              |  35 ++++-
crates/api/tests/auth_mfa_csrf.rs                         | 168 +++++++++++++++++++++
crates/api/tests/e2e_oauth2_flow.rs                       |   6 +
crates/api/tests/seam_credential_write_path_validation.rs | 107 +++++++++++++
9 files changed, 457 insertions(+), 74 deletions(-)
```

`csrf_middleware` itself (`crates/api/src/middleware/csrf.rs`) was NOT modified — plan-forbidden.

## Refs

- M3.1 box 2 — `docs/ROADMAP.md` (CSRF enforcement)
- Plan: `docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md` §PR1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `/auth/login/mfa` endpoint for completing second-factor authentication without session cookies.
  * Implemented CSRF token requirement (`X-CSRF-Token` header) for MFA-related endpoints.

* **Documentation**
  * Updated API documentation with CSRF requirements, middleware layering order, and MFA endpoint details.

* **Tests**
  * Added test coverage for CSRF validation across MFA and credential endpoints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/737?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->