### PR TITLE
feat(credential): CredentialLifecycle for BasicAuth + OAuth2 builtins (ADR-0088 D2)

### DIFF
--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -7,7 +7,7 @@ use nebula_schema::{FieldValues, Schema};
 use serde::Deserialize;
 
 use crate::{
-    Credential, CredentialContext, SecretString,
+    Credential, CredentialContext, CredentialLifecycle, CredentialPolicy, SecretString,
     contract::plugin_capability_report,
     error::{CredentialError, ProviderErrorContext, ProviderErrorKind, SecretFreeMessage},
     metadata::CredentialMetadata,
@@ -112,6 +112,14 @@ impl plugin_capability_report::IsDynamic for BasicAuthCredential {
     const VALUE: bool = false;
 }
 
+/// Basic auth is static (ADR-0088 D2): no expiry, no refresh, no provider-side
+/// revocation — consistent with its absent capability sub-trait impls.
+impl CredentialLifecycle for BasicAuthCredential {
+    fn policy(_state: &IdentityPassword) -> CredentialPolicy {
+        CredentialPolicy::static_secret()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,6 +127,15 @@ mod tests {
     #[test]
     fn key_is_basic_auth() {
         assert_eq!(BasicAuthCredential::KEY, "basic_auth");
+    }
+
+    #[test]
+    fn lifecycle_policy_is_static() {
+        let auth = IdentityPassword::new("u", SecretString::new("p"));
+        let p = BasicAuthCredential::policy(&auth);
+        assert_eq!(p.category, crate::CredentialCategory::StaticSecret);
+        assert!(!p.is_expiring());
+        assert!(!p.is_auto_renewable());
     }
 
     // Capability membership checks moved to compile-time: the absence

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -42,8 +42,9 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::oauth2_config;
 use crate::{
-    Credential, CredentialContext, CredentialState, Interactive, PendingState, Refreshable,
-    Revocable, SecretString, Testable,
+    Credential, CredentialCategory, CredentialContext, CredentialLifecycle, CredentialPolicy,
+    CredentialState, Interactive, PendingState, RefreshStrategy, Refreshable, Revocable,
+    RevokeStrategy, SecretString, Testable,
     contract::plugin_capability_report,
     error::{CredentialError, ProviderErrorContext, ProviderErrorKind, SecretFreeMessage},
     metadata::CredentialMetadata,
@@ -636,6 +637,28 @@ impl plugin_capability_report::IsDynamic for OAuth2Credential {
     const VALUE: bool = false;
 }
 
+/// OAuth2 is a refresh-pair credential (ADR-0088 D2). The policy is computed from
+/// live state: `RefreshToken` while a refresh token is held (the engine can renew
+/// non-interactively), otherwise `ReAcquire` (the refresh path returns
+/// `ReauthRequired`). Revocable handle-based (RFC 7009); expiry is the access
+/// token's inline `expires_at`. Strategies match the implemented sub-traits
+/// (`Refreshable` + `Revocable`).
+impl CredentialLifecycle for OAuth2Credential {
+    fn policy(state: &OAuth2State) -> CredentialPolicy {
+        CredentialPolicy {
+            category: CredentialCategory::RefreshPair,
+            expires_at: state.expires_at,
+            lease: None,
+            refresh: if state.refresh_token.is_some() {
+                RefreshStrategy::RefreshToken
+            } else {
+                RefreshStrategy::ReAcquire
+            },
+            revoke: RevokeStrategy::HandleBased,
+        }
+    }
+}
+
 impl OAuth2Credential {
     /// Initiate the Authorization Code flow.
     ///
@@ -853,6 +876,26 @@ mod tests {
     #[test]
     fn key_is_oauth2() {
         assert_eq!(OAuth2Credential::KEY, "oauth2");
+    }
+
+    #[test]
+    fn lifecycle_policy_reflects_refresh_token_presence() {
+        // With a refresh token the engine can renew non-interactively.
+        let with_token = make_state();
+        let p = OAuth2Credential::policy(&with_token);
+        assert_eq!(p.category, CredentialCategory::RefreshPair);
+        assert_eq!(p.refresh, RefreshStrategy::RefreshToken);
+        assert_eq!(p.revoke, RevokeStrategy::HandleBased);
+        assert!(p.is_auto_renewable());
+        assert!(p.is_expiring());
+
+        // Without a refresh token the credential must re-acquire (the refresh
+        // path would return ReauthRequired).
+        let mut without = make_state();
+        without.refresh_token = None;
+        let p2 = OAuth2Credential::policy(&without);
+        assert_eq!(p2.refresh, RefreshStrategy::ReAcquire);
+        assert!(!p2.is_auto_renewable());
     }
 
     // Capability membership is type-level after §15.4: `OAuth2Credential`

--- a/crates/credential/src/lifecycle.rs
+++ b/crates/credential/src/lifecycle.rs
@@ -38,7 +38,14 @@ pub enum CredentialCategory {
     SignedRequest,
     /// Bearer token carrying its own expiry, no refresh pair — short-lived JWT.
     BearerWithExp,
-    /// Access token + refresh token — OAuth2 authorization-code / refresh grant.
+    /// OAuth2 authorization-code / refresh-grant shape — an access token,
+    /// usually paired with a refresh token.
+    ///
+    /// This is the structural **kind**, fixed for the credential type. A given
+    /// instance may lack a refresh token (the provider issued none): it stays
+    /// `RefreshPair`, but its [`RefreshStrategy`] is computed from live state and
+    /// degrades to [`RefreshStrategy::ReAcquire`]. Category = the type; strategy =
+    /// the state-derived behaviour.
     RefreshPair,
     /// Input credential exchanged for a scoped, shorter-lived output —
     /// AWS STS AssumeRole, GCP workload-identity-federation, RFC 8693 token exchange.


### PR DESCRIPTION
## Policy-as-data coverage for the first-party builtins

Follow-up to #766. Extends the `CredentialLifecycle` seam (from #766) to the remaining first-party credentials, hand-written ahead of the `#[nebula::credential]` macro — these become the macro's **output oracle** (macro codegen must match).

- **BasicAuthCredential** → `StaticSecret` (no expiry/refresh/revoke), matching its absent capability sub-traits.
- **OAuth2Credential** → `RefreshPair`, policy **computed from live state**: `RefreshToken` while a `refresh_token` is held (engine renews non-interactively), else `ReAcquire` (the refresh path returns `ReauthRequired`); `revoke = HandleBased` (RFC 7009); expiry = the access token's inline `expires_at`. Strategy fields match the implemented sub-traits (`Refreshable` + `Revocable`) — the policy-data ↔ compile-gated-code consistency the macro will enforce.

This validates the elegant ADR-0088 case: one OAuth2 type covers both refreshable and re-acquire by what its state holds — no separate trait.

+ regression tests (refresh-token present vs absent; static inertness).

### Green
clippy `-D warnings` (--all-targets) · nextest (lifecycle/oauth2/api_key/basic_auth, 2 new) · rustdoc `-D warnings` · lefthook pre-push (clippy-full + crate-diff).

### Next
The `#[nebula::credential]` attribute macro (ADR-0088 D1) — its own focused PR; it will auto-generate these `CredentialLifecycle` impls from method presence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented credential lifecycle policies for OAuth2 and Basic Authentication credentials
  * OAuth2 credentials now support automatic refresh with token-based or re-acquisition strategies
  * Basic Authentication credentials are explicitly configured as static, non-expiring credentials

<!-- end of auto-generated comment: release notes by coderabbit.ai -->