### PR TITLE
fix(resource): guard teardown deadline vs Instant overflow; close pre-push rustdoc fallback gap

### DIFF
--- a/crates/resource/src/runtime/teardown.rs
+++ b/crates/resource/src/runtime/teardown.rs
@@ -22,6 +22,13 @@ use crate::{
 /// [`Provider::teardown_budget`] is larger. See ADR-0093.
 pub(crate) const REVOKE_TEARDOWN_CAP: Duration = Duration::from_secs(5);
 
+/// Far-future fallback horizon used when a declared teardown budget is so large
+/// that `Instant::now() + budget` would overflow `Instant` (operator
+/// misconfiguration). Library code must not panic, so we cap at a
+/// far-future-but-representable deadline instead. One hour is orders of
+/// magnitude beyond any real graceful teardown.
+const MAX_TEARDOWN_HORIZON: Duration = Duration::from_hours(1);
+
 /// Compose the teardown deadline: the resource's declared
 /// [`teardown_budget`](Provider::teardown_budget), capped short for a revoke
 /// (urgent). `now` is taken once at call time. See ADR-0093.
@@ -32,7 +39,13 @@ pub(crate) fn teardown_deadline<R: Provider>(resource: &R, reason: TeardownReaso
     } else {
         budget
     };
-    Instant::now() + effective
+    // Guard against `Instant` overflow — library code must not panic. A budget
+    // large enough to overflow `now + effective` is misconfiguration; fall back
+    // to a far-future horizon (then, defensively, `now`). See ADR-0093.
+    let now = Instant::now();
+    now.checked_add(effective)
+        .or_else(|| now.checked_add(MAX_TEARDOWN_HORIZON))
+        .unwrap_or(now)
 }
 
 /// Tear one instance down under a per-resource, per-context deadline.

--- a/scripts/pre-push-crate-diff.sh
+++ b/scripts/pre-push-crate-diff.sh
@@ -15,6 +15,11 @@ else
   echo "lefthook: no upstream ref found; running fallback smoke gate"
   cargo nextest run -p nebula-core -p nebula-engine -p nebula-execution --profile agent
   cargo check --workspace --all-features --all-targets --quiet
+  # CI "Documentation" required-job parity, also on the fallback path
+  # (reference_rustdoc_verification_gap.md): mirror the workspace-wide
+  # `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` so the no-upstream scenario
+  # this branch handles is not a rustdoc blind spot.
+  RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace --quiet
   exit 0
 fi
 


### PR DESCRIPTION
Two small fixes flagged by CodeRabbit on already-merged code (`#806`).

**1. `crates/resource/src/runtime/teardown.rs` — library panic on `Instant` overflow.**
`teardown_deadline` computed `Instant::now() + effective`, which can panic if a resource's `teardown_budget()` returns an absurdly large `Duration`. Library code must not panic. Now uses `now.checked_add(effective).or_else(|| now.checked_add(MAX_TEARDOWN_HORIZON)).unwrap_or(now)` — a far-future-but-representable horizon (1h) on overflow, then `now` defensively. Semantics preserved for all real budgets.

**2. `scripts/pre-push-crate-diff.sh` — rustdoc gate parity gap on the fallback path.**
The no-upstream-ref fallback ran nextest + `cargo check` then `exit 0`, **skipping** the `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` gate the changed-crate path has (CI Documentation parity). Added it to the fallback too.

## Verification
`bash -n scripts/pre-push-crate-diff.sh` ✅ · clippy `-D warnings` ✅ · nextest **396 passed** ✅ on `nebula-resource`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)