### PR TITLE
test(resource): SlotCell read-path benches + CodSpeed shard

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -128,6 +128,9 @@ jobs:
             log:
               - 'crates/log/**'
               - '!crates/log/**/*.md'
+            resource:
+              - 'crates/resource/**'
+              - '!crates/resource/**/*.md'
 
       - name: Plan shards
         id: plan
@@ -139,6 +142,7 @@ jobs:
           E: ${{ steps.filter.outputs.eventbus }}
           X: ${{ steps.filter.outputs.expression }}
           L: ${{ steps.filter.outputs.log }}
+          RS: ${{ steps.filter.outputs.resource }}
           EVENT: ${{ github.event_name }}
           REF: ${{ github.ref }}
           LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
@@ -155,7 +159,7 @@ jobs:
             force=1
           fi
           if [[ "$force" == "1" ]]; then
-            R=true; V=true; C=true; E=true; X=true; L=true
+            R=true; V=true; C=true; E=true; X=true; L=true; RS=true
           fi
 
           SHARDS='[]'
@@ -177,6 +181,7 @@ jobs:
           [[ "$E" == "true" ]] && add_misc_pkg "nebula-eventbus"
           [[ "$X" == "true" ]] && add_misc_pkg "nebula-expression"
           [[ "$L" == "true" ]] && add_misc_pkg "nebula-log"
+          [[ "$RS" == "true" ]] && add_misc_pkg "nebula-resource"
           if [[ -n "$M_PACKAGES" ]]; then
             add "$(jq -cn --arg packages "$M_PACKAGES" '{shard:"misc",packages:$packages}')"
           fi

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4020,6 +4020,7 @@ name = "nebula-resource"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "codspeed-criterion-compat",
  "dashmap",
  "futures",
  "insta",

--- a/crates/resource/Cargo.toml
+++ b/crates/resource/Cargo.toml
@@ -59,6 +59,11 @@ insta = { workspace = true }
 pretty_assertions = { workspace = true }
 rstest = { workspace = true }
 trybuild = "1.0"
+criterion = { workspace = true }
+
+[[bench]]
+name = "slotcell"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/resource/benches/slotcell.rs
+++ b/crates/resource/benches/slotcell.rs
@@ -1,0 +1,81 @@
+//! Lock-free read hot-path benchmarks for [`SlotCell`].
+//!
+//! `SlotCell` is the per-credential-slot holder a resource reads on **every**
+//! acquire (via the derive-emitted `<field>_slot()` accessor), so its read
+//! methods are the crate's hottest path. This bench covers:
+//!
+//! - `load` / `load_versioned` — the resolved-guard snapshot reads;
+//! - `generation` on a **bound** cell (the live-entry path) and on an
+//!   **empty** cell (the `next_generation` fallback whose ordering was relaxed
+//!   from `Acquire` to `Relaxed`) — the exact code this baseline guards;
+//! - `is_some`;
+//! - the rare serialized `store` / `take` write path, for completeness.
+//!
+//! These read methods are the `#[inline]` candidates the perf research deferred
+//! as "benchmark-gate"; this bench is the baseline an `#[inline]` change can be
+//! measured against on CodSpeed.
+
+use std::{hint::black_box, sync::Arc};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use nebula_resource::SlotCell;
+
+fn bench_slotcell_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("resource/slotcell");
+
+    // Bound cell: a resolved value is present — the common acquire-time read.
+    let bound: SlotCell<u64> = SlotCell::empty();
+    bound.store(Arc::new(0x00C0_FFEE_u64));
+
+    group.bench_function("load_bound", |b| {
+        b.iter(|| black_box(black_box(&bound).load()));
+    });
+    group.bench_function("load_versioned_bound", |b| {
+        b.iter(|| black_box(black_box(&bound).load_versioned()));
+    });
+    group.bench_function("generation_bound", |b| {
+        b.iter(|| black_box(black_box(&bound).generation()));
+    });
+    group.bench_function("is_some_bound", |b| {
+        b.iter(|| black_box(black_box(&bound).is_some()));
+    });
+
+    // Empty cell: the `generation()` no-entry fallback reads `next_generation`
+    // directly (the `Relaxed` load this crate relaxed from `Acquire`).
+    let empty: SlotCell<u64> = SlotCell::empty();
+    group.bench_function("generation_empty", |b| {
+        b.iter(|| black_box(black_box(&empty).generation()));
+    });
+    group.bench_function("load_empty", |b| {
+        b.iter(|| black_box(black_box(&empty).load()));
+    });
+
+    group.finish();
+}
+
+fn bench_slotcell_writes(c: &mut Criterion) {
+    // The rare rotation/revoke write path (serialized under the write lock).
+    // Not hot, but a number here makes a future write-path regression visible.
+    let mut group = c.benchmark_group("resource/slotcell_write");
+
+    group.bench_function("store", |b| {
+        let cell: SlotCell<u64> = SlotCell::empty();
+        let mut v = 0_u64;
+        b.iter(|| {
+            v = v.wrapping_add(1);
+            cell.store(Arc::new(black_box(v)));
+        });
+    });
+    group.bench_function("store_then_take", |b| {
+        let cell: SlotCell<u64> = SlotCell::empty();
+        b.iter(|| {
+            cell.store(Arc::new(black_box(1_u64)));
+            black_box(cell.take());
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_slotcell_reads, bench_slotcell_writes);
+criterion_main!(benches);


### PR DESCRIPTION
## What

`nebula-resource` had **no benchmarks** — despite owning the crate's hottest path, the `SlotCell` credential read performed on every acquire (and the `#[inline]` candidate the perf research deferred as "benchmark-gate"). This adds that coverage.

- **`crates/resource/benches/slotcell.rs`** (criterion, `harness = false`): microbenches for the `SlotCell` read methods —
  - `load` / `load_versioned` / `generation` / `is_some` on a **bound** cell (the common acquire-time read),
  - `generation` / `load` on an **empty** cell (the `next_generation` `Relaxed` fallback whose ordering was relaxed in #776),
  - the rare serialized `store` / `take` write path, for completeness.
- **CodSpeed shard**: registers `nebula-resource` in the dorny filter + plan step so it runs in the "misc" shard and joins the continuous-benchmark threshold gate.
- `criterion` dev-dep + `[[bench]]` in `crates/resource/Cargo.toml` (mirrors the other 8 benched crates; `criterion = codspeed-criterion-compat`).

## Why

Establishes a **baseline** so the deferred `#[inline]` decision (perf research / #776 — both deferred it as "benchmark-gate" because there was no bench) can be measured on CodSpeed in a follow-up: add `#[inline]` to the `SlotCell` reads, read the delta.

## Local numbers (criterion, ubuntu→win dev box, indicative only)

| bench | time |
|---|---|
| `slotcell/load_bound` | ~21.8 ns |
| `slotcell/load_versioned_bound` | ~27.6 ns |
| `slotcell/generation_bound` | ~19 ns |
| `slotcell/generation_empty` (Relaxed fallback) | ~9.6 ns |
| `slotcell/is_some_bound` | ~10 ns |

## Verification
- `cargo bench -p nebula-resource --bench slotcell` runs + produces numbers.
- `cargo clippy -p nebula-resource --all-targets -- -D warnings` clean (bench linted).
- `cargo nextest run -p nebula-resource` — 344 pass (manifest change safe).

## Note
`cell::Cell` (the resident-topology internal holder) is `pub(crate)`, so it can't be benched from an external `benches/` target — only the public `SlotCell` is covered here. Async `Manager::acquire_*` / `ResourceGuard` drop-vs-release benches need a tokio+fixture harness and are a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
