### PR TITLE
feat(api)!: one credential persistence path — route everything through CredentialService (ADR-0088 D7)

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -348,51 +348,39 @@ impl, and (unlike idempotency) no feature-gated PG path, because
 
 ### Credential CRUD durability (canon §11.6 / §12.5)
 
-The credential CRUD endpoints (`create` / `get` / `update` / `delete`
-/ `list` under `…/workspaces/{ws}/credentials`) are **implemented and
-work end-to-end** over the wired in-memory credential store
-(`AppState::oauth_credential_store` —
-`nebula_storage::credential::InMemoryStore`, the same real
-`nebula_credential::CredentialStore` impl the OAuth2 callback writes
-through). The type-specific `data` is persisted **write-only**: it is
-wrapped in `nebula_credential::SecretString` for its in-process
-lifetime and stored as an opaque blob; the metadata-only response
-types have no `data` field, so `get` / `list` cannot echo the secret.
+Every credential operation — CRUD (`create` / `get` / `update` /
+`delete` / `list`), lifecycle (`test` / `refresh` / `revoke`), and
+acquisition (`resolve` / `resolve/continue`) under
+`…/workspaces/{ws}/credentials` — routes through the
+**`CredentialService` facade** (ADR-0088 D7), composed by the server at
+startup (`ports::credential_service_factory`). The facade owns the
+layered store (`Audit(Cache(Encryption(in-memory)))`), runs the typed
+validate→resolve pipeline on `data`, and owner-checks every operation.
+The OAuth2 callback persists through the **same** store handle, so an
+OAuth-acquired credential is visible to `get`/`list` (flagged
+`reauth_required` until the exchange completes). When no service is
+wired, every credential endpoint returns an honest 503 — there is no
+raw-store fallback.
 
-| Aspect | Credential CRUD (in-memory store) |
+| Aspect | Credential operations (facade, in-memory backend) |
 |---|---|
-| Restart-survival | **No** — credentials are lost on restart |
+| Restart-survival | **No** — the facade's backend is in-memory; credentials are lost on restart |
 | Multi-replica share | **No** — state is process-local |
-| Encryption at rest | **No `EncryptionLayer` wired** — the blob is plaintext-at-rest in the in-memory store |
-| Cross-workspace isolation | **None today** — the in-memory credential store is global and the `{org}`/`{ws}` path segments are not bound to credential ownership; any authenticated caller with a valid `cred_<ULID>` resolves/mutates it regardless of workspace. Pre-existing crate-wide local-first gap (same as `workflow`/`execution`); closes when the owner-scoped `nebula_storage::credential::ScopeLayer` is composed in the composition root. |
+| Encryption at rest | **Yes** — the facade composes the `EncryptionLayer` adjacent to the backend (AES-256-GCM; key from `NEBULA_CRED_MASTER_KEY`, fail-closed) |
+| Cross-workspace isolation | **Yes** — the facade owner-checks every operation against the canonical `Scope::credential_owner_id`; cross-workspace ids collapse to a flat 404 |
+| Lifecycle dispatch | **Live** — `test`/`refresh`/`revoke` dispatch the registered type's capability; a type without it is refused with 400 (capability gate), never a faked success |
 
-> **Operator warning:** a credential created via
-> `POST …/credentials` stops resolving the moment the process exits and
-> is not shared across replicas, its secret blob is **not encrypted
-> at rest** in this build (the production `EncryptionLayer` from
-> `nebula_storage`, ADR-0032, is not composed here), and there is **no
-> cross-workspace isolation** — any authenticated caller holding a valid
-> `cred_<ULID>` can resolve or mutate it regardless of the `{org}`/`{ws}`
-> in the path, because no owner-scoped `ScopeLayer` / credential→workspace
-> ownership binding is wired (the same crate-wide local-first gap that
-> `workflow`/`execution` carry). Same local-first caveat as `me/*` and
-> the `memory` idempotency backend — the gap is persistence + at-rest
-> encryption + tenant-isolation *wiring* (un-composed cross-cutting
-> layers), not the CRUD capability itself. It closes when a
-> storage-backed, `EncryptionLayer`- and `ScopeLayer`-wrapped credential
-> store is composed in the composition root.
+> **Operator warning:** a credential created via `POST …/credentials`
+> stops resolving the moment the process exits and is not shared across
+> replicas — the facade's backend is in-memory (encrypted at rest, not
+> durable). Same local-first caveat as `me/*` and the `memory`
+> idempotency backend; it closes when a durable credential backend is
+> swapped in behind the facade's erased store.
 >
-> `test` / `refresh` / `revoke` / generic `resolve` /
-> `resolve/continue` / credential-type discovery remain **honest 503**
-> (canon §4.5): they require engine-owned dispatch
-> (`nebula-engine::credential`, ADR-0030/ADR-0041) and/or a
-> `CredentialRegistry` that is not wired into this build, so they
-> deliberately refuse rather than fake a credential capability. The
-> tenancy path resolver special-cases the literal `resolve` sub-route,
-> so `resolve` / `resolve/continue` are **not** shadowed by the
-> `{cred}` matcher — they reach the handler and return the honest 503
-> above (not a pre-handler 404); the genuine `/credentials/{cred}`
-> position stays strictly ULID-validated.
+> The tenancy path resolver special-cases the literal `resolve`
+> sub-route, so `resolve` / `resolve/continue` are **not** shadowed by
+> the `{cred}` matcher — they reach the handler; the genuine
+> `/credentials/{cred}` position stays strictly ULID-validated.
 
 ### Org membership durability (canon §11.6 / §11.5)
 
@@ -818,16 +806,16 @@ above for the enforcement guarantee.
 | `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}/terminate`          | Terminate execution — durable signal (§12.2)                               |
 | `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/executions/{exec}/restart`            | Restart execution `(honest 501)`                                           |
 | `GET`    | `/api/v1/orgs/{org}/workspaces/{ws}/resources`                            | List resources `(honest 501)`                                              |
-| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve`                  | Start generic credential resolve `(honest 503)`                            |
-| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve/continue`         | Continue multi-step credential resolve `(honest 503)`                      |
+| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve`                  | Start credential acquisition (facade; complete / pending / retry)          |
+| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/resolve/continue`         | Continue multi-step credential acquisition (facade)                        |
 | `GET`    | `/api/v1/orgs/{org}/workspaces/{ws}/credentials`                          | List credentials (metadata only)                                           |
 | `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials`                          | Create credential (write-only secret)                                      |
 | `GET`    | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}`                   | Get credential metadata                                                    |
 | `PUT`    | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}`                   | Update credential                                                          |
 | `DELETE` | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}`                   | Delete credential                                                          |
-| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/test`              | Test credential `(honest 503)`                                             |
-| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/refresh`           | Refresh credential token `(honest 503)`                                    |
-| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/revoke`            | Revoke credential `(honest 503)`                                           |
+| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/test`              | Test credential (capability-gated dispatch)                                |
+| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/refresh`           | Refresh credential token (capability-gated dispatch)                       |
+| `POST`   | `/api/v1/orgs/{org}/workspaces/{ws}/credentials/{cred}/revoke`            | Revoke credential (capability-gated dispatch)                              |
 | `POST`   | `/webhooks/{trigger_uuid}/{nonce}`                                         | Inbound webhook trigger (mounted when `webhook_transport` is set)          |
 | `GET`    | `/api/v1/openapi.json`                                                    | OpenAPI 3.1 specification document                                         |
 | `GET`    | `/api/v1/docs/`                                                           | Swagger UI (self-hosted)                                                   |

--- a/crates/api/src/domain/credential/dto.rs
+++ b/crates/api/src/domain/credential/dto.rs
@@ -91,6 +91,10 @@ pub struct CredentialResponse {
     pub expires_at: Option<String>,
     /// Monotonic version for CAS operations.
     pub version: u64,
+    /// True when the credential cannot be used until re-authorized
+    /// (e.g. an OAuth2 flow was started but not completed, or a refresh
+    /// failed terminally).
+    pub reauth_required: bool,
     /// User-defined tags.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
     pub tags: HashMap<String, String>,
@@ -112,6 +116,8 @@ pub struct CredentialSummary {
     pub expires_at: Option<String>,
     /// Monotonic version for CAS operations.
     pub version: u64,
+    /// True when the credential cannot be used until re-authorized.
+    pub reauth_required: bool,
 }
 
 /// Paginated list of credential summaries.
@@ -156,7 +162,18 @@ pub struct ResolveCredentialRequest {
     pub data: serde_json::Value,
 }
 
-/// Interaction type required to continue a pending credential acquisition.
+/// One form field of a `form_post` interaction.
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct FormPostField {
+    /// Form field name.
+    pub name: String,
+    /// Form field value (never secret material — interaction payloads
+    /// are UI instructions, not credential state).
+    pub value: String,
+}
+
+/// Interaction type required to continue a pending credential
+/// acquisition. Mirrors the credential contract's `InteractionRequest`.
 #[derive(Debug, Clone, Serialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum AcquisitionInteraction {
@@ -165,20 +182,25 @@ pub enum AcquisitionInteraction {
         /// URL to redirect the user to.
         url: String,
     },
-    /// User must visit the URI and enter the code (e.g. OAuth2 device_code).
+    /// Client must auto-submit a POST form to the IdP (e.g. SAML POST binding).
+    FormPost {
+        /// IdP endpoint URL.
+        url: String,
+        /// Form fields to submit.
+        fields: Vec<FormPostField>,
+    },
+    /// Information the user must act on (device code, instructions).
     DisplayInfo {
-        /// Code the user must enter at the verification URI.
-        user_code: String,
-        /// URI the user must visit.
-        verification_uri: String,
-        /// Seconds until the code expires.
+        /// Dialog title.
+        title: String,
+        /// Instructional message.
+        message: String,
+        /// Structured display payload (e.g. `UserCode` with the
+        /// verification URI, or plain `Text`).
+        data: serde_json::Value,
+        /// Seconds until this information expires.
         #[serde(skip_serializing_if = "Option::is_none")]
         expires_in: Option<u64>,
-    },
-    /// Server has issued a challenge the client must respond to.
-    Challenge {
-        /// Opaque challenge payload the client must respond to.
-        challenge_data: serde_json::Value,
     },
 }
 
@@ -198,14 +220,23 @@ pub enum ResolveCredentialResponse {
         /// Interaction the client must perform next.
         interaction: AcquisitionInteraction,
     },
+    /// The framework asked the client to poll the continuation again.
+    Retry {
+        /// Seconds to wait before re-calling `resolve/continue`.
+        retry_after_secs: u64,
+    },
 }
 
 /// Request body for continuing a pending credential acquisition.
 #[derive(Debug, Clone, Deserialize, ToSchema)]
 pub struct ContinueResolveRequest {
+    /// Credential type key the pending acquisition was started for.
+    pub credential_key: String,
     /// Token from a previous `Pending` response.
     pub pending_token: String,
-    /// User-provided input (authorization code, device confirmation, challenge answer, etc.).
+    /// Typed continuation payload — the serialized `UserInput` shape:
+    /// `"Poll"`, `{"Code":{"code":".."}}`, `{"Callback":{"params":{..}}}`,
+    /// or `{"FormData":{"params":{..}}}`.
     pub user_input: serde_json::Value,
 }
 

--- a/crates/api/src/domain/credential/handler.rs
+++ b/crates/api/src/domain/credential/handler.rs
@@ -68,8 +68,7 @@ pub async fn list_credentials(
     Query(query): Query<ListCredentialsQuery>,
 ) -> ApiResult<Json<ListCredentialsResponse>> {
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
-    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
-    let response = crate::transport::credential::list_credentials(&state, &owner_id, query).await?;
+    let response = crate::transport::credential::list_credentials(&state, &scope, query).await?;
     Ok(Json(response))
 }
 
@@ -112,8 +111,7 @@ pub async fn create_credential(
     validate_data_is_object(&body.data)?;
 
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
-    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
-    let response = crate::transport::credential::create_credential(&state, &owner_id, body).await?;
+    let response = crate::transport::credential::create_credential(&state, &scope, body).await?;
     Ok(Json(response))
 }
 
@@ -148,8 +146,7 @@ pub async fn get_credential(
     validate_credential_id(&cred)?;
 
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
-    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
-    let response = crate::transport::credential::get_credential(&state, &owner_id, &cred).await?;
+    let response = crate::transport::credential::get_credential(&state, &scope, &cred).await?;
     Ok(Json(response))
 }
 
@@ -211,9 +208,8 @@ pub async fn update_credential(
     }
 
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
-    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
     let response =
-        crate::transport::credential::update_credential(&state, &owner_id, &cred, body).await?;
+        crate::transport::credential::update_credential(&state, &scope, &cred, body).await?;
     Ok(Json(response))
 }
 
@@ -249,8 +245,7 @@ pub async fn delete_credential(
     validate_credential_id(&cred)?;
 
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
-    let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
-    crate::transport::credential::delete_credential(&state, &owner_id, &cred).await?;
+    crate::transport::credential::delete_credential(&state, &scope, &cred).await?;
     Ok(Json(AckResponse::ok()))
 }
 
@@ -282,11 +277,13 @@ pub async fn delete_credential(
 pub async fn test_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
 ) -> ApiResult<Json<TestCredentialResponse>> {
     validate_credential_id(&cred)?;
 
-    let response = crate::transport::credential::test_credential(&state, &org, &ws, &cred).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let response = crate::transport::credential::test_credential(&state, &scope, &cred).await?;
     Ok(Json(response))
 }
 
@@ -316,12 +313,13 @@ pub async fn test_credential(
 pub async fn refresh_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
 ) -> ApiResult<Json<RefreshCredentialResponse>> {
     validate_credential_id(&cred)?;
 
-    let response =
-        crate::transport::credential::refresh_credential(&state, &org, &ws, &cred).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let response = crate::transport::credential::refresh_credential(&state, &scope, &cred).await?;
     Ok(Json(response))
 }
 
@@ -352,12 +350,13 @@ pub async fn refresh_credential(
 pub async fn revoke_credential(
     State(state): State<AppState>,
     Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws, cred)): Path<(String, String, String)>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws, cred)): Path<(String, String, String)>,
 ) -> ApiResult<Json<RevokeCredentialResponse>> {
     validate_credential_id(&cred)?;
 
-    let response =
-        crate::transport::credential::revoke_credential(&state, &org, &ws, &cred).await?;
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
+    let response = crate::transport::credential::revoke_credential(&state, &scope, &cred).await?;
     Ok(Json(response))
 }
 
@@ -384,21 +383,24 @@ pub async fn revoke_credential(
         (status = 400, description = "Validation error (key or data shape).", body = ProblemDetails),
         (status = 401, description = "Authentication required.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
-        (status = 503, description = "Honest stub (honest capability contract): the route is reachable but generic credential resolution is engine-owned (`Credential::resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
+        (status = 503, description = "Credential service or credential-schema port not wired into this deployment (operational honesty: refuses rather than faking success).", body = ProblemDetails),
     ),
 )]
 pub async fn resolve_credential(
     State(state): State<AppState>,
-    Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws)): Path<(String, String)>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws)): Path<(String, String)>,
     Json(request): Json<ResolveCredentialRequest>,
 ) -> ApiResult<Json<ResolveCredentialResponse>> {
     // ── Input validation ────────────────────────────────────────────
     validate_credential_key(&request.credential_key)?;
     validate_data_is_object(&request.data)?;
 
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
     let response =
-        crate::transport::credential::resolve_credential(&state, &org, &ws, request).await?;
+        crate::transport::credential::resolve_credential(&state, &scope, &user.user_id, request)
+            .await?;
     Ok(Json(response))
 }
 
@@ -423,16 +425,18 @@ pub async fn resolve_credential(
         (status = 400, description = "Validation error (e.g. empty `pending_token`).", body = ProblemDetails),
         (status = 401, description = "Authentication required or pending token expired/already-consumed.", body = ProblemDetails),
         (status = 403, description = "Caller does not have access to this workspace.", body = ProblemDetails),
-        (status = 503, description = "Honest stub (honest capability contract): the route is reachable but generic interactive continuation is engine-owned (`Interactive::continue_resolve` dispatch via `nebula-engine::credential`) and requires a `CredentialRegistry` not wired into this build, so it refuses rather than faking success.", body = ProblemDetails),
+        (status = 503, description = "Credential service not wired into this deployment (operational honesty: refuses rather than faking success).", body = ProblemDetails),
     ),
 )]
 pub async fn continue_resolve_credential(
     State(state): State<AppState>,
-    Extension(_user): Extension<AuthenticatedUser>,
-    Path((org, ws)): Path<(String, String)>,
+    Extension(user): Extension<AuthenticatedUser>,
+    Extension(tenant): Extension<TenantContext>,
+    Path((_org, _ws)): Path<(String, String)>,
     Json(request): Json<ContinueResolveRequest>,
 ) -> ApiResult<Json<ContinueResolveResponse>> {
     // ── Input validation ────────────────────────────────────────────
+    validate_credential_key(&request.credential_key)?;
     if request.pending_token.is_empty() {
         return Err(ApiError::Validation {
             detail: "pending_token must not be empty".to_string(),
@@ -440,8 +444,10 @@ pub async fn continue_resolve_credential(
         });
     }
 
+    let scope = crate::middleware::tenancy::request_scope(&tenant)?;
     let response =
-        crate::transport::credential::continue_resolve(&state, &org, &ws, request).await?;
+        crate::transport::credential::continue_resolve(&state, &scope, &user.user_id, request)
+            .await?;
     Ok(Json(response))
 }
 
@@ -626,14 +632,8 @@ pub async fn get_oauth2_authorize_url_scoped(
     validate_credential_id(&cred)?;
     let scope = crate::middleware::tenancy::request_scope(&tenant)?;
     let owner_id = crate::transport::credential::owner_id_from_scope(&scope);
-    oauth_controller::get_oauth2_authorize_url_for_owner(
-        &cred,
-        &state,
-        &user,
-        query,
-        Some(owner_id),
-    )
-    .await
+    oauth_controller::get_oauth2_authorize_url_for_owner(&cred, &state, &user, query, owner_id)
+        .await
 }
 
 /// GET /orgs/{org}/workspaces/{ws}/credentials/{cred}/oauth2/callback — Handle OAuth2 callback.

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -65,22 +65,20 @@ pub async fn get_oauth2_authorize_url(
 
 /// Build an OAuth2 authorization URL and persist tenant-bound pending state.
 ///
-/// When `owner_id` is provided, the credential placeholder is created/read
-/// through the scoped credential store and the pending exchange records the
-/// expected credential version for callback-time CAS persistence.
+/// The credential placeholder is created/read through the owner-scoped
+/// facade store and the pending exchange records the expected credential
+/// version for callback-time CAS persistence. `owner_id` is mandatory —
+/// every OAuth credential acquisition is tenant-bound (the system-level
+/// unscoped routes are permanently disabled).
 pub async fn get_oauth2_authorize_url_for_owner(
     credential_id: &str,
     state: &AppState,
     user: &AuthenticatedUser,
     query: AuthorizationUriRequest,
-    owner_id: Option<String>,
+    owner_id: String,
 ) -> ApiResult<Json<AuthorizationUriResponse>> {
     validate_oauth_outbound_url(&query.token_url).map_err(ApiError::validation_message)?;
-    let expected_version = if let Some(owner_id) = owner_id.as_deref() {
-        Some(prepare_oauth_credential(state, owner_id, credential_id).await?)
-    } else {
-        None
-    };
+    let expected_version = prepare_oauth_credential(state, &owner_id, credential_id).await?;
 
     let csrf = generate_random_state();
     let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
@@ -209,7 +207,7 @@ where
         user,
         code,
         signed_state,
-        Some(owner_id),
+        owner_id,
         exchange_fn,
     )
     .await
@@ -237,7 +235,7 @@ async fn handle_callback_with_exchange<F, Fut>(
     user: &AuthenticatedUser,
     code: String,
     signed_state: String,
-    owner_id: Option<String>,
+    owner_id: String,
     exchange_fn: F,
 ) -> ApiResult<Json<OAuthCallbackResponse>>
 where
@@ -282,7 +280,7 @@ where
             )));
         },
     };
-    if pending_for_owner_check.owner_id.as_deref() != owner_id.as_deref() {
+    if pending_for_owner_check.owner_id != owner_id {
         return Err(ApiError::Unauthorized(
             "oauth pending state tenant mismatch".to_owned(),
         ));
@@ -327,7 +325,7 @@ where
     let oauth_state = build_oauth2_state(&token_body, &pending)?;
     persist_oauth_state(
         state,
-        owner_id.as_deref(),
+        &owner_id,
         pending.expected_version,
         credential_id,
         oauth_state,
@@ -352,8 +350,8 @@ struct OAuthPendingExchange {
     code_verifier: SecretString,
     scopes: Vec<String>,
     auth_style: nebula_credential::AuthStyle,
-    owner_id: Option<String>,
-    expected_version: Option<u64>,
+    owner_id: String,
+    expected_version: u64,
 }
 
 impl Zeroize for OAuthPendingExchange {
@@ -434,8 +432,8 @@ fn build_oauth2_state(
 
 async fn persist_oauth_state(
     state: &AppState,
-    owner_id: Option<&str>,
-    expected_version: Option<u64>,
+    owner_id: &str,
+    expected_version: u64,
     credential_id: &str,
     oauth_state: OAuth2State,
 ) -> ApiResult<()> {
@@ -445,32 +443,11 @@ async fn persist_oauth_state(
         ))
     })?;
     let now = chrono::Utc::now();
-    let (created_at, metadata, mode) = match owner_id {
-        Some(owner_id) => {
-            let store = crate::transport::credential::scoped_store(state, owner_id);
-            let existing = store
-                .get(credential_id)
-                .await
-                .map_err(|e| map_oauth_store_err(e, credential_id))?;
-            let expected_version = expected_version.ok_or_else(|| {
-                ApiError::Unauthorized("oauth pending state missing credential version".to_owned())
-            })?;
-            (
-                existing.created_at,
-                existing.metadata,
-                PutMode::CompareAndSwap { expected_version },
-            )
-        },
-        None => match state.oauth_credential_store.get(credential_id).await {
-            Ok(existing) => (existing.created_at, existing.metadata, PutMode::Overwrite),
-            Err(StoreError::NotFound { .. }) => (now, serde_json::Map::new(), PutMode::Overwrite),
-            Err(e) => {
-                return Err(ApiError::Internal(format!(
-                    "failed to read existing oauth credential: {e}"
-                )));
-            },
-        },
-    };
+    let store = crate::transport::credential::scoped_store(state, owner_id)?;
+    let existing = store
+        .get(credential_id)
+        .await
+        .map_err(|e| map_oauth_store_err(e, credential_id))?;
     let stored = StoredCredential {
         id: credential_id.to_owned(),
         credential_key: OAuth2Credential::KEY.to_owned(),
@@ -478,33 +455,19 @@ async fn persist_oauth_state(
         state_kind: OAuth2State::KIND.to_owned(),
         state_version: OAuth2State::VERSION,
         version: 0,
-        created_at,
+        created_at: existing.created_at,
         updated_at: now,
         expires_at: oauth_state.expires_at(),
-        // Refresh-coordination state belongs to the resolver; the OAuth
-        // create/exchange path inserts a fresh credential, so reauth
-        // is not required.
+        // The exchange just minted fresh tokens — the placeholder's
+        // `reauth_required` flag is cleared by this write.
         reauth_required: false,
-        metadata,
+        metadata: existing.metadata,
     };
 
-    match owner_id {
-        Some(owner_id) => {
-            crate::transport::credential::scoped_store(state, owner_id)
-                .put(stored, mode)
-                .await
-                .map_err(|e| map_oauth_store_err(e, credential_id))?;
-        },
-        None => {
-            state
-                .oauth_credential_store
-                .put(stored, mode)
-                .await
-                .map_err(|e| {
-                    ApiError::Internal(format!("failed to persist oauth credential state: {e}"))
-                })?;
-        },
-    }
+    store
+        .put(stored, PutMode::CompareAndSwap { expected_version })
+        .await
+        .map_err(|e| map_oauth_store_err(e, credential_id))?;
     Ok(())
 }
 
@@ -513,7 +476,7 @@ async fn prepare_oauth_credential(
     owner_id: &str,
     credential_id: &str,
 ) -> ApiResult<u64> {
-    let store = crate::transport::credential::scoped_store(state, owner_id);
+    let store = crate::transport::credential::scoped_store(state, owner_id)?;
     match store.get(credential_id).await {
         Ok(existing) => {
             if existing.credential_key != OAuth2Credential::KEY
@@ -577,6 +540,7 @@ mod tests {
     use super::*;
     use crate::config::JwtSecret;
     use nebula_credential::{CredentialStore, PendingStateStore};
+    use nebula_storage::credential::EnvKeyProvider;
     use nebula_storage::inmem::{
         InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
         InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
@@ -596,6 +560,12 @@ mod tests {
         let workflow_versions = InMemoryWorkflowVersionStore::new();
         let workflow_store = InMemoryWorkflowStore::new_with_versions(&workflow_versions);
 
+        let key = Arc::new(
+            EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key fixture"),
+        );
+        let svc = crate::ports::credential_service_factory::with_key_provider(key)
+            .expect("service composes");
+
         AppState::new(
             Arc::new(workflow_store),
             Arc::new(workflow_versions),
@@ -605,9 +575,17 @@ mod tests {
             Arc::new(control_queue),
             jwt_secret,
         )
+        .with_credential_service(svc)
     }
 
-    fn test_pending_exchange() -> OAuthPendingExchange {
+    /// 32 `0x42` bytes, base64 — a valid AES-256 key fixture (mirrors the
+    /// factory dev key). Not a secret: a fixed test constant.
+    const TEST_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
+    /// Canonical owner key for the test tenant.
+    const OWNER_A: &str = "org-a:ws-a";
+
+    fn test_pending_exchange(owner_id: &str, expected_version: u64) -> OAuthPendingExchange {
         OAuthPendingExchange {
             token_url: "https://provider.example.com/token".to_owned(),
             client_id: "client-id".to_owned(),
@@ -616,24 +594,42 @@ mod tests {
             code_verifier: SecretString::new("pkce-verifier"),
             scopes: vec!["read".to_owned(), "write".to_owned()],
             auth_style: nebula_credential::AuthStyle::Header,
-            owner_id: None,
-            expected_version: None,
+            owner_id: owner_id.to_owned(),
+            expected_version,
         }
     }
 
-    #[tokio::test]
-    async fn callback_persists_oauth_state_in_credential_store() {
-        let state = test_app_state();
-        let credential_id = "cred-123";
-        let user = AuthenticatedUser {
-            user_id: "user-123".to_owned(),
-        };
+    /// Read a stored credential row back through the same owner-scoped
+    /// facade store handle the OAuth path writes through.
+    async fn read_stored(
+        state: &AppState,
+        owner_id: &str,
+        credential_id: &str,
+    ) -> StoredCredential {
+        crate::transport::credential::scoped_store(state, owner_id)
+            .expect("credential service is wired in test_app_state")
+            .get(credential_id)
+            .await
+            .expect("stored oauth credential")
+    }
+
+    /// One full authorize→callback round against `credential_id` under
+    /// `OWNER_A`, exchanging for the given token body.
+    async fn run_callback_round(
+        state: &AppState,
+        user: &AuthenticatedUser,
+        credential_id: &str,
+        token_body: serde_json::Value,
+    ) {
+        let expected_version = prepare_oauth_credential(state, OWNER_A, credential_id)
+            .await
+            .expect("placeholder prepared");
 
         let csrf = generate_random_state();
         let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
         let (signed_state, payload) =
             build_signed_state(&signer, credential_id, csrf).expect("signed state");
-        let pending = test_pending_exchange();
+        let pending = test_pending_exchange(OWNER_A, expected_version);
         let pending_token = state
             .oauth_pending_store
             .put("oauth2", &user.user_id, &payload.csrf_token, pending)
@@ -645,20 +641,13 @@ mod tests {
             .await
             .insert(signed_state.clone(), pending_token);
 
-        let token_body = serde_json::json!({
-            "access_token": "access-token-value",
-            "refresh_token": "refresh-token-value",
-            "token_type": "Bearer",
-            "expires_in": 3600,
-            "scope": "scope-a scope-b"
-        });
         let callback = handle_callback_with_exchange(
             credential_id,
-            &state,
-            &user,
+            state,
+            user,
             "auth-code".to_owned(),
             signed_state,
-            None,
+            OWNER_A.to_owned(),
             move |_req| {
                 let token_body = token_body.clone();
                 async move { Ok(token_body) }
@@ -667,14 +656,32 @@ mod tests {
         .await
         .expect("callback handled");
         assert!(callback.0.exchanged);
+    }
 
-        let stored = state
-            .oauth_credential_store
-            .get(credential_id)
-            .await
-            .expect("stored oauth credential");
+    #[tokio::test]
+    async fn callback_persists_oauth_state_in_credential_store() {
+        let state = test_app_state();
+        let credential_id = "cred-123";
+        let user = AuthenticatedUser {
+            user_id: "user-123".to_owned(),
+        };
+
+        let token_body = serde_json::json!({
+            "access_token": "access-token-value",
+            "refresh_token": "refresh-token-value",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "scope-a scope-b"
+        });
+        run_callback_round(&state, &user, credential_id, token_body).await;
+
+        let stored = read_stored(&state, OWNER_A, credential_id).await;
         assert_eq!(stored.state_kind, OAuth2State::KIND);
         assert_eq!(stored.credential_key, OAuth2Credential::KEY);
+        assert!(
+            !stored.reauth_required,
+            "the exchange must clear the placeholder reauth flag"
+        );
 
         let persisted_state: OAuth2State =
             serde_json::from_slice(&stored.data).expect("oauth state json");
@@ -695,84 +702,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn callback_overwrites_existing_oauth_state() {
+    async fn second_callback_round_replaces_tokens_and_preserves_created_at() {
         let state = test_app_state();
         let credential_id = "cred-456";
         let user = AuthenticatedUser {
             user_id: "user-456".to_owned(),
         };
 
-        let old_oauth_state = OAuth2State {
-            access_token: SecretString::new("old-access-token"),
-            token_type: "Bearer".to_owned(),
-            refresh_token: Some(SecretString::new("old-refresh-token")),
-            expires_at: None,
-            scopes: vec!["old-scope".to_owned()],
-            client_id: SecretString::new("old-client-id"),
-            client_secret: SecretString::new("old-client-secret"),
-            token_url: "https://provider.example.com/token".to_owned(),
-            auth_style: nebula_credential::AuthStyle::Header,
-        };
-        persist_oauth_state(&state, None, None, credential_id, old_oauth_state)
-            .await
-            .expect("seed existing oauth state");
-        let first_created_at = state
-            .oauth_credential_store
-            .get(credential_id)
-            .await
-            .expect("seeded credential")
-            .created_at;
-
-        let csrf = generate_random_state();
-        let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
-        let (signed_state, payload) =
-            build_signed_state(&signer, credential_id, csrf).expect("signed state");
-        let pending = test_pending_exchange();
-        let pending_token = state
-            .oauth_pending_store
-            .put("oauth2", &user.user_id, &payload.csrf_token, pending)
-            .await
-            .expect("pending store put");
-        state
-            .oauth_state_tokens
-            .write()
-            .await
-            .insert(signed_state.clone(), pending_token);
-
-        let token_body = serde_json::json!({
-            "access_token": "new-access-token",
-            "refresh_token": "new-refresh-token",
-            "token_type": "Bearer",
-            "expires_in": 900,
-            "scope": "new-scope-a new-scope-b"
-        });
-        let callback = handle_callback_with_exchange(
-            credential_id,
+        run_callback_round(
             &state,
             &user,
-            "auth-code".to_owned(),
-            signed_state,
-            None,
-            move |_req| {
-                let token_body = token_body.clone();
-                async move { Ok(token_body) }
-            },
+            credential_id,
+            serde_json::json!({
+                "access_token": "old-access-token",
+                "token_type": "Bearer",
+            }),
         )
-        .await
-        .expect("callback handled");
-        assert!(callback.0.exchanged);
+        .await;
+        let first = read_stored(&state, OWNER_A, credential_id).await;
 
-        let stored = state
-            .oauth_credential_store
-            .get(credential_id)
-            .await
-            .expect("stored oauth credential");
+        run_callback_round(
+            &state,
+            &user,
+            credential_id,
+            serde_json::json!({
+                "access_token": "new-access-token",
+                "refresh_token": "new-refresh-token",
+                "token_type": "Bearer",
+                "expires_in": 900,
+                "scope": "new-scope-a new-scope-b"
+            }),
+        )
+        .await;
+
+        let stored = read_stored(&state, OWNER_A, credential_id).await;
         assert_eq!(stored.state_kind, OAuth2State::KIND);
         assert_eq!(stored.credential_key, OAuth2Credential::KEY);
-        assert_eq!(stored.version, 2);
+        assert!(
+            stored.version > first.version,
+            "the second exchange must CAS over the first ({} -> {})",
+            first.version,
+            stored.version
+        );
         assert_eq!(
-            stored.created_at, first_created_at,
-            "overwrite must preserve created_at"
+            stored.created_at, first.created_at,
+            "re-authorization must preserve created_at"
         );
 
         let persisted_state: OAuth2State =
@@ -781,16 +755,44 @@ mod tests {
             persisted_state.access_token.expose_secret().to_owned(),
             "new-access-token"
         );
-        assert_eq!(
-            persisted_state
-                .refresh_token
-                .clone()
-                .expect("refresh token")
-                .expose_secret()
-                .to_owned(),
-            "new-refresh-token"
-        );
         assert_eq!(persisted_state.scopes, vec!["new-scope-a", "new-scope-b"]);
+    }
+
+    /// The OAuth-acquired row is visible to the generic CRUD plane (one
+    /// store): `facade.get`/`list` see it under the same owner, and a
+    /// foreign owner sees nothing.
+    #[tokio::test]
+    async fn oauth_row_is_visible_to_the_crud_plane() {
+        let state = test_app_state();
+        let credential_id = "cred-crud-visible";
+        let user = AuthenticatedUser {
+            user_id: "user-vis".to_owned(),
+        };
+
+        run_callback_round(
+            &state,
+            &user,
+            credential_id,
+            serde_json::json!({
+                "access_token": "vis-access-token",
+                "token_type": "Bearer",
+            }),
+        )
+        .await;
+
+        // OWNER_A is an opaque owner string for the scoped store; assert
+        // via the scoped store that a *different* owner cannot read the
+        // row (flat NotFound) while the owning scope still can.
+        let foreign = crate::transport::credential::scoped_store(&state, "org-b:ws-b")
+            .expect("service wired");
+        let err = foreign
+            .get(credential_id)
+            .await
+            .expect_err("foreign owner must not read the oauth row");
+        assert!(matches!(err, StoreError::NotFound { .. }));
+        // And the owning scope still reads it.
+        let stored = read_stored(&state, OWNER_A, credential_id).await;
+        assert_eq!(stored.credential_key, OAuth2Credential::KEY);
     }
 
     #[tokio::test]
@@ -801,12 +803,15 @@ mod tests {
             user_id: "user-tenant-mismatch".to_owned(),
         };
 
+        let expected_version = prepare_oauth_credential(&state, OWNER_A, credential_id)
+            .await
+            .expect("placeholder prepared");
+
         let csrf = generate_random_state();
         let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
         let (signed_state, payload) =
             build_signed_state(&signer, credential_id, csrf).expect("signed state");
-        let mut pending = test_pending_exchange();
-        pending.owner_id = Some("org-a:ws-a".to_owned());
+        let pending = test_pending_exchange(OWNER_A, expected_version);
         let pending_token = state
             .oauth_pending_store
             .put("oauth2", &user.user_id, &payload.csrf_token, pending)
@@ -825,7 +830,7 @@ mod tests {
             &user,
             "auth-code".to_owned(),
             signed_state.clone(),
-            Some("org-b:ws-b".to_owned()),
+            "org-b:ws-b".to_owned(),
             |_req| async { Err::<serde_json::Value, String>("exchange should not run".to_owned()) },
         )
         .await
@@ -845,7 +850,7 @@ mod tests {
             )
             .await
             .expect("tenant mismatch must leave pending state retryable");
-        assert_eq!(still_pending.owner_id.as_deref(), Some("org-a:ws-a"));
+        assert_eq!(still_pending.owner_id, OWNER_A);
         assert!(
             state
                 .oauth_state_tokens

--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -78,7 +78,7 @@ pub async fn get_oauth2_authorize_url_for_owner(
     owner_id: String,
 ) -> ApiResult<Json<AuthorizationUriResponse>> {
     validate_oauth_outbound_url(&query.token_url).map_err(ApiError::validation_message)?;
-    let expected_version = prepare_oauth_credential(state, &owner_id, credential_id).await?;
+    prepare_oauth_credential(state, &owner_id, credential_id).await?;
 
     let csrf = generate_random_state();
     let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
@@ -103,7 +103,6 @@ pub async fn get_oauth2_authorize_url_for_owner(
             .auth_style
             .unwrap_or(nebula_credential::AuthStyle::Header),
         owner_id,
-        expected_version,
     };
     let pending_token = state
         .oauth_pending_store
@@ -323,14 +322,7 @@ where
         .await
         .map_err(ApiError::Internal)?;
     let oauth_state = build_oauth2_state(&token_body, &pending)?;
-    persist_oauth_state(
-        state,
-        &owner_id,
-        pending.expected_version,
-        credential_id,
-        oauth_state,
-    )
-    .await?;
+    persist_oauth_state(state, &owner_id, credential_id, oauth_state).await?;
 
     Ok(Json(OAuthCallbackResponse {
         credential_id: credential_id.to_owned(),
@@ -351,7 +343,6 @@ struct OAuthPendingExchange {
     scopes: Vec<String>,
     auth_style: nebula_credential::AuthStyle,
     owner_id: String,
-    expected_version: u64,
 }
 
 impl Zeroize for OAuthPendingExchange {
@@ -433,7 +424,6 @@ fn build_oauth2_state(
 async fn persist_oauth_state(
     state: &AppState,
     owner_id: &str,
-    expected_version: u64,
     credential_id: &str,
     oauth_state: OAuth2State,
 ) -> ApiResult<()> {
@@ -444,6 +434,11 @@ async fn persist_oauth_state(
     })?;
     let now = chrono::Utc::now();
     let store = crate::transport::credential::scoped_store(state, owner_id)?;
+    // CAS on the version read HERE, not on a version pinned at authorize
+    // time: a legitimate concurrent write (a rename while the user sat on
+    // the IdP consent screen) must not burn the single-use authorization
+    // code and the consumed pending state. Double-exchange is already
+    // prevented one layer up by the pending state''s single-use consume.
     let existing = store
         .get(credential_id)
         .await
@@ -465,7 +460,12 @@ async fn persist_oauth_state(
     };
 
     store
-        .put(stored, PutMode::CompareAndSwap { expected_version })
+        .put(
+            stored,
+            PutMode::CompareAndSwap {
+                expected_version: existing.version,
+            },
+        )
         .await
         .map_err(|e| map_oauth_store_err(e, credential_id))?;
     Ok(())
@@ -475,7 +475,7 @@ async fn prepare_oauth_credential(
     state: &AppState,
     owner_id: &str,
     credential_id: &str,
-) -> ApiResult<u64> {
+) -> ApiResult<()> {
     let store = crate::transport::credential::scoped_store(state, owner_id)?;
     match store.get(credential_id).await {
         Ok(existing) => {
@@ -486,7 +486,7 @@ async fn prepare_oauth_credential(
                     "credential is not an OAuth2 credential",
                 ));
             }
-            Ok(existing.version)
+            Ok(())
         },
         Err(StoreError::NotFound { .. }) => {
             let now = chrono::Utc::now();
@@ -506,7 +506,7 @@ async fn prepare_oauth_credential(
             store
                 .put(stored, PutMode::CreateOnly)
                 .await
-                .map(|created| created.version)
+                .map(|_| ())
                 .map_err(|e| map_oauth_store_err(e, credential_id))
         },
         Err(e) => Err(map_oauth_store_err(e, credential_id)),
@@ -585,7 +585,7 @@ mod tests {
     /// Canonical owner key for the test tenant.
     const OWNER_A: &str = "org-a:ws-a";
 
-    fn test_pending_exchange(owner_id: &str, expected_version: u64) -> OAuthPendingExchange {
+    fn test_pending_exchange(owner_id: &str) -> OAuthPendingExchange {
         OAuthPendingExchange {
             token_url: "https://provider.example.com/token".to_owned(),
             client_id: "client-id".to_owned(),
@@ -595,7 +595,6 @@ mod tests {
             scopes: vec!["read".to_owned(), "write".to_owned()],
             auth_style: nebula_credential::AuthStyle::Header,
             owner_id: owner_id.to_owned(),
-            expected_version,
         }
     }
 
@@ -621,7 +620,7 @@ mod tests {
         credential_id: &str,
         token_body: serde_json::Value,
     ) {
-        let expected_version = prepare_oauth_credential(state, OWNER_A, credential_id)
+        prepare_oauth_credential(state, OWNER_A, credential_id)
             .await
             .expect("placeholder prepared");
 
@@ -629,7 +628,7 @@ mod tests {
         let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
         let (signed_state, payload) =
             build_signed_state(&signer, credential_id, csrf).expect("signed state");
-        let pending = test_pending_exchange(OWNER_A, expected_version);
+        let pending = test_pending_exchange(OWNER_A);
         let pending_token = state
             .oauth_pending_store
             .put("oauth2", &user.user_id, &payload.csrf_token, pending)
@@ -795,6 +794,92 @@ mod tests {
         assert_eq!(stored.credential_key, OAuth2Credential::KEY);
     }
 
+    /// A legitimate concurrent write while the user sits on the IdP
+    /// consent screen (e.g. a teammate renames the credential, bumping
+    /// the row version) must NOT burn the single-use authorization code:
+    /// the callback CASes on the version it reads at exchange time, not
+    /// on a version pinned at authorize time.
+    #[tokio::test]
+    async fn concurrent_row_write_between_authorize_and_callback_does_not_break_exchange() {
+        let state = test_app_state();
+        let credential_id = "cred-rename-race";
+        let user = AuthenticatedUser {
+            user_id: "user-race".to_owned(),
+        };
+
+        prepare_oauth_credential(&state, OWNER_A, credential_id)
+            .await
+            .expect("placeholder prepared");
+
+        let csrf = generate_random_state();
+        let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
+        let (signed_state, payload) =
+            build_signed_state(&signer, credential_id, csrf).expect("signed state");
+        let pending = test_pending_exchange(OWNER_A);
+        let pending_token = state
+            .oauth_pending_store
+            .put("oauth2", &user.user_id, &payload.csrf_token, pending)
+            .await
+            .expect("pending store put");
+        state
+            .oauth_state_tokens
+            .write()
+            .await
+            .insert(signed_state.clone(), pending_token);
+
+        // Concurrent write lands while the consent screen is open: bump
+        // the row version via an owner-scoped CAS write.
+        let store =
+            crate::transport::credential::scoped_store(&state, OWNER_A).expect("service wired");
+        let existing = store
+            .get(credential_id)
+            .await
+            .expect("placeholder readable");
+        let bumped = StoredCredential {
+            updated_at: chrono::Utc::now(),
+            ..existing.clone()
+        };
+        store
+            .put(
+                bumped,
+                PutMode::CompareAndSwap {
+                    expected_version: existing.version,
+                },
+            )
+            .await
+            .expect("concurrent write succeeds");
+
+        // The callback still completes: the exchange CASes on the version
+        // it reads now, not the authorize-time one.
+        let token_body = serde_json::json!({
+            "access_token": "race-access-token",
+            "token_type": "Bearer",
+        });
+        let callback = handle_callback_with_exchange(
+            credential_id,
+            &state,
+            &user,
+            "auth-code".to_owned(),
+            signed_state,
+            OWNER_A.to_owned(),
+            move |_req| {
+                let token_body = token_body.clone();
+                async move { Ok(token_body) }
+            },
+        )
+        .await
+        .expect("callback survives the concurrent rename");
+        assert!(callback.0.exchanged);
+
+        let stored = read_stored(&state, OWNER_A, credential_id).await;
+        assert!(!stored.reauth_required, "exchange clears the reauth flag");
+        let persisted_state: OAuth2State =
+            serde_json::from_slice(&stored.data).expect("oauth state json");
+        assert_eq!(
+            persisted_state.access_token.expose_secret().to_owned(),
+            "race-access-token"
+        );
+    }
     #[tokio::test]
     async fn tenant_mismatch_does_not_consume_pending_state() {
         let state = test_app_state();
@@ -803,7 +888,7 @@ mod tests {
             user_id: "user-tenant-mismatch".to_owned(),
         };
 
-        let expected_version = prepare_oauth_credential(&state, OWNER_A, credential_id)
+        prepare_oauth_credential(&state, OWNER_A, credential_id)
             .await
             .expect("placeholder prepared");
 
@@ -811,7 +896,7 @@ mod tests {
         let signer = OAuthStateSigner::new(state.jwt_secret.as_bytes());
         let (signed_state, payload) =
             build_signed_state(&signer, credential_id, csrf).expect("signed state");
-        let pending = test_pending_exchange(OWNER_A, expected_version);
+        let pending = test_pending_exchange(OWNER_A);
         let pending_token = state
             .oauth_pending_store
             .put("oauth2", &user.user_id, &payload.csrf_token, pending)

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -12,10 +12,7 @@ use nebula_credential_runtime::CredentialService;
 use nebula_engine::ActionRegistry;
 use nebula_metrics::MetricsRegistry;
 use nebula_plugin::PluginRegistry;
-use nebula_storage::{
-    credential::{InMemoryPendingStore, InMemoryStore},
-    repos::WebhookActivationRepo,
-};
+use nebula_storage::{credential::InMemoryPendingStore, repos::WebhookActivationRepo};
 use nebula_storage_port::Scope;
 use nebula_storage_port::store::{
     ControlQueue, ExecutionJournalReader, ExecutionStore, NodeResultStore, WorkflowStore,
@@ -243,15 +240,14 @@ pub struct AppState {
     /// (honest capability stub, mirroring `action_registry`).
     pub credential_schema: Option<Arc<dyn crate::ports::credential_schema::CredentialSchemaPort>>,
 
-    /// Optional `CredentialService` facade — when `Some`, the credential CRUD
-    /// transport layer uses the service's encryption+audit+cache store handle
-    /// instead of the raw `InMemoryStore` wrapped by `CredentialScopeLayer`.
+    /// Optional `CredentialService` facade — the **single** credential
+    /// persistence path (ADR-0088 D7). All credential CRUD, lifecycle, and
+    /// acquisition operations route through it; the OAuth two-phase flow
+    /// writes through a `CredentialScopeLayer` over the service's
+    /// encryption+audit+cache store handle, so both planes share one store.
     ///
-    /// When `None`, the CRUD path falls back to `oauth_credential_store` (the
-    /// raw in-memory store via `CredentialScopeLayer`) for backward compatibility
-    /// during the wire-up transition — after Task 18 deletes `CredentialScopeLayer`
-    /// from `nebula-tenancy` this fallback path will be removed and `credential_service`
-    /// will be mandatory.
+    /// When `None`, every credential endpoint returns an honest 503 —
+    /// there is no raw-store fallback path.
     ///
     /// `CredentialService` is non-generic — its backend is erased behind
     /// `DynCredentialStore` / `ErasedPendingStore` at construction (ADR-0088 D4),
@@ -270,9 +266,6 @@ pub struct AppState {
 
     /// Maps signed state -> pending token so callback can consume pending data.
     pub oauth_state_tokens: Arc<RwLock<HashMap<String, PendingToken>>>,
-
-    /// Credential state store used by OAuth callback completion.
-    pub oauth_credential_store: Arc<InMemoryStore>,
 
     /// Optional org-slug → [`OrgId`] resolver.
     pub org_resolver: Option<Arc<dyn OrgResolver>>,
@@ -468,7 +461,6 @@ impl AppState {
             webhook_transport: None,
             oauth_pending_store: Arc::new(InMemoryPendingStore::new()),
             oauth_state_tokens: Arc::new(RwLock::new(HashMap::new())),
-            oauth_credential_store: Arc::new(InMemoryStore::new()),
             org_resolver: None,
             workspace_resolver: None,
             auth_backend: None,
@@ -1040,13 +1032,10 @@ impl AppState {
         self
     }
 
-    /// Attach the `CredentialService` facade for credential CRUD.
-    ///
-    /// When set, the credential transport layer uses the service's
-    /// encryption+audit+cache store stack (erased behind `DynCredentialStore`)
-    /// instead of the raw `oauth_credential_store` wrapped by
-    /// `CredentialScopeLayer`. Tenant isolation is applied by the transport
-    /// layer via `credential_store_for_owner`.
+    /// Attach the `CredentialService` facade — the single credential
+    /// persistence path (CRUD, lifecycle, acquisition, and the OAuth
+    /// two-phase writes all route through it). Without it every
+    /// credential endpoint returns an honest 503.
     #[must_use = "builder methods must be chained or built"]
     pub fn with_credential_service(mut self, service: Arc<CredentialService>) -> Self {
         self.credential_service = Some(service);

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -14,7 +14,7 @@
 //! api layer never touches a raw store or re-implements validation.
 //!
 //! The OAuth2 two-phase flow (`domain::credential::oauth`) persists
-//! through [`scoped_store`] — a `CredentialScopeLayer` over the **same**
+//! through `scoped_store` — a `CredentialScopeLayer` over the **same**
 //! facade store handle ([`CredentialService::credential_store_handle`]) —
 //! so an OAuth-acquired credential is visible to `get`/`list` and there
 //! is no second store to drift from.

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -515,14 +515,27 @@ pub async fn refresh_credential(
 ) -> ApiResult<RefreshCredentialResponse> {
     let svc = service(state)?;
     let tenant = TenantScope::from_scope(scope);
-    let head = svc
+    let report = svc
         .refresh(&tenant, cred)
         .await
         .map_err(|e| map_service_err(e, cred))?;
-    Ok(RefreshCredentialResponse {
-        refreshed: true,
-        message: "credential refreshed".to_owned(),
-        new_expires_at: head.expires_at.map(|t| t.to_rfc3339()),
+    // The facade's fallback-on-interrupt serves the still-valid stored
+    // material when the provider failed transiently — honest reporting:
+    // that is NOT a refresh, and the old expiry is not a "new" one.
+    Ok(if report.refreshed {
+        RefreshCredentialResponse {
+            refreshed: true,
+            message: "credential refreshed".to_owned(),
+            new_expires_at: report.head.expires_at.map(|t| t.to_rfc3339()),
+        }
+    } else {
+        RefreshCredentialResponse {
+            refreshed: false,
+            message: "provider temporarily unavailable; refresh did not run — stored \
+                      credential material is still valid"
+                .to_owned(),
+            new_expires_at: None,
+        }
     })
 }
 

--- a/crates/api/src/transport/credential.rs
+++ b/crates/api/src/transport/credential.rs
@@ -3,97 +3,93 @@
 //! Each function takes an `AppState` reference plus domain-specific parameters
 //! and returns `ApiResult`.
 //!
-//! ## honest capability honesty split (Phase 4)
+//! ## One persistence path (ADR-0088 D7)
 //!
-//! The CRUD subset (`create` / `get` / `update` / `delete` / `list`)
-//! persists through `scoped_store` (crate-private): the raw
-//! `InMemoryStore` (`AppState::oauth_credential_store`) wrapped by
-//! `CredentialScopeLayer`, which stamps/checks the tenant owner on every
-//! call. The OAuth2 callback path writes through `scoped_store` the same
-//! way (no type dispatch).
+//! Every credential operation routes through the **`CredentialService`
+//! facade** (`AppState::credential_service`): CRUD (`create` / `get` /
+//! `update` / `delete` / `list`), lifecycle (`test` / `refresh` /
+//! `revoke`), and acquisition (`resolve` / `continue_resolve`). The facade
+//! owns the layered store (`Audit(Cache(Encryption(raw)))`), the typed
+//! validate→resolve pipeline, and the per-operation tenant check, so the
+//! api layer never touches a raw store or re-implements validation.
 //!
-//! The lifecycle / acquisition / type-discovery functions stay **honest
-//! 503** (`ApiError::ServiceUnavailable`): `test` / `refresh` / `revoke`
-//! / `resolve` / `continue_resolve` need a `CredentialRegistry` to
-//! dispatch a concrete `Credential` and an engine-owned resolver/refresh
-//! orchestrator (`nebula-engine::credential`, engine refresh orchestration — see
-//! `docs/MATURITY.md` "engine-owned `credential` runtime surface").
-//! Neither is wired into `AppState`, so faking success would be a
-//! honest capability false capability (the worst class for a credential surface).
+//! The OAuth2 two-phase flow (`domain::credential::oauth`) persists
+//! through [`scoped_store`] — a `CredentialScopeLayer` over the **same**
+//! facade store handle ([`CredentialService::credential_store_handle`]) —
+//! so an OAuth-acquired credential is visible to `get`/`list` and there
+//! is no second store to drift from.
 //!
-//! Note: the generic `resolve_credential` / `continue_resolve`
-//! functions are honest-503 at the function boundary, and their routes
-//! **reach the handler**: `crate::middleware::tenancy::resolve_path_ids`
-//! special-cases the literal `resolve` sub-route so it is not parsed as
-//! a `{cred}` `CredentialId` (an earlier route-shadow returned a flat
-//! 404 *before* the handler — fixed). A request to
-//! `…/credentials/resolve[/continue]` therefore surfaces this honest
-//! **503** (no false success — the caller cannot obtain a fake
-//! credential); the genuine `…/credentials/{cred}` position stays
-//! strictly ULID-validated. The honest-503 is pinned by the unit test
-//! below and the `credential_e2e` route-reachability regression guard.
+//! When no service is wired (`credential_service: None`) every credential
+//! operation returns an honest 503 (§4.5 operational honesty) — there is
+//! no raw-store fallback path.
 //!
-//! ## credential secrecy secret handling
+//! ## Credential secrecy
 //!
-//! - The credential `data` blob arrives **write-only**: it is wrapped in
-//!   [`nebula_credential::SecretString`] for its in-process lifetime and
-//!   persisted via the `serde_secret` (write-only; encrypted at rest
-//!   **only when an `EncryptionLayer` is composed** — not wired here)
-//!   path into the opaque [`StoredCredential::data`] byte buffer.
+//! - Request `data` is validated against the credential type's schema
+//!   (api-side [`CredentialSchemaPort`] pre-check for structured field
+//!   errors, then the facade's canonical pipeline) and resolved into
+//!   typed state that the facade encrypts at rest. The api never stores
+//!   or echoes the raw payload.
 //! - The wire response types ([`CredentialResponse`] /
-//!   [`CredentialSummary`]) are **metadata-only** — they have no `data`
-//!   field, so `get` / `list` cannot structurally echo the secret.
+//!   [`CredentialSummary`]) are projected from the secret-free
+//!   [`CredentialHead`] — they structurally cannot carry material.
 //! - Errors carry the credential id only; no secret reaches an
 //!   `ApiError` / `ProblemDetails`. Tracing spans log `cred.id` /
 //!   `cred.key` only.
 //!
-//! Durability is process-local (in-memory store) — encryption at rest
-//! arrives with the typed credential facade in a follow-up; see the
-//! credential durability note in `crates/api/README.md`.
-//!
 //! ## Workspace isolation
 //!
-//! Workspace handlers derive an owner id from the resolved tenant scope.
-//! `scoped_store`'s `CredentialScopeLayer` stamps `metadata["owner_id"]`
-//! on write and checks it on every read, update, and delete, so credential
-//! IDs remain non-dereferenceable across workspaces.
+//! Handlers derive a [`TenantScope`] from the resolved request scope via
+//! the single canonical derivation ([`TenantScope::from_scope`] →
+//! `Scope::credential_owner_id`, ADR-0088 D7). The facade enforces the
+//! owner check on every operation; cross-workspace ids collapse to a
+//! flat 404 with no existence disclosure.
+//!
+//! [`CredentialSchemaPort`]: crate::ports::credential_schema::CredentialSchemaPort
 
-use nebula_credential::{
-    CredentialStore, PutMode, ScopeResolver, SecretString, StoreError, StoredCredential,
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use nebula_credential::resolve::{InteractionRequest, UserInput};
+use nebula_credential::{CredentialDisplay, ErasedCredentialStore, ScopeResolver};
+use nebula_credential_runtime::{
+    Acquisition, CredentialHead, CredentialService, CredentialServiceError, TenantScope,
 };
-use nebula_storage::credential::InMemoryStore;
 use nebula_storage_port::Scope;
 use nebula_tenancy::CredentialScopeLayer;
-use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 
 use crate::{
     domain::credential::dto::{
-        ContinueResolveRequest, ContinueResolveResponse, CreateCredentialRequest,
-        CredentialCapabilities, CredentialResponse, CredentialSummary, CredentialTypeInfo,
-        ListCredentialTypesResponse, ListCredentialsQuery, ListCredentialsResponse,
-        RefreshCredentialResponse, ResolveCredentialRequest, ResolveCredentialResponse,
-        RevokeCredentialResponse, TestCredentialResponse, UpdateCredentialRequest,
+        AcquisitionInteraction, ContinueResolveRequest, ContinueResolveResponse,
+        CreateCredentialRequest, CredentialCapabilities, CredentialResponse, CredentialSummary,
+        CredentialTypeInfo, FormPostField, ListCredentialTypesResponse, ListCredentialsQuery,
+        ListCredentialsResponse, RefreshCredentialResponse, ResolveCredentialRequest,
+        ResolveCredentialResponse, RevokeCredentialResponse, TestCredentialResponse,
+        UpdateCredentialRequest,
     },
     error::{ApiError, ApiResult},
     state::AppState,
 };
 
-// ── Persisted record envelope ────────────────────────────────────────────────
+// ── Service access ───────────────────────────────────────────────────────────
 
-/// Non-secret display metadata persisted alongside the credential.
-///
-/// Stored in [`StoredCredential::metadata`] (the plain JSON map) — never
-/// secret. The secret `data` blob lives separately in
-/// [`StoredCredential::data`] wrapped by [`PersistedSecretData`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct CredentialMeta {
-    credential_key: String,
-    name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    description: Option<String>,
-    #[serde(default)]
-    tags: std::collections::HashMap<String, String>,
+const NO_CREDENTIAL_SERVICE: &str = "credential service not wired: the composition root did not provide a CredentialService \
+     (set NEBULA_CRED_MASTER_KEY and compose via try_default_credential_service)";
+
+/// The wired [`CredentialService`], or an honest 503 when the composition
+/// root provided none (§4.5 operational honesty — no raw-store fallback).
+fn service(state: &AppState) -> ApiResult<&Arc<CredentialService>> {
+    state
+        .credential_service
+        .as_ref()
+        .ok_or_else(|| ApiError::ServiceUnavailable(NO_CREDENTIAL_SERVICE.to_owned()))
+}
+
+/// Canonical owner key for a resolved request scope (ADR-0088 D7) —
+/// shared with the OAuth pending-state binding so both planes key the
+/// same tenant identically.
+pub(crate) fn owner_id_from_scope(scope: &Scope) -> String {
+    scope.credential_owner_id()
 }
 
 #[derive(Debug)]
@@ -105,77 +101,176 @@ impl ScopeResolver for RequestCredentialOwner {
     }
 }
 
-pub(crate) fn owner_id_from_scope(scope: &Scope) -> String {
-    // The single canonical derivation (ADR-0088 D7) — shared with the
-    // credential-runtime plane so both key the same tenant identically. Was a
-    // local `format!("{}:{}", …)` that drifted from the runtime's `/` form.
-    scope.credential_owner_id()
-}
-
-/// Legacy alias — `oauth.rs` still uses this directly until OAuth is
-/// migrated in a follow-up. Removed when Task 18 deletes `CredentialScopeLayer`.
+/// Owner-scoped raw access to the **facade's** layered store for the
+/// OAuth two-phase write path (`domain::credential::oauth`).
+///
+/// Wraps [`CredentialService::credential_store_handle`] — the same
+/// `Audit(Cache(Encryption(raw)))` stack the facade CRUD uses — in a
+/// `CredentialScopeLayer` that stamps/checks `metadata["owner_id"]` on
+/// every call. One store, two access styles: typed facade operations and
+/// the OAuth raw-state writes; both planes stamp the same canonical
+/// owner key, so OAuth-acquired rows are visible to `get`/`list`.
 pub(crate) fn scoped_store(
     state: &AppState,
     owner_id: &str,
-) -> CredentialScopeLayer<InMemoryStore> {
-    CredentialScopeLayer::new(
-        state.oauth_credential_store.as_ref().clone(),
+) -> ApiResult<CredentialScopeLayer<ErasedCredentialStore>> {
+    let svc = service(state)?;
+    Ok(CredentialScopeLayer::new(
+        ErasedCredentialStore::new(svc.credential_store_handle()),
         Arc::new(RequestCredentialOwner(owner_id.to_owned())),
-    )
+    ))
 }
 
-/// Envelope for the type-specific secret input blob.
+// ── Error mapping ────────────────────────────────────────────────────────────
+
+/// Map a [`CredentialServiceError`] onto a typed [`ApiError`].
 ///
-/// Wraps the serialized `data` JSON in [`SecretString`] so a stray
-/// `Debug` / default `Serialize` redacts. The on-disk form uses the
-/// `serde_secret` helper (write-only; encrypted at rest **only when an
-/// `EncryptionLayer` is composed** — not wired here, so the in-memory
-/// store keeps the raw bytes in plaintext-at-rest; see the operator
-/// warning in `crates/api/README.md`). Production deployments wrap the
-/// store with `nebula_storage`'s `EncryptionLayer` (storage credential layers).
-#[derive(Serialize, Deserialize)]
-struct PersistedSecretData {
-    #[serde(with = "nebula_credential::serde_secret")]
-    blob: SecretString,
-}
-
-impl std::fmt::Debug for PersistedSecretData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        // Defence-in-depth: even though `blob` is a `SecretString`
-        // (already redacted), spell the redaction out so a future field
-        // addition does not silently start leaking.
-        f.debug_struct("PersistedSecretData")
-            .field("blob", &"[REDACTED]")
-            .finish()
+/// Cross-workspace / unknown ids collapse to a flat `404` with **no
+/// existence disclosure**. Capability gaps are client errors (`400`),
+/// optimistic-concurrency failures are `409`, expired interactive tokens
+/// are `401`, provider/backend unavailability is `503`. The mapped
+/// strings never carry secret material — the facade's error reasons are
+/// value-free by contract (schema code/path only).
+fn map_service_err(err: CredentialServiceError, cred: &str) -> ApiError {
+    match err {
+        CredentialServiceError::NotFound { .. } => {
+            ApiError::NotFound("credential not found".to_owned())
+        },
+        CredentialServiceError::VersionConflict {
+            expected, actual, ..
+        } => ApiError::VersionMismatch(format!(
+            "credential {cred}: expected version {expected}, found {actual}"
+        )),
+        CredentialServiceError::ValidationFailed { reason } => ApiError::Validation {
+            detail: format!("credential properties rejected: {reason}"),
+            errors: vec![],
+        },
+        CredentialServiceError::TypeUnknown { key } => ApiError::Validation {
+            detail: format!("unknown credential type: {key}"),
+            errors: vec![],
+        },
+        CredentialServiceError::CapabilityUnsupported { capability, key } => ApiError::Validation {
+            detail: format!("credential type '{key}' does not support capability '{capability}'"),
+            errors: vec![],
+        },
+        CredentialServiceError::PendingExpired => ApiError::Unauthorized(
+            "pending acquisition token expired or already consumed".to_owned(),
+        ),
+        CredentialServiceError::TransientProvider(reason) => ApiError::ServiceUnavailable(format!(
+            "credential provider temporarily unavailable: {reason}"
+        )),
+        CredentialServiceError::Provider(reason) => {
+            ApiError::ServiceUnavailable(format!("credential provider error: {reason}"))
+        },
+        CredentialServiceError::ExternalSourceNotWired { provider } => {
+            ApiError::ServiceUnavailable(format!(
+                "external credential source '{provider}' is configured but not wired"
+            ))
+        },
+        CredentialServiceError::Store(reason) => {
+            ApiError::Internal(format!("credential store error: {reason}"))
+        },
+        // SessionRequired / ScopeViolation / Cancelled / CapabilityWithoutOps
+        // are composition or defence-in-depth faults the api wiring prevents
+        // (a session is always attached on the acquisition paths); surfacing
+        // one is an internal bug, never a client error. `#[non_exhaustive]`
+        // future variants land here too — fail closed, no secret echo.
+        other => ApiError::Internal(format!("credential runtime error: {other}")),
     }
 }
 
-const STATE_KIND: &str = "api_managed_credential";
-const STATE_VERSION: u32 = 1;
+// ── Response projection ──────────────────────────────────────────────────────
 
-/// Serialize `data` into the opaque secret byte buffer.
-///
-/// The plaintext JSON string is held only inside this function and
-/// dropped (zeroized via [`SecretString`]) before returning the bytes.
-fn encode_secret_data(data: &serde_json::Value) -> ApiResult<Vec<u8>> {
-    let plaintext = serde_json::to_string(data).map_err(|e| {
-        // No secret in the message — only the serde shape failure.
-        ApiError::Internal(format!("failed to encode credential data: {e}"))
-    })?;
-    let envelope = PersistedSecretData {
-        blob: SecretString::new(plaintext),
-    };
-    serde_json::to_vec(&envelope)
-        .map_err(|e| ApiError::Internal(format!("failed to encode credential envelope: {e}")))
+/// Type-level facts (auth pattern + capability flags) for a credential
+/// key, sourced from the schema port (the same registry the facade
+/// dispatches on, so the two cannot drift). Unknown keys fall back to
+/// the honest "custom / no declared capabilities" classification.
+fn type_facts(state: &AppState, credential_key: &str) -> (String, CredentialCapabilities) {
+    state
+        .credential_schema
+        .as_ref()
+        .and_then(|port| port.get_type(credential_key))
+        .map(|d| {
+            (
+                d.auth_pattern,
+                CredentialCapabilities {
+                    interactive: d.capabilities.interactive,
+                    refreshable: d.capabilities.refreshable,
+                    testable: d.capabilities.testable,
+                    revocable: d.capabilities.revocable,
+                },
+            )
+        })
+        .unwrap_or_else(|| {
+            (
+                "Custom".to_owned(),
+                CredentialCapabilities {
+                    interactive: false,
+                    refreshable: false,
+                    testable: false,
+                    revocable: false,
+                },
+            )
+        })
 }
+
+/// Project a secret-free [`CredentialHead`] into the full wire response.
+fn to_response(state: &AppState, head: CredentialHead) -> CredentialResponse {
+    let (auth_pattern, capabilities) = type_facts(state, &head.credential_key);
+    CredentialResponse {
+        id: head.id,
+        credential_key: head.credential_key,
+        name: head.display.display_name.unwrap_or_default(),
+        description: head.display.description,
+        auth_pattern,
+        capabilities,
+        created_at: head.created_at.to_rfc3339(),
+        updated_at: head.updated_at.to_rfc3339(),
+        expires_at: head.expires_at.map(|t| t.to_rfc3339()),
+        version: head.version,
+        reauth_required: head.reauth_required,
+        tags: head.display.tags.into_iter().collect(),
+    }
+}
+
+/// Project a secret-free [`CredentialHead`] into the list summary.
+fn to_summary(state: &AppState, head: CredentialHead) -> CredentialSummary {
+    let (auth_pattern, _) = type_facts(state, &head.credential_key);
+    CredentialSummary {
+        id: head.id,
+        credential_key: head.credential_key,
+        name: head.display.display_name.unwrap_or_default(),
+        auth_pattern,
+        expires_at: head.expires_at.map(|t| t.to_rfc3339()),
+        version: head.version,
+        reauth_required: head.reauth_required,
+    }
+}
+
+/// Build the per-instance display metadata from request fields.
+fn display_from_parts(
+    name: Option<String>,
+    description: Option<String>,
+    tags: Option<HashMap<String, String>>,
+) -> CredentialDisplay {
+    CredentialDisplay {
+        display_name: name,
+        description,
+        tags: tags.unwrap_or_default().into_iter().collect(),
+    }
+}
+
+// ── Request `data` pre-validation (api-side structured 400s) ────────────────
 
 /// Map a secret-safe [`CredentialFieldError`] list to the api-wide
 /// validation status (400 — `ApiError::Validation`, consistent with every
 /// other request-validation failure).
 ///
 /// `CredentialFieldError` carries only an RFC-6901 path, a validator code,
-/// and a static message — never the submitted value (credential redaction redaction;
-/// credential-schema validation). The mapping introduces no value either.
+/// and a static message — never the submitted value. The mapping
+/// introduces no value either.
+///
+/// [`CredentialFieldError`]: crate::ports::credential_schema::CredentialFieldError
 fn credential_validation_error(
     errs: Vec<crate::ports::credential_schema::CredentialFieldError>,
 ) -> ApiError {
@@ -193,14 +288,13 @@ fn credential_validation_error(
     }
 }
 
-/// credential-schema validation: validate credential `data` against the credential
-/// type's resolved schema **before persist**. Authority sits with the
-/// validator (invoked behind the [`CredentialSchemaPort`]). When no port
-/// is configured the request is rejected with 503 — credential `data` is
-/// **never** persisted unvalidated (closes the honest capability/§10 fail-open the
-/// handler docstring previously mis-claimed was closed).
-///
-/// [`CredentialSchemaPort`]: crate::ports::credential_schema::CredentialSchemaPort
+/// Validate credential `data` against the credential type's resolved
+/// schema **before** it reaches the facade. The facade re-validates
+/// through its canonical pipeline (authoritative); this api-side
+/// pre-check exists to return structured field errors (RFC-6901
+/// pointers) instead of the facade's flattened reason string. When no
+/// port is configured the request is rejected with 503 — credential
+/// `data` is **never** forwarded unvalidated (fail-closed).
 fn validate_credential_data(
     state: &AppState,
     credential_key: &str,
@@ -217,331 +311,150 @@ fn validate_credential_data(
     }
 }
 
-/// Classify the auth pattern + capability flags for a built-in
-/// credential key.
-///
-/// These are **type-level** facts about the built-in credential
-/// taxonomy (`nebula_credential::credentials`), not a runtime claim
-/// that the type works end-to-end. Unknown keys fall back to the
-/// honest "custom / no declared capabilities" classification rather
-/// than asserting a capability the engine cannot honor.
-fn classify(credential_key: &str) -> (&'static str, CredentialCapabilities) {
-    match credential_key {
-        "oauth2" => (
-            "OAuth2",
-            CredentialCapabilities {
-                interactive: true,
-                refreshable: true,
-                testable: false,
-                revocable: true,
-            },
-        ),
-        "api_key" => (
-            "SecretToken",
-            CredentialCapabilities {
-                interactive: false,
-                refreshable: false,
-                testable: false,
-                revocable: false,
-            },
-        ),
-        "basic_auth" => (
-            "IdentityPassword",
-            CredentialCapabilities {
-                interactive: false,
-                refreshable: false,
-                testable: false,
-                revocable: false,
-            },
-        ),
-        _ => (
-            "Custom",
-            CredentialCapabilities {
-                interactive: false,
-                refreshable: false,
-                testable: false,
-                revocable: false,
-            },
-        ),
-    }
-}
-
-/// Project a stored credential into the metadata-only wire response.
-///
-/// Secret-safe by construction: [`CredentialResponse`] has no `data`
-/// field, and this never touches [`StoredCredential::data`].
-fn to_response(stored: &StoredCredential) -> ApiResult<CredentialResponse> {
-    let meta: CredentialMeta =
-        serde_json::from_value(serde_json::Value::Object(stored.metadata.clone()))
-            .map_err(|e| ApiError::Internal(format!("corrupt credential metadata: {e}")))?;
-    let (auth_pattern, capabilities) = classify(&meta.credential_key);
-    Ok(CredentialResponse {
-        id: stored.id.clone(),
-        credential_key: meta.credential_key,
-        name: meta.name,
-        description: meta.description,
-        auth_pattern: auth_pattern.to_owned(),
-        capabilities,
-        created_at: stored.created_at.to_rfc3339(),
-        updated_at: stored.updated_at.to_rfc3339(),
-        expires_at: stored.expires_at.map(|t| t.to_rfc3339()),
-        version: stored.version,
-        tags: meta.tags,
-    })
-}
-
-/// Project a stored credential into the lightweight list summary.
-fn to_summary(stored: &StoredCredential) -> ApiResult<CredentialSummary> {
-    let meta: CredentialMeta =
-        serde_json::from_value(serde_json::Value::Object(stored.metadata.clone()))
-            .map_err(|e| ApiError::Internal(format!("corrupt credential metadata: {e}")))?;
-    let (auth_pattern, _) = classify(&meta.credential_key);
-    Ok(CredentialSummary {
-        id: stored.id.clone(),
-        credential_key: meta.credential_key,
-        name: meta.name,
-        auth_pattern: auth_pattern.to_owned(),
-        expires_at: stored.expires_at.map(|t| t.to_rfc3339()),
-        version: stored.version,
-    })
-}
-
-/// Map a store-layer error onto a typed [`ApiError`].
-///
-/// Cross-workspace / unknown ids collapse to `404` with **no existence
-/// disclosure** (mirrors the Phase-2 owner-scoped pattern). The error
-/// string never contains secret material or credential identifiers.
-fn map_store_err(err: StoreError, cred: &str) -> ApiError {
-    match err {
-        StoreError::NotFound { .. } => ApiError::NotFound("credential not found".to_owned()),
-        StoreError::AlreadyExists { .. } => {
-            ApiError::Conflict(format!("credential {cred} already exists"))
-        },
-        StoreError::VersionConflict {
-            expected, actual, ..
-        } => ApiError::VersionMismatch(format!(
-            "credential {cred}: expected version {expected}, found {actual}"
-        )),
-        StoreError::AuditFailure(reason) => {
-            ApiError::ServiceUnavailable(format!("credential audit sink unavailable: {reason}"))
-        },
-        StoreError::Backend(e) => {
-            ApiError::Internal(format!("credential store backend error: {e}"))
-        },
-        // `StoreError` is `#[non_exhaustive]`; an unforeseen future
-        // variant is an internal store fault — never echo a secret, and
-        // do not disclose existence beyond the (client-supplied) id.
-        _ => ApiError::Internal(format!("credential store error for {cred}")),
-    }
-}
-
-/// Fetch a credential, treating a cross-workspace / unknown id as a
-/// flat 404 (no existence disclosure, problem+json error seam / Phase-2 pattern).
-async fn load(state: &AppState, owner_id: &str, cred: &str) -> ApiResult<StoredCredential> {
-    scoped_store(state, owner_id)
-        .get(cred)
-        .await
-        .map_err(|e| map_store_err(e, cred))
-}
-
 // ── CRUD ────────────────────────────────────────────────────────────────────
 
 /// Create a new credential in the given workspace.
 ///
-/// Persists the type-specific `data` as a write-only secret blob and
-/// returns metadata only (never the secret).
+/// Routes through `CredentialService::create`: schema-validate, resolve
+/// to typed state, encrypt, persist scoped to the tenant. Returns
+/// metadata only (never the secret). Interactive types (e.g. `oauth2`)
+/// are not creatable here — they go through the acquisition or OAuth
+/// flow — and are refused with a 400.
 #[tracing::instrument(skip_all, fields(cred.key = %req.credential_key))]
 pub async fn create_credential(
     state: &AppState,
-    owner_id: &str,
+    scope: &Scope,
     req: CreateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
-    // credential-schema validation: validate `data` against the type's schema BEFORE
-    // any persist/encode. No port ⇒ 503 (never persist unvalidated).
+    // api-side pre-check for structured field errors; no port ⇒ 503
+    // (never forward unvalidated). The facade re-validates afterwards.
     validate_credential_data(state, &req.credential_key, &req.data)?;
 
-    let id = nebula_core::CredentialId::new().to_string();
-    let secret_bytes = encode_secret_data(&req.data)?;
-
-    let meta = CredentialMeta {
-        credential_key: req.credential_key.clone(),
-        name: req.name.clone(),
-        description: req.description.clone(),
-        tags: req.tags.clone().unwrap_or_default(),
-    };
-    let metadata = match serde_json::to_value(&meta) {
-        Ok(serde_json::Value::Object(m)) => m,
-        Ok(_) | Err(_) => {
-            return Err(ApiError::Internal(
-                "failed to encode credential metadata".to_owned(),
-            ));
-        },
-    };
-
-    let now = chrono::Utc::now();
-    let stored = StoredCredential {
-        id: id.clone(),
-        credential_key: req.credential_key,
-        data: secret_bytes,
-        state_kind: STATE_KIND.to_owned(),
-        state_version: STATE_VERSION,
-        version: 0,
-        created_at: now,
-        updated_at: now,
-        expires_at: None,
-        reauth_required: false,
-        metadata,
-    };
-
-    let persisted = scoped_store(state, owner_id)
-        .put(stored, PutMode::CreateOnly)
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    let display = display_from_parts(Some(req.name), req.description, req.tags);
+    let head = svc
+        .create(&tenant, &req.credential_key, req.data, display)
         .await
-        .map_err(|e| map_store_err(e, &id))?;
+        .map_err(|e| map_service_err(e, "<create>"))?;
 
-    tracing::info!(cred.id = %persisted.id, "credential created");
-    to_response(&persisted)
+    tracing::info!(cred.id = %head.id, "credential created");
+    Ok(to_response(state, head))
 }
 
 /// Retrieve a single credential by ID within a workspace.
 ///
-/// Returns metadata only — the secret `data` blob is never read here
-/// and the response type has no field for it.
+/// Returns metadata only — the facade head never carries state bytes,
+/// so the response structurally cannot echo the secret.
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn get_credential(
     state: &AppState,
-    owner_id: &str,
+    scope: &Scope,
     cred: &str,
 ) -> ApiResult<CredentialResponse> {
-    let stored = load(state, owner_id, cred).await?;
-    to_response(&stored)
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    let head = svc
+        .get(&tenant, cred)
+        .await
+        .map_err(|e| map_service_err(e, cred))?;
+    Ok(to_response(state, head))
 }
 
 /// Update an existing credential in the workspace.
 ///
 /// Partial update: only provided fields change. A provided `version`
 /// engages compare-and-swap (409 on mismatch). A provided `data`
-/// re-encodes the write-only secret blob.
+/// re-runs the typed validate→resolve pipeline for the (unchanged)
+/// credential type; a metadata-only update never re-resolves or
+/// re-encrypts state.
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn update_credential(
     state: &AppState,
-    owner_id: &str,
+    scope: &Scope,
     cred: &str,
     req: UpdateCredentialRequest,
 ) -> ApiResult<CredentialResponse> {
-    let existing = load(state, owner_id, cred).await?;
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
 
-    let mut meta: CredentialMeta =
-        serde_json::from_value(serde_json::Value::Object(existing.metadata.clone()))
-            .map_err(|e| ApiError::Internal(format!("corrupt credential metadata: {e}")))?;
+    // Merge semantics: only provided display fields change. Read the
+    // current head (owner-checked) and overlay. The read-modify-write
+    // window on display is closed by the CAS version when supplied.
+    let existing = svc
+        .get(&tenant, cred)
+        .await
+        .map_err(|e| map_service_err(e, cred))?;
+
+    if let Some(ref data) = req.data {
+        validate_credential_data(state, &existing.credential_key, data)?;
+    }
+
+    let mut display = existing.display;
     if let Some(name) = req.name {
-        meta.name = name;
+        display.display_name = Some(name);
     }
     if req.description.is_some() {
-        meta.description = req.description;
+        display.description = req.description;
     }
     if let Some(tags) = req.tags {
-        meta.tags = tags;
+        display.tags = tags.into_iter().collect();
     }
-    let metadata = match serde_json::to_value(&meta) {
-        Ok(serde_json::Value::Object(m)) => m,
-        Ok(_) | Err(_) => {
-            return Err(ApiError::Internal(
-                "failed to encode credential metadata".to_owned(),
-            ));
-        },
-    };
 
-    // Re-encode the secret only when the caller supplied new data;
-    // otherwise carry the existing opaque blob through untouched.
-    // credential-schema validation: when new `data` is supplied, validate it against
-    // the (unchanged) credential type's schema before re-encode/persist.
-    let data = match req.data.as_ref() {
-        Some(value) => {
-            validate_credential_data(state, &existing.credential_key, value)?;
-            encode_secret_data(value)?
-        },
-        None => existing.data.clone(),
-    };
-
-    let mode = match req.version {
-        Some(expected_version) => PutMode::CompareAndSwap { expected_version },
-        None => PutMode::Overwrite,
-    };
-
-    let updated = StoredCredential {
-        id: existing.id.clone(),
-        credential_key: existing.credential_key.clone(),
-        data,
-        state_kind: existing.state_kind.clone(),
-        state_version: existing.state_version,
-        version: existing.version,
-        created_at: existing.created_at,
-        updated_at: chrono::Utc::now(),
-        expires_at: existing.expires_at,
-        reauth_required: existing.reauth_required,
-        metadata,
-    };
-
-    let persisted = scoped_store(state, owner_id)
-        .put(updated, mode)
+    let head = svc
+        .update(&tenant, cred, req.data, req.version, display)
         .await
-        .map_err(|e| map_store_err(e, cred))?;
+        .map_err(|e| map_service_err(e, cred))?;
 
-    tracing::info!(cred.id = %persisted.id, "credential updated");
-    to_response(&persisted)
+    tracing::info!(cred.id = %head.id, "credential updated");
+    Ok(to_response(state, head))
 }
 
 /// Delete a credential from the workspace.
 #[tracing::instrument(skip_all, fields(cred.id = %cred))]
-pub async fn delete_credential(state: &AppState, owner_id: &str, cred: &str) -> ApiResult<()> {
-    scoped_store(state, owner_id)
-        .delete(cred)
+pub async fn delete_credential(state: &AppState, scope: &Scope, cred: &str) -> ApiResult<()> {
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    svc.delete(&tenant, cred)
         .await
-        .map_err(|e| map_store_err(e, cred))?;
+        .map_err(|e| map_service_err(e, cred))?;
     tracing::info!(cred.id = %cred, "credential deleted");
     Ok(())
 }
 
 /// List credentials in the workspace with optional filters.
 ///
-/// Returns paginated metadata summaries (no secret material).
+/// Returns paginated metadata summaries (no secret material). Rows
+/// acquired through the OAuth flow share the facade store, so they
+/// appear here too — a row awaiting authorization is flagged
+/// `reauth_required`.
 #[tracing::instrument(skip_all)]
 pub async fn list_credentials(
     state: &AppState,
-    owner_id: &str,
+    scope: &Scope,
     query: ListCredentialsQuery,
 ) -> ApiResult<ListCredentialsResponse> {
-    // Push the `state_kind` filter into the store: only rows this layer
-    // manages (`STATE_KIND`) come back, so the OAuth-callback rows (a
-    // different `state_kind` + non-`CredentialMeta` metadata shape) are
-    // excluded at the source rather than fetched-then-discarded — no
-    // wasted `get` + projection, and no metadata-shape 500 risk.
-    let store = scoped_store(state, owner_id);
-    let ids = store
-        .list(Some(STATE_KIND))
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    let heads = svc
+        .list(&tenant)
         .await
-        .map_err(|e| map_store_err(e, "<list>"))?;
+        .map_err(|e| map_service_err(e, "<list>"))?;
 
-    let mut summaries: Vec<CredentialSummary> = Vec::new();
-    for id in ids {
-        // A row may vanish between `list` and `get` (concurrent delete);
-        // skip it rather than failing the whole page.
-        let Ok(stored) = store.get(&id).await else {
-            continue;
-        };
-        let summary = to_summary(&stored)?;
-        if let Some(ref key) = query.credential_key
-            && &summary.credential_key != key
-        {
-            continue;
-        }
-        if let Some(ref pattern) = query.auth_pattern
-            && &summary.auth_pattern != pattern
-        {
-            continue;
-        }
-        summaries.push(summary);
-    }
+    let mut summaries: Vec<CredentialSummary> = heads
+        .into_iter()
+        .map(|head| to_summary(state, head))
+        .filter(|s| {
+            query
+                .credential_key
+                .as_ref()
+                .is_none_or(|k| &s.credential_key == k)
+                && query
+                    .auth_pattern
+                    .as_ref()
+                    .is_none_or(|p| &s.auth_pattern == p)
+        })
+        .collect();
 
     summaries.sort_by(|a, b| a.id.cmp(&b.id));
     let total = summaries.len();
@@ -557,130 +470,198 @@ pub async fn list_credentials(
     })
 }
 
-// ── Lifecycle (honest 503 — engine-owned, no registry wired) ─────────────────
+// ── Lifecycle (test / refresh / revoke) ──────────────────────────────────────
 
 /// Test credential connectivity against the external system.
 ///
-/// **Honest 503.** A real test requires dispatching the registered
-/// `Credential`'s `Testable::test` (an outbound provider call). No
-/// `CredentialRegistry` is wired into `AppState`, and test dispatch is
-/// engine-owned (`nebula-engine::credential`, engine credential orchestration — see
-/// `docs/MATURITY.md`). A "test" that does not contact the provider
-/// would be a honest capability false capability.
+/// Dispatches the registered type's `Testable::test` through the facade.
+/// A type without the capability is refused with 400 before any decrypt.
+#[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn test_credential(
-    _state: &AppState,
-    _org: &str,
-    _ws: &str,
-    _cred: &str,
+    state: &AppState,
+    scope: &Scope,
+    cred: &str,
 ) -> ApiResult<TestCredentialResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "credential test is engine-owned (Testable::test dispatch via \
-         nebula-engine::credential) and not wired into this API build — \
-         no CredentialRegistry in AppState"
-            .into(),
-    ))
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    let report = svc
+        .test(&tenant, cred)
+        .await
+        .map_err(|e| map_service_err(e, cred))?;
+    Ok(TestCredentialResponse {
+        success: report.ok,
+        message: report.message.unwrap_or_else(|| {
+            if report.ok {
+                "credential accepted by provider".to_owned()
+            } else {
+                "credential rejected by provider".to_owned()
+            }
+        }),
+        tested_at: chrono::Utc::now().to_rfc3339(),
+    })
 }
 
 /// Force a token refresh for the credential.
 ///
-/// **Honest 503.** Refresh orchestration is engine-owned (engine credential orchestration /
-/// refresh coordinator; the L2 refresh coordinator lives in
-/// `nebula-engine::credential::refresh`). The API does not own a
-/// refresh path end-to-end, so this stays honest rather than faking a
-/// successful refresh.
+/// Dispatches the registered type's `Refreshable::refresh` through the
+/// facade (retry + cross-replica coalescing + CAS re-persist). On a
+/// transient provider failure with still-valid stored material the
+/// facade returns the cached state instead of failing the call.
+#[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn refresh_credential(
-    _state: &AppState,
-    _org: &str,
-    _ws: &str,
-    _cred: &str,
+    state: &AppState,
+    scope: &Scope,
+    cred: &str,
 ) -> ApiResult<RefreshCredentialResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "credential refresh is engine-owned (RefreshCoordinator in \
-         nebula-engine::credential, engine refresh orchestration) and not exposed \
-         through this API build"
-            .into(),
-    ))
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    let head = svc
+        .refresh(&tenant, cred)
+        .await
+        .map_err(|e| map_service_err(e, cred))?;
+    Ok(RefreshCredentialResponse {
+        refreshed: true,
+        message: "credential refreshed".to_owned(),
+        new_expires_at: head.expires_at.map(|t| t.to_rfc3339()),
+    })
 }
 
-/// Explicitly revoke the credential at the provider.
-///
-/// **Honest 503.** Revocation requires dispatching the registered
-/// `Credential`'s `Revocable::revoke` (a provider call). No registry is
-/// wired and dispatch is engine-owned.
+/// Explicitly revoke the credential at the provider and delete the row.
+#[tracing::instrument(skip_all, fields(cred.id = %cred))]
 pub async fn revoke_credential(
-    _state: &AppState,
-    _org: &str,
-    _ws: &str,
-    _cred: &str,
+    state: &AppState,
+    scope: &Scope,
+    cred: &str,
 ) -> ApiResult<RevokeCredentialResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "credential revoke is engine-owned (Revocable::revoke dispatch \
-         via nebula-engine::credential) and not wired into this API \
-         build — no CredentialRegistry in AppState"
-            .into(),
-    ))
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope);
+    svc.revoke(&tenant, cred)
+        .await
+        .map_err(|e| map_service_err(e, cred))?;
+    Ok(RevokeCredentialResponse {
+        revoked: true,
+        message: "credential revoked at the provider and removed".to_owned(),
+    })
 }
 
-// ── Acquisition (honest 503 — engine-owned resolver, no registry wired) ──────
+// ── Acquisition (resolve / continue) ─────────────────────────────────────────
+
+/// Map the facade's [`InteractionRequest`] onto the wire DTO.
+///
+/// `InteractionRequest` is `#[non_exhaustive]`; an unrecognized future
+/// arm is an internal composition gap (the api cannot instruct a UI it
+/// does not understand), surfaced as 500 — never a fake interaction.
+fn map_interaction(interaction: InteractionRequest) -> ApiResult<AcquisitionInteraction> {
+    match interaction {
+        InteractionRequest::Redirect { url } => Ok(AcquisitionInteraction::Redirect { url }),
+        InteractionRequest::FormPost { url, fields } => Ok(AcquisitionInteraction::FormPost {
+            url,
+            fields: fields
+                .into_iter()
+                .map(|(name, value)| FormPostField { name, value })
+                .collect(),
+        }),
+        InteractionRequest::DisplayInfo {
+            title,
+            message,
+            data,
+            expires_in,
+        } => Ok(AcquisitionInteraction::DisplayInfo {
+            title,
+            message,
+            data: serde_json::to_value(&data).map_err(|e| {
+                ApiError::Internal(format!("failed to encode interaction display data: {e}"))
+            })?,
+            expires_in,
+        }),
+        other => Err(ApiError::Internal(format!(
+            "unsupported credential interaction kind: {other:?}"
+        ))),
+    }
+}
+
+/// Map a facade [`Acquisition`] outcome onto the wire response.
+fn map_acquisition(acq: Acquisition) -> ApiResult<ResolveCredentialResponse> {
+    match acq {
+        Acquisition::Complete { head } => Ok(ResolveCredentialResponse::Complete {
+            credential_id: head.id,
+        }),
+        Acquisition::Pending { token, interaction } => Ok(ResolveCredentialResponse::Pending {
+            pending_token: token,
+            interaction: map_interaction(interaction)?,
+        }),
+        Acquisition::Retry { after } => Ok(ResolveCredentialResponse::Retry {
+            retry_after_secs: after.as_secs(),
+        }),
+        other => Err(ApiError::Internal(format!(
+            "unrecognized credential acquisition outcome: {other:?}"
+        ))),
+    }
+}
 
 /// Start credential acquisition / resolution.
 ///
-/// **Honest 503.** Generic resolve dispatches a registered
-/// `Credential::resolve()` by key — there is no `CredentialRegistry` in
-/// `AppState`, and credential runtime resolution is engine-owned
-/// (`nebula-engine::credential`, MATURITY P8). The interactive OAuth2
-/// pending-exchange path that *is* wired is reached through the
-/// dedicated `/credentials/{id}/oauth2/auth` controller, not this
-/// generic endpoint.
+/// Static types complete synchronously (`complete` + persisted id);
+/// interactive types return `pending` with the next UI interaction. The
+/// pending token is bound to `(kind, owner, session, token)` — the
+/// caller's user id is the session, so only the same user can continue.
+#[tracing::instrument(skip_all, fields(cred.key = %req.credential_key))]
 pub async fn resolve_credential(
-    _state: &AppState,
-    _org: &str,
-    _ws: &str,
-    _req: ResolveCredentialRequest,
+    state: &AppState,
+    scope: &Scope,
+    user_id: &str,
+    req: ResolveCredentialRequest,
 ) -> ApiResult<ResolveCredentialResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "generic credential resolve is engine-owned (Credential::resolve \
-         dispatch via nebula-engine::credential, P8) and needs a \
-         CredentialRegistry that is not wired into this API build; the \
-         interactive OAuth2 path is served by /credentials/{id}/oauth2/auth"
-            .into(),
-    ))
+    validate_credential_data(state, &req.credential_key, &req.data)?;
+
+    let svc = service(state)?;
+    let tenant = TenantScope::from_scope(scope).with_session(user_id);
+    let acq = svc
+        .resolve(&tenant, &req.credential_key, req.data)
+        .await
+        .map_err(|e| map_service_err(e, "<resolve>"))?;
+    map_acquisition(acq)
 }
 
 /// Continue a multi-step credential acquisition.
 ///
-/// **Honest 503.** Symmetric to [`resolve_credential`] — needs a
-/// registry + `Interactive::continue_resolve` dispatch (engine-owned).
-/// The wired pending-exchange path is the OAuth2 callback controller,
-/// not this generic endpoint.
+/// `user_input` is the typed continuation payload (the serialized
+/// [`UserInput`] shape: `"Poll"`, `{"Code":{"code":".."}}`,
+/// `{"Callback":{"params":{..}}}`, `{"FormData":{"params":{..}}}`).
+#[tracing::instrument(skip_all, fields(cred.key = %req.credential_key))]
 pub async fn continue_resolve(
-    _state: &AppState,
-    _org: &str,
-    _ws: &str,
-    _req: ContinueResolveRequest,
+    state: &AppState,
+    scope: &Scope,
+    user_id: &str,
+    req: ContinueResolveRequest,
 ) -> ApiResult<ContinueResolveResponse> {
-    Err(ApiError::ServiceUnavailable(
-        "generic credential continue_resolve is engine-owned \
-         (Interactive::continue_resolve dispatch via \
-         nebula-engine::credential) and not wired into this API build; \
-         the interactive OAuth2 path is served by \
-         /credentials/{id}/oauth2/callback"
-            .into(),
-    ))
+    let svc = service(state)?;
+    let user_input: UserInput = serde_json::from_value(req.user_input).map_err(|_| {
+        // The serde error text can echo the (potentially secret) payload —
+        // deliberately omitted.
+        ApiError::Validation {
+            detail: "user_input is not a recognized continuation payload \
+                     (expected Poll / Code / Callback / FormData)"
+                .to_owned(),
+            errors: vec![],
+        }
+    })?;
+    let tenant = TenantScope::from_scope(scope).with_session(user_id);
+    let acq = svc
+        .continue_resolve(&tenant, &req.credential_key, &req.pending_token, user_input)
+        .await
+        .map_err(|e| map_service_err(e, "<continue>"))?;
+    map_acquisition(acq)
 }
 
-// ── Type discovery (honest 503 — no CredentialRegistry wired) ────────────────
+// ── Type discovery (schema port) ─────────────────────────────────────────────
 
-/// List all registered credential types with their schemas and capabilities.
-///
-/// **Honest 503.** Enumerating registered types + their schemas
-/// requires a `CredentialRegistry`; none is wired into `AppState`.
-/// Returning a hand-rolled catalog would misrepresent what is actually
-/// registered (honest capability).
 /// Map a port [`CredentialTypeDescriptor`] to the wire DTO, applying the
-/// api-owned public projection to the schema (credential-schema port + #6 — the
-/// raw `json_schema()` export's `x-nebula-root-rules` / predicate operands
-/// are stripped before the unauthenticated wire).
+/// api-owned public projection to the schema (the raw `json_schema()`
+/// export's `x-nebula-root-rules` / predicate operands are stripped
+/// before the unauthenticated wire).
+///
+/// [`CredentialTypeDescriptor`]: crate::ports::credential_schema::CredentialTypeDescriptor
 fn credential_type_info_from_descriptor(
     d: crate::ports::credential_schema::CredentialTypeDescriptor,
 ) -> CredentialTypeInfo {
@@ -704,8 +685,8 @@ fn credential_type_info_from_descriptor(
 const NO_CRED_SCHEMA_PORT: &str =
     "credential type discovery unavailable: no credential-schema port configured";
 
-/// credential-schema port: list registered credential types with their
-/// public-projected input schema. No port ⇒ honest 503 (honest capability).
+/// List registered credential types with their public-projected input
+/// schema. No port ⇒ honest 503.
 pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredentialTypesResponse> {
     let port = state
         .credential_schema
@@ -719,10 +700,10 @@ pub async fn list_credential_types(state: &AppState) -> ApiResult<ListCredential
     Ok(ListCredentialTypesResponse { types })
 }
 
-/// credential-schema port: one credential type by key. No port ⇒ honest 503;
-/// unknown key ⇒ 404 (credential *types* are public catalog info, so
-/// non-existence disclosure is non-sensitive — unlike credential
-/// *instances*, which are flat-404 per IDOR rules).
+/// One credential type by key. No port ⇒ honest 503; unknown key ⇒ 404
+/// (credential *types* are public catalog info, so non-existence
+/// disclosure is non-sensitive — unlike credential *instances*, which
+/// are flat-404 per IDOR rules).
 pub async fn get_credential_type(state: &AppState, key: &str) -> ApiResult<CredentialTypeInfo> {
     let port = state
         .credential_schema
@@ -738,40 +719,17 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+    use nebula_storage::credential::EnvKeyProvider;
     use nebula_storage::inmem::{
         InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
         InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
     };
 
-    /// Permissive port so the CRUD/secret-projection unit tests still
-    /// exercise persistence after credential-schema validation closed the
-    /// unvalidated-persist fail-open (the no-port → 503 behavior is
-    /// covered by `tests/seam_credential_write_path_validation.rs`).
-    struct PermissivePort;
-    impl crate::ports::credential_schema::CredentialSchemaPort for PermissivePort {
-        fn validate_data(
-            &self,
-            _k: &str,
-            _d: &serde_json::Value,
-        ) -> Result<(), Vec<crate::ports::credential_schema::CredentialFieldError>> {
-            Ok(())
-        }
-        fn list_types(&self) -> Vec<crate::ports::credential_schema::CredentialTypeDescriptor> {
-            Vec::new()
-        }
-        fn get_type(
-            &self,
-            _k: &str,
-        ) -> Option<crate::ports::credential_schema::CredentialTypeDescriptor> {
-            None
-        }
-    }
+    /// 32 `0x42` bytes, base64 — a valid AES-256 key fixture (mirrors the
+    /// factory's dev key). Not a secret: a fixed test constant.
+    const TEST_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
 
-    fn test_state() -> AppState {
-        // Fresh raw (undecorated) in-memory port adapters — the production
-        // composition shape post-decorator-removal. These tests only
-        // exercise the credential write path, never storage rows; the
-        // per-request tenant scope is applied by the `AppState` accessors.
+    fn base_state() -> AppState {
         let exec_store = InMemoryExecutionStore::new();
         let control_queue = InMemoryControlQueue::new(&exec_store);
         let journal = InMemoryJournalReader::new(&exec_store);
@@ -787,97 +745,101 @@ mod tests {
             Arc::new(control_queue),
             jwt,
         )
-        .with_credential_schema(Arc::new(PermissivePort))
     }
 
-    /// The blob round-trips through `serde_secret`, and the redaction
-    /// envelope's `Debug` never spells the plaintext (credential secrecy).
-    #[test]
-    fn secret_data_envelope_redacts_and_round_trips() {
-        let secret = "sk-unit-NEVER-LEAK-9f9f";
-        let data = serde_json::json!({ "api_key": secret });
-        let bytes = encode_secret_data(&data).expect("encode");
-
-        // The persisted bytes DO carry the secret (write-only; at-rest
-        // encryption requires an `EncryptionLayer`, not wired here —
-        // see the operator warning in README.md). What must never leak
-        // is Debug / default Serialize of the envelope.
-        let env: PersistedSecretData = serde_json::from_slice(&bytes).expect("decode");
-        assert!(
-            !format!("{env:?}").contains(secret),
-            "PersistedSecretData Debug must not spell the secret"
-        );
-        // Default `Serialize` of the inner SecretString redacts.
-        let redacted = serde_json::to_string(&env.blob).expect("serialize");
-        assert!(
-            !redacted.contains(secret),
-            "default SecretString Serialize must redact"
-        );
-        assert_eq!(redacted, "\"[REDACTED]\"");
+    /// State with the real registry-backed schema port AND a composed
+    /// `CredentialService` — the production shape.
+    fn test_state() -> AppState {
+        let port = crate::ports::credential_schema_registry::try_default_registry_port()
+            .expect("first-party registry composes");
+        let key =
+            Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+        let svc = crate::ports::credential_service_factory::with_key_provider(key)
+            .expect("service composes");
+        base_state()
+            .with_credential_schema(port)
+            .with_credential_service(svc)
     }
 
-    /// honest capability: the engine-owned / registry-absent functions return a
-    /// typed honest 503 — never a faked success — even at the function
-    /// boundary (independent of route shadowing).
+    fn test_scope() -> Scope {
+        Scope::new("w", "o")
+    }
+
+    /// §4.5 operational honesty: with no `CredentialService` wired, every
+    /// credential operation refuses with a typed 503 — never a faked
+    /// success, and no raw-store fallback path exists.
     #[tokio::test]
-    async fn engine_owned_fns_are_honest_503() {
-        let s = test_state();
+    async fn all_credential_fns_are_503_without_service() {
+        let s = base_state();
+        let scope = test_scope();
         assert!(matches!(
-            test_credential(&s, "o", "w", "cred_x").await,
+            get_credential(&s, &scope, "cred_x").await,
             Err(ApiError::ServiceUnavailable(_))
         ));
         assert!(matches!(
-            refresh_credential(&s, "o", "w", "cred_x").await,
+            delete_credential(&s, &scope, "cred_x").await,
             Err(ApiError::ServiceUnavailable(_))
         ));
         assert!(matches!(
-            revoke_credential(&s, "o", "w", "cred_x").await,
-            Err(ApiError::ServiceUnavailable(_))
-        ));
-        assert!(matches!(
-            resolve_credential(
+            list_credentials(
                 &s,
-                "o",
-                "w",
-                ResolveCredentialRequest {
+                &scope,
+                ListCredentialsQuery {
+                    page: 1,
+                    page_size: 20,
+                    credential_key: None,
+                    auth_pattern: None,
+                }
+            )
+            .await,
+            Err(ApiError::ServiceUnavailable(_))
+        ));
+        assert!(matches!(
+            test_credential(&s, &scope, "cred_x").await,
+            Err(ApiError::ServiceUnavailable(_))
+        ));
+        assert!(matches!(
+            refresh_credential(&s, &scope, "cred_x").await,
+            Err(ApiError::ServiceUnavailable(_))
+        ));
+        assert!(matches!(
+            revoke_credential(&s, &scope, "cred_x").await,
+            Err(ApiError::ServiceUnavailable(_))
+        ));
+        // create/resolve hit the schema-port gate first (also absent here)
+        // — still a 503, never a persist.
+        assert!(matches!(
+            create_credential(
+                &s,
+                &scope,
+                CreateCredentialRequest {
                     credential_key: "api_key".into(),
-                    data: serde_json::json!({}),
+                    name: "n".into(),
+                    description: None,
+                    data: serde_json::json!({ "api_key": "k" }),
+                    tags: None,
                 }
             )
             .await,
             Err(ApiError::ServiceUnavailable(_))
         ));
         assert!(matches!(
-            continue_resolve(
-                &s,
-                "o",
-                "w",
-                ContinueResolveRequest {
-                    pending_token: "t".into(),
-                    user_input: serde_json::json!({}),
-                }
-            )
-            .await,
+            scoped_store(&s, "o:w"),
             Err(ApiError::ServiceUnavailable(_))
         ));
-        // credential-schema port: `list_credential_types`/`get_credential_type`
-        // are no longer engine-owned-503 — they are port-backed (a
-        // permissive port is wired in `test_state()`). Their no-port → 503
-        // behavior is covered by
-        // `tests/seam_credential_catalog_schema.rs::catalog_503_when_port_unconfigured`.
     }
 
-    /// CRUD over the wired in-memory store: create → get → list →
-    /// delete, asserting the response projection never carries `data`
-    /// and the secret never appears in any returned struct.
+    /// CRUD through the facade: create → get → list → update (rename via
+    /// CAS) → delete; the response projection never carries `data` and
+    /// the secret never appears in any returned struct.
     #[tokio::test]
     async fn crud_round_trips_without_secret_in_projection() {
         let s = test_state();
-        let owner_id = "o:w";
+        let scope = test_scope();
         let secret = "sk-unit-crud-NEVER-LEAK-7a7a";
         let created = create_credential(
             &s,
-            owner_id,
+            &scope,
             CreateCredentialRequest {
                 credential_key: "api_key".into(),
                 name: "Unit Key".into(),
@@ -890,21 +852,22 @@ mod tests {
         .expect("create");
         assert!(created.id.starts_with("cred_"));
         assert_eq!(created.version, 1);
+        assert_eq!(created.name, "Unit Key");
+        assert_eq!(created.auth_pattern, "SecretToken");
+        assert!(!created.reauth_required);
         let dbg = format!("{created:?}");
         assert!(
             !dbg.contains(secret),
             "CredentialResponse Debug must not carry the secret: {dbg}"
         );
 
-        let got = get_credential(&s, owner_id, &created.id)
-            .await
-            .expect("get");
+        let got = get_credential(&s, &scope, &created.id).await.expect("get");
         assert_eq!(got.id, created.id);
         assert!(!format!("{got:?}").contains(secret));
 
         let listed = list_credentials(
             &s,
-            owner_id,
+            &scope,
             ListCredentialsQuery {
                 page: 1,
                 page_size: 20,
@@ -917,12 +880,182 @@ mod tests {
         assert_eq!(listed.total, 1);
         assert!(!format!("{listed:?}").contains(secret));
 
-        delete_credential(&s, owner_id, &created.id)
+        // Metadata-only rename via CAS on the returned version; the
+        // secret state is untouched and the description survives.
+        let renamed = update_credential(
+            &s,
+            &scope,
+            &created.id,
+            UpdateCredentialRequest {
+                name: Some("Renamed Key".into()),
+                description: None,
+                data: None,
+                tags: None,
+                version: Some(created.version),
+            },
+        )
+        .await
+        .expect("rename");
+        assert_eq!(renamed.name, "Renamed Key");
+        assert_eq!(renamed.description.as_deref(), Some("d"));
+        assert!(renamed.version > created.version);
+
+        delete_credential(&s, &scope, &created.id)
             .await
             .expect("delete");
         assert!(matches!(
-            get_credential(&s, owner_id, &created.id).await,
+            get_credential(&s, &scope, &created.id).await,
             Err(ApiError::NotFound(_))
+        ));
+    }
+
+    /// Lifecycle ops on a static type are a client error (400), sourced
+    /// from the facade's capability gate — not a 503 and not a fake
+    /// success.
+    #[tokio::test]
+    async fn lifecycle_on_static_type_is_validation_error() {
+        let s = test_state();
+        let scope = test_scope();
+        let created = create_credential(
+            &s,
+            &scope,
+            CreateCredentialRequest {
+                credential_key: "api_key".into(),
+                name: "k".into(),
+                description: None,
+                data: serde_json::json!({ "api_key": "v" }),
+                tags: None,
+            },
+        )
+        .await
+        .expect("create");
+
+        assert!(matches!(
+            test_credential(&s, &scope, &created.id).await,
+            Err(ApiError::Validation { .. })
+        ));
+        assert!(matches!(
+            refresh_credential(&s, &scope, &created.id).await,
+            Err(ApiError::Validation { .. })
+        ));
+        assert!(matches!(
+            revoke_credential(&s, &scope, &created.id).await,
+            Err(ApiError::Validation { .. })
+        ));
+    }
+
+    /// Generic resolve completes synchronously for a static type and the
+    /// persisted credential is visible to the CRUD plane (one store).
+    #[tokio::test]
+    async fn resolve_complete_persists_and_is_visible_to_crud() {
+        let s = test_state();
+        let scope = test_scope();
+        let res = resolve_credential(
+            &s,
+            &scope,
+            "user-1",
+            ResolveCredentialRequest {
+                credential_key: "api_key".into(),
+                data: serde_json::json!({ "api_key": "k-resolved" }),
+            },
+        )
+        .await
+        .expect("resolve");
+        let ResolveCredentialResponse::Complete { credential_id } = res else {
+            panic!("expected Complete for a static type, got {res:?}");
+        };
+        let got = get_credential(&s, &scope, &credential_id)
+            .await
+            .expect("resolved credential is gettable");
+        assert_eq!(got.credential_key, "api_key");
+    }
+
+    /// Cross-workspace ids collapse to a flat 404 (no existence
+    /// disclosure) end-to-end through the transport mapping.
+    #[tokio::test]
+    async fn cross_workspace_get_is_flat_404() {
+        let s = test_state();
+        let scope_a = Scope::new("ws-a", "org");
+        let scope_b = Scope::new("ws-b", "org");
+        let created = create_credential(
+            &s,
+            &scope_a,
+            CreateCredentialRequest {
+                credential_key: "api_key".into(),
+                name: "a".into(),
+                description: None,
+                data: serde_json::json!({ "api_key": "k" }),
+                tags: None,
+            },
+        )
+        .await
+        .expect("create");
+
+        let err = get_credential(&s, &scope_b, &created.id)
+            .await
+            .expect_err("cross-workspace get denied");
+        assert!(matches!(err, ApiError::NotFound(_)));
+    }
+
+    /// The service-error mapping is total and secret-safe for the
+    /// client-relevant arms.
+    #[test]
+    fn service_error_mapping_statuses() {
+        assert!(matches!(
+            map_service_err(
+                CredentialServiceError::NotFound { id: "x".into() },
+                "cred_x"
+            ),
+            ApiError::NotFound(_)
+        ));
+        assert!(matches!(
+            map_service_err(
+                CredentialServiceError::VersionConflict {
+                    id: "x".into(),
+                    expected: 1,
+                    actual: 2
+                },
+                "cred_x"
+            ),
+            ApiError::VersionMismatch(_)
+        ));
+        assert!(matches!(
+            map_service_err(
+                CredentialServiceError::ValidationFailed {
+                    reason: "[code] /path".into()
+                },
+                "cred_x"
+            ),
+            ApiError::Validation { .. }
+        ));
+        assert!(matches!(
+            map_service_err(
+                CredentialServiceError::TypeUnknown { key: "nope".into() },
+                "cred_x"
+            ),
+            ApiError::Validation { .. }
+        ));
+        assert!(matches!(
+            map_service_err(
+                CredentialServiceError::CapabilityUnsupported {
+                    capability: "refresh".into(),
+                    key: "api_key".into()
+                },
+                "cred_x"
+            ),
+            ApiError::Validation { .. }
+        ));
+        assert!(matches!(
+            map_service_err(CredentialServiceError::PendingExpired, "cred_x"),
+            ApiError::Unauthorized(_)
+        ));
+        assert!(matches!(
+            map_service_err(CredentialServiceError::Provider("down".into()), "cred_x"),
+            ApiError::ServiceUnavailable(_)
+        ));
+        assert!(matches!(
+            map_service_err(CredentialServiceError::Store("io".into()), "cred_x"),
+            ApiError::Internal(_)
         ));
     }
 }

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -11,9 +11,6 @@ use std::sync::Arc;
 use nebula_api::{
     ApiConfig, AppState,
     error::ApiError,
-    ports::credential_schema::{
-        CredentialFieldError, CredentialSchemaPort, CredentialTypeDescriptor,
-    },
     state::{OrgResolver, WorkspaceResolver},
 };
 use nebula_core::{OrgId, WorkspaceId};
@@ -157,32 +154,6 @@ pub(crate) fn create_test_jwt() -> String {
 }
 
 // ── AppState builders ─────────────────────────────────────────────────────────
-
-/// Permissive [`CredentialSchemaPort`] test double: accepts any `data`,
-/// exposes no catalog types. Wired by default into [`create_state_with_queue`]
-/// so credential happy-path tests keep their pre--P4 behavior
-/// (the old fail-open persisted unvalidated; the correct test default is
-/// "a validator is present and permissive"). The reject / no-port cases
-/// are exercised explicitly by `tests/seam_credential_write_path_validation.rs`.
-pub(crate) struct PermissiveCredentialSchemaPort;
-
-impl CredentialSchemaPort for PermissiveCredentialSchemaPort {
-    fn validate_data(
-        &self,
-        _credential_key: &str,
-        _data: &serde_json::Value,
-    ) -> Result<(), Vec<CredentialFieldError>> {
-        Ok(())
-    }
-
-    fn list_types(&self) -> Vec<CredentialTypeDescriptor> {
-        Vec::new()
-    }
-
-    fn get_type(&self, _credential_key: &str) -> Option<CredentialTypeDescriptor> {
-        None
-    }
-}
 
 /// Build an `AppState` whose execution / workflow / control-queue
 /// surface is the scoped storage port, wired exactly as the composition
@@ -355,6 +326,10 @@ impl PortHandles {
 /// credential-schema port is left unset so the credential-schema validation seam test can
 /// assert the unconfigured write path returns 503 (never persists
 /// unvalidated).
+/// 32 `0x42` bytes, base64 — a valid AES-256 key fixture (mirrors the
+/// factory dev key). Not a secret: a fixed test constant.
+pub(crate) const TEST_CRED_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
 async fn build_port_state_with(with_credential_port: bool) -> (AppState, PortHandles) {
     use nebula_storage::inmem::{
         InMemoryJournalReader, InMemoryNodeResultStore, InMemoryWorkflowStore,
@@ -386,8 +361,21 @@ async fn build_port_state_with(with_credential_port: bool) -> (AppState, PortHan
     .with_workspace_resolver(Arc::new(TestWorkspaceResolver))
     .with_insecure_tenant_rbac_bypass_for_tests();
 
+    // A composed CredentialService is always wired (the production shape:
+    // encrypted-at-rest in-memory store with the first-party type set).
+    // The schema port is conditional so the write-path seam test can
+    // assert the no-port ⇒ 503 fail-closed gate with the service present.
+    let key = Arc::new(
+        nebula_storage::credential::EnvKeyProvider::from_base64(TEST_CRED_KEY_B64)
+            .expect("valid 32-byte AES key fixture"),
+    );
+    let svc = nebula_api::ports::credential_service_factory::with_key_provider(key)
+        .expect("credential service composes");
+    let state = state.with_credential_service(svc);
     let state = if with_credential_port {
-        state.with_credential_schema(Arc::new(PermissiveCredentialSchemaPort))
+        let port = nebula_api::ports::credential_schema_registry::try_default_registry_port()
+            .expect("first-party registry composes");
+        state.with_credential_schema(port)
     } else {
         state
     };

--- a/crates/api/tests/credential_e2e.rs
+++ b/crates/api/tests/credential_e2e.rs
@@ -588,17 +588,30 @@ async fn credential_unauthenticated_request_is_401() {
     );
 }
 
-// ── Honest endpoints keep returning an honest 503 ─────────────────────────────
+// ── Lifecycle / acquisition reach the wired facade ────────────────────────────
 
+/// The lifecycle and acquisition routes reach the handler and the wired
+/// `CredentialService` answers honestly:
+///
+/// - `test`/`refresh`/`revoke` on a static `api_key` row → **400**
+///   (capability gate: the type implements none of Testable /
+///   Refreshable / Revocable) — never a faked success, never a 503.
+/// - `resolve` with a static type completes synchronously (**200**,
+///   `status: "complete"`, persisted id) — the route-shadow regression
+///   guard: the literal `resolve` segment must reach the handler, not
+///   404 in tenancy ULID parsing.
+/// - `resolve/continue` on a non-interactive type → **400** (capability
+///   gate), again proving handler reachability.
+///
+/// Caller-submitted secret material must never echo in any error body.
 #[tokio::test]
-async fn credential_engine_owned_endpoints_stay_honest_503() {
+async fn credential_lifecycle_and_acquisition_answer_through_the_facade() {
     let (state, _q) = create_state_with_queue().await;
     let config = ApiConfig::for_test();
     let token = create_test_jwt();
 
-    // Seed a real credential so test/refresh/revoke reach the handler
-    // body (not a pre-handler 404) and we prove the 503 is the honest
-    // engine-owned signal, not an artifact of a missing row.
+    // Seed a real credential so test/refresh/revoke reach the capability
+    // gate on an existing row (not a pre-handler 404).
     let app = app::build_app(state.clone(), &config);
     let resp = app
         .oneshot(auth_json(
@@ -609,13 +622,14 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         ))
         .await
         .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "seed create must succeed");
     let created: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
     let cred_id = created["id"].as_str().unwrap().to_owned();
 
-    // `test` / `refresh` / `revoke` carry a valid `{cred}` ULID, so the
-    // tenancy middleware passes and the request reaches the handler →
-    // honest 503 (engine-owned dispatch, no CredentialRegistry wired).
-    let post_503: &[(&str, String, serde_json::Value)] = &[
+    // `test` / `refresh` / `revoke` on the static api_key type → 400
+    // from the facade capability gate (closure absence IS capability
+    // absence), with a secret-free problem body.
+    let capability_400: &[(&str, String, serde_json::Value)] = &[
         (
             "POST",
             ws_path(&format!("/credentials/{cred_id}/test")),
@@ -633,7 +647,7 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
         ),
     ];
 
-    for (method, path, body) in post_503 {
+    for (method, path, body) in capability_400 {
         let app = app::build_app(state.clone(), &config);
         let resp = app
             .oneshot(auth_json(method, path, &token, body))
@@ -641,102 +655,115 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
             .unwrap();
         assert_eq!(
             resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "{method} {path} must stay an honest 503 (engine-owned / no registry)"
+            StatusCode::BAD_REQUEST,
+            "{method} {path}: a static type must fail the capability gate \
+             with 400 — never a faked success, never a stub 503"
         );
         let problem = body_string(resp).await;
-        // Honest error: structured, no secret, problem+json.
         assert!(
             !problem.contains(SECRET_TOKEN),
-            "503 body must never carry a secret: {problem}"
+            "capability-gate body must never carry a secret: {problem}"
         );
     }
 
-    // `resolve` / `resolve/continue` reach the handler. The tenancy
-    // middleware special-cases the literal `resolve` sub-route so it is
-    // NOT parsed as a `{cred}` `CredentialId` (see
-    // `crates/api/src/middleware/tenancy.rs` `resolve_path_ids`).
-    // Without that guard the literal `resolve` segment failed ULID
-    // parsing and every acquisition request was a flat 404 before any
-    // handler ran — a route-shadow that made these endpoints
-    // structurally unreachable. They now hit the handler, which returns
-    // the honest engine-owned 503 (generic `Credential::resolve`
-    // dispatch is not wired into this API build); the genuine `{cred}`
-    // position stays strictly ULID-validated. Regression guard for the
-    // route-shadow.
-    // The sentinel is placed in the submitted credential material
-    // (`data` / `user_input`) so the no-secret assertion below is a
-    // *real* redaction guard, not vacuous: the honest-503 problem body
-    // must never echo caller-submitted secret material (credential secrecy / integration seam —
-    // same contract as the forced-error bodies elsewhere in this file).
-    let resolve_503: &[(&str, String, serde_json::Value)] = &[
-        (
+    // `resolve` reaches the handler (the tenancy middleware special-cases
+    // the literal `resolve` sub-route so it is NOT parsed as a `{cred}`
+    // CredentialId — regression guard for the route-shadow) and a static
+    // type completes synchronously: 200 + persisted id, no secret echo.
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_json(
             "POST",
-            ws_path("/credentials/resolve"),
-            serde_json::json!({
+            &ws_path("/credentials/resolve"),
+            &token,
+            &serde_json::json!({
                 "credential_key": "api_key",
                 "data": { "api_key": SECRET_TOKEN }
             }),
-        ),
-        (
-            "POST",
-            ws_path("/credentials/resolve/continue"),
-            serde_json::json!({
-                "pending_token": "tok",
-                "user_input": { "code": SECRET_TOKEN }
-            }),
-        ),
-    ];
-
-    for (method, path, body) in resolve_503 {
-        let app = app::build_app(state.clone(), &config);
-        let resp = app
-            .oneshot(auth_json(method, path, &token, body))
-            .await
-            .unwrap();
-        assert_eq!(
-            resp.status(),
-            StatusCode::SERVICE_UNAVAILABLE,
-            "{method} {path} must reach the handler and return the honest \
-             engine-owned 503 — NOT a pre-handler 404 (that is the tenancy \
-             route-shadow this guards against)"
-        );
-        let problem = body_string(resp).await;
-        assert!(
-            !problem.contains(SECRET_TOKEN),
-            "honest-503 problem body must not echo caller-submitted \
-             credential material (SECRET_TOKEN was in the request \
-             `data`/`user_input`): {problem}"
-        );
-    }
-
-    // Type-discovery endpoints (system-level, not workspace-scoped).
-    // credential-schema port: these are now port-backed. The shared harness wires
-    // a permissive port (zero registered types), so the *honest* result is
-    // 200 with an empty `types` list (the endpoint truthfully reports the
-    // registered set) and 404 for an unknown key — not a honest capability false
-    // capability. The genuine no-port → 503 path is covered by
-    // `tests/seam_credential_catalog_schema.rs::catalog_503_when_port_unconfigured`.
-    let app = app::build_app(state.clone(), &config);
-    let resp = app
-        .oneshot(auth_get("/api/v1/credentials/types", &token))
+        ))
         .await
         .unwrap();
     assert_eq!(
         resp.status(),
         StatusCode::OK,
-        "type listing is port-backed (200, possibly-empty) — honest, not a 503 stub"
+        "resolve must reach the handler and complete for a static type — \
+         NOT a pre-handler 404 (the tenancy route-shadow this guards against)"
     );
-    let listed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+    let resolved = body_string(resp).await;
+    assert!(
+        !resolved.contains(SECRET_TOKEN),
+        "resolve response must not echo the submitted secret: {resolved}"
+    );
+    let resolved_json: serde_json::Value = serde_json::from_str(&resolved).unwrap();
+    assert_eq!(resolved_json["status"], "complete");
+    assert!(
+        resolved_json["credential_id"]
+            .as_str()
+            .is_some_and(|id| id.starts_with("cred_")),
+        "complete resolve must return the persisted credential id"
+    );
+
+    // `resolve/continue` with a well-formed typed payload on a
+    // non-interactive type → 400 from the capability gate; the submitted
+    // material never echoes.
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_json(
+            "POST",
+            &ws_path("/credentials/resolve/continue"),
+            &token,
+            &serde_json::json!({
+                "credential_key": "api_key",
+                "pending_token": "tok",
+                "user_input": { "Code": { "code": SECRET_TOKEN } }
+            }),
+        ))
+        .await
+        .unwrap();
     assert_eq!(
-        listed["types"].as_array().map(Vec::len),
-        Some(0),
-        "permissive harness port registers zero types — honest empty catalog"
+        resp.status(),
+        StatusCode::BAD_REQUEST,
+        "continue on a non-interactive type must fail the capability gate \
+         with 400 — and must reach the handler, not 404 in tenancy"
+    );
+    let problem = body_string(resp).await;
+    assert!(
+        !problem.contains(SECRET_TOKEN),
+        "continue error body must not echo caller-submitted credential \
+         material (SECRET_TOKEN was in `user_input`): {problem}"
+    );
+
+    // Type-discovery endpoints (system-level, not workspace-scoped) are
+    // registry-backed: the first-party catalog lists the builtin types and
+    // a known key resolves.
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_get("/api/v1/credentials/types", &token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let listed: serde_json::Value = serde_json::from_str(&body_string(resp).await).unwrap();
+    let keys: Vec<&str> = listed["types"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|t| t["key"].as_str())
+        .collect();
+    assert!(
+        keys.contains(&"api_key"),
+        "registry-backed catalog must list api_key, got {keys:?}"
     );
 
     let app = app::build_app(state.clone(), &config);
     let resp = app
         .oneshot(auth_get("/api/v1/credentials/types/api_key", &token))
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "known type key resolves");
+
+    let app = app::build_app(state.clone(), &config);
+    let resp = app
+        .oneshot(auth_get("/api/v1/credentials/types/no_such_type", &token))
         .await
         .unwrap();
     assert_eq!(
@@ -746,7 +773,6 @@ async fn credential_engine_owned_endpoints_stay_honest_503() {
          non-existence disclosure is non-sensitive — unlike credential instances)"
     );
 }
-
 /// Guard-precision regression (Copilot review, PR #674): the
 /// `"credentials" if segments[7] != "resolve"` tenancy match guard must
 /// keep rejecting a **non-`resolve`, non-ULID** `{cred}` segment

--- a/crates/api/tests/credential_service_factory.rs
+++ b/crates/api/tests/credential_service_factory.rs
@@ -29,7 +29,7 @@ async fn factory_builds_service_and_create_round_trips() {
 
     // A non-interactive create round-trips through the wired ops + display.
     let scope = TenantScope::new("org", "ws");
-    let snap = svc
+    let head = svc
         .create(
             &scope,
             "api_key",
@@ -41,14 +41,15 @@ async fn factory_builds_service_and_create_round_trips() {
         )
         .await
         .expect("api_key create succeeds");
-    assert_eq!(snap.kind(), "api_key");
-    assert_eq!(snap.display().display_name.as_deref(), Some("Test key"));
+    assert_eq!(head.credential_key, "api_key");
+    assert_eq!(head.display.display_name.as_deref(), Some("Test key"));
 
-    // Retrievable, secret never echoed in the snapshot's Debug.
-    let ids = svc.list(&scope).await.expect("list");
-    assert_eq!(ids.len(), 1);
-    let got = svc.get(&scope, &ids[0]).await.expect("get");
-    assert_eq!(got.kind(), "api_key");
-    assert_eq!(got.display().display_name.as_deref(), Some("Test key"));
+    // Retrievable, secret never echoed in the head's Debug.
+    let heads = svc.list(&scope).await.expect("list");
+    assert_eq!(heads.len(), 1);
+    assert_eq!(heads[0].id, head.id);
+    let got = svc.get(&scope, &head.id).await.expect("get");
+    assert_eq!(got.credential_key, "api_key");
+    assert_eq!(got.display.display_name.as_deref(), Some("Test key"));
     assert!(!format!("{got:?}").contains("k-factory-test"));
 }

--- a/crates/api/tests/e2e_oauth2_flow.rs
+++ b/crates/api/tests/e2e_oauth2_flow.rs
@@ -14,12 +14,24 @@ use axum::{
 use common::{create_state_with_queue, create_test_jwt, ws_path};
 use nebula_api::{ApiConfig, app};
 use nebula_credential::{
-    Credential, CredentialContext, CredentialState, CredentialStore, OAuth2Credential, OAuth2State,
-    PutMode,
+    Credential, CredentialContext, CredentialState, CredentialStore, ErasedCredentialStore,
+    OAuth2Credential, OAuth2State, PutMode,
 };
 use nebula_engine::credential::CredentialResolver;
 use tower::ServiceExt;
 use url::form_urlencoded;
+
+/// The single credential store: the facade's layered store handle (the
+/// OAuth path and the CRUD plane share it — ADR-0088 D7).
+fn oauth_store_handle(state: &nebula_api::AppState) -> ErasedCredentialStore {
+    ErasedCredentialStore::new(
+        state
+            .credential_service
+            .as_ref()
+            .expect("credential service wired into test state")
+            .credential_store_handle(),
+    )
+}
 
 async fn spawn_mock_token_endpoint() -> (String, tokio::task::JoinHandle<()>) {
     let token_router = axum::Router::new().route(
@@ -227,12 +239,14 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
     assert_eq!(callback_json["credential_id"], credential_id);
     assert_eq!(callback_json["exchanged"], true);
 
-    let stored = state
-        .oauth_credential_store
+    let stored = oauth_store_handle(&state)
         .get(credential_id)
         .await
         .expect("stored oauth credential");
-    assert_eq!(stored.version, 1, "first persisted row should be version 1");
+    assert_eq!(
+        stored.version, 2,
+        "authorize creates the placeholder (v1); the callback CAS bumps it to v2"
+    );
     assert_eq!(stored.credential_key, OAuth2Credential::KEY);
     assert_eq!(stored.state_kind, OAuth2State::KIND);
 
@@ -263,17 +277,16 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
     let mut stale_record = stored.clone();
     stale_record.data = serde_json::to_vec(&persisted_state).expect("serialize stale oauth state");
     stale_record.expires_at = persisted_state.expires_at();
-    let stale_put = state
-        .oauth_credential_store
+    let stale_put = oauth_store_handle(&state)
         .put(stale_record, PutMode::Overwrite)
         .await
         .expect("persist stale oauth state");
     assert_eq!(
-        stale_put.version, 2,
+        stale_put.version, 3,
         "manual overwrite of stale state should bump StoredCredential::version (CAS basis)"
     );
 
-    let resolver = CredentialResolver::new(state.oauth_credential_store.clone());
+    let resolver = CredentialResolver::new(std::sync::Arc::new(oauth_store_handle(&state)));
     let ctx = CredentialContext::for_test("test-user");
     let handle = resolver
         .resolve_with_refresh::<OAuth2Credential>(credential_id, &ctx)
@@ -288,13 +301,12 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
         "e2e-access-token-refreshed"
     );
 
-    let refreshed = state
-        .oauth_credential_store
+    let refreshed = oauth_store_handle(&state)
         .get(credential_id)
         .await
         .expect("refreshed oauth credential in store");
     assert_eq!(
-        refreshed.version, 3,
+        refreshed.version, 4,
         "engine refresh should persist via CAS and increment version"
     );
     let refreshed_state: OAuth2State =

--- a/crates/credential-runtime/CLAUDE.md
+++ b/crates/credential-runtime/CLAUDE.md
@@ -12,6 +12,7 @@
 
 ## Key files
 - `src/service.rs` — `CredentialService`, `Acquisition`, `LayeredStore`, `test_support`; the facade + lifecycle (largest module).
+- `src/head.rs` — `CredentialHead`: the secret-free row view CRUD/refresh return (id + store CAS version + reauth flag + display); never carries state bytes.
 - `src/ops.rs` — `DispatchOps` type-erased async op table + `register_*_ops` per-capability registrars; swap for test doubles here.
 - `src/binding.rs` — `ValidatedCredentialBinding` + `TenantFingerprint`: crate-private-constructor newtype closing the `slot_bindings` confused-deputy (only `resolve_for_slot` mints one).
 - `src/scope.rs` — `TenantScope` / `FixedScopeResolver`: owner_id derivation (`Scope::credential_owner_id`, ADR-0088 D7).

--- a/crates/credential-runtime/src/builder.rs
+++ b/crates/credential-runtime/src/builder.rs
@@ -149,13 +149,19 @@ impl<B: CredentialStore + 'static> CredentialServiceBuilder<B> {
             }
         }
 
-        let layered = AuditLayer::new(
-            CacheLayer::new(
-                EncryptionLayer::new(self.raw_store, self.key_provider),
-                self.cache_config,
-            ),
-            self.audit_sink,
+        let cached = CacheLayer::new(
+            EncryptionLayer::new(self.raw_store, self.key_provider),
+            self.cache_config,
         );
+        // Two handles over the SAME cache+encryption stack: the audited
+        // top (`store`) is the access path for every real per-id
+        // operation, while the un-audited `scan_store` exists solely for
+        // `list`'s owner-filter scan — enumerating foreign rows to filter
+        // them out is not an access, so it must not mint per-credential
+        // audit `Get` events against other tenants' ids.
+        let scan: Arc<dyn DynCredentialStore> = Arc::new(cached);
+        let scan_store = ErasedCredentialStore::new(Arc::clone(&scan));
+        let layered = AuditLayer::new(scan_store.clone(), self.audit_sink);
         let store: Arc<dyn DynCredentialStore> = Arc::new(layered);
         let refresh_coordinator = self
             .refresh_coordinator
@@ -172,6 +178,7 @@ impl<B: CredentialStore + 'static> CredentialServiceBuilder<B> {
         );
         Ok(CredentialService::__from_parts(
             store,
+            scan_store,
             resolver,
             lease,
             self.pending_store,

--- a/crates/credential-runtime/src/error.rs
+++ b/crates/credential-runtime/src/error.rs
@@ -111,8 +111,8 @@ pub enum CredentialServiceError {
     /// fallback-on-interrupt path can pattern-match without string-scanning.
     ///
     /// The fallback wrapper in [`CredentialService::refresh`] intercepts this
-    /// variant when a non-expired cached snapshot is available and returns the
-    /// cached material instead of propagating the error.
+    /// variant when the stored material is still non-expired and returns the
+    /// cached head instead of propagating the error.
     ///
     /// [`Provider`]: Self::Provider
     /// [`CredentialService::refresh`]: crate::service::CredentialService::refresh

--- a/crates/credential-runtime/src/head.rs
+++ b/crates/credential-runtime/src/head.rs
@@ -1,0 +1,127 @@
+//! Secret-free credential row view returned by the facade's CRUD surface.
+//!
+//! [`CredentialHead`] is the management-plane projection of a stored
+//! credential: identity, type key, store version (the CAS token), the
+//! lifecycle timestamps, and the per-instance display metadata. It carries
+//! **no** state bytes and no projected scheme, so reading it never
+//! deserializes or decrypts credential material — a row that is not yet
+//! resolvable (e.g. an OAuth2 placeholder awaiting authorization, flagged
+//! `reauth_required`) still projects a valid head.
+//!
+//! The scheme-bearing view stays on the execution plane:
+//! [`CredentialService::resolve_for_slot`](crate::CredentialService::resolve_for_slot)
+//! produces a typed guard, and the engine resolver owns snapshot projection.
+
+use chrono::{DateTime, Utc};
+use nebula_credential::{CredentialDisplay, StoredCredential};
+use serde::Serialize;
+
+/// Secret-free management view of one stored credential row.
+///
+/// Returned by the facade CRUD operations (`create` / `get` / `list` /
+/// `update` / `refresh`). All fields are non-secret by construction:
+/// `StoredCredential::data` is never read to build a head.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[non_exhaustive]
+pub struct CredentialHead {
+    /// Credential id (`cred_<ULID>` wire form).
+    pub id: String,
+    /// `Credential::KEY` of the stored type (e.g. `"api_key"`, `"oauth2"`).
+    pub credential_key: String,
+    /// Store version — the optimistic-concurrency token for
+    /// [`update`](crate::CredentialService::update) compare-and-swap.
+    pub version: u64,
+    /// When the row was created.
+    pub created_at: DateTime<Utc>,
+    /// When the row was last written.
+    pub updated_at: DateTime<Utc>,
+    /// When the credential material expires, if it does.
+    pub expires_at: Option<DateTime<Utc>>,
+    /// True when the credential cannot be used until re-authorized (e.g.
+    /// an interactive flow was started but not completed, or a refresh
+    /// failed terminally).
+    pub reauth_required: bool,
+    /// Per-instance display metadata (name / description / tags). Empty
+    /// for system-acquired credentials that were never named.
+    pub display: CredentialDisplay,
+}
+
+impl CredentialHead {
+    /// Project a stored row into its secret-free head. `display` is passed
+    /// separately because the `metadata["display"]` persistence convention
+    /// is owned by the facade, not the row type.
+    #[must_use]
+    pub(crate) fn from_stored(stored: &StoredCredential, display: CredentialDisplay) -> Self {
+        Self {
+            id: stored.id.clone(),
+            credential_key: stored.credential_key.clone(),
+            version: stored.version,
+            created_at: stored.created_at,
+            updated_at: stored.updated_at,
+            expires_at: stored.expires_at,
+            reauth_required: stored.reauth_required,
+            display,
+        }
+    }
+
+    /// True iff this head's `expires_at` is in the past. A credential
+    /// without an explicit expiry is treated as non-expiring.
+    #[must_use]
+    pub fn is_expired(&self) -> bool {
+        self.expires_at.is_some_and(|at| at <= Utc::now())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn stored(expires_at: Option<DateTime<Utc>>) -> StoredCredential {
+        let now = Utc::now();
+        StoredCredential {
+            id: "cred_01ABCDEFGHJKMNPQRSTVWXYZ0".to_owned(),
+            credential_key: "api_key".to_owned(),
+            data: vec![1, 2, 3],
+            state_kind: "api_key_state".to_owned(),
+            state_version: 1,
+            version: 4,
+            created_at: now,
+            updated_at: now,
+            expires_at,
+            reauth_required: false,
+            metadata: serde_json::Map::new(),
+        }
+    }
+
+    #[test]
+    fn from_stored_copies_row_fields_without_data() {
+        let row = stored(None);
+        let head = CredentialHead::from_stored(&row, CredentialDisplay::default());
+        assert_eq!(head.id, row.id);
+        assert_eq!(head.credential_key, "api_key");
+        assert_eq!(head.version, 4);
+        assert!(!head.reauth_required);
+        assert!(head.display.is_empty());
+        // No `data` field exists on the head — the projection is
+        // structurally secret-free; serialize and prove the bytes absent.
+        let json = serde_json::to_value(&head).expect("serialize head");
+        assert!(json.get("data").is_none());
+    }
+
+    #[test]
+    fn is_expired_respects_expiry() {
+        let past = Utc::now() - chrono::Duration::seconds(10);
+        let future = Utc::now() + chrono::Duration::seconds(600);
+        assert!(
+            CredentialHead::from_stored(&stored(Some(past)), CredentialDisplay::default())
+                .is_expired()
+        );
+        assert!(
+            !CredentialHead::from_stored(&stored(Some(future)), CredentialDisplay::default())
+                .is_expired()
+        );
+        assert!(
+            !CredentialHead::from_stored(&stored(None), CredentialDisplay::default()).is_expired()
+        );
+    }
+}

--- a/crates/credential-runtime/src/lib.rs
+++ b/crates/credential-runtime/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod binding;
 pub mod builder;
 pub mod error;
+pub mod head;
 pub mod observer;
 pub mod ops;
 pub mod scope;
@@ -32,6 +33,7 @@ pub mod test_fixtures;
 pub use binding::{TenantFingerprint, ValidatedCredentialBinding, ValidatedCredentialBindingError};
 pub use builder::CredentialServiceBuilder;
 pub use error::CredentialServiceError;
+pub use head::CredentialHead;
 pub use observer::{CredentialObserver, EventMetricObserver, NoopObserver};
 pub use ops::{
     DispatchError, DispatchOps, register_all_builtin_ops, register_interactive_ops,

--- a/crates/credential-runtime/src/lib.rs
+++ b/crates/credential-runtime/src/lib.rs
@@ -41,7 +41,8 @@ pub use ops::{
 };
 pub use scope::{FixedScopeResolver, TenantScope};
 pub use service::{
-    Acquisition, CredentialService, CredentialTypeInfo, LayeredStore, TestReport, TypeCapabilities,
+    Acquisition, CredentialService, CredentialTypeInfo, LayeredStore, RefreshReport, TestReport,
+    TypeCapabilities,
 };
 pub use state_source::StateSource;
 

--- a/crates/credential-runtime/src/ops.rs
+++ b/crates/credential-runtime/src/ops.rs
@@ -18,8 +18,8 @@ use std::sync::Arc;
 use nebula_credential::pending_store::PendingStateStore;
 use nebula_credential::resolve::{InteractionRequest, TestResult, UserInput};
 use nebula_credential::{
-    Capabilities, Credential, CredentialContext, CredentialRecord, CredentialSnapshot,
-    CredentialState, Interactive, PendingToken, Refreshable, Revocable, Testable,
+    Capabilities, Credential, CredentialContext, CredentialState, Interactive, PendingToken,
+    Refreshable, Revocable, Testable,
 };
 use nebula_engine::credential::{
     ResolveResponse, dispatch_revoke, dispatch_test, execute_continue, execute_resolve,
@@ -195,15 +195,6 @@ type RevokeFuture<'a> =
 type RevokeFn =
     Arc<dyn for<'a> Fn(&'a [u8], &'a CredentialContext) -> RevokeFuture<'a> + Send + Sync>;
 
-/// Erased `project`: deserializes stored state bytes into `C::State`,
-/// runs `C::project`, and wraps the scheme in a secret-free
-/// [`CredentialSnapshot`]. Never returns the raw secret bytes.
-type SnapshotFn = Arc<
-    dyn Fn(&[u8], CredentialRecord) -> Result<CredentialSnapshot, CredentialServiceError>
-        + Send
-        + Sync,
->;
-
 /// Erased validation: runs the canonical credential properties pipeline
 /// for the captured concrete `C` —
 /// `schema_of::<C::Properties>().validate(FieldValues)` then a typed
@@ -215,8 +206,8 @@ type ValidateFn =
 
 /// One credential type's erased operation closures.
 ///
-/// `validate` / `resolve` / `snapshot` / `acquire` are always present
-/// (the base registration). The capability closures are `Option`: a
+/// `validate` / `resolve` / `acquire` are always present (the base
+/// registration). The capability closures are `Option`: a
 /// `Some` is set **only** by the matching capability-bounded
 /// `register_*_ops` (callable only for `C: Testable` / `Refreshable` /
 /// `Revocable` / `Interactive`), so closure presence *is* the capability
@@ -225,7 +216,6 @@ type ValidateFn =
 struct OpsEntry<PS> {
     validate: ValidateFn,
     resolve: ResolveFn<PS>,
-    snapshot: SnapshotFn,
     acquire: AcquireFn<PS>,
     test_fn: Option<TestFn>,
     refresh_fn: Option<RefreshFn>,
@@ -330,29 +320,6 @@ impl<PS: PendingStateStore> DispatchOps<PS> {
                 key: key.to_owned(),
             })?;
         (entry.resolve)(values, ctx, pending).await
-    }
-
-    /// Project decrypted state bytes for the type at `key` into a
-    /// secret-free [`CredentialSnapshot`].
-    ///
-    /// # Errors
-    ///
-    /// [`CredentialServiceError::TypeUnknown`] when `key` is absent;
-    /// [`CredentialServiceError::Internal`] when stored bytes fail to
-    /// deserialize into the registered state type.
-    pub(crate) fn snapshot(
-        &self,
-        key: &str,
-        data: &[u8],
-        record: CredentialRecord,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
-        let entry = self
-            .entries
-            .get(key)
-            .ok_or_else(|| CredentialServiceError::TypeUnknown {
-                key: key.to_owned(),
-            })?;
-        (entry.snapshot)(data, record)
     }
 
     /// Run the canonical credential properties validation pipeline for
@@ -601,14 +568,6 @@ where
         },
     );
 
-    let snapshot: SnapshotFn = Arc::new(|data: &[u8], record: CredentialRecord| {
-        let state: C::State = serde_json::from_slice(data).map_err(|e| {
-            CredentialServiceError::Internal(format!("stored state deserialization failed: {e}"))
-        })?;
-        let scheme = C::project(&state);
-        Ok(CredentialSnapshot::new(C::KEY, record, scheme))
-    });
-
     let validate: ValidateFn = Arc::new(|props: &serde_json::Value| {
         // Canonical pipeline (mirrors `properties_pipeline.rs`): schema
         // validate, then a typed `from_value` round-trip. The credential
@@ -648,7 +607,6 @@ where
         OpsEntry {
             validate,
             resolve,
-            snapshot,
             acquire,
             test_fn: None,
             refresh_fn: None,
@@ -946,7 +904,7 @@ where
 mod tests {
     use super::{DispatchOps, register_refreshable_ops, register_runtime_ops};
     use crate::test_fixtures::RefreshableFixtureCredential;
-    use nebula_credential::{Capabilities, Credential, CredentialContext, CredentialRecord};
+    use nebula_credential::{Capabilities, Credential, CredentialContext};
     use nebula_credential_builtin::BearerTokenCredential;
     use nebula_credential_testutil::InMemoryPendingStore;
     use nebula_schema::FieldValues;
@@ -993,7 +951,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn resolve_then_snapshot_roundtrip() {
+    async fn resolve_produces_persistable_state() {
         let mut ops = Ops::new();
         register_runtime_ops::<BearerTokenCredential, InMemoryPendingStore>(&mut ops)
             .expect("register ok");
@@ -1010,13 +968,9 @@ mod tests {
             .await
             .expect("resolve ok");
         assert_eq!(resolved.state_kind, "secret_token");
-
-        let snap = ops
-            .snapshot("bearer_token", &resolved.data, CredentialRecord::new())
-            .expect("snapshot ok");
-        assert_eq!(snap.kind(), "bearer_token");
-        // Snapshot redacts secrets in Debug.
-        assert!(format!("{snap:?}").contains("[REDACTED]"));
+        // The serialized state bytes are valid self-describing JSON — the
+        // refresh/test/revoke closures deserialize exactly these bytes.
+        assert!(serde_json::from_slice::<serde_json::Value>(&resolved.data).is_ok());
     }
 
     #[tokio::test]

--- a/crates/credential-runtime/src/scope.rs
+++ b/crates/credential-runtime/src/scope.rs
@@ -38,6 +38,20 @@ impl TenantScope {
         }
     }
 
+    /// Construct from an already-resolved storage [`Scope`]. The owner key
+    /// is the same canonical [`Scope::credential_owner_id`] derivation as
+    /// [`new`](Self::new) — this constructor exists so the API edge, which
+    /// holds a resolved `Scope`, cannot drift by re-deriving from raw
+    /// org/workspace strings. The session is `None`; attach one with
+    /// [`with_session`](Self::with_session).
+    #[must_use]
+    pub fn from_scope(scope: &Scope) -> Self {
+        Self {
+            owner_id: scope.credential_owner_id(),
+            session_id: None,
+        }
+    }
+
     /// Attach the interactive-flow session id. Required for the
     /// pending-store `(kind, owner, session, token)` binding that the
     /// interactive `resolve`/`continue_resolve` paths depend on; CRUD

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -42,7 +42,7 @@ use nebula_engine::credential::{CredentialResolver, LeaseLifecycle};
 use nebula_resilience::CallError;
 use nebula_resilience::retry::{BackoffConfig, RetryConfig, retry_with};
 use nebula_schema::FieldValues;
-use nebula_storage::credential::{AuditLayer, CacheLayer, EncryptionLayer};
+use nebula_storage::credential::AuditLayer;
 use serde::Serialize;
 use serde_json::Value;
 use tokio_util::sync::CancellationToken;
@@ -67,13 +67,17 @@ const DISPLAY_KEY: &str = "display";
 
 /// Layered store stack composed once at `CredentialServiceBuilder::build`:
 /// `Audit(Cache(Encryption(raw)))`. `Encryption` is adjacent to the raw
-/// backend so persisted bytes are always ciphertext (spec §6 #7).
+/// backend so persisted bytes are always ciphertext (spec §6 #7); the
+/// cache+encryption core is erased once ([`ErasedCredentialStore`]) so the
+/// facade can hold a second, **un-audited** scan handle over the same
+/// cache for `list`'s owner filter (enumerating foreign rows to discard
+/// them is not an access and must not mint audit `Get` events).
 ///
 /// `pub` so composition roots (the api layer, server binary) can name the
-/// concrete arc type without spelling out all three layer wrappers. The
-/// builder's `build()` is still the only construction path — this is a
-/// type alias, not a constructor.
-pub type LayeredStore<B> = AuditLayer<CacheLayer<EncryptionLayer<B>>>;
+/// concrete type without spelling out the layer wrappers. The builder's
+/// `build()` is still the only construction path — this is a type alias,
+/// not a constructor.
+pub type LayeredStore = AuditLayer<ErasedCredentialStore>;
 
 /// Outcome of [`CredentialService::test`] — a secret-free health-probe
 /// summary. `message` carries only the provider's failure reason (never
@@ -85,6 +89,23 @@ pub struct TestReport {
     pub ok: bool,
     /// Provider-supplied failure reason when `ok` is `false`.
     pub message: Option<String>,
+}
+
+/// Outcome of [`CredentialService::refresh`]. `refreshed` distinguishes a
+/// real provider refresh from the fallback-on-interrupt path that served
+/// the still-valid stored material after a transient provider failure —
+/// a management caller asking "did the refresh happen?" must not be told
+/// `yes` when the provider was unreachable.
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct RefreshReport {
+    /// Secret-free head of the row after the call (post-refresh on the
+    /// success path; the pre-call head on the fallback path).
+    pub head: CredentialHead,
+    /// `true` iff the provider refresh ran and the rotated state was
+    /// persisted (or coalesced by another replica). `false` when the
+    /// fallback served the existing non-expired material instead.
+    pub refreshed: bool,
 }
 
 /// Outcome of [`CredentialService::resolve`] /
@@ -154,6 +175,12 @@ pub struct CredentialTypeInfo {
 /// [`CredentialServiceBuilder`](crate::builder::CredentialServiceBuilder).
 pub struct CredentialService {
     pub(crate) store: Arc<dyn DynCredentialStore>,
+    /// Un-audited handle over the same cache+encryption core as `store`.
+    /// Used ONLY by [`list`](Self::list)'s owner-filter scan: enumerating
+    /// rows to discard the foreign ones is not an access, so it must not
+    /// mint per-credential audit `Get` events against other tenants' ids.
+    /// Every real per-id operation goes through the audited `store`.
+    pub(crate) scan_store: ErasedCredentialStore,
     /// Engine resolver wired through the layered store stack (erased at the
     /// store→resolver boundary). Used by
     /// [`resolve_for_slot`](Self::resolve_for_slot) to produce a typed
@@ -181,6 +208,7 @@ impl CredentialService {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn __from_parts(
         store: Arc<dyn DynCredentialStore>,
+        scan_store: ErasedCredentialStore,
         resolver: CredentialResolver<ErasedCredentialStore>,
         lease: LeaseLifecycle,
         pending: ErasedPendingStore,
@@ -191,6 +219,7 @@ impl CredentialService {
     ) -> Self {
         Self {
             store,
+            scan_store,
             resolver,
             lease,
             pending,
@@ -407,10 +436,15 @@ impl CredentialService {
         &self,
         scope: &TenantScope,
     ) -> Result<Vec<CredentialHead>, CredentialServiceError> {
+        // The id enumeration goes through the audited store (one `List`
+        // audit event); the per-row owner-filter reads go through the
+        // un-audited `scan_store` so foreign rows — fetched only to be
+        // discarded — never mint audit `Get` events against other
+        // tenants' ids (the audit trail must record accesses, not scans).
         let ids = self.store.list(None).await.map_err(Self::map_store_err)?;
         let mut visible = Vec::new();
         for id in ids {
-            match self.store.get(&id).await {
+            match self.scan_store.get(&id).await {
                 Ok(stored) => {
                     if Self::owner_matches(&stored, scope) {
                         visible.push(Self::head_from(&stored));
@@ -437,9 +471,14 @@ impl CredentialService {
     /// field-wise merge semantics read the current head first and merge
     /// before calling.
     ///
-    /// `expected_version = Some(v)` engages compare-and-swap (a mismatch
-    /// surfaces as [`CredentialServiceError::VersionConflict`]);
-    /// `None` is a last-writer-wins overwrite.
+    /// `expected_version = Some(v)` engages compare-and-swap on the
+    /// caller's version (a mismatch surfaces as
+    /// [`CredentialServiceError::VersionConflict`]); `None` CASes on the
+    /// version this call just loaded, so a concurrent write landing
+    /// between the load and the put surfaces as `VersionConflict` instead
+    /// of silently rolling the row — including its secret state and any
+    /// concurrently-rotated tokens — back to the loaded copy. There is no
+    /// blind-overwrite path.
     ///
     /// # Errors
     ///
@@ -508,9 +547,12 @@ impl CredentialService {
             },
         };
 
-        let mode = match expected_version {
-            Some(expected_version) => PutMode::CompareAndSwap { expected_version },
-            None => PutMode::Overwrite,
+        // No blind-overwrite path: when the caller supplied no version,
+        // CAS on the version loaded above. A display-only rename racing a
+        // token refresh must conflict, never silently restore the stale
+        // secret bytes captured at load time.
+        let mode = PutMode::CompareAndSwap {
+            expected_version: expected_version.unwrap_or(existing.version),
         };
 
         let persisted = self
@@ -636,21 +678,29 @@ impl CredentialService {
         &self,
         scope: &TenantScope,
         id: &str,
-    ) -> Result<CredentialHead, CredentialServiceError> {
+    ) -> Result<RefreshReport, CredentialServiceError> {
         // Read the current head before attempting refresh. On a transient
         // provider failure we fall back to this if the material is still
-        // non-expired — avoids propagating blips to the caller.
+        // non-expired — avoids propagating blips to the caller. The
+        // report's `refreshed: false` keeps the fallback honest for
+        // management callers.
         let cached = self.get(scope, id).await?;
 
         match self.refresh_inner(scope, id).await {
-            Ok(head) => Ok(head),
+            Ok(head) => Ok(RefreshReport {
+                head,
+                refreshed: true,
+            }),
             Err(ref e) if Self::is_transient_failure(e) && !cached.is_expired() => {
                 tracing::warn!(
                     credential.id = %id,
                     error = %e,
                     "credential refresh failed transiently; stored material still non-expired"
                 );
-                Ok(cached)
+                Ok(RefreshReport {
+                    head: cached,
+                    refreshed: false,
+                })
             },
             Err(e) => Err(e),
         }
@@ -1975,8 +2025,9 @@ mod tests {
         let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 0);
-        let head = svc.refresh(&scope, &id).await.expect("refresh ok");
-        assert_eq!(head.credential_key, "refreshable_fixture");
+        let report = svc.refresh(&scope, &id).await.expect("refresh ok");
+        assert!(report.refreshed, "fixture refresh ran for real");
+        assert_eq!(report.head.credential_key, "refreshable_fixture");
         // on_refresh fired exactly once on the success path.
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 1);
 
@@ -1984,8 +2035,8 @@ mod tests {
         // observes the first rotation (counter is 2 → token `tok-base-r2`),
         // proving the CAS write stored the refreshed bytes, not the
         // pre-refresh copy.
-        let head2 = svc.refresh(&scope, &id).await.expect("second refresh ok");
-        assert_eq!(head2.credential_key, "refreshable_fixture");
+        let report2 = svc.refresh(&scope, &id).await.expect("second refresh ok");
+        assert_eq!(report2.head.credential_key, "refreshable_fixture");
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 2);
         // Still retrievable and correctly projected post-refresh.
         let got = svc.get(&scope, &id).await.expect("get ok");

--- a/crates/credential-runtime/src/service.rs
+++ b/crates/credential-runtime/src/service.rs
@@ -35,8 +35,8 @@ use nebula_credential::resolve::{InteractionRequest, TestResult, UserInput};
 use nebula_credential::store::{PutMode, StoreError, StoredCredential};
 use nebula_credential::{
     AuthPattern, Credential, CredentialContext, CredentialDisplay, CredentialGuard, CredentialId,
-    CredentialRecord, CredentialRegistry, CredentialSnapshot, DynCredentialStore,
-    ErasedCredentialStore, ErasedPendingStore, PendingToken,
+    CredentialRegistry, DynCredentialStore, ErasedCredentialStore, ErasedPendingStore,
+    PendingToken,
 };
 use nebula_engine::credential::{CredentialResolver, LeaseLifecycle};
 use nebula_resilience::CallError;
@@ -49,6 +49,7 @@ use tokio_util::sync::CancellationToken;
 use zeroize::Zeroize;
 
 use crate::CredentialServiceError;
+use crate::head::CredentialHead;
 use crate::observer::CredentialObserver;
 use crate::ops::DispatchOps;
 use crate::scope::TenantScope;
@@ -88,15 +89,16 @@ pub struct TestReport {
 
 /// Outcome of [`CredentialService::resolve`] /
 /// [`CredentialService::continue_resolve`]. Secret-free: the `Complete`
-/// arm carries the redacting [`CredentialSnapshot`]; the `Pending` arm
-/// carries the opaque token string + the UI instruction.
+/// arm carries the management-plane [`CredentialHead`] (id + row
+/// metadata, no state bytes); the `Pending` arm carries the opaque token
+/// string + the UI instruction.
 #[derive(Debug)]
 #[non_exhaustive]
 pub enum Acquisition {
     /// Resolved synchronously and persisted.
     Complete {
-        /// Secret-free snapshot of the just-persisted credential.
-        snapshot: CredentialSnapshot,
+        /// Secret-free head of the just-persisted credential.
+        head: CredentialHead,
     },
     /// Interactive acquisition kicked off; resume via
     /// [`continue_resolve`](CredentialService::continue_resolve) with
@@ -269,7 +271,7 @@ impl CredentialService {
         credential_key: &str,
         props: Value,
         display: CredentialDisplay,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
+    ) -> Result<CredentialHead, CredentialServiceError> {
         // Fail loud if an external source was configured but its
         // resolution wiring is not implemented yet — never silently
         // resolve from the local store under a Vault-configured service.
@@ -301,7 +303,7 @@ impl CredentialService {
             .resolve(credential_key, &values, &ctx, &self.pending)
             .await?;
 
-        let snapshot = self
+        let head = self
             .persist_resolved(scope, credential_key, id, resolved, display)
             .await?;
 
@@ -312,12 +314,12 @@ impl CredentialService {
             "credential created"
         );
 
-        Ok(snapshot)
+        Ok(head)
     }
 
     /// Persist a freshly-resolved credential under `id` scoped to
-    /// `scope`, returning the secret-free snapshot projected from the
-    /// just-resolved bytes (no decrypt round-trip). Shared by [`create`]
+    /// `scope`, returning the secret-free [`CredentialHead`] of the
+    /// just-persisted row (never the state bytes). Shared by [`create`]
     /// and the synchronous-`Complete` arm of [`resolve`].
     ///
     /// [`create`]: Self::create
@@ -329,23 +331,13 @@ impl CredentialService {
         id: CredentialId,
         resolved: crate::ops::ResolvedState,
         display: CredentialDisplay,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
+    ) -> Result<CredentialHead, CredentialServiceError> {
         let mut metadata = serde_json::Map::new();
         metadata.insert(
             OWNER_ID_KEY.to_owned(),
             Value::String(scope.owner_id().to_owned()),
         );
         Self::set_display(&mut metadata, &display);
-
-        // Project the response snapshot from the just-resolved state
-        // bytes before they are moved into the stored row (avoids a
-        // round-trip + decrypt; identical projection to `get`).
-        let mut record = CredentialRecord::new();
-        record.expires_at = resolved.expires_at;
-        let snapshot = self
-            .ops
-            .snapshot(credential_key, &resolved.data, record)?
-            .with_display(display);
 
         let now = chrono::Utc::now();
         let stored = StoredCredential {
@@ -362,31 +354,38 @@ impl CredentialService {
             metadata,
         };
 
-        self.store
+        // The store returns the persisted row (with its post-put version),
+        // which is the authoritative source for the returned head — the
+        // CAS token must reflect what a subsequent `update` has to match.
+        let persisted = self
+            .store
             .put(stored, PutMode::CreateOnly)
             .await
             .map_err(Self::map_store_err)?;
 
-        Ok(snapshot)
+        Ok(CredentialHead::from_stored(&persisted, display))
     }
 
-    /// Fetch a credential's secret-free snapshot, scoped to `scope`.
+    /// Fetch a credential's secret-free [`CredentialHead`], scoped to
+    /// `scope`. Never deserializes the state bytes, so a row that is not
+    /// yet resolvable (e.g. an interactive flow awaiting authorization,
+    /// `reauth_required = true`) still reads back as a valid head.
     ///
     /// # Errors
     ///
     /// [`CredentialServiceError::NotFound`] if the id is absent **or**
-    /// belongs to another tenant (no cross-tenant existence leak);
-    /// [`CredentialServiceError::Internal`] on a decode failure.
+    /// belongs to another tenant (no cross-tenant existence leak).
     pub async fn get(
         &self,
         scope: &TenantScope,
         id: &str,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
-        self.snapshot_from_store(scope, id).await
+    ) -> Result<CredentialHead, CredentialServiceError> {
+        let stored = self.load_owned(scope, id).await?;
+        Ok(Self::head_from(&stored))
     }
 
-    /// List credential ids visible to `scope` (rows whose stored
-    /// `owner_id` matches).
+    /// List the secret-free heads of every credential visible to `scope`
+    /// (rows whose stored `owner_id` matches).
     ///
     /// # Performance contract
     ///
@@ -404,14 +403,17 @@ impl CredentialService {
     /// # Errors
     ///
     /// [`CredentialServiceError::Store`] on a backend failure.
-    pub async fn list(&self, scope: &TenantScope) -> Result<Vec<String>, CredentialServiceError> {
+    pub async fn list(
+        &self,
+        scope: &TenantScope,
+    ) -> Result<Vec<CredentialHead>, CredentialServiceError> {
         let ids = self.store.list(None).await.map_err(Self::map_store_err)?;
         let mut visible = Vec::new();
         for id in ids {
             match self.store.get(&id).await {
                 Ok(stored) => {
                     if Self::owner_matches(&stored, scope) {
-                        visible.push(id);
+                        visible.push(Self::head_from(&stored));
                     }
                 },
                 // A row that vanished between `list` and `get` is simply
@@ -423,10 +425,21 @@ impl CredentialService {
         Ok(visible)
     }
 
-    /// Replace a credential's stored state via compare-and-swap.
+    /// Update a credential's stored state and/or display metadata.
     ///
-    /// `expected_version` is the optimistic-concurrency precondition; a
-    /// mismatch surfaces as [`CredentialServiceError::VersionConflict`].
+    /// `props = Some(..)` re-runs the canonical validate→resolve pipeline
+    /// for the row's (unchanged) credential type and replaces the stored
+    /// state; `props = None` keeps the existing state bytes untouched and
+    /// rewrites only the display metadata — a rename/re-tag never
+    /// re-resolves or re-encrypts material.
+    ///
+    /// `display` is the **full replacement** value; callers that want
+    /// field-wise merge semantics read the current head first and merge
+    /// before calling.
+    ///
+    /// `expected_version = Some(v)` engages compare-and-swap (a mismatch
+    /// surfaces as [`CredentialServiceError::VersionConflict`]);
+    /// `None` is a last-writer-wins overwrite.
     ///
     /// # Errors
     ///
@@ -438,26 +451,33 @@ impl CredentialService {
         &self,
         scope: &TenantScope,
         id: &str,
-        props: Value,
-        expected_version: u64,
+        props: Option<Value>,
+        expected_version: Option<u64>,
         display: CredentialDisplay,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
+    ) -> Result<CredentialHead, CredentialServiceError> {
         // Owner check first: a cross-tenant id is reported as missing,
         // never as a version conflict (no existence leak).
         let existing = self.load_owned(scope, id).await?;
 
-        self.ops.validate(&existing.credential_key, &props)?;
-        let values = FieldValues::from_json(props).map_err(|e| {
-            CredentialServiceError::ValidationFailed {
-                reason: format!("property ingest failed: {e}"),
-            }
-        })?;
-
-        let ctx = Self::owner_context(scope);
-        let resolved = self
-            .ops
-            .resolve(&existing.credential_key, &values, &ctx, &self.pending)
-            .await?;
+        // Re-resolve only when new properties were supplied; a
+        // display-only update carries the existing state through.
+        let resolved = match props {
+            Some(props) => {
+                self.ops.validate(&existing.credential_key, &props)?;
+                let values = FieldValues::from_json(props).map_err(|e| {
+                    CredentialServiceError::ValidationFailed {
+                        reason: format!("property ingest failed: {e}"),
+                    }
+                })?;
+                let ctx = Self::owner_context(scope);
+                Some(
+                    self.ops
+                        .resolve(&existing.credential_key, &values, &ctx, &self.pending)
+                        .await?,
+                )
+            },
+            None => None,
+        };
 
         let mut metadata = existing.metadata.clone();
         metadata.insert(
@@ -467,27 +487,40 @@ impl CredentialService {
         Self::set_display(&mut metadata, &display);
 
         let now = chrono::Utc::now();
-        let stored = StoredCredential {
-            id: existing.id.clone(),
-            credential_key: existing.credential_key.clone(),
-            data: resolved.data.to_vec(),
-            state_kind: resolved.state_kind,
-            state_version: resolved.state_version,
-            version: existing.version,
-            created_at: existing.created_at,
-            updated_at: now,
-            expires_at: resolved.expires_at,
-            reauth_required: false,
-            metadata,
+        let stored = match resolved {
+            Some(resolved) => StoredCredential {
+                id: existing.id.clone(),
+                credential_key: existing.credential_key.clone(),
+                data: resolved.data.to_vec(),
+                state_kind: resolved.state_kind,
+                state_version: resolved.state_version,
+                version: existing.version,
+                created_at: existing.created_at,
+                updated_at: now,
+                expires_at: resolved.expires_at,
+                reauth_required: false,
+                metadata,
+            },
+            None => StoredCredential {
+                updated_at: now,
+                metadata,
+                ..existing.clone()
+            },
         };
 
-        self.store
-            .put(stored, PutMode::CompareAndSwap { expected_version })
+        let mode = match expected_version {
+            Some(expected_version) => PutMode::CompareAndSwap { expected_version },
+            None => PutMode::Overwrite,
+        };
+
+        let persisted = self
+            .store
+            .put(stored, mode)
             .await
             .map_err(Self::map_store_err)?;
 
         tracing::info!(credential.id = %id, "credential updated");
-        self.snapshot_from_store(scope, id).await
+        Ok(Self::head_from(&persisted))
     }
 
     /// Delete a credential scoped to `scope`.
@@ -576,13 +609,13 @@ impl CredentialService {
     /// entirely** and the now-fresher state is re-read from the store
     /// instead of clobbering it with the un-mutated local copy. On
     /// success (either path) [`CredentialObserver::on_refresh`] fires and
-    /// the fresh secret-free snapshot is returned.
+    /// the fresh secret-free [`CredentialHead`] is returned.
     ///
     /// ## Fallback-on-interrupt
     ///
     /// If the provider call fails with a **transient** error
     /// ([`CredentialServiceError::TransientProvider`]) AND the currently
-    /// cached snapshot is still non-expired, the cached snapshot is
+    /// stored material is still non-expired, the cached head is
     /// returned instead of propagating the error. This protects in-flight
     /// executions from transient provider 5xx / network blips without
     /// papering over real expiry. Terminal failures (token expired / revoked /
@@ -595,7 +628,7 @@ impl CredentialService {
     /// - [`CredentialServiceError::NotFound`] — absent or cross-tenant id.
     /// - [`CredentialServiceError::CapabilityUnsupported`] — type is not `Refreshable`.
     /// - [`CredentialServiceError::Provider`] — refresh failed after retries (terminal).
-    /// - [`CredentialServiceError::TransientProvider`] — transient failure AND cached snapshot
+    /// - [`CredentialServiceError::TransientProvider`] — transient failure AND stored material
     ///   is expired (no valid fallback available).
     /// - [`CredentialServiceError::VersionConflict`] — a concurrent write landed first.
     /// - [`CredentialServiceError::Store`] — re-persist failed.
@@ -603,19 +636,19 @@ impl CredentialService {
         &self,
         scope: &TenantScope,
         id: &str,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
-        // Snapshot the cached state before attempting refresh. On a
-        // transient provider failure we fall back to this if it is still
+    ) -> Result<CredentialHead, CredentialServiceError> {
+        // Read the current head before attempting refresh. On a transient
+        // provider failure we fall back to this if the material is still
         // non-expired — avoids propagating blips to the caller.
         let cached = self.get(scope, id).await?;
 
         match self.refresh_inner(scope, id).await {
-            Ok(snap) => Ok(snap),
+            Ok(head) => Ok(head),
             Err(ref e) if Self::is_transient_failure(e) && !cached.is_expired() => {
                 tracing::warn!(
                     credential.id = %id,
                     error = %e,
-                    "credential refresh failed transiently; returning cached non-expired snapshot"
+                    "credential refresh failed transiently; stored material still non-expired"
                 );
                 Ok(cached)
             },
@@ -630,7 +663,7 @@ impl CredentialService {
         &self,
         scope: &TenantScope,
         id: &str,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
+    ) -> Result<CredentialHead, CredentialServiceError> {
         let stored = self.load_owned(scope, id).await?;
         if !self.registry.is_refreshable(&stored.credential_key) {
             return Err(CredentialServiceError::CapabilityUnsupported {
@@ -667,7 +700,7 @@ impl CredentialService {
             // state. Re-writing the un-mutated local copy here would
             // either spuriously `VersionConflict` or clobber that fresher
             // state (concurrent-refresh contract). Skip the write entirely and return the
-            // store's current (post-coalesce) snapshot.
+            // store's current (post-coalesce) head.
             crate::ops::RefreshOutcomeKind::CoalescedReRead => {
                 let credential_id = CredentialId::parse(&stored.id).map_err(|e| {
                     CredentialServiceError::Internal(format!(
@@ -679,7 +712,7 @@ impl CredentialService {
                     credential.id = %id,
                     "credential refresh coalesced by another replica; re-reading without re-writing"
                 );
-                return self.snapshot_from_store(scope, id).await;
+                return self.get(scope, id).await;
             },
         };
 
@@ -725,7 +758,7 @@ impl CredentialService {
         })?;
         self.observer.on_refresh(&credential_id);
         tracing::info!(credential.id = %id, "credential refreshed");
-        self.snapshot_from_store(scope, id).await
+        self.get(scope, id).await
     }
 
     /// True iff this error is a transient refresh/provider failure that the
@@ -928,7 +961,7 @@ impl CredentialService {
                 // Acquisition carries no caller-supplied display metadata
                 // (the interactive/resolve flow names nothing); a later
                 // `update` can attach it.
-                let snapshot = self
+                let head = self
                     .persist_resolved(
                         scope,
                         credential_key,
@@ -943,7 +976,7 @@ impl CredentialService {
                     credential.id = %id,
                     "credential acquired"
                 );
-                Ok(Acquisition::Complete { snapshot })
+                Ok(Acquisition::Complete { head })
             },
             crate::ops::AcquireOutcome::Pending { token, interaction } => {
                 // The interaction can only be completed through
@@ -1222,22 +1255,11 @@ impl CredentialService {
         Ok(stored)
     }
 
-    /// Load + owner-check + project to a secret-free snapshot.
-    async fn snapshot_from_store(
-        &self,
-        scope: &TenantScope,
-        id: &str,
-    ) -> Result<CredentialSnapshot, CredentialServiceError> {
-        let stored = self.load_owned(scope, id).await?;
-        let mut record = CredentialRecord::new();
-        record.created_at = stored.created_at;
-        record.last_modified = stored.updated_at;
-        record.expires_at = stored.expires_at;
-        let display = Self::display_from(&stored);
-        Ok(self
-            .ops
-            .snapshot(&stored.credential_key, &stored.data, record)?
-            .with_display(display))
+    /// Project a stored row to its secret-free [`CredentialHead`],
+    /// attaching the facade-owned display sub-object. Never touches
+    /// `stored.data`.
+    fn head_from(stored: &StoredCredential) -> CredentialHead {
+        CredentialHead::from_stored(stored, Self::display_from(stored))
     }
 
     /// Whether `stored` is owned by `scope`. A row missing the
@@ -1560,7 +1582,7 @@ mod tests {
     async fn create_then_get_roundtrip_is_tenant_scoped() {
         let svc = in_memory_service();
         let scope = TenantScope::new("org1", "ws1");
-        let snap = svc
+        let head = svc
             .create(
                 &scope,
                 "bearer_token",
@@ -1569,14 +1591,15 @@ mod tests {
             )
             .await
             .expect("create ok");
-        assert_eq!(snap.kind(), "bearer_token");
+        assert_eq!(head.credential_key, "bearer_token");
 
         // The id round-trips: get with the same scope returns the row.
-        let ids = svc.list(&scope).await.expect("list ok");
-        assert_eq!(ids.len(), 1);
-        let got = svc.get(&scope, &ids[0]).await.expect("get ok");
-        assert_eq!(got.kind(), "bearer_token");
-        // Secret never appears in the snapshot's Debug.
+        let heads = svc.list(&scope).await.expect("list ok");
+        assert_eq!(heads.len(), 1);
+        assert_eq!(heads[0].id, head.id);
+        let got = svc.get(&scope, &head.id).await.expect("get ok");
+        assert_eq!(got.credential_key, "bearer_token");
+        // The secret structurally cannot appear in the head's Debug.
         assert!(!format!("{got:?}").contains("sk-secret-1"));
     }
 
@@ -1592,8 +1615,8 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let ids = svc.list(&owner).await.expect("list ok");
-        let id = &ids[0];
+        let heads = svc.list(&owner).await.expect("list ok");
+        let id = &heads[0].id;
 
         // A different tenant cannot see the credential at all.
         let other = TenantScope::new("org1", "ws2");
@@ -1650,7 +1673,7 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&scope).await.expect("list")[0].clone();
+        let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         // Stored version after CreateOnly is 1; a stale expected_version
         // of 99 must conflict.
@@ -1658,8 +1681,8 @@ mod tests {
             .update(
                 &scope,
                 &id,
-                serde_json::json!({ "token": "sk-v2" }),
-                99,
+                Some(serde_json::json!({ "token": "sk-v2" })),
+                Some(99),
                 CredentialDisplay::default(),
             )
             .await
@@ -1682,20 +1705,20 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&scope).await.expect("list")[0].clone();
+        let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         svc.update(
             &scope,
             &id,
-            serde_json::json!({ "token": "sk-new" }),
-            1,
+            Some(serde_json::json!({ "token": "sk-new" })),
+            Some(1),
             CredentialDisplay::default(),
         )
         .await
         .expect("update ok");
-        // Still resolvable post-update.
+        // Still readable post-update.
         let got = svc.get(&scope, &id).await.expect("get ok");
-        assert_eq!(got.kind(), "bearer_token");
+        assert_eq!(got.credential_key, "bearer_token");
 
         svc.delete(&scope, &id).await.expect("delete ok");
         let err = svc.get(&scope, &id).await.expect_err("gone");
@@ -1714,7 +1737,7 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&owner).await.expect("list")[0].clone();
+        let id = svc.list(&owner).await.expect("list")[0].id.clone();
 
         let other = TenantScope::new("org9", "ws9");
         assert!(matches!(
@@ -1725,8 +1748,8 @@ mod tests {
             svc.update(
                 &other,
                 &id,
-                serde_json::json!({ "token": "z" }),
-                1,
+                Some(serde_json::json!({ "token": "z" })),
+                Some(1),
                 CredentialDisplay::default(),
             )
             .await
@@ -1750,7 +1773,7 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&scope).await.expect("list")[0].clone();
+        let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         let test_err = svc.test(&scope, &id).await.expect_err("not testable");
         assert!(matches!(
@@ -1784,17 +1807,19 @@ mod tests {
             )
             .await
             .expect("resolve ok");
-        let snapshot = match acq {
-            Acquisition::Complete { snapshot } => snapshot,
+        let head = match acq {
+            Acquisition::Complete { head } => head,
             other => panic!("expected Complete, got {other:?}"),
         };
-        assert_eq!(snapshot.kind(), "bearer_token");
+        assert_eq!(head.credential_key, "bearer_token");
 
-        // The acquired credential is now a normal stored credential.
-        let ids = svc.list(&scope).await.expect("list ok");
-        assert_eq!(ids.len(), 1);
-        let got = svc.get(&scope, &ids[0]).await.expect("get ok");
-        assert_eq!(got.kind(), "bearer_token");
+        // The acquired credential is now a normal stored credential, and
+        // the returned head's id is the persisted row's id.
+        let heads = svc.list(&scope).await.expect("list ok");
+        assert_eq!(heads.len(), 1);
+        assert_eq!(heads[0].id, head.id);
+        let got = svc.get(&scope, &head.id).await.expect("get ok");
+        assert_eq!(got.credential_key, "bearer_token");
         assert!(!format!("{got:?}").contains("sk-acquired"));
     }
 
@@ -1833,7 +1858,7 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&owner).await.expect("list")[0].clone();
+        let id = svc.list(&owner).await.expect("list")[0].id.clone();
 
         let other = TenantScope::new("org9", "ws9");
         // A cross-tenant id is reported as missing on every new op —
@@ -1947,11 +1972,11 @@ mod tests {
         )
         .await
         .expect("create fixture ok");
-        let id = svc.list(&scope).await.expect("list")[0].clone();
+        let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 0);
-        let snap = svc.refresh(&scope, &id).await.expect("refresh ok");
-        assert_eq!(snap.kind(), "refreshable_fixture");
+        let head = svc.refresh(&scope, &id).await.expect("refresh ok");
+        assert_eq!(head.credential_key, "refreshable_fixture");
         // on_refresh fired exactly once on the success path.
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 1);
 
@@ -1959,12 +1984,12 @@ mod tests {
         // observes the first rotation (counter is 2 → token `tok-base-r2`),
         // proving the CAS write stored the refreshed bytes, not the
         // pre-refresh copy.
-        let snap2 = svc.refresh(&scope, &id).await.expect("second refresh ok");
-        assert_eq!(snap2.kind(), "refreshable_fixture");
+        let head2 = svc.refresh(&scope, &id).await.expect("second refresh ok");
+        assert_eq!(head2.credential_key, "refreshable_fixture");
         assert_eq!(refreshes.load(std::sync::atomic::Ordering::SeqCst), 2);
         // Still retrievable and correctly projected post-refresh.
         let got = svc.get(&scope, &id).await.expect("get ok");
-        assert_eq!(got.kind(), "refreshable_fixture");
+        assert_eq!(got.credential_key, "refreshable_fixture");
     }
 
     /// A concurrent version bump landing between refresh's internal load
@@ -1994,7 +2019,7 @@ mod tests {
         )
         .await
         .expect("create ok");
-        let id = svc.list(&scope).await.expect("list")[0].clone();
+        let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
         // 2 parties: the fixture's parked `refresh` and the writer below.
         let barrier = Arc::new(tokio::sync::Barrier::new(2));
@@ -2013,8 +2038,8 @@ mod tests {
                     .update(
                         scope_ref,
                         id_ref,
-                        serde_json::json!({ "token": "tok-race-concurrent" }),
-                        1,
+                        Some(serde_json::json!({ "token": "tok-race-concurrent" })),
+                        Some(1),
                         CredentialDisplay::default(),
                     )
                     .await;

--- a/crates/credential-runtime/src/test_fixtures.rs
+++ b/crates/credential-runtime/src/test_fixtures.rs
@@ -120,7 +120,7 @@ pub fn set_refresh_rendezvous(barrier: Option<Arc<tokio::sync::Barrier>>) {
 /// would consume the remaining attempts and the second call would
 /// succeed normally — masking the failure the test is trying to
 /// observe. Persistent firing is what lets the fallback probe assert
-/// the outer fallback branch (return cached snapshot) was actually
+/// the outer fallback branch (return cached head) was actually
 /// taken.
 #[derive(Debug, Clone, Copy)]
 pub enum RefreshFailureScript {

--- a/crates/credential-runtime/tests/adversarial.rs
+++ b/crates/credential-runtime/tests/adversarial.rs
@@ -39,7 +39,7 @@ async fn abuse1_cross_tenant_is_uniformly_not_found_no_existence_leak() {
     )
     .await
     .expect("create under A");
-    let id = svc.list(&a).await.expect("list A")[0].clone();
+    let id = svc.list(&a).await.expect("list A")[0].id.clone();
 
     // get / update / delete / test / refresh / revoke under B: every one
     // is NotFound (not VersionConflict, not CapabilityUnsupported — those
@@ -52,8 +52,8 @@ async fn abuse1_cross_tenant_is_uniformly_not_found_no_existence_leak() {
         svc.update(
             &b,
             &id,
-            json!({ "token": "z" }),
-            1,
+            Some(json!({ "token": "z" })),
+            Some(1),
             nebula_credential::CredentialDisplay::default()
         )
         .await
@@ -108,7 +108,7 @@ async fn abuse2_expr_injection_is_validation_failed_control_succeeds() {
     );
 
     // Control: a well-formed create on the same type succeeds.
-    let snap = svc
+    let head = svc
         .create(
             &scope,
             "bearer_token",
@@ -117,34 +117,21 @@ async fn abuse2_expr_injection_is_validation_failed_control_succeeds() {
         )
         .await
         .expect("well-formed create succeeds");
-    assert_eq!(snap.kind(), "bearer_token");
+    assert_eq!(head.credential_key, "bearer_token");
 }
 
 /// Abuse #3 — secret echo in responses.
 ///
-/// The facade's response/inspection type is [`CredentialSnapshot`]. Its
-/// structural guarantee is twofold and **stronger than "serializes
-/// redacted"**:
-///
-/// 1. `Debug` redacts the projected scheme to `[REDACTED]` — the secret
-///    substring is absent, the sentinel present, on a freshly-created and
-///    a re-fetched snapshot alike.
-/// 2. `CredentialSnapshot` deliberately does **not** implement `Serialize`
-///    at all (it holds a type-erased `Box<dyn Any>`), so it cannot be put
-///    on the wire by serde even by mistake. That `!Serialize` property is
-///    asserted structurally by the `tests/compile_fail` probe
-///    (`snapshot_not_serialize.rs`).
-///
-/// Spec divergence (documented in the deliverable): spec §6 #3 phrased the
-/// check as `serde_json::to_string(snapshot)` then assert the secret is
-/// absent. That is infeasible *and weaker*: `CredentialSnapshot: Serialize`
-/// does not exist, and projecting the inner `SecretToken` then serializing
-/// it would (correctly) expose the secret, because the scheme's
-/// `#[serde(with = "serde_secret")]` is the *encrypted-at-rest* path that
-/// must preserve the value. The honest facade proof is Debug-redaction +
-/// the compile-time absence of `Serialize`.
+/// The facade's management-plane response type is `CredentialHead`, which
+/// is secret-free **by construction**: it is projected from the stored row
+/// without ever reading `StoredCredential::data`, so there is no secret
+/// field to redact — `Debug` and `Serialize` structurally cannot echo the
+/// material. (The scheme-bearing `CredentialSnapshot` stays on the
+/// execution plane and deliberately does not implement `Serialize`; that
+/// property is asserted by the `tests/compile_fail` probe
+/// `snapshot_not_serialize.rs`.)
 #[tokio::test]
-async fn abuse3_no_secret_in_snapshot_debug_on_create_and_get() {
+async fn abuse3_no_secret_in_head_debug_or_serialize_on_create_and_get() {
     const SECRET: &str = "sk-do-not-leak-7f3a";
     let svc = in_memory_service();
     let scope = TenantScope::new("org1", "ws1");
@@ -161,23 +148,24 @@ async fn abuse3_no_secret_in_snapshot_debug_on_create_and_get() {
     let created_dbg = format!("{created:?}");
     assert!(
         !created_dbg.contains(SECRET),
-        "created snapshot Debug leaked the secret"
+        "created head Debug leaked the secret"
     );
+    let created_json = serde_json::to_string(&created).expect("head serializes");
     assert!(
-        created_dbg.contains("[REDACTED]"),
-        "created snapshot Debug must show the redaction sentinel"
+        !created_json.contains(SECRET),
+        "created head Serialize leaked the secret"
     );
 
-    let id = svc.list(&scope).await.expect("list")[0].clone();
-    let fetched = svc.get(&scope, &id).await.expect("get ok");
+    let fetched = svc.get(&scope, &created.id).await.expect("get ok");
     let fetched_dbg = format!("{fetched:?}");
     assert!(
         !fetched_dbg.contains(SECRET),
-        "fetched snapshot Debug leaked the secret"
+        "fetched head Debug leaked the secret"
     );
+    let fetched_json = serde_json::to_string(&fetched).expect("head serializes");
     assert!(
-        fetched_dbg.contains("[REDACTED]"),
-        "fetched snapshot Debug must show the redaction sentinel"
+        !fetched_json.contains(SECRET),
+        "fetched head Serialize leaked the secret"
     );
 }
 
@@ -201,7 +189,7 @@ async fn abuse4_static_type_capability_ops_are_unsupported() {
     )
     .await
     .expect("create ok");
-    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
     for (op_name, res) in [
         ("test", svc.test(&scope, &id).await.err()),
@@ -285,7 +273,7 @@ async fn abuse5_cross_tenant_revoke_is_not_found_before_lease_scan() {
     )
     .await
     .expect("create ok");
-    let id = svc.list(&owner).await.expect("list")[0].clone();
+    let id = svc.list(&owner).await.expect("list")[0].id.clone();
 
     // The attacker's revoke is NotFound — the owner gate runs before the
     // capability gate and before any lease release, so a foreign caller
@@ -387,17 +375,17 @@ async fn abuse7_layered_store_roundtrips_without_exposing_plaintext() {
     )
     .await
     .expect("create ok");
-    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let id = svc.list(&scope).await.expect("list")[0].id.clone();
 
     // Round-trips through Encryption(raw) transparently and the projected
     // snapshot never carries the plaintext. (Ciphertext-at-rest itself is
     // proven structurally by the compile-fail probe — the raw store can
     // never be composed without the EncryptionLayer.)
     let got = svc.get(&scope, &id).await.expect("get ok");
-    assert_eq!(got.kind(), "bearer_token");
+    assert_eq!(got.credential_key, "bearer_token");
     assert!(
         !format!("{got:?}").contains(SECRET),
-        "snapshot must not carry the plaintext secret"
+        "head must not carry the plaintext secret"
     );
 }
 

--- a/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.stderr
+++ b/crates/credential-runtime/tests/compile_fail/raw_store_without_layers.stderr
@@ -8,8 +8,8 @@ error[E0624]: associated function `__from_parts` is private
    |
    | /     pub(crate) fn __from_parts(
    | |         store: Arc<dyn DynCredentialStore>,
+   | |         scan_store: ErasedCredentialStore,
    | |         resolver: CredentialResolver<ErasedCredentialStore>,
-   | |         lease: LeaseLifecycle,
 ...  |
    | |         source: StateSource,
    | |     ) -> Self {

--- a/crates/credential-runtime/tests/display_metadata.rs
+++ b/crates/credential-runtime/tests/display_metadata.rs
@@ -23,7 +23,7 @@ async fn display_round_trips_through_create_get_and_update() {
         tags,
     };
 
-    // create() attaches the display to the returned snapshot verbatim.
+    // create() attaches the display to the returned head verbatim.
     let created = svc
         .create(
             &scope,
@@ -33,24 +33,82 @@ async fn display_round_trips_through_create_get_and_update() {
         )
         .await
         .expect("create ok");
-    assert_eq!(created.display(), &display);
+    assert_eq!(created.display, display);
 
     // get() reads it back from the reserved `metadata["display"]` sub-object.
-    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let id = created.id.clone();
     let got = svc.get(&scope, &id).await.expect("get ok");
-    assert_eq!(got.display(), &display);
+    assert_eq!(got.display, display);
 
     // update() replaces the display; cleared fields do not linger.
     let next = CredentialDisplay {
         display_name: Some("Renamed".to_owned()),
         ..Default::default()
     };
-    svc.update(&scope, &id, json!({ "token": "sk-disp" }), 1, next.clone())
-        .await
-        .expect("update ok");
+    svc.update(
+        &scope,
+        &id,
+        Some(json!({ "token": "sk-disp" })),
+        Some(created.version),
+        next.clone(),
+    )
+    .await
+    .expect("update ok");
     let after = svc.get(&scope, &id).await.expect("get ok");
-    assert_eq!(after.display(), &next);
-    assert!(after.display().description.is_none());
+    assert_eq!(after.display, next);
+    assert!(after.display.description.is_none());
+}
+
+#[tokio::test]
+async fn display_only_update_keeps_state_and_respects_cas() {
+    let svc = in_memory_service();
+    let scope = TenantScope::new("org1", "ws1");
+
+    let created = svc
+        .create(
+            &scope,
+            "bearer_token",
+            json!({ "token": "sk-disp-only" }),
+            CredentialDisplay::default(),
+        )
+        .await
+        .expect("create ok");
+
+    // props = None → display-only update; the state bytes stay untouched
+    // and the row version still advances (it is a store write).
+    let renamed = CredentialDisplay {
+        display_name: Some("Named later".to_owned()),
+        ..Default::default()
+    };
+    let updated = svc
+        .update(
+            &scope,
+            &created.id,
+            None,
+            Some(created.version),
+            renamed.clone(),
+        )
+        .await
+        .expect("display-only update ok");
+    assert_eq!(updated.display, renamed);
+    assert_eq!(updated.credential_key, "bearer_token");
+    assert!(updated.version > created.version);
+
+    // A stale CAS version is rejected.
+    let err = svc
+        .update(
+            &scope,
+            &created.id,
+            None,
+            Some(created.version),
+            CredentialDisplay::default(),
+        )
+        .await
+        .expect_err("stale CAS version must conflict");
+    assert!(matches!(
+        err,
+        nebula_credential_runtime::CredentialServiceError::VersionConflict { .. }
+    ));
 }
 
 #[tokio::test]
@@ -67,7 +125,7 @@ async fn empty_display_is_the_default_on_get() {
     .await
     .expect("create ok");
 
-    let id = svc.list(&scope).await.expect("list")[0].clone();
+    let id = svc.list(&scope).await.expect("list")[0].id.clone();
     let got = svc.get(&scope, &id).await.expect("get ok");
-    assert!(got.display().is_empty());
+    assert!(got.display.is_empty());
 }

--- a/crates/credential-runtime/tests/refresh_fallback.rs
+++ b/crates/credential-runtime/tests/refresh_fallback.rs
@@ -37,26 +37,27 @@ async fn refresh_transient_falls_back_to_cached_when_non_expired() {
     .await
     .expect("create seed");
 
-    let ids = svc.list(&scope).await.expect("list");
-    assert_eq!(ids.len(), 1);
-    let id = &ids[0];
+    let heads = svc.list(&scope).await.expect("list");
+    assert_eq!(heads.len(), 1);
+    let id = &heads[0].id;
 
-    // Cached snapshot reflects the seed token.
+    // Cached head reflects the seeded row.
     let before = svc.get(&scope, id).await.expect("pre-refresh get");
 
     // Script a transient failure for the next refresh call.
     set_refresh_failure(Some(RefreshFailureScript::Transient));
 
     // refresh() must NOT propagate the transient — it must return the
-    // cached snapshot because the cached state is still non-expired.
+    // cached head because the stored material is still non-expired.
     let after = svc
         .refresh(&scope, id)
         .await
-        .expect("refresh falls back to cached non-expired snapshot");
+        .expect("refresh falls back to cached non-expired head");
 
-    // The returned snapshot is the cached one (same id, same version).
-    assert_eq!(after.kind(), before.kind());
-    assert_eq!(after.record().version, before.record().version);
+    // The returned head is the cached one (same key, same store version —
+    // no write happened).
+    assert_eq!(after.credential_key, before.credential_key);
+    assert_eq!(after.version, before.version);
 
     // Clean any leftover script (defensive — `.take()` already consumed it).
     set_refresh_failure(None);
@@ -76,8 +77,8 @@ async fn refresh_terminal_failure_propagates() {
     .await
     .expect("create seed");
 
-    let ids = svc.list(&scope).await.expect("list");
-    let id = &ids[0];
+    let heads = svc.list(&scope).await.expect("list");
+    let id = &heads[0].id;
 
     // Script a TERMINAL failure (TokenExpired) for the next refresh call.
     set_refresh_failure(Some(RefreshFailureScript::Terminal));
@@ -112,22 +113,21 @@ async fn refresh_no_failure_returns_refreshed_snapshot() {
     .await
     .expect("create seed");
 
-    let ids = svc.list(&scope).await.expect("list");
-    let id = &ids[0];
+    let heads = svc.list(&scope).await.expect("list");
+    let id = &heads[0].id;
 
     let before = svc.get(&scope, id).await.expect("get");
 
     let after = svc.refresh(&scope, id).await.expect("refresh ok");
 
-    assert_eq!(after.kind(), before.kind());
+    assert_eq!(after.credential_key, before.credential_key);
     // A successful refresh re-persists the row via CAS in
-    // `refresh_inner` (sets `updated_at = now`). The `last_modified`
-    // timestamp on the snapshot's record must advance past the
-    // pre-refresh value.
+    // `refresh_inner` (sets `updated_at = now`). The `updated_at`
+    // timestamp on the head must advance past the pre-refresh value.
     assert!(
-        after.record().last_modified > before.record().last_modified,
-        "successful refresh must bump last_modified (before={:?}, after={:?})",
-        before.record().last_modified,
-        after.record().last_modified,
+        after.updated_at > before.updated_at,
+        "successful refresh must bump updated_at (before={:?}, after={:?})",
+        before.updated_at,
+        after.updated_at,
     );
 }

--- a/crates/credential-runtime/tests/refresh_fallback.rs
+++ b/crates/credential-runtime/tests/refresh_fallback.rs
@@ -48,16 +48,21 @@ async fn refresh_transient_falls_back_to_cached_when_non_expired() {
     set_refresh_failure(Some(RefreshFailureScript::Transient));
 
     // refresh() must NOT propagate the transient — it must return the
-    // cached head because the stored material is still non-expired.
-    let after = svc
+    // cached head because the stored material is still non-expired, and
+    // the report must say so honestly.
+    let report = svc
         .refresh(&scope, id)
         .await
         .expect("refresh falls back to cached non-expired head");
+    assert!(
+        !report.refreshed,
+        "the fallback path must report refreshed = false"
+    );
 
     // The returned head is the cached one (same key, same store version —
     // no write happened).
-    assert_eq!(after.credential_key, before.credential_key);
-    assert_eq!(after.version, before.version);
+    assert_eq!(report.head.credential_key, before.credential_key);
+    assert_eq!(report.head.version, before.version);
 
     // Clean any leftover script (defensive — `.take()` already consumed it).
     set_refresh_failure(None);
@@ -118,16 +123,20 @@ async fn refresh_no_failure_returns_refreshed_snapshot() {
 
     let before = svc.get(&scope, id).await.expect("get");
 
-    let after = svc.refresh(&scope, id).await.expect("refresh ok");
+    let report = svc.refresh(&scope, id).await.expect("refresh ok");
+    assert!(
+        report.refreshed,
+        "a real refresh must report refreshed = true"
+    );
 
-    assert_eq!(after.credential_key, before.credential_key);
+    assert_eq!(report.head.credential_key, before.credential_key);
     // A successful refresh re-persists the row via CAS in
     // `refresh_inner` (sets `updated_at = now`). The `updated_at`
     // timestamp on the head must advance past the pre-refresh value.
     assert!(
-        after.updated_at > before.updated_at,
+        report.head.updated_at > before.updated_at,
         "successful refresh must bump updated_at (before={:?}, after={:?})",
         before.updated_at,
-        after.updated_at,
+        report.head.updated_at,
     );
 }

--- a/crates/credential-runtime/tests/resolve_for_slot.rs
+++ b/crates/credential-runtime/tests/resolve_for_slot.rs
@@ -32,9 +32,9 @@ async fn resolve_for_slot_produces_guard() {
         .await
         .expect("create succeeds");
 
-    let ids = service.list(&scope).await.expect("list succeeds");
-    assert_eq!(ids.len(), 1, "expected exactly one credential");
-    let id = &ids[0];
+    let heads = service.list(&scope).await.expect("list succeeds");
+    assert_eq!(heads.len(), 1, "expected exactly one credential");
+    let id = &heads[0].id;
 
     // Step 2: validate the binding.
     let binding = service
@@ -73,8 +73,8 @@ async fn resolve_for_slot_scope_violation_rejected() {
         .await
         .expect("create succeeds");
 
-    let ids_a = service.list(&scope_a).await.expect("list scope A");
-    let id = &ids_a[0];
+    let heads_a = service.list(&scope_a).await.expect("list scope A");
+    let id = &heads_a[0].id;
 
     // Validate the binding for scope A.
     let binding_a = service
@@ -111,8 +111,8 @@ async fn resolve_for_slot_cancellation_returns_cancelled() {
         .await
         .expect("create succeeds");
 
-    let ids = service.list(&scope).await.expect("list succeeds");
-    let id = &ids[0];
+    let heads = service.list(&scope).await.expect("list succeeds");
+    let id = &heads[0].id;
 
     let binding = service
         .validate_credential_binding(&scope, id)

--- a/crates/credential-runtime/tests/validated_binding_cross_tenant.rs
+++ b/crates/credential-runtime/tests/validated_binding_cross_tenant.rs
@@ -32,7 +32,7 @@ async fn cross_tenant_binding_rejected() {
         1,
         "expected exactly one credential under scope A"
     );
-    let id = &ids_a[0];
+    let id = &ids_a[0].id;
 
     // Tenant B tries to bind to tenant A's credential — must fail with ScopeMismatch.
     let err = service

--- a/docs/plans/2026-06-09-credential-api-wiring.md
+++ b/docs/plans/2026-06-09-credential-api-wiring.md
@@ -1,7 +1,29 @@
 # Wire nebula-api → CredentialService (ADR-0088 D4 P4 + D7)
 
-Status: in progress (P1 only approved; re-gate before P2+)
-Branch: `refactor/credential-facade-dyn-erasure`
+Status: steps 1–5 DONE. P1 (dyn-erasure) + P2 steps 1–3 merged via PR #785
+(squash `5c5852ec`). Steps 4–5 (api transport → facade, split-brain store
+unification, live lifecycle/acquisition) landed on branch
+`feat/api-credential-routing`:
+
+- `refactor(credential-runtime)!` — facade CRUD/refresh return the new
+  secret-free `CredentialHead` (id + store CAS version + reauth flag +
+  display); `update` takes `props: Option` (display-only updates) +
+  `expected_version: Option`; `Acquisition::Complete` carries the head;
+  `TenantScope::from_scope`; dead `ops.snapshot` deleted.
+- `feat(api)!` — CRUD/lifecycle/acquisition through the facade; OAuth
+  two-phase writes through `scoped_store` over
+  `credential_store_handle()` (split-brain CLOSED, original P5
+  store-unification folded in); `AppState.oauth_credential_store`
+  DELETED; OAuth `owner_id` + CAS version mandatory (admin-bypass write
+  path deleted); api `classify()` dup deleted (schema port is the
+  source); honest-503 only when no service is wired.
+
+Remaining (next PRs): P4 OAuth → facade interactive acquisition
+(`resolve`→`Pending`→`continue`), P5 delete `CredentialScopeLayer` +
+transfer its tenant-isolation tests, P6 observability DoD + criterion
+p99 gate + ADR-0088 status flip.
+
+Branch (historical): `refactor/credential-facade-dyn-erasure`
 Owner decision (2026-06-09): Option **C** (P4 dyn-erasure folded into the wiring,
 one branch, expand-contract green-per-commit). Execution gated **P1-first**:
 land the non-generic facade as its own green milestone, then re-approve the


### PR DESCRIPTION
## What

Every credential operation in nebula-api — CRUD, lifecycle (`test`/`refresh`/`revoke`), and acquisition (`resolve`/`continue`) — now routes through the `CredentialService` facade. The split-brain store is gone: the OAuth two-phase flow writes through a `CredentialScopeLayer` over the facade's own store handle, so OAuth-acquired credentials are visible to `get`/`list` and there is no second store to drift from. `AppState.oauth_credential_store` is deleted.

## Why

ADR-0088 D7: one persistence path. Before this PR the api CRUD wrote raw blobs into a plaintext in-memory store while the composed facade (PR #785) sat unused, and the lifecycle/acquisition endpoints were honest-503 stubs. Now credentials are schema-validated into typed state, encrypted at rest (AES-256-GCM), owner-checked per operation, and the lifecycle dispatches the registered type's real capability.

## Key changes

- **`CredentialHead` (credential-runtime)** — facade CRUD/refresh return a secret-free row view (id + store CAS version + timestamps + `reauth_required` + display) instead of `CredentialSnapshot`, which carried neither the id nor the CAS token and could not project a not-yet-authorized row. Scheme projection stays on the execution plane (`resolve_for_slot`); the dead `ops.snapshot` closure is deleted.
- **api transport rewrite** — facade routing end-to-end; `auth_pattern`/capabilities sourced from the schema port (hardcoded `classify()` table deleted); DTOs gained `reauth_required`, a `retry` acquisition arm, and interaction shapes mirroring `InteractionRequest`; lifecycle handlers derive the tenant from the resolved request scope (previously raw path slugs).
- **OAuth hardening** — `owner_id` and CAS are mandatory (the unscoped admin-bypass write path is deleted); the exchange clears the placeholder's `reauth_required` flag.
- **No service ⇒ honest 503** on every credential endpoint; no raw-store fallback exists.

## Adversarial review (multi-agent, 5 lenses + 2 skeptics per finding) — fixed in-branch

1. **list audit pollution** — the owner-filter scan minted phantom audit `Get` events against every other tenant's ids; the facade now scans through an un-audited handle over the same cache+encryption core (audit records accesses, not scans).
2. **update lost-update (high)** — no blind-Overwrite path remains: a missing caller version CASes on the version the call just loaded, so a display rename racing a token refresh yields 409 instead of silently restoring stale rotated tokens.
3. **refresh honesty** — `RefreshReport { head, refreshed }`: the fallback-on-interrupt path reports `refreshed: false` instead of claiming a refresh that never ran.
4. **OAuth consent-screen race** — the callback CASes on the exchange-time row version, not the authorize-time one, so a concurrent rename no longer burns the single-use authorization code (regression test included).

## Verification

- `cargo nextest run -p nebula-credential-runtime --features test-util` — 52/52
- `cargo nextest run -p nebula-api` — 489/489
- clippy `-D warnings` clean on both; rustdoc `-D warnings` clean; full workspace check clean
- lefthook pre-push (workspace clippy + crate-diff nextest) green

## Out of scope (next PRs, recorded in `docs/plans/2026-06-09-credential-api-wiring.md`)

- OAuth → facade interactive acquisition (`resolve`→`Pending`→`continue`)
- Delete `nebula_tenancy::CredentialScopeLayer` + transfer its tenant-isolation tests
- Observability DoD pass + criterion p99 gate + ADR-0088 status flip
- Known documented deferral: `facade.list` is O(N global) with foreign-row decrypt — owner-indexed listing lands with the durable store adapter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `reauth_required` flag to credential metadata responses.
  * Implemented form-post-based credential acquisition interactions with structured field data.
  * Added `Retry` response type with `retry_after_secs` guidance for credential operations.

* **Improvements**
  * Enhanced cross-workspace credential isolation and ownership validation.
  * Refactored credential lifecycle operations for improved reliability and consistency.
  * Improved credential display metadata handling during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->