### PR TITLE
docs: address PR #746 Copilot review (.pi/wiki/** + conventions.json TOML notation)

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -111,6 +111,7 @@ id_ed25519
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/
+!.pi/wiki/**
 .pi-audit-*/
 .compound-engineering/*.local.yaml
 

--- a/.cursorignore
+++ b/.cursorignore
@@ -75,6 +75,7 @@ credentials/
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/
+!.pi/wiki/**
 .atl/
 
 # Compound Engineering per-project secrets / preferences

--- a/.gitignore
+++ b/.gitignore
@@ -248,6 +248,7 @@ crates/*/fuzz/Cargo.lock
 !.pi/conventions.json
 !.pi/codebase-wiki.json
 !.pi/wiki/
+!.pi/wiki/**
 
 # Local audit drops (point-in-time snapshots, not durable docs)
 .pi-audit-*/

--- a/.pi/conventions.json
+++ b/.pi/conventions.json
@@ -87,7 +87,7 @@
     },
     "dependencies": {
       "mode": "warn",
-      "description": "Layer-boundary enforcement is mechanical via deny.toml [[bans.deny]].wrappers — see CLAUDE.md § Layered Dependency Map. This convention here is advisory and complements (not replaces) cargo deny check.",
+      "description": "Layer-boundary enforcement is mechanical via the `wrappers` allowlists on the `[bans].deny` entries in `deny.toml` — see CLAUDE.md § Layered Dependency Map. This convention here is advisory and complements (not replaces) `cargo deny check`.",
       "rules": [
         {
           "id": "deps.core-not-business",


### PR DESCRIPTION
## Wave 5 fixup \u2014 Copilot review on PR #746

PR #746 (project-shared Pi tooling configs) was already merged when
Copilot review came in. Two non-blocking advisory issues that should
land separately:

1. `!.pi/wiki/` in `.gitignore`, `.cursorignore`, `.claudeignore`
   only exempts the directory entry itself; with `.pi/*` ignored
   above, files under `.pi/wiki/` stay ignored. Add explicit
   `!.pi/wiki/**` so the actual wiki content (if a contributor opts
   into committing the pi-codebase-wiki output) is exempted
   recursively. Standard git gotcha.

2. `.pi/conventions.json` description referenced
   `deny.toml [[bans.deny]].wrappers`, which is invalid TOML
   notation for this repo. The structure is `[bans]` with
   `deny = [{ crate, wrappers, ... }]` \u2014 i.e. `wrappers` is a
   field on the array elements of `[bans].deny`. Same error fixed
   in PR #740 commit `3b954465`; repeated in #746 conventions
   config. Use prose 'wrappers allowlists on the [bans].deny entries
   in deny.toml' to point at the correct location.

Both purely advisory \u2014 the `.pi/wiki/` rule has no content to
exempt today (pi-codebase-wiki writes runtime state under
`.codebase-wiki/` instead), and the conventions.json description
is a comment-string the tooling reads but does not parse as TOML.
Still worth fixing so the next Copilot review pass on this surface
does not surface the same false-positive.