### PR TITLE
refactor(env): introduce nebula-env cross-cutting reader and migrate consumers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,11 +4,12 @@
 # local development. Any `.env.*` variant is also git-ignored except this
 # `.env.example` template. Do not put secrets here.
 #
-# Variables below are grouped by the crate that reads them. Authoritative
-# source: `apps/server/src/compose.rs`, `crates/api/src/config/` (canonical
-# env-var registry in `crates/api/src/config/env.rs`), `crates/log/src/config/`,
-# `crates/storage/`, `apps/server/src/transport.rs`. Only variables that
-# the codebase actually consumes are listed.
+# Variables below are grouped by the crate that reads them. All env reads go
+# through the `nebula-env` typed reader (`crates/env/`, ADR-0086); the per-crate
+# knob sets live in `apps/server/src/compose.rs`, `crates/api/src/config/`
+# (the `API_*` registry in `crates/api/src/config/env.rs`),
+# `crates/log/src/config/`, `crates/storage/`, `apps/server/src/transport.rs`.
+# Only variables that the codebase actually consumes are listed.
 
 # ============================================================================
 # Environment metadata (apps/server, crates/api, crates/log)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,7 @@ any level.
 | Business     | `credential-builtin`, `resource`, `action`, `plugin`, `tenancy` |
 | Plugin-Proto | `plugin-sdk`, `sandbox` |
 | Core         | `core`, `validator`, `expression`, `workflow`, `execution`, `schema`, `metadata`, `storage-port` |
-| Cross-cutting| `log`, `eventbus`, `metrics`, `resilience`, `error` |
+| Cross-cutting| `log`, `eventbus`, `metrics`, `resilience`, `error`, `env` |
 
 **Plugin-Proto** is a leaf tier between Core and Business: the
 out-of-process plugin protocol (`plugin-sdk`) and the duplex transport

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3738,6 +3738,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-env"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "nebula-error"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3490,6 +3490,7 @@ dependencies = [
  "nebula-credential",
  "nebula-credential-runtime",
  "nebula-engine",
+ "nebula-env",
  "nebula-error",
  "nebula-eventbus",
  "nebula-execution",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3852,6 +3852,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "flate2",
  "insta",
+ "nebula-env",
  "nebula-error",
  "opentelemetry",
  "opentelemetry-otlp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4155,6 +4155,7 @@ dependencies = [
  "moka",
  "nebula-core",
  "nebula-credential",
+ "nebula-env",
  "nebula-storage-port",
  "nebula-tenancy",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
   "crates/credential-vault",
   "crates/credential-runtime",
   "crates/engine",
+  "crates/env",
   "crates/eventbus",
   "crates/execution",
   "crates/expression",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,6 +186,7 @@ compact_str = { version = "0.7", features = ["serde"] }
 static_assertions = "1"
 
 # Nebula internal
+nebula-env = { path = "crates/env" }
 nebula-error = { path = "crates/error" }
 nebula-error-macros = { path = "crates/error/macros" }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -12,6 +12,7 @@ homepage.workspace = true
 documentation.workspace = true
 
 [dependencies]
+nebula-env = { workspace = true }
 nebula-error = { workspace = true, features = ["derive"] }
 nebula-storage = { path = "../storage", features = ["credential-in-memory"] }
 nebula-storage-port = { path = "../storage-port" }
@@ -131,6 +132,8 @@ utoipa-swagger-ui = { workspace = true }
 
 [dev-dependencies]
 nebula-api = { path = ".", features = ["test-util"] }
+# `testing` feature adds EnvGuard for the config env-precedence unit tests.
+nebula-env = { workspace = true, features = ["testing"] }
 # Spec validation in tests — typed 3.1 parser (ADR-0047). Round-trip via
 # `oas3::OpenApi::deserialize(&served_json)` is hermetic, no fixture management.
 oas3 = { workspace = true }

--- a/crates/api/src/config/env.rs
+++ b/crates/api/src/config/env.rs
@@ -53,54 +53,47 @@ pub(super) fn parse_bool_env(suffix: &'static str, default: bool) -> Result<bool
 }
 
 #[cfg(test)]
-#[allow(
-    unsafe_code,
-    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
-)]
 pub(crate) mod tests {
-    /// Serializes env-var manipulation across tests in this module so
-    /// parallel nextest execution does not clobber shared state. We do
-    /// not pull in `temp-env`/`serial_test` just for this.
-    pub(crate) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        use std::sync::{Mutex, OnceLock};
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-    }
+    use nebula_env::testing::EnvGuard;
 
-    /// Clears every env var `from_env` reads. Must be called inside
-    /// the lock.
-    pub(crate) fn clear_env() {
-        // SAFETY: protected by `env_lock()` — caller holds the guard.
-        unsafe {
-            for key in [
-                "NEBULA_ENV",
-                "API_JWT_SECRET",
-                "API_BIND_ADDRESS",
-                "API_REQUEST_TIMEOUT",
-                "API_MAX_BODY_SIZE",
-                "API_CORS_ORIGINS",
-                "API_ENABLE_COMPRESSION",
-                "API_ENABLE_TRACING",
-                "API_RATE_LIMIT",
-                "API_KEYS",
-                "API_IDEMPOTENCY_BACKEND",
-                "API_IDEMPOTENCY_TTL_SECS",
-                "API_IDEMPOTENCY_MAX_ENTRIES",
-                "API_IDEMPOTENCY_MAX_REQUEST_BODY_BYTES",
-                "API_IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
-                "API_IDEMPOTENCY_SWEEP_INTERVAL_SECS",
-                "API_AUTH_BACKEND",
-                "API_SMTP_HOST",
-                "API_SMTP_PORT",
-                "API_SMTP_USERNAME",
-                "API_SMTP_PASSWORD",
-                "API_SMTP_FROM",
-                "API_SMTP_TLS_MODE",
-            ] {
-                std::env::remove_var(key);
-            }
+    /// Every env var the `from_env` readers consult. Cleared before each test
+    /// so the ambient process environment cannot leak into assertions;
+    /// [`EnvGuard`] records the prior values and restores them on drop.
+    const KNOWN_VARS: &[&str] = &[
+        "NEBULA_ENV",
+        "API_JWT_SECRET",
+        "API_BIND_ADDRESS",
+        "API_REQUEST_TIMEOUT",
+        "API_MAX_BODY_SIZE",
+        "API_CORS_ORIGINS",
+        "API_ENABLE_COMPRESSION",
+        "API_ENABLE_TRACING",
+        "API_RATE_LIMIT",
+        "API_KEYS",
+        "API_IDEMPOTENCY_BACKEND",
+        "API_IDEMPOTENCY_TTL_SECS",
+        "API_IDEMPOTENCY_MAX_ENTRIES",
+        "API_IDEMPOTENCY_MAX_REQUEST_BODY_BYTES",
+        "API_IDEMPOTENCY_MAX_RESPONSE_BODY_BYTES",
+        "API_IDEMPOTENCY_SWEEP_INTERVAL_SECS",
+        "API_AUTH_BACKEND",
+        "API_SMTP_HOST",
+        "API_SMTP_PORT",
+        "API_SMTP_USERNAME",
+        "API_SMTP_PASSWORD",
+        "API_SMTP_FROM",
+        "API_SMTP_TLS_MODE",
+    ];
+
+    /// Acquire an [`EnvGuard`] with every [`KNOWN_VARS`] entry cleared
+    /// (recorded for restoration on drop). The guard's process-global lock
+    /// serializes env mutation across this module's tests, replacing the
+    /// former hand-rolled `env_lock` + `clear_env` pair and their `unsafe`.
+    pub(crate) fn env_guard() -> EnvGuard {
+        let mut guard = EnvGuard::acquire();
+        for key in KNOWN_VARS {
+            guard.remove(key);
         }
+        guard
     }
 }

--- a/crates/api/src/config/env.rs
+++ b/crates/api/src/config/env.rs
@@ -40,12 +40,14 @@ pub(super) fn parse_usize_env(
 /// Parse a boolean from `API_<suffix>`. Accepts `true` / `false` /
 /// `1` / `0` (case-insensitive). Empty or unset → `default`.
 pub(super) fn parse_bool_env(suffix: &'static str, default: bool) -> Result<bool, ApiConfigError> {
-    match std::env::var(format!("API_{suffix}")) {
-        Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
-            "true" | "1" | "yes" | "on" => Ok(true),
-            "false" | "0" | "no" | "off" => Ok(false),
-            _ => Err(ApiConfigError::ParseEnum { var: suffix, raw }),
-        },
+    match nebula_env::flag(&format!("API_{suffix}")) {
+        Ok(parsed) => Ok(parsed.unwrap_or(default)),
+        Err(nebula_env::EnvError::Invalid { value, .. }) => Err(ApiConfigError::ParseEnum {
+            var: suffix,
+            raw: value,
+        }),
+        // Unset / non-Unicode: fall back to the default, matching the prior
+        // `std::env::var(..).is_err()` behaviour.
         Err(_) => Ok(default),
     }
 }

--- a/crates/api/src/config/mod.rs
+++ b/crates/api/src/config/mod.rs
@@ -567,39 +567,27 @@ impl ApiConfig {
 }
 
 #[cfg(test)]
-#[allow(
-    unsafe_code,
-    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
-)]
 mod tests {
     use super::*;
-    use crate::config::env::tests::{clear_env, env_lock};
+    use crate::config::env::tests::env_guard;
 
     #[test]
     fn from_env_rejects_missing_secret_in_production() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe { std::env::set_var("NEBULA_ENV", "production") };
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
 
         let err = ApiConfig::from_env().expect_err("production + missing must error");
         match err {
             ApiConfigError::MissingJwtSecret(mode) => assert_eq!(mode, "production"),
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
     fn from_env_rejects_short_secret() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "short");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "short");
 
         let err = ApiConfig::from_env().expect_err("short secret must error");
         match err {
@@ -609,32 +597,22 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
     fn from_env_rejects_dev_placeholder() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", JwtSecret::DEV_PLACEHOLDER);
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", JwtSecret::DEV_PLACEHOLDER);
 
         let err = ApiConfig::from_env().expect_err("dev placeholder must error");
         assert!(matches!(err, ApiConfigError::JwtSecretIsDevPlaceholder));
-
-        clear_env();
     }
 
     #[test]
     fn from_env_generates_ephemeral_in_dev() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe { std::env::set_var("NEBULA_ENV", "development") };
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "development");
 
         let cfg1 = ApiConfig::from_env().expect("dev mode must succeed");
         let cfg2 = ApiConfig::from_env().expect("dev mode must succeed");
@@ -643,36 +621,27 @@ mod tests {
         // secret so auth state remains stable until restart.
         assert_eq!(cfg1.jwt_secret.as_bytes(), cfg2.jwt_secret.as_bytes());
         assert!(cfg1.jwt_secret.as_bytes().len() >= JwtSecret::MIN_BYTES);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_missing_secret_without_env_fails_closed() {
-        let _g = env_lock();
-        clear_env();
+        let _env = env_guard();
 
         let err = ApiConfig::from_env().expect_err("unset NEBULA_ENV must fail closed");
         match err {
             ApiConfigError::MissingJwtSecret(mode) => assert_eq!(mode, "production"),
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
     fn from_env_typo_in_env_mode_does_not_fall_through() {
         // "developmnt" (typo) must NOT be treated as dev. This is the
         // security-lead's explicit ask: unknown env modes fail closed.
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe { std::env::set_var("NEBULA_ENV", "developmnt") };
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "developmnt");
 
         let err = ApiConfig::from_env().expect_err("typo must not fall through to dev");
         assert!(matches!(err, ApiConfigError::MissingJwtSecret(_)));
-
-        clear_env();
     }
 }

--- a/crates/api/src/config/oauth.rs
+++ b/crates/api/src/config/oauth.rs
@@ -42,19 +42,6 @@ use serde::{Deserialize, Serialize};
 use super::errors::ApiConfigError;
 use crate::domain::auth::backend::oauth::OAuthProvider;
 
-/// Split the `API_AUTH_OAUTH_<PROVIDER>_SCOPES` env value on whitespace
-/// AND commas, dropping empties. Operator-friendly: accepts
-/// `"user:email read:user"` or `"user:email,read:user"` or mixes.
-fn parse_scopes_env(var: &str) -> Vec<String> {
-    std::env::var(var)
-        .unwrap_or_default()
-        .split(|c: char| c.is_whitespace() || c == ',')
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(str::to_owned)
-        .collect()
-}
-
 /// OIDC scopes are hardcoded per ADR-0085 D-5 recon-4 ADOPT (c). Per-provider
 /// scope customization belongs to the operator config only for the
 /// [`OAuthEndpoints::Manual`] arm (OAuth2-only providers like GitHub).
@@ -311,7 +298,7 @@ impl OAuthProvidersConfig {
                     jwks_url: std::env::var(format!("{prefix}_JWKS_URL"))
                         .ok()
                         .filter(|s| !s.trim().is_empty()),
-                    scopes: parse_scopes_env(&format!("{prefix}_SCOPES")),
+                    scopes: nebula_env::list(&format!("{prefix}_SCOPES")),
                 },
                 (None, None) => {
                     return Err(ApiConfigError::ParseEnum {
@@ -781,24 +768,14 @@ mod tests {
         assert_eq!(err.reason, "public_url_required");
     }
 
-    /// T2.13 TRIANGULATE: `parse_scopes_env` accepts both whitespace-
-    /// and comma-separated forms (operator-friendly).
+    /// T2.13 TRIANGULATE: the scopes env value (parsed via `nebula_env::list`)
+    /// accepts both whitespace- and comma-separated forms (operator-friendly).
     #[test]
-    #[allow(
-        unsafe_code,
-        reason = "edition 2024 marks env::{set,remove}_var as unsafe; this test uses a unique var name so no concurrent reader observes the mutation"
-    )]
     fn parse_scopes_env_accepts_whitespace_and_commas() {
         let var = "API_AUTH_OAUTH_TEST_T213_SCOPES_PARSE";
-        // SAFETY: unique var name; only this test reads or writes it.
-        unsafe {
-            std::env::set_var(var, "user:email read:user,write:repo  openid");
-        }
-        let scopes = parse_scopes_env(var);
-        // SAFETY: same uniqueness invariant; symmetric cleanup.
-        unsafe {
-            std::env::remove_var(var);
-        }
+        let mut env = nebula_env::testing::EnvGuard::acquire();
+        env.set(var, "user:email read:user,write:repo  openid");
+        let scopes = nebula_env::list(var);
         assert_eq!(
             scopes,
             vec![

--- a/crates/api/src/config/sub.rs
+++ b/crates/api/src/config/sub.rs
@@ -348,24 +348,16 @@ impl Default for PaginationConfig {
 }
 
 #[cfg(test)]
-#[allow(
-    unsafe_code,
-    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
-)]
 mod tests {
     use super::*;
     use crate::config::ApiConfig;
-    use crate::config::env::tests::{clear_env, env_lock};
+    use crate::config::env::tests::env_guard;
 
     #[test]
     fn from_env_idempotency_defaults_to_memory() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Memory);
@@ -375,58 +367,40 @@ mod tests {
             cfg.idempotency.sweep_interval_secs,
             IdempotencyApiConfig::DEFAULT_SWEEP_INTERVAL_SECS
         );
-
-        clear_env();
     }
 
     #[test]
     fn from_env_idempotency_accepts_postgres_backend() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_BACKEND", "postgres");
-            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "3600");
-            std::env::set_var("API_IDEMPOTENCY_SWEEP_INTERVAL_SECS", "120");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_BACKEND", "postgres");
+        env.set("API_IDEMPOTENCY_TTL_SECS", "3600");
+        env.set("API_IDEMPOTENCY_SWEEP_INTERVAL_SECS", "120");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Postgres);
         assert_eq!(cfg.idempotency.ttl_secs, 3600);
         assert_eq!(cfg.idempotency.sweep_interval_secs, 120);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_idempotency_backend_is_case_insensitive() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_BACKEND", "POSTGRES");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_BACKEND", "POSTGRES");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.idempotency.backend, IdempotencyBackend::Postgres);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_idempotency_rejects_unknown_backend() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_BACKEND", "redis");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_BACKEND", "redis");
 
         let err = ApiConfig::from_env().expect_err("unknown backend must error");
         match err {
@@ -436,20 +410,14 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
     fn from_env_idempotency_rejects_invalid_ttl() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "not-a-number");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_TTL_SECS", "not-a-number");
 
         let err = ApiConfig::from_env().expect_err("non-numeric TTL must error");
         match err {
@@ -458,8 +426,6 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
@@ -471,14 +437,10 @@ mod tests {
 
     #[test]
     fn from_env_idempotency_rejects_zero_ttl_secs() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_TTL_SECS", "0");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_TTL_SECS", "0");
 
         let err = ApiConfig::from_env().expect_err("ttl_secs=0 must error");
         match err {
@@ -487,70 +449,46 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
     fn from_env_auth_backend_defaults_to_memory() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.auth.backend, AuthBackendKind::Memory);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_auth_backend_accepts_postgres() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_AUTH_BACKEND", "postgres");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_AUTH_BACKEND", "postgres");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.auth.backend, AuthBackendKind::Postgres);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_auth_backend_is_case_insensitive() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_AUTH_BACKEND", "PostGres");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_AUTH_BACKEND", "PostGres");
 
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(cfg.auth.backend, AuthBackendKind::Postgres);
-
-        clear_env();
     }
 
     #[test]
     fn from_env_auth_backend_rejects_unknown() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_AUTH_BACKEND", "ldap");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_AUTH_BACKEND", "ldap");
 
         let err = ApiConfig::from_env().expect_err("unknown backend must error");
         match err {
@@ -560,8 +498,6 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 
     #[test]
@@ -574,30 +510,21 @@ mod tests {
 
     #[test]
     fn from_env_smtp_absent_keeps_none() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
         let cfg = ApiConfig::from_env().expect("config must load");
         assert!(cfg.smtp.is_none(), "missing API_SMTP_HOST must yield None");
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_present_populates_full_config_with_defaults() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
-            // PORT, USERNAME, PASSWORD, TLS_MODE all unset — defaults apply.
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_FROM", "noreply@example.com");
+        // PORT, USERNAME, PASSWORD, TLS_MODE all unset — defaults apply.
         let cfg = ApiConfig::from_env().expect("config must load");
         let smtp = cfg.smtp.as_ref().expect("smtp must be populated");
         assert_eq!(smtp.host, "smtp.example.com");
@@ -610,122 +537,92 @@ mod tests {
             SmtpTlsMode::StartTls,
             "port 587 must default to STARTTLS"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_465_defaults_to_implicit_tls() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_PORT", "465");
-            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_PORT", "465");
+        env.set("API_SMTP_FROM", "noreply@example.com");
         let cfg = ApiConfig::from_env().expect("config must load");
         assert_eq!(
             cfg.smtp.as_ref().unwrap().tls,
             SmtpTlsMode::Implicit,
             "port 465 must default to implicit TLS"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_rejects_username_without_password() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
-            std::env::set_var("API_SMTP_USERNAME", "noreply@example.com");
-            // PASSWORD intentionally omitted.
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_FROM", "noreply@example.com");
+        env.set("API_SMTP_USERNAME", "noreply@example.com");
+        // PASSWORD intentionally omitted.
         let err = ApiConfig::from_env().expect_err("USERNAME without PASSWORD must fail closed");
         assert!(
             matches!(err, crate::config::ApiConfigError::SmtpAuthIncomplete),
             "wrong variant: {err:?}"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_rejects_password_without_username() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
-            std::env::set_var("API_SMTP_PASSWORD", "sekret");
-            // USERNAME intentionally omitted.
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_FROM", "noreply@example.com");
+        env.set("API_SMTP_PASSWORD", "sekret");
+        // USERNAME intentionally omitted.
         let err = ApiConfig::from_env().expect_err("PASSWORD without USERNAME must fail closed");
         assert!(
             matches!(err, crate::config::ApiConfigError::SmtpAuthIncomplete),
             "wrong variant: {err:?}"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_rejects_missing_from() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            // FROM intentionally omitted.
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        // FROM intentionally omitted.
         let err = ApiConfig::from_env().expect_err("missing API_SMTP_FROM must error");
         assert!(
             matches!(err, crate::config::ApiConfigError::SmtpFromMissing),
             "wrong variant: {err:?}"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_rejects_from_without_at() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_FROM", "not-an-email");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_FROM", "not-an-email");
         let err = ApiConfig::from_env().expect_err("invalid API_SMTP_FROM must error");
         assert!(
             matches!(err, crate::config::ApiConfigError::SmtpFromInvalid),
             "wrong variant: {err:?}"
         );
-        clear_env();
     }
 
     #[test]
     fn from_env_smtp_rejects_unknown_tls_mode() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_SMTP_HOST", "smtp.example.com");
-            std::env::set_var("API_SMTP_FROM", "noreply@example.com");
-            std::env::set_var("API_SMTP_TLS_MODE", "weird");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_SMTP_HOST", "smtp.example.com");
+        env.set("API_SMTP_FROM", "noreply@example.com");
+        env.set("API_SMTP_TLS_MODE", "weird");
         let err = ApiConfig::from_env().expect_err("unknown TLS mode must error");
         match err {
             crate::config::ApiConfigError::ParseEnum { var, raw } => {
@@ -734,19 +631,14 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-        clear_env();
     }
 
     #[test]
     fn from_env_idempotency_rejects_zero_max_entries() {
-        let _g = env_lock();
-        clear_env();
-        // SAFETY: protected by env_lock.
-        unsafe {
-            std::env::set_var("NEBULA_ENV", "production");
-            std::env::set_var("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
-            std::env::set_var("API_IDEMPOTENCY_MAX_ENTRIES", "0");
-        }
+        let mut env = env_guard();
+        env.set("NEBULA_ENV", "production");
+        env.set("API_JWT_SECRET", "this-is-a-32-byte-minimum-secret!!");
+        env.set("API_IDEMPOTENCY_MAX_ENTRIES", "0");
 
         let err = ApiConfig::from_env().expect_err("max_entries=0 must error");
         match err {
@@ -755,7 +647,5 @@ mod tests {
             },
             other => panic!("wrong variant: {other:?}"),
         }
-
-        clear_env();
     }
 }

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -1,0 +1,25 @@
+# budget-justified: foundational new cross-cutting nebula-env crate; intentional multi-file scaffold (reader/error/testing) that cannot fold into an existing module.
+[package]
+name = "nebula-env"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "Typed, cross-cutting environment-variable reader for the Nebula workflow engine"
+keywords.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[dependencies]
+thiserror = { workspace = true }
+
+[features]
+default = []
+# Test-only helpers (`EnvGuard`) that mutate process env behind a global lock.
+# Enabled automatically for this crate's own `#[cfg(test)]` build.
+testing = []
+
+[lints]
+workspace = true

--- a/crates/env/README.md
+++ b/crates/env/README.md
@@ -1,0 +1,44 @@
+# nebula-env
+
+Typed, cross-cutting environment-variable reader for the Nebula workspace.
+
+## Role
+
+**Cross-cutting** (same tier as `nebula-log` / `nebula-error` / `nebula-metrics`):
+importable from any layer, no upward dependencies, `std` + `thiserror` only.
+It provides one parsing contract so every crate stops re-implementing
+`std::env::var(...).unwrap_or_default().parse()` with subtly different
+defaults and bool/int semantics.
+
+## API
+
+| Function | Purpose |
+|----------|---------|
+| `var` / `var_opt` | required / optional string (`Err` on non-Unicode) |
+| `parse` / `parse_or` | any `FromStr` type, trimmed; `Ok(None)` / default when unset |
+| `flag` / `flag_or` | boolean — accepts `true/1/yes/on` and `false/0/no/off`, `Err` otherwise |
+| `list` | split on whitespace and commas, dropping empties |
+
+All failures surface as the typed [`EnvError`]; consumers map it into their
+own error (`ApiConfigError`, `ProviderError`, …) at the boundary.
+
+## Testing
+
+Enable the `testing` feature for `nebula_env::testing::EnvGuard` — an RAII
+guard that serializes process-env mutation behind a global lock and restores
+prior values on drop:
+
+```rust,ignore
+let mut env = nebula_env::testing::EnvGuard::acquire();
+env.set("API_RATE_LIMIT", "200");
+// ... assert behaviour ...
+// prior value (or "unset") is restored when `env` drops
+```
+
+This replaces the hand-rolled `env_lock` / `clear_env` harnesses previously
+duplicated across crate test modules.
+
+## Layer
+
+See `CLAUDE.md` → *Layered Dependency Map* (Cross-cutting row) and
+ADR-0086 for the placement rationale and the workspace env conventions.

--- a/crates/env/src/error.rs
+++ b/crates/env/src/error.rs
@@ -1,0 +1,44 @@
+//! Error type for environment-variable resolution.
+
+/// Failure reading or parsing an environment variable.
+///
+/// Consumers map this into their own typed error at the boundary
+/// (e.g. `ApiConfigError`, `ProviderError`) rather than surfacing it
+/// directly — `nebula-env` is shared infra, not a public API contract.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum EnvError {
+    /// A required variable is not set.
+    #[error("environment variable `{var}` is not set")]
+    Missing {
+        /// Variable name.
+        var: String,
+    },
+
+    /// The variable is set but its value is not valid Unicode.
+    #[error("environment variable `{var}` is not valid Unicode")]
+    NotUnicode {
+        /// Variable name.
+        var: String,
+    },
+
+    /// The variable is set but failed to parse into the requested type.
+    #[error("environment variable `{var}` could not be parsed: {message}")]
+    Parse {
+        /// Variable name.
+        var: String,
+        /// `Display` of the underlying parse error.
+        message: String,
+    },
+
+    /// The variable is set to a value outside the accepted set.
+    #[error("environment variable `{var}` has invalid value `{value}` (expected {expected})")]
+    Invalid {
+        /// Variable name.
+        var: String,
+        /// The rejected value.
+        value: String,
+        /// Human-readable description of the accepted values.
+        expected: &'static str,
+    },
+}

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -21,6 +21,22 @@
 //! Enable the `testing` feature for [`testing::EnvGuard`], an RAII guard that
 //! serializes env mutation behind a process-global lock and restores prior
 //! values on drop.
+//!
+//! ## Examples
+//!
+//! ```
+//! // Unset variables read as absent / fall back to the default — no panics.
+//! assert!(nebula_env::var("NEBULA_ENV_DOCTEST_UNSET").is_err());
+//! assert_eq!(nebula_env::var_opt("NEBULA_ENV_DOCTEST_UNSET"), Ok(None));
+//! assert_eq!(nebula_env::parse_or("NEBULA_ENV_DOCTEST_UNSET", 4u32), Ok(4));
+//! assert_eq!(nebula_env::flag_or("NEBULA_ENV_DOCTEST_UNSET", true), Ok(true));
+//! assert!(nebula_env::list("NEBULA_ENV_DOCTEST_UNSET").is_empty());
+//! ```
+
+// The reader core is unsafe-free; the only `unsafe` lives behind the
+// feature-gated `testing` module (env mutation under edition 2024).
+#![cfg_attr(not(any(test, feature = "testing")), forbid(unsafe_code))]
+#![warn(missing_docs)]
 
 mod error;
 mod reader;

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -1,0 +1,35 @@
+//! # nebula-env
+//!
+//! Typed, cross-cutting environment-variable reader for the Nebula workspace.
+//!
+//! One parsing contract shared by every crate that reads the environment,
+//! replacing the per-crate ad-hoc `std::env::var(...).unwrap_or_default().parse()`
+//! patterns and the divergent bool/int helpers previously duplicated in
+//! `nebula-api` and `nebula-log`. Consumers map [`EnvError`] into their own
+//! typed error at the boundary; `nebula-env` itself takes no runtime
+//! dependencies beyond `std` + `thiserror`.
+//!
+//! ## Reading
+//!
+//! - [`var`] / [`var_opt`] — required / optional string.
+//! - [`parse`] / [`parse_or`] — any [`FromStr`](core::str::FromStr) type.
+//! - [`flag`] / [`flag_or`] — boolean (`true/1/yes/on` vs `false/0/no/off`).
+//! - [`list`] — whitespace/comma-delimited values, empties dropped.
+//!
+//! ## Testing
+//!
+//! Enable the `testing` feature for [`testing::EnvGuard`], an RAII guard that
+//! serializes env mutation behind a process-global lock and restores prior
+//! values on drop.
+
+mod error;
+mod reader;
+
+pub use error::EnvError;
+pub use reader::{flag, flag_or, list, parse, parse_or, var, var_opt};
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+#[cfg(test)]
+mod tests;

--- a/crates/env/src/lib.rs
+++ b/crates/env/src/lib.rs
@@ -18,9 +18,10 @@
 //!
 //! ## Testing
 //!
-//! Enable the `testing` feature for [`testing::EnvGuard`], an RAII guard that
+//! Enable the `testing` feature for `testing::EnvGuard`, an RAII guard that
 //! serializes env mutation behind a process-global lock and restores prior
-//! values on drop.
+//! values on drop. (Not an intra-doc link: the module is feature-gated, so it
+//! is absent from the default doc build.)
 //!
 //! ## Examples
 //!

--- a/crates/env/src/reader.rs
+++ b/crates/env/src/reader.rs
@@ -1,0 +1,98 @@
+//! Typed environment-variable reader with uniform error reporting.
+//!
+//! One parsing contract for the whole workspace: `var`/`var_opt` for strings,
+//! `parse`/`parse_or` for `FromStr` types, `flag`/`flag_or` for booleans, and
+//! `list` for delimited values. Variable names are `&str` so dynamic,
+//! prefix-built names (e.g. per-provider OAuth vars) work uniformly.
+
+use std::str::FromStr;
+
+use crate::error::EnvError;
+
+/// Read a required variable. `Err` if unset or not valid Unicode.
+pub fn var(name: &str) -> Result<String, EnvError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(value),
+        Err(std::env::VarError::NotPresent) => Err(EnvError::Missing {
+            var: name.to_owned(),
+        }),
+        Err(std::env::VarError::NotUnicode(_)) => Err(EnvError::NotUnicode {
+            var: name.to_owned(),
+        }),
+    }
+}
+
+/// Read an optional variable. `Ok(None)` if unset; `Err` only if it is set
+/// but not valid Unicode.
+pub fn var_opt(name: &str) -> Result<Option<String>, EnvError> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(EnvError::NotUnicode {
+            var: name.to_owned(),
+        }),
+    }
+}
+
+/// Parse a variable via [`FromStr`] (after trimming). `Ok(None)` if unset.
+pub fn parse<T>(name: &str) -> Result<Option<T>, EnvError>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    match var_opt(name)? {
+        None => Ok(None),
+        Some(raw) => raw
+            .trim()
+            .parse()
+            .map(Some)
+            .map_err(|err: T::Err| EnvError::Parse {
+                var: name.to_owned(),
+                message: err.to_string(),
+            }),
+    }
+}
+
+/// Parse a variable via [`FromStr`], falling back to `default` when unset.
+pub fn parse_or<T>(name: &str, default: T) -> Result<T, EnvError>
+where
+    T: FromStr,
+    T::Err: std::fmt::Display,
+{
+    Ok(parse(name)?.unwrap_or(default))
+}
+
+/// Parse a boolean. Accepts (case-insensitive) `true/1/yes/on` and
+/// `false/0/no/off`. `Ok(None)` if unset; `Err` on any other value.
+pub fn flag(name: &str) -> Result<Option<bool>, EnvError> {
+    let Some(raw) = var_opt(name)? else {
+        return Ok(None);
+    };
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "true" | "1" | "yes" | "on" => Ok(Some(true)),
+        "false" | "0" | "no" | "off" => Ok(Some(false)),
+        _ => Err(EnvError::Invalid {
+            var: name.to_owned(),
+            value: raw,
+            expected: "true|false|1|0|yes|no|on|off",
+        }),
+    }
+}
+
+/// Parse a boolean, falling back to `default` when unset.
+pub fn flag_or(name: &str, default: bool) -> Result<bool, EnvError> {
+    Ok(flag(name)?.unwrap_or(default))
+}
+
+/// Split a variable on whitespace and commas, dropping empties. Returns an
+/// empty `Vec` when unset (operator-friendly list parsing).
+#[must_use]
+pub fn list(name: &str) -> Vec<String> {
+    std::env::var(name)
+        .unwrap_or_default()
+        .split(|c: char| c.is_whitespace() || c == ',')
+        .map(str::trim)
+        .filter(|piece| !piece.is_empty())
+        .map(str::to_owned)
+        .collect()
+}

--- a/crates/env/src/testing.rs
+++ b/crates/env/src/testing.rs
@@ -1,0 +1,90 @@
+//! Test-only helpers for manipulating process environment variables.
+//!
+//! `std::env::{set_var, remove_var}` are `unsafe` under edition 2024 because
+//! they mutate global process state without synchronization. [`EnvGuard`]
+//! serializes all mutation behind a process-global lock and restores the
+//! prior values on drop, so tests never clobber each other under nextest's
+//! in-process parallelism. This replaces the hand-rolled `env_lock` / `ENV_LOCK`
+//! harnesses previously duplicated across `nebula-api`, `nebula-log`, and
+//! `nebula-storage` test modules.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard, OnceLock, PoisonError};
+
+fn lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// RAII guard that serializes env mutation and restores prior values on drop.
+///
+/// Acquire one per test via [`EnvGuard::acquire`] and hold it for the test
+/// body; every [`set`](EnvGuard::set) / [`remove`](EnvGuard::remove) is undone
+/// when the guard drops.
+#[must_use = "the guard must be held for the duration of the test"]
+pub struct EnvGuard {
+    _lock: MutexGuard<'static, ()>,
+    saved: HashMap<String, Option<String>>,
+}
+
+impl EnvGuard {
+    /// Acquire the process-global env lock.
+    pub fn acquire() -> Self {
+        Self {
+            _lock: lock(),
+            saved: HashMap::new(),
+        }
+    }
+
+    /// Set `key` to `value`, remembering the prior value for restoration.
+    pub fn set(&mut self, key: &str, value: &str) {
+        self.remember(key);
+        // guard-justified: edition-2024 set_var is unsafe; the held lock
+        // serializes all env mutation so no other thread races this write.
+        #[allow(unsafe_code)]
+        // SAFETY: `self._lock` is held for the lifetime of this guard, so no
+        // concurrent reader or writer of the environment can observe a torn
+        // state during this single-threaded mutation.
+        unsafe {
+            std::env::set_var(key, value);
+        }
+    }
+
+    /// Remove `key`, remembering the prior value for restoration.
+    pub fn remove(&mut self, key: &str) {
+        self.remember(key);
+        // guard-justified: edition-2024 remove_var is unsafe; serialized by
+        // the held process-global lock, same invariant as `set`.
+        #[allow(unsafe_code)]
+        // SAFETY: the held lock serializes this mutation; see `set`.
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+
+    fn remember(&mut self, key: &str) {
+        self.saved
+            .entry(key.to_owned())
+            .or_insert_with(|| std::env::var(key).ok());
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, prior) in &self.saved {
+            // guard-justified: restoring env on drop is unsafe under edition
+            // 2024 but serialized by the still-held lock.
+            #[allow(unsafe_code)]
+            // SAFETY: the lock is held until this Drop completes, so the
+            // restore is serialized against all other env access.
+            unsafe {
+                match prior {
+                    Some(value) => std::env::set_var(key, value),
+                    None => std::env::remove_var(key),
+                }
+            }
+        }
+    }
+}

--- a/crates/env/src/tests.rs
+++ b/crates/env/src/tests.rs
@@ -1,0 +1,63 @@
+//! Unit tests for the typed env reader. `EnvGuard` serializes mutation and
+//! restores prior values, so these run safely under nextest parallelism.
+
+use crate::testing::EnvGuard;
+use crate::{EnvError, flag, list, parse, parse_or, var, var_opt};
+
+#[test]
+fn var_reports_missing_and_optional() {
+    let mut guard = EnvGuard::acquire();
+    guard.remove("NEBULA_ENV_TEST_X");
+    assert!(matches!(
+        var("NEBULA_ENV_TEST_X"),
+        Err(EnvError::Missing { .. })
+    ));
+    assert_eq!(var_opt("NEBULA_ENV_TEST_X"), Ok(None));
+}
+
+#[test]
+fn parse_roundtrips_and_defaults() {
+    let mut guard = EnvGuard::acquire();
+    guard.set("NEBULA_ENV_TEST_N", "42");
+    assert_eq!(parse::<u64>("NEBULA_ENV_TEST_N"), Ok(Some(42)));
+    guard.remove("NEBULA_ENV_TEST_N");
+    assert_eq!(parse_or::<u64>("NEBULA_ENV_TEST_N", 7), Ok(7));
+}
+
+#[test]
+fn parse_rejects_garbage() {
+    let mut guard = EnvGuard::acquire();
+    guard.set("NEBULA_ENV_TEST_N", "not-a-number");
+    assert!(matches!(
+        parse::<u64>("NEBULA_ENV_TEST_N"),
+        Err(EnvError::Parse { .. })
+    ));
+}
+
+#[test]
+fn flag_accepts_aliases_and_rejects_others() {
+    let mut guard = EnvGuard::acquire();
+    for value in ["true", "1", "YES", "on"] {
+        guard.set("NEBULA_ENV_TEST_B", value);
+        assert_eq!(flag("NEBULA_ENV_TEST_B"), Ok(Some(true)));
+    }
+    for value in ["false", "0", "no", "OFF"] {
+        guard.set("NEBULA_ENV_TEST_B", value);
+        assert_eq!(flag("NEBULA_ENV_TEST_B"), Ok(Some(false)));
+    }
+    guard.set("NEBULA_ENV_TEST_B", "maybe");
+    assert!(matches!(
+        flag("NEBULA_ENV_TEST_B"),
+        Err(EnvError::Invalid { .. })
+    ));
+}
+
+#[test]
+fn list_splits_on_commas_and_whitespace() {
+    let mut guard = EnvGuard::acquire();
+    guard.set("NEBULA_ENV_TEST_L", "a, b  c,,d");
+    assert_eq!(
+        list("NEBULA_ENV_TEST_L"),
+        ["a", "b", "c", "d"].map(str::to_owned)
+    );
+}

--- a/crates/log/Cargo.toml
+++ b/crates/log/Cargo.toml
@@ -80,6 +80,7 @@ full = ["ansi", "async", "file", "log-compat", "telemetry", "sentry"]
 
 [dev-dependencies]
 anyhow = { workspace = true }
+nebula-env = { workspace = true, features = ["testing"] }
 criterion = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/log/src/config/env.rs
+++ b/crates/log/src/config/env.rs
@@ -36,6 +36,42 @@ fn parse_format(value: &str) -> Option<Format> {
     }
 }
 
+/// Tri-state colour selection parsed from `NEBULA_LOG_COLORS`.
+///
+/// The documented contract is `auto | always | never`; bool-style aliases
+/// (`true/1/yes/on`, `false/0/no/off`) are also accepted for back-compat.
+/// `auto` and any unrecognized value resolve to [`ColorMode::Auto`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ColorMode {
+    Auto,
+    Always,
+    Never,
+}
+
+impl ColorMode {
+    fn parse(value: &str) -> Self {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "always" | "true" | "1" | "yes" | "on" => Self::Always,
+            "never" | "false" | "0" | "no" | "off" => Self::Never,
+            // "auto" and anything unrecognized fall back to TTY auto-detect.
+            _ => Self::Auto,
+        }
+    }
+
+    /// Resolve to a concrete ANSI on/off. `Auto` enables colours only when
+    /// stderr is a terminal; every arm still requires the `ansi` feature to
+    /// emit codes, matching `DisplayConfig`'s default derivation.
+    fn resolve(self) -> bool {
+        match self {
+            Self::Always => cfg!(feature = "ansi"),
+            Self::Never => false,
+            Self::Auto => {
+                cfg!(feature = "ansi") && std::io::IsTerminal::is_terminal(&std::io::stderr())
+            },
+        }
+    }
+}
+
 impl Config {
     /// Apply environment variable overrides to an existing configuration.
     ///
@@ -67,7 +103,7 @@ impl Config {
             applied = true;
         }
         if let Ok(v) = std::env::var("NEBULA_LOG_COLORS") {
-            self.display.colors = parse_bool(&v);
+            self.display.colors = ColorMode::parse(&v).resolve();
             applied = true;
         }
 
@@ -107,5 +143,40 @@ impl Config {
                 source: ResolvedSource::Preset,
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ColorMode;
+
+    #[test]
+    fn color_mode_parses_documented_contract() {
+        assert_eq!(ColorMode::parse("auto"), ColorMode::Auto);
+        assert_eq!(ColorMode::parse("always"), ColorMode::Always);
+        assert_eq!(ColorMode::parse("never"), ColorMode::Never);
+    }
+
+    #[test]
+    fn color_mode_accepts_bool_aliases_case_insensitively() {
+        for on in ["true", "1", "YES", "On"] {
+            assert_eq!(ColorMode::parse(on), ColorMode::Always, "{on}");
+        }
+        for off in ["false", "0", "no", "OFF", "FALSE"] {
+            assert_eq!(ColorMode::parse(off), ColorMode::Never, "{off}");
+        }
+    }
+
+    #[test]
+    fn color_mode_unrecognized_falls_back_to_auto() {
+        assert_eq!(ColorMode::parse("maybe"), ColorMode::Auto);
+        assert_eq!(ColorMode::parse(""), ColorMode::Auto);
+    }
+
+    #[test]
+    fn never_resolves_to_disabled() {
+        // Regression: the old `parse_bool` returned `true` for "never"
+        // (it is not in the false-set), silently enabling colours.
+        assert!(!ColorMode::Never.resolve());
     }
 }

--- a/crates/log/tests/config_precedence.rs
+++ b/crates/log/tests/config_precedence.rs
@@ -1,17 +1,11 @@
-#![allow(
-    unsafe_code,
-    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
-)]
-
-use std::sync::{LazyLock, Mutex};
-
+use nebula_env::testing::EnvGuard;
 use nebula_log::{Config, LogError, LoggerBuilder};
-
-static ENV_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
 
 #[test]
 fn explicit_config_has_highest_precedence() {
-    let _guard = ENV_LOCK.lock().expect("env lock poisoned");
+    // Hold the guard so this test is serialized against the env-mutating one
+    // below, even though it does not touch the environment itself.
+    let _env = EnvGuard::acquire();
 
     let explicit = Config {
         level: "trace".to_string(),
@@ -24,16 +18,13 @@ fn explicit_config_has_highest_precedence() {
 
 #[test]
 fn environment_overrides_preset_when_explicit_absent() {
-    let _guard = ENV_LOCK.lock().expect("env lock poisoned");
-
-    // SAFETY: tests are serialized by ENV_LOCK for process-wide env changes.
-    unsafe { std::env::set_var("NEBULA_LOG", "warn") };
+    let mut env = EnvGuard::acquire();
+    env.set("NEBULA_LOG", "warn");
 
     let resolved = Config::resolve_startup(None);
     assert_eq!(resolved.config.level, "warn");
 
-    // SAFETY: tests are serialized by ENV_LOCK for process-wide env changes.
-    unsafe { std::env::remove_var("NEBULA_LOG") };
+    // `NEBULA_LOG` is restored to its prior value (or unset) when `env` drops.
 }
 
 #[test]

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -13,6 +13,7 @@ documentation.workspace = true
 
 [dependencies]
 nebula-core = { path = "../core" }
+nebula-env = { workspace = true }
 nebula-credential = { path = "../credential" }
 nebula-storage-port = { path = "../storage-port" }
 
@@ -107,6 +108,8 @@ s3 = ["dep:aws-config", "dep:aws-sdk-s3"]
 msgpack-storage = ["dep:rmp-serde"]
 
 [dev-dependencies]
+# `testing` feature provides EnvGuard for the env-provider integration test.
+nebula-env = { workspace = true, features = ["testing"] }
 tokio = { workspace = true, features = ["full", "test-util"] }
 # Used by FileKeyProvider tests (key_provider.rs).
 tempfile = { workspace = true }

--- a/crates/storage/src/credential/key_provider.rs
+++ b/crates/storage/src/credential/key_provider.rs
@@ -196,7 +196,7 @@ impl EnvKeyProvider {
     /// - [`ProviderError::Decode`] on base64-decode failure.
     /// - [`ProviderError::KeyMaterialRejected`] on wrong decoded length.
     pub fn from_env() -> Result<Self, ProviderError> {
-        let raw = std::env::var(Self::ENV_VAR).map_err(|_| ProviderError::NotConfigured {
+        let raw = nebula_env::var(Self::ENV_VAR).map_err(|_| ProviderError::NotConfigured {
             name: Self::ENV_VAR.to_string(),
         })?;
         let raw = Zeroizing::new(raw);
@@ -503,11 +503,12 @@ mod tests {
         base64::engine::general_purpose::STANDARD.encode([0x42u8; 32])
     }
 
-    // Env-var manipulation (`std::env::set_var` / `remove_var`) is marked
-    // `unsafe` in Rust 2024 edition and is forbidden by this crate's
-    // `#![forbid(unsafe_code)]`. `EnvKeyProvider::from_env` is covered by the
-    // integration test at `tests/env_provider.rs`, which lives in a separate
-    // test-binary crate without that forbid. Validation-logic coverage for
+    // Env-var manipulation is forbidden by this crate's
+    // `#![forbid(unsafe_code)]` (`set_var` / `remove_var` are `unsafe` in the
+    // 2024 edition). `EnvKeyProvider::from_env` is covered by the integration
+    // test at `tests/credential_env_provider.rs`, which uses
+    // `nebula_env::testing::EnvGuard` to centralize the unsafe boundary.
+    // Validation-logic coverage for
     // dev-placeholder / wrong-length / decode-failure paths lives here via
     // `from_base64`, which exercises the same validators minus the env lookup
     // itself.

--- a/crates/storage/tests/credential_env_provider.rs
+++ b/crates/storage/tests/credential_env_provider.rs
@@ -1,51 +1,21 @@
-#![allow(
-    unsafe_code,
-    reason = "env::{set_var, remove_var} are unsafe under edition 2024"
-)]
-
 //! Integration test for [`EnvKeyProvider::from_env`].
 //!
 //! Lives outside the crate proper because the crate applies
-//! `#![forbid(unsafe_code)]` and `std::env::set_var` / `std::env::remove_var`
-//! are `unsafe` under the Rust 2024 edition. The in-crate unit tests cover
-//! the validation logic via `from_base64`; this binary exercises the env
-//! lookup itself and verifies the fail-closed contract against a missing
+//! `#![forbid(unsafe_code)]`; the unsafe env-mutation boundary is centralized
+//! behind [`nebula_env::testing::EnvGuard`], which serializes mutation under a
+//! process-global lock and restores prior values on drop. The in-crate unit
+//! tests cover the validation logic via `from_base64`; this binary exercises
+//! the env lookup itself and the fail-closed contract against a missing
 //! `NEBULA_CRED_MASTER_KEY`.
 
 use base64::Engine;
+use nebula_env::testing::EnvGuard;
 use nebula_storage::credential::{EnvKeyProvider, ProviderError};
-
-/// Serialize env-var manipulation across tests in this binary so parallel
-/// nextest execution does not clobber shared state.
-fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-    use std::sync::{Mutex, OnceLock};
-    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-    LOCK.get_or_init(|| Mutex::new(()))
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-}
-
-fn clear_env() {
-    // SAFETY: the env_lock() mutex serialises env mutations across this
-    // binary's tests, so no other test thread reads or writes the var while
-    // we mutate it. This is the same pattern used in
-    // `crates/api/src/config.rs` tests.
-    unsafe {
-        std::env::remove_var(EnvKeyProvider::ENV_VAR);
-    }
-}
-
-fn set_env(value: &str) {
-    // SAFETY: see clear_env() — env_lock() holds the invariant.
-    unsafe {
-        std::env::set_var(EnvKeyProvider::ENV_VAR, value);
-    }
-}
 
 #[test]
 fn from_env_missing_var_fails_closed() {
-    let _g = env_lock();
-    clear_env();
+    let mut env = EnvGuard::acquire();
+    env.remove(EnvKeyProvider::ENV_VAR);
 
     let err = EnvKeyProvider::from_env().expect_err("missing var must error");
     match err {
@@ -54,41 +24,32 @@ fn from_env_missing_var_fails_closed() {
         },
         other => panic!("wrong variant: {other:?}"),
     }
-
-    clear_env();
 }
 
 #[test]
 fn from_env_dev_placeholder_rejected() {
-    let _g = env_lock();
-    clear_env();
-    set_env(EnvKeyProvider::DEV_PLACEHOLDER);
+    let mut env = EnvGuard::acquire();
+    env.set(EnvKeyProvider::ENV_VAR, EnvKeyProvider::DEV_PLACEHOLDER);
 
     let err = EnvKeyProvider::from_env().expect_err("dev placeholder must error");
     assert!(matches!(err, ProviderError::DevPlaceholder));
-
-    clear_env();
 }
 
 #[test]
 fn from_env_short_value_rejected() {
-    let _g = env_lock();
-    clear_env();
+    let mut env = EnvGuard::acquire();
     let short = base64::engine::general_purpose::STANDARD.encode([0x42u8; 16]);
-    set_env(&short);
+    env.set(EnvKeyProvider::ENV_VAR, &short);
 
     let err = EnvKeyProvider::from_env().expect_err("short key must error");
     assert!(matches!(err, ProviderError::KeyMaterialRejected { .. }));
-
-    clear_env();
 }
 
 #[test]
 fn from_env_valid_key_round_trips() {
-    let _g = env_lock();
-    clear_env();
+    let mut env = EnvGuard::acquire();
     let valid = base64::engine::general_purpose::STANDARD.encode([0x11u8; 32]);
-    set_env(&valid);
+    env.set(EnvKeyProvider::ENV_VAR, &valid);
 
     let provider = EnvKeyProvider::from_env().expect("valid key must succeed");
     let version = nebula_storage::credential::KeyProvider::version(&provider);
@@ -102,6 +63,4 @@ fn from_env_valid_key_round_trips() {
         "env:".len() + 16,
         "version has 16-char fingerprint tail; got {version}"
     );
-
-    clear_env();
 }

--- a/docs/adr/0086-nebula-env-cross-cutting-reader.md
+++ b/docs/adr/0086-nebula-env-cross-cutting-reader.md
@@ -1,0 +1,75 @@
+# ADR-0086 — `nebula-env`: cross-cutting typed environment reader
+
+- **Status:** Accepted
+- **Date:** 2026-05-29
+- **Supersedes:** N/A
+- **Superseded by:** N/A
+- **Related:** `docs/plans/2026-05-29-001-refactor-env-handling-handoff.md` (audit + plan)
+
+## Context
+
+Environment-variable handling was scattered across the workspace with no
+shared contract: `nebula-api` had typed `parse_*_env` helpers, `nebula-log`
+had separate lenient `parse_bool`/`parse_format`, and many sites hand-rolled
+`std::env::var(..).unwrap_or_default().parse()`. Bool parsing diverged
+(`log` treated any non-`false` value as `true`; `api` accepted a fixed set
+and errored otherwise). Test modules in `api`, `log`, and `storage` each
+hand-rolled an env lock plus raw `unsafe` `set_var`/`remove_var` blocks
+(edition 2024), and `api`'s `clear_env` kept a manually-maintained key list
+that drifts from the real registry. Full inventory: the handoff plan above.
+
+## Decision
+
+Introduce **`nebula-env`**, a cross-cutting crate (same tier as
+`nebula-log` / `nebula-error` / `nebula-metrics` — importable at any layer,
+no upward deps, `std` + `thiserror` only). It owns one parsing contract:
+
+- `var` / `var_opt` — required / optional string (`Err` on non-Unicode).
+- `parse` / `parse_or` — any `FromStr` type, trimmed.
+- `flag` / `flag_or` — boolean. **Strict** accepted set
+  `true|1|yes|on` / `false|0|no|off` (case-insensitive); any other value is
+  `EnvError::Invalid`. This resolves the bool-semantics split in favour of
+  fail-closed parsing (handoff F3 / Q5).
+- `list` — split on whitespace and commas, dropping empties.
+
+Variable names are `&str` (not `&'static str`) so dynamically-built,
+prefixed names (per-provider OAuth vars) use the same path. All failures
+surface as the typed `EnvError`; **consumers map it into their own error at
+the boundary** (`ApiConfigError`, `ProviderError`, …) — `nebula-env` is
+shared infra, not a public error contract, so it takes no `nebula-error`
+dependency.
+
+The `testing` feature ships `EnvGuard`: an RAII guard that serializes
+process-env mutation behind a global lock and **restores prior values on
+drop**, replacing the three hand-rolled harnesses and centralizing the one
+`unsafe` boundary behind a safe API.
+
+### Layer / deny.toml
+
+Cross-cutting crates carry **no `deny.toml` `[wrappers]` entry** (they are
+importable anywhere), so `nebula-env` adds none. It is listed in the
+`CLAUDE.md` Layered Dependency Map Cross-cutting row and in
+`[workspace.dependencies]`.
+
+## Consequences
+
+- One bool/parse/list contract; consumers stop re-implementing it.
+- Test harnesses converge on `EnvGuard`; fewer `unsafe` blocks; no env
+  leakage on test panic (the guard restores on drop).
+- Migration is incremental and behavior-preserving where the existing
+  contract already matches (api OAuth scopes → `list`; api `parse_bool_env`
+  → `flag`; log precedence test → `EnvGuard`, all landed).
+
+### Deferred (follow-ups, see handoff plan)
+
+- **log `NEBULA_LOG_COLORS=auto`**: the documented `auto` value is a
+  tri-state, not a bool. Migrating log's display flags to strict `flag`
+  needs a `ColorMode { Auto, Always, Never }` decision first — NOT a
+  behavior change to slip in silently. Deferred.
+- **api `parse_u64_env` / `parse_usize_env`**: keep their typed
+  `ParseIntError` source; `nebula_env::parse` returns a `String` message, so
+  delegating would be lossy. Left as-is.
+- **api `clear_env` + storage/log test helpers**: converge on `EnvGuard`
+  and drive any "clean slate" key set off a real registry (handoff Phase 0).
+- **`DATABASE_URL`**: read only in `#[cfg(test)]` `pool()` helpers; a
+  test-harness consolidation, not a production-contract change.

--- a/docs/adr/0086-nebula-env-cross-cutting-reader.md
+++ b/docs/adr/0086-nebula-env-cross-cutting-reader.md
@@ -60,12 +60,17 @@ importable anywhere), so `nebula-env` adds none. It is listed in the
   contract already matches (api OAuth scopes → `list`; api `parse_bool_env`
   → `flag`; log precedence test → `EnvGuard`, all landed).
 
+### Resolved after the initial decision
+
+- **log `NEBULA_LOG_COLORS`**: now a real `ColorMode { Auto, Always, Never }`
+  (private to `log::config::env`). `auto` honours TTY detection; `never`
+  disables colours (regression fix — the old lenient `parse_bool` returned
+  `true` for `never`, silently enabling them); bool aliases stay accepted
+  for back-compat. The `colors: bool` field is unchanged — `ColorMode`
+  resolves to it at env-override time.
+
 ### Deferred (follow-ups, see handoff plan)
 
-- **log `NEBULA_LOG_COLORS=auto`**: the documented `auto` value is a
-  tri-state, not a bool. Migrating log's display flags to strict `flag`
-  needs a `ColorMode { Auto, Always, Never }` decision first — NOT a
-  behavior change to slip in silently. Deferred.
 - **api `parse_u64_env` / `parse_usize_env`**: keep their typed
   `ParseIntError` source; `nebula_env::parse` returns a `String` message, so
   delegating would be lossy. Left as-is.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,6 +24,7 @@ cascade and later work. Numbering starts at **0042** in this directory.
 | **Observability** | 0046, 0050 | Metrics, traces |
 | **AI (deferred)** | 0057 proposed | STRATEGY.md |
 | **Agent harness** | **0083** | Intent / structural-budget / honesty gate |
+| **Environment config** | **0086** | `nebula-env` cross-cutting typed env reader |
 
 ## Historical ADRs (0001–0041)
 

--- a/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
+++ b/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
@@ -1,0 +1,292 @@
+# Environment-variable handling — cross-crate audit & refactor handoff
+
+**Owner**: TBD on pickup
+**Status**: Handoff / Plan (audit complete, **no implementation work done**)
+**Branch of record**: `claude/crates-env-refactor-HcuWE`
+**Author of plan**: agent handoff — env-handling sweep
+**Date**: 2026-05-29
+
+> **Scope discipline**: this is an audit + refactor plan only. No code in
+> `crates/` or `apps/` was changed. Every finding below cites the
+> **concrete file:line** it was observed at so the implementer can verify
+> against the live tree before acting. Re-validate each finding before
+> starting — env-reading sites move. Implementation should be split into
+> the phases in §4 and land as separate conventional-commit PRs, not one
+> mega-refactor.
+
+---
+
+## 1. Why this exists
+
+Environment-variable handling is currently **scattered, duplicated, and
+semantically inconsistent** across the workspace. There is no single
+reader, no shared parsing conventions, and no real registry — despite
+`.env.example` claiming one exists. The same variable is read in multiple
+places with **different failure semantics**, and two crates hand-roll the
+same unsafe test harness. This handoff inventories the surface, names the
+problems, and proposes a staged refactor that stays inside the repo's
+layer discipline (`deny.toml` `[wrappers]`).
+
+---
+
+## 2. Current-state inventory
+
+### 2.1 Env-var registry (what is actually read, and where)
+
+Grouped by reader. `file:line` is the read site in non-test code as of
+this audit.
+
+**Environment metadata / identity**
+
+| Var | Read at | Notes |
+|-----|---------|-------|
+| `NEBULA_ENV` | `api/src/config/mod.rs:225`, `log/src/config/fields.rs:29`, `log/src/telemetry/sentry.rs:18`, `apps/server/src/compose.rs:448` | **Read in 4 independent places**, each with its own default (`"production"` vs `unwrap_or_default()` vs sentry fallback chain). No single source of truth. |
+| `NEBULA_SERVICE` | `log/src/config/fields.rs:28` | |
+| `NEBULA_INSTANCE` | `log/src/config/fields.rs:33` | |
+| `NEBULA_REGION` | `log/src/config/fields.rs:34` | |
+| `NEBULA_VERSION` | `log/src/config/fields.rs:30` | |
+
+**Storage**
+
+| Var | Read at | Notes |
+|-----|---------|-------|
+| `DATABASE_URL` | `storage/src/pg/{control_queue,oauth_state,org,pat,session,user,verification_token}.rs` (**7 sites**) + `apps/server/src/compose.rs:477,522` | Each site re-implements the read with **different failure semantics**: most `match … { Err => … }`, but `org.rs:290` uses `.ok()?` (silently returns `None`), while compose maps to `TransportInitError`. Same var, ~3 different error contracts. |
+| `NEBULA_CRED_MASTER_KEY` | `storage/src/credential/key_provider.rs:199` (const `ENV_VAR` at :180) | Has a `DEV_PLACEHOLDER` sentinel. Good local pattern — name lives in a const. |
+
+**HTTP / API** (all `API_`-prefixed; canonical parsers in `api/src/config/env.rs`)
+
+| Var | Read at |
+|-----|---------|
+| `API_JWT_SECRET`, `API_BIND_ADDRESS`, `API_REQUEST_TIMEOUT`, `API_MAX_BODY_SIZE`, `API_CORS_ORIGINS`, `API_ENABLE_COMPRESSION`, `API_ENABLE_TRACING`, `API_RATE_LIMIT`, `API_KEYS`, `API_PUBLIC_URL`, `API_REQUEST_ID_HEADER` | `api/src/config/mod.rs:228–304` |
+| `API_AUTH_BACKEND`, `API_IDEMPOTENCY_BACKEND`, `API_IDEMPOTENCY_{TTL_SECS,MAX_ENTRIES,MAX_REQUEST_BODY_BYTES,MAX_RESPONSE_BODY_BYTES,SWEEP_INTERVAL_SECS}` | `api/src/config/mod.rs:356–379` + `sub.rs` |
+| `API_SMTP_{HOST,PORT,USERNAME,PASSWORD,FROM,TLS_MODE}` | `api/src/config/mod.rs:451–507` |
+| `API_AUTH_OAUTH_<PROVIDER>_{CLIENT_ID,CLIENT_SECRET,DISCOVERY_URL,AUTHORIZE_URL,TOKEN_URL,USERINFO_URL,VERIFIED_EMAILS_URL,JWKS_URL,SCOPES}` | `api/src/config/oauth.rs:49,286–311` (dynamic, per-provider prefix) |
+
+**Webhook transport**
+
+| Var | Read at |
+|-----|---------|
+| `WEBHOOK_BASE_URL` | `apps/server/src/transport.rs:110` |
+| `WEBHOOK_BIND_ADDRESS`, `WEBHOOK_BOOTSTRAP_FROM_STORAGE` | `apps/server/src/compose.rs` (documented in `.env.example`) |
+
+**Logging**
+
+| Var | Read at | Notes |
+|-----|---------|-------|
+| `NEBULA_LOG`, `RUST_LOG` | `log/src/config/env.rs:46,49` | `NEBULA_LOG` overrides `RUST_LOG`. |
+| `NEBULA_LOG_FORMAT` | `log/src/config/env.rs:54` | parsed via `parse_format` |
+| `NEBULA_LOG_{TIME,SOURCE,COLORS}` | `log/src/config/env.rs:61–69` | parsed via `parse_bool` |
+
+**Telemetry (OTEL / Sentry)**
+
+| Var | Read at | Notes |
+|-----|---------|-------|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `log/src/telemetry/otel.rs:69` **and** `api/src/telemetry_init.rs:53,319` | **Same var read in two crates** independently. |
+| `OTEL_SERVICE_NAME` | `api/src/telemetry_init.rs:57,305` | Overlaps conceptually with `NEBULA_SERVICE` (log). |
+| `NEBULA_METRICS_OTLP_INTERVAL_SECS` | `api/src/telemetry_init.rs:61,324` | |
+| `SENTRY_DSN`, `SENTRY_ENV`, `SENTRY_RELEASE`, `SENTRY_TRACES_SAMPLE_RATE` | `log/src/telemetry/sentry.rs:11–25` | `SENTRY_ENV` falls back to `NEBULA_ENV`. |
+
+**Plugin protocol**
+
+| Var | Read at |
+|-----|---------|
+| `HOST_TO_PLUGIN_FRAME_CAP_ENV` (const) | `plugin-sdk/src/lib.rs:337` |
+| `ENV_SOCKET_ADDR`, `ENV_SOCKET_KIND` (consts) | `plugin-sdk/src/transport.rs:82–83` |
+
+### 2.2 Existing parsing helpers (the duplication)
+
+| Crate | Helpers | Convention |
+|-------|---------|-----------|
+| `api` (`config/env.rs`) | `parse_u64_env`, `parse_positive_u64_env`, `parse_usize_env`, `parse_bool_env` | `API_`-prefix auto-prepended; typed `ApiConfigError` (`ParseInt`/`ParseEnum`/`ZeroValue`); **fail-closed** on bad input. |
+| `log` (`config/env.rs`) | `parse_bool`, `parse_format` | free functions; **fail-open / lenient** (no error path). |
+| `storage`, `apps/server`, `api/oauth.rs` | none — inline `std::env::var(...).unwrap_or_default()/.ok()?/.parse()` | ad hoc per call site. |
+
+### 2.3 Test-harness duplication
+
+| Crate | Harness | Location |
+|-------|---------|----------|
+| `api` | `env_lock()` (`OnceLock<Mutex<()>>`) + `clear_env()` with a **hardcoded 24-key list** | `api/src/config/env.rs:58–104` (also used by `mod.rs`, `oauth.rs`, `sub.rs`) |
+| `log` | `ENV_LOCK` (`LazyLock<Mutex<()>>`) + inline `unsafe set_var` | `log/tests/config_precedence.rs:6–30`, `log/examples/sentry_test.rs` |
+| `storage` | inline `set_var`/`remove_var` | `storage/tests/credential_env_provider.rs` |
+
+Each re-declares the same `#[allow(unsafe_code, reason = "env::{set_var,
+remove_var} are unsafe under edition 2024")]` justification. The two
+locks are **independent** — they only serialize within a single test
+binary, which is correct under nextest's per-binary processes, but the
+pattern is copy-pasted rather than shared. `api`'s `clear_env()` key list
+is **manually maintained** and will silently drift from the real registry.
+
+---
+
+## 3. Findings (ranked)
+
+**F1 — No real single source of truth (severity: high).**
+`.env.example` claims "canonical env-var registry in
+`crates/api/src/config/env.rs`", but that file only contains the `API_`
+typed parsers — it has no entry for `NEBULA_*`, `OTEL_*`, `SENTRY_*`,
+`DATABASE_URL`, or the plugin vars. The "registry" is aspirational. Three
+docs (`.env.example`, `deploy/.env.example`, per-crate READMEs) and the
+code can drift independently with no mechanical check.
+
+**F2 — Same var, divergent failure semantics (severity: high).**
+`DATABASE_URL` is read at 9 sites with at least 3 different contracts
+(error, `None` via `.ok()?` at `org.rs:290`, transport-error). `NEBULA_ENV`
+is read at 4 sites with 3 different defaults. An operator who mis-sets one
+of these gets inconsistent behavior depending on which path runs first.
+
+**F3 — Inconsistent bool parsing (severity: medium).**
+`log::parse_bool` (`config/env.rs:25`) treats *anything not in
+`{"0","false","FALSE","False"}`* as `true` and never errors.
+`api::parse_bool_env` (`config/env.rs:42`) accepts
+`true/1/yes/on` and `false/0/no/off` and **errors** on anything else.
+`NEBULA_LOG_COLORS=auto` (documented in `.env.example`!) would be parsed
+as `true` by log's lenient rule — the `auto` semantics are silently lost.
+Same conceptual operation, two incompatible contracts.
+
+**F4 — Duplicate typed parsers (severity: medium).**
+`u64`/`usize`/`bool` parsing is implemented in `api`, partially in `log`,
+and hand-rolled everywhere else. No shared `parse::<T>` with a uniform
+error.
+
+**F5 — Test harness copy-paste + drift risk (severity: medium).**
+Two independent env locks; `clear_env()`'s key list is hand-maintained;
+the `unsafe` justification is re-declared in every test module.
+
+**F6 — Conceptual overlap between vars (severity: low).**
+`OTEL_SERVICE_NAME` vs `NEBULA_SERVICE`; `SENTRY_ENV` vs `NEBULA_ENV`
+(already chained); `OTEL_EXPORTER_OTLP_ENDPOINT` read independently in
+`log` and `api`. Worth a deliberate precedence decision rather than
+incidental fallback chains.
+
+---
+
+## 4. Refactor plan (staged)
+
+Two viable shapes. **Recommendation: do Phase 0–1 unconditionally
+(no new crate, no layer change), then evaluate Phase 2 (shared crate)
+against the churn it removes.**
+
+### Phase 0 — Make the registry real (docs + test, no behavior change)
+
+- Promote a single authoritative registry. Cheapest form: a
+  `crates/<x>/src/.../env_vars.rs` const table per owning crate, plus a
+  workspace-level doc table (this file's §2.1 can seed
+  `docs/ENV.md`). Stronger form: a `const &[&str]` exported per crate that
+  `.env.example` and `clear_env()` are checked against in a test.
+- Add a test that fails if `.env.example` references a var no crate reads,
+  or a crate reads a var absent from `.env.example`. This alone kills F1's
+  drift class.
+- **Blast radius**: docs + 1–2 tests. No runtime change. Conventional
+  commit: `docs(env)` / `test(env)`.
+
+### Phase 1 — In-place consolidation (no new crate; stays in layer map)
+
+1. **Unify bool parsing semantics (F3).** Pick one contract. Recommended:
+   adopt `api`'s strict `true/1/yes/on | false/0/no/off`, **plus** an
+   explicit `auto` arm where a tri-state is needed (`NEBULA_LOG_COLORS`).
+   Decide fail-open vs fail-closed *per consumer* but parse with one
+   function. **Behavior change** — call out in PR body; add RED tests for
+   `auto` and for previously-lenient inputs.
+2. **Collapse `DATABASE_URL` reads (F2).** Add one
+   `storage`-internal helper `fn database_url() -> Result<String, …>` with
+   a single error contract; replace the 7 pg-module sites + audit
+   `org.rs:290`'s `.ok()?` (is silent `None` intended there? — **open
+   question, see §6**). compose keeps its own transport-error mapping but
+   calls the same reader.
+3. **Single `NEBULA_ENV` reader (F2/F6).** One function returning a typed
+   `enum Environment { Dev, Staging, Production }` with one default;
+   `api`, `log`, `sentry`, `compose` consume it. (Lands naturally in the
+   shared crate if Phase 2 proceeds; otherwise put it in `log` since it's
+   cross-cutting metadata, or `core`.)
+- **Blast radius**: `storage` (~7 sites → 1 helper), `api`/`log` bool
+  call sites, one new `NEBULA_ENV` reader. Conventional commits:
+  `refactor(storage)`, `refactor(log)`, `refactor(api)`.
+
+### Phase 2 — Extract `nebula-env` (optional; touches layer map + deny.toml)
+
+Only if Phase 1 shows the shared surface is worth a crate. Shape:
+
+- New **cross-cutting** crate `crates/env` → `nebula-env` (same tier as
+  `log`/`error`/`metrics` in the Layered Dependency Map — importable at
+  any level). Depends only on `std` + `nebula-error` + `serde` (no tokio).
+- API surface:
+  - `EnvReader` / free fns: `var(name) -> Result<String, EnvError>`,
+    `var_opt`, `parse::<T: FromStr>`, `bool`, `list` (comma/whitespace
+    split — reuses `oauth.rs:49`'s splitter), `with_prefix("API")`.
+  - `EnvError { var: &'static str, kind: EnvErrorKind }` integrating with
+    `nebula-error` (variant types per F4); each consumer maps it into its
+    own error (`ApiConfigError`, `ProviderError`, …) at the boundary.
+  - A `testing` feature exposing the env lock + an RAII
+    `ScopedEnv` guard (set on construct, restore on drop) to replace the
+    three hand-rolled harnesses (F5) and centralize the one `unsafe` block
+    behind a safe API.
+- **deny.toml**: add `nebula-env` to `[wrappers]` with its exact consumer
+  allowlist (api, log, storage, apps/server, plugin-sdk as needed).
+  Update the Layered Dependency Map table in `CLAUDE.md`.
+- An ADR is warranted (next free number is **0086** — `docs/adr/` tops out
+  at `0085`) documenting the cross-cutting placement and the
+  prefix/parse/precedence conventions.
+- **Blast radius**: 1 new crate, `Cargo.toml` workspace member, `deny.toml`
+  wrapper entry, `CLAUDE.md` layer-map row, ADR-0086, plus migration of
+  the call sites above. Non-trivial — sequence last.
+
+### Phase 3 — Test-harness consolidation (folds into Phase 2 or stands alone)
+
+- Replace `api::env_lock`/`clear_env` and `log::ENV_LOCK` with the shared
+  `nebula-env::testing::ScopedEnv` (if Phase 2) or a single shared
+  test-util module. Drive `clear_env()` off the const registry from
+  Phase 0 so it can't drift.
+
+### Phase 4 — Generate/validate `.env.example` (closes F1 mechanically)
+
+- A small xtask/test that renders `.env.example` groups from the registry
+  consts, or asserts equality. Wire into `task dev:check`.
+
+---
+
+## 5. Sequencing recommendation
+
+1. **Phase 0** — registry + drift test. Standalone, zero risk, unblocks
+   everything else. Land first.
+2. **Phase 1** — in-place consolidation. Each sub-item is its own PR;
+   F3 (bool) and F2 (`DATABASE_URL`) are independent and parallelizable.
+3. **Decision gate** — re-assess whether the remaining duplication
+   justifies Phase 2. If the team wants the test-harness win (F5) and the
+   single `parse::<T>` (F4), proceed; otherwise stop after Phase 1.
+4. **Phase 2 + 3** — shared crate + harness, with ADR-0086 and the
+   `deny.toml`/`CLAUDE.md` updates in the same PR.
+5. **Phase 4** — generated `.env.example`, wired into the pre-PR gate.
+
+---
+
+## 6. Open questions for the owner
+
+- **Q1**: Is `storage/src/pg/org.rs:290`'s `DATABASE_URL` → `.ok()?`
+  (silent `None`) intentional (e.g. optional integration test path) or a
+  latent bug? Phase 1.2 needs this answered before unifying the contract.
+- **Q2**: Do we want a typed `Environment` enum (`Dev/Staging/Production`)
+  workspace-wide, or keep `NEBULA_ENV` as a free string? Affects Phase 1.3
+  surface.
+- **Q3**: Should `OTEL_SERVICE_NAME` and `NEBULA_SERVICE` be unified (one
+  var, one precedence) or remain distinct for OTEL-spec compatibility?
+  (F6 — leans "keep distinct, document precedence".)
+- **Q4**: Phase 2 crate placement — confirm **cross-cutting** tier
+  (alongside `log`) is acceptable, or should the reader live in `core`?
+- **Q5**: Fail-open vs fail-closed default for bool/int parse errors —
+  `api` is fail-closed, `log` is fail-open. Pick a workspace default and
+  list the deliberate exceptions.
+
+---
+
+## 7. Cross-references
+
+- Env files: `.env.example` (app-level), `deploy/.env.example` (Taskfile
+  local-dev defaults).
+- Canonical (today) API parsers: `crates/api/src/config/env.rs`.
+- Log precedence model: `crates/log/src/config/env.rs`
+  (`resolve_startup`, `apply_env_overrides`).
+- Layer map + `deny.toml [wrappers]` discipline: `CLAUDE.md`
+  §"Layered Dependency Map".
+- ADR numbering: `docs/adr/` (next free = **0086**).
+- Plan-doc convention this file follows:
+  `docs/plans/2026-05-28-001-feat-oauth-1.1-followups-plan.md`.

--- a/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
+++ b/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
@@ -24,9 +24,14 @@
   `parse_bool_env` → `nebula_env::flag` (behavior-preserving). All 42 config
   unit tests green.
 
-**Still open** (this plan, below): log `NEBULA_LOG_COLORS=auto` tri-state
-decision (Q2/Q5 — see ADR-0086 deferred list), api `clear_env` + storage/log
-test-helper convergence on `EnvGuard` (F5 / Phase 3), the registry + drift
+Also landed: api config test harness migrated to `EnvGuard` (env.rs/sub.rs/
+mod.rs — removed ~25 `unsafe` blocks + 3 module `#![allow]` + the drift-prone
+`clear_env` list, F5/Phase 3 for api), storage env-provider test on `EnvGuard`,
+and `log` `NEBULA_LOG_COLORS` is now a real `ColorMode { Auto, Always, Never }`
+(fixes the `never`→colours-on regression; resolves Q2/Q5 for colours).
+
+**Still open** (this plan, below): the remaining hand-rolled env test
+harnesses outside api/log/storage (if any), a workspace-wide registry + drift
 test (Phase 0 / F1), and generated `.env.example` (Phase 4). The api int
 parsers keep their typed `ParseIntError` source (delegation would be lossy).
 

--- a/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
+++ b/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
@@ -5,10 +5,30 @@
 # Environment-variable handling — cross-crate audit & refactor handoff
 
 **Owner**: TBD on pickup
-**Status**: Handoff / Plan (audit complete, **no implementation work done**)
+**Status**: In progress — foundation + first migrations landed (see §0)
 **Branch of record**: `claude/crates-env-refactor-HcuWE`
 **Author of plan**: agent handoff — env-handling sweep
 **Date**: 2026-05-29
+**ADR**: `docs/adr/0086-nebula-env-cross-cutting-reader.md`
+
+## 0. Progress (landed on this branch)
+
+- **`nebula-env` crate created** (cross-cutting; `var`/`var_opt`/`parse`/
+  `parse_or`/`flag`/`flag_or`/`list` + typed `EnvError` + `testing::EnvGuard`).
+  Tested, clippy-clean. Registered in the `CLAUDE.md` layer map and
+  `[workspace.dependencies]`; ADR-0086 records the conventions + the
+  bool-semantics decision (strict, fail-closed — resolves F3 / Q5).
+- **`nebula-log`**: config-precedence test migrated to `EnvGuard` (dropped a
+  hand-rolled `Mutex` lock + 3 raw `unsafe` blocks + the crate `#![allow]`).
+- **`nebula-api`**: OAuth scopes splitter → `nebula_env::list` (1:1);
+  `parse_bool_env` → `nebula_env::flag` (behavior-preserving). All 42 config
+  unit tests green.
+
+**Still open** (this plan, below): log `NEBULA_LOG_COLORS=auto` tri-state
+decision (Q2/Q5 — see ADR-0086 deferred list), api `clear_env` + storage/log
+test-helper convergence on `EnvGuard` (F5 / Phase 3), the registry + drift
+test (Phase 0 / F1), and generated `.env.example` (Phase 4). The api int
+parsers keep their typed `ParseIntError` source (delegation would be lossy).
 
 > **Scope discipline**: this is an audit + refactor plan only. No code in
 > `crates/` or `apps/` was changed. Every finding below cites the

--- a/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
+++ b/docs/plans/2026-05-29-001-refactor-env-handling-handoff.md
@@ -1,3 +1,7 @@
+<!--
+# budget-justified: handoff doc is an inventory table of env-var read sites across all crates; intentionally one contiguous reference document, not decomposable code.
+-->
+
 # Environment-variable handling — cross-crate audit & refactor handoff
 
 **Owner**: TBD on pickup


### PR DESCRIPTION
## Summary

Audited environment-variable handling across the workspace and introduced a
single typed reader, `nebula-env`, then migrated the high-value consumers off
the scattered/ad-hoc patterns. Also fixes a latent `NEBULA_LOG_COLORS`
regression found during the sweep.

The env surface was previously inconsistent: `api` had typed `parse_*_env`
helpers, `log` had separate lenient bool/format parsers, several sites
hand-rolled `std::env::var(..).unwrap_or_default().parse()`, and three test
modules each hand-rolled an `unsafe` env lock + manual cleanup. Full audit and
plan: `docs/plans/2026-05-29-001-refactor-env-handling-handoff.md`.

## What's in here

**New crate `nebula-env`** (cross-cutting tier — same as `log`/`error`/`metrics`,
importable anywhere, no `deny.toml` wrapper needed; `std` + `thiserror` only):
- `var` / `var_opt`, `parse` / `parse_or`, `flag` / `flag_or`, `list` + typed `EnvError`.
- Strict, fail-closed bool contract (`true/1/yes/on` vs `false/0/no/off`).
- `testing` feature → `EnvGuard`, an RAII guard that serializes process-env
  mutation behind a global lock and **restores prior values on drop**.
- Reader core is structurally unsafe-free
  (`#[cfg_attr(not(any(test, feature = "testing")), forbid(unsafe_code))]`);
  `#[warn(missing_docs)]`; tested doctest.

**Consumer migrations** (all behavior-preserving unless noted):
- **api**: OAuth scopes splitter → `nebula_env::list` (1:1); `parse_bool_env`
  → `nebula_env::flag`; **entire config test harness** → `EnvGuard`, removing
  ~25 raw `unsafe` blocks, 3 module-level `#[allow(unsafe_code)]`, and the
  drift-prone hand-maintained `clear_env` key list (now one `KNOWN_VARS` const).
- **log**: config-precedence test → `EnvGuard` (dropped a `Mutex` lock + 3
  `unsafe` blocks).
- **storage**: `EnvKeyProvider::from_env` reads via `nebula_env::var`
  (fail-closed contract unchanged); env-provider integration test → `EnvGuard`.
  Crate keeps `#[forbid(unsafe_code)]`.

**Bug fix** — `fix(log)`: `NEBULA_LOG_COLORS` is now a real
`ColorMode { Auto, Always, Never }`. Previously `=never` silently **enabled**
colours (the old lenient `parse_bool` returned `true` for it) and `=auto`
ignored TTY detection — both violating the `auto|always|never` contract already
documented in `.env.example`. Bool aliases stay accepted for back-compat; the
public `colors: bool` field is unchanged (`ColorMode` resolves into it).

**Docs**: ADR-0086 (placement + conventions + resolved/deferred decisions),
handoff plan, `.env.example` registry pointer, `CLAUDE.md` layer-map row.

## Verification

Each commit is self-contained and green. Per touched crate:
`cargo clippy -p <crate> -- -D warnings` clean and `cargo test -p <crate>`
passing (nextest isn't installed in the dev container; CI runs the nextest
form). DB-dependent integration tests skip cleanly with `DATABASE_URL` unset.

## Deferred (tracked in ADR-0086 / handoff, out of scope here)

- api `parse_u64_env`/`parse_usize_env` keep their typed `ParseIntError`
  source (delegating to `nebula_env::parse` would be lossy).
- A workspace-wide env registry + drift test (Phase 0) and generated
  `.env.example` (Phase 4) — a separate design task.

https://claude.ai/code/session_0161iRM3FyXqjScHCsDDzSPP

---
_Generated by [Claude Code](https://claude.ai/code/session_0161iRM3FyXqjScHCsDDzSPP)_