### PR TITLE
docs: remove nebula-config, clarify nebula-log telemetry feature

### DIFF
--- a/.ai-factory/ARCHITECTURE.md
+++ b/.ai-factory/ARCHITECTURE.md
@@ -55,11 +55,20 @@ tests, typed events for cross-crate seams.**
   scope-enforcing decorator that wraps a raw `storage-port` adapter so a
   tenant scope is substituted on every call before it reaches a handler
   (ADR-0072).
-- **`nebula-telemetry` is gone** — merged into `nebula-metrics` as the
-  single metrics path (ADR-0046). If you see `nebula-telemetry` referenced
-  anywhere in the working tree, it is drift, not real.
+- **`nebula-telemetry` (the old metric-primitives crate) is gone** —
+  merged into `nebula-metrics` as the single metrics path (ADR-0046). If
+  you see `nebula-telemetry` referenced as a workspace crate, it is drift.
+  The wider observability concept of *telemetry* (OpenTelemetry OTLP
+  distributed tracing, Sentry error reporting) lives in `nebula-log`
+  under the `telemetry` and `sentry` Cargo features respectively, not in
+  a separate crate.
 - **`nebula-system` is gone** — the cross-platform host-probe crate was
   deleted (#668). There is no process-monitoring crate today.
+- **`nebula-config` is gone** — a separate host-configuration crate was
+  considered but never landed and was retired entirely. Workspace
+  configuration today is hand-rolled at the composition root
+  (`apps/server/src/compose.rs` + the `crates/api/src/config/` env-var
+  registry); do not look for a `nebula-config` crate.
 
 ## Folder Structure
 

--- a/.ai-factory/rules/base.md
+++ b/.ai-factory/rules/base.md
@@ -45,9 +45,13 @@
   tiers, not strictly Business. `nebula-storage-port` (Core) is the storage
   seam every consumer depends on; `nebula-storage` (Exec) is the sole
   adapter; `nebula-tenancy` (Business) is the scope-enforcing decorator that
-  wraps a raw `storage-port` adapter (ADR-0072). `nebula-telemetry` was
-  absorbed into `nebula-metrics` per ADR-0046; `nebula-system` was deleted
-  (#668) — if either is referenced in the working tree, it is drift.
+  wraps a raw `storage-port` adapter (ADR-0072).
+- Retired / gone crates (any reference to these as live workspace crates is
+  drift): `nebula-telemetry` was absorbed into `nebula-metrics` per
+  ADR-0046 (the wider observability concept now lives in `nebula-log` under
+  the `telemetry` and `sentry` Cargo features, not a separate crate);
+  `nebula-system` was deleted (#668); `nebula-config` was retired entirely
+  — host-config wiring lives in `apps/server` + `crates/api/src/config/`.
 
 ## Error Handling
 

--- a/docs/INTEGRATION_MODEL.md
+++ b/docs/INTEGRATION_MODEL.md
@@ -185,9 +185,8 @@ Besides the **integration** reference crates (§3.6–§3.9), the workspace ship
 - **`nebula-error`** — **`Classify`**, **`NebulaError`**, categories/codes, structured details — **one** error taxonomy at boundaries instead of ad hoc strings.
 - **`nebula-resilience`** — composable **pipelines** (retry, timeout, circuit breaker, bulkhead, …); pairs with **`ActionError`** / retry hints in **`nebula-action`** (§3.8).
 - **`nebula-validator`** — programmatic validators + declarative **`Rule`**; **`nebula-schema`** embeds rules in **`Field`** definitions.
-- **`nebula-config`** *(planned, not yet a workspace member)* — multi-source, merged, optionally hot-reloaded **host** configuration (binaries/services) — **not** the per-node **`Schema`** story.
-- **`nebula-log`** — structured **`tracing`** pipeline (init, sinks, optional OTel/Sentry hooks).
-- **`nebula-metrics`** — lock-free in-memory primitives (registry, histograms, label interning) plus **`nebula_*` naming**, adapters, Prometheus-style **export** and label-safety guards. **Absorbs the former `nebula-telemetry` crate** — one metrics path, no two-tier stack (ADR-0046).
+- **`nebula-log`** — structured **`tracing`** pipeline (init, sinks, layers, reload). Cargo features `telemetry` (OpenTelemetry OTLP tracing exporter) and `sentry` ship the distributed-tracing/error-reporting integrations; both are off by default.
+- **`nebula-metrics`** — the single metrics path: lock-free in-memory primitives (`MetricsRegistry`, `Counter`, `Gauge`, `Histogram`, label interning) **plus** `nebula_*` naming, label-safety guards, and Prometheus-style export. Absorbs the former `nebula-telemetry` metric-primitives crate (ADR-0046).
 - **`nebula-eventbus`** — typed **broadcast** bus with back-pressure policy; **transport only** — domain **`E`** types live in owning crates.
 - **`nebula-expression`** — workflow **expression** evaluation (variable access, operators, functions) for dynamic fields — headless, not a UI.
 - **`nebula-workflow`** + **`nebula-execution`** — the execution semantics core: workflow validation/shape and durable execution lifecycle/state transitions. Read these when the question is "what does the engine guarantee at runtime," not just "how integrations are authored."


### PR DESCRIPTION
## Wave 2.1 \u2014 corrections after merged PR #740

Owner feedback after PR #740 merged:
1. `nebula-config` is gone **entirely** \u2014 not 'planned'. The host-config
   crate was retired and is not planned to return.
2. The wider observability concept of 'telemetry' (OpenTelemetry OTLP +
   Sentry) lives in **`nebula-log` under Cargo features `telemetry`/`sentry`**,
   not in a separate crate. ADR-0046 was specifically about the old
   primitive-metrics crate `nebula-telemetry` (absorbed into
   `nebula-metrics`); these are two distinct things.

### Changes

- **`docs/INTEGRATION_MODEL.md`**: drop the `nebula-config` bullet; expand
  the `nebula-log` bullet to mention the `telemetry`/`sentry` Cargo
  features (both off by default); tighten the `nebula-metrics` bullet to
  name the actual primitive types it ships.
- **`.ai-factory/ARCHITECTURE.md`** and **`.ai-factory/rules/base.md`**:
  rewrite the "retired / gone crates" notes so agents do not conflate
  the absorbed primitive-metrics crate with the OpenTelemetry/Sentry
  feature flags in `nebula-log`. Add `nebula-config` to the explicit
  'retired entirely' list with a pointer to where host-config wiring
  lives today (`apps/server/src/compose.rs` + `crates/api/src/config/`).

### Out of scope

- `crates/validator/docs/migration.md` and `crates/validator/docs/api-reference.md`
  still mention `nebula-config` as a downstream/contract reference. Those
  are **historical migration notes** about a past contract surface, not
  live workspace claims; left as-is for the same reason MATURITY journal
  entries keep their historical context.