### PR TITLE
feat(credential)!: non-generic CredentialService — facade dyn-erasure, display metadata, server compose

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -126,6 +126,16 @@ pub enum TransportInitError {
     /// dependency (the typed `RegisterError` stays inside `nebula-api`).
     #[error("credential-schema port init failed: {0}")]
     CredentialSchemaInit(String),
+    /// The `CredentialService` facade could not be composed (registry
+    /// registration, encryption key provider init, dispatch-ops
+    /// registration, or the final secure-store build failed). Most common
+    /// in production: `NEBULA_CRED_MASTER_KEY` is unset or malformed —
+    /// fail closed rather than boot with a weak/absent key. Carried as a
+    /// `String` so this crate needs no credential dependency (the typed
+    /// `CredentialServiceFactoryError` stays inside `nebula-api`), mirroring
+    /// [`Self::CredentialSchemaInit`].
+    #[error("credential service init failed: {0}")]
+    CredentialServiceInit(String),
     /// An OAuth identity-provider config entry failed boot-time
     /// validation per ADR-0085 REQ-compose-001 Invariant 1.
     ///
@@ -213,6 +223,18 @@ impl ServerRuntime {
         // (per ADR-0048).
         let idempotency_store = build_idempotency_store(&api_config).await?;
         state = state.with_idempotency_store(idempotency_store);
+        // Compose the production `CredentialService` facade inside the async
+        // context: the secure-store build spawns the lease-lifecycle reaper,
+        // which requires the tokio runtime (so this cannot live in the sync
+        // `default_state`). The factory lives in `nebula-api` (which already
+        // deps the credential crates + `tokio-util`) so this composition root
+        // stays credential-dependency-free; it mints its own process shutdown
+        // `CancellationToken` internally (no `tokio-util` dep here). Fails
+        // closed in production when `NEBULA_CRED_MASTER_KEY` is unset/malformed.
+        let credential_service =
+            nebula_api::ports::credential_service_factory::try_default_credential_service()
+                .map_err(|e| TransportInitError::CredentialServiceInit(e.to_string()))?;
+        state = state.with_credential_service(credential_service);
         // Build ONE shared `Arc<dyn EmailPort>` and pass the same Arc
         // to both `AppState::email_port` and the selected auth backend.
         // `API_SMTP_HOST` unset → dev `EchoSink` (unchanged local-first

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -42,7 +42,7 @@ nebula-schema = { path = "../schema", features = ["schemars"] }
 nebula-eventbus = { path = "../eventbus" }
 # Task 17: CredentialService facade replaces CredentialScopeLayer for credential
 # CRUD — the service owns the encryption+audit+cache stack; the api layer
-# holds it via `credential_store_handle()` (a `dyn CredentialStore` arc).
+# holds it via `credential_store_handle()` (an `Arc<dyn DynCredentialStore>`).
 # Exec-tier dep; allowlisted in deny.toml [[wrappers]] for nebula-api.
 nebula-credential-runtime = { path = "../credential-runtime" }
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -43,7 +43,7 @@ nebula-eventbus = { path = "../eventbus" }
 # Task 17: CredentialService facade replaces CredentialScopeLayer for credential
 # CRUD — the service owns the encryption+audit+cache stack; the api layer
 # holds it via `credential_store_handle()` (an `Arc<dyn DynCredentialStore>`).
-# Exec-tier dep; allowlisted in deny.toml [[wrappers]] for nebula-api.
+# Exec-tier dep; allowlisted in the deny.toml [bans].deny `wrappers` list for nebula-api.
 nebula-credential-runtime = { path = "../credential-runtime" }
 
 opentelemetry = { workspace = true }

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -183,6 +183,29 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
     }
 }
 
+/// Build the shared first-party credential registry — the single type set
+/// behind both the schema port ([`try_default_registry_port`]) and the
+/// runtime facade
+/// ([`super::credential_service_factory::try_default_credential_service`]).
+/// Extracting it keeps schema validation and dispatch on **one** registered
+/// set, so the registry's advertised capabilities and the facade's ops table
+/// cannot drift apart.
+///
+/// # Errors
+///
+/// Returns [`nebula_credential::RegisterError`] if a credential KEY is
+/// already registered (a composition bug — distinct first-party const
+/// KEYs make this unreachable in practice, but the library returns the
+/// typed error rather than panicking; the caller decides how to surface
+/// it — AGENTS.md "no `expect()` in library code").
+pub(crate) fn default_registry() -> Result<CredentialRegistry, nebula_credential::RegisterError> {
+    let mut registry = CredentialRegistry::new();
+    registry.register(ApiKeyCredential, "nebula-credential")?;
+    registry.register(BasicAuthCredential, "nebula-credential")?;
+    registry.register(OAuth2Credential, "nebula-credential")?;
+    Ok(registry)
+}
+
 /// Build the default port with the first-party credential types
 /// registered (credential-schema validation). Used by the composition root so
 /// `apps/server` needs no `nebula-credential`/`nebula-schema` dep.
@@ -196,11 +219,9 @@ impl CredentialSchemaPort for RegistryCredentialSchema {
 /// it — AGENTS.md "no `expect()` in library code").
 pub fn try_default_registry_port()
 -> Result<Arc<dyn CredentialSchemaPort>, nebula_credential::RegisterError> {
-    let mut registry = CredentialRegistry::new();
-    registry.register(ApiKeyCredential, "nebula-credential")?;
-    registry.register(BasicAuthCredential, "nebula-credential")?;
-    registry.register(OAuth2Credential, "nebula-credential")?;
-    Ok(Arc::new(RegistryCredentialSchema::new(Arc::new(registry))))
+    Ok(Arc::new(RegistryCredentialSchema::new(Arc::new(
+        default_registry()?,
+    ))))
 }
 
 #[cfg(test)]

--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -84,7 +84,7 @@ pub enum CredentialServiceFactoryError {
 /// credential types registered (`api_key`, `basic_auth`, `oauth2`).
 ///
 /// The service shares its registered type set with the schema port via
-/// [`super::credential_schema_registry::default_registry`], so the
+/// `credential_schema_registry::default_registry`, so the
 /// registry-advertised capabilities and the dispatch ops table cannot
 /// drift. OAuth2 advertises all four ops-modeled capabilities
 /// (interactive + refreshable + revocable + testable), so each matching
@@ -152,7 +152,7 @@ fn resolve_key_provider() -> Result<Arc<dyn KeyProvider>, CredentialServiceFacto
 /// [`KeyProvider`] (a durable backend, or a test) composes the same service
 /// without going through the `NEBULA_CRED_*` env resolution. Registers the
 /// first-party type set (shared with the schema port via
-/// [`super::credential_schema_registry::default_registry`]) and the matching
+/// `credential_schema_registry::default_registry`) and the matching
 /// dispatch ops.
 ///
 /// # Errors

--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -1,0 +1,217 @@
+//! Composition-root factory for the production [`CredentialService`] facade.
+//!
+//! Built here in `nebula-api` — which already depends on
+//! `nebula-credential-runtime`, `nebula-storage` (with the
+//! `credential-in-memory` adapter), `nebula-engine`, and `tokio-util` — so
+//! `apps/server` constructs a real service through a single typed call and
+//! stays free of any credential dependency, mirroring
+//! [`super::credential_schema_registry::try_default_registry_port`]. No
+//! `deny.toml` edge is added.
+//!
+//! The service composes the secure layered store
+//! (`Audit(Cache(Encryption(InMemoryStore)))`), the engine resolver, and the
+//! lease lifecycle. Storage is **encrypted-at-rest but in-memory** — durable
+//! across `.await`, not across process restart. A durable backend is a future
+//! swap behind the now-erased `CredentialService` collaborators.
+
+use std::sync::Arc;
+
+use nebula_credential::{
+    ApiKeyCredential, BasicAuthCredential, ErasedPendingStore, OAuth2Credential,
+};
+use nebula_credential_runtime::{
+    CredentialService, CredentialServiceBuilder, CredentialServiceError, DispatchError,
+    DispatchOps, NoopObserver, register_interactive_ops, register_refreshable_ops,
+    register_revocable_ops, register_runtime_ops, register_testable_ops,
+};
+use nebula_engine::credential::LeaseLifecycleConfig;
+use nebula_storage::credential::{
+    AuditEvent, AuditSink, CacheConfig, EnvKeyProvider, InMemoryPendingStore, InMemoryStore,
+    KeyProvider,
+};
+
+/// Audit sink that records every credential operation to the tracing log
+/// (metadata only — [`AuditEvent`] carries no secret material by design).
+/// Honest local-first sink: the audit trail goes to the structured log
+/// stream, not silently dropped. A durable sink (DB) is a future swap;
+/// this keeps the §14 audit trail visible without a backend.
+struct TracingAuditSink;
+
+impl AuditSink for TracingAuditSink {
+    fn record(&self, event: &AuditEvent) -> Result<(), nebula_credential::StoreError> {
+        tracing::info!(
+            target: "nebula.credential.audit",
+            cred_id = %event.credential_id,
+            op = ?event.operation,
+            result = ?event.result,
+            "credential audit event"
+        );
+        Ok(())
+    }
+}
+
+/// Construction failure for [`try_default_credential_service`].
+///
+/// Each variant names the composition step that failed. Source-chained
+/// (`#[source]`/`#[from]`) where the underlying type is reachable from
+/// `nebula-api`; stringified for the key-provider step, whose
+/// `nebula_storage::credential::ProviderError` would otherwise force an
+/// awkward direct dependency on a deeper storage error type at this seam.
+#[derive(Debug, thiserror::Error)]
+pub enum CredentialServiceFactoryError {
+    /// A first-party credential KEY failed to register in the shared
+    /// registry (a composition bug — first-party KEYs are statically
+    /// unique, so this is unreachable in practice).
+    #[error("credential registry registration failed")]
+    Registry(#[from] nebula_credential::RegisterError),
+    /// The encryption key provider could not be initialized. In production
+    /// this means `NEBULA_CRED_MASTER_KEY` is unset, malformed, or the
+    /// refused dev placeholder. The message is the provider error's
+    /// sanitized `Display` (never key material).
+    #[error("credential key provider init failed: {0}")]
+    KeyProvider(String),
+    /// A capability dispatch op failed to register (e.g. a duplicate KEY
+    /// across two registrars).
+    #[error("credential dispatch-ops registration failed")]
+    Dispatch(#[from] DispatchError),
+    /// The service builder rejected the composed parts — most often a
+    /// registry capability advertised without a matching registered op.
+    #[error("credential service build failed")]
+    Build(#[from] CredentialServiceError),
+}
+
+/// Build the production [`CredentialService`] with the first-party
+/// credential types registered (`api_key`, `basic_auth`, `oauth2`).
+///
+/// The service shares its registered type set with the schema port via
+/// [`super::credential_schema_registry::default_registry`], so the
+/// registry-advertised capabilities and the dispatch ops table cannot
+/// drift. OAuth2 advertises all four ops-modeled capabilities
+/// (interactive + refreshable + revocable + testable), so each matching
+/// `register_*_ops` is wired; API-key and basic-auth advertise none and
+/// take base ops only. A mismatch here would make
+/// [`CredentialServiceBuilder::build`] return
+/// [`CredentialServiceError::CapabilityWithoutOps`].
+///
+/// # Key provider (fail-closed in production)
+///
+/// Production reads a base64 AES-256 key from `NEBULA_CRED_MASTER_KEY`
+/// (via [`EnvKeyProvider::from_env`]); an unset or malformed key fails
+/// startup rather than silently using a weak key. For local development,
+/// `NEBULA_CRED_DEV_KEY=1` selects a fixed in-process key so the service
+/// boots without a configured master key — credentials are then **not**
+/// securely encrypted, and a loud `warn!` says so. Never set it in
+/// production.
+///
+/// # Storage durability
+///
+/// The raw store is in-memory: credential state is encrypted at rest but
+/// does **not** survive a process restart. A durable backend is a future
+/// swap behind the erased [`CredentialService`] collaborators.
+///
+/// # Errors
+///
+/// Returns [`CredentialServiceFactoryError`] if registry registration, key
+/// provider init, dispatch-ops registration, or the final service build
+/// fails. See each variant for the specific composition step.
+pub fn try_default_credential_service()
+-> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
+    with_key_provider(resolve_key_provider()?)
+}
+
+/// A fixed all-`0x42` 32-byte AES-256 key, base64-encoded — the dev-only key
+/// selected by `NEBULA_CRED_DEV_KEY=1`. The public `from_base64` constructor
+/// is used because the raw-byte `StaticKeyProvider` is test-gated and
+/// `nebula_crypto::EncryptionKey` is not a dependency of this crate. This is a
+/// deliberately weak dev placeholder, **not** a production secret.
+const DEV_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
+/// Resolve the encryption key provider: fail-closed `NEBULA_CRED_MASTER_KEY`
+/// in production ([`EnvKeyProvider::from_env`]), or the fixed in-process dev
+/// key behind an explicit `NEBULA_CRED_DEV_KEY=1` opt-in (with a loud `warn!`).
+fn resolve_key_provider() -> Result<Arc<dyn KeyProvider>, CredentialServiceFactoryError> {
+    if std::env::var("NEBULA_CRED_DEV_KEY").as_deref() == Ok("1") {
+        tracing::warn!(
+            "credential: NEBULA_CRED_DEV_KEY=1 — using a fixed in-process dev key; \
+             credentials are NOT securely encrypted. Never set this in production."
+        );
+        Ok(Arc::new(EnvKeyProvider::from_base64(DEV_KEY_B64).map_err(
+            |e| CredentialServiceFactoryError::KeyProvider(e.to_string()),
+        )?))
+    } else {
+        Ok(Arc::new(EnvKeyProvider::from_env().map_err(|e| {
+            CredentialServiceFactoryError::KeyProvider(e.to_string())
+        })?))
+    }
+}
+
+/// Build a [`CredentialService`] over the in-memory store with a
+/// caller-supplied encryption key provider.
+///
+/// Separated from [`try_default_credential_service`] so a caller with its own
+/// [`KeyProvider`] (a durable backend, or a test) composes the same service
+/// without going through the `NEBULA_CRED_*` env resolution. Registers the
+/// first-party type set (shared with the schema port via
+/// [`super::credential_schema_registry::default_registry`]) and the matching
+/// dispatch ops.
+///
+/// # Errors
+///
+/// Returns [`CredentialServiceFactoryError`] if registry registration,
+/// dispatch-ops registration, or the final service build fails.
+pub fn with_key_provider(
+    key_provider: Arc<dyn KeyProvider>,
+) -> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
+    let registry = super::credential_schema_registry::default_registry()?;
+
+    // Dispatch ops, fixed to the erased pending store so the engine resolver
+    // and `DispatchOps` need no further monomorphization. Base ops for every
+    // type; the four capability registrars only for the types that advertise
+    // them (OAuth2). This set MUST match the registry's advertised caps or
+    // `build()` returns `CapabilityWithoutOps`.
+    let mut ops = DispatchOps::<ErasedPendingStore>::new();
+    register_runtime_ops::<ApiKeyCredential, ErasedPendingStore>(&mut ops)?;
+    register_runtime_ops::<BasicAuthCredential, ErasedPendingStore>(&mut ops)?;
+    register_runtime_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+    register_interactive_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+    register_refreshable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+    register_revocable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+    register_testable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+
+    tracing::warn!(
+        "credential: audit sink is log-only (target=nebula.credential.audit); \
+         the audit trail is NOT durably persisted to a backend yet."
+    );
+    let audit_sink: Arc<dyn AuditSink> = Arc::new(TracingAuditSink);
+
+    let pending = ErasedPendingStore::new(Arc::new(InMemoryPendingStore::new()));
+    let raw_store = InMemoryStore::new();
+    let observer = Arc::new(NoopObserver::new());
+    let cache_config = CacheConfig::default();
+    let lease_config = LeaseLifecycleConfig::default();
+    // Process-wide shutdown token for the lease reaper. The token is owned by
+    // the service; the lease task stops when the service (and so this token)
+    // is dropped at process exit — `apps/server` carries no `tokio-util` dep,
+    // so the factory mints the token internally.
+    let shutdown = tokio_util::sync::CancellationToken::new();
+
+    let service = CredentialServiceBuilder::new(
+        raw_store,
+        key_provider,
+        audit_sink,
+        cache_config,
+        pending,
+        Arc::new(registry),
+        Arc::new(ops),
+        observer,
+        lease_config,
+        shutdown,
+    )
+    .build()?;
+
+    tracing::info!(
+        "credential: CredentialService composed (encrypted-at-rest in-memory store; \
+         non-durable across restart)"
+    );
+    Ok(Arc::new(service))
+}

--- a/crates/api/src/ports/mod.rs
+++ b/crates/api/src/ports/mod.rs
@@ -7,4 +7,5 @@
 
 pub mod credential_schema;
 pub mod credential_schema_registry;
+pub mod credential_service_factory;
 pub mod email;

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -253,10 +253,11 @@ pub struct AppState {
     /// from `nebula-tenancy` this fallback path will be removed and `credential_service`
     /// will be mandatory.
     ///
-    /// The concrete type is `CredentialService<InMemoryStore, InMemoryPendingStore>` —
-    /// the api always uses the in-memory backend; production composition roots that
-    /// use a durable backend wire the service through the server binary, not here.
-    pub credential_service: Option<Arc<CredentialService<InMemoryStore, InMemoryPendingStore>>>,
+    /// `CredentialService` is non-generic — its backend is erased behind
+    /// `DynCredentialStore` / `ErasedPendingStore` at construction (ADR-0088 D4),
+    /// so the api names it without a backend type parameter. The concrete
+    /// backend is chosen by the composition root (the server binary), not here.
+    pub credential_service: Option<Arc<CredentialService>>,
 
     /// Optional webhook HTTP transport. When `None`, no `/webhooks/*`
     /// routes are mounted on the app; webhook-style `WebhookAction`
@@ -1042,15 +1043,12 @@ impl AppState {
     /// Attach the `CredentialService` facade for credential CRUD.
     ///
     /// When set, the credential transport layer uses the service's
-    /// encryption+audit+cache store stack (`LayeredStore<InMemoryStore>`)
+    /// encryption+audit+cache store stack (erased behind `DynCredentialStore`)
     /// instead of the raw `oauth_credential_store` wrapped by
     /// `CredentialScopeLayer`. Tenant isolation is applied by the transport
     /// layer via `credential_store_for_owner`.
     #[must_use = "builder methods must be chained or built"]
-    pub fn with_credential_service(
-        mut self,
-        service: Arc<CredentialService<InMemoryStore, InMemoryPendingStore>>,
-    ) -> Self {
+    pub fn with_credential_service(mut self, service: Arc<CredentialService>) -> Self {
         self.credential_service = Some(service);
         self
     }

--- a/crates/api/tests/credential_service_factory.rs
+++ b/crates/api/tests/credential_service_factory.rs
@@ -1,0 +1,54 @@
+//! The credential-service factory composes a working service and the wired
+//! service performs a real create/get round-trip.
+//!
+//! This is the runtime proof for the factory's two load-bearing invariants:
+//! (1) `CredentialServiceBuilder::build` runs a capability⊆ops gate, so a
+//! successful build proves OAuth2's four advertised capabilities each have a
+//! registered dispatch op (and api_key/basic_auth advertise none); (2) the
+//! fixed dev key actually base64-decodes to a valid AES-256 key.
+
+use std::sync::Arc;
+
+use nebula_api::ports::credential_service_factory::with_key_provider;
+use nebula_credential::CredentialDisplay;
+use nebula_credential_runtime::TenantScope;
+use nebula_storage::credential::EnvKeyProvider;
+use serde_json::json;
+
+/// 32 `0x42` bytes, base64 — a valid AES-256 key fixture (mirrors the
+/// factory's dev key). Not a secret: a fixed test constant.
+const TEST_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
+#[tokio::test]
+async fn factory_builds_service_and_create_round_trips() {
+    let key = Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+    // `build()` runs the capability⊆ops gate; success proves the registry's
+    // advertised caps match the registered ops (OAuth2's four + none for the
+    // static types).
+    let svc = with_key_provider(key).expect("service composes (advertised caps match ops)");
+
+    // A non-interactive create round-trips through the wired ops + display.
+    let scope = TenantScope::new("org", "ws");
+    let snap = svc
+        .create(
+            &scope,
+            "api_key",
+            json!({ "api_key": "k-factory-test" }),
+            CredentialDisplay {
+                display_name: Some("Test key".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("api_key create succeeds");
+    assert_eq!(snap.kind(), "api_key");
+    assert_eq!(snap.display().display_name.as_deref(), Some("Test key"));
+
+    // Retrievable, secret never echoed in the snapshot's Debug.
+    let ids = svc.list(&scope).await.expect("list");
+    assert_eq!(ids.len(), 1);
+    let got = svc.get(&scope, &ids[0]).await.expect("get");
+    assert_eq!(got.kind(), "api_key");
+    assert_eq!(got.display().display_name.as_deref(), Some("Test key"));
+    assert!(!format!("{got:?}").contains("k-factory-test"));
+}

--- a/crates/credential-runtime/src/builder.rs
+++ b/crates/credential-runtime/src/builder.rs
@@ -12,9 +12,10 @@
 
 use std::sync::Arc;
 
-use nebula_credential::pending_store::PendingStateStore;
 use nebula_credential::store::CredentialStore;
-use nebula_credential::{Capabilities, CredentialRegistry};
+use nebula_credential::{
+    Capabilities, CredentialRegistry, DynCredentialStore, ErasedCredentialStore, ErasedPendingStore,
+};
 use nebula_engine::credential::{
     CredentialResolver, LeaseLifecycle, LeaseLifecycleConfig, RefreshCoordinator,
 };
@@ -33,14 +34,14 @@ use crate::state_source::StateSource;
 /// mandatory collaborators), chain optional setters, then [`build`].
 ///
 /// [`build`]: Self::build
-pub struct CredentialServiceBuilder<B: CredentialStore, PS: PendingStateStore> {
+pub struct CredentialServiceBuilder<B: CredentialStore + 'static> {
     raw_store: B,
     key_provider: Arc<dyn KeyProvider>,
     audit_sink: Arc<dyn AuditSink>,
     cache_config: CacheConfig,
-    pending_store: PS,
+    pending_store: ErasedPendingStore,
     registry: Arc<CredentialRegistry>,
-    ops: Arc<DispatchOps<PS>>,
+    ops: Arc<DispatchOps<ErasedPendingStore>>,
     observer: Arc<dyn CredentialObserver>,
     lease_config: LeaseLifecycleConfig,
     shutdown: CancellationToken,
@@ -48,7 +49,7 @@ pub struct CredentialServiceBuilder<B: CredentialStore, PS: PendingStateStore> {
     external: StateSource,
 }
 
-impl<B: CredentialStore, PS: PendingStateStore> CredentialServiceBuilder<B, PS> {
+impl<B: CredentialStore + 'static> CredentialServiceBuilder<B> {
     /// Provide every mandatory collaborator. Omitting any is a compile
     /// error (the secure-construction guarantee, no runtime check).
     #[allow(clippy::too_many_arguments)]
@@ -57,9 +58,9 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialServiceBuilder<B, PS> 
         key_provider: Arc<dyn KeyProvider>,
         audit_sink: Arc<dyn AuditSink>,
         cache_config: CacheConfig,
-        pending_store: PS,
+        pending_store: ErasedPendingStore,
         registry: Arc<CredentialRegistry>,
-        ops: Arc<DispatchOps<PS>>,
+        ops: Arc<DispatchOps<ErasedPendingStore>>,
         observer: Arc<dyn CredentialObserver>,
         lease_config: LeaseLifecycleConfig,
         shutdown: CancellationToken,
@@ -125,7 +126,7 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialServiceBuilder<B, PS> 
     /// credential type advertises `refresh` / `test` / `revoke` /
     /// `interactive` but its matching `register_*_ops` call was skipped at
     /// the composition root.
-    pub fn build(self) -> Result<CredentialService<B, PS>, CredentialServiceError> {
+    pub fn build(self) -> Result<CredentialService, CredentialServiceError> {
         // registry-advertised capabilities ⊆ ops-registered closures, per
         // credential key. DYNAMIC is a lease concern with no ops closure, so
         // the subset is scoped to the four ops-modeled capabilities.
@@ -148,20 +149,21 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialServiceBuilder<B, PS> 
             }
         }
 
-        let store = AuditLayer::new(
+        let layered = AuditLayer::new(
             CacheLayer::new(
                 EncryptionLayer::new(self.raw_store, self.key_provider),
                 self.cache_config,
             ),
             self.audit_sink,
         );
-        let store = Arc::new(store);
+        let store: Arc<dyn DynCredentialStore> = Arc::new(layered);
         let refresh_coordinator = self
             .refresh_coordinator
             .unwrap_or_else(|| Arc::new(RefreshCoordinator::new()));
-        let resolver = CredentialResolver::new(Arc::clone(&store))
-            .with_refresh_coordinator(refresh_coordinator)
-            .with_event_bus(self.observer.event_bus());
+        let resolver =
+            CredentialResolver::new(Arc::new(ErasedCredentialStore::new(Arc::clone(&store))))
+                .with_refresh_coordinator(refresh_coordinator)
+                .with_event_bus(self.observer.event_bus());
         let lease = LeaseLifecycle::spawn(
             self.lease_config,
             self.observer.lease_bus(),

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -1,8 +1,13 @@
-//! `CredentialService<B, PS>` — the sole public entry to the credential
-//! management bounded context. Generic over the raw backend `B` and
-//! pending store `PS` (both RPITIT non-object-safe; the params live only
-//! on the struct, never in operation signatures). All invariant-bearing
-//! composition is crate-private: the only constructor path is
+//! `CredentialService` — the sole public entry to the credential
+//! management bounded context. **Non-generic** (ADR-0088 D4): the raw
+//! backend and pending store are erased to `Arc<dyn DynCredentialStore>` /
+//! [`ErasedPendingStore`] at
+//! construction, so a durable backend can be swapped in without
+//! re-monomorphizing every consumer. Both ports are RPITIT (and the
+//! pending port additionally generic per call), so the erasure is the
+//! hand-rolled boxed-future bridge in `nebula_credential::erased`. All
+//! invariant-bearing composition is crate-private: the only constructor
+//! path is
 //! [`CredentialServiceBuilder`](crate::builder::CredentialServiceBuilder),
 //! whose `build()` wraps the raw backend in the layered store so an
 //! unencrypted/mis-composed service is unrepresentable.
@@ -26,12 +31,12 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use nebula_credential::pending_store::PendingStateStore;
 use nebula_credential::resolve::{InteractionRequest, TestResult, UserInput};
-use nebula_credential::store::{CredentialStore, PutMode, StoreError, StoredCredential};
+use nebula_credential::store::{PutMode, StoreError, StoredCredential};
 use nebula_credential::{
     AuthPattern, Credential, CredentialContext, CredentialGuard, CredentialId, CredentialRecord,
-    CredentialRegistry, CredentialSnapshot, PendingToken,
+    CredentialRegistry, CredentialSnapshot, DynCredentialStore, ErasedCredentialStore,
+    ErasedPendingStore, PendingToken,
 };
 use nebula_engine::credential::{CredentialResolver, LeaseLifecycle};
 use nebula_resilience::CallError;
@@ -139,16 +144,17 @@ pub struct CredentialTypeInfo {
 ///
 /// Constructed only via
 /// [`CredentialServiceBuilder`](crate::builder::CredentialServiceBuilder).
-pub struct CredentialService<B: CredentialStore, PS: PendingStateStore> {
-    pub(crate) store: Arc<LayeredStore<B>>,
-    /// Engine resolver wired through the layered store stack. Used by
+pub struct CredentialService {
+    pub(crate) store: Arc<dyn DynCredentialStore>,
+    /// Engine resolver wired through the layered store stack (erased at the
+    /// store→resolver boundary). Used by
     /// [`resolve_for_slot`](Self::resolve_for_slot) to produce a typed
     /// [`CredentialGuard`] for action slot consumption.
-    pub(crate) resolver: CredentialResolver<LayeredStore<B>>,
+    pub(crate) resolver: CredentialResolver<ErasedCredentialStore>,
     pub(crate) lease: LeaseLifecycle,
-    pub(crate) pending: PS,
+    pub(crate) pending: ErasedPendingStore,
     pub(crate) registry: Arc<CredentialRegistry>,
-    pub(crate) ops: Arc<DispatchOps<PS>>,
+    pub(crate) ops: Arc<DispatchOps<ErasedPendingStore>>,
     pub(crate) observer: Arc<dyn CredentialObserver>,
     // Read by `ensure_local_source` on every secret-resolving entry
     // point. `External` is configurable but its resolution wiring (the
@@ -157,18 +163,21 @@ pub struct CredentialService<B: CredentialStore, PS: PendingStateStore> {
     pub(crate) source: StateSource,
 }
 
-impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
+impl CredentialService {
     /// Crate-private assembly point — the builder's `build()` is the
     /// only caller. Not `pub`: external code cannot bypass the layered
     /// composition (compile-fail probe target, spec §6 #7).
+    // guard-justified: __from_parts mirrors the eight mandatory collaborators
+    // the builder composes; bundling them into a struct would just move the
+    // arity to that struct's literal at the single call site.
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn __from_parts(
-        store: Arc<LayeredStore<B>>,
-        resolver: CredentialResolver<LayeredStore<B>>,
+        store: Arc<dyn DynCredentialStore>,
+        resolver: CredentialResolver<ErasedCredentialStore>,
         lease: LeaseLifecycle,
-        pending: PS,
+        pending: ErasedPendingStore,
         registry: Arc<CredentialRegistry>,
-        ops: Arc<DispatchOps<PS>>,
+        ops: Arc<DispatchOps<ErasedPendingStore>>,
         observer: Arc<dyn CredentialObserver>,
         source: StateSource,
     ) -> Self {
@@ -184,16 +193,17 @@ impl<B: CredentialStore, PS: PendingStateStore> CredentialService<B, PS> {
         }
     }
 
-    /// Expose the composed layered store (`Audit(Cache(Encryption(raw)))`) as
-    /// a shared arc for callers that need raw access to the encrypted store
-    /// without going through type dispatch.
+    /// Expose the composed layered store (`Audit(Cache(Encryption(raw)))`,
+    /// erased) as a shared arc for callers that need raw access to the
+    /// encrypted store without going through type dispatch.
     ///
     /// The api layer uses this to replace
     /// `nebula_tenancy::CredentialScopeLayer<InMemoryStore>` with the
     /// service's encryption + audit + cache stack while still managing
     /// api-level metadata (`name` / `description` / `tags`) directly in
-    /// [`StoredCredential::metadata`].
-    pub fn credential_store_handle(&self) -> Arc<LayeredStore<B>> {
+    /// [`StoredCredential::metadata`]. The concrete layer stack is erased
+    /// behind [`DynCredentialStore`] so the backend stays swappable.
+    pub fn credential_store_handle(&self) -> Arc<dyn DynCredentialStore> {
         Arc::clone(&self.store)
     }
 
@@ -1295,7 +1305,9 @@ pub mod test_support {
     use nebula_core::accessor::MetricsEmitter;
     use nebula_credential::provider::LeaseEvent;
     use nebula_credential::store::StoreError;
-    use nebula_credential::{CredentialEvent, CredentialId, CredentialRegistry};
+    use nebula_credential::{
+        CredentialEvent, CredentialId, CredentialRegistry, ErasedPendingStore,
+    };
     use nebula_credential_builtin::register_builtins;
     use nebula_credential_testutil::InMemoryPendingStore;
     use nebula_crypto::EncryptionKey;
@@ -1339,18 +1351,15 @@ pub mod test_support {
     /// sink varies and the inner store is observable for assertions.
     pub fn service_and_raw_store_with_audit_sink(
         audit_sink: Arc<dyn AuditSink>,
-    ) -> (
-        CredentialService<InMemoryStore, InMemoryPendingStore>,
-        InMemoryStore,
-    ) {
+    ) -> (CredentialService, InMemoryStore) {
         let mut registry = CredentialRegistry::new();
         register_builtins(&mut registry).expect("register_builtins");
 
         // All three builtins are static (no capability impls), so only
         // the base ops are registered — no `register_*_ops` capability
         // call. Closure absence is "capability not supported".
-        let mut ops = DispatchOps::<InMemoryPendingStore>::new();
-        register_all_builtin_ops::<InMemoryPendingStore>(&mut ops).expect("builtin ops");
+        let mut ops = DispatchOps::<ErasedPendingStore>::new();
+        register_all_builtin_ops::<ErasedPendingStore>(&mut ops).expect("builtin ops");
 
         // `InMemoryStore` is `Arc<RwLock<..>>`-backed: the clone shares
         // the same map the layered stack writes through.
@@ -1361,7 +1370,7 @@ pub mod test_support {
             Arc::new(StaticKeyProvider::new(key)),
             audit_sink,
             CacheConfig::default(),
-            InMemoryPendingStore::new(),
+            ErasedPendingStore::new(Arc::new(InMemoryPendingStore::new())),
             Arc::new(registry),
             Arc::new(ops),
             Arc::new(NoopObserver::new()),
@@ -1382,15 +1391,13 @@ pub mod test_support {
     /// discarding the raw-store handle. Convenience over
     /// [`service_and_raw_store_with_audit_sink`] for tests that do not
     /// need to inspect the inner store.
-    pub fn service_with_audit_sink(
-        audit_sink: Arc<dyn AuditSink>,
-    ) -> CredentialService<InMemoryStore, InMemoryPendingStore> {
+    pub fn service_with_audit_sink(audit_sink: Arc<dyn AuditSink>) -> CredentialService {
         service_and_raw_store_with_audit_sink(audit_sink).0
     }
 
     /// Build an in-memory service with a no-op audit sink — the default
     /// fixture for tests / Plan-3 wiring.
-    pub fn in_memory_service() -> CredentialService<InMemoryStore, InMemoryPendingStore> {
+    pub fn in_memory_service() -> CredentialService {
         service_with_audit_sink(Arc::new(NoopAuditSink))
     }
 
@@ -1432,10 +1439,7 @@ pub mod test_support {
     /// The static builtins cannot exercise any positive capability path
     /// (refresh CAS + retry, the coalesced re-read branch, the concurrent-refresh
     /// version-conflict branch); this fixture-enabled variant does.
-    pub fn in_memory_service_with_fixtures() -> (
-        CredentialService<InMemoryStore, InMemoryPendingStore>,
-        Arc<AtomicUsize>,
-    ) {
+    pub fn in_memory_service_with_fixtures() -> (CredentialService, Arc<AtomicUsize>) {
         let mut registry = CredentialRegistry::new();
         register_builtins(&mut registry).expect("register_builtins");
         registry
@@ -1446,14 +1450,14 @@ pub mod test_support {
         // bitflag (ADR-0088 D3): `RefreshableFixtureCredential` impls
         // `Refreshable`, so `registry.is_refreshable(key)` is true without a
         // parallel dispatch flag.
-        let mut ops = DispatchOps::<InMemoryPendingStore>::new();
-        register_all_builtin_ops::<InMemoryPendingStore>(&mut ops).expect("builtin ops");
+        let mut ops = DispatchOps::<ErasedPendingStore>::new();
+        register_all_builtin_ops::<ErasedPendingStore>(&mut ops).expect("builtin ops");
         // Base ops first, then the refresh capability closure (the
         // ordering `register_refreshable_ops` enforces via
         // `DispatchError::BaseOpsMissing`).
-        register_runtime_ops::<RefreshableFixtureCredential, InMemoryPendingStore>(&mut ops)
+        register_runtime_ops::<RefreshableFixtureCredential, ErasedPendingStore>(&mut ops)
             .expect("fixture base ops");
-        register_refreshable_ops::<RefreshableFixtureCredential, InMemoryPendingStore>(&mut ops)
+        register_refreshable_ops::<RefreshableFixtureCredential, ErasedPendingStore>(&mut ops)
             .expect("fixture refreshable ops");
 
         let refreshes = Arc::new(AtomicUsize::new(0));
@@ -1468,7 +1472,7 @@ pub mod test_support {
             Arc::new(StaticKeyProvider::new(key)),
             Arc::new(NoopAuditSink),
             CacheConfig::default(),
-            InMemoryPendingStore::new(),
+            ErasedPendingStore::new(Arc::new(InMemoryPendingStore::new())),
             Arc::new(registry),
             Arc::new(ops),
             Arc::new(observer),
@@ -1819,10 +1823,8 @@ mod tests {
     #[test]
     fn owner_context_threads_session_when_scope_carries_one() {
         use super::CredentialService;
-        use nebula_credential_testutil::InMemoryPendingStore;
-        use nebula_storage::credential::InMemoryStore;
 
-        type Svc = CredentialService<InMemoryStore, InMemoryPendingStore>;
+        type Svc = CredentialService;
 
         let with = TenantScope::new("org1", "ws1").with_session("sess-xyz");
         let ctx = Svc::owner_context(&with);

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -34,9 +34,9 @@ use std::time::Duration;
 use nebula_credential::resolve::{InteractionRequest, TestResult, UserInput};
 use nebula_credential::store::{PutMode, StoreError, StoredCredential};
 use nebula_credential::{
-    AuthPattern, Credential, CredentialContext, CredentialGuard, CredentialId, CredentialRecord,
-    CredentialRegistry, CredentialSnapshot, DynCredentialStore, ErasedCredentialStore,
-    ErasedPendingStore, PendingToken,
+    AuthPattern, Credential, CredentialContext, CredentialDisplay, CredentialGuard, CredentialId,
+    CredentialRecord, CredentialRegistry, CredentialSnapshot, DynCredentialStore,
+    ErasedCredentialStore, ErasedPendingStore, PendingToken,
 };
 use nebula_engine::credential::{CredentialResolver, LeaseLifecycle};
 use nebula_resilience::CallError;
@@ -57,6 +57,12 @@ use crate::state_source::StateSource;
 /// Metadata key the facade stamps with the owning tenant. Read on every
 /// `get`/`list`/`update`/`delete` to enforce tenant isolation.
 const OWNER_ID_KEY: &str = "owner_id";
+
+/// Metadata key holding the facade-owned [`CredentialDisplay`] sub-object
+/// (a sibling to [`OWNER_ID_KEY`]). Single-writer: only the facade reads or
+/// writes it, so the multi-writer shape conflict that affected the api's old
+/// top-level metadata layout cannot recur.
+const DISPLAY_KEY: &str = "display";
 
 /// Layered store stack composed once at `CredentialServiceBuilder::build`:
 /// `Audit(Cache(Encryption(raw)))`. `Encryption` is adjacent to the raw
@@ -262,6 +268,7 @@ impl CredentialService {
         scope: &TenantScope,
         credential_key: &str,
         props: Value,
+        display: CredentialDisplay,
     ) -> Result<CredentialSnapshot, CredentialServiceError> {
         // Fail loud if an external source was configured but its
         // resolution wiring is not implemented yet — never silently
@@ -295,7 +302,7 @@ impl CredentialService {
             .await?;
 
         let snapshot = self
-            .persist_resolved(scope, credential_key, id, resolved)
+            .persist_resolved(scope, credential_key, id, resolved, display)
             .await?;
 
         self.observer.on_resolve(&id);
@@ -321,19 +328,24 @@ impl CredentialService {
         credential_key: &str,
         id: CredentialId,
         resolved: crate::ops::ResolvedState,
+        display: CredentialDisplay,
     ) -> Result<CredentialSnapshot, CredentialServiceError> {
         let mut metadata = serde_json::Map::new();
         metadata.insert(
             OWNER_ID_KEY.to_owned(),
             Value::String(scope.owner_id().to_owned()),
         );
+        Self::set_display(&mut metadata, &display);
 
         // Project the response snapshot from the just-resolved state
         // bytes before they are moved into the stored row (avoids a
         // round-trip + decrypt; identical projection to `get`).
         let mut record = CredentialRecord::new();
         record.expires_at = resolved.expires_at;
-        let snapshot = self.ops.snapshot(credential_key, &resolved.data, record)?;
+        let snapshot = self
+            .ops
+            .snapshot(credential_key, &resolved.data, record)?
+            .with_display(display);
 
         let now = chrono::Utc::now();
         let stored = StoredCredential {
@@ -428,6 +440,7 @@ impl CredentialService {
         id: &str,
         props: Value,
         expected_version: u64,
+        display: CredentialDisplay,
     ) -> Result<CredentialSnapshot, CredentialServiceError> {
         // Owner check first: a cross-tenant id is reported as missing,
         // never as a version conflict (no existence leak).
@@ -451,6 +464,7 @@ impl CredentialService {
             OWNER_ID_KEY.to_owned(),
             Value::String(scope.owner_id().to_owned()),
         );
+        Self::set_display(&mut metadata, &display);
 
         let now = chrono::Utc::now();
         let stored = StoredCredential {
@@ -911,8 +925,17 @@ impl CredentialService {
         match outcome {
             crate::ops::AcquireOutcome::Complete(resolved) => {
                 let id = CredentialId::new();
+                // Acquisition carries no caller-supplied display metadata
+                // (the interactive/resolve flow names nothing); a later
+                // `update` can attach it.
                 let snapshot = self
-                    .persist_resolved(scope, credential_key, id, resolved)
+                    .persist_resolved(
+                        scope,
+                        credential_key,
+                        id,
+                        resolved,
+                        CredentialDisplay::default(),
+                    )
                     .await?;
                 self.observer.on_resolve(&id);
                 tracing::info!(
@@ -1210,8 +1233,11 @@ impl CredentialService {
         record.created_at = stored.created_at;
         record.last_modified = stored.updated_at;
         record.expires_at = stored.expires_at;
-        self.ops
-            .snapshot(&stored.credential_key, &stored.data, record)
+        let display = Self::display_from(&stored);
+        Ok(self
+            .ops
+            .snapshot(&stored.credential_key, &stored.data, record)?
+            .with_display(display))
     }
 
     /// Whether `stored` is owned by `scope`. A row missing the
@@ -1222,6 +1248,38 @@ impl CredentialService {
             .get(OWNER_ID_KEY)
             .and_then(Value::as_str)
             .is_some_and(|o| o == scope.owner_id())
+    }
+
+    /// Write `display` into `metadata[DISPLAY_KEY]`, or remove the key when
+    /// `display` is empty so an empty default leaves no residue. Sole writer
+    /// of the reserved key (sibling to `owner_id`).
+    fn set_display(metadata: &mut serde_json::Map<String, Value>, display: &CredentialDisplay) {
+        if display.is_empty() {
+            metadata.remove(DISPLAY_KEY);
+            return;
+        }
+        // `CredentialDisplay` is plain `Option<String>` / `BTreeMap` fields,
+        // so serialization to a JSON object cannot fail; on the impossible
+        // error drop the key rather than persist a corrupt entry.
+        match serde_json::to_value(display) {
+            Ok(v) => {
+                metadata.insert(DISPLAY_KEY.to_owned(), v);
+            },
+            Err(_) => {
+                metadata.remove(DISPLAY_KEY);
+            },
+        }
+    }
+
+    /// Read the facade-owned display sub-object back from a stored row. A
+    /// missing or malformed entry yields the empty default — display metadata
+    /// is non-critical and must never fail a credential read.
+    fn display_from(stored: &StoredCredential) -> CredentialDisplay {
+        stored
+            .metadata
+            .get(DISPLAY_KEY)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+            .unwrap_or_default()
     }
 
     /// Build the minimal owner-scoped [`CredentialContext`] the resolve
@@ -1496,6 +1554,7 @@ mod tests {
     use super::test_support::in_memory_service;
     use crate::CredentialServiceError;
     use crate::scope::TenantScope;
+    use nebula_credential::CredentialDisplay;
 
     #[tokio::test]
     async fn create_then_get_roundtrip_is_tenant_scoped() {
@@ -1506,6 +1565,7 @@ mod tests {
                 &scope,
                 "bearer_token",
                 serde_json::json!({ "token": "sk-secret-1" }),
+                CredentialDisplay::default(),
             )
             .await
             .expect("create ok");
@@ -1528,6 +1588,7 @@ mod tests {
             &owner,
             "bearer_token",
             serde_json::json!({ "token": "sk-secret-2" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1551,6 +1612,7 @@ mod tests {
                 &scope,
                 "bearer_token",
                 serde_json::json!({ "token": { "$expr": "{{ $execution.id }}" } }),
+                CredentialDisplay::default(),
             )
             .await
             .expect_err("expr must be rejected");
@@ -1565,7 +1627,12 @@ mod tests {
         let svc = in_memory_service();
         let scope = TenantScope::new("org1", "ws1");
         let err = svc
-            .create(&scope, "no_such_type", serde_json::json!({}))
+            .create(
+                &scope,
+                "no_such_type",
+                serde_json::json!({}),
+                CredentialDisplay::default(),
+            )
             .await
             .expect_err("unknown type");
         assert!(matches!(err, CredentialServiceError::TypeUnknown { .. }));
@@ -1579,6 +1646,7 @@ mod tests {
             &scope,
             "bearer_token",
             serde_json::json!({ "token": "sk-v1" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1587,7 +1655,13 @@ mod tests {
         // Stored version after CreateOnly is 1; a stale expected_version
         // of 99 must conflict.
         let err = svc
-            .update(&scope, &id, serde_json::json!({ "token": "sk-v2" }), 99)
+            .update(
+                &scope,
+                &id,
+                serde_json::json!({ "token": "sk-v2" }),
+                99,
+                CredentialDisplay::default(),
+            )
             .await
             .expect_err("stale version");
         assert!(matches!(
@@ -1604,14 +1678,21 @@ mod tests {
             &scope,
             "bearer_token",
             serde_json::json!({ "token": "sk-old" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
         let id = svc.list(&scope).await.expect("list")[0].clone();
 
-        svc.update(&scope, &id, serde_json::json!({ "token": "sk-new" }), 1)
-            .await
-            .expect("update ok");
+        svc.update(
+            &scope,
+            &id,
+            serde_json::json!({ "token": "sk-new" }),
+            1,
+            CredentialDisplay::default(),
+        )
+        .await
+        .expect("update ok");
         // Still resolvable post-update.
         let got = svc.get(&scope, &id).await.expect("get ok");
         assert_eq!(got.kind(), "bearer_token");
@@ -1629,6 +1710,7 @@ mod tests {
             &owner,
             "bearer_token",
             serde_json::json!({ "token": "sk-x" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1640,9 +1722,15 @@ mod tests {
             CredentialServiceError::NotFound { .. }
         ));
         assert!(matches!(
-            svc.update(&other, &id, serde_json::json!({ "token": "z" }), 1)
-                .await
-                .expect_err("denied"),
+            svc.update(
+                &other,
+                &id,
+                serde_json::json!({ "token": "z" }),
+                1,
+                CredentialDisplay::default(),
+            )
+            .await
+            .expect_err("denied"),
             CredentialServiceError::NotFound { .. }
         ));
     }
@@ -1658,6 +1746,7 @@ mod tests {
             &scope,
             "bearer_token",
             serde_json::json!({ "token": "sk-cap" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1740,6 +1829,7 @@ mod tests {
             &owner,
             "bearer_token",
             serde_json::json!({ "token": "sk-xt" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1853,6 +1943,7 @@ mod tests {
             &scope,
             "refreshable_fixture",
             serde_json::json!({ "token": "tok-base" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create fixture ok");
@@ -1899,6 +1990,7 @@ mod tests {
             &scope,
             "refreshable_fixture",
             serde_json::json!({ "token": "tok-race" }),
+            CredentialDisplay::default(),
         )
         .await
         .expect("create ok");
@@ -1923,6 +2015,7 @@ mod tests {
                         id_ref,
                         serde_json::json!({ "token": "tok-race-concurrent" }),
                         1,
+                        CredentialDisplay::default(),
                     )
                     .await;
                 barrier.wait().await;

--- a/crates/credential-runtime/tests/adversarial.rs
+++ b/crates/credential-runtime/tests/adversarial.rs
@@ -31,9 +31,14 @@ async fn abuse1_cross_tenant_is_uniformly_not_found_no_existence_leak() {
     let a = TenantScope::new("orgA", "wsA");
     let b = TenantScope::new("orgB", "wsB");
 
-    svc.create(&a, "bearer_token", json!({ "token": "sk-tenant-A" }))
-        .await
-        .expect("create under A");
+    svc.create(
+        &a,
+        "bearer_token",
+        json!({ "token": "sk-tenant-A" }),
+        nebula_credential::CredentialDisplay::default(),
+    )
+    .await
+    .expect("create under A");
     let id = svc.list(&a).await.expect("list A")[0].clone();
 
     // get / update / delete / test / refresh / revoke under B: every one
@@ -44,9 +49,15 @@ async fn abuse1_cross_tenant_is_uniformly_not_found_no_existence_leak() {
         CredentialServiceError::NotFound { .. }
     ));
     assert!(matches!(
-        svc.update(&b, &id, json!({ "token": "z" }), 1)
-            .await
-            .expect_err("update B denied"),
+        svc.update(
+            &b,
+            &id,
+            json!({ "token": "z" }),
+            1,
+            nebula_credential::CredentialDisplay::default()
+        )
+        .await
+        .expect_err("update B denied"),
         CredentialServiceError::NotFound { .. }
     ));
     assert!(matches!(
@@ -87,6 +98,7 @@ async fn abuse2_expr_injection_is_validation_failed_control_succeeds() {
             &scope,
             "bearer_token",
             json!({ "token": { "$expr": "{{ $execution.id }}" } }),
+            nebula_credential::CredentialDisplay::default(),
         )
         .await
         .expect_err("$expr envelope must be refused");
@@ -97,7 +109,12 @@ async fn abuse2_expr_injection_is_validation_failed_control_succeeds() {
 
     // Control: a well-formed create on the same type succeeds.
     let snap = svc
-        .create(&scope, "bearer_token", json!({ "token": "sk-well-formed" }))
+        .create(
+            &scope,
+            "bearer_token",
+            json!({ "token": "sk-well-formed" }),
+            nebula_credential::CredentialDisplay::default(),
+        )
         .await
         .expect("well-formed create succeeds");
     assert_eq!(snap.kind(), "bearer_token");
@@ -133,7 +150,12 @@ async fn abuse3_no_secret_in_snapshot_debug_on_create_and_get() {
     let scope = TenantScope::new("org1", "ws1");
 
     let created = svc
-        .create(&scope, "bearer_token", json!({ "token": SECRET }))
+        .create(
+            &scope,
+            "bearer_token",
+            json!({ "token": SECRET }),
+            nebula_credential::CredentialDisplay::default(),
+        )
         .await
         .expect("create ok");
     let created_dbg = format!("{created:?}");
@@ -171,9 +193,14 @@ async fn abuse3_no_secret_in_snapshot_debug_on_create_and_get() {
 async fn abuse4_static_type_capability_ops_are_unsupported() {
     let svc = in_memory_service();
     let scope = TenantScope::new("org1", "ws1");
-    svc.create(&scope, "bearer_token", json!({ "token": "sk-cap" }))
-        .await
-        .expect("create ok");
+    svc.create(
+        &scope,
+        "bearer_token",
+        json!({ "token": "sk-cap" }),
+        nebula_credential::CredentialDisplay::default(),
+    )
+    .await
+    .expect("create ok");
     let id = svc.list(&scope).await.expect("list")[0].clone();
 
     for (op_name, res) in [
@@ -250,9 +277,14 @@ async fn abuse5_cross_tenant_revoke_is_not_found_before_lease_scan() {
     let owner = TenantScope::new("orgX", "wsX");
     let attacker = TenantScope::new("orgY", "wsY");
 
-    svc.create(&owner, "bearer_token", json!({ "token": "sk-lease" }))
-        .await
-        .expect("create ok");
+    svc.create(
+        &owner,
+        "bearer_token",
+        json!({ "token": "sk-lease" }),
+        nebula_credential::CredentialDisplay::default(),
+    )
+    .await
+    .expect("create ok");
     let id = svc.list(&owner).await.expect("list")[0].clone();
 
     // The attacker's revoke is NotFound — the owner gate runs before the
@@ -347,9 +379,14 @@ async fn abuse7_layered_store_roundtrips_without_exposing_plaintext() {
     let svc = in_memory_service();
     let scope = TenantScope::new("org1", "ws1");
 
-    svc.create(&scope, "bearer_token", json!({ "token": SECRET }))
-        .await
-        .expect("create ok");
+    svc.create(
+        &scope,
+        "bearer_token",
+        json!({ "token": SECRET }),
+        nebula_credential::CredentialDisplay::default(),
+    )
+    .await
+    .expect("create ok");
     let id = svc.list(&scope).await.expect("list")[0].clone();
 
     // Round-trips through Encryption(raw) transparently and the projected
@@ -395,7 +432,12 @@ async fn abuse8_audit_refusal_fails_closed_no_partial_write() {
     let scope = TenantScope::new("org1", "ws1");
 
     let err = svc
-        .create(&scope, "bearer_token", json!({ "token": "sk-audit" }))
+        .create(
+            &scope,
+            "bearer_token",
+            json!({ "token": "sk-audit" }),
+            nebula_credential::CredentialDisplay::default(),
+        )
         .await
         .expect_err("create must fail when the audit sink refuses");
     assert!(

--- a/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.rs
+++ b/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.rs
@@ -10,13 +10,11 @@
 //! NOT an arity/type error (we never get far enough to type-check args).
 
 use nebula_credential_runtime::CredentialService;
-use nebula_credential_testutil::InMemoryPendingStore;
-use nebula_storage::credential::InMemoryStore;
 
 fn main() {
-    // `InMemoryStore` is a raw `CredentialStore`. Reaching the private
-    // `__from_parts` to wrap it directly (skipping the EncryptionLayer)
-    // is the abuse this probe forbids. Referencing the path is enough —
-    // the privacy check fires before argument type-checking.
-    let _bypass = CredentialService::<InMemoryStore, InMemoryPendingStore>::__from_parts;
+    // Reaching the private `__from_parts` to wrap a raw store directly
+    // (skipping the EncryptionLayer) is the abuse this probe forbids.
+    // Referencing the path is enough — the privacy check fires before any
+    // argument type-checking.
+    let _bypass = CredentialService::__from_parts;
 }

--- a/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.stderr
+++ b/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.stderr
@@ -1,14 +1,14 @@
 error[E0624]: associated function `__from_parts` is private
-  --> tests/compile_fail/raw_store_without_layers.rs:21:77
+  --> tests/compile_fail/raw_store_without_layers.rs:19:38
    |
-21 |       let _bypass = CredentialService::<InMemoryStore, InMemoryPendingStore>::__from_parts;
-   |                                                                               ^^^^^^^^^^^^ private associated function
+19 |       let _bypass = CredentialService::__from_parts;
+   |                                        ^^^^^^^^^^^^ private associated function
    |
   ::: src/service.rs
    |
    | /     pub(crate) fn __from_parts(
-   | |         store: Arc<LayeredStore<B>>,
-   | |         resolver: CredentialResolver<LayeredStore<B>>,
+   | |         store: Arc<dyn DynCredentialStore>,
+   | |         resolver: CredentialResolver<ErasedCredentialStore>,
    | |         lease: LeaseLifecycle,
 ...  |
    | |         source: StateSource,

--- a/crates/credential-runtime/tests/display_metadata.rs
+++ b/crates/credential-runtime/tests/display_metadata.rs
@@ -1,0 +1,73 @@
+//! Per-instance display metadata round-trips through the facade.
+//!
+//! `create` attaches a typed `CredentialDisplay` (name / description / tags),
+//! `get` reads it back from the reserved `metadata["display"]` sub-object, and
+//! `update` replaces it (cleared fields do not linger). Empty display leaves no
+//! residue.
+
+use nebula_credential::CredentialDisplay;
+use nebula_credential_runtime::TenantScope;
+use nebula_credential_runtime::test_support::in_memory_service;
+use serde_json::json;
+
+#[tokio::test]
+async fn display_round_trips_through_create_get_and_update() {
+    let svc = in_memory_service();
+    let scope = TenantScope::new("org1", "ws1");
+
+    let mut tags = std::collections::BTreeMap::new();
+    tags.insert("env".to_owned(), "prod".to_owned());
+    let display = CredentialDisplay {
+        display_name: Some("Prod token".to_owned()),
+        description: Some("the production key".to_owned()),
+        tags,
+    };
+
+    // create() attaches the display to the returned snapshot verbatim.
+    let created = svc
+        .create(
+            &scope,
+            "bearer_token",
+            json!({ "token": "sk-disp" }),
+            display.clone(),
+        )
+        .await
+        .expect("create ok");
+    assert_eq!(created.display(), &display);
+
+    // get() reads it back from the reserved `metadata["display"]` sub-object.
+    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let got = svc.get(&scope, &id).await.expect("get ok");
+    assert_eq!(got.display(), &display);
+
+    // update() replaces the display; cleared fields do not linger.
+    let next = CredentialDisplay {
+        display_name: Some("Renamed".to_owned()),
+        ..Default::default()
+    };
+    svc.update(&scope, &id, json!({ "token": "sk-disp" }), 1, next.clone())
+        .await
+        .expect("update ok");
+    let after = svc.get(&scope, &id).await.expect("get ok");
+    assert_eq!(after.display(), &next);
+    assert!(after.display().description.is_none());
+}
+
+#[tokio::test]
+async fn empty_display_is_the_default_on_get() {
+    let svc = in_memory_service();
+    let scope = TenantScope::new("org1", "ws1");
+
+    svc.create(
+        &scope,
+        "bearer_token",
+        json!({ "token": "sk-nodisp" }),
+        CredentialDisplay::default(),
+    )
+    .await
+    .expect("create ok");
+
+    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let got = svc.get(&scope, &id).await.expect("get ok");
+    assert!(got.display().is_empty());
+}

--- a/crates/credential-runtime/tests/refresh_fallback.rs
+++ b/crates/credential-runtime/tests/refresh_fallback.rs
@@ -32,6 +32,7 @@ async fn refresh_transient_falls_back_to_cached_when_non_expired() {
         &scope,
         RefreshableFixtureCredential::KEY,
         json!({ "token": "seed-token" }),
+        nebula_credential::CredentialDisplay::default(),
     )
     .await
     .expect("create seed");
@@ -70,6 +71,7 @@ async fn refresh_terminal_failure_propagates() {
         &scope,
         RefreshableFixtureCredential::KEY,
         json!({ "token": "seed-token" }),
+        nebula_credential::CredentialDisplay::default(),
     )
     .await
     .expect("create seed");
@@ -105,6 +107,7 @@ async fn refresh_no_failure_returns_refreshed_snapshot() {
         &scope,
         RefreshableFixtureCredential::KEY,
         json!({ "token": "seed-token" }),
+        nebula_credential::CredentialDisplay::default(),
     )
     .await
     .expect("create seed");

--- a/crates/credential-runtime/tests/refresh_fallback.rs
+++ b/crates/credential-runtime/tests/refresh_fallback.rs
@@ -15,10 +15,7 @@ use serde_json::json;
 
 /// Helper — `in_memory_service_with_fixtures` returns `(service, refresh_counter)`.
 fn build() -> (
-    nebula_credential_runtime::CredentialService<
-        nebula_storage::credential::InMemoryStore,
-        nebula_credential_testutil::InMemoryPendingStore,
-    >,
+    nebula_credential_runtime::CredentialService,
     std::sync::Arc<std::sync::atomic::AtomicUsize>,
 ) {
     in_memory_service_with_fixtures()

--- a/crates/credential-runtime/tests/resolve_for_slot.rs
+++ b/crates/credential-runtime/tests/resolve_for_slot.rs
@@ -27,6 +27,7 @@ async fn resolve_for_slot_produces_guard() {
             &scope,
             BearerTokenCredential::KEY,
             json!({ "token": "test-bearer-abc123" }),
+            nebula_credential::CredentialDisplay::default(),
         )
         .await
         .expect("create succeeds");
@@ -67,6 +68,7 @@ async fn resolve_for_slot_scope_violation_rejected() {
             &scope_a,
             BearerTokenCredential::KEY,
             json!({ "token": "token-for-a" }),
+            nebula_credential::CredentialDisplay::default(),
         )
         .await
         .expect("create succeeds");
@@ -104,6 +106,7 @@ async fn resolve_for_slot_cancellation_returns_cancelled() {
             &scope,
             BearerTokenCredential::KEY,
             json!({ "token": "token-cancel-test" }),
+            nebula_credential::CredentialDisplay::default(),
         )
         .await
         .expect("create succeeds");

--- a/crates/credential-runtime/tests/validated_binding_cross_tenant.rs
+++ b/crates/credential-runtime/tests/validated_binding_cross_tenant.rs
@@ -16,7 +16,12 @@ async fn cross_tenant_binding_rejected() {
 
     // Create a credential under scope A.
     service
-        .create(&scope_a, "bearer_token", json!({ "token": "tenant-a-key" }))
+        .create(
+            &scope_a,
+            "bearer_token",
+            json!({ "token": "tenant-a-key" }),
+            nebula_credential::CredentialDisplay::default(),
+        )
         .await
         .expect("create succeeds for tenant A");
 

--- a/crates/credential-testutil/src/pending_store_memory.rs
+++ b/crates/credential-testutil/src/pending_store_memory.rs
@@ -9,15 +9,15 @@
 //! If you are adding new production code, reach for
 //! `nebula_storage::credential::InMemoryPendingStore`.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use chrono::Utc;
 use tokio::sync::RwLock;
 
-use nebula_credential::{
-    PendingState, PendingToken,
-    pending_store::{PendingStateStore, PendingStoreError},
-};
+use nebula_credential::{DynPendingStateStore, PendingToken, pending_store::PendingStoreError};
 
 /// In-memory pending store backed by a `HashMap`.
 ///
@@ -77,140 +77,148 @@ impl Default for InMemoryPendingStore {
     }
 }
 
-impl PendingStateStore for InMemoryPendingStore {
-    async fn put<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        owner_id: &str,
-        session_id: &str,
-        pending: P,
-    ) -> Result<PendingToken, PendingStoreError> {
-        let data =
-            serde_json::to_vec(&pending).map_err(|e| PendingStoreError::Backend(Box::new(e)))?;
-        let expires_at = Utc::now() + pending.expires_in();
-        let token = PendingToken::generate();
+impl DynPendingStateStore for InMemoryPendingStore {
+    fn put_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        owner_id: &'a str,
+        session_id: &'a str,
+        data: Vec<u8>,
+        expires_in: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<PendingToken, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let expires_at = Utc::now() + expires_in;
+            let token = PendingToken::generate();
 
-        let entry = PendingEntry {
-            credential_kind: credential_kind.to_owned(),
-            owner_id: owner_id.to_owned(),
-            session_id: session_id.to_owned(),
-            data,
-            expires_at,
-        };
+            let entry = PendingEntry {
+                credential_kind: credential_kind.to_owned(),
+                owner_id: owner_id.to_owned(),
+                session_id: session_id.to_owned(),
+                data,
+                expires_at,
+            };
 
-        self.entries
-            .write()
-            .await
-            .insert(token.as_str().to_owned(), entry);
+            self.entries
+                .write()
+                .await
+                .insert(token.as_str().to_owned(), entry);
 
-        Ok(token)
+            Ok(token)
+        })
     }
 
-    async fn get<P: PendingState>(&self, token: &PendingToken) -> Result<P, PendingStoreError> {
-        let mut entries = self.entries.write().await;
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+    fn get_serialized<'a>(
+        &'a self,
+        token: &'a PendingToken,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            // Expiry is deterministic; evict here too so repeated `get`
-            // probes cannot retain stale rows forever.
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
-        let data = entry.data.clone();
-        drop(entries);
-
-        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            if Utc::now() > entry.expires_at {
+                // Expiry is deterministic; evict here too so repeated `get`
+                // probes cannot retain stale rows forever.
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
+            Ok(entry.data.clone())
+        })
     }
 
-    async fn get_bound<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        token: &PendingToken,
-        owner_id: &str,
-        session_id: &str,
-    ) -> Result<P, PendingStoreError> {
-        let mut entries = self.entries.write().await;
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+    fn get_bound_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
+            if Utc::now() > entry.expires_at {
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
 
-        let mismatch = entry.credential_kind != credential_kind
-            || entry.owner_id != owner_id
-            || entry.session_id != session_id;
-        if mismatch {
-            return Err(PendingStoreError::ValidationFailed {
-                reason: "token bindings do not match".to_owned(),
-            });
-        }
+            let mismatch = entry.credential_kind != credential_kind
+                || entry.owner_id != owner_id
+                || entry.session_id != session_id;
+            if mismatch {
+                return Err(PendingStoreError::ValidationFailed {
+                    reason: "token bindings do not match".to_owned(),
+                });
+            }
 
-        let data = entry.data.clone();
-        drop(entries);
-
-        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            Ok(entry.data.clone())
+        })
     }
 
-    async fn consume<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        token: &PendingToken,
-        owner_id: &str,
-        session_id: &str,
-    ) -> Result<P, PendingStoreError> {
-        // Validate *before* removing. A wrong-owner (or otherwise malformed)
-        // `consume` request must not be able to destroy the legitimate
-        // user's pending state — that would turn any token leak into a
-        // single-shot DoS against the in-flight flow. Hold the write lock
-        // across the whole check so no concurrent consume can race between
-        // validation and removal.
-        let mut entries = self.entries.write().await;
+    fn consume_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Validate *before* removing. A wrong-owner (or otherwise
+            // malformed) `consume` request must not be able to destroy the
+            // legitimate user's pending state — that would turn any token
+            // leak into a single-shot DoS against the in-flight flow. Hold
+            // the write lock across the whole check so no concurrent consume
+            // can race between validation and removal.
+            let mut entries = self.entries.write().await;
 
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            // Expiry is deterministic; it's safe to evict the stale row now.
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
+            if Utc::now() > entry.expires_at {
+                // Expiry is deterministic; it's safe to evict the stale row now.
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
 
-        // All three binding checks are folded into one OR so the failure
-        // path is indistinguishable and does not hint at which dimension
-        // mismatched (cheap mitigation for a timing/oracle probe).
-        let mismatch = entry.credential_kind != credential_kind
-            || entry.owner_id != owner_id
-            || entry.session_id != session_id;
-        if mismatch {
-            // Intentionally leave the entry in place so the legitimate
-            // caller can still consume it.
-            return Err(PendingStoreError::ValidationFailed {
-                reason: "token bindings do not match".to_owned(),
-            });
-        }
+            // All three binding checks are folded into one OR so the failure
+            // path is indistinguishable and does not hint at which dimension
+            // mismatched (cheap mitigation for a timing/oracle probe).
+            let mismatch = entry.credential_kind != credential_kind
+                || entry.owner_id != owner_id
+                || entry.session_id != session_id;
+            if mismatch {
+                // Intentionally leave the entry in place so the legitimate
+                // caller can still consume it.
+                return Err(PendingStoreError::ValidationFailed {
+                    reason: "token bindings do not match".to_owned(),
+                });
+            }
 
-        // Only now remove the entry and deserialize from the owned bytes.
-        // Entry presence was confirmed by the get() above under the same write
-        // lock; a None here would be a lock-safety bug, so map it to Backend.
-        let entry = entries.remove(token.as_str()).ok_or_else(|| {
-            PendingStoreError::Backend(Box::new(std::io::Error::other(
-                "entry vanished under write lock",
-            )))
-        })?;
-        drop(entries);
-
-        serde_json::from_slice(&entry.data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            // Only now remove the entry and return the owned bytes. Entry
+            // presence was confirmed by the get() above under the same write
+            // lock; a None here would be a lock-safety bug, so map it to
+            // Backend.
+            let entry = entries.remove(token.as_str()).ok_or_else(|| {
+                PendingStoreError::Backend(Box::new(std::io::Error::other(
+                    "entry vanished under write lock",
+                )))
+            })?;
+            Ok(entry.data)
+        })
     }
 
-    async fn delete(&self, token: &PendingToken) -> Result<(), PendingStoreError> {
-        self.entries.write().await.remove(token.as_str());
-        Ok(())
+    fn delete<'a>(
+        &'a self,
+        token: &'a PendingToken,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.entries.write().await.remove(token.as_str());
+            Ok(())
+        })
     }
 }
 
@@ -218,6 +226,10 @@ impl PendingStateStore for InMemoryPendingStore {
 mod tests {
     use std::time::Duration;
 
+    // The typed `put`/`consume::<T>` surface comes from the blanket
+    // `PendingStateStore` impl on every `DynPendingStateStore`; pull both
+    // traits into scope so the shim smoke test exercises the typed API.
+    use nebula_credential::{PendingState, PendingStateStore};
     use serde::{Deserialize, Serialize};
     use zeroize::{Zeroize, ZeroizeOnDrop};
 

--- a/crates/credential/src/display.rs
+++ b/crates/credential/src/display.rs
@@ -1,0 +1,87 @@
+//! Per-instance credential display metadata.
+//!
+//! [`CredentialDisplay`] is the human-facing, **non-secret** metadata a user
+//! attaches to a credential *instance* (a created credential like
+//! "Prod GitHub PAT") — distinct from the type-level
+//! [`CredentialMetadata`](crate::CredentialMetadata), which describes the
+//! credential *kind*.
+//!
+//! It is carried on [`CredentialSnapshot`](crate::CredentialSnapshot) and
+//! persisted by the credential runtime under a reserved `metadata["display"]`
+//! sub-object on the stored credential (a single-writer key, sibling to the
+//! tenancy `owner_id` key). It never holds secret material, so it derives
+//! `Debug`/`Serialize` without redaction.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Human-facing, non-secret display metadata for a credential instance.
+///
+/// All fields are optional: a system-acquired credential may carry none. The
+/// type is the API/management-tier shape (a created credential's name,
+/// description, and organizational tags), kept out of the secret/lifecycle
+/// state. `BTreeMap` keeps tag ordering deterministic for stable wire output.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CredentialDisplay {
+    /// Human-readable instance name (e.g. `"Prod GitHub PAT"`). `None` when the
+    /// creator supplied none.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
+
+    /// Optional free-text description.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// User-defined tags for organization and filtering.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tags: BTreeMap<String, String>,
+}
+
+impl CredentialDisplay {
+    /// True when no display field is set (the empty default).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.display_name.is_none() && self.description.is_none() && self.tags.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_empty() {
+        assert!(CredentialDisplay::default().is_empty());
+    }
+
+    #[test]
+    fn populated_is_not_empty() {
+        let d = CredentialDisplay {
+            display_name: Some("Prod key".to_owned()),
+            ..Default::default()
+        };
+        assert!(!d.is_empty());
+    }
+
+    #[test]
+    fn empty_fields_are_skipped_in_serialization() {
+        let json = serde_json::to_value(CredentialDisplay::default()).expect("serialize");
+        // No `display_name`/`description`/`tags` keys when empty.
+        assert_eq!(json, serde_json::json!({}));
+    }
+
+    #[test]
+    fn round_trips_through_json() {
+        let mut tags = BTreeMap::new();
+        tags.insert("env".to_owned(), "prod".to_owned());
+        let d = CredentialDisplay {
+            display_name: Some("n".to_owned()),
+            description: Some("d".to_owned()),
+            tags,
+        };
+        let back: CredentialDisplay =
+            serde_json::from_value(serde_json::to_value(&d).expect("ser")).expect("de");
+        assert_eq!(d, back);
+    }
+}

--- a/crates/credential/src/erased.rs
+++ b/crates/credential/src/erased.rs
@@ -1,0 +1,392 @@
+//! Dyn-erasure bridge for the two RPITIT credential storage ports.
+//!
+//! [`CredentialStore`] and [`PendingStateStore`] both use return-position
+//! `impl Future` in trait position (RPITIT); [`PendingStateStore`]'s
+//! non-`delete` methods are additionally generic over `<P: PendingState>`.
+//! Neither is object-safe, so neither can be stored behind `dyn`. The
+//! [`CredentialService`](../../nebula_credential_runtime/index.html) facade
+//! must be **non-generic** (ADR-0088 D4) so a durable backend can be swapped
+//! in without re-monomorphizing every consumer; that requires erasing both
+//! ports to `dyn`.
+//!
+//! This module provides the hand-rolled boxed-future bridge that does it,
+//! mirroring the `ProviderFuture` idiom in
+//! [`ProviderFuture`](crate::ProviderFuture) — no `async_trait`, no
+//! `bon` (records the ADR-0088 D4 bon-deviation):
+//!
+//! - [`DynCredentialStore`] — object-safe boxed-future mirror of
+//!   [`CredentialStore`]; a blanket impl gives every `CredentialStore` a
+//!   `DynCredentialStore`, and [`ErasedCredentialStore`] wraps an
+//!   `Arc<dyn DynCredentialStore>` back into a concrete `CredentialStore`.
+//! - [`DynPendingStateStore`] — object-safe **byte-core** mirror of
+//!   [`PendingStateStore`]: the `<P: PendingState>` generic is erased to
+//!   `Vec<u8>` (serialize on put, deserialize on get/consume/get_bound). A
+//!   blanket impl gives every `DynPendingStateStore` a typed
+//!   [`PendingStateStore`], and [`ErasedPendingStore`] wraps an
+//!   `Arc<dyn DynPendingStateStore>` back into a concrete
+//!   [`PendingStateStore`].
+//!
+//! # Coherence
+//!
+//! After this module lands, **no type implements [`PendingStateStore`]
+//! directly** except the blanket here and [`ErasedPendingStore`]: backend
+//! pending stores implement [`DynPendingStateStore`] and acquire
+//! [`PendingStateStore`] via the blanket. This keeps the blanket
+//! unambiguous.
+//!
+//! Do **not** add the symmetric `impl<T: PendingStateStore> DynPendingStateStore
+//! for T`: it would make `ErasedPendingStore` (which has an explicit
+//! [`PendingStateStore`] impl) transitively a [`DynPendingStateStore`], so the
+//! blanket above would then also cover it and collide with the explicit impl
+//! (E0119). The one-directional bridge (`DynPendingStateStore` → typed
+//! [`PendingStateStore`]) is load-bearing for coherence.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use crate::pending_store::{PendingStateStore, PendingStoreError};
+use crate::store::{CredentialStore, PutMode, StoreError, StoredCredential};
+use crate::{PendingState, PendingToken};
+
+/// Boxed, `Send` future used by both bridge traits. `'a` ties the future
+/// to the borrow of `&self` (and any borrowed arguments) so the returned
+/// future may borrow from the store for its whole lifetime.
+type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// ── Credential store bridge ──────────────────────────────────────────────
+
+/// Object-safe boxed-future mirror of [`CredentialStore`].
+///
+/// Each method ties `&self` and every borrowed argument to a single
+/// lifetime `'a`, so the returned `BoxFut` may borrow from the store. A
+/// blanket impl (`impl<T: CredentialStore> DynCredentialStore for T`) makes
+/// every `CredentialStore` usable as `dyn DynCredentialStore`, and
+/// [`ErasedCredentialStore`] erases the backend at the resolver→store
+/// boundary so the facade can be non-generic.
+///
+/// The five methods mirror [`CredentialStore`] one-for-one; see that trait
+/// for the per-method contract and error semantics.
+pub trait DynCredentialStore: Send + Sync {
+    /// Boxed-future mirror of [`CredentialStore::get`].
+    fn get<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<StoredCredential, StoreError>>;
+
+    /// Boxed-future mirror of [`CredentialStore::put`].
+    fn put(
+        &self,
+        credential: StoredCredential,
+        mode: PutMode,
+    ) -> BoxFut<'_, Result<StoredCredential, StoreError>>;
+
+    /// Boxed-future mirror of [`CredentialStore::delete`].
+    fn delete<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<(), StoreError>>;
+
+    /// Boxed-future mirror of [`CredentialStore::list`].
+    fn list<'a>(
+        &'a self,
+        state_kind: Option<&'a str>,
+    ) -> BoxFut<'a, Result<Vec<String>, StoreError>>;
+
+    /// Boxed-future mirror of [`CredentialStore::exists`].
+    fn exists<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<bool, StoreError>>;
+}
+
+impl<T: CredentialStore> DynCredentialStore for T {
+    fn get<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<StoredCredential, StoreError>> {
+        Box::pin(CredentialStore::get(self, id))
+    }
+
+    fn put(
+        &self,
+        credential: StoredCredential,
+        mode: PutMode,
+    ) -> BoxFut<'_, Result<StoredCredential, StoreError>> {
+        Box::pin(CredentialStore::put(self, credential, mode))
+    }
+
+    fn delete<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<(), StoreError>> {
+        Box::pin(CredentialStore::delete(self, id))
+    }
+
+    fn list<'a>(
+        &'a self,
+        state_kind: Option<&'a str>,
+    ) -> BoxFut<'a, Result<Vec<String>, StoreError>> {
+        Box::pin(CredentialStore::list(self, state_kind))
+    }
+
+    fn exists<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<bool, StoreError>> {
+        Box::pin(CredentialStore::exists(self, id))
+    }
+}
+
+/// Concrete, `Clone`-able [`CredentialStore`] over an erased backend.
+///
+/// Wraps an `Arc<dyn DynCredentialStore>` and re-implements
+/// [`CredentialStore`] by forwarding to the boxed-future methods. This is
+/// the type the facade's resolver is monomorphized over, so the backend can
+/// be swapped (in-memory ↔ SQLite ↔ Postgres) without re-typing any
+/// consumer.
+#[derive(Clone)]
+pub struct ErasedCredentialStore(Arc<dyn DynCredentialStore>);
+
+impl std::fmt::Debug for ErasedCredentialStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ErasedCredentialStore")
+            .finish_non_exhaustive()
+    }
+}
+
+impl ErasedCredentialStore {
+    /// Wrap an erased credential backend.
+    #[must_use]
+    pub fn new(inner: Arc<dyn DynCredentialStore>) -> Self {
+        Self(inner)
+    }
+}
+
+impl CredentialStore for ErasedCredentialStore {
+    // `async fn` (not a bare forward returning the `BoxFut`) so the impl's
+    // opaque return type captures the `&self`/arg borrows the boxed future
+    // holds — a bare `self.0.get(id)` is E0700 (captured lifetime not in
+    // bounds).
+    async fn get(&self, id: &str) -> Result<StoredCredential, StoreError> {
+        self.0.get(id).await
+    }
+
+    async fn put(
+        &self,
+        credential: StoredCredential,
+        mode: PutMode,
+    ) -> Result<StoredCredential, StoreError> {
+        self.0.put(credential, mode).await
+    }
+
+    async fn delete(&self, id: &str) -> Result<(), StoreError> {
+        self.0.delete(id).await
+    }
+
+    async fn list(&self, state_kind: Option<&str>) -> Result<Vec<String>, StoreError> {
+        self.0.list(state_kind).await
+    }
+
+    async fn exists(&self, id: &str) -> Result<bool, StoreError> {
+        self.0.exists(id).await
+    }
+}
+
+// ── Pending store bridge ─────────────────────────────────────────────────
+
+/// Object-safe **byte-core** mirror of [`PendingStateStore`].
+///
+/// [`PendingStateStore`]'s `put`/`get`/`get_bound`/`consume` are generic
+/// over `<P: PendingState>`, which makes the trait non-object-safe. This
+/// bridge erases the generic to `Vec<u8>`: the typed [`PendingStateStore`]
+/// blanket below serializes on `put` and deserializes on the read paths,
+/// so a `dyn DynPendingStateStore` carries exactly the same serde round-trip
+/// the original direct impls did. `delete` carries no type parameter and is
+/// mirrored unchanged.
+///
+/// Implementors store the raw bytes plus the binding tuple
+/// (`credential_kind`, `owner_id`, `session_id`) and the absolute expiry
+/// (`Utc::now() + expires_in`), and enforce TTL eviction + 4-dimensional
+/// token binding on the read paths — see
+/// [`PendingStateStore`] for the security contract.
+pub trait DynPendingStateStore: Send + Sync {
+    /// Byte-core mirror of [`PendingStateStore::put`]. `data` is the
+    /// already-serialized pending state; `expires_in` is the type's
+    /// [`PendingState::expires_in`] TTL (the store computes the absolute
+    /// expiry as `Utc::now() + expires_in`).
+    fn put_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        owner_id: &'a str,
+        session_id: &'a str,
+        data: Vec<u8>,
+        expires_in: Duration,
+    ) -> BoxFut<'a, Result<PendingToken, PendingStoreError>>;
+
+    /// Byte-core mirror of [`PendingStateStore::get`]. Returns the stored
+    /// serialized bytes without consuming or binding-checking.
+    fn get_serialized<'a>(
+        &'a self,
+        token: &'a PendingToken,
+    ) -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+
+    /// Byte-core mirror of [`PendingStateStore::get_bound`]. Returns the
+    /// stored serialized bytes after validating the 3 binding dimensions
+    /// (without consuming).
+    fn get_bound_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+
+    /// Byte-core mirror of [`PendingStateStore::consume`]. Validates all 4
+    /// dimensions then atomically reads-and-deletes, returning the stored
+    /// serialized bytes.
+    fn consume_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+
+    /// Mirror of [`PendingStateStore::delete`] (no type parameter).
+    fn delete<'a>(&'a self, token: &'a PendingToken) -> BoxFut<'a, Result<(), PendingStoreError>>;
+}
+
+/// Typed [`PendingStateStore`] for every [`DynPendingStateStore`].
+///
+/// Serializes on `put` (`serde_json::to_vec` + [`PendingState::expires_in`])
+/// and deserializes on the read paths (`serde_json::from_slice`); serde
+/// failures map to [`PendingStoreError::Backend`]. This is the **sole**
+/// `PendingStateStore` impl in the workspace other than
+/// [`ErasedPendingStore`] — backend stores implement
+/// [`DynPendingStateStore`] and inherit [`PendingStateStore`] here.
+impl<T: DynPendingStateStore + ?Sized> PendingStateStore for T {
+    async fn put<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        owner_id: &str,
+        session_id: &str,
+        pending: P,
+    ) -> Result<PendingToken, PendingStoreError> {
+        let data =
+            serde_json::to_vec(&pending).map_err(|e| PendingStoreError::Backend(Box::new(e)))?;
+        let expires_in = pending.expires_in();
+        self.put_serialized(credential_kind, owner_id, session_id, data, expires_in)
+            .await
+    }
+
+    async fn get<P: PendingState>(&self, token: &PendingToken) -> Result<P, PendingStoreError> {
+        let data = self.get_serialized(token).await?;
+        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+    }
+
+    async fn get_bound<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        token: &PendingToken,
+        owner_id: &str,
+        session_id: &str,
+    ) -> Result<P, PendingStoreError> {
+        let data = self
+            .get_bound_serialized(credential_kind, token, owner_id, session_id)
+            .await?;
+        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+    }
+
+    async fn consume<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        token: &PendingToken,
+        owner_id: &str,
+        session_id: &str,
+    ) -> Result<P, PendingStoreError> {
+        let data = self
+            .consume_serialized(credential_kind, token, owner_id, session_id)
+            .await?;
+        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+    }
+
+    async fn delete(&self, token: &PendingToken) -> Result<(), PendingStoreError> {
+        DynPendingStateStore::delete(self, token).await
+    }
+}
+
+/// Concrete, `Clone`-able [`PendingStateStore`] over an erased backend.
+///
+/// Wraps an `Arc<dyn DynPendingStateStore>` and forwards the typed
+/// generic methods to the blanket impl on `dyn DynPendingStateStore`
+/// (which performs the serde round-trip). This is the fixed `PS` type the
+/// facade and `DispatchOps` are monomorphized over, so the pending backend
+/// can be swapped without re-typing any consumer.
+#[derive(Clone)]
+pub struct ErasedPendingStore(Arc<dyn DynPendingStateStore>);
+
+impl std::fmt::Debug for ErasedPendingStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ErasedPendingStore").finish_non_exhaustive()
+    }
+}
+
+impl ErasedPendingStore {
+    /// Wrap an erased pending backend.
+    #[must_use]
+    pub fn new(inner: Arc<dyn DynPendingStateStore>) -> Self {
+        Self(inner)
+    }
+}
+
+impl PendingStateStore for ErasedPendingStore {
+    // `async fn` so the impl's opaque return types capture the borrows;
+    // each forwards to the blanket `PendingStateStore` impl on
+    // `dyn DynPendingStateStore` (`*self.0`), which does the serde
+    // round-trip.
+    async fn put<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        owner_id: &str,
+        session_id: &str,
+        pending: P,
+    ) -> Result<PendingToken, PendingStoreError> {
+        (*self.0)
+            .put(credential_kind, owner_id, session_id, pending)
+            .await
+    }
+
+    async fn get<P: PendingState>(&self, token: &PendingToken) -> Result<P, PendingStoreError> {
+        (*self.0).get(token).await
+    }
+
+    async fn get_bound<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        token: &PendingToken,
+        owner_id: &str,
+        session_id: &str,
+    ) -> Result<P, PendingStoreError> {
+        (*self.0)
+            .get_bound(credential_kind, token, owner_id, session_id)
+            .await
+    }
+
+    async fn consume<P: PendingState>(
+        &self,
+        credential_kind: &str,
+        token: &PendingToken,
+        owner_id: &str,
+        session_id: &str,
+    ) -> Result<P, PendingStoreError> {
+        (*self.0)
+            .consume(credential_kind, token, owner_id, session_id)
+            .await
+    }
+
+    async fn delete(&self, token: &PendingToken) -> Result<(), PendingStoreError> {
+        PendingStateStore::delete(&*self.0, token).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Compile-time object-safety probe: naming `Arc<dyn …>` for both bridge
+    // traits proves they are dyn-compatible — the contract the facade's
+    // `store: Arc<dyn DynCredentialStore>` / `ErasedPendingStore(Arc<dyn …>)`
+    // rely on. Never called; mirrors `crates/storage-port/tests/object_safe.rs`.
+    fn _assert_object_safe(_a: Arc<dyn DynCredentialStore>, _b: Arc<dyn DynPendingStateStore>) {}
+
+    #[test]
+    fn bridge_traits_are_object_safe() {
+        // Compiling `_assert_object_safe`'s `Arc<dyn …>` parameters above is
+        // the proof; this test exists so the probe participates in the
+        // test target.
+    }
+}

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -90,6 +90,8 @@ mod accessor;
 mod context;
 /// Typed credential reference — `CredentialRef<C>` slot-binding handle (typed ref fields).
 mod credential_ref;
+/// Per-instance credential display metadata — `CredentialDisplay` (name / description / tags).
+mod display;
 /// Typed credential handle — CredentialHandle (ArcSwap-backed).
 mod handle;
 /// Credential metadata — static type descriptor (CredentialMetadata, builder, compat).
@@ -222,6 +224,7 @@ pub use crate::rotation::{CredentialRotationEvent, RotationError, RotationResult
 pub use crate::secrets::serde_secret;
 // Error / event / metadata / snapshot / identifiers
 pub use crate::{
+    display::CredentialDisplay,
     error::{
         CredentialAccessError, CredentialError, CryptoError, ProviderErrorContext,
         ProviderErrorKind, RefreshErrorKind, RefreshFailedContext, ResolutionStage, RetryAdvice,

--- a/crates/credential/src/lib.rs
+++ b/crates/credential/src/lib.rs
@@ -102,6 +102,9 @@ mod record;
 // ── Utility modules ─────────────────────────────────────────────────────────
 // Free-standing concerns: errors, storage, refresh coordinator, etc.
 
+/// Dyn-erasure bridge for the two RPITIT storage ports — lets the
+/// `CredentialService` facade be non-generic (ADR-0088 D4).
+pub mod erased;
 /// Error types for credential operations.
 pub mod error;
 /// Credential lifecycle events for cross-crate signaling.
@@ -160,6 +163,12 @@ pub use nebula_credential_macros::{AuthScheme, Credential, credential};
 // no Input form and is never registered in CredentialRegistry — it's a
 // Resource-side type marker per credential isolation).
 pub use no_credential::{NoCredential, NoCredentialState};
+// Dyn-erasure bridge (ADR-0088 D4): object-safe mirrors of the two RPITIT
+// storage ports + their `Arc<dyn …>` wrappers, so the runtime facade is
+// non-generic.
+pub use erased::{
+    DynCredentialStore, DynPendingStateStore, ErasedCredentialStore, ErasedPendingStore,
+};
 // Pending state store
 pub use pending_store::{PendingStateStore, PendingStoreError};
 // External provider abstraction (redesigned per external provider):

--- a/crates/credential/src/snapshot.rs
+++ b/crates/credential/src/snapshot.rs
@@ -55,7 +55,7 @@
 
 use std::{any::Any, fmt};
 
-use crate::{AuthScheme, CredentialRecord};
+use crate::{AuthScheme, CredentialDisplay, CredentialRecord};
 
 /// Error returned by [`CredentialSnapshot`] projection methods.
 ///
@@ -105,6 +105,9 @@ pub struct CredentialSnapshot {
     scheme_pattern: String,
     /// Associated credential record (runtime state).
     record: CredentialRecord,
+    /// Non-secret per-instance display metadata (name / description / tags).
+    /// Empty by default; the credential runtime populates it on read.
+    display: CredentialDisplay,
     /// Type-erased projected `AuthScheme`.
     projected: Box<dyn Any + Send + Sync>,
     /// Clone function captured at construction time from `S: AuthScheme + Clone`.
@@ -165,6 +168,7 @@ impl CredentialSnapshot {
             kind: kind.into(),
             scheme_pattern: format!("{:?}", S::pattern()),
             record,
+            display: CredentialDisplay::default(),
             projected: Box::new(scheme),
             clone_fn: clone_projected::<S>,
         }
@@ -236,6 +240,26 @@ impl CredentialSnapshot {
         &self.record
     }
 
+    /// Non-secret per-instance display metadata (name / description / tags).
+    ///
+    /// Empty unless the credential runtime attached it via
+    /// [`with_display`](Self::with_display) on the read path.
+    #[must_use]
+    pub fn display(&self) -> &CredentialDisplay {
+        &self.display
+    }
+
+    /// Attach per-instance display metadata, returning the updated snapshot.
+    ///
+    /// The credential runtime uses this to surface a stored credential's
+    /// name / description / tags on `get` / `list` without threading them
+    /// through every [`new`](Self::new) call site.
+    #[must_use = "with_display returns the updated snapshot"]
+    pub fn with_display(mut self, display: CredentialDisplay) -> Self {
+        self.display = display;
+        self
+    }
+
     /// True iff this snapshot's `expires_at` is in the past.
     ///
     /// Delegates to [`CredentialRecord::is_expired`] — a snapshot without an
@@ -257,6 +281,7 @@ impl Clone for CredentialSnapshot {
             kind: self.kind.clone(),
             scheme_pattern: self.scheme_pattern.clone(),
             record: self.record.clone(),
+            display: self.display.clone(),
             projected: (self.clone_fn)(&*self.projected),
             clone_fn: self.clone_fn,
         }
@@ -269,6 +294,7 @@ impl fmt::Debug for CredentialSnapshot {
             .field("kind", &self.kind)
             .field("scheme_pattern", &self.scheme_pattern)
             .field("record", &self.record)
+            .field("display", &self.display)
             .field("projected", &"[REDACTED]")
             .finish()
     }

--- a/crates/storage/src/credential/pending.rs
+++ b/crates/storage/src/credential/pending.rs
@@ -3,6 +3,13 @@
 //! Data is lost when the store is dropped. Use this in tests and for local
 //! development rather than mocking [`PendingStateStore`] directly.
 //!
+//! This type implements [`DynPendingStateStore`] (the object-safe byte-core
+//! port); it acquires the typed [`PendingStateStore`] surface — generic over
+//! `<P: PendingState>` — via the blanket impl in
+//! `nebula_credential::erased`, which does the serde round-trip. The serde
+//! lives in the blanket, not here: this store persists raw `Vec<u8>` plus the
+//! binding tuple and absolute expiry.
+//!
 //! # Shim note
 //!
 //! A body-identical shim exists in `nebula-credential-testutil` for crates that
@@ -10,6 +17,8 @@
 //! cargo resolution that breaks the `PendingStateStore` trait bound). Both copies
 //! implement the same trait with the same semantics. Production consumers and
 //! composition roots should prefer this storage-side copy.
+//!
+//! [`PendingStateStore`]: nebula_credential::PendingStateStore
 //!
 //! # Invariants
 //!
@@ -34,10 +43,13 @@
 //!
 //! See `crates/storage/README.md` for credential persistence layout.
 
+use std::future::Future;
+use std::pin::Pin;
+use std::time::Duration;
 use std::{collections::HashMap, sync::Arc};
 
 use chrono::Utc;
-use nebula_credential::{PendingState, PendingStateStore, PendingStoreError, PendingToken};
+use nebula_credential::{DynPendingStateStore, PendingStoreError, PendingToken};
 use tokio::sync::RwLock;
 
 /// In-memory pending store backed by a `HashMap`.
@@ -89,140 +101,147 @@ impl Default for InMemoryPendingStore {
     }
 }
 
-impl PendingStateStore for InMemoryPendingStore {
-    async fn put<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        owner_id: &str,
-        session_id: &str,
-        pending: P,
-    ) -> Result<PendingToken, PendingStoreError> {
-        let data =
-            serde_json::to_vec(&pending).map_err(|e| PendingStoreError::Backend(Box::new(e)))?;
-        let expires_at = Utc::now() + pending.expires_in();
-        let token = PendingToken::generate();
+impl DynPendingStateStore for InMemoryPendingStore {
+    fn put_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        owner_id: &'a str,
+        session_id: &'a str,
+        data: Vec<u8>,
+        expires_in: Duration,
+    ) -> Pin<Box<dyn Future<Output = Result<PendingToken, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let expires_at = Utc::now() + expires_in;
+            let token = PendingToken::generate();
 
-        let entry = PendingEntry {
-            credential_kind: credential_kind.to_owned(),
-            owner_id: owner_id.to_owned(),
-            session_id: session_id.to_owned(),
-            data,
-            expires_at,
-        };
+            let entry = PendingEntry {
+                credential_kind: credential_kind.to_owned(),
+                owner_id: owner_id.to_owned(),
+                session_id: session_id.to_owned(),
+                data,
+                expires_at,
+            };
 
-        self.entries
-            .write()
-            .await
-            .insert(token.as_str().to_owned(), entry);
+            self.entries
+                .write()
+                .await
+                .insert(token.as_str().to_owned(), entry);
 
-        Ok(token)
+            Ok(token)
+        })
     }
 
-    async fn get<P: PendingState>(&self, token: &PendingToken) -> Result<P, PendingStoreError> {
-        let mut entries = self.entries.write().await;
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+    fn get_serialized<'a>(
+        &'a self,
+        token: &'a PendingToken,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            // Expiry is deterministic; evict here too so repeated `get`
-            // probes cannot retain stale rows forever.
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
-        let data = entry.data.clone();
-        drop(entries);
-
-        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            if Utc::now() > entry.expires_at {
+                // Expiry is deterministic; evict here too so repeated `get`
+                // probes cannot retain stale rows forever.
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
+            Ok(entry.data.clone())
+        })
     }
 
-    async fn get_bound<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        token: &PendingToken,
-        owner_id: &str,
-        session_id: &str,
-    ) -> Result<P, PendingStoreError> {
-        let mut entries = self.entries.write().await;
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+    fn get_bound_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            let mut entries = self.entries.write().await;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
+            if Utc::now() > entry.expires_at {
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
 
-        let mismatch = entry.credential_kind != credential_kind
-            || entry.owner_id != owner_id
-            || entry.session_id != session_id;
-        if mismatch {
-            return Err(PendingStoreError::ValidationFailed {
-                reason: "token bindings do not match".to_owned(),
-            });
-        }
+            let mismatch = entry.credential_kind != credential_kind
+                || entry.owner_id != owner_id
+                || entry.session_id != session_id;
+            if mismatch {
+                return Err(PendingStoreError::ValidationFailed {
+                    reason: "token bindings do not match".to_owned(),
+                });
+            }
 
-        let data = entry.data.clone();
-        drop(entries);
-
-        serde_json::from_slice(&data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            Ok(entry.data.clone())
+        })
     }
 
-    async fn consume<P: PendingState>(
-        &self,
-        credential_kind: &str,
-        token: &PendingToken,
-        owner_id: &str,
-        session_id: &str,
-    ) -> Result<P, PendingStoreError> {
-        // Validate *before* removing. A wrong-owner (or otherwise malformed)
-        // `consume` request must not be able to destroy the legitimate
-        // user's pending state — that would turn any token leak into a
-        // single-shot DoS against the in-flight flow. Hold the write lock
-        // across the whole check so no concurrent consume can race between
-        // validation and removal.
-        let mut entries = self.entries.write().await;
+    fn consume_serialized<'a>(
+        &'a self,
+        credential_kind: &'a str,
+        token: &'a PendingToken,
+        owner_id: &'a str,
+        session_id: &'a str,
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            // Validate *before* removing. A wrong-owner (or otherwise
+            // malformed) `consume` request must not be able to destroy the
+            // legitimate user's pending state — that would turn any token
+            // leak into a single-shot DoS against the in-flight flow. Hold
+            // the write lock across the whole check so no concurrent consume
+            // can race between validation and removal.
+            let mut entries = self.entries.write().await;
 
-        let entry = entries
-            .get(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
+            let entry = entries
+                .get(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
 
-        if Utc::now() > entry.expires_at {
-            // Expiry is deterministic; it's safe to evict the stale row now.
-            entries.remove(token.as_str());
-            return Err(PendingStoreError::Expired);
-        }
+            if Utc::now() > entry.expires_at {
+                // Expiry is deterministic; it's safe to evict the stale row now.
+                entries.remove(token.as_str());
+                return Err(PendingStoreError::Expired);
+            }
 
-        // All three binding checks are folded into one OR so the failure
-        // path is indistinguishable and does not hint at which dimension
-        // mismatched (cheap mitigation for a timing/oracle probe).
-        let mismatch = entry.credential_kind != credential_kind
-            || entry.owner_id != owner_id
-            || entry.session_id != session_id;
-        if mismatch {
-            // Intentionally leave the entry in place so the legitimate
-            // caller can still consume it.
-            return Err(PendingStoreError::ValidationFailed {
-                reason: "token bindings do not match".to_owned(),
-            });
-        }
+            // All three binding checks are folded into one OR so the failure
+            // path is indistinguishable and does not hint at which dimension
+            // mismatched (cheap mitigation for a timing/oracle probe).
+            let mismatch = entry.credential_kind != credential_kind
+                || entry.owner_id != owner_id
+                || entry.session_id != session_id;
+            if mismatch {
+                // Intentionally leave the entry in place so the legitimate
+                // caller can still consume it.
+                return Err(PendingStoreError::ValidationFailed {
+                    reason: "token bindings do not match".to_owned(),
+                });
+            }
 
-        // Only now remove the entry and deserialize from the owned bytes.
-        // The `get` above succeeded under the same write lock, so `remove`
-        // is expected to return `Some`. Defensively surface a `NotFound`
-        // rather than `.expect(...)` panicking in library code if a future
-        // refactor ever breaks the locking discipline.
-        let entry = entries
-            .remove(token.as_str())
-            .ok_or(PendingStoreError::NotFound)?;
-        drop(entries);
-
-        serde_json::from_slice(&entry.data).map_err(|e| PendingStoreError::Backend(Box::new(e)))
+            // Only now remove the entry and return the owned bytes. The
+            // get() above succeeded under the same write lock, so remove is
+            // expected to yield Some; defensively surface a NotFound rather
+            // than panicking in library code if a future refactor ever
+            // breaks the locking discipline.
+            let entry = entries
+                .remove(token.as_str())
+                .ok_or(PendingStoreError::NotFound)?;
+            Ok(entry.data)
+        })
     }
 
-    async fn delete(&self, token: &PendingToken) -> Result<(), PendingStoreError> {
-        self.entries.write().await.remove(token.as_str());
-        Ok(())
+    fn delete<'a>(
+        &'a self,
+        token: &'a PendingToken,
+    ) -> Pin<Box<dyn Future<Output = Result<(), PendingStoreError>> + Send + 'a>> {
+        Box::pin(async move {
+            self.entries.write().await.remove(token.as_str());
+            Ok(())
+        })
     }
 }
 
@@ -230,6 +249,10 @@ impl PendingStateStore for InMemoryPendingStore {
 mod tests {
     use std::time::Duration;
 
+    // The typed `put`/`get`/`consume::<T>` surface comes from the blanket
+    // `PendingStateStore` impl on every `DynPendingStateStore`; pull both
+    // traits into scope so the tests exercise the typed API.
+    use nebula_credential::{PendingState, PendingStateStore};
     use serde::{Deserialize, Serialize};
     use zeroize::{Zeroize, ZeroizeOnDrop};
 
@@ -467,8 +490,10 @@ mod tests {
         let store = InMemoryPendingStore::new();
         let token = PendingToken::generate();
 
-        // Deleting a non-existent token should succeed.
-        store.delete(&token).await.unwrap();
-        store.delete(&token).await.unwrap();
+        // Deleting a non-existent token should succeed. `delete` is the one
+        // method present on both `DynPendingStateStore` (byte core) and the
+        // blanket `PendingStateStore`, so disambiguate to the typed surface.
+        assert!(PendingStateStore::delete(&store, &token).await.is_ok());
+        assert!(PendingStateStore::delete(&store, &token).await.is_ok());
     }
 }

--- a/docs/plans/2026-06-09-credential-api-wiring.md
+++ b/docs/plans/2026-06-09-credential-api-wiring.md
@@ -1,0 +1,166 @@
+# Wire nebula-api → CredentialService (ADR-0088 D4 P4 + D7)
+
+Status: in progress (P1 only approved; re-gate before P2+)
+Branch: `refactor/credential-facade-dyn-erasure`
+Owner decision (2026-06-09): Option **C** (P4 dyn-erasure folded into the wiring,
+one branch, expand-contract green-per-commit). Execution gated **P1-first**:
+land the non-generic facade as its own green milestone, then re-approve the
+api/server wiring.
+
+## Goal / end state (ADR-0088 D7 target)
+
+One persistence path. `CredentialService` is **non-generic**; nebula-api routes
+all credential ops through it; `apps/server` composes a real service; the
+split-brain store / raw-fallback / api `classify()` dup / `CredentialScopeLayer`
+are deleted.
+
+Authoritative ADR: **0088** (proposed). 0066/0051/0052 do not exist as files
+(superseded by 0081, amended by 0088). Reactive-only (0084). External Vault /
+proactive refresh / M12.4 bind-population are out of scope.
+
+## Why P4 (dyn-erasure) is a prerequisite
+
+On main, `CredentialService<B: CredentialStore, PS: PendingStateStore>` is generic
+and `AppState.credential_service` is hard-typed to
+`CredentialService<InMemoryStore, InMemoryPendingStore>`. Wiring api/server against
+that monomorphization re-churns every call site the day a durable backend lands.
+ADR-0088 D4 makes the facade non-generic (`Arc<dyn>` collaborators erased at
+construction) so the backend can be swapped without churn. P4 is that erasure,
+**in place** in `nebula-credential-runtime` (the crate-merge half of D4 is
+INFEASIBLE — Exec→Core is cargo-deny-forbidden — and is dropped).
+
+---
+
+# P1 — dyn-erasure → non-generic facade  (THIS milestone)
+
+### Design (validated against the live code)
+
+Object-safety blockers: `CredentialStore` (credential/src/store.rs:166) is RPITIT;
+`PendingStateStore` (credential/src/pending_store.rs:23) is RPITIT **and** every
+non-`delete` method is generic over `<P: PendingState>`. Erase via hand-rolled
+boxed-future bridge traits (no `async_trait`, no `bon` — matches
+`credential/src/provider/future.rs`; records the ADR-0088 D4 bon-deviation).
+
+**Erase the whole LayeredStore at the top** (one box at the resolver→store
+boundary; the Audit/Cache/Encryption layers stay statically composed and
+monomorphic, so cache hits never reach the box). Fix `PS = ErasedPendingStore`
+so `DispatchOps` and the engine resolver need **zero** changes.
+
+### New types — `crates/credential/src/erased.rs` (new module, exported from lib.rs)
+
+```rust
+type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// ── Credential store bridge (easy: no per-method generics) ──
+pub trait DynCredentialStore: Send + Sync {
+    fn get<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<StoredCredential, StoreError>>;
+    fn put<'a>(&'a self, credential: StoredCredential, mode: PutMode)
+        -> BoxFut<'a, Result<StoredCredential, StoreError>>;
+    fn delete<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<(), StoreError>>;
+    fn list<'a>(&'a self, state_kind: Option<&'a str>) -> BoxFut<'a, Result<Vec<String>, StoreError>>;
+    fn exists<'a>(&'a self, id: &'a str) -> BoxFut<'a, Result<bool, StoreError>>;
+}
+impl<T: CredentialStore> DynCredentialStore for T { /* Box::pin(CredentialStore::*(self, ..)) */ }
+
+#[derive(Clone)]
+pub struct ErasedCredentialStore(Arc<dyn DynCredentialStore>);
+impl ErasedCredentialStore { pub fn new(inner: Arc<dyn DynCredentialStore>) -> Self }
+impl CredentialStore for ErasedCredentialStore { /* forward to self.0.* (RPITIT returns the BoxFut) */ }
+
+// ── Pending store bridge (hard: erase <P: PendingState> to a byte core) ──
+pub trait DynPendingStateStore: Send + Sync {
+    fn put_serialized<'a>(&'a self, credential_kind: &'a str, owner_id: &'a str,
+        session_id: &'a str, data: Vec<u8>, expires_in: Duration)
+        -> BoxFut<'a, Result<PendingToken, PendingStoreError>>;
+    fn get_serialized<'a>(&'a self, token: &'a PendingToken)
+        -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+    fn get_bound_serialized<'a>(&'a self, credential_kind: &'a str, token: &'a PendingToken,
+        owner_id: &'a str, session_id: &'a str) -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+    fn consume_serialized<'a>(&'a self, credential_kind: &'a str, token: &'a PendingToken,
+        owner_id: &'a str, session_id: &'a str) -> BoxFut<'a, Result<Vec<u8>, PendingStoreError>>;
+    fn delete<'a>(&'a self, token: &'a PendingToken) -> BoxFut<'a, Result<(), PendingStoreError>>;
+}
+// Typed surface for free: serialize on put, deserialize on get/consume/get_bound.
+impl<T: DynPendingStateStore + ?Sized> PendingStateStore for T {
+    async fn put<P: PendingState>(&self, k, o, s, pending: P) -> Result<PendingToken, _> {
+        let data = serde_json::to_vec(&pending).map_err(|e| Backend(Box::new(e)))?;
+        let ttl  = pending.expires_in();
+        self.put_serialized(k, o, s, data, ttl).await
+    }
+    async fn get<P: PendingState>(&self, token) -> Result<P, _> {
+        let data = self.get_serialized(token).await?;
+        serde_json::from_slice(&data).map_err(|e| Backend(Box::new(e)))
+    }
+    // get_bound / consume: same byte→typed deserialize; delete forwards.
+}
+
+#[derive(Clone)]
+pub struct ErasedPendingStore(Arc<dyn DynPendingStateStore>);
+impl ErasedPendingStore { pub fn new(inner: Arc<dyn DynPendingStateStore>) -> Self }
+impl PendingStateStore for ErasedPendingStore { /* forward put<P>/get<P>/... to (*self.0) */ }
+```
+
+Coherence: after this change **no type impls `PendingStateStore` directly** — the
+two `InMemoryPendingStore` copies impl `DynPendingStateStore`, and the blanket
+gives them `PendingStateStore`. `ErasedPendingStore` forwards to the blanket on
+`dyn DynPendingStateStore`. Add an object-safety probe test (mirror
+`storage-port/tests/object_safe.rs`) asserting `Arc<dyn DynCredentialStore>` and
+`Arc<dyn DynPendingStateStore>` construct.
+
+### Per-file edits
+
+| File | Change |
+|------|--------|
+| `crates/credential/src/erased.rs` | NEW — the four types above + probe tests |
+| `crates/credential/src/lib.rs` | `pub mod erased;` + re-export `DynCredentialStore, DynPendingStateStore, ErasedCredentialStore, ErasedPendingStore` |
+| `crates/storage/src/credential/pending.rs` | `impl PendingStateStore for InMemoryPendingStore` → `impl DynPendingStateStore` (byte core: `put_serialized` stores `data`+`Utc::now()+expires_in`; `get/consume/get_bound_serialized` return `Vec<u8>`, keep TTL eviction + 4-D binding checks; `delete` unchanged). Existing tests use the typed API → keep passing via blanket |
+| `crates/credential-testutil/src/pending_store_memory.rs` | same inversion (impl `DynPendingStateStore`) |
+| `crates/credential-runtime/src/service.rs` | `CredentialService<B,PS>` → non-generic `CredentialService`; fields `store: Arc<dyn DynCredentialStore>`, `resolver: CredentialResolver<ErasedCredentialStore>`, `pending: ErasedPendingStore`, `ops: Arc<DispatchOps<ErasedPendingStore>>`; `__from_parts` non-generic; `credential_store_handle(&self) -> Arc<dyn DynCredentialStore>`; method bodies unchanged (calls resolve via `DynCredentialStore`/blanket) |
+| `crates/credential-runtime/src/builder.rs` | `CredentialServiceBuilder<B>` (drop PS); `pending_store: ErasedPendingStore`, `ops: Arc<DispatchOps<ErasedPendingStore>>`; `build()` → `Result<CredentialService, _>`, erases `Arc::new(layered) as Arc<dyn DynCredentialStore>`, `CredentialResolver::new(ErasedCredentialStore::new(store.clone()))` |
+| `crates/credential-runtime/src/service.rs` test_support (~1270-1500) + tests (~1822) | wrap pending in `ErasedPendingStore`, build `DispatchOps<ErasedPendingStore>` via `register_all_builtin_ops::<ErasedPendingStore>`, return `CredentialService`; `type Svc = CredentialService` |
+| `crates/api/src/state.rs` | field+setter+doc (lines ~256-259, ~1050): `Option<Arc<CredentialService>>` (drop `<InMemoryStore, InMemoryPendingStore>`). Keep the `nebula_storage::credential::{InMemoryStore, InMemoryPendingStore}` import (still used by `oauth_*_store`) |
+| compile_fail `.stderr` (credential + credential-runtime) | regen **warm**, plain `cargo test`; NEVER `TRYBUILD=overwrite` |
+
+`ops.rs` and `nebula-engine` need **no changes** (DispatchOps stays generic,
+fixed to `ErasedPendingStore` at the service; resolver stays generic over the
+store, fixed to `ErasedCredentialStore`). `deny.toml` unchanged (no new edges).
+
+### Green gate (per crate, bare commands — Windows: no `cd &&`/pipe chains)
+
+`cargo check -p` then `clippy -p … -- -D warnings` then `nextest run -p` for, in order:
+`nebula-credential` → `nebula-storage` → `nebula-credential-testutil` →
+`nebula-credential-runtime` (`--features test-util`) → `nebula-api`.
+Doctests on `nebula-credential` / `nebula-credential-runtime`. Warm + plain
+`cargo test` for trybuild. No `unwrap/expect/panic` in lib code.
+
+### Risks
+- **Pending byte round-trip**: serialize/deserialize must be exactly the
+  pre-existing serde_json path; property-test typed↔byte equivalence.
+- **Boxed-future lifetimes**: tie `&self` and borrowed args to one `'a` in the
+  Dyn trait (`fn get<'a>(&'a self, id: &'a str) -> BoxFut<'a, …>`).
+- **Hot-path box**: `resolve_for_slot` p99 ≤ 1ms — one box at the store top;
+  verify in P6 bench, erasure depth is reversible.
+- **Green-per-commit** under cross-crate erasure: commit at each per-crate-green.
+
+---
+
+# P2–P6 (deferred; re-gate after P1)
+
+- **P2 server composes service**: deps + deny wrappers; build `CredentialService`
+  in `run_transport` (`EnvKeyProvider::from_env` fail-closed, real/doc'd
+  `AuditSink`, `EventMetricObserver`, `register_builtins` +
+  `register_all_builtin_ops::<ErasedPendingStore>`, real shutdown
+  `CancellationToken` → ctrl_c + axum graceful); `with_credential_service`.
+  Note: prod `InMemoryPendingStore`/`InMemoryStore` live in
+  `nebula_storage::credential` (not testutil).
+- **P3 api rewire CRUD/lifecycle/discovery**: route `transport/credential.rs`
+  through `state.credential_service`; map `CredentialServiceError`→`ApiError`
+  (RFC 9457); honest-503 stubs become real; delete api `classify()` dup.
+- **P4 OAuth migration**: two-phase raw-bytes write → facade interactive
+  acquisition (`resolve`→`Pending`→`continue_resolve`); audit `owner_id=None`
+  admin-bypass (facade `TenantScope` has no None).
+- **P5 delete CredentialScopeLayer**: service mandatory, drop fallback,
+  `git rm tenancy/src/credential_scope.rs`, **transfer its ~20 tenant-isolation
+  tests** to facade coverage first; update deny.toml/Cargo.toml.
+- **P6 observability DoD + docs**: spans/metrics/invariants on live paths;
+  criterion p99 gate; ADR-0088 status + deviations.

--- a/docs/plans/2026-06-09-credential-api-wiring.md
+++ b/docs/plans/2026-06-09-credential-api-wiring.md
@@ -144,18 +144,71 @@ Doctests on `nebula-credential` / `nebula-credential-runtime`. Warm + plain
 
 ---
 
-# P2–P6 (deferred; re-gate after P1)
+# P2 (folded P2+P3) — server composes + api routes CRUD/lifecycle/discovery
 
-- **P2 server composes service**: deps + deny wrappers; build `CredentialService`
-  in `run_transport` (`EnvKeyProvider::from_env` fail-closed, real/doc'd
-  `AuditSink`, `EventMetricObserver`, `register_builtins` +
-  `register_all_builtin_ops::<ErasedPendingStore>`, real shutdown
-  `CancellationToken` → ctrl_c + axum graceful); `with_credential_service`.
-  Note: prod `InMemoryPendingStore`/`InMemoryStore` live in
-  `nebula_storage::credential` (not testutil).
-- **P3 api rewire CRUD/lifecycle/discovery**: route `transport/credential.rs`
-  through `state.credential_service`; map `CredentialServiceError`→`ApiError`
-  (RFC 9457); honest-503 stubs become real; delete api `classify()` dup.
+Approved 2026-06-09 (folded so the milestone is observable, not an inert slot +
+idle reaper). Tactical calls (stated, override-able): `EnvKeyProvider::from_env`
+fail-closed in prod + ephemeral dev key behind `NEBULA_CRED_DEV_KEY=1` + loud
+`warn!`; no-op `AuditSink` + honest startup `warn!` + typed injection seam;
+real shutdown `CancellationToken` → ctrl_c + axum graceful; startup `warn!` that
+credential storage is encrypted-at-rest-**in-memory** (non-durable).
+
+## Instance display-metadata model — DECIDED (researched 2026-06-09)
+
+The facade has **no** per-instance display metadata; `persist_resolved` stamps
+only `owner_id`. Lighting up `test`/`refresh`/`revoke` forces CRUD through
+`facade.create` (typed state), which today would drop the api's
+`name`/`description`/`tags`. 3-angle research (internal patterns / external prior
+art / ADR-canon): internal + external both favor **typed fields** (every other
+entity uses `display_name`/`slug` columns; AWS/Windmill/n8n use typed scalars);
+the ADR-canon "opaque map" view is weakest-grounded (canon silent; defends the
+current hack the dead `CredentialRow` shape contradicts). The conflict resolves
+by separating *layer* from *shape*: typed at every tier.
+
+**Decision — typed instance display metadata at the facade surface (lean):**
+- `nebula-credential`: add `CredentialDisplay { display_name: Option<String>,
+  description: Option<String>, tags: BTreeMap<String,String> }` (Serialize +
+  Default); add a `display: CredentialDisplay` field to `CredentialSnapshot`
+  with a `with_display(..)` builder + `display()` accessor (existing
+  `CredentialSnapshot::new` callers untouched).
+- **`StoredCredential` struct UNCHANGED.** ~20 literal sites across 6 crates
+  (incl. engine production + storage/tenancy tests) make a new struct field a
+  premature Core-contract churn, and there is no durable backend to hold columns
+  (schema 0027 has no credentials table). Instead the facade persists
+  `CredentialDisplay` under a **reserved, facade-owned `metadata["display"]`
+  sub-object** (single-writer; `owner_id` stays a sibling key — no multi-writer
+  shape conflict, the failure mode the research flagged). This keeps the typed
+  value at the API surface (the research's core conclusion) without the churn;
+  durable **columns** are deferred to the durable adapter (the rewrite).
+- `credential-runtime`: facade `create`/`update` take a `CredentialDisplay`;
+  `persist_resolved` writes `metadata["display"]`; `get`/`snapshot_from_store`
+  read it back via `snapshot.with_display(..)`. `ops.snapshot` stays
+  display-agnostic (facade attaches display at the call site).
+- `api`: map the DTO `name`/`description`/`tags` ↔ `CredentialDisplay` (plain
+  values, no domain type in DTOs — ADR-0047 safe). Drop the api `CredentialMeta`
+  shoved-into-`metadata` hack + the `classify()` dup (capabilities from the
+  registry via the schema port / facade `list_types`).
+- **Deferred (noted, not in this pass):** consolidating `CredentialRecord.tags`
+  (dormant) into the display home; durable display columns. Revisit in the
+  credential rewrite when the durable adapter lands.
+
+## Build steps
+
+1. Core domain: `CredentialDisplay` + `StoredCredential.display` +
+   `CredentialSnapshot.display` (+ accessor). Green `nebula-credential`.
+2. Facade: thread `CredentialDisplay` through `create`/`update`/`persist_resolved`
+   /`ops.snapshot`/`test_support`/tests. Green `nebula-credential-runtime`.
+3. Server (`apps/server`): deps + deny wrappers; build `CredentialService` in
+   `run_transport` per the tactical calls; `with_credential_service`. Prod
+   `InMemoryStore`/`InMemoryPendingStore` from `nebula_storage::credential`.
+4. api rewire `transport/credential.rs` + `handler.rs`: route CRUD through
+   `facade.create/get/update/delete/list`, lifecycle through
+   `facade.test/refresh/revoke`, acquisition through `facade.resolve/continue`,
+   discovery through `facade.list_types/get_type` (or the schema port);
+   `CredentialServiceError`→`ApiError` (RFC 9457, secret-safe); build
+   `TenantScope` from the request scope; delete `classify()`. Green `nebula-api`.
+5. Honest-503 → real (or proper `CapabilityUnsupported`); update the unit test
+   `engine_owned_fns_are_honest_503` to the new reality; `openapi_spec` test.
 - **P4 OAuth migration**: two-phase raw-bytes write → facade interactive
   acquisition (`resolve`→`Pending`→`continue_resolve`); audit `owner_id=None`
   admin-bypass (facade `TenantScope` has no None).

--- a/docs/plans/2026-06-09-credential-api-wiring.md
+++ b/docs/plans/2026-06-09-credential-api-wiring.md
@@ -194,8 +194,10 @@ by separating *layer* from *shape*: typed at every tier.
 
 ## Build steps
 
-1. Core domain: `CredentialDisplay` + `StoredCredential.display` +
-   `CredentialSnapshot.display` (+ accessor). Green `nebula-credential`.
+1. Core domain: `CredentialDisplay` + `CredentialSnapshot.display` (field +
+   `with_display`/`display()`). **`StoredCredential` struct stays unchanged** —
+   display persists under the facade-owned `metadata["display"]` sub-object (see
+   the decision above), not a new struct field. Green `nebula-credential`.
 2. Facade: thread `CredentialDisplay` through `create`/`update`/`persist_resolved`
    /`ops.snapshot`/`test_support`/tests. Green `nebula-credential-runtime`.
 3. Server (`apps/server`): deps + deny wrappers; build `CredentialService` in

--- a/docs/plans/2026-06-09-credential-api-wiring.md
+++ b/docs/plans/2026-06-09-credential-api-wiring.md
@@ -204,11 +204,40 @@ by separating *layer* from *shape*: typed at every tier.
 4. api rewire `transport/credential.rs` + `handler.rs`: route CRUD through
    `facade.create/get/update/delete/list`, lifecycle through
    `facade.test/refresh/revoke`, acquisition through `facade.resolve/continue`,
-   discovery through `facade.list_types/get_type` (or the schema port);
-   `CredentialServiceError`→`ApiError` (RFC 9457, secret-safe); build
-   `TenantScope` from the request scope; delete `classify()`. Green `nebula-api`.
+   discovery via the schema port (DTO-safe; facade `list_types` returns a
+   runtime type, not a DTO); `CredentialServiceError`→`ApiError` (RFC 9457,
+   secret-safe, IDOR flat-404 preserved); build `TenantScope` from the request
+   scope; source `auth_pattern`/capabilities from the schema port (delete the
+   hardcoded `classify()` dup). Green `nebula-api`.
 5. Honest-503 → real (or proper `CapabilityUnsupported`); update the unit test
    `engine_owned_fns_are_honest_503` to the new reality; `openapi_spec` test.
+
+## Step-4 design findings (surfaced 2026-06-09; resolve before building)
+
+- **DONE so far on the branch:** step 1–2 (`08084e98`) + step 3 server-compose
+  (`4da698a0`), both green + pushed to PR #785. `AppState.credential_service`
+  is now a live service; `transport/credential.rs` does **not** consume it yet.
+- **Split-brain store hazard (must resolve in step 4):** the `CredentialService`
+  owns its **own** in-memory store (built in the factory). The api's OAuth path
+  + `scoped_store` write to a **separate** `AppState.oauth_credential_store`.
+  Routing CRUD through `facade.*` while OAuth stays on `oauth_credential_store`
+  splits the data: an OAuth-created credential would be invisible to
+  `facade.get`/`facade.list` (a regression for the generic `GET /credentials/{id}`).
+  **Resolution:** point the OAuth path at the facade's store via
+  `credential_store_handle()` (`scoped_store` wraps
+  `ErasedCredentialStore::new(handle)` instead of `oauth_credential_store`), so
+  CRUD (facade methods) and OAuth (scoped layer over the same handle) share one
+  store. This folds the original P5 store-unification into step 4. Both planes
+  stamp `metadata["owner_id"]` identically, so owner scoping stays consistent;
+  `facade.get` projects an OAuth row via the registered `oauth2` ops.
+- **`None` handling:** transport must treat absent `credential_service` as an
+  honest 503 (and the transport unit tests in `transport/credential.rs` must
+  wire a service via the factory's `with_key_provider`, or assert the 503).
+- **auth_pattern/capabilities:** `CredentialResponse` sources these from the
+  schema port (`get_type(key)`), not the deleted `classify()`.
+- This is security-sensitive (IDOR, tenant isolation, secret hygiene, OAuth
+  two-phase) — build it as a deliberate pass with adversarial review, not a
+  rushed one.
 - **P4 OAuth migration**: two-phase raw-bytes write → facade interactive
   acquisition (`resolve`→`Pending`→`continue_resolve`); audit `owner_id=None`
   admin-bypass (facade `TenantScope` has no None).


### PR DESCRIPTION
## What

Wires nebula-api's credential surface toward the `CredentialService` facade
(ADR-0088 D4 / D7), landed as green, reviewable increments on one branch.

**Commits (each green at commit + push):**
1. `refactor(credential)!` — non-generic `CredentialService` via dyn-erasure
   (D4 P4). `Arc<dyn DynCredentialStore>` + `ErasedPendingStore` replace the
   `<B, PS>` generics, so a durable backend swaps in without re-monomorphizing
   consumers. `DispatchOps`/engine resolver unchanged.
2. `feat(credential)!` — typed per-instance display metadata
   (`CredentialDisplay { display_name, description, tags }`) through
   `create`/`update`/`CredentialSnapshot`, persisted under a reserved,
   facade-owned `metadata["display"]` sub-object (sibling to `owner_id`,
   single-writer). `StoredCredential` struct unchanged (avoids ~20-site churn;
   durable columns deferred to the durable adapter). Model chosen via 3-angle
   research (internal entity patterns / external secret managers / ADR-canon).
3. `feat(api)` — server composes a real `CredentialService` at startup. A
   factory in nebula-api (`ports::credential_service_factory`) builds the
   service over the in-memory store with the first-party type set
   (api_key/basic_auth/oauth2, shared with the schema port), OAuth2's four
   capability ops, a fail-closed key provider (`NEBULA_CRED_MASTER_KEY`, with a
   `NEBULA_CRED_DEV_KEY=1` dev path), and a log-only audit sink. `apps/server`
   gains no credential dep; no `deny.toml` change. `AppState.credential_service`
   is now live.
4. `docs(credential)` — records the step-4 design finding (below).

## Remaining on this branch (step 4 — api transport rewire)

`transport/credential.rs` does not consume the composed service yet. Routing
CRUD/lifecycle/discovery through the facade must first resolve a **split-brain
store**: the service owns its own store while OAuth uses a separate
`oauth_credential_store`. Resolution (recorded in
`docs/plans/2026-06-09-credential-api-wiring.md`): route the OAuth path over
`credential_store_handle()` so both planes share one store, with
`CredentialServiceError`→`ApiError` (IDOR flat-404 + secret hygiene preserved)
and the honest-503 lifecycle stubs becoming real. Security-sensitive — built as
a deliberate pass with adversarial review.

## Breaking changes

- `CredentialService`/`CredentialServiceBuilder` no longer generic over backend
  types.
- `CredentialService::create`/`::update` take a trailing `CredentialDisplay`;
  `CredentialSnapshot` gains `display` + `with_display`/`display()` (existing
  `new` callers unaffected).

The sole in-tree consumer (`nebula-api` `AppState`) is updated in-PR; no other
crate breaks.

## Tests / evidence

- `nebula-credential` 273 + `nebula-credential-runtime` 49 + `nebula-api` 484 +
  `nebula-server` 9 nextest; clippy `-D warnings`; rustdoc `-D warnings`;
  trybuild compile-fail probes; new `display_metadata` and
  `credential_service_factory` integration tests (the latter runtime-proves the
  capability⊆ops gate + a real create round-trip). All green.
- Adversarial soundness review of the dyn-erasure (no recursion /
  Send-cancellation / behavior drift).
- Push gate (lefthook): full-workspace clippy + crate-diff nextest green.

ADR: 0088 (credential subsystem rewrite, D4 / D7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-credential display metadata (name, description, tags) that persists with each credential and is retrievable via API.
  * Implemented credential service production factory with automatic key provider resolution and audit logging.

* **Bug Fixes**
  * Strengthened multi-tenant isolation enforcement for credential binding validation.

* **Documentation**
  * Added ADR-0088 outlining credential API wiring architecture and implementation plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->