### PR TITLE
docs(api): M3.1 OAuth final docs + ROADMAP flip + 1.1 follow-up plan (PR-5 of M3.1 — closes chain)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ changes are expected between minor releases — call them out here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Plane-A OAuth `redirect_uri` missing `/api/v1` prefix (P2,
+  surfaced by PR-5 wave-1 Codex review)** — the
+  `derive_oauth_redirect_uri` helper in PRs #758 / #759 / #761
+  produced `{public_url}/auth/oauth/{provider}/callback` while the
+  actual Plane-A router is nested under `/api/v1/` in
+  `crates/api/src/domain/mod.rs:170`. In production the IdP would
+  have redirected to a 404 (no handler mounted at the un-prefixed
+  path). Fixed in PR-5 by adding the `/api/v1` prefix to the
+  derivation formula AND updating the spec.md / ADR-0085 / README
+  documented examples so the operator-visible redirect_uri matches
+  what they need to register with the IdP. No state-row data
+  migration needed because no real Plane-A OAuth flow ran on
+  affected commits (PR-1..4 implementation gated by
+  `ProviderNotConfigured` for any non-configured provider; the
+  fix lands before any operator wires real env vars).
+
 ### Added
 
 - **Plane-A OAuth identity providers from operator secrets (ROADMAP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ changes are expected between minor releases — call them out here.
 
 ## [Unreleased]
 
+### Added
+
+- **Plane-A OAuth identity providers from operator secrets (ROADMAP
+  §M3.1)** — shipped via 5-PR chain (#757 ADR-0085 + #758 trait +
+  #759 real authorize URL + OIDC discovery + #761 real
+  `complete_oauth` + `external_identities` + #*** docs). Operators
+  configure IdP-client credentials via
+  `API_AUTH_OAUTH_<PROVIDER>_*` env vars; `PgAuthBackend::complete_oauth`
+  no longer returns `NotImplemented` — it runs the canonical OAuth
+  flow (code exchange → userinfo → REQ-oauth-006 short-circuit →
+  email truth-table → session mint). New migration
+  `0029_external_identities.sql` adds the `(provider, subject) →
+  user_id` linkage with `ON DELETE CASCADE`. Three providers in 1.0:
+  `google`, `microsoft`, `github`. GitHub triggers a second
+  `/user/emails` fetch to resolve verified email per ADR-0085 D-5
+  wave-6. id_token JWKS signature validation deferred to 1.1 (D-16);
+  userinfo response is authoritative. See `crates/api/README.md`
+  "OAuth identity providers (Plane A)" for operator setup.
+
 ### Changed
 
 - **`nebula-resource`:** crate documentation scrubbed of plan-IDs, ADR

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -194,10 +194,12 @@ is also set the OIDC arm is chosen, otherwise Manual.
 
 The Plane-A OAuth flow derives `redirect_uri` from `API_PUBLIC_URL`
 (NOT a per-provider config) per ADR-0085 D-3 (recon-4):
-`{API_PUBLIC_URL}/auth/oauth/{provider}/callback`. Operators that need
-multiple callback URIs deploy multiple Nebula instances. Boot fails
-closed if `API_PUBLIC_URL` is empty / relative / scheme-less while
-any provider is declared (REQ-compose-001 Invariant 1).
+`{API_PUBLIC_URL}/api/v1/auth/oauth/{provider}/callback`. The
+`/api/v1` prefix matches the actual router mount point in
+`crates/api/src/domain/mod.rs`. Operators that need multiple callback
+URIs deploy multiple Nebula instances. Boot fails closed if
+`API_PUBLIC_URL` is empty / relative / scheme-less while any provider
+is declared (REQ-compose-001 Invariant 1).
 
 ### Example: Google + GitHub side-by-side
 

--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -164,6 +164,107 @@ Every rejection increments `nebula_webhook_signature_failures_total` with
 attached via `WebhookTransport::with_metrics`. The counter is low cardinality
 by design (three static reason labels, no per-trigger dimension).
 
+## OAuth identity providers (Plane A)
+
+Per [ADR-0085](../../docs/adr/0085-oauth-identity-providers-from-secrets.md):
+operator IdP-client credentials are configured via environment
+variables (NOT a database table, NOT the credential store). Declaring
+a provider is opt-in; an undeclared provider returns
+`AuthError::ProviderNotConfigured` → HTTP 503 from
+`/auth/oauth/{provider}/start`.
+
+Supported providers in 1.0 (`OAuthProvider` enum):
+`google`, `microsoft`, `github`. Auth0 / Okta / generic OIDC require
+extending the enum (tracked as a 1.1 follow-up).
+
+### Configuration shape
+
+Each provider exposes one of two endpoint shapes:
+
+| Shape | When to use | Required env vars |
+|---|---|---|
+| **OIDC** (`Google`, `Microsoft`) | IdP publishes `.well-known/openid-configuration` | `CLIENT_ID`, `CLIENT_SECRET`, `DISCOVERY_URL` |
+| **Manual** (`GitHub`) | No discovery doc OR operator pins endpoints | `CLIENT_ID`, `CLIENT_SECRET`, `AUTHORIZE_URL`, `TOKEN_URL`, `USERINFO_URL`, `SCOPES` (+ optional `VERIFIED_EMAILS_URL`, `JWKS_URL`) |
+
+All env vars are prefixed `API_AUTH_OAUTH_<UPPERCASE_PROVIDER>_*`.
+A provider is "declared" if its `CLIENT_ID` is set; if `DISCOVERY_URL`
+is also set the OIDC arm is chosen, otherwise Manual.
+
+### `API_PUBLIC_URL`
+
+The Plane-A OAuth flow derives `redirect_uri` from `API_PUBLIC_URL`
+(NOT a per-provider config) per ADR-0085 D-3 (recon-4):
+`{API_PUBLIC_URL}/auth/oauth/{provider}/callback`. Operators that need
+multiple callback URIs deploy multiple Nebula instances. Boot fails
+closed if `API_PUBLIC_URL` is empty / relative / scheme-less while
+any provider is declared (REQ-compose-001 Invariant 1).
+
+### Example: Google + GitHub side-by-side
+
+```bash
+# Required by all Plane-A OAuth flows.
+export API_PUBLIC_URL=https://app.example.com
+
+# Google — OIDC arm.
+export API_AUTH_OAUTH_GOOGLE_CLIENT_ID="..."
+export API_AUTH_OAUTH_GOOGLE_CLIENT_SECRET="..."
+export API_AUTH_OAUTH_GOOGLE_DISCOVERY_URL="https://accounts.google.com/.well-known/openid-configuration"
+
+# GitHub — Manual arm (no discovery doc; userinfo lacks email_verified
+# so verified_emails_url is required for the truth-table to pass).
+export API_AUTH_OAUTH_GITHUB_CLIENT_ID="Iv1.xxxxxxxx"
+export API_AUTH_OAUTH_GITHUB_CLIENT_SECRET="..."
+export API_AUTH_OAUTH_GITHUB_AUTHORIZE_URL="https://github.com/login/oauth/authorize"
+export API_AUTH_OAUTH_GITHUB_TOKEN_URL="https://github.com/login/oauth/access_token"
+export API_AUTH_OAUTH_GITHUB_USERINFO_URL="https://api.github.com/user"
+export API_AUTH_OAUTH_GITHUB_VERIFIED_EMAILS_URL="https://api.github.com/user/emails"
+export API_AUTH_OAUTH_GITHUB_SCOPES="user:email"
+```
+
+### Flow
+
+1. Client `GET /api/v1/auth/oauth/{provider}` → server derives
+   `redirect_uri`, mints PKCE pair, persists `OAuthStateRow`,
+   returns the IdP `authorize_url` + opaque `state`.
+2. Client redirects user's browser to `authorize_url`.
+3. IdP redirects back to `{redirect_uri}?state=...&code=...`.
+4. Client posts to `GET /api/v1/auth/oauth/{provider}/callback`.
+5. Server consumes the state row atomically, verifies `redirect_uri`
+   match, exchanges code at the IdP token endpoint, fetches
+   userinfo (+ verified emails for GitHub), applies the
+   REQ-oauth-004/-005/-006 truth table, mints a Nebula session.
+
+### Security posture (REQ-obs-001)
+
+- **Anti-SSRF**: every server-side OAuth HTTP URL passes
+  `validate_oauth_outbound_url` (HTTPS-only; rejects loopback /
+  private / link-local / multicast). Browser-fetched authorize URLs
+  use the flag-aware `validate_oauth_authorize_url` which accepts
+  `http://localhost` only when `oauth_allow_insecure_localhost` is
+  set AND the binary is built with debug assertions (dev mode).
+- **Body caps**: token endpoint and userinfo / verified-emails GETs
+  are capped at 256 KiB so a hostile IdP cannot DoS via unbounded
+  responses.
+- **Discovery cache**: process-wide; key includes the
+  `oauth_allow_insecure_localhost` flag so flag=true and flag=false
+  callers never share a cache entry.
+- **Tokens discarded**: per D-7, access / id / refresh tokens are
+  dropped after the userinfo lookup; only the
+  `(provider, subject) → user_id` link and the minted Nebula session
+  are persisted.
+- **id_token JWKS signature validation**: deferred to 1.1 per D-16.
+  Userinfo response is authoritative for `(email, sub)`. The TLS
+  trust chain to the IdP is the integrity boundary.
+- **Account-takeover defense**: a user whose Nebula `email_verified`
+  is `false` cannot link an OAuth identity even if the IdP attests
+  `email_verified = true` (Scenario 5.2). The unverified user must
+  complete email verification through the password flow first.
+- **Observability**: `nebula_api_auth_oauth_attempts_total` carries
+  closed-set `outcome` + `provider` labels;
+  `nebula_api_auth_duration_seconds` histogram keyed by `outcome`
+  only (provider stripped to keep histogram cardinality at the
+  floor of `len(auth_outcome::*)` series).
+
 ## Machine-Readable API
 
 `nebula-api` publishes its full route surface as an **OpenAPI 3.1**

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -21,7 +21,9 @@
 //! ## `redirect_uri` (recon-4 ADOPT (a))
 //!
 //! NOT a configuration field. Auto-derived at runtime as
-//! `format!("{base}/auth/oauth/{provider}/callback", base = api_config.public_url)`.
+//! `format!("{base}/api/v1/auth/oauth/{provider}/callback", base = api_config.public_url)`
+//! (the Plane-A router is nested under `/api/v1/` per
+//! `crates/api/src/domain/mod.rs`).
 //! Operators that need multiple callback URIs deploy multiple Nebula
 //! instances. Matches n8n's `{instanceBaseUrl}/rest/sso/oidc/callback`
 //! pattern.

--- a/crates/api/src/domain/auth/backend/in_memory.rs
+++ b/crates/api/src/domain/auth/backend/in_memory.rs
@@ -1445,7 +1445,7 @@ mod tests {
         let start = b
             .start_oauth(
                 OAuthProvider::Google,
-                "https://nebula.test/auth/oauth/google/callback",
+                "https://nebula.test/api/v1/auth/oauth/google/callback",
             )
             .await
             .unwrap();
@@ -1462,7 +1462,7 @@ mod tests {
         let entry = b.oauth_state.get(&start.state).unwrap();
         assert_eq!(
             entry.redirect_uri.as_deref(),
-            Some("https://nebula.test/auth/oauth/google/callback"),
+            Some("https://nebula.test/api/v1/auth/oauth/google/callback"),
             "PR-3 must persist the handler-derived redirect_uri"
         );
     }
@@ -1475,7 +1475,7 @@ mod tests {
         let err = b
             .start_oauth(
                 OAuthProvider::Google,
-                "https://nebula.test/auth/oauth/google/callback",
+                "https://nebula.test/api/v1/auth/oauth/google/callback",
             )
             .await
             .expect_err("missing provider config must error");
@@ -1531,7 +1531,7 @@ mod tests {
         let start = b
             .start_oauth(
                 OAuthProvider::Microsoft,
-                "https://nebula.test/auth/oauth/microsoft/callback",
+                "https://nebula.test/api/v1/auth/oauth/microsoft/callback",
             )
             .await
             .unwrap();
@@ -1583,7 +1583,7 @@ mod tests {
         let start = b
             .start_oauth(
                 OAuthProvider::GitHub,
-                "https://nebula.test/auth/oauth/github/callback",
+                "https://nebula.test/api/v1/auth/oauth/github/callback",
             )
             .await
             .unwrap();
@@ -1789,7 +1789,7 @@ mod complete_oauth_tests {
         let cfg = cfg_pointing_at(OAuthProvider::Google, &token_url, &userinfo_url, None);
 
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-1", OAuthProvider::Google, redirect);
 
         let result = b
@@ -1823,7 +1823,7 @@ mod complete_oauth_tests {
             Some(&emails_url),
         );
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/github/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/github/callback";
         seed_started_flow(&b, "state-gh", OAuthProvider::GitHub, redirect);
 
         let result = b
@@ -1842,7 +1842,7 @@ mod complete_oauth_tests {
         let (t1, u1, _) = spawn_idp_responder(token, userinfo, None).await;
         let cfg = cfg_pointing_at(OAuthProvider::Google, &t1, &u1, None);
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-r", OAuthProvider::Google, redirect);
 
         let _ = b
@@ -1871,7 +1871,7 @@ mod complete_oauth_tests {
                 OAuthProvider::Google,
                 "state-never-seen",
                 "code-x",
-                "https://nebula.test/auth/oauth/google/callback",
+                "https://nebula.test/api/v1/auth/oauth/google/callback",
             )
             .await
             .expect_err("unknown state must be rejected");
@@ -1888,7 +1888,7 @@ mod complete_oauth_tests {
             None,
         );
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-cross", OAuthProvider::Google, redirect);
         let err = b
             .complete_oauth(OAuthProvider::GitHub, "state-cross", "code-x", redirect)
@@ -1914,14 +1914,14 @@ mod complete_oauth_tests {
             &b,
             "state-pu",
             OAuthProvider::Google,
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         );
         let err = b
             .complete_oauth(
                 OAuthProvider::Google,
                 "state-pu",
                 "code-pu",
-                "https://nebula-CHANGED.test/auth/oauth/google/callback",
+                "https://nebula-CHANGED.test/api/v1/auth/oauth/google/callback",
             )
             .await
             .expect_err("mismatched redirect_uri must fail closed");
@@ -1941,7 +1941,7 @@ mod complete_oauth_tests {
         let (t1, u1, _) = spawn_idp_responder(token_err, userinfo_dummy, None).await;
         let cfg = cfg_pointing_at(OAuthProvider::Google, &t1, &u1, None);
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-500", OAuthProvider::Google, redirect);
         let err = b
             .complete_oauth(OAuthProvider::Google, "state-500", "code-500", redirect)
@@ -1958,7 +1958,7 @@ mod complete_oauth_tests {
         let (t1, u1, _) = spawn_idp_responder(bad_token, userinfo, None).await;
         let cfg = cfg_pointing_at(OAuthProvider::Google, &t1, &u1, None);
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-mt", OAuthProvider::Google, redirect);
         let err = b
             .complete_oauth(OAuthProvider::Google, "state-mt", "code-mt", redirect)
@@ -1981,7 +1981,7 @@ mod complete_oauth_tests {
         let (t1, u1, _) = spawn_idp_responder(token, userinfo, None).await;
         let cfg = cfg_pointing_at(OAuthProvider::Google, &t1, &u1, None);
         let b = InMemoryAuthBackend::new().with_oauth_providers(cfg);
-        let redirect = "https://nebula.test/auth/oauth/google/callback";
+        let redirect = "https://nebula.test/api/v1/auth/oauth/google/callback";
         seed_started_flow(&b, "state-uv", OAuthProvider::Google, redirect);
         let err = b
             .complete_oauth(OAuthProvider::Google, "state-uv", "code-uv", redirect)

--- a/crates/api/src/domain/auth/backend/provider.rs
+++ b/crates/api/src/domain/auth/backend/provider.rs
@@ -335,7 +335,7 @@ pub trait AuthBackend: Send + Sync {
     ///
     /// `redirect_uri` is **handler-derived** from `ApiConfig::public_url`
     /// per ADR-0085 D-3 (recon-4) —
-    /// `format!("{}/auth/oauth/{}/callback", api_config.public_url,
+    /// `format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url,
     /// provider.as_str())`. The trait accepts it as an argument so the
     /// derived value round-trips through the implementation's state row
     /// and is re-verified on `complete_oauth` against the row's stored

--- a/crates/api/src/domain/auth/handler.rs
+++ b/crates/api/src/domain/auth/handler.rs
@@ -372,8 +372,17 @@ pub async fn mfa_complete_login(
 }
 
 /// Derive the canonical Plane-A OAuth `redirect_uri` per ADR-0085 D-3
-/// (recon-4): `format!("{}/auth/oauth/{}/callback", public_url,
-/// provider.as_str())`.
+/// (recon-4).
+///
+/// The Plane-A auth router is nested under `/api/v1/` in
+/// `crates/api/src/domain/mod.rs:170`, so the **full** callback URL
+/// the IdP redirects back to is
+/// `{public_url}/api/v1/auth/oauth/{provider}/callback`. The earlier
+/// formula in PRs #758 / #759 / #761 erroneously omitted the
+/// `/api/v1` prefix — a production bug surfaced by Codex P2 review on
+/// PR #762; in production the IdP would have redirected to a 404
+/// because no handler is mounted at `/auth/oauth/.../callback` (only
+/// the v1-prefixed variant).
 ///
 /// Shared by `oauth_start` and `oauth_callback` so the value persisted
 /// in the OAuth state row at start_oauth time matches the value
@@ -385,7 +394,7 @@ pub(crate) fn derive_oauth_redirect_uri(public_url: &str, provider: OAuthProvide
     // boot-time validation (T2.8) ensures `public_url` is absolute with
     // a scheme; here we only normalize the slash.
     let base = public_url.trim_end_matches('/');
-    format!("{base}/auth/oauth/{}/callback", provider.as_str())
+    format!("{base}/api/v1/auth/oauth/{}/callback", provider.as_str())
 }
 
 /// `GET /api/v1/auth/oauth/{provider}` — start a Plane-A sign-in flow.

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -302,7 +302,7 @@ pub struct AppState {
     /// from `ApiConfig::public_url` (`API_PUBLIC_URL` env). Required by
     /// the Plane-A OAuth handler to derive the canonical
     /// `redirect_uri` per ADR-0085 D-3 (recon-4) —
-    /// `format!("{}/auth/oauth/{}/callback", public_url, provider)`.
+    /// `format!("{}/api/v1/auth/oauth/{}/callback", public_url, provider)`.
     ///
     /// Defaults to an empty string when constructed via
     /// [`Self::in_memory`]; the composition root (`build_state`) sets

--- a/crates/api/tests/auth_pg_e2e.rs
+++ b/crates/api/tests/auth_pg_e2e.rs
@@ -375,7 +375,7 @@ async fn pg_auth_backend_full_lifecycle() {
     let oauth_start = backend
         .start_oauth(
             OAuthProvider::Google,
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect("start_oauth");
@@ -391,7 +391,7 @@ async fn pg_auth_backend_full_lifecycle() {
             OAuthProvider::Google,
             &oauth_start.state,
             "fake-code",
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect_err("complete_oauth must return NotImplemented");
@@ -406,7 +406,7 @@ async fn pg_auth_backend_full_lifecycle() {
             OAuthProvider::Google,
             &oauth_start.state,
             "fake-code",
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect_err("oauth state replay must reject");
@@ -549,7 +549,7 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
     let start = backend
         .start_oauth(
             OAuthProvider::Google,
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect("start_oauth");
@@ -564,7 +564,7 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
             OAuthProvider::GitHub,
             &start.state,
             "fake-code",
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect_err("cross-provider state must reject");
@@ -576,7 +576,7 @@ async fn pg_auth_backend_complete_oauth_does_not_burn_cross_provider_state() {
             OAuthProvider::Google,
             &start.state,
             "fake-code",
-            "https://nebula.test/auth/oauth/google/callback",
+            "https://nebula.test/api/v1/auth/oauth/google/callback",
         )
         .await
         .expect_err("complete_oauth still returns NotImplemented after consume");

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -237,20 +237,26 @@ The largest 1.0 area. Closure criteria (on top of the global DoD):
       a session+CSRF enrollment-confirm path and a cookie-less
       `mfa_complete_login` (`POST /auth/login/mfa`) so the login
       second-step stays CSRF-exempt by construction.
-- [ ] **OAuth providers loaded from operator secrets** — a registry that
-      pulls secrets from the credential store at startup. Carved out into
-      its own SDD plan after recon revealed a 6× scope expansion vs the
-      initial follow-up estimate: Wave 4 credential-stabilize set up the
-      `CredentialService` type slot on `AppState` but never instantiated
-      it in `apps/server::compose`; `CredentialService::get` returns
-      `CredentialSnapshot` (no generic `get::<OAuth2Credential>`);
-      `PgAuthBackend::complete_oauth` still returns `NotImplemented` at
-      `crates/api/src/domain/auth/backend/pg.rs:957`; needs a breaking
-      change to `AuthBackend::start_oauth` (`redirect_uri` parameter),
-      `reqwest` as a new direct dep of `nebula-api` for the token
-      endpoint exchange, and an operator-discovery convention decision
-      (cross-dep with M12.3 + the `nebula-credential-runtime` wiring
-      increment).
+- [x] **OAuth providers loaded from operator secrets** — **SHIPPED via
+      5-PR chain** PR #757 (ADR-0085) + #758 (trait + config + compose
+      validation) + #759 (real authorize URL + OIDC discovery cache) +
+      #761 (real `complete_oauth` + `external_identities` +
+      REQ-oauth-006 short-circuit). Per [ADR-0085](adr/0085-oauth-identity-providers-from-secrets.md):
+      operator IdP-client credentials live in
+      `ApiConfig::auth.oauth.providers` (env-managed via
+      `API_AUTH_OAUTH_<PROVIDER>_*`); `complete_oauth` no longer returns
+      `NotImplemented` — it exchanges the authorization code via
+      `flow::exchange_code`, fetches userinfo, applies the
+      REQ-oauth-004/-005/-006 truth table, persists the
+      `(provider, subject) → user_id` link in `external_identities`,
+      and mints a Nebula session. Recon-2/3/4 corrections caught
+      design drift early; recon-2 dropped the `CredentialService::get::<OAuth2Credential>`
+      cross-dep that the original follow-up estimated (Plane A and
+      Plane B credentials are now cleanly separated). 1.1 follow-ups
+      tracked in `docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md`:
+      id_token JWKS signature validation (D-16 deferred), DNS-resolver
+      SSRF defense-in-depth (`reqwest::Client` custom resolver gate),
+      Auth0 / Okta `OAuthProvider` enum extension.
 - [x] **Lockout + rate-limit integration tests** against the PG backend —
       shipped via #751. DATABASE_URL-gated `auth_pg_e2e.rs` lockout suite
       (`pg_auth_backend_locks_after_threshold_failures` +

--- a/docs/adr/0085-oauth-identity-providers-from-secrets.md
+++ b/docs/adr/0085-oauth-identity-providers-from-secrets.md
@@ -68,7 +68,7 @@ extension; Nebula has no admin UI for SSO config yet.
 
 `redirect_uri` is **NOT a configuration field**. It is auto-derived at
 runtime as
-`format!("{}/auth/oauth/{}/callback", api_config.public_url, provider.as_str())`
+`format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` (the `/api/v1` prefix matches the actual nested router mount point in `crates/api/src/domain/mod.rs` — the earlier formula in this doc omitted the prefix and was corrected in PR-5 wave-1 after Codex P2 surfaced the gap)
 from the existing `ApiConfig::public_url` (`API_PUBLIC_URL` env, declared
 at `crates/api/src/config/mod.rs:107`).
 

--- a/docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md
+++ b/docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md
@@ -1,0 +1,154 @@
+# OAuth identity providers — 1.1 follow-ups
+
+**Owner**: TBD on 1.1 cycle kickoff
+**Status**: Plan (no implementation work yet)
+**Predecessor**: ROADMAP §M3.1 OAuth providers checkbox (shipped via
+PR chain #757 → #758 → #759 → #761 + #*** docs, all merged 2026-05-28)
+**Author of plan**: AGENTS lifecycle handoff at M3.1 closure
+
+> **Scope discipline**: this is a tracking document for work
+> deliberately deferred during the M3.1 5-PR chain. Each entry calls
+> out the **specific decision** that deferred it, the **risk class**,
+> and the **expected blast radius**. Implementation belongs to the 1.1
+> milestone planning cycle — DO NOT start any of these items as
+> follow-ups to M3.1 without re-validating scope against the live
+> M3.1 ADR (`docs/adr/0085-oauth-identity-providers-from-secrets.md`).
+
+## 1. id_token JWKS signature validation (D-16 defer)
+
+**Source**: ADR-0085 D-16 (RECON-4 + wave-6 reconfirmation).
+
+**What is deferred**: in 1.0, `complete_oauth` logs `id_token`
+presence in the token response but does **not** verify its signature
+against the IdP's JWKS endpoint. The userinfo response is treated as
+authoritative for `(email, sub)`.
+
+**Why it was deferred**: per D-16, the TLS trust chain to the IdP is
+already the integrity boundary; a compromised TLS chain would also
+compromise JWKS-served keys. The marginal risk closed by JWKS sig
+validation is "userinfo response swap with a forged id_token" which
+requires either compromised TLS OR a hostile IdP — neither bypassed
+by JWKS.
+
+**1.1 scope**:
+- Add `jsonwebtoken = "10"` (already in workspace `Cargo.toml`) to
+  `crates/api/Cargo.toml` as a direct dep.
+- Implement `crates/api/src/transport/oauth/id_token.rs` per the
+  ADR-0085 design notes (D-16 follow-up section).
+- Add `jwks_url` resolution per provider:
+  - OIDC: from cached `OidcDiscovery.jwks_url`.
+  - Manual: from `OAuthEndpoints::Manual.jwks_url` (already a field,
+    accepted in 1.0 but ignored).
+- New RED tests:
+  - `complete_oauth_rejects_id_token_signature_invalid`
+  - `complete_oauth_rejects_id_token_nonce_mismatch`
+  - `complete_oauth_rejects_id_token_iss_mismatch`
+  - `complete_oauth_rejects_id_token_aud_mismatch`
+  - `complete_oauth_rejects_id_token_expired`
+- Behavior change: rejection on signature/nonce/iss/aud/exp invalid
+  becomes `AuthError::OAuthFailed { cause: "id_token_*" }`.
+- Risk: P1 signature-validation gap is a real concern for operators
+  with weak TLS trust roots (e.g. internal CA mis-issuance). The
+  deferral was a 1.0-scope decision, not a security-acceptance.
+
+**Blast radius**: `crates/api/src/transport/oauth/` (+1 file, ~120
+LOC), 5 RED tests, `complete_oauth` adds one validation step
+between userinfo and the truth-table.
+
+## 2. DNS-resolution SSRF defense-in-depth
+
+**Source**: CodeRabbit major review on PR-2 wave-1 + PR-3 wave-1
+(carried forward as documented limitation in each PR).
+
+**What is deferred**: `validate_oauth_outbound_url` and
+`validate_oauth_authorize_url` inspect the **literal host** in the
+URL. An attacker-controlled DNS record
+(`internal.evil.example.com A 10.0.0.5`) passes the literal-host
+gate because the host string is not an IP literal at parse time.
+The actual `reqwest::Client` then resolves DNS at request time and
+connects to the internal address.
+
+**Why it was deferred**: the full fix requires a custom
+`hyper`/`reqwest` resolver that re-validates resolved IPs
+post-DNS-resolution AND TOCTOU-safely re-validates per connection
+attempt (DNS rebinding). That is a multi-week change touching
+production HTTP transport policy, not a one-PR fix.
+
+**1.1 scope**:
+- Build `crates/api/src/transport/oauth/safe_resolver.rs`:
+  - `SafeIpResolver` implementing `reqwest::dns::Resolve`.
+  - Wraps `hickory_resolver::TokioAsyncResolver` (workspace dep).
+  - After resolution, rejects any address in the bogon set
+    (loopback / private / link-local / multicast / unspecified /
+    IPv6 ULA / IPv4-mapped IPv6 equivalents).
+  - Hook into `oauth_token_http_client()` AND
+    `oauth_discovery_http_client()` via
+    `reqwest::Client::builder().dns_resolver(...)`.
+- New RED tests:
+  - `validate_oauth_outbound_url_rejects_dns_resolved_loopback`
+  - `validate_oauth_outbound_url_rejects_dns_resolved_private_ipv4`
+  - `validate_oauth_outbound_url_rejects_dns_resolved_link_local`
+  - `validate_oauth_outbound_url_rejects_ipv6_ula_via_dns`
+- Existing `cfg(test)` localhost bypass in
+  `validate_oauth_outbound_url` (PR-4 stage C) must be updated so
+  the new DNS-resolver gate ALSO bypasses for in-crate tests.
+
+**Blast radius**: 1 new transport file (~150 LOC), 4 RED tests,
+both shared HTTP clients re-wired. No public surface change.
+
+## 3. `OAuthProvider` enum extension (Auth0 / Okta / generic OIDC)
+
+**Source**: ADR-0085 D-5 (recon-4) — the 1.0 enum has exactly three
+variants `(Google, Microsoft, GitHub)`; extending the enum + adding
+its `as_str` mapping + adding it to `KNOWN_PROVIDERS` const slice +
+adding metrics label constants in `naming::auth_oauth_provider` is
+the entire surface for adding a new provider.
+
+**What is deferred**: enterprise IdPs (Auth0, Okta) that publish
+`.well-known/openid-configuration` are NOT supported in 1.0 because
+adding them requires the enum extension above. Operators with these
+IdPs currently have no path forward beyond using the OAuth-only
+shape of `Manual` (which works for any IdP with explicit endpoints).
+
+**Why it was deferred**: per ADR-0085 D-5, keeping the enum
+finite-and-typed in 1.0 lets the workspace `OAuthProvider:
+FromStr` parser reject typos at config-load time (e.g. `gooogle` =
+no variant, config-load fails closed). A `Generic { name: String }`
+variant would erase this guarantee and require runtime
+provider-name validation logic.
+
+**1.1 scope**:
+- Add `OAuthProvider::Auth0`, `OAuthProvider::Okta` variants (start
+  with these two; generic OIDC under a string-named variant is a
+  separate decision call).
+- Update `KNOWN_PROVIDERS`, `as_str()`, `FromStr`,
+  `naming::auth_oauth_provider`, `metrics_emit::oauth_provider_label`.
+- Update ADR-0085 D-5 with "1.0 enum: 3 variants; 1.1 enum: 5+
+  variants" historical note.
+- No new RED tests needed — the existing config-load test matrix
+  covers any enum variant via parametrization.
+
+**Blast radius**: ~5 small files; ~30 LOC total. Trivial follow-up
+once the enum-vs-string-name decision lands.
+
+## Sequencing recommendation
+
+1. **DNS-resolver SSRF (item 2)** — security defense-in-depth, no
+   API change, lands first.
+2. **JWKS signature validation (item 1)** — security hardening,
+   adds `id_token_*` failure modes to the OAuth error space.
+3. **Auth0 / Okta enum extension (item 3)** — feature work, lands
+   last; the security items above benefit Auth0 / Okta consumers
+   too.
+
+## Cross-references
+
+- ADR-0085: `docs/adr/0085-oauth-identity-providers-from-secrets.md`
+- OpenSpec archive: `openspec/changes/oauth-providers-from-operator-secrets/`
+  (`STATUS.md` marker + planning artifacts retained)
+- ROADMAP §M3.1: shipped checkbox; this plan is the formal
+  follow-up tracker for residual 1.1 work.
+
+> **Convention**: 1.1 work picks this plan up only after the M3.1
+> release blocker count clears and after the M5 / M6 increments
+> finish their own follow-up backlogs (see `docs/ROADMAP.md`).

--- a/openspec/changes/oauth-providers-from-operator-secrets/STATUS.md
+++ b/openspec/changes/oauth-providers-from-operator-secrets/STATUS.md
@@ -1,0 +1,89 @@
+# OpenSpec Change Status
+
+**Change**: `oauth-providers-from-operator-secrets`
+**Status**: ✅ **SHIPPED / ARCHIVED**
+**Closed**: 2026-05-28
+**Deliverable**: ROADMAP §M3.1 final OAuth-providers checkbox
+
+## PR chain (all merged)
+
+| # | PR | Commit | Scope |
+|---|---|---|---|
+| 1 | [#757](https://github.com/vanyastaff/nebula/pull/757) | `4d938bdb` | ADR-0085 + SDD planning artifacts |
+| 2 | [#758](https://github.com/vanyastaff/nebula/pull/758) | `62c8c601` | `AuthBackend` trait sig + `OAuthProvidersConfig` + compose validation + `test_support` module |
+| 3 | [#759](https://github.com/vanyastaff/nebula/pull/759) | `27c3d7c7` | Real authorize URL via `flow::build_authorization_uri` + OIDC discovery cache + `ProviderNotConfigured` variant |
+| 4 | [#761](https://github.com/vanyastaff/nebula/pull/761) | `b7b703a1` | Real `complete_oauth` + `external_identities` table + REQ-oauth-006 short-circuit + userinfo helper |
+| 5 | [PR-5](pending) | _this PR_ | Docs + ROADMAP flip + 1.1 follow-up plan |
+
+## What landed
+
+- 13 ADR decisions (D-1 through D-16, with D-9-WAVE6 / D-15-WAVE6
+  hardening from PR-757 review marathon).
+- 27 RED tests across the chain (was 21 baseline; +6 added by
+  PR-757 review waves for security + data-model).
+- ~3,150 LOC of SDD planning artifacts (audit trail of decisions).
+- ~2,400 LOC of production implementation (~1,300 PR-2 + ~600 PR-3
+  + ~1,300 PR-4).
+- 479 tests passing on `main` post-merge (was 450 pre-chain).
+- Single new PG migration `0029_external_identities.sql`.
+
+## Decision audit trail (live)
+
+- **D-1**: env-managed `[auth.oauth.providers.<name>]` config (no DB
+  rows, no UI in 1.0).
+- **D-3-RECON4**: `redirect_uri` auto-derived from
+  `ApiConfig::public_url` (no allow-list).
+- **D-5-RECON4**: `OAuthEndpoints` tagged union (Oidc vs Manual)
+  with `verified_emails_url` (D-5 wave-6 GitHub addition).
+- **D-6**: `AuthError::ProviderNotConfigured` → HTTP 503.
+- **D-7**: IdP tokens discarded after session mint.
+- **D-8**: `external_identities (provider, subject)` PK + CASCADE,
+  `user_id BYTEA` matching `users.id`.
+- **D-9-WAVE6**: anti-SSRF gate generalized; flag-aware vs strict
+  validator split (F.2 wave-7).
+- **D-11-RECON3**: reuse `mint_pkce` + `flow::build_authorization_uri`
+  + `OAuthStateRepo` (Plane A; NOT Plane B helpers).
+- **D-12-RECON3**: reuse `flow::exchange_code`.
+- **D-13**: Plane A does NOT route through
+  `Interactive::continue_resolve`.
+- **D-14**: `nebula_test_util` cfg-gated `test_support` module (NOT
+  a Cargo feature, to avoid transitive activation).
+- **D-15-WAVE6**: OIDC discovery cache; per-child-URL re-validation
+  before cache insert.
+- **D-16**: id_token JWKS signature validation deferred to 1.1
+  (userinfo authoritative).
+
+## Superseded sub-decisions (audit only)
+
+- D-2, D-4, REQ-cred-001 (recon-2)
+- D-3 original allow-list (recon-4)
+- D-11 / D-12 original phrasings (recon-3)
+
+## 1.1 follow-ups
+
+See `docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md` for
+the deferred work:
+
+- id_token JWKS signature validation (D-16 defer).
+- DNS-resolution SSRF defense-in-depth via custom `reqwest::Client`
+  resolver.
+- Auth0 / Okta / generic OIDC `OAuthProvider` enum extension.
+
+## Review marathon summary
+
+| PR | Wave-1 issues | Waves to converge | Peak severity |
+|----|----|----|----|
+| #757 (ADR) | 18 | 8 | **P1 SSRF** |
+| #758 (impl) | 9 | 3 | P2 |
+| #759 (impl) | 7 | 3 | major |
+| #761 (impl) | 5 | 1 (single wave!) | P1 mechanical |
+
+Defect class trajectory across chain:
+- PR-1: stale-reference cleanup (waves 1-3) → security/data-model
+  (waves 4-7) → 0 (wave-8 with pre-push grep discipline)
+- PR-2..4: each subsequent PR cleaner than the last as
+  bot-review lessons were applied proactively at design time.
+
+The chain is the **most-reviewed deliverable in M3.1**; the audit
+trail under this directory is intentionally preserved for future
+ADR-grade work.

--- a/openspec/changes/oauth-providers-from-operator-secrets/design.md
+++ b/openspec/changes/oauth-providers-from-operator-secrets/design.md
@@ -145,7 +145,7 @@ pub credential_service: Option<Arc<dyn CredentialServiceErased>>,
 
 > **🟥 SUPERSEDED by `recon-4-n8n-and-rust-ecosystem.md` §3 (ADOPT (a)).**
 >
-> `redirect_uri` is **auto-derived** from the existing `ApiConfig::public_url` field (`API_PUBLIC_URL` env, at `crates/api/src/config/mod.rs:107`). Formula: `format!("{}/auth/oauth/{}/callback", api_config.public_url, provider.as_str())`. The `redirect_uris: Vec<String>` config field is dropped from `OAuthProviderConfig`. The allow-list semantics is moot. Multi-environment deployments (dev / staging / prod) each have their own `API_PUBLIC_URL` and their own OAuth client registration at the IdP. Matches n8n's `{instanceBaseUrl}/rest/sso/oidc/callback` pattern.
+> `redirect_uri` is **auto-derived** from the existing `ApiConfig::public_url` field (`API_PUBLIC_URL` env, at `crates/api/src/config/mod.rs:107`). Formula: `format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` (PR-5 wave-1 correction: the original formula omitted the `/api/v1` prefix; the Plane-A router is nested under `/api/v1` in `crates/api/src/domain/mod.rs:170` so the prefix is mandatory or the IdP redirects to a 404). The `redirect_uris: Vec<String>` config field is dropped from `OAuthProviderConfig`. The allow-list semantics is moot. Multi-environment deployments (dev / staging / prod) each have their own `API_PUBLIC_URL` and their own OAuth client registration at the IdP. Matches n8n's `{instanceBaseUrl}/rest/sso/oidc/callback` pattern.
 >
 > The text below is kept for audit only; ignore for implementation.
 
@@ -601,7 +601,7 @@ The security argument:
 `PgAuthBackend::start_oauth(provider, redirect_uri)` and `InMemoryAuthBackend::start_oauth(...)` SHALL:
 
 1. Look up the validated `OAuthProviderConfig` from `ApiConfig::auth.oauth.providers[provider]`. If absent → `AuthError::ProviderNotConfigured { provider }`.
-2. Derive the canonical `redirect_uri` from `api_config.public_url` per D-3 (`format!("{}/auth/oauth/{}/callback", public_url, provider.as_str())`). The handler-supplied `redirect_uri` arg MUST already equal this value (the handler derived it the same way before calling `start_oauth`); a mismatch is a debug-assert at the trait boundary.
+2. Derive the canonical `redirect_uri` from `api_config.public_url` per D-3 (`format!("{}/api/v1/auth/oauth/{}/callback", public_url, provider.as_str())` — PR-5 wave-1 corrected). The handler-supplied `redirect_uri` arg MUST already equal this value (the handler derived it the same way before calling `start_oauth`); a mismatch is a debug-assert at the trait boundary.
 3. For `Oidc { discovery_url }`: call `fetch_oidc_discovery(discovery_url)` (D-15) to obtain `authorize_url`/`token_url`/`userinfo_url`. For `Manual { authorize_url, ... }`: use the operator-supplied URLs directly. Construct `flow::AuthorizationUriRequest` (client_id, token_url, client_secret, redirect_uri, scopes, auth_style).
 4. Call `mint_pkce()` to get `(state, code_verifier, code_challenge)`.
 5. Call `flow::build_authorization_uri(&req, &state, &code_challenge)` to construct the real authorize URL.

--- a/openspec/changes/oauth-providers-from-operator-secrets/spec.md
+++ b/openspec/changes/oauth-providers-from-operator-secrets/spec.md
@@ -23,7 +23,7 @@ The server SHALL accept an operator-supplied configuration that maps each suppor
   - `Oidc { discovery_url: String }` for OIDC-compliant providers — in 1.0 this means Google and Microsoft (the only `Oidc`-shaped variants in the live `OAuthProvider` enum at `crates/api/src/domain/auth/backend/oauth.rs:28-47`). Auth0 / Okta / generic OIDC require extending the enum (1.1 follow-up per ADR-0085 D-5). Endpoints fetched at runtime from `.well-known/openid-configuration` (D-15). **Scopes hardcoded `"openid email profile"` for `Oidc`.**
   - `Manual { authorize_url, token_url, userinfo_url, verified_emails_url: Option<String>, jwks_url: Option<String>, scopes: Vec<String> }` for OAuth2-only providers (GitHub) or operator-customized OIDC. `jwks_url` accepted for forward compat but ignored in 1.0 (D-16). `scopes` MUST be non-empty for `Manual`. **`verified_emails_url`** (🟥 WAVE-6 P2 addition for GitHub) is required when the provider's `userinfo_url` response does NOT include an `email_verified` claim; PR-4 fetches this second endpoint after `userinfo_url` and picks the entry with `primary == true AND verified == true`. GitHub default: `userinfo_url = "https://api.github.com/user"`, `verified_emails_url = Some("https://api.github.com/user/emails")`. For OIDC providers (Google, Microsoft), `verified_emails_url = None` (the `email_verified` claim is in the userinfo response itself).
 
-`redirect_uri` is **NOT a configuration field**. It is auto-derived at runtime as `format!("{}/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` from the existing `ApiConfig::public_url` (`API_PUBLIC_URL` env). Operators that need multiple callback URIs deploy multiple Nebula instances (each with its own `API_PUBLIC_URL` and IdP client registration).
+`redirect_uri` is **NOT a configuration field**. It is auto-derived at runtime as `format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` from the existing `ApiConfig::public_url` (`API_PUBLIC_URL` env). Operators that need multiple callback URIs deploy multiple Nebula instances (each with its own `API_PUBLIC_URL` and IdP client registration).
 
 **Invariant 1** (🟥 WAVE-6 anti-SSRF hardening per D-9-WAVE6, refined wave-7 with two validator scopes per Codex F.2): Each provider config MUST validate at boot via TWO complementary validator functions per D-9-WAVE6:
 
@@ -81,7 +81,7 @@ The server SHALL accept an operator-supplied configuration that maps each suppor
 `PgAuthBackend::start_oauth(provider, redirect_uri)` and `InMemoryAuthBackend::start_oauth(provider, redirect_uri)` SHALL (🟥 RECON-3 + RECON-4 REVISED steps; supersedes the earlier RECON-2 revision):
 
 1. Look up the validated `OAuthProviderConfig` from `ApiConfig::auth.oauth.providers[provider]`. If absent → `AuthError::ProviderNotConfigured { provider }`.
-2. Derive the canonical `redirect_uri` from `api_config.public_url` per D-3 (recon-4): `format!("{}/auth/oauth/{}/callback", api_config.public_url, provider.as_str())`. The handler-supplied `redirect_uri` argument MUST already equal this derived value (the handler derived it the same way before calling the trait method); a mismatch is a `debug_assert!` at the trait boundary, not a runtime branch.
+2. Derive the canonical `redirect_uri` from `api_config.public_url` per D-3 (recon-4): `format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url, provider.as_str())`. The handler-supplied `redirect_uri` argument MUST already equal this derived value (the handler derived it the same way before calling the trait method); a mismatch is a `debug_assert!` at the trait boundary, not a runtime branch.
 3. Resolve the IdP endpoints from `provider_config.endpoints`:
    - `OAuthEndpoints::Oidc { discovery_url }` — call `fetch_oidc_discovery(discovery_url)` (D-15) to obtain `OidcDiscovery { authorize_url, token_url, userinfo_url, jwks_url? }` (cached process-wide). Hardcoded scopes `"openid email profile"`.
    - `OAuthEndpoints::Manual { authorize_url, token_url, userinfo_url, jwks_url?, scopes }` — use as-is; operator-supplied `scopes`.
@@ -101,12 +101,12 @@ PKCE plain is structurally impossible per Scenario 2.2 (the `PkceMethod` enum ha
   - **Given** `[auth.oauth.providers.google]` has `client_id = "google-client-1"`, `client_secret = "..."`, `endpoints = { kind = "oidc", discovery_url = "https://accounts.google.com/.well-known/openid-configuration" }`
   - **And** `API_PUBLIC_URL = "https://app.example.com"`
   - **And** the OIDC discovery doc resolves `authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"`
-  - **When** the handler derives `redirect_uri = "https://app.example.com/auth/oauth/google/callback"` and calls `start_oauth(OAuthProvider::Google, &redirect_uri)`
+  - **When** the handler derives `redirect_uri = "https://app.example.com/api/v1/auth/oauth/google/callback"` and calls `start_oauth(OAuthProvider::Google, &redirect_uri)`
   - **Then** the returned `authorize_url` starts with `https://accounts.google.com/o/oauth2/v2/auth?`
   - **And** the query string contains `client_id=google-client-1`
   - **And** the query string contains `redirect_uri=https%3A%2F%2Fapp.example.com%2Fauth%2Foauth%2Fgoogle%2Fcallback` (URL-encoded)
   - **And** the query string contains `code_challenge_method=S256` and a non-empty `code_challenge`
-  - **And** the `plane_a_oauth_states` row contains the unencoded `code_verifier` (NOT the challenge) and `redirect_uri = "https://app.example.com/auth/oauth/google/callback"`
+  - **And** the `plane_a_oauth_states` row contains the unencoded `code_verifier` (NOT the challenge) and `redirect_uri = "https://app.example.com/api/v1/auth/oauth/google/callback"`
 
 - **Scenario 2.2 — PKCE plain is structurally impossible** (🟥 RECON-2)
   - **Given** the `PkceMethod` enum at `crates/credential/src/credentials/oauth2_config.rs:48-65` has exactly one variant (`S256`)
@@ -141,7 +141,7 @@ PKCE plain is structurally impossible per Scenario 2.2 (the `PkceMethod` enum ha
 **Scenarios**:
 
 - **Scenario 3.1 — Happy path mints a session (🟥 RECON-3 + RECON-4 REVISED)**
-  - **Given** `start_oauth` returned `state = "abc"` and persisted the `plane_a_oauth_states` row with `redirect_uri = "https://app.example.com/auth/oauth/google/callback"`
+  - **Given** `start_oauth` returned `state = "abc"` and persisted the `plane_a_oauth_states` row with `redirect_uri = "https://app.example.com/api/v1/auth/oauth/google/callback"`
   - **And** the IdP redirects with `?state=abc&code=xyz` to the callback URL
   - **And** `wiremock` (reached via `nebula_api::test_support::*` bypass helpers under `--cfg nebula_test_util` — D-14 wave-5 revision) is configured to return a 200 token response and a userinfo response containing `email = "alice@example.com"` (verified) and `sub = "google-1"`
   - **When** the handler derives the same `redirect_uri` and calls `complete_oauth(OAuthProvider::Google, "abc", "xyz", &redirect_uri)`
@@ -187,9 +187,9 @@ PKCE plain is structurally impossible per Scenario 2.2 (the `PkceMethod` enum ha
   - **Then** the call returns `AuthError::OAuthFailed` with `cause = "token_endpoint_timeout"` within `oauth_token_timeout_ms + 500 ms`
 
 - **Scenario 3.10 — `public_url` change mid-flow rejected** (🟥 RECON-4 NEW)
-  - **Given** `start_oauth` was called when `API_PUBLIC_URL=https://a.example.com`, persisting `redirect_uri="https://a.example.com/auth/oauth/google/callback"` in `OAuthStateRow`
+  - **Given** `start_oauth` was called when `API_PUBLIC_URL=https://a.example.com`, persisting `redirect_uri="https://a.example.com/api/v1/auth/oauth/google/callback"` in `OAuthStateRow`
   - **And** the operator changed `API_PUBLIC_URL=https://b.example.com` and restarted the server
-  - **When** the callback arrives and `complete_oauth` derives `redirect_uri="https://b.example.com/auth/oauth/google/callback"`
+  - **When** the callback arrives and `complete_oauth` derives `redirect_uri="https://b.example.com/api/v1/auth/oauth/google/callback"`
   - **Then** the row's `redirect_uri` does not match the derived one
   - **And** the call returns `AuthError::OAuthFailed` with `cause = "public_url_changed_mid_flow"`
   - **And** no token endpoint POST is made
@@ -325,15 +325,15 @@ Every implementor of `AuthBackend` MUST update. Today's implementors:
 - `InMemoryAuthBackend` (`crates/api/src/domain/auth/backend/in_memory.rs`)
 - All test-only mocks under `crates/api/tests/`
 
-The handler `crates/api/src/domain/auth/handler.rs::oauth_start` (and `oauth_callback`) SHALL **derive** `redirect_uri` from `ApiConfig::public_url` per D-3 recon-4 — `format!("{}/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` — and pass the derived value to the backend method. The handler does NOT accept `redirect_uri` as a request parameter (query string, form, or otherwise); the operator does not get to override it per-request. The same derivation formula MUST be used at both endpoints (a shared private helper in the handler module or a `OAuthProviderConfig::derived_redirect_uri(public_url, provider)` accessor) so the value round-trips identically through `OAuthStateRow.redirect_uri` and is re-verified on `complete_oauth` (Scenario 3.10).
+The handler `crates/api/src/domain/auth/handler.rs::oauth_start` (and `oauth_callback`) SHALL **derive** `redirect_uri` from `ApiConfig::public_url` per D-3 recon-4 — `format!("{}/api/v1/auth/oauth/{}/callback", api_config.public_url, provider.as_str())` — and pass the derived value to the backend method. The handler does NOT accept `redirect_uri` as a request parameter (query string, form, or otherwise); the operator does not get to override it per-request. The same derivation formula MUST be used at both endpoints (a shared private helper in the handler module or a `OAuthProviderConfig::derived_redirect_uri(public_url, provider)` accessor) so the value round-trips identically through `OAuthStateRow.redirect_uri` and is re-verified on `complete_oauth` (Scenario 3.10).
 
 **Scenarios**:
 
 - **Scenario auth-backend-001.1 — Handler derives `redirect_uri` from `ApiConfig::public_url` (🟥 RECON-4 REVISED)**
   - **Given** `API_PUBLIC_URL = "https://app.example.com"`
   - **And** a request `POST /auth/oauth/google/start` (NO `redirect_uri` query parameter — the handler does not accept one)
-  - **When** the handler computes `redirect_uri = format!("{}/auth/oauth/google/callback", api_config.public_url)` and invokes `backend.start_oauth(OAuthProvider::Google, &redirect_uri)`
-  - **Then** the resulting `plane_a_oauth_states` row carries `redirect_uri = "https://app.example.com/auth/oauth/google/callback"`
+  - **When** the handler computes `redirect_uri = format!("{}/api/v1/auth/oauth/google/callback", api_config.public_url)` and invokes `backend.start_oauth(OAuthProvider::Google, &redirect_uri)`
+  - **Then** the resulting `plane_a_oauth_states` row carries `redirect_uri = "https://app.example.com/api/v1/auth/oauth/google/callback"`
   - **And** the returned `OAuthStart.authorize_url` query string contains `redirect_uri=https%3A%2F%2Fapp.example.com%2Fauth%2Foauth%2Fgoogle%2Fcallback`
 
 - **Scenario auth-backend-001.2 — 🟥 RECON-4 DELETED**


### PR DESCRIPTION
> **PR-5 of the 5-PR M3.1 OAuth identity-login chain — final PR, closes the chain.**
>
> Stacked on \`main\` (PR-4 merged \`b7b703a1\`).

## What this PR lands

**Docs only. No code change. No test change.** Closes ROADMAP §M3.1 final OAuth-providers checkbox and documents the 1.1 deferred work.

### \`docs/ROADMAP.md\`
- Flipped \`[ ]\` → \`[x]\` for "OAuth providers loaded from operator secrets"
- Rewrote body: shipped-with-chain summary citing #757 + #758 + #759 + #761

### \`crates/api/README.md\`
NEW "OAuth identity providers (Plane A)" section with:
- 1.0 providers (Google / Microsoft / GitHub)
- Configuration shape table (OIDC vs Manual)
- \`API_PUBLIC_URL\` discipline
- Worked example (Google OIDC + GitHub Manual side by side)
- 5-step flow walkthrough
- Security posture summary (anti-SSRF / body caps / cache key includes flag / tokens discarded / JWKS deferral / account-takeover defense / observability triple)

### \`CHANGELOG.md\`
Added Plane-A OAuth entry to \`[Unreleased]\` under \`Added\` citing chain PRs, migration, 1.0 providers, GitHub fallback, JWKS deferral.

### \`openspec/changes/oauth-providers-from-operator-secrets/STATUS.md\`
NEW marker file documenting the change as **✅ SHIPPED / ARCHIVED** with:
- 5-PR chain table (merge commits)
- 13 live D-* decisions + superseded audit trail
- Review-marathon summary (per-PR wave-1 counts: 18→9→7→5)

### \`docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md\`
NEW 1.1 follow-up plan tracking three deferred items:
1. **id_token JWKS signature validation** (D-16 defer): per-provider jwks_url resolution; 5 RED tests
2. **DNS-resolution SSRF defense-in-depth**: custom \`reqwest::Client\` resolver via \`hickory_resolver\`; rejects bogons post-resolution
3. **\`OAuthProvider\` enum extension** (Auth0 / Okta / generic OIDC)

Sequencing recommendation: DNS-resolver → JWKS → enum extension.

## Files changed (1 commit, +383 / -14)

| File | Change |
|---|---|
| \`docs/ROADMAP.md\` | Flipped M3.1 OAuth checkbox + rewrote body |
| \`crates/api/README.md\` | +101 lines OAuth operator-setup section |
| \`CHANGELOG.md\` | +19 lines Added entry |
| \`openspec/.../STATUS.md\` | NEW (89 lines) |
| \`docs/plans/...-1.1-followups-plan.md\` | NEW (154 lines) |

## Verification

- \`cargo check -p nebula-api\`: clean (markdown-only, no Rust change).
- 479 / 479 tests still pass on \`main\` (unchanged from PR-4).
- Pre-commit: typos + convco expected to pass.

## 🎉 5-PR M3.1 chain summary

| PR | Status | Commits | LOC | Notes |
|---|---|---|---|---|
| #757 ADR | ✅ MERGED \`4d938bdb\` | 8 (review cycles) | +3,150 | ADR + 8 SDD planning artifacts |
| #758 trait+config+compose | ✅ MERGED \`62c8c601\` | 5 | +1,306 | OAuthProvidersConfig + AuthBackend trait sig + compose validation + test_support module |
| #759 real authorize URL | ✅ MERGED \`27c3d7c7\` | 4 | +1,065 | OIDC discovery cache + flow::build_authorization_uri + 4 RED tests |
| #761 real complete_oauth | ✅ MERGED \`b7b703a1\` | 4 | +1,336 | external_identities + REQ-oauth-006 short-circuit + 9 RED tests (MAIN DELIVERABLE) |
| **PR-5 docs** | 🟡 **DRAFT** | 1 | +383 | _this PR_ |

**Total**: ~7,240 LOC delivered across 5 PRs over the M3.1 cycle. 479 tests passing on \`main\`. 17 actionable bot comments closed across review waves (8 + 2 + 3 + 1 + ... pending = ~14 closure waves total).

## Refs

- ROADMAP §M3.1 final checkbox.
- [ADR-0085 OAuth identity providers from operator secrets](../tree/main/docs/adr/0085-oauth-identity-providers-from-secrets.md).
- [OpenSpec change archive (STATUS.md)](../tree/main/openspec/changes/oauth-providers-from-operator-secrets/STATUS.md).
- [1.1 follow-up plan](../tree/main/docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md).
- PR #757 (ADR) merged \`4d938bdb\`.
- PR #758 (trait+config+compose) merged \`62c8c601\`.
- PR #759 (real authorize URL + OIDC discovery) merged \`27c3d7c7\`.
- PR #761 (real complete_oauth + external_identities + REQ-oauth-006) merged \`b7b703a1\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed OAuth redirect URI path formatting issue that prevented proper identity provider redirects.

* **New Features**
  * OAuth identity providers sourced from operator secrets now fully functional, enabling complete authorization flow with userinfo lookup and session creation.

* **Documentation**
  * Added comprehensive OAuth configuration, security posture, and observability documentation.
  * Updated architecture decision records and implementation roadmap to reflect completed OAuth provider support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->