### PR TITLE
docs: sync crate inventory and collapse duplicated AI-context layer maps (Wave 2)

### DIFF
--- a/.ai-factory/ARCHITECTURE.md
+++ b/.ai-factory/ARCHITECTURE.md
@@ -1,23 +1,25 @@
 # Architecture: Layered Modular Workspace (Cargo wrapper-enforced)
 
-> Agent-actionable subset. The README at the repo root remains the canonical
-> product / architecture document. If they disagree, **README wins** — fix
-> this file rather than the README.
+> Agent-actionable subset. The **canonical layer map lives in
+> [`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and is mechanically
+> enforced by `cargo deny` against `deny.toml [[bans]] wrappers`. The README
+> at the repo root is the product-facing crate map. If those disagree with
+> anything below, **CLAUDE.md / README / `deny.toml` win** — fix this file,
+> never the canon.
 
 ## Overview
 
 Nebula is a **layered modular monolith** built as a Cargo workspace. Every
-crate lives in exactly one of five layers, and inter-layer dependencies are
-**enforced mechanically** by `cargo deny check` against the `[[bans]]`
-`wrappers` rules in `deny.toml` — a missing entry fails CI before review. The
-result is the simple operational profile of a monolith with the modular
-discipline of microservices: any individual crate can be embedded
-independently, but the team ships one repo, one toolchain, one CI, and one
-release cadence.
+crate lives in exactly one layer, and inter-layer dependencies are enforced
+**mechanically** by `cargo deny check` against the `[[bans]] wrappers` rules
+in `deny.toml` — a missing entry fails CI before review. The result is the
+simple operational profile of a monolith with the modular discipline of
+microservices: any individual crate can be embedded independently, but the
+team ships one repo, one toolchain, one CI, one release cadence.
 
-This is not generic "Clean Architecture" or "DDD". It is a Rust-native pattern:
-**crates as modules, wrapper rules as compile-time architecture tests, and
-typed events for cross-crate seams**.
+This is not generic "Clean Architecture" or "DDD". It is a Rust-native
+pattern: **crates as modules, wrapper rules as compile-time architecture
+tests, typed events for cross-crate seams.**
 
 ## Decision Rationale
 
@@ -25,73 +27,42 @@ typed events for cross-crate seams**.
   credentials, plugins, sandbox, HTTP/webhook surface).
 - **Tech stack:** Rust 1.95+ (edition 2024, resolver 3), Tokio,
   `thiserror` + `tracing`.
-- **Workspace size:** 33 crates under `crates/` (see `Cargo.toml` `[workspace]`).
-- **Team / scaling profile:** small core team, embeddable by external teams →
-  modular discipline matters more than independent deploy.
+- **Workspace size:** 29 first-party crates under `crates/` plus
+  `apps/server` (see `Cargo.toml [workspace.members]`).
+- **Team / scaling profile:** small core team, embeddable by external
+  teams → modular discipline matters more than independent deploy.
 - **Key factor:** modularity is a hard product constraint (see README "Why
   Nebula") — `cargo deny [wrappers]` makes the layer boundaries cheap to
   enforce and impossible to drift quietly past.
 
-## Layer Map
+## What agents need to know on top of CLAUDE.md / README / deny.toml
 
-```
-┌─────────────────────────────────────────────────────────────────────────┐
-│ API / Public        api · sdk                                            │
-├─────────────────────────────────────────────────────────────────────────┤
-│ Exec                engine · storage · storage-loom-probe · sandbox ·    │
-│                     plugin-sdk                                           │
-├─────────────────────────────────────────────────────────────────────────┤
-│ Business            credential · credential-builtin · resource ·         │
-│                     action · plugin                                      │
-├─────────────────────────────────────────────────────────────────────────┤
-│ Core                core · validator · expression · workflow ·           │
-│                     execution · schema · metadata                        │
-├─────────────────────────────────────────────────────────────────────────┤
-│ Cross-cutting       log · system · eventbus · metrics ·      │
-│                     resilience · error                                   │
-└─────────────────────────────────────────────────────────────────────────┘
-```
-
-Each layer depends only on the layers below it. Cross-cutting crates are
-importable at any level.
+- Each layer depends only on layers below it; cross-cutting crates are
+  importable at any level. The exact wrapper allowlist is in `deny.toml`.
+- Cross-crate communication between siblings at the same layer goes through
+  `nebula-eventbus`, not direct imports.
+- **`nebula-credential` is shared infrastructure**, not a single-tier
+  Business crate. Exec / Business / API tiers and the first-party backends
+  (`credential-builtin`, `credential-vault`, `credential-runtime`,
+  `credential-testutil`) all consume the credential contract directly. The
+  exact consumer set is locked in `deny.toml [wrappers]`.
+- **`nebula-storage-port`** (Core) is the object-safe storage seam every
+  storage consumer depends on. **`nebula-storage`** (Exec) is the sole
+  adapter implementation. **`nebula-tenancy`** (Business) is the
+  scope-enforcing decorator that wraps a raw `storage-port` adapter so a
+  tenant scope is substituted on every call before it reaches a handler
+  (ADR-0072).
+- **`nebula-telemetry` is gone** — merged into `nebula-metrics` as the
+  single metrics path (ADR-0046). If you see `nebula-telemetry` referenced
+  anywhere in the working tree, it is drift, not real.
+- **`nebula-system` is gone** — the cross-platform host-probe crate was
+  deleted (#668). There is no process-monitoring crate today.
 
 ## Folder Structure
 
-```
-nebula/
-├── Cargo.toml                # workspace root + pinned deps
-├── deny.toml                 # [[bans]] wrappers — layer enforcement
-├── crates/
-│   ├── core/                 # Core
-│   ├── error/    +/macros/   # Cross-cutting
-│   ├── log/                  # Cross-cutting
-│   ├── system/               # Cross-cutting
-│   ├── eventbus/             # Cross-cutting
-│   ├── telemetry/            # Cross-cutting
-│   ├── metrics/              # Cross-cutting
-│   ├── resilience/           # Cross-cutting
-│   ├── validator/ +/macros/  # Core
-│   ├── expression/           # Core
-│   ├── workflow/             # Core
-│   ├── execution/            # Core
-│   ├── schema/   +/macros/   # Core
-│   ├── metadata/             # Core
-│   ├── credential/ +/macros/ # Business
-│   ├── credential-builtin/   # Business (built-in credential types)
-│   ├── resource/ +/macros/   # Business (shared infra: action, engine, plugin, sandbox, sdk)
-│   ├── action/   +/macros/   # Business
-│   ├── plugin/   +/macros/   # Business
-│   ├── plugin-sdk/           # Exec (out-of-process plugin protocol)
-│   ├── engine/               # Exec
-│   ├── storage/              # Exec (PG / SQLite migrations under storage/migrations/)
-│   ├── storage-loom-probe/   # Exec (loom-checked concurrency probe)
-│   ├── sandbox/              # Exec
-│   ├── api/                  # API / Public (HTTP + webhook module)
-│   └── sdk/      +/macros-support/   # API / Public (integration-author façade)
-└── examples/                 # root-level workspace member (NOT per-crate)
-```
-
-Per-crate layout convention:
+Full workspace member list is in **`Cargo.toml [workspace.members]`**. The
+canonical map of which crate sits in which layer is in **`CLAUDE.md` §
+"Layered Dependency Map"**. Per-crate layout convention:
 
 ```
 crates/<crate>/
@@ -108,14 +79,14 @@ crates/<crate>/
 └── macros/                   # proc-macro sub-crate, if needed
 ```
 
-Macros live in their own sub-crate (`crates/<crate>/macros/`) to keep proc-macro
-build cost out of the runtime crate.
+Macros live in their own sub-crate (`crates/<crate>/macros/`) to keep
+proc-macro build cost out of the runtime crate.
 
 ## Dependency Rules
 
 ### Allowed
 
-- ✅ Any crate may depend on **Cross-cutting** crates (`error`, `log`, `system`,
+- ✅ Any crate may depend on **Cross-cutting** crates (`error`, `log`,
   `eventbus`, `metrics`, `resilience`).
 - ✅ **Core** depends on Cross-cutting only.
 - ✅ **Business** depends on Core + Cross-cutting.
@@ -132,12 +103,12 @@ build cost out of the runtime crate.
 - ❌ Exec crates may **not** depend on API. **Exception (allowlisted):**
   `nebula-engine` may be wrapped by `nebula-cli` and (dev-only) by
   `crates/api/tests/knife.rs` — see `deny.toml` rationale.
-- ❌ Sibling crates at the same layer may **not** import each other directly —
-  cross-crate communication goes through `nebula-eventbus` (typed events) or
-  through a shared lower-layer contract crate.
+- ❌ Sibling crates at the same layer may **not** import each other
+  directly — cross-crate communication goes through `nebula-eventbus`
+  (typed events) or through a shared lower-layer contract crate.
 - ❌ `nebula-resource` is shared infra: only the explicit wrapper allowlist
-  (`action`, `engine`, `plugin`, `sandbox`, `sdk`) may depend on it. API and
-  Core must not.
+  (`action`, `engine`, `plugin`, `sandbox`, `sdk`) may depend on it. API
+  and Core must not.
 - ❌ `nebula-credential-builtin` is a first-party scaffold: plugin authors
   depend on the contract crate `nebula-credential`, **not** on `-builtin`.
 - ❌ Adding a new wrapper without a `reason` string in `deny.toml` is a CI
@@ -150,45 +121,47 @@ paths, `CODEOWNERS` sign-off).
 ## Layer / Module Communication
 
 - **Down the stack: direct typed calls.** API → Exec → Business → Core →
-  Cross-cutting. Inputs are typed; errors are `thiserror` enums; observability
-  spans + metrics are emitted at the call site.
+  Cross-cutting. Inputs are typed; errors are `thiserror` enums;
+  observability spans + metrics are emitted at the call site.
 - **Up the stack: `nebula-eventbus`.** Lower layers publish typed events;
-  higher layers subscribe. No upward direct calls. The eventbus is stable for
-  `CredentialEvent` and used by the engine; `ExecutionEvent` is still on raw
-  `mpsc` (migration tracked separately).
+  higher layers subscribe. No upward direct calls. The eventbus is stable
+  for `CredentialEvent` and used by the engine; `ExecutionEvent` is still
+  on raw `mpsc` (migration tracked separately).
 - **Cross-cutting concerns (logging, metrics, errors) are imported, not
   wrapped.** Use `tracing` directly; do not invent crate-local façades.
 - **Public extension surface = `nebula-sdk` + `nebula-plugin-sdk`.**
   Third-party integrators depend on these two crates only; the `[wrappers]`
   rules pin who is allowed to depend on each.
-- **Composition roots.** Wiring concrete impls happens in `nebula-cli` (binary)
-  or, for in-process integration tests, in `crates/api/tests/`. Library crates
-  do not perform global wiring.
+- **Composition roots.** Wiring concrete impls happens in `apps/server`
+  (binary) or, for in-process integration tests, in `crates/api/tests/`.
+  Library crates do not perform global wiring.
 
 ## Key Principles
 
-1. **Crates are modules; layers are enforced at compile time.** A merge that
-   widens a layer boundary either updates `deny.toml [[bans]] wrappers` with a
-   `reason` (and review) or fails CI. There is no soft "gentle reminder" path.
+1. **Crates are modules; layers are enforced at compile time.** A merge
+   that widens a layer boundary either updates `deny.toml [[bans]] wrappers`
+   with a `reason` (and review) or fails CI. There is no soft "gentle
+   reminder" path.
 2. **Types over tests.** Workflow shape, action I/O, parameter schemas, and
    auth patterns are Rust types. If it compiles, the shape is valid. Tests
    verify behaviour, not type safety.
-3. **Explicit over magic.** No global state, no service locators, no ambient
-   config. Actions receive everything via `Context`. If a dependency is not in
-   the function signature, it does not exist.
-4. **Delete over deprecate (internals).** For internal architecture, replace
-   the wrong API rather than adapt around it. No shims, no bridges, no
-   `legacy_compat` flags. The public `nebula-sdk` and plugin contracts are the
-   exception — they get a clear deprecation path because they are external
-   contracts.
+3. **Explicit over magic.** No global state, no service locators, no
+   ambient config. Actions receive everything via `Context`. If a
+   dependency is not in the function signature, it does not exist.
+4. **Delete over deprecate (internals).** For internal architecture,
+   replace the wrong API rather than adapt around it. No shims, no
+   bridges, no `legacy_compat` flags. The public `nebula-sdk` and plugin
+   contracts are the exception — they get a clear deprecation path because
+   they are external contracts.
 5. **Security by default.** Secrets are encrypted (AES-256-GCM with AAD
    binding), zeroized on `Drop`, redacted in `Debug`. The safe path is the
    only path.
-6. **Observability is part of Definition of Done.** Every new state, error, or
-   hot path ships with a typed error variant **and** a tracing span / event
-   **and** an invariant check — not as a follow-up.
-7. **ADRs are revisable.** Architecture decisions live as ADRs. If following
-   one forces workarounds, **supersede** the ADR — do not patch around it.
+6. **Observability is part of Definition of Done.** Every new state,
+   error, or hot path ships with a typed error variant **and** a tracing
+   span / event **and** an invariant check — not as a follow-up.
+7. **ADRs are revisable.** Architecture decisions live as ADRs. If
+   following one forces workarounds, **supersede** the ADR — do not patch
+   around it.
 
 ## Code Examples
 
@@ -237,8 +210,8 @@ while let Some(evt) = sub.recv().await { /* react */ }
 use nebula_engine::ExecutionContext; // NO — Business depending on Exec
 ```
 
-`cargo deny check bans` flags this and CI fails. Fix: invert via eventbus, or
-move the shared type down to Core / Cross-cutting.
+`cargo deny check bans` flags this and CI fails. Fix: invert via eventbus,
+or move the shared type down to Core / Cross-cutting.
 
 ### Adding a new layer-crossing edge (the only legitimate path)
 
@@ -257,15 +230,16 @@ No `reason` → CI rejects the diff.
 
 ## Anti-Patterns
 
-- ❌ **Sibling-crate `use` at the same layer.** Even if `cargo build` succeeds
-  via a transitive path, route the seam through `nebula-eventbus` or a shared
-  lower-layer crate.
+- ❌ **Sibling-crate `use` at the same layer.** Even if `cargo build`
+  succeeds via a transitive path, route the seam through `nebula-eventbus`
+  or a shared lower-layer crate.
 - ❌ **`Box<dyn Error>` / `anyhow::Error` in library APIs.** Use typed
   `thiserror` errors. `anyhow` is for binaries only.
-- ❌ **`async-trait` on hot paths.** Prefer `#[async_fn_in_trait]` (Rust 1.75+
-  stable) — verify against current 1.95+ idioms.
+- ❌ **`async-trait` on hot paths.** Prefer `#[async_fn_in_trait]` (Rust
+  1.75+ stable) — verify against current 1.95+ idioms.
 - ❌ **`Arc<Mutex<…>>` as the default for shared state.** Reach for
-  `parking_lot::Mutex`, `arc-swap`, `dashmap`, or single-writer designs first.
+  `parking_lot::Mutex`, `arc-swap`, `dashmap`, or single-writer designs
+  first.
 - ❌ **Per-crate `examples/` directories.** Runnable examples live in the
   root-level `examples/` workspace member.
 - ❌ **`unwrap()` / `expect()` / `panic!()` in library code.** Allowed in
@@ -276,6 +250,6 @@ No `reason` → CI rejects the diff.
   Cross-cutting crates are designed to be imported directly.
 - ❌ **Patching around an ADR.** If the ADR forces workarounds, write a
   superseding ADR — do not accumulate compensating code.
-- ❌ **`let _ = transition_node(...)` / silently ignoring `Result`.** Either
-  handle the typed error or propagate it; engine state machines have caused
-  bugs from swallowed transitions.
+- ❌ **`let _ = transition_node(...)` / silently ignoring `Result`.**
+  Either handle the typed error or propagate it; engine state machines
+  have caused bugs from swallowed transitions.

--- a/.ai-factory/ARCHITECTURE.md
+++ b/.ai-factory/ARCHITECTURE.md
@@ -2,17 +2,18 @@
 
 > Agent-actionable subset. The **canonical layer map lives in
 > [`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and is mechanically
-> enforced by `cargo deny` against `deny.toml [[bans]] wrappers`. The README
-> at the repo root is the product-facing crate map. If those disagree with
-> anything below, **CLAUDE.md / README / `deny.toml` win** — fix this file,
-> never the canon.
+> enforced by `cargo deny check` against the `wrappers` allowlists on the
+> `[bans].deny` entries in `deny.toml`. The README at the repo root is the
+> product-facing crate map. If those disagree with anything below, **CLAUDE.md
+> / README / `deny.toml` win** — fix this file, never the canon.
 
 ## Overview
 
 Nebula is a **layered modular monolith** built as a Cargo workspace. Every
 crate lives in exactly one layer, and inter-layer dependencies are enforced
-**mechanically** by `cargo deny check` against the `[[bans]] wrappers` rules
-in `deny.toml` — a missing entry fails CI before review. The result is the
+**mechanically** by `cargo deny check` against the `wrappers` allowlists on
+the `[bans].deny` entries in `deny.toml` — a missing entry fails CI before
+review. The result is the
 simple operational profile of a monolith with the modular discipline of
 microservices: any individual crate can be embedded independently, but the
 team ships one repo, one toolchain, one CI, one release cadence.
@@ -32,20 +33,22 @@ tests, typed events for cross-crate seams.**
 - **Team / scaling profile:** small core team, embeddable by external
   teams → modular discipline matters more than independent deploy.
 - **Key factor:** modularity is a hard product constraint (see README "Why
-  Nebula") — `cargo deny [wrappers]` makes the layer boundaries cheap to
-  enforce and impossible to drift quietly past.
+  Nebula") — the `wrappers` allowlists in `deny.toml` make the layer
+  boundaries cheap to enforce and impossible to drift quietly past.
 
 ## What agents need to know on top of CLAUDE.md / README / deny.toml
 
 - Each layer depends only on layers below it; cross-cutting crates are
-  importable at any level. The exact wrapper allowlist is in `deny.toml`.
+  importable at any level. The exact allowlist is each
+  `[bans].deny[].wrappers` field in `deny.toml`.
 - Cross-crate communication between siblings at the same layer goes through
   `nebula-eventbus`, not direct imports.
 - **`nebula-credential` is shared infrastructure**, not a single-tier
   Business crate. Exec / Business / API tiers and the first-party backends
   (`credential-builtin`, `credential-vault`, `credential-runtime`,
   `credential-testutil`) all consume the credential contract directly. The
-  exact consumer set is locked in `deny.toml [wrappers]`.
+  exact consumer set is locked in `deny.toml` under the
+  `nebula-credential` entry's `wrappers` field.
 - **`nebula-storage-port`** (Core) is the object-safe storage seam every
   storage consumer depends on. **`nebula-storage`** (Exec) is the sole
   adapter implementation. **`nebula-tenancy`** (Business) is the
@@ -95,14 +98,17 @@ proc-macro build cost out of the runtime crate.
 - ✅ A crate's `macros/` sub-crate may depend on its parent contract crate
   only as a `dev-dependency` for tests.
 
-### Forbidden (enforced by `deny.toml [[bans]] wrappers`)
+### Forbidden (enforced by the `wrappers` allowlists on the `[bans].deny` entries in `deny.toml`)
 
 - ❌ Cross-cutting crates may **not** depend on Core / Business / Exec / API.
 - ❌ Core crates may **not** depend on Business / Exec / API.
 - ❌ Business crates may **not** depend on Exec / API.
 - ❌ Exec crates may **not** depend on API. **Exception (allowlisted):**
-  `nebula-engine` may be wrapped by `nebula-cli` and (dev-only) by
-  `crates/api/tests/knife.rs` — see `deny.toml` rationale.
+  `nebula-engine` may be wrapped by `apps/server` (`nebula-server`) and by
+  `nebula-credential-runtime` (acyclic edge per ADR-0081); dev-only by
+  `crates/api/tests/knife.rs`. The allowlist also reserves an entry for the
+  planned `nebula-cli` binary, which does not exist in the workspace yet.
+  See `deny.toml` for the full rationale comments.
 - ❌ Sibling crates at the same layer may **not** import each other
   directly — cross-crate communication goes through `nebula-eventbus`
   (typed events) or through a shared lower-layer contract crate.
@@ -130,8 +136,8 @@ paths, `CODEOWNERS` sign-off).
 - **Cross-cutting concerns (logging, metrics, errors) are imported, not
   wrapped.** Use `tracing` directly; do not invent crate-local façades.
 - **Public extension surface = `nebula-sdk` + `nebula-plugin-sdk`.**
-  Third-party integrators depend on these two crates only; the `[wrappers]`
-  rules pin who is allowed to depend on each.
+  Third-party integrators depend on these two crates only; the `wrappers`
+  allowlists in `deny.toml` pin who is allowed to depend on each.
 - **Composition roots.** Wiring concrete impls happens in `apps/server`
   (binary) or, for in-process integration tests, in `crates/api/tests/`.
   Library crates do not perform global wiring.
@@ -139,9 +145,9 @@ paths, `CODEOWNERS` sign-off).
 ## Key Principles
 
 1. **Crates are modules; layers are enforced at compile time.** A merge
-   that widens a layer boundary either updates `deny.toml [[bans]] wrappers`
-   with a `reason` (and review) or fails CI. There is no soft "gentle
-   reminder" path.
+   that widens a layer boundary either updates the relevant
+   `[bans].deny[].wrappers` entry in `deny.toml` with a `reason` (and
+   review) or fails CI. There is no soft "gentle reminder" path.
 2. **Types over tests.** Workflow shape, action I/O, parameter schemas, and
    auth patterns are Rust types. If it compiles, the shape is valid. Tests
    verify behaviour, not type safety.

--- a/.ai-factory/DESCRIPTION.md
+++ b/.ai-factory/DESCRIPTION.md
@@ -19,8 +19,10 @@ API layer are in active development. Not production-ready yet.
 
 - **Language:** Rust 1.95+ (MSRV pinned via `workspace.package.rust-version`),
   edition 2024, resolver 3.
-- **Workspace:** 35+ crates under `crates/` (see `Cargo.toml` `[workspace]`
-  members) — see `AGENTS.md` for the layered map.
+- **Workspace:** 29 first-party crates under `crates/` (plus their derive
+  sub-crates and `apps/server`). The layered dependency map is canonical in
+  **[`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and mechanically
+  enforced by `cargo deny [wrappers]`. Do not duplicate the list here.
 - **Async runtime:** Tokio (multi-thread).
 - **Serialization:** `serde` / `serde_json`.
 - **Errors:** `thiserror` in libraries, `anyhow` in binaries.
@@ -35,26 +37,14 @@ API layer are in active development. Not production-ready yet.
 
 ## Architecture (high-level)
 
-Layered workspace, enforced mechanically by `cargo deny` `[wrappers]` in
-`deny.toml`:
+Layered Modular Workspace (Cargo wrapper-enforced). The exact layer table
+lives in **[`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and is
+enforced mechanically by `cargo deny` against `deny.toml [wrappers]`.
+Cross-crate communication goes through `nebula-eventbus`, not direct imports
+between siblings.
 
-```
-API / Public    api · sdk
-Exec            engine · storage · sandbox · plugin-sdk
-Business        credential · resource · action · plugin
-Core            core · validator · expression · workflow · execution · schema · metadata
-Cross-cutting   log · system · eventbus · metrics · resilience · error
-```
-
-Each layer depends only on layers below; cross-cutting crates are importable
-anywhere. Cross-crate communication goes through `nebula-eventbus`, not direct
-imports between siblings.
-
-Detailed architecture and design principles live in **README.md** (sections
-"Why Nebula", "Design Principles", "Architecture") — `.ai-factory/ARCHITECTURE.md`
-captures the agent-actionable subset.
-
-**Pattern:** Layered Modular Workspace (Cargo wrapper-enforced).
+Product framing and design principles live in **README.md**
+("Why Nebula", "Design Principles", "Architecture").
 
 ## Core Features
 

--- a/.ai-factory/DESCRIPTION.md
+++ b/.ai-factory/DESCRIPTION.md
@@ -22,7 +22,8 @@ API layer are in active development. Not production-ready yet.
 - **Workspace:** 29 first-party crates under `crates/` (plus their derive
   sub-crates and `apps/server`). The layered dependency map is canonical in
   **[`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and mechanically
-  enforced by `cargo deny [wrappers]`. Do not duplicate the list here.
+  enforced by `cargo deny check` against the `wrappers` allowlists on the
+  `[bans].deny` entries in `deny.toml`. Do not duplicate the list here.
 - **Async runtime:** Tokio (multi-thread).
 - **Serialization:** `serde` / `serde_json`.
 - **Errors:** `thiserror` in libraries, `anyhow` in binaries.
@@ -39,9 +40,9 @@ API layer are in active development. Not production-ready yet.
 
 Layered Modular Workspace (Cargo wrapper-enforced). The exact layer table
 lives in **[`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map"** and is
-enforced mechanically by `cargo deny` against `deny.toml [wrappers]`.
-Cross-crate communication goes through `nebula-eventbus`, not direct imports
-between siblings.
+enforced mechanically by `cargo deny check` against the `wrappers` fields
+on the `[bans].deny` entries in `deny.toml`. Cross-crate communication goes
+through `nebula-eventbus`, not direct imports between siblings.
 
 Product framing and design principles live in **README.md**
 ("Why Nebula", "Design Principles", "Architecture").

--- a/.ai-factory/rules/base.md
+++ b/.ai-factory/rules/base.md
@@ -29,18 +29,24 @@
 
 ## Module / Crate Structure
 
-- Layered workspace enforced by `cargo deny` (`deny.toml` `[wrappers]`):
-  - **Cross-cutting**: `log`, `system`, `eventbus`, `metrics`, `resilience`,
-    `error`.
-  - **Core**: `core`, `validator`, `expression`, `workflow`, `execution`,
-    `schema`, `metadata`.
-  - **Business**: `credential`, `resource`, `action`, `plugin`.
-  - **Exec**: `engine`, `storage`, `sandbox`, `plugin-sdk`.
-  - **API / Public**: `api`, `sdk`.
-- Cross-crate communication goes through `nebula-eventbus`, **not** direct
-  imports between sibling crates at the same layer.
-- Macros live in their own sub-crate (`crates/<crate>/macros/`) to keep proc-macro
-  build cost out of the runtime crate.
+- The **layered dependency map is canonical in
+  [`CLAUDE.md`](../../CLAUDE.md) § "Layered Dependency Map"** and mechanically
+  enforced by `cargo deny` against `deny.toml [[bans]] wrappers`. Do **not**
+  duplicate the layer list here — stale copies in agent-context files were
+  the single biggest source of LLM hallucinations before this rule landed.
+- Cross-crate communication between siblings at the same layer goes through
+  `nebula-eventbus`, **not** direct imports.
+- Macros live in their own sub-crate (`crates/<crate>/macros/`) to keep
+  proc-macro build cost out of the runtime crate.
+- Shared-infra notes the layer table alone doesn't capture: `nebula-credential`
+  (with its backends `credential-builtin`, `credential-vault`,
+  `credential-runtime`, `credential-testutil`) is consumable from multiple
+  tiers, not strictly Business. `nebula-storage-port` (Core) is the storage
+  seam every consumer depends on; `nebula-storage` (Exec) is the sole
+  adapter; `nebula-tenancy` (Business) is the scope-enforcing decorator that
+  wraps a raw `storage-port` adapter (ADR-0072). `nebula-telemetry` was
+  absorbed into `nebula-metrics` per ADR-0046; `nebula-system` was deleted
+  (#668) — if either is referenced in the working tree, it is drift.
 
 ## Error Handling
 

--- a/.ai-factory/rules/base.md
+++ b/.ai-factory/rules/base.md
@@ -31,9 +31,10 @@
 
 - The **layered dependency map is canonical in
   [`CLAUDE.md`](../../CLAUDE.md) § "Layered Dependency Map"** and mechanically
-  enforced by `cargo deny` against `deny.toml [[bans]] wrappers`. Do **not**
-  duplicate the layer list here — stale copies in agent-context files were
-  the single biggest source of LLM hallucinations before this rule landed.
+  enforced by `cargo deny check` against the `wrappers` allowlists on the
+  `[bans].deny` entries in `deny.toml`. Do **not** duplicate the layer list
+  here — stale copies in agent-context files were the single biggest source
+  of LLM hallucinations before this rule landed.
 - Cross-crate communication between siblings at the same layer goes through
   `nebula-eventbus`, **not** direct imports.
 - Macros live in their own sub-crate (`crates/<crate>/macros/`) to keep

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,7 +4,8 @@
 Modular type-safe Rust workflow engine. Edition 2024, MSRV 1.95, alpha stage.
 Layered architecture (one-way deps, no upward) — canonical map and exact
 allowlist live in [`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map";
-mechanically enforced by `cargo deny` against `deny.toml [[bans]] wrappers`.
+mechanically enforced by `cargo deny check` against the `wrappers` fields
+on the `[bans].deny` entries in `deny.toml`.
 Universal data type: serde_json::Value.
 Error handling: thiserror in libs, anyhow in binaries.
 
@@ -40,9 +41,10 @@ the same branch naming and Conventional Commit rules.
 
 1. **Layer violations** — `crates/core/*` importing from `crates/engine/*` etc.
    The exact layer hierarchy is in `CLAUDE.md` § "Layered Dependency Map";
-   `cargo deny check` against `deny.toml [[bans]] wrappers` is the
-   authoritative gate. If a `Cargo.toml` edge crosses a layer boundary
-   without an allowlist entry carrying a `reason`, CI fails before review.
+   `cargo deny check` against the `wrappers` allowlists on the `[bans].deny`
+   entries in `deny.toml` is the authoritative gate. If a `Cargo.toml` edge
+   crosses a layer boundary without an entry carrying a `reason`, CI fails
+   before review.
 2. **Panic in library code** — `unwrap()`, `expect()`, `panic!()`, indexing without bounds check, `unreachable!()` outside exhaustive match.
    Exception: `#[cfg(test)]` and binary crates allowed.
 3. **Silent error suppression** — `let _ = result;` on `Result`, `.ok()` discarding meaningful errors, `.unwrap_or_default()` on fallible IO/parse.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,7 +2,9 @@
 
 ## Project Context
 Modular type-safe Rust workflow engine. Edition 2024, MSRV 1.95, alpha stage.
-Architecture: Core → Business → Exec → API (one-way deps, no upward).
+Layered architecture (one-way deps, no upward) — canonical map and exact
+allowlist live in [`CLAUDE.md`](../CLAUDE.md) § "Layered Dependency Map";
+mechanically enforced by `cargo deny` against `deny.toml [[bans]] wrappers`.
 Universal data type: serde_json::Value.
 Error handling: thiserror in libs, anyhow in binaries.
 
@@ -37,8 +39,10 @@ the same branch naming and Conventional Commit rules.
 ### Critical (always comment)
 
 1. **Layer violations** — `crates/core/*` importing from `crates/engine/*` etc.
-   Check Cargo.toml dependencies against the layer hierarchy:
-   `core < business (credential/resource/action/plugin) < exec (engine/runtime/storage/sandbox/sdk/plugin-sdk) < api`.
+   The exact layer hierarchy is in `CLAUDE.md` § "Layered Dependency Map";
+   `cargo deny check` against `deny.toml [[bans]] wrappers` is the
+   authoritative gate. If a `Cargo.toml` edge crosses a layer boundary
+   without an allowlist entry carrying a `reason`, CI fails before review.
 2. **Panic in library code** — `unwrap()`, `expect()`, `panic!()`, indexing without bounds check, `unreachable!()` outside exhaustive match.
    Exception: `#[cfg(test)]` and binary crates allowed.
 3. **Silent error suppression** — `let _ = result;` on `Result`, `.ok()` discarding meaningful errors, `.unwrap_or_default()` on fallible IO/parse.
@@ -70,9 +74,14 @@ DO NOT comment on:
 
 ### Metrics
 
-Single path: `nebula-telemetry::MetricsRegistry` → `nebula-metrics` (Prometheus export).
-Domain crates consume via DI: `Option<Arc<MetricsRegistry>>`.
-Flag PRs that introduce alternate metrics stacks.
+Single path through **`nebula-metrics`** for everything: lock-free in-memory
+registry plus Prometheus-style export and label-safety guards. The former
+two-tier `nebula-telemetry` → `nebula-metrics` stack was collapsed (ADR-0046)
+and the `nebula-telemetry` crate is gone — if you see
+`nebula-telemetry::MetricsRegistry` anywhere in the working tree it is drift
+and should be flagged. Domain crates consume via DI:
+`Option<Arc<MetricsRegistry>>`. Flag PRs that introduce alternate metrics
+stacks.
 
 ### Errors
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,11 +77,16 @@ DO NOT comment on:
 Single path through **`nebula-metrics`** for everything: lock-free in-memory
 registry plus Prometheus-style export and label-safety guards. The former
 two-tier `nebula-telemetry` → `nebula-metrics` stack was collapsed (ADR-0046)
-and the `nebula-telemetry` crate is gone — if you see
-`nebula-telemetry::MetricsRegistry` anywhere in the working tree it is drift
-and should be flagged. Domain crates consume via DI:
+and the `nebula-telemetry` crate is gone. Domain crates consume via DI:
 `Option<Arc<MetricsRegistry>>`. Flag PRs that introduce alternate metrics
 stacks.
+
+Flag `nebula-telemetry` references **only in active code or configuration**
+(`crates/**/*.rs`, `apps/**/*.rs`, `**/*.toml`, build scripts) — those are
+drift that would not compile. Historical references in `docs/adr/0046-*`,
+`docs/MATURITY.md` journal entries, `docs/INTEGRATION_MODEL.md` migration
+notes, `crates/**/README.md`, and the `docs/plans/` archive are
+**intentional** and must NOT be flagged.
 
 ### Errors
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,13 @@
 # AGENTS.md
 
-> **Canonical agent rules and the full Nebula project map live in
-> [`CLAUDE.md`](CLAUDE.md).** Read that file — it is the single source of
-> truth for layout, architecture, commands, Git workflow, coding rules, and
-> enforced discipline. This file is an intentionally thin cross-tool pointer:
-> the owner chose `CLAUDE.md` (not `AGENTS.md`) as canonical, accepting that
-> `AGENTS.md`-only tools see just this stub.
+> Canonical agent rules and the full Nebula project map live in
+> [`CLAUDE.md`](CLAUDE.md). Read that file — it is the single source of truth
+> for layout, layered dependency map, architecture, commands, Git workflow,
+> coding rules, and the mechanically enforced discipline. This file is an
+> intentionally thin cross-tool pointer: the owner chose `CLAUDE.md` (not
+> `AGENTS.md`) as canonical, accepting that `AGENTS.md`-only tools see just
+> this stub.
 
 Nebula is a modular, type-safe **workflow automation engine** in Rust
-(edition 2024, MSRV 1.95). Product overview: `README.md`.
-
-## Git workflow (summary — `CLAUDE.md` is authoritative)
-
-- Branch from `origin/main`; squash-merge back; never force-push shared
-  history without explicit confirmation.
-- Persistent task branches go through
-  `bash scripts/worktree.sh new <slug> <type> <scope>` (creates
-  `.worktrees/<slug>` and branch `<type>/<scope>-<slug>`); finish with
-  `bash scripts/worktree.sh finish <slug>`.
-- Conventional Commits, validated by `convco`. **Allowed types:** `build`,
-  `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`,
-  `style`, `test`. **Scope:** crate name without the `nebula-` prefix, or a
-  top-level area (`docs`, `ci`, `scripts`, `github`).
-- Managed cloud/IDE worktrees that cannot live under `.worktrees/` still
-  follow these branch/commit rules — CI and `lefthook` are the gate.
-
-For **which markdown files are authoritative vs archive**, read
-[`docs/README.md`](docs/README.md) before pulling product or ADR context.
-
-Everything else — project map, layered dependency map, command catalog, full
-agent rules, and the mechanically enforced discipline (guard hooks) — is in
-[`CLAUDE.md`](CLAUDE.md).
+(edition 2024, MSRV 1.95). Product overview: [`README.md`](README.md).
+Docs entry point: [`docs/README.md`](docs/README.md).

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ Most automation platforms are runtime-interpreted, dynamically typed, and treat 
 ```
 API / Public    api (HTTP + webhook module) · sdk (integration author façade)
 Exec            engine · storage · storage-loom-probe · sandbox · plugin-sdk
-Business        credential · credential-builtin · resource · action · plugin
-Core            core · validator · expression · workflow · execution · schema · metadata
-Cross-cutting   log · system · eventbus · metrics · resilience · error
+Business        credential · credential-builtin · credential-vault · credential-runtime · credential-testutil · resource · action · plugin · tenancy
+Core            core · validator · expression · workflow · execution · schema · metadata · storage-port
+Cross-cutting   log · eventbus · metrics · resilience · error
 ```
 
 Each layer depends only on layers below it. Cross-cutting crates are importable at any level. Layer boundaries are enforced mechanically by `cargo deny` (see `deny.toml` `wrappers`) — a missing entry fails CI before review.
@@ -70,11 +70,16 @@ Source of truth: workspace members in `Cargo.toml`.
 |                   | `expression`    | Template expression engine                                                           |
 |                   | `workflow`      | `WorkflowDefinition`, DAG structure, activation-time validator                       |
 |                   | `execution`     | Execution state machine + transitions                                                |
+|                   | `storage-port`  | Object-safe storage seam: row-model traits every storage consumer depends on (ADR-0072) |
 | **Business**      | `credential`         | Encrypted storage (AES-256-GCM + AAD), key rotation, 12 universal auth schemes       |
 |                   | `credential-builtin` | First-party scaffold credential types (built on the `credential` contract)           |
+|                   | `credential-vault`   | Vault-backed credential backend (built on the `credential` contract)                 |
+|                   | `credential-runtime` | `CredentialService<B,PS>` facade and slot-binding resolver (ADR-0066)                |
+|                   | `credential-testutil`| Test shims for credential consumers (extracted from the `credential` crate, M12.2)   |
 |                   | `resource`           | External service lifecycle, typed credential refs                                    |
 |                   | `action`             | Action trait family (Stateless / Stateful / Trigger / Resource / Control)            |
 |                   | `plugin`             | In-process plugin trait + registry                                                   |
+|                   | `tenancy`            | Scope-enforcing decorator wrapping `storage-port` so a tenant scope is substituted on every call (ADR-0072) |
 | **Exec**          | `engine`             | Frontier loop, lease lifecycle, node scheduling, control consumer (ADR-0008)         |
 |                   | `storage`            | Persistence trait family + in-memory + Postgres (SQLite local path planned)          |
 |                   | `storage-loom-probe` | `loom`-checked concurrency probe for storage paths                                   |
@@ -86,8 +91,7 @@ Source of truth: workspace members in `Cargo.toml`.
 |                   | `resilience`         | Retry, circuit breaker, rate limiter, hedge, bulkhead                                |
 |                   | `log`                | Structured logging infrastructure                                                    |
 |                   | `eventbus`           | In-memory typed pub/sub for cross-crate signals                                      |
-|                   | `metrics`            | Lock-free primitives + label interning + `nebula_*` naming + Prometheus export (ADR-0046) |
-|                   | `system`             | Process monitoring, system load tracking                                             |
+|                   | `metrics`            | Lock-free primitives + label interning + `nebula_*` naming + Prometheus export (absorbs the former `nebula-telemetry` crate per ADR-0046) |
 
 ## Quick Start
 

--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -187,11 +187,9 @@ Besides the **integration** reference crates (§3.6–§3.9), the workspace ship
 - **`nebula-validator`** — programmatic validators + declarative **`Rule`**; **`nebula-schema`** embeds rules in **`Field`** definitions.
 - **`nebula-config`** — multi-source, merged, optionally hot-reloaded **host** configuration (binaries/services) — **not** the per-node **`Schema`** story.
 - **`nebula-log`** — structured **`tracing`** pipeline (init, sinks, optional OTel/Sentry hooks).
-- **`nebula-telemetry`** — in-memory **metric** primitives (registry, histograms, label interning).
-- **`nebula-metrics`** — **`nebula_*` naming**, adapters, Prometheus-style **export** and label-safety guards — sits on top of **`nebula-telemetry`**.
+- **`nebula-metrics`** — lock-free in-memory primitives (registry, histograms, label interning) plus **`nebula_*` naming**, adapters, Prometheus-style **export** and label-safety guards. **Absorbs the former `nebula-telemetry` crate** — one metrics path, no two-tier stack (ADR-0046).
 - **`nebula-eventbus`** — typed **broadcast** bus with back-pressure policy; **transport only** — domain **`E`** types live in owning crates.
 - **`nebula-expression`** — workflow **expression** evaluation (variable access, operators, functions) for dynamic fields — headless, not a UI.
-- **`nebula-system`** — cross-platform **host** probes (CPU/memory/network/disk pressure) for ops and telemetry inputs.
 - **`nebula-workflow`** + **`nebula-execution`** — the execution semantics core: workflow validation/shape and durable execution lifecycle/state transitions. Read these when the question is "what does the engine guarantee at runtime," not just "how integrations are authored."
 
 **Layering:** cross-cutting crates sit **below** API/engine-specific surfaces (see CLAUDE.md boundaries); they must not **depend upward** on integration-only crates. **Canon use:** reuse these crates for their domains instead of duplicating helpers; if something truly belongs in **`nebula-core`** (a new stable identifier or key type), extend it deliberately rather than inventing a parallel type in a leaf crate. New **auth material** types belong in **`nebula-credential`** unless an ADR moves shared vocabulary (as was done for `AuthScheme`/`AuthPattern` → `nebula-core`).

--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -185,7 +185,7 @@ Besides the **integration** reference crates (§3.6–§3.9), the workspace ship
 - **`nebula-error`** — **`Classify`**, **`NebulaError`**, categories/codes, structured details — **one** error taxonomy at boundaries instead of ad hoc strings.
 - **`nebula-resilience`** — composable **pipelines** (retry, timeout, circuit breaker, bulkhead, …); pairs with **`ActionError`** / retry hints in **`nebula-action`** (§3.8).
 - **`nebula-validator`** — programmatic validators + declarative **`Rule`**; **`nebula-schema`** embeds rules in **`Field`** definitions.
-- **`nebula-config`** — multi-source, merged, optionally hot-reloaded **host** configuration (binaries/services) — **not** the per-node **`Schema`** story.
+- **`nebula-config`** *(planned, not yet a workspace member)* — multi-source, merged, optionally hot-reloaded **host** configuration (binaries/services) — **not** the per-node **`Schema`** story.
 - **`nebula-log`** — structured **`tracing`** pipeline (init, sinks, optional OTel/Sentry hooks).
 - **`nebula-metrics`** — lock-free in-memory primitives (registry, histograms, label interning) plus **`nebula_*` naming**, adapters, Prometheus-style **export** and label-safety guards. **Absorbs the former `nebula-telemetry` crate** — one metrics path, no two-tier stack (ADR-0046).
 - **`nebula-eventbus`** — typed **broadcast** bus with back-pressure policy; **transport only** — domain **`E`** types live in owning crates.

--- a/docs/MATURITY.md
+++ b/docs/MATURITY.md
@@ -36,14 +36,16 @@ Legend:
 | nebula-plugin        | partial  | stable  | stable | stable | n/a |
 | nebula-plugin-sdk    | partial  | stable  | stable | n/a | n/a |
 | nebula-resilience    | stable   | stable  | stable | n/a | n/a |
+| nebula-storage-port  | stable   | stable  | stable | stable (ADR-0072 — object-safe row-model seam; every storage consumer depends on this and not on `nebula-storage`) | n/a |
+| nebula-storage-loom-probe | partial | stable | partial | partial (`loom`-checked concurrency probes for storage critical sections; library, no SLI) | n/a |
+| nebula-tenancy       | stable   | stable  | stable | stable (ADR-0072 scope-enforcing decorator wrapping a raw `storage-port` adapter; substitutes a tenant scope on every call before it reaches a handler) | n/a |
+| nebula-credential-vault | partial | stable | partial | partial (Vault-backed backend implementing the `credential` contract) | n/a |
+| nebula-credential-testutil | stable | stable | stable | n/a (test-only crate — shims for downstream credential consumers, extracted from `nebula-credential` during M12.2) | n/a |
 | nebula-resource      | frontier | stable  | stable | stable for the operational substrate (ADR-0067): lock-free `SlotCell` slot store + `&self`+`&Runtime` refresh/revoke hook, narrow `Manager::{refresh_slot,revoke_slot}(_for)` port, structural slot-identity dedup key closing the cross-tenant `fingerprint()==0` bleed, config CRUD + CAS update + read-only runtime-status API with no HTTP lifecycle (INTEGRATION_MODEL §13.1), ADR-0028 §7 redaction gate green. The engine-side per-slot rotation fan-out **dispatch path is wired and e2e-proven** (2026-05-17): an engine-owned `ResourceFanoutDriver` subscribes the credential-runtime `CredentialEvent::{Refreshed,Revoked}` + `LeaseEvent::LeaseRevoked` buses and drives `dispatch_refresh`/`dispatch_revoke` with per-resource drain + post-taint re-check (#679), a two-phase cancellation-safe revoke port (#681), and rotation-vs-first-acquire epoch reconcile (#680). **Still gating full §M11.5/§M12.4 closure:** *bind-population* — populating the reverse index when a credential resolves into a `#[credential]` slot in production — has no production caller (depends on the still-deferred resource-activation path: plugin-auto-population / a production `ResourceRepo`; rotation-outcome eventbus emission also still deferred per ADR-0067). A real rotation/revoke event now fans out correctly to every *bound* row, but production binds none until activation lands — so this stays `frontier`, not flipped to stable. | n/a |
-| nebula-runtime       | partial  | stable  | stable | stable | partial |
 | nebula-sandbox       | partial  | stable  | stable | partial (process isolation; signing planned) | n/a |
 | nebula-schema        | frontier | stable  | stable | stable | n/a |
 | nebula-sdk           | partial  | stable  | stable | n/a | n/a |
 | nebula-storage       | partial  | stable  | stable | stable | partial |
-| nebula-telemetry     | stable   | stable  | stable | n/a | n/a |
-| nebula-testing       | planned  | n/a     | n/a    | n/a    | n/a |
 | nebula-validator     | frontier | stable  | stable | stable | n/a |
 | nebula-workflow      | stable   | stable  | stable | stable | n/a |
 
@@ -54,7 +56,8 @@ Legend:
 This file is a living dashboard. Reviewers check truthfulness on every PR that touches a crate's public surface, test suite, or docs. Canon §17 DoD includes "MATURITY.md row updated if the PR changes crate state."
 
 Last full sweep: 2026-04-17 (Pass 4 of docs architecture redesign).
-Last targeted revision: 2026-05-20 — **M12.2 nebula-credential + nebula-credential-runtime stabilize sweep:**
+Last targeted revision: 2026-05-26 — **Crate inventory truth pass:** removed ghost rows for crates that no longer exist (`nebula-runtime`, `nebula-telemetry` — merged into `nebula-metrics` per ADR-0046; `nebula-testing` — never landed); added missing rows for crates that do exist (`nebula-storage-port`, `nebula-storage-loom-probe`, `nebula-tenancy`, `nebula-credential-vault`, `nebula-credential-testutil`). README crate map, `.ai-factory/*` layer maps, and `.github/copilot-instructions.md` synced in the same change.
+Prior: 2026-05-20 — **M12.2 nebula-credential + nebula-credential-runtime stabilize sweep:**
 `nebula-credential` API stability `frontier → stable` (error taxonomy reshape, SecretBox migration, ValidatedCredentialBinding, resolve_for_slot seam, fallback-on-interrupt, three-registry probe, dyn-compat probe, AuthStyle moved to scheme::oauth2, testutil extracted, ADR-0084 defers proactive refresh to 1.1). `nebula-credential-runtime` row added at `stable` (ADR-0066 facade extracted; all M12.2 hardening items in production path).
 Prior: 2026-05-15 — **nebula-api Phase 0 structural refactor (behavior-neutral):**
 worktree `restructure` (branch `refactor/api-restructure`) converts `nebula-api` from a

--- a/docs/adr/0083-agent-intent-honesty-gate.md
+++ b/docs/adr/0083-agent-intent-honesty-gate.md
@@ -1,8 +1,9 @@
 ---
 id: 0083
 title: agent-intent-honesty-gate
-status: proposed
+status: accepted
 date: 2026-05-18
+accepted: 2026-05-26
 supersedes: []
 superseded_by: []
 tags: [agent-harness, hooks, anti-reward-hacking, structural-budget, enforced-discipline, observability]


### PR DESCRIPTION
## Wave 2 — AI-context truth pass

Closes audit findings **A1 / B3 / B6 / H1 / H2 / H5 / M2 / M3** from
`.pi-audit-2026-05/00-FINAL-REPORT.md` (env / docs audit run on
2026-05-26).

### Why this is the single most important pass of the audit

Stale duplicated layer maps in agent-context files were the single
biggest source of LLM hallucinations on this workspace. Five different
files carried five different copies of the layer table, and three of
them referenced **crates that do not exist** (`nebula-system`,
`nebula-telemetry`, `nebula-runtime`, `nebula-testing`) or **listed
plugin-sdk under the wrong tier**. Every Copilot/Claude/Cursor session
opening this repo built its mental model from drifted docs.

The canonical layer map already lives in `CLAUDE.md` and is mechanically
enforced by `cargo deny check` against `deny.toml [[bans.wrappers]]`.
This PR stops everyone else duplicating it.

### What

Five atomic commits:

1. **`docs: sync MATURITY crate inventory to current workspace members`**
   Drops `nebula-runtime`, `nebula-telemetry`, `nebula-testing` ghost
   rows (those crates do not exist). Adds rows for `nebula-storage-port`,
   `nebula-storage-loom-probe`, `nebula-tenancy`,
   `nebula-credential-vault`, `nebula-credential-testutil`.

2. **`docs: refresh README crate map and INTEGRATION_MODEL telemetry references`**
   Adds the 5 missing rows to README crate map; drops `system` row;
   updates the metrics row note. `docs/INTEGRATION_MODEL.md` collapses
   the two-tier `telemetry → metrics` stack into a single `metrics`
   bullet (ADR-0046).

3. **`docs: collapse duplicated layer maps in agent-context files, defer to CLAUDE.md`**
   Rewrites `.ai-factory/DESCRIPTION.md`, `.ai-factory/ARCHITECTURE.md`,
   `.ai-factory/rules/base.md`, and `AGENTS.md` to **stop duplicating**
   the layer map and point at `CLAUDE.md` + `deny.toml` instead. Trims
   AGENTS.md from 33 → 13 lines. Preserves all substantive
   agent-actionable content in ARCHITECTURE.md (Dependency Rules,
   Communication, 7 Key Principles, 4 Code Examples, Anti-Patterns).

4. **`docs(github): rewrite copilot-instructions to defer layer map to CLAUDE.md`**
   Drops `nebula-telemetry::MetricsRegistry` reference (the crate is
   gone; code matching it would not compile). Drops the inline layer
   hierarchy in "What to Flag". Points Copilot at CLAUDE.md +
   `cargo deny check` as the authoritative gate.

5. **`docs: accept ADR-0083 agent-intent-honesty-gate`**
   Frontmatter `status: proposed → accepted` + adds
   `accepted: 2026-05-26`. The diff-scoped budget hook is already shipped
   (#705) and `docs/QUALITY_GATES.md` describes it in present tense;
   ADR shouldn't contradict canon.

### Verification

- Fresh-context adversarial reviewer audit: **GO** with two
  non-blocking nits (see `.pi-audit-2026-05/wave2-reviewer.md`).
- One nit folded into this PR: README quick layer block now lists
  `credential-runtime` + `credential-testutil` to match the detail
  table.
- Other nit (`plugin-sdk` + `sandbox` listed under Exec in README
  while CLAUDE.md introduced a Plugin-Proto tier) is **pre-existing
  drift** not in scope here — tracked as Wave 4 follow-up.
- `git diff --stat origin/main..HEAD`: 9 files, +163/-198 lines.
- Workspace member count cross-checked against `Cargo.toml`
  `[workspace.members]`: **29 first-party crates** under `crates/`
  (excluding `*/macros`, `apps/server`, `examples`) — every one is in
  the README crate map now.
- `rg 'nebula-telemetry|nebula-system|crates/system|crates/telemetry'`
  over the touched files: every match is in explicit
  "absorbed / drift / removed / gone" context.

### Out of scope (Wave 3+)

- `.ai-factory/ROADMAP.md` still has stale `nebula-telemetry` /
  `nebula-system` references. That file is part of the broader
  `.ai-factory/` retire-or-keep decision in Wave 3 (audit C3); not
  patching it here would just postpone the larger decision.
- README's quick layer block lists `plugin-sdk` + `sandbox` under
  `Exec` while CLAUDE.md introduced a `Plugin-Proto` tier — pre-existing
  drift, Wave 4 follow-up.
- Per-crate README missing for `crates/credential-testutil/` and
  `crates/storage-loom-probe/` — Wave 4 follow-up (audit D1).

### Reviewer notes

This PR is all docs/comments; no `.rs` or `.toml` (config) change. No
behavioural risk. The biggest visible change is `.ai-factory/ARCHITECTURE.md`
shrinking from 281 → 256 lines (-25 lines net) by replacing two
duplicated diagrams with explicit pointers; substantive
agent-actionable content unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated comprehensive architectural documentation with clarified layered dependency structure and enforcement guidelines
  * Refreshed workspace crate inventory and module structure guidance
  * Consolidated metrics documentation, reflecting unified metrics path
  * Updated developer and agent instruction guides with revised architecture references

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->