### PR TITLE
feat(credential): #[credential] attribute macro — ADR-0088 D1 (one declaration site, capability-by-method)

### DIFF
--- a/crates/credential/macros/src/credential_attr.rs
+++ b/crates/credential/macros/src/credential_attr.rs
@@ -203,8 +203,33 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
         ));
     }
 
+    // A leased/dynamic credential's expiry and renewability live in its state
+    // (lease id + duration), which the macro cannot read. A synthesized
+    // `RefreshStrategy::Lease` policy would therefore carry `lease: None` and
+    // report the credential as non-expiring / non-renewable — a lie for a
+    // Vault/k8s-style secret. Require an explicit `fn policy` in that case.
+    if items.release.is_some() && items.policy.is_none() {
+        return Err(diag::error_spanned(
+            &item.self_ty,
+            "a credential with `fn release` (Dynamic/leased) must hand-write `fn policy` — \
+             the macro cannot infer the lease id/duration from state, so it cannot synthesize \
+             a correct `RefreshStrategy::Lease` policy (set `lease: Some(LeaseRef { … })`)",
+        ));
+    }
+
     let self_ty = &item.self_ty;
     let (impl_generics, _ty_generics, where_clause) = item.generics.split_for_impl();
+
+    // Forward the author's outer attributes (e.g. `#[cfg(...)]`,
+    // `#[allow(...)]`) — minus doc comments — onto every generated impl, so a
+    // cfg-gated or lint-configured annotated block yields cfg-gated /
+    // lint-configured trait impls rather than silently unconditional ones.
+    let outer_attrs: Vec<&Attribute> = item
+        .attrs
+        .iter()
+        .filter(|a| !a.path().is_ident("doc"))
+        .collect();
+    let fwd = quote! { #(#outer_attrs)* };
 
     // ── metadata: relocate the author's, or synthesize from args ──────────
     let metadata_fn = if let Some(m) = &items.metadata {
@@ -219,27 +244,52 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
             )
         })?;
         let description = description.as_deref().unwrap_or(name);
-        let scheme_ty = assoc_type(scheme);
-        let mut builder = quote! {
-            ::nebula_credential::CredentialMetadata::builder()
-                .key(::nebula_core::credential_key!(#key))
-                .name(#name)
-                .description(#description)
-                .schema(::nebula_credential::schema_of::<Self::Properties>())
-                .pattern(<#scheme_ty as ::nebula_credential::AuthScheme>::pattern())
-        };
-        if let Some(icon) = &icon {
-            builder = quote! { #builder .icon(#icon) };
-        }
-        if let Some(url) = &doc_url {
-            builder = quote! { #builder .documentation_url(#url) };
-        }
-        quote! {
-            fn metadata() -> ::nebula_credential::CredentialMetadata
-            where
-                Self: Sized,
-            {
-                #builder .build().expect("credential metadata is valid")
+        let scheme_ty = assoc_type(scheme)?;
+        if icon.is_none() && doc_url.is_none() {
+            // No icon / doc_url ⇒ the infallible `for_credential` constructor,
+            // so the common synthesized case emits no `expect(...)` into
+            // library code. (`credential_key!` is re-exported from
+            // `nebula_credential`, so a consumer that does not directly depend
+            // on `nebula-core` still resolves the path.)
+            quote! {
+                fn metadata() -> ::nebula_credential::CredentialMetadata
+                where
+                    Self: Sized,
+                {
+                    ::nebula_credential::CredentialMetadata::for_credential::<Self>(
+                        ::nebula_credential::credential_key!(#key),
+                        #name,
+                        #description,
+                        <#scheme_ty as ::nebula_credential::AuthScheme>::pattern(),
+                    )
+                }
+            }
+        } else {
+            // Icon / doc_url require the builder, whose `build()` is fallible;
+            // the `expect` here mirrors the hand-written built-ins and the
+            // legacy `#[derive(Credential)]` (the `metadata()` trait method is
+            // infallible, and the builder is the only icon/doc_url path).
+            let mut builder = quote! {
+                ::nebula_credential::CredentialMetadata::builder()
+                    .key(::nebula_credential::credential_key!(#key))
+                    .name(#name)
+                    .description(#description)
+                    .schema(::nebula_credential::schema_of::<Self::Properties>())
+                    .pattern(<#scheme_ty as ::nebula_credential::AuthScheme>::pattern())
+            };
+            if let Some(icon) = &icon {
+                builder = quote! { #builder .icon(#icon) };
+            }
+            if let Some(url) = &doc_url {
+                builder = quote! { #builder .documentation_url(#url) };
+            }
+            quote! {
+                fn metadata() -> ::nebula_credential::CredentialMetadata
+                where
+                    Self: Sized,
+                {
+                    #builder .build().expect("credential metadata is valid")
+                }
             }
         }
     };
@@ -251,6 +301,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
     let resolve_fn = trait_item(resolve.clone());
 
     let credential_impl = quote! {
+        #fwd
         impl #impl_generics ::nebula_credential::Credential for #self_ty #where_clause {
             #properties_ty
             #scheme_item
@@ -269,6 +320,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
         let refresh_policy = items.refresh_policy.clone().map(trait_item);
         let refresh = trait_item(refresh.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::Refreshable for #self_ty #where_clause {
                 #refresh_policy
                 #refresh
@@ -278,6 +330,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
     let revocable_impl = items.revoke.as_ref().map(|revoke| {
         let revoke = trait_item(revoke.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::Revocable for #self_ty #where_clause {
                 #revoke
             }
@@ -286,6 +339,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
     let testable_impl = items.test.as_ref().map(|test| {
         let test = trait_item(test.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::Testable for #self_ty #where_clause {
                 #test
             }
@@ -295,6 +349,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
         let pending = items.pending.clone().map(trait_item);
         let cont = trait_item(cont.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::Interactive for #self_ty #where_clause {
                 #pending
                 #cont
@@ -305,6 +360,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
         let lease_ttl = items.lease_ttl.clone().map(trait_item);
         let release = trait_item(release.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::Dynamic for #self_ty #where_clause {
                 #lease_ttl
                 #release
@@ -319,22 +375,27 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
     let is_testable = items.test.is_some();
     let is_dynamic = items.release.is_some();
     let capability_impls = quote! {
+        #fwd
         impl #impl_generics
             ::nebula_credential::contract::plugin_capability_report::IsInteractive
             for #self_ty #where_clause
         { const VALUE: bool = #is_interactive; }
+        #fwd
         impl #impl_generics
             ::nebula_credential::contract::plugin_capability_report::IsRefreshable
             for #self_ty #where_clause
         { const VALUE: bool = #is_refreshable; }
+        #fwd
         impl #impl_generics
             ::nebula_credential::contract::plugin_capability_report::IsRevocable
             for #self_ty #where_clause
         { const VALUE: bool = #is_revocable; }
+        #fwd
         impl #impl_generics
             ::nebula_credential::contract::plugin_capability_report::IsTestable
             for #self_ty #where_clause
         { const VALUE: bool = #is_testable; }
+        #fwd
         impl #impl_generics
             ::nebula_credential::contract::plugin_capability_report::IsDynamic
             for #self_ty #where_clause
@@ -345,6 +406,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
     let lifecycle_impl = if let Some(policy) = &items.policy {
         let policy = trait_item(policy.clone());
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::CredentialLifecycle
                 for #self_ty #where_clause
             {
@@ -366,6 +428,7 @@ fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStre
             quote! { ::nebula_credential::RevokeStrategy::None }
         };
         quote! {
+            #fwd
             impl #impl_generics ::nebula_credential::CredentialLifecycle
                 for #self_ty #where_clause
             {
@@ -530,14 +593,17 @@ fn trait_item(mut it: ImplItem) -> ImplItem {
 
 /// Extract the right-hand-side type of an `ImplItem::Type` (the `X` in
 /// `type Scheme = X;`) for use in generated metadata bounds.
-fn assoc_type(it: &ImplItem) -> &syn::Type {
+///
+/// `classify_items` only ever routes `type Scheme` here, so the non-type case
+/// is a macro-internal invariant violation — surfaced as a normal `syn::Error`
+/// (a proper diagnostic) rather than a proc-macro panic.
+fn assoc_type(it: &ImplItem) -> syn::Result<&syn::Type> {
     match it {
-        ImplItem::Type(t) => &t.ty,
-        // Only ever called on `out.scheme`, which `classify_items` guarantees
-        // is an `ImplItem::Type`.
-        // guard-justified: classify_items routes `type Scheme` exclusively to
-        // ImplItem::Type; any other variant here is a macro-internal bug, not
-        // reachable from user input.
-        _ => unreachable!("assoc_type called on a non-type item"),
+        ImplItem::Type(t) => Ok(&t.ty),
+        other => Err(diag::error_spanned(
+            other,
+            "internal error: `type Scheme` was not classified as an associated type — \
+             please report this as a `#[credential]` macro bug",
+        )),
     }
 }

--- a/crates/credential/macros/src/credential_attr.rs
+++ b/crates/credential/macros/src/credential_attr.rs
@@ -1,0 +1,543 @@
+//! `#[nebula_credential::credential]` attribute macro — ADR-0088 D1.
+//!
+//! The single declaration site for a credential. The author writes ONE
+//! inherent `impl` block carrying the associated types and the methods the
+//! credential actually supports; this macro reads which methods are present
+//! and emits:
+//!
+//! - the base [`Credential`] impl (`KEY` + `Properties`/`Scheme`/`State` +
+//!   `metadata`/`project`/`resolve`),
+//! - one capability sub-trait impl per capability **method** supplied
+//!   (`refresh` ⇒ `Refreshable`, `revoke` ⇒ `Revocable`, `test` ⇒ `Testable`,
+//!   `continue_resolve` ⇒ `Interactive`, `release` ⇒ `Dynamic`),
+//! - the five `plugin_capability_report::IsX` consts (`true` exactly for the
+//!   capabilities whose method is present),
+//! - a [`CredentialLifecycle::policy`] whose `RefreshStrategy`/`RevokeStrategy`
+//!   are derived from those same methods.
+//!
+//! # Why an attribute macro and not a richer `#[derive]`
+//!
+//! Capability is **inferred from method presence**, never declared. There is
+//! no `capabilities(refreshable)` flag that could disagree with the impl — a
+//! credential is `Refreshable` *iff* it has a `refresh` method, so the
+//! capability-report consts and the lifecycle policy can never lie about what
+//! the type implements. This preserves the `E0046` compile-gate that the
+//! capability sub-trait split bought (declaring a capability you did not
+//! implement is unrepresentable) while collapsing the old four declaration
+//! sites (trait impl + sub-trait impl + `IsX` const + lifecycle policy) into
+//! one.
+//!
+//! # Container arguments (`#[credential(...)]`)
+//!
+//! - `key = "..."` — stable credential type key (required; becomes `Credential::KEY`).
+//! - `category = <CredentialCategory variant>` — the structural lifecycle kind
+//!   (required; e.g. `StaticSecret`, `RefreshPair`, `Leased`). Drives the
+//!   synthesized [`CredentialPolicy::category`].
+//! - `name = "..."` — human-readable name (required only when no `metadata`
+//!   method is supplied — used to synthesize one).
+//! - `description = "..."` — catalog description (optional; defaults to `name`).
+//! - `icon = "..."` — catalog icon id (optional).
+//! - `doc_url = "..."` — documentation URL (optional).
+//!
+//! # Recognized `impl` items
+//!
+//! | Item | Routes to |
+//! |------|-----------|
+//! | `type Properties` / `type Scheme` / `type State` | `Credential` (all three required) |
+//! | `type Pending` | `Interactive` (required iff `continue_resolve` present) |
+//! | `fn metadata` | `Credential` (optional — synthesized from args if absent) |
+//! | `fn project` / `fn resolve` | `Credential` (both required) |
+//! | `fn refresh` (+ `const REFRESH_POLICY`) | `Refreshable` |
+//! | `fn revoke` | `Revocable` |
+//! | `fn test` | `Testable` |
+//! | `fn continue_resolve` | `Interactive` |
+//! | `fn release` (+ `const LEASE_TTL`) | `Dynamic` |
+//! | `fn policy` | `CredentialLifecycle` (optional — synthesized if absent) |
+//!
+//! Any other item is rejected with a compile error, so a typo in a method name
+//! cannot silently drop a capability. Inherent helpers (e.g. an OAuth2
+//! `initiate_authorization_code`) live in a *separate* plain `impl` block
+//! alongside the annotated one — they are not part of the credential contract.
+
+use nebula_macro_support::{attrs, diag};
+use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
+use quote::quote;
+use syn::{Attribute, ImplItem, ItemImpl, Visibility, parse::Parser};
+
+/// The `CredentialCategory` variants accepted by `category = ...`. Validated
+/// in-macro so a typo surfaces here with the full list rather than as an
+/// opaque "no variant" error inside generated code.
+const CATEGORIES: &[&str] = &[
+    "StaticSecret",
+    "SignedRequest",
+    "BearerWithExp",
+    "RefreshPair",
+    "FederatedExchange",
+    "InteractiveRedirect",
+    "KeyPair",
+    "Leased",
+    "Session",
+    "ConnectionString",
+];
+
+/// Entry point for `#[nebula_credential::credential(...)]`.
+pub(crate) fn expand(args: TokenStream, input: TokenStream) -> TokenStream {
+    match expand_inner(args.into(), input) {
+        Ok(ts) => ts.into(),
+        Err(e) => diag::to_compile_error(e).into(),
+    }
+}
+
+/// Recognized items pulled out of the annotated `impl` block.
+#[derive(Default)]
+struct Items {
+    // Associated types.
+    properties: Option<ImplItem>,
+    scheme: Option<ImplItem>,
+    state: Option<ImplItem>,
+    pending: Option<ImplItem>,
+    // Consts.
+    refresh_policy: Option<ImplItem>,
+    lease_ttl: Option<ImplItem>,
+    // Methods.
+    metadata: Option<ImplItem>,
+    project: Option<ImplItem>,
+    resolve: Option<ImplItem>,
+    refresh: Option<ImplItem>,
+    revoke: Option<ImplItem>,
+    test: Option<ImplItem>,
+    continue_resolve: Option<ImplItem>,
+    release: Option<ImplItem>,
+    policy: Option<ImplItem>,
+}
+
+fn expand_inner(args: TokenStream2, input: TokenStream) -> syn::Result<TokenStream2> {
+    let item: ItemImpl = syn::parse(input)?;
+
+    if let Some((_, path, _)) = &item.trait_ {
+        return Err(diag::error_spanned(
+            path,
+            "#[credential] applies to an inherent `impl Type { … }`, not a trait impl — \
+             the macro generates the trait impls for you",
+        ));
+    }
+
+    // Container args, parsed by reusing the shared `#[credential(...)]` grammar.
+    let attr = Attribute::parse_outer
+        .parse2(quote! { #[credential(#args)] })?
+        .into_iter()
+        .next()
+        .ok_or_else(|| {
+            diag::error_spanned(&item.self_ty, "missing #[credential(...)] arguments")
+        })?;
+    let attr_args =
+        attrs::parse_attr(&attr, "credential")?.unwrap_or(attrs::AttrArgs { items: Vec::new() });
+
+    let key = attr_args.require_string("key", &item.self_ty)?;
+    let category = require_category(&attr_args, &item.self_ty)?;
+    let name = attr_args.get_string("name");
+    let description = attr_args.get_string("description");
+    let icon = attr_args.get_string("icon");
+    let doc_url = attr_args.get_string("doc_url");
+
+    let items = classify_items(&item)?;
+
+    // Required surface.
+    let properties = items.properties.as_ref().ok_or_else(|| {
+        diag::error_spanned(
+            &item.self_ty,
+            "#[credential] requires `type Properties = …;`",
+        )
+    })?;
+    let scheme = items.scheme.as_ref().ok_or_else(|| {
+        diag::error_spanned(&item.self_ty, "#[credential] requires `type Scheme = …;`")
+    })?;
+    let state = items.state.as_ref().ok_or_else(|| {
+        diag::error_spanned(&item.self_ty, "#[credential] requires `type State = …;`")
+    })?;
+    let project = items.project.as_ref().ok_or_else(|| {
+        diag::error_spanned(&item.self_ty, "#[credential] requires a `fn project(…)`")
+    })?;
+    let resolve = items.resolve.as_ref().ok_or_else(|| {
+        diag::error_spanned(
+            &item.self_ty,
+            "#[credential] requires an `async fn resolve(…)`",
+        )
+    })?;
+
+    // Interactive: `continue_resolve` and `type Pending` come as a pair.
+    match (&items.continue_resolve, &items.pending) {
+        (Some(_), None) => {
+            return Err(diag::error_spanned(
+                &item.self_ty,
+                "`fn continue_resolve` requires a `type Pending = …;` (the Interactive \
+                 capability needs its typed pending state)",
+            ));
+        },
+        (None, Some(p)) => {
+            return Err(diag::error_spanned(
+                p,
+                "`type Pending` is only valid alongside a `fn continue_resolve` — \
+                 remove it or add the interactive continuation method",
+            ));
+        },
+        _ => {},
+    }
+
+    // Stray tuning consts without their capability method.
+    if let Some(rp) = &items.refresh_policy
+        && items.refresh.is_none()
+    {
+        return Err(diag::error_spanned(
+            rp,
+            "`const REFRESH_POLICY` is only valid alongside a `fn refresh` (Refreshable)",
+        ));
+    }
+    if let Some(ttl) = &items.lease_ttl
+        && items.release.is_none()
+    {
+        return Err(diag::error_spanned(
+            ttl,
+            "`const LEASE_TTL` is only valid alongside a `fn release` (Dynamic)",
+        ));
+    }
+
+    let self_ty = &item.self_ty;
+    let (impl_generics, _ty_generics, where_clause) = item.generics.split_for_impl();
+
+    // ── metadata: relocate the author's, or synthesize from args ──────────
+    let metadata_fn = if let Some(m) = &items.metadata {
+        let m = trait_item(m.clone());
+        quote! { #m }
+    } else {
+        let name = name.as_deref().ok_or_else(|| {
+            diag::error_spanned(
+                self_ty,
+                "#[credential] needs either a `fn metadata(…)` or a `name = \"…\"` \
+                 argument to synthesize one",
+            )
+        })?;
+        let description = description.as_deref().unwrap_or(name);
+        let scheme_ty = assoc_type(scheme);
+        let mut builder = quote! {
+            ::nebula_credential::CredentialMetadata::builder()
+                .key(::nebula_core::credential_key!(#key))
+                .name(#name)
+                .description(#description)
+                .schema(::nebula_credential::schema_of::<Self::Properties>())
+                .pattern(<#scheme_ty as ::nebula_credential::AuthScheme>::pattern())
+        };
+        if let Some(icon) = &icon {
+            builder = quote! { #builder .icon(#icon) };
+        }
+        if let Some(url) = &doc_url {
+            builder = quote! { #builder .documentation_url(#url) };
+        }
+        quote! {
+            fn metadata() -> ::nebula_credential::CredentialMetadata
+            where
+                Self: Sized,
+            {
+                #builder .build().expect("credential metadata is valid")
+            }
+        }
+    };
+
+    let properties_ty = trait_item(properties.clone());
+    let scheme_item = trait_item(scheme.clone());
+    let state_item = trait_item(state.clone());
+    let project_fn = trait_item(project.clone());
+    let resolve_fn = trait_item(resolve.clone());
+
+    let credential_impl = quote! {
+        impl #impl_generics ::nebula_credential::Credential for #self_ty #where_clause {
+            #properties_ty
+            #scheme_item
+            #state_item
+
+            const KEY: &'static str = #key;
+
+            #metadata_fn
+            #project_fn
+            #resolve_fn
+        }
+    };
+
+    // ── capability sub-trait impls (presence-gated) ───────────────────────
+    let refreshable_impl = items.refresh.as_ref().map(|refresh| {
+        let refresh_policy = items.refresh_policy.clone().map(trait_item);
+        let refresh = trait_item(refresh.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::Refreshable for #self_ty #where_clause {
+                #refresh_policy
+                #refresh
+            }
+        }
+    });
+    let revocable_impl = items.revoke.as_ref().map(|revoke| {
+        let revoke = trait_item(revoke.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::Revocable for #self_ty #where_clause {
+                #revoke
+            }
+        }
+    });
+    let testable_impl = items.test.as_ref().map(|test| {
+        let test = trait_item(test.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::Testable for #self_ty #where_clause {
+                #test
+            }
+        }
+    });
+    let interactive_impl = items.continue_resolve.as_ref().map(|cont| {
+        let pending = items.pending.clone().map(trait_item);
+        let cont = trait_item(cont.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::Interactive for #self_ty #where_clause {
+                #pending
+                #cont
+            }
+        }
+    });
+    let dynamic_impl = items.release.as_ref().map(|release| {
+        let lease_ttl = items.lease_ttl.clone().map(trait_item);
+        let release = trait_item(release.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::Dynamic for #self_ty #where_clause {
+                #lease_ttl
+                #release
+            }
+        }
+    });
+
+    // ── capability report consts ──────────────────────────────────────────
+    let is_interactive = items.continue_resolve.is_some();
+    let is_refreshable = items.refresh.is_some();
+    let is_revocable = items.revoke.is_some();
+    let is_testable = items.test.is_some();
+    let is_dynamic = items.release.is_some();
+    let capability_impls = quote! {
+        impl #impl_generics
+            ::nebula_credential::contract::plugin_capability_report::IsInteractive
+            for #self_ty #where_clause
+        { const VALUE: bool = #is_interactive; }
+        impl #impl_generics
+            ::nebula_credential::contract::plugin_capability_report::IsRefreshable
+            for #self_ty #where_clause
+        { const VALUE: bool = #is_refreshable; }
+        impl #impl_generics
+            ::nebula_credential::contract::plugin_capability_report::IsRevocable
+            for #self_ty #where_clause
+        { const VALUE: bool = #is_revocable; }
+        impl #impl_generics
+            ::nebula_credential::contract::plugin_capability_report::IsTestable
+            for #self_ty #where_clause
+        { const VALUE: bool = #is_testable; }
+        impl #impl_generics
+            ::nebula_credential::contract::plugin_capability_report::IsDynamic
+            for #self_ty #where_clause
+        { const VALUE: bool = #is_dynamic; }
+    };
+
+    // ── lifecycle policy: relocate the author's, or synthesize ────────────
+    let lifecycle_impl = if let Some(policy) = &items.policy {
+        let policy = trait_item(policy.clone());
+        quote! {
+            impl #impl_generics ::nebula_credential::CredentialLifecycle
+                for #self_ty #where_clause
+            {
+                #policy
+            }
+        }
+    } else {
+        let category_ident = &category;
+        let refresh_strategy = if is_refreshable {
+            quote! { ::nebula_credential::RefreshStrategy::RefreshToken }
+        } else if is_dynamic {
+            quote! { ::nebula_credential::RefreshStrategy::Lease }
+        } else {
+            quote! { ::nebula_credential::RefreshStrategy::Static }
+        };
+        let revoke_strategy = if is_revocable {
+            quote! { ::nebula_credential::RevokeStrategy::HandleBased }
+        } else {
+            quote! { ::nebula_credential::RevokeStrategy::None }
+        };
+        quote! {
+            impl #impl_generics ::nebula_credential::CredentialLifecycle
+                for #self_ty #where_clause
+            {
+                fn policy(_state: &Self::State) -> ::nebula_credential::CredentialPolicy
+                where
+                    Self: Sized,
+                {
+                    ::nebula_credential::CredentialPolicy {
+                        category: ::nebula_credential::CredentialCategory::#category_ident,
+                        expires_at: ::core::option::Option::None,
+                        lease: ::core::option::Option::None,
+                        refresh: #refresh_strategy,
+                        revoke: #revoke_strategy,
+                    }
+                }
+            }
+        }
+    };
+
+    Ok(quote! {
+        #credential_impl
+        #refreshable_impl
+        #revocable_impl
+        #testable_impl
+        #interactive_impl
+        #dynamic_impl
+        #capability_impls
+        #lifecycle_impl
+    })
+}
+
+/// Pull `category = <Ident>` out of the args, validating the variant name.
+fn require_category(
+    attr_args: &attrs::AttrArgs,
+    span: &impl quote::ToTokens,
+) -> syn::Result<syn::Ident> {
+    let ident = attr_args.get_ident("category").cloned().ok_or_else(|| {
+        diag::error_spanned(
+            span,
+            "#[credential] requires `category = <CredentialCategory variant>` \
+             (e.g. `StaticSecret`, `RefreshPair`, `Leased`)",
+        )
+    })?;
+    let name = ident.to_string();
+    if !CATEGORIES.contains(&name.as_str()) {
+        return Err(diag::error_spanned(
+            &ident,
+            format!(
+                "unknown credential category `{name}` — expected one of: {}",
+                CATEGORIES.join(", ")
+            ),
+        ));
+    }
+    Ok(ident)
+}
+
+/// Classify each `impl` item by name into the recognized buckets, rejecting
+/// anything unrecognized so a misspelled method cannot silently drop a
+/// capability.
+fn classify_items(item: &ItemImpl) -> syn::Result<Items> {
+    let mut out = Items::default();
+    for it in &item.items {
+        match it {
+            ImplItem::Type(ty) => {
+                let slot = match ty.ident.to_string().as_str() {
+                    "Properties" => &mut out.properties,
+                    "Scheme" => &mut out.scheme,
+                    "State" => &mut out.state,
+                    "Pending" => &mut out.pending,
+                    other => {
+                        return Err(unknown_item(&ty.ident, other, "associated type"));
+                    },
+                };
+                set_once(slot, it.clone(), &ty.ident)?;
+            },
+            ImplItem::Const(c) => {
+                let slot = match c.ident.to_string().as_str() {
+                    "REFRESH_POLICY" => &mut out.refresh_policy,
+                    "LEASE_TTL" => &mut out.lease_ttl,
+                    "KEY" => {
+                        return Err(diag::error_spanned(
+                            &c.ident,
+                            "`KEY` is supplied via `#[credential(key = \"…\")]`, not as a \
+                             `const` in the impl block",
+                        ));
+                    },
+                    other => return Err(unknown_item(&c.ident, other, "const")),
+                };
+                set_once(slot, it.clone(), &c.ident)?;
+            },
+            ImplItem::Fn(f) => {
+                let ident = &f.sig.ident;
+                let slot = match ident.to_string().as_str() {
+                    "metadata" => &mut out.metadata,
+                    "project" => &mut out.project,
+                    "resolve" => &mut out.resolve,
+                    "refresh" => &mut out.refresh,
+                    "revoke" => &mut out.revoke,
+                    "test" => &mut out.test,
+                    "continue_resolve" => &mut out.continue_resolve,
+                    "release" => &mut out.release,
+                    "policy" => &mut out.policy,
+                    other => {
+                        return Err(diag::error_spanned(
+                            ident,
+                            format!(
+                                "unrecognized method `{other}` in #[credential] impl — move \
+                                 inherent helpers to a separate `impl` block. Recognized \
+                                 methods: metadata, project, resolve, refresh, revoke, test, \
+                                 continue_resolve, release, policy"
+                            ),
+                        ));
+                    },
+                };
+                set_once(slot, it.clone(), ident)?;
+            },
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unsupported item in #[credential] impl — only associated types, \
+                     capability consts, and recognized methods are allowed",
+                ));
+            },
+        }
+    }
+    Ok(out)
+}
+
+fn unknown_item(span: &impl quote::ToTokens, name: &str, kind: &str) -> syn::Error {
+    diag::error_spanned(
+        span,
+        format!("unrecognized {kind} `{name}` in #[credential] impl"),
+    )
+}
+
+fn set_once(
+    slot: &mut Option<ImplItem>,
+    value: ImplItem,
+    span: &impl quote::ToTokens,
+) -> syn::Result<()> {
+    if slot.is_some() {
+        return Err(diag::error_spanned(
+            span,
+            "duplicate item in #[credential] impl",
+        ));
+    }
+    *slot = Some(value);
+    Ok(())
+}
+
+/// Force a relocated item to inherited visibility — trait-impl items cannot
+/// carry `pub`, but an author writing what looks like an inherent block might.
+fn trait_item(mut it: ImplItem) -> ImplItem {
+    match &mut it {
+        ImplItem::Fn(f) => f.vis = Visibility::Inherited,
+        ImplItem::Type(t) => t.vis = Visibility::Inherited,
+        ImplItem::Const(c) => c.vis = Visibility::Inherited,
+        _ => {},
+    }
+    it
+}
+
+/// Extract the right-hand-side type of an `ImplItem::Type` (the `X` in
+/// `type Scheme = X;`) for use in generated metadata bounds.
+fn assoc_type(it: &ImplItem) -> &syn::Type {
+    match it {
+        ImplItem::Type(t) => &t.ty,
+        // Only ever called on `out.scheme`, which `classify_items` guarantees
+        // is an `ImplItem::Type`.
+        // guard-justified: classify_items routes `type Scheme` exclusively to
+        // ImplItem::Type; any other variant here is a macro-internal bug, not
+        // reachable from user input.
+        _ => unreachable!("assoc_type called on a non-type item"),
+    }
+}

--- a/crates/credential/macros/src/lib.rs
+++ b/crates/credential/macros/src/lib.rs
@@ -11,6 +11,7 @@ use proc_macro::TokenStream;
 mod auth_scheme;
 mod capability;
 mod credential;
+mod credential_attr;
 
 /// Derive macro for the `Credential` trait — Phase 5 of the M6 dependency
 /// redesign.
@@ -106,6 +107,62 @@ mod credential;
 )]
 pub fn derive_credential(input: TokenStream) -> TokenStream {
     credential::derive(input)
+}
+
+/// Attribute macro for declaring a credential as a single `impl` block
+/// (ADR-0088 D1 — the canonical authoring path, superseding
+/// `#[derive(Credential)]`).
+///
+/// Applied to an inherent `impl Type { … }`, it reads the associated types
+/// and the methods present and emits the base
+/// [`Credential`](nebula_credential::Credential) impl, one capability
+/// sub-trait impl per capability **method** supplied (`refresh` ⇒
+/// `Refreshable`, `revoke` ⇒ `Revocable`, `test` ⇒ `Testable`,
+/// `continue_resolve` ⇒ `Interactive`, `release` ⇒ `Dynamic`), the five
+/// `plugin_capability_report::IsX` consts, and a
+/// `CredentialLifecycle::policy()` derived from those same methods.
+///
+/// Capability is **inferred from method presence**, never declared — so the
+/// capability-report consts and the lifecycle policy can never disagree with
+/// the implemented capabilities (the `E0046` compile-gate is preserved while
+/// the four old declaration sites collapse into one).
+///
+/// # Arguments
+///
+/// - `key = "…"` — stable credential type key (required).
+/// - `category = <CredentialCategory variant>` — structural lifecycle kind
+///   (required; drives the synthesized policy `category`).
+/// - `name = "…"` — required only when no `fn metadata` is supplied.
+/// - `description = "…"`, `icon = "…"`, `doc_url = "…"` — optional metadata.
+///
+/// # Example
+///
+/// ```ignore
+/// use nebula_credential::credential;
+///
+/// #[credential(key = "api_key", category = StaticSecret, name = "API Key", icon = "key")]
+/// impl ApiKeyCredential {
+///     type Properties = ApiKeyProperties;
+///     type Scheme = SecretToken;
+///     type State = SecretToken;
+///
+///     fn project(state: &SecretToken) -> SecretToken { state.clone() }
+///
+///     async fn resolve(values: &FieldValues, _ctx: &CredentialContext)
+///         -> Result<ResolveResult<SecretToken, ()>, CredentialError> { /* … */ }
+/// }
+/// ```
+///
+/// # Errors
+///
+/// Emits a compile error when applied to a trait impl, when a required item
+/// (`type Properties`/`Scheme`/`State`, `fn project`/`resolve`) is missing,
+/// when `continue_resolve` and `type Pending` are not supplied as a pair, or
+/// when an unrecognized item appears (a typo cannot silently drop a
+/// capability — move inherent helpers to a separate `impl` block).
+#[proc_macro_attribute]
+pub fn credential(args: TokenStream, input: TokenStream) -> TokenStream {
+    credential_attr::expand(args, input)
 }
 
 /// Derive macro for the `AuthScheme` trait.

--- a/crates/credential/macros/src/lib.rs
+++ b/crates/credential/macros/src/lib.rs
@@ -114,9 +114,8 @@ pub fn derive_credential(input: TokenStream) -> TokenStream {
 /// `#[derive(Credential)]`).
 ///
 /// Applied to an inherent `impl Type { … }`, it reads the associated types
-/// and the methods present and emits the base
-/// [`Credential`](nebula_credential::Credential) impl, one capability
-/// sub-trait impl per capability **method** supplied (`refresh` ⇒
+/// and the methods present and emits the base `Credential` impl, one
+/// capability sub-trait impl per capability **method** supplied (`refresh` ⇒
 /// `Refreshable`, `revoke` ⇒ `Revocable`, `test` ⇒ `Testable`,
 /// `continue_resolve` ⇒ `Interactive`, `release` ⇒ `Dynamic`), the five
 /// `plugin_capability_report::IsX` consts, and a

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -8,8 +8,7 @@ use nebula_schema::{FieldValues, Schema};
 use serde::Deserialize;
 
 use crate::{
-    Credential, CredentialContext, CredentialLifecycle, CredentialPolicy, SecretString,
-    contract::plugin_capability_report,
+    CredentialContext, SecretString,
     error::{CredentialError, ProviderErrorContext, ProviderErrorKind, SecretFreeMessage},
     metadata::CredentialMetadata,
     resolve::ResolveResult,
@@ -61,12 +60,18 @@ pub struct ApiKeyProperties {
 /// ```
 pub struct ApiKeyCredential;
 
-impl Credential for ApiKeyCredential {
+// ADR-0088 D1: the whole credential surface is declared in one `impl` block.
+// `#[credential]` reads which methods are present — here only `project` +
+// `resolve`, with no capability methods — and emits the `Credential` impl, the
+// five all-`false` capability-report consts, and a `CredentialLifecycle` whose
+// policy is `StaticSecret` with no refresh and no provider-side revoke
+// (matching the absent capability sub-traits). The `category = StaticSecret`
+// arg supplies the structural lifecycle kind.
+#[nebula_credential::credential(key = "api_key", category = StaticSecret)]
+impl ApiKeyCredential {
     type Properties = ApiKeyProperties;
     type Scheme = SecretToken;
     type State = SecretToken;
-
-    const KEY: &'static str = "api_key";
 
     fn metadata() -> CredentialMetadata {
         CredentialMetadata::builder()
@@ -99,38 +104,13 @@ impl Credential for ApiKeyCredential {
     }
 }
 
-// Per Tech Spec §15.8 every credential reports its sub-trait surface
-// via `plugin_capability_report::Is*`. `ApiKeyCredential` is fully
-// static — no capability sub-trait impls — so all five constants are
-// `false`. `CredentialRegistry::register` reads these to compute the
-// `Capabilities` bitflag set.
-impl plugin_capability_report::IsInteractive for ApiKeyCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsRefreshable for ApiKeyCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsRevocable for ApiKeyCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsTestable for ApiKeyCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsDynamic for ApiKeyCredential {
-    const VALUE: bool = false;
-}
-
-/// API keys are static (ADR-0088 D2): no expiry, no refresh, no provider-side
-/// revocation — the [`CredentialCategory::StaticSecret`](crate::CredentialCategory::StaticSecret)
-/// shape. Consistent with the absent capability sub-trait impls above.
-impl CredentialLifecycle for ApiKeyCredential {
-    fn policy(_state: &SecretToken) -> CredentialPolicy {
-        CredentialPolicy::static_secret()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    // `Credential` (for `KEY` / `Properties`) and `CredentialLifecycle` (for
+    // `policy`) are only referenced by the tests now that `#[credential]`
+    // generates the trait impls via absolute paths.
+    use crate::{Credential, CredentialLifecycle};
+
     use super::*;
 
     #[test]

--- a/crates/credential/src/credentials/api_key.rs
+++ b/crates/credential/src/credentials/api_key.rs
@@ -22,7 +22,7 @@ use crate::{
 /// emits the `HasSchema` impl read via
 /// `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties). The
 /// actual auth material conversion to
-/// [`SecretToken`] happens in [`Credential::resolve`].
+/// [`SecretToken`] happens in [`Credential::resolve`](crate::Credential::resolve).
 ///
 /// The plaintext lives in a `String` here rather than `SecretString` so
 /// that the universal `#[derive(Schema)]` field-type inference applies

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -21,8 +21,8 @@ use crate::{
 /// `nebula_schema::schema_of::<Self::Properties>()` (schema-of properties). The
 /// plaintext password lives
 /// in a `String` here for schema derivation and is wrapped into
-/// [`SecretString`] inside [`Credential::resolve`] before it leaves the
-/// resolver.
+/// [`SecretString`] inside [`Credential::resolve`](crate::Credential::resolve)
+/// before it leaves the resolver.
 #[derive(Schema, Deserialize, Default)]
 pub struct BasicAuthProperties {
     /// Username for HTTP Basic authentication.

--- a/crates/credential/src/credentials/basic_auth.rs
+++ b/crates/credential/src/credentials/basic_auth.rs
@@ -7,8 +7,7 @@ use nebula_schema::{FieldValues, Schema};
 use serde::Deserialize;
 
 use crate::{
-    Credential, CredentialContext, CredentialLifecycle, CredentialPolicy, SecretString,
-    contract::plugin_capability_report,
+    CredentialContext, SecretString,
     error::{CredentialError, ProviderErrorContext, ProviderErrorKind, SecretFreeMessage},
     metadata::CredentialMetadata,
     resolve::ResolveResult,
@@ -46,12 +45,16 @@ pub struct BasicAuthProperties {
 /// - **Identity projection:** stored state is the scheme itself.
 pub struct BasicAuthCredential;
 
-impl Credential for BasicAuthCredential {
+// ADR-0088 D1: one `impl` block declares the whole credential. `#[credential]`
+// sees only `project` + `resolve` (no capability methods) and emits the
+// `Credential` impl, five all-`false` capability-report consts, and a
+// `StaticSecret` `CredentialLifecycle` policy — matching the absent capability
+// sub-traits.
+#[nebula_credential::credential(key = "basic_auth", category = StaticSecret)]
+impl BasicAuthCredential {
     type Properties = BasicAuthProperties;
     type Scheme = IdentityPassword;
     type State = IdentityPassword;
-
-    const KEY: &'static str = "basic_auth";
 
     fn metadata() -> CredentialMetadata {
         CredentialMetadata::builder()
@@ -92,36 +95,13 @@ impl Credential for BasicAuthCredential {
     }
 }
 
-// Per Tech Spec §15.8 every credential reports its sub-trait surface
-// via `plugin_capability_report::Is*`. `BasicAuthCredential` is fully
-// static — no capability sub-trait impls — so all five constants are
-// `false`.
-impl plugin_capability_report::IsInteractive for BasicAuthCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsRefreshable for BasicAuthCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsRevocable for BasicAuthCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsTestable for BasicAuthCredential {
-    const VALUE: bool = false;
-}
-impl plugin_capability_report::IsDynamic for BasicAuthCredential {
-    const VALUE: bool = false;
-}
-
-/// Basic auth is static (ADR-0088 D2): no expiry, no refresh, no provider-side
-/// revocation — consistent with its absent capability sub-trait impls.
-impl CredentialLifecycle for BasicAuthCredential {
-    fn policy(_state: &IdentityPassword) -> CredentialPolicy {
-        CredentialPolicy::static_secret()
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    // `Credential` (for `KEY`) and `CredentialLifecycle` (for `policy`) are
+    // only referenced by the tests now that `#[credential]` generates the
+    // trait impls via absolute paths.
+    use crate::{Credential, CredentialLifecycle};
+
     use super::*;
 
     #[test]

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -55,11 +55,11 @@ use crate::{
 /// Internal OAuth2 state with refresh internals.
 ///
 /// This is what gets encrypted and stored. Consumer-facing auth is
-/// [`OAuth2Token`] (via [`OAuth2Credential::project`]).
+/// [`OAuth2Token`] (via [`Credential::project`](crate::Credential::project)).
 ///
 /// Contains `client_id`, `client_secret`, and `token_url` so that
-/// [`OAuth2Credential::refresh`] can exchange a refresh token without
-/// requiring the original setup parameters.
+/// [`Refreshable::refresh`](crate::Refreshable::refresh) can exchange a refresh
+/// token without requiring the original setup parameters.
 ///
 /// Per Tech Spec §15.4 amendment — `Zeroize` + `ZeroizeOnDrop` derived
 /// so the decrypted plaintext (access/refresh tokens, client creds)
@@ -302,9 +302,10 @@ impl PendingState for OAuth2Pending {
 
 // ── OAuth2Credential ───────────────────────────────────────────────────
 
-/// OAuth2 credential type implementing the [`Credential`] trait plus
-/// the [`Interactive`], [`Refreshable`], [`Revocable`], and [`Testable`]
-/// sub-traits per Tech Spec §15.4.
+/// OAuth2 credential type implementing the [`Credential`](crate::Credential)
+/// trait plus the [`Interactive`](crate::Interactive),
+/// [`Refreshable`](crate::Refreshable), [`Revocable`](crate::Revocable), and
+/// [`Testable`](crate::Testable) sub-traits per Tech Spec §15.4.
 ///
 /// `Revocable` and `Testable` currently surface
 /// `CredentialError::Provider("OAuth2 HTTP transport has moved …")`
@@ -322,8 +323,8 @@ impl PendingState for OAuth2Pending {
 ///
 /// # Grant types and entry points
 ///
-/// Per §15.4 the base [`Credential::resolve`] returns
-/// `ResolveResult<State, ()>` and cannot carry typed
+/// Per §15.4 the base [`Credential::resolve`](crate::Credential::resolve)
+/// returns `ResolveResult<State, ()>` and cannot carry typed
 /// [`OAuth2Pending`]. The interactive entry point therefore lives on
 /// the OAuth2-specific kickoff path:
 ///
@@ -332,7 +333,7 @@ impl PendingState for OAuth2Pending {
 ///   constructs an [`OAuth2Pending`] directly via [`OAuth2Credential::initiate_authorization_code`]
 ///   and persists it to the [`PendingStateStore`](crate::pending_store::PendingStateStore). On
 ///   callback, the framework loads the typed pending state and invokes
-///   [`Interactive::continue_resolve`].
+///   [`Interactive::continue_resolve`](crate::Interactive::continue_resolve).
 /// - **Client Credentials** — base `resolve` returns `Complete(state)` once the engine wires the
 ///   moved `nebula-engine` HTTP transport (API-owned OAuth flow). For now `resolve` returns `Provider("OAuth2
 ///   HTTP transport has moved …")` so callers surface the migration explicitly rather than silently
@@ -639,8 +640,9 @@ impl OAuth2Credential {
     /// Constructs the authorization URL (with PKCE challenge + anti-CSRF
     /// state) and the typed [`OAuth2Pending`] state that the framework
     /// must persist before redirecting the user. Per Tech Spec §15.4
-    /// the base [`Credential::resolve`] cannot carry the typed pending
-    /// state; this kickoff method exists so the API endpoint
+    /// the base [`Credential::resolve`](crate::Credential::resolve) cannot
+    /// carry the typed pending state; this kickoff method exists so the API
+    /// endpoint
     /// orchestrating the OAuth2 flow can construct the pending state
     /// directly and call
     /// [`PendingStateStore::put`](crate::pending_store::PendingStateStore::put).

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -42,10 +42,8 @@ use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use super::oauth2_config;
 use crate::{
-    Credential, CredentialCategory, CredentialContext, CredentialLifecycle, CredentialPolicy,
-    CredentialState, Interactive, PendingState, RefreshStrategy, Refreshable, Revocable,
-    RevokeStrategy, SecretString, Testable,
-    contract::plugin_capability_report,
+    CredentialCategory, CredentialContext, CredentialPolicy, CredentialState, PendingState,
+    RefreshStrategy, RevokeStrategy, SecretString,
     error::{CredentialError, ProviderErrorContext, ProviderErrorKind, SecretFreeMessage},
     metadata::CredentialMetadata,
     resolve::{InteractionRequest, RefreshOutcome, ResolveResult, TestResult, UserInput},
@@ -401,12 +399,20 @@ pub struct OAuth2Properties {
     pub redirect_uri: Option<String>,
 }
 
-impl Credential for OAuth2Credential {
+// ADR-0088 D1: the full OAuth2 credential surface in one `impl` block.
+// `#[credential]` sees `continue_resolve` (+ `type Pending`), `refresh`,
+// `revoke`, and `test`, and emits the `Interactive` + `Refreshable` +
+// `Revocable` + `Testable` impls plus the matching capability-report consts.
+// The hand-written `policy()` is relocated verbatim because OAuth2's refresh
+// strategy is state-dependent (`RefreshToken` while a refresh token is held,
+// else `ReAcquire`) — the macro's synthesized policy cannot read live state.
+// The `initiate_authorization_code` kickoff helper stays in its own inherent
+// `impl` block below; it is not part of the credential contract.
+#[nebula_credential::credential(key = "oauth2", category = RefreshPair)]
+impl OAuth2Credential {
     type Properties = OAuth2Properties;
     type Scheme = OAuth2Token;
     type State = OAuth2State;
-
-    const KEY: &'static str = "oauth2";
 
     fn metadata() -> CredentialMetadata {
         CredentialMetadata::builder()
@@ -477,9 +483,7 @@ impl Credential for OAuth2Credential {
             GrantType::ClientCredentials => Err(oauth2_http_transport_disabled()),
         }
     }
-}
 
-impl Interactive for OAuth2Credential {
     type Pending = OAuth2Pending;
 
     async fn continue_resolve(
@@ -557,9 +561,7 @@ impl Interactive for OAuth2Credential {
             )),
         }
     }
-}
 
-impl Refreshable for OAuth2Credential {
     async fn refresh(
         state: &mut OAuth2State,
         _ctx: &CredentialContext,
@@ -581,9 +583,7 @@ impl Refreshable for OAuth2Credential {
         // this crate no longer performs HTTP.
         Err(oauth2_http_transport_disabled())
     }
-}
 
-impl Revocable for OAuth2Credential {
     async fn revoke(
         _state: &mut OAuth2State,
         _ctx: &CredentialContext,
@@ -596,9 +596,7 @@ impl Revocable for OAuth2Credential {
         // provider" while the token remains live.
         Err(oauth2_http_transport_disabled())
     }
-}
 
-impl Testable for OAuth2Credential {
     async fn test(
         _scheme: &OAuth2Token,
         _ctx: &CredentialContext,
@@ -612,38 +610,14 @@ impl Testable for OAuth2Credential {
         // classification.
         Err(oauth2_http_transport_disabled())
     }
-}
 
-// Per Tech Spec §15.8 (closes security-lead N6) `OAuth2Credential`
-// reports its sub-trait surface via `plugin_capability_report::Is*` so
-// the `CredentialRegistry` capability bitflag set matches the
-// implementations directly above (Interactive + Refreshable + Revocable
-// + Testable). OAuth2 is not a `Dynamic` credential — its tokens are
-// stored, refreshed, and revoked by KEY rather than leased per
-// execution.
-impl plugin_capability_report::IsInteractive for OAuth2Credential {
-    const VALUE: bool = true;
-}
-impl plugin_capability_report::IsRefreshable for OAuth2Credential {
-    const VALUE: bool = true;
-}
-impl plugin_capability_report::IsRevocable for OAuth2Credential {
-    const VALUE: bool = true;
-}
-impl plugin_capability_report::IsTestable for OAuth2Credential {
-    const VALUE: bool = true;
-}
-impl plugin_capability_report::IsDynamic for OAuth2Credential {
-    const VALUE: bool = false;
-}
-
-/// OAuth2 is a refresh-pair credential (ADR-0088 D2). The policy is computed from
-/// live state: `RefreshToken` while a refresh token is held (the engine can renew
-/// non-interactively), otherwise `ReAcquire` (the refresh path returns
-/// `ReauthRequired`). Revocable handle-based (RFC 7009); expiry is the access
-/// token's inline `expires_at`. Strategies match the implemented sub-traits
-/// (`Refreshable` + `Revocable`).
-impl CredentialLifecycle for OAuth2Credential {
+    // OAuth2 is a refresh-pair credential (ADR-0088 D2). The policy is computed
+    // from live state: `RefreshToken` while a refresh token is held (the engine
+    // can renew non-interactively), otherwise `ReAcquire` (the refresh path
+    // returns `ReauthRequired`). Revoke is handle-based (RFC 7009); expiry is
+    // the access token's inline `expires_at`. The hand-written `policy` is kept
+    // (not macro-synthesized) precisely because the refresh strategy depends on
+    // live state, which the macro's category-derived default cannot read.
     fn policy(state: &OAuth2State) -> CredentialPolicy {
         CredentialPolicy {
             category: CredentialCategory::RefreshPair,
@@ -856,6 +830,12 @@ fn build_config(
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
+
+    // Trait names referenced only by the tests now that `#[credential]`
+    // generates the trait impls via absolute paths: `Credential` (KEY /
+    // Properties), `CredentialLifecycle` (policy), and the capability
+    // sub-traits exercised by `assert_oauth2_capabilities`.
+    use crate::{Credential, CredentialLifecycle, Interactive, Refreshable, Revocable, Testable};
 
     use super::*;
 

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -152,8 +152,10 @@ pub use nebula_core::{CredentialId, CredentialKey, credential_key};
 // without forcing plugin authors onto a direct `nebula-schema` dependency
 // (schema-of properties: `Self::Properties: HasSchema` is the single source of truth).
 pub use nebula_schema::schema_of;
-// Derive macros
-pub use nebula_credential_macros::{AuthScheme, Credential};
+// Derive + attribute macros. `credential` is the ADR-0088 D1 attribute macro
+// (one-impl-block authoring); `Credential` is the legacy derive kept during
+// the migration window.
+pub use nebula_credential_macros::{AuthScheme, Credential, credential};
 // Opt-out built-in (lives at root, not under credentials::, because it has
 // no Input form and is never registered in CredentialRegistry — it's a
 // Resource-side type marker per credential isolation).

--- a/crates/credential/tests/compile_fail_credential_attr.rs
+++ b/crates/credential/tests/compile_fail_credential_attr.rs
@@ -1,0 +1,18 @@
+//! Compile-fail probes for the `#[nebula_credential::credential]` attribute
+//! macro (ADR-0088 D1).
+//!
+//! These pin the macro's safety diagnostics: a typo'd capability method is
+//! rejected (it cannot silently drop a capability), and the interactive
+//! `continue_resolve` / `type Pending` pair cannot be split.
+
+#[test]
+fn compile_fail_credential_attr_unrecognized_method() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/probes/cred_attr_unrecognized_method.rs");
+}
+
+#[test]
+fn compile_fail_credential_attr_continue_resolve_without_pending() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/probes/cred_attr_continue_resolve_without_pending.rs");
+}

--- a/crates/credential/tests/compile_fail_credential_attr.rs
+++ b/crates/credential/tests/compile_fail_credential_attr.rs
@@ -16,3 +16,9 @@ fn compile_fail_credential_attr_continue_resolve_without_pending() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/probes/cred_attr_continue_resolve_without_pending.rs");
 }
+
+#[test]
+fn compile_fail_credential_attr_pending_without_continue_resolve() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/probes/cred_attr_pending_without_continue_resolve.rs");
+}

--- a/crates/credential/tests/credential_attr_macro.rs
+++ b/crates/credential/tests/credential_attr_macro.rs
@@ -16,15 +16,19 @@
 //! Every state is `SecretToken` (itself a `CredentialState` via
 //! `identity_state!`), so the fixtures need no bespoke state type.
 
+use std::time::Duration;
+
 use nebula_credential::{
     Capabilities, Credential, CredentialCategory, CredentialContext, CredentialLifecycle,
-    RefreshStrategy, RevokeStrategy, SecretString, compute_capabilities,
+    CredentialPolicy, LeaseRef, PendingState, RefreshStrategy, RevokeStrategy, SecretString,
+    compute_capabilities,
     error::CredentialError,
-    resolve::{RefreshOutcome, ResolveResult, TestResult},
+    resolve::{RefreshOutcome, ResolveResult, TestResult, UserInput},
     scheme::SecretToken,
 };
 use nebula_metadata::Metadata;
 use nebula_schema::FieldValues;
+use serde::{Deserialize, Serialize};
 
 fn token() -> SecretToken {
     SecretToken::new(SecretString::new("t"))
@@ -85,7 +89,13 @@ fn refresh_only_synthesizes_metadata_from_args() {
     assert_eq!(meta.name(), "Refresh Only");
 }
 
-// ── Dynamic (leased): synth policy (Lease) ────────────────────────────────
+// ── Dynamic (leased): infers DYNAMIC; lease policy is hand-written ─────────
+//
+// The macro REQUIRES an explicit `fn policy` when `fn release` is present —
+// the lease id/duration live in state, which the macro cannot read, so a
+// synthesized `RefreshStrategy::Lease` with `lease: None` would lie about
+// expiry/renewability. This fixture proves the capability inference *and* that
+// the relocated lease policy reports correct expiry/renewability.
 
 struct LeasedThing;
 
@@ -112,10 +122,24 @@ impl LeasedThing {
     ) -> Result<(), CredentialError> {
         Ok(())
     }
+
+    fn policy(_state: &SecretToken) -> CredentialPolicy {
+        CredentialPolicy {
+            category: CredentialCategory::Leased,
+            expires_at: None,
+            lease: Some(LeaseRef {
+                lease_id: "vault/lease/test".to_owned(),
+                lease_duration: Duration::from_hours(1),
+                renewable: true,
+            }),
+            refresh: RefreshStrategy::Lease,
+            revoke: RevokeStrategy::HandleBased,
+        }
+    }
 }
 
 #[test]
-fn release_infers_dynamic_and_synthesizes_lease_policy() {
+fn release_infers_dynamic_with_handwritten_lease_policy() {
     assert_eq!(
         compute_capabilities::<LeasedThing>(),
         Capabilities::DYNAMIC,
@@ -124,7 +148,9 @@ fn release_infers_dynamic_and_synthesizes_lease_policy() {
     let p = LeasedThing::policy(&token());
     assert_eq!(p.category, CredentialCategory::Leased);
     assert_eq!(p.refresh, RefreshStrategy::Lease);
-    assert_eq!(p.revoke, RevokeStrategy::None);
+    assert_eq!(p.revoke, RevokeStrategy::HandleBased);
+    assert!(p.is_expiring(), "a renewable lease is expiring");
+    assert!(p.is_auto_renewable(), "a renewable lease auto-renews");
 }
 
 // ── Revocable + Testable: multi-flag inference + synth revoke (HandleBased) ─
@@ -175,4 +201,65 @@ fn revoke_and_test_infer_both_flags_and_synthesize_handle_based_revoke() {
     assert_eq!(p.refresh, RefreshStrategy::Static);
     assert_eq!(p.revoke, RevokeStrategy::HandleBased);
     assert!(!p.is_auto_renewable());
+}
+
+// ── Interactive: happy-path continue_resolve + type Pending ───────────────
+
+#[derive(Clone, Serialize, Deserialize, zeroize::Zeroize, zeroize::ZeroizeOnDrop)]
+struct MyPending {
+    nonce: String,
+}
+
+impl PendingState for MyPending {
+    const KIND: &'static str = "test_interactive_pending";
+
+    fn expires_in(&self) -> Duration {
+        Duration::from_mins(10)
+    }
+}
+
+struct InteractiveThing;
+
+#[nebula_credential::credential(
+    key = "test_interactive",
+    category = InteractiveRedirect,
+    name = "Interactive Thing"
+)]
+impl InteractiveThing {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+    type Pending = MyPending;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(token()))
+    }
+
+    async fn continue_resolve(
+        _pending: &MyPending,
+        _input: &UserInput,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, MyPending>, CredentialError> {
+        Ok(ResolveResult::Complete(token()))
+    }
+}
+
+#[test]
+fn continue_resolve_with_pending_infers_interactive() {
+    assert_eq!(
+        compute_capabilities::<InteractiveThing>(),
+        Capabilities::INTERACTIVE,
+        "`fn continue_resolve` + `type Pending` present, no other capability methods"
+    );
+    let p = InteractiveThing::policy(&token());
+    assert_eq!(p.category, CredentialCategory::InteractiveRedirect);
+    assert_eq!(p.refresh, RefreshStrategy::Static);
+    assert_eq!(p.revoke, RevokeStrategy::None);
 }

--- a/crates/credential/tests/credential_attr_macro.rs
+++ b/crates/credential/tests/credential_attr_macro.rs
@@ -1,0 +1,178 @@
+//! Integration coverage for the `#[nebula_credential::credential]` attribute
+//! macro (ADR-0088 D1).
+//!
+//! The built-in credentials (api_key / basic_auth / oauth2) are dogfooded onto
+//! the macro and their own suites are the primary oracle, but they only
+//! exercise the `StaticSecret` and `RefreshPair` shapes. These synthetic
+//! credentials cover the paths the built-ins do not:
+//!
+//! - capability **inference from method presence** for every sub-trait, folded
+//!   through [`compute_capabilities`],
+//! - the **synthesized** `CredentialLifecycle::policy()` for the
+//!   refresh / lease / revoke strategy branches (the built-ins either are
+//!   static or hand-write their policy),
+//! - the **synthesized** `metadata()` (the built-ins all hand-write theirs).
+//!
+//! Every state is `SecretToken` (itself a `CredentialState` via
+//! `identity_state!`), so the fixtures need no bespoke state type.
+
+use nebula_credential::{
+    Capabilities, Credential, CredentialCategory, CredentialContext, CredentialLifecycle,
+    RefreshStrategy, RevokeStrategy, SecretString, compute_capabilities,
+    error::CredentialError,
+    resolve::{RefreshOutcome, ResolveResult, TestResult},
+    scheme::SecretToken,
+};
+use nebula_metadata::Metadata;
+use nebula_schema::FieldValues;
+
+fn token() -> SecretToken {
+    SecretToken::new(SecretString::new("t"))
+}
+
+// ── Refreshable-only: synth metadata + synth policy (RefreshToken) ────────
+
+struct RefreshOnly;
+
+#[nebula_credential::credential(
+    key = "test_refresh_only",
+    category = RefreshPair,
+    name = "Refresh Only",
+    description = "fixture",
+    icon = "sync"
+)]
+impl RefreshOnly {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(token()))
+    }
+
+    async fn refresh(
+        _state: &mut SecretToken,
+        _ctx: &CredentialContext,
+    ) -> Result<RefreshOutcome, CredentialError> {
+        Ok(RefreshOutcome::Refreshed)
+    }
+}
+
+#[test]
+fn refresh_only_infers_refreshable_and_synthesizes_refresh_token_policy() {
+    assert_eq!(
+        compute_capabilities::<RefreshOnly>(),
+        Capabilities::REFRESHABLE,
+        "only `fn refresh` is present, so only REFRESHABLE should be reported"
+    );
+    let p = RefreshOnly::policy(&token());
+    assert_eq!(p.category, CredentialCategory::RefreshPair);
+    assert_eq!(p.refresh, RefreshStrategy::RefreshToken);
+    assert_eq!(p.revoke, RevokeStrategy::None);
+    assert!(p.is_auto_renewable());
+}
+
+#[test]
+fn refresh_only_synthesizes_metadata_from_args() {
+    let meta = RefreshOnly::metadata();
+    assert_eq!(meta.name(), "Refresh Only");
+}
+
+// ── Dynamic (leased): synth policy (Lease) ────────────────────────────────
+
+struct LeasedThing;
+
+#[nebula_credential::credential(key = "test_leased", category = Leased, name = "Leased Thing")]
+impl LeasedThing {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(token()))
+    }
+
+    async fn release(
+        _state: &SecretToken,
+        _ctx: &CredentialContext,
+    ) -> Result<(), CredentialError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn release_infers_dynamic_and_synthesizes_lease_policy() {
+    assert_eq!(
+        compute_capabilities::<LeasedThing>(),
+        Capabilities::DYNAMIC,
+        "only `fn release` is present, so only DYNAMIC should be reported"
+    );
+    let p = LeasedThing::policy(&token());
+    assert_eq!(p.category, CredentialCategory::Leased);
+    assert_eq!(p.refresh, RefreshStrategy::Lease);
+    assert_eq!(p.revoke, RevokeStrategy::None);
+}
+
+// ── Revocable + Testable: multi-flag inference + synth revoke (HandleBased) ─
+
+struct RevTest;
+
+#[nebula_credential::credential(key = "test_revtest", category = StaticSecret, name = "Rev Test")]
+impl RevTest {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(token()))
+    }
+
+    async fn revoke(
+        _state: &mut SecretToken,
+        _ctx: &CredentialContext,
+    ) -> Result<(), CredentialError> {
+        Ok(())
+    }
+
+    async fn test(
+        _scheme: &SecretToken,
+        _ctx: &CredentialContext,
+    ) -> Result<TestResult, CredentialError> {
+        Ok(TestResult::Success)
+    }
+}
+
+#[test]
+fn revoke_and_test_infer_both_flags_and_synthesize_handle_based_revoke() {
+    assert_eq!(
+        compute_capabilities::<RevTest>(),
+        Capabilities::REVOCABLE | Capabilities::TESTABLE,
+        "`fn revoke` + `fn test` present, neither refresh nor release"
+    );
+    let p = RevTest::policy(&token());
+    assert_eq!(p.category, CredentialCategory::StaticSecret);
+    assert_eq!(p.refresh, RefreshStrategy::Static);
+    assert_eq!(p.revoke, RevokeStrategy::HandleBased);
+    assert!(!p.is_auto_renewable());
+}

--- a/crates/credential/tests/probes/capabilities_declared_without_subtrait_impl.stderr
+++ b/crates/credential/tests/probes/capabilities_declared_without_subtrait_impl.stderr
@@ -12,11 +12,11 @@ help: the trait `Refreshable` is not implemented for `DummyCredential`
 help: the trait `Refreshable` is implemented for `OAuth2Credential`
   --> src/credentials/oauth2.rs
    |
-   | impl Refreshable for OAuth2Credential {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | #[nebula_credential::credential(key = "oauth2", category = RefreshPair)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `assert_capability`
   --> tests/probes/capabilities_declared_without_subtrait_impl.rs:26:10
    |
 26 | #[derive(nebula_credential_macros::Credential)]
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `assert_capability`
-   = note: this error originates in the derive macro `nebula_credential_macros::Credential` (in Nightly builds, run with -Z macro-backtrace for more info)
+   = note: this error originates in the attribute macro `nebula_credential::credential` which comes from the expansion of the derive macro `nebula_credential_macros::Credential` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/credential/tests/probes/cred_attr_continue_resolve_without_pending.rs
+++ b/crates/credential/tests/probes/cred_attr_continue_resolve_without_pending.rs
@@ -1,0 +1,45 @@
+//! `#[credential]` must reject `fn continue_resolve` without a matching
+//! `type Pending` — the Interactive capability needs its typed pending state,
+//! so the two are required as a pair.
+
+// The macro rejects the impl, so its imports go unused — silence that noise so
+// the captured .stderr pins only the macro diagnostic.
+#![allow(unused_imports)]
+
+use nebula_credential::{
+    CredentialContext, SecretString, error::CredentialError,
+    resolve::{ResolveResult, UserInput},
+    scheme::SecretToken,
+};
+use nebula_schema::FieldValues;
+
+struct Bad;
+
+#[nebula_credential::credential(key = "bad", category = InteractiveRedirect, name = "Bad")]
+impl Bad {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+    // No `type Pending` — the macro must reject the interactive method below.
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(SecretToken::new(SecretString::new("t"))))
+    }
+
+    async fn continue_resolve(
+        _pending: &SecretToken,
+        _input: &UserInput,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, SecretToken>, CredentialError> {
+        unimplemented!()
+    }
+}
+
+fn main() {}

--- a/crates/credential/tests/probes/cred_attr_continue_resolve_without_pending.stderr
+++ b/crates/credential/tests/probes/cred_attr_continue_resolve_without_pending.stderr
@@ -1,0 +1,5 @@
+error: `fn continue_resolve` requires a `type Pending = …;` (the Interactive capability needs its typed pending state)
+  --> tests/probes/cred_attr_continue_resolve_without_pending.rs:19:6
+   |
+19 | impl Bad {
+   |      ^^^

--- a/crates/credential/tests/probes/cred_attr_pending_without_continue_resolve.rs
+++ b/crates/credential/tests/probes/cred_attr_pending_without_continue_resolve.rs
@@ -1,0 +1,37 @@
+//! `#[credential]` must reject `type Pending` without a `fn continue_resolve`
+//! — the orphan half of the Interactive pair (mirror of
+//! `cred_attr_continue_resolve_without_pending`).
+
+// The macro rejects the impl, so its imports go unused — silence that noise so
+// the captured .stderr pins only the macro diagnostic.
+#![allow(unused_imports)]
+
+use nebula_credential::{
+    CredentialContext, SecretString, error::CredentialError, resolve::ResolveResult,
+    scheme::SecretToken,
+};
+use nebula_schema::FieldValues;
+
+struct Bad;
+
+#[nebula_credential::credential(key = "bad", category = InteractiveRedirect, name = "Bad")]
+impl Bad {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+    // Orphan — `type Pending` with no `fn continue_resolve` to consume it.
+    type Pending = SecretToken;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(SecretToken::new(SecretString::new("t"))))
+    }
+}
+
+fn main() {}

--- a/crates/credential/tests/probes/cred_attr_pending_without_continue_resolve.stderr
+++ b/crates/credential/tests/probes/cred_attr_pending_without_continue_resolve.stderr
@@ -1,0 +1,5 @@
+error: `type Pending` is only valid alongside a `fn continue_resolve` — remove it or add the interactive continuation method
+  --> tests/probes/cred_attr_pending_without_continue_resolve.rs:23:5
+   |
+23 |     type Pending = SecretToken;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/credential/tests/probes/cred_attr_unrecognized_method.rs
+++ b/crates/credential/tests/probes/cred_attr_unrecognized_method.rs
@@ -1,0 +1,48 @@
+//! `#[credential]` must reject an unrecognized method (here a typo'd
+//! `refrsh`) rather than silently treating it as a non-capability helper.
+//!
+//! This is the safety property that replaces the old
+//! declare-a-`capabilities(refreshable)`-flag-and-forget-the-`refresh`-impl
+//! vector: with capability inferred from method presence, a misspelled
+//! capability method must fail loudly at the macro site, never produce a
+//! credential silently missing the capability.
+
+// The macro rejects the impl, so its imports go unused — silence that noise so
+// the captured .stderr pins only the macro diagnostic.
+#![allow(unused_imports)]
+
+use nebula_credential::{
+    CredentialContext, SecretString, error::CredentialError, resolve::ResolveResult,
+    scheme::SecretToken,
+};
+use nebula_schema::FieldValues;
+
+struct Bad;
+
+#[nebula_credential::credential(key = "bad", category = StaticSecret, name = "Bad")]
+impl Bad {
+    type Properties = FieldValues;
+    type Scheme = SecretToken;
+    type State = SecretToken;
+
+    fn project(state: &SecretToken) -> SecretToken {
+        state.clone()
+    }
+
+    async fn resolve(
+        _values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<SecretToken, ()>, CredentialError> {
+        Ok(ResolveResult::Complete(SecretToken::new(SecretString::new("t"))))
+    }
+
+    // Typo — not a recognized capability method.
+    async fn refrsh(
+        _state: &mut SecretToken,
+        _ctx: &CredentialContext,
+    ) -> Result<(), CredentialError> {
+        Ok(())
+    }
+}
+
+fn main() {}

--- a/crates/credential/tests/probes/cred_attr_unrecognized_method.stderr
+++ b/crates/credential/tests/probes/cred_attr_unrecognized_method.stderr
@@ -1,0 +1,5 @@
+error: unrecognized method `refrsh` in #[credential] impl — move inherent helpers to a separate `impl` block. Recognized methods: metadata, project, resolve, refresh, revoke, test, continue_resolve, release, policy
+  --> tests/probes/cred_attr_unrecognized_method.rs:40:14
+   |
+40 |     async fn refrsh(
+   |              ^^^^^^

--- a/crates/credential/tests/probes/engine_dispatch_non_refreshable.stderr
+++ b/crates/credential/tests/probes/engine_dispatch_non_refreshable.stderr
@@ -7,10 +7,11 @@ error[E0277]: the trait bound `ApiKeyCredential: Refreshable` is not satisfied
 help: the trait `Refreshable` is implemented for `OAuth2Credential`
   --> src/credentials/oauth2.rs
    |
-   | impl Refreshable for OAuth2Credential {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   | #[nebula_credential::credential(key = "oauth2", category = RefreshPair)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `RefreshDispatcher::for_credential`
   --> tests/probes/engine_dispatch_non_refreshable.rs:18:26
    |
 18 |     fn for_credential<C: Refreshable>() -> Self {
    |                          ^^^^^^^^^^^ required by this bound in `RefreshDispatcher::for_credential`
+   = note: this error originates in the attribute macro `nebula_credential::credential` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/credential/tests/probes/sealed_capability_third_party.stderr
+++ b/crates/credential/tests/probes/sealed_capability_third_party.stderr
@@ -12,10 +12,11 @@ help: the trait `Refreshable` is not implemented for `ThirdPartyLiar`
 help: the trait `Refreshable` is implemented for `OAuth2Credential`
    --> src/credentials/oauth2.rs
     |
-    | impl Refreshable for OAuth2Credential {
-    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    | #[nebula_credential::credential(key = "oauth2", category = RefreshPair)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 note: required by a bound in `RefreshDispatcher::for_credential`
    --> tests/probes/sealed_capability_third_party.rs:126:26
     |
 126 |     fn for_credential<C: Refreshable>() -> Self {
     |                          ^^^^^^^^^^^ required by this bound in `RefreshDispatcher::for_credential`
+    = note: this error originates in the attribute macro `nebula_credential::credential` (in Nightly builds, run with -Z macro-backtrace for more info)


### PR DESCRIPTION
## What

Implements **ADR-0088 D1**: the `#[nebula_credential::credential]` attribute
macro — the single-declaration-site authoring path for a credential — and
dogfoods all three built-ins (api_key, basic_auth, oauth2) onto it.

The author writes ONE inherent `impl` block; the macro reads which methods are
present and emits the base `Credential` impl, one capability sub-trait impl per
capability **method** supplied (`refresh` ⇒ `Refreshable`, `revoke` ⇒
`Revocable`, `test` ⇒ `Testable`, `continue_resolve` ⇒ `Interactive`,
`release` ⇒ `Dynamic`), the five `plugin_capability_report::IsX` consts, and a
`CredentialLifecycle::policy()`.

## Why it's the right shape

Capability is **inferred from method presence, never declared**. There is no
`capabilities(refreshable)` flag that can disagree with the impl — so the
capability-report consts and the lifecycle policy can never lie about what the
type implements. This *strengthens* the `E0046` compile-gate the capability
sub-trait split bought (declaring a capability you didn't implement is now
**unrepresentable**) while collapsing the old four declaration sites
(trait impl + sub-trait impl + `IsX` const + lifecycle policy) into one.

- `policy()` is synthesized from the `category` arg + method presence, and is
  **author-overridable** for state-dependent policies (OAuth2 keeps its
  hand-written `RefreshToken`-while-refresh-token-held / else `ReAcquire`).
- `metadata()` is relocated if hand-written, or synthesized from args.
- A typo'd capability method is **rejected** at the macro site (it cannot
  silently produce a credential missing the capability).

## Scope (expand-contract step 2 of the ADR)

This is additive. The legacy `#[derive(Credential)]` path is untouched and
stays during the migration window; later steps migrate the rest of the
consumers and then delete the old surface.

## Validation

- All 181 credential lib tests + the full oauth2 suite remain green — the
  built-ins' existing tests are the **output oracle** the macro must reproduce
  (including the `Credential + Interactive + Refreshable + Revocable +
  Testable` type-level bound and the refresh-token-presence policy test).
- New positive integration coverage (`credential_attr_macro.rs`) for the paths
  the built-ins don't exercise: capability inference folded through
  `compute_capabilities`, and the synth policy across
  `RefreshToken`/`Lease`/`Static` + `None`/`HandleBased`.
- New compile-fail probes pin the reject diagnostics (typo'd method;
  `continue_resolve` without `type Pending`).
- Downstream consumers (api, engine, plugin, resource) compile; rustdoc
  `-D warnings` green for both crates.

## Commits

1. macro implementation + dogfood static builtins (api_key, basic_auth)
2. dogfood OAuth2 (full capability set + relocated state-dependent policy)
3. macro test coverage (positive + compile-fail)
4. crate-qualify intra-doc links broken by the import move
5. refresh compile-fail `.stderr` for the macro-dogfooded builtins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `#[credential]` attribute macro for streamlined credential declaration with automatic capability trait inference and metadata synthesis.
  * Refactored credential implementations to use the new macro for cleaner, more maintainable code.

* **Tests**
  * Added comprehensive test coverage for the credential macro, including compile-fail tests and integration tests to validate macro behavior and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->