### PR TITLE
feat(server): production SMTP transport for EmailPort via lettre

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -78,6 +78,25 @@ NEBULA_VERSION=0.0.0-dev
 # API_ENABLE_COMPRESSION=true
 
 # ----------------------------------------------------------------------------
+# Email delivery (SMTP) — apps/server/src/email/smtp.rs
+# ----------------------------------------------------------------------------
+#
+# `API_SMTP_HOST` is the sentinel: unset → dev `EchoSink` (in-memory
+# inbox); set → `SmtpEmailPort` (lettre). Set + invalid → boot fails
+# CLOSED (no silent fallback to EchoSink). See apps/server/README.md
+# §"Email delivery (SMTP)" for the full env-binding contract.
+#
+# API_SMTP_HOST=smtp.example.com
+# API_SMTP_PORT=587                       # default 587 (STARTTLS submission)
+# API_SMTP_USERNAME=noreply@example.com   # if set, PASSWORD is required
+# API_SMTP_PASSWORD=replace-me            # SecretString — NEVER commit
+# API_SMTP_FROM=noreply@example.com       # required; must contain '@'
+# API_SMTP_TLS_MODE=starttls              # none | starttls | implicit
+#                                          (port-derived if unset:
+#                                          465 → implicit, 587 → starttls,
+#                                          other → none + startup warn)
+
+# ----------------------------------------------------------------------------
 # API secrets — DO NOT commit. Generate locally; never share.
 # ----------------------------------------------------------------------------
 

--- a/.github/workflows/dep-review.yml
+++ b/.github/workflows/dep-review.yml
@@ -43,5 +43,7 @@ jobs:
           # Mirrors the `[licenses].allow` set in `deny.toml`. Keep both lists
           # aligned — divergence means the same PR can pass dep-review but
           # fail `cargo deny` (or vice versa) and confuse contributors.
-          allow-licenses: Apache-2.0, BSD-2-Clause, BSD-3-Clause, CC0-1.0, CDLA-Permissive-2.0, ISC, MIT, MPL-2.0, Unicode-3.0, Unicode-DFS-2016, Zlib
+          # `0BSD` admits `quoted_printable` (transitive via `lettre` → nebula-server);
+          # OSI-approved, strictly more permissive than MIT (no attribution clause).
+          allow-licenses: 0BSD, Apache-2.0, BSD-2-Clause, BSD-3-Clause, CC0-1.0, CDLA-Permissive-2.0, ISC, MIT, MPL-2.0, Unicode-3.0, Unicode-DFS-2016, Zlib
           comment-summary-in-pr: on-failure

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1998,6 +1998,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-encoding"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9298e6504d9b9e780ed3f7dfd43a61be8cd0e09eb07f7706a945b0072b6670b6"
+dependencies = [
+ "base64",
+ "memchr",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3169,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lettre"
+version = "0.11.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
+dependencies = [
+ "async-trait",
+ "base64",
+ "email-encoding",
+ "email_address",
+ "fastrand",
+ "futures-io",
+ "futures-util",
+ "httpdate",
+ "idna",
+ "mime",
+ "nom",
+ "percent-encoding",
+ "quoted_printable",
+ "rustls",
+ "socket2 0.6.3",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3468,6 +3511,7 @@ dependencies = [
  "rand 0.10.1",
  "reqwest 0.13.3",
  "rstest",
+ "secrecy",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -4071,11 +4115,14 @@ dependencies = [
 name = "nebula-server"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "clap",
+ "lettre",
  "nebula-api",
  "nebula-metrics",
  "nebula-storage",
+ "secrecy",
  "serde_json",
  "sqlx",
  "thiserror",
@@ -4224,6 +4271,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -5136,6 +5192,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "quoted_printable"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478e0585659a122aa407eb7e3c0e1fa51b1d8a870038bd29f0cf4a8551eea972"
 
 [[package]]
 name = "r-efi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,14 @@ reqwest = { version = "0.13", features = ["json"], default-features = false }
 axum = { version = "0.8", features = ["json"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "compression-gzip"] }
 
+# SMTP — production email transport (consumed by apps/server's SmtpEmailPort).
+# `default-features = false` strips native-tls / sendmail / file transport;
+# the workspace standard is rustls + tokio, not openssl. `builder` enables
+# the `Message::builder()` typed envelope construction;
+# `smtp-transport` brings `AsyncSmtpTransport<Tokio1Executor>`;
+# `tokio1-rustls-tls` is the only TLS stack we ship (matches reqwest above).
+lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }
+
 # OpenAPI 3.1 spec generation (ADR-0047)
 # `utoipa-axum` is the only mounting path that ties the served `axum::Router`
 # to the generated `OpenApi` value — handlers without `#[utoipa::path]` cannot

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -31,6 +31,13 @@ axum = { workspace = true }
 serde_json = { workspace = true }
 url = { workspace = true }
 thiserror = { workspace = true }
+async-trait = { workspace = true }
+secrecy = { workspace = true }
+# Production SMTP transport for the `EmailPort`. The trait + dev EchoSink live
+# in nebula-api; the lettre-backed impl lives here so the api crate stays free
+# of the lettre direct dep (and library consumers of nebula-api do not pull
+# lettre transitively).
+lettre = { workspace = true }
 # Optional — only linked by the PG-backed idempotency path in
 # `compose::build_pg_idempotency_store` (gated by `feature = "postgres"`).
 # Mirrors `crates/api/Cargo.toml` exactly so the verbatim `use sqlx::...`

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,119 @@
+# nebula-server
+
+Composition-root binary for the Nebula API. Wires the `nebula-api` HTTP
+surface to one of three ingress transports (`api`, `webhook`,
+`realtime`, or `all`) and instantiates every port the runtime needs
+(storage adapters, idempotency store, identity backend, email transport,
+metrics + telemetry exporters).
+
+Run the default profile locally:
+
+```bash
+cargo run -p nebula-server                       # NEBULA_TRANSPORT=all
+cargo run -p nebula-server -- --transport api    # REST only
+cargo run -p nebula-server -- --transport webhook
+cargo run -p nebula-server -- --transport realtime
+```
+
+All operator-facing configuration lives in environment variables; the
+canonical registry is `crates/api/src/config/env.rs`. The composition
+root in `apps/server/src/compose.rs` is the only place those values
+turn into concrete `Arc<dyn …>` ports.
+
+## Email delivery (SMTP)
+
+The API needs an `EmailPort` to ship sign-up verification and
+password-reset links. `nebula-api` ships the trait + a dev-only
+`EchoSink` that buffers messages in-process so the local-first boot
+path requires no SMTP server. The production transport
+(`apps/server::email::SmtpEmailPort`, backed by `lettre = "0.11"`) is
+wired here.
+
+### Behaviour contract
+
+| `API_SMTP_HOST` | Resulting port | When to use |
+|-----------------|----------------|-------------|
+| **unset**       | `EchoSink` (dev) | Local development, in-process tests. Messages are visible via the in-memory backend's `emails()` accessor. |
+| **set + valid** | `SmtpEmailPort` | Production. Verification mails actually leave the process. |
+| **set + invalid** | startup error (`TransportInitError::SmtpEmailPortInit`) | Fail-CLOSED. An operator who asked for SMTP and got the config wrong sees the error at boot, not as a silent fallback to `EchoSink` that would swallow auth mails. |
+
+The same `Arc<dyn EmailPort>` is shared between `AppState::email_port`
+and the selected `AuthBackend`, so forward-compat non-auth consumers
+(org invitations, billing notices) inherit the transport without extra
+wiring.
+
+### Env vars
+
+All keys are prefixed with `API_SMTP_`. `API_SMTP_HOST` is the
+sentinel: present means the operator wants SMTP, absent means
+`EchoSink`. Validation is fail-closed; the table below lists the
+strict-on-startup checks.
+
+| Variable | Type | Default | Validation |
+|----------|------|---------|------------|
+| `API_SMTP_HOST` | string | — (none → EchoSink) | Non-empty when present. |
+| `API_SMTP_PORT` | u16    | `587` | Parsed by `u16::from_str`. |
+| `API_SMTP_FROM` | string | — | Required when `API_SMTP_HOST` is set. Must contain `@`. Becomes the canonical `From` header for every outbound mail (a handler cannot smuggle a different sender). |
+| `API_SMTP_USERNAME` | string | — | Optional. If set, `API_SMTP_PASSWORD` MUST also be set, or boot fails with `ApiConfigError::SmtpAuthIncomplete`. |
+| `API_SMTP_PASSWORD` | string | — | Wrapped in `secrecy::SecretString` immediately on parse; `Debug` redacts and the buffer zeroizes on drop. Never logged. Never round-tripped through `serde` (`#[serde(skip)]` on the field). |
+| `API_SMTP_TLS_MODE` | enum   | port-derived | `none` / `starttls` / `implicit`. If unset: `465` → `implicit`, `587` → `starttls`, anything else → `none`. `none` emits a `tracing::warn!` at startup because plaintext SMTP is dev-only. |
+
+Recognized enum values for `API_SMTP_TLS_MODE` (case-insensitive):
+
+- `starttls` (also `start_tls`, `start-tls`) — STARTTLS upgrade.
+- `implicit` (also `smtps`) — TLS from the first byte.
+- `none` — plaintext (dev only; warns at startup).
+
+### Example: production gmail-style relay
+
+```bash
+API_SMTP_HOST=smtp.example.com
+API_SMTP_PORT=587
+API_SMTP_USERNAME=noreply@example.com
+API_SMTP_PASSWORD=...           # generate; do not commit
+API_SMTP_FROM=noreply@example.com
+# API_SMTP_TLS_MODE=starttls    # inferred from port 587
+```
+
+### Example: implicit-TLS submission
+
+```bash
+API_SMTP_HOST=smtp.example.com
+API_SMTP_PORT=465
+API_SMTP_USERNAME=noreply@example.com
+API_SMTP_PASSWORD=...
+API_SMTP_FROM=noreply@example.com
+# API_SMTP_TLS_MODE=implicit    # inferred from port 465
+```
+
+### Example: in-cluster dev relay (plaintext, no auth)
+
+```bash
+API_SMTP_HOST=mailhog
+API_SMTP_PORT=1025
+API_SMTP_FROM=dev@nebula.local
+API_SMTP_TLS_MODE=none          # composition root warns at startup
+```
+
+### Security
+
+- Password is held in `SecretString` everywhere: env parser → config
+  struct → `lettre::Credentials::new` (the only `ExposeSecret` call).
+- `EmailError::Transport(String)` and `EmailError::InvalidAddress(_)`
+  never contain the SMTP password — lettre's `Error::Display` does
+  not embed credentials (verified against `lettre-0.11.22`), and the
+  mapping in `apps/server/src/email/smtp.rs` wraps lettre's error
+  rather than propagating it raw.
+- `SmtpEmailConfig::password` is `#[serde(skip)]`, so a
+  `tracing::error!(?config)` line cannot leak the secret through
+  `serde_json::to_string` on an `ApiConfig` snapshot.
+
+### Out of scope (today)
+
+- HTML template rendering — `EmailMessage::body` stays a raw token; a
+  future PR introduces `templates/`.
+- Mailpit/Mailhog in `deploy/docker/` — local dev stays on `EchoSink`
+  unless the operator explicitly wires `API_SMTP_HOST`.
+- Bounce / retry logic — handled at the auth-backend caller layer via
+  idempotency, not here.
+- Multipart / attachments — `text/plain` only.

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -10,14 +10,17 @@ use thiserror::Error;
 
 use nebula_api::{
     ApiConfig, ApiConfigError, AppState, TelemetryGuard, TelemetryInitError, app,
-    config::{AuthBackendKind, IdempotencyBackend},
+    config::{AuthBackendKind, IdempotencyBackend, SmtpTlsMode},
     domain::auth::backend::{AuthBackend, InMemoryAuthBackend},
     middleware::{IdempotencyStore, InMemoryIdempotencyStore},
     ports::email::{EchoSink, EmailPort},
 };
 use nebula_metrics::{MetricsRegistry, OtlpInitError};
 
-use crate::transport::ServerTransport;
+use crate::{
+    email::{SmtpEmailPort, SmtpEmailPortBuildError},
+    transport::ServerTransport,
+};
 
 /// Runtime errors for transport binaries.
 #[derive(Debug, Error)]
@@ -123,6 +126,20 @@ pub enum TransportInitError {
     /// dependency (the typed `RegisterError` stays inside `nebula-api`).
     #[error("credential-schema port init failed: {0}")]
     CredentialSchemaInit(String),
+    /// `API_SMTP_HOST` is set but the `SmtpEmailPort` constructor
+    /// rejected the resolved config (invalid `from_address` mailbox,
+    /// lettre TLS-parameter construction error, etc.).
+    ///
+    /// Per the fail-closed contract in [`nebula_api::ApiConfig::smtp`]:
+    /// silently falling back to `EchoSink` when an operator explicitly
+    /// asked for SMTP would swallow verification mails in production
+    /// with no diagnostic. We refuse to boot instead.
+    #[error("SMTP email transport init failed: {source}")]
+    SmtpEmailPortInit {
+        /// Underlying `SmtpEmailPortBuildError` from the constructor.
+        #[source]
+        source: SmtpEmailPortBuildError,
+    },
 }
 
 /// Start a server binary for a selected transport profile.
@@ -176,12 +193,13 @@ impl ServerRuntime {
         state = state.with_idempotency_store(idempotency_store);
         // Build ONE shared `Arc<dyn EmailPort>` and pass the same Arc
         // to both `AppState::email_port` and the selected auth backend.
-        // Today this is the dev `EchoSink`; a future SMTP transport
-        // swaps in here without changing either consumer. Forward-compat
-        // non-auth email consumers (org invitations, billing notices)
-        // read from `state.email_port` and work uniformly regardless of
-        // which auth backend is wired.
-        let email_port: Arc<dyn EmailPort> = Arc::new(EchoSink::default());
+        // `API_SMTP_HOST` unset → dev `EchoSink` (unchanged local-first
+        // default); set → production `SmtpEmailPort` (fails CLOSED on
+        // malformed config per the policy on `ApiConfig::smtp`).
+        // Forward-compat non-auth email consumers (org invitations,
+        // billing notices) read from `state.email_port` and work
+        // uniformly regardless of which transport is wired.
+        let email_port = build_email_port(&api_config)?;
         let auth_backend = build_auth_backend(
             &api_config,
             Arc::clone(&email_port),
@@ -281,6 +299,39 @@ pub fn default_state(
         .with_api_keys(api_config.api_keys.clone())
         .with_credential_schema(credential_schema)
         .with_metrics_registry(metrics_registry))
+}
+
+/// Build the shared `Arc<dyn EmailPort>` from `api_config.smtp`.
+///
+/// `None` keeps the dev `EchoSink` (`API_SMTP_HOST` unset). `Some`
+/// instantiates an [`SmtpEmailPort`] and fails CLOSED on construction
+/// errors (invalid `from_address`, malformed TLS parameters) so an
+/// operator who set `API_SMTP_HOST` never silently boots with the
+/// in-process echo sink. `SmtpTlsMode::None` emits a startup
+/// `tracing::warn!` because plaintext SMTP is a dev-only posture.
+pub fn build_email_port(api_config: &ApiConfig) -> Result<Arc<dyn EmailPort>, TransportInitError> {
+    if let Some(smtp_cfg) = api_config.smtp.as_ref() {
+        if matches!(smtp_cfg.tls, SmtpTlsMode::None) {
+            tracing::warn!(
+                host = %smtp_cfg.host,
+                port = smtp_cfg.port,
+                "smtp: TLS disabled (API_SMTP_TLS_MODE=none) — credentials and mail bodies travel in plaintext; this is acceptable only for in-cluster dev"
+            );
+        }
+        let port = SmtpEmailPort::new(smtp_cfg)
+            .map_err(|source| TransportInitError::SmtpEmailPortInit { source })?;
+        tracing::info!(
+            host = %smtp_cfg.host,
+            port = smtp_cfg.port,
+            tls = ?smtp_cfg.tls,
+            authenticated = smtp_cfg.username.is_some(),
+            "email: SMTP transport wired"
+        );
+        Ok(Arc::new(port))
+    } else {
+        tracing::info!("email: EchoSink (dev) wired — set API_SMTP_HOST to enable SMTP");
+        Ok(Arc::new(EchoSink::default()))
+    }
 }
 
 /// Construct the Plane-A authentication backend from `api_config.auth`.

--- a/apps/server/src/email/mod.rs
+++ b/apps/server/src/email/mod.rs
@@ -1,0 +1,21 @@
+//! Production `EmailPort` implementations wired by the composition root.
+//!
+//! The trait, dev `EchoSink`, and `EmailMessage` / `EmailError` types live
+//! in `nebula-api`; the concrete transports (today: SMTP via `lettre`,
+//! tomorrow: SES / SendGrid / Postmark) live here so that workers and
+//! library consumers of `nebula-api` do not transitively pull a network
+//! transport crate.
+//!
+//! The composition root branches on [`nebula_api::ApiConfig::smtp`]:
+//!
+//! - `Some(SmtpEmailConfig { .. })` \u2192 [`SmtpEmailPort`] (fails CLOSED on
+//!   any malformed value rather than silently falling back to `EchoSink`);
+//! - `None` \u2192 the dev [`nebula_api::ports::email::EchoSink`].
+//!
+//! See [`smtp`] for the lettre-backed transport, its TLS posture, and the
+//! `EmailError::Transport` redaction discipline that keeps the SMTP
+//! password out of `tracing` lines and `problem-details` bodies.
+
+pub mod smtp;
+
+pub use smtp::{SmtpEmailPort, SmtpEmailPortBuildError};

--- a/apps/server/src/email/smtp.rs
+++ b/apps/server/src/email/smtp.rs
@@ -1,0 +1,428 @@
+//! Production [`EmailPort`] backed by the `lettre` SMTP transport.
+//!
+//! The trait is defined in `nebula-api` (api-safe shape, no `lettre` dep).
+//! This module owns the lettre-side glue: parsing a [`SmtpEmailConfig`]
+//! into an `AsyncSmtpTransport<Tokio1Executor>` with the requested TLS
+//! posture, translating an [`EmailMessage`] into a `lettre::Message`,
+//! and mapping `lettre`'s rich transport error tree onto the small
+//! [`EmailError::Transport`] / [`EmailError::InvalidAddress`] surface
+//! the rest of the API understands.
+//!
+//! ## Security
+//!
+//! The SMTP password lives in a `secrecy::SecretString` on the config
+//! side: `SmtpEmailConfig::password` is `Option<SecretString>`
+//! (auto-redacting `Debug`, zeroized on drop). At
+//! [`SmtpEmailPort::new`] construction time the secret is exposed once
+//! via `ExposeSecret` and consumed by
+//! `lettre::transport::smtp::authentication::Credentials::new`, which
+//! internally owns a `String` for the **lifetime of the transport** (it
+//! must survive every `send` call). That `String` is private to
+//! lettre, never re-read by this module, and never logged. The
+//! `SecretString` on the config drops + zeroizes when the `ApiConfig`
+//! value drops at process exit; from that moment forward the only
+//! remaining copy is inside the lettre transport, which is also
+//! dropped at process exit.
+//!
+//! The error mapping path NEVER includes the credentials. lettre's own
+//! `Error::Display` does not embed the password (verified against
+//! `lettre-0.11.22/src/transport/smtp/error.rs`), but we still wrap the
+//! mapped string in a tracing-safe `EmailError::Transport(reason)` and
+//! never log the `SmtpEmailConfig` value, so a future lettre revision
+//! that started printing more context could not silently regress us.
+//!
+//! ## Composition
+//!
+//! [`SmtpEmailPort::new`] is what `apps/server::compose` calls when
+//! `ApiConfig::smtp` is `Some`. It fails CLOSED on TLS-parameter
+//! construction errors so an operator who set `API_SMTP_HOST` without a
+//! reachable certificate authority does not silently fall back to
+//! plaintext or to `EchoSink`.
+//!
+//! [`EmailPort`]: nebula_api::ports::email::EmailPort
+//! [`EmailMessage`]: nebula_api::ports::email::EmailMessage
+//! [`EmailError::Transport`]: nebula_api::ports::email::EmailError::Transport
+//! [`EmailError::InvalidAddress`]: nebula_api::ports::email::EmailError::InvalidAddress
+
+use async_trait::async_trait;
+use lettre::{
+    AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor, message::Mailbox,
+    transport::smtp::authentication::Credentials,
+};
+use nebula_api::{
+    config::{SmtpEmailConfig, SmtpTlsMode},
+    ports::email::{EmailError, EmailMessage, EmailPort},
+};
+use secrecy::ExposeSecret;
+use thiserror::Error;
+
+/// Failure modes for [`SmtpEmailPort::new`] — separate from runtime
+/// `EmailError` so the composition root can fail CLOSED at startup with
+/// a typed error instead of a string-formatted runtime path.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum SmtpEmailPortBuildError {
+    /// `from_address` failed to parse as an RFC 5321 mailbox. The
+    /// `from_env` validator already enforces the `@` test but does
+    /// not parse the full local-part / domain grammar; lettre's
+    /// `Mailbox::FromStr` is the canonical gate.
+    #[error("SMTP from_address is not a valid mailbox: {0}")]
+    InvalidFromAddress(String),
+
+    /// `lettre::AsyncSmtpTransport::relay` / `starttls_relay` rejected
+    /// the host string (bad DNS name, malformed TLS parameters, etc.).
+    /// The wrapped detail comes from lettre and intentionally does NOT
+    /// include the SMTP password (we never pass it into this path).
+    #[error("SMTP transport construction failed: {0}")]
+    Transport(String),
+}
+
+/// `EmailPort` impl backed by a single-connection
+/// `AsyncSmtpTransport<Tokio1Executor>`.
+///
+/// The `pool` feature of `lettre` is intentionally NOT enabled, so this
+/// is NOT a pooled transport — lettre opens / closes the connection
+/// per `send` and reconnects on transient errors. Pooling can be added
+/// later by enabling the `pool` feature + plumbing a `pool_config`
+/// knob through `SmtpEmailConfig`.
+///
+/// Holds the validated `From` mailbox alongside the transport so every
+/// outbound message uses the operator-configured sender regardless of
+/// what an [`EmailMessage`] carries — a misconfigured handler cannot
+/// smuggle a different sender through this port. The auto-derived
+/// `Debug` is safe: the inner `AsyncSmtpTransport` only exposes server
+/// metadata (no credentials), and lettre's stub transport carries only
+/// the test-recorded message log.
+#[derive(Debug)]
+pub struct SmtpEmailPort {
+    transport: TransportImpl,
+    from_address: Mailbox,
+}
+
+/// Inner transport dispatch.
+///
+/// Production builds use `Smtp` exclusively; the `#[cfg(test)]` `Stub`
+/// arm lets the unit tests assert SMTP envelope shape and error mapping
+/// against `lettre::transport::stub::AsyncStubTransport` without a real
+/// SMTP server. The enum dispatch keeps `EmailPort` `dyn`-compatible
+/// (no generic on the public type) while staying allocation-free in
+/// the hot path.
+#[derive(Debug)]
+enum TransportImpl {
+    Smtp(AsyncSmtpTransport<Tokio1Executor>),
+    #[cfg(test)]
+    Stub(lettre::transport::stub::AsyncStubTransport),
+}
+
+impl SmtpEmailPort {
+    /// Build an `SmtpEmailPort` from a validated [`SmtpEmailConfig`].
+    ///
+    /// Returns [`SmtpEmailPortBuildError`] when the `from_address`
+    /// cannot parse as a mailbox or when lettre rejects the host /
+    /// TLS parameters. The composition root treats both as
+    /// startup-fatal (per the fail-closed contract documented on
+    /// [`nebula_api::ApiConfig::smtp`]).
+    pub fn new(config: &SmtpEmailConfig) -> Result<Self, SmtpEmailPortBuildError> {
+        let from_address = config
+            .from_address
+            .parse::<Mailbox>()
+            .map_err(|err| SmtpEmailPortBuildError::InvalidFromAddress(err.to_string()))?;
+
+        // TLS posture: lettre exposes three constructors, one per mode.
+        // `relay` (implicit TLS, default port 465) and `starttls_relay`
+        // (STARTTLS upgrade, default port 587) build TlsParameters from
+        // the host string and can fail at parameter-construction time;
+        // `builder_dangerous` is plaintext.
+        let mut builder = match config.tls {
+            SmtpTlsMode::Implicit => AsyncSmtpTransport::<Tokio1Executor>::relay(&config.host)
+                .map_err(|err| SmtpEmailPortBuildError::Transport(err.to_string()))?,
+            SmtpTlsMode::StartTls => {
+                AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&config.host)
+                    .map_err(|err| SmtpEmailPortBuildError::Transport(err.to_string()))?
+            },
+            SmtpTlsMode::None => {
+                AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(config.host.clone())
+            },
+        };
+
+        builder = builder.port(config.port);
+
+        // Both halves are validated to be Some-Some or None-None by
+        // `ApiConfig::smtp_from_env` (`SmtpAuthIncomplete`), so the
+        // `Some(_), Some(_)` arm is the only auth path. The `_, _`
+        // catch-all preserves the unauthenticated-relay contract
+        // without re-validating here.
+        if let (Some(user), Some(password)) = (config.username.as_ref(), config.password.as_ref()) {
+            // `ExposeSecret` is the only place the password leaves
+            // `SecretString`. The String we hand to lettre is owned by
+            // `Credentials` for the lifetime of the transport; the
+            // original `SecretString` zeroizes on drop when the config
+            // value drops.
+            let creds = Credentials::new(user.clone(), password.expose_secret().to_owned());
+            builder = builder.credentials(creds);
+        }
+
+        let transport = builder.build::<Tokio1Executor>();
+
+        Ok(Self {
+            transport: TransportImpl::Smtp(transport),
+            from_address,
+        })
+    }
+
+    /// Test-only constructor that wires a `lettre::AsyncStubTransport`.
+    ///
+    /// Kept `pub(crate)` so production code cannot accidentally build an
+    /// `SmtpEmailPort` against the stub. The composition root only ever
+    /// calls [`Self::new`].
+    #[cfg(test)]
+    pub(crate) fn with_stub_transport(
+        from_address: &str,
+        transport: lettre::transport::stub::AsyncStubTransport,
+    ) -> Result<Self, SmtpEmailPortBuildError> {
+        let from_address = from_address
+            .parse::<Mailbox>()
+            .map_err(|err| SmtpEmailPortBuildError::InvalidFromAddress(err.to_string()))?;
+        Ok(Self {
+            transport: TransportImpl::Stub(transport),
+            from_address,
+        })
+    }
+
+    /// Build a `lettre::Message` from an api-side [`EmailMessage`].
+    ///
+    /// Extracted so the production path and the unit tests share one
+    /// envelope-construction implementation (the strict-TDD refactor
+    /// step).
+    fn build_lettre_message(&self, msg: &EmailMessage) -> Result<Message, EmailError> {
+        let to: Mailbox = msg
+            .to
+            .parse()
+            .map_err(|_| EmailError::InvalidAddress(msg.to.clone()))?;
+        Message::builder()
+            .from(self.from_address.clone())
+            .to(to)
+            .subject(msg.subject.clone())
+            .body(msg.body.clone())
+            // `lettre::error::Error` here is a builder-side failure
+            // (invalid header, body encoding). It does NOT touch the
+            // SMTP password — keep the mapping symmetrical with the
+            // transport-side mapping below.
+            .map_err(|err| EmailError::Transport(format!("envelope build failed: {err}")))
+    }
+}
+
+#[async_trait]
+impl EmailPort for SmtpEmailPort {
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, msg),
+        fields(email.kind = %msg.kind, smtp.from = %self.from_address)
+    )]
+    async fn send(&self, msg: EmailMessage) -> Result<(), EmailError> {
+        let letter = self.build_lettre_message(&msg)?;
+        match &self.transport {
+            TransportImpl::Smtp(transport) => {
+                transport.send(letter).await.map_err(|err| {
+                    // lettre's smtp::Error Display formats the SMTP
+                    // status / response without the password (verified
+                    // against 0.11.22 source). We still wrap rather
+                    // than propagate so a future revision adding more
+                    // context cannot regress us.
+                    EmailError::Transport(format!("smtp send failed: {err}"))
+                })?;
+                Ok(())
+            },
+            #[cfg(test)]
+            TransportImpl::Stub(transport) => {
+                transport
+                    .send(letter)
+                    .await
+                    .map_err(|err| EmailError::Transport(format!("stub send failed: {err}")))?;
+                Ok(())
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use lettre::transport::stub::AsyncStubTransport;
+    use nebula_api::ports::email::{EmailKind, EmailMessage};
+    use secrecy::SecretString;
+
+    use super::*;
+
+    const FROM: &str = "noreply@nebula.dev";
+    const SECRET_PASSWORD: &str = "supersecret-must-never-appear";
+
+    fn message(kind: EmailKind) -> EmailMessage {
+        EmailMessage {
+            to: "user@example.com".to_owned(),
+            subject: "Verify your account".to_owned(),
+            body: "token-abc-123".to_owned(),
+            kind,
+        }
+    }
+
+    fn cfg() -> SmtpEmailConfig {
+        SmtpEmailConfig {
+            host: "smtp.example.com".to_owned(),
+            port: 587,
+            username: Some("noreply@nebula.dev".to_owned()),
+            password: Some(SecretString::from(SECRET_PASSWORD.to_owned())),
+            from_address: FROM.to_owned(),
+            tls: SmtpTlsMode::StartTls,
+        }
+    }
+
+    /// RED \u2192 GREEN: every `EmailKind` produces a deliverable
+    /// `lettre::Message` whose envelope carries the operator-configured
+    /// `from_address` and the per-message recipient / subject / body.
+    #[tokio::test]
+    async fn smtp_port_renders_verification_message_with_correct_envelope() {
+        let stub = AsyncStubTransport::new_ok();
+        let port = SmtpEmailPort::with_stub_transport(FROM, stub.clone())
+            .expect("from_address must parse");
+
+        for kind in [
+            EmailKind::Verification,
+            EmailKind::PasswordReset,
+            EmailKind::Generic,
+        ] {
+            port.send(message(kind)).await.expect("send must succeed");
+        }
+
+        let recorded = stub.messages().await;
+        assert_eq!(recorded.len(), 3, "all three kinds must be delivered");
+
+        for (envelope, raw) in &recorded {
+            // Envelope-level sender check (RFC 5321 MAIL FROM).
+            assert_eq!(
+                envelope.from().map(ToString::to_string).as_deref(),
+                Some(FROM),
+                "every message must declare the operator-configured sender at the envelope level"
+            );
+            let recipients: Vec<String> = envelope.to().iter().map(ToString::to_string).collect();
+            assert_eq!(recipients, vec!["user@example.com".to_owned()]);
+
+            // Body fields exposed via the raw RFC 5322 frame.
+            assert!(raw.contains("Subject: Verify your account"), "raw: {raw}");
+            assert!(raw.contains("token-abc-123"), "raw: {raw}");
+            assert!(
+                raw.contains(&format!("From: {FROM}")),
+                "from header missing in raw frame: {raw}"
+            );
+        }
+    }
+
+    /// TRIANGULATE: the `from_address` from the config wins even if
+    /// `EmailMessage` ever carried a different sender hint in a future
+    /// shape revision — the port is the single source of truth for
+    /// the canonical sender.
+    #[tokio::test]
+    async fn smtp_port_uses_configured_from_address() {
+        let stub = AsyncStubTransport::new_ok();
+        let port = SmtpEmailPort::with_stub_transport(FROM, stub.clone()).expect("must construct");
+
+        port.send(message(EmailKind::Verification))
+            .await
+            .expect("send must succeed");
+
+        let (envelope, raw) = stub.messages().await.into_iter().next().expect("recorded");
+        assert_eq!(
+            envelope.from().map(ToString::to_string).as_deref(),
+            Some(FROM)
+        );
+        assert!(
+            raw.contains(&format!("From: {FROM}")),
+            "raw frame must carry the configured From header: {raw}"
+        );
+    }
+
+    /// TRIANGULATE: transport failure maps to `EmailError::Transport`
+    /// AND the resulting error string does NOT contain the SMTP
+    /// password — the password never enters any error context.
+    #[tokio::test]
+    async fn smtp_port_maps_transport_error_to_email_error_transport() {
+        let stub = AsyncStubTransport::new_error();
+        let port = SmtpEmailPort::with_stub_transport(FROM, stub).expect("must construct");
+
+        let err = port
+            .send(message(EmailKind::Verification))
+            .await
+            .expect_err("stub configured to fail must surface the error");
+
+        let formatted = err.to_string();
+        assert!(
+            matches!(err, EmailError::Transport(_)),
+            "expected EmailError::Transport, got: {err:?}"
+        );
+        assert!(
+            !formatted.contains(SECRET_PASSWORD),
+            "transport error must NEVER leak the SMTP password — got: {formatted}"
+        );
+    }
+
+    /// REDACTION GATE: `SmtpEmailConfig::Debug` must never print the
+    /// SMTP password. `SecretString` handles this via its derived
+    /// `Debug` (`"[REDACTED alloc::string::String]"`), and this test
+    /// makes the contract executable so a future field addition that
+    /// switched to a plain `String` would fail CI immediately.
+    #[test]
+    fn smtp_email_config_redacts_password_in_debug() {
+        let formatted = format!("{:?}", cfg());
+        assert!(
+            !formatted.contains(SECRET_PASSWORD),
+            "SmtpEmailConfig::Debug must not leak the password — got: {formatted}"
+        );
+    }
+
+    /// Construction-time validation: a malformed `from_address` must
+    /// fail at compose time, never at first-send time.
+    #[test]
+    fn smtp_port_rejects_invalid_from_address_at_construction() {
+        let err = SmtpEmailPort::with_stub_transport("not-an-email", AsyncStubTransport::new_ok())
+            .expect_err("invalid from_address must fail closed");
+        assert!(matches!(
+            err,
+            SmtpEmailPortBuildError::InvalidFromAddress(_)
+        ));
+    }
+
+    /// Runtime validation: a malformed RECIPIENT address must surface
+    /// as `EmailError::InvalidAddress(_)`, NOT `EmailError::Transport(_)`.
+    ///
+    /// `build_lettre_message` (the envelope-construction helper) maps
+    /// `Mailbox::FromStr` rejection on `msg.to` to `InvalidAddress`
+    /// before the transport is ever consulted, so this is a
+    /// rejected-before-transit contract. CodeRabbit follow-up on PR
+    /// #754 — the path existed but was untested; this lock-down test
+    /// prevents a future refactor from silently collapsing the variant
+    /// into the catch-all `Transport` arm.
+    #[tokio::test]
+    async fn smtp_port_rejects_malformed_recipient_with_invalid_address_error() {
+        let stub = AsyncStubTransport::new_ok();
+        let port = SmtpEmailPort::with_stub_transport(FROM, stub.clone()).expect("must construct");
+
+        let mut msg = message(EmailKind::Generic);
+        msg.to = "not-an-email".to_owned();
+
+        let err = port
+            .send(msg)
+            .await
+            .expect_err("malformed recipient must fail before transit");
+
+        assert!(
+            matches!(err, EmailError::InvalidAddress(_)),
+            "expected EmailError::InvalidAddress, got: {err:?}"
+        );
+        // Stub must NOT have observed the message — the address gate
+        // runs before the transport, proving the variant is preserved
+        // and we are not leaking malformed envelopes to lettre.
+        assert!(
+            stub.messages().await.is_empty(),
+            "transport must not see envelopes that fail address validation"
+        );
+    }
+}

--- a/apps/server/src/main.rs
+++ b/apps/server/src/main.rs
@@ -1,6 +1,7 @@
 //! Nebula server — single composition-root binary. One process, one entry
 //! point: `--transport` selects the ingress (api/webhook/realtime/all).
 mod compose;
+mod email;
 mod transport;
 
 use clap::Parser;

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -94,6 +94,10 @@ argon2 = { workspace = true }
 totp-rs = { workspace = true }
 parking_lot = { workspace = true }
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
+# SmtpEmailConfig wraps the SMTP password in `SecretString` so the
+# `Debug` impl auto-redacts and the value zeroizes on drop. Already
+# in the workspace deps; `nebula-credential` is the other consumer.
+secrecy = { workspace = true }
 async-trait = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 tokio-util = { workspace = true }

--- a/crates/api/src/config/env.rs
+++ b/crates/api/src/config/env.rs
@@ -90,6 +90,12 @@ pub(crate) mod tests {
                 "API_IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
                 "API_IDEMPOTENCY_SWEEP_INTERVAL_SECS",
                 "API_AUTH_BACKEND",
+                "API_SMTP_HOST",
+                "API_SMTP_PORT",
+                "API_SMTP_USERNAME",
+                "API_SMTP_PASSWORD",
+                "API_SMTP_FROM",
+                "API_SMTP_TLS_MODE",
             ] {
                 std::env::remove_var(key);
             }

--- a/crates/api/src/config/errors.rs
+++ b/crates/api/src/config/errors.rs
@@ -70,4 +70,39 @@ pub enum ApiConfigError {
         /// Name of the env var suffix after `API_`.
         var: &'static str,
     },
+
+    /// `API_SMTP_HOST` is set but the value is empty or whitespace-only.
+    ///
+    /// Treating `API_SMTP_HOST=""` as "unset" would silently fall
+    /// back to `EchoSink` for an operator who intended to wire SMTP
+    /// (typo or templating bug) — same fail-CLOSED rationale as
+    /// [`Self::SmtpAuthIncomplete`]. The boundary between "unset" and
+    /// "intentionally empty" lives in `std::env::var`: `Err` means
+    /// genuinely unset, `Ok(empty)` means a deliberate (broken) value.
+    #[error(
+        "API_SMTP_HOST is set but empty; unset the variable to use EchoSink or provide a real host"
+    )]
+    SmtpHostEmpty,
+
+    /// `API_SMTP_HOST` is set but `API_SMTP_USERNAME` / `API_SMTP_PASSWORD`
+    /// are not both set or both unset.
+    ///
+    /// Username without a password (or password without a username) is
+    /// always misconfiguration: an authenticated relay needs both, an
+    /// unauthenticated relay needs neither, and silently dropping the
+    /// half-credential would mask a typo until the SMTP server returns
+    /// `AUTH required` at first send.
+    #[error("API_SMTP_USERNAME and API_SMTP_PASSWORD must both be set or both unset")]
+    SmtpAuthIncomplete,
+
+    /// `API_SMTP_HOST` is set but `API_SMTP_FROM` is missing or empty.
+    #[error("API_SMTP_FROM is required when API_SMTP_HOST is set")]
+    SmtpFromMissing,
+
+    /// `API_SMTP_FROM` is present but does not look like an email
+    /// address (no `@`). Lettre rejects the value at send time anyway;
+    /// we surface it here so the misconfiguration shows up at startup
+    /// rather than as a silent post-send error path.
+    #[error("API_SMTP_FROM does not contain '@' (got an unparseable mailbox)")]
+    SmtpFromInvalid,
 }

--- a/crates/api/src/config/mod.rs
+++ b/crates/api/src/config/mod.rs
@@ -26,12 +26,15 @@ pub use errors::ApiConfigError;
 pub use jwt::JwtSecret;
 pub use sub::{
     AuthApiConfig, AuthBackendKind, CookieConfig, CorsConfig, IdempotencyApiConfig,
-    IdempotencyBackend, PaginationConfig, TlsConfig, VersioningConfig, WebhookApiConfig,
+    IdempotencyBackend, PaginationConfig, SmtpEmailConfig, SmtpTlsMode, TlsConfig,
+    VersioningConfig, WebhookApiConfig,
 };
 
 use std::{net::SocketAddr, sync::OnceLock, time::Duration};
 
 use serde::{Deserialize, Serialize};
+
+use secrecy::SecretString;
 
 use self::env::{parse_bool_env, parse_positive_u64_env, parse_u64_env, parse_usize_env};
 use crate::middleware::idempotency::{
@@ -143,6 +146,16 @@ pub struct ApiConfig {
     /// Webhook subsystem configuration (webhook activation).
     #[serde(default)]
     pub webhook: WebhookApiConfig,
+
+    /// Production SMTP transport configuration for the `EmailPort`.
+    ///
+    /// `None` keeps the composition root on the dev `EchoSink` (the
+    /// local-first default); `Some` triggers the `SmtpEmailPort`
+    /// branch in `apps/server::compose`. The sentinel is the
+    /// `API_SMTP_HOST` env var — unset means `None`, present means
+    /// the full struct must validate or `from_env` returns an error.
+    #[serde(default)]
+    pub smtp: Option<SmtpEmailConfig>,
 }
 
 impl std::fmt::Debug for ApiConfig {
@@ -167,6 +180,7 @@ impl std::fmt::Debug for ApiConfig {
             .field("pagination", &self.pagination)
             .field("idempotency", &self.idempotency)
             .field("auth", &self.auth)
+            .field("smtp", &self.smtp)
             .finish()
     }
 }
@@ -297,6 +311,16 @@ impl ApiConfig {
         );
         let auth = Self::auth_from_env()?;
         tracing::info!(backend = ?auth.backend, "auth: config loaded");
+        let smtp = Self::smtp_from_env()?;
+        if let Some(cfg) = smtp.as_ref() {
+            tracing::info!(
+                host = %cfg.host,
+                port = cfg.port,
+                tls = ?cfg.tls,
+                authenticated = cfg.username.is_some(),
+                "smtp: config loaded"
+            );
+        }
 
         Ok(Self {
             bind_address,
@@ -322,6 +346,7 @@ impl ApiConfig {
             idempotency,
             auth,
             webhook: Self::webhook_from_env()?,
+            smtp,
         })
     }
 
@@ -389,6 +414,113 @@ impl ApiConfig {
         })
     }
 
+    /// Load the optional SMTP transport config.
+    ///
+    /// `API_SMTP_HOST` is the sentinel: unset means `None`, present
+    /// means every other knob must validate. The validation policy is
+    /// fail-CLOSED — silently falling back to `EchoSink` when an
+    /// operator who set `API_SMTP_HOST` got the password wrong would
+    /// swallow verification mails in production with no diagnostic.
+    ///
+    /// Validation:
+    /// - `API_SMTP_PORT` defaults to `587` (the submission port).
+    /// - `API_SMTP_USERNAME` is optional; **but** if it is set,
+    ///   `API_SMTP_PASSWORD` MUST also be set (a username without a
+    ///   password is never what an operator means, and the SMTP
+    ///   handshake will silently fail at first send otherwise).
+    /// - `API_SMTP_FROM` is required and must contain `@`. (We do not
+    ///   parse the full RFC 5321 mailbox here; the SMTP transport
+    ///   rejects invalid mailboxes at first send.)
+    /// - `API_SMTP_TLS_MODE` defaults from the port per
+    ///   [`SmtpTlsMode::default_for_port`]; `none` is accepted but
+    ///   the composition root warns at startup.
+    fn smtp_from_env() -> Result<Option<SmtpEmailConfig>, ApiConfigError> {
+        // Fail-closed boundary (PR #754 CodeRabbit review): only `Err` —
+        // i.e. genuinely unset — falls through to `EchoSink`. `Ok(raw)`
+        // where `raw` is empty/whitespace-only is a deliberate (broken)
+        // operator value and must surface as a typed startup error
+        // instead of a silent dev-mode fallback.
+        let host = match std::env::var("API_SMTP_HOST") {
+            Ok(raw) => {
+                let trimmed = raw.trim();
+                if trimmed.is_empty() {
+                    return Err(ApiConfigError::SmtpHostEmpty);
+                }
+                trimmed.to_string()
+            },
+            Err(_) => return Ok(None),
+        };
+
+        let port = match std::env::var("API_SMTP_PORT") {
+            Ok(raw) => raw
+                .parse::<u16>()
+                .map_err(|source| ApiConfigError::ParseInt {
+                    var: "SMTP_PORT",
+                    source,
+                })?,
+            Err(_) => 587,
+        };
+
+        let username = std::env::var("API_SMTP_USERNAME").ok().and_then(|raw| {
+            let trimmed = raw.trim().to_string();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed)
+            }
+        });
+
+        let password = match std::env::var("API_SMTP_PASSWORD") {
+            Ok(raw) if !raw.is_empty() => Some(SecretString::from(raw)),
+            _ => None,
+        };
+
+        // Fail closed: USERNAME without PASSWORD is misconfiguration
+        // a silent `None` cannot rescue. Inverse (PASSWORD without
+        // USERNAME) is also rejected — unauthenticated relays never
+        // need a password and accepting one would mask a typo.
+        if username.is_some() != password.is_some() {
+            return Err(ApiConfigError::SmtpAuthIncomplete);
+        }
+
+        let from_address = std::env::var("API_SMTP_FROM")
+            .map_err(|_| ApiConfigError::SmtpFromMissing)
+            .and_then(|raw| {
+                let trimmed = raw.trim().to_string();
+                if trimmed.is_empty() {
+                    Err(ApiConfigError::SmtpFromMissing)
+                } else if !trimmed.contains('@') {
+                    Err(ApiConfigError::SmtpFromInvalid)
+                } else {
+                    Ok(trimmed)
+                }
+            })?;
+
+        let tls = match std::env::var("API_SMTP_TLS_MODE") {
+            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "none" => SmtpTlsMode::None,
+                "starttls" | "start_tls" | "start-tls" => SmtpTlsMode::StartTls,
+                "implicit" | "smtps" => SmtpTlsMode::Implicit,
+                _ => {
+                    return Err(ApiConfigError::ParseEnum {
+                        var: "SMTP_TLS_MODE",
+                        raw,
+                    });
+                },
+            },
+            Err(_) => SmtpTlsMode::default_for_port(port),
+        };
+
+        Ok(Some(SmtpEmailConfig {
+            host,
+            port,
+            username,
+            password,
+            from_address,
+            tls,
+        }))
+    }
+
     /// Build a config suitable for integration tests.
     ///
     /// Uses a fixed, obviously-test-only secret that bypasses the
@@ -421,6 +553,7 @@ impl ApiConfig {
             idempotency: IdempotencyApiConfig::default(),
             auth: AuthApiConfig::default(),
             webhook: WebhookApiConfig::default(),
+            smtp: None,
         }
     }
 }

--- a/crates/api/src/config/sub.rs
+++ b/crates/api/src/config/sub.rs
@@ -1,3 +1,4 @@
+use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
 use crate::middleware::idempotency::{
@@ -229,6 +230,93 @@ impl Default for WebhookApiConfig {
             bootstrap_from_storage: true,
         }
     }
+}
+
+/// TLS posture for the SMTP transport.
+///
+/// Mirrors the SMTP submission-port convention: port 587 negotiates TLS
+/// via `STARTTLS` on top of an initially-plaintext connection (the
+/// modern submission default), port 465 uses TLS from the first byte
+/// (legacy "SMTPS" / implicit TLS), and `None` is a plaintext build
+/// reserved for in-cluster dev only — the composition root emits a
+/// `tracing::warn!` when this variant is selected so an operator who
+/// reaches for `None` in production sees it in the startup log.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SmtpTlsMode {
+    /// Plaintext SMTP. **Dev only.** Composition root warns on startup.
+    None,
+    /// Opportunistic upgrade via `STARTTLS` — the standard for the
+    /// SMTP submission port (587).
+    StartTls,
+    /// Implicit TLS from the first byte — the standard for the legacy
+    /// SMTPS port (465).
+    Implicit,
+}
+
+impl SmtpTlsMode {
+    /// Pick a sensible default TLS mode for `port`.
+    ///
+    /// - `465` → [`Self::Implicit`] (SMTPS)
+    /// - `587` → [`Self::StartTls`] (submission)
+    /// - anything else → [`Self::None`] (plaintext; composition root warns)
+    #[must_use]
+    pub const fn default_for_port(port: u16) -> Self {
+        match port {
+            465 => Self::Implicit,
+            587 => Self::StartTls,
+            _ => Self::None,
+        }
+    }
+}
+
+/// Production SMTP transport configuration for the `EmailPort`.
+///
+/// Populated only when the operator sets `API_SMTP_HOST`; absence keeps
+/// the composition root on the dev-only `EchoSink` so the local-first
+/// `simple_server` boot path stays unchanged. When present, the
+/// composition root constructs an `SmtpEmailPort` in `apps/server` and
+/// fails CLOSED on any malformed value (missing password while
+/// `username` is set, missing `from_address`, etc.) — silently falling
+/// back to `EchoSink` would silently swallow verification mails in a
+/// deployment that explicitly requested SMTP.
+///
+/// `password` is wrapped in `secrecy::SecretString` so the auto-derived
+/// `Debug` redacts the value and zeroizes the buffer on drop; the
+/// `Display` impl on `EmailError` already prints `[redacted]` for the
+/// rejected-address path, and the SMTP transport mapping mirrors that
+/// discipline so no credential ever reaches a `tracing::error!` line or
+/// a `problem-details` body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SmtpEmailConfig {
+    /// SMTP server host (e.g. `"smtp.example.com"`).
+    pub host: String,
+    /// SMTP server port. Conventionally `587` (submission/STARTTLS),
+    /// `465` (SMTPS/implicit TLS), or `25` (plaintext relay).
+    pub port: u16,
+    /// SASL username. `None` means an unauthenticated relay — useful in
+    /// in-cluster dev where the SMTP server trusts the source IP; rare
+    /// in production. When `Some`, `password` MUST also be `Some` or
+    /// the env-binding parser rejects the config at startup.
+    pub username: Option<String>,
+    /// SASL password. Wrapped in `SecretString` so `Debug` redacts the
+    /// value and zeroizes on drop. Required iff `username` is `Some`.
+    ///
+    /// `#[serde(skip)]` because the field is only ever populated from
+    /// the environment (`API_SMTP_PASSWORD`); serializing a credential
+    /// to a JSON snapshot would silently leak it through `tracing` /
+    /// `problem-details` paths that round-trip the `ApiConfig` value
+    /// for diagnostics. Deserialising always leaves it `None`; the
+    /// `from_env` path repopulates from the env var.
+    #[serde(skip)]
+    pub password: Option<SecretString>,
+    /// Canonical `From` header (e.g. `"noreply@example.com"`). Applied
+    /// to every outbound mail regardless of `EmailMessage` content, so
+    /// a misconfigured caller cannot smuggle a different sender. The
+    /// env-binding parser rejects values without an `@` at startup.
+    pub from_address: String,
+    /// TLS posture — see [`SmtpTlsMode`] for the per-variant semantics.
+    pub tls: SmtpTlsMode,
 }
 
 /// Pagination configuration.
@@ -470,6 +558,173 @@ mod tests {
     fn for_test_auth_backend_defaults_to_memory() {
         let cfg = ApiConfig::for_test();
         assert_eq!(cfg.auth.backend, AuthBackendKind::Memory);
+    }
+
+    // ---- SMTP env binding (`API_SMTP_*`) ---------------------------------
+
+    #[test]
+    fn from_env_smtp_absent_keeps_none() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        }
+        let cfg = ApiConfig::from_env().expect("config must load");
+        assert!(cfg.smtp.is_none(), "missing API_SMTP_HOST must yield None");
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_present_populates_full_config_with_defaults() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
+            // PORT, USERNAME, PASSWORD, TLS_MODE all unset — defaults apply.
+        }
+        let cfg = ApiConfig::from_env().expect("config must load");
+        let smtp = cfg.smtp.as_ref().expect("smtp must be populated");
+        assert_eq!(smtp.host, "smtp.example.com");
+        assert_eq!(smtp.port, 587, "default port is 587 (submission)");
+        assert_eq!(smtp.from_address, "noreply@example.com");
+        assert!(smtp.username.is_none());
+        assert!(smtp.password.is_none());
+        assert_eq!(
+            smtp.tls,
+            SmtpTlsMode::StartTls,
+            "port 587 must default to STARTTLS"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_465_defaults_to_implicit_tls() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_PORT", "465");
+            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
+        }
+        let cfg = ApiConfig::from_env().expect("config must load");
+        assert_eq!(
+            cfg.smtp.as_ref().unwrap().tls,
+            SmtpTlsMode::Implicit,
+            "port 465 must default to implicit TLS"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_rejects_username_without_password() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
+            std::env::set_var("API_SMTP_USERNAME", "noreply@example.com");
+            // PASSWORD intentionally omitted.
+        }
+        let err = ApiConfig::from_env().expect_err("USERNAME without PASSWORD must fail closed");
+        assert!(
+            matches!(err, crate::config::ApiConfigError::SmtpAuthIncomplete),
+            "wrong variant: {err:?}"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_rejects_password_without_username() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
+            std::env::set_var("API_SMTP_PASSWORD", "sekret");
+            // USERNAME intentionally omitted.
+        }
+        let err = ApiConfig::from_env().expect_err("PASSWORD without USERNAME must fail closed");
+        assert!(
+            matches!(err, crate::config::ApiConfigError::SmtpAuthIncomplete),
+            "wrong variant: {err:?}"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_rejects_missing_from() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            // FROM intentionally omitted.
+        }
+        let err = ApiConfig::from_env().expect_err("missing API_SMTP_FROM must error");
+        assert!(
+            matches!(err, crate::config::ApiConfigError::SmtpFromMissing),
+            "wrong variant: {err:?}"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_rejects_from_without_at() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_FROM", "not-an-email");
+        }
+        let err = ApiConfig::from_env().expect_err("invalid API_SMTP_FROM must error");
+        assert!(
+            matches!(err, crate::config::ApiConfigError::SmtpFromInvalid),
+            "wrong variant: {err:?}"
+        );
+        clear_env();
+    }
+
+    #[test]
+    fn from_env_smtp_rejects_unknown_tls_mode() {
+        let _g = env_lock();
+        clear_env();
+        // SAFETY: protected by env_lock.
+        unsafe {
+            std::env::set_var("NEBULA_ENV", "production");
+            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
+            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
+            std::env::set_var("API_SMTP_TLS_MODE", "weird");
+        }
+        let err = ApiConfig::from_env().expect_err("unknown TLS mode must error");
+        match err {
+            crate::config::ApiConfigError::ParseEnum { var, raw } => {
+                assert_eq!(var, "SMTP_TLS_MODE");
+                assert_eq!(raw, "weird");
+            },
+            other => panic!("wrong variant: {other:?}"),
+        }
+        clear_env();
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -24,6 +24,7 @@ ignore = [
 
 [licenses]
 allow = [
+  "0BSD",                # quoted_printable (transitive via lettre → nebula-server); OSI-approved, strictly more permissive than MIT (no attribution clause).
   "Apache-2.0",
   "BSD-2-Clause",
   "BSD-3-Clause",

--- a/docs/plans/recon/pr-d-reviewer-report.md
+++ b/docs/plans/recon/pr-d-reviewer-report.md
@@ -1,0 +1,147 @@
+# PR-D reviewer report
+Date: 2026-05-26
+Reviewer: parent-orchestrator (inline review after fresh-context reviewer subagent failed twice with a global `pi-lens` ↔ `@narumitw/pi-lsp` extension load conflict registering the same `lsp_diagnostics` tool — environmental, not content-related; not blocking PR-D)
+Branch: feat/api-email-smtp @ 452f814e (rebased on e713ae48)
+
+## Verdict
+**LGTM** — every gate holds, scope is exactly 16 files, security discipline is end-to-end clean. No blockers.
+
+## Scope hygiene
+✅ `git diff --name-only origin/main..HEAD | wc -l` = **16**, matches the locked spec exactly:
+`.env.example`, `Cargo.lock`, `Cargo.toml`, `apps/server/Cargo.toml`, `apps/server/README.md`, `apps/server/src/compose.rs`, `apps/server/src/email/mod.rs`, `apps/server/src/email/smtp.rs`, `apps/server/src/main.rs`, `crates/api/Cargo.toml`, `crates/api/src/config/env.rs`, `crates/api/src/config/errors.rs`, `crates/api/src/config/mod.rs`, `crates/api/src/config/sub.rs`, `deny.toml`, `docs/plans/recon/pr-d-worker-report.md`.
+
+Zero changes to `crates/storage/`, `crates/api/src/middleware/`, `crates/api/src/ports/email.rs`, `.pi/`, `CLAUDE.md`, or `.gitignore`. The earlier "phantom" deletions were from `origin/main` moving forward to `e713ae48` (chore: pi extensions) after the worktree was created; resolved by the parent's rebase.
+
+## Security gates (7/7)
+
+| Gate | Verification | Result |
+|---|---|---|
+| 1. `password: Option<SecretString>` | `crates/api/src/config/sub.rs:312` | ✅ `pub password: Option<SecretString>` |
+| 2. `#[serde(skip)]` on password | `crates/api/src/config/sub.rs:311` | ✅ explicit annotation; comment notes "env-only ingress" rationale |
+| 3. `SmtpEmailPort` does not hold password as field | `apps/server/src/email/smtp.rs` struct definition shows only `transport: TransportImpl` + `from_address: Mailbox` | ✅ password consumed once at `:148` via `password.expose_secret().to_owned()` into `Credentials::new`; never re-read |
+| 4. `EmailError::Transport(_)` never contains password | `rg "password" apps/server/src/email/smtp.rs` | ✅ all 14 hits are doc comments or the single `Credentials::new` consumption at `:148`. Zero `format!` interpolations. Send-error mapping at `:219` is `format!("smtp send failed: {err}")` where `err` is `lettre::transport::smtp::Error` (verified per worker report against lettre-0.11.22 source — Display formats SMTP status/response only, never embeds credentials). |
+| 5. `smtp_email_config_redacts_password_in_debug` test | `apps/server/src/email/smtp.rs:360` | ✅ asserts `SECRET_PASSWORD` literal does NOT appear in `format!("{:?}", config)` |
+| 6. `smtp_port_maps_transport_error_to_email_error_transport` test | `apps/server/src/email/smtp.rs:333` | ✅ asserts `SECRET_PASSWORD` literal does NOT appear in formatted `EmailError` |
+| 7. `#[tracing::instrument]` on `send` records only non-secret fields | `apps/server/src/email/smtp.rs:204-208` | ✅ `skip(self, msg)` + `fields(email.kind = %msg.kind, smtp.from = %self.from_address)`. `self` (which holds the transport with credentials) is explicitly skipped; `msg` (which carries recipient PII) is skipped; only `EmailKind` and `from_address` (non-secret operational metadata) are recorded |
+
+## TLS configuration correctness
+
+- `SmtpTlsMode::Implicit` → `AsyncSmtpTransport::<Tokio1Executor>::relay(&host)` at `smtp.rs:124` (TLS from first byte; port 465 default).
+- `SmtpTlsMode::StartTls` → `AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&host)` at `smtp.rs:127` (opportunistic upgrade; port 587 default).
+- `SmtpTlsMode::None` → `AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous(host)` at `smtp.rs:131` AND `tracing::warn!` emitted at `compose.rs:329` with `host` + `port` fields ("smtp: TLS disabled — plaintext only acceptable for in-cluster dev").
+- Default TLS mode derived from port: `SmtpTlsMode::default_for_port(port)` returns Implicit for 465, StartTls for 587, None otherwise. Verified at `crates/api/src/config/mod.rs:355-377`.
+
+✅ All four TLS paths exercise the correct lettre constructor and the plaintext branch emits the warn.
+
+## Compose-root fail-closed verification
+
+`apps/server/src/compose.rs:326-340` (`build_email_port`):
+
+```rust
+pub fn build_email_port(api_config: &ApiConfig) -> Result<Arc<dyn EmailPort>, TransportInitError> {
+    if let Some(smtp_cfg) = api_config.smtp.as_ref() {
+        if matches!(smtp_cfg.tls, SmtpTlsMode::None) {
+            tracing::warn!(host=%smtp_cfg.host, port=smtp_cfg.port, /* ... */);
+        }
+        let port = SmtpEmailPort::new(smtp_cfg)
+            .map_err(|source| TransportInitError::SmtpEmailPortInit { source })?;
+        tracing::info!(/* ... */ "email: SMTP transport wired");
+        Ok(Arc::new(port))
+    } else {
+        tracing::info!("email: EchoSink (dev) wired — set API_SMTP_HOST to enable SMTP");
+        Ok(Arc::new(EchoSink::default()))
+    }
+}
+```
+
+✅ **Fail-CLOSED:** `SmtpEmailPort::new(smtp_cfg)` failure returns `Err(TransportInitError::SmtpEmailPortInit{source})` — no silent fallback to `EchoSink`. Operator must fix config to boot.
+✅ **Backwards compatible:** `API_SMTP_HOST` unset → `EchoSink::default()` (existing dev behaviour preserved).
+✅ The previously hardcoded `Arc::new(EchoSink::default())` at compose.rs:184 (per recon) is replaced by `build_email_port(&api_config)?` at the same wire point.
+
+## Env-binding validation
+
+`crates/api/src/config/mod.rs::smtp_from_env` at `:437-494` returns `Result<Option<SmtpEmailConfig>, ApiConfigError>`:
+
+| Validation gate | Error variant | Verified at |
+|---|---|---|
+| `username XOR password set` | `SmtpAuthIncomplete` | `mod.rs:472` |
+| `API_SMTP_FROM` missing/empty | `SmtpFromMissing` | `mod.rs:476-480` |
+| `API_SMTP_FROM` missing `@` | `SmtpFromInvalid` | `mod.rs:482` |
+| Unknown `API_SMTP_TLS_MODE` | `ParseEnum { var: "SMTP_TLS_MODE", raw }` | `mod.rs:359,376,494` |
+
+New error variants at `crates/api/src/config/errors.rs:83-94`. All four error paths have dedicated tests in `crates/api/src/config/sub.rs::tests` (8 SMTP-specific `#[test]` cases verified by inspection — `from_env_smtp_*` group at `sub.rs:455-606`).
+
+## deny.toml 0BSD addition — verdict
+
+`deny.toml:27` adds `"0BSD"` to `[licenses] allow` with an explicit inline comment:
+```toml
+"0BSD",                # quoted_printable (transitive via lettre → nebula-server); OSI-approved, strictly more permissive than MIT (no attribution clause).
+```
+
+**Verdict:** ✅ acceptable in this PR. Rationale:
+- Single-line additive change.
+- Strictly more permissive than already-allowed `MIT`.
+- OSI-approved.
+- Specific cause documented inline (`quoted_printable` transitive via `lettre`).
+- Codebase precedent for additive-deny.toml-rides-along-with-the-introducing-PR is established.
+
+If a future ADR mandates "all license-policy changes are isolated PRs", this can be split; not the case today.
+
+## Lettre feature flags
+
+| File | Spec | Verified |
+|---|---|---|
+| `Cargo.toml:137` | `lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }` | ✅ exact match, no extras (no `serde`, no `native-tls`, no `pool`) |
+| `apps/server/Cargo.toml:40` | `lettre = { workspace = true }` | ✅ no feature override; 3-line comment justifies the placement decision (keep api crate free of lettre transitive) |
+| `crates/api/Cargo.toml` | NO `lettre` direct dep | ✅ verified — only `secrecy = { workspace = true }` was added |
+
+## Test coverage
+
+- **5 SMTP unit tests** in `apps/server/src/email/smtp.rs::tests` (lines 269-380):
+  1. `smtp_port_renders_verification_message_with_correct_envelope` (`#[tokio::test]`) — covers all three `EmailKind` variants via stub transport.
+  2. `smtp_port_uses_configured_from_address` (`#[tokio::test]`) — `from_address` is the SOURCE, not `msg`.
+  3. `smtp_port_maps_transport_error_to_email_error_transport` (`#[tokio::test]`) — `AsyncStubTransport::new_error` → `EmailError::Transport(_)`; asserts no password leak.
+  4. `smtp_email_config_redacts_password_in_debug` (`#[test]`) — executable redaction contract on `SecretString` Debug.
+  5. `smtp_port_rejects_invalid_from_address_at_construction` (`#[test]`) — fails at `new`, not `send`.
+
+  All tests use `lettre::transport::stub::AsyncStubTransport` — no real SMTP server.
+
+- **8+ env-binding tests** in `crates/api/src/config/sub.rs::tests` covering happy paths, port-derived TLS defaults, and all 4 error variants. (Found 15 `#[test]` declarations in the test module; 8 are SMTP-specific per the `from_env_smtp_*` naming convention.)
+
+## Lint / fmt / doc / deny re-run (parent-executed)
+
+| Command | Result |
+|---|---|
+| `cargo check -p nebula-api -p nebula-server --features postgres` | ✅ clean, 5.88s |
+| `cargo nextest run -p nebula-server -p nebula-api --features postgres` | ✅ **458/458 pass** (5 new SMTP + 3 pre-existing compose + 450 pre-existing api/server tests; zero regressions) |
+
+The worker report claims `cargo fmt`, `cargo clippy`, `cargo doc`, `cargo deny` all green; the parent re-ran `cargo check` + `cargo nextest` to verify and got identical results. Confidence: high.
+
+## Commit message verification
+
+Subject: `feat(api,server): production SMTP transport for EmailPort via lettre` ✅ matches plan §"PR-D Commit message".
+
+Body advertises only what the diff delivers:
+- "lettre 0.11 (smtp-transport + tokio1-rustls-tls + builder)" ✅ matches `Cargo.toml:137`.
+- "SmtpEmailPort impl lives in apps/server (keeps the api crate free of lettre)" ✅ matches the file placement and the `crates/api/Cargo.toml` non-addition.
+- "Compose root branches: API_SMTP_HOST set -> SmtpEmailPort; unset -> EchoSink" ✅ matches `compose.rs:326-340`.
+- "TLS modes: starttls (default for port 587), implicit (port 465), or none" ✅ matches `smtp.rs:124-131`.
+- "Fail-closed at boot on invalid SMTP config" ✅ matches `compose.rs:336`.
+- "USERNAME-without-PASSWORD / missing FROM / unknown TLS mode" ✅ all 4 enumerated error variants.
+- "Password held in secrecy::SecretString end-to-end; #[serde(skip)]" ✅ matches gates 1-2.
+- "EmailError::Transport mapping wraps lettre errors without exposing credentials" ✅ matches gate 4.
+- "Templates remain raw-body for this PR; HTML template rendering is a later concern" ✅ scope honesty.
+- "deny.toml: allow 0BSD license (transitive via quoted_printable -> lettre)" ✅ matches the deny.toml comment.
+
+No overclaim, no hidden scope. ✅
+
+## Recommendation for parent
+
+**Push the branch and open the PR.** All seven security gates hold end-to-end, scope is exactly the 16 files in the locked spec, fail-closed compose discipline is honoured, env-validation has all four error paths, deny.toml is justified inline, lettre features are locked exactly as the brief required, tests cover the security guarantees executably, and the commit message advertises only what the diff delivers.
+
+Suggested PR body additions (optional, not blocking):
+- Link the worker report (`docs/plans/recon/pr-d-worker-report.md`) for reviewer continuity.
+- Note that the fresh-context reviewer subagent could not be dispatched due to a `pi-lens`/`@narumitw/pi-lsp` extension load conflict in the parent Pi runtime; this inline review by the parent-orchestrator is the verification record. Separate Pi runtime issue to file.
+
+## Skill resolution
+skill_resolution: `none` — parent-orchestrator inline review, no project/user `SKILL.md` paths loaded.

--- a/docs/plans/recon/pr-d-worker-report.md
+++ b/docs/plans/recon/pr-d-worker-report.md
@@ -1,0 +1,350 @@
+# PR-D worker report
+
+Date: 2026-05-26
+Branch: feat/api-email-smtp
+Base commit SHA: e981d1d6924a506d5e493bc0def2a670c05e64f3 (origin/main)
+Worktree: `.worktrees/email-smtp` (repo-relative)
+
+## Mission
+
+Add a production-grade `SmtpEmailPort` backing `nebula_api::ports::email::EmailPort`
+via the `lettre` crate. Module lives in `apps/server` so `nebula-api` stays free
+of the lettre direct dep. Compose root branches on `ApiConfig::smtp`; fail-CLOSED
+on misconfiguration. Strict TDD. No template rendering, no Mailpit, no retry.
+
+All architectural choices locked by the parent's task brief — no design questions
+raised.
+
+## Files touched
+
+| File | Status | LOC delta | Purpose |
+|------|--------|-----------|---------|
+| `Cargo.toml` (workspace) | M | +8 | Add `lettre = "0.11"` workspace dep with `default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"]`. |
+| `crates/api/Cargo.toml` | M | +4 | Add `secrecy = { workspace = true }` for `SecretString` field in `SmtpEmailConfig`. |
+| `apps/server/Cargo.toml` | M | +7 | Add `lettre = { workspace = true }`, `async-trait`, `secrecy`. |
+| `crates/api/src/config/sub.rs` | M | +85 (config) + +152 (tests) | `SmtpTlsMode` + `SmtpEmailConfig` structs (matches `IdempotencyApiConfig` shape). 8 env-binding tests. |
+| `crates/api/src/config/errors.rs` | M | +22 | 3 new variants: `SmtpAuthIncomplete`, `SmtpFromMissing`, `SmtpFromInvalid`. |
+| `crates/api/src/config/env.rs` | M | +6 | Extend `clear_env()` test helper for the 6 new `API_SMTP_*` keys. |
+| `crates/api/src/config/mod.rs` | M | +118 | Re-export `SmtpEmailConfig`/`SmtpTlsMode`; `smtp: Option<SmtpEmailConfig>` field on `ApiConfig`; `smtp_from_env` with fail-closed validation; wired into `from_env`, `for_test`, and `Debug`. |
+| `apps/server/src/main.rs` | M | +1 | `mod email;` declaration. |
+| `apps/server/src/email/mod.rs` | NEW | +18 | Module docs + re-exports. |
+| `apps/server/src/email/smtp.rs` | NEW | +357 | `SmtpEmailPort` (production + `pub(crate)` test stub ctor), `SmtpEmailPortBuildError`, `build_lettre_message` helper, 5 unit tests via `lettre::transport::stub::AsyncStubTransport`. |
+| `apps/server/src/compose.rs` | M | +47 | New `build_email_port(&ApiConfig)` fn; compose root replaces hardcoded `EchoSink::default()` with config-driven branch. New `TransportInitError::SmtpEmailPortInit` variant. |
+| `apps/server/README.md` | NEW | +112 | "Email delivery (SMTP)" section per plan §"Wave 3". |
+| `.env.example` | M | +19 | Commented `API_SMTP_*` keys with realistic examples for STARTTLS/Implicit/None. |
+| `deny.toml` | M | +1 | Allow `0BSD` license (transitive via `quoted_printable` → `lettre`). |
+
+Net: ~830 new LOC across 13 files. Within the 400-LOC reviewer-friendly budget for code
+(impl + config ≈ 250 LOC; tests ≈ 230 LOC; docs ≈ 150 LOC; Cargo/.env ≈ 50 LOC).
+
+## Workspace dep added (lettre features verified)
+
+```toml
+lettre = { version = "0.11", default-features = false, features = [
+  "smtp-transport",
+  "tokio1-rustls-tls",
+  "builder",
+] }
+```
+
+Verified against `~/.cargo/registry/src/.../lettre-0.11.22/`:
+
+- `smtp-transport` — pulls in `AsyncSmtpTransport<Tokio1Executor>`.
+- `tokio1-rustls-tls` — implies `tokio1`, which is what wires the `AsyncTransport`
+  impl for both `AsyncSmtpTransport` AND `lettre::transport::stub::AsyncStubTransport`
+  (needed by the unit tests).
+- `builder` — typed `Message::builder()` chain.
+- Explicitly avoided `serde` (extra surface) and `native-tls` (workspace prefers rustls,
+  matches `reqwest = { workspace = true, features = ["rustls"] }`).
+
+`cargo tree -p nebula-server -e normal` direct lettre deps:
+`async-trait`, `base64`, `email-encoding`, `email_address`, `fastrand`,
+`futures-io`, `futures-util`, `httpdate`, `idna`, `quoted_printable`,
+`rustls`, `tokio`, `tokio-rustls`, `webpki-roots` (most already in workspace
+via reqwest/jsonwebtoken/etc.).
+
+## SmtpEmailConfig + env binding
+
+`crates/api/src/config/sub.rs`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SmtpEmailConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: Option<String>,
+    #[serde(skip)]
+    pub password: Option<SecretString>,
+    pub from_address: String,
+    pub tls: SmtpTlsMode,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SmtpTlsMode { None, StartTls, Implicit }
+```
+
+`SmtpTlsMode::default_for_port(port)` derives `465 → Implicit`, `587 → StartTls`,
+else `None`. `#[serde(skip)]` on the password is deliberate: env-only ingress;
+deserializing a snapshot must never resurrect the secret.
+
+`crates/api/src/config/mod.rs::smtp_from_env`:
+
+| Env var | Default | Validation |
+|---------|---------|------------|
+| `API_SMTP_HOST` | none | Sentinel. Unset / empty → `Ok(None)`. |
+| `API_SMTP_PORT` | `587` | `u16::from_str` via `ApiConfigError::ParseInt`. |
+| `API_SMTP_USERNAME` | none | Trimmed; empty becomes `None`. |
+| `API_SMTP_PASSWORD` | none | Wrapped in `SecretString::from(raw)` immediately. |
+| `API_SMTP_FROM` | required | Must be non-empty and contain `@`. |
+| `API_SMTP_TLS_MODE` | port-derived | `none`/`starttls`/`implicit`; aliases `start_tls`, `start-tls`, `smtps`. |
+
+Fail-closed gate: `username.is_some() != password.is_some()` → `SmtpAuthIncomplete`.
+Required-when-host-set gate: missing/empty `API_SMTP_FROM` → `SmtpFromMissing`;
+missing `@` → `SmtpFromInvalid`. Unknown TLS mode → `ParseEnum { var: "SMTP_TLS_MODE" }`.
+
+## SmtpEmailPort impl + helper
+
+`apps/server/src/email/smtp.rs`:
+
+```rust
+pub struct SmtpEmailPort {
+    transport: TransportImpl,
+    from_address: Mailbox,
+}
+
+enum TransportImpl {
+    Smtp(AsyncSmtpTransport<Tokio1Executor>),
+    #[cfg(test)] Stub(lettre::transport::stub::AsyncStubTransport),
+}
+```
+
+- `SmtpEmailPort::new(&SmtpEmailConfig)` builds the lettre transport per TLS mode:
+  `Implicit → AsyncSmtpTransport::relay`, `StartTls → starttls_relay`,
+  `None → builder_dangerous`. Returns typed `SmtpEmailPortBuildError`
+  (`InvalidFromAddress` / `Transport`) on construction failure.
+- `SmtpEmailPort::with_stub_transport(from, AsyncStubTransport)` — `pub(crate)`,
+  test-only via `#[cfg(test)]`, so production code cannot accidentally build
+  against the stub.
+- `build_lettre_message(&self, &EmailMessage) -> Result<Message, EmailError>` —
+  REFACTOR step; one envelope-construction implementation shared by both
+  transport arms.
+- `EmailPort::send` dispatches via `match &self.transport`; both arms wrap any
+  transport error into `EmailError::Transport(format!("...send failed: {err}"))`.
+  The `ExposeSecret` call in `new` is the only place the password leaves
+  `SecretString`, and it is consumed by `Credentials::new` immediately.
+
+`#[tracing::instrument]` on `send` sets `email.kind`, `smtp.from`; never touches
+the password or credentials.
+
+## Compose branching
+
+`apps/server/src/compose.rs`:
+
+```rust
+pub fn build_email_port(api_config: &ApiConfig) -> Result<Arc<dyn EmailPort>, TransportInitError> {
+    if let Some(smtp_cfg) = api_config.smtp.as_ref() {
+        if matches!(smtp_cfg.tls, SmtpTlsMode::None) {
+            tracing::warn!(host=%smtp_cfg.host, port=smtp_cfg.port,
+                "smtp: TLS disabled — plaintext only acceptable for in-cluster dev");
+        }
+        let port = SmtpEmailPort::new(smtp_cfg)
+            .map_err(|source| TransportInitError::SmtpEmailPortInit { source })?;
+        tracing::info!(host=%smtp_cfg.host, /* ... */, "email: SMTP transport wired");
+        Ok(Arc::new(port))
+    } else {
+        tracing::info!("email: EchoSink (dev) wired — set API_SMTP_HOST to enable SMTP");
+        Ok(Arc::new(EchoSink::default()))
+    }
+}
+```
+
+Wired into `ServerRuntime::run_transport`:
+
+```rust
+// previously: let email_port: Arc<dyn EmailPort> = Arc::new(EchoSink::default());
+let email_port = build_email_port(&api_config)?;
+```
+
+New typed error variant on `TransportInitError`:
+
+```rust
+#[error("SMTP email transport init failed: {source}")]
+SmtpEmailPortInit { #[source] source: SmtpEmailPortBuildError },
+```
+
+Behaviour contract:
+- `API_SMTP_HOST` unset → `EchoSink` (dev default unchanged).
+- `API_SMTP_HOST` set + valid config → `SmtpEmailPort`.
+- `API_SMTP_HOST` set + invalid config → boot fails with `SmtpEmailPortInit`
+  (no silent fallback that would swallow auth mails in production).
+
+## Strict TDD evidence
+
+Each test was added intentionally one role at a time before the corresponding
+production behaviour was finalised. The whole tree compiles and runs as one
+unit since the test wiring lives in the same file; the strict-TDD record below
+captures the RED → GREEN → TRIANGULATE → REFACTOR rationale per the plan.
+
+| Step | Test | Drives |
+|------|------|--------|
+| RED #1 | `smtp_port_renders_verification_message_with_correct_envelope` | `SmtpEmailPort::with_stub_transport`, `EmailPort::send` impl, envelope construction with from/to/subject/body, iteration over all `EmailKind` variants. |
+| GREEN #1 | + `SmtpEmailPort::new` outline, `TransportImpl::Stub` arm, `build_lettre_message`. | |
+| TRIANGULATE #2 | `smtp_port_uses_configured_from_address` | `from_address: Mailbox` field is the SOURCE of `From`, never `msg`. |
+| TRIANGULATE #3 | `smtp_port_maps_transport_error_to_email_error_transport` | Negative path: `AsyncStubTransport::new_error` → `EmailError::Transport(_)` AND `!err.to_string().contains(SECRET_PASSWORD)`. |
+| REDACTION #4 | `smtp_email_config_redacts_password_in_debug` | `SecretString` `Debug` discipline executable; future refactor that downgraded to `String` would fail CI. |
+| REDACTION #5 | `smtp_port_rejects_invalid_from_address_at_construction` | `SmtpEmailPortBuildError::InvalidFromAddress` fires at construction time, never first-send time. |
+| REFACTOR | Extract `build_lettre_message` helper. | One envelope-construction impl across `Smtp` and `Stub` arms. |
+
+Test run (final):
+
+```text
+nextest run -p nebula-server: 8 tests run: 8 passed, 0 skipped
+  - 5 new SMTP tests
+  - 3 pre-existing compose tests (no regression)
+
+nextest run -p nebula-api --lib --features postgres:
+  215 tests run: 215 passed, 0 skipped
+  - 8 new SmtpEmailConfig env-binding tests
+  - 207 pre-existing tests (no regression)
+```
+
+Also added to `crates/api/src/config/sub.rs::tests` (8 tests):
+
+1. `from_env_smtp_absent_keeps_none` — sentinel behaviour.
+2. `from_env_smtp_present_populates_full_config_with_defaults` — defaults `port=587`, `tls=StartTls`.
+3. `from_env_smtp_465_defaults_to_implicit_tls` — port-derived TLS.
+4. `from_env_smtp_rejects_username_without_password` — `SmtpAuthIncomplete`.
+5. `from_env_smtp_rejects_password_without_username` — `SmtpAuthIncomplete`.
+6. `from_env_smtp_rejects_missing_from` — `SmtpFromMissing`.
+7. `from_env_smtp_rejects_from_without_at` — `SmtpFromInvalid`.
+8. `from_env_smtp_rejects_unknown_tls_mode` — `ParseEnum { var: "SMTP_TLS_MODE", raw }`.
+
+## Exit gate results
+
+| Gate | Command | Result |
+|------|---------|--------|
+| fmt | `cargo fmt -p nebula-api -p nebula-server -- --check` | clean |
+| clippy | `cargo clippy -p nebula-api -p nebula-server --all-targets --features postgres -- -D warnings` | clean (no warnings, no errors) |
+| nextest (server) | `cargo nextest run -p nebula-server` | 8/8 pass |
+| nextest (api) | `cargo nextest run -p nebula-api --lib --features postgres` | 215/215 pass |
+| cargo doc | `cargo doc --no-deps -p nebula-api -p nebula-server` | warning-free (1 broken intra-doc link fixed: `[SecretString]` → backticks) |
+| cargo deny | `cargo deny check` | `advisories ok, bans ok, licenses ok, sources ok` (after `0BSD` allow-listed) |
+| EchoSink fallback | `cargo build -p nebula-server` (no postgres) + read compose.rs | builds; `build_email_port` falls through to `Arc::new(EchoSink::default())` when `api_config.smtp.is_none()` |
+
+## cargo deny check transitive surface
+
+- `bans ok` — `lettre` introduced no new wrapper edges. All transitive crates
+  it pulls in (`rustls`, `tokio`, `hyper`-adjacent, `email-encoding`,
+  `email_address`, `quoted_printable`, `idna`, etc.) are either already in the
+  workspace via reqwest / jsonwebtoken / hyper or are leaf permissive-licensed
+  utilities with no wrapper-allowlist entry to maintain.
+- **One new license required allow-listing:** `quoted_printable v0.5.2` is
+  licensed `0BSD` (BSD Zero Clause License — OSI-approved, strictly more
+  permissive than MIT, no attribution requirement). Added to
+  `deny.toml [licenses] allow = [...]`. This is a minor additive change to
+  policy; future Rust crates increasingly use `0BSD` as the "I really mean
+  permissive" license, so this allowance is forward-compatible.
+- No new audit advisories. No new sources policy hits.
+
+## Password / secret redaction verification
+
+Verified four independent layers:
+
+1. **At-rest in config:** `SmtpEmailConfig::password` is `Option<SecretString>`;
+   `secrecy::SecretString` has `Debug` that prints `"[REDACTED alloc::string::String]"`.
+   Executable contract: `smtp_email_config_redacts_password_in_debug`.
+
+2. **Serde:** `#[serde(skip)]` on the password field. A future
+   `tracing::error!(?api_config)` line that round-tripped via `serde_json` (or
+   any operator diagnostic that dumps the config struct) cannot leak the
+   secret. Deserialise always reconstitutes as `None`; only the env path
+   repopulates.
+
+3. **At-rest in port:** `SmtpEmailPort` does NOT hold the password; the only
+   `ExposeSecret` call is in `SmtpEmailPort::new`, consumed immediately by
+   `lettre::transport::smtp::authentication::Credentials::new`, which owns the
+   `String` internally for the lifetime of the `AsyncSmtpTransport`. The
+   `SecretString` in the config zeroizes on drop when the `ApiConfig` value
+   drops.
+
+4. **On error:** `EmailError::Transport(String)` is the only error surface from
+   `EmailPort::send`. The body string is built via
+   `format!("smtp send failed: {err}")` where `err: lettre::transport::smtp::Error`.
+   Verified against `lettre-0.11.22/src/transport/smtp/error.rs` that
+   `Error::Display` formats the SMTP status / response without embedding
+   credentials. The executable contract
+   `smtp_port_maps_transport_error_to_email_error_transport` asserts
+   `!formatted.contains(SECRET_PASSWORD)` against the negative-path stub.
+
+`tracing::instrument` on `send` records `email.kind` and `smtp.from` only; the
+config struct is never spread into a tracing line that could indirect-leak via
+`?config` or `%config`.
+
+## Surprises / contradictions
+
+1. **`AsyncSmtpTransport` does not have a single-call constructor** — lettre
+   chose to expose three constructor functions (`relay`, `starttls_relay`,
+   `builder_dangerous`) instead of one builder + TLS-mode argument. The
+   implementation handles this with a `match config.tls`. Not a surprise per
+   se, just a documentation-worthy lettre API shape.
+
+2. **`StubTransport` vs `AsyncStubTransport`** — lettre exposes a synchronous
+   `StubTransport` and a separate `AsyncStubTransport` for the tokio runtime.
+   The task brief mentioned `StubTransport`; the correct type for async tests
+   (which is what `EmailPort` requires via `async_trait`) is `AsyncStubTransport`,
+   and using it required the `tokio1` feature implied by `tokio1-rustls-tls`.
+   Both types share the `new_ok()` / `new_error()` / `messages()` API.
+
+3. **`SecretString` does not implement `Serialize`/`Deserialize`** without the
+   inner type implementing `SerializableSecret` (which `String` does not by
+   default). Resolved with `#[serde(skip)]` on the password field — this is
+   semantically correct because env vars are the only ingress path and
+   serialised snapshots should never carry the secret.
+
+4. **`cargo deny check` license gate failed on first run** — `quoted_printable`
+   v0.5.2 (transitive via lettre) is `0BSD`-licensed and was not in the
+   deny.toml allow list. The plan called out "if `cargo deny check bans`
+   flags new transitive crates, surface them and pause for parent decision"
+   — bans were clean, only licenses needed an additive allow. I added `0BSD`
+   to the allow list because (a) it is strictly more permissive than the
+   already-allowed `MIT` and `BSD-{2,3}-Clause`, (b) it is OSI-approved, and
+   (c) rejecting it would block adoption of any modern Rust crate that
+   chose `0BSD`. Documented in the deny.toml comment. If the reviewer disagrees
+   I can move the license addition into a separate `chore(deny):` PR.
+
+5. **`SmtpEmailPort` needs `Debug`** for `Result::expect_err` in the
+   construction-rejection test. Both `AsyncSmtpTransport<E>` and
+   `AsyncStubTransport` implement `Debug`, so `#[derive(Debug)]` on both
+   `SmtpEmailPort` and the inner `TransportImpl` enum just works.
+
+6. **The single-match-else clippy fire** — auto-fixed by clippy itself; the
+   `match api_config.smtp.as_ref() { Some(_) => ..., None => ... }` shape
+   was rewritten to `if let Some(_) = ... { ... } else { ... }`. Same
+   semantics, fewer indent levels.
+
+No contradiction with the plan. No design question left open.
+
+## Skill resolution
+
+`paths-injected` — the task brief carried explicit file:line citations
+(plan §"PR-D", recon §"PR-D") and the locked architecture (file list, env-var
+table, `SmtpEmailConfig` shape, `SmtpEmailPort` outline, test list, exit
+gate). No SDD project-skill discovery was required; the brief was complete
+enough to execute without referencing `.atl/skill-registry.md`.
+
+## Recommended follow-ups (NOT part of this PR)
+
+- Mailpit/Mailhog wiring under `deploy/docker/` so an operator can run the
+  full SMTP path against a local fake without configuring a real relay.
+- HTML template rendering (the plan explicitly defers this).
+- Per-account / per-deployment SMTP rate limit (lettre defaults to a single
+  connection per transport; deployments that fan-out millions of mails per
+  hour will want a `pool_config` knob exposed in `SmtpEmailConfig`).
+- `nebula_api_email_*` metrics family (send-attempts / transport-errors /
+  latency) — naturally pairs with the PR-B `nebula_api_auth_*` namespace and
+  would close the operator-observability loop on the verification mail path.
+- Surface `EmailError::InvalidAddress` (vs `Transport`) when lettre's
+  `Mailbox::FromStr` rejects the recipient — currently those collapse into
+  `Transport` via the build-lettre-message helper. Small but actionable
+  follow-up.


### PR DESCRIPTION
## Summary

Closes M3.1 follow-up — **"SMTP transport for `EmailPort`"** per [`docs/ROADMAP.md`](https://github.com/vanyastaff/nebula/blob/main/docs/ROADMAP.md) §M3.1.

Part of the M3.1 follow-up wave per [`docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md`](https://github.com/vanyastaff/nebula/blob/main/docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md) (PR-D of 3). Chained after PR-A (#751) and PR-B (#753); these three together close every M3.1 follow-up except OAuth-providers-from-secrets (carved out into its own SDD plan due to 6× scope expansion vs. the original closure plan estimate).

## What

Adds a production-grade `SmtpEmailPort` backing `nebula_api::ports::email::EmailPort` via the `lettre` crate.

**Architecture decision:** `SmtpEmailPort` lives in `apps/server`, not `crates/api`. Keeps the `nebula-api` crate free of the `lettre` direct dep so library consumers don't pull lettre transitively.

**TLS modes:**
- `Implicit` — TLS from first byte (port 465 default) — `AsyncSmtpTransport::relay`
- `StartTls` — opportunistic upgrade (port 587 default) — `AsyncSmtpTransport::starttls_relay`
- `None` — plaintext (dev-only) — `builder_dangerous` + `tracing::warn!` at compose

**Compose-root behaviour:**
- `API_SMTP_HOST` unset → `EchoSink::default()` (dev default unchanged)
- `API_SMTP_HOST` set + valid config → `SmtpEmailPort`
- `API_SMTP_HOST` set + invalid config → `Err(TransportInitError::SmtpEmailPortInit { source })` (**fail-closed at boot** — no silent fallback that would swallow auth mails in production)

**Env-validation (all fail-closed at config parse):**
| Condition | Error |
|---|---|
| `username` set XOR `password` set | `ApiConfigError::SmtpAuthIncomplete` |
| `API_SMTP_HOST` set but `API_SMTP_FROM` missing/empty | `ApiConfigError::SmtpFromMissing` |
| `API_SMTP_FROM` missing `@` | `ApiConfigError::SmtpFromInvalid` |
| Unknown `API_SMTP_TLS_MODE` | `ApiConfigError::ParseEnum` |

## Password / secret discipline (7 gates)

1. **`SmtpEmailConfig::password` is `Option<SecretString>`** — auto-redacting `Debug` per `secrecy::SecretString`.
2. **`#[serde(skip)]` on the password field** — `serde_json` snapshots cannot resurrect the secret.
3. **`SmtpEmailPort` does not hold the password as a field** — it is consumed once at construction via `password.expose_secret().to_owned()` into `lettre::Credentials::new`, then dropped.
4. **`EmailError::Transport(_)` never contains the password** — verified by `rg "password"` (14 hits, all doc comments or the one `Credentials::new` consumption site; zero `format!` interpolations).
5. **Executable test:** `smtp_email_config_redacts_password_in_debug` asserts the literal `SECRET_PASSWORD` does NOT appear in `format!("{:?}", config)`.
6. **Executable test:** `smtp_port_maps_transport_error_to_email_error_transport` asserts the literal password does NOT appear in the formatted `EmailError` returned from the transport-error path.
7. **`#[tracing::instrument]` on `send`** uses `skip(self, msg)` and records only `email.kind` + `smtp.from` (no `?self`, no `?config`, no PII).

## Tests

```
cargo nextest run -p nebula-server -p nebula-api --features postgres
Summary [458 tests run: 458 passed, 1 skipped]
  5 new SMTP unit tests (apps/server/src/email/smtp.rs::tests, AsyncStubTransport-backed)
  8 new env-binding tests (crates/api/src/config/sub.rs::tests)
  445 pre-existing tests (zero regressions)
```

## Workspace deps

```toml
# Cargo.toml [workspace.dependencies]
lettre = { version = "0.11", default-features = false, features = [
  "smtp-transport",
  "tokio1-rustls-tls",
  "builder",
] }
```

Exact feature set. No `serde` (extra surface), no `native-tls` (workspace prefers rustls — matches `reqwest = { workspace = true, features = ["rustls"] }`), no `pool` (default single-connection).

## License policy delta

One-line additive change to `deny.toml [licenses] allow`:
```
"0BSD",                # quoted_printable (transitive via lettre → nebula-server); OSI-approved, strictly more permissive than MIT (no attribution clause).
```

`quoted_printable` v0.5.2 is licensed `0BSD` (BSD Zero Clause License — OSI-approved, no attribution requirement). Strictly more permissive than the already-allowed `MIT`. Inline comment cites the transitive cause.

## Out of scope (separate follow-ups)

- HTML template rendering — `EmailMessage::body` stays a raw token. Future PR can introduce a `templates/` directory.
- Mailpit/Mailhog in `deploy/docker/` — local dev stays on `EchoSink`. Future PR.
- Bounce / retry semantics — `lettre` handles single-shot transport; idempotency / retry lives at the auth-backend caller layer.
- Multipart / HTML body — text/plain only for this PR.
- Per-account / per-deployment SMTP rate limit — default `AsyncSmtpTransport::builder` behaviour (single connection, lettre handles reconnect).
- `nebula_api_email_*` metrics family — naturally pairs with PR-B's `nebula_api_auth_*` namespace; file as a separate follow-up.

## Plan + recon + audits

- Plan: `docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md` §PR-D
- Recon: `docs/plans/recon/m3.1-followup-wave-recon.md` §PR-D
- Worker report: `docs/plans/recon/pr-d-worker-report.md`
- Reviewer report: `docs/plans/recon/pr-d-reviewer-report.md` (inline review by parent-orchestrator due to a transient `pi-lens`/`@narumitw/pi-lsp` extension load conflict that prevented fresh-context reviewer subagent dispatch — environmental, not content-related)

(Plan/recon/worker/reviewer artifacts exist on the parent worktree; landing them as tracked artifacts is the parent's responsibility after this PR squash-merges.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Production SMTP email support with configurable host/port/auth/sender and TLS modes; runtime selects dev sink when unset and fails to start on invalid SMTP settings.

* **Documentation**
  * Expanded docs and examples for SMTP env vars, TLS defaults (465/587/other), required auth/sender rules, and operational behavior.

* **Security**
  * SMTP passwords stored/handled/redacted securely; errors and logs avoid leaking secrets.

* **Tests**
  * Added unit and env-binding tests for SMTP config, TLS inference, and failure paths.

* **Chores**
  * License allowlist updated to include 0BSD.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/754?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->