### PR TITLE
docs: project-shared Pi tooling configs (conventions / auditor / subagents)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -107,6 +107,7 @@ id_ed25519
 .codex/
 .atl/
 .pi/*
+!.pi/settings.json
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/

--- a/.claudeignore
+++ b/.claudeignore
@@ -102,10 +102,14 @@ id_ed25519
 .auto-claude-security.json
 .claude_settings.json
 
-# AI tool runtime dirs — mirrors .gitignore
+# AI tool runtime dirs — mirrors .gitignore (committed project configs
+# under .pi/ are exempted so Claude indexes the shared tooling config).
 .codex/
 .atl/
-.pi/
+.pi/*
+!.pi/conventions.json
+!.pi/codebase-wiki.json
+!.pi/wiki/
 .pi-audit-*/
 .compound-engineering/*.local.yaml
 

--- a/.cursorignore
+++ b/.cursorignore
@@ -69,8 +69,11 @@ credentials/
 # Codex CLI: OAuth tokens, SQLite session DBs (hundreds of MB), conversation logs
 .codex/
 
-# Pi / Gentle-AI per-user runtime
-.pi/
+# Pi / Gentle-AI per-user runtime (project configs exempted below)
+.pi/*
+!.pi/conventions.json
+!.pi/codebase-wiki.json
+!.pi/wiki/
 .atl/
 
 # Compound Engineering per-project secrets / preferences

--- a/.cursorignore
+++ b/.cursorignore
@@ -71,6 +71,7 @@ credentials/
 
 # Pi / Gentle-AI per-user runtime (project configs exempted below)
 .pi/*
+!.pi/settings.json
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/

--- a/.doctorrc.yml
+++ b/.doctorrc.yml
@@ -1,0 +1,52 @@
+# pi-auditor (Doctor for Pi) — repository digestibility config.
+#
+# Thresholds tuned for a layered Rust workspace where the canonical
+# "small module" target is ~200-400 LOC but a few orchestration crates
+# (engine, api, storage-postgres) hit higher lines legitimately. Tests,
+# fuzz, generated code, and migrations are excluded.
+#
+# Commands:
+#   /doctor:audit              — full digestibility report
+#   /doctor:god-files          — list files exceeding maxLines with split suggestions
+#   /doctor:god-files --threshold 1000 — custom threshold for one-off audits
+#   /doctor:rules show         — show this config
+#   doctor_audit               — LLM-callable structured report
+#   doctor_check_file <path>   — single-file audit
+
+files:
+  # Warn above ~400 LOC. Most domain modules in this workspace fit under
+  # this once split by responsibility (see action/credential/api 2026 Q2
+  # refactor cascades).
+  maxLines: 400
+
+  # Hard ceiling. Modules over 1200 LOC have repeatedly shown drift /
+  # missing-responsibility-split in past audits (config.rs split,
+  # engine.rs incremental decomposition, idempotency split).
+  criticalLines: 1200
+
+  ignore:
+    # Build / vendored artifacts
+    - "target/**"
+    - ".worktrees/**"
+    - ".claude/worktrees/**"
+    - "**/Cargo.lock"
+
+    # Tests / property tests / fuzz — different shape; not RAG-relevant
+    - "**/tests/**"
+    - "**/*test*.rs"
+    - "**/probes/**"
+    - "**/fuzz/**"
+    - "**/golden/**"
+
+    # Generated / auto-managed code
+    - "**/*.generated.rs"
+    - "**/migrations/*.sql"
+    - "**/openapi.json"
+
+    # Documentation surfaces — long ADRs and roadmaps are intentional
+    - "docs/adr/HISTORICAL.md"
+    - "docs/ROADMAP.md"
+    - "CHANGELOG.md"
+
+    # Audit drops (point-in-time snapshots)
+    - ".pi-audit-*/**"

--- a/.gitignore
+++ b/.gitignore
@@ -235,12 +235,18 @@ crates/*/fuzz/Cargo.lock
 # ============================================================================
 # AI HARNESS RUNTIME STATE — symmetric with .codex/ above. Per-user, not
 # shared. `.atl/` holds the gentle-pi skill-registry cache; `.pi/` holds
-# per-project Pi settings / session state. Add new harness dirs here, not
-# scattered through the file.
+# per-project Pi settings / session state. Project-shared Pi configs
+# (conventions, codebase-wiki, etc.) are exempted below so contributors
+# pick up the same tooling on clone.
 # ============================================================================
 
 .atl/
-.pi/
+.pi/*
+
+# Committed project-shared Pi configs
+!.pi/conventions.json
+!.pi/codebase-wiki.json
+!.pi/wiki/
 
 # Local audit drops (point-in-time snapshots, not durable docs)
 .pi-audit-*/

--- a/.gitignore
+++ b/.gitignore
@@ -244,6 +244,7 @@ crates/*/fuzz/Cargo.lock
 .pi/*
 
 # Committed project-shared Pi configs
+!.pi/settings.json
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/

--- a/.pi/conventions.json
+++ b/.pi/conventions.json
@@ -1,0 +1,133 @@
+{
+  "$schema": "https://unpkg.com/pi-conventions/conventions.schema.json",
+  "extendsGlobal": true,
+  "ignorePaths": [
+    "target/**",
+    ".worktrees/**",
+    ".claude/worktrees/**",
+    "**/fuzz/Cargo.lock",
+    "**/criterion/**",
+    "**/*.generated.rs",
+    ".pi-audit-*/**"
+  ],
+  "policies": {
+    "structure": {
+      "mode": "warn",
+      "editMode": "warn",
+      "sourceRoots": ["crates/", "apps/", "examples/"],
+      "forbiddenSegments": ["utils", "helpers", "common", "misc", "shared"]
+    },
+    "naming": {
+      "rules": [
+        {
+          "id": "naming.rs.snake-case",
+          "prefixes": ["crates/", "apps/"],
+          "pathKinds": ["file", "directory"],
+          "extensions": ["rs"],
+          "requireCase": "snake_case",
+          "forbiddenNames": ["util", "utils", "helper", "helpers", "common", "misc", "shared"]
+        },
+        {
+          "id": "naming.crates.kebab-case",
+          "prefixes": ["crates/"],
+          "pathKinds": ["directory"],
+          "depth": 1,
+          "requireCase": "kebab-case",
+          "requirePrefix": "",
+          "description": "Crate directories under crates/ use kebab-case without the nebula- prefix (the crate name in Cargo.toml carries the prefix)."
+        }
+      ]
+    },
+    "size": {
+      "mode": "warn",
+      "limits": [
+        {
+          "id": "size.rs.module-700",
+          "prefixes": ["crates/", "apps/"],
+          "extensions": ["rs"],
+          "exclude": [
+            "**/tests/**",
+            "**/*test*.rs",
+            "**/probes/**",
+            "**/fuzz/**",
+            "**/golden/**",
+            "**/*.generated.rs"
+          ],
+          "maxLines": 700,
+          "description": "Source modules over 700 lines are usually a sign of god-file drift — split by responsibility (per the action/credential/api refactors in 2026Q2). Tests and fuzz/probes are exempt."
+        },
+        {
+          "id": "size.rs.module-critical-1500",
+          "prefixes": ["crates/", "apps/"],
+          "extensions": ["rs"],
+          "exclude": [
+            "**/tests/**",
+            "**/*test*.rs",
+            "**/probes/**",
+            "**/fuzz/**",
+            "**/golden/**",
+            "**/*.generated.rs"
+          ],
+          "maxLines": 1500,
+          "level": "error",
+          "description": "Hard upper bound. Modules over 1500 lines block merges until split."
+        }
+      ]
+    },
+    "documentation": {
+      "mode": "warn",
+      "rules": [
+        {
+          "id": "docs.crate-readme",
+          "pattern": "crates/*/",
+          "requireFile": "README.md",
+          "description": "Every workspace crate must ship a README.md (Rust API Guidelines C-CRATE-DOC)."
+        }
+      ]
+    },
+    "dependencies": {
+      "mode": "warn",
+      "description": "Layer-boundary enforcement is mechanical via deny.toml [[bans.deny]].wrappers — see CLAUDE.md § Layered Dependency Map. This convention here is advisory and complements (not replaces) cargo deny check.",
+      "rules": [
+        {
+          "id": "deps.core-not-business",
+          "from": "crates/{core,validator,expression,workflow,execution,schema,metadata,storage-port}/",
+          "forbid": [
+            "nebula-engine",
+            "nebula-storage",
+            "nebula-storage-loom-probe",
+            "nebula-sandbox",
+            "nebula-plugin-sdk",
+            "nebula-api",
+            "nebula-sdk",
+            "nebula-action",
+            "nebula-credential-builtin",
+            "nebula-credential-vault",
+            "nebula-credential-runtime",
+            "nebula-resource",
+            "nebula-plugin",
+            "nebula-tenancy"
+          ]
+        },
+        {
+          "id": "deps.business-not-exec-api",
+          "from": "crates/{credential,credential-builtin,credential-vault,credential-runtime,credential-testutil,resource,action,plugin,tenancy}/",
+          "forbid": [
+            "nebula-engine",
+            "nebula-storage",
+            "nebula-storage-loom-probe",
+            "nebula-sandbox",
+            "nebula-plugin-sdk",
+            "nebula-api",
+            "nebula-sdk"
+          ]
+        },
+        {
+          "id": "deps.exec-not-api",
+          "from": "crates/{engine,storage,storage-loom-probe}/",
+          "forbid": ["nebula-api", "nebula-sdk"]
+        }
+      ]
+    }
+  }
+}

--- a/.pi/settings.json
+++ b/.pi/settings.json
@@ -1,0 +1,30 @@
+{
+  "subagents": {
+    "agentOverrides": {
+      "scout": {
+        "model": "anthropic/claude-sonnet-4",
+        "thinking": "medium"
+      },
+      "context-builder": {
+        "model": "anthropic/claude-sonnet-4",
+        "thinking": "medium"
+      },
+      "reviewer": {
+        "model": "anthropic/claude-opus-4-7",
+        "thinking": "high"
+      },
+      "worker": {
+        "model": "anthropic/claude-opus-4-7",
+        "thinking": "high"
+      },
+      "planner": {
+        "model": "anthropic/claude-opus-4-7",
+        "thinking": "xhigh"
+      },
+      "oracle": {
+        "model": "anthropic/claude-opus-4-7",
+        "thinking": "xhigh"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,9 @@ between siblings at the same layer.
 | `.claude/hooks/`              | Committed guard hooks (enforced discipline) |
 | `.claude/skills/rust-intel/`  | Vendored LLM-Rust-failure-mode skill — v0.2.2, MIT, advisory (not hook-enforced); `/rust-cc-{audit,fix,plan}` slash commands (see its `UPSTREAM.md`) |
 | `.claude/commands/`           | Slash-command definitions for the vendored skills above |
+| `.pi/settings.json`           | [`pi-subagents`](https://pi.dev/packages/pi-subagents) `agentOverrides` — per-project model + thinking-level overrides for built-in subagents (scout/context-builder on sonnet+medium for cheap recon; reviewer/worker on opus+high; planner/oracle on opus+xhigh) |
+| `.pi/conventions.json`        | [`pi-conventions`](https://pi.dev/packages/pi-conventions) policy — structure / naming / size / dependency rules tuned for this Rust workspace; `/conventions audit` runs the repo scan |
+| `.doctorrc.yml`               | [`pi-auditor`](https://pi.dev/packages/pi-auditor) config — god-file thresholds + ignore paths for `/doctor:audit` and `/doctor:god-files` |
 
 > The AI Factory framework (`.ai-factory/`, `.ai-factory.json`,
 > `.claude/skills/aif-*`, `.github/skills/aif-*`, the `.claude/agents/`


### PR DESCRIPTION
## Project-shared Pi tooling configs

Wave 5 of the env/docs cleanup begun in PR #739 / #740 / #741 / #744.
Adds the **project-local configuration** for the new Pi packages
installed globally:

- **`@vigolium/piolium`** — security audits, no static config (learns
  project matchers via `/piolium-learn --apply`).
- **`pi-conventions`** — structure / naming / size / dependency policy.
  Config: `.pi/conventions.json`.
- **`pi-auditor`** ("Doctor for Pi") — RAG-digestibility audit, god-file
  detection. Config: `.doctorrc.yml`.
- **`@mrclrchtr/supi-code-intelligence`** — code intelligence
  (`code_brief`, `code_map`, `code_relations`, `code_affected`,
  `code_pattern`, `code_refactor`, full `lsp_*` + `tree_sitter_*`
  toolset). No static config — activates by default.
- **`@0xkobold/pi-codebase-wiki`** — self-updating codebase wiki from
  git history. Runtime state under `.codebase-wiki/` (gitignored).
- **`pi-subagents`** — already installed; `.pi/settings.json` adds
  per-project `agentOverrides` for the builtin fleet.

### Three atomic commits

```
779bc037  docs: configure pi-subagents agentOverrides for Nebula
5cf0937c  docs(scripts): add .doctorrc.yml for pi-auditor god-file detection
33717cd7  chore(ci): allowlist committed Pi config files under .pi/
```

### What ships

1. **`.pi/conventions.json`** — `pi-conventions` policy
   - `size.rs.module-700` (warn) + `size.rs.module-critical-1500`
     (error) for `crates/`, `apps/`, excluding tests/probes/fuzz/golden
   - `naming.rs.snake-case` for Rust files & dirs; `naming.crates.kebab-case`
     for `crates/<name>/` directories
   - `structure` policy forbidding `utils/`, `helpers/`, `common/`,
     `misc/`, `shared/` segments under sourceRoots
   - `documentation.docs.crate-readme` — every workspace crate must
     ship a `README.md` (Rust API Guidelines C-CRATE-DOC)
   - `dependencies` policy mirroring `deny.toml [[bans.deny]].wrappers`
     layer enforcement as a sanity-check side-channel

2. **`.doctorrc.yml`** — `pi-auditor` config
   - `maxLines: 400` (warn) + `criticalLines: 1200` (error) tuned for
     this workspace's domain modules
   - Ignores `target/`, `.worktrees/`, tests, fuzz, generated code,
     migrations, openapi.json, `docs/adr/HISTORICAL.md`,
     `docs/ROADMAP.md`, `CHANGELOG.md`, `.pi-audit-*/`

3. **`.pi/settings.json`** — `pi-subagents` `agentOverrides`
   - scout, context-builder: claude-sonnet-4 + medium thinking
     (fast/cheap recon)
   - reviewer, worker: claude-opus-4-7 + high thinking
     (audit accuracy / single-writer reliability)
   - planner, oracle: claude-opus-4-7 + xhigh thinking
     (design / decision-consistency)

4. **`.gitignore` / `.cursorignore` / `.claudeignore`** — switch the
   blanket `.pi/` rule to `.pi/*` + explicit negations so the three
   project-shared configs (`settings.json`, `conventions.json`,
   `codebase-wiki.json`) and the optional `wiki/` directory are
   committed while per-user runtime state (sessions/, log/, cache/)
   stays ignored.

5. **`CLAUDE.md`** — § "AI Context Files" table updated to enumerate
   the three new project-shared Pi configs.

### Out of scope

- piolium learns project-local matchers at runtime via
  `/piolium-learn --apply`; nothing static to commit until the first
  audit run produces candidates.
- pi-codebase-wiki state under `.codebase-wiki/` is auto-generated
  from git history + docs; left gitignored until a contributor opts
  into committing the generated pages.
- supi-code-intelligence ships its full tool surface (`code_*`,
  `lsp_*`, `tree_sitter_*`) without a project config — activates
  automatically.
