### PR TITLE
perf(ci): optimize workflow runtimes — merge clippy+check, drop warm-cache, linux-only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # ── Formatting (gate — everything else waits) ─────────────────────────────
+  # ── Formatting (parallel, non-blocking gate) ──────────────────────────────
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
@@ -62,10 +62,12 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
-  # ── Linting ────────────────────────────────────────────────────────────────
-  clippy:
-    name: Clippy
-    needs: [fmt]
+  # ── Check + Lint (merged — clippy subsumes type-check) ────────────────────
+  # Running clippy with the same flags as `cargo check` avoids a second full
+  # workspace compilation. Feature-gated checks run afterwards on the warm
+  # incremental cache.
+  check:
+    name: Check + Clippy
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
@@ -79,33 +81,11 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
-          shared-key: ci-clippy
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-on-failure: true
-      - name: Run Clippy lints
-        run: cargo clippy --workspace -- -D warnings
-
-  # ── Type check (includes --all-features) ───────────────────────────────────
-  check:
-    name: Check
-    needs: [fmt]
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: "1.96"
-      - name: Cache Cargo artifacts
-        uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
-        with:
           shared-key: ci-check
           save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
-      - name: Run cargo check
-        run: cargo check --workspace --all-features --all-targets
+      - name: Clippy (workspace, all features, all targets)
+        run: cargo clippy --workspace --all-features --all-targets -- -D warnings
       - name: Check nebula-resilience (no-default-features)
         run: cargo check -p nebula-resilience --no-default-features
       - name: Check nebula-log (no-default-features)
@@ -250,18 +230,16 @@ jobs:
   # ── Required aggregator ───────────────────────────────────────────────────
   # Single required check for branch protection. Treats `skipped` (draft-gated
   # tier 2 jobs) as success, but `failure`/`cancelled` fails the whole suite.
-  # Replace the 6 individual required checks in the ruleset with just `CI`.
   required:
     name: CI
     if: always()
-    needs: [fmt, clippy, check, doctests, msrv, doc, deny]
+    needs: [fmt, check, doctests, msrv, doc, deny]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Verify required jobs
         env:
           FMT: ${{ needs.fmt.result }}
-          CLIPPY: ${{ needs.clippy.result }}
           CHECK: ${{ needs.check.result }}
           DOCTESTS: ${{ needs.doctests.result }}
           MSRV: ${{ needs.msrv.result }}
@@ -270,7 +248,7 @@ jobs:
         run: |
           set -euo pipefail
           fail=0
-          for pair in "fmt=$FMT" "clippy=$CLIPPY" "check=$CHECK" \
+          for pair in "fmt=$FMT" "check=$CHECK" \
                      "doctests=$DOCTESTS" "msrv=$MSRV" "doc=$DOC" "deny=$DENY"; do
             name="${pair%%=*}"
             result="${pair#*=}"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -27,13 +27,9 @@ concurrency:
 
 jobs:
   smoke:
-    name: Cross-platform smoke (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
+    name: Cross-platform smoke
+    runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -116,31 +116,9 @@ jobs:
           JSON=$(printf '%s\n' "${PACKAGES[@]}" | jq -R . | jq -s -c .)
           echo "packages=$JSON" >> "$GITHUB_OUTPUT"
 
-  # Build workspace once and save cache — matrix jobs read it
-  warm-cache:
-    name: Warm Cache
-    needs: select-matrix
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
-        with:
-          toolchain: stable
-      - name: Cache Cargo artifacts
-        uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
-        with:
-          shared-key: matrix
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-on-failure: true
-      - name: Build workspace (populates cache)
-        run: cargo check --workspace --all-targets
-
   test-crates:
     name: Test ${{ matrix.package }}
-    needs: [select-matrix, warm-cache]
+    needs: [select-matrix]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -160,8 +138,8 @@ jobs:
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@8cbdedb5103daa674dcf46d3590fe06a76645684 # v2.9.1
         with:
-          shared-key: matrix
-          save-if: false
+          key: ${{ matrix.package }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
           cache-on-failure: true
 
       - name: Install cargo-nextest
@@ -211,12 +189,9 @@ jobs:
           retention-days: 3
 
   # Aggregator that branch protection's required `Tests` check points at.
-  # Without this, the dynamic matrix job names (`Test nebula-core`, ...)
-  # never satisfy the single required-check name, leaving PRs stuck on
-  # "Tests — Expected — Waiting for status to be reported".
   tests:
     name: Tests
-    needs: [select-matrix, warm-cache, test-crates]
+    needs: [select-matrix, test-crates]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -225,10 +200,9 @@ jobs:
         run: |
           set -euo pipefail
           fail=0
-          for job in select-matrix warm-cache test-crates; do
+          for job in select-matrix test-crates; do
             case "$job" in
               select-matrix) result="${{ needs.select-matrix.result }}" ;;
-              warm-cache)    result="${{ needs.warm-cache.result }}" ;;
               test-crates)   result="${{ needs.test-crates.result }}" ;;
             esac
             if [[ "$result" != "success" ]]; then


### PR DESCRIPTION
## Summary
- **Merge clippy + check** into one job — eliminates redundant full workspace compilation (~10-15 min saved)
- **Make fmt non-blocking** — runs in parallel with check/clippy instead of gating them
- **Remove warm-cache** from test-matrix — on PRs it compiled the whole workspace with save-if: false, then every matrix job rebuilt from scratch anyway
- **Linux-only** for cross-platform smoke — drop macOS/Windows matrix for now

## Impact
~20-30 min less wall-clock time on PR CI runs.

## Test plan
- [ ] Verify CI passes on this PR
- [ ] Verify Tests aggregator still works as required check