### PR TITLE
chore(docs): per-crate CLAUDE.md, native skills, HANDOFF, settings deny for AI discoverability

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -12,6 +12,12 @@
       "Bash(rustfmt *)",
       "Bash(taplo *)",
       "Bash(jq *)"
+    ],
+    "deny": [
+      "Read(./target/**)",
+      "Read(./**/target/**)",
+      "Read(./.worktrees/**)",
+      "Read(./.claude/worktrees/**)"
     ]
   },
   "hooks": {

--- a/.claude/skills/nebula-credential-lifecycle/SKILL.md
+++ b/.claude/skills/nebula-credential-lifecycle/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: nebula-credential-lifecycle
+description: Use when adding or changing credentials, OAuth refresh, secret rotation, Vault/external providers, per-tenant owner scoping, or credential slots on actions/resources.
+---
+
+# Nebula credential lifecycle
+
+**When to use:** touching anything in the credential subsystem — defining a new
+credential type, the resolve/refresh/rotate/revoke lifecycle, owner-id / tenant
+isolation, external secret backends (Vault), OAuth identity from operator
+secrets, or binding credential slots into actions and resources.
+
+Before changing code, read the relevant source first. Authority docs:
+`docs/adr/0081-m6-resource-credential-integration.md` (binding/runtime/rotation
+contract), `docs/adr/0084-pre-expiry-credential-refresh-deferred.md`
+(reactive-only 1.0), `docs/adr/0085-oauth-identity-providers-from-secrets.md`
+(Plane A vs Plane B), `docs/adr/0088-credential-subsystem-rewrite.md`
+(**proposed** — do not implement unless told), `crates/credential/README.md`,
+`crates/credential/CLAUDE.md`, `docs/INTEGRATION_MODEL.md` (§`nebula-credential`),
+and `deny.toml`.
+
+## Crate map — know which crate owns what
+
+| Crate | Layer | Owns |
+|---|---|---|
+| `nebula-credential` (`crates/credential/`) | Core / shared-infra | The typed **contract**: `Credential` trait, capability sub-traits, `AuthScheme`/scheme types, `CredentialState`, `CredentialGuard`/`SchemeGuard`, `CredentialRegistry`, `lifecycle.rs` policy data, `ExternalProvider` chain (`src/provider/`), secret primitives. **No** runtime orchestration. |
+| `nebula-credential-runtime` (`crates/credential-runtime/`) | Exec | The `CredentialService` **facade**: resolve/refresh/rotate/revoke entry points (`src/service.rs`, `src/ops.rs`), validate→encrypt→store pipeline, bind-population seam (`src/binding.rs`, `ValidatedCredentialBinding`). |
+| `nebula-credential-builtin` (`crates/credential-builtin/`) | Business | First-party concrete credential types; `register_builtins`. |
+| `nebula-credential-vault` (`crates/credential-vault/`) | Business | Concrete `LeasedProvider` backend (HashiCorp Vault, ADR-0051 Phase C). |
+| `nebula-credential-testutil` (`crates/credential-testutil/`) | test-only | `InMemoryStore` / `InMemoryPendingStore` doubles; `publish=false`. |
+| `nebula-crypto` (`crates/crypto/`) | Cross-cutting | AES-256-GCM + Argon2id + `EncryptedData`/`CryptoError`. Crypto was **extracted out** of the credential crate (ADR-0088 D7). |
+| `nebula-engine` (`crates/engine/src/credential/`) | Exec | The refresh/rotation **mechanism**: `resolver.rs`, `rotation/resource_fanout.rs`, `lease/scheduler.rs`. |
+
+Procedure: identify which of these your change belongs in **before** editing. A
+"small helper in the wrong crate" is a layer violation caught by `cargo deny`.
+
+## Checklist by task
+
+### Defining or changing a credential type
+
+1. The type lives in `nebula-credential` (contract) or a `-builtin`/plugin crate
+   — never in `-runtime`, `-engine`, or `-api`.
+2. Declare the three associated types: `Properties` (`HasSchema` companion
+   struct, NOT `Input`), `State` (persisted), `Scheme` (projected). Read the
+   `Credential` trait in `crates/credential/src/contract/`.
+3. **State-vs-Scheme split is load-bearing.** Never put projected auth material
+   in `State`; `project(&State) -> Scheme` is the only path consumer code sees.
+   `State` is what is encrypted at rest; `Scheme` is what action code receives.
+4. Secrets use the crate's primitives — `SecretString`, `CredentialGuard`,
+   `SchemeGuard` (`!Clone`, drop-zeroizes). **Never a raw `String`** for secret
+   material. `CredentialState` requires `ZeroizeOnDrop` (compile-fail-probed).
+5. Capabilities are **sub-trait membership** (`Refreshable`/`Revocable`/
+   `Testable`/`Dynamic`/`Interactive`), never const bools. A declared-but-
+   unimplemented capability is a compile error; duplicate-KEY `register` is fatal
+   in debug AND release.
+6. Schema comes from `Properties: HasSchema` via `nebula_schema::schema_of::<_>()`
+   — no per-trait `*_schema` method.
+7. **No expressions in credential property values.** Property JSON validates then
+   `serde_json::from_value::<C::Properties>` directly; the pipeline deliberately
+   omits `ValidValues::resolve`. Secrets must not depend on runtime workflow
+   state (seam: `crates/credential/tests/properties_pipeline.rs`).
+8. Crypto: import AES-256-GCM / `EncryptedData` / `encrypt_with_aad` from
+   `nebula-crypto`, not the credential crate (ADR-0088 D7). The AAD-free
+   `encrypt` path is deliberately unexposed (SEC-11).
+
+### The resolve / refresh / rotate / revoke lifecycle
+
+1. The **runtime facade `CredentialService`** (`crates/credential-runtime/src/service.rs`)
+   is the single typed entry point. New lifecycle operations go through it.
+2. Do **not** re-home the mechanism: the refresh **coordinator** (L1 in-process
+   coalesce + L2 durable `RefreshClaimRepo` claim) and rotation **fan-out** stay
+   engine-owned — `crates/engine/src/credential/resolver.rs`,
+   `rotation/resource_fanout.rs`, `lease/scheduler.rs`. Resource stays a pure
+   consumer of resolved guards; the resolver must not move into `nebula-resource`
+   (would invert the dependency).
+3. **1.0 reality check — refresh is REACTIVE-only** (ADR-0084). Flow: action uses
+   credential → resolver observes expiry (stored TTL or provider failure) → L1+L2
+   coalesce one provider call → action proceeds. Proactive/pre-expiry refresh
+   (a background scheduler) is **deferred to 1.1** — do NOT add one. Callers
+   needing warm-up call `CredentialService::refresh()` themselves.
+4. Refresh/rotation must not silently strand in-flight executions holding valid
+   material (canon §13.2). Failure is explicit in status or a typed error
+   (e.g. `ReauthRequired` for terminal failures), never a silent drop.
+5. Observability is Definition of Done: a new state/error/hot path ships a typed
+   error variant + tracing span + invariant check.
+
+### Owner-id / tenant isolation (the security primitive)
+
+1. Every lifecycle call is scoped by a **canonical `owner_id`** derived through a
+   `Scope` (`nebula-storage-port`, Core). The per-tenant boundary IS the security
+   primitive — a tenant's credentials must be invisible to other tenants.
+2. The single canonical derivation is `Scope::credential_owner_id`
+   (`nebula-storage-port`). Both producers — the API edge (`owner_id_from_scope`)
+   and the runtime `TenantScope` — route through it. Do **not** introduce a
+   second owner-id format; the `{org}/{ws}` vs `{org}:{ws}` drift was a latent
+   cross-tenant key-collision bug (ADR-0088 D7). Segments are length-prefixed so
+   the `(org, workspace)` → key map is injective.
+3. Enforcement has two physical points and that is intentional: the API plane
+   enforces via `nebula_tenancy::ScopeLayer` (Business); the runtime facade
+   enforces the same invariant in-Exec via its owner checks
+   (`owner_matches`/`load_owned` in `crates/credential-runtime/src/service.rs`).
+   They cannot collapse to one instance because Exec→Business is forbidden by
+   `cargo deny`.
+
+### Binding credential slots into actions / resources
+
+1. Actions and resources declare **typed `#[credential(key)]` slot fields**, bound
+   per-node — NOT implicit type-only resolution (ADR-0081 absorbs ADR-0042). The
+   workflow node maps `slot_name → CredentialId` explicitly.
+2. Slot field type is `CredentialGuard<C::Scheme>` (the projected scheme), not
+   `CredentialGuard<C>`. The framework projects `State → Scheme` before populating
+   the slot. Resources use `SlotCell<CredentialGuard<…>>` (lock-free ArcSwap) with
+   engine-owned hot-swap + `on_credential_refresh` reactive hooks.
+3. The **bind-population producer is still a frontier gap** — there is no
+   production credential→slot resolver wired end-to-end (M12.4). The seam exists:
+   `ValidatedCredentialBinding` + `CredentialService::resolve_for_slot`
+   (`crates/credential-runtime/src/binding.rs`), tenant-fingerprint sealed. Do
+   **not** claim bind-population is green; it is a known gap.
+
+### External secret backends (Vault / AWS / GCP / Azure)
+
+1. Implement against the `ExternalProvider` chain (`crates/credential/src/provider/`,
+   ADR-0051): dyn-safe via `ProviderFuture<'a>`, resolutions return a
+   `ProviderResolution` envelope (secret + optional lease + optional TTL). Lease-
+   aware backends impl the `LeasedProvider` sub-trait (`renew`/`revoke`).
+2. Chain fallback is error-discriminated: **only `ProviderError::NotFound` falls
+   through** to the next provider; any other error short-circuits.
+3. Wire a new backend through a **composition root** via `Arc<dyn ExternalProvider>`
+   — never a direct upward dep from an Exec/API crate. Then add the crate to the
+   appropriate `deny.toml` `[bans].deny` wrapper allowlist **with a reason**
+   string (the `wrappers = [...]` list inside the relevant `{ crate = … }` entry;
+   `nebula-credential-vault` starts with an empty consumer allowlist by design).
+
+### OAuth
+
+Two non-overlapping planes — do not conflate:
+
+- **Plane A — identity login** (ADR-0085): operator-supplied OAuth client proves
+  "this is Alice", Nebula mints its own session and **discards** IdP tokens. This
+  lives in `nebula-api` (`crates/api/src/transport/oauth/`). Operator IdP-client
+  config is **infrastructure config** in `ApiConfig::auth.oauth.providers` (env
+  vars), NOT credential rows — does not touch `CredentialService`. Anti-SSRF gate
+  (`validate_oauth_outbound_url`) applies to every server-side OAuth fetch.
+- **Plane B — credential OAuth**: a stored OAuth credential lets a workflow node
+  call a third-party API on the user's behalf. This is `nebula-credential`'s
+  `OAuth2Credential` + `Interactive::continue_resolve`. The two planes coexist;
+  Plane A must NOT route through `continue_resolve` (token-discard is a type-level
+  property).
+
+## Hard constraints
+
+- **ADR-0088 is PROPOSED, not shipped.** Its Protocol model / `#[nebula::credential]`
+  attribute macro / crate re-layering are a **future** rewrite. Design against the
+  **accepted** contract (ADR-0081/0084/0085: `Credential` trait + capability
+  sub-traits + `Properties`/`State`/`Scheme`) unless explicitly told to implement
+  the rewrite. (Partially-landed ADR-0088 pieces already in tree: `nebula-crypto`
+  extraction, `crates/credential/src/lifecycle.rs` policy data, registry collapse,
+  canonical `Scope::credential_owner_id` — verify the actual code before assuming.)
+- Cross-crate communication goes through `nebula-eventbus`, not direct sibling
+  imports across layer boundaries.
+- Library code: no `unwrap()`/`expect()`/`panic!()`; typed `thiserror`/`NebulaError`;
+  `#![forbid(unsafe_code)]`. `Debug` impls redact secret fields.
+
+## Verify
+
+- `cargo check -p nebula-credential` (or the crate you touched)
+- `cargo nextest run -p nebula-credential` (+ `-p nebula-credential-runtime`,
+  `-p nebula-engine` if you touched the facade or mechanism)
+- `cargo test -p nebula-credential --doc`
+- The `compile_fail_*.rs` trybuild probes in `crates/credential/tests/` encode the
+  load-bearing invariants — read them first when a change feels risky (they may
+  false-TIMEOUT on cold cache under nextest; warm + plain `cargo test`).
+- `task deny` after any dep/wrapper change.

--- a/.claude/skills/nebula-error-and-validation/SKILL.md
+++ b/.claude/skills/nebula-error-and-validation/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: nebula-error-and-validation
+description: Use when adding or changing error types, returning Results, classifying retryability, handling validation errors, or replacing unwrap/expect/panic in library code.
+---
+
+# nebula-error-and-validation
+
+**When to use:** Defining a new error variant, deciding error vs panic, adding
+retry classification, surfacing validation failures, or anytime the no-unwrap
+guard hook fires. Load before writing error-handling code in any lib crate.
+
+Procedure — follow top to bottom. Every rule below is grounded in a real file;
+paths are cited inline. Verify against the cited file if anything looks stale.
+
+## 0. Pick the error vocabulary (lib vs bin)
+
+- **Library crate → `thiserror` + `Classify` + `NebulaError`.** Never
+  stringly-typed errors, never `anyhow`. (`crates/error/README.md` §Contract
+  `[L2-§12.4]`; `crates/error/CLAUDE.md`.)
+- **Binary → `anyhow` is allowed**, and only there. (Same contract.)
+- A typed variant per failure mode, not a single `Other(String)` catch-all.
+  `nebula-error` ships prebuilt detail structs (`BadRequest`, `FieldViolation`,
+  `ResourceInfo`, `RequestInfo`, `ExecutionContext`, `DebugInfo`) in
+  `crates/error/src/detail_types.rs` — attach those instead of formatting prose
+  into a message.
+
+## 1. No `unwrap()/expect()/panic!()/todo!()/unimplemented!()/unreachable!()` in library code
+
+Enforced by `edit-guard.sh` (root `CLAUDE.md` §Enforced Discipline) — not
+advisory. If the guard fires, do not work around it; fix the code.
+
+Exempt contexts, per `clippy.toml`:
+
+- **Tests** — `allow-unwrap-in-tests`, `allow-expect-in-tests`,
+  `allow-panic-in-tests`, `allow-dbg-in-tests`, `allow-print-in-tests`,
+  `allow-indexing-slicing-in-tests` (lines 53-59).
+- **`const` context** — `allow-unwrap-in-consts`, `allow-expect-in-consts`
+  (lines 64-65).
+- **Binaries** — use `anyhow` (`?` + `.context(...)`), not `unwrap`.
+
+Replacement order for a fallible expression in lib code:
+
+1. Return a typed error and propagate with `?` (preferred).
+2. `let Some(x) = opt else { return Err(...) }` / `match` — `clippy.toml`
+   `matches-for-let-else = "WellKnownTypes"` (line 124) nudges this.
+3. Last resort, with a justification: put
+   `// guard-justified: <reason>` on the line directly above the construct.
+   This is the **only** escape for the discretionary edit rules; there is no
+   escape for lefthook-bypass, lint-suppression, or no-unwrap-as-a-class. The
+   same `// guard-justified:` line is also required above any `#[allow]` /
+   `todo!` / `unimplemented!` / `unreachable!` you must keep.
+
+## 2. Make retryability explicit via `Classify`
+
+Do not let transient-vs-permanent become folklore scattered per crate. Each
+error type implements `Classify` (`crates/error/src/traits.rs`):
+
+- `category()` → `ErrorCategory` (`Transient` / `Permanent` / `Internal` / …,
+  `crates/error/src/category.rs`).
+- `code()` → machine-readable `ErrorCode` (`crates/error/src/code.rs`).
+- `severity()` → `ErrorSeverity` (`Error` / `Warning` / `Info`).
+- `retry_hint()` → `RetryHint` — **the single transient-vs-permanent decision
+  surface** (`crates/error/README.md` `[L1-§4.2]`, `crates/error/src/retry.rs`).
+
+`RetryHint` is **data**, not execution. `nebula-resilience` consumes it; do not
+re-implement classification inside resilience or any consumer. Use
+`#[derive(Classify)]` (feature `derive`, from `nebula-error-macros`) where the
+mapping is mechanical.
+
+## 3. Wrap, don't log-and-discard
+
+Wrap a `Classify` error in `NebulaError<E>` (`crates/error/src/error.rs`) to
+attach typed details + a context chain, instead of logging the error and
+returning a bare one:
+
+- `Result<T, E>` is aliased to `std::result::Result<T, NebulaError<E>>`
+  (`crates/error/src/lib.rs`) — use the alias.
+- `Display` for `NebulaError<E>` **must** emit the full context chain
+  (regression fixed in `0f047d32`, #405 — do not regress;
+  `crates/error/README.md` `[L3-§12.4]`).
+- Details are TypeId-keyed and extensible (`crates/error/src/details.rs`).
+- `nebula-error` is **not** an API formatter (`nebula-api` maps to RFC 9457
+  `problem+json`) and **not** a logger (`nebula-log`). Stay in lane
+  (`crates/error/CLAUDE.md` §Conventions).
+
+## 4. Don't swallow errors on state mutations
+
+`let _ = fallible(...)` on a state transition silently hides invalid-transition
+bugs (e.g. `let _ = transition_node(...)` discarding an invalid-transition
+error). Always propagate with `?` or handle the variant explicitly. A discarded
+`Result` on a mutation is a latent durability bug, not a cleanup.
+
+## 5. Validation: one canonical `ValidationError`, validator owns `required`
+
+Validation is unified on a single structured type:
+
+- `ValidationError` is the canonical structured error (80 bytes, `Cow`-based,
+  RFC 6901 field paths), defined in
+  `crates/validator/src/foundation/error/validation_error.rs` and re-exported
+  through `nebula_schema::error` (`crates/schema/src/validated.rs` imports it).
+  Do not define a second per-crate validation error type.
+- **`nebula-validator` is the sole emitter of `required`** — the `REQUIRED`
+  code (`crates/validator/src/foundation/error/codes.rs`,
+  `pub const REQUIRED: &str = "required"`). Locked by
+  `crates/schema/tests/seam_required_emitter.rs`; do not emit a `required`
+  failure from schema or any other crate.
+- **Schema maps serde-stable modes at validate time.** `nebula-schema` keeps
+  serde-stable `VisibilityMode` / `RequiredMode` (`crates/schema/src/mode.rs`)
+  and maps them at validate time. The condition-evaluation seam lives in
+  `nebula-validator` (`policy` module / `resolve_field_policies`); the single
+  schema↔validator crossing is `validate_rules_with_ctx` + `resolve_field_policies`
+  (`crates/schema/CLAUDE.md`).
+- **No `Rule::evaluate` shim.** `Rule::evaluate` / `RuleContext` were removed,
+  not shimmed (ADR-0080 §"Condition evaluation seam (absorbs 0052)",
+  `docs/adr/0080-schema-validation-platform.md`).
+- Rule-failure codes surface validator-native verbatim (`min_length`, `min`,
+  `invalid_format`) — **no namespace remap** at the schema boundary
+  (`crates/schema/CLAUDE.md`).
+- `Validated<T>` is a proof-token: never construct one without calling
+  `validate`, and never add `Deserialize` to it — deserialized data must be
+  re-validated (`crates/validator/README.md` `[L1-§4.5]`).
+
+## 6. Pick the right retry layer (ADR-0068)
+
+`docs/adr/0068-layered-retry.md` — two disjoint layers, chosen by *who can
+recover*:
+
+- **Layer 1 — action-internal recovery → `nebula-resilience::retry_with`**
+  (`crates/resilience/src/retry.rs`). Wrap an outbound call the action itself
+  understands and can re-issue (transient `5xx`, `Retry-After`, DB reconnect,
+  rate-limit cooldown). Stays in the action's source.
+- **Layer 2 — whole-action failure → `NodeDefinition.retry_policy`**
+  (engine node-level, `crates/workflow/src/node.rs`). For sandbox
+  crash/panic/OOM, param-resolution failure, third-party plugin actions, or
+  operator-declared policy — the engine re-dispatches.
+- They compose by **timing**: Layer 1 runs first inside the action; if it
+  exhausts its budget the action returns an error, and the engine then consults
+  `retry_policy` (Layer 2). `ActionResult::Retry` was removed — do not
+  reintroduce a third surface.
+
+## 7. Observability is Definition of Done
+
+Every new error variant ships with a tracing event, and every new state error
+ships with an invariant check — not as follow-up (root `CLAUDE.md` §Agent
+Rules: "New state / error / hot path must ship with a typed error variant +
+tracing span + invariant check"). See the observability skill for the span /
+metric / log boundaries (`docs/OBSERVABILITY.md`).
+
+## Quick checklist before you finish
+
+- [ ] Lib crate uses `thiserror` + `Classify` + `NebulaError`; no `anyhow`, no
+      stringly-typed errors.
+- [ ] No `unwrap/expect/panic/todo/unimplemented/unreachable` in lib code
+      (or each is `// guard-justified:`).
+- [ ] New error type implements `Classify` with a real `retry_hint()`.
+- [ ] No `let _ =` discarding a `Result` from a state mutation.
+- [ ] Validation goes through the canonical `ValidationError`; only validator
+      emits `required`; no `Rule::evaluate` shim; no code namespace remap.
+- [ ] Retry placed in the correct layer (resilience vs node `retry_policy`).
+- [ ] New variant has a tracing event; new state error has an invariant check.

--- a/.claude/skills/nebula-layer-boundaries/SKILL.md
+++ b/.claude/skills/nebula-layer-boundaries/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: nebula-layer-boundaries
+description: Use when adding a crate dependency, hitting a cargo-deny wrappers error, deciding where code lives, or crossing layers / calling a sibling crate.
+---
+
+# Nebula layer boundaries
+
+The layer map in `CLAUDE.md` is mechanically enforced by `cargo deny check`
+against `deny.toml`'s `[bans]` `deny = [...]` `wrappers` allowlists. A new
+`use nebula_*` edge that violates a layer is a **CI failure**, not a warning.
+Load this before introducing any cross-crate edge or moving code between crates.
+
+## The 6 layers — depend DOWNWARD only
+
+From `CLAUDE.md` "Layered Dependency Map". Each layer may depend only on layers
+*below* it. An upward edge (e.g. Core depending on Business) is a violation.
+
+| Layer | Crates |
+|-------|--------|
+| API / Public | `api`, `sdk` |
+| Exec | `engine`, `storage`, `storage-loom-probe` |
+| Business | `credential-builtin`, `resource`, `action`, `plugin`, `tenancy` |
+| Plugin-Proto | `plugin-sdk`, `sandbox` |
+| Core | `core`, `validator`, `expression`, `workflow`, `execution`, `schema`, `metadata`, `storage-port` |
+| Cross-cutting | `log`, `eventbus`, `metrics`, `resilience`, `error`, `env` |
+
+- **Plugin-Proto** is a leaf tier between Core and Business. `plugin-sdk` /
+  `sandbox` depend only on Core (+ tokio/serde); `plugin` (Business) and
+  `engine` (Exec) depend on them *downward*. The `SandboxRunner` runner
+  abstraction lives in `engine`; discovery + the `SandboxError`→`ActionError`
+  seam live in `plugin`.
+- Each `+macros` companion (`action/macros`, `credential/macros`,
+  `error/macros`, `plugin/macros`, `resource/macros`, `schema/macros`,
+  `validator/macros`, `sdk/macros-support`) sits at the **same layer as its
+  parent** and ships derives only.
+- The full member list is `Cargo.toml` `[workspace.members]`; every crate opts
+  into the shared lint policy with `[lints] workspace = true`.
+
+## Cross-cutting crates are importable at ANY level
+
+`log`, `eventbus`, `metrics`, `resilience`, `error`, `env` are NOT a bottom
+layer you must stay above — they are importable from any tier. A Core crate
+depending on `nebula-error` or `nebula-eventbus` is **not** a layer violation
+and these crates carry no `wrappers` entry in `deny.toml`.
+
+## Shared-infra exceptions (NOT single-tier) — each has a locked allowlist
+
+Four crates are deliberately consumed across multiple tiers. They are not
+"Business-row" crates; each has an explicit `{ crate = ..., wrappers = [...] }`
+allowlist in `deny.toml` that **locks the exact consumer set** so a future PR
+cannot quietly add an upward edge.
+
+- **`nebula-credential`** (credential *contract*) — `deny.toml` lines ~186-213.
+  Consumed by Business (`action`, `plugin`, `resource`, `tenancy`), Exec
+  (`engine`, `storage`, `credential-runtime`), API (`api`), and the first-party
+  backends (`credential-builtin`, `credential-vault`, `credential-testutil`).
+  Plugin authors depend on this contract crate, **not** on
+  `nebula-credential-builtin` (whose wrappers list is intentionally narrow:
+  itself + `credential-runtime`).
+- **`nebula-storage-port`** (Core storage seam, ADR-0072 §2.2) — `deny.toml`
+  lines ~125-133. Object-safe repository traits, port-local DTO rows, the
+  plain-data `Scope { workspace_id, org_id }`, `StorageError`,
+  `TransitionBatch`. **No sqlx, no upward deps.** Broadly importable: the
+  adapter (`storage`), loom probe, tenancy decorator, `engine`/`api`,
+  `credential-runtime`, plus a `credential-vault` dev-dep.
+  Distinguish from **`nebula-storage`** (Exec) — the sole adapter impl
+  (InMemory + SQLite + Postgres, sqlx, migrations); its wrappers list is the
+  composition seam (`engine`, `api`, `server`, + dev-deps). The legacy
+  `ExecutionRepo`/`WorkflowRepo` surface was deleted per ADR-0072.
+- **`nebula-resource`** (shared runtime framework, ADR-0081 SF-1) — `deny.toml`
+  lines ~170-176. Consumers locked to `action`, `engine`, `examples`,
+  `plugin`, `sdk` — no upward deps from API or core/*.
+- **`nebula-expression`** (Core evaluator, ADR-0043 §9) — `deny.toml`
+  lines ~222-231. Consumers locked to `schema`, `resource`, `engine`,
+  `examples`, + an `action` dev-dep. (`nebula-credential-runtime` is similarly
+  Exec-tier shared infra with its own allowlist; see lines ~283-287.)
+
+## Reading & editing a `{ crate, wrappers = [...] }` entry
+
+A `deny.toml` `[bans]` `deny` entry of the form
+`{ crate = "nebula-X", wrappers = [ ... ], reason = "..." }` means: **only the
+crates named in `wrappers` may have a direct dependency on `nebula-X`.** Any
+other crate that adds `nebula-X` to its `Cargo.toml` fails `cargo deny check`.
+
+To legally add a new consumer:
+
+1. Add the consumer crate name to the **target's** `wrappers` array (e.g. to
+   depend on `nebula-storage-port` from a new crate, add it to the
+   `nebula-storage-port` entry — NOT to a `nebula-storage` entry).
+2. Add an inline `#` comment on the new line explaining **why** the edge is
+   legal and which direction it points (every existing entry does this — see
+   the `credential-runtime` / knife / conformance dev-dep comments). Never widen
+   silently.
+3. **Dev-dep carve-outs are normal and expected** — integration tests and
+   conformance matrices legitimately reach across boundaries (e.g.
+   `nebula-tenancy` as a dev-dep of `nebula-storage` for the scoped conformance
+   matrix; `nebula-engine` as a dev-dep of `nebula-api` for the §13 knife test).
+   Mark them as dev-only in the comment. cargo-deny has **no feature-aware /
+   dev-dep-aware wrappers**, so the allowlist is the only structural gate —
+   `publish = false` test shims (`credential-testutil`) and `test-util`-gated
+   deps still need an explicit entry.
+4. If an edge would be **upward** (lower layer → higher layer), do not add it.
+   Restructure instead: move the shared code down, or route through eventbus.
+
+## Sibling-to-sibling goes through eventbus, never a direct import
+
+`CLAUDE.md` Agent Rules: "Cross-crate communication goes through
+`nebula-eventbus` — never reach across layer boundaries with direct imports."
+Two crates at the **same** layer (e.g. two Business crates) must not import each
+other directly. Publish/subscribe through `nebula-eventbus` (cross-cutting, so
+importable from anywhere). `nebula-eventbus` is stable and already used by
+`engine` for `CredentialEvent`.
+
+## Decision recipe: "where does this helper / type go?"
+
+Placement is a **boundary decision, not a convenience** ("one small helper in
+the wrong crate" compounds).
+
+1. Enumerate every crate that will consume the new code.
+2. Find the **lowest layer all consumers can reach downward**. Put the code
+   there. A type used by both `engine` (Exec) and `action` (Business) belongs in
+   Core or a shared-infra crate, never duplicated in each.
+3. If consumers span tiers and no existing crate fits, it is shared infra —
+   add a new `wrappers` allowlist entry (see above), do not smear it upward.
+4. If it is a pure error/event/metric/config concern, it belongs in the
+   matching cross-cutting crate (`error` / `eventbus` / `metrics` / `env`).
+5. Never add an upward edge to make a helper reachable. Push the helper down.
+
+## Verify before committing
+
+1. Run `cargo deny check` (or `task deny`) — it checks layer wrappers +
+   advisories + licenses. This is a CI required job; a wrapper failure blocks
+   the merge.
+2. `task deny` is also part of `task dev:check` (the pre-PR gate) and the
+   lefthook pre-commit `deny` step.
+3. On **any** dep add/change, stage the **root `Cargo.lock`** too
+   (`git add Cargo.lock`) — a narrow `git add crates/<name>` alone breaks the
+   per-commit `--locked` build.
+4. If a wrapper edit and a code edit land together, both go in the same commit
+   so each commit stays green.

--- a/.claude/skills/nebula-observability-dod/SKILL.md
+++ b/.claude/skills/nebula-observability-dod/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: nebula-observability-dod
+description: Use when adding a new state, error path, or hot path, emitting metrics or tracing spans, or before claiming a feature done — observability is Definition of Done.
+---
+
+# Nebula observability is Definition of Done
+
+In Nebula, observability is not polish you add later — it is a binding completion
+gate. Root `CLAUDE.md` ("Agent Rules") states it directly: *"New state / error /
+hot path must ship with a typed error variant + tracing span + invariant check."*
+Canon `docs/PRODUCT_CANON.md` §4.6 makes structured observability a product
+invariant, and the operational test (`docs/OBSERVABILITY.md` §5) is: *you can
+explain what happened in a run without reading Rust source.* If your change is not
+observable to that bar, it is not done.
+
+This skill is a checklist, not an essay. Follow it.
+
+## When to use
+
+- Implementing a new execution state, error variant, or hot path.
+- Adding or naming a metric, or adding a tracing span / event.
+- Propagating trace context across a boundary (HTTP → queue → engine → action).
+- Doing the final DoD pass before calling work complete or opening a PR.
+
+## 1. The DoD triple — none is optional
+
+For any new **state**, **error path**, or **hot path**, all three must ship in the
+same change:
+
+1. **Typed error variant** — a `thiserror`/`NebulaError` variant, never a bare
+   string or `unwrap()/expect()/panic!()` in library code (root `CLAUDE.md`;
+   `edit-guard.sh` enforces it). The variant carries enough structure to classify
+   (see `nebula-error::Classify`, used by the analysis loop in
+   `docs/OBSERVABILITY.md` §5).
+2. **Tracing span / event** — a `tracing` span or event at the new path, with
+   structured fields (see §3). The subscriber is set up once by `nebula-log`; you
+   just emit at the call site.
+3. **Invariant check** — assert the state-machine / value invariant the new path
+   assumes, and emit on violation. For execution-state work, transition legality
+   lives in `crates/execution/src/transition.rs`; record durable transitions to the
+   journal (§4) rather than mutating silently.
+
+Do not split these across PRs and do not defer one as "follow-up" — that is the
+exact "observability as completion" failure the rule exists to prevent.
+
+## 2. Metrics — `nebula_*`, bounded cardinality, defined in `nebula-metrics`
+
+- **Define names in `nebula-metrics`, not at the call site.** Name constants live
+  in `crates/metrics/src/naming.rs` (the `naming` module — e.g.
+  `NEBULA_EXECUTIONS_STARTED_TOTAL`, `NEBULA_ACTION_DURATION_SECONDS`). Adding a
+  `NEBULA_*` const to a primitive file (`counter.rs`/`gauge.rs`/`histogram.rs`/
+  `registry.rs`/`labels.rs`) is a layering violation — it belongs in the **policy**
+  section (`naming.rs` / `filter.rs`). See `crates/metrics/CLAUDE.md`.
+- **`nebula_*` prefix** on every metric series (and the canon `nebula.<area>.`
+  dotted form for credential metrics, per `docs/OBSERVABILITY.md` §6).
+- **Bounded label cardinality.** Enumerate every label's value set; never put a
+  high-cardinality identifier (`execution_id`, `node_id`, `correlation_id`,
+  `trace_id`) on a metric label. `LabelAllowlist` (`crates/metrics/src/filter.rs`)
+  strips high-cardinality keys before they reach the registry — do not work around
+  it. Good labels are closed sets like `outcome={success,failure}` or
+  `tier={l1,l2}` (see the refresh-coordinator metrics in `docs/OBSERVABILITY.md`
+  §7.1 for the cardinality-by-construction pattern).
+- **Single observability crate (ADR-0046).** `nebula-telemetry` was absorbed into
+  `nebula-metrics`; primitives + naming policy + Prometheus **and** OTLP export are
+  unified there. The OTel SDK appears only in `crates/metrics/src/otlp.rs` — never
+  import `opentelemetry*` from primitives/export modules. (The README still labels
+  OTLP "planned"; that is stale — OTLP push export is implemented per
+  `crates/metrics/CLAUDE.md`.)
+- The `/metrics` HTTP endpoint serving `snapshot()` lives in `nebula-api`, not in
+  `nebula-metrics`.
+
+## 3. Tracing — one pipeline, propagated context, structured fields
+
+- **One subscriber-init pipeline.** All binaries (and integration tests) initialize
+  `tracing` through `nebula-log` (`auto_init` / `init_with`). Do not stand up a
+  second subscriber. `nebula-log` does *not* redact secrets — pass redacted forms
+  to `tracing::*!` for any credential/token field (canon §12.5; `crates/log/`).
+- **Structured fields, not interpolated strings.** Emit
+  `tracing::info!(execution_id = %id, node_id = %node, ...)`, not
+  `info!("started {id}/{node}")`. Operators query fields; they cannot query prose.
+- **Propagate W3C trace context across boundaries (ADR-0050).** The carrier is
+  `nebula_core::obs::W3cTraceContext` (no HTTP types in core). The path is:
+  `nebula-api` middleware extracts inbound `traceparent` →
+  `ControlQueueEntry::w3c_trace_context` persists it across the async handoff →
+  the engine `ControlConsumer` re-attaches via `attach_control_queue_w3c_parent`
+  before dispatch. `nebula_api::init_api_telemetry` must install **both** the
+  global `TraceContextPropagator` **and** the `tracing_opentelemetry` layer — the
+  propagator alone is a silent no-op. Outbound resource HTTP is named under
+  `nebula.action.resource_http.request` with host/scheme only (no path, no secrets).
+- Shipping spans to an external OTLP collector is gated on M9.2 and only activates
+  when an endpoint is configured (`nebula-log` `telemetry` feature); the in-process
+  propagation above works without it.
+
+## 4. Durable events — append to `execution_journal` with the fixed schema
+
+Significant, replayable events are appended to the journal, not just logged. The
+Rust WAL type is `JournalEntry` (`crates/execution/src/journal.rs`) — an
+`event`-tagged, **closed** enum (`ExecutionStarted`, `NodeScheduled`, `NodeStarted`,
+`NodeCompleted`, `NodeFailed`, `NodeSkipped`, `ExecutionCompleted`,
+`ExecutionFailed`, `CancellationRequested`). The durable `execution_journal` row
+shape is fixed (`docs/OBSERVABILITY.md` §4):
+
+```
+execution_id, node_id, attempt, correlation_id, trace_id, span_id,
+event_type (closed enum), payload (event-type specific), timestamp
+```
+
+Principle (canon / Observability Engineering): **append rich structured events
+first, aggregate to metrics second.** Never add a metric without the underlying
+journal event being available for drill-down. A new event kind extends the closed
+enum in `journal.rs` — it is not a free-form string.
+
+## 5. Which surface does each field belong to?
+
+High-cardinality identifiers go on **spans and journal events**, never on **metric
+labels**:
+
+| Field | Span attr | Journal event | Metric label |
+|---|---|---|---|
+| `execution_id`, `node_id`, `correlation_id`, `trace_id`, `span_id` | yes | yes (required, §4) | **no** |
+| `outcome`, `tier`, `event_type`, closed-set reasons | yes | yes (as `event_type`/payload) | **yes** (bounded) |
+
+Before adding a field, ask which surface it belongs to and put it only there. The
+`LabelAllowlist` guard exists because this rule was violated before.
+
+## 6. SLI/SLO awareness — make new hot paths feedable
+
+The engine has four canonical SLIs (`docs/OBSERVABILITY.md` §1–2). A new hot path
+should emit enough to keep these measurable:
+
+| SLI | Measured from | SLO target |
+|---|---|---|
+| `execution_terminal_rate` | `executions` table status counts (28d) | ≥ 99.0% |
+| `cancel_honor_latency_p95` | `cancelled_at − cancel_requested_at` histogram | ≤ 5s |
+| `checkpoint_write_success_rate` | `nebula-execution` checkpoint-write metrics | ≥ 99.9% |
+| `dispatch_lag_p95` | `control_queue_drained_at − control_queue_inserted_at` | ≤ 1s |
+
+If your change touches execution termination, cancel handling, checkpoint writes,
+or control-queue dispatch, confirm the timestamps/counters those SLIs read from are
+still emitted. Error budget = `1 − SLO`; budgets are rolling, not calendar
+(`docs/OBSERVABILITY.md` §3).
+
+## 7. Comments — behavior-first, no pinned section numbers
+
+Document *what the code does and why*, in behavior terms. Do **not** pin ADR or
+canon section numbers inside function bodies — references rot, and per project
+memory comments must read fine after a plan/spec is deleted (no plan-id /
+"Phase X" / `TODO(A-5)` either; `edit-guard.sh` enforces the TODO/FIXME side).
+Keep ADR/spec citations in the crate README or this skill, not in hot-path code.
+
+## Final DoD pass — checklist before claiming done
+
+- [ ] Typed error variant added (no `unwrap()/expect()/panic!()` in lib code).
+- [ ] Tracing span/event at the new path with structured fields (no string interp).
+- [ ] Invariant asserted; durable transition appended to `execution_journal` if it
+      changes execution state.
+- [ ] Any new metric: `nebula_*` named, constant in `crates/metrics/src/naming.rs`,
+      labels are bounded closed sets, no high-cardinality id as a label.
+- [ ] Trace context propagated if the change crosses HTTP/queue/engine boundaries.
+- [ ] No new subscriber init; secrets passed only in redacted form.
+- [ ] SLI feeds intact if the path touches terminal/cancel/checkpoint/dispatch.
+- [ ] Comments are behavior-first; no ADR/canon section numbers or plan-ids in code.
+- [ ] `cargo nextest run -p <crate>` and `task clippy` green (Stop-gate / lefthook).
+
+## References
+
+- `docs/OBSERVABILITY.md` — SLIs/SLOs, error budgets, journal event schema, cardinality rules, analysis loop.
+- `CLAUDE.md` (root, "Agent Rules") — observability is Definition of Done.
+- `docs/adr/0046-metrics-telemetry-boundary.md` — single `nebula-metrics` crate (telemetry merged in).
+- `docs/adr/0050-m3-5-w3c-trace-context-propagation.md` — W3C trace-context across HTTP → queue → engine.
+- `crates/metrics/README.md` + `crates/metrics/CLAUDE.md` — naming, cardinality, OTLP seam (`src/otlp.rs`).
+- `crates/log/README.md` + `crates/log/CLAUDE.md` — single subscriber pipeline, secret-redaction boundary.
+- `crates/execution/src/journal.rs` — `JournalEntry` closed-enum WAL.

--- a/.claude/skills/nebula-storage-port-adapter/SKILL.md
+++ b/.claude/skills/nebula-storage-port-adapter/SKILL.md
@@ -29,7 +29,7 @@ machinery; implementing a backend; or wrapping a store for tenant scoping.
 Dependency direction (`crates/storage-port/README.md`): `engine` / `api` /
 `core` depend **only on the port**; only composition roots
 (`nebula-api` `AppState`, the engine wiring, the knife test) wire the concrete
-adapter + tenancy decorator. The `deny.toml [wrappers]` blocks for
+adapter + tenancy decorator. The `deny.toml` `[bans].deny` `wrappers` blocks for
 `nebula-storage-port` (broad, Core-tier), `nebula-storage` (engine/api/server
 composition seam), and `nebula-tenancy` (api/engine + scoped-conformance
 dev-dep only) lock the exact consumer sets — a sibling crate cannot quietly

--- a/.claude/skills/nebula-storage-port-adapter/SKILL.md
+++ b/.claude/skills/nebula-storage-port-adapter/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: nebula-storage-port-adapter
+description: Use when changing storage, repository traits, CAS / leases / outbox / journal / idempotency, the spec-16 port, the SQLite/Postgres adapter, or tenant scoping of stores.
+---
+
+# nebula-storage-port-adapter
+
+Storage in Nebula is a **three-crate split** under ADR-0072
+(`docs/adr/0072-nebula-storage-spec16-port-adapter-tenancy.md`). The legacy
+`ExecutionRepo` / `WorkflowRepo` / `Pg*Repo` dual layer and the
+never-implemented `repos::{execution,workflow,execution_node,journal}`
+placeholders were **deleted** — everything runs on the port. Do not resurrect
+them.
+
+## When to use
+
+Adding or modifying a storage repository method; touching the execution CAS /
+lease handoff / control-queue outbox / journal / idempotency / refresh-claim
+machinery; implementing a backend; or wrapping a store for tenant scoping.
+
+## The three parts
+
+| Crate | Tier | Role | Holds |
+|---|---|---|---|
+| `nebula-storage-port` (`crates/storage-port/`) | Core | Pure contract — declares *what* storage does, **no backend code** | object-safe `#[async_trait]` traits, port-local DTO rows, plain-data `Scope { workspace_id, org_id }`, `StorageError`, `FencingToken`, the `TransitionBatch` unit-of-work |
+| `nebula-storage` (`crates/storage/`) | Exec | The **SOLE** adapter — implements the port | `inmem::*` (tests / single-process / loom), `sqlite::*` (feature `sqlite`), `postgres::*` (feature `postgres`); sqlx, migrations, pool, credential layer; residual `repos::*` (control-queue / idempotency / webhook / identity glue) |
+| `nebula-tenancy` (`crates/tenancy/`) | Business | Scope-substituting **decorator** + policy | `ScopeResolver` (`Principal` → `Scope`), one `Scoped*Store` per port trait, `request_scope(&TenantContext)` |
+
+Dependency direction (`crates/storage-port/README.md`): `engine` / `api` /
+`core` depend **only on the port**; only composition roots
+(`nebula-api` `AppState`, the engine wiring, the knife test) wire the concrete
+adapter + tenancy decorator. The `deny.toml [wrappers]` blocks for
+`nebula-storage-port` (broad, Core-tier), `nebula-storage` (engine/api/server
+composition seam), and `nebula-tenancy` (api/engine + scoped-conformance
+dev-dep only) lock the exact consumer sets — a sibling crate cannot quietly
+bypass the boundary.
+
+## Procedure: changing the storage contract
+
+1. **Port FIRST.** Edit the trait in `crates/storage-port/src/store/*.rs`
+   (`execution.rs`, `workflow.rs`, `control_queue.rs`, `node_result.rs`,
+   `journal.rs`, `idempotency.rs`, `checkpoint.rs`, `refresh_claim.rs`,
+   `identity.rs`, `webhook.rs`). Add/adjust DTO rows in
+   `crates/storage-port/src/dto/` — DTOs depend only on `serde_json::Value`,
+   **never** on `ActionResult` or any higher-tier type (Core-tier inversion).
+   Keep traits `#[async_trait]` + `dyn`-compatible (consumed as `Arc<dyn …>`).
+   `cargo check -p nebula-storage-port`.
+2. **Implement in ALL THREE backends.** `crates/storage/src/inmem/`,
+   `src/sqlite/` (feature `sqlite`), `src/postgres/` (feature `postgres`).
+   Never add backend-specific behavior to the port — the port declares
+   behavior; backends realize it identically (SQLite parity = API +
+   single-writer correctness, not concurrency/throughput parity, ADR-0072
+   decision 7). `cargo check -p nebula-storage --features sqlite,postgres`.
+3. **Add a tenancy decorator** if the method is tenant-scoped: a
+   `Scoped*Store` in `crates/tenancy/src/decorator/*.rs` that **substitutes**
+   the bound `Scope` on the call. Never compare-and-reject (existence oracle);
+   let the backend filter `WHERE workspace_id=? AND org_id=?` and surface an
+   id↔scope mismatch as `NotFound` / `Ok(None)`.
+4. **Run the conformance matrix** — one behavioral suite ×
+   {InMemory, SQLite, Postgres} × the scoped decorator
+   (`crates/storage/tests/conformance`, scoped variant dev-deps
+   `nebula-tenancy`). `cargo nextest run -p nebula-storage`.
+
+## Atomicity & CAS rules (non-negotiable)
+
+- **`ExecutionStore::commit` is the single source of truth** for execution
+  state (canon §11.1). It applies CAS on `version` and gates every transition
+  with the lease `FencingToken`. If persistence is unavailable it **fails** —
+  it never silently mutates in-memory state.
+- **`TransitionBatch` is the §12.2 atomic unit-of-work** — state CAS + control
+  outbox + journal append committed as **one** logical operation. Its fields
+  are private and builder-only (`crates/storage-port/src/batch.rs`), so a
+  caller cannot transition without declaring scope + expected version +
+  fencing token. Never transition state without enqueueing the outbox, and
+  never enqueue without transitioning.
+- **Lease fencing closes the zombie-runner hole** (ADR-0072 bug #1).
+  `acquire_lease` returns a monotone `FencingToken`; the engine threads it into
+  every committed `TransitionBatch`, so a superseded holder is rejected **even
+  on a matching CAS version**.
+- **Refresh-claim CAS** (ADR-0041, `crates/storage/src/credential/refresh_claim/`):
+  `try_claim` must be atomic under contention (exactly one of N concurrent
+  acquirers across N replicas wins); `heartbeat` must validate
+  `ClaimToken.generation` so a stale holder cannot extend a reclaimed claim
+  (reclaim sweep bumps generation).
+
+## Tenant scoping rules
+
+- The tenancy decorator substitutes the `Scope` on **every call before it
+  reaches a handler**. The engine/api receive an **already-scoped**
+  `Arc<dyn …Store>`; the raw adapter constructor is crate-private to wiring —
+  a confused-deputy caller is structurally unable to forge another tenant's
+  scope. **Never bypass the decorator.**
+- `Scope` is plain data and lives in the **port** (Core tier), so port
+  signatures can require it without an upward dep. `nebula-tenancy` owns
+  *policy* only — resolving `Scope` from a `Principal` (`BindingScopeResolver`
+  is fail-closed: an absent workspace binding is rejected, never widened to
+  org-only) and cross-tenant denial. It must **not** own the `Scope` type and
+  **not** add a backend/sqlx dependency.
+- Cross-tenant access returns `NotFound` (never another tenant's row, never a
+  distinct "denied" that leaks existence), proven by the cross-tenant-denial
+  conformance suite (spec §6.1). Idempotency keys are tenant-namespaced
+  (`{scope}:{key}`) so a replay-oracle cannot probe another tenant's dedup.
+
+## Concurrency proof obligation (loom)
+
+`nebula-storage-loom-probe` (`crates/storage-loom-probe/`) re-implements
+storage CAS critical sections against `loom::sync` and proves their
+single-owner invariant. **Adding a new CAS critical section ⇒ add a probe
+here.** Two probes today: refresh-claim CAS (`src/lib.rs`,
+`tests/refresh_claim_loom.rs`) and execution-lease handoff
+(`src/lease_handoff.rs`, `tests/lease_handoff_loom.rs`). The crate has **zero
+`nebula-storage` dep on purpose** (`--cfg loom` leaks to every crate; a
+transitive dep like `concurrent-queue` via `moka` would break) — probes
+**mirror** the production shape by hand and must stay invariant-equivalent
+(probe `generation` == the store's `fencing_generation`); update the mirror
+when the real adapter's CAS changes. Run:
+
+```bash
+RUSTFLAGS="--cfg loom" cargo nextest run -p nebula-storage-loom-probe \
+  --features loom-test --profile ci --no-tests=pass
+```
+
+## Migrations
+
+Two per-backend trees: `crates/storage/migrations/postgres/` and
+`crates/storage/migrations/sqlite/` (logically identical tables; dialect types
+differ). **No flat top-level tree.** The spec-16 port adapters persist through
+`port_*` tables in `0027_port_adapter_schema.sql`, which must stay
+**byte-identical** to the embedded `src/{postgres,sqlite}/schema.sql` that
+`init_schema` applies for `:memory:` / test pools (regenerate the migration
+with `cp` from the embedded schema — see each tree's README). `task db:migrate`
+applies pending Postgres migrations (`DATABASE_URL`-gated); `task db:reset`
+drops and recreates the DB (destroys local dev data).
+
+## Verification & honesty
+
+- InMemory + SQLite are runtime-verified. **Postgres is
+  done-but-pg-unverified** — `DATABASE_URL`-gated and skip-clean in the
+  worktree (e.g. `crates/storage/tests/pg_idempotency.rs`). Never claim
+  pg-verified without a live DB.
+- `engine` still uses a fixed `engine_scope() = Scope::new("nebula", "nebula")`
+  placeholder (≈20 call sites), relying on the tenancy decorator to substitute
+  the request scope; per-execution engine tenant scoping is a tracked,
+  deliberately deferred follow-up (ADR-0072 "Known follow-up"). The api/port/
+  tenancy boundary is already per-request and conformance-tested.
+
+## Never do
+
+- Re-add the deleted `ExecutionRepo` / `WorkflowRepo` / `Pg*Repo` surface or
+  the `repos::{execution,workflow,execution_node,journal}` placeholders.
+- Implement a backend inside `nebula-storage-port`, or put DTO deps on
+  higher-tier types.
+- Add backend-specific behavior to the port instead of to all three adapters.
+- Let a consumer reach the raw adapter and bypass the tenancy decorator.
+- Use `unwrap()` / `expect()` / `panic!()` in lib code — typed
+  `StorageError` / `thiserror` only.

--- a/.claude/skills/nebula-worktree-pr-workflow/SKILL.md
+++ b/.claude/skills/nebula-worktree-pr-workflow/SKILL.md
@@ -90,12 +90,14 @@ Fast single-crate inner loop (don't run the full workspace every edit):
 | `lefthook.yml` | `git commit` / `git push` (any harness) | Pre-commit + pre-push gates (§5) |
 | `.github/workflows/ci.yml` | PR / merge_group | Required jobs: `fmt`, `clippy`, `check`, `doctests`, `msrv`, `doc`, `deny` (aggregated into the single required `CI` check) |
 
-**`lefthook pre-push` MUST mirror CI required jobs.** If you change a CI required
-job, change pre-push to match, and vice versa (CLAUDE.md Agent Rules;
-`feedback_lefthook_mirrors_ci.md`). Note CI also runs `check` (incl.
+**Keep `lefthook pre-push` in sync with the CI required jobs it owns** — the
+`clippy` and changed-crate `nextest` gates. If you change one of those CI jobs,
+change pre-push to match, and vice versa (CLAUDE.md Agent Rules;
+`feedback_lefthook_mirrors_ci.md`). The remaining required jobs — `check` (incl.
 `--all-features` and several `--no-default-features` crate checks), `doc`
-(`RUSTDOCFLAGS=-D warnings cargo doc --no-deps`), and `msrv` (1.95) — these are
-CI-owned and not in pre-push, so a green pre-push does not guarantee green CI.
+(`RUSTDOCFLAGS=-D warnings cargo doc --no-deps`), and `msrv` (1.95) — are
+CI-owned and deliberately NOT mirrored in pre-push, so a green pre-push does not
+guarantee green CI.
 
 ## 5. Commit granularity and the lefthook gates
 

--- a/.claude/skills/nebula-worktree-pr-workflow/SKILL.md
+++ b/.claude/skills/nebula-worktree-pr-workflow/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: nebula-worktree-pr-workflow
+description: Use when starting a branch, committing, opening a PR, or hitting lefthook / convco / cargo-deny / fmt / clippy gate failures in this workspace.
+---
+
+# Nebula worktree + PR workflow
+
+Procedure for branching, committing, gating, and finishing work in this Rust
+workspace. Authoritative sources: `CLAUDE.md` (Agent Git Workflow / Agent Rules
+/ Common Commands / Enforced Discipline), `scripts/worktree.sh`, `lefthook.yml`,
+`.github/workflows/ci.yml`, `Taskfile.yml`.
+
+## When to use
+
+Creating a task branch, writing a commit message, running the pre-PR gate,
+finishing/merging a branch, or diagnosing a lefthook / CI required-job failure
+(`fmt`, `clippy`, `nextest`, `convco`, `deny`).
+
+## 1. Start a branch (from `origin/main`)
+
+```bash
+bash scripts/worktree.sh new <slug> <type> <scope>
+```
+
+- Creates `.worktrees/<slug>` and branch `<type>/<scope>-<slug>`, based on
+  `origin/main` (`DEFAULT_BASE` in `scripts/worktree.sh`; override with a 4th
+  `[base]` arg or `NEBULA_WORKTREE_BASE`).
+- The script `slugify`s name/type/scope and rejects empty values, `.`/`..`, and
+  path separators. It fails fast if the path or local branch already exists.
+- Equivalent task wrapper: `task wt:new` with `WT_NAME` / `WT_TYPE` / `WT_SCOPE`
+  env vars. List with `bash scripts/worktree.sh list` (`task wt:list`).
+- **Branch from `main`, squash-merge back, never force-push shared history**
+  (CLAUDE.md Agent Rules).
+- Managed cloud/IDE worktrees that can't live under `.worktrees/` still follow
+  these branch/commit rules — CI and lefthook are the gate.
+
+## 2. Commit (Conventional Commits, convco-validated)
+
+```bash
+git add <paths>
+bash scripts/worktree.sh commit <type> <scope> <summary...>
+```
+
+- Emits `<type>(<scope>): <summary>` and validates it with `convco check
+  --from-stdin` before `git commit`. Fails if there are no staged changes.
+- The `commit-msg` lefthook (`cat {1} | convco check --from-stdin`) re-validates
+  on every commit, regardless of harness.
+- **Allowed types** (from `VALID_TYPES` in `scripts/worktree.sh`): `build`,
+  `chore`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`,
+  `test`.
+- **Scope** = crate name without the `nebula-` prefix (`resilience`, `engine`,
+  `api`) or a top-level area (`docs`, `ci`, `scripts`, `github`).
+- Task wrapper: `task git:commit` with `WT_TYPE` / `WT_SCOPE` / `WT_MSG`.
+
+**Decompose chained git commands.** Run each git op as its own step so pass/fail
+is clear; do not chain unrelated git operations.
+- Wrong: `git checkout main && git pull`
+- Right: `git checkout main`, then `git pull origin main`.
+
+## 3. Pre-PR gate
+
+Authoritative local gate before opening a PR:
+
+```bash
+task dev:check
+```
+
+Runs (see `Taskfile.yml` `dev:check`): `fmt:check` → `clippy` (`-D warnings`) →
+`cargo nextest run --workspace` → `cargo test --workspace --doc` → `deny`.
+
+Fast single-crate inner loop (don't run the full workspace every edit):
+
+| Need | Command |
+|------|---------|
+| Type-check one crate | `cargo check -p <crate>` |
+| Run one crate's tests | `cargo nextest run -p <crate>` |
+| One test by name | `cargo nextest run -p <crate> <test>` |
+| Doctests for one crate | `cargo test -p <crate> --doc` |
+| Supply-chain audit | `task deny` (`cargo deny check`) |
+
+> On Windows deep worktree paths `task dev:check` (and `task fmt`) trip the
+> `cargo fmt --all` failure — see §6. Verify formatting per-crate; CI Linux
+> `fmt` is the authoritative formatting gate.
+
+## 4. Three hook layers — what each owns
+
+| Layer | Trigger | Owns |
+|-------|---------|------|
+| `.claude/hooks/*.sh` | Claude Code per-turn (edit-guard / stop-gate) | No-unwrap/expect/panic in lib code, no TODO/FIXME/plan-ids, no test-weakening, and the Stop-gate: can't end a turn with impl changed but no green clippy + nextest |
+| `lefthook.yml` | `git commit` / `git push` (any harness) | Pre-commit + pre-push gates (§5) |
+| `.github/workflows/ci.yml` | PR / merge_group | Required jobs: `fmt`, `clippy`, `check`, `doctests`, `msrv`, `doc`, `deny` (aggregated into the single required `CI` check) |
+
+**`lefthook pre-push` MUST mirror CI required jobs.** If you change a CI required
+job, change pre-push to match, and vice versa (CLAUDE.md Agent Rules;
+`feedback_lefthook_mirrors_ci.md`). Note CI also runs `check` (incl.
+`--all-features` and several `--no-default-features` crate checks), `doc`
+(`RUSTDOCFLAGS=-D warnings cargo doc --no-deps`), and `msrv` (1.95) — these are
+CI-owned and not in pre-push, so a green pre-push does not guarantee green CI.
+
+## 5. Commit granularity and the lefthook gates
+
+From `lefthook.yml`:
+
+- **pre-commit** (parallel, changed-crate scoped → cheap):
+  - `fmt-check` — `scripts/pre-commit-fmt-check.sh` on staged `.rs` (per-crate,
+    avoids the Windows `cargo fmt --all` cmdline-length break).
+  - `clippy` — `scripts/pre-commit-clippy-changed.sh` on staged `.rs` (only the
+    crates owning staged files; full-workspace clippy moved to pre-push).
+  - `typos` (whole tree), `taplo fmt --check` (staged `.toml`), `cargo deny`
+    (staged `Cargo.toml` / `Cargo.lock` / `deny.toml`).
+  - Docs-only / toml-only commits skip the clippy/fmt crate steps → cheap.
+- **pre-push** (serial, ~100s):
+  - `clippy-full` — `cargo clippy --workspace --all-targets -- -D warnings`
+    (CI `clippy` parity).
+  - `crate-diff-gate` — `scripts/pre-push-crate-diff.sh`: `cargo nextest run`
+    for changed crates; runs `--features postgres` integration tests only when
+    `DATABASE_URL` is set, otherwise emits a single WARN line and skips them.
+
+**Commit big refactors at per-touched-crate-green points** so each atomic commit
+keeps the changed crates green; an as-yet-untouched crate won't go red because
+pre-commit clippy is changed-crate scoped.
+
+## 6. Windows worktree gotchas
+
+- `cargo fmt --all` trips **OS error 206** (command-line too long) in deep
+  `.worktrees/` paths. Verify formatting per-crate (`cargo fmt -p <crate> --
+  --check`); do **not** report `task dev:check` / `task fmt:check` green from a
+  deep worktree. CI Linux `fmt` (`cargo fmt --all -- --check`) is the real gate.
+- A backgrounded `git push` looks hung but is just the slow pre-push hook
+  (full-workspace clippy + crate-diff nextest, ~100s). **Don't re-push** on the
+  first "not pushed yet" reading — wait it out.
+
+## 7. Cargo.lock discipline
+
+- On **any dependency add/change**, stage the **root `Cargo.lock`** too — not
+  just `crates/<name>`. Too-narrow staging breaks per-commit `--locked` builds.
+- Resolve lockfile **rebase conflicts** with `git checkout --theirs Cargo.lock`
+  (then let cargo reconcile). Do **not** `cargo update -p <pkg>` to fix a
+  conflict.
+
+## 8. Never bypass gates
+
+- No `git commit --no-verify`, no `git push --no-verify`, no `git push --force`
+  on shared history (`bash-deny.sh` nudges; the permission system denies the
+  blatant forms).
+- No `#[allow(...)]` / lint-suppression to fake a green clippy — a
+  lint-suppressed clippy never counts as a passing gate (`record.sh` A2).
+- No `unwrap()` / `expect()` / `panic!()` in library code (`edit-guard.sh`);
+  tests, `const`, and binaries are exempt per `clippy.toml`.
+
+## 9. Finish (after the PR is merged)
+
+```bash
+bash scripts/worktree.sh finish <slug>
+```
+
+- Requires a clean checkout in both the target worktree and the primary; it
+  switches the primary to `main`, `fetch` + `pull --ff-only`s from the tracked
+  remote, removes `.worktrees/<slug>`, prunes, and deletes the merged local
+  branch (`git branch -d`, so it refuses if the branch isn't merged).
+- Task wrapper: `task wt:finish` (`WT_NAME`). Drop a worktree without the
+  main-sync via `bash scripts/worktree.sh remove <slug>` (`task wt:remove`).
+
+## Failure → fix quick map
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `convco check` fails | Message isn't `<type>(<scope>): <summary>` or `<type>` not in the allowed list (§2). Re-run via `scripts/worktree.sh commit`. |
+| pre-commit `clippy` red | Changed-crate clippy on staged `.rs`. Fix the lint — do not `#[allow]` it (§8). |
+| pre-push `clippy-full` red | Full-workspace `-D warnings`. Run `task clippy` locally first. |
+| `cargo deny check` fails | Layer-wrapper / advisory / license violation. Inspect `deny.toml`; if a dep changed, also stage root `Cargo.lock` (§7). |
+| `fmt` red in CI but local fmt "passed" | Likely the Windows OS-error-206 false pass (§6). Verify per-crate. |
+| pre-push seems hung | Slow pre-push hook, not a hang — wait, don't re-push (§6). |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,8 @@ nebula/
 └── .github/            # CI workflows, CODEOWNERS, PR/issue templates, copilot-instructions.md
 ```
 
-Per-crate layout: each `crates/<name>/` has `Cargo.toml` and `README.md`;
+Per-crate layout: each `crates/<name>/` has `Cargo.toml`, `README.md`, and a
+`CLAUDE.md` (agent quick-map; full design stays in the README);
 some carry a sibling derive crate (`<name>/macros`) and/or a `docs/` folder.
 
 ## Layered Dependency Map
@@ -163,6 +164,7 @@ between siblings at the same layer.
 | **Agent doc map**      | `docs/README.md`              | **Start here for docs** — Tier 0–1 only; do not bulk-read `docs/adr/0*` |
 | Removed doc trees      | `docs/ARCHIVE.md`             | superpowers / audits / brainstorms moved out of repo |
 | Agent rules + map      | `CLAUDE.md`                   | **Canonical** — this file — branch / commit / PR rules + project map + enforced discipline |
+| Onboarding / handoff   | `HANDOFF.md`                  | Onboarding / handoff doc for new human or AI collaborators |
 | Product strategy       | `STRATEGY.md`                 | Direction, 2026 standard bar, flagship, tracks (complements canon) |
 | 1.0 roadmap            | `docs/ROADMAP.md`             | Production-ready 1.0 milestone checklist (M0–M14), capability/dependency-ordered |
 | Product overview       | `README.md`                   | What Nebula is, design principles, architecture |
@@ -183,11 +185,14 @@ between siblings at the same layer.
 | File                          | Purpose |
 |-------------------------------|---------|
 | `CLAUDE.md`                   | **Canonical** agent rules + project map — every AI tool should read this |
+| `crates/<crate>/CLAUDE.md`    | Per-crate agent quick-map (purpose, layer, commands, key files, crate rules); complements the human-facing README |
+| `HANDOFF.md`                  | Onboarding / handoff doc for new human or AI collaborators |
 | `AGENTS.md`                   | Thin pointer naming `CLAUDE.md` canonical (cross-tool stub) |
 | `.github/copilot-instructions.md` | GitHub Copilot guidance (defers to `CLAUDE.md`) |
 | `.cursor/rules/*.mdc`         | Cursor project rules that defer to `CLAUDE.md` |
 | `.claude/hooks/`              | Committed guard hooks (enforced discipline) |
 | `.claude/skills/rust-intel/`  | Vendored LLM-Rust-failure-mode skill — v0.2.2, MIT, advisory (not hook-enforced); `/rust-cc-{audit,fix,plan}` slash commands (see its `UPSTREAM.md`) |
+| `.claude/skills/<name>/`      | Native project skills, discoverable on demand with keyword-first descriptions — `nebula-layer-boundaries`, `nebula-credential-lifecycle`, `nebula-storage-port-adapter`, `nebula-error-and-validation`, `nebula-observability-dod`, `nebula-worktree-pr-workflow` |
 | `.claude/commands/`           | Slash-command definitions for the vendored skills above |
 | `.pi/settings.json`           | [`pi-subagents`](https://pi.dev/packages/pi-subagents) `agentOverrides` (3-tier Anthropic strategy with cross-provider fallback chains: scout/context-builder/researcher on `claude-haiku-4-5` + medium for cheap recon; reviewer/worker on `claude-sonnet-4-6` + high with inherited project context; planner/oracle on `claude-opus-4-7` + **max** effort — no token constraint for architecture / security review). Fallback order across providers: `anthropic` → `github-copilot` → `cursor-agent` → `openai-codex`. **and** vstack-namespaced per-project overrides for [`@vanillagreen/pi-hooks`](https://pi.dev/packages/%40vanillagreen/pi-hooks) (see Pi Hook Strategy below) and [`@vanillagreen/pi-output-policy`](https://pi.dev/packages/%40vanillagreen/pi-output-policy) tuning |
 | `.pi/lsp.json`                | [`@narumitw/pi-lsp`](https://pi.dev/packages/%40narumitw/pi-lsp) server map — `rust-analyzer` for `.rs` (clippy on `check`, all features, target/ excluded) and `taplo` for `.toml`; powers `lsp_diagnostics` / `lsp_fix` tools |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ some carry a sibling derive crate (`<name>/macros`) and/or a `docs/` folder.
 
 ## Layered Dependency Map
 
-Mechanically enforced by `cargo deny check` against `deny.toml` `[wrappers]`.
-Each layer depends only on layers below; cross-cutting crates are importable at
+Mechanically enforced by `cargo deny check` against the `wrappers` allowlists in
+`deny.toml` `[bans].deny`. Each layer depends only on layers below; cross-cutting crates are importable at
 any level.
 
 | Layer        | Crates |
@@ -118,7 +118,7 @@ the Exec tier (`engine`, `storage`) and the API tier consume the
 credential contract directly alongside Business (`action`, `plugin`,
 `resource`) and the first-party backends (`credential-builtin`,
 `credential-vault`). Like the cross-cutting crates it is importable from
-those tiers; the `deny.toml` `[wrappers]` allowlist locks the exact
+those tiers; the `deny.toml` `[bans].deny` `wrappers` allowlist locks the exact
 consumer set.
 
 `nebula-storage-port` (Core) is the object-safe storage seam: the spec-16

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -62,8 +62,8 @@ auto-close, so an "open" GitHub issue may already be fixed — verify with
 
 Six layers, each depends **only on layers below it**. Cross-cutting crates are
 importable at any level. Boundaries are **mechanically enforced** by
-`cargo deny check` against `deny.toml [wrappers]` — a missing edge fails CI
-before review. Cross-crate signalling goes through `nebula-eventbus`, never
+`cargo deny check` against the `wrappers` allowlists in `deny.toml` `[bans].deny`
+— a missing edge fails CI before review. Cross-crate signalling goes through `nebula-eventbus`, never
 direct sibling imports. Full map + nuances → [`CLAUDE.md`](CLAUDE.md)
 "Layered Dependency Map".
 
@@ -80,7 +80,7 @@ Three placements that are *not* a simple single-tier reading:
 
 - **`nebula-credential` is shared infra**, not Business-only — Exec (`engine`,
   `storage`) and API consume the credential contract directly alongside
-  Business; the `deny.toml [wrappers]` allowlist locks the exact consumer set.
+  Business; the `deny.toml` `[bans].deny` `wrappers` allowlist locks the exact consumer set.
 - **Storage is a port/adapter/tenancy split:** `nebula-storage-port` (Core) is
   the object-safe spec-16 row-model **contract** (no backend code);
   `nebula-storage` (Exec) is the **sole adapter** (InMemory + SQLite +
@@ -188,9 +188,10 @@ than grepping blind:
 - **Pi:** `.pi/lsp.json` already maps `rust-analyzer` for `.rs` (clippy on
   `check`, all features, `target/` excluded) and `taplo` for `.toml`; the
   `lsp_diagnostics` / `lsp_fix` tools use it.
-- `.claude/settings.json` now **denies `Read` of `target/**`** (and
-  `*.generated.rs`) so generated/build artifacts don't pollute context — rely
-  on the LSP / Grep tools for navigation instead.
+- `.claude/settings.json` now **denies `Read` of `target/**`** (and the sibling
+  worktree pool `.worktrees/**` / `.claude/worktrees/**`) so build artifacts and
+  stale duplicate crate trees don't pollute context — rely on the LSP / Grep
+  tools for navigation instead.
 
 ## 7. Active frontiers / moats
 

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,0 +1,233 @@
+# Nebula — Onboarding / Handoff
+
+> For a new human or AI collaborator taking over Nebula. This is a
+> **pointer map**, not a spec — it tells you *where* the truth lives, not what
+> it says. Read the linked canon; do not trust a summary over the source.
+>
+> **Reading order:** [`CLAUDE.md`](CLAUDE.md) (rules + layer map) →
+> [`README.md`](README.md) (product) → [`STRATEGY.md`](STRATEGY.md) (direction)
+> → [`docs/README.md`](docs/README.md) (the doc map — read it before opening
+> anything else under `docs/`).
+
+## 1. What Nebula is
+
+Nebula is a modular, type-safe **workflow automation engine** in Rust
+(edition 2024) — same space as n8n / Temporal / Restate, but shipped as a
+composable **library** (`nebula-sdk` is the headline surface), not a monolithic
+platform. Credentials, typing between nodes, durability, and resilience are
+first-class engine concerns rather than bolt-ons.
+
+- Product overview, design principles, data flow → [`README.md`](README.md)
+- Direction, the 2026 standard bar, flagship, tracks → [`STRATEGY.md`](STRATEGY.md)
+- Binding invariants (durability / credentials / operational honesty) →
+  [`docs/PRODUCT_CANON.md`](docs/PRODUCT_CANON.md)
+
+## 2. Current state & milestone
+
+**Active alpha.** Cross-cutting + Core layers are **stable**; Exec (`engine`,
+`storage`) and the API layer are being wired toward production. Not 1.0 yet.
+
+The 1.0 plan is a **capability/dependency checklist** (not a calendar) in
+[`docs/ROADMAP.md`](docs/ROADMAP.md), milestones M0–M14:
+
+- **DONE:** M0 (engine durability debts), M1 (engine correctness), M2 (retry
+  semantics + leases), M6/M11 (resource + action/credential/resource v4
+  dependency redesign), M9.2 (OTLP exporter end-to-end), most of M3 (API
+  surface — auth backend, OpenAPI 3.1, webhooks, idempotency, trace
+  propagation, OAuth-from-secrets).
+- **Open / frontier:** M3.6 (shift-left workflow validation), M4 (plugin
+  capability discovery enforcement), M5 (plugin ABI ADR), M7 (storage
+  operationalization — PG composition root, nightly loom), M8 (engine
+  concurrency loom), M9.1/M9.3 (observability sweep + mutex audit), M10
+  (docs/DX/release), **M12 (business-layer crates frontier → stable)**, M13/M14
+  (core polish + final hardening).
+
+**Stable vs frontier (status lives in [`docs/MATURITY.md`](docs/MATURITY.md)):**
+
+- **Stable:** all Cross-cutting (`error`, `log`, `eventbus`, `metrics`,
+  `resilience`, `env`), all Core (`core`, `validator`, `expression`,
+  `workflow`, `execution`, `schema`, `metadata`, `storage-port`), `storage`,
+  `nebula-credential` + `nebula-credential-runtime` (flipped 2026-05-20).
+- **Frontier / partial:** `engine` (~85%), `action`, `nebula-resource`
+  (blocked on the **bind-population** gap — see §7), `plugin` (partial),
+  `credential-builtin` (scaffold → concrete types TBD in M12.3), `sandbox`
+  (capability gate not yet enforced — M4).
+
+The ROADMAP "Status snapshot" section is the freshest narrative; trust
+`#PR` / `file:line` evidence over prose. Note: squash-merge often misses
+auto-close, so an "open" GitHub issue may already be fixed — verify with
+`git log --grep="#N"` before planning.
+
+## 3. Architecture in 30 seconds
+
+Six layers, each depends **only on layers below it**. Cross-cutting crates are
+importable at any level. Boundaries are **mechanically enforced** by
+`cargo deny check` against `deny.toml [wrappers]` — a missing edge fails CI
+before review. Cross-crate signalling goes through `nebula-eventbus`, never
+direct sibling imports. Full map + nuances → [`CLAUDE.md`](CLAUDE.md)
+"Layered Dependency Map".
+
+| Layer | Crates |
+|-------|--------|
+| API / Public | `api`, `sdk` |
+| Exec | `engine`, `storage`, `storage-loom-probe` |
+| Business | `credential-builtin`, `resource`, `action`, `plugin`, `tenancy` |
+| Plugin-Proto | `plugin-sdk`, `sandbox` |
+| Core | `core`, `validator`, `expression`, `workflow`, `execution`, `schema`, `metadata`, `storage-port` |
+| Cross-cutting | `log`, `eventbus`, `metrics`, `resilience`, `error`, `env` |
+
+Three placements that are *not* a simple single-tier reading:
+
+- **`nebula-credential` is shared infra**, not Business-only — Exec (`engine`,
+  `storage`) and API consume the credential contract directly alongside
+  Business; the `deny.toml [wrappers]` allowlist locks the exact consumer set.
+- **Storage is a port/adapter/tenancy split:** `nebula-storage-port` (Core) is
+  the object-safe spec-16 row-model **contract** (no backend code);
+  `nebula-storage` (Exec) is the **sole adapter** (InMemory + SQLite +
+  Postgres); `nebula-tenancy` (Business) is the **scope-enforcing decorator**
+  that substitutes a tenant scope on every call before it reaches a handler.
+  The legacy `ExecutionRepo`/`WorkflowRepo` surface was deleted (ADR-0072).
+- **Plugin-Proto** is a leaf tier between Core and Business: `plugin-sdk`
+  (out-of-process protocol) + `sandbox` (duplex transport). The discovery path
+  and the `SandboxError → ActionError` seam live in `nebula-plugin`, not in
+  `sandbox`.
+
+**Per-crate quick-maps:** the convention is that every `crates/<x>/` carries a
+`CLAUDE.md` agent quick-map (purpose, layer, commands, key files, crate rules)
+alongside the human-facing `README.md` — see the "AI Context Files" table in
+[`CLAUDE.md`](CLAUDE.md). When editing a crate, open its `CLAUDE.md` /
+`README.md` first.
+
+## 4. Where to start, by task type
+
+Pick the crate by intent. One-liners are condensed; the crate's own
+`README.md` (and `CLAUDE.md` quick-map) is authoritative.
+
+| I want to… | Start in (crate) | Layer | What it owns |
+|------------|------------------|-------|--------------|
+| **Touch credentials** (contract / secret primitives) | `nebula-credential` | Shared-infra | Typed Credential Contract: stored-State vs projected auth-Scheme split + secret primitives. |
+| Add a concrete credential type | `nebula-credential-builtin` | Business | First-party impls (`bearer_token`, `shared_key`, `signing_key`) + `register_builtins()` + `sealed_caps`. |
+| Wire the credential **lifecycle** (resolve/refresh/rotate/revoke/bind) | `nebula-credential-runtime` | Exec | `CredentialService<B,PS>` facade — the owner-isolated lifecycle behind one typed entry point. |
+| Add a Vault-backed secret source | `nebula-credential-vault` | Business | HashiCorp Vault backend (KV v2 + dynamic secrets + lease renew/revoke). |
+| Crypto primitives (AEAD / KDF) | `nebula-crypto` | Cross-cutting | AES-256-GCM (mandatory AAD) + Argon2id, `EncryptedData` envelope, `CryptoError`. |
+| **Storage / persistence** — define a port | `nebula-storage-port` | Core | Object-safe repo traits, port-local DTO rows, `Scope`, `StorageError`, `TransitionBatch`. No backend code. |
+| Storage — implement a backend (PG/SQLite/mem) | `nebula-storage` | Exec | Sole spec-16 adapter: execution CAS, journal, control-queue outbox, idempotency, leases, refresh claims. |
+| Multi-tenancy / scope enforcement | `nebula-tenancy` | Business | Resolves `Principal → Scope`; wraps each store in a scope-substituting decorator. |
+| Model-check a CAS critical section | `nebula-storage-loom-probe` | Exec | Loom probes mirroring refresh-claim + lease-handoff single-owner invariants. |
+| **Errors / classification** | `nebula-error` | Cross-cutting | `Classify` trait + `NebulaError<E>` (typed details/context chain + `RetryHint`). |
+| **Validation** (rules / schema-field constraints) | `nebula-validator` | Core | Composable validators + JSON-serializable `Rule` enum. |
+| **Config schema** for Action/Credential/Resource | `nebula-schema` | Core | Typed config schema with lint→validate→resolve proof-token pipeline. |
+| Expressions / `{{ }}` templates | `nebula-expression` | Core | n8n-compatible evaluator; backend for `nebula-schema`'s resolve step. |
+| **Add an action** (integration logic) | `nebula-action` | Business | Action trait family (Stateless/Stateful/Trigger/Resource) + `ActionMetadata` for discovery/validate/dispatch. |
+| Manage a long-lived resource (pool/client/bot) | `nebula-resource` | Business | acquire/health/hot-reload/scope-bounded release; hands a drop-releasing `ResourceGuard` to actions. |
+| **Engine / execution** (scheduling, leases, frontier loop) | `nebula-engine` | Exec | Composition root wiring runtime/storage/plugin/credential/resource; drives a DAG to terminal state. |
+| Execution model (status machine / journal / plan) | `nebula-execution` | Core | 8-state status machine, journal (WAL), idempotency-key shape, DAG-derived plan. |
+| Workflow definition / DAG / activation validation | `nebula-workflow` | Core | serde-round-trippable `WorkflowDefinition` + petgraph DAG + `validate_workflow`. |
+| **HTTP / REST / webhooks / OAuth transport** | `nebula-api` | API/Public | Thin axum gateway → typed port-trait calls; hosts webhook + OAuth transports. |
+| Build a plugin (author side) | `nebula-plugin-sdk` | Plugin-Proto | Implement `PluginHandler` + `run_duplex` (line-delimited JSON envelope). |
+| Host-side plugin distribution / discovery / registry | `nebula-plugin` | Business | `Plugin` trait, `ResolvedPlugin`, `PluginRegistry`, out-of-process discovery path. |
+| Host-side sandbox transport / OS hardening | `nebula-sandbox` | Plugin-Proto | `ProcessSandbox` duplex child-process transport + credential-scope identity + Linux hardening. |
+| Outbound-call resilience (retry/CB/bulkhead/timeout) | `nebula-resilience` | Cross-cutting | The **only** retry surface in the stack; composed at outbound action call sites. |
+| Logging / tracing init | `nebula-log` | Cross-cutting | Single tracing subscriber-init pipeline (format, writers, reload, OTLP/Sentry). |
+| Metrics / Prometheus / OTLP export | `nebula-metrics` | Cross-cutting | In-memory primitives, `nebula_*` naming, cardinality safety, Prometheus + OTLP. |
+| Cross-crate pub/sub | `nebula-eventbus` | Cross-cutting | Transport-only generic `EventBus<E>`; defines no domain event types. |
+| Read env vars (never panics) | `nebula-env` | Cross-cutting | Typed reader (`var`/`parse`/`flag`/`list`). |
+| The one-import integrator façade | `nebula-sdk` | API/Public | Re-export façade + `WorkflowBuilder` + `TestRuntime` test harness. |
+| Catalog/metadata leaf types | `nebula-metadata` | Core | `BaseMetadata<K>` + `Metadata` trait + Icon/Maturity/Deprecation + compat rules. |
+| Shared IDs / keys / scopes / auth enums | `nebula-core` | Core | Prefixed-ULID ids, normalized keys, scope system, auth enums, context/accessor contracts. |
+
+**Skills / slash commands** (advisory, in `.claude/skills/` + `.claude/commands/`):
+
+- `rust-intel` — load **before** writing Rust; defends against the known
+  taxonomy of LLM-Rust failure modes. `/rust-cc-audit`, `/rust-cc-fix`,
+  `/rust-cc-plan`.
+- `clippy-configuration` — for Clippy/TOML lint config work.
+
+## 5. Build / test / PR workflow
+
+Daily commands go through **`task`** (see [`CLAUDE.md`](CLAUDE.md) "Common
+Commands"; `task --list` for the full catalog). Don't call raw `cargo` for
+fmt/lint.
+
+- **Pre-PR gate:** `task dev:check` (fmt + clippy `-D warnings` + nextest +
+  doctests + deny). Fast single-crate loop: `cargo check -p <crate>` /
+  `cargo nextest run -p <crate>`.
+- **Branches:** branch from `origin/main`, squash-merge back, never force-push
+  shared history. Persistent task branches go through
+  `bash scripts/worktree.sh new <slug> <type> <scope>` (creates
+  `.worktrees/<slug>` + branch `<type>/<scope>-<slug>`); clean up with
+  `bash scripts/worktree.sh finish <slug>`.
+- **Commits:** Conventional Commits, validated by `convco`. Scope = crate name
+  without the `nebula-` prefix, or a top-level area (`docs`, `ci`).
+- **Gates:** `lefthook` (`pre-commit` per-crate fmt+clippy; `pre-push`
+  full-workspace clippy + crate-diff nextest) mirrors the CI required jobs in
+  `.github/workflows/ci.yml` (fmt, clippy, nextest, doctests, MSRV 1.95, deny).
+  Keep lefthook ↔ CI in sync if you touch either.
+- **Coding rules (enforced, not advisory):** no `unwrap()`/`expect()`/`panic!()`
+  in library code (tests/const/bins exempt); no `TODO`/`FIXME`/plan-ids in
+  committed code; **observability is Definition of Done** — every new state /
+  error / hot path ships a typed `thiserror` variant + `tracing` span +
+  invariant check. `.claude/hooks/*.sh` enforce these per-turn for Claude Code
+  (`task hooks:test` proves each guard).
+- **Local infra:** `task db:up && task db:migrate` (Postgres + sqlx);
+  `task obs:up` (Jaeger + OTEL collector).
+
+> Windows note: `cargo fmt --all` / `task dev:check` fmt:check can break with
+> OS error 206 in deep worktree paths — verify fmt per-crate; don't report
+> `dev:check` green from a deep worktree.
+
+## 6. Code intelligence (symbol navigation)
+
+For an LLM/IDE working this codebase, set up Rust symbol intelligence rather
+than grepping blind:
+
+- **Claude Code:** install a Rust LSP plugin
+  (`/plugin install <rust-lsp>@claude-plugins-official`) or wire the **serena**
+  MCP for symbol-level find/edit (find-symbol, find-referencing-symbols,
+  rename) — far cheaper than re-reading whole files.
+- **Pi:** `.pi/lsp.json` already maps `rust-analyzer` for `.rs` (clippy on
+  `check`, all features, `target/` excluded) and `taplo` for `.toml`; the
+  `lsp_diagnostics` / `lsp_fix` tools use it.
+- `.claude/settings.json` now **denies `Read` of `target/**`** (and
+  `*.generated.rs`) so generated/build artifacts don't pollute context — rely
+  on the LSP / Grep tools for navigation instead.
+
+## 7. Active frontiers / moats
+
+- **The moat: active credential lifecycle.** Per [`STRATEGY.md`](STRATEGY.md)
+  + the competitive analysis, Nebula's empty-niche bet is OAuth-refresh +
+  rotation + per-tenant isolation **as an engine primitive**. The contract +
+  facade exist (`nebula-credential`, `nebula-credential-runtime`,
+  ADR-0066/0088); for 1.0 the path is **reactive-only** (pre-expiry/proactive
+  refresh deferred to 1.1 per ADR-0084).
+- **The bind-population gap (the live frontier).** `nebula-resource` stays
+  `frontier` because there is **no production credential→slot bind-population
+  resolver** — `register_and_bind` has a quiesce contract and **zero callers**.
+  Rotation fan-out dispatch is wired (#688/#690/#703); bind-population is the
+  remaining piece, tracked under ROADMAP **M11.5 residual / M12.4**. This is the
+  reason `nebula-resource` is the active frontier crate.
+- **In-flight credential rework:** ADR-0088 is landing on `main` right now
+  (nebula-crypto extract, policy-as-data lifecycle, `#[credential]` attribute
+  macro, 4-registries→1 collapse, canonical `owner_id` derivation — see recent
+  `git log`). Check the latest commits before assuming registry/owner-id
+  shapes.
+- Decisions live in [`docs/adr/`](docs/adr/) (live = 0046+ standalone +
+  contract ADRs 0080–0082; index for 0001–0041 in
+  [`docs/adr/HISTORICAL.md`](docs/adr/HISTORICAL.md)). **Conflict order:**
+  PRODUCT_CANON → INTEGRATION_MODEL → accepted ADR → STRATEGY → crate README
+  (per [`docs/README.md`](docs/README.md)). Plans under `docs/plans/` are
+  **non-normative**.
+
+## 8. Gotchas
+
+- Recurring trap classes (the ones that repeated ≥2× across crates) →
+  [`docs/pitfalls.md`](docs/pitfalls.md). Read it before touching a hot path.
+  (e.g. `nebula-expression`: builtins must not re-enter the evaluator — the
+  `BuiltinView` boundary makes it a compile error, not a discipline rule.)
+- **Don't bulk-read `docs/adr/0*` or `glob docs/**`.** Use
+  [`docs/README.md`](docs/README.md) (the doc map) + one crate README + the
+  single cited ADR. Tier-0 docs first.
+- "Open" GitHub issues are frequently already fixed (squash-merge auto-close
+  misses) — `git log --grep="#N"` before planning work against one.
+- ADRs are point-in-time. If following one forces workarounds, supersede it
+  (don't patch around it) — that includes past-wave decisions.

--- a/crates/action/CLAUDE.md
+++ b/crates/action/CLAUDE.md
@@ -1,0 +1,33 @@
+# nebula-action — Claude Code orientation
+> Agent quick-map for `crates/action/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Defines the typed action trait family (`StatelessAction`/`StatefulAction`/`TriggerAction`/`ResourceAction` + DX specializations) and `ActionMetadata` the engine uses for discovery, validation, and dispatch.
+**Layer:** Business — depends only downward (root CLAUDE.md → Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-action`
+- `cargo nextest run -p nebula-action`  ·  doctests: `cargo test -p nebula-action --doc`
+- Derive/proc-macro tests: `crates/action/tests/derive_action.rs` + trybuild probes under `crates/action/tests/probes/` (trybuild can false-TIMEOUT under nextest `agent` profile on cold cache — warm + plain `cargo test` to confirm)
+
+## Key files
+- `src/lib.rs` — public re-export surface + module map (`#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`)
+- `src/action.rs` — base `Action` trait (`Sized`, `type Input/Output: HasSchema`, static `metadata()`/`dependencies()`); NOT object-safe
+- `src/erased.rs` + `src/factory.rs` — `ErasedAction` per-variant trait objects + `ActionFactory`/`Generic*Factory` engine-side dispatch
+- `src/from_workflow_node.rs` — `FromWorkflowNode` async slot-binding factory (derive emits the body)
+- `src/error.rs` — `ActionError` + `RetryHintCode` (retryable vs fatal)
+- `src/result.rs` / `src/output.rs` — `ActionResult` flow-control intent + `ActionOutput` (inline/blob/stream)
+- `src/webhook/` — `WebhookAction` + HMAC signature primitives (ADR-0022 fail-closed)
+
+## Conventions & never-do
+- `Action: Sized` is **not** object-safe — never write `dyn Action`; engine dispatch goes through `Arc<dyn ActionFactory>` + `Box<dyn ErasedXxx>`.
+- No `schema` method — `Input`/`Output: HasSchema` is the single source of truth; read via `nebula_schema::schema_of::<A::Input>()` (ADR-0052 P3). Don't add per-trait `*_schema`.
+- Action structs hold **only** slot fields (`#[resource]`/`#[credential]`); user form data lives on a separate `Self::Input` companion struct. `#[credential]` slots hold `CredentialGuard<C::Scheme>`, not `CredentialGuard<C>`.
+- `CheckpointPolicy` is `planned`, NOT a field on `ActionMetadata` — do not document or wire it as current.
+- This crate is NOT the sandbox driver (`nebula-sandbox`), execution state machine (`nebula-execution`), schema system (`nebula-schema`), or engine retry layer; WASM is a canon §12.6 non-goal.
+- `WebhookAction::config()` defaults to `SignaturePolicy::Required` (fail-closed); secret material never flows through the dyn `TriggerHandler` surface.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design (v4 surface, migration recipe, contract/canon invariants)
+- `docs/adr/0081-m6-resource-credential-integration.md` (consolidates ADR-0042/0043/0044/0045); `docs/INTEGRATION_MODEL.md` §`nebula-action` (CheckpointPolicy status); `docs/PRODUCT_CANON.md` §3.5/§11.3/§13.4/§13.5

--- a/crates/api/CLAUDE.md
+++ b/crates/api/CLAUDE.md
@@ -1,0 +1,35 @@
+# nebula-api — Claude Code orientation
+> Agent quick-map for `crates/api/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Thin axum HTTP gateway translating REST into typed port-trait calls; all business logic delegates downward, plus inbound webhook + OAuth transports.
+**Layer:** API/Public — depends only downward (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-api`
+- `cargo nextest run -p nebula-api`  ·  doctests: `cargo test -p nebula-api --doc`
+- OpenAPI/spec guards: `cargo nextest run -p nebula-api --test openapi_spec` (regenerates spec from the router)
+- Feature flags: `postgres` (PG idempotency + `PgAuthBackend`), `test-util` (`ApiConfig::for_test`, bypasses JWT gate — never in prod)
+- OAuth e2e test-support module needs `RUSTFLAGS="--cfg nebula_test_util"` (custom cfg, not a feature)
+
+## Key files
+- `src/lib.rs` — crate root, public re-exports (`build_app`, `AppState`, `ApiConfig`, `ApiError`)
+- `src/app.rs` — `build_app`: OpenApiRouter merge + `split_for_parts` + full middleware stack + `serve()`
+- `src/state.rs` — `AppState` builder + API-tier port traits (`OrgResolver`/`WorkspaceResolver`/`MembershipStore`/`SessionStore`/`AuthBackend`)
+- `src/error/mod.rs` — `ApiError` (§12.4 RFC 9457 seam, `#[non_exhaustive]`)
+- `src/middleware/` — auth → tenancy → rbac → csrf → idempotency stack (order is load-bearing: auth before csrf)
+- `src/domain/<x>/handler.rs` — §13 knife seams (`create_workflow`, `activate_workflow`, `start_execution`, `cancel_execution`)
+- `src/transport/webhook/` — single converged inbound webhook transport (programmatic + slug-routed)
+
+## Conventions & never-do
+- Pure library — ships NO binary/composition root; wiring lives in `apps/server` + `examples/examples/api_simple_server.rs`. Do not add a `main`.
+- No SQL driver / storage-schema knowledge here — inject spec-16 storage ports via `AppState::new` (`nebula-storage` owns adapters).
+- DTOs MUST NOT embed `nebula-core`/`-storage`/`-engine`/`-credential` types (ADR-0047 §3); wrap cross-layer types (`OrgRoleDto`/`WorkspaceRoleDto`). DTOs carry only `serde_json::Value`/wrappers.
+- All errors are RFC 9457 `application/problem+json` via a typed `ApiError` variant — never a new ad-hoc 500 for business failures.
+- §4.5 operational honesty: an unwired capability returns honest 501/503, never a faked success. Drift between router and OpenAPI spec is a compile error (`OpenApiRouter::routes(routes!(...))`).
+- Cancel/terminate signals share the durable `control_queue_repo` outbox (§12.2) — no second in-memory control channel.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design (endpoint table, CSRF route table, OAuth/idempotency env vars, durability caveats)
+- ADRs: 0047 (OpenAPI), 0048/0082 (idempotency), 0049 (webhook), 0050 (W3C trace), 0072 (storage port), 0085 (OAuth IdP)

--- a/crates/core/CLAUDE.md
+++ b/crates/core/CLAUDE.md
@@ -1,0 +1,32 @@
+# nebula-core — Claude Code orientation
+> Agent quick-map for `crates/core/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The one crate every other crate depends on for shared vocabulary — typed prefixed-ULID identifiers, normalized string keys, the hierarchical scope system, auth-scheme enums, context/accessor contracts, and lifecycle signals.
+**Layer:** Cross-cutting / Core (bottom of the stack) — nothing here depends upward; changing an identifier or key cascades workspace-wide.
+
+## Commands
+- `cargo check -p nebula-core`
+- `cargo nextest run -p nebula-core`  ·  doctests: `cargo test -p nebula-core --doc`
+- `task bench:crate CRATE=nebula-core` — runs the `id_parse_serialize` criterion bench (`harness = false`)
+
+## Key files
+- `src/lib.rs` — module wiring, re-exports, `prelude`, compile-time key macros (`plugin_key!` etc.)
+- `src/id/` — prefixed-ULID identifiers (`ExecutionId` `exe_…`, `WorkflowId` `wf_…`, …) via `domain-key`; all `Copy`, `new/nil/parse`, serde
+- `src/keys.rs` — normalized validated string keys; `SecretString` credential wrapper lives here (Debug MUST stay redacted)
+- `src/scope.rs` — `ScopeLevel`/`Scope`/`Principal`/`ScopeResolver` (Global → … → Action)
+- `src/context/` — `Context` trait, `BaseContext(Builder)`, capability traits (`HasCredentials`, `HasResources`, …)
+- `src/auth.rs` — canonical `AuthScheme` trait + `AuthPattern` enum (re-exported by `nebula-credential`)
+- `src/error.rs` — `CoreError`/`CoreResult` (thiserror; no anyhow)
+
+## Conventions & never-do
+- This is **vocabulary only**: no validation (`nebula-schema`/`nebula-validator`), no error taxonomy (`nebula-error`), no resilience, no storage/persistence — do not pull those concerns down here.
+- Identifiers/keys are stable opaque handles ([L1-§3.10]); changing their representation cascades — extend deliberately, never casually rename or re-encode.
+- `SecretString` and credential-related key types must keep `Debug` redacted ([L2-§12.5]) — no secret material in logs or error strings. Use `debug_redacted`/`debug_typed` from `guard`.
+- ID types use `domain-key` (prefixed ULIDs) — never add a direct `uuid` dependency or invent a per-type newtype.
+- `CredentialId`/`CredentialEvent` vocabulary lives in `nebula-credential`; `AuthScheme`/`AuthPattern` are canonical *here* and re-exported there.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`CoreError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, identifier conventions, prelude usage
+- Canon: `docs/PRODUCT_CANON.md` §3.10 (shared vocabulary), §12.5 (secrets/redaction) · `docs/INTEGRATION_MODEL.md` §1 · `docs/GLOSSARY.md` §1

--- a/crates/credential-builtin/CLAUDE.md
+++ b/crates/credential-builtin/CLAUDE.md
@@ -1,0 +1,28 @@
+# nebula-credential-builtin — Claude Code orientation
+> Agent quick-map for `crates/credential-builtin/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** First-party concrete `Credential` impls (`bearer_token`, `shared_key`, `signing_key`) plus `register_builtins()` and the canonical `mod sealed_caps` — so plugin authors depend only on the `nebula-credential` contract.
+**Layer:** Business (credential backend) — depends only downward (root CLAUDE.md -> Layered Dependency Map): `nebula-credential`, `-core`, `-schema`, `-error`.
+
+## Commands
+- `cargo check -p nebula-credential-builtin`
+- `cargo nextest run -p nebula-credential-builtin`  ·  doctests: `cargo test -p nebula-credential-builtin --doc`
+- `cargo test -p nebula-credential-builtin --test <name>` — trybuild compile-fail fixtures (dev-dep `trybuild`)
+
+## Key files
+- `src/lib.rs` — re-exports the three credentials + `register_builtins`; hosts canonical `pub(crate) mod sealed_caps` (per-capability inner sealed traits)
+- `src/registry.rs` — `register_builtins(&mut CredentialRegistry)`: fail-closed on duplicate KEY (Tech Spec §15.6), not first-wins
+- `src/bearer_token.rs` — opaque token → `SecretToken`; `State = Scheme` identity projection
+- `src/shared_key.rs` — shared-secret credential
+- `src/signing_key.rs` — secret key + algorithm → `SigningKey` (HMAC/SigV4/webhook)
+
+## Conventions & never-do
+- Each credential is static / non-interactive: all five `plugin_capability_report::Is*` consts are `false`; `resolve()` returns `ResolveResult::Complete` and never refreshes/revokes.
+- Concrete types live here so the contract crate's stability surface stays trait-only (Strategy §2.4); generic auth shapes still live in `nebula-credential` — don't move or duplicate them here.
+- `sealed_caps` inner traits are crate-private; external crates declare their own `mod sealed_caps` (ADR-0035 §3) — never impl these by hand or pub-export them.
+- `register_builtins` is NOT idempotent: re-registering returns `RegisterError::DuplicateKey`. Callers handle the collision; don't add silent skip-if-present.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `nebula-credential::CredentialError` (Provider + `SecretFreeMessage`); no panicking unwrap/expect/panic in lib code (the `.expect()` in `metadata()` is on a const-valid builder).
+
+## See also
+- `README.md` — full design + plugin-author onboarding · ADR-0028–0035 · `docs/INTEGRATION_MODEL.md` § Credential

--- a/crates/credential-runtime/CLAUDE.md
+++ b/crates/credential-runtime/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-credential-runtime — Claude Code orientation
+> Agent quick-map for `crates/credential-runtime/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The `CredentialService<B, PS>` facade — the owner-isolated runtime that owns the whole credential lifecycle (resolve, refresh, rotate, revoke, bind-population) behind one typed entry point (ADR-0066).
+**Layer:** Exec — depends only downward (`nebula-credential`, `nebula-tenancy`, `nebula-storage`, `nebula-engine`, `nebula-schema`; cross-cutting error/log/eventbus/resilience). `engine` + `api` consume it.
+
+## Commands
+- `cargo check -p nebula-credential-runtime`
+- `cargo nextest run -p nebula-credential-runtime`  ·  doctests: `cargo test -p nebula-credential-runtime --doc`
+- `cargo nextest run -p nebula-credential-runtime --features test-util` — needed for `test_support` / `tests/` (in-memory service); `test-util` is dev/test-only, never a release path (ADR-0023).
+- `compile_fail/` trybuild cases gate the `ValidatedCredentialBinding` sealed constructor.
+
+## Key files
+- `src/service.rs` — `CredentialService`, `Acquisition`, `LayeredStore`, `test_support`; the facade + lifecycle (largest module).
+- `src/ops.rs` — `DispatchOps` type-erased async op table + `register_*_ops` per-capability registrars; swap for test doubles here.
+- `src/binding.rs` — `ValidatedCredentialBinding` + `TenantFingerprint`: crate-private-constructor newtype closing the `slot_bindings` confused-deputy (only `resolve_for_slot` mints one).
+- `src/scope.rs` — `TenantScope` / `FixedScopeResolver`: owner_id derivation (`Scope::credential_owner_id`, ADR-0088 D7).
+- `src/error.rs` — `CredentialServiceError` taxonomy (Smithy RFC-0022: per-variant context structs, boxed payloads, 32-byte cap).
+- `src/observer.rs` — `CredentialObserver` / `EventMetricObserver` seam (e.g. the `RefreshFallback` span event).
+- `src/builder.rs` — `CredentialServiceBuilder`; secure construction is the only path.
+
+## Conventions & never-do
+- Tenant isolation lives at the facade boundary — `owner_id` propagates to every call; downstream sinks must never see cross-tenant data. Invariant-bearing composition stays crate-private.
+- Only `CredentialService::resolve_for_slot` may construct a `ValidatedCredentialBinding`; engine consumers receive the sealed value. Do not add other constructors.
+- Capability (refreshable/testable/revocable/interactive/dynamic) reads from the single `nebula_credential::CredentialRegistry` `Capabilities` bitflag — do NOT reintroduce a parallel flag table (removed in ADR-0088 D3).
+- Out of scope: proactive pre-expiry refresh (deferred to 1.1, ADR-0084); reactive `OnceCell`+`RefreshClaimRepo` path is the 1.0 contract. `test-util` MUST stay out of release builds (ADR-0023).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/adr/0066-credential-runtime-facade.md` · `docs/adr/0084-pre-expiry-credential-refresh-deferred.md` · ADR-0052 cascade (confused-deputy), ADR-0088 D3/D7 (single capability source, owner_id).

--- a/crates/credential-testutil/CLAUDE.md
+++ b/crates/credential-testutil/CLAUDE.md
@@ -1,0 +1,24 @@
+# nebula-credential-testutil — Claude Code orientation
+> Agent quick-map for `crates/credential-testutil/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** In-memory test doubles for the two `nebula-credential` storage ports (`CredentialStore`, `PendingStateStore`) so downstream tests exercise the contract without Vault/Postgres/an OAuth IdP.
+**Layer:** Business (alongside `nebula-credential`) — depends only downward. `publish = false`, internal test-only.
+
+## Commands
+- `cargo check -p nebula-credential-testutil`
+- `cargo nextest run -p nebula-credential-testutil`  ·  doctests: `cargo test -p nebula-credential-testutil --doc`
+
+## Key files
+- `src/lib.rs` — public surface: `InMemoryStore`, `InMemoryPendingStore`, `in_memory_pair()`; re-exports `store_memory` + `pending_store_memory`.
+- `src/store_memory.rs` — `InMemoryStore` impl of `nebula_credential::store::CredentialStore` (`Arc<RwLock<HashMap>>`).
+- `src/pending_store_memory.rs` — `InMemoryPendingStore` impl of `nebula_credential::pending_store::PendingStateStore`.
+
+## Conventions & never-do
+- These are **test shims**, behaviour-identical to the canonical `nebula_storage::credential::{InMemoryStore, InMemoryPendingStore}`. Production composition roots/examples/docs MUST import the `nebula-storage` variants, never this crate.
+- Do NOT consume from production code — crate is `publish = false`; consumer set is locked by `deny.toml` `[wrappers]` (`nebula-credential-runtime` via its `test-util` feature + dev-deps; `nebula-tenancy` dev-deps).
+- Do NOT cargo-cult the `tokio::RwLock<HashMap<...>>` pattern into production — the guard never crosses `.await` here (perf-irrelevant shim); doing so elsewhere is the issue-#587 perf cost.
+- Keep scope tight: no snapshot fixtures, redaction asserts, scheme builders, or first-party credential catalog (that's `nebula-credential-builtin`); cloning a store shares one backing map, all data drops with the last clone.
+- Library code uses typed `thiserror`/`NebulaError` (`StoreError`/`PendingStoreError`); no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/MATURITY.md` (M12.2 extraction record, 2026-05-20) · ADR-0081 (M6 resource/credential integration)

--- a/crates/credential-testutil/CLAUDE.md
+++ b/crates/credential-testutil/CLAUDE.md
@@ -15,7 +15,7 @@
 
 ## Conventions & never-do
 - These are **test shims**, behaviour-identical to the canonical `nebula_storage::credential::{InMemoryStore, InMemoryPendingStore}`. Production composition roots/examples/docs MUST import the `nebula-storage` variants, never this crate.
-- Do NOT consume from production code — crate is `publish = false`; consumer set is locked by `deny.toml` `[wrappers]` (`nebula-credential-runtime` via its `test-util` feature + dev-deps; `nebula-tenancy` dev-deps).
+- Do NOT consume from production code — crate is `publish = false`; consumer set is locked by the `deny.toml` `[bans].deny` `wrappers` allowlist (`nebula-credential-runtime` via its `test-util` feature + dev-deps; `nebula-tenancy` dev-deps).
 - Do NOT cargo-cult the `tokio::RwLock<HashMap<...>>` pattern into production — the guard never crosses `.await` here (perf-irrelevant shim); doing so elsewhere is the issue-#587 perf cost.
 - Keep scope tight: no snapshot fixtures, redaction asserts, scheme builders, or first-party credential catalog (that's `nebula-credential-builtin`); cloning a store shares one backing map, all data drops with the last clone.
 - Library code uses typed `thiserror`/`NebulaError` (`StoreError`/`PendingStoreError`); no panicking unwrap/expect/panic in lib code.

--- a/crates/credential-vault/CLAUDE.md
+++ b/crates/credential-vault/CLAUDE.md
@@ -1,0 +1,29 @@
+# nebula-credential-vault — Claude Code orientation
+> Agent quick-map for `crates/credential-vault/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** First-party HashiCorp Vault backend implementing `nebula-credential`'s `ExternalProvider`/`LeasedProvider` traits — KV v2 static reads + dynamic secrets with lease renew/revoke (ADR-0081).
+**Layer:** Business (credential backend) — depends only on `nebula-credential` (shared infra) downward; composition roots wire it in as `Arc<dyn ExternalProvider>`.
+
+## Commands
+- `cargo check -p nebula-credential-vault`
+- `cargo nextest run -p nebula-credential-vault`  ·  doctests: `cargo test -p nebula-credential-vault --doc`
+- Integration tests use `wiremock` (mock Vault HTTP) + `nebula-storage` cache layer: see `tests/cache_integration.rs`.
+
+## Key files
+- `src/lib.rs` — crate docs (path-prefix convention), module wiring, re-exports `VaultConfig`/`VaultError`/`VaultProvider`.
+- `src/provider.rs` — `VaultProvider` (the `ExternalProvider`/`LeasedProvider` impl), `VaultConfig`, construction-time `VaultError`, HTTP routing + error classification.
+- `src/wire.rs` — serde envelopes for Vault responses (`KvV2Envelope`, `DynamicSecretEnvelope`, `LeaseRenewEnvelope`).
+
+## Conventions & never-do
+- **Path routing is explicit, never sniffed:** bare `path` → KV v2 (`from_secret`, no lease); `dyn/<rest>` prefix → dynamic read (`with_lease`). Do NOT add "try KV then fall back" heuristics — operators control routing via the stored reference.
+- **Error mapping is contractual (ADR-0051 fall-through):** only HTTP 404 → `ProviderError::NotFound` (lets `ExternalProviderChain` fall through); 403→`AccessDenied`, 5xx/transport→`Unavailable`, other 4xx/decode→`Backend` — all short-circuit. Don't widen what maps to `NotFound`.
+- **Never leak the auth token:** `Debug` on `VaultProvider` omits the bearer token (address + KV mount only); the token rides the `X-Vault-Token` header. Keep it out of logs/spans/Debug.
+- Every issued `LeaseHandle` is attributed to `PROVIDER_NAME = "vault"` (must match `provider_name` so `handles_lease` routing works).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, path-convention table, error-classification table, cache-layer composition example.
+- `docs/adr/0081-m6-resource-credential-integration.md` — provider trait surface + fall-through rationale.
+- `crates/credential/src/provider/` — the trait definitions this crate implements.
+- `crates/storage/src/credential/provider_cache.rs` — `ProviderCacheLayer` this backend composes with.

--- a/crates/credential/CLAUDE.md
+++ b/crates/credential/CLAUDE.md
@@ -2,7 +2,7 @@
 > Agent quick-map for `crates/credential/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
 
 **Purpose:** The typed Credential Contract — declares the split between stored `State` (encrypted at rest) and projected auth `Scheme` (what action code receives); runtime resolve/refresh/rotation orchestration lives in `nebula-engine::credential`, not here.
-**Layer:** Shared-infra (credential contract) — importable by Exec/API/Business per the `deny.toml` `[wrappers]` allowlist; depends only on Core + cross-cutting (root CLAUDE.md → Layered Dependency Map).
+**Layer:** Shared-infra (credential contract) — importable by Exec/API/Business per the `deny.toml` `[bans].deny` `wrappers` allowlist; depends only on Core + cross-cutting (root CLAUDE.md → Layered Dependency Map).
 
 ## Commands
 - `cargo check -p nebula-credential`

--- a/crates/credential/CLAUDE.md
+++ b/crates/credential/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-credential — Claude Code orientation
+> Agent quick-map for `crates/credential/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The typed Credential Contract — declares the split between stored `State` (encrypted at rest) and projected auth `Scheme` (what action code receives); runtime resolve/refresh/rotation orchestration lives in `nebula-engine::credential`, not here.
+**Layer:** Shared-infra (credential contract) — importable by Exec/API/Business per the `deny.toml` `[wrappers]` allowlist; depends only on Core + cross-cutting (root CLAUDE.md → Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-credential`
+- `cargo nextest run -p nebula-credential`  ·  doctests: `cargo test -p nebula-credential --doc`
+- Feature flags: `rotation` (gated, evolving), `test-util` (test-only ctors; `nextest run -p nebula-credential --features test-util` for sibling integration seams)
+- `compile_fail_*.rs` (trybuild) encode the load-bearing invariants — read these first when a change feels risky; may false-TIMEOUT on cold cache under nextest (warm + plain `cargo test`).
+
+## Key files
+- `src/lib.rs` — flat root re-exports are the canonical surface (`use nebula_credential::SecretString`); submodules are escape hatches only.
+- `src/contract/` — `Credential` base trait + capability sub-traits (`Interactive`/`Refreshable`/`Revocable`/`Testable`/`Dynamic`), `CredentialRegistry`, resolve types.
+- `src/scheme/` — `AuthScheme` base + `SensitiveScheme`/`PublicScheme` dichotomy (§15.5) + 9 built-in scheme types.
+- `src/secrets/` — `SecretString`, `CredentialGuard`, `SchemeGuard`/`SchemeFactory` refresh surface, PKCE helpers (AES-GCM crypto moved out, see below).
+- `src/lifecycle.rs` — capabilities-as-data (`CredentialPolicy`/`RefreshStrategy`/`RevokeStrategy`, ADR-0088 D2).
+- `src/provider/` — `ExternalProvider` chain for Vault/AWS/GCP/Azure secret managers (ADR-0051); error-discriminated fallback (only `NotFound` falls through).
+
+## Conventions & never-do
+- **No expressions in credential property values** — property JSON validates then `serde_json::from_value::<C::Properties>` directly; never run `ValidValues::resolve`. Secrets must not depend on runtime workflow state (seam: `tests/properties_pipeline.rs`).
+- **Crypto lives in `nebula-crypto`** (ADR-0088): import AES-256-GCM/`EncryptedData`/`encrypt_with_aad` from there, NOT this crate. AAD-free `encrypt` is deliberately unexposed (SEC-11). This crate is not a secret-manager/storage backend (`CredentialStore` impls live in `nebula_storage::credential`; scope layer in `nebula_tenancy`).
+- **Capabilities are sub-trait membership, never const flags** — duplicate-KEY `register` is fatal in debug AND release; a declared-but-unimplemented capability is a compile error. Don't reintroduce capability bools or per-trait `*_schema` (schema = `Properties: HasSchema`, read via `schema_of`).
+- `CredentialState` requires `ZeroizeOnDrop`; `Debug` redacts secrets; `SchemeGuard` is `!Clone` and drop-zeroizes.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code (`#![forbid(unsafe_code)]`).
+
+## See also
+- `README.md` — full design (v4 / Phase 5 trait shape, П1 §15.4–15.8, migration recipe)
+- Canon §3.5 / §12.5 / §13.2; `docs/adr/0081-m6-resource-credential-integration.md`; ADR-0088 (crypto split), ADR-0051 (external providers), ADR-0033 (Plane B, in `HISTORICAL.md`)

--- a/crates/crypto/CLAUDE.md
+++ b/crates/crypto/CLAUDE.md
@@ -1,0 +1,24 @@
+# nebula-crypto — Claude Code orientation
+> Agent quick-map for `crates/crypto/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Leaf crypto primitives — AES-256-GCM authenticated encryption (mandatory AAD) + Argon2id key derivation, with the `EncryptedData` envelope and `CryptoError` taxonomy.
+**Layer:** Cross-cutting — depends only on `nebula-error` + the RustCrypto stack (root CLAUDE.md -> Layered Dependency Map); importable from any layer.
+
+## Commands
+- `cargo check -p nebula-crypto`
+- `cargo nextest run -p nebula-crypto`  ·  doctests: `cargo test -p nebula-crypto --doc`
+
+## Key files
+- `src/lib.rs` — the entire crate (single file): `EncryptionKey`, `EncryptedData`, encrypt/decrypt fns, `CryptoError`, private `fresh_nonce`.
+
+## Conventions & never-do
+- **SEC-11:** no public no-AAD `encrypt`. Production callers MUST use `encrypt_with_aad` / `encrypt_with_key_id`; the AAD-free `encrypt_no_aad` is `#[cfg(test)]`-only — do not promote it to a non-test path.
+- Plaintext outputs are wrapped in `Zeroizing<T>` and `EncryptionKey` is `ZeroizeOnDrop`. `EncryptedData` (nonce/ciphertext/tag) is public bytes by design — do NOT add a scrubbing `Drop`.
+- `encrypt_with_key_id` rejects an empty `key_id` (`CryptoError::InvalidKeyId`) so rotation lookup can pick the decryption key — keep that invariant.
+- `CryptoError` `code` strings keep the `CREDENTIAL:CRYPTO_*` prefix (stable across the credential stack) — do not rename them on a move.
+- Keep this a leaf: no PKCE/OAuth-state helpers or `serde_base64` here — those stay in `nebula-credential` (travel with the OAuth protocol).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · [ADR-0088](../../docs/adr/0088-credential-subsystem-rewrite.md) (extracted from `nebula-credential`)

--- a/crates/engine/CLAUDE.md
+++ b/crates/engine/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-engine — Claude Code orientation
+> Agent quick-map for `crates/engine/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Composition root that wires runtime + storage + plugin/credential/resource accessors into one `WorkflowEngine` and drives a workflow DAG from activation to terminal state.
+**Layer:** Exec — depends only downward (root CLAUDE.md -> Layered Dependency Map). 14 intra-workspace deps are intentional here; justify every new one against the layer rules.
+
+## Commands
+- `cargo check -p nebula-engine`
+- `cargo nextest run -p nebula-engine`  ·  doctests: none (`[lib] doctest = false`)
+- Features: `out-of-process-plugins` (OFF by default; second runtime gate `out_of_process_plugin_dirs` also required — ADR-0025), `rotation`, `test-util` (never in prod build — ADR-0023), `chaos-full` (nightly).
+
+## Key files
+- `src/lib.rs` — module map + crate-root re-exports (downstream uses `nebula_engine::X`, not deep paths).
+- `src/engine.rs` — `WorkflowEngine`: level-by-level DAG execution, bounded concurrency, `run_frontier`, Layer-2 retry heap, cancel registry. (The largest, load-bearing module.)
+- `src/control_consumer.rs` / `src/control_dispatch.rs` — durable `execution_control_queue` consumer + `EngineControlDispatch` (Start/Resume/Restart/Cancel/Terminate; canon §12.2, ADR-0008).
+- `src/credential_accessor.rs` / `src/resource_accessor.rs` — scoped accessors injected into action contexts (cross-layer bridges).
+- `src/scoped_resources.rs` — per-branch resource storage, layered lookup, RAII cleanup (M6.1/M6.2).
+- `src/runtime/` — `ActionRuntime` dispatch, sandbox runner, blob/queue plumbing.
+
+## Conventions & never-do
+- **All execution-state transitions go through `ExecutionRepo::transition` (CAS on `version`)** — no in-engine state mutation or parallel lifecycle (L2-§11.1).
+- **Engine owns the control-queue consumer** — a handler that only logs/discards rows violates canon (L2-§12.2). `Cancel` reaches the live loop via `WorkflowEngine::cancel_execution`; dispatch must be idempotent per `(execution_id, command)`.
+- **Credential accessor is deny-by-default**: empty allowlist denies all; populate via `with_action_credentials`. No fail-open. (Resources have no allowlist — scoping is the topology layer's job.)
+- Not a storage impl, action dispatcher, plugin loader, or expression evaluator — those are `nebula-storage` / `nebula-runtime` / `nebula-sandbox` / `nebula-expression`.
+- Two disjoint retry surfaces (ADR-0042): in-action `nebula-resilience::retry_with` (Layer 1, opaque to engine) vs operator-declared `retry_policy` (Layer 2, engine parks node in `WaitingRetry`).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, known open debts, architecture notes.
+- Canon `docs/PRODUCT_CANON.md` §10/§11.1/§12.2/§13 · `docs/ENGINE_GUARANTEES.md` · ADR-0008/0015/0016/0025/0042/0050.

--- a/crates/engine/CLAUDE.md
+++ b/crates/engine/CLAUDE.md
@@ -18,7 +18,7 @@
 - `src/runtime/` — `ActionRuntime` dispatch, sandbox runner, blob/queue plumbing.
 
 ## Conventions & never-do
-- **All execution-state transitions go through `ExecutionRepo::transition` (CAS on `version`)** — no in-engine state mutation or parallel lifecycle (L2-§11.1).
+- **All execution-state transitions go through the spec-16 storage port — `ExecutionStore::commit(TransitionBatch)`, CAS on `version`** — `TransitionBatch` is the only way to apply a transition (ADR-0072); no in-engine state mutation or parallel lifecycle (L2-§11.1).
 - **Engine owns the control-queue consumer** — a handler that only logs/discards rows violates canon (L2-§12.2). `Cancel` reaches the live loop via `WorkflowEngine::cancel_execution`; dispatch must be idempotent per `(execution_id, command)`.
 - **Credential accessor is deny-by-default**: empty allowlist denies all; populate via `with_action_credentials`. No fail-open. (Resources have no allowlist — scoping is the topology layer's job.)
 - Not a storage impl, action dispatcher, plugin loader, or expression evaluator — those are `nebula-storage` / `nebula-runtime` / `nebula-sandbox` / `nebula-expression`.

--- a/crates/env/CLAUDE.md
+++ b/crates/env/CLAUDE.md
@@ -1,0 +1,26 @@
+# nebula-env — Claude Code orientation
+> Agent quick-map for `crates/env/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** One typed env-var parsing contract (`var`/`parse`/`flag`/`list`) so every crate stops re-rolling `std::env::var(...).unwrap_or_default().parse()` with divergent bool/int semantics.
+**Layer:** Cross-cutting — importable from any layer, no upward deps, `std` + `thiserror` only (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-env`
+- `cargo nextest run -p nebula-env`  ·  doctests: `cargo test -p nebula-env --doc`
+- `cargo nextest run -p nebula-env --features testing` — exercise the `EnvGuard` RAII helper (feature-gated, `unsafe` env mutation)
+
+## Key files
+- `src/lib.rs` — crate root: re-exports the reader fns + `EnvError`; gates `testing` module; `forbid(unsafe_code)` unless `test`/`testing`.
+- `src/reader.rs` — the parsing contract: `var`/`var_opt`/`parse`/`parse_or`/`flag`/`flag_or`/`list`.
+- `src/error.rs` — `EnvError` (`thiserror`); the single typed failure surface consumers map at their boundary.
+- `src/testing.rs` — `testing::EnvGuard`: process-global lock + restore-on-drop for serialized env mutation in tests.
+
+## Conventions & never-do
+- Readers are total and unsafe-free: unset vars yield `Ok(None)` / default / empty list — never panic. Only failures are non-Unicode (`var`) and unparsable bool (`flag`).
+- `unsafe` lives ONLY behind the `testing` module (edition-2024 env mutation); core stays `forbid(unsafe_code)`. Don't introduce `unsafe` outside `testing`.
+- This crate does NOT define config structs or map into other crates' errors — consumers convert `EnvError` into their own typed error (`ApiConfigError`, `ProviderError`, …) at the boundary.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · ADR-0086 (placement rationale + workspace env conventions)

--- a/crates/error/CLAUDE.md
+++ b/crates/error/CLAUDE.md
@@ -1,0 +1,30 @@
+# nebula-error — Claude Code orientation
+> Agent quick-map for `crates/error/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Workspace-wide error taxonomy — the `Classify` trait, `NebulaError<E>` wrapper with extensible typed details + context chain, and `RetryHint` so transient-vs-permanent is an explicit decision, not folklore.
+**Layer:** Cross-cutting — depends only downward (root CLAUDE.md → Layered Dependency Map); has no nebula deps, importable from any tier.
+
+## Commands
+- `cargo check -p nebula-error`
+- `cargo nextest run -p nebula-error`  ·  doctests: `cargo test -p nebula-error --doc`
+- `cargo check -p nebula-error --all-features` — exercise `serde` + `derive` (`#[derive(Classify)]` from sibling `nebula-error-macros`); both off by default
+
+## Key files
+- `src/lib.rs` — public re-exports + `Result<T, E>` alias (`= Result<T, NebulaError<E>>`); module gate
+- `src/traits.rs` — `Classify` / `ErrorClassifier` — the L2-§12.4 seam every error type implements
+- `src/error.rs` — `NebulaError<E>` wrapper; `Display` must emit the full context chain (regression-fixed, do not regress)
+- `src/category.rs`, `src/severity.rs`, `src/code.rs` — `ErrorCategory` / `ErrorSeverity` / `ErrorCode` + `codes`
+- `src/retry.rs` — `RetryHint` data consumed by `nebula-resilience`
+- `src/details.rs`, `src/detail_types.rs` — TypeId-keyed `ErrorDetails` + prebuilt detail structs (`BadRequest`, `FieldViolation`, …)
+- `src/collection.rs` — `ErrorCollection` / `BatchResult` aggregation
+
+## Conventions & never-do
+- This is the foundation error crate: library crates use `thiserror` + `Classify` + `NebulaError`; `anyhow` is binaries-only (L2-§12.4).
+- Stay in your lane: NOT a resilience pipeline (`RetryHint` is data; execution lives in `nebula-resilience`), NOT an API formatter (`nebula-api` maps to RFC 9457 `problem+json`), NOT logging (`nebula-log`).
+- `Classify::retry_hint()` is the single transient-vs-permanent decision surface — do not re-implement classification per crate.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design (frontmatter canon-invariant `L2-12.4`)
+- Canon: `docs/PRODUCT_CANON.md` §3.10, §4.2 (ErrorClassifier), §12.4 · `docs/GLOSSARY.md` §6 · `docs/MATURITY.md` row `nebula-error`

--- a/crates/eventbus/CLAUDE.md
+++ b/crates/eventbus/CLAUDE.md
@@ -1,0 +1,29 @@
+# nebula-eventbus — Claude Code orientation
+> Agent quick-map for `crates/eventbus/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Transport-only generic `EventBus<E>` — in-process pub/sub broadcast with back-pressure over `tokio::sync::broadcast`; defines NO domain event types itself.
+**Layer:** Cross-cutting — zero intra-workspace deps (cleanest boundary in the workspace); importable at any level.
+
+## Commands
+- `cargo check -p nebula-eventbus`
+- `cargo nextest run -p nebula-eventbus`  ·  doctests: `cargo test -p nebula-eventbus --doc`
+- `task bench:crate CRATE=nebula-eventbus` — `emit` + `throughput` Criterion benches (`benches/`)
+
+## Key files
+- `src/lib.rs` — crate docs + module wiring; canonical `pub use` names (authoritative over README's shorter aliases)
+- `src/bus.rs` — `EventBus<E>` broadcaster; non-blocking `emit()`, async `emit_awaited()`
+- `src/subscriber.rs` — `Subscriber<E>`: `recv()`/`try_recv()`/`lagged_count()`, auto-decrement on drop
+- `src/policy.rs` / `src/outcome.rs` — `BackPressurePolicy`, `PublishOutcome` emit result
+- `src/registry.rs` / `src/scope.rs` — `EventBusRegistry` (multi-bus by key), `SubscriptionScope`/`ScopedEvent`
+- `src/filter.rs` / `src/filtered_subscriber.rs` / `src/stream.rs` — `EventFilter`, `FilteredSubscriber`, `Stream` adapters
+
+## Conventions & never-do
+- **NEVER define concrete domain event structs here** (`ExecutionEvent`, `ResourceEvent`, …) — they live in their owning crates; this crate stays generic over `E: Clone` (Contract L3-§3.10).
+- **In-process and ephemeral, not authoritative** — best-effort, no durability/ordering guarantee; a receive-and-log subscriber does NOT satisfy canon §12.2. Durable delivery (cancel/dispatch) uses `execution_control_queue`, not this bus.
+- `emit()` never blocks on slow subscribers; lag is recovered transparently (subscriber re-positions to latest). Use `lagged_count()` to observe drops; `EventBusStats` for sent/dropped/subscriber counts.
+- Keep zero intra-workspace deps — adding a `nebula-*` dependency breaks the layer boundary (`deny.toml` wrappers).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed errors; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · canon `docs/PRODUCT_CANON.md` §3.10 / §4.5 / §12.2 · sibling `nebula-metrics` (consumes this crate)

--- a/crates/execution/CLAUDE.md
+++ b/crates/execution/CLAUDE.md
@@ -19,7 +19,7 @@
 - `src/plan.rs` / `src/replay.rs` — `ExecutionPlan` (parallel schedule) and `ReplayPlan` (checkpoint resume).
 
 ## Conventions & never-do
-- This crate defines *types + transition legality only*. It must NOT own a repository interface, persist state, or enforce CAS — `nebula-storage::ExecutionRepo` is the single source of truth for persisted state (canon §11.1).
+- This crate defines *types + transition legality only*. It must NOT own a repository interface, persist state, or enforce CAS — the spec-16 storage port (`nebula-storage-port::ExecutionStore` + `TransitionBatch`, implemented by `nebula-storage`) is the single source of truth for persisted state (canon §11.1; ADR-0072).
 - Do NOT add engine-level node retry: the engine does not retry nodes (§11.2); `NodeAttempt` only seeds the attempt-keyed idempotency shape (counter stays `1`). Canonical retry is `nebula-resilience` inside an action.
 - `IdempotencyKey` here is just the deterministic key shape (§11.3); check-before-side-effect / mark-after enforcement is in storage. The control-queue / outbox also live in storage, not here.
 - 5 `panic!` sites in `transition`/`status` are state-machine invariant guards (flagged debt); do not add new ones — use typed `ExecutionError`.

--- a/crates/execution/CLAUDE.md
+++ b/crates/execution/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-execution — Claude Code orientation
+> Agent quick-map for `crates/execution/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Shared execution-time model — the 8-state `ExecutionStatus` machine, `JournalEntry` (WAL), `IdempotencyKey`, and the `ExecutionPlan` derived from the workflow DAG — so engine and storage share one truth, not two.
+**Layer:** Core — depends only downward (`nebula-core`, `nebula-error`, `nebula-workflow`); no engine/storage/api/runtime imports.
+
+## Commands
+- `cargo check -p nebula-execution`
+- `cargo nextest run -p nebula-execution`  ·  doctests: `cargo test -p nebula-execution --doc`
+- Snapshot tests use `insta` (state/plan serialization); review with `cargo insta review` after intentional shape changes.
+
+## Key files
+- `src/lib.rs` — module roots + public re-exports (the crate's whole surface).
+- `src/status.rs` — `ExecutionStatus` 8-state enum (`Pending`…`TimedOut`).
+- `src/transition.rs` — validates state-machine transition *legality* only (persistence/CAS is storage's job).
+- `src/state.rs` — `ExecutionState` / `NodeExecutionState`, serialized into the `executions` row (largest module).
+- `src/journal.rs` — `JournalEntry`, backs the append-only `execution_journal` table.
+- `src/idempotency.rs` — `IdempotencyKey` shape `{execution_id}:{node_id}:{attempt}` (format only; dedup lives in storage).
+- `src/plan.rs` / `src/replay.rs` — `ExecutionPlan` (parallel schedule) and `ReplayPlan` (checkpoint resume).
+
+## Conventions & never-do
+- This crate defines *types + transition legality only*. It must NOT own a repository interface, persist state, or enforce CAS — `nebula-storage::ExecutionRepo` is the single source of truth for persisted state (canon §11.1).
+- Do NOT add engine-level node retry: the engine does not retry nodes (§11.2); `NodeAttempt` only seeds the attempt-keyed idempotency shape (counter stays `1`). Canonical retry is `nebula-resilience` inside an action.
+- `IdempotencyKey` here is just the deterministic key shape (§11.3); check-before-side-effect / mark-after enforcement is in storage. The control-queue / outbox also live in storage, not here.
+- 5 `panic!` sites in `transition`/`status` are state-machine invariant guards (flagged debt); do not add new ones — use typed `ExecutionError`.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, durability matrix, lease-enforcement notes.
+- Canon `docs/PRODUCT_CANON.md` §11.1/§11.2/§11.3/§11.5/§12.2 · `docs/ENGINE_GUARANTEES.md` · `docs/GLOSSARY.md` §2.

--- a/crates/expression/CLAUDE.md
+++ b/crates/expression/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-expression — Claude Code orientation
+> Agent quick-map for `crates/expression/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Shared expression evaluator that resolves `{{ expression }}` templates (n8n-compatible syntax) against execution-time context — the resolution backend `nebula-schema`'s `ValidValues::resolve` step calls.
+**Layer:** Core — depends only downward (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-expression`
+- `cargo nextest run -p nebula-expression`  ·  doctests: `cargo test -p nebula-expression --doc`
+- Features: `default = cache,regex,datetime,uuid` (`full` = all). `datetime` adds IANA tz args; `regex`/`cache` pull in `moka` for true LRU.
+- Bench: `cargo bench -p nebula-expression --bench baseline`. Examples: `cargo run -p nebula-examples --example expression_template_rendering`.
+
+## Key files
+- `src/lib.rs` — public re-exports + `parse_expression` (parse-only entrypoint; template-parser-authoritative dispatch, not substring match)
+- `src/engine.rs` — `ExpressionEngine` + LRU AST cache (`evaluate`, `evaluate_template`, `cache_overview`)
+- `src/eval.rs` — `Evaluator` / `EvalFrame` AST walker; `BuiltinView` (policy-only handle) + higher-order combinators
+- `src/context.rs` — `EvaluationContext` (`$node`/`$execution`/`$workflow`/`$input`) + builder
+- `src/policy.rs` — `EvaluationPolicy` DoS budget (step limit, recursion depth)
+- `src/maybe.rs` — `MaybeExpression<T>` typed serde wrapper (literal vs expression)
+- `src/template.rs` — `Template` / `MaybeTemplate`; `{{- -}}` whitespace control
+
+## Conventions & never-do
+- `BuiltinFunction` takes `BuiltinView<'_>` (policy queries only), NOT `Evaluator` — builtins physically cannot recurse into AST eval; do NOT add an eval handle to that signature (type-enforced fix for the issue #252 step-budget bypass).
+- Higher-order combinators (`filter`/`map`/`reduce`/…) live in `eval.rs` and call `eval_with_frame` with the caller's `EvalFrame` so the step budget accumulates across iterations — never re-route them through the builtin registry.
+- `EvaluationPolicy` must bound every evaluation (recursion depth default 256 + step budget); exceeding either returns `ExpressionError`, never panics or loops.
+- NOT a validation engine (`nebula-validator`), schema system (`nebula-schema`), or HTML template engine — keep scope to `{{ }}` field resolution.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/PRODUCT_CANON.md` §3.5 (expression context at resolve step) · `docs/pitfalls.md` (builtin-frame step-budget pitfall)

--- a/crates/log/CLAUDE.md
+++ b/crates/log/CLAUDE.md
@@ -1,0 +1,28 @@
+# nebula-log — Claude Code orientation
+> Agent quick-map for `crates/log/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Single `tracing` subscriber-init pipeline for all Nebula binaries — one `auto_init`/`init_with` call wires format, writers, structured fields, runtime reload, and optional OTLP/Sentry.
+**Layer:** Cross-cutting — no upward deps; importable from any tier (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-log`
+- `cargo nextest run -p nebula-log`  ·  doctests: `cargo test -p nebula-log --doc`
+- Feature-gated paths: `cargo check -p nebula-log --features full` (or `file` / `telemetry` / `sentry` / `log-compat`); bench: `task bench:crate CRATE=nebula-log` (`benches/log_hot_path.rs`)
+
+## Key files
+- `src/lib.rs` — public API + `auto_init`/`init`/`init_with`/`init_test`; idempotent-init logic (#379 no-op guard when a dispatcher already set)
+- `src/builder/mod.rs` — `LoggerBuilder`, `LoggerGuard`, `ReloadHandle`; `build_startup` resolution (`explicit > env > preset`)
+- `src/config/` — `Config`, `Format`, `WriterConfig`, presets (`development`/`production`/`test`), env resolution, `Fields`
+- `src/observability/` — typed `ObservabilityEvent`/hooks/`OperationTracker`, semantic spans (canon §4.6/§12.5 boundary)
+- `src/telemetry/` — OTLP (`otel.rs`) + Sentry (`sentry.rs`), gated on `telemetry`/`sentry`
+- `src/writer.rs`, `src/format.rs`, `src/timing.rs` — writer backends, formatters, `Timer`/`Timed`
+
+## Conventions & never-do
+- This crate sets up the subscriber only; it does NOT redact secrets — callers must pass redacted forms to `tracing::*!` (canon §12.5). Never log raw credential/token values from here.
+- Not a metrics system (`nebula-metrics`) and not an event bus (`nebula-eventbus`) — don't add either here.
+- `LoggerGuard` is RAII; it must stay alive for the process lifetime. Duplicate init returns a no-op guard / `LogError::AlreadyInitialized` — keep init idempotent, never panic.
+- `#![forbid(unsafe_code)]` and `#![warn(missing_docs)]` — every public item needs docs; sentry uses `rustls` only (native-tls banned in `deny.toml`).
+- Library code uses typed `thiserror`/`LogError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/README.md` (extended internals) · canon `docs/PRODUCT_CANON.md` §4.6/§12.5, `docs/OBSERVABILITY.md` · sibling `nebula-metrics`

--- a/crates/metadata/CLAUDE.md
+++ b/crates/metadata/CLAUDE.md
@@ -1,0 +1,29 @@
+# nebula-metadata — Claude Code orientation
+> Agent quick-map for `crates/metadata/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Shared catalog-leaf metadata surface (`BaseMetadata<K>` + `Metadata` trait + `Icon`/`MaturityLevel`/`DeprecationNotice` + generic compat rules) that every schematized entity composes instead of redeclaring.
+**Layer:** Core — depends only downward (`nebula-core`, `nebula-schema`, `nebula-error`, `semver`, `serde`, `thiserror`); no upward deps.
+
+## Commands
+- `cargo check -p nebula-metadata`
+- `cargo nextest run -p nebula-metadata`  ·  doctests: `cargo test -p nebula-metadata --doc`
+- `#![warn(missing_docs)]` + `#![forbid(unsafe_code)]` — keep every public item documented.
+
+## Key files
+- `src/lib.rs` — module wiring + flat re-exports (the public surface)
+- `src/base.rs` — `BaseMetadata<K>` struct + `Metadata` trait (default-delegating accessors)
+- `src/compat.rs` — `BaseCompatError<K>` + `validate_base_compat` (key-immutable / version-monotonic / schema-break→major-bump)
+- `src/manifest.rs` — `PluginManifest` + `PluginManifestBuilder` + `ManifestError` (container descriptor; NOT a `BaseMetadata`)
+- `src/icon.rs` · `src/maturity.rs` · `src/deprecation.rs` — supporting catalog ornaments
+
+## Conventions & never-do
+- Consumers compose `BaseMetadata<K>` via `#[serde(flatten)]` on their own concrete struct and impl `Metadata` with a one-line `base()`; do NOT re-add the `Icon`/`MaturityLevel`/`DeprecationNotice` fields per-crate.
+- `Icon` is the single valid representation (`None`/`Inline`/`Url`); never reintroduce the old `icon: Option<String>` + `icon_url` pair.
+- `PluginManifest` is a container, not a schematized leaf: it must NOT compose `BaseMetadata` or carry a canonical input schema (ADR-0018).
+- This crate owns only the *generic* base compat rules; each consumer layers entity-specific rules in a thin wrapper enum around `BaseCompatError<K>` — don't push entity rules down here.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, composition example, consumer list
+- `docs/adr/HISTORICAL.md` (ADR-0018) — plugin bundle-descriptor carve-out · `docs/PRODUCT_CANON.md §3.5` — integration model

--- a/crates/metrics/CLAUDE.md
+++ b/crates/metrics/CLAUDE.md
@@ -1,0 +1,30 @@
+# nebula-metrics — Claude Code orientation
+> Agent quick-map for `crates/metrics/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** In-memory metric primitives (counter/gauge/histogram), `nebula_*` naming policy, label-cardinality safety, and Prometheus + OTLP export for the engine.
+**Layer:** Cross-cutting — importable at any layer; depends only on `nebula-error`, `nebula-eventbus`, and the OTel SDK.
+
+## Commands
+- `cargo check -p nebula-metrics`
+- `cargo nextest run -p nebula-metrics`  ·  doctests: `cargo test -p nebula-metrics --doc`
+- Snapshot tests use `insta`; review with `cargo insta review` after changing Prometheus output.
+
+## Key files
+- `src/lib.rs` — flat re-export surface + `mod` grouping (primitives / policy / export / instrumentation / error)
+- `src/registry.rs` — `MetricsRegistry`; `snapshot_*` methods are the public seam both exporters read
+- `src/{counter,gauge,histogram}.rs` — lock-free atomic-backed metric types
+- `src/labels.rs` — `lasso`-backed `LabelInterner` / `LabelSet` / `MetricKey` (zero-copy dimensions)
+- `src/naming.rs` — `NEBULA_*` name constants (the policy section; new names go here)
+- `src/filter.rs` — `LabelAllowlist` cardinality guard (strips high-cardinality keys)
+- `src/prometheus.rs` — text-format export (`snapshot()`, `content_type()`); `src/otlp.rs` — OTLP push exporter (ADR-0046 single OTel-SDK seam)
+
+## Conventions & never-do
+- Single observability crate (ADR-0046 absorbed `nebula-telemetry`). Keep the `mod` boundary discipline: a new `NEBULA_*` const or label policy belongs in the **policy** section (`naming.rs`/`filter.rs`), never in a primitive file.
+- `src/otlp.rs` is the ONLY place OTel SDK types appear; do not import `opentelemetry*` from primitives/export. README still calls OTLP "planned" — it is now implemented.
+- Not a log system (`nebula-log`), not the `/metrics` HTTP host (`nebula-api` serves `snapshot()`), not a tracing/spans system (use `tracing` directly).
+- `#![forbid(unsafe_code)]` and `#![warn(missing_docs)]` are crate-wide — every `pub` item needs a doc comment.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · ADR-0046 (`docs/adr/0046-metrics-telemetry-boundary.md`) · `docs/OBSERVABILITY.md`, `docs/PRODUCT_CANON.md` §4.6

--- a/crates/plugin-sdk/CLAUDE.md
+++ b/crates/plugin-sdk/CLAUDE.md
@@ -1,0 +1,28 @@
+# nebula-plugin-sdk — Claude Code orientation
+> Agent quick-map for `crates/plugin-sdk/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Plugin-author-side SDK — implement `PluginHandler` + call `run_duplex` from `main` to speak the duplex line-delimited JSON envelope protocol to the host (`nebula-sandbox`).
+**Layer:** Plugin-Proto — depends only on Core (`nebula-metadata`, `nebula-schema`) + tokio/serde; no engine-side deps (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-plugin-sdk`
+- `cargo nextest run -p nebula-plugin-sdk`  ·  doctests: `cargo test -p nebula-plugin-sdk --doc`
+- Four `[[bin]]` fixtures (`echo`/`counter`/`schema`/`resend`) drive `nebula-sandbox` integration tests — keep them building.
+- `NEBULA_PLUGIN_MAX_FRAME_BYTES` caps inbound host frame size (default 1 MiB).
+
+## Key files
+- `src/lib.rs` — `PluginHandler` trait, `PluginCtx`, `PluginError`, `run_duplex` entry point + sequential dispatch event loop.
+- `src/protocol.rs` — wire envelopes `HostToPlugin`/`PluginToHost`, `DUPLEX_PROTOCOL_VERSION` (=3), `SDK_VERSION`; host imports these.
+- `src/transport.rs` — `bind_listener`, `PluginListener`, `PluginStream` (UDS on Unix / Named Pipe on Windows) + stdout handshake line.
+- `src/bin/*_fixture.rs` — test-plugin binaries for the host-side sandbox harness.
+
+## Conventions & never-do
+- **Dispatch is sequential (slice 1c)** — one action at a time, head-of-line blocking. `Cancel`/`RpcResponse*` envelopes are intentional no-ops until slice 1d; do not pretend concurrency or broker RPC exist yet.
+- **Not isolation.** Trust model is sequential JSON dispatch to a child process (canon §12.6); never describe this as attacker-grade sandboxing. WASM is an explicit non-goal.
+- **Core-layer dep exception (§7.1):** only `nebula-metadata` + `nebula-schema` are allowed for `PluginManifest`/`ValidSchema` on the wire. Any other cross-import is a layer violation — question it hard. Wire types live here (not `nebula-plugin`) because authors link against them.
+- Envelopes must serialize to a single line — never emit raw newlines; the framing invariant is test-locked.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · ADR-0006 (`docs/adr/HISTORICAL.md`, duplex JSON-RPC over UDS/Named Pipe) · `docs/INTEGRATION_MODEL.md` §7 · `docs/PRODUCT_CANON.md` §7.1/§12.6 · siblings `nebula-sandbox` (host), `nebula-plugin` (registry).

--- a/crates/plugin/CLAUDE.md
+++ b/crates/plugin/CLAUDE.md
@@ -1,0 +1,30 @@
+# nebula-plugin — Claude Code orientation
+> Agent quick-map for `crates/plugin/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The plugin distribution/registration unit — `Plugin` trait, `ResolvedPlugin`, in-memory `PluginRegistry`, plus the host-side discovery path that registers out-of-process plugin binaries.
+**Layer:** Business — depends only downward (root CLAUDE.md -> Layered Dependency Map); consumes `nebula-sandbox`/`nebula-plugin-sdk` (Plugin-Proto) downward.
+
+## Commands
+- `cargo check -p nebula-plugin`
+- `cargo nextest run -p nebula-plugin`  ·  doctests: `cargo test -p nebula-plugin --doc`
+- Derive macro lives in the sibling crate `crates/plugin/macros/` (`nebula-plugin-macros`) — re-exported as `#[derive(Plugin)]`.
+
+## Key files
+- `src/lib.rs` — crate facade + public re-exports; module map.
+- `src/plugin.rs` — the `Plugin` base trait (`actions()`/`credentials()`/`resources()`/`on_load`/`on_unload`).
+- `src/resolved_plugin.rs` — `ResolvedPlugin`: eager component caches; enforces `{plugin.key()}.` namespace invariant + within-plugin dup rejection at construction (ADR-0027).
+- `src/registry.rs` — `PluginRegistry`: `PluginKey → Arc<ResolvedPlugin>`; `all_*` / `resolve_*` accessors.
+- `src/discovery.rs` — host-side directory scan that probes plugin binaries' `plugin.toml` + wire manifest and registers them.
+- `src/sandbox_bridge.rs` — the single `SandboxError` → `ActionError` classification seam (shared by handler + engine runner).
+- `src/manifest.rs` — local `PluginManifest` (canonical home is `nebula-metadata`; re-exported for source compat).
+
+## Conventions & never-do
+- `impl Plugin` is the single runtime source of truth for what's registered. Do NOT duplicate `fn actions()`/`fn credentials()`/`fn resources()` in `plugin.toml` (spec theater).
+- `PluginManifest` does NOT compose `BaseMetadata<K>` — a plugin is a container, not a schematized leaf.
+- This crate is NOT the loader/sandbox/isolation, NOT the authoring SDK (`nebula-plugin-sdk`), NOT `plugin.toml` parsing/signing tooling, and NOT a persistent catalog — registry is in-memory only.
+- Cross-plugin type references come via `Cargo.toml [dependencies]`; the dep-closure check is enforced by `nebula-sandbox` at activation, not here.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · canon §3.5/§7.1/§13.1 · ADR-0018, ADR-0027 (`docs/adr/HISTORICAL.md`) · `docs/INTEGRATION_MODEL.md` §7.

--- a/crates/resilience/CLAUDE.md
+++ b/crates/resilience/CLAUDE.md
@@ -1,0 +1,33 @@
+# nebula-resilience — Claude Code orientation
+> Agent quick-map for `crates/resilience/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** In-process stability-patterns pipeline (retry, circuit breaker, bulkhead, rate limiter, timeout, hedge, load-shed) that action authors compose at outbound call sites; retry filtering is driven by `nebula-error::Classify`.
+**Layer:** Cross-cutting — depends only downward (root CLAUDE.md -> Layered Dependency Map); only Nebula dep is `nebula-error`.
+
+## Commands
+- `cargo check -p nebula-resilience`  ·  all features: `cargo check -p nebula-resilience --all-features`
+- `cargo nextest run -p nebula-resilience`  ·  doctests: `cargo test -p nebula-resilience --doc`
+- loom model-check: `RUSTFLAGS="--cfg loom" cargo test -p nebula-resilience --features loom --lib loom`
+- benches: `cargo bench -p nebula-resilience` (14 criterion benches, e.g. `compose`, `retry`, `hedge`)
+- features: `serde` (default), `full` (= serde), `loom`
+
+## Key files
+- `src/lib.rs` — crate docs + re-export surface (the public API map)
+- `src/pipeline.rs` — `ResiliencePipeline<E>` / `PipelineBuilder`; composes the patterns
+- `src/error.rs` — `CallError<E>` (`#[non_exhaustive]`, no type erasure); per-pattern variants
+- `src/classifier.rs` + `src/context.rs` — `ErrorClassifier` (Classify seam) and `PolicyContext` (cancel/deadline/scope)
+- `src/circuit_breaker.rs` · `src/retry.rs` · `src/bulkhead.rs` · `src/rate_limiter.rs` · `src/hedge.rs` — the standalone patterns
+- `src/gate.rs` — cooperative-shutdown barrier; `src/sink.rs` — `MetricsSink` observability hooks
+
+## Conventions & never-do
+- **Canon §11.2: this is the ONLY retry surface in the workflow stack** — the engine does NOT re-execute nodes; never add engine-level retry expecting this crate to defer to it.
+- Retry/transient-vs-permanent is decided by `nebula-error::Classify::retry_hint()`, never by per-call folklore in action bodies.
+- NOT a durable control plane (in-process only — durable cancel/dispatch lives in `execution_control_queue`) and NOT a metrics exporter (events feed `nebula-metrics` via sinks, not the reverse).
+- `CallError<E>` keeps the caller's `E` — no forced mapping, no `Box<dyn Error>` erasure; keep variants additive (`#[non_exhaustive]`).
+- `#![deny(unsafe_code)]`; loom-gated atomics behind `cfg(loom)` for model checks only.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · crate-local guides in `docs/` (`composition.md`, `observability.md`, `gate.md`, `api-reference.md`, `architecture.md`)
+- Canon `docs/PRODUCT_CANON.md` §4.2/§4.3/§11.2 · `docs/GLOSSARY.md` (Circuit Breaker + Timeout + Retry-with-Backoff)

--- a/crates/resource/CLAUDE.md
+++ b/crates/resource/CLAUDE.md
@@ -1,0 +1,33 @@
+# nebula-resource — Claude Code orientation
+> Agent quick-map for `crates/resource/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Engine-owned resource lifecycle (acquire / health-check / hot-reload / scope-bounded release) for pool & SDK-client integrations, handed to actions as a drop-releasing `ResourceGuard`.
+**Layer:** Business — depends only downward (root CLAUDE.md → Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-resource`
+- `cargo nextest run -p nebula-resource`  ·  doctests: `cargo test -p nebula-resource --doc`
+- `cargo test -p nebula-resource --features test-util` — the rotation integration tests need `nebula-credential/test-util` (dev-only; never widen scope)
+- Derive crate: `cargo check -p nebula-resource-macros` (companion in `macros/`); examples in root `nebula-examples` (`--example resource_*`)
+
+## Key files
+- `src/lib.rs` — crate facade + re-exports; `cell::Cell` deliberately NOT re-exported (use `SlotCell`)
+- `src/resource.rs` — `Resource` trait (4 assoc types, slot-rotation hooks), `ResourceConfig`, `ResourceMetadata`
+- `src/slot.rs` / `src/cell.rs` — `SlotCell` (public, generation-stamped) vs internal epoch-blind `cell::Cell`
+- `src/registry.rs` — type-erased registry, scope-aware lookup, `(key, scope)` dedup
+- `src/manager/` — `Manager::register(RegistrationSpec)` funnel, acquire dispatch, shutdown/drain
+- `src/topology/` + `src/runtime/` — `Pooled` / `Resident` / `Bounded<Cap>` traits and their runtimes
+- `src/release_queue.rs` — `ReleaseQueue` best-effort async drain (canon §11.4); `src/recovery/` — thundering-herd `RecoveryGate`
+
+## Conventions & never-do
+- Credentials are declared as `#[credential(key="…")] field: SlotCell<CredentialGuard<C>>`; read via derive-emitted `self.<field>_slot()` (`Option<Arc<…>>`, handle `None`/unbound) — never off the raw cell. No singular `Resource::Credential`; `NoCredential` is gone.
+- This crate is NOT a connection driver, retry pipeline, secret holder, or expression evaluator — it owns the lifecycle wrapper only (see Non-goals).
+- `Bounded` cap mismatch (e.g. `Capped`/`Exclusive` without `BoundedRelease`) is a compile error, not a runtime branch — keep it typestate-enforced.
+- Async release is best-effort on crash; never assume "release ran" without an explicit checkpoint (canon §11.4).
+- `#![forbid(unsafe_code)]` + `#![warn(missing_docs)]` are active; lifecycle work emits a `ResourceEvent` variant (observability is DoD).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, migration recipe (pre-v4 → v4), topology & shared-resource reference
+- `docs/topology-reference.md` — topology selection guidance; canon invariants L2-§11.4 / §13.3

--- a/crates/sandbox/CLAUDE.md
+++ b/crates/sandbox/CLAUDE.md
@@ -1,0 +1,29 @@
+# nebula-sandbox — Claude Code orientation
+> Agent quick-map for `crates/sandbox/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Host side of the duplex JSON-envelope child-process transport to community plugins (`ProcessSandbox`), plus the credential-scope identity (`ScopeHash`) and Linux OS-hardening primitives.
+**Layer:** Plugin-Proto (leaf) — depends only on Core (`nebula-metadata`) + the plugin protocol (`nebula-plugin-sdk`); no Business/Exec dependency (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-sandbox`
+- `cargo nextest run -p nebula-sandbox`  ·  doctests: `cargo test -p nebula-sandbox --doc`
+- `discovery_schema_roundtrip` is `#[ignore]`-gated (needs a pre-built plugin fixture); `os_sandbox` Landlock/rlimit code is `cfg(target_os = "linux")` only.
+
+## Key files
+- `src/lib.rs` — `#![deny(unsafe_code)]`, `#![warn(missing_docs)]`; re-exports `ProcessSandbox`, `SandboxError`, `scope::{ScopeHash, scope_hash}`.
+- `src/dispatch.rs` — `ProcessSandbox`: lazy spawn + duplex envelope round-trip with per-call timeout + cancel race.
+- `src/scope.rs` — pure `ScopeHash` / `scope_hash` from caller slot-name strings (ADR-0025 §2); never sees a workflow node.
+- `src/os_sandbox.rs` — Linux Landlock (fixed system paths, fail-closed) + `setrlimit`, applied fork-safely via `PreparedSandbox`; no-op elsewhere.
+- `src/spawn.rs` · `src/handshake.rs` · `src/codec.rs` — process spawn, socket dial/handshake, line-delimited JSON framing.
+- `src/error.rs` — typed `SandboxError`.
+
+## Conventions & never-do
+- **Transport only, NOT a security boundary** against malicious native code (canon §12.6): provides correctness + cooperative cancel, not attacker-grade isolation.
+- **WASM / WASI is an explicit non-goal** (§12.6) — never list it as `planned` in README or `lib.rs`.
+- **No per-plugin capability/scope surface** — egress/credential/filesystem mediation is the broker's job (ADR-0025 slice 1d, unbuilt). Do not re-add the removed `PluginCapabilities`.
+- Do NOT own these — they live elsewhere: discovery + `RemoteAction`/`ProcessSandboxHandler` + `SandboxError`→`ActionError` map = `nebula-plugin`; `SandboxRunner`/`SandboxedContext`/`InProcessSandbox` = `nebula-engine`.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design, isolation roadmap, ADR 0006 status · ADR-0006 / ADR-0025 (`docs/adr/HISTORICAL.md`) · canon `docs/PRODUCT_CANON.md` §4.5/§7.1/§12.6 · `docs/INTEGRATION_MODEL.md` §7.

--- a/crates/schema/CLAUDE.md
+++ b/crates/schema/CLAUDE.md
@@ -1,0 +1,34 @@
+# nebula-schema — Claude Code orientation
+> Agent quick-map for `crates/schema/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Typed configuration schema shared by every integration concept (Actions, Credentials, Resources); enforces a lint → validate → resolve proof-token pipeline. Replaces the deleted `nebula-parameter` crate.
+**Layer:** Core — depends only downward (root CLAUDE.md -> Layered Dependency Map). Siblings: `nebula-validator` (rules), `nebula-expression` (resolution context).
+
+## Commands
+- `cargo check -p nebula-schema`
+- `cargo nextest run -p nebula-schema`  ·  doctests: `cargo test -p nebula-schema --doc`
+- `cargo test -p nebula-schema --features schemars` — JSON Schema export path (smoke test + `json_schema_export` example gated on this feature)
+- `task bench:crate CRATE=nebula-schema` — criterion benches (build/validate/serde/resolve/lookup/memory)
+
+## Key files
+- `src/lib.rs` — crate root: re-exports, quick-start docs, `extern crate self as nebula_schema` (so `field_key!` absolute paths resolve internally)
+- `src/schema.rs` — `Schema` / `SchemaBuilder` (draft model + `build()` proof-token entry)
+- `src/validated.rs` — proof-tokens: `ValidSchema`, `ValidValues`, `ResolvedValues` (the typestate sequence)
+- `src/field.rs` — unified `Field` enum + all field kinds (string/number/secret/select/object/list/mode/computed…)
+- `src/lint.rs` — structural lint passes (duplicate keys, cross-field invariants the builder type can't express)
+- `src/has_schema.rs` — `HasSchema` / `schema_of` (the sole Action/Credential schema path; ADR-0052 P3)
+- `src/json_schema.rs` — `schemars`-feature Draft 2020-12 export with `x-nebula-*` extensions
+
+## Conventions & never-do
+- Proof-tokens are compile-time-evident (L1-4.5): never add runtime flags to skip validate/resolve — the type transition IS the gate.
+- This crate is NOT a validation-rules engine (that's `nebula-validator`) nor an expression evaluator (resolution delegates to a caller-supplied `ExpressionContext`).
+- The single schema→validator crossing is `validate_rules_with_ctx` + `resolve_field_policies`; rule-failure codes surface validator-native verbatim (`min_length`, `min`, `invalid_format`) — no namespace remap (ADR-0052 P2).
+- No KDF/hashing here (removed as a weaker dup of nebula-credential's Argon2id); do not re-add.
+- Public surface is strict: `Field::*::new` needs a pre-validated `FieldKey`; use `field_key!(...)` or `Field::try_*` — no panic-on-bad-key helpers (`set_raw` removed; use `try_set_raw`).
+- `#[deny(clippy::disallowed_macros)]` bans `#[async_trait]`; use the crate's `EvalFuture` (BoxFuture) alias for object-safe async.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design (Purpose / Role / Public API / Contract / Non-goals); `CHANGELOG.md` for `set_raw` migration
+- ADR-0052 (P2 validator-native codes, P3 `schema_of` sole schema path); canon invariants L1-3.5, L1-4.5

--- a/crates/sdk/CLAUDE.md
+++ b/crates/sdk/CLAUDE.md
@@ -1,0 +1,28 @@
+# nebula-sdk — Claude Code orientation
+> Agent quick-map for `crates/sdk/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Single-crate façade so integration authors `use nebula_sdk::prelude::*` and get the action/credential/resource/schema/workflow/plugin surface plus builders and a test harness — no hunting the dependency graph.
+**Layer:** API/Public — depends only downward (root CLAUDE.md → Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-sdk`
+- `cargo nextest run -p nebula-sdk`  ·  doctests: `cargo test -p nebula-sdk --doc`
+- Features: `default = ["derive", "testing"]`; `testing` gates `src/testing.rs` + `pub use tokio`.
+
+## Key files
+- `src/lib.rs` — full-crate re-exports (`nebula_action`, `nebula_credential`, …), SDK `Error`, and `params!` / `workflow!` / `simple_action!` / `json!` macros.
+- `src/prelude.rs` — one-stop `use nebula_sdk::prelude::*` set (action traits, schema, credential/OAuth2 types).
+- `src/action.rs` — `ActionBuilder` (programmatic action metadata).
+- `src/workflow.rs` — `WorkflowBuilder` (`add_node` / `connect` / `build`).
+- `src/runtime.rs` — `TestRuntime`, `RunReport` in-process test harness.
+- `src/testing.rs` — test helpers/fixtures (feature `testing`).
+
+## Conventions & never-do
+- This is a re-export façade only: it covers exactly the five §3.5 concepts (Action, Credential, Resource, Schema, Plugin). Do NOT add a sixth integration concept or a parallel OAuth/credential type alias — those track `nebula-credential`; a new concept needs canon revision (§0.2).
+- `prelude` / `WorkflowBuilder` / `ActionBuilder` are a public open-source contract (§4.4/§7): breaking changes need explicit announcement + migration, not drive-by edits.
+- Not the engine/runtime, not an expression evaluator, not the plugin process entry point, and it does NOT re-export `nebula-resilience` — see `nebula-engine` / `nebula-expression` / `nebula-plugin-sdk`.
+- `anyhow` ergonomics are allowed for author scripts, but first-party lib code uses typed `thiserror`/`NebulaError`; no unwrap/expect/panic in lib code.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+
+## See also
+- `README.md` — full re-export list + maturity notes · canon `docs/PRODUCT_CANON.md` §3.5/§4.4/§7, `docs/INTEGRATION_MODEL.md`, `docs/MATURITY.md`.

--- a/crates/storage-loom-probe/CLAUDE.md
+++ b/crates/storage-loom-probe/CLAUDE.md
@@ -1,0 +1,30 @@
+# nebula-storage-loom-probe — Claude Code orientation
+> Agent quick-map for `crates/storage-loom-probe/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Standalone loom model-checker that re-implements `nebula-storage`'s CAS critical sections (credential refresh-claim + execution-lease handoff) against `loom::sync` and proves their single-owner invariants.
+**Layer:** Exec — depends only downward (root CLAUDE.md -> Layered Dependency Map). Has **zero `nebula-storage` dep on purpose** (see below); not consumed by any production crate.
+
+## Commands
+- `cargo check -p nebula-storage-loom-probe` (cheap: whole crate is `#![cfg(loom)]`, so this compiles to nothing without `--cfg loom`)
+- Run the probes (loom is dev-only, behind the `loom-test` feature + `--cfg loom`):
+  - `RUSTFLAGS="--cfg loom" cargo nextest run -p nebula-storage-loom-probe --features loom-test --profile ci --no-tests=pass`
+  - single probe: append `--test refresh_claim_loom` or `--test lease_handoff_loom`
+- doctests: none (`[lib] doctest = false`)
+
+## Key files
+- `src/lib.rs` — refresh-claim probe: `Repo::try_claim` (`Mutex<HashMap<u32, ClaimRow>>`), mirrors `InMemoryRefreshClaimRepo::try_claim`
+- `src/lease_handoff.rs` — execution-lease probe: `LeaseRepo::{acquire,renew,release}_lease`, mirrors `InMemoryExecutionStore` lease ops (fencing-generation, not holder-string, fenced)
+- `tests/refresh_claim_loom.rs` / `tests/lease_handoff_loom.rs` — the loom model-check harnesses
+
+## Conventions & never-do
+- **Do NOT add a `nebula-storage` (or any non-`loom`) dependency.** `--cfg loom` leaks to every crate in the build; a transitive dep (`concurrent-queue` via `moka`) would break. `loom` is the only allowed runtime dep, kept `optional` behind `loom-test`.
+- Probes **mirror** production CAS shapes by hand — they must stay invariant-equivalent (e.g. `generation` == the store's `fencing_generation`); update the mirror when the real adapter's CAS changes, don't diverge silently.
+- This crate is probes only — no production storage logic here (that lives in `nebula-storage` / `nebula-storage-port`, ADR-0072). New probes land here under the same sibling-crate / `#![cfg(loom)]` / `loom-test` discipline.
+- Loom doesn't model time: TTL/expiry is an explicit `expired: bool` flag, not a deadline.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code (probe bodies are loom test scaffolding, exempt like tests).
+
+## See also
+- `README.md` — full design, per-probe table, why-standalone rationale
+- `crates/storage/`, `crates/storage-port/` — the production adapter + Core seam these probes mirror (ADR-0072)
+- ADR-0041 (`docs/adr/HISTORICAL.md`) — original refresh-claim design

--- a/crates/storage-port/CLAUDE.md
+++ b/crates/storage-port/CLAUDE.md
@@ -1,0 +1,26 @@
+# nebula-storage-port — Claude Code orientation
+> Agent quick-map for `crates/storage-port/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Pure storage contract — object-safe `#[async_trait]` repository traits, port-local DTO rows, plain-data `Scope`, `StorageError`, and the `TransitionBatch` atomic unit-of-work. No backend code.
+**Layer:** Core — depends only downward (root CLAUDE.md -> Layered Dependency Map). Deps: `nebula-core`, async-trait, serde, chrono, uuid. **No sqlx.**
+
+## Commands
+- `cargo check -p nebula-storage-port`
+- `cargo nextest run -p nebula-storage-port`  ·  doctests: none (`doctest = false` in Cargo.toml `[lib]`)
+
+## Key files
+- `src/lib.rs` — crate root; re-exports `Scope`, `StorageError`, `FencingToken`, `TransitionBatch{,Builder,Outcome}`
+- `src/batch.rs` — `TransitionBatch`: private fields, builder-only construction; `commit` writes state+outbox+journal in one CAS+fencing-gated transaction
+- `src/store/mod.rs` — ISP-segregated role traits (`ExecutionStore`, `WorkflowStore`, `ControlQueue`, `NodeResultStore`, `ExecutionJournalReader`, identity/idempotency/refresh-claim stores)
+- `src/dto/` — port-local row DTOs (execution/workflow/control/journal/node_result/identity/webhook/idempotency), `serde_json::Value`-only
+- `src/scope.rs` — plain-data `Scope { workspace_id, org_id }`; `src/ids.rs` — re-exported core ULIDs + lease `FencingToken`
+
+## Conventions & never-do
+- This crate declares *what* storage does; **never implement a backend here** (adapters live in `nebula-storage`; scope enforcement in `nebula-tenancy`).
+- DTOs depend only on `serde_json::Value` — never on `ActionResult` or any higher-tier type (avoids Core-tier dependency inversion).
+- `Scope` is a value type with **no policy**; resolving it from a principal and cross-tenant denial belong to `nebula-tenancy`, not here.
+- Every repository trait stays `#[async_trait]` + `dyn`-compatible (consumed as `Arc<dyn …>`); keep `TransitionBatch` fields private and builder-only so a transition can't skip scope/CAS/fencing.
+- Library code uses typed `thiserror`/`StorageError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/adr/0072-nebula-storage-spec16-port-adapter-tenancy.md` (port/adapter/tenancy contract) · ADR-0041 (RefreshClaimStore shape)

--- a/crates/storage/CLAUDE.md
+++ b/crates/storage/CLAUDE.md
@@ -1,0 +1,31 @@
+# nebula-storage — Claude Code orientation
+> Agent quick-map for `crates/storage/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The sole adapter implementation (InMemory + SQLite + Postgres) of the spec-16 `nebula-storage-port` contract — execution CAS state, append-only journal, control-queue outbox, idempotency, leases, identity stores, and the durable credential refresh-claim repo.
+**Layer:** Exec — depends only downward (root CLAUDE.md -> Layered Dependency Map).
+
+## Commands
+- `cargo check -p nebula-storage`  (backends are feature-gated: add `--features sqlite,postgres`)
+- `cargo nextest run -p nebula-storage`  ·  doctests: n/a (`doctest = false` in Cargo.toml)
+- Postgres runtime tests are `DATABASE_URL`-gated + skip-clean (e.g. `tests/pg_idempotency.rs`); not pg-verified without a live DB.
+- Migrations: per-backend trees `migrations/{postgres,sqlite}/`; `0027_port_adapter_schema.sql` must stay byte-identical to embedded `src/{postgres,sqlite}/schema.sql`. `task db:migrate` (Postgres), `task db:reset` (drops data).
+
+## Key files
+- `src/lib.rs` — adapter re-exports (`InMemory*`, `StorageError`, `StorageFormat`); module/feature map.
+- `src/inmem/` — in-memory port adapters (tests / single-process / loom probe).
+- `src/sqlite/` · `src/postgres/` — feature-gated port adapters over the port-scoped schema (Postgres uses real tx + `FOR UPDATE SKIP LOCKED`).
+- `src/repos/` — residual non-port traits with live consumers (`ControlQueueRepo`, `IdempotencyStoreRepo`, `WebhookActivationRepo`, identity glue).
+- `src/credential/refresh_claim/` — ADR-0041 CAS refresh-claim repo (`try_claim`/`heartbeat`/`release`/`reclaim_stuck`); in_memory + sqlite + postgres.
+- `src/credential/layer/` — encryption / audit / cache decorators around credential persistence.
+
+## Conventions & never-do
+- `ExecutionStore::commit` is the single source of truth: CAS on `version` + lease `FencingToken` gating; if persistence is unavailable it FAILS — never silently mutate in-memory state.
+- Outbox atomicity (§12.2): control-queue writes share the SAME `TransitionBatch` as the state transition. Never transition without enqueueing, or enqueue without transitioning.
+- `try_claim` must be atomic under contention (exactly one winner of N replicas); `heartbeat` must validate `ClaimToken.generation` so a stale holder can't extend a reclaimed claim.
+- This crate is NOT the state machine (`nebula-execution`), orchestrator (`nebula-engine`), or tenant-scope enforcer (`nebula-tenancy` decorators wrap these adapters). Do NOT re-add the deleted legacy `ExecutionRepo`/`WorkflowRepo` surface (ADR-0072).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`StorageError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full durability matrix + backend status table.
+- `docs/adr/0072-nebula-storage-spec16-port-adapter-tenancy.md` (port/adapter/tenancy); ADR-0041 (refresh claim); `docs/PRODUCT_CANON.md` §11.1/§11.3/§11.5/§12.2/§12.3.

--- a/crates/tenancy/CLAUDE.md
+++ b/crates/tenancy/CLAUDE.md
@@ -1,0 +1,27 @@
+# nebula-tenancy — Claude Code orientation
+> Agent quick-map for `crates/tenancy/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Multi-tenancy security boundary — resolves an authenticated `Principal` into the port `Scope` and wraps each storage-port store in a scope-substituting decorator so callers cannot forge another tenant's scope.
+**Layer:** Business — depends only downward (`nebula-storage-port`, `nebula-core`, `nebula-credential`; no sqlx/adapter/upward deps).
+
+## Commands
+- `cargo check -p nebula-tenancy`
+- `cargo nextest run -p nebula-tenancy`  ·  doctests: disabled (`[lib] doctest = false` — none to run)
+
+## Key files
+- `src/lib.rs` — re-export surface; note `Credential`-prefixed names (`CredentialScopeLayer`, `CredentialScopeResolver`) deliberately avoid collision with the port-scope `ScopeResolver`
+- `src/resolver.rs` — `Principal`, `ScopeResolver` trait, default `BindingScopeResolver`, `request_scope(&TenantContext)`; the fail-closed `Principal`→`Scope` projection
+- `src/error.rs` — `TenancyError` (`MissingWorkspace` / `Unauthorized`); coarse on purpose, never reveals which half mismatched
+- `src/decorator/mod.rs` + `decorator/*.rs` — one `Scoped*Store` per port trait (execution, workflow, control_queue, idempotency, journal, node_result, resource, trigger, webhook); each substitutes the bound scope on every call
+- `src/credential_scope.rs` — re-homed credential `ScopeLayer` (keys on legacy `metadata["owner_id"]`, distinct from port-scope model)
+
+## Conventions & never-do
+- **Substitute, never compare-and-reject.** Decorators inject the bound `Scope`; let the backend `WHERE workspace_id=? AND org_id=?` filter. A distinct "wrong scope" vs "no row" path is an existence oracle — id↔scope mismatch must surface as `NotFound`/`Ok(None)`.
+- **Fail-closed projection.** Absent workspace binding ⇒ `TenancyError::MissingWorkspace`; never silently widen to org-only. Credential layer: `None` owner = admin/global bypass.
+- This crate owns scoping **policy** only — it must NOT own the `Scope` type (that is Core-tier `nebula-storage-port` plain data) and must NOT add a backend/sqlx dependency.
+- Keep the re-homed credential layer order (`ScopeLayer → AuditLayer → EncryptionLayer → CacheLayer → Backend`) and its fail-closed audit + zeroize-on-drop invariants intact (ADR-0029); regression-tested in `crates/storage/tests/credential_*`.
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design + threat-model table (spec §6.1) · ADR-0072 (storage port/adapter/tenancy split) · ADR-0029 (credential scope-layer fail-closed audit)

--- a/crates/validator/CLAUDE.md
+++ b/crates/validator/CLAUDE.md
@@ -1,0 +1,32 @@
+# nebula-validator — Claude Code orientation
+> Agent quick-map for `crates/validator/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** Shared validation rules engine — composable programmatic validators (`Validate<T>`) plus a JSON-serializable `Rule` enum that schema fields carry for engine-evaluated validation at lint/activation/runtime.
+**Layer:** Core — depends only downward (root CLAUDE.md -> Layered Dependency Map): `nebula-error` only, no sibling Core imports.
+
+## Commands
+- `cargo check -p nebula-validator`
+- `cargo nextest run -p nebula-validator`  ·  doctests: `cargo test -p nebula-validator --doc`
+- `cargo test -p nebula-validator --all-features` — features: `derive` (proc-macro), `network`, `temporal` (all default-on)
+- `cargo nextest run -p nebula-validator --test integration` · benches: `string_validators`, `combinators`, `rule_engine`, `error_construction`, `derive_*`
+
+## Key files
+- `src/lib.rs` — public surface + re-exports (`Rule`, `RuleKind`, `Validated`, `ExecutionMode`, `validate_rules`); `__private::regex` for derive output
+- `src/foundation/` — `Validate`/`ValidateExt` traits, `AnyValidator`, `ValidationError` (80-byte, RFC 6901 paths), `FieldPath`
+- `src/rule/mod.rs` — typed sum-of-sums `Rule` seam (`Value`/`Predicate`/`Logic`/`Deferred`/`Described`); cross-kind misuse is a compile error
+- `src/engine.rs` — `validate_rules` / `validate_rules_with_ctx`, `ExecutionMode` (`StaticOnly`/`Deferred`/`Full`)
+- `src/combinators/` — `.and()`/`.or()`/`.not()`/`when`/`unless`/`each`/`field` composition types
+- `src/validators/` — built-ins by category (length, range, content, pattern, network, temporal, nullable)
+- `src/proof.rs` — `Validated<T>` proof-token (no `Deserialize` by design)
+
+## Conventions & never-do
+- `Validated<T>` is a proof-token (canon §4.5): never construct it without calling `validate`; never add `Deserialize` — deserialized data must be re-validated.
+- Each `Rule` inner kind exposes only the method valid for it; do NOT reintroduce a flat enum or cross-kind silent-pass — typed narrowing replaced it (ADR-0052/0080).
+- This is NOT a schema system (`nebula-schema`), expression evaluator (`nebula-expression`), resilience pipeline, or API error formatter — keep those concerns out.
+- `Rule` wire format is externally-tagged tuple-compact; changing serialization breaks stored rules — keep error codes stable (`tests/fixtures/compat/error_registry_v1.json`).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`NebulaError`; no panicking unwrap/expect/panic in lib code.
+
+## See also
+- `README.md` — full design · `docs/` (architecture, api-reference, combinators, extending, migration)
+- `docs/adr/0080-schema-validation-platform.md` (ADR-0052 consolidated) — schema↔validator condition-eval seam

--- a/crates/workflow/CLAUDE.md
+++ b/crates/workflow/CLAUDE.md
@@ -1,0 +1,29 @@
+# nebula-workflow — Claude Code orientation
+> Agent quick-map for `crates/workflow/`. Full design: `README.md`. Repo-wide rules: root `CLAUDE.md`.
+
+**Purpose:** The shared, serde-round-trippable `WorkflowDefinition` + `DependencyGraph` (DAG) + activation-time `validate_workflow` that every higher layer (API, engine, storage) imports instead of re-parsing workflow JSON.
+**Layer:** Core — depends only downward (only `nebula-core` + `nebula-error`; no engine/storage/api imports).
+
+## Commands
+- `cargo check -p nebula-workflow`
+- `cargo nextest run -p nebula-workflow`  ·  doctests: none (`[lib] doctest = false` in Cargo.toml)
+
+## Key files
+- `src/lib.rs` — module wiring + public re-exports (the authoring surface).
+- `src/definition.rs` — `WorkflowDefinition`, `WorkflowConfig`, schema-version constants; JSON round-trip seam.
+- `src/node.rs` — `NodeDefinition`, `ParamValue` (unresolved expr strings), `RateLimit`, `SlotBinding`.
+- `src/connection.rs` — port-driven `Connection` edges (Spec 28); activation contract in module doc.
+- `src/graph.rs` — `DependencyGraph`: `petgraph` topo-sort + per-level batching (feeds `ExecutionPlan`).
+- `src/validate.rs` — `validate_workflow`, the canon §10 shift-left activation gate.
+- `src/builder.rs` — `WorkflowBuilder` fluent construction.
+
+## Conventions & never-do
+- `validate_workflow` is the canonical activation gate (canon §10 / §12.2): collects ALL errors into a `Result`, never mutates the definition. The *call* is enforced in `nebula-api` handlers — this crate only owns the function.
+- Edges carry NO conditions/matchers — conditional + error routing live in `ControlAction` nodes (trait in `nebula_action::control`); failed nodes activate only `from_port == "error"` edges. Do not re-add the removed `EdgeCondition`/`ResultMatcher`/`ErrorMatcher`.
+- `ParamValue` holds unresolved expression strings; this crate must NOT evaluate them (that is `nebula-expression`) and must NOT execute/schedule the DAG (that is `nebula-engine`) or persist it (that is `nebula-storage`/`nebula-api`).
+- `WorkflowDefinition` MUST survive a `serde_json` round-trip without loss — schema is a public compat surface (`docs/UPGRADE_COMPAT.md`).
+- Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
+- Library code uses typed `thiserror`/`WorkflowError`; no panicking unwrap/expect/panic in lib code (4 builder-invariant `panic!` sites are known doc-debt to migrate to `WorkflowError`).
+
+## See also
+- `README.md` — full design · `docs/PRODUCT_CANON.md` §10/§12.2 · `docs/UPGRADE_COMPAT.md` · Spec 28 (port-driven routing).

--- a/crates/workflow/CLAUDE.md
+++ b/crates/workflow/CLAUDE.md
@@ -23,7 +23,7 @@
 - `ParamValue` holds unresolved expression strings; this crate must NOT evaluate them (that is `nebula-expression`) and must NOT execute/schedule the DAG (that is `nebula-engine`) or persist it (that is `nebula-storage`/`nebula-api`).
 - `WorkflowDefinition` MUST survive a `serde_json` round-trip without loss — schema is a public compat surface (`docs/UPGRADE_COMPAT.md`).
 - Cross-crate calls go through `nebula-eventbus`, not direct sibling imports.
-- Library code uses typed `thiserror`/`WorkflowError`; no panicking unwrap/expect/panic in lib code (4 builder-invariant `panic!` sites are known doc-debt to migrate to `WorkflowError`).
+- Library code uses typed `thiserror`/`WorkflowError`; no panicking unwrap/expect/panic in lib code. (4 existing builder-invariant `panic!` sites in `src/node.rs` are flagged debt pending migration to `WorkflowError` — do not add new ones.)
 
 ## See also
 - `README.md` — full design · `docs/PRODUCT_CANON.md` §10/§12.2 · `docs/UPGRADE_COMPAT.md` · Spec 28 (port-driven routing).


### PR DESCRIPTION
## What

Applies the [large-codebases discoverability practices](https://code.claude.com/docs/en/large-codebases) to the Nebula workspace so AI agents and new collaborators orient fast.

- **Per-crate `crates/<x>/CLAUDE.md` (31 crates)** — short agent quick-map per crate: purpose, layer, exact `-p <package>` commands, key files, crate-specific invariants / never-do. Defers full design to the existing README (no duplication).
- **6 native discoverable skills** (`.claude/skills/nebula-*`) with keyword-first, load-on-demand descriptions: `layer-boundaries`, `credential-lifecycle`, `storage-port-adapter`, `error-and-validation`, `observability-dod`, `worktree-pr-workflow`.
- **`.claude/settings.json` hardening** — `permissions.deny` Read-rules for `target/` build output + the sibling-worktree pool (stale duplicate crate trees). `allow` + `hooks` preserved verbatim.
- **`HANDOFF.md`** — onboarding/handoff doc for a new human or AI collaborator (state on `main`).
- **Root `CLAUDE.md`** — registers the per-crate convention, the skills, and `HANDOFF.md` in Workspace Layout / AI Context Files / Documentation Index.

## Why

A single root `CLAUDE.md` over 31 crates either bloats context or stays too generic. Per-directory maps load only for the code you touch; native skills load only when their trigger matches. This is the doc's "Keep skills discoverable" guidance.

## How it was built

A multi-agent workflow audited each crate (README + Cargo.toml + lib.rs) and wrote its quick-map, then a skill architect proposed the discoverable set, then a verify pass (structural + quality + completeness critic) checked the output. Quality findings were triaged and fixed (stale `tests/rotation.rs` ref, drift-prone byte-count, deny-rule tightening).

## Verification

- 31/31 crates have a `CLAUDE.md`; 6/6 skills present; `settings.json` valid JSON (allow + deny + hooks intact); `HANDOFF.md` 233 lines.
- Docs/config only — **no `.rs` changes**. Pre-push gate green locally: `clippy-full` + `crate-diff-gate` (4861 tests passed).

## Deferred (needs a decision)

A `SessionStart` area/skill recommender hook (`.claude/hooks/session-start.sh`) — the doc's *active* discovery surface — is **not** in this PR (auto-mode classifier flagged a new auto-executing hook as unauthorized persistence). It's the highest-value remaining discovery lever; can be a follow-up once explicitly approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive onboarding and contributor handoff guide
  * Added skill guides documenting development practices covering credential lifecycle, error handling, architectural layers, observability standards, storage patterns, and contribution workflow
  * Added orientation guides for all project crates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->