### PR TITLE
fix(storage): atomic execution-row materialization in trigger-dedup compose (ADR-0095 P1/P2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,6 +178,7 @@ docker-compose.override.yml
 .claude/summaries/
 .claude/worktrees/
 .claude/agent-memory-local/
+.claude/agent-memory/
 .claude/scheduled_tasks.lock
 lefthook-local.yml
 

--- a/crates/action/src/capability.rs
+++ b/crates/action/src/capability.rs
@@ -36,14 +36,14 @@ pub trait ExecutionEmitter: Send + Sync {
     ///
     /// `event_id` is the source-natural idempotency key for the triggering
     /// event. `Some` enables trigger-dedup exactly-once fan-out; `None` emits
-    /// unconditionally (no dedup guard row written).  When `Some`, a second
-    /// call with the same `event_id` is deduplicated — no additional execution
-    /// is started and no second dispatch row is written. The returned
-    /// [`ExecutionId`] for a duplicate call is implementation-defined (the
-    /// current durable emitter returns a freshly-minted candidate id) and MUST
-    /// NOT be used to infer that an execution row was created. Surfacing the
-    /// original winner's id on a duplicate requires the dedup compose to read it
-    /// back in-transaction — tracked for the durable-wiring unit.
+    /// unconditionally (no dedup guard row written). When `Some`, a second call
+    /// with the same `event_id` is deduplicated — no additional execution is
+    /// started and no second dispatch row is written.
+    ///
+    /// Returns the **effective** [`ExecutionId`]: the winner's id when the call
+    /// is deduplicated (`Duplicate`), or the newly-minted id when the call
+    /// materialises a fresh execution (`Dispatched`). Callers MAY use this id
+    /// to poll status or surface progress — it always points to an existing row.
     fn emit(
         &self,
         input: serde_json::Value,

--- a/crates/engine/src/daemon/durable_emitter.rs
+++ b/crates/engine/src/daemon/durable_emitter.rs
@@ -6,49 +6,36 @@
 //! `DurableExecutionEmitter` implements [`nebula_action::ExecutionEmitter`] and
 //! wires the trigger-to-execution fan-out path end-to-end:
 //!
-//! 1. Mint a new [`ExecutionId`] (the candidate id).
-//! 2. Build a [`JobDispatchMsg`] (Start command, routing key, etc.) and, when
-//!    `event_id` is `Some`, a [`TriggerDedupRow`] guard keyed by
+//! 1. Mint a new [`ExecutionId`] candidate and build the initial
+//!    [`ExecutionState`].
+//! 2. Build a [`JobDispatchMsg`] (Start command, routing key, etc.), a
+//!    [`NewExecution`] carrying the serialised initial state, and — when
+//!    `event_id` is `Some` — a [`TriggerDedupRow`] guard keyed by
 //!    `(scope, trigger_id, event_id)`.
-//! 3. Call [`TriggerDedupInbox::claim_and_enqueue_start`] — one atomic critical
-//!    section that either inserts the dedup guard + enqueues the Start job
-//!    (`Dispatched`) or finds the guard already present (`Duplicate`).
-//! 4. **On `Dispatched`**: create a `Created` execution row via
-//!    [`ExecutionStore::create`], then return the `ExecutionId`.
-//! 5. **On `Duplicate`**: return the candidate `ExecutionId` without creating
-//!    any row (no orphan).
+//! 3. Call [`TriggerDedupInbox::claim_and_materialize_start`] — one atomic
+//!    critical section that either:
+//!    - **`Dispatched`**: inserts the dedup guard + the `Created` execution row
+//!      + enqueues the Start job; returns the effective execution id.
+//!    - **`Duplicate`**: returns the *original winner's* execution id without
+//!      touching any row.
+//! 4. Parse the returned `outcome.execution_id` back to [`ExecutionId`] and
+//!    return it to the caller.
 //!
-//! ## Ordering (claim before create) and its known limitation
+//! ## Atomicity guarantee
 //!
-//! `claim_and_enqueue_start` runs **before** `ExecutionStore::create`, so a
-//! `Duplicate` never orphans a `Created` row:
-//!
-//! ```text
-//! create_row → claim_and_enqueue (Duplicate) → Created row leaked  (avoided)
-//! claim_and_enqueue → Dispatched → create_row                      (used)
-//! ```
-//!
-//! The trade-off: the `Created` row is a **second write outside** the
-//! dedup+Start transaction. Under a concurrently-polling orchestrator a
-//! `Dispatched` Start job can be claimed in the window before the row exists;
-//! the sink then reads no row, returns `Rejected`, and the orchestrator marks
-//! the job failed — losing a legitimate first-delivery execution (never a
-//! double-spawn; a redelivery re-dedups). This slice is **harness-scoped** (no
-//! production daemon installs this emitter; the integration test emits before
-//! the orchestrator polls), so the race is latent. The correct fix folds the
-//! `Created`-row insert **into** the dedup+Start transaction — a
-//! `TriggerDedupInbox::claim_and_enqueue_start` contract change that would also
-//! let a `Duplicate` return the original winner's `ExecutionId`. That belongs
-//! with the durable-wiring unit that makes the emitter live, before any
-//! concurrent orchestrator runs against it.
+//! The dedup guard, `Created` execution row, and Start job are written in a
+//! single database transaction inside `claim_and_materialize_start`. A
+//! concurrently-polling orchestrator can never see the Start job before the
+//! execution row — the race window that existed when the Created-row was a
+//! second separate write is closed.
 //!
 //! ## Wiring honesty
 //!
 //! No prod trigger daemon installs this emitter today — all non-test
 //! `TriggerRuntimeContext::new` sites use the default `NoopExecutionEmitter`.
 //! Install via `ctx.with_emitter(Arc::new(DurableExecutionEmitter::new(...)))` in
-//! the harness or a future trigger daemon; the integration test is the sole current
-//! caller.
+//! the harness or a future trigger daemon; the integration test is the sole
+//! current caller.
 //!
 //! ## Tracing
 //!
@@ -70,8 +57,8 @@ use nebula_core::id::{ExecutionId, WorkflowId};
 use nebula_execution::ExecutionState;
 use nebula_storage_port::{
     Scope, StorageError,
-    dto::{ControlCommand, DispatchOutcome, JobDispatchMsg, TriggerDedupRow},
-    store::{ExecutionStore, TriggerDedupInbox},
+    dto::{ControlCommand, DispatchKind, JobDispatchMsg, NewExecution, TriggerDedupRow},
+    store::TriggerDedupInbox,
 };
 
 use crate::daemon::routing::RoutingResolver;
@@ -79,15 +66,14 @@ use crate::daemon::routing::RoutingResolver;
 /// Trigger fan-out through the durable dedup inbox.
 ///
 /// Holds everything needed to enqueue one trigger-originated Start job:
-/// - [`TriggerDedupInbox`] — atomic dedup + enqueue.
-/// - [`ExecutionStore`] — create the `Created` row on `Dispatched`.
+/// - [`TriggerDedupInbox`] — atomic dedup + execution-row materialise + job
+///   enqueue, all in one transaction.
 /// - [`RoutingResolver`] — derive `required_plugin_key` + `target_flavor_sha`.
 /// - Identity fields captured at construction: `workflow_id`, `trigger_id`,
 ///   `scope` — same values on every `emit` call from this trigger context.
 #[derive(Clone)]
 pub struct DurableExecutionEmitter {
     dedup: Arc<dyn TriggerDedupInbox>,
-    execution: Arc<dyn ExecutionStore>,
     resolver: Arc<dyn RoutingResolver>,
     // Cached at construction from `TriggerRuntimeContext`.
     workflow_id: WorkflowId,
@@ -108,15 +94,13 @@ impl std::fmt::Debug for DurableExecutionEmitter {
 impl DurableExecutionEmitter {
     /// Construct a durable emitter.
     ///
-    /// `dedup` MUST share the same [`SharedDispatchCore`] as the
-    /// `JobDispatchQueue` passed to the orchestrator, so
-    /// `claim_and_enqueue_start` operates in one critical section.
-    ///
-    /// [`SharedDispatchCore`]: nebula_storage::inmem::SharedDispatchCore
+    /// `dedup` MUST be backed by the same store (or share the same
+    /// `Arc<Mutex<…>>` for the InMemory adapter) as the `JobDispatchQueue`
+    /// passed to the orchestrator, so `claim_and_materialize_start` is atomic
+    /// across all three writes.
     #[must_use]
     pub fn new(
         dedup: Arc<dyn TriggerDedupInbox>,
-        execution: Arc<dyn ExecutionStore>,
         resolver: Arc<dyn RoutingResolver>,
         workflow_id: WorkflowId,
         trigger_id: NodeKey,
@@ -124,7 +108,6 @@ impl DurableExecutionEmitter {
     ) -> Self {
         Self {
             dedup,
-            execution,
             resolver,
             workflow_id,
             trigger_id,
@@ -158,12 +141,17 @@ impl DurableExecutionEmitter {
             .resolve(&self.workflow_id, &self.trigger_id)
             .map_err(ActionError::fatal_from)?;
 
-        // --- step 2: mint the candidate id + build the dispatch msg ----------
+        // --- step 2: mint the candidate id + serialise the initial state -----
         //
-        // `ExecutionId::new()` generates a fresh ULID. Minting here — before
-        // the dedup call — means the returned id is always the candidate, which
-        // on `Duplicate` matches no `Created` row (correct: no orphan).
-        let execution_id = ExecutionId::new();
+        // The candidate id is passed to `claim_and_materialize_start`.
+        // On `Dispatched` the store inserts the execution row with this id.
+        // On `Duplicate` the store returns the *winner's* id — which may differ.
+        let candidate_id = ExecutionId::new();
+
+        let mut exec_state = ExecutionState::new(candidate_id, self.workflow_id, &[]);
+        exec_state.set_workflow_input(input.clone());
+        let state_json = serde_json::to_value(&exec_state)
+            .map_err(|e| ActionError::fatal(format!("serialize execution state: {e}")))?;
 
         // Mint a fresh ULID for the job-dispatch row primary key.
         // The field is documented as "16-byte ULID (raw bytes)"; time-sortable
@@ -172,10 +160,10 @@ impl DurableExecutionEmitter {
 
         let start = JobDispatchMsg::new(
             job_id,
-            execution_id.to_string(),
+            candidate_id.to_string(),
             ControlCommand::Start,
             self.scope.clone(),
-            input.clone(),
+            input,
             event_id.as_ref().map(IdempotencyKey::as_str),
             route.target_flavor_sha.clone(),
             route.required_plugin_key.clone(),
@@ -184,92 +172,80 @@ impl DurableExecutionEmitter {
             0,              // reclaim_count: 0 on first enqueue
         );
 
+        let workflow_id_str = self.workflow_id.to_string();
+        let new_execution = NewExecution::new(&workflow_id_str, &state_json);
+
         // --- step 3: build the dedup guard row (only when event_id present) --
         let dedup_row = event_id.as_ref().map(|eid| {
             TriggerDedupRow::new(
                 self.trigger_id.as_str(),
                 eid.as_str(),
                 self.scope.clone(),
-                execution_id.to_string(),
                 chrono::Utc::now().to_rfc3339(),
             )
         });
 
-        // --- step 4: atomic dedup-insert ∧ Start-enqueue (R2 ordering) ------
+        // --- step 4: atomic dedup ∧ execution-row ∧ Start-enqueue -----------
         //
-        // `claim_and_enqueue_start` either:
-        //   Dispatched — inserted the dedup guard + enqueued the Start job
-        //   Duplicate  — guard already present; no job enqueued; no-op
+        // `claim_and_materialize_start` runs all three writes in one transaction:
+        //   Dispatched — dedup guard + Created execution row + Start job
+        //   Duplicate  — guard already present; returns winner's execution id
         //
-        // `create_row` (ExecutionStore::create) happens AFTER this call.
-        // Reversing the order orphans a Created row on Duplicate.
+        // The returned `outcome.execution_id` is the EFFECTIVE id — on
+        // Dispatched it equals `candidate_id`; on Duplicate it is the original
+        // winner's id.
         let outcome = self
             .dedup
-            .claim_and_enqueue_start(dedup_row.as_ref(), &start)
+            .claim_and_materialize_start(dedup_row.as_ref(), &start, &new_execution)
             .await
             .map_err(|e: StorageError| {
                 ActionError::retryable(format!("dedup inbox storage error: {e}"))
             })?;
 
         tracing::debug!(
-            outcome = ?outcome,
-            execution_id = %execution_id,
+            outcome_kind = ?outcome.kind,
+            effective_execution_id = %outcome.execution_id,
+            candidate_id = %candidate_id,
             trigger_id   = %self.trigger_id,
             workflow_id  = %self.workflow_id,
             event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
-            "durable_emitter: claim_and_enqueue_start"
+            "durable_emitter: claim_and_materialize_start"
         );
 
-        match outcome {
-            // --- step 5a: Dispatched — seed the Created row -----------------
-            DispatchOutcome::Dispatched => {
-                let mut exec_state = ExecutionState::new(execution_id, self.workflow_id, &[]);
-                exec_state.set_workflow_input(input);
-                let state_json = serde_json::to_value(&exec_state)
-                    .map_err(|e| ActionError::fatal(format!("serialize execution state: {e}")))?;
-                self.execution
-                    .create(
-                        &self.scope,
-                        &execution_id.to_string(),
-                        &self.workflow_id.to_string(),
-                        state_json,
-                    )
-                    .await
-                    .map_err(|e: StorageError| {
-                        ActionError::retryable(format!("create execution row: {e}"))
-                    })?;
-
+        match outcome.kind {
+            DispatchKind::Dispatched => {
                 tracing::info!(
-                    execution_id = %execution_id,
+                    execution_id = %outcome.execution_id,
                     trigger_id   = %self.trigger_id,
                     workflow_id  = %self.workflow_id,
                     event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
                     "durable_emitter: dispatched"
                 );
-
-                Ok(execution_id)
             },
-
-            // --- step 5b: Duplicate — return id, create nothing -------------
-            DispatchOutcome::Duplicate => {
+            DispatchKind::Duplicate => {
                 tracing::debug!(
-                    execution_id = %execution_id,
+                    winner_execution_id = %outcome.execution_id,
+                    candidate_id = %candidate_id,
                     trigger_id   = %self.trigger_id,
                     workflow_id  = %self.workflow_id,
                     event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
-                    "durable_emitter: duplicate (no-op)"
+                    "durable_emitter: duplicate — returning winner id"
                 );
-                Ok(execution_id)
             },
-
-            // `DispatchOutcome` is #[non_exhaustive] — a future variant whose
-            // enqueue semantics are unknown MUST be rejected fail-closed.
-            // Seeding a Created row without knowing whether a Start job was
-            // enqueued would risk orphaning or double-dispatch.
-            _ => Err(ActionError::fatal(format!(
-                "unknown DispatchOutcome variant {outcome:?}; refusing to seed an execution row"
-            ))),
+            // `DispatchKind` is #[non_exhaustive] — a future variant whose
+            // semantics are unknown MUST be rejected fail-closed.
+            _ => {
+                return Err(ActionError::fatal(format!(
+                    "unknown DispatchKind variant {:?}; refusing to return an execution id",
+                    outcome.kind
+                )));
+            },
         }
+
+        // Parse the effective id back to the typed wrapper.
+        outcome.execution_id.parse::<ExecutionId>().map_err(|e| {
+            ActionError::fatal(format!("effective execution id is not a valid ULID: {e}"))
+        })
     }
 }
 

--- a/crates/engine/src/daemon/event_source.rs
+++ b/crates/engine/src/daemon/event_source.rs
@@ -242,14 +242,13 @@ where
                     match recv {
                         Ok(event) => {
                             let payload = (self.event_to_payload)(&event);
-                            // CANCEL SAFETY: (a) a drop before `claim_and_enqueue_start`
-                            // commits is a clean no-op (no row, no job).
-                            // (b) a drop AFTER `claim_and_enqueue_start` commits but
-                            // BEFORE the `Created`-row write leaves a queued Start
-                            // with no Created row → orchestrator dispatch finds no row
-                            // → `resume_execution` Rejected → `mark_failed`
-                            // (at-most-once degrade, NEVER double-spawn — a redelivery
-                            // re-dedups). EventSourceAdapter passes `event_id = None`
+                            // CANCEL SAFETY: a drop before `claim_and_materialize_start`
+                            // commits is a clean no-op — no dedup row, no execution row,
+                            // no job (all three are atomic in one transaction).  A drop
+                            // AFTER the transaction commits is safe: the Created row, the
+                            // dedup guard, and the Start job all landed atomically, so the
+                            // orchestrator can pick up the job with a valid execution row
+                            // already present.  EventSourceAdapter passes `event_id = None`
                             // (unconditional dispatch; no dedup row written).
                             match ctx.emitter().emit(payload, None).await {
                                 Ok(_) => ctx.health().record_success(1),

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -1,7 +1,7 @@
 //! ADR-0095 D3/D5 — "first real trigger dispatch" vertical slice.
 //!
 //! Tests verify the full path: trigger fires → `DurableExecutionEmitter` →
-//! `TriggerDedupInbox::claim_and_enqueue_start` → `Orchestrator` claims →
+//! `TriggerDedupInbox::claim_and_materialize_start` → `Orchestrator` claims →
 //! `EngineExecutionSink::dispatch` drives `resume_execution` → execution runs.
 //!
 //! ## Test plan
@@ -46,7 +46,7 @@ use nebula_metrics::MetricsRegistry;
 use nebula_orchestrator::{ExecutionSink, Orchestrator};
 use nebula_storage::{
     InMemoryExecutionStore, InMemoryWorkflowVersionStore,
-    inmem::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox, new_shared_core},
+    inmem::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox},
 };
 use nebula_storage_port::{
     Scope,
@@ -373,8 +373,7 @@ use nebula_engine::daemon::routing::StaticRoutingResolver;
 
 const TEST_PLUGIN_KEY: &str = "test.dispatch.plugin";
 
-/// Build the shared InMemory dedup+queue core and return the emitter alongside
-/// both adapters for inspection.
+/// Build InMemory dedup + queue + emitter sharing one execution-store core.
 async fn make_emitter(
     stores: &TestStores,
     workflow_id: nebula_core::WorkflowId,
@@ -383,13 +382,11 @@ async fn make_emitter(
     Arc<InMemoryTriggerDedupInbox>,
     Arc<InMemoryJobDispatchQueue>,
 ) {
-    let core = new_shared_core();
-    let dedup = Arc::new(InMemoryTriggerDedupInbox::from_core(core.clone()));
-    let queue = Arc::new(InMemoryJobDispatchQueue::from_core(core));
+    let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&stores.execution));
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
     let resolver = Arc::new(StaticRoutingResolver::new(TEST_PLUGIN_KEY));
     let emitter = DurableExecutionEmitter::new(
         Arc::clone(&dedup) as Arc<dyn TriggerDedupInbox>,
-        Arc::clone(&stores.execution) as Arc<dyn ExecutionStore>,
         resolver,
         workflow_id,
         node_key!("test.trigger"),
@@ -399,7 +396,7 @@ async fn make_emitter(
 }
 
 /// `DurableExecutionEmitter::emit` with `Some(event_id)` produces:
-///  - `DispatchOutcome::Dispatched` (returned as Ok(execution_id))
+///  - `DispatchKind::Dispatched` (returned as Ok(execution_id))
 ///  - A `Created` execution row in the store
 ///  - Exactly one Start row in the job-dispatch queue
 #[tokio::test(start_paused = true)]
@@ -449,8 +446,10 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
     );
 }
 
-/// A second `emit` with the same `event_id` mints a fresh candidate id (ids
-/// DIFFER), writes NO second `Created` row, and enqueues NO second Start job.
+/// A second `emit` with the same `event_id` returns the WINNER's id (same as
+/// `id1`), writes NO second `Created` row, and enqueues NO second Start job.
+/// The dedup-inbox read-back contract: `Duplicate` returns the original
+/// winner's id in-transaction, so callers always hold a valid execution id.
 #[tokio::test(start_paused = true)]
 async fn emitter_duplicate_event_id_no_second_row() {
     let stores = TestStores::new();
@@ -469,13 +468,11 @@ async fn emitter_duplicate_event_id_no_second_row() {
         .await
         .expect("second emit (Duplicate) must succeed");
 
-    // On Duplicate the emitter returns the candidate id minted in the second
-    // call — it cannot retrieve the winner's id from the guard without a
-    // round-trip to the dedup store.  The ids differ; no orphaned Created row
-    // must exist for id2.
-    assert_ne!(
+    // On Duplicate the emitter returns the WINNER's id (id1), read back
+    // from the dedup inbox in-transaction.  Both calls return the same id.
+    assert_eq!(
         id1, id2,
-        "Duplicate emit mints a fresh candidate id — ids must differ"
+        "Duplicate emit must return the original winner's id — both calls must return the same id"
     );
 
     // Only one Start job must be in the queue (the duplicate write is a no-op).
@@ -490,23 +487,16 @@ async fn emitter_duplicate_event_id_no_second_row() {
         jobs.len()
     );
 
-    // The winner's row must exist; the duplicate's candidate id must NOT have a row
-    // (no orphaned Created row on Duplicate).
-    let row1 = stores
+    // The execution row must exist (it was created on the first Dispatched emit).
+    // Both id1 and id2 are the same id so we only need one get.
+    let row = stores
         .execution
         .get(&scope(), &id1.to_string())
         .await
-        .expect("get id1");
-    assert!(row1.is_some(), "winning execution row must exist (id1)");
-
-    let row2 = stores
-        .execution
-        .get(&scope(), &id2.to_string())
-        .await
-        .expect("get id2 (no-op)");
+        .expect("get execution row");
     assert!(
-        row2.is_none(),
-        "Duplicate candidate id must NOT have a Created row — got {row2:?}"
+        row.is_some(),
+        "winner's execution row must exist (id1 == id2 after Duplicate read-back)"
     );
 }
 
@@ -522,15 +512,14 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
     let (engine, echo_count) = make_engine(&stores).await;
     let workflow_id = save_echo_workflow(&stores).await;
 
-    // Wire: shared InMemory dedup+queue core.
-    let core = new_shared_core();
-    let dedup = Arc::new(InMemoryTriggerDedupInbox::from_core(core.clone()));
-    let queue = Arc::new(InMemoryJobDispatchQueue::from_core(core));
+    // Wire: dedup + queue share the execution store's core so all three writes
+    // (dedup guard + execution row + Start job) are atomic under one lock.
+    let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&stores.execution));
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
 
     let resolver = Arc::new(StaticRoutingResolver::new(TEST_PLUGIN_KEY));
     let emitter = DurableExecutionEmitter::new(
         Arc::clone(&dedup) as Arc<dyn TriggerDedupInbox>,
-        Arc::clone(&stores.execution) as Arc<dyn ExecutionStore>,
         resolver,
         workflow_id,
         node_key!("test.trigger"),
@@ -599,8 +588,8 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
     );
 
     // 4. Redelivery of the same event_id must NOT create a second execution.
-    // On Duplicate the emitter returns its own freshly-minted candidate id; the
-    // dedup guard ensures no second row or Start is created.
+    // On Duplicate the emitter returns the WINNER's execution id (same as
+    // execution_id from step 1) — the dedup guard read-back is in-transaction.
     let id2 = emitter
         .emit(
             serde_json::json!({"event": "tick-dup"}),
@@ -608,19 +597,19 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
         )
         .await
         .expect("duplicate emit must return Ok");
-    assert_ne!(
+    assert_eq!(
         execution_id, id2,
-        "Duplicate emit mints a fresh candidate id — ids must differ"
+        "Duplicate emit must return the original winner's id — both calls must return the same id"
     );
-    // No row must exist for the duplicate candidate.
-    let dup_row = stores
+    // The winner's row still exists (the Duplicate did not create a second one).
+    let winner_row = stores
         .execution
         .get(&scope(), &id2.to_string())
         .await
-        .expect("get dup candidate row");
+        .expect("get winner row after duplicate emit");
     assert!(
-        dup_row.is_none(),
-        "Duplicate candidate must NOT have a Created row; got {dup_row:?}"
+        winner_row.is_some(),
+        "winner's row must still exist after Duplicate emit; got {winner_row:?}"
     );
 
     // Handler was not invoked a second time.

--- a/crates/orchestrator/tests/orchestrator_wiring.rs
+++ b/crates/orchestrator/tests/orchestrator_wiring.rs
@@ -35,7 +35,7 @@ use nebula_metrics::{
     },
 };
 use nebula_orchestrator::{ExecutionSink, ExecutionSinkError, Orchestrator};
-use nebula_storage::inmem::{InMemoryJobDispatchQueue, new_shared_core};
+use nebula_storage::inmem::{InMemoryExecutionStore, InMemoryJobDispatchQueue};
 use nebula_storage_port::{
     Scope,
     dto::{CapabilityTag, ControlCommand, JobDispatchMsg},
@@ -56,9 +56,10 @@ fn proc16(label: &[u8]) -> [u8; 16] {
     id
 }
 
-/// Build a fresh `InMemoryJobDispatchQueue` over its own shared core.
+/// Build a fresh `InMemoryJobDispatchQueue` over its own execution store core.
 fn make_queue() -> Arc<InMemoryJobDispatchQueue> {
-    Arc::new(InMemoryJobDispatchQueue::from_core(new_shared_core()))
+    let store = InMemoryExecutionStore::new();
+    Arc::new(InMemoryJobDispatchQueue::new(&store))
 }
 
 fn scope() -> Scope {

--- a/crates/storage-port/src/dto/execution.rs
+++ b/crates/storage-port/src/dto/execution.rs
@@ -2,6 +2,32 @@
 use crate::Scope;
 use serde::{Deserialize, Serialize};
 
+/// Parameters for inserting a new execution row inside a compose transaction.
+///
+/// The execution id is taken from `JobDispatchMsg::execution_id` and the
+/// tenant scope from `JobDispatchMsg::scope` — single source of truth in the
+/// compose method; this struct carries only the fields that differ.
+///
+/// Construct via [`NewExecution::new`]; struct literal syntax is
+/// unavailable from external crates (`#[non_exhaustive]`).
+#[non_exhaustive]
+pub struct NewExecution<'a> {
+    /// Owning workflow id (opaque string form).
+    pub workflow_id: &'a str,
+    /// Initial execution state blob.
+    pub initial_state: &'a serde_json::Value,
+}
+
+impl<'a> NewExecution<'a> {
+    /// Construct a new-execution parameter set.
+    pub fn new(workflow_id: &'a str, initial_state: &'a serde_json::Value) -> Self {
+        Self {
+            workflow_id,
+            initial_state,
+        }
+    }
+}
+
 /// One execution row as the port exposes it.
 ///
 /// `state` is opaque `serde_json::Value` by design: the port never

--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -36,15 +36,42 @@ impl From<&str> for CapabilityTag {
     }
 }
 
-/// Whether a dispatch attempt produced a new dispatch or was deduplicated.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-#[must_use = "callers must inspect whether the dispatch landed or was a duplicate"]
+/// Whether the compose wrote new rows or found an existing dedup guard.
+///
+/// Returned by [`crate::store::TriggerDedupInbox::claim_and_materialize_start`].
+/// The `execution_id` is the EFFECTIVE id — the first winner's id on both
+/// `Dispatched` and `Duplicate` outcomes, so callers always get the canonical
+/// id for the event without a separate read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[must_use = "callers must read the effective execution id and the dispatch kind"]
 #[non_exhaustive]
-pub enum DispatchOutcome {
-    /// The job was enqueued (first writer won).
+pub struct DispatchOutcome {
+    /// The effective execution id: the new row's id on `Dispatched`; the
+    /// original winner's id (read back in-transaction) on `Duplicate`.
+    pub execution_id: String,
+    /// Whether this was the first write or a deduplicated repeat.
+    pub kind: DispatchKind,
+}
+
+impl DispatchOutcome {
+    /// Construct a dispatch outcome.
+    pub fn new(execution_id: impl Into<String>, kind: DispatchKind) -> Self {
+        Self {
+            execution_id: execution_id.into(),
+            kind,
+        }
+    }
+}
+
+/// Whether the compose performed new writes or found the event already handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum DispatchKind {
+    /// All three rows were written atomically (dedup guard + Start job +
+    /// execution row).  First writer wins.
     Dispatched,
-    /// A row with the same `(trigger_id, event_id)` already existed;
-    /// the second write was a no-op.
+    /// A dedup guard for this `(scope, trigger_id, event_id)` was already
+    /// present; no new rows were written.
     Duplicate,
 }
 

--- a/crates/storage-port/src/dto/mod.rs
+++ b/crates/storage-port/src/dto/mod.rs
@@ -17,13 +17,13 @@ mod webhook;
 mod workflow;
 
 pub use control::{ControlCommand, ControlMsg};
-pub use execution::ExecutionRecord;
+pub use execution::{ExecutionRecord, NewExecution};
 pub use idempotency::CachedRecord;
 pub use identity::{
     AuditLogRow, BlobRow, MembershipRow, OrgRow, PrincipalKind, QuotaRow, ResourceRow, ScopeKind,
     TriggerRow, UserRow, WorkspaceRow,
 };
-pub use job_dispatch::{CapabilityTag, DispatchOutcome, JobDispatchMsg};
+pub use job_dispatch::{CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg};
 pub use journal::JournalEntry;
 pub use node_result::{MAX_SUPPORTED_RESULT_SCHEMA_VERSION, NodeResultRecord};
 pub use trigger_dedup::TriggerDedupRow;

--- a/crates/storage-port/src/dto/trigger_dedup.rs
+++ b/crates/storage-port/src/dto/trigger_dedup.rs
@@ -3,6 +3,12 @@
 //! `TriggerDedupRow` is the guard inserted atomically with the `Start` job
 //! to enforce first-writer-wins trigger fan-out.  `event_id` is required and
 //! must be a source-natural idempotency key — never a freshly minted ULID.
+//!
+//! The guarded execution id is NOT carried on this row; it is sourced from
+//! `JobDispatchMsg::execution_id` (the `start` argument passed to
+//! `TriggerDedupInbox::claim_and_materialize_start`) inside each backend's
+//! atomic compose.  This avoids an API trap where a caller could pass a
+//! different id on the row and have it silently ignored.
 use crate::Scope;
 use serde::{Deserialize, Serialize};
 
@@ -12,7 +18,10 @@ use serde::{Deserialize, Serialize};
 /// event_id)` — scoped per tenant, so two tenants sharing the same
 /// `(trigger_id, event_id)` pair are never deduplicated against each other.  A
 /// second delivery of the same event from the same trigger *within one tenant*
-/// finds the row already present and is discarded (`DispatchOutcome::Duplicate`).
+/// finds the row already present and is discarded (`DispatchKind::Duplicate`).
+///
+/// The guarded execution id is sourced from `start.execution_id` inside the
+/// atomic compose, not carried on this struct.
 ///
 /// Construct via [`TriggerDedupRow::new`]; struct literal syntax is
 /// unavailable from external crates (`#[non_exhaustive]`).
@@ -26,30 +35,30 @@ pub struct TriggerDedupRow {
     /// Required (`String`, not `Option`) — a `TriggerDedupRow` is only
     /// created when dedup is desired.  Callers that want unconditional
     /// dispatch pass `None` as the `row` argument to
-    /// `TriggerDedupInbox::claim_and_enqueue_start`.
+    /// `TriggerDedupInbox::claim_and_materialize_start`.
     pub event_id: String,
     /// Tenant scope.
     pub scope: Scope,
-    /// The execution that was started as a result of this trigger event.
-    pub execution_id: String,
     /// Wall-clock creation time (RFC 3339).
     pub created_at: String,
 }
 
 impl TriggerDedupRow {
     /// Construct a trigger-dedup guard row.
+    ///
+    /// The execution id guarded by this row is supplied separately as
+    /// `start.execution_id` in `claim_and_materialize_start` — it is not
+    /// a parameter here.
     pub fn new(
         trigger_id: impl Into<String>,
         event_id: impl Into<String>,
         scope: Scope,
-        execution_id: impl Into<String>,
         created_at: impl Into<String>,
     ) -> Self {
         Self {
             trigger_id: trigger_id.into(),
             event_id: event_id.into(),
             scope,
-            execution_id: execution_id.into(),
             created_at: created_at.into(),
         }
     }

--- a/crates/storage-port/src/store/trigger_dedup.rs
+++ b/crates/storage-port/src/store/trigger_dedup.rs
@@ -1,44 +1,59 @@
 //! Trigger-dedup inbox port.
 //!
-//! The atomic compose method (`claim_and_enqueue_start`) inserts the dedup
-//! guard row and the `Start` job-dispatch row in a single transaction, so
-//! the first-writer-wins invariant and the job enqueue are inseparable.
+//! The atomic compose method (`claim_and_materialize_start`) inserts the
+//! dedup guard row, the `Start` job-dispatch row, and the `Created` execution
+//! row in **one transaction** — dedup-guard ∧ Start-job ∧ execution-row are
+//! inseparable.  On `Duplicate`, the winner's execution id is read back
+//! in-transaction so the caller receives the canonical id without a second
+//! round-trip.
 use std::time::Duration;
 
 use crate::Scope;
-use crate::dto::{DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use crate::dto::{DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow};
 use crate::error::StorageError;
 
 /// Trigger-dedup inbox: first-writer-wins guard for trigger fan-out.
 ///
 /// The `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` constraint
 /// is the CAS.  A second delivery of the same event **within the same tenant
-/// scope** finds the row present and returns `DispatchOutcome::Duplicate`
-/// without enqueuing a second job.  Two distinct tenants sharing the same
-/// `(trigger_id, event_id)` pair are NOT deduplicated — the scope columns
-/// ensure cross-tenant isolation.
+/// scope** finds the row present and returns a `DispatchOutcome` with
+/// `kind == Duplicate` and the original winner's execution id — no new rows
+/// are written.  Two distinct tenants sharing the same `(trigger_id, event_id)`
+/// pair are NOT deduplicated — the scope columns ensure cross-tenant isolation.
 ///
-/// Both methods are object-safe (concrete params only, no generics).
+/// Both methods are object-safe (concrete params only, no generics on methods).
 #[async_trait::async_trait]
 pub trait TriggerDedupInbox: Send + Sync + std::fmt::Debug {
-    /// Atomically insert the dedup guard row (when `row` is `Some`) **and**
-    /// the `Start` job-dispatch row in **one transaction**.
+    /// Atomically insert three rows in **one transaction** and return the
+    /// effective execution id.
     ///
-    /// - `row = None` — unconditional dispatch: insert `start` into the job
-    ///   queue with no dedup row.  Always returns `Dispatched`.
-    /// - `row = Some(r)` — guarded dispatch: attempt
-    ///   `INSERT INTO port_trigger_dedup_inbox … ON CONFLICT DO NOTHING`.
-    ///   If the row was inserted (affected == 1) then also insert `start` and
-    ///   return `Dispatched`.  If the row was already present (affected == 0)
-    ///   skip the job insert and return `Duplicate`.
+    /// **Compose ordering (all backends):**
     ///
-    /// This method **owns** both writes and **must not** call
-    /// [`crate::store::JobDispatchQueue::enqueue`] — doing so would require a
-    /// second connection and break atomicity.
-    async fn claim_and_enqueue_start(
+    /// 1. If `row` is `Some`, attempt the dedup `INSERT … ON CONFLICT DO NOTHING`.
+    ///    - `affected == 0` (row already present): read back the winner's
+    ///      `execution_id` from the dedup table in the same transaction, then
+    ///      return `DispatchOutcome::new(winner_id, Duplicate)` — no further
+    ///      writes.
+    ///    - `affected == 1` (first writer): continue to steps 2–3.
+    /// 2. INSERT the execution row (`port_executions`, status='Created',
+    ///    version=0, fencing_generation=0).  The execution id and scope come
+    ///    from `start.execution_id` and `start.scope`.  If this INSERT fails
+    ///    (e.g. id collision), the whole transaction rolls back — no dedup row,
+    ///    no job row.
+    /// 3. INSERT the `Start` job-dispatch row into `port_job_dispatch_queue`.
+    /// 4. Commit and return `DispatchOutcome::new(start.execution_id, Dispatched)`.
+    ///
+    /// `row = None` skips the dedup guard and always performs steps 2–4.
+    ///
+    /// This method **owns** all three writes and **must not** call
+    /// [`crate::store::JobDispatchQueue::enqueue`] or
+    /// [`crate::store::ExecutionStore::create`] — doing so would require
+    /// separate connections and break atomicity.
+    async fn claim_and_materialize_start(
         &self,
         row: Option<&TriggerDedupRow>,
         start: &JobDispatchMsg,
+        execution: &NewExecution<'_>,
     ) -> Result<DispatchOutcome, StorageError>;
 
     /// Returns `true` when a dedup row with the given

--- a/crates/storage/src/inmem/execution.rs
+++ b/crates/storage/src/inmem/execution.rs
@@ -5,7 +5,8 @@
 //! observable through the queue / reader (the conformance suite asserts
 //! this atomic-triple visibility).
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -50,6 +51,20 @@ pub(super) struct QueuedMsg {
     pub(super) error_message: Option<String>,
 }
 
+/// One queued job-dispatch row plus its processing bookkeeping.
+///
+/// Lives in `State::jobs` alongside the control queue and execution rows so
+/// `claim_and_materialize_start` writes all three atomically under one lock.
+#[derive(Debug, Clone)]
+pub(super) struct QueuedJob {
+    pub(super) msg: nebula_storage_port::dto::JobDispatchMsg,
+    pub(super) status: String,
+    pub(super) processed_by: Option<[u8; 16]>,
+    pub(super) processed_at: Option<Instant>,
+    pub(super) reclaim_count: u32,
+    pub(super) error_message: Option<String>,
+}
+
 #[derive(Debug, Default)]
 pub(super) struct State {
     pub(super) rows: HashMap<String, Row>,
@@ -57,6 +72,12 @@ pub(super) struct State {
     pub(super) queue: HashMap<[u8; 16], QueuedMsg>,
     /// Per-execution next journal sequence number.
     pub(super) next_seq: HashMap<String, u64>,
+    /// Job-dispatch queue rows keyed by the message's 16-byte id.
+    pub(super) jobs: HashMap<[u8; 16], QueuedJob>,
+    /// Dedup guard set: `(workspace_id, org_id, trigger_id, event_id)` →
+    /// winner execution_id.  The value enables Duplicate read-back without a
+    /// separate store lookup.
+    pub(super) dedup: HashMap<(String, String, String, String), String>,
 }
 
 /// Shared mutable core. One mutex guards the whole store so a `commit`
@@ -92,6 +113,43 @@ fn normalized_ttl(ttl: Duration) -> Duration {
     Duration::from_secs_f64(ttl.as_secs_f64().clamp(1.0, 86_400.0))
 }
 
+/// Insert a `Created` execution row into `st` without taking the lock.
+///
+/// Called by both `ExecutionStore::create` and the dedup compose so the row
+/// shape is defined exactly once.  Returns `Err(Duplicate)` when `id` is
+/// already present — the compose uses this as its all-or-nothing precondition
+/// check (the dedup insert already committed its slot; an id collision here
+/// rolls back the compose by propagating the error).
+pub(super) fn insert_created_row(
+    st: &mut State,
+    scope: &Scope,
+    id: &str,
+    workflow_id: &str,
+    initial_state: &serde_json::Value,
+) -> Result<(), StorageError> {
+    if st.rows.contains_key(id) {
+        return Err(StorageError::Duplicate {
+            entity: "execution",
+            detail: format!("execution {id} already exists"),
+        });
+    }
+    st.rows.insert(
+        id.to_owned(),
+        Row {
+            scope: scope.clone(),
+            workflow_id: workflow_id.to_owned(),
+            version: 0,
+            status: "Created".to_owned(),
+            state: initial_state.clone(),
+            lease_holder: None,
+            lease_expires_at: None,
+            fencing_generation: 0,
+            journal: Vec::new(),
+        },
+    );
+    Ok(())
+}
+
 #[async_trait::async_trait]
 impl ExecutionStore for InMemoryExecutionStore {
     async fn create(
@@ -102,26 +160,7 @@ impl ExecutionStore for InMemoryExecutionStore {
         initial_state: serde_json::Value,
     ) -> Result<(), StorageError> {
         let mut st = self.inner.lock();
-        if st.rows.contains_key(id) {
-            return Err(StorageError::Duplicate {
-                entity: "execution",
-                detail: format!("execution {id} already exists"),
-            });
-        }
-        st.rows.insert(
-            id.to_string(),
-            Row {
-                scope: scope.clone(),
-                workflow_id: workflow_id.to_string(),
-                version: 0,
-                status: "Created".to_string(),
-                state: initial_state,
-                lease_holder: None,
-                lease_expires_at: None,
-                fencing_generation: 0,
-                journal: Vec::new(),
-            },
-        );
+        insert_created_row(&mut st, scope, id, workflow_id, &initial_state)?;
         tracing::debug!(
             target: "nebula_storage::inmem",
             execution_id = id,

--- a/crates/storage/src/inmem/execution.rs
+++ b/crates/storage/src/inmem/execution.rs
@@ -117,9 +117,10 @@ fn normalized_ttl(ttl: Duration) -> Duration {
 ///
 /// Called by both `ExecutionStore::create` and the dedup compose so the row
 /// shape is defined exactly once.  Returns `Err(Duplicate)` when `id` is
-/// already present — the compose uses this as its all-or-nothing precondition
-/// check (the dedup insert already committed its slot; an id collision here
-/// rolls back the compose by propagating the error).
+/// already present.  The dedup compose calls this **before** writing the dedup
+/// guard or the Start job (all under one lock), so an `Err` here leaves
+/// `st.dedup` and `st.jobs` untouched — the compose is all-or-nothing by write
+/// ordering, with no rollback needed.
 pub(super) fn insert_created_row(
     st: &mut State,
     scope: &Scope,

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -1,81 +1,42 @@
-//! In-memory `JobDispatchQueue` + `TriggerDedupInbox` over a shared core.
+//! In-memory `JobDispatchQueue` + `TriggerDedupInbox` over the shared
+//! execution-store core.
 //!
-//! Both adapters wrap the same [`SharedDispatchCore`] so
-//! `claim_and_enqueue_start` performs the dedup-insert ∧ job-insert in one
-//! critical section — mirroring how `InMemoryControlQueue` shares
-//! `InMemoryExecutionStore`'s core.
+//! Both adapters wrap the same [`SharedState`] as the execution store and
+//! control queue, so `claim_and_materialize_start` writes the dedup guard,
+//! the execution row, and the Start job atomically in one critical section —
+//! mirroring how `InMemoryControlQueue` shares `InMemoryExecutionStore`'s core.
 
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use std::time::Duration;
 
-use parking_lot::Mutex;
 use tokio::time::Instant;
 
-use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::dto::{
+    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+};
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
 
-// ── shared core ─────────────────────────────────────────────────────────────
-
-/// One queued job row plus its processing bookkeeping.
-#[derive(Debug, Clone)]
-struct QueuedJob {
-    msg: JobDispatchMsg,
-    status: String,
-    processed_by: Option<[u8; 16]>,
-    processed_at: Option<Instant>,
-    reclaim_count: u32,
-    error_message: Option<String>,
-}
-
-#[derive(Debug, Default)]
-struct Core {
-    /// Job-dispatch queue rows keyed by the message's 16-byte id.
-    jobs: HashMap<[u8; 16], QueuedJob>,
-    /// Dedup guard set keyed by `(workspace_id, org_id, trigger_id, event_id)`.
-    ///
-    /// The scope columns are part of the key — identical `(trigger_id, event_id)`
-    /// values under different tenants are independent entries, mirroring the
-    /// `PRIMARY KEY (workspace_id, org_id, trigger_id, event_id)` constraint in
-    /// both the SQLite and Postgres schemas.
-    dedup: HashSet<(String, String, String, String)>,
-}
-
-/// Opaque shared dispatch core handle.
-///
-/// Both [`InMemoryJobDispatchQueue`] and [`InMemoryTriggerDedupInbox`] wrap
-/// this handle so `claim_and_enqueue_start` operates in one critical section.
-/// Construct with [`new_shared_core`] and pass the clone to both adapters.
-#[derive(Debug, Clone)]
-pub struct SharedDispatchCore(Arc<Mutex<Core>>);
-
-/// Construct a fresh shared dispatch core.  Pass the same handle to
-/// [`InMemoryJobDispatchQueue::from_core`] and
-/// [`InMemoryTriggerDedupInbox::from_core`].
-#[must_use]
-pub fn new_shared_core() -> SharedDispatchCore {
-    SharedDispatchCore(Arc::new(Mutex::new(Core::default())))
-}
+use super::execution::{QueuedJob, SharedState, insert_created_row};
 
 // ── JobDispatchQueue ─────────────────────────────────────────────────────────
 
 /// In-memory job-dispatch queue handle.
+///
+/// Shares the execution store's core so `claim_and_materialize_start` (on the
+/// dedup inbox side) operates in one critical section with the execution row
+/// and job inserts.
 #[derive(Debug, Clone)]
 pub struct InMemoryJobDispatchQueue {
-    core: SharedDispatchCore,
+    inner: SharedState,
 }
 
 impl InMemoryJobDispatchQueue {
-    /// Build from an existing shared core (share with
-    /// [`InMemoryTriggerDedupInbox`] so `claim_and_enqueue_start` is atomic).
+    /// Build a job-dispatch queue over an execution store's shared core.
     #[must_use]
-    pub fn from_core(core: SharedDispatchCore) -> Self {
-        Self { core }
-    }
-
-    fn lock(&self) -> parking_lot::MutexGuard<'_, Core> {
-        self.core.0.lock()
+    pub fn new(store: &super::InMemoryExecutionStore) -> Self {
+        Self {
+            inner: store.shared(),
+        }
     }
 }
 
@@ -83,7 +44,7 @@ impl InMemoryJobDispatchQueue {
 impl JobDispatchQueue for InMemoryJobDispatchQueue {
     #[tracing::instrument(level = "debug", skip(self, msg), fields(id = ?msg.id, command = msg.command.as_str()))]
     async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
-        let mut st = self.lock();
+        let mut st = self.inner.lock();
         st.jobs.insert(
             msg.id,
             QueuedJob {
@@ -106,7 +67,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         batch_size: u32,
         advertised_tags: &[CapabilityTag],
     ) -> Result<Vec<JobDispatchMsg>, StorageError> {
-        let mut st = self.lock();
+        let mut st = self.inner.lock();
         let now = Instant::now();
 
         // Stable order so a bounded batch is deterministic across calls.
@@ -146,7 +107,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         id: &[u8; 16],
         processor: &[u8; 16],
     ) -> Result<(), StorageError> {
-        let mut st = self.lock();
+        let mut st = self.inner.lock();
         if let Some(q) = st.jobs.get_mut(id)
             && q.status == "Processing"
             && q.processed_by.as_ref() == Some(processor)
@@ -162,7 +123,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         processor: &[u8; 16],
         error: &str,
     ) -> Result<(), StorageError> {
-        let mut st = self.lock();
+        let mut st = self.inner.lock();
         if let Some(q) = st.jobs.get_mut(id)
             && q.status == "Processing"
             && q.processed_by.as_ref() == Some(processor)
@@ -178,7 +139,7 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         reclaim_after: Duration,
         max_reclaim_count: u32,
     ) -> Result<ReclaimOutcome, StorageError> {
-        let mut st = self.lock();
+        let mut st = self.inner.lock();
         let now = Instant::now();
         let mut outcome = ReclaimOutcome::default();
         for q in st.jobs.values_mut() {
@@ -220,59 +181,95 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
 
 // ── TriggerDedupInbox ────────────────────────────────────────────────────────
 
-/// In-memory trigger-dedup inbox handle.  Shares `core` with
-/// [`InMemoryJobDispatchQueue`] so `claim_and_enqueue_start` is one
-/// critical section.
+/// In-memory trigger-dedup inbox handle.
+///
+/// Shares the execution store's core with [`InMemoryJobDispatchQueue`] so
+/// `claim_and_materialize_start` writes all three rows atomically under one
+/// lock.
 #[derive(Debug, Clone)]
 pub struct InMemoryTriggerDedupInbox {
-    core: SharedDispatchCore,
+    inner: SharedState,
 }
 
 impl InMemoryTriggerDedupInbox {
-    /// Build from an existing shared core (share with
-    /// [`InMemoryJobDispatchQueue`] so `claim_and_enqueue_start` is atomic).
+    /// Build a trigger-dedup inbox over an execution store's shared core.
     #[must_use]
-    pub fn from_core(core: SharedDispatchCore) -> Self {
-        Self { core }
-    }
-
-    fn lock(&self) -> parking_lot::MutexGuard<'_, Core> {
-        self.core.0.lock()
+    pub fn new(store: &super::InMemoryExecutionStore) -> Self {
+        Self {
+            inner: store.shared(),
+        }
     }
 }
 
 #[async_trait::async_trait]
 impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
-    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
+    #[tracing::instrument(level = "debug", skip(self, row, start, execution), fields(
         trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
         event_id   = row.as_ref().map(|r| r.event_id.as_str()),
         job_id     = ?start.id,
+        execution_id = start.execution_id.as_str(),
     ))]
-    async fn claim_and_enqueue_start(
+    async fn claim_and_materialize_start(
         &self,
         row: Option<&TriggerDedupRow>,
         start: &JobDispatchMsg,
+        execution: &NewExecution<'_>,
     ) -> Result<DispatchOutcome, StorageError> {
-        let mut st = self.lock();
-        // One critical section — both writes are inside the same lock.
-        if let Some(r) = row {
-            let key = (
+        let mut st = self.inner.lock();
+
+        // All three writes are inside one critical section (the parking_lot
+        // Mutex guard).
+        //
+        // Write order is important: `insert_created_row` MUST succeed before we
+        // write to `st.dedup`.  The Mutex is not a database transaction — there
+        // is no rollback.  If we inserted the dedup key first and then
+        // `insert_created_row` failed (id collision), the dedup entry would stay
+        // permanently, making the trigger permanently stuck as a "duplicate".
+        //
+        // Correct order:
+        //  1. Duplicate check (read-only)
+        //  2. insert_created_row — return Err immediately on failure; dedup untouched
+        //  3. st.dedup.insert — only reachable on success
+        //  4. st.jobs.insert
+
+        // Step 1: check for an existing dedup winner and return early.
+        let dedup_key = row.as_ref().map(|r| {
+            (
                 r.scope.workspace_id.clone(),
                 r.scope.org_id.clone(),
                 r.trigger_id.clone(),
                 r.event_id.clone(),
+            )
+        });
+        if let (Some(r), Some(key)) = (row, &dedup_key)
+            && let Some(winner_id) = st.dedup.get(key)
+        {
+            let winner_id = winner_id.clone();
+            tracing::debug!(
+                target: "nebula_storage::inmem",
+                trigger_id = %r.trigger_id,
+                event_id   = %r.event_id,
+                winner_execution_id = %winner_id,
+                "trigger_dedup: duplicate — returning winner id"
             );
-            if st.dedup.contains(&key) {
-                tracing::debug!(
-                    target: "nebula_storage::inmem",
-                    trigger_id = %r.trigger_id,
-                    event_id   = %r.event_id,
-                    "trigger_dedup: duplicate"
-                );
-                return Ok(DispatchOutcome::Duplicate);
-            }
-            st.dedup.insert(key);
+            return Ok(DispatchOutcome::new(winner_id, DispatchKind::Duplicate));
         }
+
+        // Step 2: insert the execution row — fail-closed before touching dedup.
+        // An id collision returns Err; neither dedup nor job maps are modified.
+        insert_created_row(
+            &mut st,
+            &start.scope,
+            &start.execution_id,
+            execution.workflow_id,
+            execution.initial_state,
+        )?;
+
+        // Step 3: claim the dedup slot (only reachable on success).
+        if let Some(key) = dedup_key {
+            st.dedup.insert(key, start.execution_id.clone());
+        }
+
         st.jobs.insert(
             start.id,
             QueuedJob {
@@ -287,9 +284,13 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
         tracing::debug!(
             target: "nebula_storage::inmem",
             job_id = ?start.id,
-            "trigger_dedup: dispatched"
+            execution_id = %start.execution_id,
+            "trigger_dedup: materialized (dedup guard + execution row + Start job)"
         );
-        Ok(DispatchOutcome::Dispatched)
+        Ok(DispatchOutcome::new(
+            start.execution_id.clone(),
+            DispatchKind::Dispatched,
+        ))
     }
 
     async fn exists(
@@ -298,15 +299,14 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
         trigger_id: &str,
         event_id: &str,
     ) -> Result<bool, StorageError> {
-        let st = self.lock();
+        let st = self.inner.lock();
         let key = (
             scope.workspace_id.clone(),
             scope.org_id.clone(),
             trigger_id.to_owned(),
             event_id.to_owned(),
         );
-        let found = st.dedup.contains(&key);
-        Ok(found)
+        Ok(st.dedup.contains_key(&key))
     }
 
     async fn cleanup(&self, _retention: Duration) -> Result<u64, StorageError> {

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -255,6 +255,19 @@ impl TriggerDedupInbox for InMemoryTriggerDedupInbox {
             return Ok(DispatchOutcome::new(winner_id, DispatchKind::Duplicate));
         }
 
+        // Step 1b: reject a colliding job-dispatch id BEFORE materializing
+        // anything. The SQL backends hit the job-dispatch primary key and roll
+        // the whole transaction back, so the in-memory backend must fail closed
+        // here too — otherwise the unconditional `st.jobs.insert` below would
+        // silently overwrite the already-queued job and still report
+        // `Dispatched`, diverging from SQL and losing the original job.
+        if st.jobs.contains_key(&start.id) {
+            return Err(StorageError::Duplicate {
+                entity: "job_dispatch",
+                detail: format!("job-dispatch id {:?} already queued", start.id),
+            });
+        }
+
         // Step 2: insert the execution row — fail-closed before touching dedup.
         // An id collision returns Err; neither dedup nor job maps are modified.
         insert_created_row(

--- a/crates/storage/src/inmem/mod.rs
+++ b/crates/storage/src/inmem/mod.rs
@@ -25,9 +25,7 @@ pub use identity::{
     InMemoryQuotaStore, InMemoryResourceStore, InMemoryTriggerStore, InMemoryUserStore,
     InMemoryWorkspaceStore,
 };
-pub use job_dispatch::{
-    InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox, SharedDispatchCore, new_shared_core,
-};
+pub use job_dispatch::{InMemoryJobDispatchQueue, InMemoryTriggerDedupInbox};
 pub use journal::InMemoryJournalReader;
 pub use node_result::{InMemoryCheckpointStore, InMemoryNodeResultStore};
 pub use workflow::{InMemoryWorkflowStore, InMemoryWorkflowVersionStore};

--- a/crates/storage/src/postgres/execution.rs
+++ b/crates/storage/src/postgres/execution.rs
@@ -15,6 +15,46 @@ use nebula_storage_port::store::{ExecutionStore, IdempotencyGuard};
 use nebula_storage_port::{FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome};
 use sqlx::{PgPool, Row};
 
+/// Insert a `Created` execution row inside an existing transaction.
+///
+/// Called by both `ExecutionStore::create` (via a single-statement tx) and the
+/// dedup compose so the `port_executions` INSERT shape is defined exactly once.
+/// A unique-violation maps to `StorageError::Duplicate` so both call sites
+/// propagate it uniformly.
+pub(super) async fn insert_created_execution(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    scope: &Scope,
+    id: &str,
+    workflow_id: &str,
+    initial_state: &serde_json::Value,
+) -> Result<(), StorageError> {
+    let now = Utc::now();
+    let res = sqlx::query(
+        "INSERT INTO port_executions \
+         (id, workspace_id, org_id, workflow_id, status, state, version, \
+          fencing_generation, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, 'Created', $5, 0, 0, $6, $6)",
+    )
+    .bind(id)
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .bind(workflow_id)
+    .bind(initial_state)
+    .bind(now)
+    .execute(&mut **tx)
+    .await;
+    match res {
+        Ok(_) => Ok(()),
+        Err(sqlx::Error::Database(db)) if db.is_unique_violation() => {
+            Err(StorageError::Duplicate {
+                entity: "execution",
+                detail: format!("execution {id} already exists"),
+            })
+        },
+        Err(e) => Err(conn_err(e)),
+    }
+}
+
 /// Postgres-backed execution aggregate. Wrap a pool whose schema was
 /// installed via [`super::init_schema`].
 #[derive(Clone, Debug)]
@@ -63,39 +103,16 @@ impl ExecutionStore for PgExecutionStore {
         workflow_id: &str,
         initial_state: serde_json::Value,
     ) -> Result<(), StorageError> {
-        let now = Utc::now();
-        let res = sqlx::query(
-            "INSERT INTO port_executions \
-             (id, workspace_id, org_id, workflow_id, status, state, version, \
-              fencing_generation, created_at, updated_at) \
-             VALUES ($1, $2, $3, $4, 'Created', $5, 0, 0, $6, $6)",
-        )
-        .bind(id)
-        .bind(&scope.workspace_id)
-        .bind(&scope.org_id)
-        .bind(workflow_id)
-        .bind(&initial_state)
-        .bind(now)
-        .execute(&self.pool)
-        .await;
-        match res {
-            Ok(_) => {
-                tracing::debug!(
-                    target: "nebula_storage::postgres",
-                    execution_id = id,
-                    workflow_id,
-                    "execution created"
-                );
-                Ok(())
-            },
-            Err(sqlx::Error::Database(db)) if db.is_unique_violation() => {
-                Err(StorageError::Duplicate {
-                    entity: "execution",
-                    detail: format!("execution {id} already exists"),
-                })
-            },
-            Err(e) => Err(conn_err(e)),
-        }
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+        insert_created_execution(&mut tx, scope, id, workflow_id, &initial_state).await?;
+        tx.commit().await.map_err(conn_err)?;
+        tracing::debug!(
+            target: "nebula_storage::postgres",
+            execution_id = id,
+            workflow_id,
+            "execution created"
+        );
+        Ok(())
     }
 
     async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -9,12 +9,14 @@
 use std::time::Duration;
 
 use chrono::Utc;
-use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::dto::{
+    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+};
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
 use sqlx::{PgPool, Row};
 
-use super::execution::conn_err;
+use super::execution::{conn_err, insert_created_execution};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -294,17 +296,23 @@ impl PgTriggerDedupInbox {
 
 #[async_trait::async_trait]
 impl TriggerDedupInbox for PgTriggerDedupInbox {
-    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
-        trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
-        event_id   = row.as_ref().map(|r| r.event_id.as_str()),
-        job_id     = ?start.id,
+    #[tracing::instrument(level = "debug", skip(self, row, start, execution), fields(
+        trigger_id   = row.as_ref().map(|r| r.trigger_id.as_str()),
+        event_id     = row.as_ref().map(|r| r.event_id.as_str()),
+        job_id       = ?start.id,
+        execution_id = start.execution_id.as_str(),
     ))]
-    async fn claim_and_enqueue_start(
+    async fn claim_and_materialize_start(
         &self,
         row: Option<&TriggerDedupRow>,
         start: &JobDispatchMsg,
+        execution: &NewExecution<'_>,
     ) -> Result<DispatchOutcome, StorageError> {
         let tags = tags_to_json(&start.capability_tags);
+
+        // All three writes live inside one transaction — atomicity by
+        // construction.  An error from any write propagates via `?` and rolls
+        // back the whole transaction.
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         if let Some(r) = row {
@@ -322,7 +330,10 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
             .bind(&r.scope.org_id)
             .bind(&r.trigger_id)
             .bind(&r.event_id)
-            .bind(&r.execution_id)
+            // Bind `start.execution_id`, not `r.execution_id` — the dedup guard must
+            // record the id that the Start job uses so the SELECT read-back on the
+            // Duplicate path returns the first writer's effective execution id.
+            .bind(&start.execution_id)
             .bind(&r.created_at)
             .execute(&mut *tx)
             .await
@@ -330,18 +341,50 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
             .rows_affected();
 
             if affected == 0 {
+                // Duplicate: read the winner's execution_id back in the same
+                // transaction so the caller has the canonical id without a
+                // second connection.
+                let winner_id: String = sqlx::query(
+                    "SELECT execution_id FROM port_trigger_dedup_inbox \
+                     WHERE workspace_id = $1 AND org_id = $2 \
+                       AND trigger_id = $3 AND event_id = $4",
+                )
+                .bind(&r.scope.workspace_id)
+                .bind(&r.scope.org_id)
+                .bind(&r.trigger_id)
+                .bind(&r.event_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(conn_err)?
+                .try_get("execution_id")
+                .map_err(conn_err)?;
+
                 tx.commit().await.map_err(conn_err)?;
                 tracing::debug!(
                     target: "nebula_storage::postgres",
                     trigger_id = %r.trigger_id,
                     event_id   = %r.event_id,
-                    "trigger_dedup: duplicate"
+                    winner_execution_id = %winner_id,
+                    "trigger_dedup: duplicate — returning winner id"
                 );
-                return Ok(DispatchOutcome::Duplicate);
+                return Ok(DispatchOutcome::new(winner_id, DispatchKind::Duplicate));
             }
         }
 
-        // Insert the Start job in the same transaction.
+        // Insert the execution row (status='Created', version=0,
+        // fencing_generation=0).  Id + scope come from `start`.
+        // A unique-violation here rolls back the whole transaction — no dedup
+        // row, no job row.
+        insert_created_execution(
+            &mut tx,
+            &start.scope,
+            &start.execution_id,
+            execution.workflow_id,
+            execution.initial_state,
+        )
+        .await?;
+
+        // Insert the Start job (same transaction).
         sqlx::query(
             "INSERT INTO port_job_dispatch_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
@@ -369,9 +412,13 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
         tracing::debug!(
             target: "nebula_storage::postgres",
             job_id = ?start.id,
-            "trigger_dedup: dispatched"
+            execution_id = %start.execution_id,
+            "trigger_dedup: materialized (dedup guard + execution row + Start job)"
         );
-        Ok(DispatchOutcome::Dispatched)
+        Ok(DispatchOutcome::new(
+            start.execution_id.clone(),
+            DispatchKind::Dispatched,
+        ))
     }
 
     async fn exists(

--- a/crates/storage/src/sqlite/execution.rs
+++ b/crates/storage/src/sqlite/execution.rs
@@ -48,6 +48,48 @@ fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
+/// Insert a `Created` execution row inside an existing transaction.
+///
+/// Called by both `ExecutionStore::create` (via a single-statement tx) and
+/// the dedup compose so the `port_executions` INSERT shape is defined exactly
+/// once.  A unique-violation maps to `StorageError::Duplicate` so both call
+/// sites propagate it uniformly.
+pub(super) async fn insert_created_execution(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    scope: &Scope,
+    id: &str,
+    workflow_id: &str,
+    initial_state: &serde_json::Value,
+) -> Result<(), StorageError> {
+    let state = serde_json::to_string(initial_state)?;
+    let ts = now_rfc3339();
+    let res = sqlx::query(
+        "INSERT INTO port_executions \
+         (id, workspace_id, org_id, workflow_id, status, state, version, \
+          fencing_generation, created_at, updated_at) \
+         VALUES (?, ?, ?, ?, 'Created', ?, 0, 0, ?, ?)",
+    )
+    .bind(id)
+    .bind(&scope.workspace_id)
+    .bind(&scope.org_id)
+    .bind(workflow_id)
+    .bind(&state)
+    .bind(&ts)
+    .bind(&ts)
+    .execute(&mut **tx)
+    .await;
+    match res {
+        Ok(_) => Ok(()),
+        Err(sqlx::Error::Database(db)) if db.is_unique_violation() => {
+            Err(StorageError::Duplicate {
+                entity: "execution",
+                detail: format!("execution {id} already exists"),
+            })
+        },
+        Err(e) => Err(conn_err(e)),
+    }
+}
+
 #[async_trait::async_trait]
 impl ExecutionStore for SqliteExecutionStore {
     async fn create(
@@ -57,41 +99,16 @@ impl ExecutionStore for SqliteExecutionStore {
         workflow_id: &str,
         initial_state: serde_json::Value,
     ) -> Result<(), StorageError> {
-        let state = serde_json::to_string(&initial_state)?;
-        let ts = now_rfc3339();
-        let res = sqlx::query(
-            "INSERT INTO port_executions \
-             (id, workspace_id, org_id, workflow_id, status, state, version, \
-              fencing_generation, created_at, updated_at) \
-             VALUES (?, ?, ?, ?, 'Created', ?, 0, 0, ?, ?)",
-        )
-        .bind(id)
-        .bind(&scope.workspace_id)
-        .bind(&scope.org_id)
-        .bind(workflow_id)
-        .bind(&state)
-        .bind(&ts)
-        .bind(&ts)
-        .execute(&self.pool)
-        .await;
-        match res {
-            Ok(_) => {
-                tracing::debug!(
-                    target: "nebula_storage::sqlite",
-                    execution_id = id,
-                    workflow_id,
-                    "execution created"
-                );
-                Ok(())
-            },
-            Err(sqlx::Error::Database(db)) if db.is_unique_violation() => {
-                Err(StorageError::Duplicate {
-                    entity: "execution",
-                    detail: format!("execution {id} already exists"),
-                })
-            },
-            Err(e) => Err(conn_err(e)),
-        }
+        let mut tx = self.pool.begin().await.map_err(conn_err)?;
+        insert_created_execution(&mut tx, scope, id, workflow_id, &initial_state).await?;
+        tx.commit().await.map_err(conn_err)?;
+        tracing::debug!(
+            target: "nebula_storage::sqlite",
+            execution_id = id,
+            workflow_id,
+            "execution created"
+        );
+        Ok(())
     }
 
     async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -10,12 +10,14 @@
 
 use std::time::Duration;
 
-use nebula_storage_port::dto::{CapabilityTag, DispatchOutcome, JobDispatchMsg, TriggerDedupRow};
+use nebula_storage_port::dto::{
+    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+};
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
 use sqlx::{Row, SqlitePool};
 
-use crate::sqlite::execution::conn_err;
+use crate::sqlite::execution::{conn_err, insert_created_execution};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -312,21 +314,25 @@ impl SqliteTriggerDedupInbox {
 
 #[async_trait::async_trait]
 impl TriggerDedupInbox for SqliteTriggerDedupInbox {
-    #[tracing::instrument(level = "debug", skip(self, row, start), fields(
-        trigger_id = row.as_ref().map(|r| r.trigger_id.as_str()),
-        event_id   = row.as_ref().map(|r| r.event_id.as_str()),
-        job_id     = ?start.id,
+    #[tracing::instrument(level = "debug", skip(self, row, start, execution), fields(
+        trigger_id   = row.as_ref().map(|r| r.trigger_id.as_str()),
+        event_id     = row.as_ref().map(|r| r.event_id.as_str()),
+        job_id       = ?start.id,
+        execution_id = start.execution_id.as_str(),
     ))]
-    async fn claim_and_enqueue_start(
+    async fn claim_and_materialize_start(
         &self,
         row: Option<&TriggerDedupRow>,
         start: &JobDispatchMsg,
+        execution: &NewExecution<'_>,
     ) -> Result<DispatchOutcome, StorageError> {
         let payload = serde_json::to_string(&start.payload)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
         let tags = tags_to_json(&start.capability_tags);
 
-        // Both writes live inside one transaction — atomicity by construction.
+        // All three writes live inside one transaction — atomicity by
+        // construction.  An error from any write propagates via `?` and rolls
+        // back the whole transaction (sqlx drops the connection on error).
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         if let Some(r) = row {
@@ -343,7 +349,10 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
             .bind(&r.scope.org_id)
             .bind(&r.trigger_id)
             .bind(&r.event_id)
-            .bind(&r.execution_id)
+            // Bind `start.execution_id`, not `r.execution_id` — the dedup guard must
+            // record the id that the Start job uses so the SELECT read-back on the
+            // Duplicate path returns the first writer's effective execution id.
+            .bind(&start.execution_id)
             .bind(&r.created_at)
             .execute(&mut *tx)
             .await
@@ -351,16 +360,48 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
             .rows_affected();
 
             if affected == 0 {
+                // Duplicate: read the winner's execution_id back in the same
+                // transaction so the caller has the canonical id without a
+                // second connection.
+                let winner_id: String = sqlx::query(
+                    "SELECT execution_id FROM port_trigger_dedup_inbox \
+                     WHERE workspace_id = ? AND org_id = ? \
+                       AND trigger_id = ? AND event_id = ?",
+                )
+                .bind(&r.scope.workspace_id)
+                .bind(&r.scope.org_id)
+                .bind(&r.trigger_id)
+                .bind(&r.event_id)
+                .fetch_one(&mut *tx)
+                .await
+                .map_err(conn_err)?
+                .try_get("execution_id")
+                .map_err(conn_err)?;
+
                 tx.commit().await.map_err(conn_err)?;
                 tracing::debug!(
                     target: "nebula_storage::sqlite",
                     trigger_id = %r.trigger_id,
                     event_id   = %r.event_id,
-                    "trigger_dedup: duplicate"
+                    winner_execution_id = %winner_id,
+                    "trigger_dedup: duplicate — returning winner id"
                 );
-                return Ok(DispatchOutcome::Duplicate);
+                return Ok(DispatchOutcome::new(winner_id, DispatchKind::Duplicate));
             }
         }
+
+        // Insert the execution row (status='Created', version=0,
+        // fencing_generation=0).  Id + scope come from `start`.
+        // A unique-violation here rolls back the whole transaction — no dedup
+        // row, no job row.
+        insert_created_execution(
+            &mut tx,
+            &start.scope,
+            &start.execution_id,
+            execution.workflow_id,
+            execution.initial_state,
+        )
+        .await?;
 
         // Insert the Start job (same transaction).
         sqlx::query(
@@ -390,9 +431,13 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
         tracing::debug!(
             target: "nebula_storage::sqlite",
             job_id = ?start.id,
-            "trigger_dedup: dispatched"
+            execution_id = %start.execution_id,
+            "trigger_dedup: materialized (dedup guard + execution row + Start job)"
         );
-        Ok(DispatchOutcome::Dispatched)
+        Ok(DispatchOutcome::new(
+            start.execution_id.clone(),
+            DispatchKind::Dispatched,
+        ))
     }
 
     async fn exists(

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -21,7 +21,8 @@ use harness::{
     Backend, InMemoryBackend, PostgresBackend, ScopedBackend, SqliteBackend, assert_atomic_triple,
     assert_cas_conflict, assert_control_queue_outbox_and_fencing, assert_create_get_roundtrip,
     assert_cross_scope_commit_is_rejected, assert_cross_scope_get_is_none,
-    assert_dedup_compose_is_atomic, assert_dispatch_without_dedup_key,
+    assert_dedup_compose_is_atomic, assert_dedup_compose_rolls_back_on_id_collision,
+    assert_dedup_duplicate_returns_winner_id, assert_dispatch_without_dedup_key,
     assert_get_published_is_highest_numbered, assert_idempotency_first_writer_wins,
     assert_idempotency_store_cross_scope_isolated, assert_idempotency_store_first_writer,
     assert_job_dispatch_fencing, assert_job_dispatch_routes_by_tag,
@@ -138,6 +139,14 @@ matrix!(
     assert_job_dispatch_routes_by_tag_superset
 );
 matrix!(trigger_dedup_is_scoped, assert_trigger_dedup_is_scoped);
+matrix!(
+    dedup_compose_rolls_back_on_id_collision,
+    assert_dedup_compose_rolls_back_on_id_collision
+);
+matrix!(
+    dedup_duplicate_returns_winner_id,
+    assert_dedup_duplicate_returns_winner_id
+);
 
 // ── Scoped variant ────────────────────────────────────────────────────────
 // The same contract suite, but every store is wrapped in the

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -21,16 +21,16 @@ use harness::{
     Backend, InMemoryBackend, PostgresBackend, ScopedBackend, SqliteBackend, assert_atomic_triple,
     assert_cas_conflict, assert_control_queue_outbox_and_fencing, assert_create_get_roundtrip,
     assert_cross_scope_commit_is_rejected, assert_cross_scope_get_is_none,
-    assert_dedup_compose_is_atomic, assert_dedup_compose_rolls_back_on_id_collision,
-    assert_dedup_duplicate_returns_winner_id, assert_dispatch_without_dedup_key,
-    assert_get_published_is_highest_numbered, assert_idempotency_first_writer_wins,
-    assert_idempotency_store_cross_scope_isolated, assert_idempotency_store_first_writer,
-    assert_job_dispatch_fencing, assert_job_dispatch_routes_by_tag,
-    assert_job_dispatch_routes_by_tag_superset, assert_journal_visibility_and_scope,
-    assert_live_lease_blocks_acquire, assert_save_with_published_version_is_atomic,
-    assert_stale_fencing_is_fenced_out, assert_trigger_dedup_first_writer,
-    assert_trigger_dedup_is_scoped, assert_webhook_activation_and_scope,
-    assert_workflow_store_contract, skip_reason,
+    assert_dedup_compose_is_atomic, assert_dedup_compose_rejects_duplicate_job_id,
+    assert_dedup_compose_rolls_back_on_id_collision, assert_dedup_duplicate_returns_winner_id,
+    assert_dispatch_without_dedup_key, assert_get_published_is_highest_numbered,
+    assert_idempotency_first_writer_wins, assert_idempotency_store_cross_scope_isolated,
+    assert_idempotency_store_first_writer, assert_job_dispatch_fencing,
+    assert_job_dispatch_routes_by_tag, assert_job_dispatch_routes_by_tag_superset,
+    assert_journal_visibility_and_scope, assert_live_lease_blocks_acquire,
+    assert_save_with_published_version_is_atomic, assert_stale_fencing_is_fenced_out,
+    assert_trigger_dedup_first_writer, assert_trigger_dedup_is_scoped,
+    assert_webhook_activation_and_scope, assert_workflow_store_contract, skip_reason,
 };
 use rstest::rstest;
 use std::future::Future;
@@ -142,6 +142,10 @@ matrix!(trigger_dedup_is_scoped, assert_trigger_dedup_is_scoped);
 matrix!(
     dedup_compose_rolls_back_on_id_collision,
     assert_dedup_compose_rolls_back_on_id_collision
+);
+matrix!(
+    dedup_compose_rejects_duplicate_job_id,
+    assert_dedup_compose_rejects_duplicate_job_id
 );
 matrix!(
     dedup_duplicate_returns_winner_id,

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -1810,6 +1810,12 @@ pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
         "[{}] None row must always be Dispatched",
         backend.name()
     );
+    assert_eq!(
+        out.execution_id,
+        job.execution_id,
+        "[{}] None-row Dispatched must carry the candidate execution id",
+        backend.name()
+    );
 
     let proc = [8u8; 16];
     let claimed = q
@@ -1835,6 +1841,12 @@ pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
         out2.kind,
         DispatchKind::Dispatched,
         "[{}] second None-row dispatch must also be Dispatched (no dedup)",
+        backend.name()
+    );
+    assert_eq!(
+        out2.execution_id,
+        job2.execution_id,
+        "[{}] second None-row dispatch must carry its candidate execution id",
         backend.name()
     );
 }

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -2169,6 +2169,78 @@ pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backe
     );
 }
 
+/// `claim_and_materialize_start` must fail closed on a colliding job-dispatch
+/// id (`start.id`) and leave all state intact.  The SQL backends hit the
+/// job-dispatch primary key and roll the transaction back; the in-memory
+/// backend must reject the collision too — never silently overwrite the queued
+/// job while reporting `Dispatched`.  (Regression guard for the codex P2
+/// backend-divergence on PR #814.)
+///
+/// The second compose reuses the SAME job id but a DIFFERENT execution id and a
+/// DIFFERENT `(trigger, event)`, so it is not a dedup duplicate — the only
+/// collision is on the job-dispatch primary key.
+pub async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+    let q = backend.job_dispatch_queue().await;
+    let s = scope_a();
+
+    // 1. First compose succeeds: enqueues job id 0xB0 (execution id "exe_176").
+    let row1 = TriggerDedupRow::new("trg_j1", "evt_j1", s.clone(), "2026-01-01T00:00:00Z");
+    let job1 = make_job(0xB0, "plugin.jid", &["plugin.jid"]);
+    let (wf1, init1) = make_new_execution();
+    let exec1 = NewExecution::new(&wf1, &init1);
+    let _ = inbox
+        .claim_and_materialize_start(Some(&row1), &job1, &exec1)
+        .await
+        .expect("first compose dispatches");
+
+    // 2. Second compose reuses the SAME job id (0xB0), different execution id.
+    let row2 = TriggerDedupRow::new("trg_j2", "evt_j2", s.clone(), "2026-01-01T00:00:00Z");
+    let mut job2 = make_job(0xB0, "plugin.jid", &["plugin.jid"]);
+    job2.execution_id = "exe_jid_other".to_owned();
+    let (wf2, init2) = make_new_execution();
+    let exec2 = NewExecution::new(&wf2, &init2);
+    let result = inbox
+        .claim_and_materialize_start(Some(&row2), &job2, &exec2)
+        .await;
+    assert!(
+        result.is_err(),
+        "[{}] compose with a colliding job-dispatch id must fail closed, got {result:?}",
+        backend.name()
+    );
+
+    // 3. The original job must be intact (NOT overwritten by job2): exactly one
+    //    queued job, still carrying the first execution id.
+    let proc = [0xB1u8; 16];
+    let claimed = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.jid")])
+        .await
+        .expect("claim after failed compose");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] exactly the original job must remain queued",
+        backend.name()
+    );
+    assert_eq!(
+        claimed[0].execution_id,
+        "exe_176",
+        "[{}] the original job must NOT be overwritten by the colliding compose",
+        backend.name()
+    );
+
+    // 4. The second dedup row must NOT have been inserted (all-or-nothing).
+    let dedup2 = inbox
+        .exists(&s, "trg_j2", "evt_j2")
+        .await
+        .expect("exists after failed compose");
+    assert!(
+        !dedup2,
+        "[{}] the colliding compose must not insert its dedup row",
+        backend.name()
+    );
+}
+
 /// `claim_and_materialize_start` returns the winner's `execution_id` on
 /// `Duplicate`, NOT a freshly-minted candidate.  This is the P2 contract
 /// upgrade over the old `claim_and_enqueue_start` which returned a

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -22,8 +22,9 @@
 use std::sync::Arc;
 
 use nebula_storage_port::dto::{
-    CachedRecord, CapabilityTag, ControlCommand, ControlMsg, DispatchOutcome, JobDispatchMsg,
-    JournalEntry, TriggerDedupRow, WebhookActivationRecord, WorkflowRecord, WorkflowVersionRecord,
+    CachedRecord, CapabilityTag, ControlCommand, ControlMsg, DispatchKind, JobDispatchMsg,
+    JournalEntry, NewExecution, TriggerDedupRow, WebhookActivationRecord, WorkflowRecord,
+    WorkflowVersionRecord,
 };
 use nebula_storage_port::store::{
     ControlQueue, ExecutionJournalReader, ExecutionStore, IdempotencyGuard, IdempotencyStore,
@@ -62,7 +63,7 @@ pub trait Backend: Send + Sync {
     /// A job-dispatch queue backed by this backend.
     async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue>;
     /// A trigger-dedup inbox backed by this backend, sharing the same
-    /// core as [`Backend::job_dispatch_queue`] so `claim_and_enqueue_start`
+    /// core as [`Backend::job_dispatch_queue`] so `claim_and_materialize_start`
     /// is all-or-nothing within the backend.
     async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox>;
 }
@@ -70,8 +71,9 @@ pub trait Backend: Send + Sync {
 /// InMemory backend (always available).
 ///
 /// Holds one execution store whose core is shared (it is `Clone` over an
-/// `Arc<Mutex<…>>`), so the control queue and journal reader observe the
-/// outbox + journal rows a `commit` wrote.
+/// `Arc<Mutex<…>>`), so the control queue, journal reader, job-dispatch queue,
+/// and trigger-dedup inbox all observe the same rows and operate atomically
+/// under one lock.
 pub struct InMemoryBackend {
     store: nebula_storage::inmem::InMemoryExecutionStore,
     guard: nebula_storage::inmem::InMemoryIdempotencyGuard,
@@ -79,9 +81,6 @@ pub struct InMemoryBackend {
     webhook: nebula_storage::inmem::InMemoryWebhookActivationStore,
     workflow: nebula_storage::inmem::InMemoryWorkflowStore,
     workflow_version: nebula_storage::inmem::InMemoryWorkflowVersionStore,
-    /// Shared dispatch core: job queue + trigger-dedup inbox share one
-    /// `Arc<Mutex<Core>>` so `claim_and_enqueue_start` is all-or-nothing.
-    dispatch_core: nebula_storage::inmem::SharedDispatchCore,
 }
 
 impl Default for InMemoryBackend {
@@ -100,7 +99,6 @@ impl Default for InMemoryBackend {
             webhook: nebula_storage::inmem::InMemoryWebhookActivationStore::new(),
             workflow,
             workflow_version,
-            dispatch_core: nebula_storage::inmem::new_shared_core(),
         }
     }
 }
@@ -139,13 +137,13 @@ impl Backend for InMemoryBackend {
         Arc::new(self.workflow_version.clone())
     }
     async fn job_dispatch_queue(&self) -> Arc<dyn JobDispatchQueue> {
-        Arc::new(nebula_storage::inmem::InMemoryJobDispatchQueue::from_core(
-            self.dispatch_core.clone(),
+        Arc::new(nebula_storage::inmem::InMemoryJobDispatchQueue::new(
+            &self.store,
         ))
     }
     async fn trigger_dedup_inbox(&self) -> Arc<dyn TriggerDedupInbox> {
-        Arc::new(nebula_storage::inmem::InMemoryTriggerDedupInbox::from_core(
-            self.dispatch_core.clone(),
+        Arc::new(nebula_storage::inmem::InMemoryTriggerDedupInbox::new(
+            &self.store,
         ))
     }
 }
@@ -1609,6 +1607,12 @@ impl<B: Backend> Backend for ScopedBackend<B> {
 
 // ── job-dispatch + dedup conformance assertions ───────────────────────────
 
+/// A `NewExecution` with placeholder content for conformance tests that focus
+/// on the dedup/routing behaviour rather than the execution-row fields.
+fn make_new_execution() -> (String, serde_json::Value) {
+    ("wf_conformance".to_owned(), serde_json::json!({}))
+}
+
 fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg {
     JobDispatchMsg::new(
         [id; 16],
@@ -1710,42 +1714,55 @@ pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
     );
 }
 
-/// `claim_and_enqueue_start` is first-writer-wins when a `TriggerDedupRow`
+/// `claim_and_materialize_start` is first-writer-wins when a `TriggerDedupRow`
 /// is provided: the second call with the same `(trigger_id, event_id)` must
-/// return `Duplicate` and must NOT enqueue a second job.
+/// return `Duplicate` and must NOT enqueue a second job.  The `Duplicate`
+/// outcome carries the winner's execution id, not the candidate's.
 pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let q = backend.job_dispatch_queue().await;
 
-    let row = TriggerDedupRow::new(
-        "trg_fw",
-        "evt_001",
-        scope_a(),
-        "exe_fw",
-        "2026-01-01T00:00:00Z",
-    );
+    let row = TriggerDedupRow::new("trg_fw", "evt_001", scope_a(), "2026-01-01T00:00:00Z");
     let job1 = make_job(0x30, "plugin.y", &["plugin.y"]);
     let job2 = make_job(0x31, "plugin.y", &["plugin.y"]);
 
+    let (wf_id, initial) = make_new_execution();
+    let exec1 = NewExecution::new(&wf_id, &initial);
+
     let out1 = inbox
-        .claim_and_enqueue_start(Some(&row), &job1)
+        .claim_and_materialize_start(Some(&row), &job1, &exec1)
         .await
         .expect("first compose");
     assert_eq!(
-        out1,
-        DispatchOutcome::Dispatched,
+        out1.kind,
+        DispatchKind::Dispatched,
         "[{}] first writer must be Dispatched",
         backend.name()
     );
+    assert_eq!(
+        out1.execution_id,
+        job1.execution_id,
+        "[{}] Dispatched outcome must carry the candidate execution id",
+        backend.name()
+    );
 
+    let (wf_id2, initial2) = make_new_execution();
+    let exec2 = NewExecution::new(&wf_id2, &initial2);
     let out2 = inbox
-        .claim_and_enqueue_start(Some(&row), &job2)
+        .claim_and_materialize_start(Some(&row), &job2, &exec2)
         .await
         .expect("second compose");
     assert_eq!(
-        out2,
-        DispatchOutcome::Duplicate,
+        out2.kind,
+        DispatchKind::Duplicate,
         "[{}] second writer must be Duplicate",
+        backend.name()
+    );
+    // Duplicate must carry the WINNER's execution id (job1's), not the candidate's.
+    assert_eq!(
+        out2.execution_id,
+        job1.execution_id,
+        "[{}] Duplicate outcome must carry the winner's execution id, not the candidate's",
         backend.name()
     );
 
@@ -1774,20 +1791,22 @@ pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
     );
 }
 
-/// `claim_and_enqueue_start` with `row = None` always dispatches without
+/// `claim_and_materialize_start` with `row = None` always dispatches without
 /// a dedup row (unconditional dispatch path).
 pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
     let q = backend.job_dispatch_queue().await;
 
     let job = make_job(0x40, "plugin.z", &["plugin.z"]);
+    let (wf_id, initial) = make_new_execution();
+    let exec = NewExecution::new(&wf_id, &initial);
     let out = inbox
-        .claim_and_enqueue_start(None, &job)
+        .claim_and_materialize_start(None, &job, &exec)
         .await
         .expect("compose none");
     assert_eq!(
-        out,
-        DispatchOutcome::Dispatched,
+        out.kind,
+        DispatchKind::Dispatched,
         "[{}] None row must always be Dispatched",
         backend.name()
     );
@@ -1806,43 +1825,64 @@ pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
 
     // A second None-row dispatch for a different job is also unconditional.
     let job2 = make_job(0x41, "plugin.z", &["plugin.z"]);
+    let (wf_id2, initial2) = make_new_execution();
+    let exec2 = NewExecution::new(&wf_id2, &initial2);
     let out2 = inbox
-        .claim_and_enqueue_start(None, &job2)
+        .claim_and_materialize_start(None, &job2, &exec2)
         .await
         .expect("compose none 2");
     assert_eq!(
-        out2,
-        DispatchOutcome::Dispatched,
+        out2.kind,
+        DispatchKind::Dispatched,
         "[{}] second None-row dispatch must also be Dispatched (no dedup)",
         backend.name()
     );
 }
 
-/// `claim_and_enqueue_start` is atomic: a dedup row in scope_a is invisible
-/// from scope_b, so a cross-scope `exists` returns false.
+/// `claim_and_materialize_start` is atomic: the dedup guard, execution row,
+/// and Start job are written together.  A dedup row in scope_a is invisible
+/// from scope_b (cross-scope `exists` returns false), and after a Dispatched
+/// compose the execution row is visible in the store and exactly one Start job
+/// is claimable from the dispatch queue.
 pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
+    let store = backend.execution_store().await;
+    let q = backend.job_dispatch_queue().await;
 
     let row = TriggerDedupRow::new(
         "trg_atomic",
         "evt_atomic",
         scope_a(),
-        "exe_atomic",
         "2026-01-01T00:00:00Z",
     );
     let job = make_job(0x50, "plugin.q", &["plugin.q"]);
+    let (wf_id, initial) = make_new_execution();
+    let exec = NewExecution::new(&wf_id, &initial);
     let outcome = inbox
-        .claim_and_enqueue_start(Some(&row), &job)
+        .claim_and_materialize_start(Some(&row), &job, &exec)
         .await
         .expect("compose");
     assert_eq!(
-        outcome,
-        DispatchOutcome::Dispatched,
+        outcome.kind,
+        DispatchKind::Dispatched,
         "[{}] compose must be Dispatched",
         backend.name()
     );
 
-    // Within scope_a: present.
+    // All three writes must be visible atomically after a Dispatched compose.
+
+    // 1. Execution row: must exist with the candidate id.
+    let exec_row = store
+        .get(&scope_a(), &job.execution_id)
+        .await
+        .expect("get execution row after compose");
+    assert!(
+        exec_row.is_some(),
+        "[{}] execution row must exist after Dispatched compose (three-way atomicity)",
+        backend.name()
+    );
+
+    // 2. Dedup guard: visible within scope_a.
     let in_scope = inbox
         .exists(&scope_a(), "trg_atomic", "evt_atomic")
         .await
@@ -1862,6 +1902,29 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
         !cross,
         "[{}] dedup row must not be visible cross-scope",
         backend.name()
+    );
+
+    // 3. Start job: exactly one claimable job must have landed, with the
+    //    correct execution id.  This closes the gap in the "three-way"
+    //    atomicity claim — a backend that commits dedup+execution but fails
+    //    to enqueue the Start job would still pass the two checks above.
+    let proc = [0xA0u8; 16];
+    let claimed = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.q")])
+        .await
+        .expect("claim_pending after compose");
+    assert_eq!(
+        claimed.len(),
+        1,
+        "[{}] exactly one Start job must be enqueued after Dispatched compose (three-way atomicity)",
+        backend.name()
+    );
+    assert_eq!(
+        claimed[0].execution_id,
+        job.execution_id,
+        "[{}] claimed Start job execution_id must match the candidate ({})",
+        backend.name(),
+        job.execution_id
     );
 }
 
@@ -1918,7 +1981,7 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
 /// under two different tenant scopes MUST NOT collide.
 ///
 /// This is the regression lock for the cross-tenant confused-deputy bug where
-/// the dedup key omitted scope: tenant B's `claim_and_enqueue_start` would
+/// the dedup key omitted scope: tenant B's `claim_and_materialize_start` would
 /// hit tenant A's dedup row and return `Duplicate`, silently dropping tenant B's
 /// job.
 ///
@@ -1933,20 +1996,8 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
 pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
     let inbox = backend.trigger_dedup_inbox().await;
 
-    let row_a = TriggerDedupRow::new(
-        "trg_iso",
-        "evt_iso",
-        scope_a(),
-        "exe_iso_a",
-        "2026-01-01T00:00:00Z",
-    );
-    let row_b = TriggerDedupRow::new(
-        "trg_iso",
-        "evt_iso",
-        scope_b(),
-        "exe_iso_b",
-        "2026-01-01T00:00:00Z",
-    );
+    let row_a = TriggerDedupRow::new("trg_iso", "evt_iso", scope_a(), "2026-01-01T00:00:00Z");
+    let row_b = TriggerDedupRow::new("trg_iso", "evt_iso", scope_b(), "2026-01-01T00:00:00Z");
     // Unique ids per job so they never collide on the job-queue PK.
     let job_a1 = make_job(0x70, "plugin.iso", &["plugin.iso"]);
     let job_b = {
@@ -1956,41 +2007,54 @@ pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
     };
     let job_a2 = make_job(0x72, "plugin.iso", &["plugin.iso"]);
 
+    let (wf_id_a1, initial_a1) = make_new_execution();
+    let exec_a1 = NewExecution::new(&wf_id_a1, &initial_a1);
     // Step 1: tenant A dispatches — must be Dispatched.
     let out_a1 = inbox
-        .claim_and_enqueue_start(Some(&row_a), &job_a1)
+        .claim_and_materialize_start(Some(&row_a), &job_a1, &exec_a1)
         .await
         .expect("step 1: tenant A dispatch");
     assert_eq!(
-        out_a1,
-        DispatchOutcome::Dispatched,
+        out_a1.kind,
+        DispatchKind::Dispatched,
         "[{}] step 1: tenant A must be Dispatched",
         backend.name()
     );
 
+    let (wf_id_b, initial_b) = make_new_execution();
+    let exec_b = NewExecution::new(&wf_id_b, &initial_b);
     // Step 2: tenant B dispatches the SAME (trigger_id, event_id) — must also
     // be Dispatched; cross-tenant MUST NOT dedup.
     let out_b = inbox
-        .claim_and_enqueue_start(Some(&row_b), &job_b)
+        .claim_and_materialize_start(Some(&row_b), &job_b, &exec_b)
         .await
         .expect("step 2: tenant B dispatch");
     assert_eq!(
-        out_b,
-        DispatchOutcome::Dispatched,
+        out_b.kind,
+        DispatchKind::Dispatched,
         "[{}] step 2: tenant B with the same (trigger_id, event_id) must be \
          Dispatched — cross-tenant dedup collision (confused-deputy bug)",
         backend.name()
     );
 
+    let (wf_id_a2, initial_a2) = make_new_execution();
+    let exec_a2 = NewExecution::new(&wf_id_a2, &initial_a2);
     // Step 3: tenant A repeats — same-tenant dedup must fire (Duplicate).
     let out_a2 = inbox
-        .claim_and_enqueue_start(Some(&row_a), &job_a2)
+        .claim_and_materialize_start(Some(&row_a), &job_a2, &exec_a2)
         .await
         .expect("step 3: tenant A repeat");
     assert_eq!(
-        out_a2,
-        DispatchOutcome::Duplicate,
+        out_a2.kind,
+        DispatchKind::Duplicate,
         "[{}] step 3: same-tenant repeat must be Duplicate",
+        backend.name()
+    );
+    // Duplicate must carry the winner's execution id (job_a1's).
+    assert_eq!(
+        out_a2.execution_id,
+        job_a1.execution_id,
+        "[{}] step 3: Duplicate outcome must carry tenant A's winner execution id",
         backend.name()
     );
 
@@ -2026,5 +2090,126 @@ pub async fn assert_trigger_dedup_is_scoped(backend: &dyn Backend) {
         a_sees_b,
         "[{}] scope_a exists must still return true (own row present)",
         backend.name()
+    );
+}
+
+/// `claim_and_materialize_start` rolls back atomically on execution-id
+/// collision: if the execution row cannot be inserted (id already exists),
+/// neither the dedup guard nor the Start job must land in the store.
+///
+/// Contract:
+/// 1. Pre-insert an execution row with a known id.
+/// 2. Attempt `claim_and_materialize_start` with a `JobDispatchMsg` whose
+///    `execution_id` matches — must return `Err(StorageError::Duplicate)`.
+/// 3. Assert: no dedup guard was inserted (`exists` returns false), and no
+///    Start job was enqueued (`claim_pending` returns empty).
+pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+    let store = backend.execution_store().await;
+    let q = backend.job_dispatch_queue().await;
+    let s = scope_a();
+
+    // Pre-insert an execution row with a known id.
+    store
+        .create(&s, "exe_collision", "wf_rollback", serde_json::json!({}))
+        .await
+        .expect("pre-insert execution row");
+
+    // Build a compose whose execution_id collides with the pre-existing row.
+    let row = TriggerDedupRow::new("trg_rb", "evt_rb", s.clone(), "2026-01-01T00:00:00Z");
+    let mut job = make_job(0x80, "plugin.rb", &["plugin.rb"]);
+    // Override the execution_id to the colliding id.
+    job.execution_id = "exe_collision".to_owned();
+
+    let (wf_id, initial) = make_new_execution();
+    let exec = NewExecution::new(&wf_id, &initial);
+    let result = inbox
+        .claim_and_materialize_start(Some(&row), &job, &exec)
+        .await;
+
+    assert!(
+        matches!(result, Err(StorageError::Duplicate { .. })),
+        "[{}] compose with a colliding execution id must return Duplicate error, got {result:?}",
+        backend.name()
+    );
+
+    // The dedup row must NOT have been inserted (rollback).
+    let dedup_exists = inbox
+        .exists(&s, "trg_rb", "evt_rb")
+        .await
+        .expect("exists after failed compose");
+    assert!(
+        !dedup_exists,
+        "[{}] dedup row must NOT exist after a rolled-back compose",
+        backend.name()
+    );
+
+    // No Start job must have been enqueued (rollback).
+    let proc = [0x9Au8; 16];
+    let enqueued = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.rb")])
+        .await
+        .expect("claim_pending after failed compose");
+    assert!(
+        enqueued.is_empty(),
+        "[{}] no Start job must be enqueued after a rolled-back compose",
+        backend.name()
+    );
+}
+
+/// `claim_and_materialize_start` returns the winner's `execution_id` on
+/// `Duplicate`, NOT a freshly-minted candidate.  This is the P2 contract
+/// upgrade over the old `claim_and_enqueue_start` which returned a
+/// caller-supplied candidate id.
+///
+/// Contract:
+/// 1. First compose with `(trg_rb2, evt_rb2)` → `Dispatched`; record
+///    `winner_id = outcome.execution_id`.
+/// 2. Second compose with the same `(trg_rb2, evt_rb2)` → `Duplicate`;
+///    `outcome.execution_id` must equal `winner_id`.
+pub async fn assert_dedup_duplicate_returns_winner_id(backend: &dyn Backend) {
+    let inbox = backend.trigger_dedup_inbox().await;
+    let s = scope_a();
+
+    let row = TriggerDedupRow::new("trg_rb2", "evt_rb2", s.clone(), "2026-01-01T00:00:00Z");
+    let job1 = make_job(0x90, "plugin.w", &["plugin.w"]);
+    let (wf_id1, initial1) = make_new_execution();
+    let exec1 = NewExecution::new(&wf_id1, &initial1);
+
+    let out1 = inbox
+        .claim_and_materialize_start(Some(&row), &job1, &exec1)
+        .await
+        .expect("first compose");
+    assert_eq!(
+        out1.kind,
+        DispatchKind::Dispatched,
+        "[{}] first compose must be Dispatched",
+        backend.name()
+    );
+    let winner_id = out1.execution_id.clone();
+
+    // Second compose: different candidate id, same (trigger_id, event_id).
+    let job2 = make_job(0x91, "plugin.w", &["plugin.w"]);
+    let (wf_id2, initial2) = make_new_execution();
+    let exec2 = NewExecution::new(&wf_id2, &initial2);
+
+    let out2 = inbox
+        .claim_and_materialize_start(Some(&row), &job2, &exec2)
+        .await
+        .expect("second compose");
+    assert_eq!(
+        out2.kind,
+        DispatchKind::Duplicate,
+        "[{}] second compose must be Duplicate",
+        backend.name()
+    );
+    assert_eq!(
+        out2.execution_id,
+        winner_id,
+        "[{}] Duplicate outcome must carry the original winner's execution id ({}), \
+         not the new candidate's ({})",
+        backend.name(),
+        winner_id,
+        job2.execution_id
     );
 }


### PR DESCRIPTION
## What

Folds the `Created` execution-row write **into** the trigger-dedup compose transaction, closing the two defects codex flagged on the U3 slice ([#812](https://github.com/vanyastaff/nebula/pull/812)):

- **P1 (lost-execution race):** previously the emitter wrote the `Created` row as a *second* write *after* `claim_and_enqueue_start` committed the Start job. Under a concurrently-polling orchestrator, a `Dispatched` Start could be claimed before the row existed → sink `Rejected` → `mark_failed` → a legitimate first-delivery execution lost. Now the dedup-guard ∧ Start-job ∧ `Created`-row are **one atomic transaction** — all-or-nothing.
- **P2 (duplicate return id):** a `Duplicate` now returns the **original winner's** `ExecutionId` (read back in-tx), not a wasted candidate id.

This is the **prerequisite** for ADR-0095 D1 (which wires the emitter to run concurrently with the orchestrator in production).

## Contract change (merged-U1 storage; active-dev, internal — no external semver)

- `TriggerDedupInbox::claim_and_enqueue_start` → **`claim_and_materialize_start`** (it now does 3 writes, not just an enqueue); gains a `&NewExecution` param (`{workflow_id, &initial_state}`; id+scope sourced from the Start msg).
- `DispatchOutcome`: fieldless enum → **`struct { execution_id, kind: DispatchKind }`** (`#[non_exhaustive]`) — total id access, extensible discriminant.
- One-fact-one-place `insert_created_execution` helper shared by `ExecutionStore::create` and the compose (the `port_executions` column contract has one home).
- **InMemory**: folded the standalone `SharedDispatchCore` into the execution store's `SharedState` (the established hub that control-queue + journal already share) so the 3-table write is one critical section; dedup `HashSet` → `HashMap<key, winner_id>` for the P2 read-back. `SharedDispatchCore`/`new_shared_core`/`from_core` deleted.
- SQLite/Postgres: the `port_executions` INSERT joins the existing single-pool transaction.
- `DurableExecutionEmitter` drops its now-dead `Arc<dyn ExecutionStore>` field; uses the id returned by the compose.

**Boundary call:** `TriggerDedupInbox` legitimately owns the `port_executions` write — the concept it owns is *the indivisible act of admitting one trigger delivery*. The rejected alternative (threading `sqlx::Transaction<DB>` into `ExecutionStore::create`) would leak backend types into the object-safe port.

## Evidence (verified locally + pre-push gate green)

- `cargo nextest` (workspace): **1092 passed, 0 skipped**. New conformance tests across InMemory / SQLite / Postgres(skip-clean): `atomic_triple_all_or_nothing`, `dedup_compose_is_atomic`, `dedup_compose_rolls_back_on_id_collision` (forced rollback), `dedup_duplicate_returns_winner_id` (P2). Slice P2 red→green: `emitter_duplicate_event_id_no_second_row`.
- `cargo clippy --all-targets --all-features -- -D warnings`: clean. `RUSTDOCFLAGS=-D warnings cargo doc`: clean.
- Postgres serializability remains `DATABASE_URL`-gated (skip-clean; never false-green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined execution materialization for improved consistency in job dispatch and deduplication.
  * Enhanced duplicate trigger handling with reliable winner execution ID tracking across all storage backends.

* **Chores**
  * Updated internal test utilities and backend conformance suite.
  * Updated gitignore to exclude local cache files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->