### PR TITLE
feat(worker): nebula-worker — library composition root for the live claim-loop (ADR-0095 D1, U-D1.3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-worker"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "nebula-action",
+ "nebula-core",
+ "nebula-engine",
+ "nebula-execution",
+ "nebula-metrics",
+ "nebula-orchestrator",
+ "nebula-storage",
+ "nebula-storage-port",
+ "nebula-workflow",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "nebula-workflow"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
   "crates/resilience",
   "crates/resource",
   "crates/orchestrator",
+  "crates/worker",
 
   "crates/validator",
   "crates/api",

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -1,0 +1,39 @@
+[package]
+name = "nebula-worker"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+description = "Generic worker runtime that wires a WorkflowEngine into an Orchestrator pull-loop (ADR-0095 D1)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+keywords.workspace = true
+
+[dependencies]
+nebula-engine = { path = "../engine" }
+nebula-orchestrator = { path = "../orchestrator" }
+nebula-storage-port = { path = "../storage-port" }
+nebula-core = { path = "../core" }
+nebula-metrics = { path = "../metrics" }
+
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros"] }
+tokio-util = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+nebula-storage = { path = "../storage" }
+nebula-action = { path = "../action" }
+nebula-workflow = { path = "../workflow" }
+nebula-execution = { path = "../execution" }
+tokio = { workspace = true, features = ["rt", "sync", "time", "macros", "test-util"] }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+
+[lib]
+doctest = false
+
+[lints]
+workspace = true

--- a/crates/worker/src/lib.rs
+++ b/crates/worker/src/lib.rs
@@ -1,0 +1,290 @@
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+//! # nebula-worker — Generic worker runtime (ADR-0095 D1)
+//!
+//! A worker is a long-running process that:
+//!
+//! 1. Boots a flavor's plugins and derives the set of [`PluginKey`]s it can serve.
+//! 2. Advertises those keys as `available_plugins` to the pull-loop.
+//! 3. Runs a **leaderless claim-loop** via [`nebula_orchestrator::Orchestrator`]:
+//!    claims [`JobDispatchQueue`] rows whose `required_plugins ⊆ available_plugins`,
+//!    hands them to [`EngineExecutionSink`], and fences each row dispatched or failed.
+//! 4. Drives execution into the engine via `resume_execution` (the sink's job).
+//!
+//! ## Wiring honesty
+//!
+//! This crate provides the **generic runtime** only. A per-flavor binary that
+//! boots concrete plugins and derives `available_plugins` from them is a later
+//! unit (U-D1.4+). Today, callers pass the `Vec<PluginKey>` they have already
+//! derived from their plugin registry.
+//!
+//! ## Construction
+//!
+//! ```rust,ignore
+//! use std::sync::Arc;
+//! use nebula_worker::WorkerRuntimeBuilder;
+//!
+//! let runtime = WorkerRuntimeBuilder::from_wired_engine(engine, stores, queue, plugins, proc_id)
+//!     .with_batch_size(16)
+//!     .build()?;
+//!
+//! runtime.spawn(shutdown_token);
+//! ```
+//!
+//! [`PluginKey`]: nebula_core::PluginKey
+//! [`JobDispatchQueue`]: nebula_storage_port::store::JobDispatchQueue
+//! [`EngineExecutionSink`]: nebula_engine::EngineExecutionSink
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use nebula_core::PluginKey;
+use nebula_engine::{EngineExecutionSink, ExecutionStores, WorkflowEngine};
+use nebula_metrics::MetricsRegistry;
+use nebula_orchestrator::Orchestrator;
+use nebula_storage_port::store::JobDispatchQueue;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+/// Errors that can be produced when building a [`WorkerRuntime`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum WorkerBuildError {
+    /// `available_plugins` is empty — the worker would never claim any job.
+    ///
+    /// A worker with no advertised plugins is a configuration error: the superset
+    /// predicate `required_plugins ⊆ available_plugins` is vacuously unsatisfiable
+    /// for any non-empty `required_plugins`, and the storage backends short-circuit
+    /// on an empty available set rather than scanning the queue.
+    #[error("available_plugins is empty — a worker must advertise at least one PluginKey")]
+    NoPlugins,
+}
+
+/// An assembled, ready-to-run worker runtime.
+///
+/// Holds the [`Orchestrator`] configured with an [`EngineExecutionSink`]
+/// connected to the provided engine and execution store.
+///
+/// Obtain via [`WorkerRuntimeBuilder::build`].
+#[must_use = "call .run() or .spawn() to start the pull loop"]
+pub struct WorkerRuntime {
+    orchestrator: Orchestrator,
+    processor_id: [u8; 16],
+    available_plugins_count: usize,
+}
+
+impl std::fmt::Debug for WorkerRuntime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("WorkerRuntime")
+            .field("processor_id", &hex_id(&self.processor_id))
+            .field("available_plugins_count", &self.available_plugins_count)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WorkerRuntime {
+    /// Run the claim-loop on the current task until `shutdown` is cancelled.
+    ///
+    /// Prefer [`spawn`](Self::spawn) unless integrating into a custom task structure.
+    ///
+    /// ## Shutdown contract
+    ///
+    /// Mirrors [`Orchestrator::run`]: flushes the in-flight batch, then returns.
+    /// Rows claimed but not yet marked remain `Processing` and are recovered by
+    /// the next runner's reclaim sweep.
+    pub async fn run(self, shutdown: CancellationToken) {
+        tracing::info!(
+            processor = %hex_id(&self.processor_id),
+            available_plugins = self.available_plugins_count,
+            "worker runtime starting (ADR-0095 D1)"
+        );
+        self.orchestrator.run(shutdown).await;
+    }
+
+    /// Spawn the claim-loop as a Tokio task.
+    ///
+    /// Returns a [`JoinHandle`] that completes when `shutdown` is cancelled.
+    /// The caller owns signal→[`CancellationToken`] wiring; this crate provides
+    /// no `tokio::signal` integration so it composes into any shutdown strategy.
+    pub fn spawn(self, shutdown: CancellationToken) -> JoinHandle<()> {
+        tracing::info!(
+            processor = %hex_id(&self.processor_id),
+            available_plugins = self.available_plugins_count,
+            "worker runtime spawning (ADR-0095 D1)"
+        );
+        self.orchestrator.spawn(shutdown)
+    }
+}
+
+/// Builder for [`WorkerRuntime`].
+///
+/// Obtained via [`WorkerRuntimeBuilder::from_wired_engine`]. Optional overrides
+/// mirror [`Orchestrator`]'s builder methods.
+#[must_use = "call .build() to produce a WorkerRuntime"]
+pub struct WorkerRuntimeBuilder {
+    engine: Arc<WorkflowEngine>,
+    stores: ExecutionStores,
+    queue: Arc<dyn JobDispatchQueue>,
+    available_plugins: Vec<PluginKey>,
+    processor_id: [u8; 16],
+    // Optional orchestrator overrides — all None means "use Orchestrator defaults".
+    batch_size: Option<u32>,
+    poll_interval: Option<Duration>,
+    reclaim_after: Option<Duration>,
+    reclaim_interval: Option<Duration>,
+    max_reclaim_count: Option<u32>,
+    metrics: Option<MetricsRegistry>,
+}
+
+impl WorkerRuntimeBuilder {
+    /// Create a builder wired to a pre-built engine and its stores.
+    ///
+    /// ## Construction invariant
+    ///
+    /// `stores.execution` MUST be the same `Arc<dyn ExecutionStore>` the `engine`
+    /// was wired with via `WorkflowEngine::with_execution_stores`. If they differ,
+    /// the sink's idempotency read and the engine's internal lease CAS observe
+    /// different rows, which breaks the idempotency contract. Passing the
+    /// `ExecutionStores` bundle here makes that structurally difficult to get wrong:
+    /// the same bundle that was passed to `with_execution_stores` provides the
+    /// `execution` field the sink needs.
+    ///
+    /// Pass the **same `ExecutionStores` bundle** you handed to
+    /// `WorkflowEngine::with_execution_stores` — do not construct a second bundle
+    /// from a different store clone. The sink's idempotency read and the engine's
+    /// lease CAS must observe the identical rows.
+    ///
+    /// `available_plugins` is the set of [`PluginKey`]s this worker can serve.
+    /// A worker with no plugins would never claim any job; [`build`] rejects
+    /// that case as [`WorkerBuildError::NoPlugins`].
+    ///
+    /// `processor_id` is a fixed 16-byte fence token recorded in the job row's
+    /// `processed_by` field. Supply the full 16 bytes — no truncation or padding
+    /// is performed, so two distinct workers with different ids cannot collapse
+    /// to the same token.
+    ///
+    /// [`build`]: Self::build
+    pub fn from_wired_engine(
+        engine: Arc<WorkflowEngine>,
+        stores: ExecutionStores,
+        queue: Arc<dyn JobDispatchQueue>,
+        available_plugins: Vec<PluginKey>,
+        processor_id: [u8; 16],
+    ) -> Self {
+        Self {
+            engine,
+            stores,
+            queue,
+            available_plugins,
+            processor_id,
+            batch_size: None,
+            poll_interval: None,
+            reclaim_after: None,
+            reclaim_interval: None,
+            max_reclaim_count: None,
+            metrics: None,
+        }
+    }
+
+    /// Override the claim batch size (default: [`Orchestrator`] default = 32).
+    pub fn with_batch_size(mut self, n: u32) -> Self {
+        self.batch_size = Some(n);
+        self
+    }
+
+    /// Override the idle poll interval (default: [`Orchestrator`] default = 100 ms).
+    pub fn with_poll_interval(mut self, d: Duration) -> Self {
+        self.poll_interval = Some(d);
+        self
+    }
+
+    /// Override the staleness window before a `Processing` row becomes reclaimable
+    /// (default: [`Orchestrator`] default = 150 s).
+    pub fn with_reclaim_after(mut self, d: Duration) -> Self {
+        self.reclaim_after = Some(d);
+        self
+    }
+
+    /// Override the reclaim sweep cadence (default: [`Orchestrator`] default = 30 s).
+    pub fn with_reclaim_interval(mut self, d: Duration) -> Self {
+        self.reclaim_interval = Some(d);
+        self
+    }
+
+    /// Override the max retry budget before an exhausted row moves to `Failed`
+    /// (default: [`Orchestrator`] default = 3).
+    pub fn with_max_reclaim_count(mut self, n: u32) -> Self {
+        self.max_reclaim_count = Some(n);
+        self
+    }
+
+    /// Inject the shared [`MetricsRegistry`] the orchestrator emits counters into.
+    ///
+    /// Without this the counters increment against a private registry no scraper
+    /// sees. Production composition roots should inject the shared registry so
+    /// counters reach the Prometheus scrape endpoint.
+    pub fn with_metrics(mut self, m: MetricsRegistry) -> Self {
+        self.metrics = Some(m);
+        self
+    }
+
+    /// Validate required fields, wire the sink, and construct [`WorkerRuntime`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WorkerBuildError::NoPlugins`] when `available_plugins` is empty.
+    pub fn build(self) -> Result<WorkerRuntime, WorkerBuildError> {
+        if self.available_plugins.is_empty() {
+            return Err(WorkerBuildError::NoPlugins);
+        }
+
+        let sink = Arc::new(EngineExecutionSink::new(
+            Arc::clone(&self.engine),
+            // Extract execution store from the bundle.
+            // INVARIANT: this must be the same Arc passed to `with_execution_stores`
+            // — enforced by documentation on `from_wired_engine`.
+            Arc::clone(&self.stores.execution),
+        ));
+
+        let available_plugins_count = self.available_plugins.len();
+
+        let mut orchestrator =
+            Orchestrator::new(self.queue, sink, self.processor_id, self.available_plugins);
+
+        if let Some(n) = self.batch_size {
+            orchestrator = orchestrator.with_batch_size(n);
+        }
+        if let Some(d) = self.poll_interval {
+            orchestrator = orchestrator.with_poll_interval(d);
+        }
+        if let Some(d) = self.reclaim_after {
+            orchestrator = orchestrator.with_reclaim_after(d);
+        }
+        if let Some(d) = self.reclaim_interval {
+            orchestrator = orchestrator.with_reclaim_interval(d);
+        }
+        if let Some(n) = self.max_reclaim_count {
+            orchestrator = orchestrator.with_max_reclaim_count(n);
+        }
+        if let Some(m) = self.metrics {
+            orchestrator = orchestrator.with_metrics(m);
+        }
+
+        Ok(WorkerRuntime {
+            orchestrator,
+            processor_id: self.processor_id,
+            available_plugins_count,
+        })
+    }
+}
+
+/// Hex-encode `processor_id` bytes for structured log fields.
+fn hex_id(bytes: &[u8]) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -1,0 +1,402 @@
+//! Integration test for `nebula-worker` — U-D1.3 acceptance proof.
+//!
+//! Verifies the full path:
+//!   `WorkerRuntimeBuilder::build` → `.spawn(cancel)` →
+//!   orchestrator claims a `Start` job → `EngineExecutionSink::dispatch` →
+//!   `WorkflowEngine::resume_execution` → execution reaches `Completed`.
+//!
+//! ## Test plan
+//!
+//! `worker_runtime_drives_execution_to_completed`
+//!   - Seeds a one-node echo workflow (published) + a `Created` execution row.
+//!   - Enqueues a `Start` `JobDispatchMsg` matching the worker's `available_plugins`.
+//!   - Builds a `WorkerRuntime` via `WorkerRuntimeBuilder` and spawns it.
+//!   - Advances virtual time so the orchestrator's poll interval fires.
+//!   - Asserts the execution row reaches `Completed` and the job row is `Dispatched`.
+//!
+//! Backend: InMemory only.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionError, ActionMetadata, action::Action, result::ActionResult, stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, PluginKey, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessRunner,
+    WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{
+    InMemoryExecutionStore, InMemoryWorkflowVersionStore, inmem::InMemoryJobDispatchQueue,
+};
+use nebula_storage_port::{
+    Scope,
+    dto::{ControlCommand, JobDispatchMsg},
+    store::{ExecutionStore, JobDispatchQueue, WorkflowVersionStore},
+};
+use nebula_worker::WorkerRuntimeBuilder;
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, TriggerBinding, ValidatedWorkflow, Version,
+    WorkflowConfig, WorkflowDefinition,
+};
+use tokio_util::sync::CancellationToken;
+
+// ── Plugin key used across all test helpers ───────────────────────────────────
+
+const TEST_PLUGIN_KEY: &str = "test.worker.plugin";
+
+// ── Shared harness ────────────────────────────────────────────────────────────
+
+/// In-memory storage adapters sharing one execution-store core.
+#[derive(Clone)]
+struct TestStores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl TestStores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+}
+
+/// Fixed placeholder scope — deliberately mirrors `engine_scope()` from `nebula-engine`
+/// (the same `("nebula","nebula")` placeholder the engine uses for every port call).
+/// The request-derived `Scope` wiring belongs to U-D1.4; do NOT re-export `engine_scope`
+/// from `nebula-engine` here — it is a placeholder slated to change.
+fn scope() -> Scope {
+    Scope::new("nebula", "nebula")
+}
+
+/// `[b; 16]` processor id helper.
+fn proc16(b: u8) -> [u8; 16] {
+    [b; 16]
+}
+
+// ── Echo action ───────────────────────────────────────────────────────────────
+
+struct EchoHandler {
+    count: Arc<AtomicU32>,
+}
+
+impl Action for EchoHandler {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(action_key!("test.echo.worker"), "Echo", "echo")
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl StatelessAction for EchoHandler {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Engine builder ────────────────────────────────────────────────────────────
+
+async fn make_engine(stores: &TestStores) -> (Arc<WorkflowEngine>, Arc<AtomicU32>) {
+    let count = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.legacy_register_stateless_with_metadata(
+        ActionMetadata::new(action_key!("test.echo.worker"), "Echo", "echo"),
+        EchoHandler {
+            count: count.clone(),
+        },
+    );
+    // `InProcessRunner` + `executor` are structural boilerplate required by
+    // `ActionRuntime::try_new` but are NOT the code path exercised by this test.
+    // The legacy-registered `EchoHandler` runs via the direct stateless dispatch path;
+    // `echo_count` is the witness that the real handler was invoked.
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .expect("ActionRuntime must build in tests"),
+    );
+    let engine = Arc::new(stores.attach(
+        WorkflowEngine::new(runtime, metrics).expect("WorkflowEngine must build in tests"),
+    ));
+    (engine, count)
+}
+
+// ── Workflow persistence ──────────────────────────────────────────────────────
+
+async fn save_echo_workflow(stores: &TestStores) -> Arc<ValidatedWorkflow> {
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = chrono::Utc::now();
+    let def = WorkflowDefinition {
+        id: workflow_id,
+        name: "worker-integration-echo".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                node_key!("step"),
+                "Step",
+                TEST_PLUGIN_KEY,
+                "test.echo.worker",
+            )
+            .unwrap(),
+        ],
+        connections: Vec::<Connection>::new(),
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: vec![
+            TriggerBinding::new(
+                node_key!("test.trigger"),
+                TEST_PLUGIN_KEY,
+                "test.trigger.action",
+            )
+            .unwrap(),
+        ],
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    let validated =
+        ValidatedWorkflow::validate(def).expect("echo workflow definition must pass validation");
+    stores
+        .versions
+        .create(
+            &scope(),
+            nebula_storage_port::dto::WorkflowVersionRecord {
+                workflow_id: validated.definition().id.to_string(),
+                number: 0,
+                published: true,
+                pinned: false,
+                definition: serde_json::to_value(validated.definition())
+                    .expect("serialize workflow"),
+            },
+        )
+        .await
+        .expect("save workflow version");
+    Arc::new(validated)
+}
+
+async fn persist_created(
+    stores: &TestStores,
+    workflow_id: nebula_core::WorkflowId,
+    execution_id: ExecutionId,
+    input: serde_json::Value,
+) {
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    exec_state.set_workflow_input(input);
+    let state_json = serde_json::to_value(&exec_state).expect("serialize execution state");
+    stores
+        .execution
+        .create(
+            &scope(),
+            &execution_id.to_string(),
+            &workflow_id.to_string(),
+            state_json,
+        )
+        .await
+        .expect("create execution row");
+}
+
+async fn read_status(stores: &TestStores, execution_id: ExecutionId) -> Option<ExecutionStatus> {
+    let record = stores
+        .execution
+        .get(&scope(), &execution_id.to_string())
+        .await
+        .expect("get execution");
+    record.and_then(|r| {
+        r.state
+            .get("status")
+            .and_then(|s| serde_json::from_value::<ExecutionStatus>(s.clone()).ok())
+    })
+}
+
+// ── Acceptance test ───────────────────────────────────────────────────────────
+
+/// Full end-to-end proof: `WorkerRuntimeBuilder::build` → `.spawn` →
+/// orchestrator claims a `Start` job → engine drives execution to `Completed`.
+#[tokio::test(start_paused = true)]
+async fn worker_runtime_drives_execution_to_completed() {
+    let stores = TestStores::new();
+    let (engine, echo_count) = make_engine(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
+
+    // Seed a `Created` execution row.
+    let execution_id = ExecutionId::new();
+    persist_created(
+        &stores,
+        workflow_id,
+        execution_id,
+        serde_json::json!({"trigger": "worker-integration"}),
+    )
+    .await;
+
+    // Assert starting state is Created.
+    let status_before = read_status(&stores, execution_id)
+        .await
+        .expect("Created row must exist before worker runs");
+    assert_eq!(
+        status_before,
+        ExecutionStatus::Created,
+        "row must be Created before worker claims it; got {status_before:?}"
+    );
+
+    // Wire a job-dispatch queue sharing the execution store's core.
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
+    let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
+
+    // Enqueue a Start job whose `required_plugins` matches the worker's advertised set.
+    let job_id = [0x11u8; 16];
+    let msg = JobDispatchMsg::new(
+        job_id,
+        execution_id.to_string(),
+        ControlCommand::Start,
+        scope(),
+        serde_json::json!({}),
+        None::<String>,
+        "sha-worker-test",
+        plugin_key.clone(),
+        vec![plugin_key.clone()],
+        None::<String>,
+        0,
+    );
+    queue.enqueue(&msg).await.expect("enqueue Start job");
+
+    // Build the WorkerRuntime via the builder.
+    let execution_stores = stores.execution_stores();
+    let runtime = WorkerRuntimeBuilder::from_wired_engine(
+        Arc::clone(&engine),
+        execution_stores,
+        Arc::clone(&queue) as Arc<dyn JobDispatchQueue>,
+        vec![plugin_key],
+        proc16(0xBB),
+    )
+    // Use a fast poll interval so virtual-time advance is small.
+    .with_poll_interval(Duration::from_millis(10))
+    .build()
+    .expect("WorkerRuntimeBuilder::build must succeed with non-empty plugin set");
+
+    // Spawn the runtime.
+    let cancel = CancellationToken::new();
+    let handle = runtime.spawn(cancel.clone());
+
+    // Bounded poll loop: drive progress by state, not by a magic sleep budget.
+    // Each iteration yields to let the worker task run, then advances virtual time
+    // by one poll interval (10 ms) so the orchestrator's sleep fires. The loop exits
+    // as soon as the execution reaches Completed, or fails the assertion after 200
+    // iterations (~2 s of virtual time) — a worker that never ticks must FAIL here.
+    let mut completed = false;
+    for _ in 0..200 {
+        tokio::task::yield_now().await;
+        if read_status(&stores, execution_id).await == Some(ExecutionStatus::Completed) {
+            completed = true;
+            break;
+        }
+        tokio::time::advance(Duration::from_millis(10)).await;
+    }
+    assert!(
+        completed,
+        "worker did not drive the execution to Completed within the poll budget"
+    );
+
+    // Cancel the worker and wait for clean shutdown.
+    cancel.cancel();
+    handle.await.expect("worker task must not panic");
+
+    // Echo handler must have been invoked exactly once.
+    assert_eq!(
+        echo_count.load(Ordering::SeqCst),
+        1,
+        "echo handler must be invoked exactly once"
+    );
+}
+
+/// `WorkerRuntimeBuilder::build` rejects an empty `available_plugins` vec.
+#[tokio::test]
+async fn builder_rejects_empty_plugins() {
+    use nebula_worker::WorkerBuildError;
+    let stores = TestStores::new();
+    let (engine, _) = make_engine(&stores).await;
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
+    let result = WorkerRuntimeBuilder::from_wired_engine(
+        engine,
+        stores.execution_stores(),
+        queue as Arc<dyn JobDispatchQueue>,
+        vec![], // intentionally empty — must be rejected
+        proc16(0x00),
+    )
+    .build();
+
+    assert!(
+        matches!(result, Err(WorkerBuildError::NoPlugins)),
+        "empty available_plugins must produce WorkerBuildError::NoPlugins; got {result:?}"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,14 @@ deny = [
   ], reason = "API is top layer; lower-level crates must not depend on it directly" },
 
   # ---- Layer enforcement: Exec ----
+  # NOTE: nebula-worker (ADR-0095 D1) is the TOP exec-layer composition root and
+  # SHOULD be ban-guarded so no business/core crate may depend on it. But it has
+  # ZERO dependents today (library-only, no binary yet), and cargo-deny flags the
+  # workspace-root instance of a banned crate that has no wrapper edge to satisfy
+  # — so a `{ crate = "nebula-worker", wrappers = [] }` entry FAILS the bans check.
+  # Add that entry together with its first consumer (the per-flavor worker binary,
+  # U-D1.F) in the consumer's wrappers list. Until then worker has no inbound edges
+  # (verify: `cargo tree -i -p nebula-worker`), so the boundary is not violable.
   { crate = "nebula-engine", wrappers = [
     "nebula-cli",
     # Dev-only: `crates/api/tests/knife.rs` wires the API + Engine composition

--- a/deny.toml
+++ b/deny.toml
@@ -82,6 +82,9 @@ deny = [
     # nebula-credential's `service/` facade composition root (the api-layer
     # credential builder) wires the engine-owned resolver + lease lifecycle;
     # the api crate consuming engine is already listed above (ADR-0092).
+    # nebula-worker is the exec-layer composition root: it wires the engine into
+    # the orchestrator pull-loop (ADR-0095 D1, U-D1.3).
+    "nebula-worker",
   ], reason = "Engine is exec-layer orchestration; business/core crates must not depend on it" },
   { crate = "nebula-storage", wrappers = [
     "nebula-engine",
@@ -94,6 +97,9 @@ deny = [
     # orchestrator dev-depends on the in-memory JobDispatchQueue adapter as its
     # test baseline (the InMemory backend is the no-DATABASE_URL conformance double).
     "nebula-orchestrator",
+    # nebula-worker dev-depends on the InMemory adapter for its integration test
+    # (the no-DATABASE_URL conformance double), same as nebula-orchestrator.
+    "nebula-worker",
   ], reason = "Storage is exec-layer; business and core crates must not depend on it directly" },
 
   # nebula-storage-port is the Core-tier storage contract: object-safe
@@ -112,6 +118,8 @@ deny = [
     "nebula-credential",
     # exec-layer consumer of the JobDispatchQueue port (capability-routed dispatch).
     "nebula-orchestrator",
+    # nebula-worker assembles the orchestrator + engine over the storage ports.
+    "nebula-worker",
   ], reason = "Storage port is a Core-tier contract; the adapter, tenancy decorator, exec/api consumers, and nebula-credential (which hosts the refresh coordinator and depends on RefreshClaimStore, ADR-0092) may depend on it" },
 
   # nebula-tenancy is the Business-tier multi-tenancy security boundary: it


### PR DESCRIPTION
## ADR-0095 D1 — `nebula-worker`: the live claim-loop

The first unit that makes the worker topology **live**. A new **library-only** crate
that assembles the already-merged pieces (engine, orchestrator, storage queue) into
a runnable worker runtime: it advertises a flavor's `available_plugins`, runs the
leaderless claim-loop pulling jobs where `required_plugins ⊆ available_plugins`, and
drives each into the engine.

### What it is
- `WorkerRuntimeBuilder::from_wired_engine(engine: Arc<WorkflowEngine>, stores:
  ExecutionStores, queue: Arc<dyn JobDispatchQueue>, available_plugins:
  Vec<PluginKey>, processor_id: [u8; 16])` + `with_*` overrides (batch size, poll /
  reclaim intervals, metrics). `build() -> Result<WorkerRuntime, WorkerBuildError>`
  (typed error, no panic in the library). `run(shutdown)` / `spawn(shutdown) ->
  JoinHandle` delegate the claim-loop to `Orchestrator`.
- **Construction invariant** (documented on the API): the `ExecutionStores.execution`
  handed to the builder MUST be the same `Arc<dyn ExecutionStore>` the engine was
  wired with — the sink's idempotency read and the engine's lease CAS must observe
  one row. Taking the `ExecutionStores` bundle makes that hard to get wrong.
- **Plugin-agnostic**: takes `Vec<PluginKey>`, not a `PluginRegistry` (the caller
  derives `available_plugins = registry.iter()...`); no `nebula-plugin` dep. No
  `tokio::signal` in the library (signal→token wiring belongs in a binary).
- A thin composition shell — all execution/claim logic already lives in
  `nebula-engine` + `nebula-orchestrator`.

### Scope honesty
**Library-only, no binary.** Concrete plugin-flavor crates don't exist yet, so a
`main` would be a fake flavor. A per-flavor worker binary + plugin boot is a later
unit (U-D1.F). This unit delivers the generic runtime + an end-to-end live proof.

### Verification
- `cargo check --workspace --all-targets` — clean (new crate in the workspace).
- `cargo nextest run -p nebula-worker` — **2 passed**: `builder_rejects_empty_plugins`
  (typed-error path) and `worker_runtime_drives_execution_to_completed` — a
  `start_paused` integration test (bounded poll loop) where a spawned `WorkerRuntime`
  drains a `Start` job and drives a real execution to `Completed`. The `echo_count`
  witness + `Created`-before / `Completed`-after asserts rule out a false-green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `rustdoc -D warnings`, `cargo deny check bans` (added `nebula-worker` to the
  engine/storage/storage-port ban wrappers — it is the exec-layer composition root),
  taplo — all green.

Reviewed by an async-runtime lens (claim-loop reality, cancel-safety, the
construction invariant) and a quality/scope lens — both COMPLETE; polish (robust
bounded-poll test, doc strengthening) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new worker runtime component capable of executing workflows. The worker is fully configurable with adjustable batch sizes, polling intervals, and reclaim behavior, with built-in validation for required plugin availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->