### PR TITLE
fix(credential)!: gate serde_secret plaintext behind explicit storage scope

### DIFF
--- a/crates/api/src/domain/credential/oauth.rs
+++ b/crates/api/src/domain/credential/oauth.rs
@@ -427,7 +427,14 @@ async fn persist_oauth_state(
     credential_id: &str,
     oauth_state: OAuth2State,
 ) -> ApiResult<()> {
-    let data = serde_json::to_vec(&oauth_state).map_err(|e| {
+    // Cleartext serialization for the encrypted-at-rest credential store;
+    // `OAuth2State`'s secret fields emit cleartext only inside this scope.
+    // Outside it the same serialize redacts, which would silently persist
+    // `[REDACTED]` in place of the tokens.
+    let data = nebula_credential::serde_secret::expose_for_serialization(|| {
+        serde_json::to_vec(&oauth_state)
+    })
+    .map_err(|e| {
         ApiError::Internal(format!(
             "failed to serialize oauth state for persistence: {e}"
         ))

--- a/crates/api/tests/e2e_oauth2_flow.rs
+++ b/crates/api/tests/e2e_oauth2_flow.rs
@@ -276,7 +276,13 @@ async fn e2e_oauth2_flow_persists_exchanged_credential_state() {
     // Force state into early-refresh window to exercise engine refresh path.
     persisted_state.expires_at = Some(chrono::Utc::now() - chrono::Duration::seconds(30));
     let mut stale_record = stored.clone();
-    stale_record.data = serde_json::to_vec(&persisted_state).expect("serialize stale oauth state");
+    // Mirror the production persist path: cleartext only inside the storage
+    // scope, so the engine refresh path below reads back real tokens (the
+    // default sink would persist `[REDACTED]`).
+    stale_record.data = nebula_credential::serde_secret::expose_for_serialization(|| {
+        serde_json::to_vec(&persisted_state)
+    })
+    .expect("serialize stale oauth state");
     stale_record.expires_at = persisted_state.expires_at();
     let stale_put = oauth_store_handle(&state)
         .put(stale_record, PutMode::Overwrite)

--- a/crates/credential/src/credentials/oauth2.rs
+++ b/crates/credential/src/credentials/oauth2.rs
@@ -1468,7 +1468,25 @@ mod tests {
     #[test]
     fn oauth2_state_serde_round_trip() {
         let state = make_state();
-        let json = serde_json::to_string(&state).unwrap();
+
+        // Default sink (logs, responses): every secret field redacts.
+        let redacted = serde_json::to_string(&state).unwrap();
+        assert!(
+            !redacted.contains("tok_abc"),
+            "access_token leaked to default serde sink"
+        );
+        assert!(
+            !redacted.contains("ref_xyz"),
+            "refresh_token leaked to default serde sink"
+        );
+        assert!(
+            !redacted.contains("csecret"),
+            "client_secret leaked to default serde sink"
+        );
+
+        // Storage scope preserves them for encrypted-at-rest persistence.
+        let json = crate::serde_secret::expose_for_serialization(|| serde_json::to_string(&state))
+            .unwrap();
         let restored: OAuth2State = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.access_token.expose_secret(), "tok_abc");
         assert_eq!(

--- a/crates/credential/src/erased.rs
+++ b/crates/credential/src/erased.rs
@@ -256,8 +256,11 @@ impl<T: DynPendingStateStore + ?Sized> PendingStateStore for T {
         session_id: &str,
         pending: P,
     ) -> Result<PendingToken, PendingStoreError> {
-        let data =
-            serde_json::to_vec(&pending).map_err(|e| PendingStoreError::Backend(Box::new(e)))?;
+        // Pending interactive state (PKCE verifier, partial OAuth2 secrets) is
+        // persisted to the (encrypted-at-rest) pending store; serialize it in
+        // cleartext only here. Outside this scope its secret fields redact.
+        let data = crate::serde_secret::expose_for_serialization(|| serde_json::to_vec(&pending))
+            .map_err(|e| PendingStoreError::Backend(Box::new(e)))?;
         let expires_in = pending.expires_in();
         self.put_serialized(credential_kind, owner_id, session_id, data, expires_in)
             .await

--- a/crates/credential/src/handle.rs
+++ b/crates/credential/src/handle.rs
@@ -17,7 +17,7 @@ struct Inner<S: AuthScheme> {
 /// Handle to a resolved credential with a specific AuthScheme.
 ///
 /// Uses `ArcSwap` internally so [`CredentialResolver`](crate::runtime::CredentialResolver)
-/// can hot-swap refreshed auth material via [`replace`](Self::replace).
+/// can hot-swap refreshed auth material via its crate-internal `replace` operation.
 /// [`Clone`](Self::clone) shares the same live scheme cell — a refresh updates
 /// every clone's next [`snapshot`](Self::snapshot), while prior snapshots stay valid.
 ///

--- a/crates/credential/src/runtime/resolver.rs
+++ b/crates/credential/src/runtime/resolver.rs
@@ -537,16 +537,23 @@ impl<S: CredentialStore> CredentialResolver<S> {
                 return Ok(None);
             }
 
+            // Cleartext serialization for an internal full-fidelity round-trip
+            // (`state` → `OAuth2State`); the intermediate `Value` is transient.
+            // Outside this scope the same serialize redacts to `[REDACTED]`,
+            // which `OAuth2State`'s secret fields would then ingest verbatim —
+            // hence the explicit scope.
+            let state_value =
+                crate::serde_secret::expose_for_serialization(|| serde_json::to_value(&*state))
+                    .map_err(|e| {
+                        CredentialError::Provider(Box::new(ProviderErrorContext::new(
+                            ProviderErrorKind::Schema,
+                            SecretFreeMessage::new(format!(
+                                "oauth2 refresh state serialization failed: {e}"
+                            )),
+                        )))
+                    })?;
             let mut oauth_state: OAuth2State =
-                serde_json::from_value(serde_json::to_value(&*state).map_err(|e| {
-                    CredentialError::Provider(Box::new(ProviderErrorContext::new(
-                        ProviderErrorKind::Schema,
-                        SecretFreeMessage::new(format!(
-                            "oauth2 refresh state serialization failed: {e}"
-                        )),
-                    )))
-                })?)
-                .map_err(|e| {
+                serde_json::from_value(state_value).map_err(|e| {
                     CredentialError::Provider(Box::new(ProviderErrorContext::new(
                         ProviderErrorKind::Schema,
                         SecretFreeMessage::new(format!("oauth2 refresh state decode failed: {e}")),
@@ -562,15 +569,19 @@ impl<S: CredentialStore> CredentialResolver<S> {
                     )))
                 })?;
 
-            *state = serde_json::from_value(serde_json::to_value(oauth_state).map_err(|e| {
-                CredentialError::Provider(Box::new(ProviderErrorContext::new(
-                    ProviderErrorKind::Schema,
-                    SecretFreeMessage::new(format!(
-                        "oauth2 refresh state serialization failed: {e}"
-                    )),
-                )))
-            })?)
-            .map_err(|e| {
+            // Cleartext serialization for the same internal round-trip on the
+            // way back (`OAuth2State` → `state`).
+            let refreshed_value =
+                crate::serde_secret::expose_for_serialization(|| serde_json::to_value(oauth_state))
+                    .map_err(|e| {
+                        CredentialError::Provider(Box::new(ProviderErrorContext::new(
+                            ProviderErrorKind::Schema,
+                            SecretFreeMessage::new(format!(
+                                "oauth2 refresh state serialization failed: {e}"
+                            )),
+                        )))
+                    })?;
+            *state = serde_json::from_value(refreshed_value).map_err(|e| {
                 CredentialError::Provider(Box::new(ProviderErrorContext::new(
                     ProviderErrorKind::Schema,
                     SecretFreeMessage::new(format!("oauth2 refresh state encode failed: {e}")),
@@ -601,10 +612,13 @@ impl<S: CredentialStore> CredentialResolver<S> {
 
         match outcome {
             RefreshOutcome::Refreshed => {
-                let data = serde_json::to_vec(&state).map_err(|e| ResolveError::Refresh {
-                    credential_id: credential_id.to_string(),
-                    reason: format!("failed to serialize refreshed state: {e}"),
-                })?;
+                // Cleartext serialization for the encrypted-at-rest store.
+                let data =
+                    crate::serde_secret::expose_for_serialization(|| serde_json::to_vec(&state))
+                        .map_err(|e| ResolveError::Refresh {
+                            credential_id: credential_id.to_string(),
+                            reason: format!("failed to serialize refreshed state: {e}"),
+                        })?;
 
                 let mut current_version = stored.version;
                 for _attempt in 0..3 {

--- a/crates/credential/src/scheme/certificate.rs
+++ b/crates/credential/src/scheme/certificate.rs
@@ -119,16 +119,19 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_preserves_secrets() {
-        // Certificate uses `#[serde(with = "serde_secret")]` which preserves
-        // the actual value (unlike the default SecretString Serialize that
-        // writes "[REDACTED]"). This test verifies that contract.
+        // Certificate routes its secret fields through `serde_secret`, which
+        // emits cleartext ONLY inside the `expose_for_serialization` storage
+        // scope (the default sink redacts to "[REDACTED]"). This pins the
+        // storage round-trip: sealed serialization preserves the secrets.
         let original = Certificate::new(
             "-----BEGIN CERTIFICATE-----\nMIIB...",
             SecretString::new("-----BEGIN PRIVATE KEY-----\nMIIE..."),
         )
         .with_passphrase(SecretString::new("hunter2"));
 
-        let json = serde_json::to_string(&original).expect("Certificate must serialize");
+        let json =
+            crate::serde_secret::expose_for_serialization(|| serde_json::to_string(&original))
+                .expect("Certificate must serialize");
         let decoded: Certificate =
             serde_json::from_str(&json).expect("Certificate must deserialize");
 

--- a/crates/credential/src/secrets/serde_secret.rs
+++ b/crates/credential/src/secrets/serde_secret.rs
@@ -1,41 +1,171 @@
-//! Serde helpers for [`SecretString`] that preserve the actual value.
+//! Sink-aware serde helpers for [`SecretString`].
 //!
 //! Use with `#[serde(with = "nebula_credential::serde_secret")]` for
 //! `SecretString` fields or `#[serde(with = "nebula_credential::serde_secret::option")]`
 //! for `Option<SecretString>` fields.
+//!
+//! # Why this exists
+//!
+//! [`SecretString`]'s own `Serialize` always writes the `[REDACTED]` sentinel,
+//! which is correct for logs and API responses but loses the value for
+//! encrypted-at-rest persistence. The naive fix — a helper that *always* writes
+//! the cleartext value — over-corrects: a serializer cannot inspect its sink,
+//! so an "always cleartext" field is emitted verbatim by any incidental
+//! `serde_json::to_string`, `tracing` value, or response serializer. That is a
+//! silent exfiltration path.
+//!
+//! These helpers therefore gate cleartext on an explicit thread-local scope
+//! ([`expose_for_serialization`]): inside the scope a field serializes its real
+//! value; outside it the field redacts to `[REDACTED]`, identical to
+//! [`SecretString`]'s default. The safe behavior is the default; cleartext is
+//! opt-in and greppable.
 
-use serde::{Deserialize, Deserializer, Serializer};
+use std::cell::Cell;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use super::SecretString;
 
-/// Serialize the actual secret value (for encrypted-at-rest storage only).
-pub fn serialize<S: Serializer>(secret: &SecretString, s: S) -> Result<S::Ok, S::Error> {
-    s.serialize_str(secret.expose_secret())
+thread_local! {
+    /// Re-entrant depth of the active cleartext-serialization scope on this
+    /// thread. `0` ⇒ secrets redact to the `[REDACTED]` sentinel (the safe
+    /// default); `> 0` ⇒ secrets serialize their cleartext value. A counter,
+    /// not a bool, so nested scopes (e.g. a sealed state whose fields are
+    /// themselves sealed) compose without the inner scope's exit re-enabling
+    /// redaction for the outer one.
+    static EXPOSE_DEPTH: Cell<u32> = const { Cell::new(0) };
 }
 
-/// Deserialize a string into a `SecretString`.
+/// `true` while the current thread is inside an [`expose_for_serialization`]
+/// scope, i.e. while `#[serde(with = "serde_secret")]` fields should emit
+/// cleartext rather than the `[REDACTED]` sentinel.
+fn cleartext_enabled() -> bool {
+    EXPOSE_DEPTH.with(|depth| depth.get() > 0)
+}
+
+/// RAII guard that raises the cleartext-serialization depth for its lifetime
+/// and lowers it on drop — including on unwind, so a panic mid-serialization
+/// cannot leave the thread stuck in cleartext mode.
+struct DepthGuard;
+
+impl DepthGuard {
+    fn enter() -> Self {
+        EXPOSE_DEPTH.with(|depth| depth.set(depth.get().saturating_add(1)));
+        Self
+    }
+}
+
+impl Drop for DepthGuard {
+    fn drop(&mut self) {
+        EXPOSE_DEPTH.with(|depth| {
+            let current = depth.get();
+            debug_assert!(
+                current > 0,
+                "cleartext-serialization depth underflow: a DepthGuard dropped \
+                 while depth was 0 — guards must be balanced and never forged"
+            );
+            depth.set(current.saturating_sub(1));
+        });
+    }
+}
+
+/// Run `f` with cleartext secret serialization enabled on the current thread,
+/// then restore the prior (redacting) behavior.
+///
+/// This is the **only** way to make a `#[serde(with = "serde_secret")]` field
+/// emit its real value. It marks the call site as a trusted full-fidelity sink:
+/// the encrypted-at-rest persistence path (the produced bytes are handed
+/// straight to the storage encryption layer) and internal full-fidelity state
+/// round-trips (e.g. OAuth2 refresh-state transforms). It is **not** for
+/// telemetry, logs, API responses, or debug output — those must redact.
+///
+/// The scope is thread-local and re-entrant. Wrap **only the synchronous
+/// `serialize` call**; never hold it across an `.await`, or an unrelated future
+/// resumed on the same worker thread could serialize cleartext. Every cleartext
+/// site is greppable (`rg expose_for_serialization`), exactly like every
+/// plaintext read is greppable via `expose_secret`.
+///
+/// # Examples
+///
+/// ```
+/// use nebula_credential::{SecretString, scheme::SecretToken, serde_secret};
+///
+/// let token = SecretToken::new(SecretString::new("sk-123"));
+///
+/// // Default sink (logs, responses, debug dumps): redacted.
+/// let redacted = serde_json::to_string(&token).expect("serialize");
+/// assert!(!redacted.contains("sk-123"));
+///
+/// // Explicit storage scope: cleartext, for encrypted-at-rest persistence.
+/// let cleartext =
+///     serde_secret::expose_for_serialization(|| serde_json::to_string(&token)).expect("serialize");
+/// assert!(cleartext.contains("sk-123"));
+/// ```
+pub fn expose_for_serialization<R>(f: impl FnOnce() -> R) -> R {
+    let _guard = DepthGuard::enter();
+    f()
+}
+
+/// Serialize a secret value: cleartext inside an [`expose_for_serialization`]
+/// scope, otherwise the `[REDACTED]` sentinel (delegating to
+/// [`SecretString`]'s own redacting `Serialize`).
+///
+/// # Permitted cleartext sink
+///
+/// Cleartext is emitted only while [`expose_for_serialization`] is active on
+/// the current thread. The caller proves the sink is trusted (encrypted-at-rest
+/// storage or an internal full-fidelity round-trip) by entering that scope; a
+/// telemetry/logging/response serializer is not a permitted sink and, by not
+/// entering the scope, receives the redacted sentinel.
+pub fn serialize<S: Serializer>(secret: &SecretString, s: S) -> Result<S::Ok, S::Error> {
+    if cleartext_enabled() {
+        s.serialize_str(secret.expose_secret())
+    } else {
+        // Delegate to SecretString's own `Serialize`, the single source of the
+        // `[REDACTED]` sentinel.
+        secret.serialize(s)
+    }
+}
+
+/// Deserialize a string into a `SecretString`, **rejecting the `[REDACTED]`
+/// sentinel**.
+///
+/// Delegates to [`SecretString`]'s own `Deserialize`. The rejection is the
+/// loud-failure half of the gate: if a persist site ever serializes outside an
+/// [`expose_for_serialization`] scope, it writes the sentinel; reading that
+/// blob back then errors here instead of silently loading `[REDACTED]` as the
+/// real secret.
 pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<SecretString, D::Error> {
-    String::deserialize(d).map(SecretString::new)
+    SecretString::deserialize(d)
 }
 
 /// Serde helpers for `Option<SecretString>`. Use as:
 /// `#[serde(with = "nebula_credential::serde_secret::option")]`.
 pub mod option {
-    use super::*;
+    use super::{Serialize, Serializer, cleartext_enabled};
+    use crate::SecretString;
+    use serde::{Deserialize, Deserializer};
 
-    /// Serialize an optional secret value (for encrypted-at-rest storage only).
+    /// Serialize an optional secret: cleartext inside an
+    /// [`expose_for_serialization`](super::expose_for_serialization) scope,
+    /// otherwise the `[REDACTED]` sentinel for `Some` and `null` for `None`.
     pub fn serialize<S: Serializer>(
         secret: &Option<SecretString>,
         s: S,
     ) -> Result<S::Ok, S::Error> {
         match secret {
-            Some(secret) => s.serialize_str(secret.expose_secret()),
+            Some(secret) if cleartext_enabled() => s.serialize_str(secret.expose_secret()),
+            // Redacting path delegates to `SecretString`'s own `Serialize` so
+            // the `Some(_)` field still appears (redacted), preserving shape.
+            Some(secret) => secret.serialize(s),
             None => s.serialize_none(),
         }
     }
 
-    /// Deserialize an optional string into an `Option<SecretString>`.
+    /// Deserialize an optional string into an `Option<SecretString>`, rejecting
+    /// the `[REDACTED]` sentinel in the `Some` case (see the non-`option`
+    /// [`deserialize`](super::deserialize) for why).
     pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<SecretString>, D::Error> {
-        Option::<String>::deserialize(d).map(|opt| opt.map(SecretString::new))
+        Option::<SecretString>::deserialize(d)
     }
 }

--- a/crates/credential/src/service/ops.rs
+++ b/crates/credential/src/service/ops.rs
@@ -528,11 +528,19 @@ where
                     })?;
                 match response {
                     ResolveResponse::Complete(state) => {
-                        let data = Zeroizing::new(serde_json::to_vec(&state).map_err(|e| {
-                            CredentialServiceError::Internal(format!(
-                                "state serialization failed: {e}"
-                            ))
-                        })?);
+                        // Cleartext serialization for the encrypted-at-rest
+                        // store; the bytes never leave this `Zeroizing` buffer
+                        // un-encrypted. Outside this scope secrets redact.
+                        let data = Zeroizing::new(
+                            crate::serde_secret::expose_for_serialization(|| {
+                                serde_json::to_vec(&state)
+                            })
+                            .map_err(|e| {
+                                CredentialServiceError::Internal(format!(
+                                    "state serialization failed: {e}"
+                                ))
+                            })?,
+                        );
                         Ok(ResolvedState {
                             data,
                             state_kind: <C::State as CredentialState>::KIND.to_owned(),
@@ -631,9 +639,14 @@ where
 {
     match response {
         ResolveResponse::Complete(state) => {
-            let data = Zeroizing::new(serde_json::to_vec(&state).map_err(|e| {
-                CredentialServiceError::Internal(format!("state serialization failed: {e}"))
-            })?);
+            // Cleartext serialization for the encrypted-at-rest store; bytes
+            // stay in this `Zeroizing` buffer until the store encrypts them.
+            let data = Zeroizing::new(
+                crate::serde_secret::expose_for_serialization(|| serde_json::to_vec(&state))
+                    .map_err(|e| {
+                        CredentialServiceError::Internal(format!("state serialization failed: {e}"))
+                    })?,
+            );
             Ok(AcquireOutcome::Complete(ResolvedState {
                 data,
                 state_kind: <C::State as CredentialState>::KIND.to_owned(),
@@ -757,11 +770,17 @@ where
                     // refreshed credential carrying a stale (possibly
                     // already-elapsed) expiry.
                     let expires_at = state.expires_at();
-                    let data = Zeroizing::new(serde_json::to_vec(&state).map_err(|e| {
-                        CredentialServiceError::Internal(format!(
-                            "refreshed state serialization failed: {e}"
-                        ))
-                    })?);
+                    // Cleartext serialization for the encrypted-at-rest store.
+                    let data = Zeroizing::new(
+                        crate::serde_secret::expose_for_serialization(|| {
+                            serde_json::to_vec(&state)
+                        })
+                        .map_err(|e| {
+                            CredentialServiceError::Internal(format!(
+                                "refreshed state serialization failed: {e}"
+                            ))
+                        })?,
+                    );
                     Ok(RefreshOutcomeKind::Rewrote { data, expires_at })
                 },
                 // Another replica already refreshed while this caller

--- a/crates/credential/tests/serde_redaction.rs
+++ b/crates/credential/tests/serde_redaction.rs
@@ -1,0 +1,205 @@
+//! Serde-redaction test for `nebula-credential` — sibling to `redaction.rs`.
+//!
+//! `redaction.rs` covers the `Debug` / `tracing` leak path. THIS file covers
+//! the **serde** path, which `redaction.rs` does not touch.
+//!
+//! # The gap this pins
+//!
+//! Every `Sensitive` scheme (`SecretToken`, `Certificate`, `OAuth2Token`,
+//! `SigningKey`, `SharedKey`, …) routes its secret fields through
+//! `#[serde(with = "crate::serde_secret")]` and `#[derive(Serialize)]`. The
+//! `serde_secret` serializer cannot inspect its sink, so a plain
+//! `serde_json::to_string(&scheme)` driven by a telemetry / logging /
+//! API-response serializer is indistinguishable from the encrypted-at-rest
+//! storage path.
+//!
+//! Contract under test: **serializing a `Sensitive` scheme to a default
+//! (non-storage) sink redacts every secret field**; cleartext is emitted only
+//! inside an explicit `serde_secret::expose_for_serialization` scope (covered
+//! by the storage-contract half below).
+//!
+//! Because the gate lives at the field-level `serde_secret` helper, it covers
+//! any scheme tier (`Sensitive` *and* `External`) by construction — the tier
+//! does not matter, only the `#[serde(with = "serde_secret")]` attribute does.
+
+use nebula_credential::{
+    SecretString,
+    scheme::{Certificate, OAuth2Token, SecretToken, SharedKey, SigningKey},
+    serde_secret,
+};
+
+/// The sentinel the default secret serializer must emit in place of plaintext.
+const SENTINEL: &str = "[REDACTED]";
+
+// ---------------------------------------------------------------------
+// Default sink: secrets must redact
+// ---------------------------------------------------------------------
+
+#[test]
+fn secret_token_does_not_serialize_plaintext_to_default_sink() {
+    let raw = "sk-serde-canary-secret-token-never-emitted";
+    let token = SecretToken::new(SecretString::new(raw));
+
+    let json = serde_json::to_string(&token).expect("SecretToken must serialize");
+
+    assert!(
+        !json.contains(raw),
+        "secret-token plaintext leaked to a default serde sink:\n{json}"
+    );
+    assert!(
+        json.contains(SENTINEL),
+        "expected the {SENTINEL} sentinel in default-sink output:\n{json}"
+    );
+}
+
+#[test]
+fn certificate_does_not_serialize_private_key_or_passphrase_to_default_sink() {
+    let key = "serde-canary-private-key-never-emitted";
+    let pass = "serde-canary-passphrase-never-emitted";
+    let cert = Certificate::new("PUBLIC-CERT-CHAIN", SecretString::new(key))
+        .with_passphrase(SecretString::new(pass));
+
+    let json = serde_json::to_string(&cert).expect("Certificate must serialize");
+
+    assert!(
+        !json.contains(key),
+        "certificate private key leaked to a default serde sink:\n{json}"
+    );
+    assert!(
+        !json.contains(pass),
+        "certificate passphrase leaked to a default serde sink:\n{json}"
+    );
+    // The cert chain is public material and SHOULD still serialize.
+    assert!(
+        json.contains("PUBLIC-CERT-CHAIN"),
+        "public cert chain should round-trip even on the default sink:\n{json}"
+    );
+    assert!(
+        json.contains(SENTINEL),
+        "expected the {SENTINEL} sentinel in default-sink output:\n{json}"
+    );
+}
+
+#[test]
+fn oauth2_token_does_not_serialize_access_token_to_default_sink() {
+    let raw = "serde-canary-oauth2-access-token-never-emitted";
+    let token = OAuth2Token::new(SecretString::new(raw)).with_scopes(vec!["read".into()]);
+
+    let json = serde_json::to_string(&token).expect("OAuth2Token must serialize");
+
+    assert!(
+        !json.contains(raw),
+        "oauth2 access token leaked to a default serde sink:\n{json}"
+    );
+    assert!(
+        json.contains(SENTINEL),
+        "expected the {SENTINEL} sentinel in default-sink output:\n{json}"
+    );
+}
+
+#[test]
+fn signing_key_does_not_serialize_plaintext_to_default_sink() {
+    let raw = "serde-canary-signing-key-never-emitted";
+    let key = SigningKey::new(SecretString::new(raw), "hmac-sha256");
+
+    let json = serde_json::to_string(&key).expect("SigningKey must serialize");
+
+    assert!(
+        !json.contains(raw),
+        "signing-key plaintext leaked to a default serde sink:\n{json}"
+    );
+    // Non-secret algorithm metadata should still serialize.
+    assert!(
+        json.contains("hmac-sha256"),
+        "non-secret algorithm metadata should serialize:\n{json}"
+    );
+    assert!(
+        json.contains(SENTINEL),
+        "expected the {SENTINEL} sentinel in default-sink output:\n{json}"
+    );
+}
+
+#[test]
+fn shared_key_does_not_serialize_plaintext_to_default_sink() {
+    let raw = "serde-canary-shared-key-never-emitted";
+    let key = SharedKey::new(SecretString::new(raw));
+
+    let json = serde_json::to_string(&key).expect("SharedKey must serialize");
+
+    assert!(
+        !json.contains(raw),
+        "shared-key plaintext leaked to a default serde sink:\n{json}"
+    );
+    assert!(
+        json.contains(SENTINEL),
+        "expected the {SENTINEL} sentinel in default-sink output:\n{json}"
+    );
+}
+
+// ---------------------------------------------------------------------
+// Storage contract: cleartext only inside `expose_for_serialization`,
+// and that scope is the *only* path that round-trips secrets.
+// ---------------------------------------------------------------------
+
+#[test]
+fn expose_scope_is_the_only_cleartext_serialization_path() {
+    let raw = "serde-canary-storage-roundtrip-token";
+    let token = SecretToken::new(SecretString::new(raw));
+
+    // Outside the scope: redacted.
+    let default_json = serde_json::to_string(&token).expect("serialize");
+    assert!(
+        !default_json.contains(raw),
+        "control: default sink must redact:\n{default_json}"
+    );
+
+    // Inside the scope: cleartext, and it round-trips (the encrypted-at-rest
+    // storage path depends on this full-fidelity serialization).
+    let sealed_json = serde_secret::expose_for_serialization(|| serde_json::to_string(&token))
+        .expect("serialize");
+    assert!(
+        sealed_json.contains(raw),
+        "storage scope must emit cleartext for at-rest persistence:\n{sealed_json}"
+    );
+    assert!(
+        !sealed_json.contains(SENTINEL),
+        "storage scope must NOT redact:\n{sealed_json}"
+    );
+
+    let recovered: SecretToken =
+        serde_json::from_str(&sealed_json).expect("sealed json must round-trip");
+    assert_eq!(recovered.token().expose_secret(), raw);
+}
+
+#[test]
+fn expose_scope_ends_when_the_closure_returns() {
+    let raw = "serde-canary-scope-does-not-leak-across-calls";
+    let token = SecretToken::new(SecretString::new(raw));
+
+    // Drive a sealed serialization, then immediately serialize again on the
+    // SAME thread with no scope. The second call must redact — proving the
+    // scope is strictly closure-scoped and does not leak forward.
+    let _sealed = serde_secret::expose_for_serialization(|| serde_json::to_string(&token));
+
+    let after = serde_json::to_string(&token).expect("serialize");
+    assert!(
+        !after.contains(raw),
+        "scope leaked past the closure — a later default-sink serialize emitted cleartext:\n{after}"
+    );
+}
+
+#[test]
+fn deserializing_a_redacted_blob_is_rejected() {
+    // Loud-failure half of the gate: a persist site that forgot the storage
+    // scope writes the `[REDACTED]` sentinel in place of the secret. Reading
+    // that blob back must error, not silently load "[REDACTED]" as the token.
+    let redacted =
+        serde_json::to_string(&SecretToken::new(SecretString::new("anything"))).expect("serialize");
+    assert!(redacted.contains(SENTINEL), "control: default sink redacts");
+
+    let result = serde_json::from_str::<SecretToken>(&redacted);
+    assert!(
+        result.is_err(),
+        "deserializing a redacted blob must be rejected; got {result:?}"
+    );
+}

--- a/crates/credential/tests/units/scheme_roundtrip_tests.rs
+++ b/crates/credential/tests/units/scheme_roundtrip_tests.rs
@@ -1,7 +1,12 @@
-//! Roundtrip serde tests for all AuthScheme types.
+//! Roundtrip serde tests for all `AuthScheme` types.
 //!
 //! Verifies that `SecretString` fields serialize their actual value (not
-//! `[REDACTED]`) and deserialize back correctly.
+//! `[REDACTED]`) and deserialize back correctly **when serialized through the
+//! encrypted-at-rest storage scope** (`serde_secret::expose_for_serialization`).
+//!
+//! Outside that scope a secret field redacts; that default-sink contract is
+//! pinned separately in `serde_redaction.rs`. These tests exercise the storage
+//! round-trip, so every `to_string` here goes through [`to_storage_json`].
 
 use nebula_credential::{
     SecretString,
@@ -9,12 +14,20 @@ use nebula_credential::{
         Certificate, ConnectionUri, IdentityPassword, InstanceBinding, KeyPair, OAuth2Token,
         SecretToken, SharedKey, SigningKey,
     },
+    serde_secret,
 };
+
+/// Serialize a scheme the way the encrypted-at-rest store does — inside the
+/// `expose_for_serialization` scope, where `serde_secret` fields emit cleartext.
+fn to_storage_json<T: serde::Serialize>(value: &T) -> String {
+    serde_secret::expose_for_serialization(|| serde_json::to_string(value))
+        .expect("scheme must serialize inside the storage scope")
+}
 
 #[test]
 fn secret_token_serde_roundtrip() {
     let token = SecretToken::new(SecretString::new("my-secret-key"));
-    let json = serde_json::to_string(&token).unwrap();
+    let json = to_storage_json(&token);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -27,7 +40,7 @@ fn secret_token_serde_roundtrip() {
 #[test]
 fn identity_password_serde_roundtrip() {
     let auth = IdentityPassword::new("admin", SecretString::new("p@ssw0rd"));
-    let json = serde_json::to_string(&auth).unwrap();
+    let json = to_storage_json(&auth);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -41,7 +54,7 @@ fn identity_password_serde_roundtrip() {
 #[test]
 fn oauth2_token_serde_roundtrip() {
     let token = OAuth2Token::new(SecretString::new("access-tok-xyz"));
-    let json = serde_json::to_string(&token).unwrap();
+    let json = to_storage_json(&token);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -54,7 +67,7 @@ fn oauth2_token_serde_roundtrip() {
 #[test]
 fn certificate_serde_roundtrip() {
     let cert = Certificate::new("TEST_CERT_CHAIN", SecretString::new("TEST_PRIVATE_KEY"));
-    let json = serde_json::to_string(&cert).unwrap();
+    let json = to_storage_json(&cert);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -69,7 +82,7 @@ fn certificate_serde_roundtrip() {
 #[test]
 fn key_pair_serde_roundtrip() {
     let kp = KeyPair::new("ssh-rsa AAAA...", SecretString::new("-----BEGIN RSA-----"));
-    let json = serde_json::to_string(&kp).unwrap();
+    let json = to_storage_json(&kp);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -117,7 +130,7 @@ fn key_pair_deserializes_without_passphrase_field() {
 #[test]
 fn signing_key_serde_roundtrip() {
     let sk = SigningKey::new(SecretString::new("signing-key"), "hmac-sha256");
-    let json = serde_json::to_string(&sk).unwrap();
+    let json = to_storage_json(&sk);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -131,7 +144,7 @@ fn signing_key_serde_roundtrip() {
 #[test]
 fn shared_key_serde_roundtrip() {
     let sk = SharedKey::new(SecretString::new("preshared-secret"));
-    let json = serde_json::to_string(&sk).unwrap();
+    let json = to_storage_json(&sk);
     assert!(
         !json.contains("REDACTED"),
         "json must not contain REDACTED: {json}"
@@ -153,7 +166,7 @@ fn connection_uri_serde_roundtrip() {
         "user".into(),
         SecretString::new("pass"),
     );
-    let json = serde_json::to_string(&cu).unwrap();
+    let json = to_storage_json(&cu);
     // Non-secret fields serialize as plaintext.
     assert!(json.contains("postgres"));
     assert!(json.contains("localhost"));
@@ -172,7 +185,9 @@ fn connection_uri_serde_roundtrip() {
 #[test]
 fn instance_binding_serde_roundtrip() {
     let ib = InstanceBinding::new("aws", "arn:aws:iam::123456789012:role/MyRole");
-    let json = serde_json::to_string(&ib).unwrap();
+    // InstanceBinding carries no secret fields, so the storage scope is a
+    // no-op here; routed through it anyway for uniformity with the suite.
+    let json = to_storage_json(&ib);
     assert!(json.contains("aws"));
     assert!(json.contains("arn:aws:iam"));
     let recovered: InstanceBinding = serde_json::from_str(&json).unwrap();

--- a/crates/resource/src/lib.rs
+++ b/crates/resource/src/lib.rs
@@ -176,6 +176,10 @@ pub use credential_fanout::{Bind, ResourceFanoutDriver, ResourceFanoutIndex, Rot
 /// impl HasCredentialSlots for MyResource {
 ///     fn credential_slot_epoch(&self) -> u64 { 0 }
 /// }
+///
+/// // `Pooled<Self>` requires `PoolProvider`; every method has a default,
+/// // so an empty impl opts the resource into pool topology.
+/// impl PoolProvider for MyResource {}
 /// ```
 pub mod prelude {
     pub use crate::{

--- a/crates/resource/src/manager/acquire.rs
+++ b/crates/resource/src/manager/acquire.rs
@@ -126,7 +126,7 @@ impl Manager {
         .with_resource_key(R::key())
     }
 
-    /// Acquires through the registry row's [`ManagedHandle::acquire`] method,
+    /// Acquires through the registry row's `ManagedHandle::acquire` method,
     /// keyed by the **collision-free structural** resolved-credential identity
     /// (key + scope + slot identity).
     ///

--- a/crates/storage/src/credential/layer/encryption.rs
+++ b/crates/storage/src/credential/layer/encryption.rs
@@ -333,7 +333,15 @@ mod tests {
             token_url: "https://example.invalid/token".to_owned(),
             auth_style: AuthStyle::Header,
         };
-        let data = serde_json::to_vec(&state).expect("serialize OAuth2 state");
+        // Mirror the production seal path: `OAuth2State`'s secret fields emit
+        // cleartext only inside the `expose_for_serialization` storage scope.
+        // Serializing through it feeds REAL plaintext into the encryption layer,
+        // so the "not plaintext in the inner row" assertion below stays
+        // meaningful instead of trivially passing on a redacted blob.
+        let data = nebula_credential::serde_secret::expose_for_serialization(|| {
+            serde_json::to_vec(&state)
+        })
+        .expect("serialize OAuth2 state");
         let cred = make_credential("enc-oauth2-state", &data);
         store.put(cred, PutMode::CreateOnly).await.unwrap();
 


### PR DESCRIPTION
## Summary

Closes a latent **serde-path exfiltration gap** in `nebula-credential`. `serde_secret` serialized secret fields in cleartext unconditionally, and serde's `Serialize` is sink-agnostic — so a `serde_json::to_string(&scheme)` driven by a logging, telemetry, or API-response serializer emitted the same plaintext as the encrypted-at-rest storage path. Surfaced by a security review; orthogonal to the F3 sensitivity work (which only added the `ExternalScheme` classification). Redaction is now the default at the serde boundary, and cleartext requires an explicit, greppable storage scope.

## Linked issue

- No linked Linear issue — surfaced by an ad-hoc security review of the serde/secret boundary.

## Type of change

- [x] `fix` — bug fix (security; behavior-breaking at the serde contract — see Breaking changes)

## Affected crates / areas

- `nebula-credential` — the gate (`secrets/serde_secret.rs`) + every in-crate persist/transform site + tests
- `nebula-api` — `persist_oauth_state` production site + e2e test
- `nebula-storage` — at-rest encryption test

## Changes

- `serde_secret::serialize` / `option::serialize` **redact by default** (delegate to `SecretString`'s `[REDACTED]` sentinel). Cleartext is emitted **only** inside `serde_secret::expose_for_serialization(|| …)` — a thread-local, re-entrant, panic-safe RAII scope. Accidental serialization to a non-storage sink can no longer leak; cleartext is an explicit, `rg`-greppable opt-in mirroring the `expose_secret` idiom.
- `serde_secret::deserialize` / `option::deserialize` now **reject the `[REDACTED]` sentinel** (delegate to `SecretString::Deserialize`). A persist site that forgets the scope writes the sentinel; read-back then errors loudly instead of silently loading `"[REDACTED]"` as the secret.
- Kept `#[derive(Serialize)]` on the schemes — the persist path (`serde_json::to_vec(&state)` → encrypt-at-rest) is load-bearing; removing serialization was not viable.
- Wired every legitimate cleartext site into the scope: credential `service/ops.rs` (×3 storage seal), `runtime/resolver.rs` (×3: refresh-state seal + two OAuth2 state transforms), `erased.rs` (PendingState put); api `persist_oauth_state`; the storage at-rest test and api e2e test.
- New `crates/credential/tests/serde_redaction.rs` (sibling to `redaction.rs`).
- Rewrote the `serde_secret::serialize` contract doc (permitted sink + how the caller proves it).

## Test plan

- **New `tests/serde_redaction.rs` (8 tests):** `SecretToken` / `Certificate` (private key + passphrase) / `OAuth2Token` / `SigningKey` / `SharedKey` serialized to a default `serde_json::to_string` sink emit no plaintext and contain the `[REDACTED]` sentinel; `expose_for_serialization` is the only cleartext path and round-trips; the scope ends at the closure boundary; a redacted blob is rejected on read-back. (TDD: witnessed all 5 schemes leak under the old code before implementing the gate.)
- Updated `scheme_roundtrip_tests.rs`, `certificate.rs`, `credentials/oauth2.rs` to the new contract (bare serialize redacts; storage round-trip needs the scope); the `oauth2.rs` test now also pins default-sink redaction on `OAuth2State`.
- Storage `oauth2_state_secrets_not_plaintext_in_inner_store` now feeds **real** plaintext through the scope, keeping the at-rest assertion meaningful.

### Local verification

- [x] `cargo fmt` — clean (per-crate; `--all` hits an unrelated os-error-206 in deep worktree paths on Windows — lefthook `fmt-check` ran per-crate and passed)
- [x] `cargo clippy --workspace -- -D warnings` — clean (lefthook pre-push `clippy-full` green; `cargo clippy -p nebula-credential --all-features -- -D warnings` clean)
- [x] `cargo nextest run --workspace` — pre-push crate-diff-gate ran the changed-crate suites (api/credential/storage): **1119 passed, 1 skipped** (PG-gated, `DATABASE_URL` unset)
- [x] `cargo test --workspace --doc` — the new `expose_for_serialization` doctest passes
- [ ] `cargo deny check` — N/A, no `Cargo.toml` change (no new dependencies)

## Breaking changes

The serde contract of credential schemes changed: `serde_json::to_*(&scheme | &state)` now **redacts by default**, and `serde_secret::deserialize` **rejects** the `[REDACTED]` sentinel. These crates are internal impl-detail (only `nebula-sdk` is public — no external semver), and every in-workspace call site was migrated in this PR. **Migration path for any future caller:** wrap a persistence/full-fidelity serialize in `serde_secret::expose_for_serialization(|| …)`, or it will silently redact (and read-back will then reject the sentinel). Marked `!` to flag the behavior change to reviewers despite the internal-only surface.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — this **strengthens** the existing credential-secrecy invariant (now enforced on the serde path, previously only Debug/tracing); no semantic drift, no new lifecycle
- [x] Layer direction preserved (no upward deps; api/storage already depend on credential)
- [x] Crate docs updated where surface changed — `serde_secret` module `//!` + the new `expose_for_serialization` rustdoc/doctest
- No ADR added: no L2 invariant changed — the gate reinforces an existing invariant rather than introducing one.

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (the new `expect` usages are in tests/doctests)
- [x] No silent error suppression — serialize errors propagate via `?`/`map_err`; the new default is *louder*, not quieter
- [x] N/A — no engine state transitions touched
- [x] **Credentials / secrets stay encrypted, redacted, and zeroized across all added paths** — this is the core of the PR; default serialization now redacts, cleartext is scoped, and read-back rejects the sentinel
- [x] No new `unsafe`

## Notes for reviewers

- The scope is thread-local and must wrap **only synchronous** serialize calls (never across `.await`) — documented on `expose_for_serialization`; every wired site obeys it (`serde_json::to_*` is synchronous, and the resolver wraps each transform individually rather than spanning the intervening `refresh().await`).
- **Pre-existing, out-of-scope:** under `cargo test -p nebula-credential --all-features` the trybuild fixture `compile_fail_capability_subtrait_testable_no_method` fails — rustc now path-qualifies `nebula_credential::TestResult` in the diagnostic vs the recorded `.stderr`. Verified pre-existing on a clean tree (`git stash`); **left untouched** because `TRYBUILD=overwrite` would diverge the fixture from the CI toolchain. Not triggered under default features (the pre-push suite was green).
