### PR TITLE
feat(api): shift-left workflow validation gate (M3.6)

### DIFF
--- a/crates/api/src/domain/execution/handler.rs
+++ b/crates/api/src/domain/execution/handler.rs
@@ -280,6 +280,7 @@ pub async fn get_execution(
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Workflow does not exist.", body = ProblemDetails),
+        (status = 422, description = "Workflow definition fails structural validation (shift-left gate).", body = ProblemDetails),
         (status = 503, description = "Control queue is unavailable; the engine cannot pick up the dispatch signal.", body = ProblemDetails),
     ),
 )]
@@ -294,11 +295,17 @@ pub async fn start_execution(
     let workflow_id_parsed = WorkflowId::parse(&workflow_id)
         .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
-    // Verify the workflow exists in the caller's tenant.
-    state
+    // Verify the workflow exists in the caller's tenant, then run the
+    // shift-left validation gate (ROADMAP M3.6 / canon §10): a structurally
+    // invalid definition is rejected with RFC 9457 *before* any execution
+    // state is created or any Start signal is enqueued. `enqueue_start_scoped`
+    // requires the `ValidatedWorkflow` witness produced here, so the dispatch
+    // path is type-prevented from skipping validation.
+    let definition = state
         .workflow_definition_scoped(&scope, workflow_id_parsed)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Workflow {workflow_id} not found")))?;
+    let validated = validate_for_dispatch(&definition)?;
 
     // Generate new execution ID
     let execution_id = ExecutionId::new();
@@ -345,7 +352,7 @@ pub async fn start_execution(
     // exists but the engine will not see the Start signal — the handler
     // fails loudly so the caller can retry. The retry is idempotent
     // at the consumer layer via CAS (control-queue CAS).
-    enqueue_start_scoped(&state, &scope, execution_id).await?;
+    enqueue_start_scoped(&state, &scope, execution_id, &validated).await?;
 
     // Build response. `started_at` is omitted on a Created execution —
     // integration seam step 3 forbids synthetic timestamps for fields the engine
@@ -395,17 +402,25 @@ pub async fn start_execution(
 /// M3.5: stamps optional [`nebula_core::W3cTraceContext`] on the row from the active HTTP span
 /// when the global propagator yields a valid carrier; otherwise enqueues without one (never
 /// fails the request for trace stamping alone).
+///
+/// M3.6: takes a [`nebula_workflow::ValidatedWorkflow`] witness by reference.
+/// The witness can only be produced by [`validate_for_dispatch`] (which runs
+/// `validate_workflow`), so the type system forbids reaching dispatch with an
+/// unvalidated definition — this is the structural "lint gate" against a
+/// future start-path handler that forgets to shift-left validate.
 pub(crate) async fn enqueue_start_scoped(
     state: &AppState,
     scope: &nebula_storage_port::Scope,
     execution_id: ExecutionId,
+    validated: &nebula_workflow::ValidatedWorkflow,
 ) -> ApiResult<()> {
     let w3c_trace_context = w3c_trace_context_for_control_queue();
     tracing::debug!(
         execution_id = %execution_id,
         command = ControlCommand::Start.as_str(),
         has_trace_context = w3c_trace_context.is_some(),
-        "execution: enqueue Start on control queue"
+        node_count = validated.definition().nodes.len(),
+        "execution: enqueue Start on control queue (shift-left validated)"
     );
     state
         .enqueue_control_scoped(
@@ -415,6 +430,44 @@ pub(crate) async fn enqueue_start_scoped(
             w3c_trace_context,
         )
         .await
+}
+
+/// Parse a stored workflow definition blob and run the shift-left structural
+/// validation gate, returning a [`nebula_workflow::ValidatedWorkflow`] dispatch
+/// witness or an RFC 9457 error (canon §10 / §12.2, ROADMAP M3.6).
+///
+/// Every start-path handler (`execute_workflow`, `start_execution`) MUST turn
+/// the stored definition into a `ValidatedWorkflow` via this helper *before* it
+/// creates an execution row or enqueues a Start signal. Because
+/// [`enqueue_start_scoped`] requires the witness, the compiler rejects any
+/// dispatch path that skips this call.
+///
+/// Error mapping:
+/// - A blob that cannot be parsed as a `WorkflowDefinition` → **400** via
+///   [`ApiError::validation_message`] (a request-level / format error), using
+///   the same `to_string`→`from_str` round-trip `activate_workflow` relies on
+///   (`from_value` cannot zero-copy-borrow `&str` for `Key<T>` fields, #343).
+/// - A parseable-but-structurally-invalid definition → **422**
+///   [`ApiError::InvalidWorkflowDefinition`], carrying every typed
+///   [`nebula_workflow::WorkflowError`] so the problem+json body gets
+///   field-level RFC 6901 pointers.
+pub(crate) fn validate_for_dispatch(
+    definition: &serde_json::Value,
+) -> ApiResult<nebula_workflow::ValidatedWorkflow> {
+    let raw_json = serde_json::to_string(definition)
+        .map_err(|e| ApiError::Internal(format!("Failed to serialize workflow definition: {e}")))?;
+    let workflow_def: nebula_workflow::WorkflowDefinition = serde_json::from_str(&raw_json)
+        .map_err(|e| {
+            ApiError::validation_message(format!(
+                "Workflow definition cannot be parsed as WorkflowDefinition: {e}"
+            ))
+        })?;
+    nebula_workflow::ValidatedWorkflow::validate(workflow_def).map_err(|errors| {
+        ApiError::InvalidWorkflowDefinition {
+            detail: format!("Workflow definition is invalid ({} error(s))", errors.len()),
+            errors,
+        }
+    })
 }
 
 /// Cancel execution

--- a/crates/api/src/domain/execution/handler.rs
+++ b/crates/api/src/domain/execution/handler.rs
@@ -276,7 +276,7 @@ pub async fn get_execution(
     request_body = StartExecutionRequest,
     responses(
         (status = 202, description = "Execution accepted; engine dispatch in flight.", body = ExecutionResponse),
-        (status = 400, description = "Invalid workflow identifier.", body = ProblemDetails),
+        (status = 400, description = "Invalid workflow identifier, or the stored workflow definition cannot be parsed as a workflow.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Workflow does not exist.", body = ProblemDetails),

--- a/crates/api/src/domain/workflow/handler.rs
+++ b/crates/api/src/domain/workflow/handler.rs
@@ -622,7 +622,7 @@ pub async fn activate_workflow(
     request_body = StartExecutionRequest,
     responses(
         (status = 202, description = "Execution accepted; engine dispatch in flight.", body = ExecutionResponse),
-        (status = 400, description = "Invalid workflow identifier.", body = ProblemDetails),
+        (status = 400, description = "Invalid workflow identifier, or the stored workflow definition cannot be parsed as a workflow.", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Workflow does not exist.", body = ProblemDetails),

--- a/crates/api/src/domain/workflow/handler.rs
+++ b/crates/api/src/domain/workflow/handler.rs
@@ -20,7 +20,7 @@ use crate::{
     domain::{
         execution::{
             dto::{ExecutionResponse, StartExecutionRequest},
-            handler::enqueue_start_scoped,
+            handler::{enqueue_start_scoped, validate_for_dispatch},
         },
         shared::PaginationParams,
         workflow::dto::{
@@ -626,6 +626,7 @@ pub async fn activate_workflow(
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
         (status = 404, description = "Workflow does not exist.", body = ProblemDetails),
+        (status = 422, description = "Workflow definition fails structural validation (shift-left gate).", body = ProblemDetails),
         (status = 500, description = "Workflow repository or execution repository unavailable.", body = ProblemDetails),
         (status = 503, description = "Control queue is unavailable; the engine cannot pick up the dispatch signal.", body = ProblemDetails),
     ),
@@ -641,11 +642,17 @@ pub async fn execute_workflow(
     let workflow_id = WorkflowId::parse(&id)
         .map_err(|e| ApiError::validation_message(format!("Invalid workflow ID: {e}")))?;
 
-    // Verify the workflow exists in the caller's tenant.
-    state
+    // Verify the workflow exists in the caller's tenant, then run the
+    // shift-left validation gate (ROADMAP M3.6 / canon §10): a structurally
+    // invalid definition is rejected with RFC 9457 *before* any execution
+    // state is created or any Start signal is enqueued. `enqueue_start_scoped`
+    // requires the `ValidatedWorkflow` witness produced here, so the dispatch
+    // path is type-prevented from skipping validation.
+    let definition = state
         .workflow_definition_scoped(&scope, workflow_id)
         .await?
         .ok_or_else(|| ApiError::NotFound(format!("Workflow {id} not found")))?;
+    let validated = validate_for_dispatch(&definition)?;
 
     // Generate new execution ID
     let execution_id = ExecutionId::new();
@@ -677,7 +684,7 @@ pub async fn execute_workflow(
     // `enqueue_start_scoped` helper so the create + enqueue contract lives
     // in one place. M3.5: it stamps optional W3C trace context on the row
     // when the HTTP span is OTel-linked.
-    enqueue_start_scoped(&state, &scope, execution_id).await?;
+    enqueue_start_scoped(&state, &scope, execution_id, &validated).await?;
 
     // Report `created_at` as the observable timestamp — the engine has not
     // transitioned `started_at` yet (that happens at dispatch time). See

--- a/crates/api/src/error/mod.rs
+++ b/crates/api/src/error/mod.rs
@@ -87,9 +87,10 @@ pub enum ApiError {
     /// invalid per `nebula_workflow::validate_workflow` (RFC 9457 **422**).
     ///
     /// Distinct from [`Self::Validation`] (400), which covers request-level
-    /// parse/format errors. This variant is returned only from
-    /// `activate_workflow` after the stored definition fails structural
-    /// DAG/schema checks.
+    /// parse/format errors. Returned by `activate_workflow` and by the
+    /// shift-left dispatch gate (`execute_workflow` / `start_execution`, via
+    /// `validate_for_dispatch`) after the stored definition fails structural
+    /// DAG/schema checks (ROADMAP M3.6).
     #[classify(category = "validation", code = "API:INVALID_WORKFLOW")]
     #[error("Invalid workflow definition: {detail}")]
     InvalidWorkflowDefinition {

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -111,6 +111,20 @@ pub(crate) fn make_cyclic_workflow_definition(
     })
 }
 
+/// Build a stored definition blob that is a valid JSON object but does NOT
+/// deserialize as a `WorkflowDefinition` (every required field absent), to
+/// exercise the parse-failure → 400 branch of the dispatch gate
+/// (`validate_for_dispatch`), distinct from the structural-validation → 422
+/// branch that [`make_cyclic_workflow_definition`] covers.
+pub(crate) fn make_malformed_workflow_definition(
+    workflow_id: &nebula_core::WorkflowId,
+) -> serde_json::Value {
+    serde_json::json!({
+        "id": workflow_id.to_string(),
+        "this_is_not": "a parseable WorkflowDefinition"
+    })
+}
+
 // ── JWT helper ────────────────────────────────────────────────────────────────
 
 /// Build a valid JWT token signed with [`TEST_JWT_SECRET`].

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -3046,6 +3046,7 @@ async fn test_start_execution_rejects_invalid_definition() {
     );
 }
 
+// budget-justified: parallel /execute + /executions rejection test data covering the 422 and 400 dispatch-gate branches
 /// Shift-left validation gate (M3.6): `POST /workflows/{id}/execute` must
 /// reject a stored definition that cannot be parsed as a `WorkflowDefinition`
 /// with 400 (request-level parse failure, distinct from the 422 structural

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -888,13 +888,15 @@ async fn test_execute_workflow() {
     let api_config = ApiConfig::for_test();
     let token = create_test_jwt();
 
-    // Create a workflow first
+    // Create a workflow first. The dispatch path now runs the shift-left
+    // validation gate (M3.6), so the stored definition must be structurally
+    // valid — a single entry node, no cycles.
     let create_request = serde_json::json!({
         "name": "Test Workflow",
         "description": "A test workflow",
         "definition": {
-            "nodes": [],
-            "edges": []
+            "nodes": [{ "id": "step_a", "name": "Step A", "action_key": "echo" }],
+            "connections": []
         }
     });
 
@@ -1238,13 +1240,15 @@ async fn test_execution_start() {
     let api_config = ApiConfig::for_test();
     let token = create_test_jwt();
 
-    // Create a workflow first
+    // Create a workflow first. The dispatch path now runs the shift-left
+    // validation gate (M3.6), so the stored definition must be structurally
+    // valid — a single entry node, no cycles.
     let create_request = serde_json::json!({
         "name": "Test Workflow",
         "description": "A test workflow",
         "definition": {
-            "nodes": [],
-            "edges": []
+            "nodes": [{ "id": "step_a", "name": "Step A", "action_key": "echo" }],
+            "connections": []
         }
     });
 
@@ -2549,7 +2553,7 @@ async fn test_issue_327_start_execution_persists_canonical_execution_state() {
     let create_request = serde_json::json!({
         "name": "Issue 327 Workflow",
         "description": "Contract test: API-created execution must round-trip through ExecutionState",
-        "definition": { "nodes": [], "edges": [] }
+        "definition": { "nodes": [{ "id": "step_a", "name": "Step A", "action_key": "echo" }], "connections": [] }
     });
     let app = app::build_app(state.clone(), &api_config);
     let response = app
@@ -2728,7 +2732,7 @@ async fn test_issue_332_start_execution_enqueues_control_start() {
     let create_request = serde_json::json!({
         "name": "Issue 332 Workflow",
         "description": "API start must emit a Start command on the control queue",
-        "definition": { "nodes": [], "edges": [] }
+        "definition": { "nodes": [{ "id": "step_a", "name": "Step A", "action_key": "echo" }], "connections": [] }
     });
     let app = app::build_app(state.clone(), &api_config);
     let response = app
@@ -2834,7 +2838,7 @@ async fn test_issue_332_execute_workflow_enqueues_control_start() {
     let create_request = serde_json::json!({
         "name": "Issue 332 Execute Workflow",
         "description": "POST /workflows/:id/execute must also emit a Start command",
-        "definition": { "nodes": [], "edges": [] }
+        "definition": { "nodes": [{ "id": "step_a", "name": "Step A", "action_key": "echo" }], "connections": [] }
     });
     let app = app::build_app(state.clone(), &api_config);
     let response = app
@@ -2910,5 +2914,126 @@ async fn test_issue_332_execute_workflow_enqueues_control_start() {
     assert_eq!(
         msg.execution_id, execution_id_str,
         "#332: queued entry must reference the newly-created execution id"
+    );
+}
+
+/// Shift-left validation gate (M3.6): `POST /workflows/{id}/execute` must
+/// reject a structurally-invalid (cyclic) stored definition with RFC 9457 422
+/// *before* any execution state is created or any Start signal is enqueued.
+#[tokio::test]
+async fn test_execute_workflow_rejects_invalid_definition() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let (state, handles) = create_state_with_port_handles().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    // Cyclic workflow: parses as a WorkflowDefinition but fails
+    // validate_workflow (CycleDetected + NoEntryNodes).
+    let workflow_id = nebula_core::WorkflowId::new();
+    handles
+        .seed_workflow(workflow_id, make_cyclic_workflow_definition(&workflow_id))
+        .await;
+
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "control queue must be empty before execute"
+    );
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(ws_path(&format!("/workflows/{workflow_id}/execute")))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-csrf-token", TEST_CSRF_TOKEN)
+                .header("cookie", TEST_CSRF_COOKIE)
+                .body(Body::from(r#"{"input":{}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "invalid workflow must be rejected with 422 before dispatch"
+    );
+    // RFC 9457: structured problem+json body.
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok());
+    assert_eq!(content_type, Some("application/problem+json"));
+
+    // The gate runs before any execution-state mutation: no Start signal was
+    // enqueued on the durable control queue.
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "rejected execute must not enqueue a Start signal"
+    );
+}
+
+/// Shift-left validation gate (M3.6): `POST /workflows/{id}/executions`
+/// (`start_execution`) must reject a structurally-invalid (cyclic) stored
+/// definition with RFC 9457 422 and enqueue no Start signal.
+#[tokio::test]
+async fn test_start_execution_rejects_invalid_definition() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let (state, handles) = create_state_with_port_handles().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let workflow_id = nebula_core::WorkflowId::new();
+    handles
+        .seed_workflow(workflow_id, make_cyclic_workflow_definition(&workflow_id))
+        .await;
+
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "control queue must be empty before start"
+    );
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(ws_path(&format!("/workflows/{workflow_id}/executions")))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-csrf-token", TEST_CSRF_TOKEN)
+                .header("cookie", TEST_CSRF_COOKIE)
+                .body(Body::from(r#"{"input":{}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "invalid workflow must be rejected with 422 before dispatch"
+    );
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok());
+    assert_eq!(content_type, Some("application/problem+json"));
+
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "rejected start must not enqueue a Start signal"
     );
 }

--- a/crates/api/tests/integration_tests.rs
+++ b/crates/api/tests/integration_tests.rs
@@ -2973,10 +2973,14 @@ async fn test_execute_workflow_rejects_invalid_definition() {
     assert_eq!(content_type, Some("application/problem+json"));
 
     // The gate runs before any execution-state mutation: no Start signal was
-    // enqueued on the durable control queue.
+    // enqueued on the durable control queue, and no running execution resulted.
     assert!(
         handles.control_queue.snapshot().is_empty(),
         "rejected execute must not enqueue a Start signal"
+    );
+    assert!(
+        handles.running_executions().await.is_empty(),
+        "rejected execute must not create a running execution"
     );
 }
 
@@ -3035,5 +3039,130 @@ async fn test_start_execution_rejects_invalid_definition() {
     assert!(
         handles.control_queue.snapshot().is_empty(),
         "rejected start must not enqueue a Start signal"
+    );
+    assert!(
+        handles.running_executions().await.is_empty(),
+        "rejected start must not create a running execution"
+    );
+}
+
+/// Shift-left validation gate (M3.6): `POST /workflows/{id}/execute` must
+/// reject a stored definition that cannot be parsed as a `WorkflowDefinition`
+/// with 400 (request-level parse failure, distinct from the 422 structural
+/// path) and enqueue no Start signal.
+#[tokio::test]
+async fn test_execute_workflow_rejects_unparseable_definition() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let (state, handles) = create_state_with_port_handles().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let workflow_id = nebula_core::WorkflowId::new();
+    handles
+        .seed_workflow(
+            workflow_id,
+            make_malformed_workflow_definition(&workflow_id),
+        )
+        .await;
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(ws_path(&format!("/workflows/{workflow_id}/execute")))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-csrf-token", TEST_CSRF_TOKEN)
+                .header("cookie", TEST_CSRF_COOKIE)
+                .body(Body::from(r#"{"input":{}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "unparseable stored definition must be rejected with 400 before dispatch"
+    );
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok());
+    assert_eq!(content_type, Some("application/problem+json"));
+
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "rejected execute must not enqueue a Start signal"
+    );
+    assert!(
+        handles.running_executions().await.is_empty(),
+        "rejected execute must not create a running execution"
+    );
+}
+
+/// Shift-left validation gate (M3.6): `POST /workflows/{id}/executions` must
+/// reject a stored definition that cannot be parsed as a `WorkflowDefinition`
+/// with 400 and enqueue no Start signal.
+#[tokio::test]
+async fn test_start_execution_rejects_unparseable_definition() {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    let (state, handles) = create_state_with_port_handles().await;
+    let api_config = ApiConfig::for_test();
+    let token = create_test_jwt();
+
+    let workflow_id = nebula_core::WorkflowId::new();
+    handles
+        .seed_workflow(
+            workflow_id,
+            make_malformed_workflow_definition(&workflow_id),
+        )
+        .await;
+
+    let app = app::build_app(state, &api_config);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(ws_path(&format!("/workflows/{workflow_id}/executions")))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .header("x-csrf-token", TEST_CSRF_TOKEN)
+                .header("cookie", TEST_CSRF_COOKIE)
+                .body(Body::from(r#"{"input":{}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        response.status(),
+        StatusCode::BAD_REQUEST,
+        "unparseable stored definition must be rejected with 400 before dispatch"
+    );
+    let content_type = response
+        .headers()
+        .get("content-type")
+        .and_then(|v| v.to_str().ok());
+    assert_eq!(content_type, Some("application/problem+json"));
+
+    assert!(
+        handles.control_queue.snapshot().is_empty(),
+        "rejected start must not enqueue a Start signal"
+    );
+    assert!(
+        handles.running_executions().await.is_empty(),
+        "rejected start must not create a running execution"
     );
 }

--- a/crates/workflow/src/lib.rs
+++ b/crates/workflow/src/lib.rs
@@ -47,5 +47,5 @@ pub use graph::DependencyGraph;
 pub(crate) use nebula_core::serde_helpers::duration_opt_ms as serde_duration_opt;
 pub use node::{NodeDefinition, ParamValue, RateLimit, SlotBinding};
 pub use state::NodeState;
-pub use validate::validate_workflow;
+pub use validate::{ValidatedWorkflow, validate_workflow};
 pub use version::Version;

--- a/crates/workflow/src/validate.rs
+++ b/crates/workflow/src/validate.rs
@@ -185,6 +185,54 @@ pub fn validate_workflow(definition: &WorkflowDefinition) -> Vec<WorkflowError> 
     errors
 }
 
+/// A [`WorkflowDefinition`] proven to pass [`validate_workflow`] with zero
+/// errors — the **shift-left dispatch witness** (canon §10 / §12.2, ROADMAP
+/// M3.6).
+///
+/// The inner definition is private and there is no `&mut` / `DerefMut`
+/// accessor, so the only way to obtain a `ValidatedWorkflow` is
+/// [`ValidatedWorkflow::validate`], which runs the full activation-time
+/// validator. Dispatch seams that require a `&ValidatedWorkflow` therefore
+/// cannot be reached with an unvalidated (or subsequently-mutated) definition:
+/// "must validate before dispatch" becomes a compile-time obligation rather
+/// than a convention every new handler has to remember.
+///
+/// The *call* to validation is still owned by the consuming layer
+/// (`nebula-api` dispatch handlers); this crate owns only the witness and the
+/// validator (see `crates/workflow/CLAUDE.md`).
+#[derive(Debug, Clone)]
+pub struct ValidatedWorkflow(WorkflowDefinition);
+
+impl ValidatedWorkflow {
+    /// Validate `definition` and, on success, wrap it as a dispatch witness.
+    ///
+    /// # Errors
+    ///
+    /// Returns every [`WorkflowError`] that [`validate_workflow`] collects when
+    /// the definition is structurally invalid. On success the definition is
+    /// moved into the witness untouched.
+    pub fn validate(definition: WorkflowDefinition) -> Result<Self, Vec<WorkflowError>> {
+        let errors = validate_workflow(&definition);
+        if errors.is_empty() {
+            Ok(Self(definition))
+        } else {
+            Err(errors)
+        }
+    }
+
+    /// Borrow the validated definition.
+    #[must_use]
+    pub fn definition(&self) -> &WorkflowDefinition {
+        &self.0
+    }
+
+    /// Consume the witness, returning the validated definition by value.
+    #[must_use]
+    pub fn into_inner(self) -> WorkflowDefinition {
+        self.0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -655,6 +703,33 @@ mod tests {
         assert!(
             workflow_err,
             "workflow-default invalid retry config must have node = None; got: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validated_workflow_accepts_valid_definition() {
+        let a = node_key!("a");
+        let b = node_key!("b");
+        let def = make_definition(
+            "ok",
+            vec![node(a.clone()), node(b.clone())],
+            vec![Connection::new(a, b)],
+        );
+        let validated = ValidatedWorkflow::validate(def.clone()).expect("valid workflow");
+        // Witness round-trips the exact definition it was built from.
+        assert_eq!(validated.definition().name, "ok");
+        assert_eq!(validated.into_inner().nodes.len(), def.nodes.len());
+    }
+
+    #[test]
+    fn validated_workflow_rejects_invalid_definition() {
+        // Empty-nodes workflow fails `validate_workflow` (NoNodes); the witness
+        // surfaces every collected error rather than silently constructing.
+        let def = make_definition("empty", vec![], vec![]);
+        let errors = ValidatedWorkflow::validate(def).expect_err("empty workflow must fail");
+        assert!(
+            errors.iter().any(|e| matches!(e, WorkflowError::NoNodes)),
+            "expected NoNodes; got: {errors:?}"
         );
     }
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -20,7 +20,7 @@
 > `#PR`) when a new gap is discovered; tick it off only after the exit
 > criteria below are verifiably met.
 
-## Status snapshot — 2026-05-26
+## Status snapshot — 2026-05-26 (M3.6 addendum 2026-06-04)
 
 - **Cross-cutting layer** (`error`, `log`, `eventbus`, `metrics`,
   `resilience`) — **stable, no pending breaks**. `nebula-telemetry` was

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -88,7 +88,10 @@
   providers from operator secrets (carved out to its own SDD plan — Wave 4
   credential-stabilize compose-root `CredentialService` instantiation
   unblocked but not wired; `complete_oauth` still returns
-  `NotImplemented`); shift-left validation audit (M3.6).
+  `NotImplemented`). **M3.6 shift-left validation closed 2026-06-04** — both
+  dispatch handlers gate on `validate_workflow` via the
+  `nebula_workflow::ValidatedWorkflow` witness before any execution-state
+  mutation (no `/execute` or `/executions` path bypasses validation).
 - **Shared infra** — `nebula-credential` is consumed by Exec + API +
   Business (the `deny.toml` `[wrappers]` allowlist locks the consumer set).
   The `nebula-credential-runtime` crate shipped (ADR-0066, #678):
@@ -354,17 +357,44 @@ The largest 1.0 area. Closure criteria (on top of the global DoD):
 
 #### M3.6 Shift-left workflow validation
 
-- [ ] Audit every `/execute` and `/workflows/{id}/run` handler — call
+> **Closed 2026-06-04** — plan
+> `docs/plans/2026-06-04-001-feat-api-m3.6-shift-left-validation-plan.md`.
+> Recon correction: the API→engine seam is the durable control queue, not a
+> direct `engine.execute_workflow` call (which has ~50 engine-test callers
+> only), so the witness is required at the dispatch seam
+> (`enqueue_start_scoped`), not forced onto the engine signature.
+
+- [x] Audit every `/execute` and `/workflows/{id}/run` handler — call
       `validate_workflow` before engine handoff per the
-      `crates/workflow/README.md` contract (current coverage map unknown).
-- [ ] Encode "must validate before dispatch" as a typed boundary — e.g. a
-      `ValidatedWorkflow` newtype the engine `Submit` API requires
-      (impossible to call without validating).
-- [ ] Map `WorkflowValidationError` → `400 Bad Request` with field-level
-      detail in problem+json.
-- [ ] Integration test: malformed workflow → 400 before any engine state
-      mutation.
-- [ ] Lint/CI gate catching a future handler that skips `validate_workflow`.
+      `crates/workflow/README.md` contract. The two dispatch handlers
+      (`domain/workflow/handler.rs::execute_workflow`,
+      `domain/execution/handler.rs::start_execution`) now run the gate via the
+      shared `validate_for_dispatch` helper before `create_execution_scoped` /
+      `enqueue_start_scoped`. (`/workflows/{id}/run` does not exist; the start
+      routes are `.../execute` and `.../executions`.)
+- [x] Encode "must validate before dispatch" as a typed boundary —
+      `nebula_workflow::ValidatedWorkflow` newtype (private field; built only
+      via `ValidatedWorkflow::validate`). The shared `enqueue_start_scoped`
+      dispatch helper requires a `&ValidatedWorkflow`, so unvalidated dispatch
+      is unrepresentable. (Placed at the dispatch seam, not on
+      `engine.execute_workflow` — see note above.)
+- [x] Map validation failure → field-level problem+json. Reuses the existing
+      `ApiError::InvalidWorkflowDefinition` → **422** path (RFC 6901 pointers
+      via `workflow_error_pointer`). 422 (not the bullet's looser "400")
+      follows the `activate_workflow` precedent: 422 is correct for
+      well-formed-but-semantically-invalid input; an unparseable blob still
+      yields 400. (canon §4.5 honesty: codebase precedent overrides roadmap
+      wording.)
+- [x] Integration test: malformed workflow → rejected before any engine state
+      mutation. `test_execute_workflow_rejects_invalid_definition` +
+      `test_start_execution_rejects_invalid_definition`
+      (`crates/api/tests/integration_tests.rs`): cyclic stored def → 422
+      problem+json **and** an empty control queue (no Start enqueued).
+- [x] Lint/CI gate catching a future handler that skips `validate_workflow` —
+      satisfied structurally: `enqueue_start_scoped` is uncallable without a
+      `ValidatedWorkflow`, so the compiler is the gate. (`restart_execution`
+      does not route through this helper; a defensive re-validate there is a
+      noted 1.1 follow-up.)
 
 **Exit:** every shipping route reachable from `build_app`; every
 state-changing endpoint replay-protected end-to-end; OpenAPI spec is the
@@ -1180,7 +1210,7 @@ Not all parallelizable. Suggested ordering (M0–M2, M6, M11 closed
 2. **M3 (API)** in parallel with M0 — biggest user-facing gap; sliceable
    (M3.1 mostly closed via #737/#738/#751/#753/#754 — only
    OAuth-secrets-from-operator remains (carved out to its own SDD plan);
-   M3.2 ✅, M3.3 ✅, M3.4 ✅, M3.5 ✅ via #742, M3.6 open).
+   M3.2 ✅, M3.3 ✅, M3.4 ✅, M3.5 ✅ via #742, M3.6 ✅ (2026-06-04)).
 3. **M1, M2 (engine correctness + retry)** after M0 — same `engine.rs`
    paths. ✅ DONE.
 4. **M4, M5 (plugin capability gate + plugin ABI contract)** in parallel

--- a/docs/plans/2026-06-04-001-feat-api-m3.6-shift-left-validation-plan.md
+++ b/docs/plans/2026-06-04-001-feat-api-m3.6-shift-left-validation-plan.md
@@ -1,0 +1,126 @@
+---
+title: "feat: API M3.6 — shift-left workflow validation before dispatch"
+type: feat
+status: done
+date: 2026-06-04
+origin:
+  - docs/ROADMAP.md §M3.6 (Shift-left workflow validation)
+  - docs/ROADMAP.md §M3 exit criteria ("no `/execute` path bypasses validation")
+scope:
+  - crates/workflow (ValidatedWorkflow witness type)
+  - crates/api (dispatch-handler gate + RFC 9457 mapping)
+---
+
+> **Next step (per ROADMAP §"Next step").** M3.6 is the only open sub-task of
+> M3 — "the largest 1.0 area". M3.1–M3.5 are closed. This plan closes the
+> last §4.5 honesty gap on the execute path: the API advertises
+> "validate before dispatch" (`crates/workflow/README.md` contract) but the
+> two start-path handlers enqueue a Start signal without ever calling
+> `validate_workflow`.
+
+## Context
+
+`nebula_workflow::validate_workflow` is the canonical activation-time gate
+(canon §10 / §12.2). Today it is called from `activate_workflow` and the
+dedicated `validate_workflow_handler`, but **not** from the dispatch path:
+
+- `domain/workflow/handler.rs::execute_workflow` (`POST .../workflows/{wf}/execute`)
+- `domain/execution/handler.rs::start_execution` (`POST .../workflows/{wf}/executions`)
+
+Both only check the workflow *exists*, then create an `ExecutionState` row and
+enqueue `ControlCommand::Start` on the durable control queue via the shared
+`enqueue_start_scoped` helper. A structurally-invalid workflow (cycle, no
+entry node, empty nodes, dangling connection) is therefore accepted with
+`202 Accepted`; the failure only surfaces later inside the engine's planner
+(`EngineError::PlanningFailed`), after state has been mutated and a client
+has been told "accepted". That is a false capability per canon §4.5.
+
+### Architecture note (why the gate is at the API, not the engine)
+
+The ROADMAP bullet suggested "a `ValidatedWorkflow` newtype the engine
+`Submit` API requires". Recon shows the API never calls
+`engine.execute_workflow` directly — the API→engine seam is the **durable
+control queue** (`enqueue_start_scoped` → control queue → engine
+`ControlConsumer`). `engine.execute_workflow(&WorkflowDefinition, …)` has
+~50 callers, all engine tests. Forcing the witness onto that signature would
+churn 50 test sites, balloon the diff past the ADR-0083 structural budget,
+risk panics on edge-case test workflows, **and still not gate the API path**.
+
+The honest boundary is the dispatch seam itself. We make
+`enqueue_start_scoped` require a `&ValidatedWorkflow` witness, so the
+compiler rejects any current or future start-path handler that reaches
+dispatch without validating — the type system *is* the "lint gate"
+(ROADMAP M3.6 bullet 5).
+
+## Goal
+
+Every dispatch path runs `validate_workflow` before any execution-state
+mutation; invalid definitions are rejected with an RFC 9457 problem+json
+response; "validate before dispatch" is a compile-time obligation.
+
+## Tasks (= ROADMAP §M3.6 bullets)
+
+1. **Audit every dispatch handler → call validate before handoff.**
+   `execute_workflow` + `start_execution` parse the stored definition (via
+   the established `to_string`→`from_str` round-trip used by
+   `activate_workflow`, #343) and validate it before `create_execution_scoped`
+   / `enqueue_start_scoped`.
+
+2. **Encode "must validate before dispatch" as a typed boundary.**
+   New `nebula_workflow::ValidatedWorkflow` newtype — private field,
+   constructible only via `ValidatedWorkflow::validate(def) -> Result<Self,
+   Vec<WorkflowError>>`. `enqueue_start_scoped` takes `&ValidatedWorkflow`,
+   making unvalidated dispatch unrepresentable.
+
+3. **Map validation failure → RFC 9457.** Reuse the existing
+   `ApiError::InvalidWorkflowDefinition` → **422 Unprocessable Entity** path
+   (field-level RFC 6901 pointers via `workflow_error_pointer`). We follow
+   the codebase precedent (`activate_workflow` returns 422 for the same
+   class), not the ROADMAP's looser "400" wording: 422 is the correct status
+   for well-formed-but-semantically-invalid input (a parse failure stays
+   400). Unparseable blobs → 400 `validation_message`.
+
+4. **Integration test: invalid workflow → rejected before any state
+   mutation.** New tests seed a cyclic workflow (mirroring
+   `activate_invalid_returns_422`) and assert both `/execute` and
+   `/executions` return 422 problem+json **and** the control queue stays
+   empty (no Start enqueued, no execution row dispatched).
+
+5. **Lint/CI gate for future handlers that skip validation.** Satisfied
+   structurally by the witness: the shared `enqueue_start_scoped` cannot be
+   called without a `ValidatedWorkflow`. Documented in the helper doc-comment
+   and the handler comments.
+
+## Affected existing tests
+
+5 integration tests create empty-node workflows (`{nodes:[],edges:[]}`) then
+dispatch, expecting 202. Empty workflows now correctly fail validation
+(`NoNodes`), so each is given a valid single-node definition (preconditions
+fixed, assertions unchanged — not weakened):
+
+- `test_execute_workflow`
+- `test_execution_start`
+- `test_issue_327_start_execution_persists_canonical_execution_state`
+- `test_issue_332_start_execution_enqueues_control_start`
+- `test_issue_332_execute_workflow_enqueues_control_start`
+
+`otlp_one_root_span.rs`, `execution_terminate_e2e.rs`, and `knife.rs` already
+seed valid workflows (`persist_slow_workflow` / `make_valid_workflow_definition`)
+and are unaffected.
+
+## Out of scope / follow-ups
+
+- `restart_execution` re-runs an existing execution and does **not** route
+  through `enqueue_start_scoped`; a defensive re-validate there is a separate
+  1.1 hardening item, noted but not gated by M3.6.
+- Engine-side `ValidatedWorkflow` enforcement on `execute_workflow` (defense
+  in depth at the control-consumer boundary) — deferred to 1.1; the API gate
+  is the 1.0 contract.
+
+## Verification
+
+- `cargo nextest run -p nebula-workflow -p nebula-api`
+- `cargo clippy -p nebula-workflow -p nebula-api --all-targets -- -D warnings`
+- `cargo nextest run -p nebula-api --test openapi_spec` (router↔spec drift)
+- Exit: ROADMAP §M3.6 all `[x]`; §M3 exit criterion "no `/execute` path
+  bypasses validation" holds.


### PR DESCRIPTION
## Summary

Implements the shift-left validation gate (ROADMAP M3.6 / canon §10) by requiring all dispatch paths (`POST /workflows/{id}/execute` and `POST /workflows/{id}/executions`) to validate the workflow definition *before* any execution state is created or any Start signal is enqueued. Invalid definitions are rejected with RFC 9457 422 (Unprocessable Entity) problem+json responses. The validation requirement is encoded as a compile-time obligation via a new `nebula_workflow::ValidatedWorkflow` witness type that `enqueue_start_scoped` requires, making unvalidated dispatch unrepresentable.

## Linked issue

- Closes ROADMAP §M3.6 (Shift-left workflow validation)
- Refs canon §10 / §12.2 (activation-time validation contract)

## Type of change

- [x] `feat` — new capability
- [x] `test` — tests only (integration tests updated + new validation tests)

## Affected crates / areas

- `nebula-workflow` — new `ValidatedWorkflow` witness type + validation tests
- `nebula-api` — dispatch handlers gate on `validate_for_dispatch` before `enqueue_start_scoped`
- `docs/` — ROADMAP updated, new plan document added

## Changes

**Core validation witness (`nebula-workflow`):**
- New `ValidatedWorkflow` newtype wrapping `WorkflowDefinition` (private field, immutable)
- `ValidatedWorkflow::validate(def) -> Result<Self, Vec<WorkflowError>>` — only constructor, runs full `validate_workflow` gate
- `definition()` and `into_inner()` accessors for borrowing/consuming the validated definition
- Unit tests: `validated_workflow_accepts_valid_definition`, `validated_workflow_rejects_invalid_definition`

**Dispatch gate (`nebula-api`):**
- New `validate_for_dispatch(definition: &serde_json::Value) -> ApiResult<ValidatedWorkflow>` helper in `domain/execution/handler.rs`
  - Parses stored definition blob (same `to_string`→`from_str` round-trip as `activate_workflow`)
  - Runs `ValidatedWorkflow::validate` and maps errors to RFC 9457 422 via `ApiError::InvalidWorkflowDefinition`
  - Unparseable blobs → 400 `validation_message` (request-level format error)
- Updated `enqueue_start_scoped` signature: now requires `&ValidatedWorkflow` witness parameter
  - Compiler prevents any dispatch path from calling this helper without validating first
  - Added tracing log with node count from validated definition
- Both dispatch handlers (`execute_workflow` in `domain/workflow/handler.rs`, `start_execution` in `domain/execution/handler.rs`) now:
  - Fetch the stored workflow definition
  - Call `validate_for_dispatch` before `create_execution_scoped` / `enqueue_start_scoped`
  - Pass the witness to `enqueue_start_scoped`
- Updated OpenAPI doc-comments to document 422 response for both endpoints

**Error handling:**
- Updated `ApiError::InvalidWorkflowDefinition` doc-comment to note it is returned by both `activate_workflow` and the shift-left dispatch gate

**Integration tests:**
- Fixed 5 existing tests that created empty-node workflows (`{nodes:[],edges:[]}`):
  - `test_execute_workflow`, `test_execution_start`, `test_issue_327_start_execution_persists_canonical_execution_state`, `test_issue_332_start_execution_enqueues_control_start`, `test_issue_332_execute_workflow_enqueues_control_start`
  - Each now seeds a valid single-node workflow (`[{ "id": "step_a", "name": "Step A", "action_key": "echo" }]`)
  - Preconditions fixed; assertions unchanged (not weakened)
- New `test_execute_workflow_rejects_invalid_definition`: seeds a cyclic workflow, asserts `POST /workflows/{id}/execute

https://claude.ai/code/session_01299nELfc7urx7XUKv9j6HC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow definitions are now validated before execution begins, preventing invalid definitions from being queued or executed.

* **Bug Fixes**
  * Invalid workflows now return HTTP 422 (Unprocessable Entity) with RFC 9457-compliant error responses instead of potentially being processed.

* **Documentation**
  * Completed M3.6 milestone for shift-left workflow validation; updated roadmap and implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->