### PR TITLE
refactor(schema)!: remove layering-violating KDF; harden secret-redaction & depth guards

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4064,7 +4064,6 @@ dependencies = [
 name = "nebula-schema"
 version = "0.1.0"
 dependencies = [
- "argon2",
  "codspeed-criterion-compat",
  "hex",
  "indexmap",
@@ -4081,7 +4080,6 @@ dependencies = [
  "serde_json",
  "smallvec",
  "subtle",
- "thiserror",
  "tokio",
  "tracing",
  "trybuild",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,11 @@ tower-http = { version = "0.6", features = ["trace", "cors", "compression-gzip"]
 # the `Message::builder()` typed envelope construction;
 # `smtp-transport` brings `AsyncSmtpTransport<Tokio1Executor>`;
 # `tokio1-rustls-tls` is the only TLS stack we ship (matches reqwest above).
-lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"] }
+lettre = { version = "0.11", default-features = false, features = [
+  "smtp-transport",
+  "tokio1-rustls-tls",
+  "builder",
+] }
 
 # OpenAPI 3.1 spec generation (ADR-0047)
 # `utoipa-axum` is the only mounting path that ties the served `axum::Router`

--- a/crates/schema/CHANGELOG.md
+++ b/crates/schema/CHANGELOG.md
@@ -12,6 +12,20 @@ covers the full set of issues raised in the nebula-schema code review.
 
 ### ⚠ Breaking Changes
 
+- **KDF removed from the schema layer.**  `KdfParams`, `KdfError`, the
+  `MIN_KDF_*` / `MAX_KDF_*` / `DEFAULT_KDF_OUTPUT_BYTES` constants,
+  `KdfParams::hash_password`, and `SecretField::kdf(...)` are deleted, along
+  with the `argon2` and `thiserror` dependencies.  Key derivation /
+  password hashing is a credential-layer concern: `nebula-credential` already
+  owns the AES-256-GCM + Argon2id pipeline (with per-record salting and AAD).
+  The schema copy was a weaker (static-salt, no AEAD), zero-consumer duplicate
+  whose synchronous Argon2 call ran on the async executor inside
+  `ValidValues::resolve` (a worker-blocking hazard under load).  Secret string
+  literals are still promoted to a zeroizing `SecretValue::String` during
+  `resolve`; configure hashing on the credential side instead.
+  `SecretValue::Bytes` / `SecretBytes` / `SecretWire` are unchanged (binary
+  tokens and externally-hashed material still round-trip).
+
 - **`ExpressionContext::evaluate` signature changed (T01).**  The trait no
   longer uses `#[async_trait::async_trait]`; impls now write
   ```rust
@@ -38,23 +52,22 @@ covers the full set of issues raised in the nebula-schema code review.
   violated the `PartialEq` contract.  Loaders are not value-comparable; if
   identity comparison is required, use `Arc::ptr_eq` on the inner handle.
 
-- **`KdfParams::Argon2id` gained a new `output_bytes` field (T06).**  The
-  variant is `#[non_exhaustive]`, so wire JSON without the field continues
-  to deserialize (default `32`).  In-code constructors must add
-  `output_bytes: None` (or `Some(n)`).
-
 ### Added
-
-- **KDF guardrails (T06).**  Public consts `MIN_KDF_*` / `MAX_KDF_*` /
-  `DEFAULT_KDF_OUTPUT_BYTES` for Argon2id memory, time, parallelism, salt
-  length, and output length, aligned to RFC 9106 §4 ("Recommended values"
-  for interactive use).  `KdfParams::hash_password` now rejects sub-minimum
-  costs in addition to over-maximum ones.
 
 - **`recursion_limit` STANDARD_CODE (T07).**  `FieldValues::from_json` and
   `try_set_raw` reject deeply-nested user JSON with the new
   `recursion_limit` code (`MAX_VALUE_DEPTH = 64`).  Closes a stack-overflow
   vector against adversarial wire payloads.
+
+- **`MAX_SCHEMA_DEPTH` schema-tree depth cap.**  New public const
+  (`= 64`, the schema-tree analogue of `MAX_VALUE_DEPTH`).
+  `validate_index_limits` now rejects schemas nested beyond it with
+  `schema.depth_limit` **before** the recursive lint passes run, so an
+  over-deep schema (including one deserialized through `serde_json::from_value`,
+  which has no streaming-parser recursion cap) cannot drive the lint/validate
+  recursion into a stack overflow.  Replaces the previous implicit `u8::MAX`
+  bound with an explicit, conservative one; schemas deeper than 64 were already
+  unusable (their values cannot validate past `MAX_VALUE_DEPTH`).
 
 - **`secret.default_forbidden` STANDARD_CODE (T18).**  Lint pass now
   hard-rejects `Field::Secret { default: Some(_) }`.  Symmetric with
@@ -70,7 +83,7 @@ covers the full set of issues raised in the nebula-schema code review.
 - **`tracing::instrument` spans on every hot-path entry point (T10).**
   Covers `ValidSchema::validate`, `ValidValues::resolve`,
   `ValidSchema::json_schema`, `LoaderRegistry::load_options` /
-  `load_records`, `lint::lint_tree`, `KdfParams::hash_password`.
+  `load_records`, and `lint::lint_tree`.
   All emit structured fields (field counts, mode flags, error counts).
 
 - **Per-crate `clippy.toml` (T17).**  `crates/schema/clippy.toml` bans

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -32,8 +32,6 @@ regex = { workspace = true }
 schemars = { version = "1.0", optional = true }
 zeroize = { workspace = true }
 hex = { workspace = true }
-argon2 = { workspace = true }
-thiserror = { workspace = true }
 tracing = { workspace = true }
 subtle = { workspace = true }
 

--- a/crates/schema/macros/src/derive_enum.rs
+++ b/crates/schema/macros/src/derive_enum.rs
@@ -53,7 +53,10 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
         let label = field_attr.label.unwrap_or_else(|| variant_name.to_string());
         let description = field_attr.description;
         let mut expr = quote! {
-            #crate_path::SelectOption::new(::serde_json::Value::String(#value.to_owned()), #label)
+            #crate_path::SelectOption::new(
+                #crate_path::__private::serde_json::Value::String(#value.to_owned()),
+                #label,
+            )
         };
         if let Some(desc) = description {
             expr = quote! { #expr.with_description(#desc) };
@@ -62,6 +65,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
     }
 
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_g #crate_path::HasSelectOptions for #ty_name #ty_g #where_g {
             fn select_options() -> ::std::vec::Vec<#crate_path::SelectOption> {
                 ::std::vec![

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -66,6 +66,7 @@ pub(crate) fn expand(input: DeriveInput) -> syn::Result<TokenStream2> {
 
     let ty_name_str = ty_name.to_string();
     Ok(quote! {
+        #[automatically_derived]
         impl #impl_g #crate_path::HasSchema for #ty_name #ty_g #where_g {
             fn schema() -> #crate_path::ValidSchema {
                 static __CACHE: ::std::sync::OnceLock<#crate_path::ValidSchema> =
@@ -241,7 +242,11 @@ fn build_field_expr(
         if field_attr.enum_select {
             match default {
                 DefaultLit::Str(s) => {
-                    expr = quote! { #expr.default(::serde_json::Value::String(#s.to_owned())) };
+                    expr = quote! {
+                        #expr.default(
+                            #crate_path::__private::serde_json::Value::String(#s.to_owned())
+                        )
+                    };
                 },
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -251,7 +256,7 @@ fn build_field_expr(
                 },
             }
         } else {
-            let default_tokens = default_lit_tokens(default, inner, field_name)?;
+            let default_tokens = default_lit_tokens(default, inner, field_name, crate_path)?;
             expr = quote! { #expr.default(#default_tokens) };
         }
     }
@@ -399,6 +404,7 @@ fn default_lit_tokens(
     lit: &DefaultLit,
     inner: &FieldKind,
     field_name: &Ident,
+    crate_path: &TokenStream2,
 ) -> syn::Result<TokenStream2> {
     let mismatch = |expected: &str, got: &str| {
         syn::Error::new_spanned(
@@ -409,30 +415,34 @@ fn default_lit_tokens(
     match (inner, lit) {
         // String-ish targets accept only string defaults.
         (FieldKind::String, DefaultLit::Str(s)) => Ok(quote! {
-            ::serde_json::Value::String(#s.to_owned())
+            #crate_path::__private::serde_json::Value::String(#s.to_owned())
         }),
         (FieldKind::String, _) => Err(mismatch("a string literal", "non-string literal")),
 
         // Integer targets accept integer defaults.
         (FieldKind::IntegerNumber, DefaultLit::Int(i)) => Ok(quote! {
-            ::serde_json::Value::Number(::serde_json::Number::from(#i))
+            #crate_path::__private::serde_json::Value::Number(
+                #crate_path::__private::serde_json::Number::from(#i)
+            )
         }),
         (FieldKind::IntegerNumber, _) => Err(mismatch("an integer literal", "non-integer literal")),
 
         // Float targets accept both integer (coerced) and float literals.
         (FieldKind::FloatNumber, DefaultLit::Float(f)) => Ok(quote! {
-            ::serde_json::Value::Number(
-                ::serde_json::Number::from_f64(#f)
+            #crate_path::__private::serde_json::Value::Number(
+                #crate_path::__private::serde_json::Number::from_f64(#f)
                     .expect("derive-provided float default is finite")
             )
         }),
         (FieldKind::FloatNumber, DefaultLit::Int(i)) => Ok(quote! {
-            ::serde_json::Value::Number(::serde_json::Number::from(#i))
+            #crate_path::__private::serde_json::Value::Number(
+                #crate_path::__private::serde_json::Number::from(#i)
+            )
         }),
         (FieldKind::FloatNumber, _) => Err(mismatch("a numeric literal", "non-numeric literal")),
 
         (FieldKind::Boolean, DefaultLit::Bool(b)) => Ok(quote! {
-            ::serde_json::Value::Bool(#b)
+            #crate_path::__private::serde_json::Value::Bool(#b)
         }),
         (FieldKind::Boolean, _) => Err(mismatch("a bool literal", "non-bool literal")),
 

--- a/crates/schema/macros/src/derive_schema.rs
+++ b/crates/schema/macros/src/derive_schema.rs
@@ -428,12 +428,25 @@ fn default_lit_tokens(
         (FieldKind::IntegerNumber, _) => Err(mismatch("an integer literal", "non-integer literal")),
 
         // Float targets accept both integer (coerced) and float literals.
-        (FieldKind::FloatNumber, DefaultLit::Float(f)) => Ok(quote! {
-            #crate_path::__private::serde_json::Value::Number(
-                #crate_path::__private::serde_json::Number::from_f64(#f)
-                    .expect("derive-provided float default is finite")
-            )
-        }),
+        (FieldKind::FloatNumber, DefaultLit::Float(f)) => {
+            // Reject non-finite defaults at EXPANSION time. A float literal can
+            // overflow to infinity (e.g. `1e400` parses to `f64::INFINITY`), and
+            // `serde_json::Number::from_f64` returns `None` for NaN/±inf — so
+            // emitting a runtime `.expect()` would panic in the consuming crate.
+            // Surface it as a spanned compile error instead (never panic in
+            // generated code).
+            if !f.is_finite() {
+                return Err(syn::Error::new_spanned(
+                    field_name,
+                    "#[field(default = ..)]: float default must be finite (NaN / infinity are not valid JSON numbers)",
+                ));
+            }
+            // `Value::from(f64)` yields `Value::Number` for a finite value (and
+            // is itself non-panicking — it maps non-finite to `Null`).
+            Ok(quote! {
+                #crate_path::__private::serde_json::Value::from(#f)
+            })
+        },
         (FieldKind::FloatNumber, DefaultLit::Int(i)) => Ok(quote! {
             #crate_path::__private::serde_json::Value::Number(
                 #crate_path::__private::serde_json::Number::from(#i)

--- a/crates/schema/macros/src/lib.rs
+++ b/crates/schema/macros/src/lib.rs
@@ -90,7 +90,7 @@ fn validate(value: &str) -> Result<(), &'static str> {
     if value.is_empty() {
         return Err("key cannot be empty");
     }
-    if value.len() > 64 {
+    if value.chars().count() > 64 {
         return Err("key max 64 chars");
     }
     let mut chars = value.chars();

--- a/crates/schema/src/context.rs
+++ b/crates/schema/src/context.rs
@@ -133,7 +133,10 @@ pub(crate) fn root_predicate_context_from_json(
 /// A pure schema property — independent of the value tree and of any
 /// JSON-vs-schema key divergence (mode envelopes use `mode`/`value` JSON keys,
 /// not variant keys), so the secret decision is always sound.
-fn field_subtree_has_secret(field: &Field) -> bool {
+///
+/// Shared with `loader::redact_secrets_in_value_for_loader` so the loader
+/// boundary applies the same blob-bypass defense this module does.
+pub(crate) fn field_subtree_has_secret(field: &Field) -> bool {
     match field {
         Field::Secret(_) => true,
         Field::Object(o) => o.fields.iter().any(field_subtree_has_secret),

--- a/crates/schema/src/expression.rs
+++ b/crates/schema/src/expression.rs
@@ -44,6 +44,13 @@ pub trait ExpressionContext: Send + Sync {
     /// Evaluate a parsed expression AST and return the resulting JSON value.
     ///
     /// Errors should use code `"expression.runtime"`.
+    ///
+    /// cancel-safe: implementors SHOULD be cancel-safe.
+    /// [`ValidValues::resolve`](crate::ValidValues::resolve) drives this future
+    /// under the caller's executor and may drop it at the `.await` if the
+    /// surrounding task is cancelled, so an `evaluate` impl that
+    /// performs external side effects must tolerate being dropped mid-flight
+    /// (e.g. be idempotent or detach durable work via its own `spawn`).
     fn evaluate<'a>(&'a self, ast: &'a ExpressionAst) -> EvalFuture<'a>;
 }
 

--- a/crates/schema/src/field.rs
+++ b/crates/schema/src/field.rs
@@ -311,7 +311,6 @@ impl StringField {
 define_field!(SecretField {
     widget: SecretWidget = SecretWidget::Plain,
     reveal_last: Option<u8> = None,
-    kdf: Option<crate::secret::KdfParams> = None,
 } expr: ExpressionMode::Allowed);
 
 impl SecretField {
@@ -319,14 +318,6 @@ impl SecretField {
     #[must_use]
     pub const fn widget(mut self, widget: SecretWidget) -> Self {
         self.widget = widget;
-        self
-    }
-
-    /// Optional KDF: after resolution, replace the user string with a hashed
-    /// [`crate::secret::SecretValue::Bytes`] (see [`crate::secret::KdfParams`]).
-    #[must_use]
-    pub fn kdf(mut self, params: crate::secret::KdfParams) -> Self {
-        self.kdf = Some(params);
         self
     }
 

--- a/crates/schema/src/key.rs
+++ b/crates/schema/src/key.rs
@@ -42,7 +42,7 @@ impl FieldKey {
         if value.is_empty() {
             return Err(Self::err(value, "key cannot be empty"));
         }
-        if value.len() > 64 {
+        if value.chars().count() > 64 {
             return Err(Self::err(value, "key max 64 chars"));
         }
         let first = bytes[0] as char;

--- a/crates/schema/src/lib.rs
+++ b/crates/schema/src/lib.rs
@@ -158,7 +158,7 @@ pub mod prelude;
 pub(crate) mod rule_ref;
 /// Top-level schema aggregate.
 pub mod schema;
-/// Secret value types, optional KDF, and `SecretWire`.
+/// Secret value types and `SecretWire`.
 pub mod secret;
 /// Value transformer definitions.
 pub mod transformer;
@@ -232,9 +232,7 @@ pub use nebula_validator::{Predicate, Rule};
 pub use option::SelectOption;
 pub use path::{FieldPath, PathSegment};
 pub use schema::{Schema, SchemaBuilder};
-pub use secret::{
-    KdfError, KdfParams, SECRET_REDACTED, SecretBytes, SecretString, SecretValue, SecretWire,
-};
+pub use secret::{SECRET_REDACTED, SecretBytes, SecretString, SecretValue, SecretWire};
 pub use transformer::Transformer;
 pub use validated::{
     FieldHandle, ResolvedLookup, ResolvedValues, SchemaFlags, ValidSchema, ValidValues,
@@ -253,5 +251,10 @@ pub mod __private {
     //! Re-exports used by `nebula-schema-macros`-generated code.
     //!
     //! Not part of the stable API. Do not depend on these from user code.
-    pub use tracing;
+    //!
+    //! `serde_json` is re-exported here so derive output can reach it via
+    //! `nebula_schema::__private::serde_json` instead of a bare `::serde_json`
+    //! path — the latter only resolves if the deriving crate happens to have an
+    //! unrenamed `serde_json` dependency of its own.
+    pub use {serde_json, tracing};
 }

--- a/crates/schema/src/loader.rs
+++ b/crates/schema/src/loader.rs
@@ -122,6 +122,10 @@ fn redact_secrets_in_value_for_loader(field: &Field, value: &mut FieldValue) {
             },
         ) => {
             let Some(var) = mode.variants.iter().find(|v| v.key == mode_key.as_str()) else {
+                // Active variant cannot be determined: over-redact the payload
+                // rather than risk handing nested secret material to a loader.
+                // Symmetric with the `Field::Mode` + `Object` arm below.
+                **mv = FieldValue::Literal(Json::String(SECRET_REDACTED.to_owned()));
                 return;
             };
             redact_secrets_in_value_for_loader(&var.field, mv.as_mut());
@@ -150,6 +154,27 @@ fn redact_secrets_in_value_for_loader(field: &Field, value: &mut FieldValue) {
             };
             redact_secrets_in_value_for_loader(&var.field, mv);
         },
+        // A structured-typed secret-bearing field whose value is not the
+        // matching structured shape (e.g. a `Literal` blob handed to an
+        // `Object`/`List`/`Mode` field via the unvalidated `FieldValues::set`):
+        // over-redact the whole value. The blob's serialized form could carry a
+        // nested secret's plaintext, and recursion can't descend a non-matching
+        // shape. Mirrors `context::strip_secret_value`'s blob-bypass defense.
+        //
+        // Scope note: the matching-shape arms above redact every *declared*
+        // `Field::Secret` leaf, and this arm collapses non-matching blobs. They
+        // do NOT drop *undeclared* sibling keys inside a matching `Object`/`List`
+        // (which `context::strip_secrets_scope` does, via `keep_undeclared=false`,
+        // to stop predicate-path smuggling). That divergence is deliberate: an
+        // undeclared key holds caller-supplied non-schema data, not a declared
+        // secret (the declared secret is already redacted), so passing it to a
+        // loader is not a secret leak — the predicate-context boundary has a
+        // stricter need that does not apply here.
+        (Field::Object(_) | Field::List(_) | Field::Mode(_), _)
+            if crate::context::field_subtree_has_secret(field) =>
+        {
+            *value = FieldValue::Literal(Json::String(SECRET_REDACTED.to_owned()));
+        },
         _ => {},
     }
 }
@@ -174,6 +199,10 @@ impl<T: Send + 'static> Loader<T> {
     /// # Errors
     ///
     /// Returns any [`ValidationError`] produced by the wrapped loader.
+    ///
+    /// cancel-safe: depends on the wrapped closure. `call` holds no state and
+    /// only awaits the loader future, so cancellation simply drops that future;
+    /// any side-effect cleanup is the loader author's responsibility.
     pub async fn call(&self, context: LoaderContext) -> Result<LoaderResult<T>, ValidationError> {
         (self.0)(context).await
     }
@@ -315,6 +344,9 @@ impl LoaderRegistry {
     /// Returns `ValidationError` with code `loader.not_registered` when `key`
     /// is not registered, or `loader.failed` if the loader returns an error.
     /// Both errors carry the requesting field's path (from `context.field_key`).
+    ///
+    /// cancel-safe: the registry holds no mutable state; a cancelled call drops
+    /// the in-flight loader future (see [`Loader::call`]).
     #[tracing::instrument(
         level = "info",
         target = "nebula_schema::loader",
@@ -362,6 +394,9 @@ impl LoaderRegistry {
     /// Returns `ValidationError` with code `loader.not_registered` when `key`
     /// is not registered, or `loader.failed` if the loader returns an error.
     /// Both errors carry the requesting field's path (from `context.field_key`).
+    ///
+    /// cancel-safe: the registry holds no mutable state; a cancelled call drops
+    /// the in-flight loader future (see [`Loader::call`]).
     #[tracing::instrument(
         level = "info",
         target = "nebula_schema::loader",
@@ -668,5 +703,73 @@ mod tests {
         let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
         let v = ctx.values.get_by_str("api_key").expect("api_key");
         assert_eq!(*v, redacted_literal());
+    }
+
+    #[test]
+    fn with_secrets_redacted_object_literal_blob_is_over_redacted() {
+        // A secret-bearing `Field::Object` whose value arrives as a `Literal`
+        // JSON blob (reachable via the unvalidated `FieldValues::set`, never via
+        // `from_json`) must be over-redacted wholesale: recursion can't descend a
+        // non-matching shape, so a nested secret's plaintext would otherwise reach
+        // the loader. Loader-side mirror of context.rs's
+        // `structured_field_with_literal_blob_does_not_leak_nested_secret`.
+        let schema = Schema::builder()
+            .add(
+                Field::object(field_key!("cfg"))
+                    .add(Field::secret(field_key!("api_key")))
+                    .add(Field::string(field_key!("label"))),
+            )
+            .build()
+            .expect("valid schema");
+        let mut values = FieldValues::new();
+        values.set(
+            k("cfg"),
+            FieldValue::Literal(json!({ "api_key": "PLAINTEXT-LEAK", "label": "x" })),
+        );
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let cfg = ctx.values.get_by_str("cfg").expect("cfg");
+        assert_eq!(*cfg, redacted_literal());
+        assert!(
+            !format!("{cfg:?}").contains("PLAINTEXT-LEAK"),
+            "blob plaintext reached the loader: {cfg:?}"
+        );
+    }
+
+    #[test]
+    fn with_secrets_redacted_typed_mode_unknown_variant_over_redacts() {
+        // A typed `FieldValue::Mode` envelope whose mode key matches no declared
+        // variant: the payload must be over-redacted (the active variant — and
+        // thus which leaves are secret — cannot be determined). Covers the typed
+        // `Mode { value: Some(..) }` unknown-variant arm; the `Field::Mode` +
+        // `Object` envelope path is covered by the tests above.
+        let schema = Schema::builder()
+            .add(Field::mode(field_key!("auth")).variant(
+                "oauth",
+                "OAuth",
+                Field::object(field_key!("creds")).add(Field::secret(field_key!("client_secret"))),
+            ))
+            .build()
+            .expect("valid schema");
+        let mut values = FieldValues::new();
+        values.set(
+            k("auth"),
+            FieldValue::Mode {
+                mode: k("nonexistent"),
+                value: Some(Box::new(FieldValue::from_json(
+                    json!({ "client_secret": "PLAINTEXT-LEAK" }),
+                ))),
+            },
+        );
+        let ctx = LoaderContext::new("k", values).with_secrets_redacted(&schema);
+        let auth = ctx.values.get_by_str("auth").expect("auth");
+        let FieldValue::Mode {
+            value: Some(payload),
+            ..
+        } = auth
+        else {
+            panic!("expected mode envelope, got {auth:?}");
+        };
+        assert_eq!(**payload, redacted_literal());
+        assert!(!format!("{auth:?}").contains("PLAINTEXT-LEAK"));
     }
 }

--- a/crates/schema/src/prelude.rs
+++ b/crates/schema/src/prelude.rs
@@ -23,11 +23,11 @@ pub use nebula_validator::{Predicate, Rule};
 pub use crate::{
     BooleanField, CodeField, ComputedField, ComputedReturn, DynamicField, EvalFuture, Expression,
     ExpressionContext, ExpressionMode, Field, FieldKey, FieldPath, FieldValue, FieldValues,
-    FileField, HasSchema, HasSelectOptions, InputHint, KdfParams, ListField, LoaderContext,
-    LoaderRegistry, ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField,
-    RequiredMode, ResolvedValues, Schema, SchemaBuilder, SecretField, SecretValue, SecretWire,
-    SelectField, SelectOption, Severity, StringField, Transformer, ValidSchema, ValidValues,
-    ValidationError, ValidationReport, VisibilityMode, builder::FieldCollector, field_key,
+    FileField, HasSchema, HasSelectOptions, InputHint, ListField, LoaderContext, LoaderRegistry,
+    ModeField, ModeVariant, NoticeField, NoticeSeverity, NumberField, ObjectField, RequiredMode,
+    ResolvedValues, Schema, SchemaBuilder, SecretField, SecretValue, SecretWire, SelectField,
+    SelectOption, Severity, StringField, Transformer, ValidSchema, ValidValues, ValidationError,
+    ValidationReport, VisibilityMode, builder::FieldCollector, field_key,
 };
 
 #[cfg(test)]
@@ -57,8 +57,7 @@ mod coverage_smoke {
         // Rule-building.
         let _: Option<Rule> = None;
         let _: Option<Predicate> = None;
-        // Secret / KDF.
-        let _: Option<KdfParams> = None;
+        // Secret material.
         let _: Option<SecretValue> = None;
         {
             use crate::SecretString;

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -498,11 +498,21 @@ impl SchemaBuilder {
         let mut fields = self.fields;
         let mut report = ValidationReport::new();
 
+        // Depth / sibling-count bounds FIRST. `validate_index_limits` is
+        // self-bounded — it stops recursing past `u8::MAX` depth via
+        // `checked_add` — so it cannot overflow the stack. The structural lint
+        // passes below recurse on the raw nesting depth with no internal cap, so
+        // an over-deep tree must be rejected here before they run. This mirrors
+        // the explicit `MAX_VALUE_DEPTH` guard the value tree already has.
+        validate_index_limits(&fields, &FieldPath::root(), 0, &mut report);
+        if report.has_errors() {
+            return Err(report);
+        }
+
         crate::lint::lint_tree(&fields, &FieldPath::root(), &mut report);
         // Root-rule diagnostics are best-effort while structural lint errors
         // are present; build still stops before indexing when any error exists.
         crate::lint::lint_root_rules(&self.root_rules, &fields, &mut report);
-        validate_index_limits(&fields, &FieldPath::root(), 0, &mut report);
 
         if report.has_errors() {
             return Err(report);
@@ -655,12 +665,45 @@ fn build_index(
     });
 }
 
+/// Maximum schema-tree nesting depth accepted by [`SchemaBuilder::build`].
+///
+/// The schema-tree analogue of [`crate::value::MAX_VALUE_DEPTH`]. Enforced by
+/// [`validate_index_limits`], which runs **before** the recursive lint passes
+/// in `build()`, so an over-deep schema is rejected with `schema.depth_limit`
+/// before any unbounded recursion (lint cycle DFS, `validate_field`,
+/// `promote_secrets_in_value`) can overflow the stack. A schema deeper than this
+/// could not have its values validated anyway — `FieldValue` parsing caps at the
+/// same `MAX_VALUE_DEPTH`.
+///
+/// This guards the *logical* tree once it has been deserialized. Untrusted
+/// schema bytes reach the system as JSON (plugin protocol, API), whose parser
+/// self-limits recursion; a non-self-limiting binary deserializer
+/// (`StorageFormat::MessagePack`, off by default) is only used for trusted
+/// at-rest data and is not fed attacker-controlled schema trees.
+pub const MAX_SCHEMA_DEPTH: u8 = 64;
+
 fn validate_index_limits(
     fields: &[Field],
     path: &FieldPath,
     depth: u8,
     report: &mut ValidationReport,
 ) {
+    // Explicit depth bound, mirroring `MAX_VALUE_DEPTH` on the value tree.
+    // Runs before the recursive descent below (and, via `build()`'s ordering,
+    // before the unbounded lint passes), so a deep tree is rejected here.
+    if depth > MAX_SCHEMA_DEPTH {
+        report.push(
+            ValidationError::builder("schema.depth_limit")
+                .at(path.clone())
+                .param("limit", Value::from(MAX_SCHEMA_DEPTH))
+                .message(format!(
+                    "schema nesting depth exceeds the {MAX_SCHEMA_DEPTH}-level limit at `{path}`"
+                ))
+                .build(),
+        );
+        return;
+    }
+
     let max_indexable_siblings = usize::from(u16::MAX) + 1;
     if fields.len() > max_indexable_siblings {
         report.push(
@@ -843,6 +886,52 @@ mod tests {
         let result = Schema::builder().add(nested_object(260)).build();
         let report = result.expect_err("deep schema should be rejected");
         assert!(report.errors().any(|e| e.code == "schema.depth_limit"));
+    }
+
+    #[test]
+    fn build_rejects_schema_just_beyond_max_depth() {
+        fn nested_object(depth: usize) -> Field {
+            let mut current: Field = Field::string(fk("leaf")).into();
+            for i in (0..depth).rev() {
+                current = Field::object(fk(&format!("n{i}"))).add(current).into();
+            }
+            current
+        }
+        // One level past the explicit cap must be rejected (pins MAX_SCHEMA_DEPTH,
+        // not just the old u8::MAX backstop).
+        let result = Schema::builder()
+            .add(nested_object(usize::from(MAX_SCHEMA_DEPTH) + 2))
+            .build();
+        let report = result.expect_err("over-deep schema should be rejected");
+        assert!(report.errors().any(|e| e.code == "schema.depth_limit"));
+    }
+
+    #[test]
+    fn deserialize_rejects_deeply_nested_schema_via_from_value() {
+        // `ValidSchema::deserialize` from an already-materialized `Value` — the
+        // `serde_json::from_value` path has no streaming-parser recursion cap
+        // (unlike `from_str`/`from_slice`, which self-limit at 128) — must be
+        // rejected by the build-time depth guard rather than recursing unbounded
+        // through the lint passes. Schema-tree analogue of value.rs's
+        // `field_value_deserialize_rejects_deeply_nested_input`.
+        fn nested_object(depth: usize) -> Field {
+            let mut current: Field = Field::string(fk("leaf")).into();
+            for i in (0..depth).rev() {
+                current = Field::object(fk(&format!("n{i}"))).add(current).into();
+            }
+            current
+        }
+        // Serialize a too-deep field to obtain the exact wire shape, then feed it
+        // back through `from_value` inside a `ValidSchema` envelope.
+        let deep = nested_object(usize::from(MAX_SCHEMA_DEPTH) + 5);
+        let wire = serde_json::json!({
+            "fields": [serde_json::to_value(&deep).expect("serialize field")]
+        });
+        let err = serde_json::from_value::<ValidSchema>(wire).expect_err("must reject");
+        assert!(
+            err.to_string().contains("depth"),
+            "expected depth-limit rejection, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -81,6 +81,14 @@ impl Schema {
     #[must_use]
     pub fn lint(&self) -> ValidationReport {
         let mut report = ValidationReport::new();
+        // Same self-bounded depth/fan-out guard `build()` runs, BEFORE the
+        // unbounded `lint_tree` recursion — so a `Schema` constructed or
+        // deserialized outside the builder cannot drive lint into a stack
+        // overflow. Stop on a structural error rather than recursing.
+        validate_index_limits(&self.fields, &FieldPath::root(), 0, &mut report);
+        if report.has_errors() {
+            return report;
+        }
         crate::lint::lint_tree(&self.fields, &FieldPath::root(), &mut report);
         report
     }
@@ -665,15 +673,18 @@ fn build_index(
     });
 }
 
-/// Maximum schema-tree nesting depth accepted by [`SchemaBuilder::build`].
+/// Maximum schema-tree nesting depth accepted by [`SchemaBuilder::build`] and
+/// [`Schema::lint`].
 ///
 /// The schema-tree analogue of [`crate::value::MAX_VALUE_DEPTH`]. Enforced by
-/// [`validate_index_limits`], which runs **before** the recursive lint passes
-/// in `build()`, so an over-deep schema is rejected with `schema.depth_limit`
-/// before any unbounded recursion (lint cycle DFS, `validate_field`,
-/// `promote_secrets_in_value`) can overflow the stack. A schema deeper than this
-/// could not have its values validated anyway — `FieldValue` parsing caps at the
-/// same `MAX_VALUE_DEPTH`.
+/// `validate_index_limits`, which runs **before** the recursive lint passes in
+/// `build()` / `lint()`, so an over-deep schema is rejected with
+/// `schema.depth_limit` before any unbounded recursion (lint cycle DFS,
+/// `validate_field`, `promote_secrets_in_value`) can overflow the stack. The
+/// guard walks every nested field shape — object fields, list items of any kind
+/// (`List<List<…>>`, `List<Mode<…>>`, not just `List<Object>`), and mode-variant
+/// payloads. A schema deeper than this could not have its values validated
+/// anyway — `FieldValue` parsing caps at the same `MAX_VALUE_DEPTH`.
 ///
 /// This guards the *logical* tree once it has been deserialized. Untrusted
 /// schema bytes reach the system as JSON (plugin protocol, API), whose parser
@@ -682,126 +693,114 @@ fn build_index(
 /// at-rest data and is not fed attacker-controlled schema trees.
 pub const MAX_SCHEMA_DEPTH: u8 = 64;
 
+/// Per-level fan-out cap: the field-handle cursor is `u16`, so a single level
+/// can index at most `u16::MAX + 1` siblings / variants.
+const MAX_INDEXABLE_SIBLINGS: usize = u16::MAX as usize + 1;
+
+fn schema_depth_limit_error(path: &FieldPath) -> ValidationError {
+    ValidationError::builder("schema.depth_limit")
+        .at(path.clone())
+        .param("limit", Value::from(MAX_SCHEMA_DEPTH))
+        .message(format!(
+            "schema nesting depth exceeds the {MAX_SCHEMA_DEPTH}-level limit at `{path}`"
+        ))
+        .build()
+}
+
+fn sibling_overflow_error(path: &FieldPath, kind: &str, actual: usize) -> ValidationError {
+    ValidationError::builder("schema.index_overflow")
+        .at(path.clone())
+        .param("limit", Value::from(MAX_INDEXABLE_SIBLINGS))
+        .param("actual", Value::from(actual))
+        .message(format!(
+            "too many {kind} at `{path}`: {actual} > {MAX_INDEXABLE_SIBLINGS}"
+        ))
+        .build()
+}
+
+/// Bound schema-tree depth and per-level sibling/variant counts BEFORE the
+/// unbounded recursive lint / validate / resolve passes run.
+///
+/// Walks **every** nested field shape those passes can traverse — object
+/// fields, list items of any kind (including `List<List<…>>` and
+/// `List<Mode<…>>`, not just `List<Object>`), and mode-variant payloads — so no
+/// nesting path escapes `MAX_SCHEMA_DEPTH`.
 fn validate_index_limits(
     fields: &[Field],
     path: &FieldPath,
     depth: u8,
     report: &mut ValidationReport,
 ) {
-    // Explicit depth bound, mirroring `MAX_VALUE_DEPTH` on the value tree.
-    // Runs before the recursive descent below (and, via `build()`'s ordering,
-    // before the unbounded lint passes), so a deep tree is rejected here.
     if depth > MAX_SCHEMA_DEPTH {
-        report.push(
-            ValidationError::builder("schema.depth_limit")
-                .at(path.clone())
-                .param("limit", Value::from(MAX_SCHEMA_DEPTH))
-                .message(format!(
-                    "schema nesting depth exceeds the {MAX_SCHEMA_DEPTH}-level limit at `{path}`"
-                ))
-                .build(),
-        );
+        report.push(schema_depth_limit_error(path));
         return;
     }
-
-    let max_indexable_siblings = usize::from(u16::MAX) + 1;
-    if fields.len() > max_indexable_siblings {
-        report.push(
-            ValidationError::builder("schema.index_overflow")
-                .at(path.clone())
-                .param("limit", Value::from(max_indexable_siblings))
-                .param("actual", Value::from(fields.len()))
-                .message(format!(
-                    "too many sibling fields at `{path}`: {} > {}",
-                    fields.len(),
-                    max_indexable_siblings
-                ))
-                .build(),
-        );
+    if fields.len() > MAX_INDEXABLE_SIBLINGS {
+        report.push(sibling_overflow_error(path, "sibling fields", fields.len()));
     }
-
     for field in fields {
         let child_path = path.clone().join(field.key().clone());
-        let Some(next_depth) = depth.checked_add(1) else {
-            report.push(
-                ValidationError::builder("schema.depth_limit")
-                    .at(child_path)
-                    .param("limit", Value::from(u8::MAX))
-                    .message("schema nesting depth exceeds supported index range")
-                    .build(),
-            );
-            continue;
-        };
-
-        validate_indexable_field_children(field, &child_path, next_depth, report);
+        validate_field_subtree_limits(field, &child_path, depth, report);
     }
 }
 
-fn validate_indexable_field_children(
+/// Recurse a single field (at nesting level `depth`) into every container kind,
+/// bounding depth and fan-out. Mirrors the structural recursion the lint /
+/// `validate_field` / `promote_secrets_in_value` passes perform, so the cap
+/// covers exactly the paths those unbounded passes can take.
+fn validate_field_subtree_limits(
     field: &Field,
     path: &FieldPath,
     depth: u8,
     report: &mut ValidationReport,
 ) {
+    if depth > MAX_SCHEMA_DEPTH {
+        report.push(schema_depth_limit_error(path));
+        return;
+    }
+    let Some(child_depth) = depth.checked_add(1) else {
+        // Unreachable while MAX_SCHEMA_DEPTH < u8::MAX, but keep the backstop so
+        // a future cap raise cannot silently overflow the u8 depth counter.
+        report.push(schema_depth_limit_error(path));
+        return;
+    };
     match field {
         Field::Object(object) => {
-            validate_index_limits(&object.fields, path, depth, report);
+            if object.fields.len() > MAX_INDEXABLE_SIBLINGS {
+                report.push(sibling_overflow_error(
+                    path,
+                    "sibling fields",
+                    object.fields.len(),
+                ));
+            }
+            for child in &object.fields {
+                let child_path = path.clone().join(child.key().clone());
+                validate_field_subtree_limits(child, &child_path, child_depth, report);
+            }
         },
         Field::List(list) => {
-            if let Some(Field::Object(object)) = list.item.as_deref() {
-                validate_index_limits(&object.fields, path, depth, report);
+            // A list item is one nesting level deeper and may be ANY field kind;
+            // descend it so `List<List<…>>` / `List<Mode<…>>` cannot bypass the cap.
+            if let Some(item) = list.item.as_deref() {
+                validate_field_subtree_limits(item, path, child_depth, report);
             }
         },
         Field::Mode(mode) => {
-            validate_mode_variant_index_limits(mode, path, depth, report);
+            if mode.variants.len() > MAX_INDEXABLE_SIBLINGS {
+                report.push(sibling_overflow_error(
+                    path,
+                    "mode variants",
+                    mode.variants.len(),
+                ));
+            }
+            for variant in &mode.variants {
+                let Some(variant_path) = mode_variant_path(path, variant.key.as_str()) else {
+                    continue;
+                };
+                validate_field_subtree_limits(&variant.field, &variant_path, child_depth, report);
+            }
         },
         _ => {},
-    }
-}
-
-fn validate_mode_variant_index_limits(
-    mode: &crate::field::ModeField,
-    path: &FieldPath,
-    depth: u8,
-    report: &mut ValidationReport,
-) {
-    let max_indexable_siblings = usize::from(u16::MAX) + 1;
-    if mode.variants.len() > max_indexable_siblings {
-        report.push(
-            ValidationError::builder("schema.index_overflow")
-                .at(path.clone())
-                .param("limit", Value::from(max_indexable_siblings))
-                .param("actual", Value::from(mode.variants.len()))
-                .message(format!(
-                    "too many mode variants at `{path}`: {} > {}",
-                    mode.variants.len(),
-                    max_indexable_siblings
-                ))
-                .build(),
-        );
-    }
-
-    let Some(variant_depth) = depth.checked_add(1) else {
-        report.push(
-            ValidationError::builder("schema.depth_limit")
-                .at(path.clone())
-                .param("limit", Value::from(u8::MAX))
-                .message("schema mode variant depth exceeds supported index range")
-                .build(),
-        );
-        return;
-    };
-
-    for variant in &mode.variants {
-        let Some(variant_path) = mode_variant_path(path, variant.key.as_str()) else {
-            continue;
-        };
-        validate_indexable_field_children(
-            variant.field.as_ref(),
-            &variant_path,
-            variant_depth,
-            report,
-        );
     }
 }
 
@@ -931,6 +930,51 @@ mod tests {
         assert!(
             err.to_string().contains("depth"),
             "expected depth-limit rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn build_rejects_deep_list_of_lists() {
+        // `List<List<List<…>>>` with no object anywhere: the depth guard must
+        // descend non-object list items, not just `List<Object>`. A list-only
+        // deep schema would otherwise bypass MAX_SCHEMA_DEPTH and still drive the
+        // unbounded lint/validate/promote recursion.
+        fn nested_list(depth: usize) -> Field {
+            let mut current: Field = Field::string(fk("leaf")).into();
+            for i in (0..depth).rev() {
+                current = Field::list(fk(&format!("l{i}"))).item(current).into();
+            }
+            current
+        }
+        let result = Schema::builder()
+            .add(nested_list(usize::from(MAX_SCHEMA_DEPTH) + 5))
+            .build();
+        let report = result.expect_err("deep list-of-lists must be rejected");
+        assert!(
+            report.errors().any(|e| e.code == "schema.depth_limit"),
+            "expected schema.depth_limit, got: {report:?}"
+        );
+    }
+
+    #[test]
+    fn lint_rejects_deeply_nested_schema_without_builder() {
+        // `Schema::lint()` runs `lint_tree` directly; it must apply the same
+        // depth guard so a `Schema` built/deserialized outside the builder cannot
+        // enter the unbounded lint recursion.
+        fn nested_object(depth: usize) -> Field {
+            let mut current: Field = Field::string(fk("leaf")).into();
+            for i in (0..depth).rev() {
+                current = Field::object(fk(&format!("n{i}"))).add(current).into();
+            }
+            current
+        }
+        let schema = Schema {
+            fields: vec![nested_object(usize::from(MAX_SCHEMA_DEPTH) + 5)],
+        };
+        let report = schema.lint();
+        assert!(
+            report.errors().any(|e| e.code == "schema.depth_limit"),
+            "Schema::lint must reject an over-deep tree, got: {report:?}"
         );
     }
 

--- a/crates/schema/src/secret.rs
+++ b/crates/schema/src/secret.rs
@@ -1,143 +1,21 @@
-//! Secret material and optional KDF parameters for `Field::Secret`.
+//! Secret material types for `Field::Secret`.
 //!
-//! `SecretValue` is **not** encryption-at-rest (that is `nebula-credential` /
-//! storage). It **does** provide zeroizing buffers, redacted `Debug` /
-//! `Display` / `Serialize` defaults, an audited [`SecretString::expose`] /
-//! [`SecretBytes::expose`], and an explicit [`SecretWire`] for callers that
-//! must persist plaintext to an already-encrypted channel.
-//!
-//! KDF cost / salt bounds align with **RFC 9106 §4** ("Recommended values"
-//! for Argon2id at server-side cost). See `MIN_KDF_MEMORY_KIB` /
-//! `MAX_KDF_MEMORY_KIB` (and the matching `*_TIME_COST`, `*_PARALLELISM`,
-//! `*_SALT_BYTES`, `*_OUTPUT_BYTES` constants exported from this module).
+//! `SecretValue` is **not** encryption-at-rest, and **not** a key-derivation
+//! layer — both belong to `nebula-credential` / storage, which own the
+//! AES-256-GCM + Argon2id pipeline. This module provides only the in-memory
+//! hygiene a schema layer needs: zeroizing buffers, redacted `Debug` /
+//! `Display` / `Serialize` defaults, a constant-time `PartialEq`, an audited
+//! [`SecretString::expose`] / [`SecretBytes::expose`], and an explicit
+//! [`SecretWire`] for callers that must serialize plaintext to an
+//! already-encrypted channel.
 
 use std::fmt;
 
-use argon2::{Argon2, Params};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use thiserror::Error;
 use zeroize::Zeroizing;
 
 /// String returned by JSON helpers when a secret must not be leaked on the wire.
 pub const SECRET_REDACTED: &str = "<redacted>";
-
-// ── KDF error + salt ---------------------------------------------------------
-
-/// Failure while hashing a secret at resolve time.
-#[derive(Debug, Error)]
-pub enum KdfError {
-    /// User-facing misconfiguration in `KdfParams` (including invalid salt
-    /// length/parity) when the failure is not a [`hex::FromHexError`].
-    #[error("invalid KDF parameters: {0}")]
-    InvalidParams(String),
-    /// Invalid hex in `salt_hex` (chained from [`hex::FromHexError`]).
-    #[error("invalid KDF parameters: {0}")]
-    InvalidSaltHex(#[from] hex::FromHexError),
-    /// Argon2 `Params` construction failed (e.g. cost tuple out of range for the
-    /// underlying CSPRNG parameters).
-    #[error("invalid KDF parameters: {0}")]
-    Argon2Params(#[source] argon2::Error),
-    /// Argon2 hashing failed (e.g. from `Argon2::hash_password_into`).
-    #[error("KDF operation failed: {0}")]
-    KdfHash(#[source] argon2::Error),
-}
-
-fn decode_salt(salt_hex: &str) -> Result<Vec<u8>, KdfError> {
-    let s = salt_hex.trim().trim_start_matches("0x");
-    if !s.len().is_multiple_of(2) {
-        return Err(KdfError::InvalidParams(
-            "KDF salt_hex must be even-length".into(),
-        ));
-    }
-    let bytes = hex::decode(s).map_err(KdfError::InvalidSaltHex)?;
-    if !(MIN_KDF_SALT_BYTES..=MAX_KDF_SALT_BYTES).contains(&bytes.len()) {
-        return Err(KdfError::InvalidParams(format!(
-            "KDF salt must decode to {MIN_KDF_SALT_BYTES}–{MAX_KDF_SALT_BYTES} bytes after hex decode"
-        )));
-    }
-    Ok(bytes)
-}
-
-// ── KDF parameters (schema wire / builder) ---------------------------------
-
-/// Key-derivation parameters for an optional post-input hashing step.
-///
-/// When set on a [`super::field::SecretField`], the resolve pipeline replaces a
-/// user `string` secret with [`SecretValue::Bytes`] (never the KDF *password*
-/// in resolved storage).
-#[non_exhaustive]
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "algorithm", rename_all = "snake_case", deny_unknown_fields)]
-pub enum KdfParams {
-    /// Argon2id (RFC 9106) using the `argon2` crate.
-    ///
-    /// Cost parameters must satisfy
-    /// `MIN_KDF_MEMORY_KIB ≤ memory_kib ≤ MAX_KDF_MEMORY_KIB`,
-    /// `MIN_KDF_TIME_COST ≤ time_cost ≤ MAX_KDF_TIME_COST`, and
-    /// `MIN_KDF_PARALLELISM ≤ parallelism ≤ MAX_KDF_PARALLELISM`.
-    /// Salt must decode to `MIN_KDF_SALT_BYTES..=MAX_KDF_SALT_BYTES`
-    /// bytes. The optional `output_bytes` may set the derived-key length
-    /// in `MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES`; default 32.
-    /// Bounds align with RFC 9106 §4 ("Recommended values") for
-    /// interactive Argon2id at server-side cost.
-    Argon2id {
-        /// Salt as even-length hex (no `0x`); RFC 9106 §3.1 recommends
-        /// at least 16 bytes. See [`MIN_KDF_SALT_BYTES`].
-        salt_hex: String,
-        /// `m` cost (memory, `KiB`). RFC 9106 §4 recommends at least
-        /// 8 MiB (8192 KiB) for interactive use.
-        memory_kib: u32,
-        /// `t` cost (iterations). Minimum 1.
-        time_cost: u32,
-        /// `p` cost (parallelism / lanes). Must be at least 1.
-        #[serde(default = "default_p_cost")]
-        parallelism: u8,
-        /// Optional length of the derived key in bytes. Defaults to 32.
-        /// Must be within `MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES`.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
-        output_bytes: Option<u8>,
-    },
-}
-
-const fn default_p_cost() -> u8 {
-    1
-}
-
-// Product-level guardrails for resolve-time KDF cost to prevent runaway
-// resource usage from unbounded user-supplied schema parameters.
-//
-// Lower bounds match RFC 9106 §4 ("Recommended values") for interactive
-// Argon2id at server-side cost. Upper bounds cap a single hash to
-// roughly the same envelope as the upstream `argon2` crate's defaults
-// for batch use; multi-tenant deployments that need stricter caps
-// should wrap `KdfParams::hash_password` and reject before invocation.
-
-/// Minimum salt length in bytes (RFC 9106 §3.1).
-pub const MIN_KDF_SALT_BYTES: usize = 16;
-/// Maximum salt length in bytes.
-pub const MAX_KDF_SALT_BYTES: usize = 64;
-
-/// Minimum Argon2id memory cost in KiB (8 MiB, per RFC 9106 §4).
-pub const MIN_KDF_MEMORY_KIB: u32 = 8 * 1024;
-/// Maximum Argon2id memory cost in KiB (256 MiB).
-pub const MAX_KDF_MEMORY_KIB: u32 = 256 * 1024;
-
-/// Minimum Argon2id iteration count.
-pub const MIN_KDF_TIME_COST: u32 = 1;
-/// Maximum Argon2id iteration count.
-pub const MAX_KDF_TIME_COST: u32 = 10;
-
-/// Minimum Argon2id parallelism (lanes).
-pub const MIN_KDF_PARALLELISM: u8 = 1;
-/// Maximum Argon2id parallelism (lanes).
-pub const MAX_KDF_PARALLELISM: u8 = 16;
-
-/// Minimum derived-key length in bytes.
-pub const MIN_KDF_OUTPUT_BYTES: u8 = 16;
-/// Maximum derived-key length in bytes.
-pub const MAX_KDF_OUTPUT_BYTES: u8 = 64;
-/// Default derived-key length in bytes when `output_bytes` is unset.
-pub const DEFAULT_KDF_OUTPUT_BYTES: u8 = 32;
 
 // ── SecretString / SecretBytes / SecretValue --------------------------------
 
@@ -220,8 +98,8 @@ impl Serialize for SecretString {
 // - Schema definitions (`Field::Secret`) flow over `serde` for catalog / plugin manifests; allowing
 //   `SecretString` here would let a default value or a leaked test fixture round-trip plaintext
 //   through schema storage.
-// - Resolved secret values are always introduced by the resolve pipeline (via `SecretValue::string`
-//   / `KdfParams::hash_password`), not by parsing wire JSON.
+// - Resolved secret values are always introduced by the resolve pipeline (via `SecretValue::string`),
+//   not by parsing wire JSON.
 //
 // As a result, `Schema` definitions must NOT contain a `default` for a
 // `Field::Secret`; the lint pass in `crate::lint` enforces this with the
@@ -246,15 +124,11 @@ impl PartialEq for SecretString {
 
 impl Eq for SecretString {}
 
-/// Opaque byte secret (hashed outputs, binary tokens).
+/// Opaque byte secret (binary tokens, externally-hashed outputs).
 #[derive(Clone)]
 pub struct SecretBytes(Zeroizing<Vec<u8>>);
 
 impl SecretBytes {
-    pub(crate) fn from_vec_unchecked(v: Vec<u8>) -> Self {
-        Self(Zeroizing::new(v))
-    }
-
     /// Return raw bytes.
     ///
     /// Emits a `tracing::trace!` line with a caller location for diagnostics.
@@ -388,88 +262,6 @@ impl Serialize for SecretWire<'_> {
     }
 }
 
-impl KdfParams {
-    /// Run the configured KDF over `password` and return hashed secret bytes.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`KdfError`] when parameters are invalid, salt decoding fails, or
-    /// hashing fails.
-    #[tracing::instrument(skip_all, fields(algo = "Argon2id"))]
-    pub fn hash_password(&self, password: &[u8]) -> Result<SecretValue, KdfError> {
-        match self {
-            Self::Argon2id {
-                salt_hex,
-                memory_kib,
-                time_cost,
-                parallelism,
-                output_bytes,
-            } => {
-                if *memory_kib < MIN_KDF_MEMORY_KIB {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 memory_kib must be >= {MIN_KDF_MEMORY_KIB} (RFC 9106 §4)"
-                    )));
-                }
-                if *memory_kib > MAX_KDF_MEMORY_KIB {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 memory_kib must be <= {MAX_KDF_MEMORY_KIB}"
-                    )));
-                }
-                if *time_cost < MIN_KDF_TIME_COST {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 time_cost must be >= {MIN_KDF_TIME_COST}"
-                    )));
-                }
-                if *time_cost > MAX_KDF_TIME_COST {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 time_cost must be <= {MAX_KDF_TIME_COST}"
-                    )));
-                }
-                if *parallelism < MIN_KDF_PARALLELISM {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 parallelism must be >= {MIN_KDF_PARALLELISM}"
-                    )));
-                }
-                if *parallelism > MAX_KDF_PARALLELISM {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 parallelism must be <= {MAX_KDF_PARALLELISM}"
-                    )));
-                }
-                let out_bytes = output_bytes.unwrap_or(DEFAULT_KDF_OUTPUT_BYTES);
-                if !(MIN_KDF_OUTPUT_BYTES..=MAX_KDF_OUTPUT_BYTES).contains(&out_bytes) {
-                    return Err(KdfError::InvalidParams(format!(
-                        "Argon2 output_bytes must be in {MIN_KDF_OUTPUT_BYTES}..={MAX_KDF_OUTPUT_BYTES}"
-                    )));
-                }
-                let salt = decode_salt(salt_hex)?;
-                let out_len = usize::from(out_bytes);
-                tracing::debug!(
-                    target: "nebula_schema::secret::kdf",
-                    memory_kib = *memory_kib,
-                    time_cost = *time_cost,
-                    parallelism = *parallelism,
-                    out_len,
-                    "running Argon2id"
-                );
-                let params = Params::new(
-                    *memory_kib,
-                    *time_cost,
-                    u32::from(*parallelism),
-                    Some(out_len),
-                )
-                .map_err(KdfError::Argon2Params)?;
-                let argon2 =
-                    Argon2::new(argon2::Algorithm::Argon2id, argon2::Version::V0x13, params);
-                let mut out = vec![0u8; out_len];
-                argon2
-                    .hash_password_into(password, &salt, &mut out)
-                    .map_err(KdfError::KdfHash)?;
-                Ok(SecretValue::Bytes(SecretBytes::from_vec_unchecked(out)))
-            },
-        }
-    }
-}
-
 // `Zeroizing<Vec<u8>>` already zeroizes the heap buffer via its blanket
 // `Drop` impl — no manual `Drop` needed here. (Symmetric with
 // `SecretString` which relies on `Zeroizing<String>` for the same
@@ -479,178 +271,144 @@ impl KdfParams {
 mod tests {
     use super::*;
 
+    // ── SecretString ────────────────────────────────────────────────────────
+
+    #[test]
+    fn string_expose_returns_plaintext() {
+        let s = SecretString::new("hunter2".to_owned());
+        assert_eq!(s.expose(), "hunter2");
+        assert!(!s.is_empty());
+        assert!(SecretString::new(String::new()).is_empty());
+    }
+
     #[test]
     fn string_debug_does_not_echo_plaintext() {
         let s = SecretString::new("hunter2".to_owned());
-        let dbg = format!("{s:?}");
-        assert!(!dbg.contains("hunter2"));
+        assert_eq!(format!("{s:?}"), "SecretString(<redacted>)");
+        assert!(!format!("{s:?}").contains("hunter2"));
+    }
+
+    #[test]
+    fn string_display_redacts() {
+        let s = SecretString::new("hunter2".to_owned());
+        assert_eq!(format!("{s}"), SECRET_REDACTED);
+        assert!(!format!("{s}").contains("hunter2"));
     }
 
     #[test]
     fn string_serialize_redacts() {
         let s = SecretString::new("hunter2".to_owned());
-        let j = serde_json::to_value(&s).expect("json");
-        assert_eq!(j, json_redacted());
+        assert_eq!(serde_json::to_value(&s).expect("json"), redacted());
     }
 
-    fn json_redacted() -> serde_json::Value {
-        serde_json::Value::String(SECRET_REDACTED.to_owned())
+    #[test]
+    fn string_eq_is_value_consistent() {
+        let a = SecretString::new("same".to_owned());
+        let b = SecretString::new("same".to_owned());
+        let c = SecretString::new("different".to_owned());
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn string_deserialize_is_rejected() {
+        assert!(serde_json::from_str::<SecretString>("\"x\"").is_err());
+    }
+
+    // ── SecretBytes ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn bytes_expose_returns_raw() {
+        let v = SecretValue::bytes(vec![1u8, 2, 3]);
+        let SecretValue::Bytes(b) = &v else {
+            panic!("expected bytes");
+        };
+        assert_eq!(b.expose(), &[1, 2, 3]);
+        assert!(!b.is_empty());
+    }
+
+    #[test]
+    fn bytes_debug_does_not_echo_plaintext() {
+        let v = SecretValue::bytes(vec![0xde, 0xad]);
+        let SecretValue::Bytes(b) = &v else {
+            panic!("expected bytes");
+        };
+        assert_eq!(format!("{b:?}"), "SecretBytes(<redacted>)");
+    }
+
+    #[test]
+    fn bytes_serialize_redacts_not_hex() {
+        // Bare `SecretBytes` serialization must redact — only `SecretWire`
+        // emits the hex plaintext form.
+        let v = SecretValue::bytes(vec![0x61, 0x62]);
+        let SecretValue::Bytes(b) = &v else {
+            panic!("expected bytes");
+        };
+        assert_eq!(serde_json::to_value(b).expect("json"), redacted());
+    }
+
+    #[test]
+    fn bytes_eq_is_value_consistent() {
+        let a = SecretValue::bytes(vec![1u8, 2, 3]);
+        let b = SecretValue::bytes(vec![1u8, 2, 3]);
+        let c = SecretValue::bytes(vec![9u8]);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn bytes_deserialize_is_rejected() {
+        assert!(serde_json::from_str::<SecretBytes>("\"x\"").is_err());
+    }
+
+    // ── SecretValue ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn value_is_empty_tracks_inner() {
+        assert!(SecretValue::string(String::new()).is_empty());
+        assert!(!SecretValue::string("x".to_owned()).is_empty());
+        assert!(SecretValue::bytes(Vec::new()).is_empty());
+        assert!(!SecretValue::bytes(vec![0u8]).is_empty());
+    }
+
+    #[test]
+    fn value_to_json_and_serialize_redact_both_variants() {
+        assert_eq!(SecretValue::string("s".to_owned()).to_json(), redacted());
+        assert_eq!(SecretValue::bytes(vec![1u8]).to_json(), redacted());
+        assert_eq!(
+            serde_json::to_value(SecretValue::string("s".to_owned())).expect("json"),
+            redacted()
+        );
+    }
+
+    // ── SecretWire ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn wire_serializes_string_plaintext() {
+        let v = SecretValue::string("plaintext".to_owned());
+        assert_eq!(
+            serde_json::to_value(SecretWire(&v)).expect("json"),
+            serde_json::Value::String("plaintext".into())
+        );
     }
 
     #[test]
     fn wire_serializes_bytes_as_hex() {
-        let b = SecretBytes::from_vec_unchecked(vec![0x61, 0x62, 0x63]);
-        let v = SecretValue::Bytes(b);
-        let ser = serde_json::to_value(SecretWire(&v)).expect("json");
-        assert_eq!(ser, serde_json::Value::String("616263".into()));
-    }
-
-    /// Helper: build a 16-byte hex salt for tests where exact contents
-    /// don't matter.
-    fn test_salt_hex() -> String {
-        "00112233445566778899aabbccddeeff".to_owned()
+        let v = SecretValue::bytes(vec![0x61, 0x62, 0x63]);
+        assert_eq!(
+            serde_json::to_value(SecretWire(&v)).expect("json"),
+            serde_json::Value::String("616263".into())
+        );
     }
 
     #[test]
-    fn kdf_invalid_salt_hex_chains_from_hex_error() {
-        let kdf = KdfParams::Argon2id {
-            // Even length but non-hex characters → `hex::FromHexError`.
-            salt_hex: "gggggggggggggggggggggggggggggggg".to_owned(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf.hash_password(b"pw").expect_err("invalid hex");
-        let KdfError::InvalidSaltHex(_) = &err else {
-            panic!("expected InvalidSaltHex, got {err:?}");
-        };
-        assert!(std::error::Error::source(&err).is_some());
-        let msg = err.to_string();
-        assert!(msg.contains("invalid KDF parameters"), "msg was: {msg}");
+    fn wire_debug_does_not_echo_plaintext() {
+        let v = SecretValue::string("topsecret".to_owned());
+        assert_eq!(format!("{:?}", SecretWire(&v)), "SecretWire(<plaintext>)");
+        assert!(!format!("{:?}", SecretWire(&v)).contains("topsecret"));
     }
 
-    #[test]
-    fn kdf_rejects_short_salt_below_min() {
-        // 8 bytes hex (16 hex chars) — below MIN_KDF_SALT_BYTES (16).
-        let kdf = KdfParams::Argon2id {
-            salt_hex: "0011223344556677".to_owned(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject short salt");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-    }
-
-    #[test]
-    fn kdf_rejects_excessive_resource_costs() {
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MAX_KDF_MEMORY_KIB + 1,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject high memory");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: MAX_KDF_TIME_COST + 1,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject high time_cost");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: MAX_KDF_PARALLELISM + 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject high parallelism");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-    }
-
-    #[test]
-    fn kdf_rejects_subminimum_costs() {
-        // memory_kib below RFC 9106 §4 minimum (8 MiB).
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB - 1,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject below-min memory");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-
-        // time_cost = 0 below MIN_KDF_TIME_COST.
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 0,
-            parallelism: 1,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject zero time_cost");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-
-        // parallelism = 0 below MIN_KDF_PARALLELISM.
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: 0,
-            output_bytes: None,
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject zero parallelism");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-    }
-
-    #[test]
-    fn kdf_rejects_output_bytes_outside_range() {
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: Some(MIN_KDF_OUTPUT_BYTES - 1),
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject sub-min output_bytes");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
-
-        let kdf = KdfParams::Argon2id {
-            salt_hex: test_salt_hex(),
-            memory_kib: MIN_KDF_MEMORY_KIB,
-            time_cost: 1,
-            parallelism: 1,
-            output_bytes: Some(MAX_KDF_OUTPUT_BYTES + 1),
-        };
-        let err = kdf
-            .hash_password(b"pw")
-            .expect_err("must reject above-max output_bytes");
-        assert!(matches!(err, KdfError::InvalidParams(_)));
+    fn redacted() -> serde_json::Value {
+        serde_json::Value::String(SECRET_REDACTED.to_owned())
     }
 }

--- a/crates/schema/src/validated.rs
+++ b/crates/schema/src/validated.rs
@@ -10,7 +10,6 @@ use std::{
 use indexmap::IndexMap;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use zeroize::Zeroize;
 
 use crate::{
     error::{Severity, ValidationError, ValidationReport},
@@ -319,7 +318,6 @@ impl ValidSchema {
     /// let full = FieldValues::from_json(json!({"name": "Alice"})).unwrap();
     /// assert!(schema.validate(&full).is_ok());
     /// ```
-    #[allow(clippy::result_large_err)]
     #[tracing::instrument(
         level = "debug",
         target = "nebula_schema::validate",
@@ -455,22 +453,29 @@ impl ValidValues {
 
     /// Resolve all `FieldValue::Expression` entries by evaluating them through
     /// `ctx`, then **promote** `Field::Secret` string literals to
-    /// `FieldValue::SecretLiteral` (and optional KDF) before the final
-    /// schema-validate pass.
+    /// `FieldValue::SecretLiteral` before the final schema-validate pass.
     ///
     /// **Expression fast path:** when `schema.flags().uses_expressions == false`,
     /// expression resolution is skipped; **secret promotion still runs** so
     /// `ResolvedValues` is consistent for secret fields.
     ///
     /// After evaluating each expression the tree is re-validated on resolved
-    /// literals. If any expression evaluation, KDF, or post-resolve type/rule
-    /// check fails, errors are returned as a [`ValidationReport`].
+    /// literals. If any expression evaluation or post-resolve type/rule check
+    /// fails, errors are returned as a [`ValidationReport`].
     ///
     /// # Errors
     ///
     /// Returns `Err(ValidationReport)` when any expression evaluation fails
     /// or when a resolved value violates a field rule.
-    #[allow(clippy::result_large_err)]
+    ///
+    /// # Cancellation
+    ///
+    /// cancel-safe: yes. `resolve` performs no external side effects of its own
+    /// — it rewrites an owned in-memory value tree and accumulates a report — so
+    /// dropping the future at any `.await` discards the partially-resolved tree
+    /// with nothing persisted. The only `.await` points are calls into the
+    /// caller-supplied [`ExpressionContext::evaluate`]; any side effects there
+    /// are that impl's responsibility (see the trait's cancel-safety note).
     #[tracing::instrument(
         level = "debug",
         target = "nebula_schema::resolve",
@@ -780,8 +785,8 @@ const fn field_value_shape_for_errors(v: &FieldValue) -> &'static str {
     }
 }
 
-/// Promote string literals to [`FieldValue::SecretLiteral`] for secret fields, invoking KDFs when
-/// configured. Recurses through object/list/mode containers.
+/// Promote string literals to [`FieldValue::SecretLiteral`] for secret fields.
+/// Recurses through object/list/mode containers.
 fn promote_secrets_in_value(
     field: &Field,
     value: &mut FieldValue,
@@ -789,7 +794,7 @@ fn promote_secrets_in_value(
     report: &mut ValidationReport,
 ) {
     match (field, &mut *value) {
-        (Field::Secret(secret), v) => promote_secret_value(secret, v, path, report),
+        (Field::Secret(_), v) => promote_secret_value(v, path, report),
         (Field::Object(obj), FieldValue::Object(map)) => {
             for ch in &obj.fields {
                 if let Some(v) = map.get_mut(ch.key()) {
@@ -845,36 +850,17 @@ fn promote_secrets_in_value(
     }
 }
 
-fn promote_secret_value(
-    secret: &crate::field::SecretField,
-    value: &mut FieldValue,
-    path: &FieldPath,
-    report: &mut ValidationReport,
-) {
+fn promote_secret_value(value: &mut FieldValue, path: &FieldPath, report: &mut ValidationReport) {
     use serde_json::Value;
     match value {
         FieldValue::Literal(Value::String(s)) => {
-            let mut password = std::mem::take(s);
-            *value = if let Some(kdf) = &secret.kdf {
-                match kdf.hash_password(password.as_bytes()) {
-                    Ok(sv) => {
-                        password.zeroize();
-                        FieldValue::SecretLiteral(sv)
-                    },
-                    Err(e) => {
-                        *s = password;
-                        report.push(
-                            ValidationError::builder("secret.kdf")
-                                .at(path.clone())
-                                .message(e.to_string())
-                                .build(),
-                        );
-                        return;
-                    },
-                }
-            } else {
-                FieldValue::SecretLiteral(SecretValue::string(password))
-            };
+            // Move the plaintext out of the JSON literal into a zeroizing
+            // `SecretString` (no copy left behind: `mem::take` empties the
+            // source `String`, which is then dropped as part of the replaced
+            // `Literal`). Hashing/KDF is a credential-layer concern
+            // (`nebula-credential`), not the schema layer's.
+            let password = std::mem::take(s);
+            *value = FieldValue::SecretLiteral(SecretValue::string(password));
         },
         FieldValue::Literal(_) => report.push(
             ValidationError::builder("type_mismatch")

--- a/crates/schema/tests/compile_fail/derive_default_float_non_finite.rs
+++ b/crates/schema/tests/compile_fail/derive_default_float_non_finite.rs
@@ -1,0 +1,15 @@
+use nebula_schema::Schema;
+
+#[derive(Schema)]
+#[allow(dead_code)]
+struct Bad {
+    // A float literal that overflows to `f64::INFINITY`. The derive must reject
+    // it at expansion time — otherwise the generated `Number::from_f64(..)`
+    // would be `None` and panic in the consuming crate at runtime.
+    #[field(default = 1e400)]
+    ratio: f64,
+}
+
+fn main() {
+    let _ = Bad::schema();
+}

--- a/crates/schema/tests/compile_fail/derive_default_float_non_finite.stderr
+++ b/crates/schema/tests/compile_fail/derive_default_float_non_finite.stderr
@@ -1,0 +1,18 @@
+error: #[field(default = ..)]: float default must be finite (NaN / infinity are not valid JSON numbers)
+  --> tests/compile_fail/derive_default_float_non_finite.rs:10:5
+   |
+10 |     ratio: f64,
+   |     ^^^^^
+
+error[E0599]: no function or associated item named `schema` found for struct `Bad` in the current scope
+  --> tests/compile_fail/derive_default_float_non_finite.rs:14:18
+   |
+ 5 | struct Bad {
+   | ---------- function or associated item `schema` not found for this struct
+...
+14 |     let _ = Bad::schema();
+   |                  ^^^^^^ function or associated item not found in `Bad`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `schema`, perhaps you need to implement it:
+           candidate #1: `HasSchema`


### PR DESCRIPTION
## Summary

Audit-driven hardening of `nebula-schema`. The headline is a **breaking removal**: the schema-layer KDF is deleted. It was a zero-consumer, weaker (static-salt, no AEAD) duplicate of `nebula-credential`'s real Argon2id pipeline, and — worse — ran a synchronous Argon2 hash **inline on the async executor** inside `ValidValues::resolve`, a worker-thread block under load. Key derivation / at-rest encryption is `nebula-credential`'s job; the schema layer just promotes secret string literals to a zeroizing `SecretValue::String`.

The rest are correctness/security hardening surfaced by the same audit + a follow-up multi-agent code review of the change itself.

## What changed (commit `refactor(schema)!`)

- **Remove KDF.** Delete `KdfParams`, `KdfError`, `KdfParams::hash_password`, `SecretField::kdf()`, the `MIN/MAX/DEFAULT_KDF_*` consts, and the `argon2` + `thiserror` deps. `SecretValue::Bytes` / `SecretBytes` / `SecretWire` are unchanged (binary tokens / externally-hashed material still round-trip).
- **Close a secret-redaction blob-bypass** in the loader path (`redact_secrets_in_value_for_loader`): a `Literal` JSON blob — or an unknown mode variant — handed to a structured secret-bearing field is now over-redacted, mirroring `context.rs`'s defense (see ADR-0034). + regression tests.
- **Proc-macro hygiene:** derive output routes `serde_json` through `nebula_schema::__private::serde_json` instead of a bare `::serde_json` (which broke for any consumer lacking/renaming the dep), and the generated impls gain `#[automatically_derived]`.
- **Stack-overflow guard:** new explicit `MAX_SCHEMA_DEPTH = 64` (the schema-tree analogue of `MAX_VALUE_DEPTH`), enforced **before** the unbounded-recursion lint passes — so a deeply-nested schema (including via `serde_json::from_value`) is rejected with `schema.depth_limit` instead of overflowing. + tests. `SchemaBuilder::build` reordered to run the self-bounded depth/index check first.
- **Cancel-safety docs** on the async surface (`resolve`, `ExpressionContext::evaluate`, `Loader::call`, `load_*`); `FieldKey` length now counts chars, not bytes.

## Breaking change

Removes public `KdfParams`, `KdfError`, `SecretField::kdf`, `KdfParams::hash_password`, and the `MIN/MAX/DEFAULT_KDF_*` consts from `nebula-schema`. Verified **zero consumers** workspace-wide. Configure password hashing / KDF on the `nebula-credential` side. `SCHEMA_WIRE_VERSION` is unchanged: `SecretField` is `#[non_exhaustive]` with no `deny_unknown_fields`, so a stale `"kdf"` key in persisted schema JSON deserializes (silently ignored).

## Verification

`cargo clippy -p nebula-schema -p nebula-schema-macros --all-features --all-targets -- -D warnings` ✓ · `cargo nextest run -p nebula-schema --all-features` → **415 passed** ✓ · `cargo check --workspace` ✓ · rustdoc `-D warnings` ✓ · pre-push (clippy-full + crate-diff nextest, 407 tests) ✓

## Notes

- Second commit `style: taplo-format root Cargo.toml` is an unrelated pre-existing taplo drift (the `lettre` features line) that lefthook checks workspace-wide; split out so this diff stays scoped. Drop it if it conflicts with other work.
- One **pre-existing** gap was left out of scope and tracked separately: serde-derived `Field`/`Schema` deserialize via a non-self-limiting binary deserializer (rmp-serde, `msgpack-storage`, off by default) can recurse during parse before the depth guard runs. No such path exists today (all schema wire is serde_json, which self-limits at 128); a complete fix needs a recursion-limiting `Deserializer` at the storage boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * KDF (Key Derivation Function) functionality has been removed from the schema layer and moved to the credential layer.
  * `SecretField` no longer supports KDF configuration; use the reveal-last-N-characters feature for masked display.

* **New Features**
  * Added recursion depth defense for user JSON input (limit: 64 levels).
  * Added schema depth validation to reject overly nested schemas (max depth: 64).

* **Bug Fixes**
  * Enhanced secret redaction to prevent plaintext leakage through shape mismatches in structured data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vanyastaff/nebula/pull/765?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->