### PR TITLE
feat(credential): source-aware resolver gate + External-source regression (incr 3b)

### DIFF
--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -21,6 +21,7 @@
 
 use std::sync::Arc;
 
+use nebula_credential::provider::ExternalProvider;
 use nebula_credential::{
     ApiKeyCredential, BasicAuthCredential, CredentialStore, ErasedPendingStore, OAuth2Credential,
 };
@@ -241,7 +242,7 @@ pub fn with_store<S: CredentialStore + 'static>(
     register_revocable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
     register_testable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
 
-    compose_credential_service(raw_store, key_provider, registry, ops)
+    compose_credential_service(raw_store, key_provider, registry, ops, None)
 }
 
 /// Compose a [`CredentialService`] over `raw_store` with a **caller-supplied
@@ -262,6 +263,7 @@ fn compose_credential_service<S: CredentialStore + 'static>(
     key_provider: Arc<dyn KeyProvider>,
     registry: CredentialRegistry,
     ops: DispatchOps<ErasedPendingStore>,
+    external_provider: Option<Arc<dyn ExternalProvider>>,
 ) -> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
     tracing::warn!(
         "credential: audit sink is log-only (target=nebula.credential.audit); \
@@ -279,7 +281,7 @@ fn compose_credential_service<S: CredentialStore + 'static>(
     // so the factory mints the token internally.
     let shutdown = tokio_util::sync::CancellationToken::new();
 
-    let service = CredentialServiceBuilder::new(
+    let mut builder = CredentialServiceBuilder::new(
         raw_store,
         key_provider,
         audit_sink,
@@ -290,8 +292,14 @@ fn compose_credential_service<S: CredentialStore + 'static>(
         observer,
         lease_config,
         shutdown,
-    )
-    .build()?;
+    );
+    if let Some(provider) = external_provider {
+        // External (unwired) source: the built service rejects resolution with
+        // `ExternalSourceNotWired` (the resolution bridge, ADR-0051, is not yet
+        // built) — `from_secure_parts` gates the resolver from this source.
+        builder = builder.external_providers(provider);
+    }
+    let service = builder.build()?;
 
     tracing::info!("credential: CredentialService composed (encrypted-at-rest)");
     Ok(Arc::new(service))
@@ -321,5 +329,29 @@ pub async fn with_memory_store_parts(
     let store = SqliteCredentialStore::connect_memory()
         .await
         .map_err(|e| CredentialServiceFactoryError::Store(e.to_string()))?;
-    compose_credential_service(store, key_provider, registry, ops)
+    compose_credential_service(store, key_provider, registry, ops, None)
+}
+
+/// Build a [`CredentialService`] over an in-memory store but with an **external
+/// [`StateSource`]** backed by `provider`, whose resolution bridge (ADR-0051) is
+/// not yet wired — every resolution path then fails closed with
+/// `ExternalSourceNotWired`. The test fixture for the wrong-source guard.
+///
+/// Test-only (`test-util` feature / `cfg(test)`).
+///
+/// # Errors
+///
+/// Returns [`CredentialServiceFactoryError`] if the in-memory store cannot be
+/// opened/migrated or the final service build fails.
+#[cfg(any(test, feature = "test-util"))]
+pub async fn with_memory_store_external(
+    key_provider: Arc<dyn KeyProvider>,
+    registry: CredentialRegistry,
+    ops: DispatchOps<ErasedPendingStore>,
+    provider: Arc<dyn ExternalProvider>,
+) -> Result<Arc<CredentialService>, CredentialServiceFactoryError> {
+    let store = SqliteCredentialStore::connect_memory()
+        .await
+        .map_err(|e| CredentialServiceFactoryError::Store(e.to_string()))?;
+    compose_credential_service(store, key_provider, registry, ops, Some(provider))
 }

--- a/crates/api/tests/credential_facade_lifecycle_e2e.rs
+++ b/crates/api/tests/credential_facade_lifecycle_e2e.rs
@@ -337,8 +337,16 @@ async fn external_source_rejects_create() {
         )
         .await
         .expect_err("create against an unwired external source must fail closed");
-    assert!(
-        matches!(err, CredentialServiceError::ExternalSourceNotWired { .. }),
-        "expected ExternalSourceNotWired, got {err:?}"
-    );
+    // Assert the provider value, not just the variant: a provider-mapping
+    // regression (wrong/empty name) must fail this test, locking the
+    // source → error contract.
+    match err {
+        CredentialServiceError::ExternalSourceNotWired { provider } => {
+            assert_eq!(
+                provider, "stub-vault",
+                "the error must carry the configured provider's name"
+            );
+        },
+        other => panic!("expected ExternalSourceNotWired, got {other:?}"),
+    }
 }

--- a/crates/api/tests/credential_facade_lifecycle_e2e.rs
+++ b/crates/api/tests/credential_facade_lifecycle_e2e.rs
@@ -21,11 +21,16 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use nebula_api::ports::credential_service_factory::with_memory_store_parts;
+use nebula_api::ports::credential_service_factory::{
+    with_memory_store_external, with_memory_store_parts,
+};
 use nebula_core::auth::{
     AuthPattern, AuthScheme, EgressShape, RefreshStrategyKind, SchemeFamily, SensitiveScheme,
 };
 use nebula_credential::error::CredentialError;
+use nebula_credential::provider::{
+    ExternalProvider, ExternalReference, ProviderError, ProviderFuture,
+};
 use nebula_credential::resolve::{RefreshOutcome, ResolveResult};
 use nebula_credential::{
     CredentialContext, CredentialDisplay, CredentialMetadata, CredentialRegistry,
@@ -159,9 +164,11 @@ impl TestLifecycleCred {
 
 // ── Harness ────────────────────────────────────────────────────────────
 
-async fn build_service() -> Arc<CredentialService> {
-    let key = Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+fn test_key() -> Arc<EnvKeyProvider> {
+    Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"))
+}
 
+fn test_registry_and_ops() -> (CredentialRegistry, DispatchOps<ErasedPendingStore>) {
     let mut registry = CredentialRegistry::new();
     registry
         .register(TestLifecycleCred, "nebula-api-test")
@@ -173,10 +180,44 @@ async fn build_service() -> Arc<CredentialService> {
         .expect("refreshable ops");
     register_revocable_ops::<TestLifecycleCred, ErasedPendingStore>(&mut ops)
         .expect("revocable ops");
+    (registry, ops)
+}
 
-    with_memory_store_parts(key, registry, ops)
+async fn build_service() -> Arc<CredentialService> {
+    let (registry, ops) = test_registry_and_ops();
+    with_memory_store_parts(test_key(), registry, ops)
         .await
         .expect("service composes (advertised caps match ops)")
+}
+
+/// A service whose state source is an external provider with no resolution
+/// bridge wired — every resolution path must fail closed.
+async fn build_external_service() -> Arc<CredentialService> {
+    let (registry, ops) = test_registry_and_ops();
+    with_memory_store_external(test_key(), registry, ops, Arc::new(StubExternalProvider))
+        .await
+        .expect("service composes over an external (unwired) source")
+}
+
+/// Stub external provider: its `resolve` is never reached because the source
+/// gate fails closed first (the ADR-0051 resolution bridge is unbuilt).
+#[derive(Debug)]
+struct StubExternalProvider;
+
+impl ExternalProvider for StubExternalProvider {
+    fn resolve<'a>(&'a self, _reference: &'a ExternalReference) -> ProviderFuture<'a> {
+        ProviderFuture::ready(Err(ProviderError::Unavailable {
+            reason: "stub external provider — resolution bridge not wired".to_owned(),
+        }))
+    }
+
+    // The `ExternalProvider` trait fixes the `-> &str` signature; returning a
+    // `&'static` literal here is what the stub needs, so the lint's suggested
+    // `-> &'static str` cannot apply.
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn provider_name(&self) -> &str {
+        "stub-vault"
+    }
 }
 
 /// Read the persisted `last_validated_at` straight off the layered store (the
@@ -276,5 +317,28 @@ async fn validate_credential_binding_rejects_tombstoned() {
             ValidatedCredentialBindingError::CredentialTombstoned { .. }
         ),
         "expected CredentialTombstoned, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn external_source_rejects_create() {
+    // Wrong-source guard: the external resolution bridge (ADR-0051) is not
+    // wired, so a service built with an external source must reject secret
+    // resolution rather than fall back to reading local bytes. `create`
+    // resolves props → state, so it fails closed with ExternalSourceNotWired.
+    let svc = build_external_service().await;
+
+    let err = svc
+        .create(
+            &scope(),
+            "test_lifecycle",
+            json!({ "token": "v1" }),
+            CredentialDisplay::default(),
+        )
+        .await
+        .expect_err("create against an unwired external source must fail closed");
+    assert!(
+        matches!(err, CredentialServiceError::ExternalSourceNotWired { .. }),
+        "expected ExternalSourceNotWired, got {err:?}"
     );
 }

--- a/crates/api/tests/credential_facade_lifecycle_e2e.rs
+++ b/crates/api/tests/credential_facade_lifecycle_e2e.rs
@@ -211,9 +211,8 @@ impl ExternalProvider for StubExternalProvider {
         }))
     }
 
-    // The `ExternalProvider` trait fixes the `-> &str` signature; returning a
-    // `&'static` literal here is what the stub needs, so the lint's suggested
-    // `-> &'static str` cannot apply.
+    // guard-justified: the `ExternalProvider` trait fixes the `-> &str` return,
+    // so the lint's suggested `-> &'static str` cannot apply to this impl.
     #[allow(clippy::unnecessary_literal_bound)]
     fn provider_name(&self) -> &str {
         "stub-vault"

--- a/crates/credential/docs/PHASE1.md
+++ b/crates/credential/docs/PHASE1.md
@@ -322,3 +322,22 @@ jitter is applied once at the scheduler seam, never here — §24 invariant):
   injecting `StateSource::External` + a stub provider) **and the structural Q10 source-awareness**
   (move the per-call `ensure_local_source` gate into the resolver tail by construction) — both
   separable from the harness; tracked as 3b-2 / 3c.
+- 2026-06-14: **3b remainder (External-source regression + structural Q10) landed.** Q10: the
+  source gate is now enforced at the **resolver tail** by construction, not only by the facade's
+  per-call `ensure_local_source`. `CredentialResolver` gained an `external_source_unwired` flag +
+  `gate_external_source` setter; `resolve` / `resolve_scoped` / `resolve_with_refresh` (and so
+  `scheme_factory`) call `ensure_source_wired` first and return the new
+  `ResolveError::ExternalSourceNotWired`. `from_secure_parts` derives the gate from the configured
+  `StateSource` at the **single** construction point, so a service built on an external (unwired)
+  source CANNOT hold a resolver that still reads local bytes — this closes the source-gate bypass
+  on the direct-resolver path (`scheme_factory` → `resolve_with_refresh`), the **same bypass class
+  as the FIX-1 owner/tombstone gap**. `resolve_for_slot` dropped its per-call `ensure_local_source`
+  (now resolver-enforced) and maps the resolver error to the facade
+  `ExternalSourceNotWired { provider }`; the create/resolve/continue_resolve facade gates stay
+  (local-creation paths, not resolver-routed). Factory: `compose_credential_service` takes an
+  optional `ExternalProvider`; new test-util `with_memory_store_external`. Tests: resolver-gate unit
+  (`gated_resolver_refuses_resolution_at_the_tail` — a gated resolver refuses even with a live row)
+  + api E2E `external_source_rejects_create` (create on an external service → `ExternalSourceNotWired`).
+  381 credential lib green + 4 facade E2E; workspace clippy `--all-targets` + credential/api
+  `--all-features` + rustdoc `-D warnings` + fmt clean. **Increment 3b COMPLETE.** Next: **2b**
+  (store-port `OwnerScopedKey` seal) → **7** (read-audit + provider-string redaction).

--- a/crates/credential/src/runtime/resolver.rs
+++ b/crates/credential/src/runtime/resolver.rs
@@ -51,6 +51,14 @@ pub struct CredentialResolver<S: CredentialStore> {
     /// refresh can [`CredentialHandle::replace`] in place instead of minting
     /// disconnected handles on every resolve/refresh cycle.
     handle_cache: Arc<HandleCache>,
+    /// When `true`, the service is configured with an external
+    /// [`StateSource`](crate::service) whose resolution bridge is not yet wired,
+    /// so **every** resolution path refuses to read local bytes (fail-closed at
+    /// the resolver tail — see [`gate_external_source`](Self::gate_external_source)).
+    /// This closes the source gate on the direct-resolver paths
+    /// (`scheme_factory` → `resolve_with_refresh`) that bypass the facade's
+    /// per-call check, by construction rather than by discipline.
+    external_source_unwired: bool,
 }
 
 impl<S: CredentialStore> Clone for CredentialResolver<S> {
@@ -61,6 +69,7 @@ impl<S: CredentialStore> Clone for CredentialResolver<S> {
             transport: Arc::clone(&self.transport),
             event_bus: self.event_bus.clone(),
             handle_cache: Arc::clone(&self.handle_cache),
+            external_source_unwired: self.external_source_unwired,
         }
     }
 }
@@ -84,7 +93,26 @@ impl<S: CredentialStore> CredentialResolver<S> {
             transport,
             event_bus: None,
             handle_cache: Arc::new(Mutex::new(HashMap::new())),
+            external_source_unwired: false,
         }
+    }
+
+    /// Fail-closed the resolver against an external, not-yet-wired state source.
+    ///
+    /// Set by the composition root when the service is built with
+    /// [`StateSource::External`](crate::service). Once gated, **every** resolution
+    /// entry point ([`resolve`](Self::resolve) / [`resolve_scoped`](Self::resolve_scoped)
+    /// / [`resolve_with_refresh`](Self::resolve_with_refresh), and therefore
+    /// [`scheme_factory`](Self::scheme_factory)) returns
+    /// [`ResolveError::ExternalSourceNotWired`] instead of reading local bytes —
+    /// so the direct-resolver paths that bypass the facade's per-call source
+    /// check cannot silently resolve from the wrong place. The external provider
+    /// resolution bridge (ADR-0051) is not yet built; until it lands, gated is a
+    /// hard error, never a local-store fallback.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn gate_external_source(mut self, unwired: bool) -> Self {
+        self.external_source_unwired = unwired;
+        self
     }
 
     fn handle_cache_key<C: Credential>(credential_id: &str) -> (String, TypeId) {
@@ -188,6 +216,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     where
         C: Credential,
     {
+        self.ensure_source_wired()?;
         let stored = self.load_and_verify::<C>(credential_id).await?;
         let state: C::State = self.deserialize::<C>(credential_id, &stored)?;
         let scheme = C::project(&state);
@@ -217,6 +246,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     where
         C: Credential,
     {
+        self.ensure_source_wired()?;
         // Load the raw row, then verify owner BEFORE any type/kind signal: a
         // kind-mismatch error on a foreign id would be an existence/type oracle
         // (a cross-tenant probe could distinguish "absent" from "exists but wrong
@@ -267,6 +297,7 @@ impl<S: CredentialStore> CredentialResolver<S> {
     where
         C: Refreshable + CredentialLifecycle,
     {
+        self.ensure_source_wired()?;
         let stored = self.load_and_verify::<C>(credential_id).await?;
         let state: C::State = self.deserialize::<C>(credential_id, &stored)?;
 
@@ -562,6 +593,17 @@ impl<S: CredentialStore> CredentialResolver<S> {
         if let Some(bus) = &self.event_bus {
             let _ = bus.emit(CredentialEvent::Refreshed { credential_id });
         }
+    }
+
+    /// Fail-closed at the resolution tail when the configured state source is
+    /// external and its resolution bridge is unwired. Called by every resolution
+    /// entry point so the gate is structural, not per-call discipline (see
+    /// [`gate_external_source`](Self::gate_external_source)).
+    fn ensure_source_wired(&self) -> Result<(), ResolveError> {
+        if self.external_source_unwired {
+            return Err(ResolveError::ExternalSourceNotWired);
+        }
+        Ok(())
     }
 
     async fn load_and_verify<C>(
@@ -966,6 +1008,13 @@ pub enum ResolveError {
         /// Why re-authentication is required.
         reason: ReauthReason,
     },
+    /// The service is configured with an external [`StateSource`](crate::service)
+    /// whose resolution bridge (ADR-0051) is not yet wired, so the resolver
+    /// refuses to read local bytes. Fail-closed: never a silent local-store
+    /// fallback. The facade maps this to
+    /// `CredentialServiceError::ExternalSourceNotWired`.
+    #[error("external state source is not wired; cannot resolve credential material")]
+    ExternalSourceNotWired,
 }
 
 /// Fail-closed owner gate for the scoped resolution path: the loaded row's
@@ -1540,6 +1589,26 @@ mod refresh_revoke_race {
 
         assert!(
             matches!(err, ResolveError::Store(StoreError::NotFound { .. })),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn gated_resolver_refuses_resolution_at_the_tail() {
+        // Q10 structural: a resolver gated for an external (unwired) source
+        // refuses to read local bytes on EVERY resolution path — even though
+        // the store holds a live row — so the direct-resolver paths
+        // (`scheme_factory` → `resolve_with_refresh`) that bypass the facade's
+        // per-call check are fail-closed by construction.
+        let store = Arc::new(ScriptedStore::new(live_row(), false));
+        let resolver = resolver_with(Arc::clone(&store)).gate_external_source(true);
+
+        let err = resolver
+            .resolve::<TestCred>(TEST_ID)
+            .await
+            .expect_err("a gated resolver must refuse to resolve from the local store");
+        assert!(
+            matches!(err, ResolveError::ExternalSourceNotWired),
             "got {err:?}"
         );
     }

--- a/crates/credential/src/service/facade.rs
+++ b/crates/credential/src/service/facade.rs
@@ -222,6 +222,13 @@ impl CredentialService {
         observer: Arc<dyn CredentialObserver>,
         source: StateSource,
     ) -> Self {
+        // Tie the resolver's source gate to the configured source at the single
+        // construction point: a service built with an external (unwired) source
+        // CANNOT hold a resolver that still reads local bytes. This makes the
+        // direct-resolver paths (`scheme_factory` → `resolve_with_refresh`, which
+        // bypass the facade's per-call source check) fail-closed by construction,
+        // so the gate cannot drift from the source a future code path forgets.
+        let resolver = resolver.gate_external_source(matches!(source, StateSource::External(_)));
         Self {
             store,
             scan_store,
@@ -1289,13 +1296,14 @@ impl CredentialService {
         C: Credential,
         C::Scheme: Zeroize + Clone,
     {
-        // 0. Source gate: a service configured with an `External` state source
-        //    has no local-decrypt resolution path wired, so resolving a slot
-        //    against it must fail with `ExternalSourceNotWired` rather than read
-        //    local bytes. This guard is present on every other secret-resolving
-        //    entry point; resolve_for_slot — the moat path — must not be the one
-        //    that skips it.
-        self.ensure_local_source()?;
+        // Source gate is enforced at the resolver tail (`resolve_scoped` →
+        // `ensure_source_wired`), set from the configured `StateSource` at
+        // `from_secure_parts`. A service with an external (unwired) source
+        // therefore fails closed by construction here — and on the
+        // `scheme_factory` direct path that never reaches this method — instead
+        // of relying on a per-call check this moat path could forget. The
+        // mapping below turns the resolver's `ExternalSourceNotWired` into the
+        // facade error.
 
         // 1. Defence-in-depth fingerprint check: even though
         //    `validate_credential_binding` enforced the scope at
@@ -1332,6 +1340,18 @@ impl CredentialService {
                     match e {
                         ResolveError::Store(StoreError::NotFound { id }) => {
                             CredentialServiceError::NotFound { id }
+                        },
+                        // The resolver tail fail-closed on an external, unwired
+                        // source. Surface the typed facade error with the
+                        // configured provider's name (only `External` reaches
+                        // this arm — the gate is derived from the source).
+                        ResolveError::ExternalSourceNotWired => {
+                            CredentialServiceError::ExternalSourceNotWired {
+                                provider: match &self.source {
+                                    StateSource::External(p) => p.provider_name().to_owned(),
+                                    StateSource::LocalEncrypted => "unknown".to_owned(),
+                                },
+                            }
                         },
                         other => CredentialServiceError::Internal(other.to_string()),
                     }


### PR DESCRIPTION
## Increment 3b remainder — External-source regression + structural Q10

Completes Increment 3b (the harness + lifecycle regressions landed in [#798](https://github.com/vanyastaff/nebula/pull/798)).

### Structural Q10 — source gate at the resolver tail (closes a FIX-1-class bypass)
The external-state-source gate was a **per-call facade check** (`ensure_local_source`) on `create`/`resolve`/`continue_resolve`/`resolve_for_slot`. The direct-resolver path **`scheme_factory` → `resolve_with_refresh` bypassed it entirely** — the same bypass class as the FIX-1 owner/tombstone gap (a facade gate the moat path skips).

Now the gate is enforced **at the resolver tail, by construction**:
- `CredentialResolver` gains `external_source_unwired` + `gate_external_source`; `resolve` / `resolve_scoped` / `resolve_with_refresh` (and therefore `scheme_factory`) call `ensure_source_wired` first and return the new `ResolveError::ExternalSourceNotWired` (the enum is `#[non_exhaustive]` — additive, non-breaking).
- `from_secure_parts` derives the gate from the configured `StateSource` at the **single** construction point, so an external (unwired) service **cannot** hold a resolver that still reads local bytes — the gate can't drift from the source a future path forgets.
- `resolve_for_slot` drops its per-call `ensure_local_source` (now resolver-enforced) and maps the resolver error to the facade `ExternalSourceNotWired { provider }`. The `create`/`resolve`/`continue_resolve` facade gates stay — they are local-creation paths, not resolver-routed.

### External-source regression (the deferred 3b test)
- Factory: `compose_credential_service` takes an optional `ExternalProvider`; new test-util `with_memory_store_external`.
- Tests: resolver-gate unit (`gated_resolver_refuses_resolution_at_the_tail` — a gated resolver refuses even with a live row in the store) + api E2E `external_source_rejects_create` (create on an external service → `ExternalSourceNotWired`).

### Verification
- `cargo nextest run -p nebula-credential` → **381 passed**; facade E2E → **4 passed**
- `cargo clippy --workspace --all-targets -- -D warnings` → clean
- `cargo clippy -p nebula-credential --all-features` / `-p nebula-api --all-features --all-targets` → clean
- `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-credential -p nebula-api --no-deps` → clean
- `cargo fmt --check` → clean

**Increment 3b COMPLETE.** Next roadmap: **2b** (store-port `OwnerScopedKey` seal — the structural close of the *owner* half, where the source-awareness restructure naturally pairs) → **7** (read-audit + provider-string redaction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external credential source handling with fail-closed enforcement. The system now explicitly rejects credential operations when an external source is not properly configured, preventing unintended fallback behavior.

* **Tests**
  * Added end-to-end test coverage for external credential source rejection scenarios.

* **Documentation**
  * Updated progress documentation with completion of external-source gating implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->