### PR TITLE
feat(storage)!: superset claim predicate + rename capability_tags→required_plugins (ADR-0095 D1)

### DIFF
--- a/crates/engine/src/daemon/durable_emitter.rs
+++ b/crates/engine/src/daemon/durable_emitter.rs
@@ -7,7 +7,7 @@
 //! wires the trigger-to-execution fan-out path end-to-end:
 //!
 //! 1. Resolve routing from the [`ValidatedWorkflow`] (fail-fast before minting
-//!    an id): `required_plugin_key` + `capability_tags` + flavor SHA.
+//!    an id): `required_plugin_key` + `required_plugins` + flavor SHA.
 //! 2. Mint a new [`ExecutionId`] candidate and build the initial
 //!    [`ExecutionState`].
 //! 3. Build a [`JobDispatchMsg`] (Start command, routing key, etc.), a
@@ -75,8 +75,8 @@ use crate::daemon::routing::RoutingResolver;
 ///   be reached with an unvalidated definition.
 /// - [`TriggerDedupInbox`] — atomic dedup + execution-row materialise + job
 ///   enqueue, all in one transaction.
-/// - [`RoutingResolver`] — derive `required_plugin_key` + `target_flavor_sha`
-///   from the validated definition.
+/// - [`RoutingResolver`] — derive `required_plugin_key` + `required_plugins`
+///   + `target_flavor_sha` from the validated definition.
 /// - Identity fields captured at construction: `trigger_id`, `scope` — same
 ///   values on every `emit` call from this trigger context.
 #[derive(Clone)]
@@ -177,7 +177,7 @@ impl DurableExecutionEmitter {
             event_id.as_ref().map(IdempotencyKey::as_str),
             route.target_flavor_sha.clone(),
             route.required_plugin_key.clone(),
-            route.capability_tags.clone(),
+            route.required_plugins.clone(),
             None::<String>, // w3c_traceparent: future D1
             0,              // reclaim_count: 0 on first enqueue
         );

--- a/crates/engine/src/daemon/routing.rs
+++ b/crates/engine/src/daemon/routing.rs
@@ -22,8 +22,7 @@
 
 use std::collections::BTreeSet;
 
-use nebula_core::NodeKey;
-use nebula_storage_port::dto::CapabilityTag;
+use nebula_core::{NodeKey, PluginKey};
 use nebula_workflow::ValidatedWorkflow;
 
 // ── types ─────────────────────────────────────────────────────────────────────
@@ -34,31 +33,25 @@ use nebula_workflow::ValidatedWorkflow;
 /// Returned by [`RoutingResolver::resolve`].  The `required_plugin_key` is
 /// written into the `JobDispatchMsg::required_plugin_key` field; the
 /// orchestrator claims rows whose `required_plugin_key` is a member of the
-/// worker's advertised capability set.
+/// worker's `available_plugins`.
 ///
-/// `capability_tags` carries the full set of plugin keys the workflow needs
-/// (trigger + enabled nodes).  **Note:** the current orchestrator claim
-/// predicate tests only `required_plugin_key ∈ advertised_tags`
-/// (`storage-port` `job_dispatch.rs`) — it does NOT yet apply the superset
-/// check `job.capability_tags ⊆ advertised_tags`.  `capability_tags` is a
-/// forward seam for that future multi-plugin routing unit; until then it is
-/// written into the `JobDispatchMsg` for observability and future use.
+/// `required_plugins` carries the full set of plugin keys the workflow needs
+/// (trigger + enabled nodes, deduplicated and sorted).  The claim predicate
+/// is the superset check `job.required_plugins ⊆ worker.available_plugins`;
+/// `required_plugin_key` is kept as an index-friendly pre-filter (sound
+/// because `required_plugins ⊇ {required_plugin_key}` by construction).
 ///
 /// `target_flavor_sha` is a version-pin guard written into the message but
 /// not yet used for routing.
 #[must_use = "a DispatchRoute must be written into the JobDispatchMsg; dropping it yields an un-claimable job"]
 #[derive(Debug, Clone)]
 pub struct DispatchRoute {
-    /// The advertised `PluginKey` string this job requires a worker to support.
-    pub required_plugin_key: String,
-    /// Full set of plugin-key capability tags the workflow needs (trigger
-    /// binding + enabled nodes, deduplicated and sorted).
-    ///
-    /// Populated now for observability and future multi-plugin routing.
-    /// The current claim predicate only checks `required_plugin_key`; the
-    /// superset predicate (`job.capability_tags ⊆ advertised_tags`) is a
-    /// later deliverable.
-    pub capability_tags: Vec<CapabilityTag>,
+    /// The primary required plugin (the trigger's plugin); an element of
+    /// `required_plugins`; used as the index pre-filter.
+    pub required_plugin_key: PluginKey,
+    /// Full set of plugin keys the workflow needs (trigger binding + enabled
+    /// nodes, deduplicated and sorted).  Superset of `{required_plugin_key}`.
+    pub required_plugins: Vec<PluginKey>,
     /// SHA of the plugin flavor this message targets (version-pin guard; not
     /// yet used for routing).
     pub target_flavor_sha: String,
@@ -131,7 +124,7 @@ pub const SLICE_FLAVOR_SHA: &str = "slice-flavor-0000000000000000000000000000000
 ///    Because [`ValidatedWorkflow`] rejects duplicate trigger-binding ids, the
 ///    `.find()` result is always unique.
 /// 2. The binding's `plugin_key` becomes `required_plugin_key`.
-/// 3. `capability_tags` is the deduplicated, sorted union of `plugin_key`
+/// 3. `required_plugins` is the deduplicated, sorted union of `plugin_key`
 ///    values from every trigger binding **and** every **enabled** node.
 ///    Disabled nodes are excluded — they are skipped at execution time and
 ///    their plugin is not required on the target worker.
@@ -196,37 +189,37 @@ impl RoutingResolver for DefinitionRoutingResolver {
             })?;
 
         // Step 2 — the binding's plugin_key is the required routing key.
-        let required_plugin_key = binding.plugin_key.as_str().to_owned();
+        // `plugin_key` is already a `PluginKey` — no stringification needed.
+        let required_plugin_key = binding.plugin_key.clone();
         tracing::debug!(
             required_plugin_key = %required_plugin_key,
             "resolved required plugin key"
         );
 
-        // Step 3 — capability_tags: deduplicated, sorted union of plugin_key
+        // Step 3 — required_plugins: deduplicated, sorted union of plugin_key
         // values from all trigger bindings and all ENABLED nodes.
         // Disabled nodes are skipped at execution time; their plugin is not
         // needed on the target worker.
-        let mut keys: BTreeSet<&str> = BTreeSet::new();
+        let mut keys: BTreeSet<&PluginKey> = BTreeSet::new();
         for tb in &def.trigger_bindings {
-            keys.insert(tb.plugin_key.as_str());
+            keys.insert(&tb.plugin_key);
         }
         for node in &def.nodes {
             if node.enabled {
-                keys.insert(node.plugin_key.as_str());
+                keys.insert(&node.plugin_key);
             }
         }
         // The required key is always present: we just resolved it from the
         // trigger bindings, which are unconditionally added above.
-        let capability_tags: Vec<CapabilityTag> =
-            keys.into_iter().map(CapabilityTag::from).collect();
+        let required_plugins: Vec<PluginKey> = keys.into_iter().cloned().collect();
         tracing::debug!(
-            capability_tag_count = capability_tags.len(),
-            "resolved capability tags"
+            required_plugin_count = required_plugins.len(),
+            "resolved required plugins"
         );
 
         Ok(DispatchRoute {
             required_plugin_key,
-            capability_tags,
+            required_plugins,
             target_flavor_sha: self.flavor_sha.clone(),
         })
     }
@@ -236,7 +229,7 @@ impl RoutingResolver for DefinitionRoutingResolver {
 mod tests {
     use std::collections::HashMap;
 
-    use nebula_core::{WorkflowId, node_key};
+    use nebula_core::{PluginKey, WorkflowId, node_key, plugin_key};
     use nebula_workflow::{
         CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, TriggerBinding, ValidatedWorkflow,
         Version, WorkflowConfig, WorkflowDefinition,
@@ -315,9 +308,9 @@ mod tests {
     }
 
     #[test]
-    fn resolves_required_key_and_sorted_capability_set() {
+    fn resolves_required_key_and_sorted_required_plugins() {
         // trigger plugin = "p.trig", node plugins = [("p.a", true), ("p.b", true)]
-        // expected capability_tags = sorted { "p.a", "p.b", "p.trig" }
+        // expected required_plugins = sorted { "p.a", "p.b", "p.trig" }
         let workflow = make_validated("test.trigger", "p.trig", &[("p.a", true), ("p.b", true)]);
         let resolver = DefinitionRoutingResolver::new(SLICE_FLAVOR_SHA);
         let fired = node_key!("test.trigger");
@@ -325,30 +318,27 @@ mod tests {
             .resolve(&workflow, &fired)
             .expect("trigger present in bindings must resolve");
 
-        assert_eq!(route.required_plugin_key, "p.trig");
+        assert_eq!(route.required_plugin_key, plugin_key!("p.trig"));
         assert_eq!(route.target_flavor_sha, SLICE_FLAVOR_SHA);
 
-        let tags: Vec<&str> = route
-            .capability_tags
+        let plugins: Vec<&str> = route
+            .required_plugins
             .iter()
-            .map(CapabilityTag::as_str)
+            .map(PluginKey::as_str)
             .collect();
         // Sorted BTreeSet order: p.a < p.b < p.trig
-        assert_eq!(tags, vec!["p.a", "p.b", "p.trig"]);
+        assert_eq!(plugins, vec!["p.a", "p.b", "p.trig"]);
 
-        // Required key is a member of the capability set.
+        // Required key is a member of the required_plugins set.
         assert!(
-            route
-                .capability_tags
-                .iter()
-                .any(|t| t.as_str() == route.required_plugin_key),
-            "required_plugin_key must be in capability_tags"
+            route.required_plugins.contains(&route.required_plugin_key),
+            "required_plugin_key must be in required_plugins"
         );
     }
 
     #[test]
-    fn disabled_node_plugin_excluded_from_capability_tags() {
-        // "p.disabled" belongs to a disabled node — it must NOT appear in tags.
+    fn disabled_node_plugin_excluded_from_required_plugins() {
+        // "p.disabled" belongs to a disabled node — it must NOT appear.
         // "p.enabled" belongs to an enabled node — it MUST appear.
         // "p.trig" is the trigger binding — it MUST appear.
         let workflow = make_validated(
@@ -361,35 +351,36 @@ mod tests {
             .resolve(&workflow, &node_key!("test.trigger"))
             .unwrap();
 
-        let tags: Vec<&str> = route
-            .capability_tags
-            .iter()
-            .map(CapabilityTag::as_str)
-            .collect();
+        let trig = plugin_key!("p.trig");
+        let enabled = plugin_key!("p.enabled");
+        let disabled = "p.disabled".parse::<PluginKey>().unwrap();
         assert!(
-            tags.contains(&"p.trig"),
-            "trigger plugin must be in capability_tags; got {tags:?}"
+            route.required_plugins.contains(&trig),
+            "trigger plugin must be in required_plugins; got {:?}",
+            route.required_plugins
         );
         assert!(
-            tags.contains(&"p.enabled"),
-            "enabled node plugin must be in capability_tags; got {tags:?}"
+            route.required_plugins.contains(&enabled),
+            "enabled node plugin must be in required_plugins; got {:?}",
+            route.required_plugins
         );
         assert!(
-            !tags.contains(&"p.disabled"),
-            "disabled node plugin must NOT be in capability_tags; got {tags:?}"
+            !route.required_plugins.contains(&disabled),
+            "disabled node plugin must NOT be in required_plugins; got {:?}",
+            route.required_plugins
         );
     }
 
     #[test]
-    fn capability_tags_deduplicated_when_trigger_and_node_share_plugin() {
-        // trigger plugin = "p.shared", node plugin = "p.shared" — only one tag.
+    fn required_plugins_deduplicated_when_trigger_and_node_share_plugin() {
+        // trigger plugin = "p.shared", node plugin = "p.shared" — only one entry.
         let workflow = make_validated("test.trigger", "p.shared", &[("p.shared", true)]);
         let resolver = DefinitionRoutingResolver::default();
         let fired = node_key!("test.trigger");
         let route = resolver.resolve(&workflow, &fired).unwrap();
 
-        assert_eq!(route.capability_tags.len(), 1);
-        assert_eq!(route.capability_tags[0].as_str(), "p.shared");
+        assert_eq!(route.required_plugins.len(), 1);
+        assert_eq!(route.required_plugins[0], plugin_key!("p.shared"));
     }
 
     #[test]

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -36,7 +36,7 @@ use nebula_action::{
     ActionError, ActionMetadata, ExecutionEmitter, IdempotencyKey, action::Action,
     result::ActionResult, stateless::StatelessAction,
 };
-use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_core::{Dependencies, PluginKey, action_key, id::ExecutionId, node_key};
 use nebula_engine::{
     ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, EngineExecutionSink,
     InProcessRunner, WorkflowEngine,
@@ -50,7 +50,7 @@ use nebula_storage::{
 };
 use nebula_storage_port::{
     Scope,
-    dto::{CapabilityTag, ControlCommand, JobDispatchMsg, WorkflowVersionRecord},
+    dto::{ControlCommand, JobDispatchMsg, WorkflowVersionRecord},
     store::{ExecutionStore, JobDispatchQueue, TriggerDedupInbox, WorkflowVersionStore},
 };
 use nebula_workflow::{
@@ -306,6 +306,7 @@ async fn sink_dispatch_drives_resume_execution() {
     .await;
 
     let sink = EngineExecutionSink::new(Arc::clone(&engine), stores.execution.clone());
+    let test_plugin_key: PluginKey = "test.plugin".parse().unwrap();
     let msg = JobDispatchMsg::new(
         [42u8; 16],
         execution_id.to_string(),
@@ -314,8 +315,8 @@ async fn sink_dispatch_drives_resume_execution() {
         serde_json::json!({}),
         None::<String>,
         "sha-abc",
-        "test.plugin",
-        vec![CapabilityTag::from("test.plugin")],
+        test_plugin_key.clone(),
+        vec![test_plugin_key],
         None::<String>,
         0,
     );
@@ -356,6 +357,7 @@ async fn sink_dispatch_redelivery_is_idempotent() {
     persist_created(&stores, workflow_id, execution_id, serde_json::json!({})).await;
 
     let sink = EngineExecutionSink::new(Arc::clone(&engine), stores.execution.clone());
+    let test_plugin_key: PluginKey = "test.plugin".parse().unwrap();
     let msg = JobDispatchMsg::new(
         [7u8; 16],
         execution_id.to_string(),
@@ -364,8 +366,8 @@ async fn sink_dispatch_redelivery_is_idempotent() {
         serde_json::json!({}),
         None::<String>,
         "sha-abc",
-        "test.plugin",
-        vec![CapabilityTag::from("test.plugin")],
+        test_plugin_key.clone(),
+        vec![test_plugin_key],
         None::<String>,
         0,
     );
@@ -423,7 +425,7 @@ async fn make_emitter(
 ///  - `DispatchKind::Dispatched` (returned as Ok(execution_id))
 ///  - A `Created` execution row in the store
 ///  - Exactly one Start row in the job-dispatch queue with the correct routing
-///    fields (`required_plugin_key` and exact `capability_tags`)
+///    fields (`required_plugin_key` and exact `required_plugins`)
 #[tokio::test(start_paused = true)]
 async fn emitter_dispatched_creates_row_and_enqueues_start() {
     let stores = TestStores::new();
@@ -450,8 +452,9 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
     );
 
     // Exactly one Start job in the queue, claimable by the test plugin key.
+    let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
     let jobs = queue
-        .claim_pending(&proc16(1), 10, &[CapabilityTag::from(TEST_PLUGIN_KEY)])
+        .claim_pending(&proc16(1), 10, &[plugin_key])
         .await
         .expect("claim_pending must succeed");
     assert_eq!(
@@ -472,19 +475,21 @@ async fn emitter_dispatched_creates_row_and_enqueues_start() {
 
     // The route written into the job must match the exact expected values.
     // The echo workflow has one trigger binding (TEST_PLUGIN_KEY) and one
-    // enabled node (TEST_PLUGIN_KEY), so capability_tags = [TEST_PLUGIN_KEY]
+    // enabled node (TEST_PLUGIN_KEY), so required_plugins = [TEST_PLUGIN_KEY]
     // (deduplicated).
     assert_eq!(
-        jobs[0].required_plugin_key, TEST_PLUGIN_KEY,
+        jobs[0].required_plugin_key.as_str(),
+        TEST_PLUGIN_KEY,
         "required_plugin_key on enqueued job must equal TEST_PLUGIN_KEY"
     );
-    let expected_tags = vec![CapabilityTag::from(TEST_PLUGIN_KEY)];
+    let expected_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
+    let expected_plugins = vec![expected_key];
     assert_eq!(
-        jobs[0].capability_tags, expected_tags,
-        "capability_tags on enqueued job must equal exactly {{TEST_PLUGIN_KEY}}; \
+        jobs[0].required_plugins, expected_plugins,
+        "required_plugins on enqueued job must equal exactly {{TEST_PLUGIN_KEY}}; \
          trigger and node share the same plugin key so dedup yields one entry. \
          got: {:?}",
-        jobs[0].capability_tags
+        jobs[0].required_plugins
     );
 }
 
@@ -518,8 +523,9 @@ async fn emitter_duplicate_event_id_no_second_row() {
     );
 
     // Only one Start job must be in the queue (the duplicate write is a no-op).
+    let plugin_key2: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
     let jobs = queue
-        .claim_pending(&proc16(2), 10, &[CapabilityTag::from(TEST_PLUGIN_KEY)])
+        .claim_pending(&proc16(2), 10, &[plugin_key2])
         .await
         .expect("claim_pending must succeed");
     assert_eq!(
@@ -591,11 +597,12 @@ async fn trigger_dispatch_end_to_end_real_engine_resume() {
         stores.execution.clone() as Arc<dyn ExecutionStore>,
     ));
     let cancel = CancellationToken::new();
+    let orch_plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
     let orch = Orchestrator::new(
         Arc::clone(&queue) as Arc<dyn JobDispatchQueue>,
         sink as Arc<dyn ExecutionSink>,
         proc16(0xAA),
-        vec![CapabilityTag::from(TEST_PLUGIN_KEY)],
+        vec![orch_plugin_key],
     );
 
     let cancel_clone = cancel.clone();

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,15 +1,14 @@
 //! Capability-routed job-dispatch pull loop for the Nebula orchestration layer.
 //!
 //! `nebula-orchestrator` owns exactly one thing: the **leaderless routing pull-loop** —
-//! claim [`JobDispatchQueue`] rows whose `required_plugin_key` is in the worker's
-//! advertised [`CapabilityTag`] set, hand each [`JobDispatchMsg`] to an [`ExecutionSink`],
-//! fence-mark the row dispatched/failed, plus a periodic [`JobDispatchQueue::reclaim_stuck`]
-//! sweep.
+//! claim [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`, hand each
+//! [`JobDispatchMsg`] to an [`ExecutionSink`], fence-mark the row dispatched/failed, plus a
+//! periodic [`JobDispatchQueue::reclaim_stuck`] sweep.
 //!
 //! ## What this crate defers
 //!
 //! - **Execution** → future `nebula-worker`: the real [`ExecutionSink`] drives the engine Start
-//!   path, reads `PluginRegistry` at boot to derive `advertised_tags`, and constructs an
+//!   path, reads `PluginRegistry` at boot to derive `available_plugins`, and constructs an
 //!   [`Orchestrator`] with a concrete sink implementation.
 //! - **Enqueue** → `DurableExecutionEmitter`: the orchestrator never enqueues, only consumes.
 //!
@@ -23,7 +22,6 @@
 //! [`JobDispatchQueue`]: nebula_storage_port::store::JobDispatchQueue
 //! [`JobDispatchQueue::reclaim_stuck`]: nebula_storage_port::store::JobDispatchQueue::reclaim_stuck
 //! [`JobDispatchMsg`]: nebula_storage_port::dto::JobDispatchMsg
-//! [`CapabilityTag`]: nebula_storage_port::dto::CapabilityTag
 
 pub mod orchestrator;
 pub mod sink;

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -25,6 +25,7 @@
 
 use std::{sync::Arc, time::Duration};
 
+use nebula_core::PluginKey;
 use nebula_metrics::{
     MetricsRegistry,
     naming::{
@@ -32,7 +33,7 @@ use nebula_metrics::{
         orchestrator_dispatch_outcome, orchestrator_reclaim_outcome,
     },
 };
-use nebula_storage_port::dto::{CapabilityTag, JobDispatchMsg};
+use nebula_storage_port::dto::JobDispatchMsg;
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -72,10 +73,9 @@ pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
 
 /// Capability-routed job-dispatch pull loop (ADR-0095).
 ///
-/// Claims [`JobDispatchQueue`] rows whose `required_plugin_key` is in
-/// `advertised_tags`, hands each to an [`ExecutionSink`], and fences the row
-/// dispatched or failed. A periodic sweep reclaims rows stuck in `Processing`
-/// after a crashed runner.
+/// Claims [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`,
+/// hands each to an [`ExecutionSink`], and fences the row dispatched or failed.
+/// A periodic sweep reclaims rows stuck in `Processing` after a crashed runner.
 ///
 /// Construct with [`Orchestrator::new`] and optional builder methods, then
 /// call [`Orchestrator::run`] (or [`Orchestrator::spawn`]).
@@ -90,7 +90,7 @@ pub struct Orchestrator {
     /// truncate/pad of an arbitrary-length id, which would let two distinct
     /// workers collapse to the same token and ack each other's rows.
     processor_id: [u8; 16],
-    advertised_tags: Vec<CapabilityTag>,
+    available_plugins: Vec<PluginKey>,
     batch_size: u32,
     poll_interval: Duration,
     reclaim_after: Duration,
@@ -115,13 +115,13 @@ impl Orchestrator {
         queue: Arc<dyn JobDispatchQueue>,
         sink: Arc<dyn ExecutionSink>,
         processor_id: [u8; 16],
-        advertised_tags: Vec<CapabilityTag>,
+        available_plugins: Vec<PluginKey>,
     ) -> Self {
         Self {
             queue,
             sink,
             processor_id,
-            advertised_tags,
+            available_plugins,
             batch_size: DEFAULT_BATCH_SIZE,
             poll_interval: DEFAULT_POLL_INTERVAL,
             reclaim_after: DEFAULT_RECLAIM_AFTER,
@@ -203,7 +203,7 @@ impl Orchestrator {
             reclaim_after_ms = self.reclaim_after.as_millis() as u64,
             reclaim_interval_ms = self.reclaim_interval.as_millis() as u64,
             max_reclaim_count = self.max_reclaim_count,
-            advertised_tags = ?self.advertised_tags.iter().map(CapabilityTag::as_str).collect::<Vec<_>>(),
+            available_plugins = ?self.available_plugins.iter().map(PluginKey::as_str).collect::<Vec<_>>(),
             "orchestrator started (ADR-0095)"
         );
 
@@ -313,7 +313,7 @@ impl Orchestrator {
     async fn tick(&self, consecutive_errors: &mut u32) -> Option<Duration> {
         let claimed: Result<Vec<JobDispatchMsg>, String> = self
             .queue
-            .claim_pending(&self.processor_id, self.batch_size, &self.advertised_tags)
+            .claim_pending(&self.processor_id, self.batch_size, &self.available_plugins)
             .await
             .map_err(|e| e.to_string());
 
@@ -347,15 +347,13 @@ impl Orchestrator {
 
     async fn handle_entry(&self, msg: JobDispatchMsg) {
         // The queue routing predicate is enforced at claim time
-        // (`required_plugin_key ∈ advertised_tags`). This assert documents the
-        // port invariant in debug builds only — it is not a release guard.
+        // (`required_plugin_key ∈ available_plugins`). This assert documents
+        // the port invariant in debug builds only — it is not a release guard.
         debug_assert!(
-            self.advertised_tags
-                .iter()
-                .any(|t| t.as_str() == msg.required_plugin_key),
-            "claim routing invariant violated: required_plugin_key {:?} not in advertised_tags {:?}",
+            self.available_plugins.contains(&msg.required_plugin_key),
+            "claim routing invariant violated: required_plugin_key {:?} not in available_plugins {:?}",
             msg.required_plugin_key,
-            self.advertised_tags
+            self.available_plugins
         );
 
         let row_id = msg.id;

--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -346,9 +346,11 @@ impl Orchestrator {
     }
 
     async fn handle_entry(&self, msg: JobDispatchMsg) {
-        // The queue routing predicate is enforced at claim time
-        // (`required_plugin_key ∈ available_plugins`). This assert documents
-        // the port invariant in debug builds only — it is not a release guard.
+        // The queue routing predicate (`required_plugins ⊆ available_plugins`)
+        // is enforced at claim time. This assert checks the implied single-key
+        // condition (`required_plugin_key ∈ available_plugins`, since
+        // `required_plugin_key ∈ required_plugins` by the DTO invariant) in
+        // debug builds only — it is not a release guard.
         debug_assert!(
             self.available_plugins.contains(&msg.required_plugin_key),
             "claim routing invariant violated: required_plugin_key {:?} not in available_plugins {:?}",

--- a/crates/orchestrator/tests/orchestrator_wiring.rs
+++ b/crates/orchestrator/tests/orchestrator_wiring.rs
@@ -27,6 +27,7 @@ use std::{
 };
 
 use async_trait::async_trait;
+use nebula_core::PluginKey;
 use nebula_metrics::{
     MetricsRegistry,
     naming::{
@@ -38,7 +39,7 @@ use nebula_orchestrator::{ExecutionSink, ExecutionSinkError, Orchestrator};
 use nebula_storage::inmem::{InMemoryExecutionStore, InMemoryJobDispatchQueue};
 use nebula_storage_port::{
     Scope,
-    dto::{CapabilityTag, ControlCommand, JobDispatchMsg},
+    dto::{ControlCommand, JobDispatchMsg},
     store::JobDispatchQueue,
 };
 use tokio::sync::Notify;
@@ -67,7 +68,13 @@ fn scope() -> Scope {
 }
 
 /// Build a minimal [`JobDispatchMsg`] stamped with `row_id`.
+///
+/// `required_plugin_key` must be a valid `PluginKey` string (lowercase
+/// alphanumeric, hyphens, dots; no trailing hyphen).
 fn make_msg(row_id: u8, required_plugin_key: &str, execution_id: &str) -> JobDispatchMsg {
+    let key: PluginKey = required_plugin_key
+        .parse()
+        .expect("test plugin key must be valid");
     JobDispatchMsg::new(
         [row_id; 16],
         execution_id,
@@ -76,8 +83,8 @@ fn make_msg(row_id: u8, required_plugin_key: &str, execution_id: &str) -> JobDis
         serde_json::json!({}),
         None::<String>,
         "sha-abc",
-        required_plugin_key,
-        vec![CapabilityTag::from(required_plugin_key)],
+        key.clone(),
+        vec![key],
         None::<String>,
         0,
     )
@@ -299,7 +306,7 @@ async fn routes_by_tag() {
         queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
         proc16(b"proc-alpha"),
-        vec![CapabilityTag::from("alpha")],
+        vec!["alpha".parse::<PluginKey>().unwrap()],
     )
     .with_batch_size(8)
     .with_poll_interval(Duration::from_millis(10));
@@ -324,12 +331,13 @@ async fn routes_by_tag() {
     let seen = spy.snapshot();
     assert_eq!(seen.len(), 1, "spy must see exactly one job");
     assert_eq!(
-        seen[0].required_plugin_key, "alpha",
+        seen[0].required_plugin_key.as_str(),
+        "alpha",
         "dispatched job must be the alpha job"
     );
 
     // Beta job must still be Pending — claimable by a beta-capable worker.
-    let beta_tags = vec![CapabilityTag::from("beta")];
+    let beta_tags = vec!["beta".parse::<PluginKey>().unwrap()];
     let leftover = queue
         .claim_pending(&proc16(b"beta-worker-"), 8, &beta_tags)
         .await
@@ -339,7 +347,7 @@ async fn routes_by_tag() {
         1,
         "beta job must still be Pending after alpha-only orchestrator ran"
     );
-    assert_eq!(leftover[0].required_plugin_key, "beta");
+    assert_eq!(leftover[0].required_plugin_key.as_str(), "beta");
 }
 
 // ── test 2: claim_route_sink_mark_dispatched ──────────────────────────────────
@@ -362,7 +370,7 @@ async fn claim_route_sink_mark_dispatched() {
         queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
         proc16(b"proc-1"),
-        vec![CapabilityTag::from("plugin-a")],
+        vec!["plugin-a".parse::<PluginKey>().unwrap()],
     )
     .with_batch_size(4)
     .with_poll_interval(Duration::from_millis(10))
@@ -399,7 +407,7 @@ async fn claim_route_sink_mark_dispatched() {
     assert_eq!(dispatched, 1, "dispatched counter must be 1");
 
     // Row is terminal — a fresh processor finds nothing Pending.
-    let tags = vec![CapabilityTag::from("plugin-a")];
+    let tags = vec!["plugin-a".parse::<PluginKey>().unwrap()];
     let leftover = queue
         .claim_pending(&proc16(b"fresh-proc--"), 8, &tags)
         .await
@@ -436,7 +444,7 @@ async fn dispatched_row_not_reclaimed() {
         queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
         proc16(b"proc-nd"),
-        vec![CapabilityTag::from("plugin-b")],
+        vec!["plugin-b".parse::<PluginKey>().unwrap()],
     )
     .with_batch_size(4)
     .with_poll_interval(Duration::from_millis(10));
@@ -464,7 +472,7 @@ async fn dispatched_row_not_reclaimed() {
 
     // Second processor sees nothing — the row is Dispatched (terminal) and
     // must not be re-served via claim_pending.
-    let tags = vec![CapabilityTag::from("plugin-b")];
+    let tags = vec!["plugin-b".parse::<PluginKey>().unwrap()];
     let second = queue
         .claim_pending(&proc16(b"proc-nd-2---"), 8, &tags)
         .await
@@ -507,7 +515,7 @@ async fn reclaim_during_slow_sink_is_at_least_once() {
         .await
         .unwrap();
 
-    let tags = vec![CapabilityTag::from("plugin-b2")];
+    let tags = vec!["plugin-b2".parse::<PluginKey>().unwrap()];
     let proc_a = proc16(b"proc-aloe-a-");
     let proc_b = proc16(b"proc-aloe-b-");
 
@@ -616,7 +624,7 @@ async fn sink_failure_marks_failed() {
         queue.clone() as Arc<dyn JobDispatchQueue>,
         spy.clone() as Arc<dyn ExecutionSink>,
         proc16(b"proc-fail---"),
-        vec![CapabilityTag::from("plugin-c")],
+        vec!["plugin-c".parse::<PluginKey>().unwrap()],
     )
     .with_batch_size(4)
     .with_poll_interval(Duration::from_millis(10))
@@ -653,7 +661,7 @@ async fn sink_failure_marks_failed() {
     assert_eq!(failed, 1, "failed counter must be 1");
 
     // Failed row must not be re-served by a subsequent claim.
-    let tags = vec![CapabilityTag::from("plugin-c")];
+    let tags = vec!["plugin-c".parse::<PluginKey>().unwrap()];
     let leftover = queue
         .claim_pending(&proc16(b"other-proc--"), 8, &tags)
         .await
@@ -685,7 +693,7 @@ async fn reclaim_recovers_crashed() {
         .unwrap();
 
     // Claim the row without marking it — simulates a crashed runner.
-    let tags = vec![CapabilityTag::from("plugin-d")];
+    let tags = vec!["plugin-d".parse::<PluginKey>().unwrap()];
     let claimed = queue
         .claim_pending(&proc16(b"crashed-proc"), 1, &tags)
         .await
@@ -755,7 +763,7 @@ async fn reclaim_recovers_crashed() {
     let queue2 = make_queue();
     let spy2 = RecordingSink::new();
     let registry2 = MetricsRegistry::new();
-    let tags2 = vec![CapabilityTag::from("plugin-d2")];
+    let tags2 = vec!["plugin-d2".parse::<PluginKey>().unwrap()];
 
     queue2
         .enqueue(&make_msg(41, "plugin-d2", "exec-5"))
@@ -860,7 +868,7 @@ async fn graceful_shutdown_flushes_in_flight_dispatch() {
         .await
         .unwrap();
 
-    let tags = vec![CapabilityTag::from("plugin-e")];
+    let tags = vec!["plugin-e".parse::<PluginKey>().unwrap()];
     let shutdown = CancellationToken::new();
 
     // Pre-register the `Notified` future BEFORE spawning the orchestrator so
@@ -968,7 +976,7 @@ async fn graceful_shutdown_flushes_multi_row_batch() {
         .await
         .unwrap();
 
-    let tags = vec![CapabilityTag::from("plugin-f")];
+    let tags = vec!["plugin-f".parse::<PluginKey>().unwrap()];
     let shutdown = CancellationToken::new();
 
     // Pre-register `entered_fut` BEFORE spawning — `notify_one()` inside

--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -2,43 +2,15 @@
 //!
 //! `JobDispatchMsg` is the durable unit of work enqueued by the emitter and
 //! pulled by the orchestrator.  The routing predicate is
-//! `capability_tags ⊆ advertised_tags`: a worker may claim a job only when
-//! its advertised set is a superset of the job's `capability_tags`.
+//! `required_plugins ⊆ available_plugins`: a worker may claim a job only
+//! when its advertised set is a superset of the job's `required_plugins`.
 //! `required_plugin_key` is kept as an index-friendly pre-filter (sound
-//! because the DTO invariant guarantees `capability_tags ⊇ {required_plugin_key}`).
+//! because the DTO invariant guarantees `required_plugins ⊇ {required_plugin_key}`).
 //! `target_flavor_sha` is a version-pin guard and is never used for routing.
+use nebula_core::PluginKey;
+
 use crate::Scope;
 use crate::dto::ControlCommand;
-use serde::{Deserialize, Serialize};
-
-/// Opaque capability routing tag (advertised PluginKey strings).
-///
-/// A worker advertises the set of `CapabilityTag`s it supports; the
-/// orchestrator claims only jobs whose `capability_tags` are fully covered
-/// by the advertised set (superset predicate: `job.capability_tags ⊆
-/// worker.advertised`).  The tag is the canonical `PluginKey` string form.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct CapabilityTag(pub String);
-
-impl CapabilityTag {
-    /// Borrow the inner tag string.
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl From<String> for CapabilityTag {
-    fn from(s: String) -> Self {
-        Self(s)
-    }
-}
-
-impl From<&str> for CapabilityTag {
-    fn from(s: &str) -> Self {
-        Self(s.to_owned())
-    }
-}
 
 /// Whether the compose wrote new rows or found an existing dedup guard.
 ///
@@ -88,7 +60,7 @@ pub enum DispatchKind {
 ///
 /// Construct via [`JobDispatchMsg::new`]; struct literal syntax is
 /// unavailable from external crates (`#[non_exhaustive]`).
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 #[non_exhaustive]
 pub struct JobDispatchMsg {
     /// 16-byte ULID primary key (raw bytes).
@@ -111,14 +83,16 @@ pub struct JobDispatchMsg {
     pub event_id: Option<String>,
     /// Version-pin guard (SHA of the plugin flavor).  Not a routing key.
     pub target_flavor_sha: String,
-    /// Routing key: the advertised `PluginKey` this job requires.
+    /// The primary required plugin (the trigger's plugin); an element of
+    /// `required_plugins`; used as the index pre-filter.
     ///
     /// The orchestrator claims only rows whose `required_plugin_key` is a
-    /// member of a worker's advertised `capability_tags`.
-    pub required_plugin_key: String,
-    /// Full set of capability tags accepted by this job (superset of
-    /// `required_plugin_key`).  Stored as a JSON array in the backend.
-    pub capability_tags: Vec<CapabilityTag>,
+    /// member of the worker's `available_plugins`.
+    pub required_plugin_key: PluginKey,
+    /// Full set of plugin keys required by this job (trigger + enabled nodes,
+    /// deduplicated and sorted).  Superset of `{required_plugin_key}`.
+    /// Stored as a JSON array of strings in the backend.
+    pub required_plugins: Vec<PluginKey>,
     /// Optional W3C `traceparent` captured at enqueue time.
     pub w3c_traceparent: Option<String>,
     /// Times this row was reclaimed back to `Pending` after a crashed runner.
@@ -128,13 +102,13 @@ pub struct JobDispatchMsg {
 impl JobDispatchMsg {
     /// Construct a job-dispatch message.
     ///
-    /// **Invariant:** `capability_tags` must contain `required_plugin_key`.
+    /// **Invariant:** `required_plugins` must contain `required_plugin_key`.
     /// The storage backends rely on this to use `required_plugin_key` as a
     /// sound index pre-filter for the superset routing predicate
-    /// (`capability_tags ⊆ advertised_tags`).  The `DefinitionRoutingResolver`
-    /// always inserts the plugin key into `capability_tags`, so real producers
-    /// satisfy this invariant by construction; a `debug_assert` catches
-    /// violations in test.
+    /// (`required_plugins ⊆ available_plugins`).  The
+    /// `DefinitionRoutingResolver` always inserts the plugin key into
+    /// `required_plugins`, so real producers satisfy this invariant by
+    /// construction; a `debug_assert` catches violations in test.
     // guard-justified: constructor over all DTO fields; a builder adds no safety
     // for an internal #[non_exhaustive] record whose fields are all independent.
     #[allow(clippy::too_many_arguments)]
@@ -146,20 +120,17 @@ impl JobDispatchMsg {
         payload: serde_json::Value,
         event_id: Option<impl Into<String>>,
         target_flavor_sha: impl Into<String>,
-        required_plugin_key: impl Into<String>,
-        capability_tags: Vec<CapabilityTag>,
+        required_plugin_key: PluginKey,
+        required_plugins: Vec<PluginKey>,
         w3c_traceparent: Option<impl Into<String>>,
         reclaim_count: u32,
     ) -> Self {
-        let required_plugin_key = required_plugin_key.into();
         debug_assert!(
-            capability_tags
-                .iter()
-                .any(|t| t.as_str() == required_plugin_key),
-            "capability_tags must contain required_plugin_key \
+            required_plugins.contains(&required_plugin_key),
+            "required_plugins must contain required_plugin_key \
              (invariant required by the superset routing pre-filter): \
              required_plugin_key = {required_plugin_key:?}, \
-             capability_tags = {capability_tags:?}"
+             required_plugins = {required_plugins:?}"
         );
         Self {
             id,
@@ -170,7 +141,7 @@ impl JobDispatchMsg {
             event_id: event_id.map(Into::into),
             target_flavor_sha: target_flavor_sha.into(),
             required_plugin_key,
-            capability_tags,
+            required_plugins,
             w3c_traceparent: w3c_traceparent.map(Into::into),
             reclaim_count,
         }

--- a/crates/storage-port/src/dto/job_dispatch.rs
+++ b/crates/storage-port/src/dto/job_dispatch.rs
@@ -1,9 +1,12 @@
 //! Job-dispatch message DTO and routing types.
 //!
 //! `JobDispatchMsg` is the durable unit of work enqueued by the emitter and
-//! pulled by the orchestrator.  The routing key is `required_plugin_key`
-//! matched against a worker's `capability_tags`; `target_flavor_sha` is a
-//! separate version-pin guard and is never used for routing.
+//! pulled by the orchestrator.  The routing predicate is
+//! `capability_tags ⊆ advertised_tags`: a worker may claim a job only when
+//! its advertised set is a superset of the job's `capability_tags`.
+//! `required_plugin_key` is kept as an index-friendly pre-filter (sound
+//! because the DTO invariant guarantees `capability_tags ⊇ {required_plugin_key}`).
+//! `target_flavor_sha` is a version-pin guard and is never used for routing.
 use crate::Scope;
 use crate::dto::ControlCommand;
 use serde::{Deserialize, Serialize};
@@ -11,8 +14,9 @@ use serde::{Deserialize, Serialize};
 /// Opaque capability routing tag (advertised PluginKey strings).
 ///
 /// A worker advertises the set of `CapabilityTag`s it supports; the
-/// orchestrator claims only rows whose `required_plugin_key` is a member of
-/// that set.  The tag is the canonical `PluginKey` string form.
+/// orchestrator claims only jobs whose `capability_tags` are fully covered
+/// by the advertised set (superset predicate: `job.capability_tags ⊆
+/// worker.advertised`).  The tag is the canonical `PluginKey` string form.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct CapabilityTag(pub String);
 
@@ -124,9 +128,13 @@ pub struct JobDispatchMsg {
 impl JobDispatchMsg {
     /// Construct a job-dispatch message.
     ///
-    /// `capability_tags` must include `required_plugin_key`; callers are
-    /// responsible for that invariant (no enforcement here to keep the
-    /// constructor cheap).
+    /// **Invariant:** `capability_tags` must contain `required_plugin_key`.
+    /// The storage backends rely on this to use `required_plugin_key` as a
+    /// sound index pre-filter for the superset routing predicate
+    /// (`capability_tags ⊆ advertised_tags`).  The `DefinitionRoutingResolver`
+    /// always inserts the plugin key into `capability_tags`, so real producers
+    /// satisfy this invariant by construction; a `debug_assert` catches
+    /// violations in test.
     // guard-justified: constructor over all DTO fields; a builder adds no safety
     // for an internal #[non_exhaustive] record whose fields are all independent.
     #[allow(clippy::too_many_arguments)]
@@ -143,6 +151,16 @@ impl JobDispatchMsg {
         w3c_traceparent: Option<impl Into<String>>,
         reclaim_count: u32,
     ) -> Self {
+        let required_plugin_key = required_plugin_key.into();
+        debug_assert!(
+            capability_tags
+                .iter()
+                .any(|t| t.as_str() == required_plugin_key),
+            "capability_tags must contain required_plugin_key \
+             (invariant required by the superset routing pre-filter): \
+             required_plugin_key = {required_plugin_key:?}, \
+             capability_tags = {capability_tags:?}"
+        );
         Self {
             id,
             execution_id: execution_id.into(),
@@ -151,7 +169,7 @@ impl JobDispatchMsg {
             payload,
             event_id: event_id.map(Into::into),
             target_flavor_sha: target_flavor_sha.into(),
-            required_plugin_key: required_plugin_key.into(),
+            required_plugin_key,
             capability_tags,
             w3c_traceparent: w3c_traceparent.map(Into::into),
             reclaim_count,

--- a/crates/storage-port/src/dto/mod.rs
+++ b/crates/storage-port/src/dto/mod.rs
@@ -23,7 +23,7 @@ pub use identity::{
     AuditLogRow, BlobRow, MembershipRow, OrgRow, PrincipalKind, QuotaRow, ResourceRow, ScopeKind,
     TriggerRow, UserRow, WorkspaceRow,
 };
-pub use job_dispatch::{CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg};
+pub use job_dispatch::{DispatchKind, DispatchOutcome, JobDispatchMsg};
 pub use journal::JournalEntry;
 pub use node_result::{MAX_SUPPORTED_RESULT_SCHEMA_VERSION, NodeResultRecord};
 pub use trigger_dedup::TriggerDedupRow;

--- a/crates/storage-port/src/store/job_dispatch.rs
+++ b/crates/storage-port/src/store/job_dispatch.rs
@@ -12,7 +12,12 @@ use crate::store::ReclaimOutcome;
 
 /// Durable capability-routed job-dispatch queue.
 ///
-/// The routing predicate is `required_plugin_key ∈ advertised_tags`.
+/// The routing predicate is `capability_tags ⊆ advertised_tags`: a worker may
+/// claim a job only if its advertised tags are a superset of every tag the job
+/// requires.  The DTO invariant guarantees `capability_tags ⊇ {required_plugin_key}`,
+/// so the superset predicate strictly subsumes the old single-key rule —
+/// `required_plugin_key ∈ advertised_tags` is kept as a sound index pre-filter.
+///
 /// Postgres uses `FOR UPDATE SKIP LOCKED` on `claim_pending`; SQLite uses a
 /// single-consumer status flip.  Both are object-safe and Send+Sync.
 #[async_trait::async_trait]
@@ -20,11 +25,24 @@ pub trait JobDispatchQueue: Send + Sync + std::fmt::Debug {
     /// Durably enqueue a job-dispatch message.
     async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError>;
 
-    /// Atomically claim up to `batch_size` pending jobs whose
-    /// `required_plugin_key` is a member of `advertised_tags`.
+    /// Claim up to `batch_size` pending jobs whose `capability_tags ⊆
+    /// advertised_tags` (the worker's advertised set must be a superset of
+    /// every tag the job requires).
     ///
-    /// Postgres uses `FOR UPDATE SKIP LOCKED`; SQLite uses a single-consumer
-    /// status flip with an explicit `AND status = 'Pending'` guard.
+    /// `required_plugin_key ∈ advertised_tags` is retained as an index-friendly
+    /// pre-filter (sound by the DTO invariant); the exact superset check is
+    /// applied inside the same statement, eliminating any TOCTOU window.
+    ///
+    /// Claim mechanics per backend:
+    /// - **InMemory**: predicate + status flip inside one `parking_lot` Mutex
+    ///   critical section — single atomic step.
+    /// - **Postgres**: candidate subquery with `FOR UPDATE SKIP LOCKED` feeds a
+    ///   single `UPDATE … RETURNING` — the lock prevents concurrent double-claim.
+    /// - **SQLite**: transactional `SELECT` (superset filter) + per-row
+    ///   `UPDATE … AND status = 'Pending'` guard inside one transaction; a
+    ///   concurrent actor that flips the row first causes `rows_affected = 0`
+    ///   and the row is skipped — no double-dispatch (single-consumer boundary,
+    ///   spec §5).
     async fn claim_pending(
         &self,
         processor: &[u8; 16],

--- a/crates/storage-port/src/store/job_dispatch.rs
+++ b/crates/storage-port/src/store/job_dispatch.rs
@@ -1,22 +1,28 @@
 //! Capability-routed job-dispatch queue port.
 //!
-//! The orchestrator pulls jobs by advertising the set of `CapabilityTag`s its
+//! The orchestrator pulls jobs by advertising the set of [`PluginKey`]s its
 //! workers support; the queue delivers only rows whose `required_plugin_key`
 //! is a member of that set.  The claim/fence/reclaim shape mirrors
 //! `ControlQueue` — `ReclaimOutcome` is reused from that module.
+//!
+//! [`PluginKey`]: nebula_core::PluginKey
 use std::time::Duration;
 
-use crate::dto::{CapabilityTag, JobDispatchMsg};
+use nebula_core::PluginKey;
+
+use crate::dto::JobDispatchMsg;
 use crate::error::StorageError;
 use crate::store::ReclaimOutcome;
 
 /// Durable capability-routed job-dispatch queue.
 ///
-/// The routing predicate is `capability_tags ⊆ advertised_tags`: a worker may
-/// claim a job only if its advertised tags are a superset of every tag the job
-/// requires.  The DTO invariant guarantees `capability_tags ⊇ {required_plugin_key}`,
-/// so the superset predicate strictly subsumes the old single-key rule —
-/// `required_plugin_key ∈ advertised_tags` is kept as a sound index pre-filter.
+/// The routing predicate is `required_plugins ⊆ available_plugins`: a worker
+/// may claim a job only if its advertised plugin set is a superset of every
+/// plugin the job requires.  The DTO invariant guarantees
+/// `required_plugins ⊇ {required_plugin_key}`, so the superset predicate
+/// strictly subsumes the single-key pre-filter —
+/// `required_plugin_key ∈ available_plugins` is kept as a sound index
+/// pre-filter.
 ///
 /// Postgres uses `FOR UPDATE SKIP LOCKED` on `claim_pending`; SQLite uses a
 /// single-consumer status flip.  Both are object-safe and Send+Sync.
@@ -25,13 +31,14 @@ pub trait JobDispatchQueue: Send + Sync + std::fmt::Debug {
     /// Durably enqueue a job-dispatch message.
     async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError>;
 
-    /// Claim up to `batch_size` pending jobs whose `capability_tags ⊆
-    /// advertised_tags` (the worker's advertised set must be a superset of
-    /// every tag the job requires).
+    /// Claim up to `batch_size` pending jobs whose `required_plugins ⊆
+    /// available_plugins` (the worker's advertised plugin set must be a
+    /// superset of every plugin the job requires).
     ///
-    /// `required_plugin_key ∈ advertised_tags` is retained as an index-friendly
-    /// pre-filter (sound by the DTO invariant); the exact superset check is
-    /// applied inside the same statement, eliminating any TOCTOU window.
+    /// `required_plugin_key ∈ available_plugins` is retained as an
+    /// index-friendly pre-filter (sound by the DTO invariant); the exact
+    /// superset check is applied inside the same statement, eliminating any
+    /// TOCTOU window.
     ///
     /// Claim mechanics per backend:
     /// - **InMemory**: predicate + status flip inside one `parking_lot` Mutex
@@ -47,7 +54,7 @@ pub trait JobDispatchQueue: Send + Sync + std::fmt::Debug {
         &self,
         processor: &[u8; 16],
         batch_size: u32,
-        advertised_tags: &[CapabilityTag],
+        available_plugins: &[PluginKey],
     ) -> Result<Vec<JobDispatchMsg>, StorageError>;
 
     /// Mark a claimed job dispatched (terminal success).  Only the runner

--- a/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/postgres/0031_job_dispatch_and_trigger_dedup.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     event_id            TEXT,
     target_flavor_sha   TEXT NOT NULL DEFAULT '',
     required_plugin_key TEXT NOT NULL,
-    capability_tags     JSONB NOT NULL DEFAULT '[]',
+    required_plugins    JSONB NOT NULL DEFAULT '[]',
     w3c_traceparent     TEXT,
     reclaim_count       INTEGER NOT NULL DEFAULT 0,
     processed_by        BYTEA,
@@ -24,8 +24,8 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
     ON port_job_dispatch_queue (status, required_plugin_key);
 
-CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
-    ON port_job_dispatch_queue USING GIN (capability_tags);
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_plugins
+    ON port_job_dispatch_queue USING GIN (required_plugins);
 
 -- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
 -- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants

--- a/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
+++ b/crates/storage/migrations/sqlite/0031_job_dispatch_and_trigger_dedup.sql
@@ -13,7 +13,7 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     event_id            TEXT,
     target_flavor_sha   TEXT NOT NULL DEFAULT '',
     required_plugin_key TEXT NOT NULL,
-    capability_tags     TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    required_plugins    TEXT NOT NULL DEFAULT '[]',  -- JSON array of PluginKey strings
     w3c_traceparent     TEXT,
     reclaim_count       INTEGER NOT NULL DEFAULT 0,
     processed_by        BLOB,

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -67,18 +67,30 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         batch_size: u32,
         advertised_tags: &[CapabilityTag],
     ) -> Result<Vec<JobDispatchMsg>, StorageError> {
+        // Parity with SQLite + Postgres: an empty advertised set claims nothing.
+        if advertised_tags.is_empty() {
+            return Ok(Vec::new());
+        }
         let mut st = self.inner.lock();
         let now = Instant::now();
 
         // Stable order so a bounded batch is deterministic across calls.
+        //
+        // Superset predicate: the worker may claim a job only when its
+        // advertised tags cover every tag in `capability_tags`.  The check is
+        // inside the parking_lot Mutex so the predicate + status flip are
+        // atomic (no TOCTOU window).  Empty `capability_tags` ⇒ `all()` is
+        // vacuously true ⇒ claimable by any non-empty advertised set (subset
+        // of anything).
         let mut ids: Vec<[u8; 16]> = st
             .jobs
             .iter()
             .filter(|(_, q)| {
                 q.status == "Pending"
-                    && advertised_tags
+                    && q.msg
+                        .capability_tags
                         .iter()
-                        .any(|t| t.as_str() == q.msg.required_plugin_key)
+                        .all(|ct| advertised_tags.iter().any(|at| at.as_str() == ct.as_str()))
             })
             .map(|(id, _)| *id)
             .collect();

--- a/crates/storage/src/inmem/job_dispatch.rs
+++ b/crates/storage/src/inmem/job_dispatch.rs
@@ -8,13 +8,13 @@
 
 use std::time::Duration;
 
-use tokio::time::Instant;
-
+use nebula_core::PluginKey;
 use nebula_storage_port::dto::{
-    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+    DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
 };
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
+use tokio::time::Instant;
 
 use super::execution::{QueuedJob, SharedState, insert_created_row};
 
@@ -60,15 +60,15 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    #[tracing::instrument(level = "debug", skip(self, available_plugins), fields(batch_size))]
     async fn claim_pending(
         &self,
         processor: &[u8; 16],
         batch_size: u32,
-        advertised_tags: &[CapabilityTag],
+        available_plugins: &[PluginKey],
     ) -> Result<Vec<JobDispatchMsg>, StorageError> {
         // Parity with SQLite + Postgres: an empty advertised set claims nothing.
-        if advertised_tags.is_empty() {
+        if available_plugins.is_empty() {
             return Ok(Vec::new());
         }
         let mut st = self.inner.lock();
@@ -77,20 +77,19 @@ impl JobDispatchQueue for InMemoryJobDispatchQueue {
         // Stable order so a bounded batch is deterministic across calls.
         //
         // Superset predicate: the worker may claim a job only when its
-        // advertised tags cover every tag in `capability_tags`.  The check is
-        // inside the parking_lot Mutex so the predicate + status flip are
-        // atomic (no TOCTOU window).  Empty `capability_tags` ⇒ `all()` is
-        // vacuously true ⇒ claimable by any non-empty advertised set (subset
-        // of anything).
+        // available plugins cover every plugin in `required_plugins`.  The
+        // check is inside the parking_lot Mutex so the predicate + status flip
+        // are atomic (no TOCTOU window).  Empty `required_plugins` ⇒ `all()`
+        // is vacuously true ⇒ claimable by any non-empty available set.
         let mut ids: Vec<[u8; 16]> = st
             .jobs
             .iter()
             .filter(|(_, q)| {
                 q.status == "Pending"
                     && q.msg
-                        .capability_tags
+                        .required_plugins
                         .iter()
-                        .all(|ct| advertised_tags.iter().any(|at| at.as_str() == ct.as_str()))
+                        .all(|rp| available_plugins.contains(rp))
             })
             .map(|(id, _)| *id)
             .collect();

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -3,15 +3,15 @@
 //!
 //! `claim_pending` uses `FOR UPDATE SKIP LOCKED` so multiple consumers can
 //! drain the queue concurrently without double-dispatch.  The routing
-//! predicate is `capability_tags ⊆ advertised_tags`: the worker's advertised
-//! tag set must be a superset of every tag the job requires.
+//! predicate is `required_plugins ⊆ available_plugins`: the worker's
+//! available plugin set must be a superset of every plugin the job requires.
 //!
 //! Implementation: `required_plugin_key = ANY($pre_filter)` is an
-//! index-friendly pre-filter (sound because `capability_tags ⊇
-//! {required_plugin_key}` by DTO invariant), then `capability_tags <@
-//! $advertised_jsonb` applies the exact JSONB "is contained by" superset check
-//! in the same statement.  `advertised_tags` is bound twice — once as `text[]`
-//! for `= ANY` and once as `JSONB` for `<@`.
+//! index-friendly pre-filter (sound because `required_plugins ⊇
+//! {required_plugin_key}` by DTO invariant), then `required_plugins <@
+//! $available_jsonb` applies the exact JSONB "is contained by" superset check
+//! in the same statement.  `available_plugins` is bound twice — once as
+//! `text[]` for `= ANY` and once as `JSONB` for `<@`.
 //!
 //! PERF: `<@` is NOT GIN-accelerated — `jsonb_ops` indexes `@>` / existence,
 //! not `<@` — so it runs as a filter over the rows the `(status,
@@ -19,13 +19,14 @@
 //! representation (text[] + `array_ops`, or a tag-membership table) is the
 //! tracked pre-production follow-up.  See `schema.sql` PERF NOTE.
 //!
-//! Ids are raw 16-byte ULID (`BYTEA`).  `capability_tags` is a `JSONB` array.
+//! Ids are raw 16-byte ULID (`BYTEA`).  `required_plugins` is a `JSONB` array.
 
 use std::time::Duration;
 
 use chrono::Utc;
+use nebula_core::PluginKey;
 use nebula_storage_port::dto::{
-    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+    DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
 };
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
@@ -58,30 +59,40 @@ fn decode_command(s: &str) -> Result<nebula_storage_port::dto::ControlCommand, S
     }
 }
 
-fn tags_to_json(tags: &[CapabilityTag]) -> serde_json::Value {
-    let strs: Vec<&str> = tags.iter().map(CapabilityTag::as_str).collect();
+fn plugins_to_jsonb(plugins: &[PluginKey]) -> serde_json::Value {
     serde_json::Value::Array(
-        strs.into_iter()
-            .map(|s| serde_json::Value::String(s.to_owned()))
+        plugins
+            .iter()
+            .map(|k| serde_json::Value::String(k.as_str().to_owned()))
             .collect(),
     )
 }
 
 fn row_to_msg(row: &sqlx::postgres::PgRow) -> Result<JobDispatchMsg, StorageError> {
     let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
-    let tags_val: serde_json::Value = row.try_get("capability_tags").map_err(conn_err)?;
-    let tags: Vec<CapabilityTag> = tags_val
+    let plugins_val: serde_json::Value = row.try_get("required_plugins").map_err(conn_err)?;
+    let required_plugins: Vec<PluginKey> = plugins_val
         .as_array()
-        .ok_or_else(|| StorageError::Serialization("capability_tags not a JSON array".to_owned()))?
+        .ok_or_else(|| StorageError::Serialization("required_plugins not a JSON array".to_owned()))?
         .iter()
         .map(|v| {
             v.as_str()
                 .ok_or_else(|| {
-                    StorageError::Serialization("capability_tag element is not a string".to_owned())
+                    StorageError::Serialization(
+                        "required_plugins element is not a string".to_owned(),
+                    )
                 })
-                .map(|s| CapabilityTag(s.to_owned()))
+                .and_then(|s| {
+                    s.parse::<PluginKey>()
+                        .map_err(|e| StorageError::Serialization(e.to_string()))
+                })
         })
         .collect::<Result<_, _>>()?;
+    let required_plugin_key: PluginKey = row
+        .try_get::<String, _>("required_plugin_key")
+        .map_err(conn_err)?
+        .parse::<PluginKey>()
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
     Ok(JobDispatchMsg::new(
         decode_id(&id_bytes)?,
         row.try_get::<String, _>("execution_id").map_err(conn_err)?,
@@ -95,9 +106,8 @@ fn row_to_msg(row: &sqlx::postgres::PgRow) -> Result<JobDispatchMsg, StorageErro
             .map_err(conn_err)?,
         row.try_get::<String, _>("target_flavor_sha")
             .map_err(conn_err)?,
-        row.try_get::<String, _>("required_plugin_key")
-            .map_err(conn_err)?,
-        tags,
+        required_plugin_key,
+        required_plugins,
         row.try_get::<Option<String>, _>("w3c_traceparent")
             .map_err(conn_err)?,
         row.try_get::<i32, _>("reclaim_count").map_err(conn_err)? as u32,
@@ -124,12 +134,12 @@ impl PgJobDispatchQueue {
 impl JobDispatchQueue for PgJobDispatchQueue {
     #[tracing::instrument(level = "debug", skip(self, msg), fields(id = ?msg.id, command = msg.command.as_str()))]
     async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
-        let tags = tags_to_json(&msg.capability_tags);
+        let plugins = plugins_to_jsonb(&msg.required_plugins);
         sqlx::query(
             "INSERT INTO port_job_dispatch_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
               payload, event_id, target_flavor_sha, required_plugin_key, \
-              capability_tags, w3c_traceparent, reclaim_count) \
+              required_plugins, w3c_traceparent, reclaim_count) \
              VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8, $9, $10, $11, $12)",
         )
         .bind(msg.id.as_slice())
@@ -140,8 +150,8 @@ impl JobDispatchQueue for PgJobDispatchQueue {
         .bind(&msg.payload)
         .bind(msg.event_id.as_deref())
         .bind(&msg.target_flavor_sha)
-        .bind(&msg.required_plugin_key)
-        .bind(&tags)
+        .bind(msg.required_plugin_key.as_str())
+        .bind(&plugins)
         .bind(msg.w3c_traceparent.as_deref())
         .bind(i32::try_from(msg.reclaim_count).unwrap_or(i32::MAX))
         .execute(&self.pool)
@@ -151,27 +161,27 @@ impl JobDispatchQueue for PgJobDispatchQueue {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    #[tracing::instrument(level = "debug", skip(self, available_plugins), fields(batch_size))]
     async fn claim_pending(
         &self,
         processor: &[u8; 16],
         batch_size: u32,
-        advertised_tags: &[CapabilityTag],
+        available_plugins: &[PluginKey],
     ) -> Result<Vec<JobDispatchMsg>, StorageError> {
-        if advertised_tags.is_empty() {
+        if available_plugins.is_empty() {
             return Ok(Vec::new());
         }
         // `processed_at_ms` is epoch-millis (BIGINT) — same representation as
         // `port_control_queue`, so reclaim cutoff arithmetic is identical on both dialects.
         let now_ms = Utc::now().timestamp_millis();
-        let tags_strs: Vec<&str> = advertised_tags.iter().map(CapabilityTag::as_str).collect();
-        // `capability_tags <@ $advertised_jsonb`: JSONB "is contained by" operator
+        let plugin_strs: Vec<&str> = available_plugins.iter().map(PluginKey::as_str).collect();
+        // `required_plugins <@ $available_jsonb`: JSONB "is contained by" operator
         // (NOT GIN-accelerated — see the module PERF note; runs as a filter over
-        // the pre-filtered rows).  A job's `capability_tags` must be a subset of
-        // the advertised JSONB array.  Built via `tags_to_json` — the same helper
-        // `enqueue` uses — so `$3` (text[]) and `$4` (jsonb) are always derived
-        // from the same source and can never diverge.
-        let advertised_jsonb = tags_to_json(advertised_tags);
+        // the pre-filtered rows).  A job's `required_plugins` must be a subset of
+        // the available JSONB array.  Built via `plugins_to_jsonb` — the same
+        // helper `enqueue` uses — so `$3` (text[]) and `$4` (jsonb) are always
+        // derived from the same source and can never diverge.
+        let available_jsonb = plugins_to_jsonb(available_plugins);
         let rows = sqlx::query(
             "UPDATE port_job_dispatch_queue \
              SET status = 'Processing', processed_by = $1, processed_at_ms = $2 \
@@ -179,19 +189,19 @@ impl JobDispatchQueue for PgJobDispatchQueue {
                  SELECT id FROM port_job_dispatch_queue \
                  WHERE status = 'Pending' \
                    AND required_plugin_key = ANY($3) \
-                   AND capability_tags <@ $4 \
+                   AND required_plugins <@ $4 \
                  ORDER BY id \
                  LIMIT $5 \
                  FOR UPDATE SKIP LOCKED \
              ) \
              RETURNING id, execution_id, workspace_id, org_id, command, \
                        payload, event_id, target_flavor_sha, required_plugin_key, \
-                       capability_tags, w3c_traceparent, reclaim_count",
+                       required_plugins, w3c_traceparent, reclaim_count",
         )
         .bind(processor.as_slice())
         .bind(now_ms)
-        .bind(&tags_strs)
-        .bind(&advertised_jsonb)
+        .bind(&plugin_strs)
+        .bind(&available_jsonb)
         .bind(i64::from(batch_size))
         .fetch_all(&self.pool)
         .await
@@ -332,7 +342,7 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
         start: &JobDispatchMsg,
         execution: &NewExecution<'_>,
     ) -> Result<DispatchOutcome, StorageError> {
-        let tags = tags_to_json(&start.capability_tags);
+        let plugins = plugins_to_jsonb(&start.required_plugins);
 
         // All three writes live inside one transaction — atomicity by
         // construction.  An error from any write propagates via `?` and rolls
@@ -413,7 +423,7 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
             "INSERT INTO port_job_dispatch_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
               payload, event_id, target_flavor_sha, required_plugin_key, \
-              capability_tags, w3c_traceparent, reclaim_count) \
+              required_plugins, w3c_traceparent, reclaim_count) \
              VALUES ($1, $2, $3, $4, $5, 'Pending', $6, $7, $8, $9, $10, $11, $12)",
         )
         .bind(start.id.as_slice())
@@ -424,8 +434,8 @@ impl TriggerDedupInbox for PgTriggerDedupInbox {
         .bind(&start.payload)
         .bind(start.event_id.as_deref())
         .bind(&start.target_flavor_sha)
-        .bind(&start.required_plugin_key)
-        .bind(&tags)
+        .bind(start.required_plugin_key.as_str())
+        .bind(&plugins)
         .bind(start.w3c_traceparent.as_deref())
         .bind(i32::try_from(start.reclaim_count).unwrap_or(i32::MAX))
         .execute(&mut *tx)

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -10,8 +10,14 @@
 //! index-friendly pre-filter (sound because `capability_tags ⊇
 //! {required_plugin_key}` by DTO invariant), then `capability_tags <@
 //! $advertised_jsonb` applies the exact JSONB "is contained by" superset check
-//! (GIN-assisted) in the same statement.  `advertised_tags` is bound twice —
-//! once as `text[]` for `= ANY` and once as `JSONB` for `<@`.
+//! in the same statement.  `advertised_tags` is bound twice — once as `text[]`
+//! for `= ANY` and once as `JSONB` for `<@`.
+//!
+//! PERF: `<@` is NOT GIN-accelerated — `jsonb_ops` indexes `@>` / existence,
+//! not `<@` — so it runs as a filter over the rows the `(status,
+//! required_plugin_key)` B-tree returns.  Fine pre-fleet; a `<@`-indexable
+//! representation (text[] + `array_ops`, or a tag-membership table) is the
+//! tracked pre-production follow-up.  See `schema.sql` PERF NOTE.
 //!
 //! Ids are raw 16-byte ULID (`BYTEA`).  `capability_tags` is a `JSONB` array.
 
@@ -160,8 +166,9 @@ impl JobDispatchQueue for PgJobDispatchQueue {
         let now_ms = Utc::now().timestamp_millis();
         let tags_strs: Vec<&str> = advertised_tags.iter().map(CapabilityTag::as_str).collect();
         // `capability_tags <@ $advertised_jsonb`: JSONB "is contained by" operator
-        // (GIN-assisted).  A job's `capability_tags` must be a subset of the
-        // advertised JSONB array.  Built via `tags_to_json` — the same helper
+        // (NOT GIN-accelerated — see the module PERF note; runs as a filter over
+        // the pre-filtered rows).  A job's `capability_tags` must be a subset of
+        // the advertised JSONB array.  Built via `tags_to_json` — the same helper
         // `enqueue` uses — so `$3` (text[]) and `$4` (jsonb) are always derived
         // from the same source and can never diverge.
         let advertised_jsonb = tags_to_json(advertised_tags);

--- a/crates/storage/src/postgres/job_dispatch.rs
+++ b/crates/storage/src/postgres/job_dispatch.rs
@@ -3,8 +3,17 @@
 //!
 //! `claim_pending` uses `FOR UPDATE SKIP LOCKED` so multiple consumers can
 //! drain the queue concurrently without double-dispatch.  The routing
-//! predicate is `required_plugin_key = ANY($tags)`.  Ids are raw 16-byte
-//! ULID (`BYTEA`).  `capability_tags` is a `JSONB` array.
+//! predicate is `capability_tags ⊆ advertised_tags`: the worker's advertised
+//! tag set must be a superset of every tag the job requires.
+//!
+//! Implementation: `required_plugin_key = ANY($pre_filter)` is an
+//! index-friendly pre-filter (sound because `capability_tags ⊇
+//! {required_plugin_key}` by DTO invariant), then `capability_tags <@
+//! $advertised_jsonb` applies the exact JSONB "is contained by" superset check
+//! (GIN-assisted) in the same statement.  `advertised_tags` is bound twice —
+//! once as `text[]` for `= ANY` and once as `JSONB` for `<@`.
+//!
+//! Ids are raw 16-byte ULID (`BYTEA`).  `capability_tags` is a `JSONB` array.
 
 use std::time::Duration;
 
@@ -150,6 +159,12 @@ impl JobDispatchQueue for PgJobDispatchQueue {
         // `port_control_queue`, so reclaim cutoff arithmetic is identical on both dialects.
         let now_ms = Utc::now().timestamp_millis();
         let tags_strs: Vec<&str> = advertised_tags.iter().map(CapabilityTag::as_str).collect();
+        // `capability_tags <@ $advertised_jsonb`: JSONB "is contained by" operator
+        // (GIN-assisted).  A job's `capability_tags` must be a subset of the
+        // advertised JSONB array.  Built via `tags_to_json` — the same helper
+        // `enqueue` uses — so `$3` (text[]) and `$4` (jsonb) are always derived
+        // from the same source and can never diverge.
+        let advertised_jsonb = tags_to_json(advertised_tags);
         let rows = sqlx::query(
             "UPDATE port_job_dispatch_queue \
              SET status = 'Processing', processed_by = $1, processed_at_ms = $2 \
@@ -157,8 +172,9 @@ impl JobDispatchQueue for PgJobDispatchQueue {
                  SELECT id FROM port_job_dispatch_queue \
                  WHERE status = 'Pending' \
                    AND required_plugin_key = ANY($3) \
+                   AND capability_tags <@ $4 \
                  ORDER BY id \
-                 LIMIT $4 \
+                 LIMIT $5 \
                  FOR UPDATE SKIP LOCKED \
              ) \
              RETURNING id, execution_id, workspace_id, org_id, command, \
@@ -168,6 +184,7 @@ impl JobDispatchQueue for PgJobDispatchQueue {
         .bind(processor.as_slice())
         .bind(now_ms)
         .bind(&tags_strs)
+        .bind(&advertised_jsonb)
         .bind(i64::from(batch_size))
         .fetch_all(&self.pool)
         .await

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -286,18 +286,19 @@ CREATE TABLE IF NOT EXISTS port_blobs (
 );
 
 -- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
--- (BYTEA).  `capability_tags` is a JSONB array.  Claim predicate:
---   `required_plugin_key = ANY($advertised)`            (B-tree pre-filter below)
---   AND `capability_tags <@ $advertised_jsonb`          (JSONB subset / superset check)
--- The pre-filter is sound — `capability_tags ⊇ {required_plugin_key}` (DTO
+-- (BYTEA).  `required_plugins` is a JSONB array of PluginKey strings.
+-- Claim predicate:
+--   `required_plugin_key = ANY($available)`            (B-tree pre-filter below)
+--   AND `required_plugins <@ $available_jsonb`         (JSONB subset / superset check)
+-- The pre-filter is sound — `required_plugins ⊇ {required_plugin_key}` (DTO
 -- invariant) — so it never drops a row the subset check would accept.
 -- PERF NOTE: the `<@` subset check is NOT GIN-accelerated.  The built-in
 -- `jsonb_ops` GIN class indexes `@>` / existence / jsonpath, NOT `<@` (only the
 -- `array_ops` class indexes `<@`, and only for native arrays).  So `<@` runs as
 -- a filter over the rows the `(status, required_plugin_key)` B-tree returns —
--- acceptable pre-fleet.  Before production scale, move `capability_tags` to a
+-- acceptable pre-fleet.  Before production scale, move `required_plugins` to a
 -- `<@`-indexable representation (text[] + `array_ops`, or a normalized
--- tag-membership table).  Tracked as an ADR-0095 D1 follow-up.
+-- plugin-membership table).  Tracked as an ADR-0095 D1 follow-up.
 -- `processed_at_ms` is epoch-millis (BIGINT) for parity with the
 -- `port_control_queue` reclaim arithmetic.
 CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
@@ -311,7 +312,7 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     event_id            TEXT,
     target_flavor_sha   TEXT NOT NULL DEFAULT '',
     required_plugin_key TEXT NOT NULL,
-    capability_tags     JSONB NOT NULL DEFAULT '[]',
+    required_plugins    JSONB NOT NULL DEFAULT '[]',
     w3c_traceparent     TEXT,
     reclaim_count       INTEGER NOT NULL DEFAULT 0,
     processed_by        BYTEA,
@@ -325,8 +326,8 @@ CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
 -- jsonb_ops GIN: does NOT accelerate the current `<@` subset claim (see the
 -- PERF NOTE above); retained for future `@>` / existence membership queries.
 -- The `<@`-indexable representation is the tracked pre-production follow-up.
-CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
-    ON port_job_dispatch_queue USING GIN (capability_tags);
+CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_plugins
+    ON port_job_dispatch_queue USING GIN (required_plugins);
 
 -- Trigger-dedup inbox.  `PRIMARY KEY(workspace_id, org_id, trigger_id, event_id)` is
 -- the CAS for first-writer-wins fan-out dedup, scoped per tenant so two tenants

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -287,11 +287,14 @@ CREATE TABLE IF NOT EXISTS port_blobs (
 
 -- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
 -- (BYTEA).  `capability_tags` is a JSONB array; the routing predicate is
--- `required_plugin_key = ANY($advertised_tags)`.
+-- `capability_tags <@ $advertised_jsonb` (JSONB "is contained by": the job's
+-- tags must be a subset of the worker's advertised set).
+-- `required_plugin_key = ANY($advertised_tags)` is kept as a sound index
+-- pre-filter (DTO invariant: capability_tags ⊇ {required_plugin_key}).
 -- `processed_at_ms` is epoch-millis (BIGINT) for parity with the
 -- `port_control_queue` reclaim arithmetic.
--- The GIN index on `capability_tags` accelerates membership queries on
--- Postgres (SQLite uses json_each; this index is Postgres-only).
+-- The GIN index on `capability_tags` accelerates the `<@` superset check
+-- on Postgres (SQLite uses json_each + NOT EXISTS; this index is Postgres-only).
 CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     id                  BYTEA PRIMARY KEY,
     execution_id        TEXT NOT NULL,

--- a/crates/storage/src/postgres/schema.sql
+++ b/crates/storage/src/postgres/schema.sql
@@ -286,15 +286,20 @@ CREATE TABLE IF NOT EXISTS port_blobs (
 );
 
 -- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
--- (BYTEA).  `capability_tags` is a JSONB array; the routing predicate is
--- `capability_tags <@ $advertised_jsonb` (JSONB "is contained by": the job's
--- tags must be a subset of the worker's advertised set).
--- `required_plugin_key = ANY($advertised_tags)` is kept as a sound index
--- pre-filter (DTO invariant: capability_tags ⊇ {required_plugin_key}).
+-- (BYTEA).  `capability_tags` is a JSONB array.  Claim predicate:
+--   `required_plugin_key = ANY($advertised)`            (B-tree pre-filter below)
+--   AND `capability_tags <@ $advertised_jsonb`          (JSONB subset / superset check)
+-- The pre-filter is sound — `capability_tags ⊇ {required_plugin_key}` (DTO
+-- invariant) — so it never drops a row the subset check would accept.
+-- PERF NOTE: the `<@` subset check is NOT GIN-accelerated.  The built-in
+-- `jsonb_ops` GIN class indexes `@>` / existence / jsonpath, NOT `<@` (only the
+-- `array_ops` class indexes `<@`, and only for native arrays).  So `<@` runs as
+-- a filter over the rows the `(status, required_plugin_key)` B-tree returns —
+-- acceptable pre-fleet.  Before production scale, move `capability_tags` to a
+-- `<@`-indexable representation (text[] + `array_ops`, or a normalized
+-- tag-membership table).  Tracked as an ADR-0095 D1 follow-up.
 -- `processed_at_ms` is epoch-millis (BIGINT) for parity with the
 -- `port_control_queue` reclaim arithmetic.
--- The GIN index on `capability_tags` accelerates the `<@` superset check
--- on Postgres (SQLite uses json_each + NOT EXISTS; this index is Postgres-only).
 CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     id                  BYTEA PRIMARY KEY,
     execution_id        TEXT NOT NULL,
@@ -317,6 +322,9 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_status_key
     ON port_job_dispatch_queue (status, required_plugin_key);
 
+-- jsonb_ops GIN: does NOT accelerate the current `<@` subset claim (see the
+-- PERF NOTE above); retained for future `@>` / existence membership queries.
+-- The `<@`-indexable representation is the tracked pre-production follow-up.
 CREATE INDEX IF NOT EXISTS idx_port_job_dispatch_queue_tags
     ON port_job_dispatch_queue USING GIN (capability_tags);
 

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -2,11 +2,16 @@
 //!
 //! Single-consumer status flip (no `FOR UPDATE SKIP LOCKED` equivalent —
 //! spec §5 SQLite boundary, documented not hidden).  Ids are the raw 16-byte
-//! ULID (`BLOB`).  `capability_tags` is a JSON array stored for informational
-//! purposes; the **routing predicate** filters on `required_plugin_key` directly
-//! (`WHERE required_plugin_key = ?` per advertised tag, equivalent to Postgres
-//! `required_plugin_key = ANY($tags)`).  `capability_tags` is never used for
-//! routing — only `required_plugin_key` is the dispatch selector.
+//! ULID (`BLOB`).  `capability_tags` is a JSON array; the **routing predicate**
+//! is `capability_tags ⊆ advertised_tags`: a worker claims a job only when its
+//! advertised set covers every tag in the job's `capability_tags`.
+//!
+//! Implementation: `required_plugin_key IN (<advertised>)` is an index-friendly
+//! pre-filter (sound because `capability_tags ⊇ {required_plugin_key}` by DTO
+//! invariant), then the exact superset test is applied in the same SELECT via
+//! `NOT EXISTS (SELECT 1 FROM json_each(capability_tags) je WHERE je.value NOT
+//! IN (<advertised>))`.  Both clauses bind the same advertised list, eliminating
+//! any TOCTOU window between pre-filter and claim.
 
 use std::time::Duration;
 
@@ -138,29 +143,49 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
             return Ok(Vec::new());
         }
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
-        // Routing: claim rows whose `required_plugin_key` is a member of the
-        // advertised set.  This mirrors Postgres `required_plugin_key = ANY($3)`
-        // exactly — the `capability_tags` JSON array is NOT the routing key.
-        // SQLite has no array-bind, so we build one SELECT per advertised tag
-        // and union them.  Each branch checks `required_plugin_key = ?` directly.
-        let union_selects: String = advertised_tags
+
+        // Superset predicate: a job is claimable when `capability_tags ⊆
+        // advertised_tags`.  SQLite has no array bind, so we interpolate a
+        // parameter-placeholder list and bind the advertised tags twice —
+        // once for the index-friendly `required_plugin_key IN (…)` pre-filter
+        // and once for the exact `NOT EXISTS` superset check.
+        //
+        // The pre-filter and superset check are in the same SELECT statement,
+        // so no row is fetched that fails the superset test.  A concurrent
+        // actor that flips a selected row to 'Processing' first is caught by
+        // the per-row `UPDATE … AND status = 'Pending'` guard below
+        // (rows_affected = 0 → row skipped); the whole exchange is inside one
+        // transaction (single-consumer SQLite boundary, spec §5).
+        //
+        // `NOT EXISTS` reads: "no element in json_each(capability_tags) is
+        // absent from the advertised set", i.e. every required tag is covered.
+        // An empty `capability_tags` JSON array yields no rows from json_each
+        // ⇒ NOT EXISTS is vacuously true ⇒ claimable by anyone (consistent
+        // with the InMemory backend).
+        let placeholders = advertised_tags
             .iter()
-            .map(|_| {
-                "SELECT id FROM port_job_dispatch_queue \
-                 WHERE status = 'Pending' AND required_plugin_key = ?"
-                    .to_owned()
-            })
+            .map(|_| "?")
             .collect::<Vec<_>>()
-            .join(" UNION ");
+            .join(", ");
         let select_sql = format!(
             "SELECT id, execution_id, workspace_id, org_id, command, \
                     payload, event_id, target_flavor_sha, required_plugin_key, \
                     capability_tags, w3c_traceparent, reclaim_count \
              FROM port_job_dispatch_queue \
-             WHERE id IN ({union_selects}) \
+             WHERE status = 'Pending' \
+               AND required_plugin_key IN ({placeholders}) \
+               AND NOT EXISTS ( \
+                   SELECT 1 FROM json_each(capability_tags) je \
+                   WHERE je.value NOT IN ({placeholders}) \
+               ) \
              ORDER BY id LIMIT ?"
         );
         let mut q = sqlx::query(sqlx::AssertSqlSafe(select_sql));
+        // Bind advertised tags for the IN pre-filter.
+        for tag in advertised_tags {
+            q = q.bind(tag.as_str());
+        }
+        // Bind advertised tags again for the NOT IN superset check.
         for tag in advertised_tags {
             q = q.bind(tag.as_str());
         }
@@ -172,7 +197,8 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
         for row in &rows {
             let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
             // Conditional claim — AND status = 'Pending' guard prevents
-            // double-claim if a concurrent actor flipped the row.
+            // double-claim if a concurrent actor flipped the row between the
+            // SELECT above and this UPDATE (single-consumer SQLite boundary).
             let won = sqlx::query(
                 "UPDATE port_job_dispatch_queue \
                  SET status = 'Processing', processed_by = ?, \

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -2,21 +2,22 @@
 //!
 //! Single-consumer status flip (no `FOR UPDATE SKIP LOCKED` equivalent —
 //! spec §5 SQLite boundary, documented not hidden).  Ids are the raw 16-byte
-//! ULID (`BLOB`).  `capability_tags` is a JSON array; the **routing predicate**
-//! is `capability_tags ⊆ advertised_tags`: a worker claims a job only when its
-//! advertised set covers every tag in the job's `capability_tags`.
+//! ULID (`BLOB`).  `required_plugins` is a JSON array; the **routing predicate**
+//! is `required_plugins ⊆ available_plugins`: a worker claims a job only when
+//! its available plugin set covers every plugin the job requires.
 //!
-//! Implementation: `required_plugin_key IN (<advertised>)` is an index-friendly
-//! pre-filter (sound because `capability_tags ⊇ {required_plugin_key}` by DTO
+//! Implementation: `required_plugin_key IN (<available>)` is an index-friendly
+//! pre-filter (sound because `required_plugins ⊇ {required_plugin_key}` by DTO
 //! invariant), then the exact superset test is applied in the same SELECT via
-//! `NOT EXISTS (SELECT 1 FROM json_each(capability_tags) je WHERE je.value NOT
-//! IN (<advertised>))`.  Both clauses bind the same advertised list, eliminating
+//! `NOT EXISTS (SELECT 1 FROM json_each(required_plugins) je WHERE je.value NOT
+//! IN (<available>))`.  Both clauses bind the same available list, eliminating
 //! any TOCTOU window between pre-filter and claim.
 
 use std::time::Duration;
 
+use nebula_core::PluginKey;
 use nebula_storage_port::dto::{
-    CapabilityTag, DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
+    DispatchKind, DispatchOutcome, JobDispatchMsg, NewExecution, TriggerDedupRow,
 };
 use nebula_storage_port::store::{JobDispatchQueue, ReclaimOutcome, TriggerDedupInbox};
 use nebula_storage_port::{Scope, StorageError};
@@ -49,16 +50,28 @@ fn decode_command(s: &str) -> Result<nebula_storage_port::dto::ControlCommand, S
     }
 }
 
-fn tags_to_json(tags: &[CapabilityTag]) -> String {
-    let strs: Vec<&str> = tags.iter().map(CapabilityTag::as_str).collect();
+fn plugins_to_json(plugins: &[PluginKey]) -> String {
+    let strs: Vec<&str> = plugins.iter().map(PluginKey::as_str).collect();
     serde_json::to_string(&strs).unwrap_or_else(|_| "[]".to_owned())
 }
 
 fn row_to_msg(row: &sqlx::sqlite::SqliteRow) -> Result<JobDispatchMsg, StorageError> {
     let id_bytes: Vec<u8> = row.try_get("id").map_err(conn_err)?;
-    let tags_json: String = row.try_get("capability_tags").map_err(conn_err)?;
-    let tags: Vec<String> =
-        serde_json::from_str(&tags_json).map_err(|e| StorageError::Serialization(e.to_string()))?;
+    let plugins_json: String = row.try_get("required_plugins").map_err(conn_err)?;
+    let plugin_strs: Vec<String> = serde_json::from_str(&plugins_json)
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
+    let required_plugins: Vec<PluginKey> = plugin_strs
+        .iter()
+        .map(|s| {
+            s.parse::<PluginKey>()
+                .map_err(|e| StorageError::Serialization(e.to_string()))
+        })
+        .collect::<Result<_, _>>()?;
+    let required_plugin_key: PluginKey = row
+        .try_get::<String, _>("required_plugin_key")
+        .map_err(conn_err)?
+        .parse::<PluginKey>()
+        .map_err(|e| StorageError::Serialization(e.to_string()))?;
     let payload_json: String = row.try_get("payload").map_err(conn_err)?;
     Ok(JobDispatchMsg::new(
         decode_id(&id_bytes)?,
@@ -74,9 +87,8 @@ fn row_to_msg(row: &sqlx::sqlite::SqliteRow) -> Result<JobDispatchMsg, StorageEr
             .map_err(conn_err)?,
         row.try_get::<String, _>("target_flavor_sha")
             .map_err(conn_err)?,
-        row.try_get::<String, _>("required_plugin_key")
-            .map_err(conn_err)?,
-        tags.into_iter().map(CapabilityTag).collect(),
+        required_plugin_key,
+        required_plugins,
         row.try_get::<Option<String>, _>("w3c_traceparent")
             .map_err(conn_err)?,
         row.try_get::<i64, _>("reclaim_count").map_err(conn_err)? as u32,
@@ -105,12 +117,12 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
     async fn enqueue(&self, msg: &JobDispatchMsg) -> Result<(), StorageError> {
         let payload = serde_json::to_string(&msg.payload)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
-        let tags = tags_to_json(&msg.capability_tags);
+        let plugins = plugins_to_json(&msg.required_plugins);
         sqlx::query(
             "INSERT INTO port_job_dispatch_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
               payload, event_id, target_flavor_sha, required_plugin_key, \
-              capability_tags, w3c_traceparent, reclaim_count) \
+              required_plugins, w3c_traceparent, reclaim_count) \
              VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(msg.id.as_slice())
@@ -121,8 +133,8 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
         .bind(&payload)
         .bind(msg.event_id.as_deref())
         .bind(&msg.target_flavor_sha)
-        .bind(&msg.required_plugin_key)
-        .bind(&tags)
+        .bind(msg.required_plugin_key.as_str())
+        .bind(&plugins)
         .bind(msg.w3c_traceparent.as_deref())
         .bind(i64::from(msg.reclaim_count))
         .execute(&self.pool)
@@ -132,24 +144,24 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
         Ok(())
     }
 
-    #[tracing::instrument(level = "debug", skip(self, advertised_tags), fields(batch_size))]
+    #[tracing::instrument(level = "debug", skip(self, available_plugins), fields(batch_size))]
     async fn claim_pending(
         &self,
         processor: &[u8; 16],
         batch_size: u32,
-        advertised_tags: &[CapabilityTag],
+        available_plugins: &[PluginKey],
     ) -> Result<Vec<JobDispatchMsg>, StorageError> {
-        if advertised_tags.is_empty() {
+        if available_plugins.is_empty() {
             return Ok(Vec::new());
         }
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
-        // Superset predicate: a job is claimable when `capability_tags ⊆
-        // advertised_tags`.  The advertised set is bound ONCE as a JSON array
+        // Superset predicate: a job is claimable when `required_plugins ⊆
+        // available_plugins`.  The available set is bound ONCE as a JSON array
         // and unfolded via `json_each` into a CTE, referenced by both the
         // index-friendly `required_plugin_key IN (…)` pre-filter and the exact
         // `NOT EXISTS` superset check — no dynamic placeholder expansion and no
-        // per-tag bind, so the SQLite bound-variable limit is never a concern.
+        // per-plugin bind, so the SQLite bound-variable limit is never a concern.
         //
         // The pre-filter and superset check share one SELECT, so no row is
         // fetched that fails the superset test.  A concurrent actor that flips
@@ -158,27 +170,27 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
         // row skipped); the whole exchange is inside one transaction
         // (single-consumer SQLite boundary, spec §5).
         //
-        // `NOT EXISTS` reads: "no element in json_each(capability_tags) is
-        // absent from the advertised set", i.e. every required tag is covered.
-        // An empty `capability_tags` JSON array yields no rows from json_each
+        // `NOT EXISTS` reads: "no element in json_each(required_plugins) is
+        // absent from the available set", i.e. every required plugin is covered.
+        // An empty `required_plugins` JSON array yields no rows from json_each
         // ⇒ NOT EXISTS is vacuously true ⇒ claimable by anyone (consistent
         // with the InMemory backend).
-        let advertised_json = tags_to_json(advertised_tags);
+        let available_json = plugins_to_json(available_plugins);
         let rows = sqlx::query(
-            "WITH advertised(tag) AS (SELECT value FROM json_each(?1)) \
+            "WITH available(plugin) AS (SELECT value FROM json_each(?1)) \
              SELECT id, execution_id, workspace_id, org_id, command, \
                     payload, event_id, target_flavor_sha, required_plugin_key, \
-                    capability_tags, w3c_traceparent, reclaim_count \
+                    required_plugins, w3c_traceparent, reclaim_count \
              FROM port_job_dispatch_queue \
              WHERE status = 'Pending' \
-               AND required_plugin_key IN (SELECT tag FROM advertised) \
+               AND required_plugin_key IN (SELECT plugin FROM available) \
                AND NOT EXISTS ( \
-                   SELECT 1 FROM json_each(capability_tags) je \
-                   WHERE je.value NOT IN (SELECT tag FROM advertised) \
+                   SELECT 1 FROM json_each(required_plugins) je \
+                   WHERE je.value NOT IN (SELECT plugin FROM available) \
                ) \
              ORDER BY id LIMIT ?2",
         )
-        .bind(&advertised_json)
+        .bind(&available_json)
         .bind(i64::from(batch_size))
         .fetch_all(&mut *tx)
         .await
@@ -346,7 +358,7 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
     ) -> Result<DispatchOutcome, StorageError> {
         let payload = serde_json::to_string(&start.payload)
             .map_err(|e| StorageError::Serialization(e.to_string()))?;
-        let tags = tags_to_json(&start.capability_tags);
+        let plugins = plugins_to_json(&start.required_plugins);
 
         // All three writes live inside one transaction — atomicity by
         // construction.  An error from any write propagates via `?` and rolls
@@ -426,7 +438,7 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
             "INSERT INTO port_job_dispatch_queue \
              (id, execution_id, workspace_id, org_id, command, status, \
               payload, event_id, target_flavor_sha, required_plugin_key, \
-              capability_tags, w3c_traceparent, reclaim_count) \
+              required_plugins, w3c_traceparent, reclaim_count) \
              VALUES (?, ?, ?, ?, ?, 'Pending', ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(start.id.as_slice())
@@ -437,8 +449,8 @@ impl TriggerDedupInbox for SqliteTriggerDedupInbox {
         .bind(&payload)
         .bind(start.event_id.as_deref())
         .bind(&start.target_flavor_sha)
-        .bind(&start.required_plugin_key)
-        .bind(&tags)
+        .bind(start.required_plugin_key.as_str())
+        .bind(&plugins)
         .bind(start.w3c_traceparent.as_deref())
         .bind(i64::from(start.reclaim_count))
         .execute(&mut *tx)

--- a/crates/storage/src/sqlite/job_dispatch.rs
+++ b/crates/storage/src/sqlite/job_dispatch.rs
@@ -145,52 +145,44 @@ impl JobDispatchQueue for SqliteJobDispatchQueue {
         let mut tx = self.pool.begin().await.map_err(conn_err)?;
 
         // Superset predicate: a job is claimable when `capability_tags ⊆
-        // advertised_tags`.  SQLite has no array bind, so we interpolate a
-        // parameter-placeholder list and bind the advertised tags twice —
-        // once for the index-friendly `required_plugin_key IN (…)` pre-filter
-        // and once for the exact `NOT EXISTS` superset check.
+        // advertised_tags`.  The advertised set is bound ONCE as a JSON array
+        // and unfolded via `json_each` into a CTE, referenced by both the
+        // index-friendly `required_plugin_key IN (…)` pre-filter and the exact
+        // `NOT EXISTS` superset check — no dynamic placeholder expansion and no
+        // per-tag bind, so the SQLite bound-variable limit is never a concern.
         //
-        // The pre-filter and superset check are in the same SELECT statement,
-        // so no row is fetched that fails the superset test.  A concurrent
-        // actor that flips a selected row to 'Processing' first is caught by
-        // the per-row `UPDATE … AND status = 'Pending'` guard below
-        // (rows_affected = 0 → row skipped); the whole exchange is inside one
-        // transaction (single-consumer SQLite boundary, spec §5).
+        // The pre-filter and superset check share one SELECT, so no row is
+        // fetched that fails the superset test.  A concurrent actor that flips
+        // a selected row to 'Processing' first is caught by the per-row
+        // `UPDATE … AND status = 'Pending'` guard below (rows_affected = 0 →
+        // row skipped); the whole exchange is inside one transaction
+        // (single-consumer SQLite boundary, spec §5).
         //
         // `NOT EXISTS` reads: "no element in json_each(capability_tags) is
         // absent from the advertised set", i.e. every required tag is covered.
         // An empty `capability_tags` JSON array yields no rows from json_each
         // ⇒ NOT EXISTS is vacuously true ⇒ claimable by anyone (consistent
         // with the InMemory backend).
-        let placeholders = advertised_tags
-            .iter()
-            .map(|_| "?")
-            .collect::<Vec<_>>()
-            .join(", ");
-        let select_sql = format!(
-            "SELECT id, execution_id, workspace_id, org_id, command, \
+        let advertised_json = tags_to_json(advertised_tags);
+        let rows = sqlx::query(
+            "WITH advertised(tag) AS (SELECT value FROM json_each(?1)) \
+             SELECT id, execution_id, workspace_id, org_id, command, \
                     payload, event_id, target_flavor_sha, required_plugin_key, \
                     capability_tags, w3c_traceparent, reclaim_count \
              FROM port_job_dispatch_queue \
              WHERE status = 'Pending' \
-               AND required_plugin_key IN ({placeholders}) \
+               AND required_plugin_key IN (SELECT tag FROM advertised) \
                AND NOT EXISTS ( \
                    SELECT 1 FROM json_each(capability_tags) je \
-                   WHERE je.value NOT IN ({placeholders}) \
+                   WHERE je.value NOT IN (SELECT tag FROM advertised) \
                ) \
-             ORDER BY id LIMIT ?"
-        );
-        let mut q = sqlx::query(sqlx::AssertSqlSafe(select_sql));
-        // Bind advertised tags for the IN pre-filter.
-        for tag in advertised_tags {
-            q = q.bind(tag.as_str());
-        }
-        // Bind advertised tags again for the NOT IN superset check.
-        for tag in advertised_tags {
-            q = q.bind(tag.as_str());
-        }
-        q = q.bind(i64::from(batch_size));
-        let rows = q.fetch_all(&mut *tx).await.map_err(conn_err)?;
+             ORDER BY id LIMIT ?2",
+        )
+        .bind(&advertised_json)
+        .bind(i64::from(batch_size))
+        .fetch_all(&mut *tx)
+        .await
+        .map_err(conn_err)?;
 
         let mut claimed = Vec::with_capacity(rows.len());
         let now_ms = chrono::Utc::now().timestamp_millis();

--- a/crates/storage/src/sqlite/schema.sql
+++ b/crates/storage/src/sqlite/schema.sql
@@ -287,8 +287,10 @@ CREATE TABLE IF NOT EXISTS port_blobs (
 );
 
 -- Capability-routed job-dispatch queue.  `id` is the raw 16-byte ULID
--- (BLOB).  `capability_tags` is a JSON array; the routing predicate is
--- `EXISTS (SELECT 1 FROM json_each(capability_tags) WHERE value = ?)`.
+-- (BLOB).  `required_plugins` is a JSON array of PluginKey strings; the
+-- routing predicate is `required_plugins ⊆ available_plugins` (superset
+-- check via NOT EXISTS + json_each).  `required_plugin_key` is the
+-- denormalised primary/pre-filter key (index target).
 -- `processed_at_ms` is epoch-millis (INTEGER) for parity with
 -- `port_control_queue` and the reclaim arithmetic.
 CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
@@ -302,7 +304,7 @@ CREATE TABLE IF NOT EXISTS port_job_dispatch_queue (
     event_id            TEXT,
     target_flavor_sha   TEXT NOT NULL DEFAULT '',
     required_plugin_key TEXT NOT NULL,
-    capability_tags     TEXT NOT NULL DEFAULT '[]',  -- JSON array
+    required_plugins    TEXT NOT NULL DEFAULT '[]',  -- JSON array of PluginKey strings
     w3c_traceparent     TEXT,
     reclaim_count       INTEGER NOT NULL DEFAULT 0,
     processed_by        BLOB,

--- a/crates/storage/tests/conformance.rs
+++ b/crates/storage/tests/conformance.rs
@@ -26,7 +26,7 @@ use harness::{
     assert_dispatch_without_dedup_key, assert_get_published_is_highest_numbered,
     assert_idempotency_first_writer_wins, assert_idempotency_store_cross_scope_isolated,
     assert_idempotency_store_first_writer, assert_job_dispatch_fencing,
-    assert_job_dispatch_routes_by_tag, assert_job_dispatch_routes_by_tag_superset,
+    assert_job_dispatch_routes_by_plugin, assert_job_dispatch_routes_by_plugin_superset,
     assert_journal_visibility_and_scope, assert_live_lease_blocks_acquire,
     assert_save_with_published_version_is_atomic, assert_stale_fencing_is_fenced_out,
     assert_trigger_dedup_first_writer, assert_trigger_dedup_is_scoped,
@@ -121,8 +121,8 @@ matrix!(
     assert_get_published_is_highest_numbered
 );
 matrix!(
-    job_dispatch_routes_by_tag,
-    assert_job_dispatch_routes_by_tag
+    job_dispatch_routes_by_plugin,
+    assert_job_dispatch_routes_by_plugin
 );
 matrix!(job_dispatch_fencing, assert_job_dispatch_fencing);
 matrix!(
@@ -135,8 +135,8 @@ matrix!(
 );
 matrix!(dedup_compose_is_atomic, assert_dedup_compose_is_atomic);
 matrix!(
-    job_dispatch_routes_by_tag_superset,
-    assert_job_dispatch_routes_by_tag_superset
+    job_dispatch_routes_by_plugin_superset,
+    assert_job_dispatch_routes_by_plugin_superset
 );
 matrix!(trigger_dedup_is_scoped, assert_trigger_dedup_is_scoped);
 matrix!(

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -1639,10 +1639,9 @@ fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg 
     )
 }
 
-/// `claim_pending` only delivers rows whose `required_plugin_key` is a
-/// member of the advertised set; rows requiring an unadvertised key are not
-/// delivered.
-pub async fn assert_job_dispatch_routes_by_tag(backend: &dyn Backend) {
+/// `claim_pending` only delivers rows whose required plugin is in the worker's
+/// `available_plugins`; a row requiring an unavailable plugin is not delivered.
+pub async fn assert_job_dispatch_routes_by_plugin(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
     let job_a = make_job(0x10, "plugin.alpha", &["plugin.alpha"]);
@@ -1963,7 +1962,7 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
 /// 4. Advertised `["plugin.alpha", "plugin.beta", "plugin.gamma"]` → claimed
 ///    (strict superset); claimed job identity verified.
 /// 5. Empty advertised set → claims nothing (parity across all backends).
-pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
+pub async fn assert_job_dispatch_routes_by_plugin_superset(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
     // Job requires alpha AND beta (required_plugins covers both; invariant upheld).

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -21,10 +21,10 @@
 
 use std::sync::Arc;
 
+use nebula_core::PluginKey;
 use nebula_storage_port::dto::{
-    CachedRecord, CapabilityTag, ControlCommand, ControlMsg, DispatchKind, JobDispatchMsg,
-    JournalEntry, NewExecution, TriggerDedupRow, WebhookActivationRecord, WorkflowRecord,
-    WorkflowVersionRecord,
+    CachedRecord, ControlCommand, ControlMsg, DispatchKind, JobDispatchMsg, JournalEntry,
+    NewExecution, TriggerDedupRow, WebhookActivationRecord, WorkflowRecord, WorkflowVersionRecord,
 };
 use nebula_storage_port::store::{
     ControlQueue, ExecutionJournalReader, ExecutionStore, IdempotencyGuard, IdempotencyStore,
@@ -1614,6 +1614,16 @@ fn make_new_execution() -> (String, serde_json::Value) {
 }
 
 fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg {
+    let key: PluginKey = required_plugin_key
+        .parse()
+        .expect("conformance test plugin key must be valid");
+    let required_plugins: Vec<PluginKey> = tags
+        .iter()
+        .map(|s| {
+            s.parse::<PluginKey>()
+                .expect("conformance test tag must be valid")
+        })
+        .collect();
     JobDispatchMsg::new(
         [id; 16],
         format!("exe_{id}"),
@@ -1622,8 +1632,8 @@ fn make_job(id: u8, required_plugin_key: &str, tags: &[&str]) -> JobDispatchMsg 
         serde_json::json!({}),
         None::<&str>,
         "sha256:abc",
-        required_plugin_key,
-        tags.iter().map(|s| CapabilityTag::from(*s)).collect(),
+        key,
+        required_plugins,
         None::<&str>,
         0,
     )
@@ -1643,7 +1653,7 @@ pub async fn assert_job_dispatch_routes_by_tag(backend: &dyn Backend) {
     let proc = [9u8; 16];
     // Advertise only alpha — must NOT receive beta.
     let claimed = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+        .claim_pending(&proc, 16, &["plugin.alpha".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim");
     assert_eq!(
@@ -1653,7 +1663,7 @@ pub async fn assert_job_dispatch_routes_by_tag(backend: &dyn Backend) {
         backend.name()
     );
     assert_eq!(
-        claimed[0].required_plugin_key,
+        claimed[0].required_plugin_key.as_str(),
         "plugin.alpha",
         "[{}] claimed row must be alpha",
         backend.name()
@@ -1661,14 +1671,14 @@ pub async fn assert_job_dispatch_routes_by_tag(backend: &dyn Backend) {
 
     // Advertise only beta — beta row is still Pending (alpha took none).
     let claimed_b = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.beta")])
+        .claim_pending(&proc, 16, &["plugin.beta".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim beta");
     assert_eq!(claimed_b.len(), 1, "[{}] beta row claimed", backend.name());
 
     // Advertise an unrelated tag — nothing claimed.
     let nothing = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.gamma")])
+        .claim_pending(&proc, 16, &["plugin.gamma".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim gamma");
     assert!(
@@ -1688,7 +1698,7 @@ pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
     let runner_a = [1u8; 16];
     let runner_b = [2u8; 16];
     let claimed = q
-        .claim_pending(&runner_a, 16, &[CapabilityTag::from("plugin.x")])
+        .claim_pending(&runner_a, 16, &["plugin.x".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim");
     assert_eq!(claimed.len(), 1, "[{}] claimed one row", backend.name());
@@ -1704,7 +1714,7 @@ pub async fn assert_job_dispatch_fencing(backend: &dyn Backend) {
         .expect("mark_dispatched (claimant)");
     // After mark_dispatched, a fresh claim should find no pending rows.
     let after = q
-        .claim_pending(&runner_a, 16, &[CapabilityTag::from("plugin.x")])
+        .claim_pending(&runner_a, 16, &["plugin.x".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim after dispatch");
     assert!(
@@ -1769,7 +1779,7 @@ pub async fn assert_trigger_dedup_first_writer(backend: &dyn Backend) {
     // Only one job row must have been enqueued.
     let proc = [7u8; 16];
     let claimed = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.y")])
+        .claim_pending(&proc, 16, &["plugin.y".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim");
     assert_eq!(
@@ -1819,7 +1829,7 @@ pub async fn assert_dispatch_without_dedup_key(backend: &dyn Backend) {
 
     let proc = [8u8; 16];
     let claimed = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.z")])
+        .claim_pending(&proc, 16, &["plugin.z".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim");
     assert_eq!(
@@ -1922,7 +1932,7 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
     //    to enqueue the Start job would still pass the two checks above.
     let proc = [0xA0u8; 16];
     let claimed = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.q")])
+        .claim_pending(&proc, 16, &["plugin.q".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim_pending after compose");
     assert_eq!(
@@ -1941,10 +1951,10 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
 }
 
 /// `claim_pending` enforces a superset predicate: a worker may claim a job
-/// only when its advertised tags cover EVERY tag in the job's `capability_tags`.
+/// only when its `available_plugins` cover EVERY plugin in the job's `required_plugins`.
 ///
 /// Contract (job has `required_plugin_key = "plugin.alpha"` and
-/// `capability_tags = ["plugin.alpha", "plugin.beta"]`):
+/// `required_plugins = ["plugin.alpha", "plugin.beta"]`):
 ///
 /// 1. Advertised `["plugin.alpha"]` only → NOT claimed (missing beta).
 /// 2. Advertised `["plugin.beta"]` only → NOT claimed (missing alpha; the
@@ -1956,7 +1966,7 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
 pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
-    // Job requires alpha AND beta (capability_tags covers both; invariant upheld).
+    // Job requires alpha AND beta (required_plugins covers both; invariant upheld).
     let job = make_job(0x60, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
     q.enqueue(&job).await.expect("enqueue superset job");
 
@@ -1965,20 +1975,20 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
     // 1. Alpha-only worker: pre-filter passes (required_plugin_key = alpha) but
     //    superset check fails — beta is required and not advertised.
     let claimed_by_alpha_only = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+        .claim_pending(&proc, 16, &["plugin.alpha".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim alpha-only");
     assert!(
         claimed_by_alpha_only.is_empty(),
         "[{}] alpha-only worker must not claim a job that also requires beta \
-         (superset predicate: all capability_tags must be covered)",
+         (superset predicate: all required_plugins must be covered)",
         backend.name()
     );
 
     // 2. Beta-only worker: pre-filter rejects (required_plugin_key = alpha not
     //    in advertised) and the superset check would also fail independently.
     let claimed_by_beta_only = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.beta")])
+        .claim_pending(&proc, 16, &["plugin.beta".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim beta-only");
     assert!(
@@ -1994,8 +2004,8 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
             &proc,
             16,
             &[
-                CapabilityTag::from("plugin.alpha"),
-                CapabilityTag::from("plugin.beta"),
+                "plugin.alpha".parse::<PluginKey>().unwrap(),
+                "plugin.beta".parse::<PluginKey>().unwrap(),
             ],
         )
         .await
@@ -2007,7 +2017,7 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
         backend.name()
     );
     assert_eq!(
-        claimed_by_both[0].required_plugin_key,
+        claimed_by_both[0].required_plugin_key.as_str(),
         "plugin.alpha",
         "[{}] claimed job must be the alpha-required one",
         backend.name()
@@ -2021,9 +2031,9 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
             &proc,
             16,
             &[
-                CapabilityTag::from("plugin.alpha"),
-                CapabilityTag::from("plugin.beta"),
-                CapabilityTag::from("plugin.gamma"),
+                "plugin.alpha".parse::<PluginKey>().unwrap(),
+                "plugin.beta".parse::<PluginKey>().unwrap(),
+                "plugin.gamma".parse::<PluginKey>().unwrap(),
             ],
         )
         .await
@@ -2041,15 +2051,15 @@ pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
         backend.name()
     );
     assert_eq!(
-        claimed_by_superset[0].required_plugin_key,
+        claimed_by_superset[0].required_plugin_key.as_str(),
         "plugin.alpha",
         "[{}] claimed job must be the alpha-required one",
         backend.name()
     );
 
     // 5. Empty advertised set → claims nothing — parity with SQLite + Postgres
-    //    which both short-circuit on empty advertised_tags.  Re-enqueue a
-    //    conforming job (capability_tags ⊇ {required_plugin_key}) to confirm
+    //    which both short-circuit on empty available_plugins.  Re-enqueue a
+    //    conforming job (required_plugins ⊇ {required_plugin_key}) to confirm
     //    it stays Pending.
     let job3 = make_job(0x62, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
     q.enqueue(&job3)
@@ -2236,7 +2246,7 @@ pub async fn assert_dedup_compose_rolls_back_on_id_collision(backend: &dyn Backe
     // No Start job must have been enqueued (rollback).
     let proc = [0x9Au8; 16];
     let enqueued = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.rb")])
+        .claim_pending(&proc, 16, &["plugin.rb".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim_pending after failed compose");
     assert!(
@@ -2290,7 +2300,7 @@ pub async fn assert_dedup_compose_rejects_duplicate_job_id(backend: &dyn Backend
     //    queued job, still carrying the first execution id.
     let proc = [0xB1u8; 16];
     let claimed = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.jid")])
+        .claim_pending(&proc, 16, &["plugin.jid".parse::<PluginKey>().unwrap()])
         .await
         .expect("claim after failed compose");
     assert_eq!(

--- a/crates/storage/tests/conformance/mod.rs
+++ b/crates/storage/tests/conformance/mod.rs
@@ -1940,51 +1940,128 @@ pub async fn assert_dedup_compose_is_atomic(backend: &dyn Backend) {
     );
 }
 
-/// Routing is keyed on `required_plugin_key`, NOT on membership in the
-/// `capability_tags` superset.
+/// `claim_pending` enforces a superset predicate: a worker may claim a job
+/// only when its advertised tags cover EVERY tag in the job's `capability_tags`.
 ///
-/// A job with `required_plugin_key = "plugin.alpha"` and
-/// `capability_tags = ["plugin.alpha", "plugin.beta"]` must NOT be claimed
-/// by a worker that advertises only `["plugin.beta"]`.  This assertion
-/// exists to lock cross-backend equivalence between Postgres
-/// (`required_plugin_key = ANY($tags)`) and SQLite
-/// (`required_plugin_key = ?` per advertised tag).
+/// Contract (job has `required_plugin_key = "plugin.alpha"` and
+/// `capability_tags = ["plugin.alpha", "plugin.beta"]`):
+///
+/// 1. Advertised `["plugin.alpha"]` only → NOT claimed (missing beta).
+/// 2. Advertised `["plugin.beta"]` only → NOT claimed (missing alpha; the
+///    `required_plugin_key` pre-filter also rejects it independently).
+/// 3. Advertised `["plugin.alpha", "plugin.beta"]` → claimed (exact superset).
+/// 4. Advertised `["plugin.alpha", "plugin.beta", "plugin.gamma"]` → claimed
+///    (strict superset); claimed job identity verified.
+/// 5. Empty advertised set → claims nothing (parity across all backends).
 pub async fn assert_job_dispatch_routes_by_tag_superset(backend: &dyn Backend) {
     let q = backend.job_dispatch_queue().await;
 
-    // Job requires alpha but lists both alpha and beta in capability_tags.
+    // Job requires alpha AND beta (capability_tags covers both; invariant upheld).
     let job = make_job(0x60, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
     q.enqueue(&job).await.expect("enqueue superset job");
 
     let proc = [0xAAu8; 16];
 
-    // A worker advertising only beta must NOT claim this job.
-    let claimed_by_beta = q
+    // 1. Alpha-only worker: pre-filter passes (required_plugin_key = alpha) but
+    //    superset check fails — beta is required and not advertised.
+    let claimed_by_alpha_only = q
+        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+        .await
+        .expect("claim alpha-only");
+    assert!(
+        claimed_by_alpha_only.is_empty(),
+        "[{}] alpha-only worker must not claim a job that also requires beta \
+         (superset predicate: all capability_tags must be covered)",
+        backend.name()
+    );
+
+    // 2. Beta-only worker: pre-filter rejects (required_plugin_key = alpha not
+    //    in advertised) and the superset check would also fail independently.
+    let claimed_by_beta_only = q
         .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.beta")])
         .await
         .expect("claim beta-only");
     assert!(
-        claimed_by_beta.is_empty(),
+        claimed_by_beta_only.is_empty(),
         "[{}] beta-only worker must not claim an alpha-required job \
-         (routing is on required_plugin_key, not capability_tags superset)",
+         (pre-filter on required_plugin_key rejects it)",
         backend.name()
     );
 
-    // A worker advertising alpha must claim it.
-    let claimed_by_alpha = q
-        .claim_pending(&proc, 16, &[CapabilityTag::from("plugin.alpha")])
+    // 3. Exact-superset worker: advertises both alpha and beta — must claim.
+    let claimed_by_both = q
+        .claim_pending(
+            &proc,
+            16,
+            &[
+                CapabilityTag::from("plugin.alpha"),
+                CapabilityTag::from("plugin.beta"),
+            ],
+        )
         .await
-        .expect("claim alpha");
+        .expect("claim alpha+beta");
     assert_eq!(
-        claimed_by_alpha.len(),
+        claimed_by_both.len(),
         1,
-        "[{}] alpha worker must claim the alpha-required job",
+        "[{}] worker advertising [alpha, beta] must claim the job (exact superset)",
         backend.name()
     );
     assert_eq!(
-        claimed_by_alpha[0].required_plugin_key,
+        claimed_by_both[0].required_plugin_key,
         "plugin.alpha",
         "[{}] claimed job must be the alpha-required one",
+        backend.name()
+    );
+
+    // 4. Strict-superset worker (re-enqueue to get a fresh Pending row).
+    let job2 = make_job(0x61, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
+    q.enqueue(&job2).await.expect("enqueue superset job 2");
+    let claimed_by_superset = q
+        .claim_pending(
+            &proc,
+            16,
+            &[
+                CapabilityTag::from("plugin.alpha"),
+                CapabilityTag::from("plugin.beta"),
+                CapabilityTag::from("plugin.gamma"),
+            ],
+        )
+        .await
+        .expect("claim strict superset");
+    assert_eq!(
+        claimed_by_superset.len(),
+        1,
+        "[{}] worker advertising [alpha, beta, gamma] must claim a job requiring [alpha, beta]",
+        backend.name()
+    );
+    assert_eq!(
+        claimed_by_superset[0].id,
+        job2.id,
+        "[{}] claimed job must be the strict-superset job (id match)",
+        backend.name()
+    );
+    assert_eq!(
+        claimed_by_superset[0].required_plugin_key,
+        "plugin.alpha",
+        "[{}] claimed job must be the alpha-required one",
+        backend.name()
+    );
+
+    // 5. Empty advertised set → claims nothing — parity with SQLite + Postgres
+    //    which both short-circuit on empty advertised_tags.  Re-enqueue a
+    //    conforming job (capability_tags ⊇ {required_plugin_key}) to confirm
+    //    it stays Pending.
+    let job3 = make_job(0x62, "plugin.alpha", &["plugin.alpha", "plugin.beta"]);
+    q.enqueue(&job3)
+        .await
+        .expect("enqueue job for empty-advertised check");
+    let claimed_empty_adv = q
+        .claim_pending(&proc, 16, &[])
+        .await
+        .expect("claim with empty advertised");
+    assert!(
+        claimed_empty_adv.is_empty(),
+        "[{}] empty advertised set must claim nothing (parity with SQL backends)",
         backend.name()
     );
 }


### PR DESCRIPTION
## ADR-0095 D1 — superset claim predicate + capability-routing rename

> **DX rename folded in** (owner-directed): the non-self-documenting
> `capability_tags` / `CapabilityTag(String)` became **`required_plugins:
> Vec<PluginKey>`** (job) / **`available_plugins: &[PluginKey]`** (worker), and
> `required_plugin_key: String` → `PluginKey`. `CapabilityTag` deleted; the SQL
> column `capability_tags` → `required_plugins` (edited in the create migration,
> unreleased). Wire format unchanged (`PluginKey` serializes as a string), so no
> data migration. Predicate now reads `required_plugins ⊆ available_plugins`.

### Superset claim predicate (closes multi-plugin routing)

Makes the `capability_tags` forward-seam (populated by `DefinitionRoutingResolver`,
#817) **load-bearing**. The job-dispatch claim predicate changes from the
single-key `required_plugin_key ∈ advertised_tags` to a **superset match**:
a worker claims a Pending job only if its advertised capability tags contain
**every** tag in `job.capability_tags`.

### Why
A workflow runs in-process on one worker, so that worker needs **all** of the
workflow's plugins (trigger + every node). A single-key predicate let a worker
holding just one of them claim the job and then fail mid-execution on a plugin
it lacks. The superset predicate routes a multi-plugin workflow only to a worker
(flavor) that carries the full set — correct for real flavors with plugin
subsets, with no route-shape change (the data was already on the job).

### What changed (`crates/storage*`)
- **Predicate** (all 3 backends, conformance-locked identical semantics):
  - **InMemory** — `capability_tags.iter().all(|ct| advertised.contains(ct))` under the existing mutex; gains an empty-advertised early-return for parity.
  - **Postgres** — `capability_tags <@ $advertised::jsonb` inside `FOR UPDATE SKIP LOCKED … RETURNING`. NOTE: `<@` is **not** GIN-accelerated (`jsonb_ops` indexes `@>`/existence, not `<@`); it filters over the `(status, required_plugin_key)` B-tree pre-filtered rows. A `<@`-indexable representation (text[] + `array_ops`, or a tag-membership table) is the tracked pre-production follow-up.
  - **SQLite** — `NOT EXISTS (json_each(capability_tags) … NOT IN advertised)` inside the transactional, status-guarded claim.
- **`required_plugin_key` kept as a sound, index-friendly pre-filter** — the DTO invariant `capability_tags ⊇ {required_plugin_key}` (now `debug_assert`ed in `JobDispatchMsg::new`) means it never drops a row the superset would accept.
- **Docs corrected** — DTO + trait docs describe the superset rule and the honest per-backend atomicity (no overclaim that SQLite is a single atomic statement; the `status='Pending'` + `rows_affected` guard prevents double-claim). Postgres `schema.sql` comments updated.
- **Conformance** — `assert_job_dispatch_routes_by_tag_superset` inverted: a job needing {alpha,beta} is claimed by advertised ⊇{alpha,beta}, NOT by {alpha} alone nor {beta} alone; added empty-advertised (claims nothing) + strict-superset identity assertions.

### Verification
- `cargo nextest run -p nebula-storage` — **264 passed** (superset + routing across InMemory/SQLite; Postgres skips clean without `DATABASE_URL`, per existing policy — the PG `<@` SQL is correct by construction; `<@` semantics/direction confirmed, indexability corrected after review — see the Postgres note above).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps -p nebula-storage -p nebula-storage-port` — clean.
- No schema migration (columns + GIN index already existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced job dispatch routing to require workers to support all required plugins for a job, enabling more precise worker-to-job matching.

* **Bug Fixes**
  * Improved job routing accuracy by strengthening the requirement that a worker's available plugin set must fully cover all plugins required by a dispatched job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->