### PR TITLE
docs(roadmap): close M3.1 follow-up wave (#751 #753 #754)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -79,10 +79,16 @@
   routes (#737). **OTLP exporter end-to-end** wired (#742, M9.2 ✅) —
   traces via `init_api_telemetry`, metrics via the new `otlp` module in
   `nebula-metrics` on the `MetricsRegistry::snapshot_*` seam, observability stack in
-  `deploy/docker/` ready for `task obs:up`. Remaining: OAuth providers
-  from operator secrets + lockout/rate-limit PG integration tests +
-  `nebula_api_auth_*` metrics family (M3.1 follow-ups); shift-left
-  validation audit (M3.6).
+  `deploy/docker/` ready for `task obs:up`. **M3.1 follow-up wave shipped**
+  (#751/#753/#754): lockout PG e2e tests, `nebula_api_auth_*` metrics
+  family (12-value closed `outcome` set, `AuthError→outcome` exhaustive
+  coverage gate, no-pooling `_duration_seconds` histogram), production
+  SMTP transport via `lettre` 0.11 (fail-closed on empty/invalid
+  `API_SMTP_HOST`, `SecretString`-redacted password). Remaining: OAuth
+  providers from operator secrets (carved out to its own SDD plan — Wave 4
+  credential-stabilize compose-root `CredentialService` instantiation
+  unblocked but not wired; `complete_oauth` still returns
+  `NotImplemented`); shift-left validation audit (M3.6).
 - **Shared infra** — `nebula-credential` is consumed by Exec + API +
   Business (the `deny.toml` `[wrappers]` allowlist locks the consumer set).
   The `nebula-credential-runtime` crate shipped (ADR-0066, #678):
@@ -221,8 +227,9 @@ The largest 1.0 area. Closure criteria (on top of the global DoD):
       when `Postgres` is requested without `DATABASE_URL`. Transactional
       flows (`register_user`, `verify_email`, `complete_password_reset`)
       use direct `sqlx::Transaction` for atomicity. `EmailPort` trait
-      decouples email delivery from the backend (dev `EchoSink`; SMTP is
-      a separate follow-up).
+      decouples email delivery from the backend (dev `EchoSink`;
+      production `SmtpEmailPort` via `lettre` 0.11 shipped via #754 —
+      see follow-up checkbox below).
 - [x] **CSRF enforcement** for state-changing `/auth/*` and `/api/v1/*` —
       shipped via #737. Existing `csrf_middleware` (double-submit cookie)
       now layered on credential write paths and on a new session-bearing
@@ -231,11 +238,62 @@ The largest 1.0 area. Closure criteria (on top of the global DoD):
       `mfa_complete_login` (`POST /auth/login/mfa`) so the login
       second-step stays CSRF-exempt by construction.
 - [ ] **OAuth providers loaded from operator secrets** — a registry that
-      pulls secrets from the credential store at startup (cross-dep with
-      M12.3 + the `nebula-credential-runtime` wiring increment).
-- [ ] **Lockout + rate-limit integration tests** against the PG backend.
-- [ ] **Observability:** typed `AuthError` → `ApiError` mapping audit +
-      `nebula_api_auth_*` metrics family for failed/locked-out attempts.
+      pulls secrets from the credential store at startup. Carved out into
+      its own SDD plan after recon revealed a 6× scope expansion vs the
+      initial follow-up estimate: Wave 4 credential-stabilize set up the
+      `CredentialService` type slot on `AppState` but never instantiated
+      it in `apps/server::compose`; `CredentialService::get` returns
+      `CredentialSnapshot` (no generic `get::<OAuth2Credential>`);
+      `PgAuthBackend::complete_oauth` still returns `NotImplemented` at
+      `crates/api/src/domain/auth/backend/pg.rs:957`; needs a breaking
+      change to `AuthBackend::start_oauth` (`redirect_uri` parameter),
+      `reqwest` as a new direct dep of `nebula-api` for the token
+      endpoint exchange, and an operator-discovery convention decision
+      (cross-dep with M12.3 + the `nebula-credential-runtime` wiring
+      increment).
+- [x] **Lockout + rate-limit integration tests** against the PG backend —
+      shipped via #751. DATABASE_URL-gated `auth_pg_e2e.rs` lockout suite
+      (`pg_auth_backend_locks_after_threshold_failures` +
+      `pg_auth_backend_lockout_window_expiry_allows_login` +
+      `pg_auth_backend_success_clears_subthreshold_failures`) exercises
+      the threshold-cross arming, window-expiry release, and the
+      sub-threshold + success-clears branch end-to-end. Per-account HTTP
+      rate-limit (vs the existing per-IP `RateLimitState`) is a separate
+      enhancement and is not what this follow-up gates.
+- [x] **Observability:** typed `AuthError` → `ApiError` mapping audit +
+      `nebula_api_auth_*` metrics family for failed/locked-out attempts
+      — shipped via #753. Closed 12-value `outcome` set
+      (`success`/`invalid_creds`/`invalid_input`/`invalid_mfa_code`/
+      `mfa_required`/`token_invalid`/`lockout`/`email_unverified`/
+      `rate_limit`/`oauth_failed`/`conflict`/`internal`); `provider`
+      label (3 values, bounded by `OAuthProvider` enum) only on
+      `nebula_api_auth_oauth_*`; closed set enforced by `&'static str`
+      constants in `naming::auth_outcome` /
+      `naming::auth_oauth_provider` (mirrors `idempotency_reject_reason`
+      precedent, NOT a global `LabelAllowlist::only` switch — that
+      would have stripped existing `tenant_id`/`webhook_key_kind`/`tier`/
+      `reason` labels). `_duration_seconds` histogram with default
+      seconds-shaped buckets (the `_LATENCY_MS` idempotency precedent
+      mis-uses ms-shaped observations against seconds-shaped buckets;
+      that is a separate one-line follow-up). `AuthError→outcome` mapping
+      is enforced at compile time by an exhaustive `match` with no
+      catch-all arm in `default_outcome_for`; a `#[test]` visits all 14
+      variants. `UserNotFound→invalid_creds` is a deliberate collapse to
+      prevent user-enumeration via metric exposure.
+- [x] **SMTP transport for `EmailPort`** — shipped via #754.
+      `SmtpEmailPort` lives in `apps/server` (keeps `nebula-api` free of
+      the `lettre` direct dep); `SmtpEmailConfig` env-bound via
+      `API_SMTP_*` mirroring `IdempotencyApiConfig` precedent; compose
+      root branches on `api_config.smtp.is_some()` and fails CLOSED at
+      boot on invalid SMTP config (`SmtpHostEmpty` /
+      `SmtpAuthIncomplete` / `SmtpFromMissing` / `SmtpFromInvalid` /
+      `ParseEnum`) rather than silently falling back to `EchoSink`.
+      Password held in `secrecy::SecretString` on the config side;
+      `lettre::Credentials` owns an internal `String` for the transport
+      lifetime (never re-read, never logged). TLS modes: starttls
+      (default for 587), implicit (default for 465), none (dev only —
+      emits a startup `tracing::warn!`). HTML template rendering and a
+      dev `Mailpit`/`Mailhog` stack are deferred to a future PR.
 
 #### M3.2 OpenAPI 3.1 spec generation — ✅ CLOSED 2026-05-07
 
@@ -1114,8 +1172,8 @@ Not all parallelizable. Suggested ordering (M0–M2, M6, M11 closed
 
 1. **M0 (durability)** — small, foundational, removes false claims. ✅ DONE.
 2. **M3 (API)** in parallel with M0 — biggest user-facing gap; sliceable
-   (M3.1 mostly closed via #737/#738 — only OAuth-secrets-from-operator,
-   lockout integration tests, and `nebula_api_auth_*` metrics remain;
+   (M3.1 mostly closed via #737/#738/#751/#753/#754 — only
+   OAuth-secrets-from-operator remains (carved out to its own SDD plan);
    M3.2 ✅, M3.3 ✅, M3.4 ✅, M3.5 ✅ via #742, M3.6 open).
 3. **M1, M2 (engine correctness + retry)** after M0 — same `engine.rs`
    paths. ✅ DONE.

--- a/docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md
+++ b/docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md
@@ -1,0 +1,556 @@
+---
+title: "feat: API M3.1 follow-up wave — PG lockout e2e + auth metrics + SMTP transport"
+type: feat
+status: proposed
+date: 2026-05-26
+origin:
+  - docs/ROADMAP.md §M3.1 follow-ups (lockout + rate-limit tests; `nebula_api_auth_*` metrics family; SMTP transport)
+  - docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md §"Not in scope" (items 1, 3, 4)
+recon:
+  - docs/plans/recon/m3.1-followup-wave-recon.md (citations for all PRs)
+---
+
+> **For agentic workers:** Three small-to-medium chained PRs. Use the
+> `pi-subagents` worker (forked context) + fresh reviewer pattern per PR.
+> Strict TDD evidence via `task dev:check`. Each PR squash-merges to `main`
+> before the next worker starts. **DO NOT** bundle these into one PR — they
+> are mounted on the same `apps/server` composition root and would balloon
+> the review surface past the 400-LOC reviewer-friendly budget.
+
+## Context
+
+The M3 closure (PRs #737 / #738 / #742, ROADMAP synced via #745) shipped
+the PG-backed `AuthBackend`, CSRF enforcement, and OTLP exporter
+end-to-end. Four follow-ups were explicitly carved out as out-of-scope of
+the closure plan; recon at `docs/plans/recon/m3.1-followup-wave-recon.md`
+confirms three of them are unblocked and small. The fourth — **OAuth
+providers from operator secrets** — recon revealed is a 6× scope expansion
+(~600-900 LOC) requiring an ADR-level decision on operator credential
+discovery, a breaking `AuthBackend::start_oauth` signature change, and the
+unwired compose-root `CredentialService` instantiation. It is **deferred
+to its own SDD cycle** (see §"Out of scope" below).
+
+## Goal
+
+Close three M3.1 follow-ups for 1.0:
+
+1. **PR-A — Lockout + rate-limit PG e2e tests** against the `PgAuthBackend`
+   (ROADMAP §M3.1 "Lockout + rate-limit integration tests").
+2. **PR-B — `nebula_api_auth_*` metrics family + `AuthError → ApiError`
+   mapping audit** (ROADMAP §M3.1 "typed `AuthError` → `ApiError` mapping
+   audit + `nebula_api_auth_*` metrics family for failed/locked-out
+   attempts").
+3. **PR-D — Production SMTP transport for `EmailPort`** via the `lettre`
+   crate (ROADMAP §M3.1 closure-plan deferral §line 25).
+
+After PR-D squash-merges, all four ROADMAP §M3.1 follow-up checkboxes flip
+to `[x]` except the OAuth-from-secrets bullet (carved out into its own
+SDD plan).
+
+## Out of scope
+
+- **PR-C (OAuth providers from operator secrets)** — carved out into its
+  own SDD plan because recon revealed:
+  - `CredentialService` is in `AppState` at the type level but **never
+    instantiated** in `apps/server/src/compose.rs` (recon §"Cross-dep
+    status").
+  - `CredentialService::get` returns `CredentialSnapshot`, not generic
+    `get::<OAuth2Credential>` — requires a typed-decode seam.
+  - `PgAuthBackend::complete_oauth` literally `return
+    Err(AuthError::NotImplemented(...))` at `crates/api/src/domain/auth/backend/pg.rs:957`.
+  - Requires a breaking change to `AuthBackend::start_oauth` (add
+    `redirect_uri`).
+  - Requires `reqwest` as a new direct dep of `nebula-api` for the OAuth
+    token endpoint exchange.
+  - Requires an ADR on operator credential-discovery convention
+    (config-map vs name convention vs new `CredentialKind`).
+
+  This is an entire sub-milestone, not a follow-up. Will be filed as
+  `docs/plans/<date>-feat-api-oauth-providers-from-secrets-plan.md` after
+  this wave merges.
+
+- **PR-E (webhook per-outcome `REQUESTS_TOTAL` + latency histogram +
+  cardinality regression test, M3.3 follow-up)** — independent of M3.1
+  auth follow-ups; tracked separately on ROADMAP §M3.3.
+
+- **M3.6 (shift-left workflow validation)** — entire sub-milestone, its
+  own future SDD plan.
+
+## Architecture
+
+### PR-A (lockout e2e)
+The lockout logic is complete in storage (`crates/storage/src/pg/user.rs:34,37,242-270`
+with `LOCKOUT_THRESHOLD=5` and `LOCKOUT_DURATION=15min`) and exercised by
+`PgAuthBackend::authenticate_password`
+(`crates/api/src/domain/auth/backend/pg.rs:382-430`). The gap is **e2e
+coverage**: `rg "locked_until" crates/api/tests/` returns zero matches.
+
+The e2e suite extends `crates/api/tests/auth_pg_e2e.rs` (currently 542
+LOC) with a new lockout-scenario test that drives `authenticate_password`
+N times until `AuthError::AccountLocked` is returned, then verifies the
+post-lockout-window success path. Reuses the existing `pool()` /
+`build_backend(pool)` fixtures. Per-account rate-limit is **explicitly
+out of scope** for this PR — the current middleware is per-IP only
+(`crates/api/src/middleware/rate_limit.rs:52-56`), and adding a
+per-account dimension is a separate enhancement.
+
+### PR-B (auth metrics + mapping audit)
+The `MetricsRegistry` API
+(`crates/metrics/src/registry.rs:145,152,159,191,206,215`) supports
+`counter`, `gauge`, `histogram` (unlabeled) and `_labeled` variants with
+a `LabelAllowlist` cardinality filter (`crates/metrics/src/filter.rs`).
+Existing API namespaces in `crates/metrics/src/naming.rs` are
+`NEBULA_API_IDEMPOTENCY_*` (5 constants) — recon confirms zero
+`NEBULA_API_AUTH_*` allocations today.
+
+The `AuthError` enum
+(`crates/api/src/domain/auth/backend/error.rs:12-65`) has 14 variants;
+the `AuthError → ApiError` mapping at `:101-132` covers all 14
+explicitly — **no fall-through** to generic `Internal` except the
+intentional `Crypto`/`Internal` arms. The audit confirms the mapping is
+correct; the gap is **metric emission**, not mapping holes.
+
+Decision (per advisor consultation):
+- **Emission point:** `PgAuthBackend` constructor accepts
+  `Option<Arc<MetricsRegistry>>` (mirrors `IdempotencyLayer::with_metrics`
+  precedent).
+- **Labels:** `outcome ∈ {success, invalid_creds, lockout, mfa_required,
+  email_unverified, rate_limit, internal}` for the per-attempt counter;
+  `provider` only on `nebula_api_auth_oauth_*` counters; nothing else.
+- **Allowlist:** `LabelAllowlist::only(["outcome", "provider"])`.
+- **Oracle consult:** before the metric constants land in `naming.rs`,
+  spawn `oracle` (forked context) to sandbox-check the label set against
+  the existing label-allowlist usage in idempotency and webhook
+  namespaces, ensuring the cardinality budget holds.
+
+### PR-D (SMTP transport)
+Recon confirms `lettre` (or any SMTP crate) is **not in the workspace**
+today (`rg "lettre|async-smtp" Cargo.toml crates/ apps/` returns zero
+hits). PR-D adds `lettre = { version = "0.11", default-features = false,
+features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }` to
+`[workspace.dependencies]`, then implements
+`apps/server/src/email/smtp.rs::SmtpEmailPort` as an `EmailPort` impl
+(trait at `crates/api/src/ports/email.rs:111-117`).
+
+Composition root branches on a new `Option<SmtpEmailConfig>` in
+`ApiConfig`: when present + non-empty `host`, instantiate `SmtpEmailPort`;
+else fall back to the existing `EchoSink` dev impl. Env-binding follows
+the `IdempotencyApiConfig` pattern at
+`crates/api/src/config/sub.rs:91-190` with `API_SMTP_*` prefixes.
+
+**Template scope:** explicitly out of scope. `EmailMessage::body` stays a
+raw token. A future PR introduces a `templates/` directory.
+
+**Mailpit/Mailhog in dev stack:** out of scope for this PR. Local dev
+stays on `EchoSink`. Production deploys point `API_SMTP_HOST` at the
+operator's SMTP server.
+
+## Tech Stack
+
+- Rust 1.95 (edition 2024, resolver 3)
+- `lettre = "0.11"` with `smtp-transport,tokio1-rustls-tls,builder`
+  (NEW workspace dep for PR-D)
+- `sqlx`, `tokio`, `argon2`, `nebula-metrics` — already in workspace
+- `cargo nextest run` for tests; `task dev:check` between commits
+- `convco` for commit-message validation (CLAUDE.md Agent Git Workflow)
+
+## Cross-deps (DO NOT DUPLICATE)
+
+| Dep | Status | Handling |
+|---|---|---|
+| Closure plan `2026-05-25-002` PRs #737/#738/#742 | merged | Base for this wave; recon assumes their state on `main` (commit `2bcf5d3b`). |
+| Credential-stabilize Wave 4 / Task 17 (`nebula-api → CredentialService` instantiation in compose) | **NOT shipped** | Not needed for PR-A/B/D. Recon confirms `credential_service` slot is in `AppState` but never populated in `compose.rs`. The OAuth wiring follow-up (carved out) is the consumer of that wiring. |
+| ADR-0046 (metrics/telemetry flat layout) | DONE | PR-B respects flat layout — `naming.rs` is the only file that gets new constants; no submodule tree. |
+| `MetricsRegistry::snapshot_*` OTLP exporter (PR #742) | DONE | PR-B counters/histograms flow through the existing exporter seam without code changes. |
+| CODEOWNERS | unchanged | `crates/api/`, `apps/server/`, `crates/storage/` all `@vanyastaff` (`.github/CODEOWNERS`). No new ownership routing. |
+
+## Worktree + branch plan
+
+Three chained branches, each from `origin/main`. Squash-merge each PR
+before the next worker starts.
+
+| PR | Branch | Slug |
+|----|--------|------|
+| PR-A | `feat/api-pg-auth-lockout-rl-tests` | `pg-auth-lockout-tests` |
+| PR-B | `feat/api-auth-metrics-mapping` | `auth-metrics-mapping` |
+| PR-D | `feat/api-email-smtp` | `email-smtp` |
+
+Creation pattern (per CLAUDE.md Agent Git Workflow):
+
+```bash
+bash scripts/worktree.sh new pg-auth-lockout-tests feat api
+```
+
+---
+
+## Pre-flight (run once before PR-A)
+
+### Task 0: Verify clean base
+
+- [ ] **Step 1: Fetch latest main + verify clean state**
+
+```bash
+git fetch origin main
+git status -sb        # main...origin/main, no diverge
+```
+
+- [ ] **Step 2: `task dev:check` green on `main`**
+
+```bash
+cd C:/Users/vanya/RustroverProjects/nebula
+task dev:check
+```
+
+Memory note: if `cargo fmt --all` fails on Windows due to deep
+worktree paths, fall back to `cargo fmt -p <crate> -- --check` per
+touched crate (project memory `cargo_fmt_all_winpath`).
+
+- [ ] **Step 3: Read the recon doc**
+
+`docs/plans/recon/m3.1-followup-wave-recon.md` is the source of truth
+for every `file:line` citation in this plan. Workers open it before
+starting their PR.
+
+---
+
+## PR-A — Lockout + rate-limit PG e2e tests (~250 LOC)
+
+**Branch:** `feat/api-pg-auth-lockout-rl-tests`
+**Worker:** single `worker` subagent (forked context).
+**Reviewer:** fresh-context `reviewer` on final diff.
+**Estimated LOC:** ~250 (test-only; well under the single-worker budget).
+
+### Wave 1 — Lockout e2e against `PgAuthBackend`
+
+**Files:**
+- `crates/api/tests/auth_pg_e2e.rs:542` — extend with lockout test
+  (~200 LOC). Reuses `pool()` / `unique_email()` / `build_backend(pool)`
+  fixtures at lines 63-97.
+
+- [ ] **Step 1: Test `authenticate_password` returns `AccountLocked`
+  after `LOCKOUT_THRESHOLD` failures**
+
+Drive 5 failed-password attempts; assert the 6th returns
+`AuthError::AccountLocked`. Verify `users.locked_until > NOW()` directly
+via the pool to confirm the storage-layer column was armed.
+
+- [ ] **Step 2: Test post-lockout-window allow path**
+
+Either advance the clock (if a clock abstraction exists) or update
+`users.locked_until` directly to `NOW() - 1s` and assert the next
+correct-password attempt succeeds.
+
+- [ ] **Step 3: Test `record_login_success` clears lockout state**
+
+After a successful auth following the post-window allow, verify
+`users.failed_login_count = 0` and `users.locked_until IS NULL`.
+
+### Wave 2 — Rate-limit middleware smoke (optional, scope-flag)
+
+**Decision:** Skip in this PR — current middleware is per-IP only at the
+HTTP edge (`crates/api/src/middleware/rate_limit.rs:52-56`), not
+auth-aware. Adding a per-account dimension is a separate enhancement and
+not what ROADMAP §M3.1 follow-up asks for. The lockout path **is** the
+rate-limit-on-auth surface for 1.0.
+
+### PR-A Acceptance criteria
+
+- [ ] `task dev:check` green
+- [ ] `cargo nextest run -p nebula-api --test auth_pg_e2e` passes against
+      a live `task db:up` Postgres (DATABASE_URL set)
+- [ ] No regression in existing `auth_pg_e2e.rs` lifecycle test
+- [ ] Fresh `reviewer` audits: confirms no new fixture leaks, no flake
+      risk from shared user state, lockout assertion uses
+      `AuthError::AccountLocked` not string-matching
+
+### PR-A Commit message
+
+```
+test(api): e2e lockout coverage for PgAuthBackend
+
+Drives PgAuthBackend::authenticate_password through LOCKOUT_THRESHOLD
+failures; asserts AccountLocked is returned and users.locked_until is
+armed. Verifies post-window allow + record_login_success clears state.
+
+Closes M3.1 follow-up "Lockout integration tests against the PG
+backend" per docs/ROADMAP.md.
+
+Per-account rate-limit on the HTTP middleware is a separate
+enhancement and is not what this follow-up gates.
+
+Tests: crates/api/tests/auth_pg_e2e.rs — extended (+~200 LOC).
+```
+
+---
+
+## PR-B — `nebula_api_auth_*` metrics + `AuthError → ApiError` audit (~400 LOC)
+
+**Branch:** `feat/api-auth-metrics-mapping`
+**Worker:** single `worker` subagent (forked context), with an `oracle`
+consult before metric constants land.
+**Reviewer:** fresh-context `reviewer` on final diff.
+**Estimated LOC:** ~400.
+
+### Wave 1 — Metric constants + label allowlist
+
+**Files:**
+- `crates/metrics/src/naming.rs` — add `NEBULA_API_AUTH_ATTEMPTS_TOTAL`,
+  `NEBULA_API_AUTH_LATENCY_MS` (histogram), `NEBULA_API_AUTH_LOCKED_OUT_TOTAL`,
+  `NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL`, `NEBULA_API_AUTH_MFA_ATTEMPTS_TOTAL`.
+- `crates/metrics/src/filter.rs` — extend `LabelAllowlist` consumers or
+  document the new label set if appropriate.
+
+- [ ] **Step 1: `oracle` consult on label set**
+
+Before adding the constants, spawn `oracle` (forked context) with this
+prompt:
+
+> "Audit the proposed `nebula_api_auth_*` label set for cardinality
+> safety against the existing `nebula_api_idempotency_*` and webhook
+> metric namespaces. Labels: `outcome ∈ {success, invalid_creds,
+> lockout, mfa_required, email_unverified, rate_limit, internal}` on
+> attempt counters; `provider ∈ {google, github, ...}` only on
+> `nebula_api_auth_oauth_*` counters. Confirm `LabelAllowlist::only`
+> usage matches existing precedent. Reject the label set or propose a
+> narrower one if any leak risk."
+
+- [ ] **Step 2: Add constants after oracle sign-off**
+
+### Wave 2 — Backend injection + emission
+
+**Files:**
+- `crates/api/src/domain/auth/backend/pg.rs` — extend
+  `PgAuthBackend::new` to accept `Option<Arc<MetricsRegistry>>`; emit
+  counters in `authenticate_password`, `start_mfa_enrollment`,
+  `verify_mfa`, `mfa_complete_login`, `start_oauth`, `complete_oauth`,
+  `register_user`, `verify_email`, `complete_password_reset`.
+- `crates/api/src/domain/auth/backend/in_memory.rs` — mirror the
+  constructor signature for parity (`Option`, default = `None`); emit
+  the same counters when registry is present.
+- `apps/server/src/compose.rs` — thread `metrics_registry` into
+  `build_auth_backend` (already on `AppState`).
+
+- [ ] **Step 3: Emit counters per hot-path method**
+- [ ] **Step 4: Compose root threads registry into backend**
+
+### Wave 3 — Mapping audit + tests
+
+**Files:**
+- `crates/api/src/domain/auth/backend/error.rs:101-132` — review and
+  document each `From<AuthError> for ApiError` arm with a short rationale
+  comment (the mapping is correct per recon; the audit is documentation
+  + a `From`-mapping coverage test that asserts every `AuthError` variant
+  maps to an explicit `ApiError` arm and not `Internal`).
+- New: `crates/api/tests/auth_metrics.rs` (~80 LOC) — boots a minimal
+  `PgAuthBackend` + `MetricsRegistry` + asserts the `nebula_api_auth_*`
+  counters increment on success / lockout / invalid-creds paths.
+  DATABASE_URL-gated.
+
+- [ ] **Step 5: Add From-coverage exhaustiveness test in `error.rs`**
+
+Use a match-all pattern on `AuthError` variants and `#[deny(non_exhaustive)]`
+(or an exhaustive match returning a known `ApiError` taxonomy) to make
+adding a new variant fail compilation until the mapping is updated.
+
+- [ ] **Step 6: Add `auth_metrics.rs` e2e**
+
+### PR-B Acceptance criteria
+
+- [ ] `task dev:check` green
+- [ ] `cargo nextest run -p nebula-api` passes
+- [ ] `cargo doc --no-deps -p nebula-api` warning-free
+- [ ] `oracle` sign-off documented in commit message
+- [ ] Fresh `reviewer` audits: cardinality budget, label-allowlist
+      placement, no high-cardinality leaks (user_id, email, IP)
+- [ ] No new `clippy::cast_*` warnings on the new metric arithmetic
+
+### PR-B Commit message
+
+```
+feat(api,metrics): nebula_api_auth_* counters + AuthError mapping audit
+
+Adds the auth metric namespace (attempts, locked-out, oauth, mfa, latency)
+per ROADMAP §M3.1 follow-up. Labels:
+- outcome on per-attempt counters
+- provider only on nebula_api_auth_oauth_*
+LabelAllowlist::only(["outcome", "provider"]) enforces the cardinality
+budget; verified against existing nebula_api_idempotency_* precedent.
+
+Audits AuthError -> ApiError mapping at
+crates/api/src/domain/auth/backend/error.rs: all 14 variants map to
+explicit ApiError arms; documented per-arm rationale; coverage test
+fails compilation on a new variant without explicit mapping.
+
+Closes M3.1 follow-up "AuthError -> ApiError mapping audit +
+nebula_api_auth_* metrics family" per docs/ROADMAP.md.
+
+Tests: crates/api/tests/auth_metrics.rs (DATABASE_URL-gated) +
+extended unit tests in error.rs.
+```
+
+---
+
+## PR-D — SMTP transport for `EmailPort` (~400 LOC)
+
+**Branch:** `feat/api-email-smtp`
+**Worker:** single `worker` subagent (forked context).
+**Reviewer:** fresh-context `reviewer` on final diff.
+**Estimated LOC:** ~400 (~250 impl + ~80 config + ~70 tests).
+
+### Wave 1 — Workspace dep + `SmtpEmailConfig`
+
+**Files:**
+- `Cargo.toml` (workspace root) — add `lettre = { version = "0.11",
+  default-features = false, features = ["smtp-transport",
+  "tokio1-rustls-tls", "builder"] }` to `[workspace.dependencies]`.
+- `crates/api/src/config/sub.rs` — add `SmtpEmailConfig { host, port,
+  username, password, from_address, tls_mode }` (~50 LOC, mirrors
+  `IdempotencyApiConfig` at `:91-190`).
+- `crates/api/src/config/env.rs` — bind `API_SMTP_HOST`, `API_SMTP_PORT`,
+  `API_SMTP_USERNAME`, `API_SMTP_PASSWORD`, `API_SMTP_FROM`,
+  `API_SMTP_TLS_MODE` via `parse_*_env` helpers (~30 LOC).
+- `crates/api/src/config/mod.rs` — add `smtp: Option<SmtpEmailConfig>`
+  field; `from_env` branches on `API_SMTP_HOST` presence.
+
+- [ ] **Step 1: Workspace dep**
+- [ ] **Step 2: `SmtpEmailConfig` struct + env binding**
+- [ ] **Step 3: Wire `Option<SmtpEmailConfig>` into `ApiConfig::from_env`**
+
+### Wave 2 — `SmtpEmailPort` impl
+
+**Files:**
+- `apps/server/Cargo.toml` — add `lettre = { workspace = true }` (consumer-
+  side; keep `nebula-api` itself dep-free of `lettre`).
+- New: `apps/server/src/email/mod.rs` + `apps/server/src/email/smtp.rs`
+  (~170 LOC) — `SmtpEmailPort` struct wrapping
+  `AsyncSmtpTransport<Tokio1Executor>`; constructor from
+  `SmtpEmailConfig`; `impl EmailPort` mapping `EmailMessage` to
+  `lettre::Message` + sending via the transport. Map `lettre::Error` to
+  `EmailError::Transport(String)`.
+- `apps/server/src/compose.rs:184` — replace hardcoded
+  `EchoSink::default()` with a `match config.smtp { Some(cfg) =>
+  SmtpEmailPort::new(cfg)?, None => Arc::new(EchoSink::default()) }`
+  branch.
+
+- [ ] **Step 4: `SmtpEmailPort` impl with TLS handling**
+- [ ] **Step 5: Compose root branches on `config.smtp`**
+
+### Wave 3 — Tests + docs
+
+**Files:**
+- New: `apps/server/src/email/tests.rs` (or inline `#[cfg(test)] mod
+  tests`) — `lettre`'s `StubTransport` lets tests assert the SMTP envelope
+  without a real server (~50 LOC). Tests:
+  - `smtp_port_renders_verification_message`
+  - `smtp_port_uses_configured_from_address`
+  - `smtp_port_returns_transport_error_on_send_failure`
+- `crates/api/README.md` or `apps/server/README.md` — new section
+  "Email delivery (SMTP)" documenting the env vars + the
+  `Option<SmtpEmailConfig>` semantics.
+- `.env.example` — add the new `API_SMTP_*` keys (commented out, with
+  example values).
+
+- [ ] **Step 6: `StubTransport`-based unit tests**
+- [ ] **Step 7: Docs + `.env.example`**
+
+### PR-D Acceptance criteria
+
+- [ ] `task dev:check` green
+- [ ] `cargo nextest run` passes (StubTransport tests are not network-gated)
+- [ ] `cargo deny check` — no new wrapper edges
+  (`lettre` is a leaf transport crate)
+- [ ] When `API_SMTP_HOST` is unset, `apps/server` boots with `EchoSink`
+      (no surprise prod-switch)
+- [ ] Fresh `reviewer` audits: TLS config branches honored, password env
+      var redacted from any Debug/Display, no panic-on-misconfig in
+      compose
+- [ ] README + `.env.example` reflect the new env contract
+
+### PR-D Commit message
+
+```
+feat(api,server): production SMTP transport for EmailPort via lettre
+
+Adds lettre 0.11 (smtp-transport + tokio1-rustls-tls + builder) to
+the workspace; SmtpEmailPort impl lives in apps/server (keeps the
+api crate free of lettre). SmtpEmailConfig is env-bound via the
+API_SMTP_* prefix mirroring IdempotencyApiConfig precedent.
+
+Compose root branches: API_SMTP_HOST set -> SmtpEmailPort; unset ->
+EchoSink (dev default unchanged). TLS modes: starttls (default for
+port 587), implicit (port 465), or none.
+
+Closes M3.1 follow-up "SMTP transport for EmailPort" per
+docs/ROADMAP.md.
+
+Tests: apps/server email::smtp::tests via lettre StubTransport.
+Templates remain raw-body for this PR; HTML template rendering is a
+later concern.
+```
+
+---
+
+## Subagent matrix
+
+| Step | Agent | Why |
+|------|-------|-----|
+| PR-A worker | `worker` (forked ctx) | Test-only; ~250 LOC, single writer |
+| PR-A review | `reviewer` (fresh ctx) | Audit lockout assertion / fixture leaks |
+| PR-B worker | `worker` (forked ctx) | Multi-file but isolated to metrics surface |
+| PR-B oracle | `oracle` (fork ctx) | Lock label set + cardinality budget before constants land |
+| PR-B review | `reviewer` (fresh ctx) | Cardinality budget + label-allowlist placement |
+| PR-D worker | `worker` (forked ctx) | New crate dep + new impl; single writer |
+| PR-D review | `reviewer` (fresh ctx) | TLS modes, password redaction, compose branching |
+
+**Single-writer discipline:** never run two workers in parallel on
+overlapping crates. PR-A → PR-B → PR-D strictly sequential; the next
+worker starts only after the previous PR squash-merges.
+
+## Verification gate (full-slice)
+
+After PR-D squash-merges, before declaring the M3.1 follow-up wave
+closed:
+
+- [ ] `task dev:check` clean on `main`
+- [ ] `cargo deny check` green
+- [ ] `cargo doc --no-deps --workspace` warning-free
+- [ ] ROADMAP §M3.1 follow-up checkboxes (lockout tests, metrics +
+      mapping audit, SMTP transport) flipped to `[x]`
+- [ ] OAuth-from-secrets bullet stays open with a pointer to the new
+      SDD plan slug
+- [ ] MATURITY.md API row updated if appropriate (likely no status
+      change — `partial` until M3.6 ships)
+
+## Risks + mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| PR-A lockout test depends on clock advancement; the codebase has no clock abstraction | Mitigation: update `users.locked_until` column directly to `NOW() - 1s` to simulate window expiry. Document the test technique inline. |
+| PR-B cardinality blow-up from a stray label | Oracle consult before constants land; reviewer cross-checks `LabelAllowlist::only` usage |
+| PR-D `lettre` brings new transitive deps (rustls, hyper, etc.) | Use `default-features = false` + minimal feature set; reviewer audits `cargo deny check` output |
+| PR-D password leakage via Debug | Use `secrecy::SecretString` or manual `Debug` impl that prints `[redacted]`; reviewer confirms |
+| Windows fmt path issues | Documented in pre-flight (per-crate `cargo fmt -p` fallback) |
+
+## Rollout
+
+1. Land PR-A. Squash-merge. Update local main + verify `task dev:check`.
+2. Land PR-B. Squash-merge. Update local main + verify.
+3. Land PR-D. Squash-merge. Update local main + verify.
+4. ROADMAP update in a small `docs(roadmap):` commit on `main`:
+   - Flip three §M3.1 boxes to `[x]`
+   - Leave OAuth-from-secrets open with new SDD-plan slug pointer
+5. (Optional) File the OAuth-from-secrets SDD plan stub:
+   `docs/plans/<date>-feat-api-oauth-providers-from-secrets-plan.md`.
+
+## Memory + audit
+
+- Plan saved to: `docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md`
+- Recon saved to: `docs/plans/recon/m3.1-followup-wave-recon.md`
+- Engram unavailable in this Pi session; phase artifacts stay as
+  OpenSpec/markdown files under `docs/plans/`.
+
+## Cross-link
+
+After PR-D merges, this plan becomes the historical artifact for the
+M3.1 follow-up wave. The OAuth-from-secrets sub-plan will cross-link
+back here as its blocked-by predecessor.

--- a/docs/plans/recon/m3.1-followup-wave-recon.md
+++ b/docs/plans/recon/m3.1-followup-wave-recon.md
@@ -1,0 +1,351 @@
+# M3.1 follow-up wave recon
+Date: 2026-05-26
+Recon scope: PR-A (lockout PG tests), PR-B (auth metrics + ApiError mapping), PR-C (OAuth from secrets), PR-D (SMTP transport)
+
+---
+
+## Cross-dep status (BLOCKING for PR-C)
+
+**⚠️ PARTIALLY SHIPPED — PR-C is BLOCKED on code-exchange wiring, not on the credential dep itself.**
+
+### What shipped
+
+- `nebula-credential-runtime` dep: present in `crates/api/Cargo.toml` (line: `nebula-credential-runtime = { path = "../credential-runtime" }`).
+- `CredentialService` slot in `AppState`: `crates/api/src/state.rs:231` —
+  `pub credential_service: Option<Arc<CredentialService<InMemoryStore, InMemoryPendingStore>>>`.
+- `compose.rs` instantiation: [NOT FOUND] — no `CredentialService` instantiation in `apps/server/src/compose.rs`. The `credential_service` slot is present in the type but never populated in the server compose root.
+- Git log grep (`credential.*stabilize|Wave 4|Task 17`): commit `e66bedb1` = `feat(credential)!: stabilize sweep — M12.2 hardening + ValidatedBinding + resolve_for_slot (#732)` — this is the credential crate stabilisation, NOT the API wiring. No commit mentions "Task 17" or wires `CredentialService` into the server compose.
+
+### What is NOT shipped
+
+- `start_oauth` (`crates/api/src/domain/auth/backend/pg.rs:895`): uses a synthetic authorize URL hardcoded to `https://nebula.local/...`; no `CredentialService::get` call.
+- `complete_oauth` (`crates/api/src/domain/auth/backend/pg.rs:932-968`): consumes the state row then **explicitly returns `AuthError::NotImplemented`** — `"oauth provider code exchange is not yet wired"` (line 957).
+- `InMemoryAuthBackend::complete_oauth` (`crates/api/src/domain/auth/backend/in_memory.rs:749-767`): also returns `NotImplemented("complete_oauth requires a configured provider backend")`.
+- `AuthBackend::start_oauth` trait signature (`crates/api/src/domain/auth/backend/provider.rs:207`): does NOT accept `redirect_uri` — flagged in pg.rs:35 doc comment as deferred.
+
+**Verdict:** `CredentialService` type is wired into `AppState` at the type level, but the compose root never populates it, and neither OAuth backend calls `CredentialService::get`. PR-C needs: (1) compose root wiring, (2) trait signature extension (`redirect_uri`), (3) code-exchange implementation against `CredentialService::get::<OAuth2Credential>`.
+
+---
+
+## PR-A — lockout + rate-limit PG e2e tests
+
+### 1. Current state
+
+**Lockout logic (storage layer):**
+- Constants: `crates/storage/src/pg/user.rs:34` — `pub const LOCKOUT_THRESHOLD: i32 = 5` and `:37` — `pub const LOCKOUT_DURATION: Duration = Duration::from_mins(15)`.
+- `record_login_failure`: `crates/storage/src/pg/user.rs:242-270` — single atomic `UPDATE` that bumps `failed_login_count + 1` and arms `locked_until = NOW() + make_interval(secs => $3)` when `failed_login_count + 1 >= LOCKOUT_THRESHOLD`.
+- `record_login_success`: `crates/storage/src/pg/user.rs:224-241` — resets both columns + sets `last_login_at`.
+- Unit test in storage crate: `crates/storage/src/pg/user.rs:362` — `record_login_failure_increments_then_locks` (lines 362-392); `record_login_success_clears_failures_and_lock` (lines 394-413). Both DATABASE_URL gated.
+
+**Lockout check in PgAuthBackend:**
+- `crates/api/src/domain/auth/backend/pg.rs:382-430` — `authenticate_password` checks `user.locked_until > Utc::now()` at line ~396 and returns `AuthError::AccountLocked`.
+- `record_login_failure` called at line ~405; `record_login_success` at ~412.
+
+**Rate-limit middleware (per-IP only):**
+- `crates/api/src/middleware/rate_limit.rs:52-56` — `RateLimitState { limiter: Arc<DefaultKeyedRateLimiter<IpAddr>>, ... }`. Keyed on `IpAddr`, no per-account dimension.
+- Configured via `ApiConfig::rate_limit_per_second` (`crates/api/src/config/mod.rs:94`) bound to `API_RATE_LIMIT` env var (line 265), default 100 req/s.
+
+**Existing PG e2e harness (`crates/api/tests/auth_pg_e2e.rs`):**
+- DATABASE_URL gating: `async fn pool() -> Option<Pool<Postgres>>` at lines ~63-81; returns `None` silently when `DATABASE_URL` absent — mirrors `crates/storage/src/pg/*::tests::pool` convention exactly.
+- Migration: `static SPEC16_MIGRATOR = sqlx::migrate!("../storage/migrations/postgres")` (line ~56), run once per process via `OnceCell` (line ~58).
+- Fixtures: `unique_email(label)` (line ~84); `build_backend(pool)` → `(Arc<PgAuthBackend>, Arc<EchoSink>)` (line ~91).
+- Lifecycle coverage: steps 1–12 in one `#[tokio::test]` — registration, email verify, password auth, MFA enroll/verify, PAT CRUD, password reset, `start_oauth` / `complete_oauth` replay test (lines ~100-542).
+- Total: 542 lines.
+
+### 2. Gap
+
+- **No e2e test hits the locked-out path against `PgAuthBackend`**: `rg "locked_until" crates/api/tests/` → `[NOT FOUND]` (empty output — query run, 0 hits).
+- No test drives `authenticate_password` Nx until `AccountLocked` is returned via the HTTP stack (i.e., exercises `ApiError::AccountLocked` → HTTP 423 path end-to-end).
+- No test exercises the rate-limit middleware under lockout conditions (the per-IP `RateLimitState` has no auth-aware dimension — no per-account counter exists).
+
+### 3. Touch surface
+
+| File | Current LOC | Role |
+|---|---|---|
+| `crates/api/tests/auth_pg_e2e.rs` | 542 | Extend with lockout scenario tests |
+| `crates/storage/src/pg/user.rs` | 414 | No changes needed — lockout logic complete |
+| `crates/api/src/domain/auth/backend/pg.rs` | 996 | No changes needed — AccountLocked check in place |
+| `crates/api/src/middleware/rate_limit.rs` | 146 | Potentially extend for per-account rate limiter if required |
+
+New file (if per-account rate limit PG test is in scope): none yet defined.
+
+### 4. Dependencies / blockers
+
+- `DATABASE_URL` env var — must be set to a live Postgres for these tests to run (same gating as existing harness).
+- No new Cargo deps needed — `sqlx`, `tokio`, `nebula-api` with `postgres` feature already present.
+- Migration in `crates/storage/migrations/postgres/` — no new migration needed; `locked_until` column already exists (used by storage unit tests).
+
+### 5. Existing tests to reference
+
+- `crates/storage/src/pg/user.rs:362-392` — `record_login_failure_increments_then_locks` — shows the exact loop pattern to drive N failures.
+- `crates/api/tests/auth_pg_e2e.rs:63-97` — `pool()` + `unique_email()` + `build_backend()` fixture setup.
+- The existing auth e2e lifecycle test (lines 100-542) shows the full `authenticate_password` + MFA round-trip — the lockout test should follow the same `Option`-early-return guard at the top.
+
+---
+
+## PR-B — nebula_api_auth_* metrics + AuthError mapping
+
+### 1. Current state
+
+**MetricsRegistry API (`crates/metrics/src/registry.rs`):**
+- `counter(name)` → `MetricsResult<Counter>` (line 145) — unlabeled.
+- `gauge(name)` → `MetricsResult<Gauge>` (line 152) — unlabeled.
+- `histogram(name)` → `MetricsResult<Histogram>` (line 159) — unlabeled, default buckets.
+- `counter_labeled(name, &LabelSet)` → `MetricsResult<Counter>` (line 191).
+- `histogram_labeled(name, &LabelSet)` (line 206); `histogram_with_buckets_labeled(name, &LabelSet, Vec<f64>)` (line 215).
+- Label allowlist: `crates/metrics/src/filter.rs` — `LabelAllowlist::all()` (no-op) or `LabelAllowlist::only([...])` to strip high-cardinality keys.
+- Metric names are string constants declared in `crates/metrics/src/naming.rs`.
+
+**Existing `nebula_api_*` namespaces in `naming.rs`:**
+- `NEBULA_API_IDEMPOTENCY_HITS_TOTAL` (line 124)
+- `NEBULA_API_IDEMPOTENCY_MISSES_TOTAL` (line 132)
+- `NEBULA_API_IDEMPOTENCY_REJECTS_TOTAL` (line 151)
+- `NEBULA_API_IDEMPOTENCY_STORE_SATURATION_PPM` (line 183)
+- `NEBULA_API_IDEMPOTENCY_LATENCY_MS` (line 192)
+- **`nebula_api_auth_*` namespace: `[NOT FOUND]`** — no constants in `crates/metrics/src/naming.rs` or `crates/api/src/`. Confirmed unallocated.
+
+**`MetricsRegistry` in `AppState`:**
+- `crates/api/src/state.rs:231` — `pub metrics_registry: Option<Arc<MetricsRegistry>>`.
+- Injected via `with_metrics_registry` (line 997). Currently only consumed by the idempotency layer (threaded in at `build_app` time via `IdempotencyLayer::with_metrics`).
+
+**`AuthError` enum (all variants) — `crates/api/src/domain/auth/backend/error.rs:12-65`:**
+```
+NotImplemented(&'static str)
+EmailAlreadyRegistered
+UserNotFound
+InvalidCredentials
+InvalidInput(&'static str)
+AccountLocked
+EmailNotVerified
+MfaRequired
+InvalidMfaCode
+InvalidToken
+RateLimit
+OAuthFailed(String)
+Crypto(String)
+Internal(String)
+```
+
+**`AuthError → ApiError` mapping (`crates/api/src/domain/auth/backend/error.rs:101-132`):**
+| AuthError | ApiError | HTTP |
+|---|---|---|
+| `NotImplemented` | `ServiceUnavailable` | 503 |
+| `EmailAlreadyRegistered` | `Conflict` | 409 |
+| `UserNotFound` | `NotFound` | 404 |
+| `InvalidCredentials` | `Unauthorized` | 401 |
+| `InvalidInput` | `validation_message` (400) | 400 |
+| `AccountLocked` | `AccountLocked` | 423 |
+| `EmailNotVerified` | `Forbidden` | 403 |
+| `MfaRequired` | `MfaRequired` | 401 |
+| `InvalidMfaCode` | `Unauthorized` | 401 |
+| `InvalidToken` | `Unauthorized` | 401 |
+| `RateLimit` | `RateLimitExceeded` | 429 |
+| `OAuthFailed` | `UpstreamError` | 502 |
+| `Crypto` | `Internal` | 500 |
+| `Internal` | `Internal` | 500 |
+
+**Mapping quality:** All 14 variants have explicit arms — **no fall-through to generic Internal** except the intentional `Crypto` and `Internal` arms. `EmailError → AuthError::Internal` is the only lossy collapse (error.rs:72-79), documented with a TODO to revisit for transient vs. hard-reject. `StorageError::Duplicate{entity:"user"}` → `EmailAlreadyRegistered`; everything else → `Internal` (error.rs:83-97). Status-code tests exist for 5 variants (lines 135-175).
+
+**ApiError taxonomy (`crates/api/src/error/mod.rs:35-190`):** Validation(400), Unauthorized(401), Forbidden(403), NotFound(404), Conflict(409), RateLimitExceeded(429), Internal(500), ServiceUnavailable(503), Storage(503), InvalidWorkflowDefinition(422), SessionExpired(401), MfaRequired(401), InsufficientRole(403), QuotaExceeded(403), VersionMismatch(409), Gone(410), Unprocessable(422), AccountLocked(423), UpstreamError(502), StorageFull(507), NotImplemented(501).
+
+**Hot-path auth methods (where metrics should be emitted):**
+- `PgAuthBackend::authenticate_password` — `crates/api/src/domain/auth/backend/pg.rs:382` — calls `record_login_failure` (line ~405) and `record_login_success` (line ~412); lockout check at line ~396.
+- `PgAuthBackend::register_user` — same file, near line 100 (sign-up path).
+- `PgAuthBackend::verify_email` — same file.
+- `PgAuthBackend::request_password_reset` / `complete_password_reset` — same file.
+- `PgAuthBackend::start_mfa_enrollment` / `confirm_mfa_enrollment` / `verify_mfa` — same file, ~700-890.
+- `PgAuthBackend::start_oauth` / `complete_oauth` — lines 895-968.
+
+### 2. Gap
+
+- Zero `nebula_api_auth_*` constants in `crates/metrics/src/naming.rs`.
+- No metric emission call-sites in `crates/api/src/domain/auth/backend/pg.rs` or handlers.
+- `AppState::metrics_registry` is `Option<Arc<MetricsRegistry>>` — the auth backend doesn't receive it today; would need injection (same pattern as `IdempotencyLayer::with_metrics`).
+
+### 3. Touch surface
+
+| File | LOC | Change |
+|---|---|---|
+| `crates/metrics/src/naming.rs` | (full file ~200+ lines) | Add `NEBULA_API_AUTH_*` constants |
+| `crates/api/src/domain/auth/backend/pg.rs` | 996 | Inject `Arc<MetricsRegistry>` + emit counters |
+| `crates/api/src/domain/auth/backend/provider.rs` | unknown | Possibly extend `PgAuthBackend::new` signature |
+| `crates/api/src/domain/auth/backend/error.rs` | 185 | Possibly add metric label helpers; tests for new variants |
+| `apps/server/src/compose.rs` | 500 | Thread registry into `PgAuthBackend` |
+
+### 4. Dependencies / blockers
+
+- No new workspace deps — `nebula-metrics` already in `crates/api/Cargo.toml`.
+- Cardinality design decision needed: per-outcome labels (`outcome = "lockout" | "success" | "invalid_creds" | "mfa_required"` etc.) vs. per-variant counters. Must pass through `LabelAllowlist`.
+
+---
+
+## PR-C — OAuth providers from operator secrets
+
+### 1. Current state
+
+**Handler entry points:**
+- `oauth_start` handler: `crates/api/src/domain/auth/handler.rs:390-421` — calls `backend.start_oauth(provider)`.
+- `oauth_callback` handler: `crates/api/src/domain/auth/handler.rs:425-465` — calls `backend.complete_oauth(provider, state, code)`.
+
+**`OAuthProvider` enum and parsing:**
+- `crates/api/src/domain/auth/backend/provider.rs:207,212` — trait methods.
+- `oauth::OAuthProvider` — from `crates/api/src/transport/oauth/state.rs` (exact enum not read but imported by backend and handler).
+
+**In-memory provider stub:**
+- `InMemoryAuthBackend::start_oauth` at `in_memory.rs:724` — synthetic URL, no config read.
+- `InMemoryAuthBackend::complete_oauth` at `in_memory.rs:749` — returns `NotImplemented`.
+
+**PG backend stubs:**
+- `PgAuthBackend::start_oauth` at `pg.rs:895` — synthetic URL, no `CredentialService` call; `redirect_uri = None` column comment at line ~914.
+- `PgAuthBackend::complete_oauth` at `pg.rs:932` — consumes state row, then `return Err(AuthError::NotImplemented(...))` at line 957.
+
+**`OAuth2Credential` / `OAuth2Config`:**
+- `crates/credential/src/credentials/oauth2.rs` — `OAuth2Config` with `GrantType` (AuthCode, ClientCredentials, DeviceCode), `AuthCodeBuilder`, `ClientCredentialsBuilder`, `DeviceCodeBuilder`, `PkceMethod` (lines 40-47 pub-use block).
+- `OAuth2State` / `OAuth2Token` types exist in the same file.
+
+**`CredentialService::get` signature:**
+- `crates/credential-runtime/src/service.rs:361-371`:
+  ```rust
+  pub async fn get(
+      &self,
+      scope: &TenantScope,
+      id: &str,
+  ) -> Result<CredentialSnapshot, CredentialServiceError>
+  ```
+  Returns a `CredentialSnapshot` (not generic typed — no `get::<C>` method, confirmed by grep).
+
+**`AppState::credential_service`:**
+- `crates/api/src/state.rs:231` — `Option<Arc<CredentialService<InMemoryStore, InMemoryPendingStore>>>`. Set via `with_credential_service` (line ~239).
+- Never set in `apps/server/src/compose.rs` (confirmed by `[NOT FOUND]` for any `credential_service` set call in compose.rs).
+
+**No `CredentialKind` / `oauth_provider` tag found:**
+- `rg "CredentialKind|oauth_provider" crates/` → hits in `crates/api/src/ports/credential_schema_registry.rs` and `crates/credential/*`, not in auth backend. No operator-discovery tagging mechanism in auth domain.
+
+### 2. Gap
+
+- `complete_oauth` returns `NotImplemented` — the actual provider code exchange (HTTP token endpoint call) is entirely missing.
+- `start_oauth` uses a synthetic authorize URL — real OAuth discovery via `CredentialService::get` not wired.
+- `AuthBackend::start_oauth` trait lacks `redirect_uri` parameter (flagged in `pg.rs:35`).
+- `CredentialService` type is `InMemoryStore` only in `AppState`; a PG-backed version for production deployment not wired.
+- `CredentialService` compose root injection missing entirely in `apps/server/src/compose.rs`.
+- No mechanism today to look up "which credential ID is the OAuth2 config for provider X" — would need a naming convention or operator config key.
+
+### 3. Touch surface
+
+| File | LOC | Change |
+|---|---|---|
+| `crates/api/src/domain/auth/backend/pg.rs` | 996 | Implement `start_oauth` + `complete_oauth` with real token exchange |
+| `crates/api/src/domain/auth/backend/provider.rs` | unknown | Extend `start_oauth` signature to accept `redirect_uri` |
+| `crates/api/src/domain/auth/backend/in_memory.rs` | 992 | Extend stub signatures to match trait |
+| `crates/api/src/domain/auth/handler.rs` | 468 | Pass `redirect_uri` from request to `start_oauth` |
+| `apps/server/src/compose.rs` | 500 | Instantiate and inject `CredentialService` |
+| `crates/api/src/state.rs` | ~1000 (estimated) | Possibly widen `CredentialService` generic or use `dyn` |
+| `crates/api/tests/e2e_oauth2_flow.rs` | unknown | Extend with operator-secret-backed provider flow |
+
+### 4. Dependencies / blockers
+
+- **BLOCKER**: `CredentialService::get` returns `CredentialSnapshot`, not a generic typed `get::<OAuth2Credential>`. PR-C must decode the credential payload from snapshot to `OAuth2Config` — no typed accessor exists today.
+- **BLOCKER**: Compose root never instantiates `CredentialService` — needs a PG-backed variant for production (currently only `InMemoryStore` variant in the `AppState` type param).
+- Needs an HTTP client (e.g. `reqwest`) for the OAuth token endpoint exchange — not currently a dep of `nebula-api`. Must be added to `Cargo.toml`.
+- `redirect_uri` plumbing: trait change is breaking (all `AuthBackend` impls must update).
+- Operator discovery mechanism: how does the API know which credential ID holds the Google / GitHub OAuth2 config? No tagging or naming convention exists today — requires a design decision.
+
+---
+
+## PR-D — SMTP transport for EmailPort
+
+### 1. Current state
+
+**`EmailPort` trait (`crates/api/src/ports/email.rs`):**
+```rust
+// Full trait (lines 111-117):
+#[async_trait]
+pub trait EmailPort: Send + Sync {
+    async fn send(&self, msg: EmailMessage) -> Result<(), EmailError>;
+}
+```
+
+**`EmailMessage` shape (lines 61-76):**
+```rust
+pub struct EmailMessage {
+    pub to: String,
+    pub subject: String,
+    pub body: String,
+    pub kind: EmailKind,  // Verification | PasswordReset | Generic
+}
+```
+
+**`EmailError` (lines 78-101):** `Transport(String)` | `InvalidAddress(String)` (display prints `[redacted]`).
+
+**`EchoSink` dev impl (lines 118-163):** `Arc<RwLock<Vec<EmailMessage>>>` inbox; `peek()`, `drain()`, `send()` with minimal `@` check.
+
+**Composition root usage (`apps/server/src/compose.rs`):**
+- Line 184: `let email_port: Arc<dyn EmailPort> = Arc::new(EchoSink::default());` — hardcoded `EchoSink`, no config-driven SMTP path.
+- Line 185: passed to `build_auth_backend`.
+- Line 188: `AppState.with_email_port(email_port)`.
+- Comment at line 179: `"Today this is the dev EchoSink; a future SMTP transport"` — explicit TODO.
+- `build_pg_auth_backend` (line 406) receives `email_port: Arc<dyn EmailPort>` and passes it directly to `PgAuthBackend::new(pool, email_port)` (line 429).
+
+**Config pattern (`crates/api/src/config/sub.rs:91-190`):**
+- `IdempotencyApiConfig` shows the pattern: fields bound to `API_IDEMPOTENCY_*` env vars, `Default` impl, `Serialize`/`Deserialize`.
+- `crates/api/src/config/env.rs`: `parse_u64_env`, `parse_bool_env`, `parse_usize_env` helpers — prefix `API_<SUFFIX>`.
+
+**SMTP in the codebase:**
+- `docs/plans/2026-05-25-002-feat-api-m3-closure-plan.md` — references SMTP as deferred.
+- `crates/api/src/domain/auth/backend/error.rs` — `EmailError → AuthError::Internal` comment mentions "bring-up SMTP transport".
+- `crates/core/src/slug.rs` — [NOT FOUND for SMTP].
+- `docs/ROADMAP.md` and `docs/INTEGRATION_MODEL.md` — mention SMTP conceptually.
+- **No `lettre` or `async-smtp` dep anywhere in the workspace** — `rg "lettre|async-smtp" Cargo.toml crates/ apps/` → zero hits.
+
+### 2. Gap
+
+- No `SmtpEmailConfig` struct in `crates/api/src/config/`.
+- No SMTP impl of `EmailPort` anywhere in the workspace.
+- `apps/server/src/compose.rs:184` hardcodes `EchoSink` with no config-driven branch.
+- No `lettre` (or any email crate) in workspace `Cargo.toml`.
+
+### 3. Touch surface
+
+| File | LOC | Change |
+|---|---|---|
+| `Cargo.toml` (workspace root) | — | Add `lettre` (or chosen crate) to `[workspace.dependencies]` |
+| `apps/server/Cargo.toml` | — | Add dep reference |
+| `crates/api/src/config/sub.rs` | ~280 | Add `SmtpEmailConfig` struct + env binding |
+| `crates/api/src/config/mod.rs` | 537 | Add `smtp: Option<SmtpEmailConfig>` field + `from_env` branch |
+| `apps/server/src/compose.rs` | 500 | Replace hardcoded `EchoSink` with config-gated SMTP impl |
+| New file: `apps/server/src/email/smtp.rs` (or `crates/api/src/ports/smtp.rs`) | 0 | `SmtpEmailPort` impl of `EmailPort` |
+
+### 4. Dependencies / blockers
+
+- **No SMTP crate in workspace** — must add `lettre` or equivalent.
+- CODEOWNERS: `apps/server/` and `crates/api/` → both `@vanyastaff` (`.github/CODEOWNERS` lines: `/crates/api/ @vanyastaff`, `/apps/ @vanyastaff`). Single owner, no review routing issue.
+- New env vars needed (e.g. `API_SMTP_HOST`, `API_SMTP_PORT`, `API_SMTP_USERNAME`, `API_SMTP_PASSWORD`, `API_SMTP_FROM`) — must follow `parse_*_env` pattern in `crates/api/src/config/env.rs`.
+- TLS handling: `lettre` supports STARTTLS and implicit TLS — config struct needs a `tls` mode field.
+- Template rendering not yet addressed — `EmailMessage::body` is raw token today; production SMTP will need a template strategy (out of scope for this PR but a future gap).
+
+### 5. Existing tests to reference
+
+- `crates/api/src/ports/email.rs:170+` — `EchoSink` unit tests (`echo_sink_buffers_sent_message`, `echo_sink_drain_clears_inbox`, `echo_sink_rejects_invalid_address`) — minimal contract to replicate for the SMTP impl.
+- `crates/api/tests/auth_pg_e2e.rs:91` — `build_backend` with `Arc<EchoSink>` — the SMTP test would swap in a wiremock SMTP server or `lettre::transport::stub`.
+
+---
+
+## Open questions for plan author
+
+1. **PR-A / per-account rate limit**: The current `RateLimitState` is per-IP only (`DefaultKeyedRateLimiter<IpAddr>`). PR-A says "rate-limit PG integration tests" — is a per-account (per-`user_id`) rate limiter in scope for PR-A, or are the tests only for the lockout path? If per-account RL is in scope, a new `DefaultKeyedRateLimiter<Uuid>` (or similar) in the auth backend or middleware is needed.
+
+2. **PR-B / metric emission point**: Should `nebula_api_auth_*` metrics be emitted from inside `PgAuthBackend` (requires injecting `Arc<MetricsRegistry>` into the backend) or from the handler layer (via `State<AppState>` which carries `metrics_registry`)? The idempotency precedent injects at layer construction; the handler approach is simpler but misses storage-layer retries.
+
+3. **PR-B / label cardinality**: Proposed label: `outcome` with values `success | lockout | invalid_creds | mfa_required | rate_limit | internal | ...`. Confirm the closed set before wiring `LabelAllowlist::only(["outcome", "provider"])` in `OtlpExporterBuilder`.
+
+4. **PR-C / `CredentialService` generic param**: `AppState` today is `CredentialService<InMemoryStore, InMemoryPendingStore>`. Production OAuth needs a PG-backed store. Should the type param become `dyn`-erased (a breaking change to `AppState`) or should PR-C introduce a separate `OAuthProviderRepository` seam that wraps `CredentialService`?
+
+5. **PR-C / operator-discovery convention**: No tagging mechanism exists to discover "which credential ID is the Google OAuth2 config". Options: (a) config key in `AuthApiConfig` (e.g. `oauth_providers: HashMap<String, String>` mapping provider key → credential ID); (b) credential name convention (`"oauth2/<provider>"`); (c) new `CredentialKind` discriminant. Decision needed before PR-C design.
+
+6. **PR-C / `redirect_uri` in trait**: Extending `AuthBackend::start_oauth` to accept `redirect_uri: Option<&str>` is a breaking change to the trait. All implementors (`PgAuthBackend`, `InMemoryAuthBackend`, and any consumer mocks) must update. Confirm this is the right seam vs. encoding `redirect_uri` in an operator-level config.
+
+7. **PR-D / SMTP crate choice**: `lettre` (async, TLS, `tokio` integration, actively maintained) vs. an HTTP-relay approach (SendGrid / SES API — no SMTP server dependency). Confirm before adding the workspace dep.
+
+8. **PR-D / template rendering scope**: Should PR-D introduce a `templates/` directory and render proper HTML email bodies, or keep `EmailMessage::body` as raw token and defer templates to a later PR? Current `EchoSink` tests rely on raw-token body.
+
+9. **PR-C / reqwest dep**: Adding `reqwest` to `nebula-api` for the token endpoint exchange would be the first direct HTTP-client dep in that crate. Confirm this is acceptable or if a separate `nebula-oauth-client` crate is preferred.


### PR DESCRIPTION
## Summary

Closes the M3.1 follow-up wave by flipping the three relevant ROADMAP checkboxes and landing the wave plan + recon as tracked artifacts under [`docs/plans/`](../tree/main/docs/plans/).

## Wave shipped

| PR | Closes ROADMAP §M3.1 follow-up |
|---|---|
| #751 `test(api): e2e lockout coverage for PgAuthBackend` | "Lockout + rate-limit integration tests against the PG backend" |
| #753 `feat(api): nebula_api_auth_* counters + AuthError mapping audit` | "Observability: typed AuthError → ApiError mapping audit + nebula_api_auth_* metrics family" |
| #754 `feat(server): production SMTP transport for EmailPort via lettre` | EmailPort note: "SMTP is a separate follow-up" |

## What's NOT closed

**"OAuth providers loaded from operator secrets"** — stays as `[ ]` with a detailed reason note. Recon during the wave (see `docs/plans/recon/m3.1-followup-wave-recon.md` §"Cross-dep status") revealed a 6× scope expansion vs the initial follow-up estimate:

- Wave 4 of credential-stabilize set up the `CredentialService` type slot on `AppState` but **never instantiated** it in `apps/server::compose`.
- `CredentialService::get` returns `CredentialSnapshot`, NOT a generic typed `get::<OAuth2Credential>` — needs a typed-decode seam.
- `PgAuthBackend::complete_oauth` still returns `AuthError::NotImplemented` at [`crates/api/src/domain/auth/backend/pg.rs:957`](../blob/main/crates/api/src/domain/auth/backend/pg.rs#L957).
- Needs a breaking change to `AuthBackend::start_oauth` (add `redirect_uri` parameter).
- Needs `reqwest` as a new direct dep of `nebula-api` for the OAuth token endpoint exchange.
- Needs an ADR-level decision on operator credential-discovery convention (config-map vs name convention vs new `CredentialKind`).

This is a full SDD cycle (recon → proposal → design → tasks → apply), not a follow-up. Will be filed as its own SDD plan slug after this PR merges.

## Wave plan + recon artifacts

This PR lands the master wave plan and the main recon doc as tracked artifacts (the per-PR worker/oracle/reviewer reports for #753 and #754 were already committed inline with those PRs as `docs/plans/recon/pr-{b,d}-*.md`; #751's worker/reviewer reports lived only in its worktree and weren't tracked — small enough that the PR description carries the verification trail):

- `docs/plans/2026-05-26-001-feat-api-m3.1-followup-wave-plan.md` — master plan with per-PR scope, acceptance, commit-message templates, subagent matrix, and risk + rollout sections
- `docs/plans/recon/m3.1-followup-wave-recon.md` — main recon (`scout` output) with `file:line` citations for every claim across the four follow-ups

## ROADMAP changes

Three edits to `docs/ROADMAP.md`:

1. **Status snapshot** (§"API layer"): the "Remaining: OAuth providers + lockout/rate-limit + nebula_api_auth_* metrics" sentence is replaced with a summary of the wave (with the four oracle-locked decisions for #753: 12-value outcome set, no global `LabelAllowlist::only`, `_duration_seconds` histogram avoiding the idempotency `_LATENCY_MS` precedent bug, no standalone `locked_out_total`) and a one-paragraph note on the OAuth carve-out.
2. **§M3.1 checkboxes** (lines 233-240): two flipped to `[x]` with closure detail; one stays `[ ]` with the full carve-out rationale; one new `[x]` for the SMTP transport.
3. **§"Sub-project ordering rationale"** (line 1116): "M3.1 mostly closed via #737/#738" updated to "via #737/#738/#751/#753/#754 — only OAuth-secrets-from-operator remains (carved out to its own SDD plan)".

## Verification

- All three PRs merged cleanly (#751 → `7ed13a52`, #753 → `237c5abd`, #754 → `a04a9ee5`).
- PR #754 hit one merge conflict on `apps/server/src/compose.rs::build_auth_backend` against #753's metrics-registry threading; resolved cleanly (`build_email_port(&api_config)?` from #754 + `Some(Arc::clone(&metrics_registry))` from #753).
- Local `cargo nextest run -p nebula-server -p nebula-api --features postgres` post-merge: 469/469 pass.
- `lefthook pre-push` clean on this docs branch (clippy-full + crate-diff-gate).

After this merge, M3.1 has one remaining open item (OAuth-from-secrets) and the wave is closed.