### PR TITLE
feat(engine)!: DefinitionRoutingResolver — registry-free trigger routing (ADR-0095 D1, U-D1.2b)

### DIFF
--- a/crates/engine/src/daemon/durable_emitter.rs
+++ b/crates/engine/src/daemon/durable_emitter.rs
@@ -6,19 +6,21 @@
 //! `DurableExecutionEmitter` implements [`nebula_action::ExecutionEmitter`] and
 //! wires the trigger-to-execution fan-out path end-to-end:
 //!
-//! 1. Mint a new [`ExecutionId`] candidate and build the initial
+//! 1. Resolve routing from the [`ValidatedWorkflow`] (fail-fast before minting
+//!    an id): `required_plugin_key` + `capability_tags` + flavor SHA.
+//! 2. Mint a new [`ExecutionId`] candidate and build the initial
 //!    [`ExecutionState`].
-//! 2. Build a [`JobDispatchMsg`] (Start command, routing key, etc.), a
+//! 3. Build a [`JobDispatchMsg`] (Start command, routing key, etc.), a
 //!    [`NewExecution`] carrying the serialised initial state, and — when
 //!    `event_id` is `Some` — a [`TriggerDedupRow`] guard keyed by
 //!    `(scope, trigger_id, event_id)`.
-//! 3. Call [`TriggerDedupInbox::claim_and_materialize_start`] — one atomic
+//! 4. Call [`TriggerDedupInbox::claim_and_materialize_start`] — one atomic
 //!    critical section that either:
 //!    - **`Dispatched`**: inserts the dedup guard + the `Created` execution row
 //!      + enqueues the Start job; returns the effective execution id.
 //!    - **`Duplicate`**: returns the *original winner's* execution id without
 //!      touching any row.
-//! 4. Parse the returned `outcome.execution_id` back to [`ExecutionId`] and
+//! 5. Parse the returned `outcome.execution_id` back to [`ExecutionId`] and
 //!    return it to the caller.
 //!
 //! ## Atomicity guarantee
@@ -53,30 +55,36 @@ use std::sync::Arc;
 
 use nebula_action::{ActionError, ExecutionEmitter, IdempotencyKey};
 use nebula_core::NodeKey;
-use nebula_core::id::{ExecutionId, WorkflowId};
+use nebula_core::id::ExecutionId;
 use nebula_execution::ExecutionState;
 use nebula_storage_port::{
     Scope, StorageError,
     dto::{ControlCommand, DispatchKind, JobDispatchMsg, NewExecution, TriggerDedupRow},
     store::TriggerDedupInbox,
 };
+use nebula_workflow::ValidatedWorkflow;
 
 use crate::daemon::routing::RoutingResolver;
 
 /// Trigger fan-out through the durable dedup inbox.
 ///
 /// Holds everything needed to enqueue one trigger-originated Start job:
+/// - [`ValidatedWorkflow`] — the validated workflow being triggered.  Passed
+///   to [`RoutingResolver`] so routing is derived from the definition without a
+///   registry lookup.  Using a validation witness ensures this seam can never
+///   be reached with an unvalidated definition.
 /// - [`TriggerDedupInbox`] — atomic dedup + execution-row materialise + job
 ///   enqueue, all in one transaction.
-/// - [`RoutingResolver`] — derive `required_plugin_key` + `target_flavor_sha`.
-/// - Identity fields captured at construction: `workflow_id`, `trigger_id`,
-///   `scope` — same values on every `emit` call from this trigger context.
+/// - [`RoutingResolver`] — derive `required_plugin_key` + `target_flavor_sha`
+///   from the validated definition.
+/// - Identity fields captured at construction: `trigger_id`, `scope` — same
+///   values on every `emit` call from this trigger context.
 #[derive(Clone)]
 pub struct DurableExecutionEmitter {
+    workflow: Arc<ValidatedWorkflow>,
     dedup: Arc<dyn TriggerDedupInbox>,
     resolver: Arc<dyn RoutingResolver>,
     // Cached at construction from `TriggerRuntimeContext`.
-    workflow_id: WorkflowId,
     trigger_id: NodeKey,
     scope: Scope,
 }
@@ -84,7 +92,7 @@ pub struct DurableExecutionEmitter {
 impl std::fmt::Debug for DurableExecutionEmitter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DurableExecutionEmitter")
-            .field("workflow_id", &self.workflow_id)
+            .field("workflow_id", &self.workflow.definition().id)
             .field("trigger_id", &self.trigger_id)
             .field("scope", &self.scope)
             .finish_non_exhaustive()
@@ -102,14 +110,14 @@ impl DurableExecutionEmitter {
     pub fn new(
         dedup: Arc<dyn TriggerDedupInbox>,
         resolver: Arc<dyn RoutingResolver>,
-        workflow_id: WorkflowId,
+        workflow: Arc<ValidatedWorkflow>,
         trigger_id: NodeKey,
         scope: Scope,
     ) -> Self {
         Self {
+            workflow,
             dedup,
             resolver,
-            workflow_id,
             trigger_id,
             scope,
         }
@@ -126,7 +134,7 @@ impl DurableExecutionEmitter {
         skip(self, input),
         fields(
             trigger_id  = %self.trigger_id,
-            workflow_id = %self.workflow_id,
+            workflow_id = %self.workflow.definition().id,
             event_id    = event_id.as_ref().map(IdempotencyKey::as_str),
         )
     )]
@@ -135,10 +143,12 @@ impl DurableExecutionEmitter {
         input: serde_json::Value,
         event_id: Option<IdempotencyKey>,
     ) -> Result<ExecutionId, ActionError> {
-        // --- step 1: resolve routing (fail-fast before minting an id) --------
+        let workflow_id = self.workflow.definition().id;
+
+        // --- step 1: resolve routing from validated definition (fail-fast) ----
         let route = self
             .resolver
-            .resolve(&self.workflow_id, &self.trigger_id)
+            .resolve(&self.workflow, &self.trigger_id)
             .map_err(ActionError::fatal_from)?;
 
         // --- step 2: mint the candidate id + serialise the initial state -----
@@ -148,7 +158,7 @@ impl DurableExecutionEmitter {
         // On `Duplicate` the store returns the *winner's* id — which may differ.
         let candidate_id = ExecutionId::new();
 
-        let mut exec_state = ExecutionState::new(candidate_id, self.workflow_id, &[]);
+        let mut exec_state = ExecutionState::new(candidate_id, workflow_id, &[]);
         exec_state.set_workflow_input(input.clone());
         let state_json = serde_json::to_value(&exec_state)
             .map_err(|e| ActionError::fatal(format!("serialize execution state: {e}")))?;
@@ -172,7 +182,7 @@ impl DurableExecutionEmitter {
             0,              // reclaim_count: 0 on first enqueue
         );
 
-        let workflow_id_str = self.workflow_id.to_string();
+        let workflow_id_str = workflow_id.to_string();
         let new_execution = NewExecution::new(&workflow_id_str, &state_json);
 
         // --- step 3: build the dedup guard row (only when event_id present) --
@@ -207,7 +217,7 @@ impl DurableExecutionEmitter {
             effective_execution_id = %outcome.execution_id,
             candidate_id = %candidate_id,
             trigger_id   = %self.trigger_id,
-            workflow_id  = %self.workflow_id,
+            workflow_id  = %workflow_id,
             event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
             "durable_emitter: claim_and_materialize_start"
         );
@@ -217,7 +227,7 @@ impl DurableExecutionEmitter {
                 tracing::info!(
                     execution_id = %outcome.execution_id,
                     trigger_id   = %self.trigger_id,
-                    workflow_id  = %self.workflow_id,
+                    workflow_id  = %workflow_id,
                     event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
                     "durable_emitter: dispatched"
                 );
@@ -227,7 +237,7 @@ impl DurableExecutionEmitter {
                     winner_execution_id = %outcome.execution_id,
                     candidate_id = %candidate_id,
                     trigger_id   = %self.trigger_id,
-                    workflow_id  = %self.workflow_id,
+                    workflow_id  = %workflow_id,
                     event_id     = event_id.as_ref().map(IdempotencyKey::as_str),
                     "durable_emitter: duplicate — returning winner id"
                 );

--- a/crates/engine/src/daemon/mod.rs
+++ b/crates/engine/src/daemon/mod.rs
@@ -104,6 +104,6 @@ pub use event_source::{EventSource, EventSourceAdapter, EventSourceConfig, Event
 pub use execution_sink::EngineExecutionSink;
 pub use registry::{AnyDaemonHandle, DaemonError, DaemonRegistry};
 pub use routing::{
-    DispatchRoute, RoutingError, RoutingResolver, SLICE_FLAVOR_SHA, StaticRoutingResolver,
+    DefinitionRoutingResolver, DispatchRoute, RoutingError, RoutingResolver, SLICE_FLAVOR_SHA,
 };
 pub use runtime::DaemonRuntime;

--- a/crates/engine/src/daemon/routing.rs
+++ b/crates/engine/src/daemon/routing.rs
@@ -5,39 +5,62 @@
 //! attached to each enqueued [`JobDispatchMsg`].  The engine's orchestrator
 //! pull-loop claims only rows whose `required_plugin_key` is in the worker's
 //! advertised capability set, so the resolver is the single place that maps a
-//! `(workflow_id, trigger_id)` pair onto a dispatch route.
+//! `(validated_workflow, trigger_id)` pair onto a dispatch route.
 //!
-//! ## Slice scope
+//! ## D1 implementation
 //!
-//! This slice ships [`StaticRoutingResolver`] — a single hardcoded mapping
-//! used in the integration test harness.  Dynamic flavour-SHA derivation and
-//! per-workflow plugin-key lookup are D1 work (follow-up ADR-0095 deliverable).
+//! This module ships [`DefinitionRoutingResolver`] — a registry-free resolver
+//! that reads `plugin_key` directly from the [`ValidatedWorkflow`]'s inner
+//! definition.  No external lookup is required: the definition is
+//! self-describing.  Taking [`ValidatedWorkflow`] rather than a raw
+//! `WorkflowDefinition` closes the duplicate-trigger-id hole
+//! by construction: validation rejects duplicate `trigger_binding` ids before
+//! the resolver is ever reached, so `.find()` always picks a unique match.
 //!
 //! [`DurableExecutionEmitter`]: super::durable_emitter::DurableExecutionEmitter
 //! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
 
-use nebula_core::{NodeKey, id::WorkflowId};
+use std::collections::BTreeSet;
+
+use nebula_core::NodeKey;
 use nebula_storage_port::dto::CapabilityTag;
+use nebula_workflow::ValidatedWorkflow;
 
 // ── types ─────────────────────────────────────────────────────────────────────
 
-/// A resolved dispatch route for one `(workflow_id, trigger_id)` pair.
+/// A resolved dispatch route for one `(validated_workflow, fired_trigger_id)`
+/// pair.
 ///
 /// Returned by [`RoutingResolver::resolve`].  The `required_plugin_key` is
 /// written into the `JobDispatchMsg::required_plugin_key` field; the
-/// orchestrator claims only rows whose key is in the worker's advertised
-/// capability set.
+/// orchestrator claims rows whose `required_plugin_key` is a member of the
+/// worker's advertised capability set.
+///
+/// `capability_tags` carries the full set of plugin keys the workflow needs
+/// (trigger + enabled nodes).  **Note:** the current orchestrator claim
+/// predicate tests only `required_plugin_key ∈ advertised_tags`
+/// (`storage-port` `job_dispatch.rs`) — it does NOT yet apply the superset
+/// check `job.capability_tags ⊆ advertised_tags`.  `capability_tags` is a
+/// forward seam for that future multi-plugin routing unit; until then it is
+/// written into the `JobDispatchMsg` for observability and future use.
+///
 /// `target_flavor_sha` is a version-pin guard written into the message but
-/// never used for routing.
+/// not yet used for routing.
+#[must_use = "a DispatchRoute must be written into the JobDispatchMsg; dropping it yields an un-claimable job"]
 #[derive(Debug, Clone)]
 pub struct DispatchRoute {
     /// The advertised `PluginKey` string this job requires a worker to support.
     pub required_plugin_key: String,
-    /// Full set of capability tags accepted by this job (superset of
-    /// `required_plugin_key`).
+    /// Full set of plugin-key capability tags the workflow needs (trigger
+    /// binding + enabled nodes, deduplicated and sorted).
+    ///
+    /// Populated now for observability and future multi-plugin routing.
+    /// The current claim predicate only checks `required_plugin_key`; the
+    /// superset predicate (`job.capability_tags ⊆ advertised_tags`) is a
+    /// later deliverable.
     pub capability_tags: Vec<CapabilityTag>,
     /// SHA of the plugin flavor this message targets (version-pin guard; not
-    /// used for routing).
+    /// yet used for routing).
     pub target_flavor_sha: String,
 }
 
@@ -45,40 +68,49 @@ pub struct DispatchRoute {
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]
 pub enum RoutingError {
-    /// No route could be determined for the given `(workflow_id, trigger_id)`.
-    #[error("no route found for workflow `{workflow_id}` trigger `{trigger_id}`")]
-    NotFound {
-        /// The workflow id that could not be routed.
+    /// The fired trigger id is not present in the workflow's `trigger_bindings`.
+    ///
+    /// Fail-closed: a trigger absent from the validated definition can never
+    /// produce a valid dispatch route, so the job is rejected rather than
+    /// routing to an arbitrary worker.
+    #[error("trigger `{trigger_id}` not found in trigger_bindings of workflow `{workflow_id}`")]
+    TriggerNotOnWorkflow {
+        /// The workflow whose definition was inspected.
         workflow_id: String,
-        /// The trigger node key that could not be routed.
+        /// The trigger node key that was not present.
         trigger_id: String,
     },
 }
 
 // ── trait ─────────────────────────────────────────────────────────────────────
 
-/// Port for mapping `(workflow_id, trigger_id)` → [`DispatchRoute`].
+/// Port for mapping `(validated_workflow, fired_trigger_id)` → [`DispatchRoute`].
+///
+/// Taking [`ValidatedWorkflow`] rather than a raw `WorkflowDefinition` makes
+/// "must validate before dispatch" a compile-time obligation: callers cannot
+/// reach this seam with an unvalidated definition.
 ///
 /// The [`DurableExecutionEmitter`] holds an `Arc<dyn RoutingResolver>` so the
-/// routing strategy can be swapped without touching the emitter.  In the slice
-/// harness a [`StaticRoutingResolver`] with a single hardcoded route is used;
-/// the production implementation (D1) reads the plugin registry.
+/// routing strategy can be swapped without touching the emitter.  The
+/// production implementation, [`DefinitionRoutingResolver`], reads `plugin_key`
+/// directly from the definition — no registry needed.
 ///
 /// [`DurableExecutionEmitter`]: super::durable_emitter::DurableExecutionEmitter
 pub trait RoutingResolver: Send + Sync + std::fmt::Debug {
-    /// Resolve the dispatch route for a trigger.
+    /// Resolve the dispatch route for a fired trigger.
     ///
     /// # Errors
     ///
-    /// Returns [`RoutingError::NotFound`] when no route can be determined.
+    /// Returns [`RoutingError::TriggerNotOnWorkflow`] when `fired_trigger_id`
+    /// is not present in `workflow.definition().trigger_bindings`.
     fn resolve(
         &self,
-        workflow_id: &WorkflowId,
-        trigger_id: &NodeKey,
+        workflow: &ValidatedWorkflow,
+        fired_trigger_id: &NodeKey,
     ) -> Result<DispatchRoute, RoutingError>;
 }
 
-// ── StaticRoutingResolver ─────────────────────────────────────────────────────
+// ── DefinitionRoutingResolver ─────────────────────────────────────────────────
 
 /// Pinned flavor SHA used by the slice harness.
 ///
@@ -86,94 +118,285 @@ pub trait RoutingResolver: Send + Sync + std::fmt::Debug {
 /// would defeat version-pin guards in integration tests).
 pub const SLICE_FLAVOR_SHA: &str = "slice-flavor-0000000000000000000000000000000000000001";
 
-/// A single-mapping routing resolver for the trigger-dispatch slice.
+/// Registry-free routing resolver that reads plugin routing data directly from
+/// the validated workflow definition.
 ///
-/// Returns one [`DispatchRoute`] for every `(workflow_id, trigger_id)` pair —
-/// the caller supplies the `required_plugin_key` at construction time.  Used
-/// by the integration test harness; production wiring is D1.
+/// No external registry is required: the definition carries an explicit
+/// `plugin_key` on every [`TriggerBinding`] and enabled [`NodeDefinition`].
 ///
-/// # Invariant
+/// ## Route derivation
 ///
-/// `required_plugin_key` must be non-empty — an empty key matches no worker's
-/// advertised capability set, so every dispatch would be permanently
-/// un-claimable. Enforced by a `debug_assert!` in [`StaticRoutingResolver::new`]
-/// (fast-fail on obvious misuse) **and** a fail-closed runtime check in
-/// [`RoutingResolver::resolve`] so the invariant also holds in release builds.
+/// 1. Locate the [`TriggerBinding`] whose `id` matches `fired_trigger_id` —
+///    fail closed ([`RoutingError::TriggerNotOnWorkflow`]) if absent.
+///    Because [`ValidatedWorkflow`] rejects duplicate trigger-binding ids, the
+///    `.find()` result is always unique.
+/// 2. The binding's `plugin_key` becomes `required_plugin_key`.
+/// 3. `capability_tags` is the deduplicated, sorted union of `plugin_key`
+///    values from every trigger binding **and** every **enabled** node.
+///    Disabled nodes are excluded — they are skipped at execution time and
+///    their plugin is not required on the target worker.
+///    The required key is always a member.
+///
+/// [`TriggerBinding`]: nebula_workflow::TriggerBinding
+/// [`NodeDefinition`]: nebula_workflow::NodeDefinition
 #[derive(Debug, Clone)]
-pub struct StaticRoutingResolver {
-    required_plugin_key: String,
+pub struct DefinitionRoutingResolver {
+    flavor_sha: String,
 }
 
-impl StaticRoutingResolver {
-    /// Build a resolver that always returns a route with the given plugin key.
+impl DefinitionRoutingResolver {
+    /// Build a resolver pinned to the given flavor SHA.
     ///
     /// # Panics
     ///
-    /// Panics in debug builds when `required_plugin_key` is empty (broken
-    /// invariant: an empty routing key would never match a worker's capability
-    /// set, making every dispatch permanently un-claimable).
+    /// Panics in debug builds when `flavor_sha` is empty (an empty SHA would
+    /// make the version-pin guard trivially match any job, defeating its
+    /// purpose).
     #[must_use]
-    pub fn new(required_plugin_key: impl Into<String>) -> Self {
-        let key = required_plugin_key.into();
-        debug_assert!(!key.is_empty(), "required_plugin_key must not be empty");
-        Self {
-            required_plugin_key: key,
-        }
+    pub fn new(flavor_sha: impl Into<String>) -> Self {
+        let sha = flavor_sha.into();
+        debug_assert!(!sha.is_empty(), "flavor_sha must not be empty");
+        Self { flavor_sha: sha }
     }
 }
 
-impl RoutingResolver for StaticRoutingResolver {
+impl Default for DefinitionRoutingResolver {
+    /// Returns a resolver pinned to [`SLICE_FLAVOR_SHA`].
+    fn default() -> Self {
+        Self::new(SLICE_FLAVOR_SHA)
+    }
+}
+
+impl RoutingResolver for DefinitionRoutingResolver {
+    #[tracing::instrument(
+        level = "debug",
+        skip(self, workflow),
+        fields(
+            fired_trigger_id = %fired_trigger_id,
+            workflow_id      = %workflow.definition().id,
+        )
+    )]
     fn resolve(
         &self,
-        workflow_id: &WorkflowId,
-        trigger_id: &NodeKey,
+        workflow: &ValidatedWorkflow,
+        fired_trigger_id: &NodeKey,
     ) -> Result<DispatchRoute, RoutingError> {
-        // Fail closed in release too: an empty routing key matches no worker's
-        // advertised capability set, so the job would be permanently
-        // un-claimable. `new`'s debug_assert catches obvious misuse early; this
-        // guard upholds the invariant in release builds as well.
-        if self.required_plugin_key.is_empty() {
-            return Err(RoutingError::NotFound {
-                workflow_id: workflow_id.to_string(),
-                trigger_id: trigger_id.to_string(),
-            });
+        let def = workflow.definition();
+
+        // Step 1 — locate the trigger binding (fail closed if absent).
+        // ValidatedWorkflow guarantees no duplicate trigger-binding ids, so
+        // this find always returns the unique match.
+        let binding = def
+            .trigger_bindings
+            .iter()
+            .find(|b| b.id == *fired_trigger_id)
+            .ok_or_else(|| RoutingError::TriggerNotOnWorkflow {
+                workflow_id: def.id.to_string(),
+                trigger_id: fired_trigger_id.to_string(),
+            })?;
+
+        // Step 2 — the binding's plugin_key is the required routing key.
+        let required_plugin_key = binding.plugin_key.as_str().to_owned();
+        tracing::debug!(
+            required_plugin_key = %required_plugin_key,
+            "resolved required plugin key"
+        );
+
+        // Step 3 — capability_tags: deduplicated, sorted union of plugin_key
+        // values from all trigger bindings and all ENABLED nodes.
+        // Disabled nodes are skipped at execution time; their plugin is not
+        // needed on the target worker.
+        let mut keys: BTreeSet<&str> = BTreeSet::new();
+        for tb in &def.trigger_bindings {
+            keys.insert(tb.plugin_key.as_str());
         }
+        for node in &def.nodes {
+            if node.enabled {
+                keys.insert(node.plugin_key.as_str());
+            }
+        }
+        // The required key is always present: we just resolved it from the
+        // trigger bindings, which are unconditionally added above.
+        let capability_tags: Vec<CapabilityTag> =
+            keys.into_iter().map(CapabilityTag::from).collect();
+        tracing::debug!(
+            capability_tag_count = capability_tags.len(),
+            "resolved capability tags"
+        );
+
         Ok(DispatchRoute {
-            required_plugin_key: self.required_plugin_key.clone(),
-            capability_tags: vec![CapabilityTag::from(self.required_plugin_key.as_str())],
-            target_flavor_sha: SLICE_FLAVOR_SHA.to_owned(),
+            required_plugin_key,
+            capability_tags,
+            target_flavor_sha: self.flavor_sha.clone(),
         })
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
+    use nebula_core::{WorkflowId, node_key};
+    use nebula_workflow::{
+        CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, TriggerBinding, ValidatedWorkflow,
+        Version, WorkflowConfig, WorkflowDefinition,
+    };
+
     use super::*;
 
-    #[test]
-    fn resolve_returns_route_for_nonempty_key() {
-        let resolver = StaticRoutingResolver::new("plugin.demo");
-        let route = resolver
-            .resolve(&WorkflowId::new(), &NodeKey::new("trigger").unwrap())
-            .expect("non-empty key resolves to a route");
-        assert_eq!(route.required_plugin_key, "plugin.demo");
-        assert_eq!(
-            route.capability_tags,
-            vec![CapabilityTag::from("plugin.demo")]
-        );
-        assert_eq!(route.target_flavor_sha, SLICE_FLAVOR_SHA);
+    /// Build a minimal validated workflow.
+    ///
+    /// `trigger_plugin` is the plugin for the single trigger binding with
+    /// `id == trigger_id`.  `nodes` is a slice of `(plugin_key, enabled)` pairs.
+    fn make_validated(
+        trigger_id: &str,
+        trigger_plugin: &str,
+        nodes: &[(&str, bool)],
+    ) -> ValidatedWorkflow {
+        let now = chrono::Utc::now();
+        let trigger_key = NodeKey::new(trigger_id).unwrap();
+        let trigger = TriggerBinding::new(trigger_key, trigger_plugin, "test.action").unwrap();
+        let node_defs: Vec<NodeDefinition> = nodes
+            .iter()
+            .enumerate()
+            .map(|(i, &(pk, enabled))| {
+                let mut n = NodeDefinition::new(
+                    NodeKey::new(format!("node{i}")).unwrap(),
+                    "Node",
+                    pk,
+                    "test.action",
+                )
+                .unwrap();
+                if !enabled {
+                    n = n.disabled();
+                }
+                n
+            })
+            .collect();
+        let def = WorkflowDefinition {
+            id: WorkflowId::new(),
+            name: "test-routing".into(),
+            description: None,
+            version: Version::new(0, 1, 0),
+            nodes: node_defs,
+            connections: Vec::<Connection>::new(),
+            variables: HashMap::new(),
+            config: WorkflowConfig::default(),
+            trigger_bindings: vec![trigger],
+            tags: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            owner_id: None,
+            ui_metadata: None,
+            schema_version: CURRENT_SCHEMA_VERSION,
+        };
+        ValidatedWorkflow::validate(def).expect("test definition must be valid")
     }
 
     #[test]
-    fn resolve_fails_closed_on_empty_key() {
-        // Build directly to bypass `new`'s debug_assert and exercise the
-        // release-path runtime guard in `resolve`.
-        let resolver = StaticRoutingResolver {
-            required_plugin_key: String::new(),
-        };
+    fn fail_closed_when_trigger_not_in_bindings() {
+        // Verifies the fail-closed path: a fired trigger id absent from
+        // trigger_bindings must return TriggerNotOnWorkflow.
+        let workflow = make_validated("real.trigger", "p.trig", &[("p.a", true)]);
+        let resolver = DefinitionRoutingResolver::default();
+        let absent = node_key!("absent.trigger");
         let err = resolver
-            .resolve(&WorkflowId::new(), &NodeKey::new("trigger").unwrap())
-            .expect_err("empty routing key must fail closed");
-        assert!(matches!(err, RoutingError::NotFound { .. }));
+            .resolve(&workflow, &absent)
+            .expect_err("trigger absent from bindings must fail closed");
+        assert!(
+            matches!(err, RoutingError::TriggerNotOnWorkflow { .. }),
+            "expected TriggerNotOnWorkflow, got {err:?}"
+        );
+        let RoutingError::TriggerNotOnWorkflow {
+            trigger_id,
+            workflow_id: _,
+        } = err;
+        assert_eq!(trigger_id, "absent.trigger");
+    }
+
+    #[test]
+    fn resolves_required_key_and_sorted_capability_set() {
+        // trigger plugin = "p.trig", node plugins = [("p.a", true), ("p.b", true)]
+        // expected capability_tags = sorted { "p.a", "p.b", "p.trig" }
+        let workflow = make_validated("test.trigger", "p.trig", &[("p.a", true), ("p.b", true)]);
+        let resolver = DefinitionRoutingResolver::new(SLICE_FLAVOR_SHA);
+        let fired = node_key!("test.trigger");
+        let route = resolver
+            .resolve(&workflow, &fired)
+            .expect("trigger present in bindings must resolve");
+
+        assert_eq!(route.required_plugin_key, "p.trig");
+        assert_eq!(route.target_flavor_sha, SLICE_FLAVOR_SHA);
+
+        let tags: Vec<&str> = route
+            .capability_tags
+            .iter()
+            .map(CapabilityTag::as_str)
+            .collect();
+        // Sorted BTreeSet order: p.a < p.b < p.trig
+        assert_eq!(tags, vec!["p.a", "p.b", "p.trig"]);
+
+        // Required key is a member of the capability set.
+        assert!(
+            route
+                .capability_tags
+                .iter()
+                .any(|t| t.as_str() == route.required_plugin_key),
+            "required_plugin_key must be in capability_tags"
+        );
+    }
+
+    #[test]
+    fn disabled_node_plugin_excluded_from_capability_tags() {
+        // "p.disabled" belongs to a disabled node — it must NOT appear in tags.
+        // "p.enabled" belongs to an enabled node — it MUST appear.
+        // "p.trig" is the trigger binding — it MUST appear.
+        let workflow = make_validated(
+            "test.trigger",
+            "p.trig",
+            &[("p.enabled", true), ("p.disabled", false)],
+        );
+        let resolver = DefinitionRoutingResolver::default();
+        let route = resolver
+            .resolve(&workflow, &node_key!("test.trigger"))
+            .unwrap();
+
+        let tags: Vec<&str> = route
+            .capability_tags
+            .iter()
+            .map(CapabilityTag::as_str)
+            .collect();
+        assert!(
+            tags.contains(&"p.trig"),
+            "trigger plugin must be in capability_tags; got {tags:?}"
+        );
+        assert!(
+            tags.contains(&"p.enabled"),
+            "enabled node plugin must be in capability_tags; got {tags:?}"
+        );
+        assert!(
+            !tags.contains(&"p.disabled"),
+            "disabled node plugin must NOT be in capability_tags; got {tags:?}"
+        );
+    }
+
+    #[test]
+    fn capability_tags_deduplicated_when_trigger_and_node_share_plugin() {
+        // trigger plugin = "p.shared", node plugin = "p.shared" — only one tag.
+        let workflow = make_validated("test.trigger", "p.shared", &[("p.shared", true)]);
+        let resolver = DefinitionRoutingResolver::default();
+        let fired = node_key!("test.trigger");
+        let route = resolver.resolve(&workflow, &fired).unwrap();
+
+        assert_eq!(route.capability_tags.len(), 1);
+        assert_eq!(route.capability_tags[0].as_str(), "p.shared");
+    }
+
+    #[test]
+    fn default_uses_slice_flavor_sha() {
+        let workflow = make_validated("t", "some.plugin", &[("some.plugin", true)]);
+        let resolver = DefinitionRoutingResolver::default();
+        let route = resolver.resolve(&workflow, &node_key!("t")).unwrap();
+        assert_eq!(route.target_flavor_sha, SLICE_FLAVOR_SHA);
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -93,9 +93,9 @@ pub use credential::{
 pub use credential_accessor::EngineCredentialAccessor;
 pub use daemon::{
     AnyDaemonHandle, Daemon, DaemonConfig, DaemonError, DaemonRegistry, DaemonRuntime,
-    DispatchRoute, DurableExecutionEmitter, EngineExecutionSink, EventSource, EventSourceAdapter,
-    EventSourceConfig, EventSourceRuntime, RestartPolicy, RoutingError, RoutingResolver,
-    SLICE_FLAVOR_SHA, StaticRoutingResolver,
+    DefinitionRoutingResolver, DispatchRoute, DurableExecutionEmitter, EngineExecutionSink,
+    EventSource, EventSourceAdapter, EventSourceConfig, EventSourceRuntime, RestartPolicy,
+    RoutingError, RoutingResolver, SLICE_FLAVOR_SHA,
 };
 pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, WorkflowEngine};
 pub use error::EngineError;

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -12,7 +12,7 @@
 //!
 //! **C-series (DurableExecutionEmitter unit tests)**
 //! - `emitter_dispatched_creates_row_and_enqueues_start` — emit with Some(event_id) → Dispatched,
-//!   Created row exists, Start row in queue.
+//!   Created row exists, Start row in queue with exact routing fields.
 //! - `emitter_duplicate_event_id_no_second_row` — emit same event_id twice → id unchanged,
 //!   no second Created row, no second Start row.
 //!
@@ -54,7 +54,8 @@ use nebula_storage_port::{
     store::{ExecutionStore, JobDispatchQueue, TriggerDedupInbox, WorkflowVersionStore},
 };
 use nebula_workflow::{
-    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, TriggerBinding, ValidatedWorkflow, Version,
+    WorkflowConfig, WorkflowDefinition,
 };
 use tokio_util::sync::CancellationToken;
 
@@ -176,11 +177,20 @@ async fn make_engine(stores: &TestStores) -> (Arc<WorkflowEngine>, Arc<AtomicU32
     (engine, count)
 }
 
-/// Save a single-node echo workflow, return its id.
-async fn save_echo_workflow(stores: &TestStores) -> nebula_core::WorkflowId {
+/// Build, validate, persist, and return the echo workflow.
+///
+/// The workflow carries:
+/// - one node `"step"` with `plugin_key = TEST_PLUGIN_KEY`
+/// - one trigger binding `id = node_key!("test.trigger")` with
+///   `plugin_key = TEST_PLUGIN_KEY`
+///
+/// Both emitter tests and the acceptance test fire `node_key!("test.trigger")`,
+/// so the resolver will find this binding and produce `required_plugin_key ==
+/// TEST_PLUGIN_KEY`.
+async fn save_echo_workflow(stores: &TestStores) -> Arc<ValidatedWorkflow> {
     let workflow_id = nebula_core::WorkflowId::new();
     let now = chrono::Utc::now();
-    let wf = WorkflowDefinition {
+    let def = WorkflowDefinition {
         id: workflow_id,
         name: "dispatch-slice-echo".into(),
         description: None,
@@ -189,7 +199,7 @@ async fn save_echo_workflow(stores: &TestStores) -> nebula_core::WorkflowId {
             NodeDefinition::new(
                 node_key!("step"),
                 "Step",
-                "core",
+                TEST_PLUGIN_KEY,
                 "test.echo.dispatch_slice",
             )
             .unwrap(),
@@ -197,7 +207,14 @@ async fn save_echo_workflow(stores: &TestStores) -> nebula_core::WorkflowId {
         connections: Vec::<Connection>::new(),
         variables: HashMap::new(),
         config: WorkflowConfig::default(),
-        trigger_bindings: Vec::new(),
+        trigger_bindings: vec![
+            TriggerBinding::new(
+                node_key!("test.trigger"),
+                TEST_PLUGIN_KEY,
+                "test.trigger.action",
+            )
+            .unwrap(),
+        ],
         tags: Vec::new(),
         created_at: now,
         updated_at: now,
@@ -205,21 +222,24 @@ async fn save_echo_workflow(stores: &TestStores) -> nebula_core::WorkflowId {
         ui_metadata: None,
         schema_version: CURRENT_SCHEMA_VERSION,
     };
+    let validated =
+        ValidatedWorkflow::validate(def).expect("echo workflow definition must pass validation");
     stores
         .versions
         .create(
             &scope(),
             WorkflowVersionRecord {
-                workflow_id: wf.id.to_string(),
+                workflow_id: validated.definition().id.to_string(),
                 number: 0,
                 published: true,
                 pinned: false,
-                definition: serde_json::to_value(&wf).expect("serialize workflow"),
+                definition: serde_json::to_value(validated.definition())
+                    .expect("serialize workflow"),
             },
         )
         .await
         .expect("save workflow version");
-    workflow_id
+    Arc::new(validated)
 }
 
 /// Persist a pristine `Created` execution row, mirroring the API handler.
@@ -258,7 +278,7 @@ async fn read_status(stores: &TestStores, execution_id: ExecutionId) -> Option<E
     })
 }
 
-/// Helper: `[1u8; 16]` processor id.
+/// Helper: `[b; 16]` processor id.
 fn proc16(b: u8) -> [u8; 16] {
     [b; 16]
 }
@@ -267,15 +287,14 @@ fn proc16(b: u8) -> [u8; 16] {
 
 /// `EngineExecutionSink::dispatch` on a `Created` row drives `resume_execution`
 /// and the execution reaches `Completed`.
-///
-/// This is the RED→GREEN behavior test for the sink (Checkpoint B).
 #[tokio::test(start_paused = true)]
 async fn sink_dispatch_drives_resume_execution() {
     let stores = TestStores::new();
     let (engine, echo_count) = make_engine(&stores).await;
-    let workflow_id = save_echo_workflow(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
 
-    // Seed a Created row (the emitter will do this in prod; we seed it directly
+    // Seed a Created row (the emitter does this in prod; we seed it directly
     // for the isolated sink unit test).
     let execution_id = ExecutionId::new();
     persist_created(
@@ -307,8 +326,8 @@ async fn sink_dispatch_drives_resume_execution() {
         "EngineExecutionSink::dispatch must succeed on a Created row: {result:?}"
     );
 
-    // Assert the execution actually ran — status must be Completed (not just
-    // Created, which would mean resume_execution was never driven).
+    // Status must be Completed — not just Created, which would mean
+    // resume_execution was never driven.
     let status = read_status(&stores, execution_id)
         .await
         .expect("execution row must exist after dispatch");
@@ -330,7 +349,8 @@ async fn sink_dispatch_drives_resume_execution() {
 async fn sink_dispatch_redelivery_is_idempotent() {
     let stores = TestStores::new();
     let (engine, echo_count) = make_engine(&stores).await;
-    let workflow_id = save_echo_workflow(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
 
     let execution_id = ExecutionId::new();
     persist_created(&stores, workflow_id, execution_id, serde_json::json!({})).await;
@@ -371,20 +391,16 @@ async fn sink_dispatch_redelivery_is_idempotent() {
 }
 
 // ── C-series: DurableExecutionEmitter unit tests ─────────────────────────────
-//
-// These tests are written against `DurableExecutionEmitter` which is declared
-// in `nebula_engine::daemon::durable_emitter`.  They become GREEN at
-// Checkpoint C when that module is added.
 
 use nebula_engine::daemon::durable_emitter::DurableExecutionEmitter;
-use nebula_engine::daemon::routing::StaticRoutingResolver;
+use nebula_engine::daemon::routing::{DefinitionRoutingResolver, SLICE_FLAVOR_SHA};
 
 const TEST_PLUGIN_KEY: &str = "test.dispatch.plugin";
 
 /// Build InMemory dedup + queue + emitter sharing one execution-store core.
 async fn make_emitter(
     stores: &TestStores,
-    workflow_id: nebula_core::WorkflowId,
+    workflow: Arc<ValidatedWorkflow>,
 ) -> (
     DurableExecutionEmitter,
     Arc<InMemoryTriggerDedupInbox>,
@@ -392,11 +408,11 @@ async fn make_emitter(
 ) {
     let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&stores.execution));
     let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
-    let resolver = Arc::new(StaticRoutingResolver::new(TEST_PLUGIN_KEY));
+    let resolver = Arc::new(DefinitionRoutingResolver::new(SLICE_FLAVOR_SHA));
     let emitter = DurableExecutionEmitter::new(
         Arc::clone(&dedup) as Arc<dyn TriggerDedupInbox>,
         resolver,
-        workflow_id,
+        workflow,
         node_key!("test.trigger"),
         scope(),
     );
@@ -406,12 +422,13 @@ async fn make_emitter(
 /// `DurableExecutionEmitter::emit` with `Some(event_id)` produces:
 ///  - `DispatchKind::Dispatched` (returned as Ok(execution_id))
 ///  - A `Created` execution row in the store
-///  - Exactly one Start row in the job-dispatch queue
+///  - Exactly one Start row in the job-dispatch queue with the correct routing
+///    fields (`required_plugin_key` and exact `capability_tags`)
 #[tokio::test(start_paused = true)]
 async fn emitter_dispatched_creates_row_and_enqueues_start() {
     let stores = TestStores::new();
-    let workflow_id = save_echo_workflow(&stores).await;
-    let (emitter, _dedup, queue) = make_emitter(&stores, workflow_id).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let (emitter, _dedup, queue) = make_emitter(&stores, Arc::clone(&workflow)).await;
 
     let event_id = IdempotencyKey::new("evt-001");
     let execution_id = emitter
@@ -432,7 +449,7 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
         "row must be in Created state immediately after emit; got {status:?}"
     );
 
-    // Exactly one Start job in the queue.
+    // Exactly one Start job in the queue, claimable by the test plugin key.
     let jobs = queue
         .claim_pending(&proc16(1), 10, &[CapabilityTag::from(TEST_PLUGIN_KEY)])
         .await
@@ -452,6 +469,23 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
         matches!(jobs[0].command, ControlCommand::Start),
         "job command must be Start"
     );
+
+    // The route written into the job must match the exact expected values.
+    // The echo workflow has one trigger binding (TEST_PLUGIN_KEY) and one
+    // enabled node (TEST_PLUGIN_KEY), so capability_tags = [TEST_PLUGIN_KEY]
+    // (deduplicated).
+    assert_eq!(
+        jobs[0].required_plugin_key, TEST_PLUGIN_KEY,
+        "required_plugin_key on enqueued job must equal TEST_PLUGIN_KEY"
+    );
+    let expected_tags = vec![CapabilityTag::from(TEST_PLUGIN_KEY)];
+    assert_eq!(
+        jobs[0].capability_tags, expected_tags,
+        "capability_tags on enqueued job must equal exactly {{TEST_PLUGIN_KEY}}; \
+         trigger and node share the same plugin key so dedup yields one entry. \
+         got: {:?}",
+        jobs[0].capability_tags
+    );
 }
 
 /// A second `emit` with the same `event_id` returns the WINNER's id (same as
@@ -461,8 +495,8 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
 #[tokio::test(start_paused = true)]
 async fn emitter_duplicate_event_id_no_second_row() {
     let stores = TestStores::new();
-    let workflow_id = save_echo_workflow(&stores).await;
-    let (emitter, _dedup, queue) = make_emitter(&stores, workflow_id).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let (emitter, _dedup, queue) = make_emitter(&stores, Arc::clone(&workflow)).await;
 
     let event_id = IdempotencyKey::new("evt-dup");
 
@@ -518,18 +552,18 @@ async fn emitter_duplicate_event_id_no_second_row() {
 async fn trigger_dispatch_end_to_end_real_engine_resume() {
     let stores = TestStores::new();
     let (engine, echo_count) = make_engine(&stores).await;
-    let workflow_id = save_echo_workflow(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
 
     // Wire: dedup + queue share the execution store's core so all three writes
     // (dedup guard + execution row + Start job) are atomic under one lock.
     let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&stores.execution));
     let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
 
-    let resolver = Arc::new(StaticRoutingResolver::new(TEST_PLUGIN_KEY));
+    let resolver = Arc::new(DefinitionRoutingResolver::new(SLICE_FLAVOR_SHA));
     let emitter = DurableExecutionEmitter::new(
         Arc::clone(&dedup) as Arc<dyn TriggerDedupInbox>,
         resolver,
-        workflow_id,
+        Arc::clone(&workflow),
         node_key!("test.trigger"),
         scope(),
     );


### PR DESCRIPTION
## ADR-0095 D1 — DefinitionRoutingResolver (registry-free trigger routing)

Turns the trigger-dispatch slice's hardcoded `StaticRoutingResolver` into a real
resolver that derives the dispatch route from the self-describing workflow
definition — no registry, no string-parsing. Builds on the trigger-binding
contract merged in #815.

> Supersedes #816 (auto-closed when #815's base branch was deleted on merge);
> rebased onto `main`, diff is the engine routing change only.

### What changed (`crates/engine/src/daemon/`)
- **`RoutingResolver::resolve(&ValidatedWorkflow, fired_trigger_id: &NodeKey)`** —
  takes the **validation witness** `ValidatedWorkflow` so duplicate
  trigger-binding ids are rejected *before* the resolver runs — the fired-trigger
  lookup is sound by construction, not a runtime `.find()` assumption.
- **`DefinitionRoutingResolver`** replaces `StaticRoutingResolver` (deleted, no
  shim). `required_plugin_key` = the fired trigger's `plugin_key`;
  `capability_tags` = the deduped set of every **enabled** node's + every
  trigger's `plugin_key` (disabled nodes excluded — they never execute). Reads
  `plugin_key` straight from the definition, so the orchestrator links **no**
  plugin crate.
- **`capability_tags` is a forward seam** (documented in-code): today's claim
  predicate is `required_plugin_key ∈ advertised_tags`; the superset predicate
  (`job.capability_tags ⊆ advertised_tags`) that consumes the full set is a later
  unit (closes the multi-plugin-workflow routing wall, the common case).
- **`DurableExecutionEmitter`** holds `Arc<ValidatedWorkflow>` and resolves per
  emit. `DispatchRoute` is `#[must_use]`; `RoutingError::TriggerNotOnWorkflow` is
  the typed fail-closed variant.

### Verification
- `cargo check --workspace --all-targets` — clean
- `cargo nextest run -p nebula-engine` — **332 passed**; pre-push gate ran the full
  suite (**1087 passed**) + `rustdoc -D warnings` on all changed crates — green
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
- Tests: exact-set `capability_tags` assertions (unit + slice-level
  `JobDispatchMsg` wiring), disabled-node exclusion, fail-closed
  `TriggerNotOnWorkflow`.

### Follow-up
- **superset claim-predicate** (`worker.tags ⊇ job.capability_tags`) — storage +
  orchestrator unit; the `capability_tags` seam here carries the truth so it lands
  non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured the internal workflow execution routing system to derive routing decisions dynamically from validated workflow definitions rather than static configuration.
  * Updated the execution emission flow to align with definition-driven routing behavior.

* **Tests**
  * Enhanced test coverage to validate the new routing logic and verify enqueued job routing fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->