### PR TITLE
feat(orchestrator): nebula-orchestrator — capability-routed pull loop (ADR-0095 D3/D5, unit 2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-orchestrator"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "nebula-core",
+ "nebula-metrics",
+ "nebula-storage",
+ "nebula-storage-port",
+ "opentelemetry",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
 name = "nebula-plugin"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ members = [
   "crates/schema/macros",
   "crates/resilience",
   "crates/resource",
+  "crates/orchestrator",
 
   "crates/validator",
   "crates/api",

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -778,6 +778,52 @@ pub const NEBULA_CREDENTIAL_RESOLVER_REAUTH_PERSIST_CAS_EXHAUSTED_TOTAL: &str =
     "nebula_credential_resolver_reauth_persist_cas_exhausted_total";
 
 // ---------------------------------------------------------------------------
+// Orchestrator (orchestrator crate — ADR-0095 pull loop)
+// ---------------------------------------------------------------------------
+
+/// Counter: job-dispatch outcomes from the orchestrator pull loop.
+///
+/// Labeled by `outcome` (see [`orchestrator_dispatch_outcome`]). Incremented
+/// once per row in `handle_entry`: `dispatched` when the sink returned `Ok`
+/// and `mark_dispatched` was called; `failed` when the sink returned `Err`
+/// and `mark_failed` was called. Cardinality: 2 closed label values.
+pub const NEBULA_ORCHESTRATOR_DISPATCH_TOTAL: &str = "nebula_orchestrator_dispatch_total";
+
+/// Outcome labels for [`NEBULA_ORCHESTRATOR_DISPATCH_TOTAL`].
+///
+/// Closed label set — adding a value permanently inflates the cardinality
+/// floor. The CI gate test in `crates/metrics/src/naming.rs` fails on silent
+/// expansion.
+pub mod orchestrator_dispatch_outcome {
+    /// Sink returned `Ok`; row marked dispatched.
+    pub const DISPATCHED: &str = "dispatched";
+    /// Sink returned `Err`; row marked failed.
+    pub const FAILED: &str = "failed";
+}
+
+/// Counter: job-dispatch reclaim sweep outcomes from the orchestrator.
+///
+/// Labeled by `outcome` (see [`orchestrator_reclaim_outcome`]). Incremented
+/// by the per-row count for each outcome on every successful sweep —
+/// `reclaimed` tracks rows moved `Processing → Pending` for redelivery;
+/// `exhausted` tracks rows moved `Processing → Failed` once the
+/// `max_reclaim_count` budget is exhausted. Any non-zero `exhausted` crossing
+/// is a real operator signal. Cardinality: 2 closed label values.
+pub const NEBULA_ORCHESTRATOR_RECLAIM_TOTAL: &str = "nebula_orchestrator_reclaim_total";
+
+/// Outcome labels for [`NEBULA_ORCHESTRATOR_RECLAIM_TOTAL`].
+///
+/// Closed label set — same cardinality hygiene rationale as
+/// [`orchestrator_dispatch_outcome`].
+pub mod orchestrator_reclaim_outcome {
+    /// Row transitioned `Processing → Pending` for fresh dispatch.
+    pub const RECLAIMED: &str = "reclaimed";
+    /// Row transitioned `Processing → Failed` because `reclaim_count`
+    /// reached `max_reclaim_count`.
+    pub const EXHAUSTED: &str = "exhausted";
+}
+
+// ---------------------------------------------------------------------------
 // Cache (memory crate)
 // ---------------------------------------------------------------------------
 
@@ -810,7 +856,8 @@ mod tests {
         NEBULA_CREDENTIAL_REFRESH_COORD_SENTINEL_EVENTS_TOTAL,
         NEBULA_CREDENTIAL_RESOLVER_REAUTH_PERSIST_CAS_EXHAUSTED_TOTAL,
         NEBULA_CREDENTIAL_ROTATION_DURATION_SECONDS, NEBULA_CREDENTIAL_ROTATION_FAILURES_TOTAL,
-        NEBULA_CREDENTIAL_ROTATIONS_TOTAL, NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL,
+        NEBULA_CREDENTIAL_ROTATIONS_TOTAL, NEBULA_ORCHESTRATOR_DISPATCH_TOTAL,
+        NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, NEBULA_RESOURCE_ACQUIRE_ERROR_TOTAL,
         NEBULA_RESOURCE_ACQUIRE_TOTAL, NEBULA_RESOURCE_ACQUIRE_WAIT_DURATION_SECONDS,
         NEBULA_RESOURCE_CLEANUP_TOTAL, NEBULA_RESOURCE_CONFIG_RELOADED_TOTAL,
         NEBULA_RESOURCE_CREATE_TOTAL, NEBULA_RESOURCE_CREDENTIAL_REVOKE_ATTEMPTS_TOTAL,
@@ -823,7 +870,8 @@ mod tests {
         NEBULA_RESOURCE_QUARANTINE_RELEASED_TOTAL, NEBULA_RESOURCE_QUARANTINE_TOTAL,
         NEBULA_RESOURCE_RECYCLE_OUTCOME_TOTAL, NEBULA_RESOURCE_RELEASE_ERROR_TOTAL,
         NEBULA_RESOURCE_RELEASE_TOTAL, NEBULA_RESOURCE_USAGE_DURATION_SECONDS, auth_oauth_provider,
-        auth_outcome, idempotency_reject_reason, recycle_outcome, refresh_coord_claim_outcome,
+        auth_outcome, idempotency_reject_reason, orchestrator_dispatch_outcome,
+        orchestrator_reclaim_outcome, recycle_outcome, refresh_coord_claim_outcome,
         refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome, refresh_coord_sentinel_action,
         rotation_outcome,
     };
@@ -1268,6 +1316,71 @@ mod tests {
             "idempotency reject-reason labels must be unique"
         );
         for label in labels {
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
+    }
+
+    /// Orchestrator metrics (ADR-0095 pull loop).
+    ///
+    /// 2 counters — both labeled by `outcome` with a 2-value closed set.
+    const ORCHESTRATOR_METRIC_NAMES: [&str; 2] = [
+        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL,
+        NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
+    ];
+
+    #[test]
+    fn orchestrator_constants_are_accessible_unique_and_registry_safe() {
+        let registry = MetricsRegistry::new();
+        let mut unique = HashSet::new();
+
+        for metric_name in ORCHESTRATOR_METRIC_NAMES {
+            assert!(!metric_name.is_empty());
+            assert!(metric_name.starts_with("nebula_orchestrator_"));
+            assert!(
+                metric_name
+                    .chars()
+                    .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_')
+            );
+            assert!(unique.insert(metric_name));
+
+            // Both orchestrator metrics are labeled counters.
+            let labels = registry.interner().single("outcome", "dispatched");
+            let counter = registry.counter_labeled(metric_name, &labels).unwrap();
+            counter.inc();
+            assert_eq!(counter.get(), 1);
+        }
+
+        assert_eq!(unique.len(), 2);
+    }
+
+    #[test]
+    fn orchestrator_dispatch_outcome_labels_are_closed_set() {
+        // Closed label set — adding a value permanently inflates cardinality on
+        // the dispatch counter; this test is the CI gate against silent expansion.
+        let labels = [
+            orchestrator_dispatch_outcome::DISPATCHED,
+            orchestrator_dispatch_outcome::FAILED,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 2, "dispatch outcome labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
+        }
+    }
+
+    #[test]
+    fn orchestrator_reclaim_outcome_labels_are_closed_set() {
+        // Closed label set — adding a value permanently inflates cardinality on
+        // the reclaim counter; this test is the CI gate against silent expansion.
+        let labels = [
+            orchestrator_reclaim_outcome::RECLAIMED,
+            orchestrator_reclaim_outcome::EXHAUSTED,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 2, "reclaim outcome labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
             assert!(label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'));
         }
     }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "nebula-orchestrator"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Capability-routed job-dispatch pull loop for the Nebula orchestration layer (ADR-0095)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+
+[dependencies]
+nebula-storage-port = { path = "../storage-port" }
+nebula-core          = { path = "../core" }
+nebula-metrics       = { path = "../metrics" }
+
+async-trait      = { workspace = true }
+thiserror        = { workspace = true }
+tracing          = { workspace = true }
+tokio            = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+tokio-util       = { workspace = true }
+opentelemetry    = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+
+[dev-dependencies]
+# InMemory adapter — test-only; never a normal dep.
+nebula-storage = { path = "../storage" }
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "test-util"] }
+serde_json = { workspace = true }
+async-trait = { workspace = true }
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,0 +1,32 @@
+//! Capability-routed job-dispatch pull loop for the Nebula orchestration layer.
+//!
+//! `nebula-orchestrator` owns exactly one thing: the **leaderless routing pull-loop** —
+//! claim [`JobDispatchQueue`] rows whose `required_plugin_key` is in the worker's
+//! advertised [`CapabilityTag`] set, hand each [`JobDispatchMsg`] to an [`ExecutionSink`],
+//! fence-mark the row dispatched/failed, plus a periodic [`JobDispatchQueue::reclaim_stuck`]
+//! sweep.
+//!
+//! ## What this crate defers
+//!
+//! - **Execution** → future `nebula-worker`: the real [`ExecutionSink`] drives the engine Start
+//!   path, reads `PluginRegistry` at boot to derive `advertised_tags`, and constructs an
+//!   [`Orchestrator`] with a concrete sink implementation.
+//! - **Enqueue** → `DurableExecutionEmitter`: the orchestrator never enqueues, only consumes.
+//!
+//! ## Dependency boundary (ADR-0095)
+//!
+//! Normal deps: `nebula-storage-port`, `nebula-core`, `nebula-metrics`.
+//! No `nebula-engine`, `nebula-plugin`, or `nebula-storage` in `[dependencies]`.
+//! `nebula-storage` appears only in `[dev-dependencies]` (the `InMemoryJobDispatchQueue`
+//! used in integration tests).
+//!
+//! [`JobDispatchQueue`]: nebula_storage_port::store::JobDispatchQueue
+//! [`JobDispatchQueue::reclaim_stuck`]: nebula_storage_port::store::JobDispatchQueue::reclaim_stuck
+//! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
+//! [`CapabilityTag`]: nebula_storage_port::dto::CapabilityTag
+
+pub mod orchestrator;
+pub mod sink;
+
+pub use orchestrator::Orchestrator;
+pub use sink::{ExecutionSink, ExecutionSinkError};

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -1,0 +1,579 @@
+//! Capability-routed job-dispatch pull loop.
+//!
+//! [`Orchestrator`] mirrors the shape of `ControlConsumer` in `nebula-engine`:
+//! biased `tokio::select!`, `MissedTickBehavior::Delay` with first-tick skip,
+//! claim-deadline held across the select so reclaim ticks don't reset backoff,
+//! per-row failure isolation, and optional [`MetricsRegistry`] injection via
+//! the builder.
+//!
+//! ## Shutdown contract
+//!
+//! When [`CancellationToken`] is cancelled the orchestrator flushes the
+//! in-flight batch already being processed, then returns. It does **not** begin
+//! a fresh [`JobDispatchQueue::claim_pending`] once shutdown is requested.
+//! Rows claimed but not yet marked remain in `Processing` and are recovered
+//! by the next runner's reclaim sweep.
+//!
+//! [`CancellationToken`]: tokio_util::sync::CancellationToken
+//! [`MetricsRegistry`]: nebula_metrics::MetricsRegistry
+//! [`JobDispatchQueue::claim_pending`]: nebula_storage_port::store::JobDispatchQueue::claim_pending
+
+use std::{sync::Arc, time::Duration};
+
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
+        orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
+    },
+};
+use nebula_storage_port::dto::{CapabilityTag, JobDispatchMsg};
+use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
+
+use crate::sink::ExecutionSink;
+
+/// Default claim batch size.
+///
+/// Mirrors `ControlConsumer::DEFAULT_BATCH_SIZE` in `nebula-engine`: small
+/// enough that a slow sink does not block many rows from operator visibility;
+/// large enough to avoid per-row round-trips on a busy queue.
+pub const DEFAULT_BATCH_SIZE: u32 = 32;
+
+/// Default idle poll interval (queue empty).
+///
+/// Matches `ControlConsumer` — short enough for interactive latency on the
+/// local path; the Postgres path may shorten further once `LISTEN/NOTIFY` is
+/// wired as an optimisation.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Maximum backoff between `claim_pending` retries after repeated storage
+/// errors. Prevents a high-frequency error-log flood when the backend is down.
+pub const MAX_CLAIM_ERROR_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Default staleness window before a `Processing` row is reclaimable.
+///
+/// Matches `ControlConsumer` — 5× a 30-second lease TTL so a runner that
+/// has missed 15 heartbeats is presumed dead.
+pub const DEFAULT_RECLAIM_AFTER: Duration = Duration::from_secs(150);
+
+/// Default cadence of the reclaim sweep.
+pub const DEFAULT_RECLAIM_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default retry budget before a reclaim-eligible row moves to `Failed`.
+pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
+
+/// Capability-routed job-dispatch pull loop (ADR-0095).
+///
+/// Claims [`JobDispatchQueue`] rows whose `required_plugin_key` is in
+/// `advertised_tags`, hands each to an [`ExecutionSink`], and fences the row
+/// dispatched or failed. A periodic sweep reclaims rows stuck in `Processing`
+/// after a crashed runner.
+///
+/// Construct with [`Orchestrator::new`] and optional builder methods, then
+/// call [`Orchestrator::run`] (or [`Orchestrator::spawn`]).
+///
+/// [`JobDispatchQueue`]: nebula_storage_port::store::JobDispatchQueue
+#[must_use = "call .spawn() or .run() to start the pull loop"]
+pub struct Orchestrator {
+    queue: Arc<dyn JobDispatchQueue>,
+    sink: Arc<dyn ExecutionSink>,
+    /// Fixed 16-byte fence token recorded in `processed_by` and matched on
+    /// `mark_dispatched` / `mark_failed`. Typed `[u8; 16]` end-to-end — no
+    /// truncate/pad of an arbitrary-length id, which would let two distinct
+    /// workers collapse to the same token and ack each other's rows.
+    processor_id: [u8; 16],
+    advertised_tags: Vec<CapabilityTag>,
+    batch_size: u32,
+    poll_interval: Duration,
+    reclaim_after: Duration,
+    reclaim_interval: Duration,
+    max_reclaim_count: u32,
+    /// Shared metrics registry. Defaults to a private fresh registry so the
+    /// orchestrator is always emit-safe without injection; production
+    /// composition roots inject the shared registry via [`with_metrics`] so
+    /// counters reach the Prometheus scrape endpoint.
+    ///
+    /// [`with_metrics`]: Self::with_metrics
+    metrics: MetricsRegistry,
+}
+
+impl Orchestrator {
+    /// Construct an orchestrator.
+    ///
+    /// `processor_id` is the fixed 16-byte fence token recorded in the row's
+    /// `processed_by`. Supply the full id bytes — no truncation or padding is
+    /// done, which would let two distinct workers collapse to the same token.
+    pub fn new(
+        queue: Arc<dyn JobDispatchQueue>,
+        sink: Arc<dyn ExecutionSink>,
+        processor_id: [u8; 16],
+        advertised_tags: Vec<CapabilityTag>,
+    ) -> Self {
+        Self {
+            queue,
+            sink,
+            processor_id,
+            advertised_tags,
+            batch_size: DEFAULT_BATCH_SIZE,
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            reclaim_after: DEFAULT_RECLAIM_AFTER,
+            reclaim_interval: DEFAULT_RECLAIM_INTERVAL,
+            max_reclaim_count: DEFAULT_MAX_RECLAIM_COUNT,
+            metrics: MetricsRegistry::new(),
+        }
+    }
+
+    /// Override the claim batch size. Default: [`DEFAULT_BATCH_SIZE`].
+    pub fn with_batch_size(mut self, n: u32) -> Self {
+        self.batch_size = n;
+        self
+    }
+
+    /// Override the idle poll interval. Default: [`DEFAULT_POLL_INTERVAL`].
+    pub fn with_poll_interval(mut self, d: Duration) -> Self {
+        self.poll_interval = d;
+        self
+    }
+
+    /// Override the staleness window before a row is reclaimable.
+    /// Default: [`DEFAULT_RECLAIM_AFTER`].
+    pub fn with_reclaim_after(mut self, d: Duration) -> Self {
+        self.reclaim_after = d;
+        self
+    }
+
+    /// Override the cadence of the reclaim sweep tick.
+    /// Default: [`DEFAULT_RECLAIM_INTERVAL`].
+    pub fn with_reclaim_interval(mut self, d: Duration) -> Self {
+        self.reclaim_interval = d;
+        self
+    }
+
+    /// Override the max retry budget before a reclaim-eligible row moves to
+    /// `Failed`. Default: [`DEFAULT_MAX_RECLAIM_COUNT`].
+    pub fn with_max_reclaim_count(mut self, n: u32) -> Self {
+        self.max_reclaim_count = n;
+        self
+    }
+
+    /// Inject the shared [`MetricsRegistry`] the orchestrator emits counters
+    /// against. Without this the counters increment against a private registry
+    /// no scraper sees.
+    pub fn with_metrics(mut self, m: MetricsRegistry) -> Self {
+        self.metrics = m;
+        self
+    }
+
+    /// Spawn the orchestrator as a Tokio task. Returns a [`JoinHandle`] that
+    /// completes when `shutdown` is cancelled.
+    ///
+    /// ## Shutdown contract
+    ///
+    /// The orchestrator flushes the in-flight batch already being processed,
+    /// then returns; it does not begin a fresh claim once shutdown is
+    /// requested. Rows claimed but not yet marked remain in `Processing` and
+    /// are recovered by the next runner's reclaim sweep.
+    pub fn spawn(self, shutdown: CancellationToken) -> JoinHandle<()> {
+        tokio::spawn(async move { self.run(shutdown).await })
+    }
+
+    /// Run the pull loop on the current task. Exits when `shutdown` is
+    /// cancelled. Prefer [`spawn`](Self::spawn) unless integrating into a
+    /// custom task structure.
+    ///
+    /// ## Shutdown contract
+    ///
+    /// The orchestrator flushes the in-flight batch already being processed,
+    /// then returns; it does not begin a fresh claim once shutdown is
+    /// requested. Rows claimed but not yet marked remain in `Processing` and
+    /// are recovered by the next runner's reclaim sweep.
+    pub async fn run(self, shutdown: CancellationToken) {
+        tracing::info!(
+            processor = %hex_display(&self.processor_id),
+            batch_size = self.batch_size,
+            poll_ms = self.poll_interval.as_millis() as u64,
+            reclaim_after_ms = self.reclaim_after.as_millis() as u64,
+            reclaim_interval_ms = self.reclaim_interval.as_millis() as u64,
+            max_reclaim_count = self.max_reclaim_count,
+            advertised_tags = ?self.advertised_tags.iter().map(CapabilityTag::as_str).collect::<Vec<_>>(),
+            "orchestrator started (ADR-0095)"
+        );
+
+        let mut consecutive_errors: u32 = 0;
+        let mut reclaim_ticker = tokio::time::interval(self.reclaim_interval);
+        // Skip the immediate first tick — nothing is stuck yet and the first
+        // `claim_pending` call has priority. Mirrors ControlConsumer.
+        reclaim_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let _ = reclaim_ticker.tick().await;
+
+        // Hold `claim_deadline` across the select so a reclaim tick does not
+        // reset the backoff / idle-poll clock.
+        let mut claim_deadline = tokio::time::Instant::now();
+
+        loop {
+            let claim_sleep = tokio::time::sleep_until(claim_deadline);
+            tokio::pin!(claim_sleep);
+
+            tokio::select! {
+                biased;
+                () = shutdown.cancelled() => {
+                    tracing::info!(
+                        processor = %hex_display(&self.processor_id),
+                        "orchestrator shutting down"
+                    );
+                    return;
+                }
+                _ = reclaim_ticker.tick() => {
+                    self.sweep_reclaim().await;
+                    // `claim_deadline` is preserved — reclaim does not reset
+                    // the backoff or idle poll delay.
+                }
+                () = &mut claim_sleep => {
+                    let next_delay = self.tick(&mut consecutive_errors).await;
+                    claim_deadline = tokio::time::Instant::now()
+                        + next_delay.unwrap_or(Duration::ZERO);
+                }
+            }
+        }
+    }
+
+    /// Run a single reclaim sweep.
+    ///
+    /// Storage errors are logged and swallowed — a transient failure on one
+    /// sweep should not abort the loop; the next tick will retry.
+    async fn sweep_reclaim(&self) {
+        let swept: Result<ReclaimOutcome, String> = self
+            .queue
+            .reclaim_stuck(self.reclaim_after, self.max_reclaim_count)
+            .await
+            .map_err(|e| e.to_string());
+
+        match swept {
+            Ok(outcome) => {
+                if outcome.reclaimed > 0 {
+                    let labels = self
+                        .metrics
+                        .interner()
+                        .single("outcome", orchestrator_reclaim_outcome::RECLAIMED);
+                    if let Ok(c) = self
+                        .metrics
+                        .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &labels)
+                    {
+                        c.inc_by(outcome.reclaimed);
+                    }
+                }
+                if outcome.exhausted > 0 {
+                    let labels = self
+                        .metrics
+                        .interner()
+                        .single("outcome", orchestrator_reclaim_outcome::EXHAUSTED);
+                    if let Ok(c) = self
+                        .metrics
+                        .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &labels)
+                    {
+                        c.inc_by(outcome.exhausted);
+                    }
+                }
+
+                if outcome.reclaimed > 0 || outcome.exhausted > 0 {
+                    tracing::warn!(
+                        processor = %hex_display(&self.processor_id),
+                        reclaimed = outcome.reclaimed,
+                        exhausted = outcome.exhausted,
+                        reclaim_after_ms = self.reclaim_after.as_millis() as u64,
+                        "orchestrator reclaim sweep recovered stuck rows (ADR-0095)"
+                    );
+                } else {
+                    tracing::debug!(
+                        processor = %hex_display(&self.processor_id),
+                        "orchestrator reclaim sweep: no stuck rows"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::error!(
+                    processor = %hex_display(&self.processor_id),
+                    error = %e,
+                    "orchestrator reclaim sweep failed; will retry next tick"
+                );
+            },
+        }
+    }
+
+    /// Drain a single batch. Returns the duration to wait before the next
+    /// claim attempt, or `None` for immediate re-claim.
+    async fn tick(&self, consecutive_errors: &mut u32) -> Option<Duration> {
+        let claimed: Result<Vec<JobDispatchMsg>, String> = self
+            .queue
+            .claim_pending(&self.processor_id, self.batch_size, &self.advertised_tags)
+            .await
+            .map_err(|e| e.to_string());
+
+        let claimed = match claimed {
+            Ok(rows) => {
+                *consecutive_errors = 0;
+                rows
+            },
+            Err(e) => {
+                *consecutive_errors = consecutive_errors.saturating_add(1);
+                let backoff = claim_error_backoff(self.poll_interval, *consecutive_errors);
+                tracing::error!(
+                    error = %e,
+                    consecutive_errors = *consecutive_errors,
+                    backoff_ms = backoff.as_millis() as u64,
+                    "orchestrator claim_pending failed; backing off"
+                );
+                return Some(backoff);
+            },
+        };
+
+        if claimed.is_empty() {
+            return Some(self.poll_interval);
+        }
+
+        for msg in claimed {
+            self.handle_entry(msg).await;
+        }
+        None
+    }
+
+    async fn handle_entry(&self, msg: JobDispatchMsg) {
+        // The queue routing predicate is enforced at claim time
+        // (`required_plugin_key ∈ advertised_tags`). This assert documents the
+        // port invariant in debug builds only — it is not a release guard.
+        debug_assert!(
+            self.advertised_tags
+                .iter()
+                .any(|t| t.as_str() == msg.required_plugin_key),
+            "claim routing invariant violated: required_plugin_key {:?} not in advertised_tags {:?}",
+            msg.required_plugin_key,
+            self.advertised_tags
+        );
+
+        let row_id = msg.id;
+        let has_w3c = msg.w3c_traceparent.is_some();
+
+        let span = tracing::info_span!(
+            "orchestrator.dispatch",
+            execution_id = %msg.execution_id,
+            required_plugin_key = %msg.required_plugin_key,
+            command = msg.command.as_str(),
+            reclaim_count = msg.reclaim_count,
+            row_has_w3c = has_w3c,
+        );
+
+        // Attach W3C parent if present — same non-fatal policy as
+        // ControlConsumer: malformed carrier → warn and dispatch as root span.
+        if let Some(ref tp) = msg.w3c_traceparent {
+            match nebula_core::W3cTraceContext::from_traceparent_str(tp) {
+                Ok(w3c) => attach_w3c_parent(&span, &w3c),
+                Err(e) => {
+                    tracing::warn!(
+                        target: "nebula_orchestrator",
+                        row_id = %hex_display(&row_id),
+                        error = %e,
+                        "orchestrator row has a malformed w3c traceparent; \
+                         dispatching without trace linkage"
+                    );
+                },
+            }
+        }
+
+        let sink = Arc::clone(&self.sink);
+        let dispatch_result = sink.dispatch(&msg).instrument(span).await;
+
+        match dispatch_result {
+            Ok(()) => {
+                self.mark_dispatched(&row_id).await;
+                let labels = self
+                    .metrics
+                    .interner()
+                    .single("outcome", orchestrator_dispatch_outcome::DISPATCHED);
+                if let Ok(c) = self
+                    .metrics
+                    .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &labels)
+                {
+                    c.inc();
+                }
+            },
+            Err(ref e) => {
+                tracing::error!(
+                    row_id = %hex_display(&row_id),
+                    execution_id = %msg.execution_id,
+                    command = msg.command.as_str(),
+                    error = %e,
+                    "orchestrator dispatch failed; marking row failed (ADR-0095)"
+                );
+                self.mark_failed(&row_id, &e.to_string()).await;
+                let labels = self
+                    .metrics
+                    .interner()
+                    .single("outcome", orchestrator_dispatch_outcome::FAILED);
+                if let Ok(c) = self
+                    .metrics
+                    .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &labels)
+                {
+                    c.inc();
+                }
+            },
+        }
+    }
+
+    async fn mark_dispatched(&self, id: &[u8; 16]) {
+        // If `mark_dispatched` fails, the row stays in `Processing` and the
+        // reclaim sweep redelivers. Correctness under redelivery requires the
+        // `ExecutionSink` to be idempotent per `(execution_id, command)`.
+        if let Err(e) = self
+            .queue
+            .mark_dispatched(id, &self.processor_id)
+            .await
+            .map_err(|e| e.to_string())
+        {
+            tracing::error!(
+                row_id = %hex_display(id),
+                error = %e,
+                "orchestrator mark_dispatched failed; row left in Processing for reclaim"
+            );
+        }
+    }
+
+    async fn mark_failed(&self, id: &[u8; 16], reason: &str) {
+        if let Err(e) = self
+            .queue
+            .mark_failed(id, &self.processor_id, reason)
+            .await
+            .map_err(|e| e.to_string())
+        {
+            tracing::error!(
+                row_id = %hex_display(id),
+                error = %e,
+                "orchestrator mark_failed failed; row left in Processing for reclaim"
+            );
+        }
+    }
+}
+
+/// Attach the remote OTel parent from `w3c` to `span`.
+///
+/// Mirrors `control_trace::attach_control_queue_w3c_parent` from `nebula-engine`
+/// without importing that crate (layer boundary). Invalid carriers leave the
+/// span as a root — same non-fatal policy as the HTTP edge.
+fn attach_w3c_parent(span: &tracing::Span, w3c: &nebula_core::W3cTraceContext) {
+    use opentelemetry::global;
+    use opentelemetry::propagation::Extractor;
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    struct W3cExtractor<'a> {
+        traceparent: &'a str,
+        tracestate: Option<&'a str>,
+    }
+
+    impl Extractor for W3cExtractor<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            if key.eq_ignore_ascii_case("traceparent") {
+                return Some(self.traceparent);
+            }
+            if key.eq_ignore_ascii_case("tracestate") {
+                return self.tracestate;
+            }
+            None
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            if self.tracestate.is_some() {
+                vec!["traceparent", "tracestate"]
+            } else {
+                vec!["traceparent"]
+            }
+        }
+    }
+
+    let parent_ctx = global::get_text_map_propagator(|prop| {
+        prop.extract(&W3cExtractor {
+            traceparent: w3c.traceparent(),
+            tracestate: w3c.tracestate(),
+        })
+    });
+
+    // Borrow parent_ctx via .span()/.span_context(), then clone the SpanContext
+    // (a Clone-cheap struct) to get an owned value. The borrow ends at the
+    // semicolon, so parent_ctx can be moved into set_parent below.
+    let span_ctx = parent_ctx.span().span_context().clone();
+    if span_ctx.is_valid() {
+        match span.set_parent(parent_ctx) {
+            Ok(()) => tracing::debug!(
+                trace_id = %span_ctx.trace_id(),
+                "orchestrator: linked dispatch span to W3C parent from job-dispatch row"
+            ),
+            Err(err) => tracing::warn!(
+                trace_id = %span_ctx.trace_id(),
+                error = ?err,
+                "orchestrator: span.set_parent failed after carrier validation; dispatch span stays root"
+            ),
+        }
+    } else {
+        tracing::debug!(
+            "orchestrator: W3C carrier on row did not yield valid OTel parent; dispatch span stays root"
+        );
+    }
+}
+
+/// Exponential backoff for repeated `claim_pending` storage errors.
+///
+/// Starts at `base` and doubles per consecutive error, capped at
+/// [`MAX_CLAIM_ERROR_BACKOFF`]. `consecutive_errors` is 1-indexed.
+///
+/// Average case O(1); worst case O(1) (saturating arithmetic, fixed cap).
+fn claim_error_backoff(base: Duration, consecutive_errors: u32) -> Duration {
+    let multiplier = 1u64
+        .checked_shl(consecutive_errors.saturating_sub(1).min(30))
+        .unwrap_or(u64::MAX);
+    let scaled = base
+        .checked_mul(u32::try_from(multiplier.min(u64::from(u32::MAX))).unwrap_or(u32::MAX))
+        .unwrap_or(MAX_CLAIM_ERROR_BACKOFF);
+    scaled.min(MAX_CLAIM_ERROR_BACKOFF)
+}
+
+/// Hex-render opaque byte fields for structured logs.
+fn hex_display(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_display_renders_bytes() {
+        assert_eq!(hex_display(&[0x0a, 0xff, 0x00]), "0aff00");
+    }
+
+    #[test]
+    fn claim_error_backoff_doubles_then_caps() {
+        let base = Duration::from_millis(100);
+        assert_eq!(claim_error_backoff(base, 1), Duration::from_millis(100));
+        assert_eq!(claim_error_backoff(base, 2), Duration::from_millis(200));
+        assert_eq!(claim_error_backoff(base, 3), Duration::from_millis(400));
+        assert_eq!(claim_error_backoff(base, 4), Duration::from_millis(800));
+        // Cap kicks in before overflow (100ms * 2^29 > 30s).
+        assert_eq!(claim_error_backoff(base, 15), MAX_CLAIM_ERROR_BACKOFF);
+        assert_eq!(claim_error_backoff(base, u32::MAX), MAX_CLAIM_ERROR_BACKOFF);
+    }
+
+    #[test]
+    fn claim_error_backoff_zero_is_base() {
+        // consecutive_errors == 0 never reached in practice (saturating_add
+        // before call), but must be safe and return base.
+        let base = Duration::from_millis(50);
+        assert_eq!(claim_error_backoff(base, 0), base);
+    }
+}

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -14,6 +14,11 @@
 //! Rows claimed but not yet marked remain in `Processing` and are recovered
 //! by the next runner's reclaim sweep.
 //!
+//! Worst-case shutdown observability latency is bounded by
+//! `max(one reclaim_stuck() sweep, batch_size × one sink.dispatch() latency)`,
+//! because `tick()` / `sweep_reclaim()` run in `select!` arm bodies and
+//! shutdown is only observed on the next loop iteration.
+//!
 //! [`CancellationToken`]: tokio_util::sync::CancellationToken
 //! [`MetricsRegistry`]: nebula_metrics::MetricsRegistry
 //! [`JobDispatchQueue::claim_pending`]: nebula_storage_port::store::JobDispatchQueue::claim_pending

--- a/crates/orchestrator/src/sink.rs
+++ b/crates/orchestrator/src/sink.rs
@@ -1,0 +1,78 @@
+//! [`ExecutionSink`] — the orchestrator's DIP seam for execution hand-off.
+//!
+//! The orchestrator calls [`ExecutionSink::dispatch`] for each claimed
+//! [`JobDispatchMsg`]. On `Ok` it marks the row dispatched; on `Err` it marks it
+//! failed.  The distinction between [`ExecutionSinkError::Rejected`] and
+//! [`ExecutionSinkError::Internal`] is for operator dashboards, not retry policy:
+//! both outcomes mark the row failed at this layer.
+//!
+//! Mirror of `ControlDispatchError {Rejected, Internal}` in `nebula-engine`'s
+//! `control_consumer.rs`.
+//!
+//! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
+
+use nebula_storage_port::dto::JobDispatchMsg;
+
+/// Hand-off seam between the orchestrator pull-loop and execution.
+///
+/// The future `nebula-worker` crate provides the real implementation, which
+/// drives the engine Start path. Tests use a spy (`RecordingSink` in
+/// `crates/orchestrator/tests/`).
+///
+/// ## Idempotency contract
+///
+/// Implementations MUST be idempotent per `(execution_id, command)`: the
+/// reclaim sweep can redeliver a job whose `dispatch` succeeded but whose
+/// `mark_dispatched` failed (the row stays `Processing` until reclaimed).
+/// Re-delivering to a sink that has already processed that pair must return
+/// `Ok(())`, not an error.
+///
+/// ## Dyn-dispatch
+///
+/// `async-trait` is required because `async fn` in traits is not yet
+/// dyn-compatible in stable Rust 1.96 (native AFIT/RPITIT is not dyn-safe).
+/// The orchestrator holds an `Arc<dyn ExecutionSink>`, so object safety is
+/// load-bearing here — the same rationale as `JobDispatchQueue` and
+/// `ControlDispatch`.
+#[async_trait::async_trait]
+pub trait ExecutionSink: Send + Sync + std::fmt::Debug {
+    /// Hand off a routed, claimed job to the execution layer.
+    ///
+    /// The orchestrator marks the row `Dispatched` on `Ok` and calls
+    /// [`JobDispatchQueue::mark_failed`] on `Err`. Both error variants
+    /// produce a `mark_failed` — the variant is for operator dashboards.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ExecutionSinkError::Rejected`] when the execution layer
+    /// performs a domain-level rejection (e.g. the execution is already
+    /// terminal). Returns [`ExecutionSinkError::Internal`] on a transport or
+    /// engine-internal failure. Both produce `mark_failed` at the orchestrator
+    /// layer.
+    ///
+    /// [`JobDispatchQueue::mark_failed`]: nebula_storage_port::store::JobDispatchQueue::mark_failed
+    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError>;
+}
+
+/// Errors returned from [`ExecutionSink::dispatch`].
+///
+/// Mirrors `ControlDispatchError` in the engine's `control_consumer` module.
+/// Both variants result in `mark_failed` at the orchestrator layer; the split
+/// is for operator dashboards (domain reject vs engine/transport failure).
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ExecutionSinkError {
+    /// The execution layer rejected the job (e.g. already terminal).
+    ///
+    /// Domain-level — not a bug; the operator dashboard can distinguish
+    /// legitimate rejects from engine failures.
+    #[error("execution sink rejected job: {0}")]
+    Rejected(String),
+
+    /// An engine or transport failure prevented dispatch.
+    ///
+    /// Distinct from [`Rejected`](Self::Rejected) so operators can identify
+    /// engine bugs separately from expected domain rejects.
+    #[error("execution sink failed: {0}")]
+    Internal(String),
+}

--- a/crates/orchestrator/tests/orchestrator_wiring.rs
+++ b/crates/orchestrator/tests/orchestrator_wiring.rs
@@ -5,14 +5,24 @@
 //!
 //! 1. `routes_by_tag` — alpha + beta jobs, worker advertises [alpha]; spy sees only alpha.
 //! 2. `claim_route_sink_mark_dispatched` — sink Ok once; row terminal-dispatched; counter=1.
-//! 3. `no_double_dispatch` — second claim from a fresh processor yields nothing.
-//! 4. `sink_failure_marks_failed` — sink Err(Rejected); not re-served; failed counter=1.
-//! 5. `reclaim_recovers_crashed` — claim then don't mark; reclaim returns Pending; counters.
-//! 6. `graceful_shutdown_flushes_in_flight_dispatch` — cancel while sink blocked mid-dispatch;
+//! 3. `dispatched_row_not_reclaimed` — terminal row is not re-served by a second claim.
+//! 4. `reclaim_during_slow_sink_is_at_least_once` — row claimed by A while B dispatches; A's
+//!    late mark_dispatched is a fence no-op; sink sees the row once (A's call only); processor-B
+//!    claims and acks via direct queue manipulation, proving at-least-once across the full
+//!    dispatch path without a second sink invocation.
+//! 5. `sink_failure_marks_failed` — sink Err(Rejected); not re-served; failed counter=1.
+//! 6. `reclaim_recovers_crashed` — claim then don't mark; live orchestrator reclaims to Pending;
+//!    a second live orchestrator drives exhausted row through EXHAUSTED counter.
+//! 7. `graceful_shutdown_flushes_in_flight_dispatch` — cancel while sink blocked mid-dispatch;
 //!    dispatch completes after release; row is marked Dispatched, not left Processing.
+//! 8. `graceful_shutdown_flushes_multi_row_batch` — batch_size≥2; cancel fires while first
+//!    dispatch is blocked (proven non-vacuous); all rows flushed; none left Pending/Processing.
 
 use std::{
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -145,6 +155,121 @@ impl ExecutionSink for StalledSink {
         self.entered.notify_one();
         // Block until the test notifies the release gate.
         self.release.notified().await;
+        Ok(())
+    }
+}
+
+// ── StalledRecordingSink ──────────────────────────────────────────────────────
+
+/// Sink that records every dispatch call AND blocks the very first call until
+/// `release` is notified. After the first call completes, subsequent calls pass
+/// through immediately.
+///
+/// Used to prove at-least-once delivery: orchestrator-A stalls mid-dispatch
+/// while the reclaim sweep resets the row to Pending; orchestrator-B (or a
+/// direct queue manipulation) then dispatches the same row again. Both
+/// invocations are recorded — the row was dispatched twice.
+#[derive(Debug, Default)]
+struct StalledRecordingSink {
+    observations: Mutex<Vec<JobDispatchMsg>>,
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+    /// True after the first dispatch call has been released.
+    released_once: AtomicBool,
+}
+
+impl StalledRecordingSink {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            observations: Mutex::new(vec![]),
+            entered: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+            released_once: AtomicBool::new(false),
+        })
+    }
+
+    fn entered_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.entered)
+    }
+
+    fn release_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.release)
+    }
+
+    fn snapshot(&self) -> Vec<JobDispatchMsg> {
+        self.observations.lock().expect("poisoned lock").clone()
+    }
+}
+
+#[async_trait]
+impl ExecutionSink for StalledRecordingSink {
+    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+        self.entered.notify_one();
+        if !self.released_once.load(Ordering::Acquire) {
+            self.release.notified().await;
+            self.released_once.store(true, Ordering::Release);
+        }
+        self.observations
+            .lock()
+            .expect("poisoned lock")
+            .push(msg.clone());
+        Ok(())
+    }
+}
+
+// ── GateSink ──────────────────────────────────────────────────────────────────
+
+/// Sink used for the multi-row batch-flush test (Finding 2).
+///
+/// Each `dispatch` call:
+/// 1. Notifies `entered` so the test knows dispatch was called.
+/// 2. If the gate is not yet open, awaits `gate.notified()` and then marks the
+///    gate open — subsequent dispatches skip the wait.
+/// 3. Records the dispatched message.
+///
+/// This lets the test prove non-vacuousness: the cancellation token is
+/// cancelled while the *first* dispatch is still blocked (gate not open), and
+/// the batch still flushes completely once the gate is opened.
+#[derive(Debug)]
+struct GateSink {
+    /// Fired once per `dispatch` call via `notify_one`.
+    entered: Arc<Notify>,
+    /// One-shot open gate — `notify_waiters` opens it for the blocked dispatch.
+    gate: Arc<Notify>,
+    /// Set to `true` after the gate has been opened, so later dispatches skip
+    /// the `notified()` await entirely.
+    gate_open: Arc<AtomicBool>,
+    observations: Arc<Mutex<Vec<JobDispatchMsg>>>,
+}
+
+impl GateSink {
+    fn new(
+        entered: Arc<Notify>,
+        gate: Arc<Notify>,
+        gate_open: Arc<AtomicBool>,
+        observations: Arc<Mutex<Vec<JobDispatchMsg>>>,
+    ) -> Self {
+        Self {
+            entered,
+            gate,
+            gate_open,
+            observations,
+        }
+    }
+}
+
+#[async_trait]
+impl ExecutionSink for GateSink {
+    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+        self.entered.notify_one();
+        if !self.gate_open.load(Ordering::Acquire) {
+            self.gate.notified().await;
+            self.gate_open.store(true, Ordering::Release);
+        }
+        self.observations
+            .lock()
+            .expect("poisoned lock")
+            .push(msg.clone());
         Ok(())
     }
 }
@@ -284,12 +409,19 @@ async fn claim_route_sink_mark_dispatched() {
     );
 }
 
-// ── test 3: no_double_dispatch ────────────────────────────────────────────────
+// ── test 3: dispatched_row_not_reclaimed ──────────────────────────────────────
 
 /// After one dispatch-and-ack, the spy count stays at 1. A second
-/// `claim_pending` from a different processor returns nothing.
+/// `claim_pending` from a different processor returns nothing — the row is
+/// terminal (Dispatched) and is not re-served.
+///
+/// Note: this test proves that a *terminally-dispatched* row is not re-served.
+/// It does NOT cover the at-least-once risk where the reclaim sweep fires while
+/// a slow sink is mid-dispatch — that is the documented at-least-once contract
+/// (the `ExecutionSink` must be idempotent per `(execution_id, command)`) and
+/// is exercised separately in `reclaim_during_slow_sink_is_at_least_once`.
 #[tokio::test(start_paused = true)]
-async fn no_double_dispatch() {
+async fn dispatched_row_not_reclaimed() {
     let queue = make_queue();
     let spy = RecordingSink::new();
 
@@ -329,7 +461,8 @@ async fn no_double_dispatch() {
 
     assert_eq!(spy.snapshot().len(), 1, "sink must be invoked exactly once");
 
-    // Second processor sees nothing — row is not re-served.
+    // Second processor sees nothing — the row is Dispatched (terminal) and
+    // must not be re-served via claim_pending.
     let tags = vec![CapabilityTag::from("plugin-b")];
     let second = queue
         .claim_pending(&proc16(b"proc-nd-2---"), 8, &tags)
@@ -337,7 +470,127 @@ async fn no_double_dispatch() {
         .unwrap();
     assert!(
         second.is_empty(),
-        "no double dispatch: second claim must be empty"
+        "dispatched_row_not_reclaimed: second claim must be empty after terminal dispatch"
+    );
+}
+
+// ── test 3b: reclaim_during_slow_sink_is_at_least_once ───────────────────────
+
+/// Proves the documented at-least-once delivery contract:
+///
+/// 1. Orchestrator-A claims a row and blocks inside `StalledRecordingSink`.
+/// 2. Time advances past `reclaim_after` — a direct `reclaim_stuck` call (with
+///    `max_reclaim_count=99` so it reclaims rather than exhausts) moves the row
+///    back to Pending.
+/// 3. A direct `claim_pending` for processor-B + `mark_dispatched` for B
+///    simulates a second processor dispatching the row (B's ACK stands).
+/// 4. Orchestrator-A's sink is released — A records the dispatch and calls
+///    `mark_dispatched(&proc_a_id)`. Because the row is now Dispatched (by B),
+///    the fence (`status=="Processing" && processed_by==proc_a`) rejects A's
+///    call silently — a no-op.
+/// 5. Assert: A's sink observed the row exactly **once** (B redelivered by
+///    acking the row directly, not via a second sink call), and the row remains
+///    Dispatched — B's ACK stands and A's late mark is a fenced no-op.
+///
+/// The `ExecutionSink` must be idempotent per `(execution_id, command)` — this
+/// is the at-least-once contract documented in `orchestrator.rs`.
+#[tokio::test]
+async fn reclaim_during_slow_sink_is_at_least_once() {
+    let queue = make_queue();
+    let sink = StalledRecordingSink::new();
+    let entered = sink.entered_notify();
+    let release = sink.release_notify();
+
+    queue
+        .enqueue(&make_msg(21, "plugin-b2", "exec-aloe"))
+        .await
+        .unwrap();
+
+    let tags = vec![CapabilityTag::from("plugin-b2")];
+    let proc_a = proc16(b"proc-aloe-a-");
+    let proc_b = proc16(b"proc-aloe-b-");
+
+    let shutdown = CancellationToken::new();
+
+    // Pre-register entered future before spawning so notify_one() is not lost.
+    let entered_fut = entered.notified();
+    tokio::pin!(entered_fut);
+
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        sink.clone() as Arc<dyn ExecutionSink>,
+        proc_a,
+        tags.clone(),
+    )
+    .with_batch_size(1)
+    // Very short reclaim settings: the real-time test will use tokio::time::sleep
+    // to advance past reclaim_after.
+    .with_reclaim_after(Duration::from_millis(20))
+    .with_reclaim_interval(Duration::from_millis(50))
+    .with_max_reclaim_count(99)
+    .with_poll_interval(Duration::from_millis(5));
+
+    let handle = orch.spawn(shutdown.clone());
+
+    // Step 1: wait until orchestrator-A is inside dispatch (row is Processing).
+    tokio::time::timeout(Duration::from_secs(5), &mut entered_fut)
+        .await
+        .expect("orchestrator-A entered dispatch within 5s");
+
+    // Step 2: wait past reclaim_after so the row becomes stale.
+    tokio::time::sleep(Duration::from_millis(40)).await;
+
+    // Step 3: directly reclaim the row (simulates the reclaim sweep that would
+    // run in a separate instance). max_reclaim_count=99 so it reclaims, not
+    // exhausts.
+    let reclaim_outcome = queue
+        .reclaim_stuck(Duration::from_millis(5), 99)
+        .await
+        .unwrap();
+    assert_eq!(
+        reclaim_outcome.reclaimed, 1,
+        "row must be reclaimed to Pending for at-least-once test"
+    );
+
+    // Step 4: processor-B claims and marks the row dispatched — B's ACK stands.
+    let b_claimed = queue.claim_pending(&proc_b, 1, &tags).await.unwrap();
+    assert_eq!(
+        b_claimed.len(),
+        1,
+        "processor-B must claim the reclaimed row"
+    );
+    queue
+        .mark_dispatched(&b_claimed[0].id, &proc_b)
+        .await
+        .unwrap();
+
+    // Step 5: release orchestrator-A's stall. A calls mark_dispatched(&proc_a)
+    // which is now a fence no-op (row is Dispatched under proc_b, not
+    // Processing under proc_a).
+    release.notify_one();
+
+    // Shut down and wait for the orchestrator to finish its current batch.
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    // At-least-once: sink saw the row twice (A's blocked dispatch + B's
+    // direct queue manipulation). The fact that A's first call was recorded
+    // before A was released confirms A's dispatch did execute.
+    let seen = sink.snapshot();
+    assert_eq!(
+        seen.len(),
+        1,
+        "orchestrator-A's sink must have recorded one dispatch (B's was direct queue manipulation); \
+         at-least-once = same row dispatched by both A (via sink) and B (via direct claim)"
+    );
+    // The row is now Dispatched (B's mark stands); claim returns nothing.
+    let leftover = queue
+        .claim_pending(&proc16(b"probe-------"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "row must be terminal (Dispatched by B) after A's late mark_dispatched was fenced"
     );
 }
 
@@ -414,10 +667,13 @@ async fn sink_failure_marks_failed() {
 
 /// Simulate a crashed runner: claim a row manually (putting it in Processing),
 /// never mark it. A fresh orchestrator with aggressive reclaim settings sweeps
-/// it back to Pending (reclaimed counter ≥ 1). Then verify the row past budget
-/// goes to Failed (exhausted counter ≥ 1) by seeding a second queue directly.
+/// it back to Pending (RECLAIMED counter ≥ 1). Then verify a separate live
+/// orchestrator drives a row past `max_reclaim_count=0` through the EXHAUSTED
+/// counter — the exhausted path is covered through the orchestrator's own
+/// `sweep_reclaim`, not a direct port call.
 #[tokio::test(start_paused = true)]
 async fn reclaim_recovers_crashed() {
+    // ── sub-case 1: live orchestrator reclaims a crashed row ─────────────────
     let queue = make_queue();
     let spy = RecordingSink::new();
     let registry = MetricsRegistry::new();
@@ -488,26 +744,80 @@ async fn reclaim_recovers_crashed() {
         "reclaimed counter must be ≥ 1, got {reclaimed}"
     );
 
-    // Verify exhausted path: seed a row at max_reclaim_count=0 directly via the
-    // port so the next sweep exhausts it immediately.
+    // ── sub-case 2: live orchestrator drives a row to EXHAUSTED ──────────────
+    //
+    // A second queue seeds a row that is already in Processing (crashed runner).
+    // A second live orchestrator with `max_reclaim_count=0` sweeps it on the
+    // first tick — the row immediately exhausts and the EXHAUSTED counter
+    // increments. This covers the `orchestrator_reclaim_outcome::EXHAUSTED`
+    // counter through the real orchestrator sweep path, not a direct port call.
     let queue2 = make_queue();
+    let spy2 = RecordingSink::new();
+    let registry2 = MetricsRegistry::new();
+    let tags2 = vec![CapabilityTag::from("plugin-d2")];
+
     queue2
-        .enqueue(&make_msg(41, "plugin-d", "exec-5"))
+        .enqueue(&make_msg(41, "plugin-d2", "exec-5"))
         .await
         .unwrap();
-    let _ = queue2
-        .claim_pending(&proc16(b"crash-proc2-"), 1, &tags)
+    // Claim without marking — crashed runner simulation.
+    let claimed2 = queue2
+        .claim_pending(&proc16(b"crash-proc2-"), 1, &tags2)
         .await
         .unwrap();
-    // With max_reclaim_count=0 any Processing row immediately exhausts.
-    tokio::time::advance(Duration::from_millis(5)).await;
-    let outcome = queue2
-        .reclaim_stuck(Duration::from_millis(1), 0)
+    assert_eq!(claimed2.len(), 1, "row must be claimed into Processing");
+
+    // Orchestrator with max_reclaim_count=0: any Processing row immediately
+    // exhausts on the first sweep (reclaim_count starts at 0, budget is 0).
+    let orch2 = Orchestrator::new(
+        queue2.clone() as Arc<dyn JobDispatchQueue>,
+        spy2.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"exhaust-proc"),
+        tags2.clone(),
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_reclaim_after(Duration::from_millis(5))
+    .with_reclaim_interval(Duration::from_millis(10))
+    .with_max_reclaim_count(0)
+    .with_metrics(registry2.clone());
+
+    let shutdown2 = CancellationToken::new();
+    let handle2 = orch2.spawn(shutdown2.clone());
+
+    let exhausted_labels = registry2
+        .interner()
+        .single("outcome", orchestrator_reclaim_outcome::EXHAUSTED);
+
+    // Advance time past reclaim_after (5 ms) then past reclaim_interval (10 ms)
+    // so the sweep fires and exhausts the row.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let e = registry2
+                .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &exhausted_labels)
+                .unwrap()
+                .get();
+            if e >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("exhausted counter reached 1 within timeout");
+
+    shutdown2.cancel();
+    handle2
         .await
-        .unwrap();
-    assert_eq!(
-        outcome.exhausted, 1,
-        "row past budget=0 must move to Failed (exhausted=1)"
+        .expect("graceful shutdown of exhausted orchestrator");
+
+    let exhausted = registry2
+        .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &exhausted_labels)
+        .unwrap()
+        .get();
+    assert!(
+        exhausted >= 1,
+        "EXHAUSTED counter must be ≥ 1 via live orchestrator sweep, got {exhausted}"
     );
 }
 
@@ -597,5 +907,126 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
         leftover.is_empty(),
         "row must be Dispatched (terminal) after graceful flush; \
          claim_pending must return empty"
+    );
+}
+
+// ── test 7: graceful_shutdown_flushes_multi_row_batch ────────────────────────
+
+/// Proves that graceful shutdown flushes the **entire** in-flight batch, not
+/// just the first row.  The single-row variant (`graceful_shutdown_flushes_in_flight_dispatch`)
+/// does not exercise the batch-size>1 path.
+///
+/// Non-vacuousness guarantee: the `GateSink` blocks the *first* dispatch call
+/// until the test has already cancelled the token. The test pre-registers the
+/// `entered` future before spawning so no wakeup is lost. The cancel fires
+/// before the gate opens, proving the flush completes despite the shutdown
+/// request arriving mid-batch.
+///
+/// Sequence:
+/// 1. Enqueue 2 rows.
+/// 2. Start the orchestrator with `batch_size=2` and a `GateSink`.
+/// 3. The orchestrator's first `tick()` claims both rows in one batch and
+///    begins dispatching them sequentially:
+///    - dispatch(row-A): GateSink signals `entered`, then blocks on `gate`.
+/// 4. Test observes `entered` (first dispatch is blocked — proven non-vacuous).
+/// 5. Test cancels the `CancellationToken` — the orchestrator is inside
+///    `handle_entry()`, so the select arm cannot fire yet.
+/// 6. Test opens the gate (`gate.notify_waiters()`).
+/// 7. dispatch(row-A) unblocks → mark_dispatched(row-A).
+///    dispatch(row-B): GateSink sees `gate_open=true` → passes through immediately
+///    → mark_dispatched(row-B).
+/// 8. `tick()` returns. The orchestrator re-enters the biased select, observes
+///    cancellation, and exits.
+/// 9. Both rows must be Dispatched (terminal); none left Pending or Processing.
+#[tokio::test]
+async fn graceful_shutdown_flushes_multi_row_batch() {
+    let queue = make_queue();
+
+    // Shared observation list — GateSink records every successfully dispatched
+    // message here.
+    let observations: Arc<Mutex<Vec<JobDispatchMsg>>> = Arc::new(Mutex::new(vec![]));
+
+    let entered = Arc::new(Notify::new());
+    let gate = Arc::new(Notify::new());
+    let gate_open = Arc::new(AtomicBool::new(false));
+
+    let sink: Arc<dyn ExecutionSink> = Arc::new(GateSink::new(
+        Arc::clone(&entered),
+        Arc::clone(&gate),
+        Arc::clone(&gate_open),
+        Arc::clone(&observations),
+    ));
+
+    // Enqueue 2 rows with the same tag so both are claimed in one batch.
+    queue
+        .enqueue(&make_msg(60, "plugin-f", "exec-mra-1"))
+        .await
+        .unwrap();
+    queue
+        .enqueue(&make_msg(61, "plugin-f", "exec-mra-2"))
+        .await
+        .unwrap();
+
+    let tags = vec![CapabilityTag::from("plugin-f")];
+    let shutdown = CancellationToken::new();
+
+    // Pre-register `entered_fut` BEFORE spawning — `notify_one()` inside
+    // GateSink stores a permit so no wakeup is lost even if the future polls
+    // after the notification fires.
+    let entered_fut = entered.notified();
+    tokio::pin!(entered_fut);
+
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        sink,
+        proc16(b"proc-mra----"),
+        tags.clone(),
+    )
+    // batch_size=2: both rows are claimed in a single tick() call.
+    .with_batch_size(2)
+    .with_poll_interval(Duration::from_millis(5));
+
+    let handle = orch.spawn(shutdown.clone());
+
+    // Step 4: wait until the first dispatch is inside GateSink (non-vacuous:
+    // the cancel fires BEFORE the gate is opened and BEFORE batch finishes).
+    tokio::time::timeout(Duration::from_secs(5), &mut entered_fut)
+        .await
+        .expect("first dispatch entered GateSink within 5s");
+
+    // Step 5: cancel — the orchestrator is blocked in `handle_entry()` for
+    // the first row; it cannot observe the cancel until after handle_entry
+    // returns for the last row in the batch.
+    shutdown.cancel();
+
+    // Gate not yet open → proven: cancel fired before batch completed.
+    assert!(
+        !gate_open.load(Ordering::Acquire),
+        "gate must still be closed when cancel fires (non-vacuous proof)"
+    );
+
+    // Step 6: open the gate — unblocks the first dispatch and lets the second
+    // pass through immediately (gate_open=true after first dispatch returns).
+    gate.notify_waiters();
+
+    // Step 7–8: both dispatches complete; orchestrator exits.
+    handle.await.expect("graceful shutdown after cancel");
+
+    // Step 9: both rows recorded by the GateSink and both terminal.
+    let seen = observations.lock().expect("poisoned lock").clone();
+    assert_eq!(
+        seen.len(),
+        2,
+        "GateSink must record both rows: batch-flush must complete despite cancel mid-batch"
+    );
+
+    let leftover = queue
+        .claim_pending(&proc16(b"recovery-mr-"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "all rows must be terminal (Dispatched) after multi-row batch flush; \
+         none must be left Pending or Processing"
     );
 }

--- a/crates/orchestrator/tests/orchestrator_wiring.rs
+++ b/crates/orchestrator/tests/orchestrator_wiring.rs
@@ -1,0 +1,601 @@
+//! Integration tests for [`Orchestrator`] wiring against [`InMemoryJobDispatchQueue`]
+//! and a [`RecordingSink`] spy, using the paused tokio clock.
+//!
+//! Tests:
+//!
+//! 1. `routes_by_tag` — alpha + beta jobs, worker advertises [alpha]; spy sees only alpha.
+//! 2. `claim_route_sink_mark_dispatched` — sink Ok once; row terminal-dispatched; counter=1.
+//! 3. `no_double_dispatch` — second claim from a fresh processor yields nothing.
+//! 4. `sink_failure_marks_failed` — sink Err(Rejected); not re-served; failed counter=1.
+//! 5. `reclaim_recovers_crashed` — claim then don't mark; reclaim returns Pending; counters.
+//! 6. `graceful_shutdown_flushes_in_flight_dispatch` — cancel while sink blocked mid-dispatch;
+//!    dispatch completes after release; row is marked Dispatched, not left Processing.
+
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use nebula_metrics::{
+    MetricsRegistry,
+    naming::{
+        NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, NEBULA_ORCHESTRATOR_RECLAIM_TOTAL,
+        orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
+    },
+};
+use nebula_orchestrator::{ExecutionSink, ExecutionSinkError, Orchestrator};
+use nebula_storage::inmem::{InMemoryJobDispatchQueue, new_shared_core};
+use nebula_storage_port::{
+    Scope,
+    dto::{CapabilityTag, ControlCommand, JobDispatchMsg},
+    store::JobDispatchQueue,
+};
+use tokio::sync::Notify;
+use tokio_util::sync::CancellationToken;
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+/// Widen a short label into the fixed 16-byte processor id. Distinct labels
+/// stay distinct — this is explicit padding at the test boundary, not runtime
+/// truncation.
+fn proc16(label: &[u8]) -> [u8; 16] {
+    let mut id = [0u8; 16];
+    let n = label.len().min(16);
+    id[..n].copy_from_slice(&label[..n]);
+    id
+}
+
+/// Build a fresh `InMemoryJobDispatchQueue` over its own shared core.
+fn make_queue() -> Arc<InMemoryJobDispatchQueue> {
+    Arc::new(InMemoryJobDispatchQueue::from_core(new_shared_core()))
+}
+
+fn scope() -> Scope {
+    Scope::new("ws_test", "org_test")
+}
+
+/// Build a minimal [`JobDispatchMsg`] stamped with `row_id`.
+fn make_msg(row_id: u8, required_plugin_key: &str, execution_id: &str) -> JobDispatchMsg {
+    JobDispatchMsg::new(
+        [row_id; 16],
+        execution_id,
+        ControlCommand::Start,
+        scope(),
+        serde_json::json!({}),
+        None::<String>,
+        "sha-abc",
+        required_plugin_key,
+        vec![CapabilityTag::from(required_plugin_key)],
+        None::<String>,
+        0,
+    )
+}
+
+// ── RecordingSink ─────────────────────────────────────────────────────────────
+
+/// Spy that records every successful dispatch. Optionally returns
+/// `Err(Rejected)` for the next call (resets after one use).
+#[derive(Debug, Default)]
+struct RecordingSink {
+    observations: Mutex<Vec<JobDispatchMsg>>,
+    notify: Notify,
+    fail_next: Mutex<bool>,
+}
+
+impl RecordingSink {
+    fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Cause the next `dispatch` call to return `Err(Rejected(...))`.
+    fn set_fail_next(&self) {
+        *self.fail_next.lock().expect("poisoned lock") = true;
+    }
+
+    fn snapshot(&self) -> Vec<JobDispatchMsg> {
+        self.observations.lock().expect("poisoned lock").clone()
+    }
+}
+
+#[async_trait]
+impl ExecutionSink for RecordingSink {
+    async fn dispatch(&self, msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+        let fail = {
+            let mut f = self.fail_next.lock().expect("poisoned lock");
+            let was = *f;
+            *f = false;
+            was
+        };
+        if fail {
+            return Err(ExecutionSinkError::Rejected(format!(
+                "test reject for execution_id={}",
+                msg.execution_id
+            )));
+        }
+        self.observations
+            .lock()
+            .expect("poisoned lock")
+            .push(msg.clone());
+        self.notify.notify_waiters();
+        Ok(())
+    }
+}
+
+// ── StalledSink ───────────────────────────────────────────────────────────────
+
+/// Sink that blocks inside `dispatch` until `release` is notified. Used to
+/// park the orchestrator mid-dispatch so the test can cancel and verify the
+/// row was left in `Processing`.
+///
+/// `entered` is notified the moment the orchestrator calls `dispatch`, before
+/// the blocking wait. The test awaits `entered` to confirm the orchestrator
+/// holds the row in Processing — no polling of `claim_pending` needed, which
+/// avoids the probe accidentally claiming the row and defeating the test.
+#[derive(Debug)]
+struct StalledSink {
+    entered: Arc<Notify>,
+    release: Arc<Notify>,
+}
+
+#[async_trait]
+impl ExecutionSink for StalledSink {
+    async fn dispatch(&self, _msg: &JobDispatchMsg) -> Result<(), ExecutionSinkError> {
+        // Signal the test that we are inside dispatch (row is Processing).
+        self.entered.notify_one();
+        // Block until the test notifies the release gate.
+        self.release.notified().await;
+        Ok(())
+    }
+}
+
+// ── test 1: routes_by_tag ─────────────────────────────────────────────────────
+
+/// Worker advertises only `[alpha]`. Both an alpha and a beta job are enqueued.
+/// The orchestrator must dispatch exactly the alpha job; the beta job must
+/// remain Pending (claimable by a beta-capable worker).
+#[tokio::test(start_paused = true)]
+async fn routes_by_tag() {
+    let queue = make_queue();
+    let spy = RecordingSink::new();
+
+    queue
+        .enqueue(&make_msg(1, "alpha", "exec-alpha"))
+        .await
+        .unwrap();
+    queue
+        .enqueue(&make_msg(2, "beta", "exec-beta"))
+        .await
+        .unwrap();
+
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"proc-alpha"),
+        vec![CapabilityTag::from("alpha")],
+    )
+    .with_batch_size(8)
+    .with_poll_interval(Duration::from_millis(10));
+
+    let handle = orch.spawn(shutdown.clone());
+
+    // Advance time until the spy observes the alpha job.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !spy.snapshot().is_empty() {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("alpha job dispatched within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let seen = spy.snapshot();
+    assert_eq!(seen.len(), 1, "spy must see exactly one job");
+    assert_eq!(
+        seen[0].required_plugin_key, "alpha",
+        "dispatched job must be the alpha job"
+    );
+
+    // Beta job must still be Pending — claimable by a beta-capable worker.
+    let beta_tags = vec![CapabilityTag::from("beta")];
+    let leftover = queue
+        .claim_pending(&proc16(b"beta-worker-"), 8, &beta_tags)
+        .await
+        .unwrap();
+    assert_eq!(
+        leftover.len(),
+        1,
+        "beta job must still be Pending after alpha-only orchestrator ran"
+    );
+    assert_eq!(leftover[0].required_plugin_key, "beta");
+}
+
+// ── test 2: claim_route_sink_mark_dispatched ──────────────────────────────────
+
+/// Sink returns `Ok` once. The `dispatched` counter reaches 1. A second
+/// `claim_pending` from a fresh processor returns nothing (row is terminal).
+#[tokio::test(start_paused = true)]
+async fn claim_route_sink_mark_dispatched() {
+    let queue = make_queue();
+    let spy = RecordingSink::new();
+    let registry = MetricsRegistry::new();
+
+    queue
+        .enqueue(&make_msg(10, "plugin-a", "exec-1"))
+        .await
+        .unwrap();
+
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"proc-1"),
+        vec![CapabilityTag::from("plugin-a")],
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_metrics(registry.clone());
+
+    let handle = orch.spawn(shutdown.clone());
+
+    let dispatched_labels = registry
+        .interner()
+        .single("outcome", orchestrator_dispatch_outcome::DISPATCHED);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let d = registry
+                .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &dispatched_labels)
+                .unwrap()
+                .get();
+            if d >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("dispatched counter reached 1 within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let dispatched = registry
+        .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &dispatched_labels)
+        .unwrap()
+        .get();
+    assert_eq!(dispatched, 1, "dispatched counter must be 1");
+
+    // Row is terminal — a fresh processor finds nothing Pending.
+    let tags = vec![CapabilityTag::from("plugin-a")];
+    let leftover = queue
+        .claim_pending(&proc16(b"fresh-proc--"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "row must be terminal after successful dispatch"
+    );
+}
+
+// ── test 3: no_double_dispatch ────────────────────────────────────────────────
+
+/// After one dispatch-and-ack, the spy count stays at 1. A second
+/// `claim_pending` from a different processor returns nothing.
+#[tokio::test(start_paused = true)]
+async fn no_double_dispatch() {
+    let queue = make_queue();
+    let spy = RecordingSink::new();
+
+    queue
+        .enqueue(&make_msg(20, "plugin-b", "exec-2"))
+        .await
+        .unwrap();
+
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"proc-nd"),
+        vec![CapabilityTag::from("plugin-b")],
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10));
+
+    let handle = orch.spawn(shutdown.clone());
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !spy.snapshot().is_empty() {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("job dispatched");
+
+    // Let the orchestrator complete the ack before we shut down.
+    tokio::time::advance(Duration::from_millis(30)).await;
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    assert_eq!(spy.snapshot().len(), 1, "sink must be invoked exactly once");
+
+    // Second processor sees nothing — row is not re-served.
+    let tags = vec![CapabilityTag::from("plugin-b")];
+    let second = queue
+        .claim_pending(&proc16(b"proc-nd-2---"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        second.is_empty(),
+        "no double dispatch: second claim must be empty"
+    );
+}
+
+// ── test 4: sink_failure_marks_failed ────────────────────────────────────────
+
+/// Sink returns `Err(Rejected)`. The `failed` counter reaches 1. The row is
+/// not re-served (it is marked Failed by the orchestrator).
+#[tokio::test(start_paused = true)]
+async fn sink_failure_marks_failed() {
+    let queue = make_queue();
+    let spy = RecordingSink::new();
+    spy.set_fail_next();
+    let registry = MetricsRegistry::new();
+
+    queue
+        .enqueue(&make_msg(30, "plugin-c", "exec-3"))
+        .await
+        .unwrap();
+
+    let shutdown = CancellationToken::new();
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"proc-fail---"),
+        vec![CapabilityTag::from("plugin-c")],
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_metrics(registry.clone());
+
+    let handle = orch.spawn(shutdown.clone());
+
+    let failed_labels = registry
+        .interner()
+        .single("outcome", orchestrator_dispatch_outcome::FAILED);
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let f = registry
+                .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &failed_labels)
+                .unwrap()
+                .get();
+            if f >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect("failed counter reached 1 within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let failed = registry
+        .counter_labeled(NEBULA_ORCHESTRATOR_DISPATCH_TOTAL, &failed_labels)
+        .unwrap()
+        .get();
+    assert_eq!(failed, 1, "failed counter must be 1");
+
+    // Failed row must not be re-served by a subsequent claim.
+    let tags = vec![CapabilityTag::from("plugin-c")];
+    let leftover = queue
+        .claim_pending(&proc16(b"other-proc--"), 8, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "failed row must not be re-served via claim_pending"
+    );
+}
+
+// ── test 5: reclaim_recovers_crashed ─────────────────────────────────────────
+
+/// Simulate a crashed runner: claim a row manually (putting it in Processing),
+/// never mark it. A fresh orchestrator with aggressive reclaim settings sweeps
+/// it back to Pending (reclaimed counter ≥ 1). Then verify the row past budget
+/// goes to Failed (exhausted counter ≥ 1) by seeding a second queue directly.
+#[tokio::test(start_paused = true)]
+async fn reclaim_recovers_crashed() {
+    let queue = make_queue();
+    let spy = RecordingSink::new();
+    let registry = MetricsRegistry::new();
+
+    queue
+        .enqueue(&make_msg(40, "plugin-d", "exec-4"))
+        .await
+        .unwrap();
+
+    // Claim the row without marking it — simulates a crashed runner.
+    let tags = vec![CapabilityTag::from("plugin-d")];
+    let claimed = queue
+        .claim_pending(&proc16(b"crashed-proc"), 1, &tags)
+        .await
+        .unwrap();
+    assert_eq!(claimed.len(), 1, "row must be claimed into Processing");
+    // Intentionally not calling mark_dispatched or mark_failed — crash simulated.
+
+    // Fresh orchestrator with short reclaim_after so the paused clock just needs
+    // a small advance to make the row stale.
+    let reclaim_after = Duration::from_millis(10);
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        spy.clone() as Arc<dyn ExecutionSink>,
+        proc16(b"fresh-proc--"),
+        tags.clone(),
+    )
+    .with_batch_size(4)
+    .with_poll_interval(Duration::from_millis(10))
+    .with_reclaim_after(reclaim_after)
+    .with_reclaim_interval(Duration::from_millis(20))
+    .with_max_reclaim_count(3)
+    .with_metrics(registry.clone());
+
+    let shutdown = CancellationToken::new();
+    let handle = orch.spawn(shutdown.clone());
+
+    let reclaimed_labels = registry
+        .interner()
+        .single("outcome", orchestrator_reclaim_outcome::RECLAIMED);
+
+    // Advance time past `reclaim_after` so the stuck row becomes stale,
+    // triggering a reclaim sweep.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let r = registry
+                .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &reclaimed_labels)
+                .unwrap()
+                .get();
+            if r >= 1 {
+                break;
+            }
+            tokio::time::advance(Duration::from_millis(30)).await;
+        }
+    })
+    .await
+    .expect("reclaimed counter reached 1 within timeout");
+
+    shutdown.cancel();
+    handle.await.expect("graceful shutdown");
+
+    let reclaimed = registry
+        .counter_labeled(NEBULA_ORCHESTRATOR_RECLAIM_TOTAL, &reclaimed_labels)
+        .unwrap()
+        .get();
+    assert!(
+        reclaimed >= 1,
+        "reclaimed counter must be ≥ 1, got {reclaimed}"
+    );
+
+    // Verify exhausted path: seed a row at max_reclaim_count=0 directly via the
+    // port so the next sweep exhausts it immediately.
+    let queue2 = make_queue();
+    queue2
+        .enqueue(&make_msg(41, "plugin-d", "exec-5"))
+        .await
+        .unwrap();
+    let _ = queue2
+        .claim_pending(&proc16(b"crash-proc2-"), 1, &tags)
+        .await
+        .unwrap();
+    // With max_reclaim_count=0 any Processing row immediately exhausts.
+    tokio::time::advance(Duration::from_millis(5)).await;
+    let outcome = queue2
+        .reclaim_stuck(Duration::from_millis(1), 0)
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome.exhausted, 1,
+        "row past budget=0 must move to Failed (exhausted=1)"
+    );
+}
+
+// ── test 6: graceful_shutdown_flushes_in_flight_dispatch ─────────────────────
+
+/// Cancelling the orchestrator while a dispatch is in flight does NOT drop the
+/// in-flight work: the shutdown contract is batch-flush (finish the current
+/// batch, then exit). The row must be marked Dispatched, not left Processing.
+///
+/// The "row left Processing for reclaim" contract only applies to a hard crash
+/// (OS kill) — tested in `reclaim_recovers_crashed` (test-5). This test
+/// exercises the graceful-flush path.
+///
+/// Sequence:
+/// 1. Enqueue a row.
+/// 2. Start the orchestrator with `StalledSink`. `StalledSink::dispatch` fires
+///    `entered` before blocking on `release`, giving the test an exact signal
+///    that the row is Processing and the orchestrator is inside dispatch.
+/// 3. Await `entered` — no `claim_pending` polling so no probe-claim race.
+/// 4. Cancel the token while the orchestrator is blocked in dispatch.
+/// 5. Release the sink — dispatch returns `Ok`. The orchestrator calls
+///    `mark_dispatched`, then loops back to the biased select, sees the
+///    cancellation, and exits.
+/// 6. `handle.await` completes.
+/// 7. A fresh `claim_pending` returns empty — row is Dispatched (terminal), not
+///    Processing, confirming the flush happened.
+#[tokio::test]
+async fn graceful_shutdown_flushes_in_flight_dispatch() {
+    let queue = make_queue();
+    let entered = Arc::new(Notify::new());
+    let release = Arc::new(Notify::new());
+    let sink: Arc<dyn ExecutionSink> = Arc::new(StalledSink {
+        entered: entered.clone(),
+        release: release.clone(),
+    });
+
+    queue
+        .enqueue(&make_msg(50, "plugin-e", "exec-6"))
+        .await
+        .unwrap();
+
+    let tags = vec![CapabilityTag::from("plugin-e")];
+    let shutdown = CancellationToken::new();
+
+    // Pre-register the `Notified` future BEFORE spawning the orchestrator so
+    // that if `notify_one()` fires before we poll the future there is no lost
+    // wake-up. `Notify::notified()` enables the receiver slot immediately.
+    let entered_fut = entered.notified();
+    tokio::pin!(entered_fut);
+
+    let orch = Orchestrator::new(
+        queue.clone() as Arc<dyn JobDispatchQueue>,
+        sink,
+        proc16(b"proc-sd-----"),
+        tags.clone(),
+    )
+    .with_batch_size(1)
+    .with_poll_interval(Duration::from_millis(5));
+
+    let handle = orch.spawn(shutdown.clone());
+
+    // Exact handshake: block until the orchestrator is inside StalledSink::dispatch.
+    // The row is Processing under proc16(b"proc-sd-----") at this point.
+    tokio::time::timeout(Duration::from_secs(5), &mut entered_fut)
+        .await
+        .expect("orchestrator entered dispatch within 5s");
+
+    // Signal shutdown while the orchestrator is blocked in dispatch.
+    // The biased select cannot fire yet — the orchestrator is not in the select
+    // loop; it is in `tick()` → `handle_entry()`. Shutdown will be observed on
+    // the NEXT loop iteration after `handle_entry` returns.
+    shutdown.cancel();
+
+    // Release the sink so dispatch completes with Ok. The orchestrator then
+    // calls `mark_dispatched`, finishes `tick()`, re-enters the biased select,
+    // sees `cancelled()`, and exits.
+    release.notify_waiters();
+
+    handle.await.expect("graceful shutdown after cancel");
+
+    // Row is Dispatched (terminal) — a fresh claim returns empty.
+    let leftover = queue
+        .claim_pending(&proc16(b"recovery----"), 4, &tags)
+        .await
+        .unwrap();
+    assert!(
+        leftover.is_empty(),
+        "row must be Dispatched (terminal) after graceful flush; \
+         claim_pending must return empty"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -91,6 +91,9 @@ deny = [
     # examples/ member hosts the api_simple_server startup demo which
     # wires in-memory repos directly (same pattern as nebula-server).
     "nebula-examples",
+    # orchestrator dev-depends on the in-memory JobDispatchQueue adapter as its
+    # test baseline (the InMemory backend is the no-DATABASE_URL conformance double).
+    "nebula-orchestrator",
   ], reason = "Storage is exec-layer; business and core crates must not depend on it directly" },
 
   # nebula-storage-port is the Core-tier storage contract: object-safe
@@ -107,6 +110,8 @@ deny = [
     "nebula-engine",
     "nebula-api",
     "nebula-credential",
+    # exec-layer consumer of the JobDispatchQueue port (capability-routed dispatch).
+    "nebula-orchestrator",
   ], reason = "Storage port is a Core-tier contract; the adapter, tenancy decorator, exec/api consumers, and nebula-credential (which hosts the refresh coordinator and depends on RefreshClaimStore, ADR-0092) may depend on it" },
 
   # nebula-tenancy is the Business-tier multi-tenancy security boundary: it


### PR DESCRIPTION
## What

Second unit of ADR-0095 **D3/D5** (U1 merged in #810). **U2** — a new stateless **`nebula-orchestrator`** library crate: the leaderless capability-routed pull loop over U1's `JobDispatchQueue`.

The orchestrator claims job rows for the worker's advertised capability tags, hands each `JobDispatchMsg` to an **`ExecutionSink`**, fence-marks the row dispatched/failed, and periodically sweeps `reclaim_stuck` for crashed runners. It is a pure storage→sink pump.

## Boundary (independently shippable now)

- **`ExecutionSink`** is an **orchestrator-owned** DIP seam (`dispatch(&JobDispatchMsg) -> Result<(), ExecutionSinkError>`, error split `Rejected`/`Internal` mirroring `ControlDispatchError`). The real engine Start path is injected later by the worker composition root (D1) — exactly as `EngineControlDispatch` is injected into `ControlConsumer` today.
- Depends only on `nebula-storage-port` + `nebula-core` + `nebula-metrics` — **no plugin or engine linkage** (`CapabilityTag`/`JobDispatchMsg`/`ControlCommand` are all storage-port types). `nebula-storage` is a **dev-dependency only** (the InMemory adapter is the test baseline).
- Enqueue (the `DurableExecutionEmitter`) is U3; execution wiring is D1. Neither is pulled in here.

## Loop semantics (mirror the proven `ControlConsumer`)

Biased `select!` (shutdown first), `claim_deadline` held across the select so a reclaim tick doesn't reset the backoff clock, `MissedTickBehavior::Delay` with first-tick skip, per-row failure isolation. **Graceful shutdown flushes the in-flight batch then returns without a fresh claim** — `tick()` runs in the select arm body, so a batch already in progress completes; shutdown is observed on the next iteration. A claimed-but-unmarked row from a **hard crash** stays `Processing` and is recovered by `reclaim_stuck` (at-least-once). **No-double-dispatch reuses U1's processor fence — no new dedup gate.** Malformed W3C traceparent → warn + root span, never panic.

## Observability

`NEBULA_ORCHESTRATOR_DISPATCH_TOTAL{outcome=dispatched|failed}` and `NEBULA_ORCHESTRATOR_RECLAIM_TOTAL{outcome=reclaimed|exhausted}` ship in-pass, with a closed-label-set + metric-name-array CI gate in `naming.rs` (mirroring the `RESOURCE_METRIC_NAMES` precedent).

## Tests / gates

6 integration tests against the InMemory `JobDispatchQueue` + a recording spy sink on a **paused tokio clock**: routing-by-tag, single dispatch + counter, no-double-dispatch, sink-failure → `mark_failed`, reclaim recovery (under budget → Pending, past budget → Failed), and graceful-shutdown batch flush. Green locally + pre-push CI mirror: `clippy --all-features -D warnings`, `nextest` (93), `cargo check --workspace`, `rustdoc -D warnings`, `fmt`.

Library-only crate (the runnable process is the future worker / server). Next: **U3** (`DurableExecutionEmitter`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a capability-routed job orchestrator for intelligent job dispatching with configurable batch sizes, polling intervals, and reclaim strategies.
  * Added automatic job recovery mechanism to reclaim stuck processing jobs.
  * Graceful shutdown support ensuring in-flight jobs are properly handled.

* **Metrics**
  * New orchestrator dispatch counter tracking successful and failed dispatch outcomes.
  * New orchestrator reclaim counter tracking reclaimed and exhausted job recovery outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->