### PR TITLE
test(credential): facade lifecycle E2E harness + regressions (incr 3b)

### DIFF
--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -25,8 +25,8 @@ use nebula_credential::{
     ApiKeyCredential, BasicAuthCredential, CredentialStore, ErasedPendingStore, OAuth2Credential,
 };
 use nebula_credential::{
-    CredentialService, CredentialServiceError, DispatchError, DispatchOps, NoopObserver,
-    register_interactive_ops, register_refreshable_ops, register_revocable_ops,
+    CredentialRegistry, CredentialService, CredentialServiceError, DispatchError, DispatchOps,
+    NoopObserver, register_interactive_ops, register_refreshable_ops, register_revocable_ops,
     register_runtime_ops, register_testable_ops,
 };
 use nebula_engine::credential::LeaseLifecycleConfig;
@@ -241,6 +241,28 @@ pub fn with_store<S: CredentialStore + 'static>(
     register_revocable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
     register_testable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
 
+    compose_credential_service(raw_store, key_provider, registry, ops)
+}
+
+/// Compose a [`CredentialService`] over `raw_store` with a **caller-supplied
+/// registry + dispatch ops**, wrapping the shared secure stack (audit / cache /
+/// encryption / in-memory pending / lease lifecycle). The registry's advertised
+/// capabilities MUST match the ops table or [`CredentialServiceBuilder::build`]
+/// returns [`CredentialServiceError::CapabilityWithoutOps`].
+///
+/// Both [`with_store`] (first-party set) and the test factory variants funnel
+/// through here so the secure-stack composition lives in exactly one place.
+///
+/// # Errors
+///
+/// Returns [`CredentialServiceFactoryError::Build`] if the builder rejects the
+/// composed parts (capability/ops mismatch).
+fn compose_credential_service<S: CredentialStore + 'static>(
+    raw_store: S,
+    key_provider: Arc<dyn KeyProvider>,
+    registry: CredentialRegistry,
+    ops: DispatchOps<ErasedPendingStore>,
+) -> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
     tracing::warn!(
         "credential: audit sink is log-only (target=nebula.credential.audit); \
          the audit trail is NOT durably persisted to a backend yet."
@@ -273,4 +295,31 @@ pub fn with_store<S: CredentialStore + 'static>(
 
     tracing::info!("credential: CredentialService composed (encrypted-at-rest)");
     Ok(Arc::new(service))
+}
+
+/// Build a [`CredentialService`] over a unique in-memory SQLite database with a
+/// **caller-supplied registry + dispatch ops** — the test fixture for exercising
+/// the facade against credential types the first-party set lacks (e.g. a
+/// non-interactive *and* Revocable type, which no builtin is: `api_key` /
+/// `basic_auth` aren't Revocable and `oauth2` is interactive, so neither can be
+/// created-then-revoked without an OAuth handshake).
+///
+/// Test-only (`test-util` feature / `cfg(test)`); never compiled into a release
+/// build (ADR-0023). Mirrors [`with_memory_store`] but takes the registry/ops
+/// the caller composed instead of the first-party set.
+///
+/// # Errors
+///
+/// Returns [`CredentialServiceFactoryError`] if the in-memory store cannot be
+/// opened/migrated or the final service build fails (capability/ops mismatch).
+#[cfg(any(test, feature = "test-util"))]
+pub async fn with_memory_store_parts(
+    key_provider: Arc<dyn KeyProvider>,
+    registry: CredentialRegistry,
+    ops: DispatchOps<ErasedPendingStore>,
+) -> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
+    let store = SqliteCredentialStore::connect_memory()
+        .await
+        .map_err(|e| CredentialServiceFactoryError::Store(e.to_string()))?;
+    compose_credential_service(store, key_provider, registry, ops)
 }

--- a/crates/api/tests/credential_facade_lifecycle_e2e.rs
+++ b/crates/api/tests/credential_facade_lifecycle_e2e.rs
@@ -1,0 +1,280 @@
+//! Facade lifecycle E2E (Increment 3b): exercise `CredentialService` refresh /
+//! revoke / binding-validation against a credential type the first-party set
+//! lacks — one that is **non-interactive *and* Revocable *and* Refreshable**.
+//!
+//! No first-party builtin fits: `api_key`/`basic_auth` aren't Revocable, and
+//! `oauth2` is interactive (can't be created without the OAuth handshake). So
+//! the harness registers a local `TestLifecycleCred` via the custom-registry
+//! factory variant ([`with_memory_store_parts`]) over the real
+//! `Audit(Cache(Encryption(SQLite)))` stack.
+//!
+//! Regressions pinned here (the facade refresh/revoke paths have no in-crate
+//! unit coverage — `nebula-credential` cannot host this harness without a
+//! `credential→storage` dev-dep cycle):
+//! - `refresh` advances `last_validated_at` (the FIX-2 wiring bug that shipped
+//!   dead and was caught only by static review — no test had exercised it).
+//! - a revoked credential is unresolvable: `refresh`/`get` fail closed as
+//!   `NotFound` (no resurrection through the service).
+//! - `validate_credential_binding` rejects a tombstoned id with the typed
+//!   `CredentialTombstoned` (Q9 end-to-end).
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nebula_api::ports::credential_service_factory::with_memory_store_parts;
+use nebula_core::auth::{
+    AuthPattern, AuthScheme, EgressShape, RefreshStrategyKind, SchemeFamily, SensitiveScheme,
+};
+use nebula_credential::error::CredentialError;
+use nebula_credential::resolve::{RefreshOutcome, ResolveResult};
+use nebula_credential::{
+    CredentialContext, CredentialDisplay, CredentialMetadata, CredentialRegistry,
+    CredentialService, CredentialServiceError, DispatchOps, DynCredentialStore, ErasedPendingStore,
+    TenantScope, ValidatedCredentialBindingError, identity_state, register_refreshable_ops,
+    register_revocable_ops, register_runtime_ops, schema_of,
+};
+use nebula_schema::{FieldValues, Schema};
+use nebula_storage::credential::EnvKeyProvider;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+/// 32 `0x42` bytes, base64 — a valid AES-256 key fixture (mirrors the factory's
+/// dev key). Not a secret: a fixed test constant.
+const TEST_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
+// ── A non-interactive, Refreshable, Revocable test credential ──────────
+
+/// Active family declaring an engine-drivable `RefreshToken` class so a
+/// `Refreshable` credential passes the F3 containment law at registration
+/// (`SchemeFamily::supports_active_refresh`).
+struct TestRefreshFamily;
+
+impl SchemeFamily for TestRefreshFamily {
+    const EGRESS: &'static [EgressShape] = &[EgressShape::InlineSecret];
+    fn refresh_classes() -> &'static [RefreshStrategyKind] {
+        &[RefreshStrategyKind::RefreshToken]
+    }
+    fn pattern() -> AuthPattern {
+        AuthPattern::OAuth2
+    }
+}
+
+/// Stored state == projected scheme (identity). Holds the secret bytes so it is
+/// `Sensitive` (zeroized on drop); `generation` lets `refresh` produce visibly
+/// rotated material.
+#[derive(Serialize, Deserialize, Clone, Zeroize, ZeroizeOnDrop)]
+struct TestScheme {
+    token: String,
+    generation: u32,
+}
+
+impl AuthScheme for TestScheme {
+    type Family = TestRefreshFamily;
+    fn pattern() -> AuthPattern {
+        AuthPattern::OAuth2
+    }
+}
+
+impl SensitiveScheme for TestScheme {}
+
+identity_state!(TestScheme, "test_lifecycle_state", 1);
+
+/// Create-form properties.
+//
+// `token` is read by the `#[derive(Schema)]`/`Deserialize` derives and consumed
+// at runtime through `FieldValues` in `resolve`, never via direct field access —
+// `dead_code` cannot see those paths on a private test struct.
+#[derive(Schema, Deserialize, Default)]
+#[allow(dead_code)]
+struct TestProps {
+    /// Initial secret token.
+    #[field(secret, label = "Token")]
+    #[validate(required)]
+    token: String,
+}
+
+/// The credential type under test. `#[credential]` reads the methods present —
+/// here `refresh` + `revoke` (and no interactive/test method) — and emits the
+/// `Credential`/`Refreshable`/`Revocable` impls + the capability-report consts
+/// (refreshable + revocable true; interactive/testable/dynamic false).
+struct TestLifecycleCred;
+
+#[nebula_credential::credential(key = "test_lifecycle")]
+impl TestLifecycleCred {
+    type Properties = TestProps;
+    type Scheme = TestScheme;
+    type State = TestScheme;
+
+    fn metadata() -> CredentialMetadata {
+        CredentialMetadata::builder()
+            .key(nebula_core::credential_key!("test_lifecycle"))
+            .name("Test Lifecycle Credential")
+            .description("non-interactive refreshable+revocable credential for facade E2E tests")
+            .schema(schema_of::<Self::Properties>())
+            .pattern(AuthPattern::OAuth2)
+            .build()
+            .expect("test_lifecycle metadata is valid")
+    }
+
+    fn project(state: &TestScheme) -> TestScheme {
+        state.clone()
+    }
+
+    async fn resolve(
+        values: &FieldValues,
+        _ctx: &CredentialContext,
+    ) -> Result<ResolveResult<TestScheme, ()>, CredentialError> {
+        let token = values.get_string_by_str("token").ok_or_else(|| {
+            CredentialError::InvalidInput("missing required field 'token'".into())
+        })?;
+        Ok(ResolveResult::Complete(TestScheme {
+            token: token.to_owned(),
+            generation: 1,
+        }))
+    }
+
+    async fn refresh(
+        state: &mut TestScheme,
+        _ctx: &CredentialContext,
+    ) -> Result<RefreshOutcome, CredentialError> {
+        // Simulate a provider-contacting rotation: bump the material so the
+        // facade takes the `Rewrote` success arm (which must stamp
+        // `last_validated_at`).
+        state.generation += 1;
+        state.token = format!("v{}", state.generation);
+        Ok(RefreshOutcome::Refreshed)
+    }
+
+    async fn revoke(
+        state: &mut TestScheme,
+        _ctx: &CredentialContext,
+    ) -> Result<(), CredentialError> {
+        // Provider-side revoke succeeds; the facade writes the tombstone and
+        // drops the bytes. Clearing here mirrors a real impl zeroing material.
+        state.token.clear();
+        Ok(())
+    }
+}
+
+// ── Harness ────────────────────────────────────────────────────────────
+
+async fn build_service() -> Arc<CredentialService> {
+    let key = Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+
+    let mut registry = CredentialRegistry::new();
+    registry
+        .register(TestLifecycleCred, "nebula-api-test")
+        .expect("test_lifecycle registers (unique key)");
+
+    let mut ops = DispatchOps::<ErasedPendingStore>::new();
+    register_runtime_ops::<TestLifecycleCred, ErasedPendingStore>(&mut ops).expect("runtime ops");
+    register_refreshable_ops::<TestLifecycleCred, ErasedPendingStore>(&mut ops)
+        .expect("refreshable ops");
+    register_revocable_ops::<TestLifecycleCred, ErasedPendingStore>(&mut ops)
+        .expect("revocable ops");
+
+    with_memory_store_parts(key, registry, ops)
+        .await
+        .expect("service composes (advertised caps match ops)")
+}
+
+/// Read the persisted `last_validated_at` straight off the layered store (the
+/// service head does not expose it).
+async fn last_validated(svc: &CredentialService, id: &str) -> chrono::DateTime<chrono::Utc> {
+    let store: Arc<dyn DynCredentialStore> = svc.credential_store_handle();
+    let row = store.get(id).await.expect("stored row present");
+    row.last_validated_at()
+        .expect("a created/refreshed credential carries a last_validated_at stamp")
+}
+
+fn scope() -> TenantScope {
+    TenantScope::new("org", "ws")
+}
+
+async fn create_cred(svc: &CredentialService) -> String {
+    svc.create(
+        &scope(),
+        "test_lifecycle",
+        json!({ "token": "v1" }),
+        CredentialDisplay::default(),
+    )
+    .await
+    .expect("create succeeds")
+    .id
+}
+
+// ── Regressions ──────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn refresh_advances_last_validated_at() {
+    // FIX-2 E2E: a provider-contacting facade refresh MUST advance the
+    // re-validation anchor. The original FIX-2 built the stamped metadata but
+    // never wired it into the written row, so the anchor stayed at creation
+    // time — invisible to clippy and unit tests, caught only by static review.
+    let svc = build_service().await;
+    let id = create_cred(&svc).await;
+
+    let t0 = last_validated(&svc, &id).await;
+    // Guarantee a measurable gap so a discarded stamp (t1 == t0) is
+    // distinguishable from an advanced one (t1 > t0).
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    svc.refresh(&scope(), &id).await.expect("refresh succeeds");
+
+    let t1 = last_validated(&svc, &id).await;
+    assert!(
+        t1 > t0,
+        "refresh must advance last_validated_at (was {t0}, now {t1}) — a discarded \
+         stamp would leave it at creation time"
+    );
+}
+
+#[tokio::test]
+async fn revoke_then_refresh_and_get_are_not_found() {
+    // A revoked credential is gone: neither a refresh nor a read may resurrect
+    // or serve it. `load_owned` maps the tombstone to `NotFound`.
+    let svc = build_service().await;
+    let id = create_cred(&svc).await;
+
+    svc.revoke(&scope(), &id).await.expect("revoke succeeds");
+
+    let refreshed = svc.refresh(&scope(), &id).await;
+    assert!(
+        matches!(refreshed, Err(CredentialServiceError::NotFound { .. })),
+        "refresh of a revoked credential must fail closed as NotFound, got {refreshed:?}"
+    );
+
+    let got = svc.get(&scope(), &id).await;
+    assert!(
+        matches!(got, Err(CredentialServiceError::NotFound { .. })),
+        "a revoked credential must read as NotFound (idempotent revoke view), got {got:?}"
+    );
+}
+
+#[tokio::test]
+async fn validate_credential_binding_rejects_tombstoned() {
+    // Q9 E2E: a slot binding against a revoked credential surfaces the typed
+    // `CredentialTombstoned`, not a bare NotFound — so the workflow author
+    // learns the slot stopped resolving because the credential was revoked.
+    let svc = build_service().await;
+    let id = create_cred(&svc).await;
+
+    svc.validate_credential_binding(&scope(), &id)
+        .await
+        .expect("a live credential binds");
+
+    svc.revoke(&scope(), &id).await.expect("revoke succeeds");
+
+    let err = svc
+        .validate_credential_binding(&scope(), &id)
+        .await
+        .expect_err("a tombstoned credential must not bind");
+    assert!(
+        matches!(
+            err,
+            ValidatedCredentialBindingError::CredentialTombstoned { .. }
+        ),
+        "expected CredentialTombstoned, got {err:?}"
+    );
+}

--- a/crates/credential/docs/PHASE1.md
+++ b/crates/credential/docs/PHASE1.md
@@ -302,3 +302,23 @@ jitter is applied once at the scheduler seam, never here — §24 invariant):
   never a break. Independent follow-up worth a task: no test asserts a `Sensitive` scheme's `Serialize`
   can't leak plaintext to a non-storage sink (`serde_secret::serialize` exposes plaintext, gated only
   by call-site) — hardening, orthogonal to F3.
+- 2026-06-14: **increment 3b (facade E2E harness + lifecycle regressions) — harness + 3 regressions
+  landed.** Home = `crates/api/tests` (api depends on credential + storage, so it hosts the harness
+  `nebula-credential` cannot without a `credential→storage` dev-dep cycle). Factory variant
+  `credential_service_factory::with_memory_store_parts(key, registry, ops)` (test-util-gated) composes
+  the real `Audit(Cache(Encryption(SQLite)))` stack over a **caller-supplied registry + ops**;
+  `with_store` now funnels through the extracted `compose_credential_service` so the secure-stack
+  composition lives in one place. New `credential_facade_lifecycle_e2e.rs` registers a local
+  `TestLifecycleCred` (non-interactive **and** Refreshable **and** Revocable — no first-party builtin
+  is: `api_key`/`basic_auth` aren't Revocable, `oauth2` is interactive) on an active `SchemeFamily`
+  (so it passes the 5d containment law). Three regressions: (1) `refresh_advances_last_validated_at` —
+  the FIX-2 wiring bug (PR #797 `7111cb32`) that shipped dead because **no test exercised the facade
+  refresh path**; the discriminator is a 10 ms gap then `t1 > t0` (a discarded stamp leaves it at
+  creation time); (2) `revoke_then_refresh_and_get_are_not_found` — a revoked credential is
+  unresolvable through the service (no resurrection); (3) `validate_credential_binding_rejects_tombstoned`
+  — Q9 end-to-end (typed `CredentialTombstoned`). 493 api tests green (incl. the existing factory
+  round-trips after the refactor); workspace clippy `--all-targets` + api `--all-features` + rustdoc
+  `-D warnings` + fmt clean. **Remaining 3b: the External-source regression** (needs a factory variant
+  injecting `StateSource::External` + a stub provider) **and the structural Q10 source-awareness**
+  (move the per-call `ensure_local_source` gate into the resolver tail by construction) — both
+  separable from the harness; tracked as 3b-2 / 3c.


### PR DESCRIPTION
## Increment 3b — facade E2E harness + lifecycle regressions

Builds the `CredentialService` E2E harness the facade refresh/revoke paths lacked — **the exact gap that let [#797](https://github.com/vanyastaff/nebula/pull/797)'s dead FIX-2 stamp ship**: no test exercised `facade::refresh_inner`, and clippy can't see a discarded struct field. Caught then only by static review (Codex/CodeRabbit); now pinned by a test.

**Home = `crates/api/tests`** (not in-credential): `nebula-api` depends on both `nebula-credential` and `nebula-storage`, so it can host a harness `nebula-credential` cannot — a credential dev-dep on storage would be a `credential→storage` cycle.

### Factory
- Extract `compose_credential_service` (the secure-stack composition: `Audit(Cache(Encryption(SQLite)))` + lease + pending + observer) so it lives in one place.
- Add test-util-gated `with_memory_store_parts(key, registry, ops)` — composes over a **caller-supplied registry + dispatch ops**, so a test can register a credential type the first-party set lacks. `with_store` (production) now funnels through the shared core.

### Test credential
`TestLifecycleCred`: **non-interactive AND Refreshable AND Revocable** — no first-party builtin is (`api_key`/`basic_auth` aren't Revocable; `oauth2` is interactive, can't be created without the OAuth handshake). On an active `SchemeFamily` so it passes the F3 (5d) containment law at registration.

### Regressions (3)
- `refresh_advances_last_validated_at` — the FIX-2 path. Discriminator: a 10 ms gap then `t1 > t0` (a discarded stamp leaves the anchor at creation time → `t1 == t0` → fail). This is the test that would have caught #797's bug.
- `revoke_then_refresh_and_get_are_not_found` — a revoked credential is unresolvable through the service (no resurrection); `load_owned` maps the tombstone to `NotFound`.
- `validate_credential_binding_rejects_tombstoned` — Q9 end-to-end: typed `CredentialTombstoned`, not a bare `NotFound`.

### Verification
- `cargo nextest run -p nebula-api` → **493 passed** (incl. the existing factory round-trips after the `compose_credential_service` refactor)
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo clippy -p nebula-api --all-features --all-targets` → clean
- `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-api --no-deps` → clean
- `cargo fmt --check` → clean

### Remaining 3b (separable, tracked in `PHASE1.md`)
- **External-source regression** — needs a factory variant injecting `StateSource::External` + a stub provider (asserts `ExternalSourceNotWired`).
- **Structural Q10 source-awareness** — move the per-call `ensure_local_source` gate into the resolver tail by construction (a refactor, distinct from the harness).

Next roadmap after 3b: **2b** (store-port `OwnerScopedKey` seal) → **7** (read-audit + provider-string redaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end tests for credential lifecycle operations, including refresh timestamp validation, revocation prevention, and tombstone credential rejection.

* **Documentation**
  * Updated project documentation to reflect Phase 1 progress and newly added regression test coverage for credential lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->