### PR TITLE
feat(api): real authorize URL via flow::build_authorization_uri + OIDC discovery cache (PR-3 of M3.1)

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -400,13 +400,20 @@ pub async fn build_auth_backend(
     email_port: Arc<dyn EmailPort>,
     metrics_registry: Option<Arc<MetricsRegistry>>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
+    // PR-3 T3.8 / T3.9: thread the validated OAuth providers config
+    // into both backends so `start_oauth` can emit real authorize
+    // URLs. The Arc share is cheap and read-only at runtime.
+    let oauth_providers = Arc::new(api_config.auth.oauth.clone());
     match api_config.auth.backend {
         AuthBackendKind::Memory => Ok(Arc::new(
             InMemoryAuthBackend::new()
                 .with_email_port(email_port)
-                .with_metrics(metrics_registry),
+                .with_metrics(metrics_registry)
+                .with_oauth_providers(oauth_providers),
         )),
-        AuthBackendKind::Postgres => build_pg_auth_backend(email_port, metrics_registry).await,
+        AuthBackendKind::Postgres => {
+            build_pg_auth_backend(email_port, metrics_registry, oauth_providers).await
+        },
     }
 }
 
@@ -506,6 +513,7 @@ async fn build_pg_idempotency_store(
 async fn build_pg_auth_backend(
     email_port: Arc<dyn EmailPort>,
     metrics_registry: Option<Arc<MetricsRegistry>>,
+    oauth_providers: Arc<nebula_api::config::OAuthProvidersConfig>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
     use nebula_api::domain::auth::backend::PgAuthBackend;
     use sqlx::postgres::PgPoolOptions;
@@ -528,8 +536,10 @@ async fn build_pg_auth_backend(
         backend = "postgres",
         "auth: PG-backed identity backend wired"
     );
-    let backend: Arc<dyn AuthBackend> =
-        Arc::new(PgAuthBackend::new(pool, email_port, metrics_registry));
+    let backend: Arc<dyn AuthBackend> = Arc::new(
+        PgAuthBackend::new(pool, email_port, metrics_registry)
+            .with_oauth_providers(oauth_providers),
+    );
     Ok(backend)
 }
 
@@ -537,6 +547,7 @@ async fn build_pg_auth_backend(
 async fn build_pg_auth_backend(
     _email_port: Arc<dyn EmailPort>,
     _metrics_registry: Option<Arc<MetricsRegistry>>,
+    _oauth_providers: Arc<nebula_api::config::OAuthProvidersConfig>,
 ) -> Result<Arc<dyn AuthBackend>, TransportInitError> {
     Err(TransportInitError::AuthBackendUnavailable {
         requested: "postgres",

--- a/crates/api/src/domain/auth/backend/error.rs
+++ b/crates/api/src/domain/auth/backend/error.rs
@@ -14,6 +14,23 @@ pub enum AuthError {
     #[error("auth capability not implemented: {0}")]
     NotImplemented(&'static str),
 
+    /// Operator has not declared an OAuth identity provider for the
+    /// requested key.
+    ///
+    /// Per ADR-0085 D-6: returned when `start_oauth` / `complete_oauth`
+    /// runs for a `provider` that is absent from
+    /// `ApiConfig::auth.oauth.providers` (env var
+    /// `API_AUTH_OAUTH_<PROVIDER>_CLIENT_ID` is unset). Maps to
+    /// HTTP 503 Service Unavailable (NOT 400) because the operator can
+    /// fix it by setting the env vars without any code change — it's
+    /// a deployment state, not a caller error.
+    #[error("OAuth provider `{provider}` is not configured on this Nebula instance")]
+    ProviderNotConfigured {
+        /// Snake_case provider key (matches the `OAuthProvider` enum
+        /// variant).
+        provider: String,
+    },
+
     /// Email already registered.
     #[error("email already registered")]
     EmailAlreadyRegistered,
@@ -113,6 +130,10 @@ impl From<AuthError> for ApiError {
             AuthError::NotImplemented(what) => {
                 ApiError::ServiceUnavailable(format!("not implemented: {what}"))
             },
+            AuthError::ProviderNotConfigured { provider } => ApiError::ServiceUnavailable(format!(
+                "OAuth provider `{provider}` is not configured; set API_AUTH_OAUTH_{}_CLIENT_ID and related env vars",
+                provider.to_ascii_uppercase()
+            )),
             AuthError::EmailAlreadyRegistered => {
                 ApiError::Conflict("email already registered".to_owned())
             },
@@ -172,6 +193,7 @@ mod tests {
     fn default_outcome_for(err: &AuthError) -> &'static str {
         match err {
             AuthError::NotImplemented(_) => auth_outcome::INTERNAL,
+            AuthError::ProviderNotConfigured { .. } => auth_outcome::OAUTH_FAILED,
             AuthError::EmailAlreadyRegistered => auth_outcome::CONFLICT,
             AuthError::UserNotFound => auth_outcome::INVALID_CREDS,
             AuthError::InvalidCredentials => auth_outcome::INVALID_CREDS,
@@ -195,8 +217,14 @@ mod tests {
         // is `default_outcome_for`'s exhaustive `match`; this test
         // additionally verifies the label values are non-empty closed
         // strings.
-        let cases: [(&str, AuthError); 14] = [
+        let cases: [(&str, AuthError); 15] = [
             ("NotImplemented", AuthError::NotImplemented("x")),
+            (
+                "ProviderNotConfigured",
+                AuthError::ProviderNotConfigured {
+                    provider: "google".to_owned(),
+                },
+            ),
             ("EmailAlreadyRegistered", AuthError::EmailAlreadyRegistered),
             ("UserNotFound", AuthError::UserNotFound),
             ("InvalidCredentials", AuthError::InvalidCredentials),

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -941,7 +941,14 @@ impl AuthBackend for InMemoryAuthBackend {
             },
             |result| match result {
                 Ok(_) => auth_outcome::SUCCESS,
-                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                // PR-3 wave-2 (CodeRabbit G.6): include
+                // `ProviderNotConfigured` in the OAUTH_FAILED bucket
+                // so the in-memory backend's metrics labels match the
+                // PG backend (G.5) and the `default_outcome_for`
+                // exhaustive table.
+                Err(AuthError::OAuthFailed(_) | AuthError::ProviderNotConfigured { .. }) => {
+                    auth_outcome::OAUTH_FAILED
+                },
                 Err(_) => auth_outcome::INTERNAL,
             },
         )

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -125,6 +125,13 @@ pub struct InMemoryAuthBackend {
     /// surface keeps `None` to preserve the previous no-emission
     /// semantics.
     metrics: Option<Arc<MetricsRegistry>>,
+    /// Operator OAuth providers config (Plane A). Same shape as
+    /// `PgAuthBackend.oauth_providers`. Defaults to empty so existing
+    /// tests that construct the backend via `InMemoryAuthBackend::new`
+    /// without OAuth config keep working (start_oauth returns
+    /// `ProviderNotConfigured`); tests that exercise OAuth call
+    /// [`InMemoryAuthBackend::with_oauth_providers`] explicitly.
+    oauth_providers: Arc<crate::config::OAuthProvidersConfig>,
 }
 
 impl Default for InMemoryAuthBackend {
@@ -141,6 +148,7 @@ impl Default for InMemoryAuthBackend {
             email_port: Arc::clone(&echo) as Arc<dyn EmailPort>,
             default_echo: Some(echo),
             metrics: None,
+            oauth_providers: Arc::new(crate::config::OAuthProvidersConfig::default()),
         }
     }
 }
@@ -217,6 +225,19 @@ impl InMemoryAuthBackend {
     #[must_use]
     pub fn with_metrics(mut self, metrics: Option<Arc<MetricsRegistry>>) -> Self {
         self.metrics = metrics;
+        self
+    }
+
+    /// Attach the operator OAuth providers config. Mirrors
+    /// `PgAuthBackend::with_oauth_providers`. Tests that exercise the
+    /// real authorize-URL emission path (PR-3) wire this; tests that
+    /// only need the trait surface keep the empty default.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_oauth_providers(
+        mut self,
+        providers: Arc<crate::config::OAuthProvidersConfig>,
+    ) -> Self {
+        self.oauth_providers = providers;
         self
     }
 
@@ -846,30 +867,60 @@ impl AuthBackend for InMemoryAuthBackend {
         .await
     }
 
-    // PR-2 T2.9: trait sig gained `redirect_uri: &str` per ADR-0085
-    // D-3 recon-4. Handler derives from `ApiConfig::public_url`; we
-    // accept and currently ignore the arg until PR-3 wires it into the
-    // OAuthStateEntry.
+    // PR-3 T3.9 GREEN: rewrite to emit a REAL authorize URL via
+    // `flow::build_authorization_uri` after resolving the provider's
+    // endpoints. Symmetric to `PgAuthBackend::start_oauth`; the only
+    // difference is the OAuth state row goes into the DashMap (with
+    // `redirect_uri` captured in the entry for PR-4 verification).
     async fn start_oauth(
         &self,
         provider: OAuthProvider,
-        _redirect_uri: &str,
+        redirect_uri: &str,
     ) -> Result<OAuthStart, AuthError> {
+        use secrecy::ExposeSecret;
+
+        use crate::transport::oauth::{
+            discovery::resolve_provider_endpoints,
+            flow::{AuthorizationUriRequest, build_authorization_uri},
+        };
+
         let provider_label = metrics_emit::oauth_provider_label(provider);
+        let redirect_uri = redirect_uri.to_owned();
+        let oauth_providers = Arc::clone(&self.oauth_providers);
         metrics_emit::run_with_metrics(
             &self.metrics,
             NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
             Some(provider_label),
             async move {
+                let provider_cfg = oauth_providers.providers.get(&provider).ok_or_else(|| {
+                    AuthError::ProviderNotConfigured {
+                        provider: provider.as_str().to_owned(),
+                    }
+                })?;
+                let endpoints = resolve_provider_endpoints(
+                    provider_cfg,
+                    oauth_providers.oauth_allow_insecure_localhost,
+                )
+                .await
+                .map_err(|e| AuthError::OAuthFailed(e.to_string()))?;
                 let pkce = mint_pkce()?;
-                // No real provider config in the in-memory backend — return a
-                // synthetic authorize URL so tests can verify the contract.
-                let authorize_url = format!(
-                    "https://nebula.local/oauth/{}/authorize?state={}&code_challenge={}&code_challenge_method=S256",
-                    provider.as_str(),
-                    pkce.state,
-                    pkce.code_challenge,
-                );
+                let auth_req = AuthorizationUriRequest {
+                    auth_url: endpoints.authorize_url.clone(),
+                    token_url: endpoints.token_url.clone(),
+                    client_id: provider_cfg.client_id.expose_secret().to_owned(),
+                    client_secret: provider_cfg.client_secret.expose_secret().to_owned(),
+                    redirect_uri: redirect_uri.clone(),
+                    scopes: Some(endpoints.scopes),
+                    auth_style: None,
+                };
+                let authorize_url =
+                    build_authorization_uri(&auth_req, &pkce.state, &pkce.code_challenge)
+                        .map_err(|e| {
+                            AuthError::OAuthFailed(format!(
+                                "authorize URL construction failed: {e}"
+                            ))
+                        })?
+                        .to_string();
                 self.oauth_state.insert(
                     pkce.state.clone(),
                     OAuthStateEntry {
@@ -877,6 +928,10 @@ impl AuthBackend for InMemoryAuthBackend {
                         code_verifier: pkce.code_verifier,
                         expires_at: expiry_unix(OAUTH_STATE_TTL),
                         consumed: false,
+                        // PR-3: capture handler-derived redirect_uri
+                        // for PR-4 to re-verify against the user's
+                        // callback.
+                        redirect_uri: Some(redirect_uri),
                     },
                 );
                 Ok(OAuthStart {
@@ -1121,7 +1176,37 @@ mod tests {
 
     #[tokio::test]
     async fn oauth_start_persists_state_entry() {
-        let b = InMemoryAuthBackend::new();
+        // PR-3: start_oauth now requires a configured provider per
+        // ADR-0085 D-6. The legacy synthetic-URL path is gone;
+        // declare a Manual provider with localhost endpoints so the
+        // test exercises the real authorize-URL emission against the
+        // operator-config path.
+        use std::collections::HashMap;
+
+        use crate::config::{OAuthEndpoints, OAuthProviderConfig, OAuthProvidersConfig};
+        use secrecy::SecretString;
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            OAuthProvider::Google,
+            OAuthProviderConfig {
+                client_id: SecretString::new("test-client".into()),
+                client_secret: SecretString::new("test-secret".into()),
+                endpoints: OAuthEndpoints::Manual {
+                    authorize_url: "https://example.invalid/authorize".to_owned(),
+                    token_url: "https://example.invalid/token".to_owned(),
+                    userinfo_url: "https://example.invalid/userinfo".to_owned(),
+                    verified_emails_url: None,
+                    jwks_url: None,
+                    scopes: vec!["openid".to_owned(), "email".to_owned()],
+                },
+            },
+        );
+        let cfg = Arc::new(OAuthProvidersConfig {
+            providers,
+            oauth_allow_insecure_localhost: false,
+        });
+        let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
         let start = b
             .start_oauth(
                 OAuthProvider::Google,
@@ -1129,8 +1214,149 @@ mod tests {
             )
             .await
             .unwrap();
-        assert!(start.authorize_url.contains("state="));
+        assert!(
+            start.authorize_url.contains("state="),
+            "authorize URL must include state query param: {}",
+            start.authorize_url
+        );
+        assert!(
+            start.authorize_url.contains("code_challenge_method=S256"),
+            "authorize URL must include PKCE S256 marker"
+        );
         assert!(b.oauth_state.contains_key(&start.state));
+        let entry = b.oauth_state.get(&start.state).unwrap();
+        assert_eq!(
+            entry.redirect_uri.as_deref(),
+            Some("https://nebula.test/auth/oauth/google/callback"),
+            "PR-3 must persist the handler-derived redirect_uri"
+        );
+    }
+
+    /// T3.6 RED-then-GREEN: start_oauth returns ProviderNotConfigured
+    /// when the provider is absent from `oauth.providers` map.
+    #[tokio::test]
+    async fn start_oauth_returns_provider_not_configured_when_provider_absent() {
+        let b = InMemoryAuthBackend::new();
+        let err = b
+            .start_oauth(
+                OAuthProvider::Google,
+                "https://nebula.test/auth/oauth/google/callback",
+            )
+            .await
+            .expect_err("missing provider config must error");
+        match err {
+            AuthError::ProviderNotConfigured { provider } => {
+                assert_eq!(provider, "google");
+            },
+            other => panic!("expected ProviderNotConfigured, got: {other:?}"),
+        }
+    }
+
+    /// T3.3 RED-then-GREEN: OIDC provider returns real authorize URL
+    /// via the flow helper (PKCE S256 markers + state query param).
+    #[tokio::test]
+    async fn start_oauth_emits_real_authorize_url_with_pkce_s256_for_oidc_provider() {
+        use std::collections::HashMap;
+
+        use crate::config::{OAuthEndpoints, OAuthProviderConfig, OAuthProvidersConfig};
+        use secrecy::SecretString;
+
+        // Oidc arm bypassed via a Manual fixture pointing at a fake
+        // domain — the test does not actually fetch the discovery
+        // doc (that's the discovery::tests path); it exercises the
+        // authorize-URL construction step which is identical for both
+        // arms after `resolve_provider_endpoints` returns.
+        let mut providers = HashMap::new();
+        providers.insert(
+            OAuthProvider::Microsoft,
+            OAuthProviderConfig {
+                client_id: SecretString::new("my-client-id".into()),
+                client_secret: SecretString::new("my-client-secret".into()),
+                endpoints: OAuthEndpoints::Manual {
+                    authorize_url: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize"
+                        .to_owned(),
+                    token_url: "https://login.microsoftonline.com/common/oauth2/v2.0/token"
+                        .to_owned(),
+                    userinfo_url: "https://graph.microsoft.com/oidc/userinfo".to_owned(),
+                    verified_emails_url: None,
+                    jwks_url: None,
+                    scopes: vec![
+                        "openid".to_owned(),
+                        "email".to_owned(),
+                        "profile".to_owned(),
+                    ],
+                },
+            },
+        );
+        let cfg = Arc::new(OAuthProvidersConfig {
+            providers,
+            oauth_allow_insecure_localhost: false,
+        });
+        let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
+        let start = b
+            .start_oauth(
+                OAuthProvider::Microsoft,
+                "https://nebula.test/auth/oauth/microsoft/callback",
+            )
+            .await
+            .unwrap();
+        let url = start.authorize_url;
+        assert!(url.starts_with("https://login.microsoftonline.com"));
+        assert!(url.contains("client_id=my-client-id"));
+        assert!(url.contains("code_challenge="));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("response_type=code"));
+        assert!(
+            url.contains("scope=openid+email+profile")
+                || url.contains("scope=openid%20email%20profile"),
+            "scopes joined: {url}"
+        );
+        assert!(url.contains("state="));
+    }
+
+    /// T3.4 RED-then-GREEN: Manual provider with explicit endpoints
+    /// builds authorize URL against the operator-configured
+    /// `authorize_url` (e.g. GitHub).
+    #[tokio::test]
+    async fn start_oauth_emits_real_authorize_url_for_manual_provider_with_explicit_endpoints() {
+        use std::collections::HashMap;
+
+        use crate::config::{OAuthEndpoints, OAuthProviderConfig, OAuthProvidersConfig};
+        use secrecy::SecretString;
+
+        let mut providers = HashMap::new();
+        providers.insert(
+            OAuthProvider::GitHub,
+            OAuthProviderConfig {
+                client_id: SecretString::new("gh-app-id".into()),
+                client_secret: SecretString::new("gh-app-secret".into()),
+                endpoints: OAuthEndpoints::Manual {
+                    authorize_url: "https://github.com/login/oauth/authorize".to_owned(),
+                    token_url: "https://github.com/login/oauth/access_token".to_owned(),
+                    userinfo_url: "https://api.github.com/user".to_owned(),
+                    verified_emails_url: Some("https://api.github.com/user/emails".to_owned()),
+                    jwks_url: None,
+                    scopes: vec!["user:email".to_owned()],
+                },
+            },
+        );
+        let cfg = Arc::new(OAuthProvidersConfig {
+            providers,
+            oauth_allow_insecure_localhost: false,
+        });
+        let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
+        let start = b
+            .start_oauth(
+                OAuthProvider::GitHub,
+                "https://nebula.test/auth/oauth/github/callback",
+            )
+            .await
+            .unwrap();
+        let url = start.authorize_url;
+        assert!(url.starts_with("https://github.com/login/oauth/authorize"));
+        assert!(url.contains("client_id=gh-app-id"));
+        assert!(url.contains("scope=user%3Aemail"));
+        assert!(url.contains("code_challenge_method=S256"));
     }
 
     #[tokio::test]

--- a/crates/api/src/domain/auth/backend/oauth.rs
+++ b/crates/api/src/domain/auth/backend/oauth.rs
@@ -82,6 +82,13 @@ pub struct OAuthStateEntry {
     pub expires_at: u64,
     /// Set on first `complete` call to prevent replay.
     pub consumed: bool,
+    /// Handler-derived redirect_uri persisted at `start_oauth` time
+    /// so `complete_oauth` can re-verify it against the user's
+    /// callback per ADR-0085 REQ-oauth-003 Scenario 3.10
+    /// (`public_url_changed_mid_flow` defense). `None` for entries
+    /// minted before PR-3 wired the field (left to support legacy
+    /// test fixtures that constructed the entry directly).
+    pub redirect_uri: Option<String>,
 }
 
 /// PKCE pair — `state` plus `code_verifier`/`code_challenge`.

--- a/crates/api/src/domain/auth/backend/pg.rs
+++ b/crates/api/src/domain/auth/backend/pg.rs
@@ -159,6 +159,19 @@ pub struct PgAuthBackend {
     /// from operator dashboards; tests that don't exercise the emission
     /// seam pass `None`.
     metrics: Option<Arc<MetricsRegistry>>,
+    /// Operator-supplied OAuth providers config (Plane A). Defaults
+    /// to empty per `OAuthProvidersConfig::default()` so backends
+    /// constructed without an explicit `with_oauth_providers` call
+    /// behave as if no provider is declared (start_oauth returns
+    /// `ProviderNotConfigured`, matching the boot fail-closed
+    /// posture of REQ-compose-001 Invariant 1). Production
+    /// composition root wires it from `api_config.auth.oauth`.
+    ///
+    /// Wrapped in `Arc` because the backend itself is wrapped in an
+    /// `Arc<dyn AuthBackend>` and the config is read-only at runtime
+    /// — sharing one allocation across the backend's clones avoids
+    /// repeated deep-copies of the secrets map.
+    oauth_providers: Arc<crate::config::OAuthProvidersConfig>,
 }
 
 impl PgAuthBackend {
@@ -186,7 +199,23 @@ impl PgAuthBackend {
             pool,
             email_port,
             metrics,
+            oauth_providers: Arc::new(crate::config::OAuthProvidersConfig::default()),
         }
+    }
+
+    /// Attach the operator OAuth providers config. Composition root
+    /// calls this with `Arc::new(api_config.auth.oauth.clone())` so
+    /// the backend can serve real authorize URLs (PR-3) and complete
+    /// OAuth flows (PR-4). Tests skip this when they don't exercise
+    /// OAuth — the default empty config makes start_oauth return
+    /// `ProviderNotConfigured` for any provider.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_oauth_providers(
+        mut self,
+        providers: Arc<crate::config::OAuthProvidersConfig>,
+    ) -> Self {
+        self.oauth_providers = providers;
+        self
     }
 
     /// Wrap into an `Arc<dyn AuthBackend>` for [`crate::AppState`].
@@ -1024,46 +1053,87 @@ impl AuthBackend for PgAuthBackend {
         .await
     }
 
-    #[tracing::instrument(level = "info", skip(self), fields(provider = %provider.as_str()))]
-    // PR-2 T2.9: trait sig gained `redirect_uri: &str`. PR-3 wires it
-    // into the AuthorizationUriRequest + persists into the
-    // OAuthStateRow; for now the param is accepted and ignored so the
-    // trait compiles — behavior is still the synthetic URL until PR-3.
+    #[tracing::instrument(level = "info", skip(self, redirect_uri), fields(provider = %provider.as_str()))]
+    // PR-3 T3.8 GREEN: rewrite to emit a REAL authorize URL via
+    // `flow::build_authorization_uri` after resolving the provider's
+    // endpoints (Oidc → discovery doc cache; Manual → operator
+    // config). Replaces the synthetic `https://nebula.local/...`
+    // placeholder from before PR-3.
     async fn start_oauth(
         &self,
         provider: OAuthProvider,
-        _redirect_uri: &str,
+        redirect_uri: &str,
     ) -> Result<OAuthStart, AuthError> {
+        use secrecy::ExposeSecret;
+
+        use crate::transport::oauth::{
+            discovery::resolve_provider_endpoints,
+            flow::{AuthorizationUriRequest, build_authorization_uri},
+        };
+
         let provider_label = metrics_emit::oauth_provider_label(provider);
+        let redirect_uri = redirect_uri.to_owned();
+        let oauth_providers = Arc::clone(&self.oauth_providers);
         metrics_emit::run_with_metrics(
             &self.metrics,
             NEBULA_API_AUTH_OAUTH_ATTEMPTS_TOTAL,
             Some(provider_label),
             async move {
+                // Step 1: lookup the operator config for `provider`;
+                // 503 ProviderNotConfigured per ADR-0085 D-6 if absent.
+                let provider_cfg = oauth_providers.providers.get(&provider).ok_or_else(|| {
+                    AuthError::ProviderNotConfigured {
+                        provider: provider.as_str().to_owned(),
+                    }
+                })?;
+
+                // Step 2: resolve endpoints (Oidc → discovery cache;
+                // Manual → operator config). Any SSRF / fetch failure
+                // bubbles up as AuthError::OAuthFailed with the
+                // typed DiscoveryError formatted.
+                let endpoints = resolve_provider_endpoints(
+                    provider_cfg,
+                    oauth_providers.oauth_allow_insecure_localhost,
+                )
+                .await
+                .map_err(|e| AuthError::OAuthFailed(e.to_string()))?;
+
+                // Step 3: mint PKCE pair.
                 let pkce = mint_pkce()?;
-        // Synthetic authorize URL (same shape the in-memory backend
-        // uses) — real provider config (client_id/secret, token
-        // endpoint) is deferred to a follow-up. See `complete_oauth`
-        // for the `NotImplemented` punt.
-        let authorize_url = format!(
-            "https://nebula.local/oauth/{}/authorize?state={}&code_challenge={}&code_challenge_method=S256",
-            provider.as_str(),
-            pkce.state,
-            pkce.code_challenge,
-        );
-        let now = Utc::now();
-        let expires_at = now + chrono_duration(OAUTH_STATE_TTL)?;
+
+                // Step 4: build the authorize URL with PKCE S256
+                // params. `build_authorization_uri` is the same
+                // helper Plane-B uses, ensuring uniform query-string
+                // construction across the two planes.
+                let auth_req = AuthorizationUriRequest {
+                    auth_url: endpoints.authorize_url.clone(),
+                    token_url: endpoints.token_url.clone(),
+                    client_id: provider_cfg.client_id.expose_secret().to_owned(),
+                    client_secret: provider_cfg.client_secret.expose_secret().to_owned(),
+                    redirect_uri: redirect_uri.clone(),
+                    scopes: Some(endpoints.scopes.clone()),
+                    auth_style: None,
+                };
+                let authorize_url =
+                    build_authorization_uri(&auth_req, &pkce.state, &pkce.code_challenge)
+                        .map_err(|e| {
+                            AuthError::OAuthFailed(format!(
+                                "authorize URL construction failed: {e}"
+                            ))
+                        })?
+                        .to_string();
+
+                // Step 5: persist the OAuth state row with the
+                // handler-derived redirect_uri so complete_oauth can
+                // re-verify it (Scenario 3.10 public_url_changed_mid_flow).
+                let now = Utc::now();
+                let expires_at = now + chrono_duration(OAUTH_STATE_TTL)?;
                 self.oauth_state_repo
                     .create(&OAuthStateRow {
                         state: pkce.state.clone(),
                         provider: provider.as_str().to_owned(),
                         code_verifier: pkce.code_verifier,
-                        // `redirect_uri = None`: the `AuthBackend::start_oauth`
-                        // trait signature does not yet accept a `redirect_uri`
-                        // parameter. The column stays correctly nullable; a
-                        // future trait-signature change picks it up without a
-                        // migration.
-                        redirect_uri: None,
+                        redirect_uri: Some(redirect_uri),
                         created_at: now,
                         expires_at,
                         consumed_at: None,

--- a/crates/api/src/domain/auth/backend/pg.rs
+++ b/crates/api/src/domain/auth/backend/pg.rs
@@ -1146,7 +1146,16 @@ impl AuthBackend for PgAuthBackend {
             },
             |result| match result {
                 Ok(_) => auth_outcome::SUCCESS,
-                Err(AuthError::OAuthFailed(_)) => auth_outcome::OAUTH_FAILED,
+                // PR-3 wave-2 (CodeRabbit G.5): classify the new
+                // fail-closed `ProviderNotConfigured` variant as
+                // OAUTH_FAILED in the inline closure too, mirroring
+                // the `default_outcome_for` table in error.rs. Without
+                // this, an unconfigured-provider error gets the
+                // `internal` label and looks like a server bug in
+                // dashboards instead of a deployment-state issue.
+                Err(AuthError::OAuthFailed(_) | AuthError::ProviderNotConfigured { .. }) => {
+                    auth_outcome::OAUTH_FAILED
+                },
                 Err(_) => auth_outcome::INTERNAL,
             },
         )

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -91,7 +91,12 @@ pub fn oauth_token_http_client_test_unchecked() -> &'static reqwest::Client {
 pub async fn fetch_oidc_discovery_unchecked(
     url: &str,
 ) -> Result<OidcDiscovery, FetchDiscoveryError> {
-    crate::transport::oauth::discovery::fetch_oidc_discovery(url, true).await
+    // Per Codex / Copilot wave-1 PR-3 review: must skip the strict
+    // gate on the discovery URL itself so wiremock on `127.0.0.1`
+    // works; production `fetch_oidc_discovery` always strict-gates
+    // the discovery URL. Body cap / disabled redirects / child-URL
+    // re-validation all stay in force.
+    crate::transport::oauth::discovery::fetch_oidc_discovery_skipping_url_gate(url, true).await
 }
 
 /// Test-only: clear the process-wide discovery cache so tests can

--- a/crates/api/src/test_support.rs
+++ b/crates/api/src/test_support.rs
@@ -64,34 +64,39 @@ pub fn oauth_token_http_client_test_unchecked() -> &'static reqwest::Client {
     oauth_token_http_client()
 }
 
-/// Failure modes for [`fetch_oidc_discovery_unchecked`].
+/// Test-only OIDC discovery fetcher: same code path as production but
+/// with `oauth_allow_insecure_localhost = true` forced so wiremock
+/// listeners on `127.0.0.1`/`localhost` are accepted by the
+/// flag-aware gate on the discovery-returned authorize URL.
 ///
-/// Typed (not stringly) error per the public-API discipline — tests
-/// can `match` on a variant instead of substring-grepping a message.
-/// PR-3 lands the real fetch behavior; this typed shape is forward-
-/// compatible.
-#[derive(Debug, Error)]
-pub enum DiscoveryUncheckedError {
-    /// The discovery fetch is not yet wired up. Returned by the PR-2
-    /// placeholder; PR-3 replaces this variant with real fetch / parse
-    /// errors.
-    #[error(
-        "fetch_oidc_discovery_unchecked: PR-3 has not yet landed (openspec T3.1); the placeholder always returns this variant"
-    )]
-    PlaceholderUntilPr3,
-}
-
-/// Placeholder for the OIDC discovery doc fetcher bypass, to be wired
-/// in PR-3 once `crates/api/src/transport/oauth/discovery.rs` lands
-/// per T3.1. Defined here in PR-2 so the integration test crate has a
-/// stable module path to import. Returns
-/// [`DiscoveryUncheckedError::PlaceholderUntilPr3`] until PR-3 fills it
-/// in.
+/// Server-side fetched URLs (token / userinfo / jwks) still go through
+/// the STRICT `validate_oauth_outbound_url` gate — wiremock setups
+/// MUST publish endpoint URLs as HTTPS-with-self-signed-cert when
+/// using this helper for end-to-end fixtures. Most integration
+/// fixtures point the discovery doc at a wiremock-served
+/// `.well-known/openid-configuration` whose returned
+/// `authorization_endpoint` is `http://localhost:PORT/authorize` and
+/// whose `token_endpoint` / `userinfo_endpoint` go through
+/// `oauth_token_http_client_test_unchecked` (which bypasses
+/// `validate_oauth_outbound_url` entirely).
+///
+/// PR-3 wire-up: was a `PlaceholderUntilPr3` placeholder; now
+/// delegates to the real cache.
 ///
 /// # Errors
 ///
-/// Always returns `Err(PlaceholderUntilPr3)` until PR-3 lands the
-/// discovery cache.
-pub async fn fetch_oidc_discovery_unchecked(_url: &str) -> Result<(), DiscoveryUncheckedError> {
-    Err(DiscoveryUncheckedError::PlaceholderUntilPr3)
+/// Returns the same [`FetchDiscoveryError`] (alias of
+/// `crate::transport::oauth::discovery::DiscoveryError`) as the
+/// production path.
+pub async fn fetch_oidc_discovery_unchecked(
+    url: &str,
+) -> Result<OidcDiscovery, FetchDiscoveryError> {
+    crate::transport::oauth::discovery::fetch_oidc_discovery(url, true).await
+}
+
+/// Test-only: clear the process-wide discovery cache so tests can
+/// exercise the fetch path repeatedly without cross-test
+/// contamination.
+pub fn clear_discovery_cache_for_tests() {
+    crate::transport::oauth::discovery::clear_discovery_cache_for_tests();
 }

--- a/crates/api/src/transport/oauth/discovery.rs
+++ b/crates/api/src/transport/oauth/discovery.rs
@@ -1,0 +1,272 @@
+//! OIDC discovery doc fetcher + process-lifetime cache.
+//!
+//! Per ADR-0085 D-15-WAVE6: when an OAuth provider declares
+//! `endpoints = { kind = "oidc", discovery_url = "..." }` in operator
+//! config, Nebula resolves the real endpoints (authorize / token /
+//! userinfo / jwks) by fetching the IdP's
+//! `.well-known/openid-configuration` document at first
+//! `start_oauth` time and caches the result for the process lifetime
+//! (single-process cache; multi-replica deployments re-fetch per
+//! replica, which is fine — discovery docs change rarely and a stale
+//! cache is upper-bounded by process restart cadence).
+//!
+//! ## Anti-SSRF gates (D-9-WAVE6 + F.2 wave-7 split)
+//!
+//! `fetch_oidc_discovery` runs the strict
+//! [`validate_oauth_outbound_url`] gate on:
+//! - The `discovery_url` itself (server-side GET).
+//! - Each child URL RETURNED in the parsed discovery JSON
+//!   (`token_url` / `userinfo_url` / `jwks_url` when present) before
+//!   the cache insert.
+//!
+//! And the flag-aware [`validate_oauth_authorize_url`] gate on the
+//! discovery-returned `authorize_url` (browser-fetched; honors the
+//! `oauth_allow_insecure_localhost` flag in dev builds only).
+//!
+//! ANY child URL rejection skips the cache insert and returns
+//! [`DiscoveryError::EndpointSsrfRejected`] — no partial cache
+//! entries.
+
+use std::sync::OnceLock;
+use std::time::Duration;
+
+use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use super::flow::{validate_oauth_authorize_url, validate_oauth_outbound_url};
+use super::http::oauth_token_http_client;
+
+/// Time budget for the discovery doc GET. Matches the token-endpoint
+/// 5000ms default per REQ-obs-001; the discovery doc is small JSON
+/// and shouldn't take longer.
+const DISCOVERY_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Parsed `.well-known/openid-configuration` document. Only the four
+/// fields Plane A consumes are deserialized; unknown fields are
+/// ignored (per the OIDC discovery spec which says clients SHOULD
+/// gracefully handle additional metadata).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcDiscovery {
+    /// OAuth authorize endpoint. Browser-fetched at `start_oauth`
+    /// time. Validated by the flag-aware gate per F.2 wave-7.
+    #[serde(rename = "authorization_endpoint")]
+    pub authorize_url: String,
+    /// OAuth token endpoint. Server-fetched at `complete_oauth` time.
+    /// Validated by the strict gate.
+    #[serde(rename = "token_endpoint")]
+    pub token_url: String,
+    /// Userinfo endpoint. Server-fetched at `complete_oauth` time
+    /// with `Authorization: Bearer <access_token>`. Authoritative for
+    /// `(email, sub)` per ADR-0085 D-16 (id_token JWKS validation
+    /// deferred to 1.1). Validated by the strict gate.
+    #[serde(rename = "userinfo_endpoint")]
+    pub userinfo_url: String,
+    /// Optional JWKS URL. Validated by the strict gate when present.
+    /// Accepted for 1.1 forward compat; PR-4 logs id_token presence
+    /// only and does NOT verify signatures in 1.0.
+    #[serde(default, rename = "jwks_uri")]
+    pub jwks_url: Option<String>,
+}
+
+/// Process-wide cache keyed by the operator-configured `discovery_url`.
+/// Single-process scope — multi-replica deployments re-fetch per
+/// replica on first use. Stale-cache risk is bounded by process
+/// restart cadence; discovery docs change rarely. No TTL: a cached
+/// entry lives until the process restarts.
+static DISCOVERY_CACHE: OnceLock<DashMap<String, OidcDiscovery>> = OnceLock::new();
+
+fn cache() -> &'static DashMap<String, OidcDiscovery> {
+    DISCOVERY_CACHE.get_or_init(DashMap::new)
+}
+
+/// Failure modes for [`fetch_oidc_discovery`].
+#[derive(Debug, Error)]
+pub enum DiscoveryError {
+    /// Strict gate rejected the `discovery_url` before any HTTP call.
+    /// Caller typo or unsafe operator config — operator must fix
+    /// `API_AUTH_OAUTH_<PROVIDER>_DISCOVERY_URL`.
+    #[error("OIDC discovery URL `{url}` rejected by anti-SSRF gate: {reason}")]
+    DiscoveryUrlRejected {
+        /// The rejected URL.
+        url: String,
+        /// Reason from `validate_oauth_outbound_url`.
+        reason: String,
+    },
+    /// Network or HTTP-level failure during the discovery doc GET.
+    #[error("OIDC discovery fetch failed for `{url}`: {source}")]
+    HttpError {
+        /// The URL being fetched.
+        url: String,
+        /// Underlying `reqwest` error.
+        #[source]
+        source: reqwest::Error,
+    },
+    /// Non-200 response from the IdP discovery endpoint.
+    #[error("OIDC discovery `{url}` returned HTTP {status}")]
+    NonSuccessStatus {
+        /// The URL being fetched.
+        url: String,
+        /// HTTP status code.
+        status: u16,
+    },
+    /// Response body did not deserialize to [`OidcDiscovery`].
+    /// Either malformed JSON or missing one of the required fields
+    /// (`authorization_endpoint` / `token_endpoint` / `userinfo_endpoint`).
+    #[error("OIDC discovery `{url}` body parse failed: {source}")]
+    ParseError {
+        /// The URL being fetched.
+        url: String,
+        /// Underlying serde error.
+        #[source]
+        source: serde_json::Error,
+    },
+    /// A URL RETURNED in the discovery response failed the post-fetch
+    /// SSRF re-validation (D-15-WAVE6). Hostile / misconfigured IdP
+    /// tried to point Nebula at an internal address via the
+    /// discovery channel.
+    #[error(
+        "OIDC discovery from `{discovery_url}` returned an unsafe child URL for `{field}`: {reason}"
+    )]
+    EndpointSsrfRejected {
+        /// The discovery_url that was fetched.
+        discovery_url: String,
+        /// Which child field failed (`authorize_url` / `token_url` /
+        /// `userinfo_url` / `jwks_url`).
+        field: &'static str,
+        /// Reason from the validator.
+        reason: String,
+    },
+}
+
+/// Fetch and cache the OIDC discovery document for `url`.
+///
+/// Steps per ADR-0085 D-15-WAVE6:
+/// 1. Strict-gate the `discovery_url` itself.
+/// 2. Cache hit returns immediately.
+/// 3. GET via shared `oauth_token_http_client()` with a 5s timeout.
+/// 4. Parse JSON into [`OidcDiscovery`].
+/// 5. Validate each child URL per its threat model
+///    (strict for token / userinfo / jwks; flag-aware for authorize).
+/// 6. Cache insert + return.
+///
+/// `oauth_allow_insecure_localhost` is the operator's
+/// `API_AUTH_OAUTH_ALLOW_INSECURE_LOCALHOST` flag (relaxes
+/// `http://localhost` for the discovery-returned authorize URL ONLY
+/// in dev builds).
+///
+/// # Errors
+///
+/// Returns [`DiscoveryError`] on any of the steps above. The cache
+/// stays empty for the failed URL so a retry after the operator
+/// fixes the issue takes effect immediately.
+pub async fn fetch_oidc_discovery(
+    url: &str,
+    oauth_allow_insecure_localhost: bool,
+) -> Result<OidcDiscovery, DiscoveryError> {
+    // Step 1: strict gate on the discovery URL itself.
+    validate_oauth_outbound_url(url).map_err(|reason| DiscoveryError::DiscoveryUrlRejected {
+        url: url.to_owned(),
+        reason,
+    })?;
+
+    // Step 2: cache check (entry lives until process restart).
+    if let Some(cached) = cache().get(url) {
+        return Ok(cached.clone());
+    }
+
+    // Step 3: GET with bounded timeout via the shared OAuth HTTP
+    // client (per ADR-0085 D-7: same client + policy as token POST).
+    let response = oauth_token_http_client()
+        .get(url)
+        .timeout(DISCOVERY_FETCH_TIMEOUT)
+        .send()
+        .await
+        .map_err(|source| DiscoveryError::HttpError {
+            url: url.to_owned(),
+            source,
+        })?;
+    let status = response.status();
+    if !status.is_success() {
+        return Err(DiscoveryError::NonSuccessStatus {
+            url: url.to_owned(),
+            status: status.as_u16(),
+        });
+    }
+    let body = response
+        .bytes()
+        .await
+        .map_err(|source| DiscoveryError::HttpError {
+            url: url.to_owned(),
+            source,
+        })?;
+
+    // Step 4: parse JSON.
+    let discovery: OidcDiscovery =
+        serde_json::from_slice(&body).map_err(|source| DiscoveryError::ParseError {
+            url: url.to_owned(),
+            source,
+        })?;
+
+    // Step 5: re-validate each returned child URL per its threat
+    // model. ANY failure aborts cache insert.
+    //
+    // The browser-fetched authorize URL goes through the flag-aware
+    // gate so a localhost IdP works in dev when the operator opts in.
+    // Production builds (`!cfg!(debug_assertions)`) reject the flag's
+    // effect inside the validator itself; we just pass `false` for
+    // `in_release_build` since this call site is server-side
+    // discovery cache (boot/runtime) and the flag-aware behaviour is
+    // already encoded in the validator function.
+    let in_release_build = !cfg!(debug_assertions);
+    validate_oauth_authorize_url(
+        &discovery.authorize_url,
+        oauth_allow_insecure_localhost,
+        in_release_build,
+    )
+    .map_err(|reason| DiscoveryError::EndpointSsrfRejected {
+        discovery_url: url.to_owned(),
+        field: "authorize_url",
+        reason,
+    })?;
+    validate_oauth_outbound_url(&discovery.token_url).map_err(|reason| {
+        DiscoveryError::EndpointSsrfRejected {
+            discovery_url: url.to_owned(),
+            field: "token_url",
+            reason,
+        }
+    })?;
+    validate_oauth_outbound_url(&discovery.userinfo_url).map_err(|reason| {
+        DiscoveryError::EndpointSsrfRejected {
+            discovery_url: url.to_owned(),
+            field: "userinfo_url",
+            reason,
+        }
+    })?;
+    if let Some(ref jwks_url) = discovery.jwks_url {
+        validate_oauth_outbound_url(jwks_url).map_err(|reason| {
+            DiscoveryError::EndpointSsrfRejected {
+                discovery_url: url.to_owned(),
+                field: "jwks_url",
+                reason,
+            }
+        })?;
+    }
+
+    // Step 6: cache insert + return.
+    cache().insert(url.to_owned(), discovery.clone());
+    Ok(discovery)
+}
+
+/// Test-only: clear the cache so tests can exercise the fetch path
+/// without inter-test contamination. `pub(crate)` so the unit-test
+/// module + the `nebula_test_util` cfg-gated `test_support` module
+/// can reach it.
+#[cfg(any(test, nebula_test_util))]
+#[allow(
+    dead_code,
+    reason = "surfaced only through the test_support cfg-gated re-export; in regular `cargo test` the inner cache is not yet exercised"
+)]
+pub(crate) fn clear_discovery_cache_for_tests() {
+    cache().clear();
+}

--- a/crates/api/src/transport/oauth/discovery.rs
+++ b/crates/api/src/transport/oauth/discovery.rs
@@ -258,6 +258,72 @@ pub async fn fetch_oidc_discovery(
     Ok(discovery)
 }
 
+/// Resolved authorize / token / userinfo / scopes triple from an
+/// [`OAuthProviderConfig`]. The OAuth `start_oauth` and
+/// `complete_oauth` paths consume this uniformly regardless of
+/// whether the provider is configured as Oidc or Manual.
+///
+/// PR-3 consumes `authorize_url` + `scopes` for the authorize-URL
+/// emission; PR-4 consumes `token_url` + `userinfo_url` for the
+/// code exchange + userinfo lookup.
+#[derive(Debug, Clone)]
+pub struct ResolvedEndpoints {
+    /// Browser-fetched authorize URL.
+    pub authorize_url: String,
+    /// Server-side token endpoint URL.
+    pub token_url: String,
+    /// Server-side userinfo endpoint URL.
+    pub userinfo_url: String,
+    /// Optional second userinfo endpoint for verified-email lookup
+    /// (e.g. GitHub's `/user/emails`). PR-4 consumes when `Some`.
+    pub verified_emails_url: Option<String>,
+    /// Space-joined scopes string for the authorize URL.
+    pub scopes: String,
+}
+
+/// Resolve a provider's endpoints into the runtime-uniform
+/// [`ResolvedEndpoints`] shape. For Oidc providers this fetches the
+/// discovery doc (cache-served after first hit) and runs the
+/// post-fetch SSRF re-validation; for Manual providers it returns
+/// the operator-configured URLs as-is (already validated at boot).
+///
+/// # Errors
+///
+/// Returns the underlying [`DiscoveryError`] for Oidc providers when
+/// the discovery doc fetch or post-fetch validation fails.
+pub async fn resolve_provider_endpoints(
+    cfg: &crate::config::OAuthProviderConfig,
+    oauth_allow_insecure_localhost: bool,
+) -> Result<ResolvedEndpoints, DiscoveryError> {
+    use crate::config::OAuthEndpoints;
+
+    match &cfg.endpoints {
+        OAuthEndpoints::Oidc { discovery_url } => {
+            let doc = fetch_oidc_discovery(discovery_url, oauth_allow_insecure_localhost).await?;
+            Ok(ResolvedEndpoints {
+                authorize_url: doc.authorize_url,
+                token_url: doc.token_url,
+                userinfo_url: doc.userinfo_url,
+                verified_emails_url: None,
+                scopes: cfg.endpoints.scopes().join(" "),
+            })
+        },
+        OAuthEndpoints::Manual {
+            authorize_url,
+            token_url,
+            userinfo_url,
+            verified_emails_url,
+            ..
+        } => Ok(ResolvedEndpoints {
+            authorize_url: authorize_url.clone(),
+            token_url: token_url.clone(),
+            userinfo_url: userinfo_url.clone(),
+            verified_emails_url: verified_emails_url.clone(),
+            scopes: cfg.endpoints.scopes().join(" "),
+        }),
+    }
+}
+
 /// Test-only: clear the cache so tests can exercise the fetch path
 /// without inter-test contamination. `pub(crate)` so the unit-test
 /// module + the `nebula_test_util` cfg-gated `test_support` module

--- a/crates/api/src/transport/oauth/discovery.rs
+++ b/crates/api/src/transport/oauth/discovery.rs
@@ -31,16 +31,46 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use dashmap::DashMap;
+use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use super::flow::{validate_oauth_authorize_url, validate_oauth_outbound_url};
-use super::http::oauth_token_http_client;
 
 /// Time budget for the discovery doc GET. Matches the token-endpoint
 /// 5000ms default per REQ-obs-001; the discovery doc is small JSON
 /// and shouldn't take longer.
 const DISCOVERY_FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Response body cap for OIDC discovery (256 KiB).
+///
+/// Mirrors [`super::http::OAUTH_TOKEN_HTTP_MAX_RESPONSE_BYTES`] so a
+/// hostile / misconfigured IdP cannot DoS the server by serving an
+/// unbounded JSON blob through the discovery channel. Real discovery
+/// docs are small (~2-10 KiB).
+const DISCOVERY_MAX_RESPONSE_BYTES: usize = 256 * 1024;
+
+/// HTTP client used ONLY for OIDC discovery fetches.
+///
+/// Separate from [`super::http::oauth_token_http_client`] because
+/// discovery has a stricter posture:
+/// - **Redirects disabled** (`Policy::none()`): a valid HTTPS
+///   `discovery_url` cannot be allowed to redirect Nebula to
+///   `http://localhost` / a private IP. Without redirects there is
+///   no post-validation TOCTOU surface (Copilot wave-1 review).
+/// - Same connect / read timeouts as the token client.
+static OAUTH_DISCOVERY_HTTP_CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+
+fn oauth_discovery_http_client() -> &'static reqwest::Client {
+    OAUTH_DISCOVERY_HTTP_CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(DISCOVERY_FETCH_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("nebula: oauth discovery http client must build")
+    })
+}
 
 /// Parsed `.well-known/openid-configuration` document. Only the four
 /// fields Plane A consumes are deserialized; unknown fields are
@@ -121,6 +151,17 @@ pub enum DiscoveryError {
         #[source]
         source: serde_json::Error,
     },
+    /// Discovery response body exceeded the
+    /// `DISCOVERY_MAX_RESPONSE_BYTES` ceiling (256 KiB). Hostile / misconfigured
+    /// IdP tried to serve an unbounded JSON blob through the discovery
+    /// channel.
+    #[error("OIDC discovery `{url}` body exceeded {max} bytes")]
+    BodyTooLarge {
+        /// The URL being fetched.
+        url: String,
+        /// The byte cap that was hit.
+        max: usize,
+    },
     /// A URL RETURNED in the discovery response failed the post-fetch
     /// SSRF re-validation (D-15-WAVE6). Hostile / misconfigured IdP
     /// tried to point Nebula at an internal address via the
@@ -164,22 +205,62 @@ pub async fn fetch_oidc_discovery(
     url: &str,
     oauth_allow_insecure_localhost: bool,
 ) -> Result<OidcDiscovery, DiscoveryError> {
-    // Step 1: strict gate on the discovery URL itself.
-    validate_oauth_outbound_url(url).map_err(|reason| DiscoveryError::DiscoveryUrlRejected {
-        url: url.to_owned(),
-        reason,
-    })?;
+    fetch_oidc_discovery_inner(url, oauth_allow_insecure_localhost, true).await
+}
+
+/// Test-only escape hatch (gated by `#[cfg(any(test, nebula_test_util))]`)
+/// that runs the same fetch flow but **skips** the strict gate on the
+/// `discovery_url` itself — so wiremock fixtures on `127.0.0.1` can
+/// publish a `.well-known/openid-configuration` URL.
+///
+/// Per Codex / Copilot wave-1 review: the PR-2 `fetch_oidc_discovery_unchecked`
+/// shim that just delegated to the production path was broken for the
+/// documented localhost wiremock use case because the discovery URL
+/// itself was rejected before the discovery JSON could even be
+/// fetched. This split fixes that while preserving:
+/// - Bounded body cap (256 KiB).
+/// - Disabled redirects.
+/// - Post-fetch child-URL re-validation — with the flag-aware
+///   authorize gate threaded through so the discovery-served
+///   `authorize_url` can be `http://localhost:PORT/...` in dev.
+/// - Strict gate on token / userinfo / jwks (those are server-side
+///   fetches; wiremock fixtures MUST serve HTTPS-with-self-signed-cert
+///   for them OR the test reaches them via `oauth_token_http_client_test_unchecked`).
+#[cfg(any(test, nebula_test_util))]
+pub async fn fetch_oidc_discovery_skipping_url_gate(
+    url: &str,
+    oauth_allow_insecure_localhost: bool,
+) -> Result<OidcDiscovery, DiscoveryError> {
+    fetch_oidc_discovery_inner(url, oauth_allow_insecure_localhost, false).await
+}
+
+async fn fetch_oidc_discovery_inner(
+    url: &str,
+    oauth_allow_insecure_localhost: bool,
+    gate_discovery_url: bool,
+) -> Result<OidcDiscovery, DiscoveryError> {
+    // Step 1: strict gate on the discovery URL itself — unless the
+    // test-only bypass set `gate_discovery_url = false` so wiremock
+    // can serve the doc from `127.0.0.1`.
+    if gate_discovery_url {
+        validate_oauth_outbound_url(url).map_err(|reason| {
+            DiscoveryError::DiscoveryUrlRejected {
+                url: url.to_owned(),
+                reason,
+            }
+        })?;
+    }
 
     // Step 2: cache check (entry lives until process restart).
     if let Some(cached) = cache().get(url) {
         return Ok(cached.clone());
     }
 
-    // Step 3: GET with bounded timeout via the shared OAuth HTTP
-    // client (per ADR-0085 D-7: same client + policy as token POST).
-    let response = oauth_token_http_client()
+    // Step 3: GET with bounded timeout via the discovery-only client
+    // (redirects disabled per Copilot wave-1: a valid HTTPS
+    // discovery_url MUST NOT redirect us to an unvalidated host).
+    let response = oauth_discovery_http_client()
         .get(url)
-        .timeout(DISCOVERY_FETCH_TIMEOUT)
         .send()
         .await
         .map_err(|source| DiscoveryError::HttpError {
@@ -193,17 +274,39 @@ pub async fn fetch_oidc_discovery(
             status: status.as_u16(),
         });
     }
-    let body = response
-        .bytes()
-        .await
-        .map_err(|source| DiscoveryError::HttpError {
+
+    // Body size cap (Copilot wave-1): mirror the token POST 256 KiB
+    // ceiling so a hostile IdP cannot serve an unbounded JSON blob
+    // through the discovery channel. Streaming check covers both
+    // `Content-Length`-honest and chunked-no-length adversarial
+    // responses.
+    if let Some(claimed) = response.content_length()
+        && claimed > DISCOVERY_MAX_RESPONSE_BYTES as u64
+    {
+        return Err(DiscoveryError::BodyTooLarge {
+            url: url.to_owned(),
+            max: DISCOVERY_MAX_RESPONSE_BYTES,
+        });
+    }
+    let mut buf: Vec<u8> = Vec::new();
+    let mut stream = response.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|source| DiscoveryError::HttpError {
             url: url.to_owned(),
             source,
         })?;
+        if buf.len().saturating_add(chunk.len()) > DISCOVERY_MAX_RESPONSE_BYTES {
+            return Err(DiscoveryError::BodyTooLarge {
+                url: url.to_owned(),
+                max: DISCOVERY_MAX_RESPONSE_BYTES,
+            });
+        }
+        buf.extend_from_slice(&chunk);
+    }
 
     // Step 4: parse JSON.
     let discovery: OidcDiscovery =
-        serde_json::from_slice(&body).map_err(|source| DiscoveryError::ParseError {
+        serde_json::from_slice(&buf).map_err(|source| DiscoveryError::ParseError {
             url: url.to_owned(),
             source,
         })?;
@@ -259,7 +362,9 @@ pub async fn fetch_oidc_discovery(
 }
 
 /// Resolved authorize / token / userinfo / scopes triple from an
-/// [`OAuthProviderConfig`]. The OAuth `start_oauth` and
+/// `OAuthProviderConfig` (intentional bare-name to avoid an intra-doc
+/// link target that's outside this module's scope). The OAuth
+/// `start_oauth` and
 /// `complete_oauth` paths consume this uniformly regardless of
 /// whether the provider is configured as Oidc or Manual.
 ///
@@ -335,4 +440,154 @@ pub async fn resolve_provider_endpoints(
 )]
 pub(crate) fn clear_discovery_cache_for_tests() {
     cache().clear();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::sync::OnceLock;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+
+    /// Wave-1 Copilot: cover the strict gate that rejects unsafe
+    /// discovery URLs BEFORE any HTTP call.
+    #[tokio::test]
+    async fn discovery_rejects_unsafe_discovery_url_via_strict_gate() {
+        let err = fetch_oidc_discovery("http://10.0.0.5/.well-known/openid-configuration", false)
+            .await
+            .expect_err("HTTP + private IP must be rejected");
+        assert!(matches!(err, DiscoveryError::DiscoveryUrlRejected { .. }));
+    }
+
+    /// Spin up a tiny TCP listener that responds with a fixed HTTP/1.1
+    /// payload to the first request. Returns the bound URL.
+    async fn spawn_oneshot_responder(payload: Vec<u8>) -> String {
+        // Use a guaranteed-unique env-derived test target so this
+        // function works under concurrent nextest runs.
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let url = format!("http://{addr}/.well-known/openid-configuration");
+
+        tokio::spawn(async move {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // Drain request line (best-effort; small).
+                let mut throwaway = [0u8; 4096];
+                let _ = tokio::io::AsyncReadExt::read(&mut sock, &mut throwaway).await;
+                let _ = sock.write_all(&payload).await;
+                let _ = sock.shutdown().await;
+            }
+        });
+
+        url
+    }
+
+    fn http_response_with_body(body: &[u8]) -> Vec<u8> {
+        let mut out = Vec::new();
+        write!(
+            &mut out,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        )
+        .unwrap();
+        out.extend_from_slice(body);
+        out
+    }
+
+    /// Wave-1 Copilot E.5: cover the cache-hit path and the post-fetch
+    /// child-URL validation.
+    ///
+    /// Uses the `fetch_oidc_discovery_skipping_url_gate` test bypass
+    /// to point at `127.0.0.1` (production gate would reject the
+    /// loopback discovery URL before any network call).
+    #[tokio::test]
+    async fn discovery_caches_doc_and_serves_subsequent_calls_from_cache() {
+        // Each test gets a fresh cache to avoid cross-test leakage.
+        static GUARD: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        let _lock = GUARD
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        clear_discovery_cache_for_tests();
+
+        let doc = serde_json::json!({
+            "authorization_endpoint": "https://login.example.com/oauth/authorize",
+            "token_endpoint": "https://login.example.com/oauth/token",
+            "userinfo_endpoint": "https://login.example.com/oauth/userinfo"
+        })
+        .to_string();
+        let url = spawn_oneshot_responder(http_response_with_body(doc.as_bytes())).await;
+
+        // First call performs the actual GET.
+        let first = fetch_oidc_discovery_skipping_url_gate(&url, true)
+            .await
+            .expect("first fetch must succeed");
+        assert_eq!(first.token_url, "https://login.example.com/oauth/token");
+
+        // Second call returns the cached copy without spawning a
+        // second listener — verified by the fact that no second
+        // responder is running on the URL.
+        let second = fetch_oidc_discovery_skipping_url_gate(&url, true)
+            .await
+            .expect("second fetch must hit cache");
+        assert_eq!(second.token_url, first.token_url);
+    }
+
+    /// Wave-1 Copilot E.5: cover the post-fetch child-URL re-validation
+    /// when a discovery doc returns an unsafe internal-IP endpoint.
+    #[tokio::test]
+    async fn discovery_rejects_child_url_pointing_at_internal_ip() {
+        static GUARD: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        let _lock = GUARD
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        clear_discovery_cache_for_tests();
+
+        // Hostile discovery doc: valid authorize_url but internal-IP
+        // token_endpoint (post-fetch strict gate must reject).
+        let doc = serde_json::json!({
+            "authorization_endpoint": "https://login.example.com/oauth/authorize",
+            "token_endpoint": "http://10.0.0.5/internal-token",
+            "userinfo_endpoint": "https://login.example.com/oauth/userinfo"
+        })
+        .to_string();
+        let url = spawn_oneshot_responder(http_response_with_body(doc.as_bytes())).await;
+        let err = fetch_oidc_discovery_skipping_url_gate(&url, true)
+            .await
+            .expect_err("internal-IP child URL must be rejected");
+        match err {
+            DiscoveryError::EndpointSsrfRejected { field, .. } => {
+                assert_eq!(field, "token_url");
+            },
+            other => panic!("expected EndpointSsrfRejected, got: {other:?}"),
+        }
+    }
+
+    /// Wave-1 Copilot E.2: cover the body-size cap.
+    #[tokio::test]
+    async fn discovery_rejects_oversized_body_via_content_length() {
+        static GUARD: OnceLock<tokio::sync::Mutex<()>> = OnceLock::new();
+        let _lock = GUARD
+            .get_or_init(|| tokio::sync::Mutex::new(()))
+            .lock()
+            .await;
+        clear_discovery_cache_for_tests();
+
+        // Claim a body length over the 256 KiB cap. The gate trips
+        // before any chunk read.
+        let body_len = DISCOVERY_MAX_RESPONSE_BYTES + 1;
+        let mut response = Vec::new();
+        write!(
+            &mut response,
+            "HTTP/1.1 200 OK\r\nContent-Length: {body_len}\r\n\r\n"
+        )
+        .unwrap();
+        // No body bytes follow — we never get past the size gate.
+        let url = spawn_oneshot_responder(response).await;
+        let err = fetch_oidc_discovery_skipping_url_gate(&url, true)
+            .await
+            .expect_err("oversized Content-Length must be rejected");
+        assert!(matches!(err, DiscoveryError::BodyTooLarge { .. }));
+    }
 }

--- a/crates/api/src/transport/oauth/discovery.rs
+++ b/crates/api/src/transport/oauth/discovery.rs
@@ -99,14 +99,31 @@ pub struct OidcDiscovery {
     pub jwks_url: Option<String>,
 }
 
-/// Process-wide cache keyed by the operator-configured `discovery_url`.
-/// Single-process scope — multi-replica deployments re-fetch per
-/// replica on first use. Stale-cache risk is bounded by process
-/// restart cadence; discovery docs change rarely. No TTL: a cached
-/// entry lives until the process restarts.
-static DISCOVERY_CACHE: OnceLock<DashMap<String, OidcDiscovery>> = OnceLock::new();
+/// Composite cache key.
+///
+/// Per CodeRabbit wave-2 G.2: the cache MUST vary with the
+/// `oauth_allow_insecure_localhost` flag. A discovery doc whose
+/// `authorize_url` is `http://localhost` passes the flag-aware gate
+/// only when the flag is `true`. If the cache were keyed by URL
+/// alone, a flag=true fetch would populate the cache with a
+/// localhost-authorize entry, and a subsequent flag=false caller
+/// (which would have been rejected) would receive the cached unsafe
+/// value — a cross-flag cache-poisoning surface.
+#[derive(Hash, PartialEq, Eq, Clone)]
+struct DiscoveryCacheKey {
+    url: String,
+    allow_localhost: bool,
+}
 
-fn cache() -> &'static DashMap<String, OidcDiscovery> {
+/// Process-wide cache keyed by the operator-configured `discovery_url`
+/// AND the `oauth_allow_insecure_localhost` flag (CodeRabbit wave-2
+/// G.2 — see [`DiscoveryCacheKey`]). Single-process scope; multi-
+/// replica deployments re-fetch per replica on first use. Stale-cache
+/// risk is bounded by process restart cadence; discovery docs change
+/// rarely. No TTL: a cached entry lives until the process restarts.
+static DISCOVERY_CACHE: OnceLock<DashMap<DiscoveryCacheKey, OidcDiscovery>> = OnceLock::new();
+
+fn cache() -> &'static DashMap<DiscoveryCacheKey, OidcDiscovery> {
     DISCOVERY_CACHE.get_or_init(DashMap::new)
 }
 
@@ -252,7 +269,14 @@ async fn fetch_oidc_discovery_inner(
     }
 
     // Step 2: cache check (entry lives until process restart).
-    if let Some(cached) = cache().get(url) {
+    // Key includes `oauth_allow_insecure_localhost` per CodeRabbit
+    // wave-2 G.2 — see [`DiscoveryCacheKey`] for the poisoning
+    // scenario being defended against.
+    let key = DiscoveryCacheKey {
+        url: url.to_owned(),
+        allow_localhost: oauth_allow_insecure_localhost,
+    };
+    if let Some(cached) = cache().get(&key) {
         return Ok(cached.clone());
     }
 
@@ -356,8 +380,8 @@ async fn fetch_oidc_discovery_inner(
         })?;
     }
 
-    // Step 6: cache insert + return.
-    cache().insert(url.to_owned(), discovery.clone());
+    // Step 6: cache insert + return. Key includes the flag per G.2.
+    cache().insert(key, discovery.clone());
     Ok(discovery)
 }
 
@@ -429,6 +453,13 @@ pub async fn resolve_provider_endpoints(
     }
 }
 
+// guard-justified: the `#[allow(dead_code)]` directly below is needed
+// because this helper is reached through two mutually-exclusive
+// surfaces — (a) the `#[cfg(test)]` unit-tests in this module, and (b)
+// the `#[cfg(nebula_test_util)]` re-export in `test_support.rs` for
+// integration tests. In a vanilla `cargo build` neither surface is
+// compiled, so the function looks dead to the lint without the
+// directive. Per CodeRabbit wave-2 G.1.
 /// Test-only: clear the cache so tests can exercise the fetch path
 /// without inter-test contamination. `pub(crate)` so the unit-test
 /// module + the `nebula_test_util` cfg-gated `test_support` module

--- a/crates/api/src/transport/oauth/mod.rs
+++ b/crates/api/src/transport/oauth/mod.rs
@@ -16,6 +16,7 @@
 //!
 //! Part of `nebula-api` base deps (rollout window closed 2026-04-24).
 
+pub mod discovery;
 pub mod flow;
 pub mod http;
 pub mod state;


### PR DESCRIPTION
> **PR-3 of the 5-PR M3.1 OAuth identity-login chain** per [ADR-0085](../tree/main/docs/adr/0085-oauth-identity-providers-from-secrets.md).
> Stacked on top of PR #758 (merged \`62c8c601\`).

## What this PR lands

Closes the M3.1 \`start_oauth\` honesty gap: both backends now emit **REAL** OAuth provider authorize URLs (PKCE S256 + client config from operator secrets) instead of the \`https://nebula.local/...\` synthetic placeholder. \`complete_oauth\` still returns \`NotImplemented\` until PR-4.

### Stage A — \`transport/oauth/discovery.rs\` (NEW, ~270 LOC)
Per ADR-0085 **D-15-WAVE6**:
- \`OidcDiscovery\` struct (serde Deserialize from \`.well-known/openid-configuration\`)
- Process-wide \`DashMap\` cache (no TTL, bounded by process restart)
- Typed \`DiscoveryError\` enum (5 variants)
- \`fetch_oidc_discovery(url, oauth_allow_insecure_localhost)\`: strict-gate → cache check → GET (5s timeout) → parse → per-child-URL re-validation (token/userinfo/jwks strict, authorize flag-aware) → cache insert
- \`resolve_provider_endpoints(cfg, allow_localhost) → ResolvedEndpoints\` runtime-uniform helper consumed by both backends

### Stage B — \`AuthError::ProviderNotConfigured\` (ADR-0085 **D-6**)
- New variant \`ProviderNotConfigured { provider: String }\`
- ApiError mapping → **HTTP 503** with actionable message
- \`default_outcome_for()\` classifies as \`OAUTH_FAILED\`
- Exhaustive-mapping audit case array bumped 14 → 15

### Stage C — backends gain \`oauth_providers\` field + builder
- \`PgAuthBackend.oauth_providers: Arc<OAuthProvidersConfig>\` (defaults to empty)
- \`InMemoryAuthBackend.oauth_providers\`: same
- \`with_oauth_providers(providers)\` builder method on both
- \`compose.rs::build_auth_backend\` wires \`Arc::new(api_config.auth.oauth.clone())\`

### Stage D + E — \`{Pg,InMemory}AuthBackend::start_oauth\` REAL
Per ADR-0085 D-3 / D-11-RECON3 / D-15-WAVE6:
1. Lookup provider → \`ProviderNotConfigured\` if absent
2. \`resolve_provider_endpoints\` (Oidc → discovery; Manual → as-is)
3. \`mint_pkce\`
4. \`flow::build_authorization_uri(AuthorizationUriRequest, &state, &code_challenge)\` → real URL
5. Persist state row with \`redirect_uri = Some(redirect_uri)\` (was \`None\` pre-PR-3) for PR-4 Scenario 3.10 defense
6. Return real \`OAuthStart\`

\`OAuthStateEntry\` gains \`redirect_uri: Option<String>\` field for the in-memory path.

### \`test_support.rs\` upgraded
- \`fetch_oidc_discovery_unchecked\` PR-2 placeholder → now delegates to real cache with \`allow_localhost = true\` for wiremock fixtures
- Re-exports \`OidcDiscovery\` + \`FetchDiscoveryError\`
- New \`clear_discovery_cache_for_tests()\` helper

## Commits

| # | Stage | Files | LOC |
|---|---|---|---|
| \`14790df7\` | A + B: discovery + ProviderNotConfigured | 4 | +333 / -27 |
| \`50553eb6\` | C + D + E: backends + real start_oauth + 3 RED tests | 5 | +423 / -43 |

**Total**: ~686 LOC across 2 commits.

## RED tests landed (per tasks.md T3.x)

3 new tests in \`in_memory::tests\`:
- \`start_oauth_returns_provider_not_configured_when_provider_absent\` (T3.6)
- \`start_oauth_emits_real_authorize_url_with_pkce_s256_for_oidc_provider\` (T3.3, Microsoft fixture)
- \`start_oauth_emits_real_authorize_url_for_manual_provider_with_explicit_endpoints\` (T3.4, GitHub fixture)

Plus the legacy \`oauth_start_persists_state_entry\` test reworked to use the real config path.

## TODO (optional polish before mark-ready)

- [ ] **T3.1 discovery RED tests** (\`discovery_fetches_and_caches_well_known_doc\`) — needs wiremock fixture; out of \`in_memory::tests\` scope, ships in PR-4 with full e2e suite.
- [ ] **T3.5 RED**: \`start_oauth_persists_redirect_uri_into_oauth_state_row\` — currently covered indirectly by the reworked \`oauth_start_persists_state_entry\`; can add explicit PG-level assertion if reviewers ask.
- [ ] **T3.2 RED**: \`discovery_fetches_and_caches_well_known_doc\` — same as T3.1, ships with PR-4 wiremock suite.

## Test status

\`cargo nextest run -p nebula-api --no-fail-fast\` → **466 / 466 PASS** (was 463 before, +3 new RED tests).

\`cargo clippy -p nebula-api --all-targets\`: clean.
\`cargo check --workspace\`: clean.

## Open follow-up: DNS-resolution SSRF (carried from PR-2 wave-1)

PR-2 documented (CodeRabbit major) that \`validate_oauth_outbound_url\` inspects only the literal host — a hostile DNS record (\`internal.evil.example.com A 10.0.0.5\`) bypasses the gate. The full fix requires \`reqwest::Client\` configured with a custom resolver. **Not addressed in PR-3** since the actual production HTTP fetch surface (token POST + userinfo GET) lands in PR-4; resolver-gate work lives there.

## Refs

- ROADMAP §M3.1 (PR-3 of the 5-PR chain).
- ADR-0085 D-3 / D-6 / D-9-WAVE6 / D-11-RECON3 / D-15-WAVE6 / F.2 wave-7.
- openspec/changes/oauth-providers-from-operator-secrets/tasks.md T3.1, T3.3, T3.4, T3.6, T3.7, T3.8, T3.9.
- PR #757 (PR-1 ADR) merged \`4d938bdb\`.
- PR #758 (PR-2 trait + config + compose) merged \`62c8c601\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * OIDC provider discovery now properly resolves endpoints with process-level caching
  * Added error messaging for unconfigured OAuth providers

* **Bug Fixes**
  * OAuth authorization now generates real URLs based on operator configuration instead of synthetic placeholders
  * Redirect URI validation is now properly implemented in OAuth flows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/759?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->