### PR TITLE
docs: third-pass fix for credential-testutil + storage-loom-probe READMEs

### DIFF
--- a/crates/credential-testutil/README.md
+++ b/crates/credential-testutil/README.md
@@ -13,8 +13,7 @@ related: [nebula-credential, nebula-credential-runtime, nebula-tenancy]
 `nebula-credential-testutil` ships **in-memory test doubles** for the
 two credential-storage ports defined by `nebula-credential`. Downstream
 crates that need to exercise the credential contract without standing
-up a real backend (Vault, Postgres, an OAuth IdP) depend on this crate
-in their `dev-dependencies`.
+up a real backend (Vault, Postgres, an OAuth IdP) depend on this crate.
 
 The crate was extracted from `nebula-credential` during the M12.2
 stabilize sweep (2026-05-20) so the contract crate itself stays free
@@ -23,36 +22,45 @@ extraction rationale.
 
 ## Public surface
 
-The full crate surface fits in a single import block:
-
 ```rust
 use nebula_credential_testutil::{
-    InMemoryStore,        // implements nebula_credential::store::CredentialStore
-    InMemoryPendingStore, // implements nebula_credential::store::PendingCredentialStore
+    InMemoryStore,        // impls nebula_credential::store::CredentialStore
+    InMemoryPendingStore, // impls nebula_credential::pending_store::PendingStateStore
     in_memory_pair,       // -> (InMemoryStore, InMemoryPendingStore)
 };
+
+// The two backing modules are also re-exported publicly:
+use nebula_credential_testutil::{pending_store_memory, store_memory};
 ```
 
-That is the full export list as of v0.1.0
-(`crates/credential-testutil/src/lib.rs`). Both stores are simple
-`Mutex`-backed `HashMap` implementations sufficient for unit and
-integration tests of credential consumers; they intentionally do not
-emulate persistence, encryption, or concurrent eviction semantics.
+That is the full public surface as of v0.1.0 (verify with
+`grep '^pub' crates/credential-testutil/src/lib.rs`). Both stores
+hold their data in `Arc<tokio::sync::RwLock<HashMap<...>>>`. Cloning
+either store produces another handle to the same backing map
+(cheap `Arc` clone), so tests can share a single store across multiple
+task handles. All data is lost when the last clone drops.
+
+Both shims are **behaviour-identical** to the production
+`InMemoryStore` / `InMemoryPendingStore` in
+`nebula_storage::credential::*`; they live here only so the
+`nebula-credential` contract crate does not have to export
+`#[cfg(test)]`-style code itself. Production composition roots should
+import the `nebula-storage` variants.
 
 ## Layer
 
-Sits in the **Business** layer alongside `nebula-credential` itself;
-the `deny.toml` `[bans].deny[].wrappers` allowlist locks the exact
-consumer set. It is **test-only** (`publish = false`) — production
-crates must depend on `nebula-credential` directly, never on this
-helper.
+Sits in the **Business** layer alongside `nebula-credential` itself.
+The `deny.toml` `[bans].deny[].wrappers` allowlist locks the exact
+consumer set. The crate is **internal-only** (`publish = false`).
 
-Current consumers (dev-deps only):
+Real consumers (`rg credential-testutil crates/*/Cargo.toml`):
 
-- `nebula-credential-runtime` — facade tests under the `test-util`
-  feature, plus its own integration suite.
-- `nebula-tenancy` — scope-enforcement tests over the in-memory
-  stores.
+- **`nebula-credential-runtime`** — declared in two roles in its
+  manifest: an optional normal dependency activated by the
+  `test-util` feature **and** a `dev-dependency` for its own test
+  suite.
+- **`nebula-tenancy`** — `dev-dependency` for scope-enforcement tests
+  over the in-memory stores.
 
 ## Out of scope
 
@@ -68,8 +76,9 @@ Current consumers (dev-deps only):
 ## Related
 
 - `crates/credential/` — contract crate this helper supports.
-- `crates/credential-runtime/` — runtime facade; primary consumer.
-- `crates/tenancy/` — scope-enforcement decorator; secondary consumer.
+- `crates/credential-runtime/` — runtime facade; primary consumer
+  (both via the `test-util` feature and dev-deps).
+- `crates/tenancy/` — scope-enforcement decorator; dev-deps consumer.
 - ADR-0081 — M6 resource/credential integration (absorbs the earlier
   ADR-0042–0045, 0051, 0066–0067 cascade per `docs/adr/README.md`).
 - `docs/MATURITY.md` — extraction record (2026-05-20).

--- a/crates/storage-loom-probe/README.md
+++ b/crates/storage-loom-probe/README.md
@@ -1,27 +1,30 @@
 ---
 name: nebula-storage-loom-probe
-role: Standalone loom-checked concurrency probe (CAS atomicity)
+role: Standalone loom-checked concurrency probes for storage critical sections
 status: partial
 last-reviewed: 2026-05-26
-related: [nebula-storage, nebula-credential]
+related: [nebula-storage, nebula-credential, nebula-execution]
 ---
 
 # nebula-storage-loom-probe
 
 ## Purpose
 
-`nebula-storage-loom-probe` is a **standalone, loom-checked probe**
-that re-creates the CAS shape used by the credential refresh-claim
-pattern and exercises it under `loom`'s concurrency model checker. It
-exists so the refresh-coordinator's atomicity invariant is *proven*,
-not just unit-tested.
+`nebula-storage-loom-probe` is a **standalone, loom-checked sibling
+crate** that hosts concurrency-model-checker probes for critical
+sections in `nebula-storage`. As of today it ships two probes
+(verify with `ls crates/storage-loom-probe/src/` and
+`ls crates/storage-loom-probe/tests/`):
 
-The CAS shape is implemented locally inside this crate — the design
-notes for the underlying refresh-claim pattern lived in ADR-0041
-(now historical, see `docs/adr/HISTORICAL.md` row for `0041`); the
-production implementation lives in `nebula-storage`. **This probe does
-not depend on `nebula-storage`** (see "Why a standalone crate?" below);
-the manifest carries only an optional `loom` dependency.
+| Probe | Module | Test file | What it proves |
+|---|---|---|---|
+| Refresh-claim CAS | `lib.rs` body (`ClaimRow`, `Mutex<HashMap<…>>`) | `tests/refresh_claim_loom.rs` | At-most-one-valid-claim per `credential_id` under the production `InMemoryRefreshClaimRepo::try_claim` shape. |
+| Execution-lease handoff | `pub mod lease_handoff` | `tests/lease_handoff_loom.rs` | Single-owner invariant for the execution-lease handoff dance. |
+
+Both probes mirror the production shape locally — the crate
+**intentionally has no `nebula-storage` dependency** (see "Why a
+standalone crate?" below); shapes are re-implemented inside this
+crate against `loom::sync`.
 
 ## Why a standalone crate?
 
@@ -34,10 +37,12 @@ fails when the cfg leaks in transitively.
 
 This probe is a sibling crate that depends **only on `loom`** (and
 only when the `loom-test` feature is on), so `--cfg loom` activates
-code only where `loom` is in scope. The probe mirrors the
-`Mutex<HashMap<id, ClaimRow>>` + expiry check + write shape used by
-the production refresh-claim repo with `loom::sync::Mutex` so the
-model checker can explore lock acquisition itself.
+code only where `loom` is in scope. The probe re-creates the CAS
+shape used in
+`nebula_storage::credential::InMemoryRefreshClaimRepo::try_claim`
+(a `Mutex<HashMap<id, ClaimRow>>` + expiry check + write) with
+`loom::sync::Mutex` so the model checker can explore lock acquisition
+itself.
 
 ## Layer
 
@@ -45,11 +50,13 @@ The crate sits in the **Exec** layer per CLAUDE.md § "Layered
 Dependency Map". Not consumed by any production crate; runs only under
 `RUSTFLAGS="--cfg loom"` in dev / CI.
 
-## Running the probe
+## Running the probes
 
 The crate exposes the `loom-test` Cargo feature
 (`crates/storage-loom-probe/Cargo.toml`); enable it together with the
-`--cfg loom` rustc flag:
+`--cfg loom` rustc flag.
+
+Both probes (run separately or together):
 
 ```bash
 RUSTFLAGS="--cfg loom" cargo nextest run \
@@ -58,23 +65,43 @@ RUSTFLAGS="--cfg loom" cargo nextest run \
   --profile ci --no-tests=pass
 ```
 
-The probe file itself is gated by `#![cfg(loom)]`, so a normal
-`cargo check -p nebula-storage-loom-probe` (no feature, no cfg) is
-cheap and does not require the loom dep at all.
+Only one probe at a time:
+
+```bash
+# Refresh-claim CAS
+RUSTFLAGS="--cfg loom" cargo nextest run \
+  -p nebula-storage-loom-probe --features loom-test \
+  --profile ci --no-tests=pass \
+  --test refresh_claim_loom
+
+# Execution-lease handoff
+RUSTFLAGS="--cfg loom" cargo nextest run \
+  -p nebula-storage-loom-probe --features loom-test \
+  --profile ci --no-tests=pass \
+  --test lease_handoff_loom
+```
+
+The crate root and probe test files are gated by `#![cfg(loom)]`, so a
+normal `cargo check -p nebula-storage-loom-probe` (no feature, no cfg)
+is cheap and does not require the loom dep at all.
 
 ## Out of scope
 
 - Production storage code — see `nebula-storage` (Exec adapter) and
   `nebula-storage-port` (Core seam, ADR-0072).
-- Other concurrency invariants — this probe is scoped to the
-  refresh-claim CAS shape only. Each probe added in the future should
-  follow the same sibling-crate / `cfg(loom)` discipline.
+- Probes for invariants outside the two listed above. Each new probe
+  should land here under the same sibling-crate / `cfg(loom)` /
+  `loom-test` feature discipline.
 
 ## Related
 
-- `crates/storage/` — the production adapter whose CAS pattern this
-  probe mirrors.
+- `crates/storage/` — production adapter whose CAS patterns these
+  probes mirror.
 - `crates/storage-port/` — Core storage seam (ADR-0072).
-- ADR-0041 (historical, `docs/adr/HISTORICAL.md`) — the refresh-claim
-  design that motivates this probe.
+- `crates/credential/` — the credential contract whose refresh-claim
+  pattern motivates the first probe.
+- `crates/execution/` — owns the execution-lease lifecycle whose
+  handoff motivates the second probe.
+- ADR-0041 (historical, `docs/adr/HISTORICAL.md`) — original
+  refresh-claim design.
 - ADR-0072 — live `storage-port` / `storage` / `tenancy` redesign.


### PR DESCRIPTION
## Third revision \u2014 closes 6 review hits from PR #749

PR #749 (first fixup for PR #748) shipped READMEs that still had six
wrong claims. Six inline comments from Copilot and CodeRabbit on #749
surfaced them all. Every claim cross-checked against `src/lib.rs`,
`Cargo.toml`, and `tests/` this time.

### credential-testutil fixes

- **Trait paths:** `nebula_credential::store::PendingCredentialStore`
  was not real. Actual paths (verified against
  `src/store_memory.rs:18` and `src/pending_store_memory.rs:19-20`):
  `nebula_credential::store::CredentialStore` and
  `nebula_credential::pending_store::PendingStateStore`.
- **Lock primitive:** said 'Mutex-backed'. Both stores use
  `Arc<tokio::sync::RwLock<HashMap<...>>>` (src/store_memory.rs:16,
  src/pending_store_memory.rs:15). Fixed wording + added clone-semantics
  note.
- **Public surface:** missed the two public modules
  (`pending_store_memory`, `store_memory`) that `lib.rs` also
  re-exports. Added to the import code block.
- **Consumer roles:** 'dev-deps only' was wrong for
  `nebula-credential-runtime` \u2014 its Cargo.toml declares the crate as
  both an optional normal dependency (line 25, gated by the
  `test-util` feature) AND a dev-dependency (line 50). Reworded.

### storage-loom-probe fixes

- The crate ships **two** probes, not one. Previous README only
  covered the refresh-claim CAS shape and missed the
  `lease_handoff` probe (`pub mod lease_handoff` in lib.rs:31,
  `tests/lease_handoff_loom.rs`). Added a Probes table at the top
  enumerating both, plus per-probe run commands.

### Verification

Every claim cross-checked before commit:
1. Trait paths -> `rg` in `credential/src/store.rs` + `pending_store.rs`
2. Lock primitive -> `rg 'tokio::sync::'` in `testutil/src/`
3. Public modules -> `grep '^pub' testutil/src/lib.rs`
4. Consumer roles -> `rg credential-testutil` in `credential-runtime`
   + `tenancy` Cargo.toml
5. storage-loom-probe probes -> `find tests/` + `rg 'pub mod' lib.rs`
6. No `nebula-storage` dep -> `grep storage-loom-probe/Cargo.toml`

### Pattern note

This is the third iteration on the same two READMEs (17 false claims
caught across PR #748 + #749 review). Discipline written to project
memory: always run the six-step source-truth checklist before opening
any per-crate README PR.