### PR TITLE
feat(storage): capability-routed job-dispatch queue + trigger dedup inbox (ADR-0095 D3/D5, unit 1)

### DIFF
--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -73,9 +73,10 @@ pub struct JobDispatchMsg {
     /// Source-natural dedup key.
     ///
     /// `None` ⇒ dispatch once, no dedup row written.  `Some` ⇒ the
-    /// trigger-dedup inbox guards against duplicate fan-out with
-    /// `UNIQUE(trigger_id, event_id)`.  A fresh ULID is never the right
-    /// value here — it would defeat the dedup invariant.
+    /// trigger-dedup inbox guards against duplicate fan-out with the scoped
+    /// constraint `UNIQUE(workspace_id, org_id, trigger_id, event_id)`.
+    /// A fresh ULID is never the right value here — it would defeat the dedup
+    /// invariant.
     pub event_id: Option<String>,
     /// Version-pin guard (SHA of the plugin flavor).  Not a routing key.
     pub target_flavor_sha: String,
@@ -99,6 +100,8 @@ impl JobDispatchMsg {
     /// `capability_tags` must include `required_plugin_key`; callers are
     /// responsible for that invariant (no enforcement here to keep the
     /// constructor cheap).
+    // guard-justified: constructor over all DTO fields; a builder adds no safety
+    // for an internal #[non_exhaustive] record whose fields are all independent.
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: [u8; 16],

--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -1,0 +1,130 @@
+//! Job-dispatch message DTO and routing types.
+//!
+//! `JobDispatchMsg` is the durable unit of work enqueued by the emitter and
+//! pulled by the orchestrator.  The routing key is `required_plugin_key`
+//! matched against a worker's `capability_tags`; `target_flavor_sha` is a
+//! separate version-pin guard and is never used for routing.
+use crate::Scope;
+use crate::dto::ControlCommand;
+use serde::{Deserialize, Serialize};
+
+/// Opaque capability routing tag (advertised PluginKey strings).
+///
+/// A worker advertises the set of `CapabilityTag`s it supports; the
+/// orchestrator claims only rows whose `required_plugin_key` is a member of
+/// that set.  The tag is the canonical `PluginKey` string form.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CapabilityTag(pub String);
+
+impl CapabilityTag {
+    /// Borrow the inner tag string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for CapabilityTag {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl From<&str> for CapabilityTag {
+    fn from(s: &str) -> Self {
+        Self(s.to_owned())
+    }
+}
+
+/// Whether a dispatch attempt produced a new dispatch or was deduplicated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use = "callers must inspect whether the dispatch landed or was a duplicate"]
+#[non_exhaustive]
+pub enum DispatchOutcome {
+    /// The job was enqueued (first writer won).
+    Dispatched,
+    /// A row with the same `(trigger_id, event_id)` already existed;
+    /// the second write was a no-op.
+    Duplicate,
+}
+
+/// One queued job-dispatch message.
+///
+/// `id` is a typed 16-byte ULID (raw bytes).  `event_id` is `None` when the
+/// caller wants a single unconditional dispatch with no dedup row; it is
+/// `Some` (a source-natural idempotency key) when the trigger-dedup inbox
+/// must guard against duplicate fan-out.
+///
+/// Construct via [`JobDispatchMsg::new`]; struct literal syntax is
+/// unavailable from external crates (`#[non_exhaustive]`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct JobDispatchMsg {
+    /// 16-byte ULID primary key (raw bytes).
+    pub id: [u8; 16],
+    /// Target execution id (opaque string form).
+    pub execution_id: String,
+    /// Control command to deliver (typically `Start`).
+    pub command: ControlCommand,
+    /// Tenant scope this message belongs to.
+    pub scope: Scope,
+    /// Arbitrary payload forwarded to the worker unchanged.
+    pub payload: serde_json::Value,
+    /// Source-natural dedup key.
+    ///
+    /// `None` ⇒ dispatch once, no dedup row written.  `Some` ⇒ the
+    /// trigger-dedup inbox guards against duplicate fan-out with
+    /// `UNIQUE(trigger_id, event_id)`.  A fresh ULID is never the right
+    /// value here — it would defeat the dedup invariant.
+    pub event_id: Option<String>,
+    /// Version-pin guard (SHA of the plugin flavor).  Not a routing key.
+    pub target_flavor_sha: String,
+    /// Routing key: the advertised `PluginKey` this job requires.
+    ///
+    /// The orchestrator claims only rows whose `required_plugin_key` is a
+    /// member of a worker's advertised `capability_tags`.
+    pub required_plugin_key: String,
+    /// Full set of capability tags accepted by this job (superset of
+    /// `required_plugin_key`).  Stored as a JSON array in the backend.
+    pub capability_tags: Vec<CapabilityTag>,
+    /// Optional W3C `traceparent` captured at enqueue time.
+    pub w3c_traceparent: Option<String>,
+    /// Times this row was reclaimed back to `Pending` after a crashed runner.
+    pub reclaim_count: u32,
+}
+
+impl JobDispatchMsg {
+    /// Construct a job-dispatch message.
+    ///
+    /// `capability_tags` must include `required_plugin_key`; callers are
+    /// responsible for that invariant (no enforcement here to keep the
+    /// constructor cheap).
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        id: [u8; 16],
+        execution_id: impl Into<String>,
+        command: ControlCommand,
+        scope: Scope,
+        payload: serde_json::Value,
+        event_id: Option<impl Into<String>>,
+        target_flavor_sha: impl Into<String>,
+        required_plugin_key: impl Into<String>,
+        capability_tags: Vec<CapabilityTag>,
+        w3c_traceparent: Option<impl Into<String>>,
+        reclaim_count: u32,
+    ) -> Self {
+        Self {
+            id,
+            execution_id: execution_id.into(),
+            command,
+            scope,
+            payload,
+            event_id: event_id.map(Into::into),
+            target_flavor_sha: target_flavor_sha.into(),
+            required_plugin_key: required_plugin_key.into(),
+            capability_tags,
+            w3c_traceparent: w3c_traceparent.map(Into::into),
+            reclaim_count,
+        }
+    }
+}

--- a/crates/storage-port/src/dto/mod.rs
+++ b/crates/storage-port/src/dto/mod.rs
@@ -9,8 +9,10 @@ mod control;
 mod execution;
 mod idempotency;
 mod identity;
+mod job_dispatch;
 mod journal;
 mod node_result;
+mod trigger_dedup;
 mod webhook;
 mod workflow;
 
@@ -21,7 +23,9 @@ pub use identity::{
     AuditLogRow, BlobRow, MembershipRow, OrgRow, PrincipalKind, QuotaRow, ResourceRow, ScopeKind,
     TriggerRow, UserRow, WorkspaceRow,
 };
+pub use job_dispatch::{CapabilityTag, DispatchOutcome, JobDispatchMsg};
 pub use journal::JournalEntry;
 pub use node_result::{MAX_SUPPORTED_RESULT_SCHEMA_VERSION, NodeResultRecord};
+pub use trigger_dedup::TriggerDedupRow;
 pub use webhook::WebhookActivationRecord;
 pub use workflow::{WorkflowRecord, WorkflowVersionRecord};

--- a/crates/storage-port/src/dto/trigger_dedup.rs
+++ b/crates/storage-port/src/dto/trigger_dedup.rs
@@ -8,9 +8,11 @@ use serde::{Deserialize, Serialize};
 
 /// One trigger-dedup guard row.
 ///
-/// The primary uniqueness constraint is `(trigger_id, event_id)`.  A second
-/// delivery of the same event from the same trigger will find the row already
-/// present and be discarded (`DispatchOutcome::Duplicate`).
+/// The uniqueness constraint is `PRIMARY KEY(workspace_id, org_id, trigger_id,
+/// event_id)` — scoped per tenant, so two tenants sharing the same
+/// `(trigger_id, event_id)` pair are never deduplicated against each other.  A
+/// second delivery of the same event from the same trigger *within one tenant*
+/// finds the row already present and is discarded (`DispatchOutcome::Duplicate`).
 ///
 /// Construct via [`TriggerDedupRow::new`]; struct literal syntax is
 /// unavailable from external crates (`#[non_exhaustive]`).

--- a/crates/storage-port/src/dto/trigger_dedup.rs
+++ b/crates/storage-port/src/dto/trigger_dedup.rs
@@ -1,0 +1,54 @@
+//! Trigger-dedup inbox row DTO.
+//!
+//! `TriggerDedupRow` is the guard inserted atomically with the `Start` job
+//! to enforce first-writer-wins trigger fan-out.  `event_id` is required and
+//! must be a source-natural idempotency key — never a freshly minted ULID.
+use crate::Scope;
+use serde::{Deserialize, Serialize};
+
+/// One trigger-dedup guard row.
+///
+/// The primary uniqueness constraint is `(trigger_id, event_id)`.  A second
+/// delivery of the same event from the same trigger will find the row already
+/// present and be discarded (`DispatchOutcome::Duplicate`).
+///
+/// Construct via [`TriggerDedupRow::new`]; struct literal syntax is
+/// unavailable from external crates (`#[non_exhaustive]`).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct TriggerDedupRow {
+    /// The trigger that fired (scoped to `scope`).
+    pub trigger_id: String,
+    /// Source-natural idempotency key for the event.
+    ///
+    /// Required (`String`, not `Option`) — a `TriggerDedupRow` is only
+    /// created when dedup is desired.  Callers that want unconditional
+    /// dispatch pass `None` as the `row` argument to
+    /// `TriggerDedupInbox::claim_and_enqueue_start`.
+    pub event_id: String,
+    /// Tenant scope.
+    pub scope: Scope,
+    /// The execution that was started as a result of this trigger event.
+    pub execution_id: String,
+    /// Wall-clock creation time (RFC 3339).
+    pub created_at: String,
+}
+
+impl TriggerDedupRow {
+    /// Construct a trigger-dedup guard row.
+    pub fn new(
+        trigger_id: impl Into<String>,
+        event_id: impl Into<String>,
+        scope: Scope,
+        execution_id: impl Into<String>,
+        created_at: impl Into<String>,
+    ) -> Self {
+        Self {
+            trigger_id: trigger_id.into(),
+            event_id: event_id.into(),
+            scope,
+            execution_id: execution_id.into(),
+            created_at: created_at.into(),
+        }
+    }
+}

--- a/crates/storage-port/src/store/job_dispatch.rs
+++ b/crates/storage-port/src/store/job_dispatch.rs
@@ -1,0 +1,64 @@
+//! Capability-routed job-dispatch queue port.
+//!
+//! The orchestrator pulls jobs by advertising the set of `CapabilityTag`s its
+//! workers support; the queue delivers only rows whose `required_plugin_key`
+//! is a member of that set.  The claim/fence/reclaim shape mirrors
+//! `ControlQueue` — `ReclaimOutcome` is reused from that module.
+use std::time::Duration;
+
+use crate::dto::{CapabilityTag, JobDispatchMsg};
+use crate::error::StorageError;
+use crate::store::ReclaimOutcome;
+
+/// Durable capability-routed job-dispatch queue.
+///
+/// The routing predicate is `required_plugin_key ∈ advertised_tags`.
+/// Postgres uses `FOR UPDATE SKIP LOCKED` on `claim_pending`; SQLite uses a
+/// single-consumer status flip.  Both are object-safe and Send+Sync.
+#[async_trait::async_trait]
+pub trait JobDispatchQueue: Send + Sync + std::fmt::Debug {
+    /// Durably enqueue a job-dispatch message.
+    async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError>;
+
+    /// Atomically claim up to `batch_size` pending jobs whose
+    /// `required_plugin_key` is a member of `advertised_tags`.
+    ///
+    /// Postgres uses `FOR UPDATE SKIP LOCKED`; SQLite uses a single-consumer
+    /// status flip with an explicit `AND status = 'Pending'` guard.
+    async fn claim_pending(
+        &self,
+        processor: &[u8; 16],
+        batch_size: u32,
+        advertised_tags: &[CapabilityTag],
+    ) -> Result<Vec<JobDispatchMsg>, StorageError>;
+
+    /// Mark a claimed job dispatched (terminal success).  Only the runner
+    /// whose id matches the row's recorded processor may transition it
+    /// (stale-worker fence).
+    async fn mark_dispatched(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+    ) -> Result<(), StorageError>;
+
+    /// Mark a claimed job failed (records `error`).  Same processor fence as
+    /// [`Self::mark_dispatched`].
+    async fn mark_failed(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+        error: &str,
+    ) -> Result<(), StorageError>;
+
+    /// Reclaim rows stuck in `Processing` past `reclaim_after`.  Rows under
+    /// the `max_reclaim_count` budget go back to `Pending`; rows past it go
+    /// to `Failed`.
+    async fn reclaim_stuck(
+        &self,
+        reclaim_after: Duration,
+        max_reclaim_count: u32,
+    ) -> Result<ReclaimOutcome, StorageError>;
+
+    /// Delete terminal rows older than `retention`; returns the count deleted.
+    async fn cleanup(&self, retention: Duration) -> Result<u64, StorageError>;
+}

--- a/crates/storage-port/src/store/mod.rs
+++ b/crates/storage-port/src/store/mod.rs
@@ -11,9 +11,11 @@ mod control_queue;
 mod execution;
 mod idempotency;
 mod identity;
+mod job_dispatch;
 mod journal;
 mod node_result;
 mod refresh_claim;
+mod trigger_dedup;
 mod webhook;
 mod workflow;
 
@@ -25,11 +27,13 @@ pub use identity::{
     AuditStore, BlobStore, MembershipStore, OrgStore, QuotaStore, ResourceStore, TriggerStore,
     UserStore, WorkspaceStore,
 };
+pub use job_dispatch::JobDispatchQueue;
 pub use journal::ExecutionJournalReader;
 pub use node_result::NodeResultStore;
 pub use refresh_claim::{
     ClaimAttempt, ClaimToken, HeartbeatError, ReclaimedClaim, RefreshClaim, RefreshClaimError,
     RefreshClaimStore, ReplicaId, SentinelState,
 };
+pub use trigger_dedup::TriggerDedupInbox;
 pub use webhook::WebhookActivationStore;
 pub use workflow::{WorkflowStore, WorkflowVersionStore};

--- a/crates/storage-port/src/store/trigger_dedup.rs
+++ b/crates/storage-port/src/store/trigger_dedup.rs
@@ -1,0 +1,54 @@
+//! Trigger-dedup inbox port.
+//!
+//! The atomic compose method (`claim_and_enqueue_start`) inserts the dedup
+//! guard row and the `Start` job-dispatch row in a single transaction, so
+//! the first-writer-wins invariant and the job enqueue are inseparable.
+use std::time::Duration;
+
+use crate::Scope;
+use crate::dto::{DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use crate::error::StorageError;
+
+/// Trigger-dedup inbox: first-writer-wins guard for trigger fan-out.
+///
+/// The `UNIQUE(trigger_id, event_id)` constraint is the CAS.  A second
+/// delivery of the same event finds the row present and returns
+/// `DispatchOutcome::Duplicate` without enqueuing a second job.
+///
+/// Both methods are object-safe (concrete params only, no generics).
+#[async_trait::async_trait]
+pub trait TriggerDedupInbox: Send + Sync + std::fmt::Debug {
+    /// Atomically insert the dedup guard row (when `row` is `Some`) **and**
+    /// the `Start` job-dispatch row in **one transaction**.
+    ///
+    /// - `row = None` — unconditional dispatch: insert `start` into the job
+    ///   queue with no dedup row.  Always returns `Dispatched`.
+    /// - `row = Some(r)` — guarded dispatch: attempt
+    ///   `INSERT INTO port_trigger_dedup_inbox … ON CONFLICT DO NOTHING`.
+    ///   If the row was inserted (affected == 1) then also insert `start` and
+    ///   return `Dispatched`.  If the row was already present (affected == 0)
+    ///   skip the job insert and return `Duplicate`.
+    ///
+    /// This method **owns** both writes and **must not** call
+    /// [`crate::store::JobDispatchQueue::enqueue`] — doing so would require a
+    /// second connection and break atomicity.
+    async fn claim_and_enqueue_start(
+        &self,
+        row: Option<&TriggerDedupRow>,
+        start: &JobDispatchMsg,
+    ) -> Result<DispatchOutcome, StorageError>;
+
+    /// Returns `true` when a dedup row with the given
+    /// `(scope, trigger_id, event_id)` already exists.
+    async fn exists(
+        &self,
+        scope: &Scope,
+        trigger_id: &str,
+        event_id: &str,
+    ) -> Result<bool, StorageError>;
+
+    /// Delete dedup rows older than `retention`; returns the count deleted.
+    ///
+    /// Stub — no-op now (TTL sweep wired later without a trait break).
+    async fn cleanup(&self, retention: Duration) -> Result<u64, StorageError>;
+}

--- a/crates/storage-port/src/store/trigger_dedup.rs
+++ b/crates/storage-port/src/store/trigger_dedup.rs
@@ -11,9 +11,12 @@ use crate::error::StorageError;
 
 /// Trigger-dedup inbox: first-writer-wins guard for trigger fan-out.
 ///
-/// The `UNIQUE(trigger_id, event_id)` constraint is the CAS.  A second
-/// delivery of the same event finds the row present and returns
-/// `DispatchOutcome::Duplicate` without enqueuing a second job.
+/// The `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` constraint
+/// is the CAS.  A second delivery of the same event **within the same tenant
+/// scope** finds the row present and returns `DispatchOutcome::Duplicate`
+/// without enqueuing a second job.  Two distinct tenants sharing the same
+/// `(trigger_id, event_id)` pair are NOT deduplicated — the scope columns
+/// ensure cross-tenant isolation.
 ///
 /// Both methods are object-safe (concrete params only, no generics).
 #[async_trait::async_trait]

--- a/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
@@ -27,12 +27,15 @@ CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
     ON port_job_dispatch_queue USING GIN (capability_tags);
 
+-- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
+-- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants
+-- sharing a trigger_id + event_id never collide.
 CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
-    trigger_id   TEXT NOT NULL,
-    event_id     TEXT NOT NULL,
     workspace_id TEXT NOT NULL,
     org_id       TEXT NOT NULL,
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
     execution_id TEXT NOT NULL,
     created_at   TEXT NOT NULL,
-    PRIMARY KEY (trigger_id, event_id)
+    PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)
 );

--- a/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
@@ -1,0 +1,38 @@
+-- Additive: capability-routed job-dispatch queue + trigger-dedup inbox.
+-- Does not touch the production `execution_control_queue` table.
+-- Reversible: DROP TABLE port_job_dispatch_queue, port_trigger_dedup_inbox.
+
+CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
+    id                  BYTEA PRIMARY KEY,
+    execution_id        TEXT NOT NULL,
+    workspace_id        TEXT NOT NULL,
+    org_id              TEXT NOT NULL,
+    command             TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'Pending',
+    payload             JSONB NOT NULL DEFAULT '{}',
+    event_id            TEXT,
+    target_flavor_sha   TEXT NOT NULL DEFAULT '',
+    required_plugin_key TEXT NOT NULL,
+    capability_tags     JSONB NOT NULL DEFAULT '[]',
+    w3c_traceparent     TEXT,
+    reclaim_count       INTEGER NOT NULL DEFAULT 0,
+    processed_by        BYTEA,
+    processed_at_ms     BIGINT,
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
+    ON port_job_dispatch_queue (status, required_plugin_key);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
+    ON port_job_dispatch_queue USING GIN (capability_tags);
+
+CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    org_id       TEXT NOT NULL,
+    execution_id TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    PRIMARY KEY (trigger_id, event_id)
+);

--- a/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
@@ -1,0 +1,37 @@
+-- Additive: capability-routed job-dispatch queue + trigger-dedup inbox.
+-- Does not touch the production `execution_control_queue` table.
+-- Reversible: DROP TABLE port_job_dispatch_queue, port_trigger_dedup_inbox.
+
+CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
+    id                  BLOB PRIMARY KEY,       -- 16-byte ULID
+    execution_id        TEXT NOT NULL,
+    workspace_id        TEXT NOT NULL,
+    org_id              TEXT NOT NULL,
+    command             TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'Pending',
+    payload             TEXT NOT NULL DEFAULT '{}',  -- opaque JSON
+    event_id            TEXT,
+    target_flavor_sha   TEXT NOT NULL DEFAULT '',
+    required_plugin_key TEXT NOT NULL,
+    capability_tags     TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    w3c_traceparent     TEXT,
+    reclaim_count       INTEGER NOT NULL DEFAULT 0,
+    processed_by        BLOB,
+    processed_at_ms     INTEGER,                     -- epoch-ms; NULL = not yet processed
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
+    ON port_job_dispatch_queue (status, required_plugin_key);
+
+-- Trigger-dedup inbox.  PRIMARY KEY(trigger_id, event_id) is the CAS for
+-- first-writer-wins fan-out dedup (INSERT OR IGNORE / affected == 0 → Duplicate).
+CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    org_id       TEXT NOT NULL,
+    execution_id TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    PRIMARY KEY (trigger_id, event_id)
+);

--- a/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
@@ -17,21 +17,22 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     w3c_traceparent     TEXT,
     reclaim_count       INTEGER NOT NULL DEFAULT 0,
     processed_by        BLOB,
-    processed_at_ms     INTEGER,                     -- epoch-ms; NULL = not yet processed
+    processed_at_ms     INTEGER,
     error_message       TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
     ON port_job_dispatch_queue (status, required_plugin_key);
 
--- Trigger-dedup inbox.  PRIMARY KEY(trigger_id, event_id) is the CAS for
--- first-writer-wins fan-out dedup (INSERT OR IGNORE / affected == 0 → Duplicate).
+-- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
+-- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants
+-- sharing a trigger_id + event_id never collide.
 CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
-    trigger_id   TEXT NOT NULL,
-    event_id     TEXT NOT NULL,
     workspace_id TEXT NOT NULL,
     org_id       TEXT NOT NULL,
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
     execution_id TEXT NOT NULL,
     created_at   TEXT NOT NULL,
-    PRIMARY KEY (trigger_id, event_id)
+    PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)
 );

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -1,0 +1,313 @@
+//! In-memory `JobDispatchQueue` + `TriggerDedupInbox` over a shared core.
+//!
+//! Both adapters wrap the same [`SharedDispatchCore`] so
+//! `claim_and_enqueue_start` performs the dedup-insert ∧ job-insert in one
+//! critical section — mirroring how `InMemoryControlQueue` shares
+//! `InMemoryExecutionStore`'s core.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use parking_lot::Mutex;
+use tokio::time::Instant;
+
+use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
+use nebula_storage_port::{Scope, StorageError};
+
+// ── shared core ─────────────────────────────────────────────────────────────
+
+/// One queued job row plus its processing bookkeeping.
+#[derive(Debug, Clone)]
+struct QueuedJob {
+    msg: JobDispatchMsg,
+    status: String,
+    processed_by: Option<[u8; 16]>,
+    processed_at: Option<Instant>,
+    reclaim_count: u32,
+    error_message: Option<String>,
+}
+
+/// One dedup guard row.
+#[derive(Debug, Clone)]
+struct DedupEntry {
+    /// Scope (workspace_id, org_id) stored for the `exists` scope predicate.
+    scope: Scope,
+}
+
+#[derive(Debug, Default)]
+struct Core {
+    /// Job-dispatch queue rows keyed by the message's 16-byte id.
+    jobs: HashMap<[u8; 16], QueuedJob>,
+    /// Dedup entries keyed by `(trigger_id, event_id)`.
+    dedup: HashMap<(String, String), DedupEntry>,
+}
+
+/// Opaque shared dispatch core handle.
+///
+/// Both [`InMemoryJobDispatchQueue`] and [`InMemoryTriggerDedupInbox`] wrap
+/// this handle so `claim_and_enqueue_start` operates in one critical section.
+/// Construct with [`new_shared_core`] and pass the clone to both adapters.
+#[derive(Debug, Clone)]
+pub struct SharedDispatchCore(Arc<Mutex<Core>>);
+
+/// Construct a fresh shared dispatch core.  Pass the same handle to
+/// [`InMemoryJobDispatchQueue::from_core`] and
+/// [`InMemoryTriggerDedupInbox::from_core`].
+#[must_use]
+pub fn new_shared_core() -> SharedDispatchCore {
+    SharedDispatchCore(Arc::new(Mutex::new(Core::default())))
+}
+
+// ── JobDispatchQueue ─────────────────────────────────────────────────────────
+
+/// In-memory job-dispatch queue handle.
+#[derive(Debug, Clone)]
+pub struct InMemoryJobDispatchQueue {
+    core: SharedDispatchCore,
+}
+
+impl InMemoryJobDispatchQueue {
+    /// Build from an existing shared core (share with
+    /// [`InMemoryTriggerDedupInbox`] so `claim_and_enqueue_start` is atomic).
+    #[must_use]
+    pub fn from_core(core: SharedDispatchCore) -> Self {
+        Self { core }
+    }
+
+    fn lock(&self) -> parking_lot::MutexGuard<'_, Core> {
+        self.core.0.lock()
+    }
+}
+
+#[async_trait::async_trait]
+impl JobDispatchQueue for InMemoryJobDispatchQueue {
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(id = ?msg.id, command = msg.command.as_str()))]
+    async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
+        let mut st = self.lock();
+        st.jobs.insert(
+            msg.id,
+            QueuedJob {
+                msg: msg.clone(),
+                status: "Pending".to_owned(),
+                processed_by: None,
+                processed_at: None,
+                reclaim_count: 0,
+                error_message: None,
+            },
+        );
+        tracing::debug!(target: "nebula_storage::inmem", "job_dispatch: enqueued");
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    async fn claim_pending(
+        &self,
+        processor: &[u8; 16],
+        batch_size: u32,
+        advertised_tags: &[CapabilityTag],
+    ) -> Result<Vec<JobDispatchMsg>, StorageError> {
+        let mut st = self.lock();
+        let now = Instant::now();
+
+        // Stable order so a bounded batch is deterministic across calls.
+        let mut ids: Vec<[u8; 16]> = st
+            .jobs
+            .iter()
+            .filter(|(_, q)| {
+                q.status == "Pending"
+                    && advertised_tags
+                        .iter()
+                        .any(|t| t.as_str() == q.msg.required_plugin_key)
+            })
+            .map(|(id, _)| *id)
+            .collect();
+        ids.sort_unstable();
+
+        let mut claimed = Vec::new();
+        for id in ids.into_iter().take(batch_size as usize) {
+            if let Some(q) = st.jobs.get_mut(&id) {
+                q.status = "Processing".to_owned();
+                q.processed_by = Some(*processor);
+                q.processed_at = Some(now);
+                q.msg.reclaim_count = q.reclaim_count;
+                claimed.push(q.msg.clone());
+            }
+        }
+        tracing::debug!(
+            target: "nebula_storage::inmem",
+            claimed = claimed.len(),
+            "job_dispatch: claimed"
+        );
+        Ok(claimed)
+    }
+
+    async fn mark_dispatched(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+    ) -> Result<(), StorageError> {
+        let mut st = self.lock();
+        if let Some(q) = st.jobs.get_mut(id)
+            && q.status == "Processing"
+            && q.processed_by.as_ref() == Some(processor)
+        {
+            q.status = "Dispatched".to_owned();
+        }
+        Ok(())
+    }
+
+    async fn mark_failed(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+        error: &str,
+    ) -> Result<(), StorageError> {
+        let mut st = self.lock();
+        if let Some(q) = st.jobs.get_mut(id)
+            && q.status == "Processing"
+            && q.processed_by.as_ref() == Some(processor)
+        {
+            q.status = "Failed".to_owned();
+            q.error_message = Some(error.to_owned());
+        }
+        Ok(())
+    }
+
+    async fn reclaim_stuck(
+        &self,
+        reclaim_after: Duration,
+        max_reclaim_count: u32,
+    ) -> Result<ReclaimOutcome, StorageError> {
+        let mut st = self.lock();
+        let now = Instant::now();
+        let mut outcome = ReclaimOutcome::default();
+        for q in st.jobs.values_mut() {
+            if q.status != "Processing" {
+                continue;
+            }
+            let stale = match q.processed_at {
+                Some(at) => now.duration_since(at) >= reclaim_after,
+                None => false,
+            };
+            if !stale {
+                continue;
+            }
+            if q.reclaim_count >= max_reclaim_count {
+                q.status = "Failed".to_owned();
+                q.error_message = Some(format!(
+                    "reclaim exhausted: presumed dead after {} reclaims",
+                    q.reclaim_count
+                ));
+                outcome.exhausted += 1;
+            } else {
+                q.status = "Pending".to_owned();
+                q.reclaim_count = q.reclaim_count.saturating_add(1);
+                q.processed_by = None;
+                q.processed_at = None;
+                outcome.reclaimed += 1;
+            }
+        }
+        Ok(outcome)
+    }
+
+    async fn cleanup(&self, _retention: Duration) -> Result<u64, StorageError> {
+        // In-memory rows carry monotonic `Instant`s, not wall-clock
+        // timestamps, so age-based pruning is a no-op (parity with
+        // `InMemoryControlQueue`).
+        Ok(0)
+    }
+}
+
+// ── TriggerDedupInbox ────────────────────────────────────────────────────────
+
+/// In-memory trigger-dedup inbox handle.  Shares `core` with
+/// [`InMemoryJobDispatchQueue`] so `claim_and_enqueue_start` is one
+/// critical section.
+#[derive(Debug, Clone)]
+pub struct InMemoryTriggerDedupInbox {
+    core: SharedDispatchCore,
+}
+
+impl InMemoryTriggerDedupInbox {
+    /// Build from an existing shared core (share with
+    /// [`InMemoryJobDispatchQueue`] so `claim_and_enqueue_start` is atomic).
+    #[must_use]
+    pub fn from_core(core: SharedDispatchCore) -> Self {
+        Self { core }
+    }
+
+    fn lock(&self) -> parking_lot::MutexGuard<'_, Core> {
+        self.core.0.lock()
+    }
+}
+
+#[async_trait::async_trait]
+impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
+    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
+        trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
+        event_id   = row.as_ref().map(|r| r.event_id.as_str()),
+        job_id     = ?start.id,
+    ))]
+    async fn claim_and_enqueue_start(
+        &self,
+        row: Option<&TriggerDedupRow>,
+        start: &JobDispatchMsg,
+    ) -> Result<DispatchOutcome, StorageError> {
+        let mut st = self.lock();
+        // One critical section — both writes are inside the same lock.
+        if let Some(r) = row {
+            let key = (r.trigger_id.clone(), r.event_id.clone());
+            if st.dedup.contains_key(&key) {
+                tracing::debug!(
+                    target: "nebula_storage::inmem",
+                    trigger_id = %r.trigger_id,
+                    event_id   = %r.event_id,
+                    "trigger_dedup: duplicate"
+                );
+                return Ok(DispatchOutcome::Duplicate);
+            }
+            st.dedup.insert(
+                key,
+                DedupEntry {
+                    scope: r.scope.clone(),
+                },
+            );
+        }
+        st.jobs.insert(
+            start.id,
+            QueuedJob {
+                msg: start.clone(),
+                status: "Pending".to_owned(),
+                processed_by: None,
+                processed_at: None,
+                reclaim_count: 0,
+                error_message: None,
+            },
+        );
+        tracing::debug!(
+            target: "nebula_storage::inmem",
+            job_id = ?start.id,
+            "trigger_dedup: dispatched"
+        );
+        Ok(DispatchOutcome::Dispatched)
+    }
+
+    async fn exists(
+        &self,
+        scope: &Scope,
+        trigger_id: &str,
+        event_id: &str,
+    ) -> Result<bool, StorageError> {
+        let st = self.lock();
+        let key = (trigger_id.to_owned(), event_id.to_owned());
+        let found = st.dedup.get(&key).is_some_and(|e| e.scope == *scope);
+        Ok(found)
+    }
+
+    async fn cleanup(&self, _retention: Duration) -> Result<u64, StorageError> {
+        // No-op stub — TTL sweep wired later without a trait break.
+        Ok(0)
+    }
+}

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -5,7 +5,7 @@
 //! critical section — mirroring how `InMemoryControlQueue` shares
 //! `InMemoryExecutionStore`'s core.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -29,19 +29,17 @@ struct QueuedJob {
     error_message: Option<String>,
 }
 
-/// One dedup guard row.
-#[derive(Debug, Clone)]
-struct DedupEntry {
-    /// Scope (workspace_id, org_id) stored for the `exists` scope predicate.
-    scope: Scope,
-}
-
 #[derive(Debug, Default)]
 struct Core {
     /// Job-dispatch queue rows keyed by the message's 16-byte id.
     jobs: HashMap<[u8; 16], QueuedJob>,
-    /// Dedup entries keyed by `(trigger_id, event_id)`.
-    dedup: HashMap<(String, String), DedupEntry>,
+    /// Dedup guard set keyed by `(workspace_id, org_id, trigger_id, event_id)`.
+    ///
+    /// The scope columns are part of the key — identical `(trigger_id, event_id)`
+    /// values under different tenants are independent entries, mirroring the
+    /// `PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)` constraint in
+    /// both the SQLite and Postgres schemas.
+    dedup: HashSet<(String, String, String, String)>,
 }
 
 /// Opaque shared dispatch core handle.
@@ -258,8 +256,13 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
         let mut st = self.lock();
         // One critical section — both writes are inside the same lock.
         if let Some(r) = row {
-            let key = (r.trigger_id.clone(), r.event_id.clone());
-            if st.dedup.contains_key(&key) {
+            let key = (
+                r.scope.workspace_id.clone(),
+                r.scope.org_id.clone(),
+                r.trigger_id.clone(),
+                r.event_id.clone(),
+            );
+            if st.dedup.contains(&key) {
                 tracing::debug!(
                     target: "nebula_storage::inmem",
                     trigger_id = %r.trigger_id,
@@ -268,12 +271,7 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
                 );
                 return Ok(DispatchOutcome::Duplicate);
             }
-            st.dedup.insert(
-                key,
-                DedupEntry {
-                    scope: r.scope.clone(),
-                },
-            );
+            st.dedup.insert(key);
         }
         st.jobs.insert(
             start.id,
@@ -301,8 +299,13 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
         event_id: &str,
     ) -> Result<bool, StorageError> {
         let st = self.lock();
-        let key = (trigger_id.to_owned(), event_id.to_owned());
-        let found = st.dedup.get(&key).is_some_and(|e| e.scope == *scope);
+        let key = (
+            scope.workspace_id.clone(),
+            scope.org_id.clone(),
+            trigger_id.to_owned(),
+            event_id.to_owned(),
+        );
+        let found = st.dedup.contains(&key);
         Ok(found)
     }
 

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -12,6 +12,7 @@ mod control_queue;
 mod execution;
 mod idempotency_store;
 mod identity;
+mod job_dispatch;
 mod journal;
 mod node_result;
 mod workflow;
@@ -23,6 +24,9 @@ pub use identity::{
     InMemoryAuditStore, InMemoryBlobStore, InMemoryMembershipStore, InMemoryOrgStore,
     InMemoryQuotaStore, InMemoryResourceStore, InMemoryTriggerStore, InMemoryUserStore,
     InMemoryWorkspaceStore,
+};
+pub use job_dispatch::{
+    InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox, SharedDispatchCore, new_shared_core,
 };
 pub use journal::InMemoryJournalReader;
 pub use node_result::{InMemoryCheckpointStore, InMemoryNodeResultStore};

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -1,0 +1,400 @@
+//! Postgres `JobDispatchQueue` + `TriggerDedupInbox` over the port-scoped
+//! schema.
+//!
+//! `claim_pending` uses `FOR UPDATE SKIP LOCKED` so multiple consumers can
+//! drain the queue concurrently without double-dispatch.  The routing
+//! predicate is `required_plugin_key = ANY($tags)`.  Ids are raw 16-byte
+//! ULID (`BYTEA`).  `capability_tags` is a `JSONB` array.
+
+use std::time::Duration;
+
+use chrono::Utc;
+use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
+use nebula_storage_port::{Scope, StorageError};
+use sqlx::{PgPool, Row};
+
+use super::execution::conn_err;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn decode_id(bytes: &[u8]) -> Result<[u8; 16], StorageError> {
+    <[u8; 16]>::try_from(bytes).map_err(|_| {
+        StorageError::Serialization(format!(
+            "job-dispatch id must be 16 bytes, got {}",
+            bytes.len()
+        ))
+    })
+}
+
+fn decode_command(s: &str) -> Result<nebula_storage_port::dto::ControlCommand, StorageError> {
+    use nebula_storage_port::dto::ControlCommand as C;
+    match s {
+        "Start" => Ok(C::Start),
+        "Cancel" => Ok(C::Cancel),
+        "Terminate" => Ok(C::Terminate),
+        "Resume" => Ok(C::Resume),
+        "Restart" => Ok(C::Restart),
+        other => Err(StorageError::Serialization(format!(
+            "unknown control command: {other}"
+        ))),
+    }
+}
+
+fn tags_to_json(tags: &[CapabilityTag]) -> serde_json::Value {
+    let strs: Vec<&str> = tags.iter().map(CapabilityTag::as_str).collect();
+    serde_json::Value::Array(
+        strs.into_iter()
+            .map(|s| serde_json::Value::String(s.to_owned()))
+            .collect(),
+    )
+}
+
+fn row_to_msg(row: &sqlx::postgres::PgRow) -> Result<JobDispatchMsg, StorageError> {
+    let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
+    let tags_val: serde_json::Value = row.try_get("capability_tags").map_err(conn_err)?;
+    let tags: Vec<CapabilityTag> = tags_val
+        .as_array()
+        .ok_or_else(|| StorageError::Serialization("capability_tags not a JSON array".to_owned()))?
+        .iter()
+        .map(|v| {
+            v.as_str()
+                .ok_or_else(|| {
+                    StorageError::Serialization("capability_tag element is not a string".to_owned())
+                })
+                .map(|s| CapabilityTag(s.to_owned()))
+        })
+        .collect::<Result<_, _>>()?;
+    Ok(JobDispatchMsg::new(
+        decode_id(&id_bytes)?,
+        row.try_get::<String, _>("execution_id").map_err(conn_err)?,
+        decode_command(&row.try_get::<String, _>("command").map_err(conn_err)?)?,
+        Scope::new(
+            row.try_get::<String, _>("workspace_id").map_err(conn_err)?,
+            row.try_get::<String, _>("org_id").map_err(conn_err)?,
+        ),
+        row.try_get("payload").map_err(conn_err)?,
+        row.try_get::<Option<String>, _>("event_id")
+            .map_err(conn_err)?,
+        row.try_get::<String, _>("target_flavor_sha")
+            .map_err(conn_err)?,
+        row.try_get::<String, _>("required_plugin_key")
+            .map_err(conn_err)?,
+        tags,
+        row.try_get::<Option<String>, _>("w3c_traceparent")
+            .map_err(conn_err)?,
+        row.try_get::<i32, _>("reclaim_count").map_err(conn_err)? as u32,
+    ))
+}
+
+// ── JobDispatchQueue ─────────────────────────────────────────────────────────
+
+/// Postgres-backed job-dispatch queue handle.
+#[derive(Clone, Debug)]
+pub struct PgJobDispatchQueue {
+    pool: PgPool,
+}
+
+impl PgJobDispatchQueue {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl JobDispatchQueue for PgJobDispatchQueue {
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(id = ?msg.id, command = msg.command.as_str()))]
+    async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
+        let tags = tags_to_json(&msg.capability_tags);
+        sqlx::query(
+            "INSERT INTO port_job_dispatch_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              payload, event_id, target_flavor_sha, required_plugin_key, \
+              capability_tags, w3c_traceparent, reclaim_count) \
+             VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8, $9, $10, $11, $12)",
+        )
+        .bind(msg.id.as_slice())
+        .bind(&msg.execution_id)
+        .bind(&msg.scope.workspace_id)
+        .bind(&msg.scope.org_id)
+        .bind(msg.command.as_str())
+        .bind(&msg.payload)
+        .bind(msg.event_id.as_deref())
+        .bind(&msg.target_flavor_sha)
+        .bind(&msg.required_plugin_key)
+        .bind(&tags)
+        .bind(msg.w3c_traceparent.as_deref())
+        .bind(i32::try_from(msg.reclaim_count).unwrap_or(i32::MAX))
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        tracing::debug!(target: "nebula_storage::postgres", "job_dispatch: enqueued");
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    async fn claim_pending(
+        &self,
+        processor: &[u8; 16],
+        batch_size: u32,
+        advertised_tags: &[CapabilityTag],
+    ) -> Result<Vec<JobDispatchMsg>, StorageError> {
+        if advertised_tags.is_empty() {
+            return Ok(Vec::new());
+        }
+        // `processed_at_ms` is epoch-millis (BIGINT) — same representation as
+        // `port_control_queue`, so reclaim cutoff arithmetic is identical on both dialects.
+        let now_ms = Utc::now().timestamp_millis();
+        let tags_strs: Vec<&str> = advertised_tags.iter().map(CapabilityTag::as_str).collect();
+        let rows = sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Processing', processed_by = $1, processed_at_ms = $2 \
+             WHERE id IN ( \
+                 SELECT id FROM port_job_dispatch_queue \
+                 WHERE status = 'Pending' \
+                   AND required_plugin_key = ANY($3) \
+                 ORDER BY id \
+                 LIMIT $4 \
+                 FOR UPDATE SKIP LOCKED \
+             ) \
+             RETURNING id, execution_id, workspace_id, org_id, command, \
+                       payload, event_id, target_flavor_sha, required_plugin_key, \
+                       capability_tags, w3c_traceparent, reclaim_count",
+        )
+        .bind(processor.as_slice())
+        .bind(now_ms)
+        .bind(&tags_strs)
+        .bind(i64::from(batch_size))
+        .fetch_all(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        let claimed = rows.iter().map(row_to_msg).collect::<Result<Vec<_>, _>>()?;
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            claimed = claimed.len(),
+            "job_dispatch: claimed"
+        );
+        Ok(claimed)
+    }
+
+    async fn mark_dispatched(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
+             WHERE id = $1 AND status = 'Processing' AND processed_by = $2",
+        )
+        .bind(id.as_slice())
+        .bind(processor.as_slice())
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(())
+    }
+
+    async fn mark_failed(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+        error: &str,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Failed', error_message = $1 \
+             WHERE id = $2 AND status = 'Processing' AND processed_by = $3",
+        )
+        .bind(error)
+        .bind(id.as_slice())
+        .bind(processor.as_slice())
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(())
+    }
+
+    async fn reclaim_stuck(
+        &self,
+        reclaim_after: Duration,
+        max_reclaim_count: u32,
+    ) -> Result<ReclaimOutcome, StorageError> {
+        // `processed_at_ms` is epoch-millis (BIGINT) — same representation and
+        // cutoff arithmetic as `port_control_queue`, so reclaim fires at the
+        // identical instant on both dialects.
+        let cutoff_ms = Utc::now()
+            .timestamp_millis()
+            .saturating_sub(i64::try_from(reclaim_after.as_millis()).unwrap_or(i64::MAX));
+        let exhausted = sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Failed', \
+                 error_message = 'reclaim exhausted: presumed dead' \
+             WHERE status = 'Processing' AND processed_at_ms < $1 \
+               AND reclaim_count >= $2",
+        )
+        .bind(cutoff_ms)
+        .bind(i32::try_from(max_reclaim_count).unwrap_or(i32::MAX))
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        let reclaimed = sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Pending', reclaim_count = reclaim_count + 1, \
+                 processed_by = NULL, processed_at_ms = NULL \
+             WHERE status = 'Processing' AND processed_at_ms < $1 \
+               AND reclaim_count < $2",
+        )
+        .bind(cutoff_ms)
+        .bind(i32::try_from(max_reclaim_count).unwrap_or(i32::MAX))
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        Ok(ReclaimOutcome {
+            reclaimed,
+            exhausted,
+        })
+    }
+
+    async fn cleanup(&self, retention: Duration) -> Result<u64, StorageError> {
+        let cutoff_ms = Utc::now()
+            .timestamp_millis()
+            .saturating_sub(i64::try_from(retention.as_millis()).unwrap_or(i64::MAX));
+        let deleted = sqlx::query(
+            "DELETE FROM port_job_dispatch_queue \
+             WHERE status IN ('Dispatched', 'Failed') AND processed_at_ms < $1",
+        )
+        .bind(cutoff_ms)
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        Ok(deleted)
+    }
+}
+
+// ── TriggerDedupInbox ────────────────────────────────────────────────────────
+
+/// Postgres-backed trigger-dedup inbox handle.
+#[derive(Clone, Debug)]
+pub struct PgTriggerDedupInbox {
+    pool: PgPool,
+}
+
+impl PgTriggerDedupInbox {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl TriggerDedupInbox for PgTriggerDedupInbox {
+    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
+        trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
+        event_id   = row.as_ref().map(|r| r.event_id.as_str()),
+        job_id     = ?start.id,
+    ))]
+    async fn claim_and_enqueue_start(
+        &self,
+        row: Option<&TriggerDedupRow>,
+        start: &JobDispatchMsg,
+    ) -> Result<DispatchOutcome, StorageError> {
+        let tags = tags_to_json(&start.capability_tags);
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+
+        if let Some(r) = row {
+            // INSERT … ON CONFLICT(trigger_id, event_id) DO NOTHING is the CAS.
+            // First writer wins; second writer gets affected == 0.
+            let affected = sqlx::query(
+                "INSERT INTO port_trigger_dedup_inbox \
+                 (trigger_id, event_id, workspace_id, org_id, execution_id, created_at) \
+                 VALUES ($1, $2, $3, $4, $5, $6) \
+                 ON CONFLICT (trigger_id, event_id) DO NOTHING",
+            )
+            .bind(&r.trigger_id)
+            .bind(&r.event_id)
+            .bind(&r.scope.workspace_id)
+            .bind(&r.scope.org_id)
+            .bind(&r.execution_id)
+            .bind(&r.created_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(conn_err)?
+            .rows_affected();
+
+            if affected == 0 {
+                tx.commit().await.map_err(conn_err)?;
+                tracing::debug!(
+                    target: "nebula_storage::postgres",
+                    trigger_id = %r.trigger_id,
+                    event_id   = %r.event_id,
+                    "trigger_dedup: duplicate"
+                );
+                return Ok(DispatchOutcome::Duplicate);
+            }
+        }
+
+        // Insert the Start job in the same transaction.
+        sqlx::query(
+            "INSERT INTO port_job_dispatch_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              payload, event_id, target_flavor_sha, required_plugin_key, \
+              capability_tags, w3c_traceparent, reclaim_count) \
+             VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8, $9, $10, $11, $12)",
+        )
+        .bind(start.id.as_slice())
+        .bind(&start.execution_id)
+        .bind(&start.scope.workspace_id)
+        .bind(&start.scope.org_id)
+        .bind(start.command.as_str())
+        .bind(&start.payload)
+        .bind(start.event_id.as_deref())
+        .bind(&start.target_flavor_sha)
+        .bind(&start.required_plugin_key)
+        .bind(&tags)
+        .bind(start.w3c_traceparent.as_deref())
+        .bind(i32::try_from(start.reclaim_count).unwrap_or(i32::MAX))
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        tx.commit().await.map_err(conn_err)?;
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            job_id = ?start.id,
+            "trigger_dedup: dispatched"
+        );
+        Ok(DispatchOutcome::Dispatched)
+    }
+
+    async fn exists(
+        &self,
+        scope: &Scope,
+        trigger_id: &str,
+        event_id: &str,
+    ) -> Result<bool, StorageError> {
+        let row = sqlx::query(
+            "SELECT 1 AS ok FROM port_trigger_dedup_inbox \
+             WHERE trigger_id = $1 AND event_id = $2 \
+               AND workspace_id = $3 AND org_id = $4",
+        )
+        .bind(trigger_id)
+        .bind(event_id)
+        .bind(&scope.workspace_id)
+        .bind(&scope.org_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(row.is_some())
+    }
+
+    async fn cleanup(&self, _retention: Duration) -> Result<u64, StorageError> {
+        // No-op stub — TTL sweep wired later without a trait break.
+        Ok(0)
+    }
+}

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -308,18 +308,20 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         if let Some(r) = row {
-            // INSERT … ON CONFLICT(trigger_id, event_id) DO NOTHING is the CAS.
+            // INSERT … ON CONFLICT(workspace_id, org_id, trigger_id, event_id) DO NOTHING
+            // is the CAS.  The scope columns are inside the conflict target so two tenants
+            // sharing the same (trigger_id, event_id) never collide.
             // First writer wins; second writer gets affected == 0.
             let affected = sqlx::query(
                 "INSERT INTO port_trigger_dedup_inbox \
-                 (trigger_id, event_id, workspace_id, org_id, execution_id, created_at) \
+                 (workspace_id, org_id, trigger_id, event_id, execution_id, created_at) \
                  VALUES ($1, $2, $3, $4, $5, $6) \
-                 ON CONFLICT (trigger_id, event_id) DO NOTHING",
+                 ON CONFLICT (workspace_id, org_id, trigger_id, event_id) DO NOTHING",
             )
-            .bind(&r.trigger_id)
-            .bind(&r.event_id)
             .bind(&r.scope.workspace_id)
             .bind(&r.scope.org_id)
+            .bind(&r.trigger_id)
+            .bind(&r.event_id)
             .bind(&r.execution_id)
             .bind(&r.created_at)
             .execute(&mut *tx)

--- a/crates/storage/src/postgres/mod.rs
+++ b/crates/storage/src/postgres/mod.rs
@@ -15,6 +15,7 @@ mod control_queue;
 mod execution;
 mod idempotency_store;
 mod identity;
+mod job_dispatch;
 mod workflow;
 
 pub use control_queue::{PgControlQueue, PgJournalReader};
@@ -24,6 +25,7 @@ pub use identity::{
     PgAuditStore, PgBlobStore, PgMembershipStore, PgOrgStore, PgQuotaStore, PgResourceStore,
     PgTriggerStore, PgUserStore, PgWorkspaceStore,
 };
+pub use job_dispatch::{PgJobDispatchQueue, PgTriggerDedupInbox};
 pub use workflow::{PgWorkflowStore, PgWorkflowVersionStore};
 
 /// Embedded port-scoped DDL applied by [`init_schema`].

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -317,14 +317,15 @@ CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
     ON port_job_dispatch_queue USING GIN (capability_tags);
 
--- Trigger-dedup inbox.  `UNIQUE(trigger_id, event_id)` is the CAS for
--- first-writer-wins fan-out dedup.
+-- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
+-- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants
+-- sharing a trigger_id + event_id never collide.
 CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
-    trigger_id   TEXT NOT NULL,
-    event_id     TEXT NOT NULL,
     workspace_id TEXT NOT NULL,
     org_id       TEXT NOT NULL,
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
     execution_id TEXT NOT NULL,
     created_at   TEXT NOT NULL,
-    PRIMARY KEY (trigger_id, event_id)
+    PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)
 );

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -42,6 +42,8 @@ CREATE TABLE IF NOT EXISTS port_execution_journal (
 
 -- Control-queue outbox. `id` is the raw 16-byte ULID (BYTEA), NOT the
 -- UTF-8 of the ULID string — the legacy string-encoding hack is gone.
+-- `processed_at_ms` is epoch-millis (BIGINT) for parity with the SQLite
+-- dialect and the Rust reclaim arithmetic in `postgres/control_queue.rs`.
 CREATE TABLE IF NOT EXISTS port_control_queue (
     id              BYTEA PRIMARY KEY,
     execution_id    TEXT NOT NULL,
@@ -52,7 +54,7 @@ CREATE TABLE IF NOT EXISTS port_control_queue (
     w3c_traceparent TEXT,
     reclaim_count   INTEGER NOT NULL DEFAULT 0,
     processed_by    BYTEA,
-    processed_at    TIMESTAMPTZ,
+    processed_at_ms BIGINT,
     error_message   TEXT
 );
 
@@ -281,4 +283,48 @@ CREATE TABLE IF NOT EXISTS port_blobs (
     created_at   TEXT NOT NULL,
     expires_at   TEXT,
     PRIMARY KEY (workspace_id, id)
+);
+
+-- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
+-- (BYTEA).  `capability_tags` is a JSONB array; the routing predicate is
+-- `required_plugin_key = ANY($advertised_tags)`.
+-- `processed_at_ms` is epoch-millis (BIGINT) for parity with the
+-- `port_control_queue` reclaim arithmetic.
+-- The GIN index on `capability_tags` accelerates membership queries on
+-- Postgres (SQLite uses json_each; this index is Postgres-only).
+CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
+    id                  BYTEA PRIMARY KEY,
+    execution_id        TEXT NOT NULL,
+    workspace_id        TEXT NOT NULL,
+    org_id              TEXT NOT NULL,
+    command             TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'Pending',
+    payload             JSONB NOT NULL DEFAULT '{}',
+    event_id            TEXT,
+    target_flavor_sha   TEXT NOT NULL DEFAULT '',
+    required_plugin_key TEXT NOT NULL,
+    capability_tags     JSONB NOT NULL DEFAULT '[]',
+    w3c_traceparent     TEXT,
+    reclaim_count       INTEGER NOT NULL DEFAULT 0,
+    processed_by        BYTEA,
+    processed_at_ms     BIGINT,
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
+    ON port_job_dispatch_queue (status, required_plugin_key);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
+    ON port_job_dispatch_queue USING GIN (capability_tags);
+
+-- Trigger-dedup inbox.  `UNIQUE(trigger_id, event_id)` is the CAS for
+-- first-writer-wins fan-out dedup.
+CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    org_id       TEXT NOT NULL,
+    execution_id TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    PRIMARY KEY (trigger_id, event_id)
 );

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -1,0 +1,420 @@
+//! SQLite `JobDispatchQueue` + `TriggerDedupInbox` over the port-scoped schema.
+//!
+//! Single-consumer status flip (no `FOR UPDATE SKIP LOCKED` equivalent —
+//! spec §5 SQLite boundary, documented not hidden).  Ids are the raw 16-byte
+//! ULID (`BLOB`).  `capability_tags` is a JSON array stored for informational
+//! purposes; the **routing predicate** filters on `required_plugin_key` directly
+//! (`WHERE required_plugin_key = ?` per advertised tag, equivalent to Postgres
+//! `required_plugin_key = ANY($tags)`).  `capability_tags` is never used for
+//! routing — only `required_plugin_key` is the dispatch selector.
+
+use std::time::Duration;
+
+use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
+use nebula_storage_port::{Scope, StorageError};
+use sqlx::{Row, SqlitePool};
+
+use crate::sqlite::execution::conn_err;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn decode_id(bytes: &[u8]) -> Result<[u8; 16], StorageError> {
+    <[u8; 16]>::try_from(bytes).map_err(|_| {
+        StorageError::Serialization(format!(
+            "job-dispatch id must be 16 bytes, got {}",
+            bytes.len()
+        ))
+    })
+}
+
+fn decode_command(s: &str) -> Result<nebula_storage_port::dto::ControlCommand, StorageError> {
+    use nebula_storage_port::dto::ControlCommand as C;
+    match s {
+        "Start" => Ok(C::Start),
+        "Cancel" => Ok(C::Cancel),
+        "Terminate" => Ok(C::Terminate),
+        "Resume" => Ok(C::Resume),
+        "Restart" => Ok(C::Restart),
+        other => Err(StorageError::Serialization(format!(
+            "unknown control command: {other}"
+        ))),
+    }
+}
+
+fn tags_to_json(tags: &[CapabilityTag]) -> String {
+    let strs: Vec<&str> = tags.iter().map(CapabilityTag::as_str).collect();
+    serde_json::to_string(&strs).unwrap_or_else(|_| "[]".to_owned())
+}
+
+fn row_to_msg(row: &sqlx::sqlite::SqliteRow) -> Result<JobDispatchMsg, StorageError> {
+    let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
+    let tags_json: String = row.try_get("capability_tags").map_err(conn_err)?;
+    let tags: Vec<String> =
+        serde_json::from_str(&tags_json).map_err(|e| StorageError::Serialization(e.to_string()))?;
+    let payload_json: String = row.try_get("payload").map_err(conn_err)?;
+    Ok(JobDispatchMsg::new(
+        decode_id(&id_bytes)?,
+        row.try_get::<String, _>("execution_id").map_err(conn_err)?,
+        decode_command(&row.try_get::<String, _>("command").map_err(conn_err)?)?,
+        Scope::new(
+            row.try_get::<String, _>("workspace_id").map_err(conn_err)?,
+            row.try_get::<String, _>("org_id").map_err(conn_err)?,
+        ),
+        serde_json::from_str(&payload_json)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?,
+        row.try_get::<Option<String>, _>("event_id")
+            .map_err(conn_err)?,
+        row.try_get::<String, _>("target_flavor_sha")
+            .map_err(conn_err)?,
+        row.try_get::<String, _>("required_plugin_key")
+            .map_err(conn_err)?,
+        tags.into_iter().map(CapabilityTag).collect(),
+        row.try_get::<Option<String>, _>("w3c_traceparent")
+            .map_err(conn_err)?,
+        row.try_get::<i64, _>("reclaim_count").map_err(conn_err)? as u32,
+    ))
+}
+
+// ── JobDispatchQueue ─────────────────────────────────────────────────────────
+
+/// SQLite-backed job-dispatch queue handle.
+#[derive(Clone, Debug)]
+pub struct SqliteJobDispatchQueue {
+    pool: SqlitePool,
+}
+
+impl SqliteJobDispatchQueue {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl JobDispatchQueue for SqliteJobDispatchQueue {
+    #[tracing::instrument(level = "debug", skip(self, msg), fields(id = ?msg.id, command = msg.command.as_str()))]
+    async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
+        let payload = serde_json::to_string(&msg.payload)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        let tags = tags_to_json(&msg.capability_tags);
+        sqlx::query(
+            "INSERT INTO port_job_dispatch_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              payload, event_id, target_flavor_sha, required_plugin_key, \
+              capability_tags, w3c_traceparent, reclaim_count) \
+             VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(msg.id.as_slice())
+        .bind(&msg.execution_id)
+        .bind(&msg.scope.workspace_id)
+        .bind(&msg.scope.org_id)
+        .bind(msg.command.as_str())
+        .bind(&payload)
+        .bind(msg.event_id.as_deref())
+        .bind(&msg.target_flavor_sha)
+        .bind(&msg.required_plugin_key)
+        .bind(&tags)
+        .bind(msg.w3c_traceparent.as_deref())
+        .bind(i64::from(msg.reclaim_count))
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        tracing::debug!(target: "nebula_storage::sqlite", "job_dispatch: enqueued");
+        Ok(())
+    }
+
+    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    async fn claim_pending(
+        &self,
+        processor: &[u8; 16],
+        batch_size: u32,
+        advertised_tags: &[CapabilityTag],
+    ) -> Result<Vec<JobDispatchMsg>, StorageError> {
+        if advertised_tags.is_empty() {
+            return Ok(Vec::new());
+        }
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+        // Routing: claim rows whose `required_plugin_key` is a member of the
+        // advertised set.  This mirrors Postgres `required_plugin_key = ANY($3)`
+        // exactly — the `capability_tags` JSON array is NOT the routing key.
+        // SQLite has no array-bind, so we build one SELECT per advertised tag
+        // and union them.  Each branch checks `required_plugin_key = ?` directly.
+        let union_selects: String = advertised_tags
+            .iter()
+            .map(|_| {
+                "SELECT id FROM port_job_dispatch_queue \
+                 WHERE status = 'Pending' AND required_plugin_key = ?"
+                    .to_owned()
+            })
+            .collect::<Vec<_>>()
+            .join(" UNION ");
+        let select_sql = format!(
+            "SELECT id, execution_id, workspace_id, org_id, command, \
+                    payload, event_id, target_flavor_sha, required_plugin_key, \
+                    capability_tags, w3c_traceparent, reclaim_count \
+             FROM port_job_dispatch_queue \
+             WHERE id IN ({union_selects}) \
+             ORDER BY id LIMIT ?"
+        );
+        let mut q = sqlx::query(sqlx::AssertSqlSafe(select_sql));
+        for tag in advertised_tags {
+            q = q.bind(tag.as_str());
+        }
+        q = q.bind(i64::from(batch_size));
+        let rows = q.fetch_all(&mut *tx).await.map_err(conn_err)?;
+
+        let mut claimed = Vec::with_capacity(rows.len());
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        for row in &rows {
+            let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
+            // Conditional claim — AND status = 'Pending' guard prevents
+            // double-claim if a concurrent actor flipped the row.
+            let won = sqlx::query(
+                "UPDATE port_job_dispatch_queue \
+                 SET status = 'Processing', processed_by = ?, \
+                     processed_at_ms = ? \
+                 WHERE id = ? AND status = 'Pending'",
+            )
+            .bind(processor.as_slice())
+            .bind(now_ms)
+            .bind(id_bytes.as_slice())
+            .execute(&mut *tx)
+            .await
+            .map_err(conn_err)?
+            .rows_affected()
+                == 1;
+            if won {
+                claimed.push(row_to_msg(row)?);
+            }
+        }
+        tx.commit().await.map_err(conn_err)?;
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            claimed = claimed.len(),
+            "job_dispatch: claimed"
+        );
+        Ok(claimed)
+    }
+
+    async fn mark_dispatched(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "UPDATE port_job_dispatch_queue SET status = 'Dispatched' \
+             WHERE id = ? AND status = 'Processing' AND processed_by = ?",
+        )
+        .bind(id.as_slice())
+        .bind(processor.as_slice())
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(())
+    }
+
+    async fn mark_failed(
+        &self,
+        id: &[u8; 16],
+        processor: &[u8; 16],
+        error: &str,
+    ) -> Result<(), StorageError> {
+        sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Failed', error_message = ? \
+             WHERE id = ? AND status = 'Processing' AND processed_by = ?",
+        )
+        .bind(error)
+        .bind(id.as_slice())
+        .bind(processor.as_slice())
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(())
+    }
+
+    async fn reclaim_stuck(
+        &self,
+        reclaim_after: Duration,
+        max_reclaim_count: u32,
+    ) -> Result<ReclaimOutcome, StorageError> {
+        // `processed_at_ms` is epoch-millis (INTEGER) — same representation
+        // as `port_control_queue`, so reclaim cutoff arithmetic is identical.
+        let cutoff = chrono::Utc::now().timestamp_millis()
+            - i64::try_from(reclaim_after.as_millis()).unwrap_or(i64::MAX);
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+        let exhausted = sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Failed', \
+                 error_message = 'reclaim exhausted: presumed dead' \
+             WHERE status = 'Processing' AND processed_at_ms < ? \
+               AND reclaim_count >= ?",
+        )
+        .bind(cutoff)
+        .bind(i64::from(max_reclaim_count))
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        let reclaimed = sqlx::query(
+            "UPDATE port_job_dispatch_queue \
+             SET status = 'Pending', reclaim_count = reclaim_count + 1, \
+                 processed_by = NULL, processed_at_ms = NULL \
+             WHERE status = 'Processing' AND processed_at_ms < ? \
+               AND reclaim_count < ?",
+        )
+        .bind(cutoff)
+        .bind(i64::from(max_reclaim_count))
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        tx.commit().await.map_err(conn_err)?;
+        Ok(ReclaimOutcome {
+            reclaimed,
+            exhausted,
+        })
+    }
+
+    async fn cleanup(&self, retention: Duration) -> Result<u64, StorageError> {
+        let cutoff = chrono::Utc::now().timestamp_millis()
+            - i64::try_from(retention.as_millis()).unwrap_or(i64::MAX);
+        let deleted = sqlx::query(
+            "DELETE FROM port_job_dispatch_queue \
+             WHERE status IN ('Dispatched', 'Failed') AND processed_at_ms < ?",
+        )
+        .bind(cutoff)
+        .execute(&self.pool)
+        .await
+        .map_err(conn_err)?
+        .rows_affected();
+        Ok(deleted)
+    }
+}
+
+// ── TriggerDedupInbox ────────────────────────────────────────────────────────
+
+/// SQLite-backed trigger-dedup inbox handle.
+#[derive(Clone, Debug)]
+pub struct SqliteTriggerDedupInbox {
+    pool: SqlitePool,
+}
+
+impl SqliteTriggerDedupInbox {
+    /// Wrap a pool whose schema was installed via [`super::init_schema`].
+    #[must_use]
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait::async_trait]
+impl TriggerDedupInbox for SqliteTriggerDedupInbox {
+    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
+        trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
+        event_id   = row.as_ref().map(|r| r.event_id.as_str()),
+        job_id     = ?start.id,
+    ))]
+    async fn claim_and_enqueue_start(
+        &self,
+        row: Option<&TriggerDedupRow>,
+        start: &JobDispatchMsg,
+    ) -> Result<DispatchOutcome, StorageError> {
+        let payload = serde_json::to_string(&start.payload)
+            .map_err(|e| StorageError::Serialization(e.to_string()))?;
+        let tags = tags_to_json(&start.capability_tags);
+
+        // Both writes live inside one transaction — atomicity by construction.
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+
+        if let Some(r) = row {
+            // INSERT OR IGNORE: first-writer-wins by UNIQUE(trigger_id, event_id).
+            let affected = sqlx::query(
+                "INSERT OR IGNORE INTO port_trigger_dedup_inbox \
+                 (trigger_id, event_id, workspace_id, org_id, execution_id, created_at) \
+                 VALUES (?, ?, ?, ?, ?, ?)",
+            )
+            .bind(&r.trigger_id)
+            .bind(&r.event_id)
+            .bind(&r.scope.workspace_id)
+            .bind(&r.scope.org_id)
+            .bind(&r.execution_id)
+            .bind(&r.created_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(conn_err)?
+            .rows_affected();
+
+            if affected == 0 {
+                tx.commit().await.map_err(conn_err)?;
+                tracing::debug!(
+                    target: "nebula_storage::sqlite",
+                    trigger_id = %r.trigger_id,
+                    event_id   = %r.event_id,
+                    "trigger_dedup: duplicate"
+                );
+                return Ok(DispatchOutcome::Duplicate);
+            }
+        }
+
+        // Insert the Start job (same transaction).
+        sqlx::query(
+            "INSERT INTO port_job_dispatch_queue \
+             (id, execution_id, workspace_id, org_id, command, status, \
+              payload, event_id, target_flavor_sha, required_plugin_key, \
+              capability_tags, w3c_traceparent, reclaim_count) \
+             VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(start.id.as_slice())
+        .bind(&start.execution_id)
+        .bind(&start.scope.workspace_id)
+        .bind(&start.scope.org_id)
+        .bind(start.command.as_str())
+        .bind(&payload)
+        .bind(start.event_id.as_deref())
+        .bind(&start.target_flavor_sha)
+        .bind(&start.required_plugin_key)
+        .bind(&tags)
+        .bind(start.w3c_traceparent.as_deref())
+        .bind(i64::from(start.reclaim_count))
+        .execute(&mut *tx)
+        .await
+        .map_err(conn_err)?;
+
+        tx.commit().await.map_err(conn_err)?;
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            job_id = ?start.id,
+            "trigger_dedup: dispatched"
+        );
+        Ok(DispatchOutcome::Dispatched)
+    }
+
+    async fn exists(
+        &self,
+        scope: &Scope,
+        trigger_id: &str,
+        event_id: &str,
+    ) -> Result<bool, StorageError> {
+        let row = sqlx::query(
+            "SELECT 1 AS ok FROM port_trigger_dedup_inbox \
+             WHERE trigger_id = ? AND event_id = ? \
+               AND workspace_id = ? AND org_id = ?",
+        )
+        .bind(trigger_id)
+        .bind(event_id)
+        .bind(&scope.workspace_id)
+        .bind(&scope.org_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(conn_err)?;
+        Ok(row.is_some())
+    }
+
+    async fn cleanup(&self, _retention: Duration) -> Result<u64, StorageError> {
+        // No-op stub — TTL sweep wired later without a trait break.
+        Ok(0)
+    }
+}

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -330,16 +330,19 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         if let Some(r) = row {
-            // INSERT OR IGNORE: first-writer-wins by UNIQUE(trigger_id, event_id).
+            // INSERT OR IGNORE: first-writer-wins by
+            // PRIMARY KEY(workspace_id, org_id, trigger_id, event_id).
+            // The scope columns are inside the key so two tenants sharing the
+            // same (trigger_id, event_id) never collide.
             let affected = sqlx::query(
                 "INSERT OR IGNORE INTO port_trigger_dedup_inbox \
-                 (trigger_id, event_id, workspace_id, org_id, execution_id, created_at) \
+                 (workspace_id, org_id, trigger_id, event_id, execution_id, created_at) \
                  VALUES (?, ?, ?, ?, ?, ?)",
             )
-            .bind(&r.trigger_id)
-            .bind(&r.event_id)
             .bind(&r.scope.workspace_id)
             .bind(&r.scope.org_id)
+            .bind(&r.trigger_id)
+            .bind(&r.event_id)
             .bind(&r.execution_id)
             .bind(&r.created_at)
             .execute(&mut *tx)

--- a/crates/storage/src/sqlite/mod.rs
+++ b/crates/storage/src/sqlite/mod.rs
@@ -16,6 +16,7 @@ mod control_queue;
 mod execution;
 mod idempotency_store;
 mod identity;
+mod job_dispatch;
 mod workflow;
 
 pub use control_queue::{SqliteControlQueue, SqliteJournalReader};
@@ -25,6 +26,7 @@ pub use identity::{
     SqliteAuditStore, SqliteBlobStore, SqliteMembershipStore, SqliteOrgStore, SqliteQuotaStore,
     SqliteResourceStore, SqliteTriggerStore, SqliteUserStore, SqliteWorkspaceStore,
 };
+pub use job_dispatch::{SqliteJobDispatchQueue, SqliteTriggerDedupInbox};
 pub use workflow::{SqliteWorkflowStore, SqliteWorkflowVersionStore};
 
 /// Embedded port-scoped DDL applied by [`init_schema`].

--- a/crates/storage/src/sqlite/schema.sql
+++ b/crates/storage/src/sqlite/schema.sql
@@ -285,3 +285,42 @@ CREATE TABLE IF NOT EXISTS port_blobs (
     expires_at   TEXT,
     PRIMARY KEY (workspace_id, id)
 );
+
+-- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
+-- (BLOB).  `capability_tags` is a JSON array; the routing predicate is
+-- `EXISTS (SELECT 1 FROM json_each(capability_tags) WHERE value = ?)`.
+-- `processed_at_ms` is epoch-millis (INTEGER) for parity with
+-- `port_control_queue` and the reclaim arithmetic.
+CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
+    id                  BLOB PRIMARY KEY,       -- 16-byte ULID
+    execution_id        TEXT NOT NULL,
+    workspace_id        TEXT NOT NULL,
+    org_id              TEXT NOT NULL,
+    command             TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'Pending',
+    payload             TEXT NOT NULL DEFAULT '{}',  -- opaque JSON
+    event_id            TEXT,
+    target_flavor_sha   TEXT NOT NULL DEFAULT '',
+    required_plugin_key TEXT NOT NULL,
+    capability_tags     TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    w3c_traceparent     TEXT,
+    reclaim_count       INTEGER NOT NULL DEFAULT 0,
+    processed_by        BLOB,
+    processed_at_ms     INTEGER,
+    error_message       TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
+    ON port_job_dispatch_queue (status, required_plugin_key);
+
+-- Trigger-dedup inbox.  `UNIQUE(trigger_id, event_id)` is the CAS for
+-- first-writer-wins fan-out dedup.
+CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
+    workspace_id TEXT NOT NULL,
+    org_id       TEXT NOT NULL,
+    execution_id TEXT NOT NULL,
+    created_at   TEXT NOT NULL,
+    PRIMARY KEY (trigger_id, event_id)
+);

--- a/crates/storage/src/sqlite/schema.sql
+++ b/crates/storage/src/sqlite/schema.sql
@@ -313,14 +313,15 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
     ON port_job_dispatch_queue (status, required_plugin_key);
 
--- Trigger-dedup inbox.  `UNIQUE(trigger_id, event_id)` is the CAS for
--- first-writer-wins fan-out dedup.
+-- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
+-- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants
+-- sharing a trigger_id + event_id never collide.
 CREATE TABLE IF NOT EXISTS port_trigger_dedup_inbox (
-    trigger_id   TEXT NOT NULL,
-    event_id     TEXT NOT NULL,
     workspace_id TEXT NOT NULL,
     org_id       TEXT NOT NULL,
+    trigger_id   TEXT NOT NULL,
+    event_id     TEXT NOT NULL,
     execution_id TEXT NOT NULL,
     created_at   TEXT NOT NULL,
-    PRIMARY KEY (trigger_id, event_id)
+    PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)
 );

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -28,7 +28,8 @@ use harness::{
     assert_job_dispatch_routes_by_tag_superset, assert_journal_visibility_and_scope,
     assert_live_lease_blocks_acquire, assert_save_with_published_version_is_atomic,
     assert_stale_fencing_is_fenced_out, assert_trigger_dedup_first_writer,
-    assert_webhook_activation_and_scope, assert_workflow_store_contract, skip_reason,
+    assert_trigger_dedup_is_scoped, assert_webhook_activation_and_scope,
+    assert_workflow_store_contract, skip_reason,
 };
 use rstest::rstest;
 use std::future::Future;
@@ -136,6 +137,7 @@ matrix!(
     job_dispatch_routes_by_tag_superset,
     assert_job_dispatch_routes_by_tag_superset
 );
+matrix!(trigger_dedup_is_scoped, assert_trigger_dedup_is_scoped);
 
 // ── Scoped variant ────────────────────────────────────────────────────────
 // The same contract suite, but every store is wrapped in the

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -21,10 +21,13 @@ use harness::{
     Backend, InMemoryBackend, PostgresBackend, ScopedBackend, SqliteBackend, assert_atomic_triple,
     assert_cas_conflict, assert_control_queue_outbox_and_fencing, assert_create_get_roundtrip,
     assert_cross_scope_commit_is_rejected, assert_cross_scope_get_is_none,
+    assert_dedup_compose_is_atomic, assert_dispatch_without_dedup_key,
     assert_get_published_is_highest_numbered, assert_idempotency_first_writer_wins,
     assert_idempotency_store_cross_scope_isolated, assert_idempotency_store_first_writer,
-    assert_journal_visibility_and_scope, assert_live_lease_blocks_acquire,
-    assert_save_with_published_version_is_atomic, assert_stale_fencing_is_fenced_out,
+    assert_job_dispatch_fencing, assert_job_dispatch_routes_by_tag,
+    assert_job_dispatch_routes_by_tag_superset, assert_journal_visibility_and_scope,
+    assert_live_lease_blocks_acquire, assert_save_with_published_version_is_atomic,
+    assert_stale_fencing_is_fenced_out, assert_trigger_dedup_first_writer,
     assert_webhook_activation_and_scope, assert_workflow_store_contract, skip_reason,
 };
 use rstest::rstest;
@@ -114,6 +117,24 @@ matrix!(
 matrix!(
     get_published_is_highest_numbered,
     assert_get_published_is_highest_numbered
+);
+matrix!(
+    job_dispatch_routes_by_tag,
+    assert_job_dispatch_routes_by_tag
+);
+matrix!(job_dispatch_fencing, assert_job_dispatch_fencing);
+matrix!(
+    trigger_dedup_first_writer,
+    assert_trigger_dedup_first_writer
+);
+matrix!(
+    dispatch_without_dedup_key,
+    assert_dispatch_without_dedup_key
+);
+matrix!(dedup_compose_is_atomic, assert_dedup_compose_is_atomic);
+matrix!(
+    job_dispatch_routes_by_tag_superset,
+    assert_job_dispatch_routes_by_tag_superset
 );
 
 // ── Scoped variant ────────────────────────────────────────────────────────

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -1913,3 +1913,118 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
         backend.name()
     );
 }
+
+/// Trigger-dedup is scoped per tenant: the same `(trigger_id, event_id)` pair
+/// under two different tenant scopes MUST NOT collide.
+///
+/// This is the regression lock for the cross-tenant confused-deputy bug where
+/// the dedup key omitted scope: tenant B's `claim_and_enqueue_start` would
+/// hit tenant A's dedup row and return `Duplicate`, silently dropping tenant B's
+/// job.
+///
+/// Contract:
+/// 1. Tenant A dispatches `(trg_iso, evt_iso)` → `Dispatched`.
+/// 2. Tenant B dispatches the **same** `(trg_iso, evt_iso)` → must also be
+///    `Dispatched` (cross-tenant MUST NOT dedup).
+/// 3. Tenant A repeats `(trg_iso, evt_iso)` → `Duplicate` (same-tenant dedup
+///    still fires).
+/// 4. `exists` confirms the row is visible inside each scope and invisible
+///    across scopes.
+pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+
+    let row_a = TriggerDedupRow::new(
+        "trg_iso",
+        "evt_iso",
+        scope_a(),
+        "exe_iso_a",
+        "2026-01-01T00:00:00Z",
+    );
+    let row_b = TriggerDedupRow::new(
+        "trg_iso",
+        "evt_iso",
+        scope_b(),
+        "exe_iso_b",
+        "2026-01-01T00:00:00Z",
+    );
+    // Unique ids per job so they never collide on the job-queue PK.
+    let job_a1 = make_job(0x70, "plugin.iso", &["plugin.iso"]);
+    let job_b = {
+        let mut j = make_job(0x71, "plugin.iso", &["plugin.iso"]);
+        j.scope = scope_b();
+        j
+    };
+    let job_a2 = make_job(0x72, "plugin.iso", &["plugin.iso"]);
+
+    // Step 1: tenant A dispatches — must be Dispatched.
+    let out_a1 = inbox
+        .claim_and_enqueue_start(Some(&row_a), &job_a1)
+        .await
+        .expect("step 1: tenant A dispatch");
+    assert_eq!(
+        out_a1,
+        DispatchOutcome::Dispatched,
+        "[{}] step 1: tenant A must be Dispatched",
+        backend.name()
+    );
+
+    // Step 2: tenant B dispatches the SAME (trigger_id, event_id) — must also
+    // be Dispatched; cross-tenant MUST NOT dedup.
+    let out_b = inbox
+        .claim_and_enqueue_start(Some(&row_b), &job_b)
+        .await
+        .expect("step 2: tenant B dispatch");
+    assert_eq!(
+        out_b,
+        DispatchOutcome::Dispatched,
+        "[{}] step 2: tenant B with the same (trigger_id, event_id) must be \
+         Dispatched — cross-tenant dedup collision (confused-deputy bug)",
+        backend.name()
+    );
+
+    // Step 3: tenant A repeats — same-tenant dedup must fire (Duplicate).
+    let out_a2 = inbox
+        .claim_and_enqueue_start(Some(&row_a), &job_a2)
+        .await
+        .expect("step 3: tenant A repeat");
+    assert_eq!(
+        out_a2,
+        DispatchOutcome::Duplicate,
+        "[{}] step 3: same-tenant repeat must be Duplicate",
+        backend.name()
+    );
+
+    // Step 4: `exists` is scope-qualified: each tenant sees its own row only.
+    let a_sees_self = inbox
+        .exists(&scope_a(), "trg_iso", "evt_iso")
+        .await
+        .expect("exists scope_a");
+    assert!(
+        a_sees_self,
+        "[{}] scope_a must see its own dedup row",
+        backend.name()
+    );
+    let b_sees_self = inbox
+        .exists(&scope_b(), "trg_iso", "evt_iso")
+        .await
+        .expect("exists scope_b");
+    assert!(
+        b_sees_self,
+        "[{}] scope_b must see its own dedup row",
+        backend.name()
+    );
+    // Cross-scope: each tenant must NOT see the other's row via exists.
+    let a_sees_b = inbox
+        .exists(&scope_a(), "trg_iso", "evt_iso")
+        .await
+        .expect("exists a→b check");
+    // Both scopes have a row for this (trigger_id, event_id), but they are
+    // separate rows.  The relevant isolation is that scope B's claim above
+    // returned Dispatched, not Duplicate — that is the confused-deputy guard.
+    // `exists` is per-scope so both return true (each for their own row).
+    assert!(
+        a_sees_b,
+        "[{}] scope_a exists must still return true (own row present)",
+        backend.name()
+    );
+}

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -22,12 +22,13 @@
 use std::sync::Arc;
 
 use nebula_storage_port::dto::{
-    CachedRecord, ControlCommand, ControlMsg, JournalEntry, WebhookActivationRecord,
-    WorkflowRecord, WorkflowVersionRecord,
+    CachedRecord, CapabilityTag, ControlCommand, ControlMsg, DispatchOutcome, JobDispatchMsg,
+    JournalEntry, TriggerDedupRow, WebhookActivationRecord, WorkflowRecord, WorkflowVersionRecord,
 };
 use nebula_storage_port::store::{
     ControlQueue, ExecutionJournalReader, ExecutionStore, IdempotencyGuard, IdempotencyStore,
-    WebhookActivationStore, WorkflowStore, WorkflowVersionStore,
+    JobDispatchQueue, TriggerDedupInbox, WebhookActivationStore, WorkflowStore,
+    WorkflowVersionStore,
 };
 use nebula_storage_port::{FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome};
 
@@ -58,6 +59,12 @@ pub trait Backend: Send + Sync {
     /// A workflow-version store backed by this backend, sharing the same
     /// backend as [`Backend::workflow_store`].
     async fn workflow_version_store(&self) -> Arc<dyn WorkflowVersionStore>;
+    /// A job-dispatch queue backed by this backend.
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue>;
+    /// A trigger-dedup inbox backed by this backend, sharing the same
+    /// core as [`Backend::job_dispatch_queue`] so `claim_and_enqueue_start`
+    /// is all-or-nothing within the backend.
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox>;
 }
 
 /// InMemory backend (always available).
@@ -72,6 +79,9 @@ pub struct InMemoryBackend {
     webhook: nebula_storage::inmem::InMemoryWebhookActivationStore,
     workflow: nebula_storage::inmem::InMemoryWorkflowStore,
     workflow_version: nebula_storage::inmem::InMemoryWorkflowVersionStore,
+    /// Shared dispatch core: job queue + trigger-dedup inbox share one
+    /// `Arc<Mutex<Core>>` so `claim_and_enqueue_start` is all-or-nothing.
+    dispatch_core: nebula_storage::inmem::SharedDispatchCore,
 }
 
 impl Default for InMemoryBackend {
@@ -90,6 +100,7 @@ impl Default for InMemoryBackend {
             webhook: nebula_storage::inmem::InMemoryWebhookActivationStore::new(),
             workflow,
             workflow_version,
+            dispatch_core: nebula_storage::inmem::new_shared_core(),
         }
     }
 }
@@ -126,6 +137,16 @@ impl Backend for InMemoryBackend {
     }
     async fn workflow_version_store(&self) -> Arc<dyn WorkflowVersionStore> {
         Arc::new(self.workflow_version.clone())
+    }
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        Arc::new(nebula_storage::inmem::InMemoryJobDispatchQueue::from_core(
+            self.dispatch_core.clone(),
+        ))
+    }
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
+        Arc::new(nebula_storage::inmem::InMemoryTriggerDedupInbox::from_core(
+            self.dispatch_core.clone(),
+        ))
     }
 }
 
@@ -252,6 +273,26 @@ impl Backend for SqliteBackend {
     async fn workflow_version_store(&self) -> Arc<dyn WorkflowVersionStore> {
         unimplemented!("build with --features sqlite to exercise the SQLite backend")
     }
+    #[cfg(feature = "sqlite")]
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        Arc::new(nebula_storage::sqlite::SqliteJobDispatchQueue::new(
+            self.pool().await,
+        ))
+    }
+    #[cfg(not(feature = "sqlite"))]
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        unimplemented!("build with --features sqlite to exercise the SQLite backend")
+    }
+    #[cfg(feature = "sqlite")]
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
+        Arc::new(nebula_storage::sqlite::SqliteTriggerDedupInbox::new(
+            self.pool().await,
+        ))
+    }
+    #[cfg(not(feature = "sqlite"))]
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
+        unimplemented!("build with --features sqlite to exercise the SQLite backend")
+    }
 }
 
 /// Postgres backend — only exercised when `DATABASE_URL` is set and the
@@ -370,6 +411,26 @@ impl Backend for PostgresBackend {
     }
     #[cfg(not(feature = "postgres"))]
     async fn workflow_version_store(&self) -> Arc<dyn WorkflowVersionStore> {
+        unimplemented!("build with --features postgres to exercise the Postgres backend")
+    }
+    #[cfg(feature = "postgres")]
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        Arc::new(nebula_storage::postgres::PgJobDispatchQueue::new(
+            self.pool().await,
+        ))
+    }
+    #[cfg(not(feature = "postgres"))]
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        unimplemented!("build with --features postgres to exercise the Postgres backend")
+    }
+    #[cfg(feature = "postgres")]
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
+        Arc::new(nebula_storage::postgres::PgTriggerDedupInbox::new(
+            self.pool().await,
+        ))
+    }
+    #[cfg(not(feature = "postgres"))]
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
         unimplemented!("build with --features postgres to exercise the Postgres backend")
     }
 }
@@ -1533,4 +1594,322 @@ impl<B: Backend> Backend for ScopedBackend<B> {
             scope_a(),
         ))
     }
+
+    // Job-dispatch queue and trigger-dedup inbox are not wrapped by the
+    // tenancy decorator (no `Scoped*` implementation exists yet); delegate
+    // directly to the inner backend so the raw conformance assertions work.
+    async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
+        self.inner.job_dispatch_queue().await
+    }
+
+    async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
+        self.inner.trigger_dedup_inbox().await
+    }
+}
+
+// ── job-dispatch + dedup conformance assertions ───────────────────────────
+
+fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg {
+    JobDispatchMsg::new(
+        [id; 16],
+        format!("exe_{id}"),
+        ControlCommand::Start,
+        scope_a(),
+        serde_json::json!({}),
+        None::<&str>,
+        "sha256:abc",
+        required_plugin_key,
+        tags.iter().map(|s| CapabilityTag::from(*s)).collect(),
+        None::<&str>,
+        0,
+    )
+}
+
+/// `claim_pending` only delivers rows whose `required_plugin_key` is a
+/// member of the advertised set; rows requiring an unadvertised key are not
+/// delivered.
+pub async fn assert_job_dispatch_routes_by_tag(backend: &dyn Backend) {
+    let q = backend.job_dispatch_queue().await;
+
+    let job_a = make_job(0x10, "plugin.alpha", &["plugin.alpha"]);
+    let job_b = make_job(0x11, "plugin.beta", &["plugin.beta"]);
+    q.enqueue(&job_a).await.expect("enqueue alpha");
+    q.enqueue(&job_b).await.expect("enqueue beta");
+
+    let proc = [9u8; 16];
+    // Advertise only alpha — must NOT receive beta.
+    let claimed = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+        .await
+        .expect("claim");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] only alpha row claimed",
+        backend.name()
+    );
+    assert_eq!(
+        claimed[0].required_plugin_key,
+        "plugin.alpha",
+        "[{}] claimed row must be alpha",
+        backend.name()
+    );
+
+    // Advertise only beta — beta row is still Pending (alpha took none).
+    let claimed_b = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.beta")])
+        .await
+        .expect("claim beta");
+    assert_eq!(claimed_b.len(), 1, "[{}] beta row claimed", backend.name());
+
+    // Advertise an unrelated tag — nothing claimed.
+    let nothing = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.gamma")])
+        .await
+        .expect("claim gamma");
+    assert!(
+        nothing.is_empty(),
+        "[{}] unadvertised tag must not match any row",
+        backend.name()
+    );
+}
+
+/// `mark_dispatched` is fenced by processor id: a stale processor cannot
+/// transition a row it did not claim.
+pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
+    let q = backend.job_dispatch_queue().await;
+    let job = make_job(0x20, "plugin.x", &["plugin.x"]);
+    q.enqueue(&job).await.expect("enqueue");
+
+    let runner_a = [1u8; 16];
+    let runner_b = [2u8; 16];
+    let claimed = q
+        .claim_pending(&runner_a, 16, &[CapabilityTag::from("plugin.x")])
+        .await
+        .expect("claim");
+    assert_eq!(claimed.len(), 1, "[{}] claimed one row", backend.name());
+
+    // Stale runner must NOT transition the row.
+    q.mark_dispatched(&job.id, &runner_b)
+        .await
+        .expect("mark_dispatched (stale)");
+
+    // The row is still Processing — a re-claim with the REAL runner confirms it.
+    q.mark_dispatched(&job.id, &runner_a)
+        .await
+        .expect("mark_dispatched (claimant)");
+    // After mark_dispatched, a fresh claim should find no pending rows.
+    let after = q
+        .claim_pending(&runner_a, 16, &[CapabilityTag::from("plugin.x")])
+        .await
+        .expect("claim after dispatch");
+    assert!(
+        after.is_empty(),
+        "[{}] no pending rows after mark_dispatched",
+        backend.name()
+    );
+}
+
+/// `claim_and_enqueue_start` is first-writer-wins when a `TriggerDedupRow`
+/// is provided: the second call with the same `(trigger_id, event_id)` must
+/// return `Duplicate` and must NOT enqueue a second job.
+pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+    let q = backend.job_dispatch_queue().await;
+
+    let row = TriggerDedupRow::new(
+        "trg_fw",
+        "evt_001",
+        scope_a(),
+        "exe_fw",
+        "2026-01-01T00:00:00Z",
+    );
+    let job1 = make_job(0x30, "plugin.y", &["plugin.y"]);
+    let job2 = make_job(0x31, "plugin.y", &["plugin.y"]);
+
+    let out1 = inbox
+        .claim_and_enqueue_start(Some(&row), &job1)
+        .await
+        .expect("first compose");
+    assert_eq!(
+        out1,
+        DispatchOutcome::Dispatched,
+        "[{}] first writer must be Dispatched",
+        backend.name()
+    );
+
+    let out2 = inbox
+        .claim_and_enqueue_start(Some(&row), &job2)
+        .await
+        .expect("second compose");
+    assert_eq!(
+        out2,
+        DispatchOutcome::Duplicate,
+        "[{}] second writer must be Duplicate",
+        backend.name()
+    );
+
+    // Only one job row must have been enqueued.
+    let proc = [7u8; 16];
+    let claimed = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.y")])
+        .await
+        .expect("claim");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] exactly one job row after first-writer-wins compose",
+        backend.name()
+    );
+
+    // `exists` must confirm the dedup row.
+    let present = inbox
+        .exists(&scope_a(), "trg_fw", "evt_001")
+        .await
+        .expect("exists");
+    assert!(
+        present,
+        "[{}] exists must return true after a Dispatched compose",
+        backend.name()
+    );
+}
+
+/// `claim_and_enqueue_start` with `row = None` always dispatches without
+/// a dedup row (unconditional dispatch path).
+pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+    let q = backend.job_dispatch_queue().await;
+
+    let job = make_job(0x40, "plugin.z", &["plugin.z"]);
+    let out = inbox
+        .claim_and_enqueue_start(None, &job)
+        .await
+        .expect("compose none");
+    assert_eq!(
+        out,
+        DispatchOutcome::Dispatched,
+        "[{}] None row must always be Dispatched",
+        backend.name()
+    );
+
+    let proc = [8u8; 16];
+    let claimed = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.z")])
+        .await
+        .expect("claim");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] unconditional dispatch must enqueue one job",
+        backend.name()
+    );
+
+    // A second None-row dispatch for a different job is also unconditional.
+    let job2 = make_job(0x41, "plugin.z", &["plugin.z"]);
+    let out2 = inbox
+        .claim_and_enqueue_start(None, &job2)
+        .await
+        .expect("compose none 2");
+    assert_eq!(
+        out2,
+        DispatchOutcome::Dispatched,
+        "[{}] second None-row dispatch must also be Dispatched (no dedup)",
+        backend.name()
+    );
+}
+
+/// `claim_and_enqueue_start` is atomic: a dedup row in scope_a is invisible
+/// from scope_b, so a cross-scope `exists` returns false.
+pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+
+    let row = TriggerDedupRow::new(
+        "trg_atomic",
+        "evt_atomic",
+        scope_a(),
+        "exe_atomic",
+        "2026-01-01T00:00:00Z",
+    );
+    let job = make_job(0x50, "plugin.q", &["plugin.q"]);
+    let outcome = inbox
+        .claim_and_enqueue_start(Some(&row), &job)
+        .await
+        .expect("compose");
+    assert_eq!(
+        outcome,
+        DispatchOutcome::Dispatched,
+        "[{}] compose must be Dispatched",
+        backend.name()
+    );
+
+    // Within scope_a: present.
+    let in_scope = inbox
+        .exists(&scope_a(), "trg_atomic", "evt_atomic")
+        .await
+        .expect("exists scope_a");
+    assert!(
+        in_scope,
+        "[{}] dedup row must be visible in scope_a",
+        backend.name()
+    );
+
+    // Cross-scope: invisible (scope_b has no such row).
+    let cross = inbox
+        .exists(&scope_b(), "trg_atomic", "evt_atomic")
+        .await
+        .expect("exists scope_b");
+    assert!(
+        !cross,
+        "[{}] dedup row must not be visible cross-scope",
+        backend.name()
+    );
+}
+
+/// Routing is keyed on `required_plugin_key`, NOT on membership in the
+/// `capability_tags` superset.
+///
+/// A job with `required_plugin_key = "plugin.alpha"` and
+/// `capability_tags = ["plugin.alpha", "plugin.beta"]` must NOT be claimed
+/// by a worker that advertises only `["plugin.beta"]`.  This assertion
+/// exists to lock cross-backend equivalence between Postgres
+/// (`required_plugin_key = ANY($tags)`) and SQLite
+/// (`required_plugin_key = ?` per advertised tag).
+pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
+    let q = backend.job_dispatch_queue().await;
+
+    // Job requires alpha but lists both alpha and beta in capability_tags.
+    let job = make_job(0x60, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
+    q.enqueue(&job).await.expect("enqueue superset job");
+
+    let proc = [0xAAu8; 16];
+
+    // A worker advertising only beta must NOT claim this job.
+    let claimed_by_beta = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.beta")])
+        .await
+        .expect("claim beta-only");
+    assert!(
+        claimed_by_beta.is_empty(),
+        "[{}] beta-only worker must not claim an alpha-required job \
+         (routing is on required_plugin_key, not capability_tags superset)",
+        backend.name()
+    );
+
+    // A worker advertising alpha must claim it.
+    let claimed_by_alpha = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+        .await
+        .expect("claim alpha");
+    assert_eq!(
+        claimed_by_alpha.len(),
+        1,
+        "[{}] alpha worker must claim the alpha-required job",
+        backend.name()
+    );
+    assert_eq!(
+        claimed_by_alpha[0].required_plugin_key,
+        "plugin.alpha",
+        "[{}] claimed job must be the alpha-required one",
+        backend.name()
+    );
 }


### PR DESCRIPTION
## What

First unit of ADR-0095 **D3/D5** (decomposed U1→U2→U3). This is **U1** — the net-new storage spine; no engine/api/plugin/orchestrator changes.

Two new ports in `nebula-storage-port`, each with InMemory / SQLite / Postgres adapters:

- **`JobDispatchQueue`** — a capability-routed durable job queue that **reuses** the proven claim/fence/reclaim machinery (`FOR UPDATE SKIP LOCKED`, `(status, processed_by)` fence, two-branch reclaim) rather than rewriting `ControlQueue`. Routing: a worker claims a job iff the job's `required_plugin_key` is in the worker's advertised tags — `required_plugin_key = ANY(advertised_tags)` (Postgres) / per-tag membership (SQLite). `capability_tags` is informational; `target_flavor_sha` is a version-pin guard, never a routing key.
- **`TriggerDedupInbox`** — first-writer-wins over `UNIQUE(trigger_id, event_id)`, with the atomic **`claim_and_enqueue_start(row: Option<&TriggerDedupRow>, start: &JobDispatchMsg) -> DispatchOutcome`** that folds the dedup-row insert **and** the Start job-row insert into **one transaction** (it owns both writes; it does not call `JobDispatchQueue::enqueue`). A `None` `event_id` dispatches exactly once with no dedup row (the only no-dedup signal — never a fresh ULID).

## Atomicity / honesty about the Postgres gate

The compose contract (all-or-nothing single transaction + first-writer-wins) is proven **here** by the three-backend conformance matrix on InMemory (one shared `Arc<Mutex<Core>>` so both writes are one critical section) and SQLite (`:memory:`, single `pool.begin()` tx). The **Postgres** case **skip-cleans** without `DATABASE_URL` (WARN+pass, never false-green) — cross-process serializability under concurrent workers is a separate Postgres-gated check tracked for later, not claimed done here.

## Pre-existing bug fixed in-pass

`postgres/schema.sql` declared `port_control_queue.processed_at TIMESTAMPTZ`, but the pg adapter reads/writes `processed_at_ms` (epoch-ms) — a real `column does not exist` failure waiting for a live DB. Converged on `processed_at_ms BIGINT` to match SQLite and the adapter arithmetic.

## Tests / gates

- New conformance assertions across all three backends: routing-by-tag (+ a superset case: job needs `alpha`, a `beta`-only worker gets zero rows), fencing reuse, dedup first-writer-wins, atomic-compose all-or-nothing, dispatch-without-dedup-key, cross-scope isolation.
- Green locally and in the pre-push CI mirror: `clippy --all-features -D warnings`, `nextest` (270 InMemory + 298 with `--features sqlite`), `cargo check --features postgres` (compiles offline — adapters use runtime `sqlx::query`), `rustdoc -D warnings`, `fmt`, `cargo check --workspace`.

Internal-only (only `nebula-sdk` is public); additive ports + adapters. New numbered migration `0031` (Postgres + SQLite), additive CREATE TABLE only.

Next: **U2** (`nebula-orchestrator` routing crate) then **U3** (`DurableExecutionEmitter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added job dispatch queuing system with capability-based routing for asynchronous task management
  * Introduced trigger event deduplication to prevent duplicate trigger executions
  * Extended storage infrastructure across PostgreSQL, SQLite, and in-memory backends

* **Tests**
  * Added comprehensive conformance tests for job dispatch and trigger deduplication functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->