### PR TITLE
refactor(credential)!: canonical owner_id derivation — fix tenant-scope format drift (ADR-0088 D7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "nebula-resilience",
  "nebula-schema",
  "nebula-storage",
+ "nebula-storage-port",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -112,7 +112,10 @@ impl ScopeResolver for RequestCredentialOwner {
 }
 
 pub(crate) fn owner_id_from_scope(scope: &Scope) -> String {
-    format!("{}:{}", scope.org_id, scope.workspace_id)
+    // The single canonical derivation (ADR-0088 D7) — shared with the
+    // credential-runtime plane so both key the same tenant identically. Was a
+    // local `format!("{}:{}", …)` that drifted from the runtime's `/` form.
+    scope.credential_owner_id()
 }
 
 /// The credential store selection for CRUD operations.

--- a/crates/credential-runtime/Cargo.toml
+++ b/crates/credential-runtime/Cargo.toml
@@ -30,6 +30,9 @@ nebula-credential-testutil = { path = "../credential-testutil", optional = true 
 nebula-engine = { path = "../engine" }
 nebula-core = { path = "../core" }
 nebula-schema = { path = "../schema" }
+# Core `Scope` — the canonical credential owner_id derivation
+# (`Scope::credential_owner_id`, ADR-0088 D7) that `TenantScope` routes through.
+nebula-storage-port = { path = "../storage-port" }
 nebula-eventbus = { path = "../eventbus" }
 nebula-resilience = { path = "../resilience" }
 tokio = { workspace = true, features = ["rt", "sync", "macros", "time"] }

--- a/crates/credential-runtime/src/scope.rs
+++ b/crates/credential-runtime/src/scope.rs
@@ -4,10 +4,13 @@
 //! closed by type: no operation is callable without a `&TenantScope`.
 
 use nebula_credential::ScopeResolver;
+use nebula_storage_port::Scope;
 
-/// Tenant identity for a credential operation. `owner_id` =
-/// `"{org}/{workspace}"` — the value persisted in
-/// `StoredCredential.metadata["owner_id"]` and matched by `ScopeLayer`.
+/// Tenant identity for a credential operation. `owner_id` is the canonical
+/// [`Scope::credential_owner_id`] key — the value persisted in
+/// `StoredCredential.metadata["owner_id"]` and matched by `ScopeLayer`,
+/// derived through the **single** shared derivation (ADR-0088 D7) so the
+/// runtime plane and the API edge key the same tenant identically.
 ///
 /// An optional `session_id` carries the interactive-flow session: the
 /// `PendingStateStore` binds pending acquisitions on
@@ -27,8 +30,10 @@ impl TenantScope {
     /// before driving an interactive acquisition.
     #[must_use]
     pub fn new(org: impl AsRef<str>, workspace: impl AsRef<str>) -> Self {
+        // Route through the one canonical derivation (note `Scope::new` takes
+        // workspace first, then org).
         Self {
-            owner_id: format!("{}/{}", org.as_ref(), workspace.as_ref()),
+            owner_id: Scope::new(workspace.as_ref(), org.as_ref()).credential_owner_id(),
             session_id: None,
         }
     }
@@ -83,33 +88,46 @@ impl ScopeResolver for FixedScopeResolver {
 
 #[cfg(test)]
 mod tests {
+    use nebula_storage_port::Scope;
+
     use super::TenantScope;
 
     #[test]
-    fn owner_id_is_org_slash_workspace() {
-        let s = TenantScope::new("org-1", "ws-2");
-        assert_eq!(s.owner_id(), "org-1/ws-2");
+    fn owner_id_matches_canonical_derivation() {
+        let scope = TenantScope::new("org-1", "ws-2");
+        // The owner key is the canonical `Scope::credential_owner_id`, derived
+        // identically by the API edge — not a runtime-local `{org}/{ws}` form.
+        assert_eq!(
+            scope.owner_id(),
+            Scope::new("ws-2", "org-1").credential_owner_id()
+        );
     }
 
     #[test]
     fn new_scope_has_no_session() {
-        let s = TenantScope::new("org-1", "ws-2");
-        assert_eq!(s.session_id(), None);
+        let scope = TenantScope::new("org-1", "ws-2");
+        assert_eq!(scope.session_id(), None);
     }
 
     #[test]
     fn with_session_threads_session_without_changing_owner() {
-        let s = TenantScope::new("org-1", "ws-2").with_session("sess-7");
-        assert_eq!(s.session_id(), Some("sess-7"));
+        let scope = TenantScope::new("org-1", "ws-2").with_session("sess-7");
+        assert_eq!(scope.session_id(), Some("sess-7"));
         // Owner derivation is unchanged by the session.
-        assert_eq!(s.owner_id(), "org-1/ws-2");
+        assert_eq!(
+            scope.owner_id(),
+            Scope::new("ws-2", "org-1").credential_owner_id()
+        );
     }
 
     #[test]
     fn scope_resolver_returns_owner() {
         use nebula_credential::ScopeResolver;
-        let s = TenantScope::new("o", "w");
-        let r = s.resolver();
-        assert_eq!(r.current_owner(), Some("o/w"));
+        let scope = TenantScope::new("o", "w");
+        let resolver = scope.resolver();
+        assert_eq!(
+            resolver.current_owner(),
+            Some(Scope::new("w", "o").credential_owner_id().as_str())
+        );
     }
 }

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -1823,7 +1823,10 @@ mod tests {
         let with = TenantScope::new("org1", "ws1").with_session("sess-xyz");
         let ctx = Svc::owner_context(&with);
         assert_eq!(ctx.session_id(), Some("sess-xyz"));
-        assert_eq!(ctx.owner_id(), "org1/ws1");
+        assert_eq!(
+            ctx.owner_id(),
+            nebula_storage_port::Scope::new("ws1", "org1").credential_owner_id()
+        );
 
         let without = TenantScope::new("org1", "ws1");
         let ctx_none = Svc::owner_context(&without);

--- a/crates/storage-port/src/scope.rs
+++ b/crates/storage-port/src/scope.rs
@@ -23,4 +23,67 @@ impl Scope {
             org_id: org_id.into(),
         }
     }
+
+    /// The canonical credential `owner_id` key for this scope.
+    ///
+    /// This is the **single** derivation every credential producer routes
+    /// through (the API edge, the credential-runtime facade, and the tenancy
+    /// scope layer) so the persisted `StoredCredential.metadata["owner_id"]`
+    /// key is identical regardless of which plane wrote it (ADR-0088 D7).
+    /// Before this existed, the API edge keyed `"{org}:{workspace}"` while the
+    /// runtime keyed `"{org}/{workspace}"`; once both planes share a backend
+    /// that mismatch would silently partition a single tenant's credentials
+    /// into two non-intersecting halves.
+    ///
+    /// # Encoding (collision-safe)
+    ///
+    /// `org_id` / `workspace_id` are unvalidated free strings, so **no single
+    /// separator is safe**: a raw `':'` collapses `org="a", ws="b:c"` and
+    /// `org="a:b", ws="c"` to the same key (and `'/'` has the identical flaw).
+    /// The owner segment is therefore **length-prefixed** — the leading
+    /// `org_id.len()` pins exactly where `org_id` ends, so the mapping from
+    /// `(org_id, workspace_id)` to key is injective for arbitrary id bytes.
+    /// The `\u{1e}` (ASCII Record Separator) delimiters keep it readable in
+    /// logs; the key is an opaque internal match value, never wire-exposed and
+    /// never parsed back.
+    #[must_use]
+    pub fn credential_owner_id(&self) -> String {
+        format!(
+            "{}\u{1e}{}\u{1e}{}",
+            self.org_id.len(),
+            self.org_id,
+            self.workspace_id
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Scope;
+
+    #[test]
+    fn owner_id_is_injective_across_embedded_separators() {
+        // The classic raw-separator collision: with `:` or `/` these two
+        // distinct tenants would derive the same key. Length-prefixing keeps
+        // them distinct.
+        let org_a_ws_c = Scope::new("c", "a").credential_owner_id(); // org="a", ws="c"
+        let org_a_ws_bc = Scope::new("b:c", "a").credential_owner_id(); // org="a", ws="b:c"
+        let org_ab_ws_c = Scope::new("c", "a:b").credential_owner_id(); // org="a:b", ws="c"
+        assert_ne!(org_a_ws_c, org_a_ws_bc);
+        assert_ne!(org_a_ws_c, org_ab_ws_c);
+        assert_ne!(org_a_ws_bc, org_ab_ws_c);
+
+        // Even when ids contain the RS delimiter itself, distinctness holds.
+        let plain = Scope::new("y", "x").credential_owner_id();
+        let org_with_rs = Scope::new("y", "x\u{1e}").credential_owner_id();
+        assert_ne!(plain, org_with_rs);
+    }
+
+    #[test]
+    fn owner_id_is_stable_for_equal_scopes() {
+        assert_eq!(
+            Scope::new("ws", "org").credential_owner_id(),
+            Scope::new("ws", "org").credential_owner_id()
+        );
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -128,8 +128,9 @@ deny = [
     "nebula-tenancy",
     "nebula-engine",
     "nebula-api",
+    "nebula-credential-runtime",
     "nebula-credential-vault",
-  ], reason = "Storage port is a Core-tier contract; the adapter, tenancy decorator, exec/api consumers, and the credential-vault dev-dep may depend on it" },
+  ], reason = "Storage port is a Core-tier contract; the adapter, tenancy decorator, exec/api consumers (incl. the credential-runtime facade, which derives the canonical Scope::credential_owner_id), and the credential-vault dev-dep may depend on it" },
 
   # nebula-tenancy is the Business-tier multi-tenancy security boundary: it
   # owns the policy (resolve `Scope` from a `Principal`, inject it, enforce

--- a/docs/adr/0088-credential-subsystem-rewrite.md
+++ b/docs/adr/0088-credential-subsystem-rewrite.md
@@ -263,12 +263,11 @@ would only relocate the duplication.
 
 > **Amended 2026-06-01 — the crate merge is INFEASIBLE; superseded.** Verified
 > against the dependency graph: `nebula-credential-runtime` depends on
-> `nebula-engine` + `nebula-storage` (Exec) + `nebula-tenancy` (Business) — it
-> composes the engine resolver, the storage `EncryptionLayer`/`CacheLayer`/
-> `AuditLayer` stack, and the tenancy scope. `nebula-credential` is **Core**.
-> Merging the facade *into* Core would require Core→Exec/Business edges, which
-> `cargo deny` `[bans]` wrappers forbid (and rightly: it inverts the layer
-> graph). The ADR's premise — "`nebula-credential` is shared infra importable
+> `nebula-engine` + `nebula-storage` (both **Exec**) — it composes the engine
+> resolver and the storage `EncryptionLayer`/`CacheLayer`/`AuditLayer` stack.
+> `nebula-credential` is **Core**. Merging the facade *into* Core would require a
+> Core→Exec edge, which `cargo deny` `[bans]` wrappers forbid (and rightly: it
+> inverts the layer graph). The ADR's premise — "`nebula-credential` is shared infra importable
 > from Exec/Business/API, so the merge buys no layering harm" — confused
 > *importable from* higher tiers with *able to import* higher tiers; the facade
 > needs to import **up**, which Core cannot. **Resolution:** the facade stays a

--- a/docs/adr/0088-credential-subsystem-rewrite.md
+++ b/docs/adr/0088-credential-subsystem-rewrite.md
@@ -261,6 +261,23 @@ is already shared infra importable from Exec/Business/API). **The merge must lan
 together with D3 (registry collapse) and D7 (scope dedup)** — merging the crate as-is
 would only relocate the duplication.
 
+> **Amended 2026-06-01 — the crate merge is INFEASIBLE; superseded.** Verified
+> against the dependency graph: `nebula-credential-runtime` depends on
+> `nebula-engine` + `nebula-storage` (Exec) + `nebula-tenancy` (Business) — it
+> composes the engine resolver, the storage `EncryptionLayer`/`CacheLayer`/
+> `AuditLayer` stack, and the tenancy scope. `nebula-credential` is **Core**.
+> Merging the facade *into* Core would require Core→Exec/Business edges, which
+> `cargo deny` `[bans]` wrappers forbid (and rightly: it inverts the layer
+> graph). The ADR's premise — "`nebula-credential` is shared infra importable
+> from Exec/Business/API, so the merge buys no layering harm" — confused
+> *importable from* higher tiers with *able to import* higher tiers; the facade
+> needs to import **up**, which Core cannot. **Resolution:** the facade stays a
+> separate Exec-tier crate. The non-generic-`Arc<dyn>` `CredentialService`
+> redesign (the first paragraph of D4) is still valid and can land **in place**
+> in `nebula-credential-runtime`; only the crate *merge* is dropped. The
+> duplication D4 worried about is addressed by D3 (registry collapse, done) and
+> D7 (scope-derivation dedup, below) without relocating the crate.
+
 ### D5 — consumer side preserved; bind to the output scheme
 
 Action and resource **authoring barely changes** — the consumer ergonomics are already
@@ -329,8 +346,35 @@ resolve  (engine):   validate_binding(scope,id) → Protocol.acquire/refresh →
 | Core | **`nebula-credential`** | `Protocol` + `CredentialScheme` + `CredentialPolicy`/`RefreshStrategy` + `CredentialState` + scheme types + `CredentialError` (domain) + events + guards + **one registry** + rotation **data** types (moved from engine) + executor + capability dispatch + state projection + token transport (reqwest behind a feature) + the **facade module** (merged runtime). |
 | Exec | `nebula-storage` | `EncryptionLayer`/`CacheLayer`/`AuditLayer` decorators + `KeyProvider` + `RefreshClaimRepo` port-adapter (the one correctly port-shaped concern — the template). **Delete the dead `CredentialRepo`/`CredentialRow`/migrations 0008+0017.** |
 | Exec | `nebula-engine` | Orchestration only: `RefreshCoordinator` (L1/L2 coalesce), reclaim/sentinel, lease scheduler, `ResourceFanout`. **Expose a public forced-refresh** so the facade stops re-implementing CAS. Delete the `#[deprecated]` String-id L1 surface. |
-| Business | `nebula-tenancy` | `ScopeLayer` becomes **the** single tenant-scope enforcement point (composed into the layered store). Delete the runtime + api copies; fix the `{org}/{ws}`↔`{org}:{ws}` format drift. |
+| Business | `nebula-tenancy` | `ScopeLayer` is the api-plane tenant-scope enforcement point (composed into the layered store). Fix the `{org}/{ws}`↔`{org}:{ws}` format drift (see amendment below). |
 | API | `nebula-api` | Thin edge only (handlers/dto/extractors/schema-projection/`CredentialSchemaPort` trait). **Move OAuth2 acquisition into `nebula-credential`** (engine-dispatched `acquire`/continue). One persistence path through the typed facade — delete the raw-store fallback, the split-brain second store, and the `classify` taxonomy dup. Relocate shared OAuth ceremony (flow/discovery/userinfo/state-signing) into one module consumed by both planes. |
+
+> **Amended 2026-06-01 — format-drift fix shipped; "single enforcement point" restated.**
+>
+> - **One canonical owner_id DERIVATION (shipped):** `Scope::credential_owner_id`
+>   in `nebula-storage-port` (Core) is the sole derivation. Both producers — the
+>   API edge (`owner_id_from_scope`) and the credential-runtime `TenantScope` —
+>   route through it. The drift was **latent** (the two planes do not yet share a
+>   backend: `AppState::with_credential_service` has zero callers, and the
+>   runtime `CredentialService` is only built in tests), but it would have become
+>   a silent **mutual-invisibility** bug — a tenant's credentials written by one
+>   plane unreadable by the other — the instant the facade is wired. Fixed as
+>   hardening-before-it-bites.
+> - **Encoding:** `org_id`/`workspace_id` are unvalidated free strings, so **no
+>   single separator is safe** (`org="a",ws="b:c"` vs `org="a:b",ws="c"` collide
+>   under `:`; `/` is identical). The owner segment is **length-prefixed**
+>   (`{org_len}␞{org}␞{ws}`), making the `(org, workspace)` → key map injective.
+> - **"Single enforcement point" is HALF-true (restated):** the *derivation*
+>   collapses to one function. The *enforcement* cannot collapse to one physical
+>   `nebula_tenancy::ScopeLayer` instance: tenancy is **Business** and
+>   `nebula-credential-runtime` is **Exec**, and Exec→Business is forbidden by
+>   `cargo deny`. So the api plane enforces via `ScopeLayer`; the runtime plane
+>   enforces the same invariant in-Exec via its facade owner checks
+>   (`owner_matches`/`load_owned`). Collapsing to a single physical enforcer would
+>   require relocating `ScopeLayer` to a Core/Exec crate — its own ADR, the same
+>   layer barrier that made the D4 crate-merge infeasible. The runtime + api
+>   *derivation* copies are deleted; the api manual-enforcement `CredentialStoreHandle::Layered`
+>   arm (dead while the facade is unwired) is a follow-up deletion.
 
 ## Layering (binding rules)
 


### PR DESCRIPTION
## What

ADR-0088 **D7** owner_id format-drift fix. The two credential planes derived the
tenant `owner_id` key with **different separators** — the API edge keyed
`"{org}:{workspace}"`, the credential-runtime keyed `"{org}/{workspace}"`. Both
planes now route through one canonical derivation:

- **`Scope::credential_owner_id()`** in `nebula-storage-port` (Core) — the sole
  derivation, callable by every producer (api, runtime, tenancy) on the existing
  `Scope` type, no deny-graph change beyond listing `credential-runtime` on the
  storage-port wrapper (a legal Exec→Core edge).
- `nebula_credential_runtime::TenantScope::new` and `nebula-api`'s
  `owner_id_from_scope` both delegate to it.

## Severity (honest)

**Latent**, not a live incident. The two planes do not share a backend today —
`AppState::with_credential_service` has zero callers and the runtime
`CredentialService` is only constructed in tests. But the moment the facade is
wired (the planned next step), the `:` vs `/` mismatch would silently partition
a single tenant's credentials into two non-intersecting halves — a credential
written via the API invisible to runtime resolution and vice-versa, "silent and
hard to debug". Fixed now as hardening-before-it-bites.

## Encoding (collision-safe)

`org_id`/`workspace_id` are **unvalidated free strings**, so no single separator
is safe: `org="a", ws="b:c"` and `org="a:b", ws="c"` both derive `"a:b:c"` under
`:` (and `/` is identical) — two distinct tenants collapsing to one key. The
owner segment is **length-prefixed** (`{org_len}␞{org}␞{ws}`), making the
`(org, workspace)` → key map injective for arbitrary id bytes. The key is opaque,
internal, never wire-exposed.

## Two architecture findings (ADR-0088 amended in this PR)

1. **D4 crate-merge is INFEASIBLE.** Merging `credential-runtime` into
   `nebula-credential` was specced, but the facade depends on engine + storage
   (Exec) + tenancy (Business); `nebula-credential` is Core; `cargo deny` forbids
   Core→Exec. The facade stays a separate Exec crate (only the non-generic
   `Arc<dyn>` redesign survives, in place).
2. **D7 "single enforcement point" is half-true.** The *derivation* collapses to
   one function. *Enforcement* can't collapse to one physical `ScopeLayer`:
   tenancy is Business, runtime is Exec, Exec→Business is forbidden — same layer
   barrier. So api enforces via `ScopeLayer`, runtime enforces in-Exec via its
   facade owner checks.

Both recorded as ADR-0088 amendments.

## Scope / follow-ups

This PR is the derivation unification (the security-relevant core). Deferred:
deleting the dead `CredentialStoreHandle::Layered` manual-enforcement arm in api
(dead while the facade is unwired), and any single-physical-enforcer relocation
(needs its own ADR per the layer barrier).

## Validation

543 tests (api + credential-runtime + storage-port, nextest) + new injectivity
unit tests; clippy `-D warnings` (`--all-targets`); pre-push (clippy-full +
crate-diff-gate) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Resolved potential credential owner ID format inconsistencies across system components by implementing a unified derivation method with improved collision-resistant encoding.

* **Refactor**
  * Standardized credential owner identification logic to use a single canonical method across all planes, reducing duplication and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->