### PR TITLE
feat(api): nebula_api_auth_* counters + AuthError mapping audit

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -182,7 +182,12 @@ impl ServerRuntime {
         // read from `state.email_port` and work uniformly regardless of
         // which auth backend is wired.
         let email_port: Arc<dyn EmailPort> = Arc::new(EchoSink::default());
-        let auth_backend = build_auth_backend(&api_config, Arc::clone(&email_port)).await?;
+        let auth_backend = build_auth_backend(
+            &api_config,
+            Arc::clone(&email_port),
+            Some(Arc::clone(&metrics_registry)),
+        )
+        .await?;
         state = state
             .with_auth_backend(auth_backend)
             .with_email_port(email_port);
@@ -300,12 +305,15 @@ pub fn default_state(
 pub async fn build_auth_backend(
     api_config: &ApiConfig,
     email_port: Arc<dyn EmailPort>,
+    metrics_registry: Option<Arc<MetricsRegistry>>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
     match api_config.auth.backend {
         AuthBackendKind::Memory => Ok(Arc::new(
-            InMemoryAuthBackend::new().with_email_port(email_port),
+            InMemoryAuthBackend::new()
+                .with_email_port(email_port)
+                .with_metrics(metrics_registry),
         )),
-        AuthBackendKind::Postgres => build_pg_auth_backend(email_port).await,
+        AuthBackendKind::Postgres => build_pg_auth_backend(email_port, metrics_registry).await,
     }
 }
 
@@ -404,6 +412,7 @@ async fn build_pg_idempotency_store(
 #[cfg(feature = "postgres")]
 async fn build_pg_auth_backend(
     email_port: Arc<dyn EmailPort>,
+    metrics_registry: Option<Arc<MetricsRegistry>>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
     use nebula_api::domain::auth::backend::PgAuthBackend;
     use sqlx::postgres::PgPoolOptions;
@@ -426,13 +435,15 @@ async fn build_pg_auth_backend(
         backend = "postgres",
         "auth: PG-backed identity backend wired"
     );
-    let backend: Arc<dyn AuthBackend> = Arc::new(PgAuthBackend::new(pool, email_port));
+    let backend: Arc<dyn AuthBackend> =
+        Arc::new(PgAuthBackend::new(pool, email_port, metrics_registry));
     Ok(backend)
 }
 
 #[cfg(not(feature = "postgres"))]
 async fn build_pg_auth_backend(
     _email_port: Arc<dyn EmailPort>,
+    _metrics_registry: Option<Arc<MetricsRegistry>>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
     Err(TransportInitError::AuthBackendUnavailable {
         requested: "postgres",

--- a/crates/api/src/domain/auth/backend/error.rs
+++ b/crates/api/src/domain/auth/backend/error.rs
@@ -141,12 +141,99 @@ impl From<AuthError> for ApiError {
 #[cfg(test)]
 mod tests {
     use axum::http::StatusCode;
+    use nebula_metrics::naming::auth_outcome;
 
     use super::*;
 
     fn status(e: AuthError) -> StatusCode {
         let api: ApiError = e.into();
         api.to_problem_details().0
+    }
+
+    /// Exhaustive mapping from [`AuthError`] to a closed
+    /// `nebula_metrics::naming::auth_outcome::*` label.
+    ///
+    /// **This is the compile-time gate for the auth metrics cardinality
+    /// budget.** The `match` deliberately has no catch-all arm: adding
+    /// a new [`AuthError`] variant fails compilation here until it has
+    /// a closed-set mapping. Per-method emission sites in
+    /// `crates/api/src/domain/auth/backend/{pg,in_memory}.rs` use their
+    /// own narrower `match`es to capture per-method overrides (e.g.
+    /// `complete_password_reset` collapses `InvalidCredentials` to
+    /// `invalid_input`, not the default `invalid_creds`); this function
+    /// is the safety net that guarantees *every* variant has at least
+    /// one valid label, not the source of truth for every emission site.
+    ///
+    /// Notable collapses documented in the oracle locked spec:
+    /// - `UserNotFound` -> `invalid_creds` (user-enumeration defence;
+    ///   see [`auth_outcome::INVALID_CREDS`] doc comment).
+    /// - `NotImplemented` / `Crypto` / `Internal` -> `internal`
+    ///   (operator-side, not caller-side).
+    fn default_outcome_for(err: &AuthError) -> &'static str {
+        match err {
+            AuthError::NotImplemented(_) => auth_outcome::INTERNAL,
+            AuthError::EmailAlreadyRegistered => auth_outcome::CONFLICT,
+            AuthError::UserNotFound => auth_outcome::INVALID_CREDS,
+            AuthError::InvalidCredentials => auth_outcome::INVALID_CREDS,
+            AuthError::InvalidInput(_) => auth_outcome::INVALID_INPUT,
+            AuthError::AccountLocked => auth_outcome::LOCKOUT,
+            AuthError::EmailNotVerified => auth_outcome::EMAIL_UNVERIFIED,
+            AuthError::MfaRequired => auth_outcome::MFA_REQUIRED,
+            AuthError::InvalidMfaCode => auth_outcome::INVALID_MFA_CODE,
+            AuthError::InvalidToken => auth_outcome::TOKEN_INVALID,
+            AuthError::RateLimit => auth_outcome::RATE_LIMIT,
+            AuthError::OAuthFailed(_) => auth_outcome::OAUTH_FAILED,
+            AuthError::Crypto(_) => auth_outcome::INTERNAL,
+            AuthError::Internal(_) => auth_outcome::INTERNAL,
+        }
+    }
+
+    #[test]
+    fn every_auth_error_variant_has_a_closed_outcome_label() {
+        // Enumerates all 14 `AuthError` variants and confirms each maps
+        // to a closed `auth_outcome::*` constant. The compile-time gate
+        // is `default_outcome_for`'s exhaustive `match`; this test
+        // additionally verifies the label values are non-empty closed
+        // strings.
+        let cases: [(&str, AuthError); 14] = [
+            ("NotImplemented", AuthError::NotImplemented("x")),
+            ("EmailAlreadyRegistered", AuthError::EmailAlreadyRegistered),
+            ("UserNotFound", AuthError::UserNotFound),
+            ("InvalidCredentials", AuthError::InvalidCredentials),
+            ("InvalidInput", AuthError::InvalidInput("x")),
+            ("AccountLocked", AuthError::AccountLocked),
+            ("EmailNotVerified", AuthError::EmailNotVerified),
+            ("MfaRequired", AuthError::MfaRequired),
+            ("InvalidMfaCode", AuthError::InvalidMfaCode),
+            ("InvalidToken", AuthError::InvalidToken),
+            ("RateLimit", AuthError::RateLimit),
+            ("OAuthFailed", AuthError::OAuthFailed("x".into())),
+            ("Crypto", AuthError::Crypto("x".into())),
+            ("Internal", AuthError::Internal("x".into())),
+        ];
+        for (name, err) in &cases {
+            let outcome = default_outcome_for(err);
+            assert!(!outcome.is_empty(), "{name} produced empty outcome label");
+            // Verify the outcome is one of the 12 closed-set values.
+            let closed = [
+                auth_outcome::SUCCESS,
+                auth_outcome::INVALID_CREDS,
+                auth_outcome::INVALID_INPUT,
+                auth_outcome::INVALID_MFA_CODE,
+                auth_outcome::MFA_REQUIRED,
+                auth_outcome::TOKEN_INVALID,
+                auth_outcome::LOCKOUT,
+                auth_outcome::EMAIL_UNVERIFIED,
+                auth_outcome::RATE_LIMIT,
+                auth_outcome::OAUTH_FAILED,
+                auth_outcome::CONFLICT,
+                auth_outcome::INTERNAL,
+            ];
+            assert!(
+                closed.contains(&outcome),
+                "{name} -> {outcome:?} is not in the auth_outcome closed set",
+            );
+        }
     }
 
     #[test]

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -16,6 +16,13 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
 use nebula_core::{Principal, UserId};
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_API_AUTH_ATTEMPTS_TOTAL, NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+        NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL, auth_outcome,
+    },
+};
 
 use super::{
     dto::{SignupRequest, UserProfile},
@@ -26,7 +33,7 @@ use super::{
     pat::{self, MintedPat, PatRecord, compute_pat_expires_at},
     provider::{
         AuthBackend, CreatePatParams, MfaEnrollment, OAuthCompletion, OAuthStart, PasswordOutcome,
-        ProfilePatch,
+        ProfilePatch, metrics_emit,
     },
     session::{self, SESSION_TTL, SessionRecord, expires_at},
 };
@@ -111,6 +118,13 @@ pub struct InMemoryAuthBackend {
     /// in a custom port — callers that need introspection in that mode
     /// must keep their own `EchoSink` reference.
     default_echo: Option<Arc<EchoSink>>,
+    /// Optional `nebula_api_auth_*` emission seam (mirror of the
+    /// `PgAuthBackend` slot so the trait-level contract stays uniform).
+    /// `None` skips emission. Production composition root threads in
+    /// the shared `Arc<MetricsRegistry>`; the existing in-memory test
+    /// surface keeps `None` to preserve the previous no-emission
+    /// semantics.
+    metrics: Option<Arc<MetricsRegistry>>,
 }
 
 impl Default for InMemoryAuthBackend {
@@ -126,6 +140,7 @@ impl Default for InMemoryAuthBackend {
             oauth_state: DashMap::default(),
             email_port: Arc::clone(&echo) as Arc<dyn EmailPort>,
             default_echo: Some(echo),
+            metrics: None,
         }
     }
 }
@@ -190,6 +205,18 @@ impl InMemoryAuthBackend {
     pub fn with_email_port(mut self, port: Arc<dyn EmailPort>) -> Self {
         self.email_port = port;
         self.default_echo = None;
+        self
+    }
+
+    /// Wire an optional [`MetricsRegistry`] so the backend records
+    /// `nebula_api_auth_*` counters / histogram on every outcome
+    /// branch. Mirrors the `IdempotencyLayer::with_metrics` precedent
+    /// and the constructor injection on `super::pg::PgAuthBackend`
+    /// (feature-gated under `postgres`); tests that don't care opt
+    /// out by passing `None` (the default).
+    #[must_use]
+    pub fn with_metrics(mut self, metrics: Option<Arc<MetricsRegistry>>) -> Self {
+        self.metrics = metrics;
         self
     }
 
@@ -299,51 +326,65 @@ impl AuthBackend for InMemoryAuthBackend {
     }
 
     async fn register_user(&self, req: SignupRequest) -> Result<UserProfile, AuthError> {
-        let email = req.email.trim().to_lowercase();
-        if email.is_empty() || !email.contains('@') {
-            return Err(AuthError::InvalidCredentials);
-        }
-        if req.password.len() < 8 {
-            return Err(AuthError::InvalidCredentials);
-        }
-        let display_name = req.display_name.trim();
-        if display_name.is_empty() || display_name.len() > 128 {
-            return Err(AuthError::InvalidCredentials);
-        }
-        if self.users_by_email.contains_key(&email) {
-            return Err(AuthError::EmailAlreadyRegistered);
-        }
-        let hash = password::hash_password(req.password.expose())?;
-        let id = UserId::new();
-        let record = UserRecord {
-            id,
-            email: email.clone(),
-            display_name: display_name.to_owned(),
-            avatar_url: None,
-            password_hash: Some(hash),
-            email_verified: false,
-            failed_login_count: 0,
-            locked_until: None,
-            mfa_secret: None,
-            mfa_enabled: false,
-        };
-        let profile = record.profile();
-        self.put_user(record);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let email = req.email.trim().to_lowercase();
+                if email.is_empty() || !email.contains('@') {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                if req.password.len() < 8 {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                let display_name = req.display_name.trim();
+                if display_name.is_empty() || display_name.len() > 128 {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                if self.users_by_email.contains_key(&email) {
+                    return Err(AuthError::EmailAlreadyRegistered);
+                }
+                let hash = password::hash_password(req.password.expose())?;
+                let id = UserId::new();
+                let record = UserRecord {
+                    id,
+                    email: email.clone(),
+                    display_name: display_name.to_owned(),
+                    avatar_url: None,
+                    password_hash: Some(hash),
+                    email_verified: false,
+                    failed_login_count: 0,
+                    locked_until: None,
+                    mfa_secret: None,
+                    mfa_enabled: false,
+                };
+                let profile = record.profile();
+                self.put_user(record);
 
-        // Signup deliberately commits the user record before queueing
-        // the verification email. If email dispatch fails the user
-        // still exists in an unverified state and can recover via
-        // `request_password_reset` — the reset flow does not require
-        // `email_verified` to be set to issue its cooldown-bounded
-        // reset token. Rolling back the user on transient transport
-        // failure would silently destroy the durable account on every
-        // retry and is the wrong default for a bring-up backend.
-        let token = self.issue_verification_token(id, VerificationKind::EmailVerify)?;
-        self.record_email(&email, &token, EmailKind::Verification)
-            .await?;
+                // Signup deliberately commits the user record before queueing
+                // the verification email. If email dispatch fails the user
+                // still exists in an unverified state and can recover via
+                // `request_password_reset` — the reset flow does not require
+                // `email_verified` to be set to issue its cooldown-bounded
+                // reset token. Rolling back the user on transient transport
+                // failure would silently destroy the durable account on every
+                // retry and is the wrong default for a bring-up backend.
+                let token = self.issue_verification_token(id, VerificationKind::EmailVerify)?;
+                self.record_email(&email, &token, EmailKind::Verification)
+                    .await?;
 
-        tracing::info!(user_id = %id, "user registered");
-        Ok(profile)
+                tracing::info!(user_id = %id, "user registered");
+                Ok(profile)
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::EmailAlreadyRegistered) => auth_outcome::CONFLICT,
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_CREDS,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn authenticate_password(
@@ -352,64 +393,79 @@ impl AuthBackend for InMemoryAuthBackend {
         password_input: &str,
         totp: Option<&str>,
     ) -> Result<PasswordOutcome, AuthError> {
-        let user = self
-            .lookup_user_by_email(email)
-            .ok_or(AuthError::InvalidCredentials)?;
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let user = self
+                    .lookup_user_by_email(email)
+                    .ok_or(AuthError::InvalidCredentials)?;
 
-        if let Some(until) = user.locked_until
-            && until > Utc::now()
-        {
-            return Err(AuthError::AccountLocked);
-        }
-
-        let stored_hash = user
-            .password_hash
-            .as_ref()
-            .ok_or(AuthError::InvalidCredentials)?;
-        if !password::verify_password(stored_hash, password_input)? {
-            self.users.alter(&user.id, |_, mut u| {
-                u.failed_login_count += 1;
-                if u.failed_login_count >= LOCKOUT_THRESHOLD {
-                    let until =
-                        Utc::now() + chrono::Duration::from_std(LOCKOUT_TTL).unwrap_or_default();
-                    u.locked_until = Some(until);
+                if let Some(until) = user.locked_until
+                    && until > Utc::now()
+                {
+                    return Err(AuthError::AccountLocked);
                 }
-                u
-            });
-            return Err(AuthError::InvalidCredentials);
-        }
 
-        // Reset failure counter on success.
-        self.users.alter(&user.id, |_, mut u| {
-            u.failed_login_count = 0;
-            u.locked_until = None;
-            u
-        });
-
-        if user.mfa_enabled {
-            if let Some(code) = totp {
-                let secret = user
-                    .mfa_secret
-                    .as_deref()
-                    .ok_or_else(|| AuthError::Internal("mfa enabled without secret".to_owned()))?;
-                if !mfa::verify_code(secret, code)? {
-                    return Err(AuthError::InvalidMfaCode);
+                let stored_hash = user
+                    .password_hash
+                    .as_ref()
+                    .ok_or(AuthError::InvalidCredentials)?;
+                if !password::verify_password(stored_hash, password_input)? {
+                    self.users.alter(&user.id, |_, mut u| {
+                        u.failed_login_count += 1;
+                        if u.failed_login_count >= LOCKOUT_THRESHOLD {
+                            let until = Utc::now()
+                                + chrono::Duration::from_std(LOCKOUT_TTL).unwrap_or_default();
+                            u.locked_until = Some(until);
+                        }
+                        u
+                    });
+                    return Err(AuthError::InvalidCredentials);
                 }
-                Ok(PasswordOutcome::Authenticated(user.profile()))
-            } else {
-                let challenge_token = session::random_token(24)?;
-                self.mfa_challenges.insert(
-                    challenge_token.clone(),
-                    MfaChallenge {
-                        user_id: user.id,
-                        expires_at: Self::now_secs() + MFA_CHALLENGE_TTL.as_secs(),
-                    },
-                );
-                Ok(PasswordOutcome::MfaRequired { challenge_token })
-            }
-        } else {
-            Ok(PasswordOutcome::Authenticated(user.profile()))
-        }
+
+                // Reset failure counter on success.
+                self.users.alter(&user.id, |_, mut u| {
+                    u.failed_login_count = 0;
+                    u.locked_until = None;
+                    u
+                });
+
+                if user.mfa_enabled {
+                    if let Some(code) = totp {
+                        let secret = user.mfa_secret.as_deref().ok_or_else(|| {
+                            AuthError::Internal("mfa enabled without secret".to_owned())
+                        })?;
+                        if !mfa::verify_code(secret, code)? {
+                            return Err(AuthError::InvalidMfaCode);
+                        }
+                        Ok(PasswordOutcome::Authenticated(user.profile()))
+                    } else {
+                        let challenge_token = session::random_token(24)?;
+                        self.mfa_challenges.insert(
+                            challenge_token.clone(),
+                            MfaChallenge {
+                                user_id: user.id,
+                                expires_at: Self::now_secs() + MFA_CHALLENGE_TTL.as_secs(),
+                            },
+                        );
+                        Ok(PasswordOutcome::MfaRequired { challenge_token })
+                    }
+                } else {
+                    Ok(PasswordOutcome::Authenticated(user.profile()))
+                }
+            },
+            |result| match result {
+                Ok(PasswordOutcome::Authenticated(_)) => auth_outcome::SUCCESS,
+                Ok(PasswordOutcome::MfaRequired { .. }) => auth_outcome::MFA_REQUIRED,
+                Err(AuthError::AccountLocked) => auth_outcome::LOCKOUT,
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_CREDS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn verify_mfa(
@@ -417,28 +473,41 @@ impl AuthBackend for InMemoryAuthBackend {
         challenge_token: &str,
         code: &str,
     ) -> Result<UserProfile, AuthError> {
-        let now = Self::now_secs();
-        let entry = self
-            .mfa_challenges
-            .remove(challenge_token)
-            .ok_or(AuthError::InvalidToken)?
-            .1;
-        if entry.expires_at <= now {
-            return Err(AuthError::InvalidToken);
-        }
-        let user = self
-            .users
-            .get(&entry.user_id)
-            .ok_or(AuthError::UserNotFound)?
-            .clone();
-        let secret = user
-            .mfa_secret
-            .as_deref()
-            .ok_or_else(|| AuthError::Internal("mfa challenge for non-mfa user".to_owned()))?;
-        if !mfa::verify_code(secret, code)? {
-            return Err(AuthError::InvalidMfaCode);
-        }
-        Ok(user.profile())
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let now = Self::now_secs();
+                let entry = self
+                    .mfa_challenges
+                    .remove(challenge_token)
+                    .ok_or(AuthError::InvalidToken)?
+                    .1;
+                if entry.expires_at <= now {
+                    return Err(AuthError::InvalidToken);
+                }
+                let user = self
+                    .users
+                    .get(&entry.user_id)
+                    .ok_or(AuthError::UserNotFound)?
+                    .clone();
+                let secret = user.mfa_secret.as_deref().ok_or_else(|| {
+                    AuthError::Internal("mfa challenge for non-mfa user".to_owned())
+                })?;
+                if !mfa::verify_code(secret, code)? {
+                    return Err(AuthError::InvalidMfaCode);
+                }
+                Ok(user.profile())
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn create_session(&self, user_id: &str) -> Result<SessionRecord, AuthError> {
@@ -632,118 +701,188 @@ impl AuthBackend for InMemoryAuthBackend {
         token: &str,
         new_password: &str,
     ) -> Result<(), AuthError> {
-        let entry = self
-            .verification_tokens
-            .remove(token)
-            .ok_or(AuthError::InvalidToken)?
-            .1;
-        if entry.kind != VerificationKind::PasswordReset {
-            return Err(AuthError::InvalidToken);
-        }
-        if entry.expires_at <= Self::now_secs() {
-            return Err(AuthError::InvalidToken);
-        }
-        if new_password.len() < 8 {
-            return Err(AuthError::InvalidCredentials);
-        }
-        let new_hash = password::hash_password(new_password)?;
-        self.users.alter(&entry.user_id, |_, mut u| {
-            u.password_hash = Some(new_hash.clone());
-            u.failed_login_count = 0;
-            u.locked_until = None;
-            u
-        });
-        Ok(())
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let entry = self
+                    .verification_tokens
+                    .remove(token)
+                    .ok_or(AuthError::InvalidToken)?
+                    .1;
+                if entry.kind != VerificationKind::PasswordReset {
+                    return Err(AuthError::InvalidToken);
+                }
+                if entry.expires_at <= Self::now_secs() {
+                    return Err(AuthError::InvalidToken);
+                }
+                if new_password.len() < 8 {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                let new_hash = password::hash_password(new_password)?;
+                self.users.alter(&entry.user_id, |_, mut u| {
+                    u.password_hash = Some(new_hash.clone());
+                    u.failed_login_count = 0;
+                    u.locked_until = None;
+                    u
+                });
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                // Per oracle per-method map: `complete_password_reset`
+                // collapses `InvalidCredentials` to `invalid_input`
+                // because the failure is shape-validation of
+                // `new_password` (short / blank).
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_INPUT,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn verify_email(&self, token: &str) -> Result<(), AuthError> {
-        let entry = self
-            .verification_tokens
-            .remove(token)
-            .ok_or(AuthError::InvalidToken)?
-            .1;
-        if entry.kind != VerificationKind::EmailVerify {
-            return Err(AuthError::InvalidToken);
-        }
-        if entry.expires_at <= Self::now_secs() {
-            return Err(AuthError::InvalidToken);
-        }
-        self.users.alter(&entry.user_id, |_, mut u| {
-            u.email_verified = true;
-            u
-        });
-        Ok(())
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let entry = self
+                    .verification_tokens
+                    .remove(token)
+                    .ok_or(AuthError::InvalidToken)?
+                    .1;
+                if entry.kind != VerificationKind::EmailVerify {
+                    return Err(AuthError::InvalidToken);
+                }
+                if entry.expires_at <= Self::now_secs() {
+                    return Err(AuthError::InvalidToken);
+                }
+                self.users.alter(&entry.user_id, |_, mut u| {
+                    u.email_verified = true;
+                    u
+                });
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn start_mfa_enrollment(&self, user_id: &str) -> Result<MfaEnrollment, AuthError> {
-        let parsed: UserId = user_id
-            .parse()
-            .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
-        let user_email = self
-            .users
-            .get(&parsed)
-            .ok_or(AuthError::UserNotFound)?
-            .email
-            .clone();
-        let (secret, uri) = mfa::mint_secret(&user_email)?;
-        // Save secret but DO NOT flip mfa_enabled until confirm_mfa_enrollment.
-        self.users.alter(&parsed, |_, mut u| {
-            u.mfa_secret = Some(secret.clone());
-            u.mfa_enabled = false;
-            u
-        });
-        Ok(MfaEnrollment {
-            otpauth_uri: uri,
-            secret_base32: secret,
-        })
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let parsed: UserId = user_id
+                    .parse()
+                    .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
+                let user_email = self
+                    .users
+                    .get(&parsed)
+                    .ok_or(AuthError::UserNotFound)?
+                    .email
+                    .clone();
+                let (secret, uri) = mfa::mint_secret(&user_email)?;
+                // Save secret but DO NOT flip mfa_enabled until confirm_mfa_enrollment.
+                self.users.alter(&parsed, |_, mut u| {
+                    u.mfa_secret = Some(secret.clone());
+                    u.mfa_enabled = false;
+                    u
+                });
+                Ok(MfaEnrollment {
+                    otpauth_uri: uri,
+                    secret_base32: secret,
+                })
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn confirm_mfa_enrollment(&self, user_id: &str, code: &str) -> Result<(), AuthError> {
-        let parsed: UserId = user_id
-            .parse()
-            .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
-        let user = self
-            .users
-            .get(&parsed)
-            .ok_or(AuthError::UserNotFound)?
-            .clone();
-        let secret = user
-            .mfa_secret
-            .as_deref()
-            .ok_or(AuthError::InvalidMfaCode)?;
-        if !mfa::verify_code(secret, code)? {
-            return Err(AuthError::InvalidMfaCode);
-        }
-        self.users.alter(&parsed, |_, mut u| {
-            u.mfa_enabled = true;
-            u
-        });
-        Ok(())
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let parsed: UserId = user_id
+                    .parse()
+                    .map_err(|_| AuthError::Internal("invalid user_id".to_owned()))?;
+                let user = self
+                    .users
+                    .get(&parsed)
+                    .ok_or(AuthError::UserNotFound)?
+                    .clone();
+                let secret = user
+                    .mfa_secret
+                    .as_deref()
+                    .ok_or(AuthError::InvalidMfaCode)?;
+                if !mfa::verify_code(secret, code)? {
+                    return Err(AuthError::InvalidMfaCode);
+                }
+                self.users.alter(&parsed, |_, mut u| {
+                    u.mfa_enabled = true;
+                    u
+                });
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError> {
-        let pkce = mint_pkce()?;
-        // No real provider config in the in-memory backend — return a
-        // synthetic authorize URL so tests can verify the contract.
-        let authorize_url = format!(
-            "https://nebula.local/oauth/{}/authorize?state={}&code_challenge={}&code_challenge_method=S256",
-            provider.as_str(),
-            pkce.state,
-            pkce.code_challenge,
-        );
-        self.oauth_state.insert(
-            pkce.state.clone(),
-            OAuthStateEntry {
-                provider,
-                code_verifier: pkce.code_verifier,
-                expires_at: expiry_unix(OAUTH_STATE_TTL),
-                consumed: false,
+        let provider_label = metrics_emit::oauth_provider_label(provider);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
+            Some(provider_label),
+            async move {
+                let pkce = mint_pkce()?;
+                // No real provider config in the in-memory backend — return a
+                // synthetic authorize URL so tests can verify the contract.
+                let authorize_url = format!(
+                    "https://nebula.local/oauth/{}/authorize?state={}&code_challenge={}&code_challenge_method=S256",
+                    provider.as_str(),
+                    pkce.state,
+                    pkce.code_challenge,
+                );
+                self.oauth_state.insert(
+                    pkce.state.clone(),
+                    OAuthStateEntry {
+                        provider,
+                        code_verifier: pkce.code_verifier,
+                        expires_at: expiry_unix(OAUTH_STATE_TTL),
+                        consumed: false,
+                    },
+                );
+                Ok(OAuthStart {
+                    authorize_url,
+                    state: pkce.state,
+                })
             },
-        );
-        Ok(OAuthStart {
-            authorize_url,
-            state: pkce.state,
-        })
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     async fn complete_oauth(
@@ -752,20 +891,38 @@ impl AuthBackend for InMemoryAuthBackend {
         state: &str,
         _code: &str,
     ) -> Result<OAuthCompletion, AuthError> {
-        let entry = self
-            .oauth_state
-            .get_mut(state)
-            .ok_or(AuthError::InvalidToken)?;
-        if entry.consumed || entry.expires_at <= Self::now_secs() || entry.provider != provider {
-            return Err(AuthError::InvalidToken);
-        }
-        // The in-memory backend cannot actually exchange a code with a
-        // real provider; return NotImplemented so callers know they need
-        // a configured backend.
-        drop(entry);
-        Err(AuthError::NotImplemented(
-            "complete_oauth requires a configured provider backend",
-        ))
+        let provider_label = metrics_emit::oauth_provider_label(provider);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
+            Some(provider_label),
+            async move {
+                let entry = self
+                    .oauth_state
+                    .get_mut(state)
+                    .ok_or(AuthError::InvalidToken)?;
+                if entry.consumed
+                    || entry.expires_at <= Self::now_secs()
+                    || entry.provider != provider
+                {
+                    return Err(AuthError::InvalidToken);
+                }
+                // The in-memory backend cannot actually exchange a code with a
+                // real provider; return NotImplemented so callers know they need
+                // a configured backend.
+                drop(entry);
+                Err(AuthError::NotImplemented(
+                    "complete_oauth requires a configured provider backend",
+                ))
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 }
 

--- a/crates/api/src/domain/auth/backend/pg.rs
+++ b/crates/api/src/domain/auth/backend/pg.rs
@@ -64,6 +64,13 @@ use std::{sync::Arc, time::Duration};
 use async_trait::async_trait;
 use chrono::Utc;
 use nebula_core::{Principal, UserId};
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_API_AUTH_ATTEMPTS_TOTAL, NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+        NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL, auth_outcome,
+    },
+};
 use sha2::{Digest, Sha256};
 use sqlx::{Pool, Postgres};
 
@@ -82,7 +89,7 @@ use super::{
     pat::{self, MintedPat, PatRecord, compute_pat_expires_at},
     provider::{
         AuthBackend, CreatePatParams, MfaEnrollment, OAuthCompletion, OAuthStart, PasswordOutcome,
-        ProfilePatch,
+        ProfilePatch, metrics_emit,
     },
     session::{self, SESSION_TTL, SessionRecord, expires_at},
 };
@@ -143,15 +150,33 @@ pub struct PgAuthBackend {
     /// here, so the slot is always consumed by exactly the same
     /// transport.
     email_port: Arc<dyn EmailPort>,
+    /// Optional `nebula_api_auth_*` emission seam. `None` skips
+    /// emission (mirrors the `IdempotencyLayer::with_metrics`
+    /// `Option<Arc<MetricsRegistry>>` precedent at
+    /// `crates/api/src/middleware/idempotency/layer.rs`). Production
+    /// composition always populates this with the shared
+    /// `Arc<MetricsRegistry>` so the closed-set counters are observable
+    /// from operator dashboards; tests that don't exercise the emission
+    /// seam pass `None`.
+    metrics: Option<Arc<MetricsRegistry>>,
 }
 
 impl PgAuthBackend {
-    /// Construct a backend from a live `sqlx::Pool<Postgres>` and a
-    /// shared `Arc<dyn EmailPort>`. The five PG identity repos are
-    /// built internally from the pool (each holds its own clone, which
-    /// is cheap — `Pool` is an `Arc` internally).
+    /// Construct a backend from a live `sqlx::Pool<Postgres>`, a
+    /// shared `Arc<dyn EmailPort>`, and an optional `Arc<MetricsRegistry>`
+    /// for the `nebula_api_auth_*` emission seam.
+    ///
+    /// The five PG identity repos are built internally from the pool
+    /// (each holds its own clone, which is cheap — `Pool` is an `Arc`
+    /// internally). `metrics` follows the `IdempotencyLayer::with_metrics`
+    /// precedent: `None` for tests that do not exercise the emission
+    /// path, `Some(_)` from the production composition root.
     #[must_use]
-    pub fn new(pool: Pool<Postgres>, email_port: Arc<dyn EmailPort>) -> Self {
+    pub fn new(
+        pool: Pool<Postgres>,
+        email_port: Arc<dyn EmailPort>,
+        metrics: Option<Arc<MetricsRegistry>>,
+    ) -> Self {
         Self {
             user_repo: Arc::new(PgUserRepo::new(pool.clone())),
             session_repo: Arc::new(PgSessionRepo::new(pool.clone())),
@@ -160,6 +185,7 @@ impl PgAuthBackend {
             oauth_state_repo: Arc::new(PgOAuthStateRepo::new(pool.clone())),
             pool,
             email_port,
+            metrics,
         }
     }
 
@@ -272,110 +298,130 @@ impl AuthBackend for PgAuthBackend {
         fields(display_name_len = req.display_name.len()),
     )]
     async fn register_user(&self, req: SignupRequest) -> Result<UserProfile, AuthError> {
-        let email = req.email.trim().to_lowercase();
-        if email.is_empty() || !email.contains('@') {
-            return Err(AuthError::InvalidCredentials);
-        }
-        if req.password.len() < MIN_PASSWORD_LEN {
-            return Err(AuthError::InvalidCredentials);
-        }
-        let display_name = req.display_name.trim();
-        if display_name.is_empty() || display_name.len() > 128 {
-            return Err(AuthError::InvalidCredentials);
-        }
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let email = req.email.trim().to_lowercase();
+                if email.is_empty() || !email.contains('@') {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                if req.password.len() < MIN_PASSWORD_LEN {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                let display_name = req.display_name.trim();
+                if display_name.is_empty() || display_name.len() > 128 {
+                    return Err(AuthError::InvalidCredentials);
+                }
 
-        // Argon2id outside the tx — the work is slow and the row-level
-        // lock window must stay short.
-        let password_hash = password::hash_password(req.password.expose())?;
+                // Argon2id outside the tx — the work is slow and the row-level
+                // lock window must stay short.
+                let password_hash = password::hash_password(req.password.expose())?;
 
-        let user_id = UserId::new();
-        let user_bytes = user_id.as_bytes();
-        let verification_plaintext = session::random_token(24)?;
-        let verification_hash = sha256_token(&verification_plaintext);
-        let now = Utc::now();
-        let expires_at = now + chrono_duration(VERIFICATION_TTL)?;
+                let user_id = UserId::new();
+                let user_bytes = user_id.as_bytes();
+                let verification_plaintext = session::random_token(24)?;
+                let verification_hash = sha256_token(&verification_plaintext);
+                let now = Utc::now();
+                let expires_at = now + chrono_duration(VERIFICATION_TTL)?;
 
-        // Two-step tx bypasses the repo abstraction: orphan-row
-        // prevention requires user + verification-token INSERT
-        // atomicity. The repos are pool-bound; convert to
-        // `Executor`-generic when a fourth multi-step flow appears.
-        let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
+                // Two-step tx bypasses the repo abstraction: orphan-row
+                // prevention requires user + verification-token INSERT
+                // atomicity. The repos are pool-bound; convert to
+                // `Executor`-generic when a fourth multi-step flow appears.
+                let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
 
-        let user_insert = sqlx::query(
-            "INSERT INTO users \
+                let user_insert = sqlx::query(
+                    "INSERT INTO users \
              (id, email, email_verified_at, display_name, avatar_url, password_hash, \
               created_at, last_login_at, locked_until, failed_login_count, mfa_enabled, \
               mfa_secret, version, deleted_at) \
              VALUES ($1, $2, NULL, $3, NULL, $4, $5, NULL, NULL, 0, FALSE, NULL, 0, NULL)",
-        )
-        .bind(user_bytes.as_slice())
-        .bind(&email)
-        .bind(display_name)
-        .bind(&password_hash)
-        .bind(now)
-        .execute(&mut *tx)
-        .await;
+                )
+                .bind(user_bytes.as_slice())
+                .bind(&email)
+                .bind(display_name)
+                .bind(&password_hash)
+                .bind(now)
+                .execute(&mut *tx)
+                .await;
 
-        if let Err(err) = user_insert {
-            // Roll back implicitly by dropping the tx without commit;
-            // surface a typed conflict for the unique-email index.
-            if is_unique_violation(&err) {
-                return Err(AuthError::EmailAlreadyRegistered);
-            }
-            return Err(map_sqlx_err(err));
-        }
+                if let Err(err) = user_insert {
+                    // Roll back implicitly by dropping the tx without commit;
+                    // surface a typed conflict for the unique-email index.
+                    if is_unique_violation(&err) {
+                        return Err(AuthError::EmailAlreadyRegistered);
+                    }
+                    return Err(map_sqlx_err(err));
+                }
 
-        sqlx::query(
-            "INSERT INTO verification_tokens \
+                sqlx::query(
+                    "INSERT INTO verification_tokens \
              (token_hash, user_id, kind, payload, created_at, expires_at, consumed_at) \
              VALUES ($1, $2, $3, NULL, $4, $5, NULL)",
+                )
+                .bind(verification_hash.as_slice())
+                .bind(user_bytes.as_slice())
+                .bind(KIND_EMAIL_VERIFICATION)
+                .bind(now)
+                .bind(expires_at)
+                .execute(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?;
+
+                tx.commit().await.map_err(map_sqlx_err)?;
+
+                // Email send happens AFTER the tx commits. A delivery failure
+                // here returns `AuthError::Internal` — the user still exists in
+                // an unverified state and can recover by requesting a password
+                // reset (the reset flow does not require an email-verified
+                // account to issue the cooldown-bounded token).
+                // Signup deliberately commits the user record before queueing
+                // the verification email so a transient transport failure does
+                // not destroy the durable account on retry.
+                if let Err(err) = self
+                    .email_port
+                    .send(EmailMessage {
+                        to: email.clone(),
+                        subject: "Verify your email".to_owned(),
+                        body: verification_plaintext,
+                        kind: EmailKind::Verification,
+                    })
+                    .await
+                {
+                    tracing::error!(
+                        error = %err,
+                        user_id = %user_id,
+                        "failed to deliver verification email after user-create commit",
+                    );
+                    return Err(AuthError::Internal(format!("email: {err}")));
+                }
+
+                tracing::info!(user_id = %user_id, "user registered");
+                Ok(UserProfile {
+                    user_id: user_id.to_string(),
+                    email,
+                    display_name: display_name.to_owned(),
+                    avatar_url: None,
+                    email_verified: false,
+                    mfa_enabled: false,
+                })
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::EmailAlreadyRegistered) => auth_outcome::CONFLICT,
+                // Register-side validation rejections (short password,
+                // missing @, blank display name) come back as
+                // `InvalidCredentials` from the existing implementation;
+                // per oracle locked spec map them to `invalid_creds` on
+                // the attempts counter (no `invalid_input` split for the
+                // register path).
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_CREDS,
+                Err(_) => auth_outcome::INTERNAL,
+            },
         )
-        .bind(verification_hash.as_slice())
-        .bind(user_bytes.as_slice())
-        .bind(KIND_EMAIL_VERIFICATION)
-        .bind(now)
-        .bind(expires_at)
-        .execute(&mut *tx)
         .await
-        .map_err(map_sqlx_err)?;
-
-        tx.commit().await.map_err(map_sqlx_err)?;
-
-        // Email send happens AFTER the tx commits. A delivery failure
-        // here returns `AuthError::Internal` — the user still exists in
-        // an unverified state and can recover by requesting a password
-        // reset (the reset flow does not require an email-verified
-        // account to issue the cooldown-bounded token).
-        // Signup deliberately commits the user record before queueing
-        // the verification email so a transient transport failure does
-        // not destroy the durable account on retry.
-        if let Err(err) = self
-            .email_port
-            .send(EmailMessage {
-                to: email.clone(),
-                subject: "Verify your email".to_owned(),
-                body: verification_plaintext,
-                kind: EmailKind::Verification,
-            })
-            .await
-        {
-            tracing::error!(
-                error = %err,
-                user_id = %user_id,
-                "failed to deliver verification email after user-create commit",
-            );
-            return Err(AuthError::Internal(format!("email: {err}")));
-        }
-
-        tracing::info!(user_id = %user_id, "user registered");
-        Ok(UserProfile {
-            user_id: user_id.to_string(),
-            email,
-            display_name: display_name.to_owned(),
-            avatar_url: None,
-            email_verified: false,
-            mfa_enabled: false,
-        })
     }
 
     #[tracing::instrument(level = "info", skip(self, email, password_input, totp), fields(email_len = email.len()))]
@@ -385,62 +431,78 @@ impl AuthBackend for PgAuthBackend {
         password_input: &str,
         totp: Option<&str>,
     ) -> Result<PasswordOutcome, AuthError> {
-        let user = self
-            .user_repo
-            .get_by_email(email)
-            .await?
-            .ok_or(AuthError::InvalidCredentials)?;
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let user = self
+                    .user_repo
+                    .get_by_email(email)
+                    .await?
+                    .ok_or(AuthError::InvalidCredentials)?;
 
-        if let Some(until) = user.locked_until
-            && until > Utc::now()
-        {
-            return Err(AuthError::AccountLocked);
-        }
-
-        let stored_hash = user
-            .password_hash
-            .as_deref()
-            .ok_or(AuthError::InvalidCredentials)?;
-        if !password::verify_password(stored_hash, password_input)? {
-            self.user_repo.record_login_failure(&user.id).await?;
-            return Err(AuthError::InvalidCredentials);
-        }
-
-        // record_login_success ONLY; no `update` call — a profile
-        // update would CAS-conflict with concurrent patches and
-        // spuriously bump `version` on every login.
-        self.user_repo.record_login_success(&user.id).await?;
-
-        if user.mfa_enabled {
-            let secret = decode_mfa_secret(&user)?;
-            if let Some(code) = totp {
-                if !mfa::verify_code(&secret, code)? {
-                    return Err(AuthError::InvalidMfaCode);
+                if let Some(until) = user.locked_until
+                    && until > Utc::now()
+                {
+                    return Err(AuthError::AccountLocked);
                 }
-                Ok(PasswordOutcome::Authenticated(row_to_profile(&user)?))
-            } else {
-                let challenge_plaintext = session::random_token(24)?;
-                let challenge_hash = sha256_token(&challenge_plaintext);
-                let now = Utc::now();
-                let expires_at = now + chrono_duration(MFA_CHALLENGE_TTL)?;
-                self.verification_token_repo
-                    .create(&VerificationTokenRow {
-                        token_hash: challenge_hash.to_vec(),
-                        user_id: user.id.clone(),
-                        kind: KIND_MFA_CHALLENGE.to_owned(),
-                        payload: None,
-                        created_at: now,
-                        expires_at,
-                        consumed_at: None,
-                    })
-                    .await?;
-                Ok(PasswordOutcome::MfaRequired {
-                    challenge_token: challenge_plaintext,
-                })
-            }
-        } else {
-            Ok(PasswordOutcome::Authenticated(row_to_profile(&user)?))
-        }
+
+                let stored_hash = user
+                    .password_hash
+                    .as_deref()
+                    .ok_or(AuthError::InvalidCredentials)?;
+                if !password::verify_password(stored_hash, password_input)? {
+                    self.user_repo.record_login_failure(&user.id).await?;
+                    return Err(AuthError::InvalidCredentials);
+                }
+
+                // record_login_success ONLY; no `update` call — a profile
+                // update would CAS-conflict with concurrent patches and
+                // spuriously bump `version` on every login.
+                self.user_repo.record_login_success(&user.id).await?;
+
+                if user.mfa_enabled {
+                    let secret = decode_mfa_secret(&user)?;
+                    if let Some(code) = totp {
+                        if !mfa::verify_code(&secret, code)? {
+                            return Err(AuthError::InvalidMfaCode);
+                        }
+                        Ok(PasswordOutcome::Authenticated(row_to_profile(&user)?))
+                    } else {
+                        let challenge_plaintext = session::random_token(24)?;
+                        let challenge_hash = sha256_token(&challenge_plaintext);
+                        let now = Utc::now();
+                        let expires_at = now + chrono_duration(MFA_CHALLENGE_TTL)?;
+                        self.verification_token_repo
+                            .create(&VerificationTokenRow {
+                                token_hash: challenge_hash.to_vec(),
+                                user_id: user.id.clone(),
+                                kind: KIND_MFA_CHALLENGE.to_owned(),
+                                payload: None,
+                                created_at: now,
+                                expires_at,
+                                consumed_at: None,
+                            })
+                            .await?;
+                        Ok(PasswordOutcome::MfaRequired {
+                            challenge_token: challenge_plaintext,
+                        })
+                    }
+                } else {
+                    Ok(PasswordOutcome::Authenticated(row_to_profile(&user)?))
+                }
+            },
+            |result| match result {
+                Ok(PasswordOutcome::Authenticated(_)) => auth_outcome::SUCCESS,
+                Ok(PasswordOutcome::MfaRequired { .. }) => auth_outcome::MFA_REQUIRED,
+                Err(AuthError::AccountLocked) => auth_outcome::LOCKOUT,
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_CREDS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self, challenge_token, code))]
@@ -449,26 +511,40 @@ impl AuthBackend for PgAuthBackend {
         challenge_token: &str,
         code: &str,
     ) -> Result<UserProfile, AuthError> {
-        let challenge_hash = sha256_token(challenge_token);
-        // `consume_by_hash_and_kind` filters on `kind` inside the same
-        // UPDATE so a non-MFA token (e.g. password_reset) sent to this
-        // endpoint does NOT match and is NOT consumed; the row stays
-        // available for the valid follow-up at its real route.
-        let token_row = self
-            .verification_token_repo
-            .consume_by_hash_and_kind(&challenge_hash, KIND_MFA_CHALLENGE)
-            .await?
-            .ok_or(AuthError::InvalidToken)?;
-        let user = self
-            .user_repo
-            .get(&token_row.user_id)
-            .await?
-            .ok_or(AuthError::UserNotFound)?;
-        let secret = decode_mfa_secret(&user)?;
-        if !mfa::verify_code(&secret, code)? {
-            return Err(AuthError::InvalidMfaCode);
-        }
-        row_to_profile(&user)
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let challenge_hash = sha256_token(challenge_token);
+                // `consume_by_hash_and_kind` filters on `kind` inside the same
+                // UPDATE so a non-MFA token (e.g. password_reset) sent to this
+                // endpoint does NOT match and is NOT consumed; the row stays
+                // available for the valid follow-up at its real route.
+                let token_row = self
+                    .verification_token_repo
+                    .consume_by_hash_and_kind(&challenge_hash, KIND_MFA_CHALLENGE)
+                    .await?
+                    .ok_or(AuthError::InvalidToken)?;
+                let user = self
+                    .user_repo
+                    .get(&token_row.user_id)
+                    .await?
+                    .ok_or(AuthError::UserNotFound)?;
+                let secret = decode_mfa_secret(&user)?;
+                if !mfa::verify_code(&secret, code)? {
+                    return Err(AuthError::InvalidMfaCode);
+                }
+                row_to_profile(&user)
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(user_id))]
@@ -735,165 +811,228 @@ impl AuthBackend for PgAuthBackend {
         token: &str,
         new_password: &str,
     ) -> Result<(), AuthError> {
-        // Validate length BEFORE the tx so a malformed input never
-        // burns the reset token: the atomic UPDATE that consumes the
-        // token is the serialization point, and we do not want a 400
-        // path to leave the token marked consumed.
-        if new_password.len() < MIN_PASSWORD_LEN {
-            return Err(AuthError::InvalidCredentials);
-        }
-        // Argon2id BEFORE the tx so the slow work stays outside the
-        // row-lock window.
-        let new_hash = password::hash_password(new_password)?;
-        let token_hash = sha256_token(token);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                // Validate length BEFORE the tx so a malformed input never
+                // burns the reset token: the atomic UPDATE that consumes the
+                // token is the serialization point, and we do not want a 400
+                // path to leave the token marked consumed.
+                if new_password.len() < MIN_PASSWORD_LEN {
+                    return Err(AuthError::InvalidCredentials);
+                }
+                // Argon2id BEFORE the tx so the slow work stays outside the
+                // row-lock window.
+                let new_hash = password::hash_password(new_password)?;
+                let token_hash = sha256_token(token);
 
-        // Three-step tx bypasses the repo abstraction: the
-        // consume-token / update-password / revoke-siblings sequence
-        // must be atomic so a partial application cannot strand a
-        // burned token against an unchanged password. The repos are
-        // pool-bound; convert to `Executor`-generic when a fourth
-        // multi-step flow appears.
-        let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
+                // Three-step tx bypasses the repo abstraction: the
+                // consume-token / update-password / revoke-siblings sequence
+                // must be atomic so a partial application cannot strand a
+                // burned token against an unchanged password. The repos are
+                // pool-bound; convert to `Executor`-generic when a fourth
+                // multi-step flow appears.
+                let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
 
-        let consumed: Option<(Vec<u8>,)> = sqlx::query_as(
-            "UPDATE verification_tokens SET consumed_at = NOW() \
+                let consumed: Option<(Vec<u8>,)> = sqlx::query_as(
+                    "UPDATE verification_tokens SET consumed_at = NOW() \
              WHERE token_hash = $1 AND kind = $2 \
                AND consumed_at IS NULL AND expires_at > NOW() \
              RETURNING user_id",
-        )
-        .bind(token_hash.as_slice())
-        .bind(KIND_PASSWORD_RESET)
-        .fetch_optional(&mut *tx)
-        .await
-        .map_err(map_sqlx_err)?;
+                )
+                .bind(token_hash.as_slice())
+                .bind(KIND_PASSWORD_RESET)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?;
 
-        let Some((user_id_bytes,)) = consumed else {
-            return Err(AuthError::InvalidToken);
-        };
+                let Some((user_id_bytes,)) = consumed else {
+                    return Err(AuthError::InvalidToken);
+                };
 
-        // No CAS guard inside the tx — the consumed-by-hash row IS
-        // the serialization point: only one caller can successfully
-        // burn the token, so concurrent password-set races are
-        // impossible for the same reset link. `version` is still
-        // bumped so any concurrent reader sees the world advance.
-        let updated = sqlx::query(
-            "UPDATE users SET \
+                // No CAS guard inside the tx — the consumed-by-hash row IS
+                // the serialization point: only one caller can successfully
+                // burn the token, so concurrent password-set races are
+                // impossible for the same reset link. `version` is still
+                // bumped so any concurrent reader sees the world advance.
+                let updated = sqlx::query(
+                    "UPDATE users SET \
                  password_hash = $2, failed_login_count = 0, locked_until = NULL, \
                  version = version + 1 \
              WHERE id = $1 AND deleted_at IS NULL",
-        )
-        .bind(user_id_bytes.as_slice())
-        .bind(&new_hash)
-        .execute(&mut *tx)
-        .await
-        .map_err(map_sqlx_err)?
-        .rows_affected();
-        if updated == 0 {
-            return Err(AuthError::UserNotFound);
-        }
+                )
+                .bind(user_id_bytes.as_slice())
+                .bind(&new_hash)
+                .execute(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?
+                .rows_affected();
+                if updated == 0 {
+                    return Err(AuthError::UserNotFound);
+                }
 
-        // Revoke any in-flight sibling reset tokens so a stolen second
-        // link cannot be replayed after a successful reset.
-        sqlx::query(
-            "UPDATE verification_tokens SET consumed_at = NOW() \
-             WHERE user_id = $1 AND kind = $2 AND consumed_at IS NULL",
-        )
-        .bind(user_id_bytes.as_slice())
-        .bind(KIND_PASSWORD_RESET)
-        .execute(&mut *tx)
-        .await
-        .map_err(map_sqlx_err)?;
+                // Revoke any in-flight sibling reset tokens so a stolen second
+                // link cannot be replayed after a successful reset.
+                sqlx::query(
+                    "UPDATE verification_tokens SET consumed_at = NOW() \
+                     WHERE user_id = $1 AND kind = $2 AND consumed_at IS NULL",
+                )
+                .bind(user_id_bytes.as_slice())
+                .bind(KIND_PASSWORD_RESET)
+                .execute(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?;
 
-        tx.commit().await.map_err(map_sqlx_err)?;
-        Ok(())
+                tx.commit().await.map_err(map_sqlx_err)?;
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                // Per oracle per-method map: `complete_password_reset`
+                // collapses `InvalidCredentials` to `invalid_input`
+                // because the failure is shape-validation of
+                // `new_password` (short / blank), not a credential
+                // mismatch.
+                Err(AuthError::InvalidCredentials) => auth_outcome::INVALID_INPUT,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self, token))]
     async fn verify_email(&self, token: &str) -> Result<(), AuthError> {
-        let token_hash = sha256_token(token);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let token_hash = sha256_token(token);
 
-        // Two-step tx bypasses the repo abstraction: the token-consume
-        // + email-verified flip must be atomic so a CAS-loss or vanished
-        // user row cannot strand a burned verification token against an
-        // unchanged `email_verified_at`. The repos are pool-bound;
-        // convert to `Executor`-generic when a fourth multi-step flow
-        // appears.
-        let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
+                // Two-step tx bypasses the repo abstraction: the token-consume
+                // + email-verified flip must be atomic so a CAS-loss or vanished
+                // user row cannot strand a burned verification token against an
+                // unchanged `email_verified_at`. The repos are pool-bound;
+                // convert to `Executor`-generic when a fourth multi-step flow
+                // appears.
+                let mut tx = self.pool.begin().await.map_err(map_sqlx_err)?;
 
-        let consumed: Option<(Vec<u8>,)> = sqlx::query_as(
-            "UPDATE verification_tokens SET consumed_at = NOW() \
+                let consumed: Option<(Vec<u8>,)> = sqlx::query_as(
+                    "UPDATE verification_tokens SET consumed_at = NOW() \
              WHERE token_hash = $1 AND kind = $2 \
                AND consumed_at IS NULL AND expires_at > NOW() \
              RETURNING user_id",
+                )
+                .bind(token_hash.as_slice())
+                .bind(KIND_EMAIL_VERIFICATION)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?;
+
+                let Some((user_id_bytes,)) = consumed else {
+                    return Err(AuthError::InvalidToken);
+                };
+
+                // No CAS guard inside the tx — the consumed-by-hash row IS
+                // the serialization point for this user's email-verify flow.
+                // Bump `version` so concurrent readers see the world advance.
+                let updated = sqlx::query(
+                    "UPDATE users SET \
+                         email_verified_at = NOW(), \
+                         version = version + 1 \
+                     WHERE id = $1 AND deleted_at IS NULL",
+                )
+                .bind(user_id_bytes.as_slice())
+                .execute(&mut *tx)
+                .await
+                .map_err(map_sqlx_err)?
+                .rows_affected();
+                if updated == 0 {
+                    return Err(AuthError::UserNotFound);
+                }
+
+                tx.commit().await.map_err(map_sqlx_err)?;
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(_) => auth_outcome::INTERNAL,
+            },
         )
-        .bind(token_hash.as_slice())
-        .bind(KIND_EMAIL_VERIFICATION)
-        .fetch_optional(&mut *tx)
         .await
-        .map_err(map_sqlx_err)?;
-
-        let Some((user_id_bytes,)) = consumed else {
-            return Err(AuthError::InvalidToken);
-        };
-
-        // No CAS guard inside the tx — the consumed-by-hash row IS
-        // the serialization point for this user's email-verify flow.
-        // Bump `version` so concurrent readers see the world advance.
-        let updated = sqlx::query(
-            "UPDATE users SET \
-                 email_verified_at = NOW(), \
-                 version = version + 1 \
-             WHERE id = $1 AND deleted_at IS NULL",
-        )
-        .bind(user_id_bytes.as_slice())
-        .execute(&mut *tx)
-        .await
-        .map_err(map_sqlx_err)?
-        .rows_affected();
-        if updated == 0 {
-            return Err(AuthError::UserNotFound);
-        }
-
-        tx.commit().await.map_err(map_sqlx_err)?;
-        Ok(())
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(user_id))]
     async fn start_mfa_enrollment(&self, user_id: &str) -> Result<MfaEnrollment, AuthError> {
-        let mut row = fetch_user_by_id(&self.user_repo, user_id).await?;
-        let (secret, uri) = mfa::mint_secret(&row.email)?;
-        // Save secret but DO NOT flip mfa_enabled until
-        // confirm_mfa_enrollment. Encryption-at-rest of the MFA secret
-        // is deferred to a follow-up that wires the credential
-        // service's master-key envelope into the identity surface.
-        row.mfa_secret = Some(secret.as_bytes().to_vec());
-        row.mfa_enabled = false;
-        let expected_version = row.version;
-        self.user_repo.update(&row, expected_version).await?;
-        Ok(MfaEnrollment {
-            otpauth_uri: uri,
-            secret_base32: secret,
-        })
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let mut row = fetch_user_by_id(&self.user_repo, user_id).await?;
+                let (secret, uri) = mfa::mint_secret(&row.email)?;
+                // Save secret but DO NOT flip mfa_enabled until
+                // confirm_mfa_enrollment. Encryption-at-rest of the MFA secret
+                // is deferred to a follow-up that wires the credential
+                // service's master-key envelope into the identity surface.
+                row.mfa_secret = Some(secret.as_bytes().to_vec());
+                row.mfa_enabled = false;
+                let expected_version = row.version;
+                self.user_repo.update(&row, expected_version).await?;
+                Ok(MfaEnrollment {
+                    otpauth_uri: uri,
+                    secret_base32: secret,
+                })
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self, code), fields(user_id))]
     async fn confirm_mfa_enrollment(&self, user_id: &str, code: &str) -> Result<(), AuthError> {
-        let mut row = fetch_user_by_id(&self.user_repo, user_id).await?;
-        let secret = decode_mfa_secret(&row).map_err(|_| AuthError::InvalidMfaCode)?;
-        if !mfa::verify_code(&secret, code)? {
-            return Err(AuthError::InvalidMfaCode);
-        }
-        if !row.mfa_enabled {
-            row.mfa_enabled = true;
-            let expected_version = row.version;
-            self.user_repo.update(&row, expected_version).await?;
-        }
-        Ok(())
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+            None,
+            async move {
+                let mut row = fetch_user_by_id(&self.user_repo, user_id).await?;
+                let secret = decode_mfa_secret(&row).map_err(|_| AuthError::InvalidMfaCode)?;
+                if !mfa::verify_code(&secret, code)? {
+                    return Err(AuthError::InvalidMfaCode);
+                }
+                if !row.mfa_enabled {
+                    row.mfa_enabled = true;
+                    let expected_version = row.version;
+                    self.user_repo.update(&row, expected_version).await?;
+                }
+                Ok(())
+            },
+            |result| match result {
+                Ok(()) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidMfaCode) => auth_outcome::INVALID_MFA_CODE,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(provider = %provider.as_str()))]
     async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError> {
-        let pkce = mint_pkce()?;
+        let provider_label = metrics_emit::oauth_provider_label(provider);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
+            Some(provider_label),
+            async move {
+                let pkce = mint_pkce()?;
         // Synthetic authorize URL (same shape the in-memory backend
         // uses) — real provider config (client_id/secret, token
         // endpoint) is deferred to a follow-up. See `complete_oauth`
@@ -906,26 +1045,34 @@ impl AuthBackend for PgAuthBackend {
         );
         let now = Utc::now();
         let expires_at = now + chrono_duration(OAUTH_STATE_TTL)?;
-        self.oauth_state_repo
-            .create(&OAuthStateRow {
-                state: pkce.state.clone(),
-                provider: provider.as_str().to_owned(),
-                code_verifier: pkce.code_verifier,
-                // `redirect_uri = None`: the `AuthBackend::start_oauth`
-                // trait signature does not yet accept a `redirect_uri`
-                // parameter. The column stays correctly nullable; a
-                // future trait-signature change picks it up without a
-                // migration.
-                redirect_uri: None,
-                created_at: now,
-                expires_at,
-                consumed_at: None,
-            })
-            .await?;
-        Ok(OAuthStart {
-            authorize_url,
-            state: pkce.state,
-        })
+                self.oauth_state_repo
+                    .create(&OAuthStateRow {
+                        state: pkce.state.clone(),
+                        provider: provider.as_str().to_owned(),
+                        code_verifier: pkce.code_verifier,
+                        // `redirect_uri = None`: the `AuthBackend::start_oauth`
+                        // trait signature does not yet accept a `redirect_uri`
+                        // parameter. The column stays correctly nullable; a
+                        // future trait-signature change picks it up without a
+                        // migration.
+                        redirect_uri: None,
+                        created_at: now,
+                        expires_at,
+                        consumed_at: None,
+                    })
+                    .await?;
+                Ok(OAuthStart {
+                    authorize_url,
+                    state: pkce.state,
+                })
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 
     #[tracing::instrument(level = "info", skip(self, state, _code), fields(provider = %provider.as_str(), state_len = state.len()))]
@@ -935,29 +1082,48 @@ impl AuthBackend for PgAuthBackend {
         state: &str,
         _code: &str,
     ) -> Result<OAuthCompletion, AuthError> {
-        // `consume_by_state_and_provider` filters on `provider` inside
-        // the same UPDATE — a state crossed between providers does NOT
-        // match and is NOT consumed; the row stays available for the
-        // valid callback at the correct provider. The single-statement
-        // UPDATE is the PKCE replay defence: a second callback at the
-        // same `(state, provider)` is the loser and sees None.
-        //
-        // The PG path enforces the replay window even though the
-        // actual provider code-exchange is still `NotImplemented`;
-        // when a follow-up wires real provider configs and
-        // `CredentialService::get::<OAuth2Credential>`, it replaces
-        // the `NotImplemented` return with the real exchange without
-        // changing any storage semantics.
-        let _row = self
-            .oauth_state_repo
-            .consume_by_state_and_provider(state, provider.as_str())
-            .await?
-            .ok_or(AuthError::InvalidToken)?;
-        Err(AuthError::NotImplemented(
-            "oauth provider code exchange is not yet wired; complete_oauth \
-             currently consumes the state row but does not exchange the \
-             authorization code",
-        ))
+        let provider_label = metrics_emit::oauth_provider_label(provider);
+        metrics_emit::run_with_metrics(
+            &self.metrics,
+            NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
+            Some(provider_label),
+            async move {
+                // `consume_by_state_and_provider` filters on `provider` inside
+                // the same UPDATE — a state crossed between providers does NOT
+                // match and is NOT consumed; the row stays available for the
+                // valid callback at the correct provider. The single-statement
+                // UPDATE is the PKCE replay defence: a second callback at the
+                // same `(state, provider)` is the loser and sees None.
+                //
+                // The PG path enforces the replay window even though the
+                // actual provider code-exchange is still `NotImplemented`;
+                // when a follow-up wires real provider configs and
+                // `CredentialService::get::<OAuth2Credential>`, it replaces
+                // the `NotImplemented` return with the real exchange without
+                // changing any storage semantics.
+                let _row = self
+                    .oauth_state_repo
+                    .consume_by_state_and_provider(state, provider.as_str())
+                    .await?
+                    .ok_or(AuthError::InvalidToken)?;
+                Err(AuthError::NotImplemented(
+                    "oauth provider code exchange is not yet wired; complete_oauth \
+                     currently consumes the state row but does not exchange the \
+                     authorization code",
+                ))
+            },
+            |result| match result {
+                Ok(_) => auth_outcome::SUCCESS,
+                Err(AuthError::InvalidToken) => auth_outcome::TOKEN_INVALID,
+                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                // Per oracle per-method map: `complete_oauth` collapses
+                // `NotImplemented` to `internal` because the PG path is
+                // wired-but-incomplete until PR-C lands the real
+                // provider code-exchange.
+                Err(_) => auth_outcome::INTERNAL,
+            },
+        )
+        .await
     }
 }
 

--- a/crates/api/src/domain/auth/backend/provider.rs
+++ b/crates/api/src/domain/auth/backend/provider.rs
@@ -3,6 +3,16 @@
 //! Replaces the older `SessionStore` trait. All auth-domain operations
 //! (signup / login / MFA / OAuth / sessions / PATs) flow through this single
 //! trait so callers never have to ask "which slot is the right one?".
+//!
+//! ## Metrics emission helpers (`metrics_emit`)
+//!
+//! Both [`super::InMemoryAuthBackend`] and (under `feature = "postgres"`)
+//! `super::pg::PgAuthBackend` share the closed-set emission discipline for
+//! the `nebula_api_auth_*` family. The shared helpers live in a private
+//! `metrics_emit` submodule below so the two backends cannot drift on
+//! label key/value strings (the module is `pub(super)` so it is hidden
+//! from the public API surface; its existence is documented here for
+//! the maintainer audience).
 
 use async_trait::async_trait;
 use nebula_core::Principal;
@@ -14,6 +24,124 @@ use super::{
     pat::{MintedPat, PatRecord},
     session::SessionRecord,
 };
+
+/// Shared `nebula_api_auth_*` emission helpers consumed by
+/// [`super::InMemoryAuthBackend`] and `super::pg::PgAuthBackend`
+/// (the latter is feature-gated under `postgres` so an intra-doc
+/// link cannot resolve unconditionally — kept as plain code for that
+/// reason).
+///
+/// The single `run_with_metrics` entry point wraps a backend method's
+/// future, classifies the resolved `Result` into a closed-set
+/// `auth_outcome::*` label, bumps the per-method counter, and observes
+/// the duration histogram in a single place — mirrors the
+/// `record_outcome` / `LatencyGuard` pattern in
+/// `crates/api/src/middleware/idempotency/layer.rs` but lifted into a
+/// helper module so both backends share one wire and cannot drift.
+///
+/// Closed-set guarantee: every emission path here builds labels from
+/// `&'static str` constants in `nebula_metrics::naming::auth_outcome`
+/// / `naming::auth_oauth_provider`; no `format!` / `to_string` value
+/// can reach a label key or value at the call site (oracle locked spec
+/// decision 3 — closed cardinality enforced by-construction at the
+/// call site, no `LabelAllowlist::only(...)`).
+pub(super) mod metrics_emit {
+    use std::sync::Arc;
+
+    use nebula_metrics::{
+        MetricsRegistry,
+        naming::{NEBULA_API_AUTH_DURATION_SECONDS, auth_oauth_provider},
+    };
+
+    use super::{AuthError, OAuthProvider};
+
+    /// Map an [`OAuthProvider`] enum value to its closed-set provider
+    /// label string from
+    /// [`nebula_metrics::naming::auth_oauth_provider`].
+    ///
+    /// Returning the constant directly (not `provider.as_str()`)
+    /// makes the closed-set guarantee visible to the reviewer: the
+    /// `match` cannot produce a non-constant value. If a new
+    /// `OAuthProvider` variant lands without a matching constant, this
+    /// fails compilation.
+    #[must_use]
+    pub(crate) fn oauth_provider_label(provider: OAuthProvider) -> &'static str {
+        match provider {
+            OAuthProvider::Google => auth_oauth_provider::GOOGLE,
+            OAuthProvider::GitHub => auth_oauth_provider::GITHUB,
+            OAuthProvider::Microsoft => auth_oauth_provider::MICROSOFT,
+        }
+    }
+
+    /// Run `body` under the auth metrics wire and return its `Result`.
+    ///
+    /// On completion the resolved `Result` is passed to `classify` to
+    /// pick an `auth_outcome::*` label (the per-method closed-set
+    /// derivation lives at the call site); the resulting outcome is
+    /// then used to:
+    ///
+    /// 1. Bump `counter_name` with labels `{outcome}` (or
+    ///    `{outcome, provider}` if `provider` is `Some`).
+    /// 2. Observe [`NEBULA_API_AUTH_DURATION_SECONDS`] keyed by
+    ///    `{outcome}` only (never `provider`) with the elapsed time
+    ///    in seconds (NOT milliseconds).
+    ///
+    /// When `metrics` is `None`, emission is a no-op and the helper
+    /// returns the inner `Result` unchanged. Mirrors the
+    /// `let Some(reg) = self.metrics.as_ref() else { return; };`
+    /// early-return pattern in `idempotency/layer.rs`.
+    pub(crate) async fn run_with_metrics<T, F, C>(
+        metrics: &Option<Arc<MetricsRegistry>>,
+        counter_name: &'static str,
+        provider: Option<&'static str>,
+        body: F,
+        classify: C,
+    ) -> Result<T, AuthError>
+    where
+        F: Future<Output = Result<T, AuthError>>,
+        C: FnOnce(&Result<T, AuthError>) -> &'static str,
+    {
+        let start = std::time::Instant::now();
+        let result = body.await;
+        let outcome = classify(&result);
+        let Some(registry) = metrics.as_ref() else {
+            return result;
+        };
+
+        // Counter labels: oauth path adds `provider`; everything else
+        // is `outcome` only. All values are `&'static str` constants
+        // — no runtime stringification can reach the label.
+        let counter_labels = match provider {
+            Some(provider_label) => registry
+                .interner()
+                .label_set(&[("outcome", outcome), ("provider", provider_label)]),
+            None => registry.interner().single("outcome", outcome),
+        };
+        if let Ok(counter) = registry.counter_labeled(counter_name, &counter_labels) {
+            counter.inc();
+        }
+
+        // Histogram: outcome-only labels regardless of which counter
+        // family fired — the duration view is always keyed by outcome
+        // to keep the histogram cardinality at the floor of
+        // `len(auth_outcome::*)` series.
+        let hist_labels = if provider.is_some() {
+            registry.interner().single("outcome", outcome)
+        } else {
+            counter_labels
+        };
+        if let Ok(histogram) =
+            registry.histogram_labeled(NEBULA_API_AUTH_DURATION_SECONDS, &hist_labels)
+        {
+            // Seconds, not milliseconds. Default seconds-shaped buckets
+            // span 5 ms ... 10 s which is correct for Argon2id-dominated
+            // auth duration.
+            histogram.observe(start.elapsed().as_secs_f64());
+        }
+
+        result
+    }
+}
 
 /// Partial profile mutation for [`AuthBackend::update_user_profile`].
 ///

--- a/crates/api/tests/auth_metrics.rs
+++ b/crates/api/tests/auth_metrics.rs
@@ -1,0 +1,456 @@
+//! `nebula_api_auth_*` emission seam coverage.
+//!
+//! Validates the locked-spec metrics wired in
+//! `crates/api/src/domain/auth/backend/{pg,in_memory}.rs` against the
+//! closed `auth_outcome` and `auth_oauth_provider` label sets defined in
+//! [`nebula_metrics::naming`].
+//!
+//! Two complementary suites live here:
+//!
+//! - The [`memory_backend`] tests run **without** `DATABASE_URL` so the
+//!   emission seam is exercised in CI on every PR, even when no Postgres
+//!   is reachable. They cover the `outcome=success` and
+//!   `outcome=invalid_creds` paths against [`InMemoryAuthBackend`] per
+//!   the oracle locked-spec risk item 5 ("label-key drift catcher
+//!   regardless of DATABASE_URL availability").
+//! - The [`pg_backend`] tests are `#[cfg(feature = "postgres")]` and
+//!   silently no-op when `DATABASE_URL` is absent (mirrors the
+//!   `auth_pg_e2e.rs` gating pattern). When the env var is set they
+//!   exercise the same closed-set against [`PgAuthBackend`] using a
+//!   live Postgres.
+
+#![cfg(test)]
+
+use std::sync::Arc;
+
+use nebula_api::{
+    domain::auth::backend::{
+        AuthBackend, InMemoryAuthBackend, PasswordOutcome, SignupRequest, dto::SecretString,
+        error::AuthError,
+    },
+    ports::email::{EchoSink, EmailPort},
+};
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{NEBULA_API_AUTH_ATTEMPTS_TOTAL, NEBULA_API_AUTH_DURATION_SECONDS, auth_outcome},
+};
+
+/// Bump-then-snapshot helper: returns the labeled counter's current
+/// value, instantiating it on demand. Used to assert the seam wired the
+/// closed-set `outcome` label correctly.
+fn counter_value(registry: &MetricsRegistry, name: &str, outcome: &'static str) -> u64 {
+    let labels = registry.interner().single("outcome", outcome);
+    registry
+        .counter_labeled(name, &labels)
+        .expect("counter_labeled lookup")
+        .get()
+}
+
+/// Same for the histogram — returns the sample count.
+fn histogram_count(registry: &MetricsRegistry, outcome: &'static str) -> usize {
+    let labels = registry.interner().single("outcome", outcome);
+    registry
+        .histogram_labeled(NEBULA_API_AUTH_DURATION_SECONDS, &labels)
+        .expect("histogram_labeled lookup")
+        .count()
+}
+
+fn signup_for(email: &str) -> SignupRequest {
+    SignupRequest {
+        email: email.to_owned(),
+        password: SecretString::new("hunter22".to_owned()),
+        display_name: "Auth Metrics".to_owned(),
+    }
+}
+
+/// Build an `InMemoryAuthBackend` with metrics wired through a fresh
+/// `MetricsRegistry`. The caller keeps the registry handle so it can
+/// assert against post-call counter / histogram state.
+fn build_in_memory_with_metrics() -> (InMemoryAuthBackend, Arc<MetricsRegistry>) {
+    let registry = Arc::new(MetricsRegistry::new());
+    let sink = Arc::new(EchoSink::default());
+    let port: Arc<dyn EmailPort> = Arc::clone(&sink) as _;
+    let backend = InMemoryAuthBackend::new()
+        .with_email_port(port)
+        .with_metrics(Some(Arc::clone(&registry)));
+    (backend, registry)
+}
+
+mod memory_backend {
+    //! `InMemoryAuthBackend` emission coverage (NOT `DATABASE_URL`-gated).
+    //!
+    //! The oracle locked-spec risk item 5 calls out that the
+    //! production PG path is `DATABASE_URL`-gated, so a memory-backend
+    //! test is required to catch label-key drift in CI on every PR
+    //! regardless of Postgres availability.
+
+    use super::*;
+
+    /// `register_user` then `authenticate_password` (correct credentials)
+    /// must each bump `attempts_total{outcome=success}` exactly once
+    /// and observe the histogram twice (one per method).
+    #[tokio::test]
+    async fn success_path_increments_success_outcome() {
+        let (backend, registry) = build_in_memory_with_metrics();
+        let email = "memory-success@nebula-test.example";
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            0,
+            "fresh registry: success counter must start at zero"
+        );
+
+        let profile = backend
+            .register_user(signup_for(email))
+            .await
+            .expect("register_user");
+        assert_eq!(profile.email, email);
+
+        // After register: one success bump + one histogram sample.
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            1,
+            "register_user must increment outcome=success"
+        );
+        assert_eq!(
+            histogram_count(&registry, auth_outcome::SUCCESS),
+            1,
+            "register_user must observe duration histogram"
+        );
+
+        match backend
+            .authenticate_password(email, "hunter22", None)
+            .await
+            .expect("authenticate_password")
+        {
+            PasswordOutcome::Authenticated(p) => assert_eq!(p.user_id, profile.user_id),
+            PasswordOutcome::MfaRequired { .. } => panic!("MFA not enabled"),
+        }
+
+        // After authenticate (success): success counter == 2 and
+        // histogram count == 2.
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            2,
+            "authenticate_password (ok) must increment outcome=success"
+        );
+        assert_eq!(
+            histogram_count(&registry, auth_outcome::SUCCESS),
+            2,
+            "authenticate_password must observe duration histogram"
+        );
+        // And no spurious bumps on other outcomes.
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::INVALID_CREDS,
+            ),
+            0,
+            "no invalid_creds bump on the happy path"
+        );
+    }
+
+    /// `authenticate_password` with a wrong password must bump
+    /// `attempts_total{outcome=invalid_creds}` (NOT `success`) and add
+    /// to the `outcome=invalid_creds` histogram bucket.
+    #[tokio::test]
+    async fn invalid_password_increments_invalid_creds_outcome() {
+        let (backend, registry) = build_in_memory_with_metrics();
+        let email = "memory-invalid@nebula-test.example";
+
+        backend
+            .register_user(signup_for(email))
+            .await
+            .expect("register_user");
+
+        // Drain the success-from-register counter so the assertion
+        // below reads the post-failed-login delta only.
+        let success_after_register = counter_value(
+            &registry,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            auth_outcome::SUCCESS,
+        );
+        assert_eq!(success_after_register, 1);
+        let invalid_before = counter_value(
+            &registry,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            auth_outcome::INVALID_CREDS,
+        );
+
+        let err = backend
+            .authenticate_password(email, "wrong-password", None)
+            .await
+            .expect_err("wrong-password authenticate must fail");
+        assert!(matches!(err, AuthError::InvalidCredentials));
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::INVALID_CREDS
+            ),
+            invalid_before + 1,
+            "wrong-password authenticate must increment outcome=invalid_creds"
+        );
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            success_after_register,
+            "wrong-password authenticate must NOT increment outcome=success"
+        );
+        assert!(
+            histogram_count(&registry, auth_outcome::INVALID_CREDS) >= 1,
+            "wrong-password authenticate must observe duration histogram \
+             under outcome=invalid_creds"
+        );
+    }
+
+    /// `register_user` with a duplicate email must bump
+    /// `attempts_total{outcome=conflict}` per the oracle per-method map
+    /// (`EmailAlreadyRegistered -> conflict`).
+    #[tokio::test]
+    async fn duplicate_signup_increments_conflict_outcome() {
+        let (backend, registry) = build_in_memory_with_metrics();
+        let email = "memory-conflict@nebula-test.example";
+
+        backend
+            .register_user(signup_for(email))
+            .await
+            .expect("first register_user");
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::CONFLICT
+            ),
+            0,
+            "conflict counter must be zero before the duplicate signup"
+        );
+
+        let err = backend
+            .register_user(signup_for(email))
+            .await
+            .expect_err("duplicate register_user must fail");
+        assert!(matches!(err, AuthError::EmailAlreadyRegistered));
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::CONFLICT
+            ),
+            1,
+            "duplicate register_user must increment outcome=conflict"
+        );
+    }
+
+    /// `None` metrics registry must not panic. The `IdempotencyLayer`
+    /// precedent guarantees the `let Some(reg) = ... else { return; };`
+    /// early-return pattern; the auth backends mirror this discipline
+    /// so a backend constructed without metrics still runs the full
+    /// flow.
+    #[tokio::test]
+    async fn no_metrics_registry_is_a_no_op_on_emission() {
+        let backend = InMemoryAuthBackend::new();
+        let email = "memory-no-metrics@nebula-test.example";
+
+        backend
+            .register_user(signup_for(email))
+            .await
+            .expect("register_user without metrics must succeed");
+        match backend
+            .authenticate_password(email, "hunter22", None)
+            .await
+            .expect("authenticate_password without metrics must succeed")
+        {
+            PasswordOutcome::Authenticated(_) => {},
+            PasswordOutcome::MfaRequired { .. } => panic!("MFA not enabled"),
+        }
+    }
+}
+
+#[cfg(feature = "postgres")]
+mod pg_backend {
+    //! `PgAuthBackend` emission coverage.
+    //!
+    //! `DATABASE_URL`-gated. Mirrors `auth_pg_e2e.rs::pool` exactly:
+    //! when the env var is absent the test no-ops; when set it runs
+    //! against a live Postgres with the spec-16 migrations applied
+    //! once per process.
+    //!
+    //! Asserts the same `outcome=success` and `outcome=invalid_creds`
+    //! invariants as the memory-backend suite so a wire regression in
+    //! the PG path (e.g. wrong counter constant, label-key typo) is
+    //! caught by CI when the gated suite runs.
+
+    use nebula_api::domain::auth::backend::PgAuthBackend;
+    use sqlx::{Pool, Postgres, postgres::PgPoolOptions};
+
+    use super::*;
+
+    static SPEC16_MIGRATOR: sqlx::migrate::Migrator =
+        sqlx::migrate!("../storage/migrations/postgres");
+    static SCHEMA_READY: tokio::sync::OnceCell<()> = tokio::sync::OnceCell::const_new();
+
+    async fn pool() -> Option<Pool<Postgres>> {
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(url) => url,
+            Err(std::env::VarError::NotPresent) => return None,
+            Err(err) => panic!("DATABASE_URL is set but invalid: {err}"),
+        };
+        let pool = PgPoolOptions::new()
+            .max_connections(4)
+            .connect(&url)
+            .await
+            .expect("connect to DATABASE_URL");
+        SCHEMA_READY
+            .get_or_init(|| async {
+                SPEC16_MIGRATOR
+                    .run(&pool)
+                    .await
+                    .expect("spec-16 postgres migrations");
+            })
+            .await;
+        Some(pool)
+    }
+
+    /// Generate a unique-per-run email so re-runs against a persistent
+    /// Postgres do not collide on the `idx_users_email_active` unique
+    /// index.
+    fn unique_email(label: &str) -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time is sane")
+            .as_nanos();
+        format!("{label}-{nanos:x}@nebula-metrics.test")
+    }
+
+    fn build_pg_backend_with_metrics(
+        pool: Pool<Postgres>,
+    ) -> (Arc<PgAuthBackend>, Arc<MetricsRegistry>) {
+        let registry = Arc::new(MetricsRegistry::new());
+        let sink = Arc::new(EchoSink::default());
+        let port: Arc<dyn EmailPort> = Arc::clone(&sink) as _;
+        let backend = Arc::new(PgAuthBackend::new(pool, port, Some(Arc::clone(&registry))));
+        (backend, registry)
+    }
+
+    /// `PgAuthBackend::register_user` + `authenticate_password` happy
+    /// path must each bump `attempts_total{outcome=success}` and
+    /// observe the duration histogram. Mirrors the
+    /// `memory_backend::success_path_increments_success_outcome` test
+    /// against the production PG path.
+    #[tokio::test]
+    async fn pg_success_path_increments_success_outcome() {
+        let Some(pool) = pool().await else { return };
+        let (backend, registry) = build_pg_backend_with_metrics(pool);
+        let email = unique_email("pg-success");
+
+        let profile = backend
+            .register_user(signup_for(&email))
+            .await
+            .expect("register_user");
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            1,
+            "PgAuthBackend::register_user must increment outcome=success"
+        );
+        assert_eq!(
+            histogram_count(&registry, auth_outcome::SUCCESS),
+            1,
+            "PgAuthBackend::register_user must observe duration histogram"
+        );
+
+        match backend
+            .authenticate_password(&email, "hunter22", None)
+            .await
+            .expect("authenticate_password")
+        {
+            PasswordOutcome::Authenticated(p) => assert_eq!(p.user_id, profile.user_id),
+            PasswordOutcome::MfaRequired { .. } => panic!("MFA not enabled"),
+        }
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            2,
+            "PgAuthBackend::authenticate_password (ok) must increment outcome=success"
+        );
+    }
+
+    /// Wrong-password against `PgAuthBackend` bumps
+    /// `attempts_total{outcome=invalid_creds}` (NOT `success`).
+    #[tokio::test]
+    async fn pg_invalid_password_increments_invalid_creds_outcome() {
+        let Some(pool) = pool().await else { return };
+        let (backend, registry) = build_pg_backend_with_metrics(pool);
+        let email = unique_email("pg-invalid");
+
+        backend
+            .register_user(signup_for(&email))
+            .await
+            .expect("register_user");
+
+        let success_after_register = counter_value(
+            &registry,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            auth_outcome::SUCCESS,
+        );
+        let invalid_before = counter_value(
+            &registry,
+            NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+            auth_outcome::INVALID_CREDS,
+        );
+
+        let err = backend
+            .authenticate_password(&email, "wrong-password", None)
+            .await
+            .expect_err("wrong-password authenticate must fail");
+        assert!(matches!(err, AuthError::InvalidCredentials));
+
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::INVALID_CREDS,
+            ),
+            invalid_before + 1,
+            "PgAuthBackend wrong-password authenticate must increment outcome=invalid_creds"
+        );
+        assert_eq!(
+            counter_value(
+                &registry,
+                NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+                auth_outcome::SUCCESS
+            ),
+            success_after_register,
+            "PgAuthBackend wrong-password authenticate must NOT bump outcome=success"
+        );
+    }
+}

--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -93,10 +93,15 @@ fn unique_email(label: &str) -> String {
 
 /// Build a fresh backend wired to the caller's echo sink so the test
 /// can introspect every delivered message against ONE known port.
+///
+/// `metrics: None` keeps the existing lifecycle test orthogonal to the
+/// `nebula_api_auth_*` emission seam; the dedicated
+/// `auth_metrics.rs` test exercises the metrics path against the same
+/// constructor.
 fn build_backend(pool: Pool<Postgres>) -> (Arc<PgAuthBackend>, Arc<EchoSink>) {
     let sink = Arc::new(EchoSink::default());
     let port: Arc<dyn EmailPort> = Arc::clone(&sink) as _;
-    (Arc::new(PgAuthBackend::new(pool, port)), sink)
+    (Arc::new(PgAuthBackend::new(pool, port, None)), sink)
 }
 
 fn signup_for(email: &str) -> SignupRequest {

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -192,6 +192,130 @@ pub const NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM: &str =
 pub const NEBULA_API_IDEMPOTENCY_LATENCY_MS: &str = "nebula_api_idempotency_latency_ms";
 
 // ---------------------------------------------------------------------------
+// API: auth (Plane-A identity backend)
+// ---------------------------------------------------------------------------
+
+/// Counter: password-authentication attempts.
+///
+/// Labeled by `outcome` (see [`auth_outcome`]). Closed label set — adding
+/// a value permanently inflates the cardinality floor. Covers the full
+/// `authenticate_password` flow including the early `AccountLocked` guard
+/// and the post-success MFA-challenge branch, plus the register / email
+/// verify / password reset attempt families.
+///
+/// `outcome="user_not_found"` is **intentionally absent**: the backend
+/// returns `InvalidCredentials` for a missing email (see
+/// `crates/api/src/domain/auth/backend/pg.rs`) so probe-based user
+/// enumeration cannot read the metric.
+pub const NEBULA_API_AUTH_ATTEMPTS_TOTAL: &str = "nebula_api_auth_attempts_total";
+
+/// Counter: MFA verification attempts (TOTP / challenge-token).
+///
+/// Labeled by `outcome` (see [`auth_outcome`]). Subset of the auth outcome
+/// set: `success`, `invalid_mfa_code`, `token_invalid`, `internal`.
+/// Separated from [`NEBULA_API_AUTH_ATTEMPTS_TOTAL`] so a brute-force on
+/// TOTP is dashboardable independently from a brute-force on passwords.
+pub const NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL: &str = "nebula_api_auth_mfa_attempts_total";
+
+/// Counter: OAuth flow attempts (start + callback).
+///
+/// Labeled by `outcome` (see [`auth_outcome`]) and `provider` (closed
+/// 3-value set — see [`auth_oauth_provider`] — bounded at compile time by
+/// `OAuthProvider::as_str()`). Operator-bounded cardinality ceiling:
+/// `outcome (<= 6) x provider (3) = 18` series.
+///
+/// `complete_oauth` currently returns `NotImplemented` on the PG backend
+/// (`pg.rs`); emission still fires (as `outcome=internal`) so the
+/// operator dashboard reflects the gap until a follow-up wires the real
+/// provider code-exchange.
+pub const NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL: &str = "nebula_api_auth_oauth_attempts_total";
+
+/// Histogram: auth backend method duration in seconds.
+///
+/// Labeled by `outcome` (see [`auth_outcome`]). Default seconds-shaped
+/// buckets are intentional — auth duration is dominated by Argon2id
+/// (100-500 ms) plus DB round-trips, so the 5 ms ... 10 s default span
+/// is correct. **DO NOT** observe in milliseconds — the
+/// [`NEBULA_API_IDEMPOTENCY_LATENCY_MS`] precedent is a latent
+/// unit/bucket mismatch and must not be copied here.
+pub const NEBULA_API_AUTH_DURATION_SECONDS: &str = "nebula_api_auth_duration_seconds";
+
+/// Outcome labels for the auth counters and histogram.
+///
+/// Closed label set — adding a value permanently inflates cardinality on
+/// every auth series, so the unit test in this module is a CI gate against
+/// silent expansion. The matching `#[test]` in
+/// `crates/api/src/domain/auth/backend/error.rs` is the compile-time gate
+/// that fires when a new `AuthError` variant lacks a mapping here.
+///
+/// `user_not_found` is **intentionally absent**: see the
+/// [`NEBULA_API_AUTH_ATTEMPTS_TOTAL`] doc comment.
+pub mod auth_outcome {
+    /// Authentication succeeded; no MFA challenge pending.
+    pub const SUCCESS: &str = "success";
+    /// Password verify failed, or email unknown (the latter is collapsed
+    /// to this value to prevent user-enumeration via metric exposure —
+    /// a `outcome=user_not_found` series would let an operator dashboard
+    /// reveal whether a probed email exists, which is a security
+    /// regression. The backend code path already returns
+    /// `AuthError::InvalidCredentials` rather than `UserNotFound` at the
+    /// password-verify site, so this collapse is also consistent with
+    /// what the backend actually emits today).
+    pub const INVALID_CREDS: &str = "invalid_creds";
+    /// Caller-supplied input field failed shape validation (blank /
+    /// oversized / malformed). Distinct from [`INVALID_CREDS`] because
+    /// high rates indicate caller bugs, not auth attacks.
+    pub const INVALID_INPUT: &str = "invalid_input";
+    /// MFA TOTP code did not verify.
+    pub const INVALID_MFA_CODE: &str = "invalid_mfa_code";
+    /// Authentication succeeded so far, but a TOTP code is required to
+    /// complete the login. Not a [`SUCCESS`] — the auth has not
+    /// completed.
+    pub const MFA_REQUIRED: &str = "mfa_required";
+    /// One-time token (verification / reset / mfa-challenge / oauth-state)
+    /// is unknown, expired, or already consumed.
+    pub const TOKEN_INVALID: &str = "token_invalid";
+    /// Account is in the post-threshold cooldown window. Fires on
+    /// subsequent attempts during the window, not on the arming event
+    /// (which is invisible to the auth backend without a storage API
+    /// change).
+    pub const LOCKOUT: &str = "lockout";
+    /// Email-verification flow has not completed for this account.
+    pub const EMAIL_UNVERIFIED: &str = "email_unverified";
+    /// Rate limit hit on a sensitive endpoint. Reserved for handler-layer
+    /// middleware rejections that surface through `AuthError::RateLimit`;
+    /// the PG/in-memory backends never produce this outcome today, but
+    /// the value stays in the closed set for forward-compat.
+    pub const RATE_LIMIT: &str = "rate_limit";
+    /// OAuth provider returned an error or state-token verification
+    /// failed.
+    pub const OAUTH_FAILED: &str = "oauth_failed";
+    /// Resource already exists (email already registered on signup).
+    pub const CONFLICT: &str = "conflict";
+    /// Internal backend error (storage failure, crypto failure, lock
+    /// poisoning, unexpected `From<EmailError>` collapse,
+    /// `NotImplemented` on a wired-but-incomplete provider path).
+    pub const INTERNAL: &str = "internal";
+}
+
+/// Provider labels for [`NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL`].
+///
+/// Mirror of `OAuthProvider::as_str()` in
+/// `crates/api/src/domain/auth/backend/oauth.rs`. Closed 3-value set
+/// bounded by the enum at compile time. A user-supplied unknown provider
+/// query param is rejected by `OAuthProvider::from_str` with
+/// `AuthError::OAuthFailed` *before* any metric arm runs, so this set
+/// cannot leak.
+pub mod auth_oauth_provider {
+    /// Sign-in via Google.
+    pub const GOOGLE: &str = "google";
+    /// Sign-in via GitHub.
+    pub const GITHUB: &str = "github";
+    /// Sign-in via Microsoft.
+    pub const MICROSOFT: &str = "microsoft";
+}
+
+// ---------------------------------------------------------------------------
 // Webhook (api crate — transport-layer signature enforcement)
 // ---------------------------------------------------------------------------
 
@@ -644,6 +768,8 @@ mod tests {
     use crate::registry::MetricsRegistry;
 
     use super::{
+        NEBULA_API_AUTH_ATTEMPTS_TOTAL, NEBULA_API_AUTH_DURATION_SECONDS,
+        NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL, NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
         NEBULA_API_IDEMPOTENCY_HITS_TOTAL, NEBULA_API_IDEMPOTENCY_LATENCY_MS,
         NEBULA_API_IDEMPOTENCY_MISSES_TOTAL, NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL,
         NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM, NEBULA_CACHE_EVICTIONS, NEBULA_CACHE_HITS,
@@ -667,9 +793,9 @@ mod tests {
         NEBULA_RESOURCE_POOL_EXHAUSTED_TOTAL, NEBULA_RESOURCE_POOL_WAITERS,
         NEBULA_RESOURCE_QUARANTINE_RELEASED_TOTAL, NEBULA_RESOURCE_QUARANTINE_TOTAL,
         NEBULA_RESOURCE_RELEASE_ERROR_TOTAL, NEBULA_RESOURCE_RELEASE_TOTAL,
-        NEBULA_RESOURCE_USAGE_DURATION_SECONDS, idempotency_reject_reason,
-        refresh_coord_claim_outcome, refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome,
-        refresh_coord_sentinel_action, rotation_outcome,
+        NEBULA_RESOURCE_USAGE_DURATION_SECONDS, auth_oauth_provider, auth_outcome,
+        idempotency_reject_reason, refresh_coord_claim_outcome, refresh_coord_coalesced_tier,
+        refresh_coord_reclaim_outcome, refresh_coord_sentinel_action, rotation_outcome,
     };
 
     const RESOURCE_METRIC_NAMES: [&str; 21] = [
@@ -980,6 +1106,105 @@ mod tests {
             }
         }
         assert_eq!(unique.len(), 5);
+    }
+
+    /// API auth metrics (M3.1 follow-up wave §PR-B).
+    ///
+    /// 3 counters + 1 histogram = 4 metric names. Counters are labeled
+    /// per the oracle locked spec: `attempts_total{outcome}` /
+    /// `mfa_attempts_total{outcome}` against the 12-value closed
+    /// [`auth_outcome`] set; `oauth_attempts_total{outcome, provider}`
+    /// adds the 3-value closed [`auth_oauth_provider`] dimension; the
+    /// histogram uses default seconds-shaped buckets keyed by `outcome`.
+    const API_AUTH_METRIC_NAMES: [&str; 4] = [
+        NEBULA_API_AUTH_ATTEMPTS_TOTAL,
+        NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL,
+        NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
+        NEBULA_API_AUTH_DURATION_SECONDS,
+    ];
+
+    #[test]
+    fn api_auth_constants_are_accessible_unique_and_registry_safe() {
+        let registry = MetricsRegistry::new();
+        let mut unique = HashSet::new();
+        for metric_name in API_AUTH_METRIC_NAMES {
+            assert!(!metric_name.is_empty());
+            assert!(metric_name.starts_with("nebula_api_auth_"));
+            assert!(
+                metric_name
+                    .chars()
+                    .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+            );
+            assert!(unique.insert(metric_name));
+
+            if metric_name == NEBULA_API_AUTH_DURATION_SECONDS {
+                let labels = registry.interner().single("outcome", auth_outcome::SUCCESS);
+                let histogram = registry.histogram_labeled(metric_name, &labels).unwrap();
+                histogram.observe(0.05);
+                assert_eq!(histogram.count(), 1);
+            } else if metric_name == NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL {
+                let labels = registry.interner().label_set(&[
+                    ("outcome", auth_outcome::SUCCESS),
+                    ("provider", auth_oauth_provider::GOOGLE),
+                ]);
+                let counter = registry.counter_labeled(metric_name, &labels).unwrap();
+                counter.inc();
+                assert_eq!(counter.get(), 1);
+            } else {
+                let labels = registry.interner().single("outcome", auth_outcome::SUCCESS);
+                let counter = registry.counter_labeled(metric_name, &labels).unwrap();
+                counter.inc();
+                assert_eq!(counter.get(), 1);
+            }
+        }
+        assert_eq!(unique.len(), 4);
+    }
+
+    #[test]
+    fn auth_outcome_labels_are_closed_set() {
+        // Closed label set per the oracle locked spec — adding a value
+        // here permanently inflates cardinality on every auth series so
+        // this test is the CI gate against silent expansion. Mirrors
+        // `idempotency_reject_reason_labels_are_closed_set`.
+        let labels = [
+            auth_outcome::SUCCESS,
+            auth_outcome::INVALID_CREDS,
+            auth_outcome::INVALID_INPUT,
+            auth_outcome::INVALID_MFA_CODE,
+            auth_outcome::MFA_REQUIRED,
+            auth_outcome::TOKEN_INVALID,
+            auth_outcome::LOCKOUT,
+            auth_outcome::EMAIL_UNVERIFIED,
+            auth_outcome::RATE_LIMIT,
+            auth_outcome::OAUTH_FAILED,
+            auth_outcome::CONFLICT,
+            auth_outcome::INTERNAL,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 12, "auth outcome labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
+    }
+
+    #[test]
+    fn auth_oauth_provider_labels_are_closed_set() {
+        // Bounded at compile time by the `OAuthProvider` enum
+        // (`Google | GitHub | Microsoft`). A user-supplied unknown
+        // provider is rejected by `from_str` with `OAuthFailed` before
+        // any metric arm runs, so the set cannot leak.
+        let labels = [
+            auth_oauth_provider::GOOGLE,
+            auth_oauth_provider::GITHUB,
+            auth_oauth_provider::MICROSOFT,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 3, "auth oauth provider labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes M3.1 follow-up — **"AuthError → ApiError mapping audit + `nebula_api_auth_*` metrics family for failed/locked-out attempts"** per [`docs/ROADMAP.md`](https://github.com/vanyastaff/nebula/blob/main/docs/ROADMAP.md) §M3.1.

Part of the M3.1 follow-up wave per [`docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md`](https://github.com/vanyastaff/nebula/blob/main/docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md) (PR-B of 3). Chained after PR-A (#751).

## What

Four new counters/histogram in the `nebula_api_auth_*` namespace, emitted from `PgAuthBackend` and `InMemoryAuthBackend`:

| Constant | Type | Labels |
|---|---|---|
| `nebula_api_auth_attempts_total` | counter | `outcome` (12-value closed set) |
| `nebula_api_auth_mfa_attempts_total` | counter | `outcome` |
| `nebula_api_auth_oauth_attempts_total` | counter | `outcome`, `provider` (3-value closed set bounded by `OAuthProvider` enum) |
| `nebula_api_auth_duration_seconds` | histogram (default seconds buckets) | `outcome` |

**Outcome closed set (12 values):** `success`, `invalid_creds`, `invalid_input`, `invalid_mfa_code`, `mfa_required`, `token_invalid`, `lockout`, `email_unverified`, `rate_limit`, `oauth_failed`, `conflict`, `internal`.

## Architectural decisions (oracle-locked)

The implementation followed an `oracle` consult before any constants landed (see [`docs/plans/recon/pr-b-oracle-verdict.md`](https://github.com/vanyastaff/nebula/blob/main/docs/plans/recon/pr-b-oracle-verdict.md)). Four substantive changes vs. the initial plan:

1. **Histogram is `_duration_seconds`, NOT `_latency_ms`.** Default `MetricsRegistry` buckets are seconds-shaped; `NEBULA_API_IDEMPOTENCY_LATENCY_MS` ships a unit/bucket mismatch (observes ms against seconds buckets) — copying that precedent would have made auth latency dashboards equally broken. Idempotency bug is left untouched per scope; flagged for separate follow-up.
2. **No standalone `locked_out_total` counter.** `PgUserRepo::record_login_failure` does not signal the threshold-cross to the caller, so the arming event is invisible without a storage API change. `attempts_total{outcome=lockout}` captures every observable lockout effect (subsequent attempts during the cooldown window).
3. **No `OtlpMetricsConfig::with_allowlist(["outcome", "provider"])` call site.** A global exporter allowlist would silently strip `tenant_id`, `webhook_key_kind`, `tier`, `action`, `reason` labels from every other namespace (webhook, idempotency, refresh-coord). Closed cardinality is enforced **by-construction** at every emission via `&'static str` constants in `naming::auth_outcome` / `naming::auth_oauth_provider` (mirrors the existing `idempotency_reject_reason::*` precedent).
4. **12 outcome values, not 7.** Added `token_invalid`, `oauth_failed`, `invalid_mfa_code`, `invalid_input`, `conflict` for signal fidelity vs the full `AuthError` enum.

## `AuthError → ApiError` mapping audit

- All 14 `AuthError` variants map to explicit `ApiError` arms (no fall-through `Internal` collapse) — verified at `crates/api/src/domain/auth/backend/error.rs:101-132`.
- New compile-time gate: `default_outcome_for(&AuthError) → &'static str` uses an exhaustive `match` with **no catch-all arm**. Adding a new `AuthError` variant fails compilation until mapped to an `auth_outcome::*` constant. The `every_auth_error_variant_has_a_closed_outcome_label` `#[test]` enumerates all 14 variants and asserts each maps into the 12-element closed set.
- `UserNotFound → invalid_creds` is a **deliberate collapse** to prevent user-enumeration via metric exposure (an `outcome=user_not_found` series would let an operator dashboard reveal whether a probed email exists). Documented on `auth_outcome::INVALID_CREDS`.

## Emission seam

`PgAuthBackend::new` and `InMemoryAuthBackend::with_metrics` accept `Option<Arc<MetricsRegistry>>`, mirroring `IdempotencyLayer::with_metrics` (`crates/api/src/middleware/idempotency/layer.rs:73-83`). When `None`, every emission is a no-op via `let Some(reg) = self.metrics.as_ref() else { return; }`. Compose root threads `metrics_registry` from `AppState` through `build_auth_backend`.

Shared helper `metrics_emit::run_with_metrics` (`crates/api/src/domain/auth/backend/provider.rs:42-148`) wraps each backend method's future: start timer → await body → classify result → emit counter + histogram with `&'static str` labels. Histogram observation uses `elapsed.as_secs_f64()` — NOT `* 1000.0`.

## Test evidence

```
cargo nextest run -p nebula-metrics
Summary [80 tests run: 80 passed, 0 skipped]

DATABASE_URL=postgresql://nebula:nebula@localhost:5432/nebula \
  cargo nextest run -p nebula-api --test auth_metrics --test auth_pg_e2e --features postgres
Summary [11 tests run: 11 passed, 0 skipped]
  (5 auth_pg_e2e lifecycle + 4 memory_backend + 2 pg_backend)

cargo nextest run -p nebula-api --test auth_metrics --features postgres
Summary [6 tests run: 6 passed, 0 skipped]
  (PG suite no-ops cleanly when DATABASE_URL absent)
```

All triangulated: every emitting method covered with both a positive and a negative outcome.

## Out of scope (separate follow-ups)

- **`NEBULA_API_IDEMPOTENCY_LATENCY_MS` unit/bucket bug** at `crates/api/src/middleware/idempotency/layer.rs:215` — one-line fix, separate PR.
- **Distinct "lockout transition armed" counter** — requires `UserRepo::record_login_failure` to return `LockoutTransition { armed: bool }`. Storage-port ABI change; file as ROADMAP §M3.1 follow-up.
- **`complete_oauth` real code exchange** — currently returns `NotImplemented`, so `outcome=internal` dominates the OAuth callback signal. Will resolve via PR-C (OAuth-from-secrets sub-plan, deferred per the wave plan).

## Plan + recon + audits

- Plan: `docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md` §PR-B
- Recon: `docs/plans/recon/m3.1-followup-wave-recon.md` §PR-B
- Oracle verdict (locked spec): `docs/plans/recon/pr-b-oracle-verdict.md`
- Worker report: `docs/plans/recon/pr-b-worker-report.md`
- Reviewer report: `docs/plans/recon/pr-b-reviewer-report.md`

(Plan/recon/oracle/worker/reviewer artifacts exist on the parent worktree; landing them as tracked artifacts is the parent's responsibility after this PR squash-merges.)