### PR TITLE
refactor(action): by-value metadata() accessor + symmetric metadata API (ADR-0090)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4013,6 +4013,7 @@ dependencies = [
  "nebula-action",
  "nebula-core",
  "nebula-credential",
+ "nebula-metadata",
  "nebula-plugin",
  "nebula-resource",
  "nebula-schema",

--- a/crates/action/macros/src/action.rs
+++ b/crates/action/macros/src/action.rs
@@ -76,10 +76,8 @@ fn expand(input: DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
             type Input = #input_ty;
             type Output = #output_ty;
 
-            fn metadata() -> &'static ::nebula_action::ActionMetadata {
-                static METADATA: ::std::sync::OnceLock<::nebula_action::ActionMetadata> =
-                    ::std::sync::OnceLock::new();
-                METADATA.get_or_init(|| #metadata_init)
+            fn metadata() -> ::nebula_action::ActionMetadata {
+                #metadata_init
             }
 
             fn dependencies() -> &'static ::nebula_core::Dependencies {

--- a/crates/action/src/action.rs
+++ b/crates/action/src/action.rs
@@ -38,9 +38,8 @@ use crate::metadata::ActionMetadata;
 /// type Input = serde_json::Value;
 /// type Output = serde_json::Value;
 ///
-/// fn metadata() -> &'static ActionMetadata {
-/// static M: OnceLock<ActionMetadata> = OnceLock::new();
-/// M.get_or_init(|| ActionMetadata::new(action_key!("echo"), "Echo", "Echoes input"))
+/// fn metadata() -> ActionMetadata {
+/// ActionMetadata::new(action_key!("echo"), "Echo", "Echoes input")
 /// }
 /// fn dependencies() -> &'static Dependencies {
 /// static D: OnceLock<Dependencies> = OnceLock::new();
@@ -65,8 +64,15 @@ pub trait Action: Sized + Send + Sync + 'static {
     /// What this action produces; serialized to JSON for downstream nodes.
     type Output: HasSchema + Serialize + Send + Sync;
 
-    /// Static metadata describing this action type (key, version, ports, etc.).
-    fn metadata() -> &'static ActionMetadata;
+    /// Metadata describing this action type (key, version, ports, etc.).
+    ///
+    /// Returned by value, symmetric with
+    /// [`Credential::metadata`](nebula_credential) and
+    /// `Resource::metadata`. Authors build it fresh — no `static`/`OnceLock`
+    /// boilerplate. The engine caches the result once per registered factory
+    /// (see `ActionFactory`), so the cold per-call cost is paid only at
+    /// registration, not per dispatch.
+    fn metadata() -> ActionMetadata;
 
     /// Slot-binding declarations (`#[resource]` / `#[credential]` fields, Phase 3 / S3+).
     fn dependencies() -> &'static Dependencies;

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -38,24 +38,24 @@
 //!     Action, ActionCategory, DeclaresDependencies, ActionError,
 //!     ActionMetadata, ControlAction, ControlInput, ControlOutcome,
 //! };
-//! use nebula_core::action_key;
+//! use nebula_core::{Dependencies, action_key};
 //!
-//! pub struct MyIf {
-//!     metadata: ActionMetadata,
-//! }
-//!
-//! impl MyIf {
-//!     pub fn new() -> Self {
-//!         Self {
-//!             metadata: ActionMetadata::new(action_key!("control.if"), "If", "Binary branch")
-//!                 .with_category(ActionCategory::Control),
-//!         }
-//!     }
-//! }
+//! pub struct MyIf;
 //!
 //! impl DeclaresDependencies for MyIf {}
 //! impl Action for MyIf {
-//!     fn metadata(&self) -> &ActionMetadata { &self.metadata }
+//!     type Input = serde_json::Value;
+//!     type Output = serde_json::Value;
+//!
+//!     fn metadata() -> ActionMetadata {
+//!         ActionMetadata::new(action_key!("control.if"), "If", "Binary branch")
+//!             .with_category(ActionCategory::Control)
+//!     }
+//!
+//!     fn dependencies() -> &'static Dependencies {
+//!         static D: std::sync::OnceLock<Dependencies> = std::sync::OnceLock::new();
+//!         D.get_or_init(Dependencies::new)
+//!     }
 //! }
 //!
 //! impl ControlAction for MyIf {
@@ -461,12 +461,12 @@ pub struct ControlActionAdapter<A: ControlAction> {
 impl<A: ControlAction> ControlActionAdapter<A> {
     /// Wrap a typed control action.
     ///
-    /// The adapter clones the action's metadata, stamps the appropriate
+    /// The adapter takes the action's metadata, stamps the appropriate
     /// [`ActionCategory`] (Control or Terminal), and caches the result
     /// in an `Arc` so subsequent `metadata()` calls are cheap.
     #[must_use]
     pub fn new(action: A) -> Self {
-        let mut meta = <A as Action>::metadata().clone();
+        let mut meta = <A as Action>::metadata();
         meta.category = derive_category(&meta);
         Self {
             action,
@@ -760,13 +760,10 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.if"), "TestIf", "Binary branch")
-                    .with_inputs(default_input_ports())
-                    .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.if"), "TestIf", "Binary branch")
+                .with_inputs(default_input_ports())
+                .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -802,12 +799,9 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.stop"), "TestStop", "Terminate")
-                    .with_outputs(Vec::new())
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.stop"), "TestStop", "Terminate")
+                .with_outputs(Vec::new())
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -951,7 +945,7 @@ mod tests {
     fn adapter_preserves_original_outputs_after_stamp() {
         // The adapter only rewrites `category`; it must not touch `outputs`
         // or any other metadata field.
-        let original_outputs = <TestIf as Action>::metadata().outputs.clone();
+        let original_outputs = <TestIf as Action>::metadata().outputs;
         let adapter = ControlActionAdapter::new(TestIf::new());
         assert_eq!(
             StatelessHandler::metadata(&adapter).outputs,

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -15,7 +15,7 @@
 //! [`FromWorkflowNode::from_workflow_node`](crate::FromWorkflowNode::from_workflow_node)
 //! and then erasing to the matching [`ErasedAction`] variant.
 
-use std::{any::Any, future::Future, marker::PhantomData, pin::Pin};
+use std::{any::Any, future::Future, marker::PhantomData, pin::Pin, sync::OnceLock};
 
 use async_trait::async_trait;
 use nebula_workflow::NodeDefinition;
@@ -67,12 +67,14 @@ pub trait ActionFactory: Send + Sync + 'static {
 /// Generic factory that produces [`ErasedAction::Stateless`] for any type
 /// implementing [`StatelessAction`] + [`FromWorkflowNode`].
 pub struct GenericStatelessFactory<A> {
+    meta: OnceLock<ActionMetadata>,
     _phantom: PhantomData<fn() -> A>,
 }
 
 impl<A> Default for GenericStatelessFactory<A> {
     fn default() -> Self {
         Self {
+            meta: OnceLock::new(),
             _phantom: PhantomData,
         }
     }
@@ -93,7 +95,7 @@ where
     <A as Action>::Output: Serialize + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        self.meta.get_or_init(<A as Action>::metadata)
     }
 
     fn instantiate<'a>(
@@ -103,7 +105,8 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let inner = ErasedStatelessImpl::<A>::new(action);
+            let meta = <A as Action>::metadata();
+            let inner = ErasedStatelessImpl::<A>::new(action, meta);
             Ok(ErasedAction::Stateless(Box::new(inner)))
         })
     }
@@ -111,11 +114,12 @@ where
 
 struct ErasedStatelessImpl<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ErasedStatelessImpl<A> {
-    fn new(action: A) -> Self {
-        Self { action }
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
     }
 }
 
@@ -127,7 +131,7 @@ where
     <A as Action>::Output: Serialize + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     async fn dispatch(
@@ -157,12 +161,14 @@ where
 /// Generic factory that produces [`ErasedAction::Stateful`] for any type
 /// implementing [`StatefulAction`] + [`FromWorkflowNode`].
 pub struct GenericStatefulFactory<A> {
+    meta: OnceLock<ActionMetadata>,
     _phantom: PhantomData<fn() -> A>,
 }
 
 impl<A> Default for GenericStatefulFactory<A> {
     fn default() -> Self {
         Self {
+            meta: OnceLock::new(),
             _phantom: PhantomData,
         }
     }
@@ -184,7 +190,7 @@ where
     A::State: Serialize + DeserializeOwned + Clone + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        self.meta.get_or_init(<A as Action>::metadata)
     }
 
     fn instantiate<'a>(
@@ -194,7 +200,8 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let inner = ErasedStatefulImpl::<A>::new(action);
+            let meta = <A as Action>::metadata();
+            let inner = ErasedStatefulImpl::<A>::new(action, meta);
             Ok(ErasedAction::Stateful(Box::new(inner)))
         })
     }
@@ -202,11 +209,12 @@ where
 
 struct ErasedStatefulImpl<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ErasedStatefulImpl<A> {
-    fn new(action: A) -> Self {
-        Self { action }
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
     }
 }
 
@@ -219,7 +227,7 @@ where
     A::State: Serialize + DeserializeOwned + Clone + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     fn init_state(&self) -> Result<Value, ActionError> {
@@ -290,12 +298,14 @@ where
 /// Generic factory that produces [`ErasedAction::Trigger`] for any type
 /// implementing [`TriggerAction`] + [`FromWorkflowNode`].
 pub struct GenericTriggerFactory<A> {
+    meta: OnceLock<ActionMetadata>,
     _phantom: PhantomData<fn() -> A>,
 }
 
 impl<A> Default for GenericTriggerFactory<A> {
     fn default() -> Self {
         Self {
+            meta: OnceLock::new(),
             _phantom: PhantomData,
         }
     }
@@ -315,7 +325,7 @@ where
     <A as TriggerAction>::Error: Into<ActionError>,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        self.meta.get_or_init(<A as Action>::metadata)
     }
 
     fn instantiate<'a>(
@@ -325,7 +335,8 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let inner = ErasedTriggerImpl::<A>::new(action);
+            let meta = <A as Action>::metadata();
+            let inner = ErasedTriggerImpl::<A>::new(action, meta);
             Ok(ErasedAction::Trigger(Box::new(inner)))
         })
     }
@@ -333,11 +344,12 @@ where
 
 struct ErasedTriggerImpl<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ErasedTriggerImpl<A> {
-    fn new(action: A) -> Self {
-        Self { action }
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
     }
 }
 
@@ -348,7 +360,7 @@ where
     <A as TriggerAction>::Error: Into<ActionError>,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     async fn start(&self, ctx: &dyn TriggerContext) -> Result<(), ActionError> {
@@ -390,12 +402,14 @@ where
 /// Generic factory that produces [`ErasedAction::Resource`] for any type
 /// implementing [`ResourceAction`] + [`FromWorkflowNode`].
 pub struct GenericResourceFactory<A> {
+    meta: OnceLock<ActionMetadata>,
     _phantom: PhantomData<fn() -> A>,
 }
 
 impl<A> Default for GenericResourceFactory<A> {
     fn default() -> Self {
         Self {
+            meta: OnceLock::new(),
             _phantom: PhantomData,
         }
     }
@@ -414,7 +428,7 @@ where
     A: ResourceAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        self.meta.get_or_init(<A as Action>::metadata)
     }
 
     fn instantiate<'a>(
@@ -424,7 +438,8 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let inner = ErasedResourceImpl::<A>::new(action);
+            let meta = <A as Action>::metadata();
+            let inner = ErasedResourceImpl::<A>::new(action, meta);
             Ok(ErasedAction::Resource(Box::new(inner)))
         })
     }
@@ -432,11 +447,12 @@ where
 
 struct ErasedResourceImpl<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ErasedResourceImpl<A> {
-    fn new(action: A) -> Self {
-        Self { action }
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
     }
 }
 
@@ -446,7 +462,7 @@ where
     A: ResourceAction + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     async fn configure(
@@ -479,12 +495,14 @@ where
 /// Generic factory that produces [`ErasedAction::Control`] for any type
 /// implementing [`ControlAction`] + [`FromWorkflowNode`].
 pub struct GenericControlFactory<A> {
+    meta: OnceLock<ActionMetadata>,
     _phantom: PhantomData<fn() -> A>,
 }
 
 impl<A> Default for GenericControlFactory<A> {
     fn default() -> Self {
         Self {
+            meta: OnceLock::new(),
             _phantom: PhantomData,
         }
     }
@@ -503,7 +521,7 @@ where
     A: ControlAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        self.meta.get_or_init(<A as Action>::metadata)
     }
 
     fn instantiate<'a>(
@@ -513,7 +531,8 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let inner = ErasedControlImpl::<A>::new(action);
+            let meta = <A as Action>::metadata();
+            let inner = ErasedControlImpl::<A>::new(action, meta);
             Ok(ErasedAction::Control(Box::new(inner)))
         })
     }
@@ -521,11 +540,12 @@ where
 
 struct ErasedControlImpl<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ErasedControlImpl<A> {
-    fn new(action: A) -> Self {
-        Self { action }
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
     }
 }
 
@@ -535,7 +555,7 @@ where
     A: ControlAction + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     async fn dispatch(

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -105,7 +105,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let meta = <A as Action>::metadata();
+            let meta = self.metadata().clone();
             let inner = ErasedStatelessImpl::<A>::new(action, meta);
             Ok(ErasedAction::Stateless(Box::new(inner)))
         })
@@ -200,7 +200,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let meta = <A as Action>::metadata();
+            let meta = self.metadata().clone();
             let inner = ErasedStatefulImpl::<A>::new(action, meta);
             Ok(ErasedAction::Stateful(Box::new(inner)))
         })
@@ -335,7 +335,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let meta = <A as Action>::metadata();
+            let meta = self.metadata().clone();
             let inner = ErasedTriggerImpl::<A>::new(action, meta);
             Ok(ErasedAction::Trigger(Box::new(inner)))
         })
@@ -438,7 +438,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let meta = <A as Action>::metadata();
+            let meta = self.metadata().clone();
             let inner = ErasedResourceImpl::<A>::new(action, meta);
             Ok(ErasedAction::Resource(Box::new(inner)))
         })
@@ -531,7 +531,7 @@ where
     ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
-            let meta = <A as Action>::metadata();
+            let meta = self.metadata().clone();
             let inner = ErasedControlImpl::<A>::new(action, meta);
             Ok(ErasedAction::Control(Box::new(inner)))
         })

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -156,85 +156,63 @@ impl ActionMetadata {
         }
     }
 
-    /// Create metadata whose `parameters` schema is auto-derived from a
-    /// [`StatelessAction`](crate::StatelessAction) implementation's `Input`
-    /// type.
+    /// Create metadata from a key alone — name defaults to the key string and
+    /// description is empty.
     ///
-    /// Prefer this over [`ActionMetadata::new`] + [`ActionMetadata::with_schema`]
-    /// when the author owns a typed `Input` struct — the compiler then
-    /// enforces that the declared `Input` type agrees with the schema the
-    /// engine, UI, and validator will see.
+    /// Convenience constructor symmetric with `ResourceMetadata::from_key` and
+    /// `CredentialMetadata::from_key`, useful for fixtures and placeholder
+    /// catalog entries where only the key is meaningful.
+    #[must_use]
+    pub fn from_key(key: &ActionKey) -> Self {
+        Self::new(key.clone(), key.to_string(), String::new())
+    }
+
+    /// Begin building metadata with the required catalog fields seeded.
+    ///
+    /// Symmetric entry point with `ResourceMetadata::builder` /
+    /// `CredentialMetadata::builder`. `ActionMetadata` uses a consuming fluent
+    /// builder — the `with_*` methods take and return `Self` — so this returns
+    /// the value directly; chain `with_*` and finish with
+    /// [`build`](Self::build), or use the value as-is.
+    #[must_use]
+    pub fn builder(
+        key: ActionKey,
+        name: impl Into<String>,
+        description: impl Into<String>,
+    ) -> Self {
+        Self::new(key, name, description)
+    }
+
+    /// Create metadata whose `parameters` schema is auto-derived from the
+    /// action's [`Input`](crate::Action::Input) type.
+    ///
+    /// Symmetric with `CredentialMetadata::for_credential` and
+    /// `ResourceMetadata::for_resource`. Prefer this over
+    /// [`ActionMetadata::new`] + [`ActionMetadata::with_schema`] when the
+    /// author owns a typed `Input` struct — the compiler then enforces that
+    /// the declared `Input` type agrees with the schema the engine, UI, and
+    /// validator will see. Works for any action kind (stateless, stateful,
+    /// paginated, batch, trigger, …) because every [`Action`](crate::Action)
+    /// has an `Input: HasSchema`.
     ///
     /// # Example
     ///
     /// ```ignore
-    /// use nebula_action::{ActionMetadata, StatelessAction};
+    /// use nebula_action::ActionMetadata;
     /// use nebula_core::action_key;
     ///
-    /// struct MyAction;
-    /// impl StatelessAction for MyAction {
-    /// type Input = MyInput; // must impl HasSchema
-    /// type Output = MyOutput;
-    /// //...
-    /// }
-    ///
-    /// let meta = ActionMetadata::for_stateless::<MyAction>(
-    /// action_key!("my.action"), "My Action", "desc",
+    /// let meta = ActionMetadata::for_action::<MyAction>(
+    ///     action_key!("my.action"), "My Action", "desc",
     /// );
     /// ```
     #[must_use]
-    pub fn for_stateless<A>(
+    pub fn for_action<A>(
         key: ActionKey,
         name: impl Into<String>,
         description: impl Into<String>,
     ) -> Self
     where
-        A: crate::stateless::StatelessAction,
-    {
-        Self::new(key, name, description)
-            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
-    }
-
-    /// Create metadata whose `parameters` schema is auto-derived from a
-    /// [`StatefulAction`](crate::StatefulAction)'s `Input` type.
-    #[must_use]
-    pub fn for_stateful<A>(
-        key: ActionKey,
-        name: impl Into<String>,
-        description: impl Into<String>,
-    ) -> Self
-    where
-        A: crate::stateful::StatefulAction,
-    {
-        Self::new(key, name, description)
-            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
-    }
-
-    /// Create metadata whose `parameters` schema is auto-derived from a
-    /// [`PaginatedAction`](crate::PaginatedAction)'s `Input` type.
-    #[must_use]
-    pub fn for_paginated<A>(
-        key: ActionKey,
-        name: impl Into<String>,
-        description: impl Into<String>,
-    ) -> Self
-    where
-        A: crate::stateful::PaginatedAction,
-    {
-        Self::new(key, name, description)
-            .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
-    }
-
-    /// Create metadata whose `parameters` schema is auto-derived from a
-    /// [`BatchAction`](crate::BatchAction)'s `Input` type.
-    #[must_use]
-    pub fn for_batch<A>(
-        key: ActionKey,
-        name: impl Into<String>,
-        description: impl Into<String>,
-    ) -> Self
-    where
-        A: crate::stateful::BatchAction,
+        A: crate::action::Action,
     {
         Self::new(key, name, description)
             .with_schema(<A::Input as nebula_schema::HasSchema>::schema())

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -159,9 +159,10 @@ impl ActionMetadata {
     /// Create metadata from a key alone — name defaults to the key string and
     /// description is empty.
     ///
-    /// Convenience constructor symmetric with `ResourceMetadata::from_key` and
-    /// `CredentialMetadata::from_key`, useful for fixtures and placeholder
-    /// catalog entries where only the key is meaningful.
+    /// Convenience constructor symmetric with `ResourceMetadata::from_key`,
+    /// useful for fixtures and placeholder catalog entries where only the key
+    /// is meaningful. (`CredentialMetadata` has no `from_key` — its required
+    /// `AuthPattern` has no meaningful default.)
     #[must_use]
     pub fn from_key(key: &ActionKey) -> Self {
         Self::new(key.clone(), key.to_string(), String::new())

--- a/crates/action/src/poll/mod.rs
+++ b/crates/action/src/poll/mod.rs
@@ -1052,6 +1052,7 @@ struct CycleOutcome<C> {
 /// - **`Err`**: cursor = pre-poll position. No events dispatched.
 pub struct PollTriggerAdapter<A: PollAction> {
     action: A,
+    meta: ActionMetadata,
     started: AtomicBool,
     poll_warn: WarnThrottle,
     serialize_warn: WarnThrottle,
@@ -1062,8 +1063,10 @@ impl<A: PollAction> PollTriggerAdapter<A> {
     /// Wrap a typed poll action.
     #[must_use]
     pub fn new(action: A) -> Self {
+        let meta = <A as Action>::metadata();
         Self {
             action,
+            meta,
             started: AtomicBool::new(false),
             poll_warn: WarnThrottle::new(),
             serialize_warn: WarnThrottle::new(),
@@ -1296,7 +1299,7 @@ where
     A::Event: Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     fn start<'life0, 'life1, 'a>(

--- a/crates/action/src/resource.rs
+++ b/crates/action/src/resource.rs
@@ -99,13 +99,18 @@ pub trait ResourceHandler: Send + Sync + 'static {
 /// ```
 pub struct ResourceActionAdapter<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> ResourceActionAdapter<A> {
     /// Wrap a typed resource action.
     #[must_use]
-    pub fn new(action: A) -> Self {
-        Self { action }
+    pub fn new(action: A) -> Self
+    where
+        A: Action,
+    {
+        let meta = <A as Action>::metadata();
+        Self { action, meta }
     }
 
     /// Consume the adapter, returning the inner action.
@@ -121,7 +126,7 @@ where
     A: ResourceAction + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     /// Configure the resource by delegating to the typed action.
@@ -199,15 +204,12 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    nebula_core::action_key!("test.resource_action"),
-                    "MockResource",
-                    "Creates a string pool",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.resource_action"),
+                "MockResource",
+                "Creates a string pool",
+            )
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/action/src/stateful.rs
+++ b/crates/action/src/stateful.rs
@@ -458,13 +458,18 @@ pub trait StatefulHandler: Send + Sync + 'static {
 /// engine checkpointing.
 pub struct StatefulActionAdapter<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> StatefulActionAdapter<A> {
     /// Wrap a typed stateful action.
     #[must_use]
-    pub fn new(action: A) -> Self {
-        Self { action }
+    pub fn new(action: A) -> Self
+    where
+        A: Action,
+    {
+        let meta = <A as Action>::metadata();
+        Self { action, meta }
     }
 
     /// Consume the adapter, returning the inner action.
@@ -483,7 +488,7 @@ where
     A::State: Serialize + DeserializeOwned + Clone + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     fn init_state(&self) -> Result<Value, ActionError> {
@@ -633,15 +638,12 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    nebula_core::action_key!("test.counter"),
-                    "Counter",
-                    "Counts up to 3",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.counter"),
+                "Counter",
+                "Counts up to 3",
+            )
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -754,15 +756,12 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    nebula_core::action_key!("test.mutate_fail"),
-                    "MutateFail",
-                    "Mutates state then fails",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.mutate_fail"),
+                "MutateFail",
+                "Mutates state then fails",
+            )
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/action/src/stateless.rs
+++ b/crates/action/src/stateless.rs
@@ -96,13 +96,18 @@ pub trait StatelessHandler: Send + Sync + 'static {
 /// strongly-typed Rust.
 pub struct StatelessActionAdapter<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> StatelessActionAdapter<A> {
     /// Wrap a typed stateless action.
     #[must_use]
-    pub fn new(action: A) -> Self {
-        Self { action }
+    pub fn new(action: A) -> Self
+    where
+        A: Action,
+    {
+        let meta = <A as Action>::metadata();
+        Self { action, meta }
     }
 
     /// Consume the adapter, returning the inner action.
@@ -118,7 +123,7 @@ where
     A: StatelessAction + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     async fn execute(
@@ -206,15 +211,12 @@ mod tests {
         type Input = AddInput;
         type Output = AddOutput;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    nebula_core::action_key!("math.add"),
-                    "Add",
-                    "Adds two numbers",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("math.add"),
+                "Add",
+                "Adds two numbers",
+            )
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/action/src/trigger/mod.rs
+++ b/crates/action/src/trigger/mod.rs
@@ -466,13 +466,18 @@ pub trait TriggerHandler: Send + Sync + 'static {
 /// ```
 pub struct TriggerActionAdapter<A> {
     action: A,
+    meta: ActionMetadata,
 }
 
 impl<A> TriggerActionAdapter<A> {
     /// Wrap a typed trigger action.
     #[must_use]
-    pub fn new(action: A) -> Self {
-        Self { action }
+    pub fn new(action: A) -> Self
+    where
+        A: Action,
+    {
+        let meta = <A as Action>::metadata();
+        Self { action, meta }
     }
 
     /// Consume the adapter, returning the inner action.
@@ -489,7 +494,7 @@ where
     A::Error: Into<ActionError>,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     /// Start the trigger by delegating to the typed action.
@@ -599,16 +604,12 @@ mod tests {
         type Input = Value;
         type Output = Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            use std::sync::OnceLock;
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    nebula_core::action_key!("test.trigger_action"),
-                    "MockTrigger",
-                    "Tracks start/stop",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.trigger_action"),
+                "MockTrigger",
+                "Tracks start/stop",
+            )
         }
         fn dependencies() -> &'static nebula_core::Dependencies {
             use std::sync::OnceLock;

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -1561,6 +1561,7 @@ pub struct WebhookTriggerAdapter<A: WebhookAction> {
     /// because webhook configuration does not belong on the base
     /// trigger trait.
     config: WebhookConfig,
+    meta: ActionMetadata,
     state: RwLock<Option<Arc<A::State>>>,
     /// Shared with every [`InFlightGuard`] so the guard can decrement
     /// and notify on drop without needing a lifetime back to `self`.
@@ -1573,16 +1574,18 @@ pub struct WebhookTriggerAdapter<A: WebhookAction> {
 impl<A: WebhookAction> WebhookTriggerAdapter<A> {
     /// Wrap a typed webhook action.
     ///
-    /// Reads [`WebhookAction::config`] once and caches the result so
-    /// the dispatch path does not re-enter the action on every
-    /// request, and so the runtime / test harness can forward the
+    /// Reads [`WebhookAction::config`] and [`Action::metadata`] once and
+    /// caches both so the dispatch path does not re-enter the action on
+    /// every request, and so the runtime / test harness can forward the
     /// policy to the transport without re-downcasting the handler.
     #[must_use]
     pub fn new(action: A) -> Self {
         let config = action.config();
+        let meta = <A as Action>::metadata();
         Self {
             action,
             config,
+            meta,
             state: RwLock::new(None),
             in_flight: Arc::new(AtomicU32::new(0)),
             idle_notify: Arc::new(Notify::new()),
@@ -1624,7 +1627,7 @@ where
     A::State: Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        <A as Action>::metadata()
+        &self.meta
     }
 
     fn start<'life0, 'life1, 'a>(

--- a/crates/action/src/webhook/providers/generic.rs
+++ b/crates/action/src/webhook/providers/generic.rs
@@ -105,15 +105,12 @@ impl Action for GenericWebhookAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("nebula.webhook.generic"),
-                "Generic Webhook",
-                "Provider-agnostic HMAC-signed webhook trigger.",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("nebula.webhook.generic"),
+            "Generic Webhook",
+            "Provider-agnostic HMAC-signed webhook trigger.",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/src/webhook/providers/slack.rs
+++ b/crates/action/src/webhook/providers/slack.rs
@@ -63,15 +63,12 @@ impl Action for SlackWebhookAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("nebula.webhook.slack"),
-                "Slack Webhook",
-                "Slack-flavoured signed webhook trigger.",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("nebula.webhook.slack"),
+            "Slack Webhook",
+            "Slack-flavoured signed webhook trigger.",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/src/webhook/providers/stripe.rs
+++ b/crates/action/src/webhook/providers/stripe.rs
@@ -61,15 +61,12 @@ impl Action for StripeWebhookAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("nebula.webhook.stripe"),
-                "Stripe Webhook",
-                "Stripe-flavoured signed webhook trigger.",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("nebula.webhook.stripe"),
+            "Stripe Webhook",
+            "Stripe-flavoured signed webhook trigger.",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/dx_batch.rs
+++ b/crates/action/tests/dx_batch.rs
@@ -55,15 +55,12 @@ impl Action for DoublerBatch {
     type Input = NumberList;
     type Output = BatchOutput;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.doubler_batch"),
-                "DoublerBatch",
-                "Batch doubler",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.doubler_batch"),
+            "DoublerBatch",
+            "Batch doubler",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/dx_control.rs
+++ b/crates/action/tests/dx_control.rs
@@ -55,12 +55,9 @@ impl Action for DemoIf {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(action_key!("demo.if"), "If", "Binary branch")
-                .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("demo.if"), "If", "Binary branch")
+            .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -154,21 +151,18 @@ impl Action for DemoSwitch {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("demo.switch"),
-                "Switch",
-                "N-way branch by status field",
-            )
-            .with_outputs(vec![
-                OutputPort::flow("active"),
-                OutputPort::flow("pending"),
-                OutputPort::flow("archived"),
-                OutputPort::flow("default"),
-            ])
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.switch"),
+            "Switch",
+            "N-way branch by status field",
+        )
+        .with_outputs(vec![
+            OutputPort::flow("active"),
+            OutputPort::flow("pending"),
+            OutputPort::flow("archived"),
+            OutputPort::flow("default"),
+        ])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -251,16 +245,13 @@ impl Action for DemoRouter {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(action_key!("demo.router"), "Router", "Multi-rule routing")
-                .with_outputs(vec![
-                    OutputPort::flow("high"),
-                    OutputPort::flow("medium"),
-                    OutputPort::flow("low"),
-                ])
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("demo.router"), "Router", "Multi-rule routing")
+            .with_outputs(vec![
+                OutputPort::flow("high"),
+                OutputPort::flow("medium"),
+                OutputPort::flow("low"),
+            ])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -338,16 +329,13 @@ impl Action for NeverMatchRouter {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("demo.never_match_router"),
-                "NeverMatchRouter",
-                "Drops every input — used to test Drop code path",
-            )
-            .with_outputs(vec![OutputPort::flow("out")])
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.never_match_router"),
+            "NeverMatchRouter",
+            "Drops every input — used to test Drop code path",
+        )
+        .with_outputs(vec![OutputPort::flow("out")])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -386,16 +374,13 @@ impl Action for DemoFilter {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("demo.filter"),
-                "Filter",
-                "Drop items below threshold",
-            )
-            .with_outputs(vec![OutputPort::flow("out")])
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.filter"),
+            "Filter",
+            "Drop items below threshold",
+        )
+        .with_outputs(vec![OutputPort::flow("out")])
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -466,11 +451,8 @@ impl Action for DemoNoOp {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(action_key!("demo.noop"), "NoOp", "Pass-through placeholder")
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("demo.noop"), "NoOp", "Pass-through placeholder")
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -529,16 +511,13 @@ impl Action for DemoStop {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("demo.stop"),
-                "Stop",
-                "Terminate execution with success",
-            )
-            .with_outputs(Vec::new())
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.stop"),
+            "Stop",
+            "Terminate execution with success",
+        )
+        .with_outputs(Vec::new())
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -604,16 +583,13 @@ impl Action for DemoFail {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("demo.fail"),
-                "Fail",
-                "Terminate execution with failure",
-            )
-            .with_outputs(Vec::new())
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.fail"),
+            "Fail",
+            "Terminate execution with failure",
+        )
+        .with_outputs(Vec::new())
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/dx_paginated.rs
+++ b/crates/action/tests/dx_paginated.rs
@@ -37,15 +37,12 @@ impl Action for NumberPaginator {
     type Input = serde_json::Value;
     type Output = NumberPage;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.number_paginator"),
-                "NumberPaginator",
-                "Paginate numbers",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.number_paginator"),
+            "NumberPaginator",
+            "Paginate numbers",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -93,15 +90,12 @@ impl Action for LimitedPaginator {
     type Input = serde_json::Value;
     type Output = NumberPage;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.limited_paginator"),
-                "LimitedPaginator",
-                "Paginate with limit",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.limited_paginator"),
+            "LimitedPaginator",
+            "Paginate with limit",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/dx_poll.rs
+++ b/crates/action/tests/dx_poll.rs
@@ -27,15 +27,12 @@ impl Action for TickPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.tick"),
-                "Tick Poller",
-                "Test poll trigger",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.tick"),
+            "Tick Poller",
+            "Test poll trigger",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -174,15 +171,12 @@ impl Action for ZeroIntervalPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.tick.zero"),
-                "Zero Interval",
-                "Returns Duration::ZERO from poll_config",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.tick.zero"),
+            "Zero Interval",
+            "Returns Duration::ZERO from poll_config",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -460,15 +454,12 @@ impl Action for FailingValidator {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.validate.fail"),
-                "Failing Validator",
-                "validate() returns Err",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.validate.fail"),
+            "Failing Validator",
+            "validate() returns Err",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -522,15 +513,12 @@ impl Action for StartFromNowPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.initial_cursor"),
-                "Start From Now",
-                "initial_cursor returns 1000",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.initial_cursor"),
+            "Start From Now",
+            "initial_cursor returns 1000",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -634,15 +622,12 @@ impl Action for ReadyPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.retry_batch"),
-                "Retry Batch",
-                "always-ready, emitter fails",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.retry_batch"),
+            "Retry Batch",
+            "always-ready, emitter fails",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -756,15 +741,12 @@ impl Action for DropPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.drop_loss"),
-                "Drop Loss",
-                "all events dropped under DropAndContinue",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.drop_loss"),
+            "Drop Loss",
+            "all events dropped under DropAndContinue",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -856,15 +838,12 @@ impl Action for HugeOverridePoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.huge_override"),
-                "Huge Override",
-                "override_next = 1h, max_interval = 200ms",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.huge_override"),
+            "Huge Override",
+            "override_next = 1h, max_interval = 200ms",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -942,15 +921,12 @@ impl Action for EmptyPartialPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.empty_partial"),
-                "Empty Partial",
-                "returns Partial with no events and a retryable error",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.empty_partial"),
+            "Empty Partial",
+            "returns Partial with no events and a retryable error",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -1029,15 +1005,12 @@ impl Action for SlowPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.first_poll.immediate"),
-                "Slow Poller",
-                "base_interval 10min, first poll should still run immediately",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.first_poll.immediate"),
+            "Slow Poller",
+            "base_interval 10min, first poll should still run immediately",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -1187,15 +1160,12 @@ impl Action for WildConfigPoller {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.wild_config"),
-                "Wild Config",
-                "Configurable PollConfig for clamp tests",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.wild_config"),
+            "Wild Config",
+            "Configurable PollConfig for clamp tests",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/dx_webhook.rs
+++ b/crates/action/tests/dx_webhook.rs
@@ -30,15 +30,12 @@ impl Action for TestWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook"),
-                "Test Webhook",
-                "Test webhook action",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook"),
+            "Test Webhook",
+            "Test webhook action",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -187,15 +184,12 @@ impl Action for CountingWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.count"),
-                "Counting Webhook",
-                "Counts activate/deactivate",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.count"),
+            "Counting Webhook",
+            "Counts activate/deactivate",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -296,15 +290,12 @@ impl Action for ErroringWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.error"),
-                "Erroring Webhook",
-                "handle_request always returns Err",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.error"),
+            "Erroring Webhook",
+            "handle_request always returns Err",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -370,15 +361,12 @@ impl Action for HangingWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.hang"),
-                "Hanging Webhook",
-                "handle_request hangs forever",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.hang"),
+            "Hanging Webhook",
+            "handle_request hangs forever",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -505,15 +493,12 @@ impl Action for SlowWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.slow"),
-                "Slow Webhook",
-                "handle_request awaits a flag",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.slow"),
+            "Slow Webhook",
+            "handle_request awaits a flag",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/execution_integration.rs
+++ b/crates/action/tests/execution_integration.rs
@@ -35,11 +35,8 @@ impl Action for EchoAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(action_key!("test.echo"), "Echo", "Echo input to output")
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("test.echo"), "Echo", "Echo input to output")
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -89,11 +86,8 @@ impl Action for CounterAction {
     type Input = ();
     type Output = U32Out;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(action_key!("test.counter"), "Counter", "Count then break")
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("test.counter"), "Counter", "Count then break")
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -174,15 +168,12 @@ impl Action for NoOpTrigger {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.noop_trigger"),
-                "NoOp Trigger",
-                "Start/stop no-op",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.noop_trigger"),
+            "NoOp Trigger",
+            "Start/stop no-op",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {
@@ -241,15 +232,12 @@ impl Action for MigratableAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.migratable"),
-                "Migratable",
-                "Migrates v1 state",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.migratable"),
+            "Migratable",
+            "Migrates v1 state",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/probes/missing_trigger_source.rs
+++ b/crates/action/tests/probes/missing_trigger_source.rs
@@ -16,9 +16,8 @@ impl Action for BadTrigger {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| ActionMetadata::new(action_key!("bad.trigger"), "Bad", "x"))
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("bad.trigger"), "Bad", "x")
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/action/tests/probes/missing_trigger_source.stderr
+++ b/crates/action/tests/probes/missing_trigger_source.stderr
@@ -1,7 +1,7 @@
 error[E0046]: not all trait items implemented, missing: `Source`
-  --> tests/probes/missing_trigger_source.rs:29:1
+  --> tests/probes/missing_trigger_source.rs:28:1
    |
-29 | impl TriggerAction for BadTrigger {
+28 | impl TriggerAction for BadTrigger {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing `Source` in implementation
    |
    = help: implement the missing item: `type Source = /* Type */;`

--- a/crates/action/tests/resource_roundtrip.rs
+++ b/crates/action/tests/resource_roundtrip.rs
@@ -39,15 +39,12 @@ impl Action for PoolAction {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.resource.pool"),
-                "Pool",
-                "Typed pool resource",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.resource.pool"),
+            "Pool",
+            "Typed pool resource",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/action/tests/schema_validator_expression_pipeline.rs
+++ b/crates/action/tests/schema_validator_expression_pipeline.rs
@@ -78,15 +78,12 @@ impl Action for PipelineProbe {
     type Input = PipelineInput;
     type Output = PipelineOutput;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.phase9.pipeline_probe"),
-                "PipelineProbe",
-                "Phase 9 / Task 9.1 schema → validator → expression pipeline probe",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.phase9.pipeline_probe"),
+            "PipelineProbe",
+            "Phase 9 / Task 9.1 schema → validator → expression pipeline probe",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -880,16 +880,12 @@ pub(crate) mod engine_seam {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static nebula_action::metadata::ActionMetadata {
-            static M: std::sync::OnceLock<nebula_action::metadata::ActionMetadata> =
-                std::sync::OnceLock::new();
-            M.get_or_init(|| {
-                nebula_action::metadata::ActionMetadata::new(
-                    nebula_core::action_key!("seam.slow.static"),
-                    "SlowAction",
-                    "static",
-                )
-            })
+        fn metadata() -> nebula_action::metadata::ActionMetadata {
+            nebula_action::metadata::ActionMetadata::new(
+                nebula_core::action_key!("seam.slow.static"),
+                "SlowAction",
+                "static",
+            )
         }
         fn dependencies() -> &'static nebula_core::Dependencies {
             static D: std::sync::OnceLock<nebula_core::Dependencies> = std::sync::OnceLock::new();

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -378,16 +378,12 @@ impl nebula_action::action::Action for KnifeEcho {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static nebula_action::metadata::ActionMetadata {
-        static M: std::sync::OnceLock<nebula_action::metadata::ActionMetadata> =
-            std::sync::OnceLock::new();
-        M.get_or_init(|| {
-            nebula_action::metadata::ActionMetadata::new(
-                nebula_core::action_key!("knife.echo.static"),
-                "KnifeEcho",
-                "static",
-            )
-        })
+    fn metadata() -> nebula_action::metadata::ActionMetadata {
+        nebula_action::metadata::ActionMetadata::new(
+            nebula_core::action_key!("knife.echo.static"),
+            "KnifeEcho",
+            "static",
+        )
     }
     fn dependencies() -> &'static nebula_core::Dependencies {
         static D: std::sync::OnceLock<nebula_core::Dependencies> = std::sync::OnceLock::new();

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -60,15 +60,12 @@ impl Action for GitHubLikeWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.integration"),
-                "GitHub-like",
-                "Integration test webhook",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.integration"),
+            "GitHub-like",
+            "Integration test webhook",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -409,15 +406,12 @@ impl Action for HangingWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.hang"),
-                "Hanging",
-                "Handler that never returns",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.hang"),
+            "Hanging",
+            "Handler that never returns",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -620,15 +614,12 @@ impl Action for UnsignedWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.unsigned"),
-                "Unsigned",
-                "OptionalAcceptUnsigned regression guard",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.unsigned"),
+            "Unsigned",
+            "OptionalAcceptUnsigned regression guard",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -670,15 +661,12 @@ impl Action for DefaultConfigWebhook {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                nebula_core::action_key!("test.webhook.default_config.static"),
-                "DefaultConfig",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            nebula_core::action_key!("test.webhook.default_config.static"),
+            "DefaultConfig",
+            "static",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/credential/src/metadata.rs
+++ b/crates/credential/src/metadata.rs
@@ -36,6 +36,22 @@ pub enum CredentialMetadataBuildError {
 /// `description`, `schema`, `icon`, `documentation_url`, `tags`,
 /// `maturity`, `deprecation`) lives on the composed [`BaseMetadata`];
 /// `pattern` is the credential-specific classifier.
+///
+/// # Constructors
+///
+/// The accessor and type-driven constructor mirror the other catalog leaves
+/// (`ActionMetadata` / `ResourceMetadata`): [`Credential::metadata`](crate::Credential::metadata) returns
+/// `CredentialMetadata` by value, and [`for_credential`](Self::for_credential)
+/// derives the schema from a typed `Credential` impl, symmetric with
+/// `ActionMetadata::for_action` and `ResourceMetadata::for_resource`.
+///
+/// Two constructors are deliberately *not* mirrored, because `pattern`
+/// ([`AuthPattern`]) is a required identity field with no meaningful default:
+/// there is no `from_key` (a key-only credential carries no auth pattern and
+/// is meaningless), and [`builder`](Self::builder) stays an imperative
+/// `Option`-field builder (rather than the seeded `builder(key, name,
+/// description)` of the other two) for the config-driven / icon / doc-url
+/// path, where `pattern` and `schema` are supplied as setters.
 #[non_exhaustive]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CredentialMetadata {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -5287,11 +5287,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.echo.static"), "Echo", "echoes input")
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.echo.static"), "Echo", "echoes input")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -5315,9 +5312,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| ActionMetadata::new(action_key!("test.fail.static"), "Fail", "fails"))
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.fail.static"), "Fail", "fails")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -5343,9 +5339,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| ActionMetadata::new(action_key!("test.slow.static"), "Slow", "delays"))
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.slow.static"), "Slow", "delays")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -5930,9 +5925,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| ActionMetadata::new(action_key!("test.skip.static"), "Skip", "skips"))
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.skip.static"), "Skip", "skips")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -5958,11 +5952,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.branch.static"), "Branch", "branches")
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.branch.static"), "Branch", "branches")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -7352,11 +7343,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("counting.static"), "Counting", "counts calls")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("counting.static"), "Counting", "counts calls")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -7468,11 +7456,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("versioned.v1.static"), "V1", "v1 static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("versioned.v1.static"), "V1", "v1 static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -7497,11 +7482,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("versioned.v2.static"), "V2", "v2 static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("versioned.v2.static"), "V2", "v2 static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -8046,11 +8028,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("never.static"), "Never", "must not run")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("never.static"), "Never", "must not run")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -8692,9 +8671,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| ActionMetadata::new(action_key!("boom.static"), "Boom", "panics"))
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("boom.static"), "Boom", "panics")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -9720,15 +9698,12 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(
-                    action_key!("test.factory.echo"),
-                    "FactoryEcho",
-                    "echo via factory dispatch",
-                )
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                action_key!("test.factory.echo"),
+                "FactoryEcho",
+                "echo via factory dispatch",
+            )
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -148,7 +148,7 @@ impl ActionRegistry {
         <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
         <A as Action>::Output: serde::Serialize + Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Stateless(Arc::new(StatelessActionAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -167,7 +167,7 @@ impl ActionRegistry {
         <A as Action>::Output: serde::Serialize + Send + Sync,
         A::State: serde::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Stateful(Arc::new(StatefulActionAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -184,7 +184,7 @@ impl ActionRegistry {
         A: TriggerAction + Send + Sync + 'static,
         A::Error: Into<ActionError>,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Trigger(Arc::new(TriggerActionAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -201,7 +201,7 @@ impl ActionRegistry {
         A: WebhookAction + Send + Sync + 'static,
         <A as WebhookAction>::State: Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Trigger(Arc::new(WebhookTriggerAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -219,7 +219,7 @@ impl ActionRegistry {
         <A as PollAction>::Cursor: Send + Sync,
         <A as PollAction>::Event: Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Trigger(Arc::new(PollTriggerAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -235,7 +235,7 @@ impl ActionRegistry {
     where
         A: Action + ResourceAction + Send + Sync + 'static,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let handler = ActionHandler::Resource(Arc::new(ResourceActionAdapter::new(action)));
         self.register(metadata, handler);
     }
@@ -293,7 +293,7 @@ impl ActionRegistry {
         <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
         <A as Action>::Output: serde::Serialize + Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericStatelessFactory::<A>::new());
         self.register_factory(metadata, factory);
     }
@@ -306,7 +306,7 @@ impl ActionRegistry {
         <A as Action>::Output: serde::Serialize + Send + Sync,
         A::State: serde::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericStatefulFactory::<A>::new());
         self.register_factory(metadata, factory);
     }
@@ -317,7 +317,7 @@ impl ActionRegistry {
         A: TriggerAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
         <A as TriggerAction>::Error: Into<ActionError>,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericTriggerFactory::<A>::new());
         self.register_factory(metadata, factory);
     }
@@ -327,7 +327,7 @@ impl ActionRegistry {
     where
         A: ResourceAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericResourceFactory::<A>::new());
         self.register_factory(metadata, factory);
     }
@@ -337,7 +337,7 @@ impl ActionRegistry {
     where
         A: ControlAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
     {
-        let metadata = <A as Action>::metadata().clone();
+        let metadata = <A as Action>::metadata();
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericControlFactory::<A>::new());
         self.register_factory(metadata, factory);
     }
@@ -470,7 +470,7 @@ mod tests {
         action::Action, error::ActionError, metadata::ActionMetadata, result::ActionResult,
         stateless::StatelessAction,
     };
-    use nebula_core::Dependencies;
+    use nebula_core::{Dependencies, action_key};
 
     use super::*;
 
@@ -480,11 +480,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(ActionKey::new("test.noop").unwrap(), "Noop", "Does nothing")
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.noop"), "Noop", "Does nothing")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -1381,11 +1381,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.echo.static"), "Echo", "echoes input")
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.echo.static"), "Echo", "echoes input")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -1409,11 +1406,8 @@ mod tests {
         type Input = serde_json::Value;
         type Output = serde_json::Value;
 
-        fn metadata() -> &'static ActionMetadata {
-            static M: OnceLock<ActionMetadata> = OnceLock::new();
-            M.get_or_init(|| {
-                ActionMetadata::new(action_key!("test.fail.static"), "Fail", "always fails")
-            })
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(action_key!("test.fail.static"), "Fail", "always fails")
         }
         fn dependencies() -> &'static Dependencies {
             static D: OnceLock<Dependencies> = OnceLock::new();
@@ -1838,15 +1832,12 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(
-                        action_key!("test.multi_out.static"),
-                        "MultiOut",
-                        "multi-port fan-out",
-                    )
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(
+                    action_key!("test.multi_out.static"),
+                    "MultiOut",
+                    "multi-port fan-out",
+                )
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -1927,11 +1918,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("test.branch.static"), "Branch", "static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("test.branch.static"), "Branch", "static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -2000,11 +1988,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("test.collection.static"), "Coll", "static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("test.collection.static"), "Coll", "static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -2075,11 +2060,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("test.binary.static"), "Bin", "static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("test.binary.static"), "Bin", "static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();
@@ -2143,11 +2125,8 @@ mod tests {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| {
-                    ActionMetadata::new(action_key!("test.ref.static"), "Ref", "static")
-                })
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(action_key!("test.ref.static"), "Ref", "static")
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -118,15 +118,12 @@ impl Action for CountingEchoHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.counting_echo.static"),
-                "CountingEcho",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.counting_echo.static"),
+            "CountingEcho",
+            "static",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -156,15 +153,12 @@ impl Action for SlowCancellableHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.slow_cancellable.static"),
-                "SlowCancellable",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.slow_cancellable.static"),
+            "SlowCancellable",
+            "static",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -66,15 +66,12 @@ impl Action for PipelineWitness {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.phase9.pipeline_witness"),
-                "PipelineWitness",
-                "Phase 9 e2e pipeline witness",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.phase9.pipeline_witness"),
+            "PipelineWitness",
+            "Phase 9 e2e pipeline witness",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -39,9 +39,8 @@ macro_rules! variant_a_action {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| ActionMetadata::new($key, $name, $desc))
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, $desc)
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -174,9 +174,8 @@ macro_rules! placeholder_action_impl {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| ActionMetadata::new($key, $name, $desc))
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, $desc)
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -51,15 +51,12 @@ impl Action for ResourceConsumerHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.resource_consumer.static"),
-                "ResourceConsumer",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.resource_consumer.static"),
+            "ResourceConsumer",
+            "static",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -94,15 +91,12 @@ impl Action for ResourceProbeHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.resource_probe.static"),
-                "ResourceProbe",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.resource_probe.static"),
+            "ResourceProbe",
+            "static",
+        )
     }
     fn dependencies() -> &'static Dependencies {
         static D: OnceLock<Dependencies> = OnceLock::new();
@@ -345,15 +339,12 @@ impl Action for IntegrationAcquireHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| {
-            ActionMetadata::new(
-                action_key!("test.engine_integration.acquire"),
-                "IntegrationAcquire",
-                "static",
-            )
-        })
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.engine_integration.acquire"),
+            "IntegrationAcquire",
+            "static",
+        )
     }
 
     fn dependencies() -> &'static Dependencies {

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -242,10 +242,8 @@ impl Action for NoopHandler {
     type Input = serde_json::Value;
     type Output = serde_json::Value;
 
-    fn metadata() -> &'static ActionMetadata {
-        use std::sync::OnceLock;
-        static M: OnceLock<ActionMetadata> = OnceLock::new();
-        M.get_or_init(|| ActionMetadata::new(action_key!("test.noop.static"), "Noop", "static"))
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("test.noop.static"), "Noop", "static")
     }
     fn dependencies() -> &'static Dependencies {
         use std::sync::OnceLock;

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -46,9 +46,8 @@ macro_rules! placeholder_action_impl {
             type Input = serde_json::Value;
             type Output = serde_json::Value;
 
-            fn metadata() -> &'static ActionMetadata {
-                static M: OnceLock<ActionMetadata> = OnceLock::new();
-                M.get_or_init(|| ActionMetadata::new($key, $name, $desc))
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, $desc)
             }
             fn dependencies() -> &'static Dependencies {
                 static D: OnceLock<Dependencies> = OnceLock::new();

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -15,6 +15,7 @@ documentation.workspace = true
 # Core re-exports
 nebula-core = { path = "../core" }
 nebula-action = { path = "../action" }
+nebula-metadata = { path = "../metadata" }
 nebula-workflow = { path = "../workflow" }
 nebula-schema = { path = "../schema" }
 nebula-credential = { path = "../credential" }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -246,16 +246,12 @@ macro_rules! simple_action {
             type Input = $input;
             type Output = $output;
 
-            fn metadata() -> &'static $crate::nebula_action::ActionMetadata {
-                static METADATA: ::std::sync::OnceLock<$crate::nebula_action::ActionMetadata> =
-                    ::std::sync::OnceLock::new();
-                METADATA.get_or_init(|| {
-                    $crate::nebula_action::ActionMetadata::for_stateless::<$name>(
-                        $crate::nebula_core::action_key!($key),
-                        stringify!($name),
-                        "",
-                    )
-                })
+            fn metadata() -> $crate::nebula_action::ActionMetadata {
+                $crate::nebula_action::ActionMetadata::for_action::<$name>(
+                    $crate::nebula_core::action_key!($key),
+                    stringify!($name),
+                    "",
+                )
             }
 
             fn dependencies() -> &'static $crate::nebula_core::Dependencies {

--- a/crates/sdk/src/prelude.rs
+++ b/crates/sdk/src/prelude.rs
@@ -56,9 +56,15 @@ pub use nebula_credential::{
     SnapshotError,
 };
 pub use nebula_credential::{CredentialContext, CredentialId};
+// Shared catalog-metadata vocabulary — the `Metadata` trait plus the
+// `BaseMetadata` prefix and value types that `ActionMetadata`,
+// `CredentialMetadata`, and `ResourceMetadata` all compose. Re-exported so the
+// uniform `metadata()` accessor surface (`key`/`name`/`version`/`icon`/…) is
+// usable across all three catalog leaves from a single import.
+pub use nebula_metadata::{BaseMetadata, DeprecationNotice, Icon, MaturityLevel, Metadata};
 // Plugin types
 pub use nebula_plugin::{Plugin, PluginManifest};
-pub use nebula_resource::Resource;
+pub use nebula_resource::{Resource, ResourceMetadata};
 // Derive macros (re-exported from their respective domain crates)
 // Action, Credential, and Plugin derive macros are already in scope from the
 // domain crate imports above (same names, macro namespace).

--- a/docs/adr/0090-metadata-crate-placement-and-symmetric-api.md
+++ b/docs/adr/0090-metadata-crate-placement-and-symmetric-api.md
@@ -1,0 +1,158 @@
+---
+# budget-justified: ADR prose document — one contiguous decision record (crate-placement rationale + Bevy prior-art table + symmetric-API contract), not decomposable code
+id: 0090
+title: metadata-crate-placement-and-symmetric-api
+status: accepted
+date: 2026-06-09
+supersedes: []
+amends: []
+superseded_by: []
+tags: [crate-boundaries, metadata, layering, api, dx, prelude, compile-time, bevy]
+related:
+  - CLAUDE.md  # Layered Dependency Map
+  - crates/core/CLAUDE.md  # vocabulary-only charter
+  - crates/metadata/CLAUDE.md
+  - crates/action/CLAUDE.md
+  - crates/credential/CLAUDE.md
+  - crates/resource/CLAUDE.md
+  - crates/sdk/CLAUDE.md
+---
+
+# 0090. `nebula-metadata` stays a focused Core-layer crate; metadata DX via prelude, not a merge; symmetric by-value metadata API
+
+## Status
+
+**Accepted** (2026-06-09).
+
+Two questions were posed: (1) should `nebula-metadata` be **merged into
+`nebula-core`**, and (2) make the metadata accessor/constructor API
+**symmetric** across `Action` / `Credential` / `Resource` for DX. The answer to
+(1) is **no — keep it a separate crate**; (2) is **done**, and is independent of
+(1).
+
+## Context
+
+`nebula-metadata` (Core tier) owns the shared catalog-leaf vocabulary:
+`BaseMetadata<K>`, the `Metadata` trait (single required `base()` + 11 defaulted
+accessors), `Icon` / `MaturityLevel` / `DeprecationNotice`, `validate_base_compat`,
+and the `PluginManifest` container descriptor. It depends on `nebula-core` +
+`nebula-schema` (only for the `ValidSchema` field on `BaseMetadata`) +
+`nebula-error`. Consumers: `action`, `credential`, `resource`, `plugin`,
+`plugin-sdk`, `sandbox`.
+
+The merge proposal ("move it into `nebula-core`") has a real, non-obvious cost.
+`nebula-core` is the **universal bottom crate** — every crate depends on it —
+and its charter (`crates/core/CLAUDE.md`) is explicit: *"vocabulary only: no
+validation (`nebula-schema`/`nebula-validator`) … do not pull those concerns
+down here."* Merging `metadata` into `core` forces `core → nebula-schema →
+{validator, expression}`. Measured blast radius: **5 crates depend on `core` but
+not on `schema` today** — `storage-port` (chartered "no sqlx, no upward deps,
+minimal", ADR-0072), `storage`, `tenancy`, `workflow`, `execution` — and none of
+them use metadata. The merge would inject an expression-evaluator subtree into
+all five, and into every `core`-relink fan-out. The cycle is clean (validator /
+expression do not depend on `core`), and `cargo deny` needs no wrappers edit
+(`core`/`metadata`/`schema` are all broadly importable) — so the merge is
+*mechanically* possible; it is the *coupling* that disqualifies it.
+
+Prior art (Bevy, ~59-crate workspace; tokio; large-Rust-workspace practice) is
+unanimous and directly analogous:
+
+| Nebula | Bevy analogue | Lesson |
+|--------|---------------|--------|
+| `nebula-metadata` (type-descriptor crate) | `bevy_reflect` (type metadata/reflection) | Kept a **separate** crate; the heavier core depends **on** it (`bevy_ecs → bevy_reflect`), never merged — *"would force every reflection consumer to take a dependency on ECS."* |
+| `nebula-core` (universal bottom) | `bevy_platform` / the deleted `bevy_core` | Bevy **deleted** `bevy_core` (issue #16892) — *"a utilities crate, which we would like to avoid"* — dissolving its types **outward** into focused homes. Shared types move **out of** catch-all bottoms, never **into** them. |
+| "single clean import" DX | `bevy` + `bevy_internal` umbrella, `bevy::prelude` | DX is a **re-export** problem (facade/prelude), solved **without** collapsing the crate graph. |
+
+The one case Bevy *did* fold a type into a bottom crate (`Name → bevy_ecs`) was
+gated on two tests: universally applicable **and** "wouldn't change the
+dependency graph." The metadata-into-core merge fails **both** (5 non-users; it
+injects a heavy subtree).
+
+Crucially, the symmetric-API goal is **independent** of crate placement: it
+edits `ActionMetadata` / `CredentialMetadata` / `ResourceMetadata` in their own
+crates, which reference `BaseMetadata` by import path regardless of where
+`BaseMetadata` lives. The merge would only change *where `BaseMetadata`
+physically lives* — a cosmetic import path — at the coupling cost above.
+
+## Decision
+
+**D1 — Do not merge.** `nebula-metadata` remains a focused Core-layer crate.
+`nebula-core` keeps its vocabulary-only charter; the 6-layer DAG and the 5
+non-user crates are untouched.
+
+**D2 — Symmetric by-value accessor.** `Action::metadata()` changes from
+`fn metadata() -> &'static ActionMetadata` to **`fn metadata() -> ActionMetadata`**
+(by value), matching `Credential::metadata()` and `Resource::metadata()` which
+were already by-value. This deletes the `static`/`OnceLock` boilerplate every
+action author hand-wrote. The engine-internal object-safe surfaces
+(`ActionFactory`, the `Erased*` traits, the typed→Handler adapters) keep
+returning `&ActionMetadata` backed by an internal cache (`OnceLock` on
+long-lived factories, a stored field on per-dispatch adapters) — a cold-author /
+hot-engine split, not part of the symmetric public contract.
+
+**D3 — Unified constructors where semantically sound.** All three expose
+`new(…)`, `for_<entity>::<T>()` (schema derived from the companion type), and
+`from_key(&key)`. `Action`'s four `for_stateless` / `for_stateful` /
+`for_paginated` / `for_batch` collapse into a single `for_action::<A>` (every
+`Action` has `Input: HasSchema`). `Resource` is the reference shape and is
+unchanged.
+
+`Credential` is a **deliberate, documented partial exception**: its required
+`pattern` (`AuthPattern`, no meaningful default) makes a `from_key` constructor
+meaningless, and its imperative `Option`-field `builder()` (used on the
+icon/doc-url path) is *not* reshaped to the seeded `builder(key, name,
+description)` form of the other two. The accessor (by value) and `for_credential`
+/ `new` are symmetric; the constructor difference is intrinsic to the type, not
+drift, and is documented on `CredentialMetadata`.
+
+**D4 — DX via prelude, not a merge.** The "single clean import" is delivered
+through `nebula-sdk`'s existing facade: `nebula_sdk::prelude` now re-exports the
+shared `Metadata` trait + `BaseMetadata` + value types and all three
+`XMetadata`, so `use nebula_sdk::prelude::*` yields the full symmetric metadata
+surface from one import (the Bevy/tokio way). `nebula-sdk` gains a direct
+`nebula-metadata` dependency (Core → API, downward; no `deny.toml` change).
+
+## Consequences
+
+- **Positive.** `nebula-core` stays the lean universal vocabulary crate its
+  charter promises; the enforced layer DAG and the 5 innocent `core`-dependents
+  are untouched; no schema/validator/expression subtree enters the universal
+  relink fan-out. Action authors lose ~4 lines of `OnceLock` boilerplate per
+  impl. The three catalog leaves now present an identical `metadata()` accessor
+  and a near-identical constructor set; the prelude gives one-import DX.
+- **Breaking (0.x, intended).** `Action::metadata()` return type changed —
+  every hand-written `impl Action` (and the `#[derive(Action)]` macro, the
+  `simple_action!` macro) was migrated to by-value. `ActionMetadata`'s four
+  `for_*` constructors collapsed to `for_action`. No external semver guarantee
+  is in force pre-1.0.
+- **Neutral.** `nebula-metadata` keeps its `schema` edge; the option to push it
+  lower by genericizing `BaseMetadata.schema` was considered and rejected as
+  unnecessary scope (no consumer needs `BaseMetadata` without a schema today).
+- **Guidance recorded.** Crate count is not the metric for this workspace — DAG
+  shape is (wide/layered, thin stable bottom, heavy deps at the leaves). Merge
+  only *false* splits (always co-used, same dependency weight and change
+  cadence, no DAG-width gain). `sdk` / `api` are functional top crates, **not**
+  umbrellas; the workspace's facade need is met by the `sdk` **prelude**, not a
+  new umbrella crate.
+
+## Alternatives considered
+
+- **(B) Merge into `nebula-core` + rewrite the charter.** Rejected: the
+  "god-core" anti-pattern; injects `schema → {validator, expression}` into 5
+  non-user crates and the universal relink fan-out, to change a cosmetic import
+  path. Requires inverting `core`'s own stated charter — a signal of fighting
+  the architecture.
+- **(C) Merge into `nebula-schema` instead.** Less wrong (spares `core`) but
+  still collapses two genuinely separate concerns with different change cadence
+  (the validation/expression engine vs. the catalog-descriptor vocabulary), and
+  serves the DX goal no better than the prelude.
+- **(D) Genericize / make optional `BaseMetadata.schema` so metadata can sit
+  lower without the validator/expression weight.** A valid technique, but
+  unnecessary: nothing keeps `metadata` from where it is, and `schema` is a
+  required, used field today. Banked for if a truly minimal consumer ever needs
+  `BaseMetadata` without a schema.
+- **(A-partial) Force full constructor symmetry onto `Credential`
+  (`from_key` + seeded `builder`).** Rejected for the documented reasons in D3:
+  `from_key` is semantically invalid without an `AuthPattern`, and the builder
+  reshape is high-churn (≈15 call sites, incl. in-flight `credential-builtin`)
+  for marginal symmetry.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -25,6 +25,7 @@ cascade and later work. Numbering starts at **0042** in this directory.
 | **AI agent & tools** | 0057 (agent SDK direction, proposed); **0089** (resource-advertised tools — primary tool source, proposed, amends 0057) | Agent loop, tools, MCP-shape, tool scoping |
 | **Agent harness** | **0083** | Intent / structural-budget / honesty gate |
 | **Environment config** | **0086** | `nebula-env` cross-cutting typed env reader |
+| **Crate boundaries & metadata** | **0090** | Where shared metadata types live; many-crate hygiene; symmetric `metadata()` API |
 
 ## Historical ADRs (0001–0041)
 


### PR DESCRIPTION
## What

Makes the catalog-leaf metadata API **symmetric** across `Action` / `Credential` / `Resource`, and records the decision (ADR-0090) to keep `nebula-metadata` a separate Core-layer crate rather than merging it into `nebula-core`.

## Why not merge metadata into core

The merge was proposed but **rejected** on evidence:
- **Prior art (Bevy, ~59 crates):** `bevy_reflect` (type-metadata, the direct analogue of `nebula-metadata`) is kept a *separate* crate that `bevy_ecs` depends on — never merged, precisely so reflection consumers don't drag in ECS. Bevy went further and *deleted* `bevy_core`, dissolving its types **outward** into focused homes. Shared types move out of catch-all bottoms, not into them.
- **Blast radius:** 5 crates depend on `core` but **not** `schema` today (`storage-port`, `storage`, `tenancy`, `workflow`, `execution`) and use no metadata. Merging would inject a `schema → validator → expression` subtree into all five and into every `core`-relink fan-out, violating core's vocabulary-only charter — to change a cosmetic import path.

The DX goal is met instead via the existing `nebula-sdk` facade (the Bevy/tokio way). See **ADR-0090**.

## Symmetric API (the actual change)

- **`Action::metadata()` now returns `ActionMetadata` by value** (was `&'static`), matching `Credential`/`Resource`. This deletes the per-author `static OnceLock` boilerplate. Engine-internal object-safe surfaces (`ActionFactory`, `Erased*`, typed→Handler adapters) keep returning `&ActionMetadata` from an internal cache (cold-author / hot-engine split). `#[derive(Action)]` and `simple_action!` emit by-value.
- **Constructors unified:** Action's four `for_{stateless,stateful,paginated,batch}` collapse into one `for_action::<A>`; Action gains `from_key` + `builder(key, name, description)`. `Resource` was already the reference shape.
- **One-import DX:** `use nebula_sdk::prelude::*` now yields the shared `Metadata` trait + `BaseMetadata` + value types + all three `XMetadata`.
- **Deliberate exception:** `Credential` keeps its imperative builder and has no `from_key` — its required `AuthPattern` has no meaningful default, so those would be misleading. Documented on `CredentialMetadata`.

## Verification

All green: `cargo check --workspace --all-targets`; clippy `-D warnings` (action/engine/api/sdk/credential); nextest **1620 passed**; doctests (action/credential/sdk); `cargo deny check`; rustdoc `-D warnings`. Net **−13 LoC** (boilerplate removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added unified metadata constructor methods: `from_key()`, `builder()`, and generic `for_action()` for consistent API design across action types.

* **Refactor**
  * Simplified action metadata API to return owned values instead of static references, enabling more flexible metadata handling at runtime.
  * Consolidated specialized metadata constructors into a single generic approach.

* **Documentation**
  * Added architecture decision record documenting symmetric metadata API design and crate organization decisions.
  * Enhanced SDK prelude exports to include metadata types for improved developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->