### PR TITLE
docs: fix credential-testutil + storage-loom-probe READMEs (rewrite to match reality)

### DIFF
--- a/crates/credential-testutil/README.md
+++ b/crates/credential-testutil/README.md
@@ -1,61 +1,75 @@
 ---
 name: nebula-credential-testutil
-role: Test shims for downstream credential consumers
+role: In-memory test doubles for credential storage
 status: stable
 last-reviewed: 2026-05-26
-related: [nebula-credential, nebula-credential-runtime]
+related: [nebula-credential, nebula-credential-runtime, nebula-tenancy]
 ---
 
 # nebula-credential-testutil
 
 ## Purpose
 
-`nebula-credential-testutil` ships the **test fixtures, mock adapters,
-and assertion helpers** that downstream crates use to exercise the
-`nebula-credential` contract surface without standing up a full
-credential runtime.
+`nebula-credential-testutil` ships **in-memory test doubles** for the
+two credential-storage ports defined by `nebula-credential`. Downstream
+crates that need to exercise the credential contract without standing
+up a real backend (Vault, Postgres, an OAuth IdP) depend on this crate
+in their `dev-dependencies`.
 
-Extracted from `nebula-credential` during the M12.2 stabilize sweep
-(2026-05-20) so the contract crate itself stays free of `test-util`
-gated code paths. See `docs/MATURITY.md` for the extraction rationale
-and `nebula-credential` README for the parent contract.
+The crate was extracted from `nebula-credential` during the M12.2
+stabilize sweep (2026-05-20) so the contract crate itself stays free
+of `test-util` gated code paths. See `docs/MATURITY.md` for the
+extraction rationale.
 
-## What's inside
+## Public surface
 
-- **In-memory `CredentialStore` mock** — round-trips encrypted credential
-  rows without persistence; covers create / read / update / delete +
-  rotation semantics for adapter tests.
-- **Snapshot fixtures** — pre-built `StoredCredential` rows that mirror
-  the canonical OAuth2 / API-key / mTLS / Basic shapes the workspace
-  ships, ready to feed into resolver / dispatch tests.
-- **Assertion helpers** — `assert_no_plaintext_drop` and friends that
-  verify the zeroization invariants on `Drop` paths without manually
-  reaching into `SecretBox` internals.
-- **`scheme` builders** — minimal `AuthScheme` factories so resource /
-  action tests can construct credential bindings without depending on
-  `nebula-credential-builtin`.
+The full crate surface fits in a single import block:
+
+```rust
+use nebula_credential_testutil::{
+    InMemoryStore,        // implements nebula_credential::store::CredentialStore
+    InMemoryPendingStore, // implements nebula_credential::store::PendingCredentialStore
+    in_memory_pair,       // -> (InMemoryStore, InMemoryPendingStore)
+};
+```
+
+That is the full export list as of v0.1.0
+(`crates/credential-testutil/src/lib.rs`). Both stores are simple
+`Mutex`-backed `HashMap` implementations sufficient for unit and
+integration tests of credential consumers; they intentionally do not
+emulate persistence, encryption, or concurrent eviction semantics.
 
 ## Layer
 
-This crate sits in the **Business** layer alongside `nebula-credential`
-itself; the `deny.toml` `[bans].deny[].wrappers` allowlist locks the
-exact consumer set. It is **test-only** (`publish = false`) — production
+Sits in the **Business** layer alongside `nebula-credential` itself;
+the `deny.toml` `[bans].deny[].wrappers` allowlist locks the exact
+consumer set. It is **test-only** (`publish = false`) — production
 crates must depend on `nebula-credential` directly, never on this
 helper.
+
+Current consumers (dev-deps only):
+
+- `nebula-credential-runtime` — facade tests under the `test-util`
+  feature, plus its own integration suite.
+- `nebula-tenancy` — scope-enforcement tests over the in-memory
+  stores.
 
 ## Out of scope
 
 - Production credential storage (see `nebula-storage` adapter + the
   `nebula-credential` contract).
 - First-party credential type catalog (see `nebula-credential-builtin`).
-- Runtime facade / dispatch coordination (see `nebula-credential-runtime`,
-  ADR-0066).
+- Runtime facade / dispatch coordination (see
+  `nebula-credential-runtime`).
+- Snapshot fixtures, redaction assertions, scheme builders, or any
+  other helper not exported by `lib.rs` today — those are *not* part
+  of this crate.
 
 ## Related
 
 - `crates/credential/` — contract crate this helper supports.
-- `crates/credential-runtime/` — runtime facade (ADR-0066) that
-  consumes this in its own tests.
-- `crates/credential-vault/` — Vault-backed backend; uses these
-  fixtures in its integration tests.
+- `crates/credential-runtime/` — runtime facade; primary consumer.
+- `crates/tenancy/` — scope-enforcement decorator; secondary consumer.
+- ADR-0081 — M6 resource/credential integration (absorbs the earlier
+  ADR-0042–0045, 0051, 0066–0067 cascade per `docs/adr/README.md`).
 - `docs/MATURITY.md` — extraction record (2026-05-20).

--- a/crates/storage-loom-probe/README.md
+++ b/crates/storage-loom-probe/README.md
@@ -1,9 +1,9 @@
 ---
 name: nebula-storage-loom-probe
-role: Loom-checked concurrency probe for storage critical sections
+role: Standalone loom-checked concurrency probe (CAS atomicity)
 status: partial
 last-reviewed: 2026-05-26
-related: [nebula-storage, nebula-storage-port, nebula-credential]
+related: [nebula-storage, nebula-credential]
 ---
 
 # nebula-storage-loom-probe
@@ -12,9 +12,16 @@ related: [nebula-storage, nebula-storage-port, nebula-credential]
 
 `nebula-storage-loom-probe` is a **standalone, loom-checked probe**
 that re-creates the CAS shape used by the credential refresh-claim
-pattern (ADR-0041) and exercises it under `loom`'s concurrency model
-checker. It exists so the refresh-coordinator's atomicity invariant
-is *proven*, not just unit-tested.
+pattern and exercises it under `loom`'s concurrency model checker. It
+exists so the refresh-coordinator's atomicity invariant is *proven*,
+not just unit-tested.
+
+The CAS shape is implemented locally inside this crate — the design
+notes for the underlying refresh-claim pattern lived in ADR-0041
+(now historical, see `docs/adr/HISTORICAL.md` row for `0041`); the
+production implementation lives in `nebula-storage`. **This probe does
+not depend on `nebula-storage`** (see "Why a standalone crate?" below);
+the manifest carries only an optional `loom` dependency.
 
 ## Why a standalone crate?
 
@@ -25,31 +32,35 @@ Those crates have their own `cfg(loom)` blocks that import `loom::sync`
 from their own dep graph — they never declared loom, so the build
 fails when the cfg leaks in transitively.
 
-This probe is a sibling crate that depends **only on `loom`**, so
-`--cfg loom` activates code only where `loom` is in scope. The probe
-mirrors `nebula_storage::credential::InMemoryRefreshClaimRepo::try_claim`
-shape (`Mutex<HashMap<id, ClaimRow>>` + expiry check + write) with
-`loom::sync::Mutex` so the model checker can explore lock acquisition
-itself.
+This probe is a sibling crate that depends **only on `loom`** (and
+only when the `loom-test` feature is on), so `--cfg loom` activates
+code only where `loom` is in scope. The probe mirrors the
+`Mutex<HashMap<id, ClaimRow>>` + expiry check + write shape used by
+the production refresh-claim repo with `loom::sync::Mutex` so the
+model checker can explore lock acquisition itself.
 
 ## Layer
 
-The crate sits in the **Exec** layer per CLAUDE.md § "Layered Dependency
-Map" — it imports the credential-claim shape from `nebula-storage` but
-otherwise stays leaf. Not consumed by any production crate; runs only
-under `RUSTFLAGS="--cfg loom"` in CI / dev.
+The crate sits in the **Exec** layer per CLAUDE.md § "Layered
+Dependency Map". Not consumed by any production crate; runs only under
+`RUSTFLAGS="--cfg loom"` in dev / CI.
 
 ## Running the probe
+
+The crate exposes the `loom-test` Cargo feature
+(`crates/storage-loom-probe/Cargo.toml`); enable it together with the
+`--cfg loom` rustc flag:
 
 ```bash
 RUSTFLAGS="--cfg loom" cargo nextest run \
   -p nebula-storage-loom-probe \
-  --features loom
+  --features loom-test \
+  --profile ci --no-tests=pass
 ```
 
 The probe file itself is gated by `#![cfg(loom)]`, so a normal
-`cargo check -p nebula-storage-loom-probe` is cheap and does not
-require the loom dep.
+`cargo check -p nebula-storage-loom-probe` (no feature, no cfg) is
+cheap and does not require the loom dep at all.
 
 ## Out of scope
 
@@ -64,5 +75,6 @@ require the loom dep.
 - `crates/storage/` — the production adapter whose CAS pattern this
   probe mirrors.
 - `crates/storage-port/` — Core storage seam (ADR-0072).
-- ADR-0041 — refresh-coordinator design that drives this probe.
-- ADR-0072 — `storage-port` / `storage` / `tenancy` redesign.
+- ADR-0041 (historical, `docs/adr/HISTORICAL.md`) — the refresh-claim
+  design that motivates this probe.
+- ADR-0072 — live `storage-port` / `storage` / `tenancy` redesign.


### PR DESCRIPTION
## Fixup for PR #748 \u2014 11 inline review hits

PR #748 shipped per-crate READMEs that claimed APIs and dependencies
that do not exist. Eleven inline review comments from Copilot,
chatgpt-codex-connector, and CodeRabbit on #748 surfaced them all.
Rewriting both READMEs strictly from the actual code.

### credential-testutil

Real exports per `src/lib.rs`:
- `InMemoryStore` (impls `CredentialStore`)
- `InMemoryPendingStore` (impls `PendingCredentialStore`)
- `in_memory_pair()`

That is the **entire** public surface. The previous README claimed
'Snapshot fixtures', 'assert_no_plaintext_drop helpers', and 'scheme
builders' \u2014 none exist.

Real consumers per `rg credential-testutil crates/*/Cargo.toml`:
- `nebula-credential-runtime` (dev-deps + optional `test-util` feature)
- `nebula-tenancy` (dev-deps)

NOT `nebula-credential-vault` (no dep on testutil).

ADR-0066 reference replaced with **ADR-0081** (ADR-0066 was evicted;
absorbed by ADR-0081 per `docs/adr/README.md`).

### storage-loom-probe

- Dropped claim that the probe 'imports the credential-claim shape
  from `nebula-storage`'. The manifest **intentionally** has no
  `nebula-storage` dep (the whole reason this exists as a sibling
  crate); the CAS shape is mirrored locally.
- Fixed run command: `--features loom` -> `--features loom-test`
  (the actual feature name in Cargo.toml). Added the
  `--profile ci --no-tests=pass` nextest flags per CodeRabbit
  suggestion.
- Qualified ADR-0041 references as historical (evicted to
  `docs/adr/HISTORICAL.md` per the 2026-05-18 eviction pass).
  ADR-0072 remains live as a related anchor.

### Verification

- New READMEs sanity-checked against `grep '^pub' src/lib.rs`,
  `Cargo.toml` deps + features, `docs/adr/HISTORICAL.md` /
  `docs/adr/README.md` ADR live-list.
- No Rust code touched; no public surface change.
- `convco check` passes.

### Lesson

Original PR #748 commit message claimed 'no new claims invented' and
then invented 8+ across 2 READMEs. Pattern saved to project memory:
always run the source-truth checklist before shipping per-crate
README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated credential test utility documentation, clarifying the public interface, scope, and intended usage patterns for downstream testing.
* Revised storage concurrency probe documentation with updated testing instructions and related design references.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/749?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->