### PR TITLE
test(api): e2e lockout coverage for PgAuthBackend

### DIFF
--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -47,7 +47,17 @@ use nebula_api::{
     },
     ports::email::{EchoSink, EmailKind, EmailPort},
 };
+use nebula_core::UserId;
 use sqlx::{Pool, Postgres, postgres::PgPoolOptions};
+
+/// Mirrors `nebula_storage::pg::user::LOCKOUT_THRESHOLD` (the module is
+/// `pub(crate)` so the constant is not re-exported from
+/// `nebula-storage`). If the storage-side value changes from 5, this
+/// constant must change with it; the lockout assertions below will
+/// otherwise fail loudly (off-by-one between the test loop bound and
+/// the storage-side CASE check) — which is the desired regression
+/// signal. Source: `crates/storage/src/pg/user.rs:34`.
+const LOCKOUT_THRESHOLD_LOCAL: u32 = 5;
 
 // `sqlx::migrate!` resolves paths relative to the calling crate's
 // `CARGO_MANIFEST_DIR` (`crates/api`); the production schema lives in
@@ -538,5 +548,274 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
     assert!(
         matches!(correct_err, AuthError::NotImplemented(_)),
         "expected NotImplemented after successful consume, got: {correct_err:?}"
+    );
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Lockout coverage (M3.1 follow-up)
+//
+// Storage-layer logic in `crates/storage/src/pg/user.rs`
+// (`record_login_failure` arms `locked_until` once
+// `failed_login_count + 1 >= LOCKOUT_THRESHOLD`) and
+// `PgAuthBackend::authenticate_password` returns `AuthError::AccountLocked`
+// when `users.locked_until > NOW()`. Both surfaces have unit-test
+// coverage in their owning crates; the three tests below drive the
+// end-to-end flow through the backend trait so a future refactor that
+// breaks the wiring is caught against the production code path.
+//
+// The current rate-limit middleware (`crates/api/src/middleware/rate_limit.rs`)
+// is per-IP only; a per-account dimension is explicitly out of scope
+// of this follow-up — the lockout column is the auth-aware throttle
+// surface for 1.0.
+// ─────────────────────────────────────────────────────────────────────
+
+/// Convert the `UserProfile::user_id` String back into the 16-byte
+/// payload that the `users` PG table indexes on.
+fn user_id_bytes(user_id: &str) -> [u8; 16] {
+    user_id
+        .parse::<UserId>()
+        .expect("user_id must round-trip through ULID parser")
+        .as_bytes()
+}
+
+/// Run an authenticated `register_user` + `verify_email` flow so the
+/// account is in the same state every lockout test starts from.
+async fn verified_user(
+    backend: &Arc<PgAuthBackend>,
+    sink: &Arc<EchoSink>,
+    email: &str,
+) -> nebula_api::domain::auth::backend::UserProfile {
+    let profile = backend
+        .register_user(signup_for(email))
+        .await
+        .expect("register_user");
+    let verification_token = {
+        let drained = sink.drain();
+        assert_eq!(
+            drained.len(),
+            1,
+            "register_user must enqueue exactly one verification email"
+        );
+        assert_eq!(drained[0].kind, EmailKind::Verification);
+        drained[0].body.clone()
+    };
+    backend
+        .verify_email(&verification_token)
+        .await
+        .expect("verify_email");
+    profile
+}
+
+/// Read `(failed_login_count, locked_until)` directly from the row so
+/// the test can assert the storage-layer state independent of the
+/// backend's read path.
+async fn lockout_state(
+    pool: &Pool<Postgres>,
+    user_id: &str,
+) -> (i32, Option<chrono::DateTime<chrono::Utc>>) {
+    let id_bytes = user_id_bytes(user_id);
+    sqlx::query_as::<_, (i32, Option<chrono::DateTime<chrono::Utc>>)>(
+        "SELECT failed_login_count, locked_until FROM users WHERE id = $1",
+    )
+    .bind(&id_bytes[..])
+    .fetch_one(pool)
+    .await
+    .expect("SELECT lockout state")
+}
+
+/// Force-expire the lockout window without sleeping for 15 minutes.
+/// Mirrors what a future operator unlock RPC would do, but the test
+/// owns the manipulation explicitly so the production code path stays
+/// untouched. Asserts the row exists so a typo'd id fails loudly.
+async fn expire_lockout(pool: &Pool<Postgres>, user_id: &str) {
+    let id_bytes = user_id_bytes(user_id);
+    let rows = sqlx::query(
+        "UPDATE users \
+             SET locked_until = NOW() - INTERVAL '1 second' \
+             WHERE id = $1 AND locked_until IS NOT NULL",
+    )
+    .bind(&id_bytes[..])
+    .execute(pool)
+    .await
+    .expect("UPDATE locked_until")
+    .rows_affected();
+    assert_eq!(
+        rows, 1,
+        "expire_lockout must touch exactly one armed lock; got {rows}"
+    );
+}
+
+/// Lockout fires once `record_login_failure` crosses
+/// `LOCKOUT_THRESHOLD`. The Nth wrong-password attempt still returns
+/// `InvalidCredentials` (the lock arms on the same call but the
+/// pre-check guard already let it through); the (N+1)th attempt
+/// observes the armed lock and short-circuits to `AccountLocked`.
+#[tokio::test]
+async fn pg_auth_backend_locks_after_threshold_failures() {
+    let Some(pool) = pool().await else { return };
+    let (backend, sink) = build_backend(pool.clone());
+    let email = unique_email("lockout");
+    let profile = verified_user(&backend, &sink, &email).await;
+
+    // Drive N wrong-password attempts. Each is `InvalidCredentials`;
+    // the Nth call records the failure that arms `locked_until`.
+    for attempt in 1..=LOCKOUT_THRESHOLD_LOCAL {
+        let err = backend
+            .authenticate_password(&email, "wrong-password", None)
+            .await
+            .expect_err("wrong password must reject before lockout");
+        assert!(
+            matches!(err, AuthError::InvalidCredentials),
+            "attempt {attempt}/{LOCKOUT_THRESHOLD_LOCAL} must surface InvalidCredentials, got: {err:?}"
+        );
+    }
+
+    // Storage row reflects the armed lockout immediately.
+    let (count_at_lock, locked_until) = lockout_state(&pool, &profile.user_id).await;
+    assert_eq!(
+        count_at_lock, LOCKOUT_THRESHOLD_LOCAL as i32,
+        "failed_login_count must equal the threshold after N rejected attempts"
+    );
+    let lock_deadline = locked_until.expect("locked_until must be armed");
+    assert!(
+        lock_deadline > chrono::Utc::now(),
+        "locked_until ({lock_deadline}) must be in the future immediately after the Nth failure"
+    );
+
+    // The (N+1)th attempt — even with the CORRECT password — must be
+    // rejected with AccountLocked, NOT InvalidCredentials. This is the
+    // pre-password lockout guard at `pg.rs:authenticate_password`.
+    let locked_err = backend
+        .authenticate_password(&email, "hunter22", None)
+        .await
+        .expect_err("correct password during lockout window must reject");
+    assert!(
+        matches!(locked_err, AuthError::AccountLocked),
+        "locked account must surface AccountLocked, got: {locked_err:?}"
+    );
+
+    // The wrong password during the lockout window also surfaces
+    // AccountLocked — proves the guard runs before the password check
+    // (no `record_login_failure` side-effect; counter does not
+    // increment past the threshold).
+    let wrong_during_lock = backend
+        .authenticate_password(&email, "still-wrong", None)
+        .await
+        .expect_err("wrong password during lockout window must reject");
+    assert!(
+        matches!(wrong_during_lock, AuthError::AccountLocked),
+        "wrong password during lockout must surface AccountLocked, got: {wrong_during_lock:?}"
+    );
+    let (count_after_locked_attempts, _) = lockout_state(&pool, &profile.user_id).await;
+    assert_eq!(
+        count_after_locked_attempts, LOCKOUT_THRESHOLD_LOCAL as i32,
+        "failed_login_count must not grow once the lockout pre-check fires"
+    );
+}
+
+/// Once the lockout window expires, a correct-password login must
+/// succeed and `record_login_success` must clear both the failure
+/// counter and `locked_until`.
+#[tokio::test]
+async fn pg_auth_backend_lockout_window_expiry_allows_login() {
+    let Some(pool) = pool().await else { return };
+    let (backend, sink) = build_backend(pool.clone());
+    let email = unique_email("lockout-expire");
+    let profile = verified_user(&backend, &sink, &email).await;
+
+    // Drive the account into the locked state.
+    for _ in 0..LOCKOUT_THRESHOLD_LOCAL {
+        let _ = backend
+            .authenticate_password(&email, "wrong-password", None)
+            .await
+            .expect_err("wrong password must reject");
+    }
+    let (_, locked_until) = lockout_state(&pool, &profile.user_id).await;
+    assert!(
+        locked_until.is_some(),
+        "sanity: account must be locked before we expire the window"
+    );
+
+    // Force-expire the window without waiting 15 minutes.
+    expire_lockout(&pool, &profile.user_id).await;
+
+    // Correct password during the expired window succeeds. The user
+    // has no MFA enabled, so the outcome is Authenticated.
+    match backend
+        .authenticate_password(&email, "hunter22", None)
+        .await
+        .expect("authenticate_password after lockout expiry")
+    {
+        PasswordOutcome::Authenticated(p) => {
+            assert_eq!(p.user_id, profile.user_id);
+        },
+        PasswordOutcome::MfaRequired { .. } => {
+            panic!("MFA is not enabled on the lockout fixture")
+        },
+    }
+
+    // record_login_success cleared both columns.
+    let (final_count, final_lock) = lockout_state(&pool, &profile.user_id).await;
+    assert_eq!(
+        final_count, 0,
+        "successful auth must reset failed_login_count to 0"
+    );
+    assert!(
+        final_lock.is_none(),
+        "successful auth must clear locked_until, got: {final_lock:?}"
+    );
+}
+
+/// Negative control: below-threshold failures followed by a single
+/// success must clear the counter without ever arming the lock. This
+/// covers the `record_login_success` side-effect on the happy path
+/// and proves the threshold check is `>=` not `>`.
+#[tokio::test]
+async fn pg_auth_backend_success_clears_subthreshold_failures() {
+    let Some(pool) = pool().await else { return };
+    let (backend, sink) = build_backend(pool.clone());
+    let email = unique_email("lockout-clears");
+    let profile = verified_user(&backend, &sink, &email).await;
+
+    // Drive THRESHOLD - 1 wrong-password attempts. Each is
+    // InvalidCredentials; the lock must NOT arm.
+    let below_threshold = LOCKOUT_THRESHOLD_LOCAL - 1;
+    for attempt in 1..=below_threshold {
+        let err = backend
+            .authenticate_password(&email, "wrong-password", None)
+            .await
+            .expect_err("sub-threshold wrong password must reject");
+        assert!(
+            matches!(err, AuthError::InvalidCredentials),
+            "sub-threshold attempt {attempt} must surface InvalidCredentials, got: {err:?}"
+        );
+    }
+    let (mid_count, mid_lock) = lockout_state(&pool, &profile.user_id).await;
+    assert_eq!(
+        mid_count, below_threshold as i32,
+        "failed_login_count must reflect each below-threshold failure"
+    );
+    assert!(
+        mid_lock.is_none(),
+        "sub-threshold failures must never arm locked_until, got: {mid_lock:?}"
+    );
+
+    // One successful authentication wipes the counter.
+    match backend
+        .authenticate_password(&email, "hunter22", None)
+        .await
+        .expect("correct password below threshold must succeed")
+    {
+        PasswordOutcome::Authenticated(p) => assert_eq!(p.user_id, profile.user_id),
+        PasswordOutcome::MfaRequired { .. } => panic!("MFA is not enabled"),
+    }
+    let (after_count, after_lock) = lockout_state(&pool, &profile.user_id).await;
+    assert_eq!(
+        after_count, 0,
+        "successful auth must reset failed_login_count, got: {after_count}"
+    );
+    assert!(
+        after_lock.is_none(),
+        "successful auth must keep locked_until null when never armed, got: {after_lock:?}"
     );
 }

--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -627,11 +627,15 @@ async fn lockout_state(
 /// Mirrors what a future operator unlock RPC would do, but the test
 /// owns the manipulation explicitly so the production code path stays
 /// untouched. Asserts the row exists so a typo'd id fails loudly.
+///
+/// Uses `INTERVAL '1 hour'` instead of `'1 second'` so a PG-vs-test
+/// process clock skew >1 s (common in containerised CI) cannot leave
+/// the row still locked when the test next probes (#751 Copilot review).
 async fn expire_lockout(pool: &Pool<Postgres>, user_id: &str) {
     let id_bytes = user_id_bytes(user_id);
     let rows = sqlx::query(
         "UPDATE users \
-             SET locked_until = NOW() - INTERVAL '1 second' \
+             SET locked_until = NOW() - INTERVAL '1 hour' \
              WHERE id = $1 AND locked_until IS NOT NULL",
     )
     .bind(&id_bytes[..])
@@ -677,8 +681,13 @@ async fn pg_auth_backend_locks_after_threshold_failures() {
         "failed_login_count must equal the threshold after N rejected attempts"
     );
     let lock_deadline = locked_until.expect("locked_until must be armed");
+    // Allow 5 s of negative skew: PG and the test process can disagree on
+    // wall-clock time by ~1 s in containerised CI; treating the lock as
+    // armed if `lock_deadline` is at least "recent" past gives the test
+    // headroom without weakening the assertion (LOCKOUT_DURATION is 15 min
+    // so a 5 s skew is still ~0.5% of the window) (#751 Copilot review).
     assert!(
-        lock_deadline > chrono::Utc::now(),
+        lock_deadline > chrono::Utc::now() - chrono::Duration::seconds(5),
         "locked_until ({lock_deadline}) must be in the future immediately after the Nth failure"
     );
 


### PR DESCRIPTION
## Summary

Closes M3.1 follow-up — **"Lockout integration tests against the PG backend"** per [`docs/ROADMAP.md`](https://github.com/vanyastaff/nebula/blob/main/docs/ROADMAP.md) §M3.1.

Part of the M3.1 follow-up wave per [`docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md`](https://github.com/vanyastaff/nebula/blob/main/docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md) (PR-A of 3).

## What

Adds three `#[tokio::test]` cases to `crates/api/tests/auth_pg_e2e.rs` (+279 LOC, test-only) covering the lockout state machine end-to-end against `PgAuthBackend`:

1. `pg_auth_backend_locks_after_threshold_failures` — drives `LOCKOUT_THRESHOLD` wrong-password attempts; asserts each surfaces `InvalidCredentials`; verifies `users.locked_until` arms on the threshold-crossing call; asserts the next attempt (correct or wrong password) is short-circuited with `AccountLocked` and `failed_login_count` does not grow past the threshold (proves the pre-check fires before `record_login_failure`).
2. `pg_auth_backend_lockout_window_expiry_allows_login` — force-expires `locked_until` to simulate window elapse; asserts the next correct-password attempt returns `Ok` and clears `(failed_login_count, locked_until)`.
3. `pg_auth_backend_success_clears_subthreshold_failures` — negative control: `THRESHOLD - 1` failures (no lock) → one success → state cleared.

## Why

The lockout logic was complete in storage (`crates/storage/src/pg/user.rs:34,37,242-270`) and exercised by `PgAuthBackend::authenticate_password` (`crates/api/src/domain/auth/backend/pg.rs:382-430`), but `rg "locked_until" crates/api/tests/` returned zero matches before this PR — no e2e coverage existed for the locked-out path against the production backend.

## Scope discipline

This PR touches **only** `crates/api/tests/auth_pg_e2e.rs`. Zero changes to:
- `crates/storage/src/pg/user.rs` (lockout SQL is correct and shipping)
- `crates/api/src/domain/auth/backend/pg.rs` (`AccountLocked` check is in place)
- `crates/api/src/middleware/rate_limit.rs` (per-account rate-limit is a separate enhancement and not what this follow-up gates)

## Test evidence

```
DATABASE_URL=postgresql://nebula:nebula@localhost:5432/nebula \
  cargo nextest run -p nebula-api --test auth_pg_e2e --features postgres
Summary [2.447s] 8 tests run: 8 passed, 0 skipped
```

Reviewer (fresh-context) re-ran twice — no flake, deterministic.

## Notes

- `LOCKOUT_THRESHOLD_LOCAL = 5` mirrors the storage const. `pub(crate) mod user` in `crates/storage/src/pg/mod.rs` blocks a direct import; the drift signal is engineered into the test assertions (off-by-one in either direction surfaces as a `matches!` panic with a clear diagnostic). A one-line `pub use` to upgrade this to a compile-time link is a small sibling-PR follow-up, not part of this PR.
- The workspace `task dev:check` reveals **pre-existing failures in `nebula-storage` `pg::control_queue` tests** (`column reference "id" is ambiguous` at `crates/storage/src/pg/control_queue.rs:1058`). Independently reproduced on `origin/main` with no contribution from this PR (empty diff to `crates/storage/`). To be filed as a separate issue.

## Plan + recon

- Plan: `docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md` §PR-A
- Recon: `docs/plans/recon/m3.1-followup-wave-recon.md` §PR-A
- Worker report: `docs/plans/recon/pr-a-worker-report.md`
- Reviewer report: `docs/plans/recon/pr-a-reviewer-report.md`

(Recon/plan files exist on the parent worktree; landing them as a tracked artifact is the parent's responsibility after this PR squash-merges.)