### PR TITLE
refactor(resource): complete EventBus migration — restore dropped lifecycle events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,7 @@ dependencies = [
  "nebula-core",
  "nebula-credential",
  "nebula-error",
+ "nebula-eventbus",
  "nebula-expression",
  "nebula-metadata",
  "nebula-metrics",

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -1017,13 +1017,13 @@ mod shared_resource {
         let mut found = false;
         for _ in 0..16 {
             match events.try_recv() {
-                Ok(ResourceEvent::ConfigReloaded { key }) => {
+                Some(ResourceEvent::ConfigReloaded { key }) => {
                     assert_eq!(key, TelegramBot::key());
                     found = true;
                     break;
                 },
-                Ok(_) => continue,
-                Err(_) => break,
+                Some(_) => continue,
+                None => break,
             }
         }
         assert!(

--- a/crates/engine/tests/resource_rotation_redaction.rs
+++ b/crates/engine/tests/resource_rotation_redaction.rs
@@ -276,7 +276,7 @@ impl Resident for SecretBearingResource {
 /// expected slot variants were observed so the event surface is proven
 /// non-empty (not trivially redaction-clean by emitting nothing).
 struct EventSink {
-    rx: tokio::sync::broadcast::Receiver<ResourceEvent>,
+    rx: nebula_eventbus::Subscriber<ResourceEvent>,
 }
 
 #[derive(Default)]
@@ -296,41 +296,34 @@ impl EventSink {
         // broadcast channel is a fixed 256-slot buffer (constructed
         // internally by `Manager`; capacity is not caller-controllable
         // here) and this gate emits ≤2 events per direction, so `Lagged`
-        // cannot trigger under load — the panic below is a guard that
-        // converts the impossible-by-construction case into a hard fail
-        // rather than a worthless pass.
-        loop {
-            match self.rx.try_recv() {
-                Ok(evt) => {
-                    // `ResourceEvent` derives `Debug` (no `Display`); the
-                    // Debug rendering expands every struct field name +
-                    // value, so a credential in any field — including the
-                    // `error: String` on the `*Failed` variants — would
-                    // surface here verbatim.
-                    d.rendered.push_str(&format!("{evt:?}\n"));
-                    match (&evt, want_revoke) {
-                        (ResourceEvent::SlotRefreshed { .. }, false)
-                        | (ResourceEvent::SlotRevoked { .. }, true) => {
-                            d.saw_success_variant = true;
-                        },
-                        (ResourceEvent::SlotRefreshFailed { .. }, false)
-                        | (ResourceEvent::SlotRevokeFailed { .. }, true) => {
-                            d.saw_failed_variant = true;
-                        },
-                        _ => {},
-                    }
-                    d.count += 1;
+        // cannot trigger under load — the `Subscriber` wrapper
+        // automatically skips lagged events and continues, so we drain
+        // until `None` (empty or closed).
+        while let Some(evt) = self.rx.try_recv() {
+            // `ResourceEvent` derives `Debug` (no `Display`); the
+            // Debug rendering expands every struct field name +
+            // value, so a credential in any field — including the
+            // `error: String` on the `*Failed` variants — would
+            // surface here verbatim.
+            d.rendered.push_str(&format!("{evt:?}\n"));
+            match (&evt, want_revoke) {
+                (ResourceEvent::SlotRefreshed { .. }, false)
+                | (ResourceEvent::SlotRevoked { .. }, true) => {
+                    d.saw_success_variant = true;
                 },
-                Err(tokio::sync::broadcast::error::TryRecvError::Empty) => break,
-                Err(tokio::sync::broadcast::error::TryRecvError::Closed) => break,
-                Err(tokio::sync::broadcast::error::TryRecvError::Lagged(n)) => {
-                    panic!(
-                        "EventSink lagged by {n}: events were dropped — \
-                         redaction gate would be incomplete (false-clean risk)"
-                    );
+                (ResourceEvent::SlotRefreshFailed { .. }, false)
+                | (ResourceEvent::SlotRevokeFailed { .. }, true) => {
+                    d.saw_failed_variant = true;
                 },
+                _ => {},
             }
+            d.count += 1;
         }
+        assert_eq!(
+            self.rx.lagged_count(),
+            0,
+            "event lag detected — security gate may have missed events"
+        );
         d
     }
 }

--- a/crates/engine/tests/resource_rotation_redaction.rs
+++ b/crates/engine/tests/resource_rotation_redaction.rs
@@ -271,10 +271,11 @@ impl Resident for SecretBearingResource {
     }
 }
 
-/// Drains the `ResourceEvent` broadcast sink, returning every event's
-/// Debug **and** Display rendering joined into one haystack. Asserts the
-/// expected slot variants were observed so the event surface is proven
-/// non-empty (not trivially redaction-clean by emitting nothing).
+/// Drains the `ResourceEvent` subscriber, joining every event's Debug
+/// rendering into one haystack (`ResourceEvent` derives `Debug` only, no
+/// `Display`). Asserts the expected slot variants were observed so the event
+/// surface is proven non-empty (not trivially redaction-clean by emitting
+/// nothing).
 struct EventSink {
     rx: nebula_eventbus::Subscriber<ResourceEvent>,
 }
@@ -293,12 +294,13 @@ impl EventSink {
         // The drain MUST be loud on a dropped event: a silent stop on
         // `Lagged` would skip an event that may have carried credential
         // material, yielding a false-clean from this security gate. The
-        // broadcast channel is a fixed 256-slot buffer (constructed
-        // internally by `Manager`; capacity is not caller-controllable
-        // here) and this gate emits ≤2 events per direction, so `Lagged`
-        // cannot trigger under load — the `Subscriber` wrapper
-        // automatically skips lagged events and continues, so we drain
-        // until `None` (empty or closed).
+        // event bus is a fixed 256-slot buffer (constructed internally by
+        // `Manager`; capacity is not caller-controllable here) and this gate
+        // emits ≤2 events per direction, so lag cannot trigger under load —
+        // the `Subscriber` wrapper automatically skips lagged events and
+        // continues, so we drain until `None` (empty or closed). The
+        // `lagged_count() == 0` assertion after the loop fails the gate if
+        // any event was nonetheless skipped.
         while let Some(evt) = self.rx.try_recv() {
             // `ResourceEvent` derives `Debug` (no `Display`); the
             // Debug rendering expands every struct field name +

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -18,6 +18,7 @@ default = []
 # Nebula ecosystem
 nebula-core = { path = "../core" }
 nebula-credential = { path = "../credential" }
+nebula-eventbus = { path = "../eventbus" }
 nebula-expression = { path = "../expression", default-features = false, features = ["cache"] }
 nebula-metrics = { path = "../metrics" }
 nebula-metadata = { path = "../metadata" }

--- a/crates/resource/docs/README.md
+++ b/crates/resource/docs/README.md
@@ -251,7 +251,7 @@ Supported kinds: `transient`, `permanent`, `exhausted` (with optional
 | Fast-fail during backend recovery           | `RegistrationSpec::recovery_gate: Some(Arc<RecoveryGate>)`    |
 | Config hot-reload (fingerprint-based)       | Implement `ResourceConfig::fingerprint`; call `Manager::reload_config` |
 | Per-tenant credential isolation             | Build `SlotIdentity::from_bindings(…)` and acquire via `acquire_<topo>_for_identity` |
-| Lifecycle event stream                      | `manager.subscribe_events()` → `broadcast::Receiver<ResourceEvent>` |
+| Lifecycle event stream                      | `manager.subscribe_events()` → `Subscriber<ResourceEvent>` (re-exported from `nebula_resource`)    |
 | Async background cleanup                    | `ReleaseQueue` (owned by `Manager`, transparent to callers)   |
 | Atomic operation counters                   | `manager.metrics()` → `Option<&ResourceOpsMetrics>`           |
 

--- a/crates/resource/docs/events.md
+++ b/crates/resource/docs/events.md
@@ -7,23 +7,25 @@ Lifecycle event system for observability and diagnostics.
 ## Overview
 
 The `Manager` emits `ResourceEvent`s on every significant lifecycle
-transition. Events are broadcast via a `tokio::sync::broadcast` channel —
-see `Manager::subscribe_events()` for the receiver type.
+transition. Events are published through a `nebula_eventbus::EventBus<ResourceEvent>`
+— see `Manager::subscribe_events()` for the subscriber type.
 
 Subscribe with `Manager::subscribe_events()`:
 
 ```rust,ignore
-let mut rx = manager.subscribe_events();
+use nebula_resource::Subscriber;
+
+let mut rx: Subscriber<ResourceEvent> = manager.subscribe_events();
 tokio::spawn(async move {
-    while let Ok(event) = rx.recv().await {
+    while let Some(event) = rx.recv().await {
         tracing::info!(?event, "resource lifecycle event");
     }
 });
 ```
 
-The channel buffer is fixed at construction; slow consumers receive
-`tokio::sync::broadcast::error::RecvError::Lagged` when they fall
-behind — see [Slow consumers](#slow-consumers) below.
+Lag handling is automatic: when a subscriber falls behind, the
+`EventBus` skips to the latest event internally — subscribers never
+need to handle a lag error explicitly.
 
 ---
 
@@ -92,7 +94,7 @@ non-resource-scoped variant, but every variant shipped today returns
 ### Metrics collection
 
 ```rust,ignore
-while let Ok(event) = rx.recv().await {
+while let Some(event) = rx.recv().await {
     match &event {
         ResourceEvent::AcquireSuccess { duration, .. } => {
             histogram.record(duration.as_millis() as f64);
@@ -111,21 +113,21 @@ while let Ok(event) = rx.recv().await {
 
 ### Slow consumers
 
-Slow consumers receive `tokio::sync::broadcast::error::RecvError::Lagged(n)`
-when the channel overruns — *n* events were dropped. Handle it:
+The `EventBus` handles buffer overflow internally: when a subscriber
+falls behind, the bus skips to the latest event automatically.
+Subscribers do **not** need to handle `RecvError::Lagged` explicitly —
+the lag recovery is transparent.
 
 ```rust,ignore
-match rx.recv().await {
-    Ok(event) => handle(event),
-    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-        tracing::warn!(dropped = n, "event consumer lagged");
-    }
-    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+// Simple consumption loop — no lag error handling needed.
+while let Some(event) = rx.recv().await {
+    handle(event);
 }
 ```
 
-The broadcast channel drops oldest events on overflow — there is no
-back-pressure or retry mechanism inside the Manager.
+There is no back-pressure or retry mechanism inside the Manager; the
+EventBus drops oldest events on overflow and advances slow subscribers
+to the latest position.
 
 ### Auditing slot rotation
 
@@ -154,8 +156,11 @@ aggregate.
 
 ## Differences from v1
 
-- **No `EventBus`** — events come directly from `Manager::subscribe_events()`;
-  no separate bus crate, no subscriber registration.
+- **Uses `nebula_eventbus::EventBus`** — events are published through the
+  shared EventBus crate; `Manager::subscribe_events()` returns a
+  `Subscriber<ResourceEvent>` (re-exported from `nebula_resource`).
 - **No `HookRegistry`** — pre/post hooks were removed. Use events for observation.
 - **No filtered subscriptions** — filter in your consumer logic.
-- **No `BackPressurePolicy`** — the broadcast channel drops oldest on overflow.
+- **Automatic lag handling** — the EventBus drops oldest on overflow and
+  skips slow subscribers to the latest event; no explicit `RecvError::Lagged`
+  handling required.

--- a/crates/resource/src/context.rs
+++ b/crates/resource/src/context.rs
@@ -230,21 +230,16 @@ pub fn scope_to_level(scope: &Scope) -> ScopeLevel {
 /// rows registered at those levels remain reachable without falling through to
 /// an unrelated Global row.
 pub fn scope_levels_for_acquire(scope: &Scope) -> Vec<ScopeLevel> {
-    let mut levels = Vec::with_capacity(5);
-    if let Some(id) = scope.execution_id {
-        levels.push(ScopeLevel::Execution(id));
-    }
-    if let Some(id) = scope.workflow_id {
-        levels.push(ScopeLevel::Workflow(id));
-    }
-    if let Some(id) = scope.workspace_id {
-        levels.push(ScopeLevel::Workspace(id));
-    }
-    if let Some(id) = scope.org_id {
-        levels.push(ScopeLevel::Organization(id));
-    }
-    levels.push(ScopeLevel::Global);
-    levels
+    [
+        scope.execution_id.map(ScopeLevel::Execution),
+        scope.workflow_id.map(ScopeLevel::Workflow),
+        scope.workspace_id.map(ScopeLevel::Workspace),
+        scope.org_id.map(ScopeLevel::Organization),
+        Some(ScopeLevel::Global),
+    ]
+    .into_iter()
+    .flatten()
+    .collect()
 }
 
 /// Builds a minimal [`Scope`] bag containing only the given level's id field.

--- a/crates/resource/src/error.rs
+++ b/crates/resource/src/error.rs
@@ -49,6 +49,41 @@ pub enum ErrorKind {
     Ambiguous,
 }
 
+impl ErrorKind {
+    /// Returns the `(category, code-string)` classification for this error kind.
+    ///
+    /// Consolidates the per-variant category and code into a single match so
+    /// that adding a new variant only requires one update site.
+    fn classification(&self) -> (nebula_error::ErrorCategory, &'static str) {
+        match self {
+            Self::Transient => (nebula_error::ErrorCategory::External, "RESOURCE:TRANSIENT"),
+            Self::Permanent => (nebula_error::ErrorCategory::Internal, "RESOURCE:PERMANENT"),
+            Self::Exhausted { .. } => {
+                (nebula_error::ErrorCategory::Exhausted, "RESOURCE:EXHAUSTED")
+            },
+            Self::Backpressure => (
+                nebula_error::ErrorCategory::RateLimit,
+                "RESOURCE:BACKPRESSURE",
+            ),
+            Self::NotFound => (nebula_error::ErrorCategory::NotFound, "RESOURCE:NOT_FOUND"),
+            Self::Cancelled => (nebula_error::ErrorCategory::Cancelled, "RESOURCE:CANCELLED"),
+            Self::Revoked => (nebula_error::ErrorCategory::Unavailable, "RESOURCE:REVOKED"),
+            Self::Ambiguous => (nebula_error::ErrorCategory::Conflict, "RESOURCE:AMBIGUOUS"),
+        }
+    }
+
+    /// Whether this error kind is retryable by default.
+    ///
+    /// `Transient`, `Exhausted`, `Backpressure`, and `Revoked` represent
+    /// conditions that resolve with time or backoff.
+    fn is_default_retryable(&self) -> bool {
+        matches!(
+            self,
+            Self::Transient | Self::Exhausted { .. } | Self::Backpressure | Self::Revoked
+        )
+    }
+}
+
 /// Whether the error is resource-wide or target-specific.
 ///
 /// Currently a single-variant `#[non_exhaustive]` enum: only [`Resource`]
@@ -110,13 +145,7 @@ impl Error {
     /// with time or backoff (`Revoked` clears once the credential is
     /// re-registered).
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self.kind,
-            ErrorKind::Transient
-                | ErrorKind::Exhausted { .. }
-                | ErrorKind::Backpressure
-                | ErrorKind::Revoked
-        )
+        self.kind.is_default_retryable()
     }
 
     /// Returns the retry-after hint, if available.
@@ -269,44 +298,15 @@ impl std::error::Error for Error {
 
 impl nebula_error::Classify for Error {
     fn category(&self) -> nebula_error::ErrorCategory {
-        match &self.kind {
-            ErrorKind::Transient => nebula_error::ErrorCategory::External,
-            ErrorKind::Permanent => nebula_error::ErrorCategory::Internal,
-            ErrorKind::Exhausted { .. } => nebula_error::ErrorCategory::Exhausted,
-            ErrorKind::Backpressure => nebula_error::ErrorCategory::RateLimit,
-            ErrorKind::NotFound => nebula_error::ErrorCategory::NotFound,
-            ErrorKind::Cancelled => nebula_error::ErrorCategory::Cancelled,
-            // Non-terminal: the taint clears on credential re-registration.
-            // `Unavailable` is the retryable family the shared classifier
-            // uses for "temporarily down, try again" (see
-            // `ErrorCategory::is_default_retryable`).
-            ErrorKind::Revoked => nebula_error::ErrorCategory::Unavailable,
-            // Caller/wiring fault, not an internal breach: the caller asked
-            // for a `(key, scope)` that resolves to more than one tenant's
-            // registration without pinning a slot identity. `Conflict` is
-            // the client-error, non-retryable family (it is NOT a server
-            // 5xx — see `ErrorCategory::is_client_error` /
-            // `is_server_error`), so the deny surfaces as a caller conflict
-            // rather than `Internal`.
-            ErrorKind::Ambiguous => nebula_error::ErrorCategory::Conflict,
-        }
+        self.kind.classification().0
     }
 
     fn code(&self) -> nebula_error::ErrorCode {
-        nebula_error::ErrorCode::new(match &self.kind {
-            ErrorKind::Transient => "RESOURCE:TRANSIENT",
-            ErrorKind::Permanent => "RESOURCE:PERMANENT",
-            ErrorKind::Exhausted { .. } => "RESOURCE:EXHAUSTED",
-            ErrorKind::Backpressure => "RESOURCE:BACKPRESSURE",
-            ErrorKind::NotFound => "RESOURCE:NOT_FOUND",
-            ErrorKind::Cancelled => "RESOURCE:CANCELLED",
-            ErrorKind::Revoked => "RESOURCE:REVOKED",
-            ErrorKind::Ambiguous => "RESOURCE:AMBIGUOUS",
-        })
+        nebula_error::ErrorCode::new(self.kind.classification().1)
     }
 
     fn is_retryable(&self) -> bool {
-        self.is_retryable()
+        self.kind.is_default_retryable()
     }
 
     fn retry_hint(&self) -> Option<nebula_error::RetryHint> {

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -16,7 +16,8 @@ use std::{
 };
 
 use nebula_core::ResourceKey;
-use tokio::sync::{Notify, OwnedSemaphorePermit, broadcast};
+use nebula_eventbus::EventBus;
+use tokio::sync::{Notify, OwnedSemaphorePermit};
 
 use crate::{events::ResourceEvent, resource::Resource, topology_tag::TopologyTag};
 
@@ -103,15 +104,15 @@ pub struct ResourceGuard<R: Resource> {
     /// See the [`manager`](crate::manager) module docs for the canonical
     /// invariant.
     drain_counters: Option<DrainTrackers>,
-    /// Optional manager broadcast sender for emitting
-    /// [`ResourceEvent::Released`] on drop. Attached by
+    /// Optional manager event bus for emitting [`ResourceEvent::Released`]
+    /// on drop. Attached by
     /// [`Manager::run_acquire`](crate::manager::Manager) right after the
     /// underlying topology runtime hands back the guard. `None` for
     /// guards minted outside the manager funnel (tests, fixtures, ad-hoc
     /// owned guards) — in that case the released event is silently
-    /// skipped, matching the existing best-effort
-    /// `event_tx.send(...).ok()` contract elsewhere in the crate.
-    event_tx: Option<broadcast::Sender<ResourceEvent>>,
+    /// skipped, matching the existing best-effort emit contract elsewhere
+    /// in the crate.
+    event_bus: Option<Arc<EventBus<ResourceEvent>>>,
 }
 
 enum GuardInner<R: Resource> {
@@ -140,7 +141,7 @@ impl<R: Resource> ResourceGuard<R> {
             topology_tag,
             acquired_at: Instant::now(),
             drain_counters: None,
-            event_tx: None,
+            event_bus: None,
         }
     }
 
@@ -189,7 +190,7 @@ impl<R: Resource> ResourceGuard<R> {
             topology_tag,
             acquired_at: Instant::now(),
             drain_counters: None,
-            event_tx: None,
+            event_bus: None,
         }
     }
 
@@ -212,7 +213,7 @@ impl<R: Resource> ResourceGuard<R> {
             topology_tag,
             acquired_at: Instant::now(),
             drain_counters: None,
-            event_tx: None,
+            event_bus: None,
         }
     }
 
@@ -234,17 +235,14 @@ impl<R: Resource> ResourceGuard<R> {
         self
     }
 
-    /// Attaches the manager's broadcast sender so this guard emits
+    /// Attaches the manager's event bus so this guard emits
     /// [`ResourceEvent::Released`] on drop. Wired by
     /// [`Manager::run_acquire`](crate::manager::Manager) right after the
     /// topology runtime hands back the guard. Without this, the guard
-    /// silently skips the released event — the existing best-effort
-    /// `event_tx.send(...).ok()` discipline applies here too.
-    // TODO(eventbus-migration): convert to EventBus — currently unused
-    // because `Manager::run_acquire` no longer holds a broadcast sender.
-    #[allow(dead_code)]
-    pub(crate) fn with_event_tx(mut self, event_tx: broadcast::Sender<ResourceEvent>) -> Self {
-        self.event_tx = Some(event_tx);
+    /// silently skips the released event — the existing best-effort emit
+    /// discipline applies here too.
+    pub(crate) fn with_event_bus(mut self, event_bus: Arc<EventBus<ResourceEvent>>) -> Self {
+        self.event_bus = Some(event_bus);
         self
     }
 
@@ -425,11 +423,11 @@ impl<R: Resource> Drop for ResourceGuard<R> {
         }
 
         // Best-effort `Released` event — wired by `Manager::run_acquire`
-        // via `with_event_tx`. Emitted **after** the release callback runs
+        // via `with_event_bus`. Emitted **after** the release callback runs
         // so observers see the event in the same order as the underlying
-        // recycle/destroy effect. Send failures (no subscribers) are
-        // expected and silently dropped via `.ok()`, matching every other
-        // event sink in the crate.
+        // recycle/destroy effect. The `PublishOutcome` is intentionally
+        // discarded (no subscribers is the expected normal case), matching
+        // every other event sink in the crate.
         //
         // Skip the emit when `inner` is `None` — that state is only
         // produced by `detach()`, which hands the lease to the caller
@@ -437,14 +435,13 @@ impl<R: Resource> Drop for ResourceGuard<R> {
         // here would be a false lifecycle signal: subscribers would see a
         // release for a lease that is still live in caller ownership.
         if self.inner.is_some()
-            && let Some(tx) = self.event_tx.take()
+            && let Some(bus) = self.event_bus.take()
         {
-            tx.send(ResourceEvent::Released {
+            let _ = bus.emit(ResourceEvent::Released {
                 key: self.resource_key.clone(),
                 held,
                 tainted: event_tainted,
-            })
-            .ok();
+            });
         }
     }
 }

--- a/crates/resource/src/guard.rs
+++ b/crates/resource/src/guard.rs
@@ -240,6 +240,9 @@ impl<R: Resource> ResourceGuard<R> {
     /// topology runtime hands back the guard. Without this, the guard
     /// silently skips the released event — the existing best-effort
     /// `event_tx.send(...).ok()` discipline applies here too.
+    // TODO(eventbus-migration): convert to EventBus — currently unused
+    // because `Manager::run_acquire` no longer holds a broadcast sender.
+    #[allow(dead_code)]
     pub(crate) fn with_event_tx(mut self, event_tx: broadcast::Sender<ResourceEvent>) -> Self {
         self.event_tx = Some(event_tx);
         self

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -79,6 +79,9 @@ pub use manager::{
 };
 pub use metrics::{OutcomeCountersSnapshot, ResourceOpsMetrics, ResourceOpsSnapshot};
 pub use nebula_core::{ExecutionId, ResourceKey, ScopeLevel, WorkflowId, resource_key};
+/// Re-export [`Subscriber`] so callers of [`Manager::subscribe_events`] do not
+/// need a direct `nebula-eventbus` dependency.
+pub use nebula_eventbus::Subscriber;
 // Credential surface re-exported so resource consumers don't need a
 // direct nebula-credential dep for trait shape.
 //

--- a/crates/resource/src/manager/gate.rs
+++ b/crates/resource/src/manager/gate.rs
@@ -53,11 +53,8 @@ pub(super) enum GateAdmission {
     /// without re-reading state (which would race the ticket).
     Probe {
         ticket: RecoveryTicket,
-        #[allow(dead_code)]
         attempt: u32,
-        #[allow(dead_code)]
         backoff_on_fail: Duration,
-        #[allow(dead_code)]
         last_failure: Option<String>,
     },
 }

--- a/crates/resource/src/manager/gate.rs
+++ b/crates/resource/src/manager/gate.rs
@@ -53,8 +53,11 @@ pub(super) enum GateAdmission {
     /// without re-reading state (which would race the ticket).
     Probe {
         ticket: RecoveryTicket,
+        #[allow(dead_code)]
         attempt: u32,
+        #[allow(dead_code)]
         backoff_on_fail: Duration,
+        #[allow(dead_code)]
         last_failure: Option<String>,
     },
 }

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -502,7 +502,12 @@ pub struct Manager {
     pub(super) registry: Registry,
     pub(super) cancel: CancellationToken,
     pub(super) metrics: Option<ResourceOpsMetrics>,
-    pub(super) event_bus: EventBus<ResourceEvent>,
+    /// Shared lifecycle-event sink. Held behind `Arc` so the same bus can be
+    /// wired into per-resource [`RecoveryGate`](crate::recovery::gate::RecoveryGate)s
+    /// and into each [`ResourceGuard`](crate::guard::ResourceGuard) (for its
+    /// `Released`-on-drop emit) without exposing the underlying broadcast
+    /// sender across module boundaries.
+    pub(super) event_bus: Arc<EventBus<ResourceEvent>>,
     pub(super) release_queue: Arc<ReleaseQueue>,
     pub(super) release_queue_handle: tokio::sync::Mutex<Option<ReleaseQueueHandle>>,
     /// Tracks active `ResourceGuard`s for drain-aware shutdown.
@@ -523,7 +528,7 @@ impl Manager {
 
     /// Creates a new empty manager with the given configuration.
     pub fn with_config(config: ManagerConfig) -> Self {
-        let event_bus = EventBus::new(256);
+        let event_bus = Arc::new(EventBus::new(256));
         let cancel = CancellationToken::new();
         let (release_queue, release_queue_handle) =
             ReleaseQueue::with_cancel(config.release_queue_workers, cancel.clone());
@@ -568,9 +573,14 @@ impl Manager {
 
     /// Subscribes to resource lifecycle events.
     ///
-    /// Returns a [`Subscriber`] that receives [`ResourceEvent`]s
-    /// emitted during registration, removal, and acquisition. Slow consumers
-    /// that fall behind the 256-event buffer will observe lagged events.
+    /// Returns a [`Subscriber`](crate::Subscriber) that receives
+    /// [`ResourceEvent`]s emitted during registration, removal, and
+    /// acquisition. The buffer is fixed at 256 events: a slow consumer that
+    /// falls behind has the *oldest* unread events skipped (the subscriber
+    /// auto-recovers and re-positions to the latest event — it never returns
+    /// a lag error). Use
+    /// [`Subscriber::lagged_count`](crate::Subscriber::lagged_count) to
+    /// observe how many events were skipped.
     pub fn subscribe_events(&self) -> crate::Subscriber<ResourceEvent> {
         self.event_bus.subscribe()
     }
@@ -688,6 +698,17 @@ impl Manager {
         // it *before* building the runtime.)
 
         let key = R::key();
+
+        // Wire the manager's event bus into the optional recovery gate so its
+        // state transitions emit `ResourceEvent::RecoveryGateChanged`.
+        // Idempotent at the `RecoveryGate` end: a gate handed to a second
+        // manager (test composition, scoped registry) keeps its first sink
+        // and ignores this call. Cheap and lock-free — `OnceLock::set` is one
+        // CAS over a cloned `Arc`.
+        if let Some(gate) = recovery_gate.as_deref() {
+            gate.set_event_sink(Arc::clone(&self.event_bus), key.clone());
+        }
+
         let managed = Arc::new(ManagedResource {
             resource,
             config: arc_swap::ArcSwap::from_pointee(config),
@@ -2025,6 +2046,29 @@ impl Manager {
         self.reject_if_tainted_or_shutting_down_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
 
+        // Publish a `RetryAttempt` event when this acquire is the recovery
+        // probe (the CAS-claimed single-probe slot that follows a transient
+        // backend failure). `backoff_on_fail` carries the delay the gate
+        // would impose *if this probe fails again* — the next caller's wait,
+        // not a wait this acquire incurs. Emitted **before** `dispatch()` so
+        // observers see the attempt go out rather than only the result. The
+        // error field carries the prior failure message snapshotted in
+        // `admit_through_gate` before the CAS rotated the gate.
+        if let gate::GateAdmission::Probe {
+            attempt,
+            backoff_on_fail,
+            last_failure,
+            ..
+        } = &gate_admission
+        {
+            let _ = self.event_bus.emit(ResourceEvent::RetryAttempt {
+                key: R::key(),
+                attempt: *attempt,
+                backoff: *backoff_on_fail,
+                error: last_failure.clone().unwrap_or_default(),
+            });
+        }
+
         let result = dispatch().await;
 
         // Settle the gate ticket based on the acquire result. #322: this
@@ -2035,7 +2079,13 @@ impl Manager {
         settle_gate_admission(gate_admission, &result);
         self.record_acquire_result(&result, started);
         match result {
-            Ok(h) => Ok(h.with_drain_tracker(in_flight.release_to_guard())),
+            // Attach the manager's event bus so the guard's `Drop` emits
+            // `ResourceEvent::Released`. Done here, on the success path only,
+            // because failed acquires never minted a guard to begin with —
+            // there is nothing to release.
+            Ok(h) => Ok(h
+                .with_drain_tracker(in_flight.release_to_guard())
+                .with_event_bus(Arc::clone(&self.event_bus))),
             Err(e) => Err(e),
         }
     }

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -199,39 +199,41 @@
 //! The topology collapse + cross-tenant-barrier + latent-bug closure that
 //! produced this module deliberately did **not** fix every issue it
 //! surfaced. This ledger is the durable record of what was consciously left
-//! for separate work, so nothing is silently inherited. Severity is the
-//! item's own risk, independent of when it is scheduled.
+//! for separate work, so nothing is silently inherited once the originating
+//! plan is gone. Every item is also filed as a tracked issue (linked); this
+//! ledger is the in-tree index, not the sole record. Severity is the item's
+//! own risk, independent of when it is scheduled.
 //!
 //! ## Latent bugs surfaced but out of scope
 //!
-//! - **`reload_config` never drains/rebuilds the live runtime — MED-HIGH.**
-//!   `reload_config` swaps the config `ArcSwap` (and the Pool
+//! - **`reload_config` never drains/rebuilds the live runtime — MED-HIGH**
+//!   ([#712]). `reload_config` swaps the config `ArcSwap` (and the Pool
 //!   fingerprint) but never drains in-flight work or rebuilds the
 //!   caller-supplied live `Arc<R::Runtime>` for any topology, so a reload
 //!   that should rotate the running runtime is silently not applied to it.
 //!   Deferred because the reload redesign (drain-then-rebuild + a truthful
 //!   outcome contract) is a separate concern; see the **accepted relabel**
 //!   note below for why this is a preserved no-op, not a regression.
-//! - **Pool `CreateGuard` cancel-drop leaks the runtime — MED.**
+//! - **Pool `CreateGuard` cancel-drop leaks the runtime — MED** ([#713]).
 //!   A *cancelled* acquire whose in-flight `create` already built a runtime
 //!   drops it synchronously without the async `destroy()`, leaking the
 //!   server-side handle. (The *other* `CreateGuard` race — an in-flight
 //!   create completing *after a revoke* — is the same isolation defect as
 //!   the revoke→recycle TOCTOU and **was fixed** by the pooled revoke-epoch
 //!   fence; only the cancelled-acquire leak remains.)
-//! - **Resident recreate `take()`+destroy-under-lock vs dispatch — MED.**
-//!   The resident recreate clears the slot then destroys under the
+//! - **Resident recreate `take()`+destroy-under-lock vs dispatch — MED**
+//!   ([#714]). The resident recreate clears the slot then destroys under the
 //!   lock; a concurrent revoke/refresh dispatch in that window can run
 //!   against the absent/old runtime, losing the revoke for that window.
 //!   Resident internals, out of the collapse seam.
 //! - **`graceful_shutdown` phase-4 detached workers can outlive
-//!   `release_queue_timeout` — LOW.** The timeout bounds the wait,
+//!   `release_queue_timeout` — LOW** ([#715]). The timeout bounds the wait,
 //!   not the detached release work; it eventually drains. shutdown.rs was
 //!   not opened by the collapse.
-//! - **`RecoveryTicket` Drop counts a panicked probe as an attempt — LOW.**
-//!   A defensible-but-untested default; recovery internals.
+//! - **`RecoveryTicket` Drop counts a panicked probe as an attempt — LOW**
+//!   ([#716]). A defensible-but-untested default; recovery internals.
 //!
-//! ## Separable acquire-path perf micro-folds — LOW
+//! ## Separable acquire-path perf micro-folds — LOW ([#717])
 //!
 //! The collapse took only the perf wins **inseparable** from it (one
 //! generic acquire pipeline instead of five byte-identical ones; a single
@@ -244,18 +246,19 @@
 //! regardless; any ordering tuning is a separate reviewed change with a
 //! re-stated memory-model proof.
 //!
-//! ## Cross-crate dedup / layer placement — LOW
+//! ## Cross-crate dedup / layer placement — LOW ([#718])
 //!
-//! Cross-layer type relocation was explicitly out of scope. Deferred:
-//! `ErrorKind` ≈ `nebula_error::ErrorCategory` reconciliation; hardcoded
-//! acquire backoff vs `nebula_resilience::BackoffConfig`; relocating the
-//! live `RecoveryGate` + `ReleaseQueue` to `nebula-resilience`;
-//! `events.rs` raw `broadcast` → `nebula_eventbus::EventBus`; unifying
-//! `CreateGuard`/`SessionGuard` into one `DefuseGuard<T>`; revisiting the
-//! `register_resolved` JSON/`{{ }}` expression coupling and its engine-ABI
-//! positional shape (see the accepted-exception note below).
+//! Cross-layer type relocation was explicitly out of scope (no ADR in this
+//! work). Deferred: `ErrorKind` ≈ `nebula_error::ErrorCategory`
+//! reconciliation; hardcoded acquire backoff vs
+//! `nebula_resilience::BackoffConfig`; relocating the live `RecoveryGate` +
+//! `ReleaseQueue` to `nebula-resilience`; `events.rs` raw `broadcast` →
+//! `nebula_eventbus::EventBus`; unifying `CreateGuard`/`SessionGuard` into
+//! one `DefuseGuard<T>`; revisiting the `register_resolved` JSON/`{{ }}`
+//! expression coupling and its engine-ABI positional shape (see the
+//! accepted-exception note below).
 //!
-//! ## Further `Manager` code-line reduction — LOW
+//! ## Further `Manager` code-line reduction — LOW ([#719])
 //!
 //! `crates/resource/src/manager/mod.rs` is 2552 lines: ~1224 comment/doc,
 //! ~117 blank, ~1211 code. The structural de-spaghettification root-cause
@@ -281,30 +284,49 @@
 //!   `ReloadOutcome::SwappedImmediately` for every variant. This is **only
 //!   an enum label change**: `reload_config` never drained or rebuilt the
 //!   live runtime for that topology under either label (that missing
-//!   behavior is the deferred `reload_config` redesign listed above). A
-//!   characterization net pins the per-topology `reload_config` outcome
-//!   so the relabel is auditable as a preserved no-op, not a silent
-//!   behavior change. The now-unreachable draining variant was removed
-//!   from `ReloadOutcome` once that net landed.
+//!   behavior is exactly [#712]). A characterization net pins the
+//!   per-topology `reload_config` outcome so the relabel is auditable as a
+//!   preserved no-op, not a silent behavior change. The now-unreachable
+//!   draining variant was removed from `ReloadOutcome` once that net
+//!   landed.
 //! - **`register_resolved` carries one `// guard-justified:`
 //!   `#[allow(clippy::too_many_arguments)]`.** The four register-chain
 //!   `too_many_arguments` allows the collapse targeted are gone; this last
 //!   one is the irreducible engine ABI — the production engine registrar
-//!   dispatches into `register_resolved` positionally with an 8-param
-//!   JSON-driven shape (down from 9 after the `AcquireResilience` wrapper
-//!   was dropped manager-side), and collapsing it into a struct would
-//!   re-introduce the navigation hop the single register funnel removed
-//!   for the one erased call site. It is a candidate for the
-//!   cross-crate-dedup follow-up, not a defect. (The three
-//!   `too_many_arguments` allows in `runtime/pool.rs` are pre-existing
-//!   pool internals untouched by this work.)
-//! - **Cross-tenant fixes were latent, not live.** The original 64-bit
-//!   `DefaultHasher` barrier defect (structurally fixed here via the
-//!   collision-free `SlotIdentity` structural set) and the pooled
-//!   revoke→recycle TOCTOU were not reachable in production (this crate is
-//!   `frontier`; there is no production credential→slot resolver), which
-//!   is why seam-coupled remediation was acceptable over a standalone
-//!   hotfix.
+//!   dispatches into `register_resolved` positionally with a 9-param
+//!   JSON-driven shape, and collapsing it into a struct would re-introduce
+//!   the navigation hop the single register funnel removed for the one
+//!   erased call site. It is a candidate for the cross-crate-dedup
+//!   follow-up ([#718]), not a defect. (The three `too_many_arguments`
+//!   allows in `runtime/pool.rs` are pre-existing pool internals untouched
+//!   by this work.)
+//! - **R15/R16 cross-tenant fixes were latent, not live.** The original
+//!   64-bit `DefaultHasher` barrier defect ([#684], **closed** —
+//!   structurally fixed here via the collision-free `SlotIdentity`
+//!   structural set) and the pooled revoke→recycle TOCTOU were not
+//!   reachable in production (this crate is `frontier`; there is no
+//!   production credential→slot resolver), which is why seam-coupled
+//!   remediation was acceptable over a standalone hotfix.
+//!
+//! ## Consumer-migration history (honest record)
+//!
+//! The expand-contract migration of in-tree consumers initially named, but
+//! did **not** migrate, the three `m6_*` example binaries
+//! (`m6_postgres_pool`, `m6_resident_http`, `m6_telegram_multi_workflow`);
+//! they were migrated to `RegistrationSpec` / the structural `SlotIdentity`
+//! in a later, separately-committed step before the old surface was
+//! deleted. Recorded so the migration history is not misread as
+//! single-step.
+//!
+//! [#684]: https://github.com/vanyastaff/nebula/issues/684
+//! [#712]: https://github.com/vanyastaff/nebula/issues/712
+//! [#713]: https://github.com/vanyastaff/nebula/issues/713
+//! [#714]: https://github.com/vanyastaff/nebula/issues/714
+//! [#715]: https://github.com/vanyastaff/nebula/issues/715
+//! [#716]: https://github.com/vanyastaff/nebula/issues/716
+//! [#717]: https://github.com/vanyastaff/nebula/issues/717
+//! [#718]: https://github.com/vanyastaff/nebula/issues/718
+//! [#719]: https://github.com/vanyastaff/nebula/issues/719
 
 use std::{
     future::Future,
@@ -316,7 +338,8 @@ use std::{
 };
 
 use nebula_core::{Context, LayerLifecycle, ResourceKey, ScopeLevel};
-use tokio::sync::{Notify, broadcast};
+use nebula_eventbus::EventBus;
+use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
 use crate::{
@@ -479,7 +502,7 @@ pub struct Manager {
     pub(super) registry: Registry,
     pub(super) cancel: CancellationToken,
     pub(super) metrics: Option<ResourceOpsMetrics>,
-    pub(super) event_tx: broadcast::Sender<ResourceEvent>,
+    pub(super) event_bus: EventBus<ResourceEvent>,
     pub(super) release_queue: Arc<ReleaseQueue>,
     pub(super) release_queue_handle: tokio::sync::Mutex<Option<ReleaseQueueHandle>>,
     /// Tracks active `ResourceGuard`s for drain-aware shutdown.
@@ -500,7 +523,7 @@ impl Manager {
 
     /// Creates a new empty manager with the given configuration.
     pub fn with_config(config: ManagerConfig) -> Self {
-        let (event_tx, _) = broadcast::channel(256);
+        let event_bus = EventBus::new(256);
         let cancel = CancellationToken::new();
         let (release_queue, release_queue_handle) =
             ReleaseQueue::with_cancel(config.release_queue_workers, cancel.clone());
@@ -519,7 +542,7 @@ impl Manager {
             registry: Registry::new(),
             cancel,
             metrics,
-            event_tx,
+            event_bus,
             release_queue: Arc::new(release_queue),
             release_queue_handle: tokio::sync::Mutex::new(Some(release_queue_handle)),
             drain_tracker: Arc::new((AtomicU64::new(0), Notify::new())),
@@ -545,13 +568,11 @@ impl Manager {
 
     /// Subscribes to resource lifecycle events.
     ///
-    /// Returns a [`broadcast::Receiver`] that receives [`ResourceEvent`]s
+    /// Returns a [`Subscriber`] that receives [`ResourceEvent`]s
     /// emitted during registration, removal, and acquisition. Slow consumers
-    /// that fall behind the 256-event buffer will receive a
-    /// [`RecvError::Lagged`](broadcast::error::RecvError::Lagged) on the
-    /// next recv.
-    pub fn subscribe_events(&self) -> broadcast::Receiver<ResourceEvent> {
-        self.event_tx.subscribe()
+    /// that fall behind the 256-event buffer will observe lagged events.
+    pub fn subscribe_events(&self) -> crate::Subscriber<ResourceEvent> {
+        self.event_bus.subscribe()
     }
 
     /// Erased acquire hook for a resident row.
@@ -638,14 +659,7 @@ impl Manager {
     ///
     /// # Errors
     ///
-    /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if
-    ///   [`ResourceConfig::validate`](crate::ResourceConfig::validate)
-    ///   returns an error on the provided config.
-    /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if
-    ///   the supplied [`TopologyRuntime`] variant does not match the
-    ///   resource's topology trait (e.g., `TopologyRuntime::Pool` for a
-    ///   `Resource` that does not implement
-    ///   [`Pooled`](crate::topology::pooled::Pooled)).
+    /// Returns an error if config validation fails on the provided config.
     pub fn register<R: Resource>(&self, spec: RegistrationSpec<R>) -> Result<(), Error> {
         use crate::resource::ResourceConfig as _;
 
@@ -661,29 +675,19 @@ impl Manager {
 
         config.validate()?;
 
-        // Pool min/max sanity is enforced at `PoolRuntime` construction,
-        // which the caller has already invoked to build the
+        // #390 (pool min/max sanity) is enforced at `PoolRuntime`
+        // construction, which the caller has already invoked to build the
         // `TopologyRuntime::Pool` handed in here. No separate
         // register-time pool-config check is needed: an invalid
         // `(min_size, max_size)` from operator/JSON config is rejected by
         // the fallible `PoolRuntime::try_new` (typed `Error::permanent`)
         // that the engine registrar uses to construct the runtime, so the
         // failure surfaces *before* this funnel as a registration error
-        // rather than an abort.
+        // rather than an abort. (The deleted `register_pooled[_with]`
+        // shorthands re-validated the raw config only because they took
+        // it *before* building the runtime.)
 
         let key = R::key();
-
-        // Wire the manager's broadcast sink into the optional recovery
-        // gate so its state transitions emit
-        // `ResourceEvent::RecoveryGateChanged`. Idempotent at the
-        // `RecoveryGate` end: a gate handed to a second manager (test
-        // composition, scoped registry) keeps its first sink and
-        // ignores this call. Cheap and lock-free — `OnceLock::set`
-        // is one CAS.
-        if let Some(gate) = recovery_gate.as_deref() {
-            gate.set_event_sink(self.event_tx.clone(), key.clone());
-        }
-
         let managed = Arc::new(ManagedResource {
             resource,
             config: arc_swap::ArcSwap::from_pointee(config),
@@ -716,8 +720,8 @@ impl Manager {
             m.record_create();
         }
         let _ = self
-            .event_tx
-            .send(ResourceEvent::Registered { key: key.clone() });
+            .event_bus
+            .emit(ResourceEvent::Registered { key: key.clone() });
 
         tracing::debug!(%key, "resource registered");
         Ok(())
@@ -852,7 +856,7 @@ impl Manager {
     ///
     /// `nebula-resource → nebula-expression` is allowed under deny.toml's
     /// `[[bans]]` `nebula-resource` wrapper allowlist (Business → Core layer
-    /// edge per typed ref fields).
+    /// edge per typed ref fields / Phase 9, R-040 R8).
     ///
     /// # Errors
     ///
@@ -1284,7 +1288,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_slot_refresh_outcome(crate::metrics::SlotDispatchOutcome::Success);
                 }
-                let _ = self.event_tx.send(ResourceEvent::SlotRefreshed {
+                let _ = self.event_bus.emit(ResourceEvent::SlotRefreshed {
                     key: key.clone(),
                     slot: slot.to_owned(),
                 });
@@ -1294,7 +1298,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_slot_refresh_outcome(crate::metrics::SlotDispatchOutcome::Failed);
                 }
-                let _ = self.event_tx.send(ResourceEvent::SlotRefreshFailed {
+                let _ = self.event_bus.emit(ResourceEvent::SlotRefreshFailed {
                     key: key.clone(),
                     slot: slot.to_owned(),
                     error: e.to_string(),
@@ -1848,18 +1852,7 @@ impl Manager {
     ///   [`acquire_pooled_for_identity`](Self::acquire_pooled_for_identity)
     ///   when the resolved slot identity is known; this identity-agnostic
     ///   path stays fail-closed for the no-identity caller.
-    /// - Propagates pool-specific acquire errors
-    ///   ([`Backpressure`](crate::error::ErrorKind::Backpressure) on
-    ///   semaphore exhaustion, [`Transient`](crate::error::ErrorKind::Transient)
-    ///   on `Resource::create` failure, etc.).
-    ///
-    /// # Cancellation
-    ///
-    /// Cancel-safe: a cancelled acquire (`ctx.cancel_token()` fired, or
-    /// the manager-wide cancel token cancelled) decrements both the
-    /// manager-wide drain tracker and the per-resource in-flight counter
-    /// via `InFlightCounter`'s `Drop` impl before returning, so no
-    /// in-flight runtime is leaked.
+    /// - Propagates pool-specific acquire errors.
     pub async fn acquire_pooled<R>(
         &self,
         ctx: &ResourceContext,
@@ -2032,33 +2025,6 @@ impl Manager {
         self.reject_if_tainted_or_shutting_down_post_count::<R>(&managed)?;
         let gate_admission = admit_through_gate(&managed.recovery_gate)?;
 
-        // Publish a `RetryAttempt` event when this acquire is the recovery
-        // probe (the CAS-claimed single-probe slot that follows a
-        // transient backend failure). The `backoff_on_fail` field carries
-        // the delay the gate would impose *if this probe fails again* —
-        // the next caller's wait, not a wait this acquire incurs. The
-        // event is emitted **before** `dispatch()` so observers see the
-        // attempt go out rather than only the result. The error field is
-        // populated with the prior failure message from the
-        // soon-to-be-retired `Failed` state, snapshotted in
-        // `admit_through_gate` before the CAS rotated the gate.
-        if let gate::GateAdmission::Probe {
-            attempt,
-            backoff_on_fail,
-            last_failure,
-            ..
-        } = &gate_admission
-        {
-            self.event_tx
-                .send(ResourceEvent::RetryAttempt {
-                    key: R::key(),
-                    attempt: *attempt,
-                    backoff: *backoff_on_fail,
-                    error: last_failure.clone().unwrap_or_default(),
-                })
-                .ok();
-        }
-
         let result = dispatch().await;
 
         // Settle the gate ticket based on the acquire result. #322: this
@@ -2069,13 +2035,7 @@ impl Manager {
         settle_gate_admission(gate_admission, &result);
         self.record_acquire_result(&result, started);
         match result {
-            // Attach the manager's broadcast sender so the guard's `Drop`
-            // emits `ResourceEvent::Released`. Done here, on the success
-            // path only, because failed acquires never minted a guard
-            // to begin with — there is nothing to release.
-            Ok(h) => Ok(h
-                .with_drain_tracker(in_flight.release_to_guard())
-                .with_event_tx(self.event_tx.clone())),
+            Ok(h) => Ok(h.with_drain_tracker(in_flight.release_to_guard())),
             Err(e) => Err(e),
         }
     }
@@ -2086,19 +2046,9 @@ impl Manager {
     ///
     /// - [`ErrorKind::NotFound`](crate::error::ErrorKind::NotFound) if no resource of type `R` is
     ///   registered.
-    /// - [`ErrorKind::Cancelled`](crate::error::ErrorKind::Cancelled) if the manager is shutting
-    ///   down.
     /// - [`ErrorKind::Permanent`](crate::error::ErrorKind::Permanent) if the resource is not using
     ///   resident topology.
-    /// - Propagates resident-specific acquire errors (notably
-    ///   [`Transient`](crate::error::ErrorKind::Transient) on first-acquire
-    ///   `Resource::create` failure).
-    ///
-    /// # Cancellation
-    ///
-    /// Cancel-safe in the same way as
-    /// [`acquire_pooled`](Self::acquire_pooled): both drain trackers are
-    /// decremented via RAII before returning, no runtime leaks.
+    /// - Propagates resident-specific acquire errors.
     pub async fn acquire_resident<R>(
         &self,
         ctx: &ResourceContext,
@@ -2218,16 +2168,7 @@ impl Manager {
     ///   bounded topology.
     /// - [`ErrorKind::Ambiguous`](crate::error::ErrorKind::Ambiguous) if more
     ///   than one resolved-credential registration exists for `(R, scope)`.
-    /// - Propagates the cap's acquire errors
-    ///   ([`Backpressure`](crate::error::ErrorKind::Backpressure) on
-    ///   permit timeout, [`Cancelled`](crate::error::ErrorKind::Cancelled)
-    ///   on closed semaphore).
-    ///
-    /// # Cancellation
-    ///
-    /// Cancel-safe in the same way as
-    /// [`acquire_pooled`](Self::acquire_pooled): both drain trackers are
-    /// decremented via RAII before returning.
+    /// - Propagates the cap's acquire errors (permit timeout / closed).
     pub async fn acquire_bounded<R>(
         &self,
         ctx: &ResourceContext,
@@ -2467,8 +2408,8 @@ impl Manager {
         managed.set_phase(crate::state::ResourcePhase::Ready);
 
         let _ = self
-            .event_tx
-            .send(ResourceEvent::ConfigReloaded { key: R::key() });
+            .event_bus
+            .emit(ResourceEvent::ConfigReloaded { key: R::key() });
 
         // Reload outcome. `reload_config` swaps the config `ArcSwap`
         // without rebuilding the caller-supplied live `Arc<R::Runtime>` for
@@ -2476,7 +2417,7 @@ impl Manager {
         // the honest outcome is `SwappedImmediately` for every variant: the
         // config is swapped, the live runtime is not rebuilt. The genuine
         // "drain + rebuild the live runtime on reload" behavior is the
-        // separately-tracked deferred `reload_config` redesign.
+        // separately-tracked deferred `reload_config` redesign ([#712]).
         let outcome = ReloadOutcome::SwappedImmediately;
 
         tracing::info!(key = %R::key(), ?outcome, "resource config reloaded");
@@ -2498,8 +2439,8 @@ impl Manager {
             m.record_destroy();
         }
         let _ = self
-            .event_tx
-            .send(ResourceEvent::Removed { key: key.clone() });
+            .event_bus
+            .emit(ResourceEvent::Removed { key: key.clone() });
         tracing::debug!(%key, "resource removed");
         Ok(())
     }
@@ -2595,7 +2536,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_acquire();
                 }
-                let _ = self.event_tx.send(ResourceEvent::AcquireSuccess {
+                let _ = self.event_bus.emit(ResourceEvent::AcquireSuccess {
                     key: R::key(),
                     duration: started.elapsed(),
                 });
@@ -2612,36 +2553,22 @@ impl Manager {
                 // `AcquireFailed` stream remains the canonical "acquire
                 // didn't succeed" feed.
                 if matches!(e.kind(), crate::error::ErrorKind::Backpressure) {
-                    self.event_tx
-                        .send(ResourceEvent::BackpressureDetected { key: R::key() })
-                        .ok();
+                    let _ = self
+                        .event_bus
+                        .emit(ResourceEvent::BackpressureDetected { key: R::key() });
                 }
-                self.event_tx
-                    .send(ResourceEvent::AcquireFailed {
-                        key: R::key(),
-                        error: e.to_string(),
-                    })
-                    .ok();
+                let _ = self.event_bus.emit(ResourceEvent::AcquireFailed {
+                    key: R::key(),
+                    error: e.to_string(),
+                });
             },
         }
     }
 
-    /// Broadcasts a [`ResourceEvent`] to current subscribers.
-    ///
-    /// `broadcast::Sender::send` only returns `Err` when there are **zero**
-    /// receivers — an expected, non-error condition (events are a passive
-    /// observability stream, not a delivery guarantee). This helper names
-    /// that contract in one place so the absence of a subscriber is
-    /// explicitly a deliberate no-op rather than a silently discarded
-    /// `Result` at the emit site.
+    /// Best-effort event emission. The `PublishOutcome` is intentionally
+    /// discarded — events are observability aids, not delivery guarantees.
     fn emit(&self, event: ResourceEvent) {
-        match self.event_tx.send(event) {
-            Ok(_subscribers) => {},
-            // No subscribers attached — the event stream is best-effort
-            // observability, so this is the documented normal case, not a
-            // failure to propagate.
-            Err(broadcast::error::SendError(_dropped)) => {},
-        }
+        let _ = self.event_bus.emit(event);
     }
 }
 

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -2575,13 +2575,16 @@ impl Manager {
         result: &Result<crate::guard::ResourceGuard<R>, Error>,
         started: Instant,
     ) {
+        // Resolve the resource key once: `R::key()` re-validates and re-interns
+        // the literal on each call, and the error path emits up to two events.
+        let key = R::key();
         match result {
             Ok(_) => {
                 if let Some(m) = &self.metrics {
                     m.record_acquire();
                 }
                 self.emit(ResourceEvent::AcquireSuccess {
-                    key: R::key(),
+                    key,
                     duration: started.elapsed(),
                 });
             },
@@ -2597,10 +2600,10 @@ impl Manager {
                 // `AcquireFailed` stream remains the canonical "acquire
                 // didn't succeed" feed.
                 if matches!(e.kind(), crate::error::ErrorKind::Backpressure) {
-                    self.emit(ResourceEvent::BackpressureDetected { key: R::key() });
+                    self.emit(ResourceEvent::BackpressureDetected { key: key.clone() });
                 }
                 self.emit(ResourceEvent::AcquireFailed {
-                    key: R::key(),
+                    key,
                     error: e.to_string(),
                 });
             },

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -740,9 +740,7 @@ impl Manager {
         if let Some(m) = &self.metrics {
             m.record_create();
         }
-        let _ = self
-            .event_bus
-            .emit(ResourceEvent::Registered { key: key.clone() });
+        self.emit(ResourceEvent::Registered { key: key.clone() });
 
         tracing::debug!(%key, "resource registered");
         Ok(())
@@ -1309,7 +1307,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_slot_refresh_outcome(crate::metrics::SlotDispatchOutcome::Success);
                 }
-                let _ = self.event_bus.emit(ResourceEvent::SlotRefreshed {
+                self.emit(ResourceEvent::SlotRefreshed {
                     key: key.clone(),
                     slot: slot.to_owned(),
                 });
@@ -1319,7 +1317,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_slot_refresh_outcome(crate::metrics::SlotDispatchOutcome::Failed);
                 }
-                let _ = self.event_bus.emit(ResourceEvent::SlotRefreshFailed {
+                self.emit(ResourceEvent::SlotRefreshFailed {
                     key: key.clone(),
                     slot: slot.to_owned(),
                     error: e.to_string(),
@@ -2061,7 +2059,7 @@ impl Manager {
             ..
         } = &gate_admission
         {
-            let _ = self.event_bus.emit(ResourceEvent::RetryAttempt {
+            self.emit(ResourceEvent::RetryAttempt {
                 key: R::key(),
                 attempt: *attempt,
                 backoff: *backoff_on_fail,
@@ -2457,9 +2455,7 @@ impl Manager {
         // so `status()` snapshots stay self-consistent.
         managed.set_phase(crate::state::ResourcePhase::Ready);
 
-        let _ = self
-            .event_bus
-            .emit(ResourceEvent::ConfigReloaded { key: R::key() });
+        self.emit(ResourceEvent::ConfigReloaded { key: R::key() });
 
         // Reload outcome. `reload_config` swaps the config `ArcSwap`
         // without rebuilding the caller-supplied live `Arc<R::Runtime>` for
@@ -2488,9 +2484,7 @@ impl Manager {
         if let Some(m) = &self.metrics {
             m.record_destroy();
         }
-        let _ = self
-            .event_bus
-            .emit(ResourceEvent::Removed { key: key.clone() });
+        self.emit(ResourceEvent::Removed { key: key.clone() });
         tracing::debug!(%key, "resource removed");
         Ok(())
     }
@@ -2586,7 +2580,7 @@ impl Manager {
                 if let Some(m) = &self.metrics {
                     m.record_acquire();
                 }
-                let _ = self.event_bus.emit(ResourceEvent::AcquireSuccess {
+                self.emit(ResourceEvent::AcquireSuccess {
                     key: R::key(),
                     duration: started.elapsed(),
                 });
@@ -2603,11 +2597,9 @@ impl Manager {
                 // `AcquireFailed` stream remains the canonical "acquire
                 // didn't succeed" feed.
                 if matches!(e.kind(), crate::error::ErrorKind::Backpressure) {
-                    let _ = self
-                        .event_bus
-                        .emit(ResourceEvent::BackpressureDetected { key: R::key() });
+                    self.emit(ResourceEvent::BackpressureDetected { key: R::key() });
                 }
-                let _ = self.event_bus.emit(ResourceEvent::AcquireFailed {
+                self.emit(ResourceEvent::AcquireFailed {
                     key: R::key(),
                     error: e.to_string(),
                 });

--- a/crates/resource/src/manager/mod.rs
+++ b/crates/resource/src/manager/mod.rs
@@ -252,11 +252,13 @@
 //! work). Deferred: `ErrorKind` ≈ `nebula_error::ErrorCategory`
 //! reconciliation; hardcoded acquire backoff vs
 //! `nebula_resilience::BackoffConfig`; relocating the live `RecoveryGate` +
-//! `ReleaseQueue` to `nebula-resilience`; `events.rs` raw `broadcast` →
-//! `nebula_eventbus::EventBus`; unifying `CreateGuard`/`SessionGuard` into
-//! one `DefuseGuard<T>`; revisiting the `register_resolved` JSON/`{{ }}`
-//! expression coupling and its engine-ABI positional shape (see the
-//! accepted-exception note below).
+//! `ReleaseQueue` to `nebula-resilience`; unifying
+//! `CreateGuard`/`SessionGuard` into one `DefuseGuard<T>`; revisiting the
+//! `register_resolved` JSON/`{{ }}` expression coupling and its engine-ABI
+//! positional shape (see the accepted-exception note below). The
+//! `events.rs` `broadcast` → `nebula_eventbus::EventBus` migration listed
+//! here originally has since **landed** (wired through `Manager`,
+//! `ResourceGuard`, and `RecoveryGate`).
 //!
 //! ## Further `Manager` code-line reduction — LOW ([#719])
 //!
@@ -502,11 +504,12 @@ pub struct Manager {
     pub(super) registry: Registry,
     pub(super) cancel: CancellationToken,
     pub(super) metrics: Option<ResourceOpsMetrics>,
-    /// Shared lifecycle-event sink. Held behind `Arc` so the same bus can be
-    /// wired into per-resource [`RecoveryGate`](crate::recovery::gate::RecoveryGate)s
-    /// and into each [`ResourceGuard`](crate::guard::ResourceGuard) (for its
-    /// `Released`-on-drop emit) without exposing the underlying broadcast
-    /// sender across module boundaries.
+    /// Shared lifecycle-event sink. Held behind `Arc` so the same
+    /// [`EventBus`] can be wired into per-resource
+    /// [`RecoveryGate`](crate::recovery::gate::RecoveryGate)s and into each
+    /// [`ResourceGuard`](crate::guard::ResourceGuard) (for its
+    /// `Released`-on-drop emit) without exposing the bus's internal transport
+    /// across module boundaries.
     pub(super) event_bus: Arc<EventBus<ResourceEvent>>,
     pub(super) release_queue: Arc<ReleaseQueue>,
     pub(super) release_queue_handle: tokio::sync::Mutex<Option<ReleaseQueueHandle>>,

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -323,7 +323,7 @@ impl Manager {
         let reason = error.to_string();
         for managed in self.registry.all_managed() {
             managed.set_failed_erased(&reason);
-            let _ = self.event_tx.send(ResourceEvent::HealthChanged {
+            let _ = self.event_bus.emit(ResourceEvent::HealthChanged {
                 key: managed.resource_key(),
                 healthy: false,
             });

--- a/crates/resource/src/manager/shutdown.rs
+++ b/crates/resource/src/manager/shutdown.rs
@@ -317,13 +317,13 @@ impl Manager {
     /// `lookup` rejected acquires via the cancel token — the exact "phase
     /// corruption" failure mode this method closes.
     ///
-    /// Broadcast send errors (no live subscribers) are intentionally
-    /// ignored, matching the rest of the manager's event-emission policy.
+    /// Emission is best-effort (no live subscribers is a no-op), matching the
+    /// rest of the manager's event-emission policy via the `emit` helper.
     pub(super) fn set_phase_all_failed(&self, error: &ShutdownError) {
         let reason = error.to_string();
         for managed in self.registry.all_managed() {
             managed.set_failed_erased(&reason);
-            let _ = self.event_bus.emit(ResourceEvent::HealthChanged {
+            self.emit(ResourceEvent::HealthChanged {
                 key: managed.resource_key(),
                 healthy: false,
             });

--- a/crates/resource/src/recovery/gate.rs
+++ b/crates/resource/src/recovery/gate.rs
@@ -377,6 +377,9 @@ impl RecoveryGate {
     /// `set_event_sink` is a no-op by design. Treat one
     /// `Arc<RecoveryGate>` as belonging to one resource registration; if
     /// recovery-group sharing matters, give each resource its own gate.
+    // TODO(eventbus-migration): convert to EventBus — currently unused
+    // because `Manager::register` no longer wires a broadcast sender.
+    #[allow(dead_code)]
     pub(crate) fn set_event_sink(&self, tx: broadcast::Sender<ResourceEvent>, key: ResourceKey) {
         // OnceLock::set returns Err on second call — we treat that as
         // a no-op rather than a programming error, since the manager

--- a/crates/resource/src/recovery/gate.rs
+++ b/crates/resource/src/recovery/gate.rs
@@ -22,7 +22,8 @@ use std::{
 
 use arc_swap::ArcSwap;
 use nebula_core::ResourceKey;
-use tokio::sync::{Notify, broadcast};
+use nebula_eventbus::EventBus;
+use tokio::sync::Notify;
 
 use crate::events::ResourceEvent;
 
@@ -34,7 +35,7 @@ const MAX_BACKOFF: Duration = Duration::from_mins(5);
 /// (see [`RecoveryGate::set_event_sink`]).
 #[derive(Debug)]
 struct EventSink {
-    tx: broadcast::Sender<ResourceEvent>,
+    bus: Arc<EventBus<ResourceEvent>>,
     key: ResourceKey,
 }
 
@@ -280,17 +281,15 @@ struct RecoveryGateInner {
 
 impl RecoveryGateInner {
     /// Best-effort emit of [`ResourceEvent::RecoveryGateChanged`] for the
-    /// new state. Silently drops the broadcast result when no subscribers
-    /// are attached — same fail-open contract as every other
-    /// `event_tx.send(...)` site in the manager.
+    /// new state. The `EventBus` `PublishOutcome` is intentionally discarded
+    /// when no subscribers are attached — same fail-open contract as every
+    /// other event-emit site in the manager.
     fn emit_state(&self, new_state: &GateState) {
         if let Some(sink) = self.event_sink.get() {
-            sink.tx
-                .send(ResourceEvent::RecoveryGateChanged {
-                    key: sink.key.clone(),
-                    state: gate_state_label(new_state),
-                })
-                .ok();
+            let _ = sink.bus.emit(ResourceEvent::RecoveryGateChanged {
+                key: sink.key.clone(),
+                state: gate_state_label(new_state),
+            });
         }
     }
 }
@@ -363,8 +362,8 @@ impl RecoveryGate {
     /// [`ResourceEvent::RecoveryGateChanged`]. Wired by
     /// [`Manager::register`](crate::Manager::register) at registration
     /// time; not part of the public crate surface — the
-    /// `broadcast::Sender` is an internal transport detail the manager
-    /// owns.
+    /// `Arc<EventBus<ResourceEvent>>` is an internal transport detail the
+    /// manager owns.
     ///
     /// **Idempotent** — the first call wins; subsequent calls silently
     /// no-op so a gate handed to multiple registries does not flip
@@ -377,14 +376,11 @@ impl RecoveryGate {
     /// `set_event_sink` is a no-op by design. Treat one
     /// `Arc<RecoveryGate>` as belonging to one resource registration; if
     /// recovery-group sharing matters, give each resource its own gate.
-    // TODO(eventbus-migration): convert to EventBus — currently unused
-    // because `Manager::register` no longer wires a broadcast sender.
-    #[allow(dead_code)]
-    pub(crate) fn set_event_sink(&self, tx: broadcast::Sender<ResourceEvent>, key: ResourceKey) {
+    pub(crate) fn set_event_sink(&self, bus: Arc<EventBus<ResourceEvent>>, key: ResourceKey) {
         // OnceLock::set returns Err on second call — we treat that as
         // a no-op rather than a programming error, since the manager
         // may re-register a resource that already had a gate wired.
-        self.inner.event_sink.set(EventSink { tx, key }).ok();
+        self.inner.event_sink.set(EventSink { bus, key }).ok();
     }
 
     /// Attempts to begin a recovery.

--- a/crates/resource/src/registry.rs
+++ b/crates/resource/src/registry.rs
@@ -144,6 +144,14 @@ pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// RPITIT method. Forwards to `ManagedResource::dispatch_slot_hook`
     /// with `refresh = true`, which borrows the live runtime per topology
     /// and invokes the resource's `&self` hook.
+    ///
+    /// # Cancel Safety
+    ///
+    /// This method is cancel-safe. The resource taint and revoke-epoch
+    /// bump are applied synchronously by the caller before this future is
+    /// polled. Dropping the returned future after taint leaves the
+    /// resource consistently marked as tainted — no partial-taint state
+    /// is possible and new acquires remain rejected.
     fn dispatch_on_refresh_erased<'a>(
         &'a self,
         slot: &'a str,
@@ -152,6 +160,15 @@ pub trait AnyManagedResource: sealed::Sealed + Send + Sync + 'static {
     /// Type-erased per-slot revoke dispatch (boxed for the same reason as
     /// [`Self::dispatch_on_refresh_erased`]; forwards to
     /// `ManagedResource::dispatch_slot_hook` with `refresh = false`).
+    ///
+    /// # Cancel Safety
+    ///
+    /// This method is cancel-safe. The resource taint and revoke-epoch
+    /// bump are performed synchronously before any `.await` point (in the
+    /// caller's `taint_slot_for_identity` phase). Dropping the returned
+    /// future after taint leaves the resource consistently marked as
+    /// tainted — no partial-taint state is possible, new acquires are
+    /// still rejected, and the credential is never silently un-revoked.
     fn dispatch_on_revoke_erased<'a>(
         &'a self,
         slot: &'a str,

--- a/crates/resource/src/release_queue.rs
+++ b/crates/resource/src/release_queue.rs
@@ -93,6 +93,7 @@ pub struct ReleaseQueueHandle {
 /// ReleaseQueue::shutdown(handle).await;
 /// # }
 /// ```
+#[must_use = "dropping the queue closes its channels — keep it alive to submit work"]
 pub struct ReleaseQueue {
     senders: Vec<mpsc::Sender<TaskFactory>>,
     fallback_tx: mpsc::Sender<TaskFactory>,

--- a/crates/resource/src/resource.rs
+++ b/crates/resource/src/resource.rs
@@ -372,6 +372,10 @@ pub trait Resource: Send + Sync + 'static {
     /// generation, so any post-build slot transition yields a different
     /// epoch — proving a credential rotated/was revoked in between.
     ///
+    /// For resources with no `#[credential]` slots, this returns `0`
+    /// permanently (slot-less resources rely on runtime-presence checks
+    /// only, not epoch-based rotation tracking).
+    ///
     /// `#[derive(Resource)]` emits the real implementation: an
     /// order-sensitive positional fold
     /// (`acc = acc * K + slot.generation()`, fixed odd `K`) over every

--- a/crates/resource/src/runtime/bounded.rs
+++ b/crates/resource/src/runtime/bounded.rs
@@ -41,6 +41,20 @@ use crate::{
     topology_tag::TopologyTag,
 };
 
+// ─── Static error messages ───────────────────────────────────────────────────
+
+/// The concurrency semaphore was closed (runtime is shutting down).
+const ERR_SEMAPHORE_CLOSED: &str = "bounded: semaphore closed";
+
+/// Timed out waiting for a concurrency permit.
+const ERR_PERMIT_TIMEOUT: &str = "bounded: timed out waiting for a permit";
+
+/// Exclusive runtime was poisoned by a prior failed reset (S4).
+const ERR_POISONED: &str = "bounded: exclusive runtime poisoned by a prior failed reset \
+     (S4) — re-register the resource to obtain a fresh instance";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// Runtime state for a [`Bounded`](crate::topology::bounded::Bounded)
 /// resource.
 ///
@@ -311,11 +325,9 @@ where
                 let timeout = options.remaining().unwrap_or(self.config.acquire_timeout);
                 match time::timeout(timeout, sem.clone().acquire_owned()).await {
                     Ok(Ok(p)) => Some(p),
-                    Ok(Err(_)) => return Err(Error::permanent("bounded: semaphore closed")),
+                    Ok(Err(_)) => return Err(Error::permanent(ERR_SEMAPHORE_CLOSED)),
                     Err(_) => {
-                        return Err(Error::backpressure(
-                            "bounded: timed out waiting for a permit",
-                        ));
+                        return Err(Error::backpressure(ERR_PERMIT_TIMEOUT));
                     },
                 }
             },
@@ -338,10 +350,7 @@ where
             if let Some(m) = &metrics {
                 m.record_acquire_error();
             }
-            return Err(Error::permanent(
-                "bounded: exclusive runtime poisoned by a prior failed reset \
-                 (S4) — re-register the resource to obtain a fresh instance",
-            ));
+            return Err(Error::permanent(ERR_POISONED));
         }
 
         // 2. Mint the lease.

--- a/crates/resource/src/runtime/managed.rs
+++ b/crates/resource/src/runtime/managed.rs
@@ -110,7 +110,7 @@ impl<R: Resource> ManagedResource<R> {
     /// resource to `Failed` so callers cannot subsequently acquire a
     /// resource the manager has already declared bankrupt. Per-resource
     /// `HealthChanged{healthy:false}` event emission is owned by the
-    /// manager because it holds the broadcast channel.
+    /// manager because it holds the event bus.
     pub(crate) fn set_failed(&self, error: impl Into<String>) {
         let next = ResourceStatus {
             phase: ResourcePhase::Failed,
@@ -211,6 +211,14 @@ impl<R: Resource> ManagedResource<R> {
     /// The `refresh` flag selects the hook exactly once per topology arm
     /// (mirroring the pool selector); both directions share identical
     /// per-topology runtime-borrow semantics.
+    ///
+    /// # Cancel Safety
+    ///
+    /// This method is cancel-safe. The resource taint and revoke-epoch
+    /// bump are performed synchronously by the caller before this future
+    /// is polled. Dropping the returned future after taint leaves the
+    /// resource consistently marked as tainted — no partial-taint state
+    /// is possible and new acquires remain rejected.
     pub(crate) async fn dispatch_slot_hook(&self, slot: &str, refresh: bool) -> Result<(), Error> {
         match &self.topology {
             // Reconcile-aware (per-resource revoke deferral / #680): serialises

--- a/crates/resource/src/runtime/pool.rs
+++ b/crates/resource/src/runtime/pool.rs
@@ -30,6 +30,30 @@ use crate::{
     topology_tag::TopologyTag,
 };
 
+// ─── Static error messages ───────────────────────────────────────────────────
+
+/// Pool cannot operate with zero max size.
+const ERR_MAX_SIZE_ZERO: &str = "PoolRuntime: config.max_size must be > 0 (got 0 — would \
+     deadlock the checkout semaphore on first acquire)";
+
+/// The checkout semaphore was closed (pool is shutting down).
+const ERR_SEMAPHORE_CLOSED: &str = "pool semaphore closed";
+
+/// All pool slots are in use and the timeout expired.
+const ERR_POOL_FULL_TIMEOUT: &str = "pool full: timed out waiting for available slot";
+
+/// The create-semaphore was closed (pool is shutting down).
+const ERR_CREATE_SEMAPHORE_CLOSED: &str = "pool: create semaphore closed";
+
+/// Timed out waiting for a create-semaphore permit.
+const ERR_CREATE_SEMAPHORE_TIMEOUT: &str =
+    "pool: create timed out waiting for create-semaphore permit";
+
+/// The `resource.create()` call exceeded `create_timeout`.
+const ERR_CREATE_TIMED_OUT: &str = "pool: create timed out";
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 /// A single pooled instance with its metrics and config fingerprint.
 ///
 /// The semaphore permit no longer lives here — it is held in
@@ -156,10 +180,7 @@ impl<R: Resource> PoolRuntime<R> {
         // violation); invariants that must hold for the pool to function
         // at all are rejected here, never silently clamped.
         if config.max_size == 0 {
-            return Err(Error::permanent(
-                "PoolRuntime: config.max_size must be > 0 (got 0 — would \
-                 deadlock the checkout semaphore on first acquire)",
-            ));
+            return Err(Error::permanent(ERR_MAX_SIZE_ZERO));
         }
         if config.min_size > config.max_size {
             return Err(Error::permanent(format!(
@@ -647,10 +668,8 @@ where
         let timeout = options.remaining().unwrap_or(self.config.create_timeout);
         match tokio::time::timeout(timeout, self.semaphore.clone().acquire_owned()).await {
             Ok(Ok(permit)) => Ok(permit),
-            Ok(Err(_closed)) => Err(Error::permanent("pool semaphore closed")),
-            Err(_timeout) => Err(Error::backpressure(
-                "pool full: timed out waiting for available slot",
-            )),
+            Ok(Err(_closed)) => Err(Error::permanent(ERR_SEMAPHORE_CLOSED)),
+            Err(_timeout) => Err(Error::backpressure(ERR_POOL_FULL_TIMEOUT)),
         }
     }
 
@@ -701,7 +720,7 @@ where
                     )));
                 },
                 Err(tokio::sync::TryAcquireError::Closed) => {
-                    return Err(Error::permanent("pool: create semaphore closed"));
+                    return Err(Error::permanent(ERR_CREATE_SEMAPHORE_CLOSED));
                 },
             }
         } else {
@@ -713,12 +732,10 @@ where
             {
                 Ok(Ok(permit)) => permit,
                 Ok(Err(_)) => {
-                    return Err(Error::permanent("pool: create semaphore closed"));
+                    return Err(Error::permanent(ERR_CREATE_SEMAPHORE_CLOSED));
                 },
                 Err(_) => {
-                    return Err(Error::backpressure(
-                        "pool: create timed out waiting for create-semaphore permit",
-                    ));
+                    return Err(Error::backpressure(ERR_CREATE_SEMAPHORE_TIMEOUT));
                 },
             }
         };
@@ -731,7 +748,7 @@ where
                 Ok(Ok(rt)) => rt,
                 Ok(Err(e)) => return Err(e.into()),
                 Err(_timeout) => {
-                    return Err(Error::transient("pool: create timed out"));
+                    return Err(Error::transient(ERR_CREATE_TIMED_OUT));
                 },
             };
 

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -1142,6 +1142,111 @@ async fn acquire_emits_success_event() {
     );
 }
 
+/// Dropping a manager-minted guard must emit `ResourceEvent::Released`.
+///
+/// Regression guard for the EventBus migration: the guard's release sink is
+/// wired by `Manager::run_acquire` (`with_event_bus`). If that wiring is
+/// dropped, acquires still succeed and every other test stays green — only
+/// this assertion fails — so the `Released` lifecycle signal is pinned here.
+#[tokio::test]
+async fn drop_guard_emits_released_event() {
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt =
+        ResidentRuntime::<ResidentTestResource>::new(resident::config::Config::default());
+
+    manager
+        .register(RegistrationSpec {
+            resource,
+            config: test_config(),
+            scope: ScopeLevel::Global,
+            slot_identity: SlotIdentity::Unbound,
+            topology: TopologyRuntime::Resident(resident_rt),
+            acquire: Manager::erased_acquire_resident_for::<ResidentTestResource>(),
+            recovery_gate: None,
+        })
+        .unwrap();
+
+    let mut rx = manager.subscribe_events();
+
+    let ctx = test_ctx();
+    let handle: ResourceGuard<ResidentTestResource> = manager
+        .acquire_resident(&ctx, &AcquireOptions::default())
+        .await
+        .expect("acquire should succeed");
+
+    // Drop the guard — its `Drop` impl runs the release pathway and emits
+    // `Released` after the recycle/destroy effect.
+    drop(handle);
+
+    let mut saw_released = false;
+    while let Some(event) = rx.try_recv() {
+        if matches!(
+            &event,
+            nebula_resource::ResourceEvent::Released { key, .. }
+                if key == &resource_key!("test-resident")
+        ) {
+            saw_released = true;
+            break;
+        }
+    }
+    assert!(
+        saw_released,
+        "expected a Released event after the guard was dropped",
+    );
+}
+
+/// Registering a resource with a recovery gate must wire the manager's event
+/// bus into that gate, so its state transitions surface as
+/// `ResourceEvent::RecoveryGateChanged`.
+///
+/// Regression guard for the EventBus migration: the sink is attached in
+/// `Manager::register` (`gate.set_event_sink`). If that wiring is dropped the
+/// gate still functions but goes silent — only this assertion catches it.
+#[tokio::test]
+async fn recovery_gate_transition_emits_event_via_manager_bus() {
+    let manager = Manager::new();
+    let resource = ResidentTestResource::new();
+    let resident_rt =
+        ResidentRuntime::<ResidentTestResource>::new(resident::config::Config::default());
+    let gate = Arc::new(RecoveryGate::new(RecoveryGateConfig::default()));
+
+    manager
+        .register(RegistrationSpec {
+            resource,
+            config: test_config(),
+            scope: ScopeLevel::Global,
+            slot_identity: SlotIdentity::Unbound,
+            topology: TopologyRuntime::Resident(resident_rt),
+            acquire: Manager::erased_acquire_resident_for::<ResidentTestResource>(),
+            recovery_gate: Some(Arc::clone(&gate)),
+        })
+        .unwrap();
+
+    let mut rx = manager.subscribe_events();
+
+    // Drive the gate Idle -> InProgress; the CAS publishes the transition
+    // through the sink the manager wired at registration time.
+    let ticket = gate.try_begin().expect("gate starts idle");
+    ticket.resolve();
+
+    let mut saw_gate_change = false;
+    while let Some(event) = rx.try_recv() {
+        if matches!(
+            &event,
+            nebula_resource::ResourceEvent::RecoveryGateChanged { key, .. }
+                if key == &resource_key!("test-resident")
+        ) {
+            saw_gate_change = true;
+            break;
+        }
+    }
+    assert!(
+        saw_gate_change,
+        "expected a RecoveryGateChanged event after the gate transitioned",
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Pool concurrency scenarios
 // ---------------------------------------------------------------------------

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -1225,26 +1225,30 @@ async fn recovery_gate_transition_emits_event_via_manager_bus() {
 
     let mut rx = manager.subscribe_events();
 
-    // Drive the gate Idle -> InProgress; the CAS publishes the transition
-    // through the sink the manager wired at registration time.
+    // Drive the gate Idle -> InProgress and assert *that* transition is
+    // observed before resolving — pinning the `try_begin` emission to the
+    // manager-wired sink specifically, not merely the later resolve-side
+    // InProgress -> Idle event (which would pass even with broken wiring of
+    // the begin path).
     let ticket = gate.try_begin().expect("gate starts idle");
-    ticket.resolve();
 
-    let mut saw_gate_change = false;
+    let mut saw_in_progress = false;
     while let Some(event) = rx.try_recv() {
-        if matches!(
-            &event,
-            nebula_resource::ResourceEvent::RecoveryGateChanged { key, .. }
-                if key == &resource_key!("test-resident")
-        ) {
-            saw_gate_change = true;
+        if let nebula_resource::ResourceEvent::RecoveryGateChanged { key, state } = &event
+            && key == &resource_key!("test-resident")
+            && state.contains("in_progress")
+        {
+            saw_in_progress = true;
             break;
         }
     }
     assert!(
-        saw_gate_change,
-        "expected a RecoveryGateChanged event after the gate transitioned",
+        saw_in_progress,
+        "expected a RecoveryGateChanged(in_progress) event after gate.try_begin()",
     );
+
+    // Resolve to leave the gate idle for any later reuse; not asserted here.
+    ticket.resolve();
 }
 
 // ---------------------------------------------------------------------------
@@ -4514,7 +4518,7 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
     );
 
     // Assertion: per-resource HealthChanged{healthy:false} was
-    // emitted. Drain through the channel until we find it (other
+    // emitted. Drain the event subscriber until we find it (other
     // events like `Registered` and `AcquireSuccess` were also emitted
     // earlier).
     let mut saw_health_change = false;

--- a/crates/resource/tests/basic_integration.rs
+++ b/crates/resource/tests/basic_integration.rs
@@ -4413,7 +4413,7 @@ async fn graceful_shutdown_abort_marks_resources_failed_not_ready() {
     // events like `Registered` and `AcquireSuccess` were also emitted
     // earlier).
     let mut saw_health_change = false;
-    while let Ok(event) = events.try_recv() {
+    while let Some(event) = events.try_recv() {
         if let ResourceEvent::HealthChanged {
             key,
             healthy: false,

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -580,7 +580,7 @@ async fn revoke_failure_emits_slot_revoke_failed_not_refresh() {
     // Drain the broadcast channel and assert the failure event is the
     // revoke variant, never the refresh one.
     let mut saw_revoke_failed = false;
-    while let Ok(evt) = events.try_recv() {
+    while let Some(evt) = events.try_recv() {
         match evt {
             ResourceEvent::SlotRevokeFailed {
                 key: k,

--- a/crates/resource/tests/manager_refresh_slot.rs
+++ b/crates/resource/tests/manager_refresh_slot.rs
@@ -577,7 +577,7 @@ async fn revoke_failure_emits_slot_revoke_failed_not_refresh() {
         "revoke_slot must surface the hook error, got: {err}"
     );
 
-    // Drain the broadcast channel and assert the failure event is the
+    // Drain the event subscriber and assert the failure event is the
     // revoke variant, never the refresh one.
     let mut saw_revoke_failed = false;
     while let Some(evt) = events.try_recv() {


### PR DESCRIPTION
## Summary

Builds on the `nebula-resource` EventBus migration (the work in #733) and finishes
it properly. The original migration could not clone the bus into the recovery gate
or the guard (`EventBus` is not `Clone`), so it parked those sinks behind
`#[allow(dead_code)]` + `// TODO(eventbus-migration)` and dropped the emit sites —
a behavioral regression hidden behind green per-crate CI:

- `ResourceEvent::Released` (guard drop) — no longer emitted
- `ResourceEvent::RetryAttempt` (recovery probe) — no longer emitted
- `ResourceEvent::RecoveryGateChanged` (gate transition) — no longer wired

This branch supersedes #733: it includes that diff and completes it.

## Changes

**Complete the migration (no deferral):**
- `Manager` holds `Arc<EventBus<ResourceEvent>>`, so the same bus is shared (cheap
  `Arc` clone, no extra channels) into each `RecoveryGate` (`set_event_sink`) and
  `ResourceGuard` (`with_event_bus`); `register` and `run_acquire` re-wire them.
- Remove every `#[allow(dead_code)]`, the `TODO(eventbus-migration)` markers, and
  the now-live `GateAdmission::Probe` field allows (the fields are used again).
- Fix the `subscribe_events` rustdoc to describe EventBus lag semantics
  (oldest events skipped + auto-recovery + `lagged_count`).

**Cleanup / perf:**
- Route all event emission through the single private `Manager::emit()` helper so the
  best-effort / outcome-discarded contract lives in one place (was split across the
  helper + 10 inline `let _ = self.event_bus.emit(...)` sites).
- Resolve `R::key()` once in `record_acquire_result` (it re-validates + re-interns on
  each call; the failure path emitted up to two events).

**Tests:**
- Add `drop_guard_emits_released_event` and
  `recovery_gate_transition_emits_event_via_manager_bus` — the two emit paths a
  passing suite would otherwise miss (and which let the original regression slip
  through).

## Review

A 7-angle review (3 correctness + 3 cleanup + altitude) ran over the full diff:
- **Correctness (line-by-line, removed-behavior, cross-file): clean.** Error
  classification → `(category, code)`, retryability, scope-level order, and
  best-effort emit semantics are preserved 1:1 vs `main`; zero broken call sites
  across crates.
- The only actionable finding was the `R::key()` dedup (applied above). The rest
  were design/style or out-of-scope (e.g. `#[derive(Classify)]` is deferred as
  #718 — `Error` is a struct over `ErrorKind` with a custom `retry_hint`).

## Verification

`cargo check`, `clippy -p nebula-resource -- -D warnings`, resource tests (22 suites,
0 failures), `rustdoc -D warnings`, and the cross-crate `nebula-engine` resource
tests (incl. the `rotation`-feature redaction security gate) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New lifecycle event emitted when resource guards are released.
  * Automatic skip-to-latest behavior for slow event subscribers.

* **Documentation**
  * Updated lifecycle event docs and subscription examples to match new subscriber semantics.
  * Clarified error classification and retryability guidance.

* **Improvements**
  * More reliable event emission and delivery with explicit lag detection.
  * Compiler warning added for improper release-queue usage.

* **Tests**
  * New integration tests covering guard release and recovery-gate events.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->