### PR TITLE
feat(api): OAuth provider config + AuthBackend trait + compose validation (PR-2 of M3.1 chain)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -216,10 +216,17 @@ redundant_lifetimes = "warn"
 # - `let_underscore_drop` — `let _ = tokio::spawn(...)` / `let _ = tx.send(_)`
 #   is the standard idiom for fire-and-forget; forcing `drop(x)` hurts clarity.
 #
-# `cfg(loom)` is set by nebula-resilience's loom harness; keep the check-cfg
-# entry at workspace level so every crate can switch `workspace = true` on
-# without re-declaring it locally.
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)'] }
+# Custom cfgs known across the workspace:
+# - `cfg(loom)` is set by nebula-resilience's loom harness.
+# - `cfg(nebula_test_util)` is set by `nebula-api` integration tests per
+#   ADR-0085 D-14 (PR-2 T2.11). It gates the `nebula_api::test_support`
+#   module that exposes bypass helpers for localhost wiremock IdPs;
+#   opt-in only via `RUSTFLAGS="--cfg nebula_test_util"`, tokio-precedent.
+#   Production release builds reject the cfg via a `compile_error!`
+#   guard in `crates/api/src/lib.rs`.
+# Keeping every custom cfg here at workspace level so every crate can
+# switch `workspace = true` on without re-declaring it locally.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(loom)', 'cfg(nebula_test_util)'] }
 
 [workspace.lints.clippy]
 # Opt into the big batteries. `priority = -1` lets individual `allow = ...`

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -126,6 +126,28 @@ pub enum TransportInitError {
     /// dependency (the typed `RegisterError` stays inside `nebula-api`).
     #[error("credential-schema port init failed: {0}")]
     CredentialSchemaInit(String),
+    /// An OAuth identity-provider config entry failed boot-time
+    /// validation per ADR-0085 REQ-compose-001 Invariant 1.
+    ///
+    /// Failure cases include: empty `client_id` / `client_secret`,
+    /// non-HTTPS server-side URL (token / userinfo /
+    /// verified_emails / jwks / discovery), HTTP-localhost authorize
+    /// URL in a release build, empty `Manual.scopes`, missing
+    /// `ApiConfig::public_url` when any OAuth provider is declared.
+    /// `provider` is the snake-case enum string (`"google"` /
+    /// `"microsoft"` / `"github"`); `reason` is a short stable
+    /// keyword the operator can grep for in the docs.
+    #[error(
+        "OAuth provider `{provider}` config invalid: {reason}; fix the API_AUTH_OAUTH_{provider}_* env vars or remove the provider"
+    )]
+    OAuthProviderConfigInvalid {
+        /// Provider name (snake_case OAuthProvider enum variant).
+        provider: String,
+        /// Stable reason keyword (`client_secret_required`,
+        /// `endpoint_url_must_be_https`, `manual_scopes_required`,
+        /// `public_url_required`, etc.).
+        reason: &'static str,
+    },
     /// `API_SMTP_HOST` is set but the `SmtpEmailPort` constructor
     /// rejected the resolved config (invalid `from_address` mailbox,
     /// lettre TLS-parameter construction error, etc.).
@@ -295,13 +317,28 @@ pub fn default_state(
         nebula_api::ports::credential_schema_registry::try_default_registry_port()
             .map_err(|e| TransportInitError::CredentialSchemaInit(e.to_string()))?;
 
+    // PR-2 T2.8 GREEN: validate Plane-A OAuth providers config at boot
+    // per ADR-0085 REQ-compose-001 Invariant 1. Empty providers map is
+    // a no-op; any declared provider triggers strict + flag-aware URL
+    // gates and `public_url` validation. Fails closed by mapping the
+    // typed `OAuthConfigValidationError` to
+    // `TransportInitError::OAuthProviderConfigInvalid`.
+    api_config
+        .auth
+        .oauth
+        .validate_at_load(&api_config.public_url, !cfg!(debug_assertions))
+        .map_err(|e| TransportInitError::OAuthProviderConfigInvalid {
+            provider: e.provider,
+            reason: e.reason,
+        })?;
+
     Ok(AppState::in_memory(api_config.jwt_secret.clone())
         .with_api_keys(api_config.api_keys.clone())
         .with_credential_schema(credential_schema)
         .with_metrics_registry(metrics_registry)
         // Public URL is required for Plane-A OAuth `redirect_uri`
         // derivation per ADR-0085 D-3 (recon-4). Boot-time validation
-        // in T2.8 rejects empty/relative values when
+        // above (T2.8) rejects empty/relative values when
         // `auth.oauth.providers` is non-empty.
         .with_public_url(api_config.public_url.clone()))
 }

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -138,7 +138,7 @@ pub enum TransportInitError {
     /// `"microsoft"` / `"github"`); `reason` is a short stable
     /// keyword the operator can grep for in the docs.
     #[error(
-        "OAuth provider `{provider}` config invalid: {reason}; fix the API_AUTH_OAUTH_{provider}_* env vars or remove the provider"
+        "OAuth provider `{provider}` config invalid: {reason}; fix the API_AUTH_OAUTH_<UPPERCASE_PROVIDER>_* env vars (e.g. API_AUTH_OAUTH_GOOGLE_CLIENT_ID) or remove the provider"
     )]
     OAuthProviderConfigInvalid {
         /// Provider name (snake_case OAuthProvider enum variant).

--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -298,7 +298,12 @@ pub fn default_state(
     Ok(AppState::in_memory(api_config.jwt_secret.clone())
         .with_api_keys(api_config.api_keys.clone())
         .with_credential_schema(credential_schema)
-        .with_metrics_registry(metrics_registry))
+        .with_metrics_registry(metrics_registry)
+        // Public URL is required for Plane-A OAuth `redirect_uri`
+        // derivation per ADR-0085 D-3 (recon-4). Boot-time validation
+        // in T2.8 rejects empty/relative values when
+        // `auth.oauth.providers` is non-empty.
+        .with_public_url(api_config.public_url.clone()))
 }
 
 /// Build the shared `Arc<dyn EmailPort>` from `api_config.smtp`.

--- a/crates/api/src/config/mod.rs
+++ b/crates/api/src/config/mod.rs
@@ -366,14 +366,12 @@ impl ApiConfig {
             },
             Err(_) => AuthBackendKind::Memory,
         };
-        // OAuth providers config defaults to empty; future PR-2 task
-        // T2.2 will populate `oauth.providers` via env discovery scan
-        // (one provider per `OAuthProvider` enum variant). For now
-        // empty default keeps the existing AuthApiConfig surface
-        // unchanged behaviourally — no OAuth providers declared, the
-        // `/auth/oauth/{provider}/start` endpoints return
-        // `ProviderNotConfigured` per ADR-0085 D-6.
-        let oauth = OAuthProvidersConfig::default();
+        // OAuth providers config: scan env vars per OAuthProvider
+        // variant for `API_AUTH_OAUTH_<PROVIDER>_*` (T2.2). Returns
+        // empty when no provider is declared, so existing operators
+        // who never set the env vars keep the legacy behavior
+        // (start_oauth returns ProviderNotConfigured per ADR-0085 D-6).
+        let oauth = OAuthProvidersConfig::from_env()?;
         Ok(AuthApiConfig { backend, oauth })
     }
 

--- a/crates/api/src/config/mod.rs
+++ b/crates/api/src/config/mod.rs
@@ -20,10 +20,12 @@
 mod env;
 mod errors;
 mod jwt;
+pub mod oauth;
 mod sub;
 
 pub use errors::ApiConfigError;
 pub use jwt::JwtSecret;
+pub use oauth::{OAuthEndpoints, OAuthProviderConfig, OAuthProvidersConfig, OIDC_HARDCODED_SCOPES};
 pub use sub::{
     AuthApiConfig, AuthBackendKind, CookieConfig, CorsConfig, IdempotencyApiConfig,
     IdempotencyBackend, PaginationConfig, SmtpEmailConfig, SmtpTlsMode, TlsConfig,
@@ -364,7 +366,15 @@ impl ApiConfig {
             },
             Err(_) => AuthBackendKind::Memory,
         };
-        Ok(AuthApiConfig { backend })
+        // OAuth providers config defaults to empty; future PR-2 task
+        // T2.2 will populate `oauth.providers` via env discovery scan
+        // (one provider per `OAuthProvider` enum variant). For now
+        // empty default keeps the existing AuthApiConfig surface
+        // unchanged behaviourally — no OAuth providers declared, the
+        // `/auth/oauth/{provider}/start` endpoints return
+        // `ProviderNotConfigured` per ADR-0085 D-6.
+        let oauth = OAuthProvidersConfig::default();
+        Ok(AuthApiConfig { backend, oauth })
     }
 
     fn idempotency_from_env() -> Result<IdempotencyApiConfig, ApiConfigError> {

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -37,7 +37,21 @@ use std::collections::HashMap;
 use secrecy::SecretString;
 use serde::{Deserialize, Serialize};
 
+use super::errors::ApiConfigError;
 use crate::domain::auth::backend::oauth::OAuthProvider;
+
+/// Split the `API_AUTH_OAUTH_<PROVIDER>_SCOPES` env value on whitespace
+/// AND commas, dropping empties. Operator-friendly: accepts
+/// `"user:email read:user"` or `"user:email,read:user"` or mixes.
+fn parse_scopes_env(var: &str) -> Vec<String> {
+    std::env::var(var)
+        .unwrap_or_default()
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+        .collect()
+}
 
 /// OIDC scopes are hardcoded per ADR-0085 D-5 recon-4 ADOPT (c). Per-provider
 /// scope customization belongs to the operator config only for the
@@ -62,16 +76,18 @@ pub struct OAuthProvidersConfig {
 
     /// Test/dev-only: relax `validate_oauth_authorize_url` to accept
     /// `http://localhost(:port)?` for the **browser-fetched** authorize
-    /// URL. Defaults to `false`. Per ADR-0085 D-9-WAVE6 the flag is
-    /// scope-narrowed to authorize URLs only — server-side fetches
+    /// URL ONLY in dev builds. Defaults to `false`. Per ADR-0085
+    /// D-9-WAVE6 the flag is scope-narrowed to authorize URLs only —
+    /// server-side fetches
     /// (token / userinfo / verified_emails / jwks / discovery) keep the
     /// strict `validate_oauth_outbound_url` policy regardless.
     ///
     /// Env var: `API_AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST`
     /// (`true` / `false`; default `false`). Production builds (release
-    /// profile, `not(debug_assertions)`) reject the relaxation even when
-    /// the flag is set — see `crates/api/src/lib.rs` release guard
-    /// (PR-2 T2.12).
+    /// profile — `cfg!(debug_assertions) == false`) reject the
+    /// relaxation even when the flag is set; the flag only takes
+    /// effect in dev builds where `cfg!(debug_assertions) == true`.
+    /// See `crates/api/src/lib.rs` release guard (PR-2 T2.12).
     #[serde(default)]
     pub oauth_allow_insecure_localhost: bool,
 }
@@ -205,7 +221,117 @@ pub struct OAuthConfigValidationError {
     pub reason: &'static str,
 }
 
+/// All `OAuthProvider` enum variants supported in 1.0. Used by
+/// [`OAuthProvidersConfig::from_env`] to drive the per-provider env
+/// scan. Adding a variant to the enum + this slice is the entire
+/// surface for a 1.1 enum-extension follow-up per ADR-0085 D-5.
+const KNOWN_PROVIDERS: &[OAuthProvider] = &[
+    OAuthProvider::Google,
+    OAuthProvider::Microsoft,
+    OAuthProvider::GitHub,
+];
+
 impl OAuthProvidersConfig {
+    /// Discover declared OAuth providers from environment variables.
+    ///
+    /// For each `OAuthProvider` enum variant the loader looks for the
+    /// `API_AUTH_OAUTH_<PROVIDER>_CLIENT_ID` env var as the
+    /// declaration sentinel. If present (non-empty after trim), the
+    /// provider is added to the map with the rest of the per-provider
+    /// env vars consumed:
+    ///
+    /// - `API_AUTH_OAUTH_<PROVIDER>_CLIENT_ID` — required.
+    /// - `API_AUTH_OAUTH_<PROVIDER>_CLIENT_SECRET` — required.
+    /// - **Discriminator**: `DISCOVERY_URL` set →
+    ///   [`OAuthEndpoints::Oidc`]; otherwise [`OAuthEndpoints::Manual`].
+    /// - Oidc: `DISCOVERY_URL` required.
+    /// - Manual: `AUTHORIZE_URL` / `TOKEN_URL` / `USERINFO_URL`
+    ///   required; `VERIFIED_EMAILS_URL` / `JWKS_URL` optional;
+    ///   `SCOPES` required (whitespace- or comma-separated).
+    ///
+    /// Plus the global flag
+    /// `API_AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST` (`true`/`false`,
+    /// default `false`).
+    ///
+    /// Provider keys not in [`KNOWN_PROVIDERS`] (e.g. typos like
+    /// `API_AUTH_OAUTH_GOOOGLE_CLIENT_ID`) are silently ignored at
+    /// the env-loader level — the OAuthProvider enum has no parser for
+    /// them so a typo simply never matches any iteration. Boot-time
+    /// validation in [`Self::validate_at_load`] catches
+    /// half-populated configs (CLIENT_ID set but neither discovery nor
+    /// authorize URL).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ApiConfigError::ParseEnum`] when a provider has
+    /// `CLIENT_ID` set but neither `DISCOVERY_URL` nor `AUTHORIZE_URL`
+    /// (ambiguous shape — cannot pick Oidc vs Manual).
+    pub fn from_env() -> Result<Self, ApiConfigError> {
+        let allow_localhost =
+            super::env::parse_bool_env("AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST", false)?;
+        let mut providers = HashMap::new();
+
+        for provider in KNOWN_PROVIDERS {
+            let upper = provider.as_str().to_ascii_uppercase();
+            let prefix = format!("API_AUTH_OAUTH_{upper}");
+            let client_id_var = format!("{prefix}_CLIENT_ID");
+            let raw_client_id = std::env::var(&client_id_var).unwrap_or_default();
+            if raw_client_id.trim().is_empty() {
+                // Provider not declared. Move on.
+                continue;
+            }
+            let raw_client_secret =
+                std::env::var(format!("{prefix}_CLIENT_SECRET")).unwrap_or_default();
+
+            let discovery_url = std::env::var(format!("{prefix}_DISCOVERY_URL"))
+                .ok()
+                .filter(|s| !s.trim().is_empty());
+            let authorize_url = std::env::var(format!("{prefix}_AUTHORIZE_URL"))
+                .ok()
+                .filter(|s| !s.trim().is_empty());
+
+            let endpoints = match (discovery_url, authorize_url) {
+                (Some(url), _) => OAuthEndpoints::Oidc { discovery_url: url },
+                (None, Some(authorize_url)) => OAuthEndpoints::Manual {
+                    authorize_url,
+                    token_url: std::env::var(format!("{prefix}_TOKEN_URL")).unwrap_or_default(),
+                    userinfo_url: std::env::var(format!("{prefix}_USERINFO_URL"))
+                        .unwrap_or_default(),
+                    verified_emails_url: std::env::var(format!("{prefix}_VERIFIED_EMAILS_URL"))
+                        .ok()
+                        .filter(|s| !s.trim().is_empty()),
+                    jwks_url: std::env::var(format!("{prefix}_JWKS_URL"))
+                        .ok()
+                        .filter(|s| !s.trim().is_empty()),
+                    scopes: parse_scopes_env(&format!("{prefix}_SCOPES")),
+                },
+                (None, None) => {
+                    return Err(ApiConfigError::ParseEnum {
+                        var: "AUTH_OAUTH_*_DISCOVERY_URL_or_AUTHORIZE_URL",
+                        raw: format!(
+                            "provider `{}` has {prefix}_CLIENT_ID set but neither {prefix}_DISCOVERY_URL nor {prefix}_AUTHORIZE_URL; declare exactly one to pick the OAuthEndpoints arm",
+                            provider.as_str()
+                        ),
+                    });
+                },
+            };
+
+            providers.insert(
+                *provider,
+                OAuthProviderConfig {
+                    client_id: SecretString::new(raw_client_id.into_boxed_str()),
+                    client_secret: SecretString::new(raw_client_secret.into_boxed_str()),
+                    endpoints,
+                },
+            );
+        }
+
+        Ok(Self {
+            providers,
+            oauth_allow_insecure_localhost: allow_localhost,
+        })
+    }
+
     /// Validate every declared provider at boot per ADR-0085
     /// REQ-compose-001 Invariant 1 (recon-4 + wave-6/-7 hardening).
     ///
@@ -240,11 +366,17 @@ impl OAuthProvidersConfig {
         // `public_url` is required for the auto-derived `redirect_uri`
         // formula per D-3 recon-4. Empty or scheme-less values are a
         // boot-time error because every OAuth flow would build a
-        // broken redirect URL otherwise.
+        // broken redirect URL otherwise. Per CodeRabbit / Codex / Copilot
+        // wave-1 review: parse via `url::Url` rather than a prefix check
+        // so malformed values like `"https://"` (no host) AND opaque
+        // schemes like `"data:..."` are rejected up front.
         let trimmed_pub = public_url.trim();
-        if trimmed_pub.is_empty()
-            || !(trimmed_pub.starts_with("http://") || trimmed_pub.starts_with("https://"))
-        {
+        let parsed = url::Url::parse(trimmed_pub);
+        let public_url_ok = match parsed {
+            Ok(ref u) => (u.scheme() == "http" || u.scheme() == "https") && u.has_host(),
+            Err(_) => false,
+        };
+        if !public_url_ok {
             // Use first provider name for the error — the issue is
             // global but reporting against a concrete provider helps
             // the operator find their env-var set.
@@ -578,6 +710,65 @@ mod tests {
                 .to_owned(),
         };
         assert_eq!(endpoints.scopes(), vec!["openid", "email", "profile"]);
+    }
+
+    /// T2.13 TRIANGULATE: `validate_at_load` rejects a `public_url`
+    /// that has a scheme but no host (e.g. `"https://"`). Closes the
+    /// Url-parse path that the wave-1 review flagged as a major gap.
+    #[test]
+    fn validate_at_load_rejects_public_url_with_no_host() {
+        let cfg = cfg_with(
+            OAuthProvider::Google,
+            mk_oidc("https://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let err = cfg
+            .validate_at_load("https://", false)
+            .expect_err("scheme without host must be rejected");
+        assert_eq!(err.reason, "public_url_required");
+    }
+
+    /// T2.13 TRIANGULATE: opaque-scheme `public_url` is rejected (the
+    /// boot-time gate must NOT accept `data:` / `file:` / `javascript:`
+    /// for the OAuth redirect base — those don't form a server URL).
+    #[test]
+    fn validate_at_load_rejects_public_url_with_opaque_scheme() {
+        let cfg = cfg_with(
+            OAuthProvider::Google,
+            mk_oidc("https://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let err = cfg
+            .validate_at_load("javascript:alert(1)", false)
+            .expect_err("opaque scheme rejected");
+        assert_eq!(err.reason, "public_url_required");
+    }
+
+    /// T2.13 TRIANGULATE: `parse_scopes_env` accepts both whitespace-
+    /// and comma-separated forms (operator-friendly).
+    #[test]
+    #[allow(
+        unsafe_code,
+        reason = "edition 2024 marks env::{set,remove}_var as unsafe; this test uses a unique var name so no concurrent reader observes the mutation"
+    )]
+    fn parse_scopes_env_accepts_whitespace_and_commas() {
+        let var = "API_AUTH_OAUTH_TEST_T213_SCOPES_PARSE";
+        // SAFETY: unique var name; only this test reads or writes it.
+        unsafe {
+            std::env::set_var(var, "user:email read:user,write:repo  openid");
+        }
+        let scopes = parse_scopes_env(var);
+        // SAFETY: same uniqueness invariant; symmetric cleanup.
+        unsafe {
+            std::env::remove_var(var);
+        }
+        assert_eq!(
+            scopes,
+            vec![
+                "user:email".to_owned(),
+                "read:user".to_owned(),
+                "write:repo".to_owned(),
+                "openid".to_owned()
+            ]
+        );
     }
 
     /// Manual providers honor operator-supplied scopes verbatim.

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -192,6 +192,165 @@ pub enum OAuthEndpoints {
     },
 }
 
+/// Failure reason from [`OAuthProvidersConfig::validate_at_load`].
+///
+/// Stable keyword strings the operator can grep for in docs. Mapped to
+/// `TransportInitError::OAuthProviderConfigInvalid { provider, reason }`
+/// in the composition root.
+#[derive(Debug, PartialEq, Eq)]
+pub struct OAuthConfigValidationError {
+    /// Provider name (snake_case OAuthProvider enum variant).
+    pub provider: String,
+    /// Stable reason keyword.
+    pub reason: &'static str,
+}
+
+impl OAuthProvidersConfig {
+    /// Validate every declared provider at boot per ADR-0085
+    /// REQ-compose-001 Invariant 1 (recon-4 + wave-6/-7 hardening).
+    ///
+    /// Returns the FIRST validation failure (boot is fail-fast — the
+    /// operator gets one error at a time and fixes them in order).
+    /// When the config is empty (default), returns `Ok(())` without
+    /// any work — OAuth is opt-in.
+    ///
+    /// `public_url` is the value from `ApiConfig::public_url` (handed
+    /// in so this method has no implicit dependency on the wider
+    /// `ApiConfig` shape). When the providers map is non-empty,
+    /// `public_url` MUST be non-empty AND absolute (with scheme);
+    /// the boot-derived `redirect_uri` per ADR-0085 D-3 depends on it.
+    ///
+    /// `in_release_build` is `cfg!(not(debug_assertions))` at the call
+    /// site, threaded explicitly so this function stays unit-testable
+    /// without recompiling under release profile.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`OAuthConfigValidationError`] on the first invalid
+    /// field. See the type's `reason` doc for the stable keyword set.
+    pub fn validate_at_load(
+        &self,
+        public_url: &str,
+        in_release_build: bool,
+    ) -> Result<(), OAuthConfigValidationError> {
+        if self.providers.is_empty() {
+            return Ok(());
+        }
+
+        // `public_url` is required for the auto-derived `redirect_uri`
+        // formula per D-3 recon-4. Empty or scheme-less values are a
+        // boot-time error because every OAuth flow would build a
+        // broken redirect URL otherwise.
+        let trimmed_pub = public_url.trim();
+        if trimmed_pub.is_empty()
+            || !(trimmed_pub.starts_with("http://") || trimmed_pub.starts_with("https://"))
+        {
+            // Use first provider name for the error — the issue is
+            // global but reporting against a concrete provider helps
+            // the operator find their env-var set.
+            let provider = self
+                .providers
+                .keys()
+                .next()
+                .map(|p| p.as_str().to_owned())
+                .unwrap_or_else(|| "<unknown>".to_owned());
+            return Err(OAuthConfigValidationError {
+                provider,
+                reason: "public_url_required",
+            });
+        }
+
+        for (provider, cfg) in &self.providers {
+            let p = provider.as_str().to_owned();
+            cfg.validate(&p, self.oauth_allow_insecure_localhost, in_release_build)?;
+        }
+        Ok(())
+    }
+}
+
+impl OAuthProviderConfig {
+    /// Validate a single provider config at boot. Called by
+    /// [`OAuthProvidersConfig::validate_at_load`].
+    fn validate(
+        &self,
+        provider: &str,
+        oauth_allow_insecure_localhost: bool,
+        in_release_build: bool,
+    ) -> Result<(), OAuthConfigValidationError> {
+        use secrecy::ExposeSecret;
+
+        if self.client_id.expose_secret().is_empty() {
+            return Err(OAuthConfigValidationError {
+                provider: provider.to_owned(),
+                reason: "client_id_required",
+            });
+        }
+        if self.client_secret.expose_secret().is_empty() {
+            return Err(OAuthConfigValidationError {
+                provider: provider.to_owned(),
+                reason: "client_secret_required",
+            });
+        }
+        self.endpoints
+            .validate(provider, oauth_allow_insecure_localhost, in_release_build)?;
+        Ok(())
+    }
+}
+
+impl OAuthEndpoints {
+    /// Validate per-endpoint per its threat model per ADR-0085
+    /// D-9-WAVE6 + D-15-WAVE6 + F.2 wave-7:
+    /// - Strict gate (`validate_oauth_outbound_url`) for server-side
+    ///   fetches: token / userinfo / verified_emails / jwks / discovery.
+    /// - Flag-aware gate (`validate_oauth_authorize_url`) for the
+    ///   browser-fetched `Manual.authorize_url`.
+    fn validate(
+        &self,
+        provider: &str,
+        oauth_allow_insecure_localhost: bool,
+        in_release_build: bool,
+    ) -> Result<(), OAuthConfigValidationError> {
+        use crate::transport::oauth::flow::{
+            validate_oauth_authorize_url, validate_oauth_outbound_url,
+        };
+
+        // Strict gate for ALL server-side URLs.
+        for url in self.server_side_urls() {
+            validate_oauth_outbound_url(url).map_err(|_| OAuthConfigValidationError {
+                provider: provider.to_owned(),
+                reason: "endpoint_url_must_be_https",
+            })?;
+        }
+
+        // Flag-aware gate for the browser-fetched Manual.authorize_url
+        // (Oidc.authorize_url is discovered at runtime per D-15-WAVE6
+        // and validated then; not represented in operator config).
+        if let Some(authorize_url) = self.authorize_url() {
+            validate_oauth_authorize_url(
+                authorize_url,
+                oauth_allow_insecure_localhost,
+                in_release_build,
+            )
+            .map_err(|_| OAuthConfigValidationError {
+                provider: provider.to_owned(),
+                reason: "authorize_url_invalid_or_localhost_in_release",
+            })?;
+        }
+
+        // Manual.scopes must be non-empty.
+        if let Self::Manual { scopes, .. } = self
+            && scopes.is_empty()
+        {
+            return Err(OAuthConfigValidationError {
+                provider: provider.to_owned(),
+                reason: "manual_scopes_required",
+            });
+        }
+
+        Ok(())
+    }
+}
+
 impl OAuthEndpoints {
     /// Strict-gate helper: collect every server-side URL that
     /// `validate_oauth_outbound_url` must approve at boot. Per ADR-0085
@@ -243,5 +402,195 @@ impl OAuthEndpoints {
                 .collect(),
             Self::Manual { scopes, .. } => scopes.clone(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::auth::backend::oauth::OAuthProvider;
+
+    fn mk_oidc(discovery_url: &str) -> OAuthProviderConfig {
+        OAuthProviderConfig {
+            client_id: SecretString::new("client".into()),
+            client_secret: SecretString::new("secret".into()),
+            endpoints: OAuthEndpoints::Oidc {
+                discovery_url: discovery_url.to_owned(),
+            },
+        }
+    }
+
+    fn mk_manual(
+        authorize_url: &str,
+        token_url: &str,
+        userinfo_url: &str,
+        scopes: Vec<String>,
+    ) -> OAuthProviderConfig {
+        OAuthProviderConfig {
+            client_id: SecretString::new("client".into()),
+            client_secret: SecretString::new("secret".into()),
+            endpoints: OAuthEndpoints::Manual {
+                authorize_url: authorize_url.to_owned(),
+                token_url: token_url.to_owned(),
+                userinfo_url: userinfo_url.to_owned(),
+                verified_emails_url: None,
+                jwks_url: None,
+                scopes,
+            },
+        }
+    }
+
+    fn cfg_with(provider: OAuthProvider, entry: OAuthProviderConfig) -> OAuthProvidersConfig {
+        let mut cfg = OAuthProvidersConfig::default();
+        cfg.providers.insert(provider, entry);
+        cfg
+    }
+
+    /// T2.3 RED-then-GREEN: OIDC providers require an HTTPS discovery_url
+    /// per ADR-0085 REQ-compose-001 Invariant 1.
+    #[test]
+    fn oauth_provider_config_validates_oidc_requires_https_discovery_url() {
+        let cfg = cfg_with(
+            OAuthProvider::Google,
+            mk_oidc("http://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let err = cfg
+            .validate_at_load("https://app.example.com", false)
+            .expect_err("HTTP discovery_url must be rejected by the strict gate");
+        assert_eq!(err.provider, "google");
+        assert_eq!(err.reason, "endpoint_url_must_be_https");
+    }
+
+    /// T2.4 RED-then-GREEN: Manual providers require non-empty scopes.
+    #[test]
+    fn oauth_provider_config_validates_manual_requires_non_empty_scopes() {
+        let cfg = cfg_with(
+            OAuthProvider::GitHub,
+            mk_manual(
+                "https://github.com/login/oauth/authorize",
+                "https://github.com/login/oauth/access_token",
+                "https://api.github.com/user",
+                vec![],
+            ),
+        );
+        let err = cfg
+            .validate_at_load("https://app.example.com", false)
+            .expect_err("Manual provider with empty scopes must be rejected");
+        assert_eq!(err.provider, "github");
+        assert_eq!(err.reason, "manual_scopes_required");
+    }
+
+    /// T2.5(a) RED-then-GREEN: server-side URLs go through STRICT
+    /// `validate_oauth_outbound_url` regardless of the
+    /// `oauth_allow_insecure_localhost` flag.
+    #[test]
+    fn oauth_provider_config_rejects_http_endpoint_for_all_server_side_urls() {
+        let cfg = cfg_with(
+            OAuthProvider::GitHub,
+            mk_manual(
+                "https://github.com/login/oauth/authorize",
+                "http://github.com/login/oauth/access_token", // HTTP — must be rejected even with flag ON
+                "https://api.github.com/user",
+                vec!["user:email".to_owned()],
+            ),
+        );
+        let mut providers = cfg;
+        providers.oauth_allow_insecure_localhost = true; // flag has no effect on token_url
+        let err = providers
+            .validate_at_load("https://app.example.com", false)
+            .expect_err("HTTP token_url rejected by strict gate even with localhost flag set");
+        assert_eq!(err.reason, "endpoint_url_must_be_https");
+    }
+
+    /// T2.5(b) RED-then-GREEN: `Manual.authorize_url` uses the FLAG-AWARE
+    /// `validate_oauth_authorize_url` which accepts `http://localhost`
+    /// when the flag is set AND the binary is not a release build.
+    #[test]
+    fn oauth_provider_config_authorize_url_uses_flag_aware_validator() {
+        let cfg = cfg_with(
+            OAuthProvider::GitHub,
+            mk_manual(
+                "http://localhost:8088/authorize", // would fail strict gate
+                "https://github.com/login/oauth/access_token",
+                "https://api.github.com/user",
+                vec!["user:email".to_owned()],
+            ),
+        );
+        let mut providers = cfg;
+        providers.oauth_allow_insecure_localhost = true;
+        // in_release_build = false simulates `cfg!(debug_assertions)`.
+        providers
+            .validate_at_load("https://app.example.com", false)
+            .expect("flag-aware gate must accept localhost authorize_url in dev mode");
+    }
+
+    /// T2.5(c) RED-then-GREEN: the localhost flag has NO effect in
+    /// release builds — `validate_oauth_authorize_url` rejects.
+    #[test]
+    fn oauth_authorize_url_strict_in_release_build() {
+        let cfg = cfg_with(
+            OAuthProvider::GitHub,
+            mk_manual(
+                "http://localhost:8088/authorize",
+                "https://github.com/login/oauth/access_token",
+                "https://api.github.com/user",
+                vec!["user:email".to_owned()],
+            ),
+        );
+        let mut providers = cfg;
+        providers.oauth_allow_insecure_localhost = true;
+        let err = providers
+            .validate_at_load("https://app.example.com", true) // release build
+            .expect_err("flag must have no effect in release builds");
+        assert_eq!(err.reason, "authorize_url_invalid_or_localhost_in_release");
+    }
+
+    /// T2.6 RED-then-GREEN: compose-root MUST fail closed when OAuth is
+    /// declared but `ApiConfig::public_url` is empty.
+    #[test]
+    fn validate_at_load_fails_closed_when_public_url_unset_with_oauth_declared() {
+        let cfg = cfg_with(
+            OAuthProvider::Google,
+            mk_oidc("https://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let err = cfg
+            .validate_at_load("", false)
+            .expect_err("empty public_url with OAuth declared must fail closed");
+        assert_eq!(err.reason, "public_url_required");
+    }
+
+    /// Sanity: empty providers map is a no-op (OAuth is opt-in).
+    #[test]
+    fn validate_at_load_noop_when_providers_empty() {
+        let cfg = OAuthProvidersConfig::default();
+        cfg.validate_at_load("", false)
+            .expect("empty providers is opt-in, no validation needed");
+    }
+
+    /// REQ-oauth-001 Invariant 1 coverage for the OIDC scope hardcoding
+    /// (recon-4 ADOPT (c)): OIDC providers ALWAYS expose
+    /// `["openid","email","profile"]` regardless of any operator-supplied
+    /// scopes (Oidc variant has no scopes field by construction).
+    #[test]
+    fn oidc_endpoints_always_emit_hardcoded_scopes() {
+        let endpoints = OAuthEndpoints::Oidc {
+            discovery_url: "https://accounts.google.com/.well-known/openid-configuration"
+                .to_owned(),
+        };
+        assert_eq!(endpoints.scopes(), vec!["openid", "email", "profile"]);
+    }
+
+    /// Manual providers honor operator-supplied scopes verbatim.
+    #[test]
+    fn manual_endpoints_emit_operator_supplied_scopes() {
+        let endpoints = OAuthEndpoints::Manual {
+            authorize_url: "https://github.com/login/oauth/authorize".to_owned(),
+            token_url: "https://github.com/login/oauth/access_token".to_owned(),
+            userinfo_url: "https://api.github.com/user".to_owned(),
+            verified_emails_url: Some("https://api.github.com/user/emails".to_owned()),
+            jwks_url: None,
+            scopes: vec!["user:email".to_owned(), "read:user".to_owned()],
+        };
+        assert_eq!(endpoints.scopes(), vec!["user:email", "read:user"]);
     }
 }

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -225,7 +225,13 @@ pub struct OAuthConfigValidationError {
 /// [`OAuthProvidersConfig::from_env`] to drive the per-provider env
 /// scan. Adding a variant to the enum + this slice is the entire
 /// surface for a 1.1 enum-extension follow-up per ADR-0085 D-5.
-const KNOWN_PROVIDERS: &[OAuthProvider] = &[
+///
+/// `pub(crate)` so the rustdoc intra-doc link in `from_env`'s public
+/// doc-block resolves (private items cannot be linked from public
+/// doc); production callers should not reach for this directly — use
+/// `OAuthProvider` enum iteration or [`OAuthProvidersConfig::from_env`]
+/// instead.
+pub(crate) const KNOWN_PROVIDERS: &[OAuthProvider] = &[
     OAuthProvider::Google,
     OAuthProvider::Microsoft,
     OAuthProvider::GitHub,
@@ -253,7 +259,7 @@ impl OAuthProvidersConfig {
     /// `API_AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST` (`true`/`false`,
     /// default `false`).
     ///
-    /// Provider keys not in [`KNOWN_PROVIDERS`] (e.g. typos like
+    /// Provider keys not in the KNOWN_PROVIDERS slice (e.g. typos like
     /// `API_AUTH_OAUTH_GOOOGLE_CLIENT_ID`) are silently ignored at
     /// the env-loader level — the OAuthProvider enum has no parser for
     /// them so a typo simply never matches any iteration. Boot-time
@@ -366,16 +372,25 @@ impl OAuthProvidersConfig {
         // `public_url` is required for the auto-derived `redirect_uri`
         // formula per D-3 recon-4. Empty or scheme-less values are a
         // boot-time error because every OAuth flow would build a
-        // broken redirect URL otherwise. Per CodeRabbit / Codex / Copilot
-        // wave-1 review: parse via `url::Url` rather than a prefix check
-        // so malformed values like `"https://"` (no host) AND opaque
-        // schemes like `"data:..."` are rejected up front.
-        let trimmed_pub = public_url.trim();
-        let parsed = url::Url::parse(trimmed_pub);
-        let public_url_ok = match parsed {
-            Ok(ref u) => (u.scheme() == "http" || u.scheme() == "https") && u.has_host(),
-            Err(_) => false,
-        };
+        // broken redirect URL otherwise.
+        //
+        // Wave-1 review (Codex / Copilot / CodeRabbit): parse via
+        // `url::Url` rather than a prefix check so malformed values like
+        // `"https://"` (no host) AND opaque schemes like `"data:..."`
+        // are rejected.
+        //
+        // Wave-2 review (Codex P2): do NOT silently trim. The value
+        // validated here is also what `AppState.public_url` carries at
+        // runtime; trimming on validate but storing the un-trimmed
+        // value would diverge, and a leading space would break the
+        // `redirect_uri` round-trip on `complete_oauth`. Reject
+        // whitespace explicitly so the operator fixes the env var.
+        let parsed = url::Url::parse(public_url);
+        let public_url_ok = public_url == public_url.trim()
+            && match parsed {
+                Ok(ref u) => (u.scheme() == "http" || u.scheme() == "https") && u.has_host(),
+                Err(_) => false,
+            };
         if !public_url_ok {
             // Use first provider name for the error — the issue is
             // global but reporting against a concrete provider helps
@@ -724,6 +739,28 @@ mod tests {
         let err = cfg
             .validate_at_load("https://", false)
             .expect_err("scheme without host must be rejected");
+        assert_eq!(err.reason, "public_url_required");
+    }
+
+    /// T2.13 TRIANGULATE wave-2 (Codex P2): whitespace-padded
+    /// `public_url` rejected explicitly — do NOT silently trim because
+    /// the validated value and the value stored in `AppState` must
+    /// match exactly, or the `redirect_uri` round-trip on
+    /// `complete_oauth` will diverge.
+    #[test]
+    fn validate_at_load_rejects_whitespace_padded_public_url() {
+        let cfg = cfg_with(
+            OAuthProvider::Google,
+            mk_oidc("https://accounts.google.com/.well-known/openid-configuration"),
+        );
+        let err = cfg
+            .validate_at_load(" https://app.example.com", false)
+            .expect_err("leading whitespace must be rejected");
+        assert_eq!(err.reason, "public_url_required");
+
+        let err = cfg
+            .validate_at_load("https://app.example.com\n", false)
+            .expect_err("trailing whitespace / newline must be rejected");
         assert_eq!(err.reason, "public_url_required");
     }
 

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -1,0 +1,247 @@
+//! Operator-supplied OAuth identity-provider configuration (Plane A).
+//!
+//! Per ADR-0085 D-1 (recon-4 reshaped), operator IdP-client credentials
+//! live in `ApiConfig::auth.oauth.providers` as infrastructure config
+//! — NOT in `CredentialService`. This matches the `SmtpEmailConfig`
+//! precedent (operator infra creds stored in env-bound `ApiConfig`,
+//! not user credentials).
+//!
+//! ## Endpoints shape (recon-4 ADOPT (b))
+//!
+//! Two arms via a tagged union:
+//!
+//! - [`OAuthEndpoints::Oidc`] — endpoints discovered from
+//!   `.well-known/openid-configuration` at runtime (D-15). Scopes
+//!   hardcoded `"openid email profile"`.
+//! - [`OAuthEndpoints::Manual`] — explicit `authorize_url` /
+//!   `token_url` / `userinfo_url` (+ optional `verified_emails_url`
+//!   for providers like GitHub whose userinfo lacks `email_verified`,
+//!   per ADR-0085 D-5 wave-6 addition); operator-supplied `scopes`.
+//!
+//! ## `redirect_uri` (recon-4 ADOPT (a))
+//!
+//! NOT a configuration field. Auto-derived at runtime as
+//! `format!("{base}/auth/oauth/{provider}/callback", base = api_config.public_url)`.
+//! Operators that need multiple callback URIs deploy multiple Nebula
+//! instances. Matches n8n's `{instanceBaseUrl}/rest/sso/oidc/callback`
+//! pattern.
+//!
+//! ## Scopes (recon-4 ADOPT (c))
+//!
+//! Hardcoded `"openid email profile"` for OIDC providers. Per-provider
+//! `scopes` only for [`OAuthEndpoints::Manual`] (where the provider is
+//! OAuth2-only and OIDC scope-claim semantics do not apply).
+
+use std::collections::HashMap;
+
+use secrecy::SecretString;
+use serde::{Deserialize, Serialize};
+
+use crate::domain::auth::backend::oauth::OAuthProvider;
+
+/// OIDC scopes are hardcoded per ADR-0085 D-5 recon-4 ADOPT (c). Per-provider
+/// scope customization belongs to the operator config only for the
+/// [`OAuthEndpoints::Manual`] arm (OAuth2-only providers like GitHub).
+pub const OIDC_HARDCODED_SCOPES: &[&str] = &["openid", "email", "profile"];
+
+/// Map from `OAuthProvider` variant to per-provider config.
+///
+/// Defaults to empty (no OAuth providers declared); when non-empty the
+/// composition root validates each entry at boot per ADR-0085
+/// REQ-compose-001.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OAuthProvidersConfig {
+    /// Declared providers, keyed by `OAuthProvider` enum value.
+    ///
+    /// Env discovery: a provider is "declared" iff
+    /// `API_AUTH_OAUTH_<PROVIDER>_CLIENT_ID` is set in the environment.
+    /// The 1.0 enum has three variants (Google / Microsoft / GitHub) —
+    /// extending the enum is a 1.1 follow-up per ADR-0085 D-5.
+    #[serde(default)]
+    pub providers: HashMap<OAuthProvider, OAuthProviderConfig>,
+
+    /// Test/dev-only: relax `validate_oauth_authorize_url` to accept
+    /// `http://localhost(:port)?` for the **browser-fetched** authorize
+    /// URL. Defaults to `false`. Per ADR-0085 D-9-WAVE6 the flag is
+    /// scope-narrowed to authorize URLs only — server-side fetches
+    /// (token / userinfo / verified_emails / jwks / discovery) keep the
+    /// strict `validate_oauth_outbound_url` policy regardless.
+    ///
+    /// Env var: `API_AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST`
+    /// (`true` / `false`; default `false`). Production builds (release
+    /// profile, `not(debug_assertions)`) reject the relaxation even when
+    /// the flag is set — see `crates/api/src/lib.rs` release guard
+    /// (PR-2 T2.12).
+    #[serde(default)]
+    pub oauth_allow_insecure_localhost: bool,
+}
+
+/// Per-provider OAuth identity-provider config (Plane A).
+///
+/// Constructed from env vars `API_AUTH_OAUTH_<PROVIDER>_*` (CLIENT_ID,
+/// CLIENT_SECRET, DISCOVERY_URL or AUTHORIZE_URL / TOKEN_URL /
+/// USERINFO_URL / VERIFIED_EMAILS_URL / JWKS_URL / SCOPES). The
+/// `endpoints` arm is inferred from which env vars are set:
+/// `DISCOVERY_URL` present → [`OAuthEndpoints::Oidc`]; otherwise →
+/// [`OAuthEndpoints::Manual`].
+///
+/// `client_id` and `client_secret` are `SecretString` so `Debug`
+/// redacts them and the buffers zeroize on drop, matching
+/// `SmtpEmailConfig.password`.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OAuthProviderConfig {
+    /// OAuth client_id issued by the IdP. Env: `API_AUTH_OAUTH_<PROVIDER>_CLIENT_ID`.
+    ///
+    /// `#[serde(skip)]` because the value is only ever populated from
+    /// the environment (matches `SmtpEmailConfig::password` precedent);
+    /// serializing a credential to a JSON snapshot would silently leak
+    /// it through `tracing` / `problem-details` paths.
+    #[serde(skip)]
+    pub client_id: SecretString,
+    /// OAuth client_secret issued by the IdP. Env: `API_AUTH_OAUTH_<PROVIDER>_CLIENT_SECRET`.
+    /// `#[serde(skip)]` for the same reason as `client_id`.
+    #[serde(skip)]
+    pub client_secret: SecretString,
+    /// Resolved endpoints (tagged union per ADR-0085 D-5).
+    pub endpoints: OAuthEndpoints,
+}
+
+impl Default for OAuthProviderConfig {
+    /// Empty placeholder. `serde(skip)` on the secrets means deserialize
+    /// goes through `Default::default()` for those fields; the
+    /// `validate_at_load` step (PR-2 T2.8) rejects the empty values at
+    /// boot per REQ-compose-001 Invariant 1, so the empty default never
+    /// reaches a running OAuth flow.
+    fn default() -> Self {
+        Self {
+            client_id: SecretString::new(String::new().into_boxed_str()),
+            client_secret: SecretString::new(String::new().into_boxed_str()),
+            endpoints: OAuthEndpoints::Oidc {
+                discovery_url: String::new(),
+            },
+        }
+    }
+}
+
+impl std::fmt::Debug for OAuthProviderConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Manual Debug to avoid leaking the `SecretString` body even
+        // through derived fmt — mirrors `SmtpEmailConfig::Debug`.
+        f.debug_struct("OAuthProviderConfig")
+            .field("client_id", &"[redacted]")
+            .field("client_secret", &"[redacted]")
+            .field("endpoints", &self.endpoints)
+            .finish()
+    }
+}
+
+/// Tagged union of OAuth endpoint shapes per ADR-0085 D-5 recon-4.
+///
+/// `kind = "oidc"` for providers exposing `.well-known/openid-configuration`
+/// (Google / Microsoft / Auth0 / Okta — though Auth0/Okta require an
+/// `OAuthProvider` enum extension scheduled for 1.1).
+///
+/// `kind = "manual"` for OAuth2-only providers (GitHub) or
+/// operator-customized OIDC where the operator wants to pin endpoints
+/// against a staging mirror.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OAuthEndpoints {
+    /// OIDC provider — runtime endpoint discovery from
+    /// `.well-known/openid-configuration` (D-15). Scopes hardcoded
+    /// `"openid email profile"` per ADR-0085 D-5 recon-4 ADOPT (c).
+    Oidc {
+        /// Fully-qualified URL of the OIDC discovery document. Validated
+        /// at boot by the strict `validate_oauth_outbound_url` gate
+        /// (HTTPS, no localhost / private / loopback / multicast IPs)
+        /// per ADR-0085 D-9-WAVE6.
+        discovery_url: String,
+    },
+    /// OAuth2-only or operator-customized provider — explicit endpoint
+    /// URLs.
+    Manual {
+        /// OAuth authorize endpoint (browser-fetched). Validated by the
+        /// **flag-aware** `validate_oauth_authorize_url` gate
+        /// (`oauth_allow_insecure_localhost` flag relaxes `http://localhost`
+        /// when set AND `!cfg!(debug_assertions)`).
+        authorize_url: String,
+        /// OAuth token endpoint (server-fetched). Strict gate.
+        token_url: String,
+        /// OAuth userinfo endpoint (server-fetched, with `Authorization:
+        /// Bearer <access_token>`). Strict gate. The response is the
+        /// authoritative source for `(email, sub)` per ADR-0085 D-16
+        /// (id_token JWKS validation deferred to 1.1).
+        userinfo_url: String,
+        /// Optional second userinfo endpoint for providers whose primary
+        /// userinfo response lacks `email_verified` (GitHub's
+        /// `/user/emails`). Strict gate. Per ADR-0085 D-5 wave-6, PR-4
+        /// fetches this AFTER `userinfo_url` and picks the entry where
+        /// `primary == true AND verified == true`. `None` means the
+        /// primary userinfo response includes `email_verified` inline
+        /// (the OIDC norm).
+        #[serde(default)]
+        verified_emails_url: Option<String>,
+        /// Optional JWKS URL. Accepted for forward compat but ignored in
+        /// 1.0 per ADR-0085 D-16 (id_token signature validation deferred
+        /// to 1.1). Strict gate when present.
+        #[serde(default)]
+        jwks_url: Option<String>,
+        /// Per-provider scopes (non-empty). OAuth2-only providers (e.g.
+        /// GitHub needs `["user:email"]` for `/user/emails` access).
+        scopes: Vec<String>,
+    },
+}
+
+impl OAuthEndpoints {
+    /// Strict-gate helper: collect every server-side URL that
+    /// `validate_oauth_outbound_url` must approve at boot. Per ADR-0085
+    /// D-9-WAVE6 the strict gate covers token / userinfo /
+    /// verified_emails / jwks / discovery; the authorize URL goes
+    /// through the flag-aware gate via [`Self::authorize_url`].
+    #[must_use]
+    pub fn server_side_urls(&self) -> Vec<&str> {
+        match self {
+            Self::Oidc { discovery_url } => vec![discovery_url.as_str()],
+            Self::Manual {
+                token_url,
+                userinfo_url,
+                verified_emails_url,
+                jwks_url,
+                ..
+            } => {
+                let mut urls = vec![token_url.as_str(), userinfo_url.as_str()];
+                if let Some(url) = verified_emails_url.as_deref() {
+                    urls.push(url);
+                }
+                if let Some(url) = jwks_url.as_deref() {
+                    urls.push(url);
+                }
+                urls
+            },
+        }
+    }
+
+    /// Flag-aware-gate helper: the operator-supplied authorize URL when
+    /// the provider is `Manual` (the OIDC arm's authorize URL is
+    /// discovered at runtime and validated then per D-15-WAVE6).
+    #[must_use]
+    pub fn authorize_url(&self) -> Option<&str> {
+        match self {
+            Self::Oidc { .. } => None,
+            Self::Manual { authorize_url, .. } => Some(authorize_url.as_str()),
+        }
+    }
+
+    /// Scope resolution per ADR-0085 D-5 recon-4 ADOPT (c): hardcoded
+    /// `"openid email profile"` for OIDC; operator-supplied for Manual.
+    #[must_use]
+    pub fn scopes(&self) -> Vec<String> {
+        match self {
+            Self::Oidc { .. } => OIDC_HARDCODED_SCOPES
+                .iter()
+                .map(|s| (*s).to_owned())
+                .collect(),
+            Self::Manual { scopes, .. } => scopes.clone(),
+        }
+    }
+}

--- a/crates/api/src/config/sub.rs
+++ b/crates/api/src/config/sub.rs
@@ -203,6 +203,16 @@ pub struct AuthApiConfig {
     /// composition root flips this for production deployments via
     /// `API_AUTH_BACKEND=postgres`.
     pub backend: AuthBackendKind,
+
+    /// Operator-supplied OAuth identity-provider configuration (Plane A).
+    ///
+    /// Empty by default — no OAuth providers declared, the
+    /// `/auth/oauth/{provider}/start` endpoints return
+    /// `AuthError::ProviderNotConfigured` per ADR-0085 D-6. When
+    /// non-empty, every entry is validated synchronously at boot per
+    /// REQ-compose-001 (PR-2 T2.8).
+    #[serde(default)]
+    pub oauth: super::oauth::OAuthProvidersConfig,
 }
 
 /// Webhook subsystem configuration (webhook activation).

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -846,7 +846,15 @@ impl AuthBackend for InMemoryAuthBackend {
         .await
     }
 
-    async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError> {
+    // PR-2 T2.9: trait sig gained `redirect_uri: &str` per ADR-0085
+    // D-3 recon-4. Handler derives from `ApiConfig::public_url`; we
+    // accept and currently ignore the arg until PR-3 wires it into the
+    // OAuthStateEntry.
+    async fn start_oauth(
+        &self,
+        provider: OAuthProvider,
+        _redirect_uri: &str,
+    ) -> Result<OAuthStart, AuthError> {
         let provider_label = metrics_emit::oauth_provider_label(provider);
         metrics_emit::run_with_metrics(
             &self.metrics,
@@ -885,11 +893,16 @@ impl AuthBackend for InMemoryAuthBackend {
         .await
     }
 
+    // PR-2 T2.9: trait sig gained `redirect_uri: &str`. PR-4 verifies
+    // it against the OAuthStateEntry's stored redirect_uri (Scenario
+    // 3.10 public_url_changed_mid_flow). For now the param is accepted
+    // and ignored — complete_oauth still returns NotImplemented.
     async fn complete_oauth(
         &self,
         provider: OAuthProvider,
         state: &str,
         _code: &str,
+        _redirect_uri: &str,
     ) -> Result<OAuthCompletion, AuthError> {
         let provider_label = metrics_emit::oauth_provider_label(provider);
         metrics_emit::run_with_metrics(
@@ -1109,7 +1122,13 @@ mod tests {
     #[tokio::test]
     async fn oauth_start_persists_state_entry() {
         let b = InMemoryAuthBackend::new();
-        let start = b.start_oauth(OAuthProvider::Google).await.unwrap();
+        let start = b
+            .start_oauth(
+                OAuthProvider::Google,
+                "https://nebula.test/auth/oauth/google/callback",
+            )
+            .await
+            .unwrap();
         assert!(start.authorize_url.contains("state="));
         assert!(b.oauth_state.contains_key(&start.state));
     }

--- a/crates/api/src/domain/auth/backend/oauth.rs
+++ b/crates/api/src/domain/auth/backend/oauth.rs
@@ -24,7 +24,16 @@ use super::error::AuthError;
 pub const OAUTH_STATE_TTL: Duration = Duration::from_mins(10);
 
 /// Supported Plane-A OAuth providers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+///
+/// Serialize/Deserialize derived so `OAuthProvidersConfig` can use
+/// `HashMap<OAuthProvider, OAuthProviderConfig>` keyed by enum value
+/// (per ADR-0085 D-5). `serde(rename_all = "snake_case")` so TOML keys
+/// like `[auth.oauth.providers.google]` deserialize directly into the
+/// enum without a custom `Deserialize` impl. Drift between `FromStr`
+/// and `Deserialize` is closed because both use the same lowercase
+/// strings (verified by a unit test).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum OAuthProvider {
     /// Sign in with Google.
     Google,

--- a/crates/api/src/domain/auth/backend/pg.rs
+++ b/crates/api/src/domain/auth/backend/pg.rs
@@ -1025,7 +1025,15 @@ impl AuthBackend for PgAuthBackend {
     }
 
     #[tracing::instrument(level = "info", skip(self), fields(provider = %provider.as_str()))]
-    async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError> {
+    // PR-2 T2.9: trait sig gained `redirect_uri: &str`. PR-3 wires it
+    // into the AuthorizationUriRequest + persists into the
+    // OAuthStateRow; for now the param is accepted and ignored so the
+    // trait compiles — behavior is still the synthetic URL until PR-3.
+    async fn start_oauth(
+        &self,
+        provider: OAuthProvider,
+        _redirect_uri: &str,
+    ) -> Result<OAuthStart, AuthError> {
         let provider_label = metrics_emit::oauth_provider_label(provider);
         metrics_emit::run_with_metrics(
             &self.metrics,
@@ -1075,12 +1083,18 @@ impl AuthBackend for PgAuthBackend {
         .await
     }
 
-    #[tracing::instrument(level = "info", skip(self, state, _code), fields(provider = %provider.as_str(), state_len = state.len()))]
+    // PR-2 T2.9: trait sig gained `redirect_uri: &str`. PR-4 verifies
+    // it against the OAuthStateRow's persisted redirect_uri to close
+    // the `public_url_changed_mid_flow` defense (REQ-oauth-003
+    // Scenario 3.10). For now the param is accepted and ignored —
+    // complete_oauth still returns NotImplemented until PR-4.
+    #[tracing::instrument(level = "info", skip(self, state, _code, _redirect_uri), fields(provider = %provider.as_str(), state_len = state.len()))]
     async fn complete_oauth(
         &self,
         provider: OAuthProvider,
         state: &str,
         _code: &str,
+        _redirect_uri: &str,
     ) -> Result<OAuthCompletion, AuthError> {
         let provider_label = metrics_emit::oauth_provider_label(provider);
         metrics_emit::run_with_metrics(

--- a/crates/api/src/domain/auth/backend/provider.rs
+++ b/crates/api/src/domain/auth/backend/provider.rs
@@ -332,15 +332,37 @@ pub trait AuthBackend: Send + Sync {
     async fn confirm_mfa_enrollment(&self, user_id: &str, code: &str) -> Result<(), AuthError>;
 
     /// Begin a Plane-A OAuth sign-in.
-    async fn start_oauth(&self, provider: OAuthProvider) -> Result<OAuthStart, AuthError>;
+    ///
+    /// `redirect_uri` is **handler-derived** from `ApiConfig::public_url`
+    /// per ADR-0085 D-3 (recon-4) —
+    /// `format!("{}/auth/oauth/{}/callback", api_config.public_url,
+    /// provider.as_str())`. The trait accepts it as an argument so the
+    /// derived value round-trips through the implementation's state row
+    /// and is re-verified on `complete_oauth` against the row's stored
+    /// value (closes the `public_url_changed_mid_flow` defense per
+    /// REQ-oauth-003 Scenario 3.10). Implementations MUST NOT derive
+    /// the redirect_uri themselves; the handler is the single source of
+    /// truth (T2.10 shared helper).
+    async fn start_oauth(
+        &self,
+        provider: OAuthProvider,
+        redirect_uri: &str,
+    ) -> Result<OAuthStart, AuthError>;
 
     /// Complete a Plane-A OAuth sign-in. The implementation exchanges the
     /// provider's `code` for an access token, fetches the user profile,
     /// upserts the user, and mints a session.
+    ///
+    /// `redirect_uri` is **handler-derived** per the same formula as
+    /// [`Self::start_oauth`]. The implementation MUST compare it against
+    /// the persisted state-row value and return
+    /// `AuthError::OAuthFailed { cause: "public_url_changed_mid_flow" }`
+    /// on mismatch (Scenario 3.10).
     async fn complete_oauth(
         &self,
         provider: OAuthProvider,
         state: &str,
         code: &str,
+        redirect_uri: &str,
     ) -> Result<OAuthCompletion, AuthError>;
 }

--- a/crates/api/src/domain/auth/handler.rs
+++ b/crates/api/src/domain/auth/handler.rs
@@ -371,6 +371,23 @@ pub async fn mfa_complete_login(
     mint_session_response(backend, user).await
 }
 
+/// Derive the canonical Plane-A OAuth `redirect_uri` per ADR-0085 D-3
+/// (recon-4): `format!("{}/auth/oauth/{}/callback", public_url,
+/// provider.as_str())`.
+///
+/// Shared by `oauth_start` and `oauth_callback` so the value persisted
+/// in the OAuth state row at start_oauth time matches the value
+/// re-derived at callback time (`public_url_changed_mid_flow` defense
+/// per REQ-oauth-003 Scenario 3.10 — PR-4 wires the comparison).
+#[must_use]
+pub(crate) fn derive_oauth_redirect_uri(public_url: &str, provider: OAuthProvider) -> String {
+    // Trim trailing slash so we always emit a single `/` separator. The
+    // boot-time validation (T2.8) ensures `public_url` is absolute with
+    // a scheme; here we only normalize the slash.
+    let base = public_url.trim_end_matches('/');
+    format!("{base}/auth/oauth/{}/callback", provider.as_str())
+}
+
 /// `GET /api/v1/auth/oauth/{provider}` — start a Plane-A sign-in flow.
 #[utoipa::path(
     get,
@@ -393,8 +410,9 @@ pub async fn oauth_start(
 ) -> ApiResult<Json<OAuthStartResponse>> {
     let backend = backend(&state)?;
     let provider: OAuthProvider = provider.parse().map_err(ApiError::from)?;
+    let redirect_uri = derive_oauth_redirect_uri(&state.public_url, provider);
     let start = backend
-        .start_oauth(provider)
+        .start_oauth(provider, &redirect_uri)
         .await
         .map_err(ApiError::from)?;
     Ok(Json(OAuthStartResponse {
@@ -429,8 +447,9 @@ pub async fn oauth_callback(
 ) -> ApiResult<axum::response::Response> {
     let backend = backend(&state)?;
     let provider: OAuthProvider = provider.parse().map_err(ApiError::from)?;
+    let redirect_uri = derive_oauth_redirect_uri(&state.public_url, provider);
     let result = backend
-        .complete_oauth(provider, &params.state, &params.code)
+        .complete_oauth(provider, &params.state, &params.code, &redirect_uri)
         .await;
 
     match result {

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -23,7 +23,7 @@ use crate::{
     transport::oauth::{
         flow::{
             AuthorizationUriRequest, TokenExchangeRequest, build_authorization_uri,
-            validate_token_endpoint,
+            validate_oauth_outbound_url,
         },
         state::{OAuthStateSigner, build_signed_state},
     },
@@ -75,7 +75,7 @@ pub async fn get_oauth2_authorize_url_for_owner(
     query: AuthorizationUriRequest,
     owner_id: Option<String>,
 ) -> ApiResult<Json<AuthorizationUriResponse>> {
-    validate_token_endpoint(&query.token_url).map_err(ApiError::validation_message)?;
+    validate_oauth_outbound_url(&query.token_url).map_err(ApiError::validation_message)?;
     let expected_version = if let Some(owner_id) = owner_id.as_deref() {
         Some(prepare_oauth_credential(state, owner_id, credential_id).await?)
     } else {

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -78,6 +78,36 @@ pub mod telemetry_init;
 mod trace_capture;
 pub mod transport;
 
+/// Test-only helpers for `nebula-api` integration tests against
+/// localhost wiremock IdPs. Gated by the custom cfg `nebula_test_util`
+/// (NOT a Cargo feature — features are additive and can transitively
+/// activate; custom cfg requires explicit `RUSTFLAGS="--cfg
+/// nebula_test_util"` opt-in per the tokio_unstable precedent).
+///
+/// Tests enable via:
+/// ```sh
+/// RUSTFLAGS="--cfg nebula_test_util" cargo nextest run -p nebula-api --test oauth_provider_e2e
+/// ```
+///
+/// See ADR-0085 D-14 and PR-2 tasks T2.11 / T2.12.
+#[cfg(nebula_test_util)]
+pub mod test_support;
+
+// Release-build guard per ADR-0085 D-14 + tasks T2.12: if the
+// `nebula_test_util` cfg is somehow set in a release build (operator
+// passes `RUSTFLAGS="--cfg nebula_test_util"` to `cargo build
+// --release`), refuse to compile. `not(debug_assertions)` is the
+// canonical release-profile detection cfg (set automatically by
+// `cargo build --release` and any `[profile.<name>] debug-assertions =
+// false`). The earlier proposal `cfg(feature = "release")` was
+// structurally wrong — release is a Cargo profile, NOT a feature.
+#[cfg(all(nebula_test_util, not(debug_assertions)))]
+compile_error!(
+    "nebula_test_util cfg must NOT be active in release builds; \
+     remove --cfg nebula_test_util from RUSTFLAGS. \
+     See ADR-0085 D-14 for the test-only bypass-helpers contract."
+);
+
 pub use app::build_app;
 pub use config::{ApiConfig, ApiConfigError, JwtSecret};
 pub use domain::resource::handler::{

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -298,6 +298,19 @@ pub struct AppState {
     /// only build the dev backend.
     pub email_port: Option<Arc<dyn crate::ports::email::EmailPort>>,
 
+    /// Publicly-reachable base URL for this Nebula instance, sourced
+    /// from `ApiConfig::public_url` (`API_PUBLIC_URL` env). Required by
+    /// the Plane-A OAuth handler to derive the canonical
+    /// `redirect_uri` per ADR-0085 D-3 (recon-4) —
+    /// `format!("{}/auth/oauth/{}/callback", public_url, provider)`.
+    ///
+    /// Defaults to an empty string when constructed via
+    /// [`Self::in_memory`]; the composition root (`build_state`) sets
+    /// it from the parsed `ApiConfig`. Empty / relative values are
+    /// rejected at boot when `auth.oauth.providers` is non-empty (T2.8
+    /// REQ-compose-001 Invariant 1).
+    pub public_url: Arc<str>,
+
     /// Optional membership store for RBAC role lookups.
     pub membership_store: Option<Arc<dyn MembershipStore>>,
 
@@ -459,6 +472,7 @@ impl AppState {
             workspace_resolver: None,
             auth_backend: None,
             email_port: None,
+            public_url: Arc::from(""),
             membership_store: None,
             allow_insecure_tenant_rbac_bypass: false,
             idempotency_store: None,
@@ -1084,6 +1098,16 @@ impl AppState {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_email_port(mut self, port: Arc<dyn crate::ports::email::EmailPort>) -> Self {
         self.email_port = Some(port);
+        self
+    }
+
+    /// Set the publicly-reachable base URL for this Nebula instance.
+    /// Required for Plane-A OAuth `redirect_uri` derivation per
+    /// ADR-0085 D-3 (recon-4). Composition roots call this with
+    /// `ApiConfig::public_url`. Tests can pass any absolute URL.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_public_url(mut self, public_url: impl Into<Arc<str>>) -> Self {
+        self.public_url = public_url.into();
         self
     }
 

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -7,17 +7,91 @@
 //! GET, OIDC discovery GET) against `wiremock` listening on `127.0.0.1`.
 //! The strict anti-SSRF gate
 //! ([`crate::transport::oauth::flow::validate_oauth_outbound_url`])
-//! rejects loopback / private / non-HTTPS URLs by design \u2014 production
+//! rejects loopback / private / non-HTTPS URLs by design — production
 //! traffic must not reach internal infra.
 //!
 //! Per ADR-0085 D-14 + D-9-WAVE6, this module exposes ALL three bypass
 //! helpers needed to mount wiremock against `127.0.0.1` for tests:
 //!
-//! - [`exchange_code_unchecked`] \u2014 token endpoint POST, skips
+//! - [`exchange_code_unchecked`] — token endpoint POST, skips
 //!   `validate_oauth_outbound_url`.
-//! - [`oauth_token_http_client_test_unchecked`] \u2014 returns the same
+//! - [`oauth_token_http_client_test_unchecked`] — returns the same
 //!   shared `reqwest::Client` used in production, intended for direct
 //!   userinfo / verified-emails GETs from test code that has already
 //!   confirmed it is using a safe localhost target.
-//! - [`fetch_oidc_discovery_unchecked`] \u2014 PR-3 will populate this once
-//!   the discovery cache lands; for now this is a placeholder so PR-2's\n//!   `test_support` scaffold compiles and integration test files can\n//!   import the module path.\n//!\n//! ## Production-build guard\n//!\n//! The release-build guard in `crates/api/src/lib.rs`\n//! (`#[cfg(all(nebula_test_util, not(debug_assertions)))]\n//! compile_error!`) refuses to compile if the cfg is set in a release\n//! build. Production binaries (no `RUSTFLAGS` opt-in) do NOT contain\n//! this module at all.\n//!\n//! ## How tests opt in\n//!\n//! ```sh\n//! RUSTFLAGS=\"--cfg nebula_test_util\" cargo nextest run -p nebula-api \\\n//!     --test oauth_provider_e2e\n//! ```\n\n// Re-export `flow::exchange_code_unchecked` for integration tests.\n//\n// `exchange_code_unchecked` is private to `flow.rs` and the in-crate\n// tests reach it directly; integration tests live in a separate crate\n// and need this `pub` re-export to call it. The `nebula_test_util` cfg\n// gate ensures the symbol is unreachable from production builds.\npub use crate::transport::oauth::flow::exchange_code_unchecked;\n\nuse crate::transport::oauth::http::oauth_token_http_client;\n\n/// Return the same shared `reqwest::Client` used by production OAuth\n/// HTTP calls, intended for direct userinfo / verified-emails GETs\n/// from test code mounting wiremock on localhost. Bypassing\n/// `validate_oauth_outbound_url` is the caller's responsibility \u2014 this\n/// helper only exposes the client without invoking the SSRF gate.\n///\n/// Production code MUST NOT use this helper; the `nebula_test_util` cfg\n/// gate guarantees it does not exist in release builds.\n#[must_use]\npub fn oauth_token_http_client_test_unchecked() -> &'static reqwest::Client {\n    oauth_token_http_client()\n}\n\n/// Placeholder for the OIDC discovery doc fetcher bypass, to be wired\n/// in PR-3 once `crates/api/src/transport/oauth/discovery.rs` lands\n/// per T3.1. Defined here in PR-2 so the integration test crate has a\n/// stable module path to import. Returns an error until PR-3 fills it\n/// in.\n///\n/// # Errors\n///\n/// Always returns `Err` until PR-3 lands the discovery cache.\npub async fn fetch_oidc_discovery_unchecked(_url: &str) -> Result<(), String> {\n    Err(\"fetch_oidc_discovery_unchecked: PR-3 not yet landed (T3.1)\".to_owned())\n}
+//! - [`fetch_oidc_discovery_unchecked`] — PR-3 will populate this once
+//!   the discovery cache lands; for now this is a placeholder so PR-2's
+//!   `test_support` scaffold compiles and integration test files can
+//!   import the module path.
+//!
+//! ## Production-build guard
+//!
+//! The release-build guard in `crates/api/src/lib.rs`
+//! (`#[cfg(all(nebula_test_util, not(debug_assertions)))]
+//! compile_error!`) refuses to compile if the cfg is set in a release
+//! build. Production binaries (no `RUSTFLAGS` opt-in) do NOT contain
+//! this module at all.
+//!
+//! ## How tests opt in
+//!
+//! ```sh
+//! RUSTFLAGS="--cfg nebula_test_util" cargo nextest run -p nebula-api \
+//!     --test oauth_provider_e2e
+//! ```
+
+use thiserror::Error;
+
+// Re-export `flow::exchange_code_unchecked` for integration tests.
+//
+// `exchange_code_unchecked` is private to `flow.rs` and the in-crate
+// tests reach it directly; integration tests live in a separate crate
+// and need this `pub` re-export to call it. The `nebula_test_util` cfg
+// gate ensures the symbol is unreachable from production builds.
+pub use crate::transport::oauth::flow::exchange_code_unchecked;
+
+use crate::transport::oauth::http::oauth_token_http_client;
+
+/// Return the same shared `reqwest::Client` used by production OAuth
+/// HTTP calls, intended for direct userinfo / verified-emails GETs
+/// from test code mounting wiremock on localhost. Bypassing
+/// `validate_oauth_outbound_url` is the caller's responsibility — this
+/// helper only exposes the client without invoking the SSRF gate.
+///
+/// Production code MUST NOT use this helper; the `nebula_test_util` cfg
+/// gate guarantees it does not exist in release builds.
+#[must_use]
+pub fn oauth_token_http_client_test_unchecked() -> &'static reqwest::Client {
+    oauth_token_http_client()
+}
+
+/// Failure modes for [`fetch_oidc_discovery_unchecked`].
+///
+/// Typed (not stringly) error per the public-API discipline — tests
+/// can `match` on a variant instead of substring-grepping a message.
+/// PR-3 lands the real fetch behavior; this typed shape is forward-
+/// compatible.
+#[derive(Debug, Error)]
+pub enum DiscoveryUncheckedError {
+    /// The discovery fetch is not yet wired up. Returned by the PR-2
+    /// placeholder; PR-3 replaces this variant with real fetch / parse
+    /// errors.
+    #[error(
+        "fetch_oidc_discovery_unchecked: PR-3 has not yet landed (openspec T3.1); the placeholder always returns this variant"
+    )]
+    PlaceholderUntilPr3,
+}
+
+/// Placeholder for the OIDC discovery doc fetcher bypass, to be wired
+/// in PR-3 once `crates/api/src/transport/oauth/discovery.rs` lands
+/// per T3.1. Defined here in PR-2 so the integration test crate has a
+/// stable module path to import. Returns
+/// [`DiscoveryUncheckedError::PlaceholderUntilPr3`] until PR-3 fills it
+/// in.
+///
+/// # Errors
+///
+/// Always returns `Err(PlaceholderUntilPr3)` until PR-3 lands the
+/// discovery cache.
+pub async fn fetch_oidc_discovery_unchecked(_url: &str) -> Result<(), DiscoveryUncheckedError> {
+    Err(DiscoveryUncheckedError::PlaceholderUntilPr3)
+}

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -1,0 +1,23 @@
+//! Test-only OAuth bypass helpers. Gated by `#[cfg(nebula_test_util)]`.
+//!
+//! ## Why this module exists
+//!
+//! Integration tests for the Plane-A OAuth identity flow (PR-4) need to
+//! exercise the server-side IdP HTTP call sites (token POST, userinfo
+//! GET, OIDC discovery GET) against `wiremock` listening on `127.0.0.1`.
+//! The strict anti-SSRF gate
+//! ([`crate::transport::oauth::flow::validate_oauth_outbound_url`])
+//! rejects loopback / private / non-HTTPS URLs by design \u2014 production
+//! traffic must not reach internal infra.
+//!
+//! Per ADR-0085 D-14 + D-9-WAVE6, this module exposes ALL three bypass
+//! helpers needed to mount wiremock against `127.0.0.1` for tests:
+//!
+//! - [`exchange_code_unchecked`] \u2014 token endpoint POST, skips
+//!   `validate_oauth_outbound_url`.
+//! - [`oauth_token_http_client_test_unchecked`] \u2014 returns the same
+//!   shared `reqwest::Client` used in production, intended for direct
+//!   userinfo / verified-emails GETs from test code that has already
+//!   confirmed it is using a safe localhost target.
+//! - [`fetch_oidc_discovery_unchecked`] \u2014 PR-3 will populate this once
+//!   the discovery cache lands; for now this is a placeholder so PR-2's\n//!   `test_support` scaffold compiles and integration test files can\n//!   import the module path.\n//!\n//! ## Production-build guard\n//!\n//! The release-build guard in `crates/api/src/lib.rs`\n//! (`#[cfg(all(nebula_test_util, not(debug_assertions)))]\n//! compile_error!`) refuses to compile if the cfg is set in a release\n//! build. Production binaries (no `RUSTFLAGS` opt-in) do NOT contain\n//! this module at all.\n//!\n//! ## How tests opt in\n//!\n//! ```sh\n//! RUSTFLAGS=\"--cfg nebula_test_util\" cargo nextest run -p nebula-api \\\n//!     --test oauth_provider_e2e\n//! ```\n\n// Re-export `flow::exchange_code_unchecked` for integration tests.\n//\n// `exchange_code_unchecked` is private to `flow.rs` and the in-crate\n// tests reach it directly; integration tests live in a separate crate\n// and need this `pub` re-export to call it. The `nebula_test_util` cfg\n// gate ensures the symbol is unreachable from production builds.\npub use crate::transport::oauth::flow::exchange_code_unchecked;\n\nuse crate::transport::oauth::http::oauth_token_http_client;\n\n/// Return the same shared `reqwest::Client` used by production OAuth\n/// HTTP calls, intended for direct userinfo / verified-emails GETs\n/// from test code mounting wiremock on localhost. Bypassing\n/// `validate_oauth_outbound_url` is the caller's responsibility \u2014 this\n/// helper only exposes the client without invoking the SSRF gate.\n///\n/// Production code MUST NOT use this helper; the `nebula_test_util` cfg\n/// gate guarantees it does not exist in release builds.\n#[must_use]\npub fn oauth_token_http_client_test_unchecked() -> &'static reqwest::Client {\n    oauth_token_http_client()\n}\n\n/// Placeholder for the OIDC discovery doc fetcher bypass, to be wired\n/// in PR-3 once `crates/api/src/transport/oauth/discovery.rs` lands\n/// per T3.1. Defined here in PR-2 so the integration test crate has a\n/// stable module path to import. Returns an error until PR-3 fills it\n/// in.\n///\n/// # Errors\n///\n/// Always returns `Err` until PR-3 lands the discovery cache.\npub async fn fetch_oidc_discovery_unchecked(_url: &str) -> Result<(), String> {\n    Err(\"fetch_oidc_discovery_unchecked: PR-3 not yet landed (T3.1)\".to_owned())\n}

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -80,11 +80,18 @@ pub struct TokenExchangeRequest {
 
 /// Exchange authorization code for tokens.
 pub async fn exchange_code(req: &TokenExchangeRequest) -> Result<serde_json::Value, String> {
-    validate_token_endpoint(&req.token_url)?;
+    validate_oauth_outbound_url(&req.token_url)?;
     exchange_code_unchecked(req).await
 }
 
-async fn exchange_code_unchecked(req: &TokenExchangeRequest) -> Result<serde_json::Value, String> {
+// `pub(crate)` so the test-only `crate::test_support` module (gated by
+// `#[cfg(nebula_test_util)]`) can `pub use` this for integration tests
+// against localhost wiremock IdPs per ADR-0085 D-14. Production builds
+// without the cfg never compile `test_support`, so the symbol stays
+// effectively private to flow.rs internals.
+pub(crate) async fn exchange_code_unchecked(
+    req: &TokenExchangeRequest,
+) -> Result<serde_json::Value, String> {
     let client = oauth_token_http_client();
 
     let mut form: Vec<(&str, &str)> = vec![
@@ -120,19 +127,102 @@ async fn exchange_code_unchecked(req: &TokenExchangeRequest) -> Result<serde_jso
         .map_err(|e| e.to_string())
 }
 
-/// Validate that an OAuth token endpoint is safe for server-side exchange.
+/// Validate that an OAuth outbound (server-side fetched) URL is safe.
 ///
-/// API callers control this URL during interactive OAuth setup, so the
-/// backend rejects non-HTTPS URLs and obvious loopback/private/link-local
-/// hosts before `reqwest` can reach internal services.
-pub fn validate_token_endpoint(raw: &str) -> Result<(), String> {
-    let url = Url::parse(raw).map_err(|e| format!("invalid OAuth token endpoint URL: {e}"))?;
+/// API callers control these URLs via operator config or via OIDC
+/// discovery doc parsing. This strict gate rejects non-HTTPS schemes
+/// and obvious loopback / private / link-local / multicast hosts
+/// before `reqwest` can reach internal services (anti-SSRF).
+///
+/// Per ADR-0085 D-9-WAVE6, this strict gate applies to:
+/// - Token endpoint POST.
+/// - Userinfo endpoint GET.
+/// - GitHub-style verified-emails endpoint GET (per D-5 wave-6).
+/// - JWKS endpoint (D-16 deferred but URL still validated when present).
+/// - OIDC discovery doc GET, AND each URL returned in the discovery
+///   response before the cache insert (D-15-WAVE6).
+///
+/// The browser-fetched authorize URL goes through the **flag-aware**
+/// [`validate_oauth_authorize_url`] instead, which respects
+/// `oauth_allow_insecure_localhost` for dev convenience without
+/// weakening server-side anti-SSRF.
+///
+/// Renamed from `validate_token_endpoint` in wave-6 to signal the
+/// generalized scope. A `validate_token_endpoint` shim is kept below
+/// for backward source-compat during the PR-2..PR-4 transition; new
+/// callers should use `validate_oauth_outbound_url` directly.
+pub fn validate_oauth_outbound_url(raw: &str) -> Result<(), String> {
+    let url = Url::parse(raw).map_err(|e| format!("invalid OAuth outbound URL: {e}"))?;
     if url.scheme() != "https" {
-        return Err("OAuth token endpoint must use https".to_owned());
+        return Err("OAuth outbound URL must use https".to_owned());
     }
 
     validate_token_endpoint_host(url.host())?;
     Ok(())
+}
+
+/// Deprecated alias — use [`validate_oauth_outbound_url`].
+///
+/// Kept as a shim during the PR-2..PR-4 wave-6/-7 transition so existing
+/// call sites compile while they migrate. New code MUST call
+/// `validate_oauth_outbound_url` directly.
+#[deprecated(
+    since = "0.1.0",
+    note = "renamed to validate_oauth_outbound_url per ADR-0085 D-9-WAVE6; the rename signals the gate covers ALL server-side OAuth fetches, not just the token endpoint"
+)]
+pub fn validate_token_endpoint(raw: &str) -> Result<(), String> {
+    validate_oauth_outbound_url(raw)
+}
+
+/// Flag-aware validator for the **browser-fetched** OAuth authorize URL.
+///
+/// Per ADR-0085 D-9-WAVE6 wave-7 split (Codex F.2): the authorize URL
+/// is fetched by the user's browser, NOT the server, so it has no
+/// SSRF surface. To enable localhost-IdP dev workflows (e.g. wiremock
+/// on `127.0.0.1` serving the authorize page), this validator accepts
+/// `http://localhost(:port)?(/.*)?` when the operator opts in via the
+/// `oauth_allow_insecure_localhost` flag AND the binary is NOT a
+/// release build (`debug_assertions` enabled).
+///
+/// Production builds (`!cfg!(debug_assertions)`) reject the relaxation
+/// regardless of the flag, mirroring the `nebula_test_util` cfg's
+/// release-build guard in `crates/api/src/lib.rs`.
+///
+/// This gate is intended ONLY for `OAuthEndpoints::Manual.authorize_url`
+/// (static operator config) and the dynamic `authorize_url` returned
+/// inside an [`crate::config::OAuthEndpoints::Oidc`] discovery
+/// response. All other URL fields must go through the strict
+/// [`validate_oauth_outbound_url`].
+pub fn validate_oauth_authorize_url(
+    raw: &str,
+    oauth_allow_insecure_localhost: bool,
+    in_release_build: bool,
+) -> Result<(), String> {
+    let url = Url::parse(raw).map_err(|e| format!("invalid OAuth authorize URL: {e}"))?;
+
+    let scheme = url.scheme();
+    let is_localhost_http = scheme == "http"
+        && matches!(url.host(), Some(Host::Domain(h)) if h.eq_ignore_ascii_case("localhost"));
+
+    if scheme == "https" {
+        validate_token_endpoint_host(url.host())?;
+        return Ok(());
+    }
+
+    if is_localhost_http && oauth_allow_insecure_localhost && !in_release_build {
+        // Browser-fetched URL on localhost during dev/integration runs.
+        // No SSRF surface; explicit operator opt-in.
+        return Ok(());
+    }
+
+    if is_localhost_http && in_release_build {
+        return Err(
+            "OAuth authorize URL: oauth_allow_insecure_localhost has no effect in release builds"
+                .to_owned(),
+        );
+    }
+
+    Err("OAuth authorize URL must use https (or http://localhost when oauth_allow_insecure_localhost = true in dev builds)".to_owned())
 }
 
 fn validate_token_endpoint_host(host: Option<Host<&str>>) -> Result<(), String> {
@@ -263,7 +353,7 @@ mod tests {
             "https://[ff02::1]/token",
             "https://[fec0::1]/token",
         ] {
-            let err = validate_token_endpoint(raw)
+            let err = validate_oauth_outbound_url(raw)
                 .expect_err("private IPv4-mapped and local IPv6 addresses must be rejected");
             assert!(
                 err.to_lowercase().contains("token endpoint"),

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -134,6 +134,23 @@ pub(crate) async fn exchange_code_unchecked(
 /// and obvious loopback / private / link-local / multicast hosts
 /// before `reqwest` can reach internal services (anti-SSRF).
 ///
+/// ## Defense-in-depth limitation (CodeRabbit wave-1 major)
+///
+/// This function inspects only the **literal host** in the URL. An
+/// attacker-controlled DNS record (`internal.evil.example.com
+/// A 10.0.0.5`) passes this gate because the host string is not an
+/// IP literal at parse time. The full fix requires a `reqwest::Client`
+/// configured with a custom resolver that re-validates resolved IPs
+/// post-DNS-resolution. That is a follow-up scheduled with PR-3 / PR-4
+/// where the production OAuth HTTP path actually runs; for now this
+/// validator is the first of two defenses (the second is network
+/// segmentation in the deployment topology, and the third will be
+/// the post-DNS resolver gate).
+///
+/// PR-2 scope: catch the operator-typo cases (literal IP, `localhost`,
+/// HTTP scheme) at boot time, where the cost is zero and the error
+/// message is actionable.
+///
 /// Per ADR-0085 D-9-WAVE6, this strict gate applies to:
 /// - Token endpoint POST.
 /// - Userinfo endpoint GET.

--- a/crates/api/src/transport/oauth/flow.rs
+++ b/crates/api/src/transport/oauth/flow.rs
@@ -338,8 +338,13 @@ mod tests {
         let err = exchange_code(&req)
             .await
             .expect_err("loopback token URLs must fail before any request");
+        // Error message updated in PR-2 from "token endpoint" to
+        // "outbound URL" after the validate_token_endpoint ->
+        // validate_oauth_outbound_url rename (ADR-0085 D-9-WAVE6
+        // generalized the gate to all server-side OAuth fetches).
+        let lower = err.to_lowercase();
         assert!(
-            err.to_lowercase().contains("token endpoint"),
+            lower.contains("outbound url") || lower.contains("must use https"),
             "expected endpoint validation error, got: {err}"
         );
     }
@@ -355,8 +360,12 @@ mod tests {
         ] {
             let err = validate_oauth_outbound_url(raw)
                 .expect_err("private IPv4-mapped and local IPv6 addresses must be rejected");
+            // PR-2: error message text changed with the rename per D-9-WAVE6.
+            let lower = err.to_lowercase();
             assert!(
-                err.to_lowercase().contains("token endpoint"),
+                lower.contains("outbound url")
+                    || lower.contains("private or local")
+                    || lower.contains("must include a host"),
                 "expected endpoint validation error for {raw}, got: {err}"
             );
         }

--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -373,7 +373,10 @@ async fn pg_auth_backend_full_lifecycle() {
 
     // ── 11. start OAuth (persists row) ────────────────────────────────
     let oauth_start = backend
-        .start_oauth(OAuthProvider::Google)
+        .start_oauth(
+            OAuthProvider::Google,
+            "https://nebula.test/auth/oauth/google/callback",
+        )
         .await
         .expect("start_oauth");
     assert!(oauth_start.authorize_url.contains("state="));
@@ -384,7 +387,12 @@ async fn pg_auth_backend_full_lifecycle() {
     // follow-up — the PG path consumes the state row atomically
     // (replay defence) and then returns NotImplemented.
     let not_impl = backend
-        .complete_oauth(OAuthProvider::Google, &oauth_start.state, "fake-code")
+        .complete_oauth(
+            OAuthProvider::Google,
+            &oauth_start.state,
+            "fake-code",
+            "https://nebula.test/auth/oauth/google/callback",
+        )
         .await
         .expect_err("complete_oauth must return NotImplemented");
     assert!(
@@ -394,7 +402,12 @@ async fn pg_auth_backend_full_lifecycle() {
     // Replay: the row was consumed by the first call, so a second one
     // returns InvalidToken (atomic single-shot).
     let replay_err = backend
-        .complete_oauth(OAuthProvider::Google, &oauth_start.state, "fake-code")
+        .complete_oauth(
+            OAuthProvider::Google,
+            &oauth_start.state,
+            "fake-code",
+            "https://nebula.test/auth/oauth/google/callback",
+        )
         .await
         .expect_err("oauth state replay must reject");
     assert!(matches!(replay_err, AuthError::InvalidToken));
@@ -534,20 +547,33 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
     let (backend, _sink) = build_backend(pool);
 
     let start = backend
-        .start_oauth(OAuthProvider::Google)
+        .start_oauth(
+            OAuthProvider::Google,
+            "https://nebula.test/auth/oauth/google/callback",
+        )
         .await
         .expect("start_oauth");
 
     // Wrong provider — must not consume the row.
     let wrong_provider_err = backend
-        .complete_oauth(OAuthProvider::GitHub, &start.state, "fake-code")
+        .complete_oauth(
+            OAuthProvider::GitHub,
+            &start.state,
+            "fake-code",
+            "https://nebula.test/auth/oauth/github/callback",
+        )
         .await
         .expect_err("cross-provider state must reject");
     assert!(matches!(wrong_provider_err, AuthError::InvalidToken));
 
     // Correct provider — the state row is still consumable.
     let correct_err = backend
-        .complete_oauth(OAuthProvider::Google, &start.state, "fake-code")
+        .complete_oauth(
+            OAuthProvider::Google,
+            &start.state,
+            "fake-code",
+            "https://nebula.test/auth/oauth/google/callback",
+        )
         .await
         .expect_err("complete_oauth still returns NotImplemented after consume");
     assert!(

--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -554,13 +554,17 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
         .await
         .expect("start_oauth");
 
-    // Wrong provider — must not consume the row.
+    // Wrong provider — must not consume the row. Per CodeRabbit wave-1
+    // review: pass the SAME redirect_uri used at start so the
+    // regression tests one dimension (provider mismatch) without
+    // entangling the redirect_uri mismatch defense (Scenario 3.10 —
+    // separate test in PR-4).
     let wrong_provider_err = backend
         .complete_oauth(
             OAuthProvider::GitHub,
             &start.state,
             "fake-code",
-            "https://nebula.test/auth/oauth/github/callback",
+            "https://nebula.test/auth/oauth/google/callback",
         )
         .await
         .expect_err("cross-provider state must reject");


### PR DESCRIPTION
> **PR-2 of the 5-PR M3.1 OAuth identity-login chain** per [ADR-0085](../tree/main/docs/adr/0085-oauth-identity-providers-from-secrets.md) and [tasks.md](../tree/main/openspec/changes/oauth-providers-from-operator-secrets/tasks.md).
>
> Stacked on top of PR #757 (merged \`4d938bdb\`).

## What this PR lands

**T2.1**: scaffold `crates/api/src/config/oauth.rs` — `OAuthProvidersConfig`, `OAuthProviderConfig`, `OAuthEndpoints` tagged union (Oidc/Manual with `verified_emails_url` per D-5 wave-6).

**T2.7b**: scaffold `validate_oauth_authorize_url(url, flag, in_release_build)` — flag-aware validator for browser-fetched authorize URLs per D-9-WAVE6 + F.2 wave-7.

**T2.9**: extend `AuthBackend` trait — `start_oauth(provider, redirect_uri)` AND `complete_oauth(provider, state, code, redirect_uri)`. Both impls (Pg/InMemory) updated; param is accepted-and-ignored pending PR-3/PR-4 behavior change.

**T2.10**: handler derives `redirect_uri` from `ApiConfig::public_url` via shared `derive_oauth_redirect_uri(public_url, provider)` helper — single source of truth for both `oauth_start` and `oauth_callback`. AppState gains `public_url: Arc<str>` + `with_public_url()` builder.

**T2.11**: `crates/api/src/test_support.rs` (new) gated by `#[cfg(nebula_test_util)]` — exposes `exchange_code_unchecked` + `oauth_token_http_client_test_unchecked()` + placeholder `fetch_oidc_discovery_unchecked()` for integration tests against localhost wiremock.

**T2.12**: release-build guard `#[cfg(all(nebula_test_util, not(debug_assertions)))] compile_error!` in `crates/api/src/lib.rs`. `not(debug_assertions)` is the canonical release-profile detection cfg (NOT a Cargo feature \u2014 fixed wave-5).

**T2.3 + T2.4 + T2.5 + T2.6 + T2.8**: \`OAuthProvidersConfig::validate_at_load\` GREEN implementation + 9 RED tests covering REQ-compose-001 Invariant 1 (HTTPS strict + flag-aware split + Manual.scopes + public_url required). Compose-root invocation maps failures to new \`TransportInitError::OAuthProviderConfigInvalid { provider, reason }\` (fail-closed).

## Cumulative commit chain

| Commit | Stage | Files | LOC |
|---|---|---|---|
| \`5add2596\` | 1+2: scaffold types + validator split + test_support | 9 | +444 |
| \`ba499c86\` | 3: trait sig + handler derives + AppState public_url | 8 | +154 |
| \`3e697a8e\` | 4: validate_at_load + compose wiring + 9 RED tests | 2 | +387 |

**Total**: ~985 LOC across 3 commits.

## Test status

\`cargo nextest run -p nebula-api --no-fail-fast\` \u2192 **459 / 459 PASS** (was 450 before, +9 new RED tests).

CI required jobs expected to pass on all commits.

## What's TODO before this PR is ready for non-draft review

- [ ] **T2.2**: env-var scan to populate \`OAuthProvidersConfig\` from \`API_AUTH_OAUTH_<PROVIDER>_*\` env vars. Currently the config defaults to empty so no behaviour change without env setup. ~100 LOC follow-up.
- [ ] **T2.7 dedicated RED test**: handler-level assertion that \`derive_oauth_redirect_uri\` is called for both \`oauth_start\` and \`oauth_callback\`. Indirect coverage already exists via auth_pg_e2e.rs (passes new redirect_uri arg through the trait call), but no dedicated handler-level test. ~40 LOC.
- [ ] **T2.13**: TRIANGULATE \u2014 env-binding round-trip; provider key typo at config-load fails; Manual missing endpoint URL rejected. ~50 LOC.
- [ ] **T2.14**: REFACTOR pass.

The PR is opened as **DRAFT** to invite bot review on the substantive landed code while T2.2 + T2.7 + T2.13 + T2.14 follow up. If reviewers find issues now, we fold them into the same PR before mark-ready.

## Strict TDD evidence note

Per \`openspec/config.yaml\` strict TDD discipline:
- Stage 4 (commit 3e697a8e): 9 RED tests bundled with their GREEN \`validate_at_load\` impl in one commit because the tests reference the new method. Commit-level audit: \`git show 3e697a8e --stat\` shows both files moving together.
- Stage 3 (commit ba499c86): handler / trait changes shipped without a prior RED commit; this was a TDD-discipline shortcut. Pre-stage-3 state is verifiable via \`git checkout 5add2596\` for a reviewer who wants to manually run the existing oauth tests against the unchanged handler/trait to see them pass (no regression introduced).

## Refs

- ROADMAP \u00a7M3.1 (PR-2 of the 5-PR chain closing the final auth-backend honesty gap).
- ADR-0085 D-1 / D-3 / D-5 / D-6 / D-7 / D-8 / D-9-WAVE6 / D-11-RECON3 / D-12-RECON3 / D-13 / D-14 / D-15-WAVE6 / D-16.
- openspec/changes/oauth-providers-from-operator-secrets/tasks.md (T2.1 \u2013 T2.15).
- PR #757 (PR-1 ADR) merged \`4d938bdb\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth provider config: OIDC discovery and manual OAuth2 endpoints with scope handling.
  * Startup validation of OAuth configs and explicit public_url support for correct redirect URIs.
  * OAuth flows now require a handler-provided redirect URI to guard redirect consistency.

* **Tests**
  * Test-only utilities added (gated) to assist integration tests with localhost/wiremock and token-exchange helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/758?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->