### PR TITLE
fix(engine)!: thread real tenant Scope; delete engine_scope() placeholder (ADR-0095 D1, U-D1.4c)

### DIFF
--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -201,10 +201,9 @@ pub(crate) struct PortHandles {
 /// directly under this scope (`seed_*`) and the engine seam binds its
 /// store handles to it (see `engine_seam`), so harness writes, engine
 /// writes, and API reads all key on the same `(TEST_WS, TEST_ORG)`
-/// tuple. The engine's internal `engine_scope()` placeholder is
-/// substituted by the request-scope-bound decorator the seam wraps the
-/// stores in (engine per-execution scoping is a separate, tracked
-/// follow-up — see storage port migration "Known follow-up").
+/// tuple. The engine threads the real per-message tenant scope through
+/// `resume_execution`; the request-scope-bound decorator the seam wraps
+/// the stores in binds those calls to the request scope.
 pub(crate) fn port_scope() -> Scope {
     Scope::new(TEST_WS, TEST_ORG)
 }
@@ -1026,15 +1025,14 @@ pub(crate) mod engine_seam {
         );
 
         // `AppState` now stores **raw** port handles and applies the
-        // per-request tenant scope in its accessors; the engine, by
-        // contrast, still calls its store handles with the internal
-        // `engine_scope()` placeholder (a separate, tracked follow-up —
-        // see storage port migration "Known follow-up: engine per-execution tenant
-        // scoping"). To keep the seam coherent the engine-side handles
+        // per-request tenant scope in its accessors; the engine now
+        // threads the real per-message tenant `Scope` through
+        // `resume_execution` (the `engine_scope()` placeholder was
+        // deleted). To keep the seam coherent the engine-side handles
         // are wrapped here in `nebula-tenancy` decorators bound to
         // `port_scope()` — the request scope the API derives and the
-        // tests seed under. The decorator substitutes its bound scope
-        // for whatever the engine passes, so engine writes, harness
+        // tests seed under. The decorator binds whatever the engine
+        // passes to that scope, so engine writes, harness
         // `seed_*` writes, and API reads all key on the same tenant.
         // This is the decorator's intended composition-seam use (the
         // security primitive, bound correctly), not a shim. The

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -531,14 +531,13 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     );
 
     // `AppState` stores **raw** port handles and applies the per-request
-    // tenant scope in its accessors; the engine still calls its handles
-    // with the internal `engine_scope()` placeholder (a separate, tracked
-    // follow-up — see storage port migration "Known follow-up: engine per-execution
-    // tenant scoping"). Wrap the engine-side handles in `nebula-tenancy`
-    // decorators bound to `knife_scope()` (= `port_scope()`, the scope
-    // the API derives and this test seeded the workflow/execution under)
-    // so the decorator substitutes the engine's scope and engine reads,
-    // the API-enqueued `Start`, and the seeded rows all key on the same
+    // tenant scope in its accessors; the engine now threads the real
+    // per-message tenant `Scope` through `resume_execution` (the
+    // `engine_scope()` placeholder was deleted). Wrap the engine-side
+    // handles in `nebula-tenancy` decorators bound to `knife_scope()`
+    // (= `port_scope()`, the scope the API derives and this test seeded
+    // the workflow/execution under) so the decorator binds engine reads,
+    // the API-enqueued `Start`, and the seeded rows to the same
     // tenant. The echo node never checkpoints or replays, so a fresh
     // in-memory checkpoint/idempotency pair suffices for the two
     // `ExecutionStores` fields `AppState` does not expose.

--- a/crates/engine/docs/DESIGN.md
+++ b/crates/engine/docs/DESIGN.md
@@ -52,7 +52,7 @@ plugin-registry — и рискует разойтись с canon §12.2 control
 | `runtime::{ActionRuntime, ActionRegistry, ActionRunner, InProcessRunner, TaskQueue, MemoryQueue, BlobStorage, DataPassingPolicy, BoundedStreamBuffer, StatefulCheckpoint(-Sink)}` | `runtime/runtime.rs:61-116`, `registry.rs:53`, `runner.rs:25-89`, `queue.rs:22-132` |
 | `scoped_resources::{BranchId, ScopedResourceMap, DashScopedResourceMap, LayeredResourceAccessor, ScopedResourceGuard, run_cleanup(_with_timeout)}` (per-branch хранение, scoped→global precedence, RAII LIFO-cleanup с таймаутом) | `scoped_resources.rs:116-698` |
 | `daemon::{Daemon, DaemonRegistry, DaemonRuntime, EventSource, EventSourceRuntime/Adapter, RestartPolicy, DaemonError}` | `daemon/mod.rs:37-52`, `registry.rs:38-273`, `runtime.rs:37`, `event_source.rs:32-164` |
-| `store_seam::{ExecutionStores, WorkflowStores, engine_scope, node_output_record…}` (мост к spec-16 storage-port) | `store_seam.rs:44-126` |
+| `store_seam::{ExecutionStores, WorkflowStores, node_output_record…}` (мост к spec-16 storage-port; реальный per-message `Scope` протягивается в `resume_execution`, плейсхолдер удалён) | `store_seam.rs:44-126` |
 | `ExecutionResult` · `EngineError` · `ExecutionEvent` (eventbus broadcast) · `NodeOutput` | `result.rs:10` · `error.rs:10` · `event.rs:19` · `node_output.rs:9` |
 | `resource_status::{ResourceRuntimeStatus, EngineResourceStatus, EngineManagerResourceStatus}` | `resource_status.rs:45-91` |
 | Re-export plugin-типов: `Plugin, PluginKey, PluginManifest, PluginRegistry, ResolvedPlugin` | `lib.rs:102` |

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -37,6 +37,7 @@ use nebula_metrics::{
     MetricsRegistry,
     naming::{NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, control_reclaim_outcome},
 };
+use nebula_storage_port::Scope;
 use nebula_storage_port::dto::ControlCommand;
 use nebula_storage_port::store::ControlQueue;
 use tokio::task::JoinHandle;
@@ -126,6 +127,10 @@ pub trait ControlDispatch: Send + Sync {
     /// Deliver a `Start` command to a newly-created execution (control-queue wiring,
     /// , #332).
     ///
+    /// `scope` is the per-message tenant scope sourced from `ControlMsg.scope`;
+    /// it scopes the idempotency status read and the engine's resume path so
+    /// that execution rows from a different tenant are never visible.
+    ///
     /// Enqueued by the API `start_execution` / `execute_workflow` handlers
     /// once the `ExecutionState::Created` row has been persisted. A2 wired
     /// the canonical engine-side body in
@@ -138,9 +143,15 @@ pub trait ControlDispatch: Send + Sync {
     /// Implementations must guard via CAS on `ExecutionRepo::transition` —
     /// a `Start` arriving for an already-running or already-terminal
     /// execution must be `Ok()`, not a second run.
-    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
+    async fn dispatch_start(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Cancel` command to a running execution.
+    ///
+    /// `scope` is the per-message tenant scope from `ControlMsg.scope`.
     ///
     /// A3 wired this into the engine's cooperative-cancel path (closes
     /// #330). The canonical engine-owned body lives in
@@ -155,9 +166,15 @@ pub trait ControlDispatch: Send + Sync {
     /// can fail after a successful dispatch, and the reclaim path (B1)
     /// will redeliver; because the signal itself is idempotent, re-delivery
     /// is safe without a short-circuit on persisted status.
-    async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
+    async fn dispatch_cancel(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Terminate` command to a running execution.
+    ///
+    /// `scope` is the per-message tenant scope from `ControlMsg.scope`.
     ///
     /// calls this "forced termination", but there is no distinct
     /// forced-shutdown path in the engine today — cooperative cancel via
@@ -170,10 +187,13 @@ pub trait ControlDispatch: Send + Sync {
     /// **Idempotency:** same contract as [`dispatch_cancel`](Self::dispatch_cancel).
     async fn dispatch_terminate(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Resume` command to a suspended execution.
+    ///
+    /// `scope` is the per-message tenant scope from `ControlMsg.scope`.
     ///
     /// A2 wired the canonical body in
     /// [`crate::control_dispatch::EngineControlDispatch`].
@@ -182,9 +202,15 @@ pub trait ControlDispatch: Send + Sync {
     /// Implementations must guard via CAS on `ExecutionRepo::transition` —
     /// a `Resume` arriving for an already-running or already-terminal
     /// execution must be `Ok()`, not a second start.
-    async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError>;
+    async fn dispatch_resume(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError>;
 
     /// Deliver a `Restart` command to an execution.
+    ///
+    /// `scope` is the per-message tenant scope from `ControlMsg.scope`.
     ///
     /// A2 wired the canonical body in
     /// [`crate::control_dispatch::EngineControlDispatch`]. Full
@@ -196,8 +222,11 @@ pub trait ControlDispatch: Send + Sync {
     ///
     /// **Idempotency:** same `Resume` contract applies — double-restart
     /// rewinds twice. Guard with a monotonic restart counter or CAS.
-    async fn dispatch_restart(&self, execution_id: ExecutionId)
-    -> Result<(), ControlDispatchError>;
+    async fn dispatch_restart(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError>;
 }
 
 /// A raw claimed control message. The `execution_id` decode (and its
@@ -221,6 +250,11 @@ struct ClaimedRow {
     execution_id: ExecutionId,
     /// Command to deliver.
     command: ControlCommand,
+    /// Tenant scope this message belongs to (from `ControlMsg.scope`).
+    ///
+    /// Threaded into every `dispatch_*` call so the engine reads and drives
+    /// the execution under the correct tenant — cross-tenant isolation invariant #7.
+    scope: Scope,
     /// W3C `traceparent` carrier captured at enqueue, if any.
     w3c: Option<nebula_core::W3cTraceContext>,
 }
@@ -235,6 +269,10 @@ impl RawClaimed {
     /// Normalize into a [`ClaimedRow`], decoding `execution_id` (carried
     /// as the opaque string form — parsed directly, no "UTF-8 of the
     /// ULID string" decode).
+    ///
+    /// `scope` is taken directly from `ControlMsg.scope` — it is the
+    /// tenant this message belongs to and must be threaded into every
+    /// dispatch call (cross-tenant isolation invariant #7).
     fn normalize(self) -> Result<ClaimedRow, String> {
         let m = self.0;
         let execution_id = m.execution_id.parse::<ExecutionId>().map_err(|e| {
@@ -268,6 +306,7 @@ impl RawClaimed {
             id: m.id,
             execution_id,
             command: m.command,
+            scope: m.scope,
             w3c,
         })
     }
@@ -580,6 +619,7 @@ impl ControlConsumer {
             id: row_id,
             execution_id,
             command,
+            scope,
             w3c: w3c_opt,
         } = match raw.normalize() {
             Ok(row) => row,
@@ -617,23 +657,23 @@ impl ControlConsumer {
             match command {
                 ControlCommand::Start => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Start (A2)");
-                    dispatch.dispatch_start(execution_id).await
+                    dispatch.dispatch_start(&scope, execution_id).await
                 },
                 ControlCommand::Cancel => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Cancel (A3)");
-                    dispatch.dispatch_cancel(execution_id).await
+                    dispatch.dispatch_cancel(&scope, execution_id).await
                 },
                 ControlCommand::Terminate => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Terminate (A3)");
-                    dispatch.dispatch_terminate(execution_id).await
+                    dispatch.dispatch_terminate(&scope, execution_id).await
                 },
                 ControlCommand::Resume => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Resume (A2)");
-                    dispatch.dispatch_resume(execution_id).await
+                    dispatch.dispatch_resume(&scope, execution_id).await
                 },
                 ControlCommand::Restart => {
                     tracing::debug!(%execution_id, "control-queue: dispatching Restart (A2)");
-                    dispatch.dispatch_restart(execution_id).await
+                    dispatch.dispatch_restart(&scope, execution_id).await
                 },
             }
         }

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -49,7 +49,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use nebula_core::id::ExecutionId;
 use nebula_execution::ExecutionStatus;
-use nebula_storage_port::store::ExecutionStore;
+use nebula_storage_port::{Scope, store::ExecutionStore};
 
 use crate::{
     WorkflowEngine,
@@ -89,16 +89,20 @@ impl EngineControlDispatch {
         Self { engine, execution }
     }
 
-    /// Read the persisted [`ExecutionStatus`] for an execution, returning
-    /// `None` if the row does not exist.
+    /// Read the persisted [`ExecutionStatus`] for an execution under the given
+    /// tenant `scope`, returning `None` if the row does not exist.
+    ///
+    /// `scope` MUST be the per-message scope from `ControlMsg.scope` so that
+    /// execution rows belonging to a different tenant are never visible here
+    /// (cross-tenant isolation invariant #7).
     async fn read_status(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<Option<ExecutionStatus>, ControlDispatchError> {
-        let scope = crate::store_seam::engine_scope();
         let json = self
             .execution
-            .get(&scope, &execution_id.to_string())
+            .get(scope, &execution_id.to_string())
             .await
             .map_err(|e| {
                 ControlDispatchError::Internal(format!(
@@ -124,13 +128,17 @@ impl EngineControlDispatch {
     }
 
     /// Drive an execution that is `Created` or `Paused` through the engine's
-    /// resume path. Shared by `dispatch_start`, `dispatch_resume`, and
-    /// `dispatch_restart` — the three commands converge on the same engine
-    /// entry today because the engine does not yet distinguish a
-    /// `restart-from-input` rewind from a normal resume (true rewind
-    /// requires durable output purge — tracked separately).
-    async fn drive(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
-        match self.engine.resume_execution(execution_id).await {
+    /// resume path under the given tenant scope. Shared by `dispatch_start`,
+    /// `dispatch_resume`, and `dispatch_restart` — the three commands converge
+    /// on the same engine entry today because the engine does not yet
+    /// distinguish a `restart-from-input` rewind from a normal resume (true
+    /// rewind requires durable output purge — tracked separately).
+    async fn drive(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
+        match self.engine.resume_execution(scope, execution_id).await {
             Ok(_) => Ok(()),
             // Concurrent dispatcher already holds the lease — the canonical
             // idempotency outcome. Returning `Ok()` here prevents
@@ -144,7 +152,7 @@ impl EngineControlDispatch {
                 // `resume_execution`. This catches both the "already terminal"
                 // `PlanningFailed` that `resume_execution` surfaces on re-entry
                 // and the race where a parallel `Cancel` beat us to the row.
-                if let Ok(Some(status)) = self.read_status(execution_id).await
+                if let Ok(Some(status)) = self.read_status(scope, execution_id).await
                     && (status.is_terminal() || matches!(status, ExecutionStatus::Cancelling))
                 {
                     return Ok(());
@@ -159,8 +167,12 @@ impl EngineControlDispatch {
 
 #[async_trait]
 impl ControlDispatch for EngineControlDispatch {
-    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
-        match self.read_status(execution_id).await? {
+    async fn dispatch_start(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
+        match self.read_status(scope, execution_id).await? {
             None => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} not found — start command orphaned"
             ))),
@@ -176,15 +188,19 @@ impl ControlDispatch for EngineControlDispatch {
                 | ExecutionStatus::TimedOut,
             ) => Ok(()),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
-                self.drive(execution_id).await
+                self.drive(scope, execution_id).await
             },
         }
     }
 
-    async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_resume(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         // `Resume` and `Start` converge on the same engine entry today — see
         // the `drive` docs. The idempotency read mirrors `dispatch_start`.
-        match self.read_status(execution_id).await? {
+        match self.read_status(scope, execution_id).await? {
             None => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} not found — resume command orphaned"
             ))),
@@ -197,16 +213,17 @@ impl ControlDispatch for EngineControlDispatch {
                 | ExecutionStatus::TimedOut,
             ) => Ok(()),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
-                self.drive(execution_id).await
+                self.drive(scope, execution_id).await
             },
         }
     }
 
     async fn dispatch_restart(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        //        // rewind-from-input restart requires durable output purge plus a
+        // rewind-from-input restart requires durable output purge plus a
         // restart counter — neither exists yet. For A2, treat restart as a
         // re-entrant drive of the engine's resume path and honor the same
         // terminal / running idempotency outcomes.
@@ -214,7 +231,7 @@ impl ControlDispatch for EngineControlDispatch {
         // Restart-of-terminal intentionally errors so operators see the gap
         // in the `execution_control_queue.error_message` rather than the
         // command silently succeeding and not actually restarting anything.
-        match self.read_status(execution_id).await? {
+        match self.read_status(scope, execution_id).await? {
             None => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} not found — restart command orphaned"
             ))),
@@ -226,16 +243,19 @@ impl ControlDispatch for EngineControlDispatch {
                 | ExecutionStatus::TimedOut),
             ) => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} is already {status}; rewind-from-input restart \
- requires durable output purge — not yet implemented \
-                 follow-up"
+                 requires durable output purge — not yet implemented follow-up"
             ))),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
-                self.drive(execution_id).await
+                self.drive(scope, execution_id).await
             },
         }
     }
 
-    async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_cancel(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         // A3 — every non-orphan `Cancel` signals the engine's
         // cancel registry, regardless of the persisted status.
         //
@@ -254,7 +274,7 @@ impl ControlDispatch for EngineControlDispatch {
         // returns `false` without side effects. Signalling always is the
         // honest minimum: it closes the live-loop gap and is safe under
         // at-least-once redelivery.
-        match self.read_status(execution_id).await? {
+        match self.read_status(scope, execution_id).await? {
             // Producer bug: queue row written without the execution row (or a
             // row that disappeared between enqueue and drain). Surface so the
             // diagnosis lands on `execution_control_queue.error_message`.
@@ -276,6 +296,7 @@ impl ControlDispatch for EngineControlDispatch {
 
     async fn dispatch_terminate(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         // names `Terminate` "forced termination", but there is no
@@ -291,6 +312,6 @@ impl ControlDispatch for EngineControlDispatch {
         // (cancel-registry and cooperative-cancel contract) for
         // the design rationale and the upgrade path to a true forced-shutdown
         // distinction.
-        self.dispatch_cancel(execution_id).await
+        self.dispatch_cancel(scope, execution_id).await
     }
 }

--- a/crates/engine/src/daemon/execution_sink.rs
+++ b/crates/engine/src/daemon/execution_sink.rs
@@ -222,27 +222,38 @@ mod tests {
 
     /// Invariant #7 — fail-closed cross-tenant isolation (U-D1.4c).
     ///
-    /// Persisting an execution under scope-A then dispatching a `JobDispatchMsg`
-    /// carrying scope-B must yield `ExecutionSinkError::Rejected` because
-    /// `read_status` under scope-B finds no row.
+    /// The row is seeded under `single_tenant_scope()` — `("nebula","nebula")`,
+    /// the exact value the old `engine_scope()` constant returned. A
+    /// `JobDispatchMsg` carrying `scope_b = ("wsB","orgB")` is then dispatched.
     ///
-    /// Under the old `engine_scope()` placeholder BOTH scopes collapsed to
-    /// `("nebula","nebula")` so the dispatch would succeed — proving the
-    /// placeholder masked cross-tenant access.  This test cannot pass until
-    /// `read_status` uses the message's real scope.
+    /// **Why this is RED on the old code:**
+    /// The old `read_status` called `self.execution.get(engine_scope(), id)` — i.e.
+    /// `get(("nebula","nebula"), id)` — which FINDS the seeded row, so the `None`
+    /// arm is NOT taken. Control falls through to `drive`, which calls
+    /// `resume_execution(engine_scope(), id)`. The engine has no workflow store
+    /// attached (minimal construction), so `resume_execution` returns
+    /// `EngineError::StoreNotConfigured` which maps to `ExecutionSinkError::Internal`
+    /// — NOT `Rejected`. The `assert!(matches!(Rejected))` therefore fails → RED.
+    ///
+    /// **Why this is GREEN on the new code:**
+    /// `read_status` now reads under `msg.scope = scope_b = ("wsB","orgB")`.
+    /// The store holds no row under that scope → `None` → the function returns
+    /// `Err(Rejected("not found …"))` immediately, never reaching `drive` → GREEN.
     #[tokio::test]
     async fn cross_tenant_dispatch_is_rejected() {
-        let scope_a = Scope::new("wsA", "orgA");
+        // The row is intentionally seeded under single_tenant_scope() — the same
+        // ("nebula","nebula") the OLD engine_scope() constant always returned.
+        // This makes the test RED when read_status is reverted to the constant.
+        let single_tenant = crate::store_seam::single_tenant_scope();
         let scope_b = Scope::new("wsB", "orgB");
 
-        // Seed an execution row under scope-A.
         let execution_store: Arc<dyn ExecutionStore> = Arc::new(InMemoryExecutionStore::new());
         let execution_id = ExecutionId::new();
         let exec_state = ExecutionState::new(execution_id, nebula_core::id::WorkflowId::new(), &[]);
         let state_json = serde_json::to_value(&exec_state).unwrap();
         execution_store
             .create(
-                &scope_a,
+                &single_tenant, // row lives under ("nebula","nebula") = old constant
                 &execution_id.to_string(),
                 &nebula_core::id::WorkflowId::new().to_string(),
                 state_json,
@@ -250,19 +261,19 @@ mod tests {
             .await
             .unwrap();
 
-        // Wire a sink backed by a minimal engine — the test never reaches
-        // resume_execution because read_status short-circuits with None first.
+        // Minimal engine (no stores) — the test must short-circuit in read_status,
+        // never reaching resume_execution.
         let metrics = nebula_metrics::MetricsRegistry::new();
         let engine = Arc::new(WorkflowEngine::new(minimal_runtime(), metrics).expect("engine"));
         let sink = EngineExecutionSink::new(Arc::clone(&engine), Arc::clone(&execution_store));
 
-        // Build a dispatch msg carrying scope-B for the scope-A execution.
+        // Dispatch under scope_b — a different tenant than the row's scope.
         let plugin_key = plugin_key!("test.cross_tenant");
         let msg = JobDispatchMsg::new(
             [0u8; 16],
             execution_id.to_string(),
             ControlCommand::Start,
-            scope_b, // <- wrong scope: execution lives under scope-A
+            scope_b, // wrong tenant: row lives under single_tenant, not scope_b
             serde_json::Value::Null,
             None::<String>,
             "sha",
@@ -274,10 +285,9 @@ mod tests {
 
         let result = sink.dispatch(&msg).await;
 
-        // Must be Rejected — not found under scope-B.
-        // Under the old placeholder both scopes aliased to ("nebula","nebula")
-        // so this would have returned Ok(()) after successfully finding the row —
-        // proving the placeholder masked the cross-tenant gap.
+        // New code: read_status reads under scope_b → None → Rejected.
+        // Old code: read_status reads under ("nebula","nebula") → finds the row →
+        //   drive → resume_execution → Internal (no store) — NOT Rejected → RED.
         match result {
             Err(ExecutionSinkError::Rejected(msg)) => {
                 assert!(

--- a/crates/engine/src/daemon/execution_sink.rs
+++ b/crates/engine/src/daemon/execution_sink.rs
@@ -220,7 +220,7 @@ mod tests {
         )
     }
 
-    /// Invariant #7 — fail-closed cross-tenant isolation (U-D1.4c).
+    /// Invariant #7 — fail-closed cross-tenant isolation.
     ///
     /// The row is seeded under `single_tenant_scope()` — `("nebula","nebula")`,
     /// the exact value the old `engine_scope()` constant returned. A

--- a/crates/engine/src/daemon/execution_sink.rs
+++ b/crates/engine/src/daemon/execution_sink.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use nebula_core::id::ExecutionId;
 use nebula_execution::ExecutionStatus;
 use nebula_orchestrator::{ExecutionSink, ExecutionSinkError};
-use nebula_storage_port::{dto::JobDispatchMsg, store::ExecutionStore};
+use nebula_storage_port::{Scope, dto::JobDispatchMsg, store::ExecutionStore};
 
 use crate::{WorkflowEngine, error::EngineError};
 
@@ -67,16 +67,20 @@ impl EngineExecutionSink {
         Self { engine, execution }
     }
 
-    /// Read the persisted [`ExecutionStatus`] for idempotency, returning
-    /// `None` if the row does not exist.
+    /// Read the persisted [`ExecutionStatus`] for idempotency under the given
+    /// tenant `scope`, returning `None` if the row does not exist.
+    ///
+    /// `scope` MUST be the per-message scope from `JobDispatchMsg.scope` so
+    /// that a row persisted under a different tenant is never visible here
+    /// (cross-tenant isolation invariant #7).
     async fn read_status(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<Option<ExecutionStatus>, ExecutionSinkError> {
-        let scope = crate::store_seam::engine_scope();
         let json = self
             .execution
-            .get(&scope, &execution_id.to_string())
+            .get(scope, &execution_id.to_string())
             .await
             .map_err(|e| {
                 ExecutionSinkError::Internal(format!(
@@ -101,13 +105,17 @@ impl EngineExecutionSink {
         }
     }
 
-    /// Drive an execution through `resume_execution`.
+    /// Drive an execution through `resume_execution` under the given tenant scope.
     ///
     /// Maps [`EngineError::Leased`] to `Ok(())` (sibling runner already owns
     /// the dispatch; we should not mark the row Failed) and re-checks terminal
     /// status before surfacing other engine errors as `Internal`.
-    async fn drive(&self, execution_id: ExecutionId) -> Result<(), ExecutionSinkError> {
-        match self.engine.resume_execution(execution_id).await {
+    async fn drive(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ExecutionSinkError> {
+        match self.engine.resume_execution(scope, execution_id).await {
             Ok(_) => Ok(()),
             // Concurrent dispatcher already holds the lease — the canonical
             // idempotency outcome. Returning Ok prevents the orchestrator from
@@ -117,7 +125,7 @@ impl EngineExecutionSink {
                 // Last-ditch idempotency guard: re-read in case a sibling
                 // driver beat us to terminal state between our initial read and
                 // the engine's own `get_state` inside `resume_execution`.
-                if let Ok(Some(status)) = self.read_status(execution_id).await
+                if let Ok(Some(status)) = self.read_status(scope, execution_id).await
                     && (status.is_terminal() || matches!(status, ExecutionStatus::Cancelling))
                 {
                     return Ok(());
@@ -149,7 +157,10 @@ impl ExecutionSink for EngineExecutionSink {
             ))
         })?;
 
-        match self.read_status(execution_id).await? {
+        // msg.scope is the per-message tenant scope derived from the dispatch
+        // row. read_status uses it so a row persisted under a different tenant
+        // is not visible here — cross-tenant isolation invariant #7.
+        match self.read_status(&msg.scope, execution_id).await? {
             None => Err(ExecutionSinkError::Rejected(format!(
                 "execution {execution_id} not found — start command orphaned"
             ))),
@@ -164,8 +175,117 @@ impl ExecutionSink for EngineExecutionSink {
                 | ExecutionStatus::TimedOut,
             ) => Ok(()),
             Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
-                self.drive(execution_id).await
+                self.drive(&msg.scope, execution_id).await
             },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use nebula_core::{id::ExecutionId, plugin_key};
+    use nebula_execution::ExecutionState;
+    use nebula_orchestrator::{ExecutionSink, ExecutionSinkError};
+    use nebula_storage::InMemoryExecutionStore;
+    use nebula_storage_port::{
+        Scope,
+        dto::{ControlCommand, JobDispatchMsg},
+        store::ExecutionStore,
+    };
+
+    use nebula_action::ActionResult;
+
+    use super::EngineExecutionSink;
+    use crate::{
+        ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessRunner,
+        WorkflowEngine,
+    };
+
+    /// Build the minimal `ActionRuntime` needed to construct a `WorkflowEngine`.
+    /// The engine is never asked to actually run a workflow in this test — the
+    /// cross-tenant check short-circuits in `read_status` before `resume_execution`
+    /// is ever called.
+    fn minimal_runtime() -> Arc<ActionRuntime> {
+        let registry = Arc::new(ActionRegistry::new());
+        let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+            Box::pin(async move { Ok(ActionResult::success(input)) })
+        });
+        let runner = Arc::new(InProcessRunner::new(executor));
+        let metrics = nebula_metrics::MetricsRegistry::new();
+        Arc::new(
+            ActionRuntime::try_new(registry, runner, DataPassingPolicy::default(), metrics)
+                .expect("minimal runtime"),
+        )
+    }
+
+    /// Invariant #7 — fail-closed cross-tenant isolation (U-D1.4c).
+    ///
+    /// Persisting an execution under scope-A then dispatching a `JobDispatchMsg`
+    /// carrying scope-B must yield `ExecutionSinkError::Rejected` because
+    /// `read_status` under scope-B finds no row.
+    ///
+    /// Under the old `engine_scope()` placeholder BOTH scopes collapsed to
+    /// `("nebula","nebula")` so the dispatch would succeed — proving the
+    /// placeholder masked cross-tenant access.  This test cannot pass until
+    /// `read_status` uses the message's real scope.
+    #[tokio::test]
+    async fn cross_tenant_dispatch_is_rejected() {
+        let scope_a = Scope::new("wsA", "orgA");
+        let scope_b = Scope::new("wsB", "orgB");
+
+        // Seed an execution row under scope-A.
+        let execution_store: Arc<dyn ExecutionStore> = Arc::new(InMemoryExecutionStore::new());
+        let execution_id = ExecutionId::new();
+        let exec_state = ExecutionState::new(execution_id, nebula_core::id::WorkflowId::new(), &[]);
+        let state_json = serde_json::to_value(&exec_state).unwrap();
+        execution_store
+            .create(
+                &scope_a,
+                &execution_id.to_string(),
+                &nebula_core::id::WorkflowId::new().to_string(),
+                state_json,
+            )
+            .await
+            .unwrap();
+
+        // Wire a sink backed by a minimal engine — the test never reaches
+        // resume_execution because read_status short-circuits with None first.
+        let metrics = nebula_metrics::MetricsRegistry::new();
+        let engine = Arc::new(WorkflowEngine::new(minimal_runtime(), metrics).expect("engine"));
+        let sink = EngineExecutionSink::new(Arc::clone(&engine), Arc::clone(&execution_store));
+
+        // Build a dispatch msg carrying scope-B for the scope-A execution.
+        let plugin_key = plugin_key!("test.cross_tenant");
+        let msg = JobDispatchMsg::new(
+            [0u8; 16],
+            execution_id.to_string(),
+            ControlCommand::Start,
+            scope_b, // <- wrong scope: execution lives under scope-A
+            serde_json::Value::Null,
+            None::<String>,
+            "sha",
+            plugin_key.clone(),
+            vec![plugin_key],
+            None::<String>,
+            0,
+        );
+
+        let result = sink.dispatch(&msg).await;
+
+        // Must be Rejected — not found under scope-B.
+        // Under the old placeholder both scopes aliased to ("nebula","nebula")
+        // so this would have returned Ok(()) after successfully finding the row —
+        // proving the placeholder masked the cross-tenant gap.
+        match result {
+            Err(ExecutionSinkError::Rejected(msg)) => {
+                assert!(
+                    msg.contains("not found"),
+                    "expected 'not found' in rejection message, got: {msg}"
+                );
+            },
+            other => panic!("expected Rejected, got: {other:?}"),
         }
     }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -993,6 +993,7 @@ impl WorkflowEngine {
     /// integration test in `crates/engine/tests/lease_takeover.rs`.
     pub async fn replay_execution(
         &self,
+        scope: &Scope,
         workflow: &WorkflowDefinition,
         plan: nebula_execution::ReplayPlan,
         budget: ExecutionBudget,
@@ -1105,10 +1106,9 @@ impl WorkflowEngine {
 
         // Run the frontier loop — same as execute_workflow, just different seed + pre-populated
         // outputs.
-        let replay_scope = crate::store_seam::test_scope();
         let failed_node = self
             .run_frontier(
-                &replay_scope,
+                scope,
                 &graph,
                 &node_map,
                 &outputs,
@@ -1385,45 +1385,47 @@ impl WorkflowEngine {
     /// This method is used in tests and local library mode. Production code
     /// enters the engine via [`Self::resume_execution`] (which carries the
     /// real per-message tenant scope from the control-queue / job-dispatch row).
-    /// Tests use the in-memory adapters (no tenancy decorator) and call this
-    /// method with the fixed test scope so all adapters observe one coherent tenant.
+    /// Tests and library-mode callers pass [`crate::store_seam::single_tenant_scope`]
+    /// (or a real scope) explicitly — this method does not manufacture one.
     pub async fn execute_workflow(
         &self,
+        scope: &Scope,
         workflow: &WorkflowDefinition,
         input: serde_json::Value,
         budget: ExecutionBudget,
     ) -> Result<ExecutionResult, EngineError> {
-        let scope = crate::store_seam::test_scope();
-        self.execute_workflow_scoped(&scope, workflow, input, budget, None)
+        self.execute_workflow_scoped(scope, workflow, input, budget, None)
             .await
     }
 
     /// Like [`execute_workflow`](Self::execute_workflow) with per-run resource-acquire scope.
     ///
+    /// `scope` is the storage tenant scope; pass
+    /// [`crate::store_seam::single_tenant_scope`] for tests and library mode.
+    ///
     /// `run_acquire_scope` supplies `org_id` / `workspace_id` for resource acquisition.
     /// Fields set here override the engine default from
     /// [`with_resource_acquire_scope`](Self::with_resource_acquire_scope).
     ///
-    /// Storage port calls use the fixed test scope (same as
-    /// [`execute_workflow`](Self::execute_workflow)). Production code uses
-    /// [`resume_execution`](Self::resume_execution).
+    /// Production code uses [`resume_execution`](Self::resume_execution).
     pub async fn execute_workflow_with_acquire_scope(
         &self,
+        scope: &Scope,
         workflow: &WorkflowDefinition,
         input: serde_json::Value,
         budget: ExecutionBudget,
         run_acquire_scope: Option<nebula_core::scope::Scope>,
     ) -> Result<ExecutionResult, EngineError> {
-        let scope = crate::store_seam::test_scope();
-        self.execute_workflow_scoped(&scope, workflow, input, budget, run_acquire_scope)
+        self.execute_workflow_scoped(scope, workflow, input, budget, run_acquire_scope)
             .await
     }
 
     /// Internal implementation — thread `scope` through the storage port calls.
     ///
     /// Called by [`execute_workflow`], [`execute_workflow_with_acquire_scope`], and
-    /// [`replay_execution`] with the test scope; called by [`resume_execution`] with
-    /// the per-message tenant scope from the control-queue / job-dispatch row.
+    /// [`replay_execution`] with a caller-supplied scope; called by
+    /// [`resume_execution`] with the per-message tenant scope from the
+    /// control-queue / job-dispatch row.
     async fn execute_workflow_scoped(
         &self,
         scope: &Scope,
@@ -5495,7 +5497,7 @@ mod tests {
     /// post-execution assertions read the durable state the same way
     /// they did against the old execution repo, mirroring the
     /// production port path's scope/record semantics; test helpers call
-    /// [`crate::store_seam::test_scope`] for all store operations.
+    /// [`crate::store_seam::single_tenant_scope`] for all store operations.
     ///
     /// This is test scaffolding, not a production shim: the bundle's
     /// fields are the same port traits production consumes; only the
@@ -5563,7 +5565,7 @@ mod tests {
         /// Persist a workflow definition as the published version 0 so the
         /// resume path's `get_published` lookup resolves it.
         async fn save_workflow(&self, wf: &WorkflowDefinition) {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             let definition = serde_json::to_value(wf).unwrap();
             self.versions
                 .create(
@@ -5587,7 +5589,7 @@ mod tests {
             &self,
             id: ExecutionId,
         ) -> Result<Option<(u64, serde_json::Value)>, StorageError> {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             Ok(self
                 .execution
                 .get(&scope, &id.to_string())
@@ -5602,7 +5604,7 @@ mod tests {
             id: ExecutionId,
             node: NodeKey,
         ) -> Result<Option<serde_json::Value>, StorageError> {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             Ok(self
                 .node_results
                 .load_node_output(&scope, &id.to_string(), node.as_str())
@@ -5621,7 +5623,7 @@ mod tests {
             workflow_id: WorkflowId,
             state: serde_json::Value,
         ) {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             self.execution
                 .create(&scope, &id.to_string(), &workflow_id.to_string(), state)
                 .await
@@ -5637,7 +5639,7 @@ mod tests {
             node: NodeKey,
             output: serde_json::Value,
         ) {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             self.node_results
                 .save_node_output(
                     &scope,
@@ -5659,7 +5661,7 @@ mod tests {
             id: ExecutionId,
             node: NodeKey,
         ) -> Result<Option<nebula_storage_port::dto::NodeResultRecord>, StorageError> {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             self.node_results
                 .load_node_result(&scope, &id.to_string(), node.as_str())
                 .await
@@ -5676,7 +5678,7 @@ mod tests {
             holder: &str,
             ttl: std::time::Duration,
         ) -> Result<bool, StorageError> {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             Ok(self
                 .execution
                 .acquire_lease(&scope, &id.to_string(), holder, ttl)
@@ -5689,7 +5691,7 @@ mod tests {
         /// without perturbing it — the port analog of the
         /// legacy `ExecutionRepo::check_idempotency`.
         fn is_idempotency_marked(&self, id: ExecutionId, node: NodeKey, attempt: u32) -> bool {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             self.idempotency
                 .is_marked(&scope, &id.to_string(), node.as_str(), attempt)
         }
@@ -5714,7 +5716,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hello"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -5743,7 +5750,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(42), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(42),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -5783,7 +5795,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("start"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("start"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -5827,7 +5844,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("input"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("input"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -5849,7 +5871,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok even when a node fails");
 
@@ -5864,7 +5891,12 @@ mod tests {
 
         let wf = make_workflow(vec![], vec![]);
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await;
 
         assert!(matches!(result, Err(EngineError::PlanningFailed(_))));
@@ -5887,7 +5919,12 @@ mod tests {
         );
 
         engine
-            .execute_workflow(&wf, serde_json::json!("test"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("test"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -5924,7 +5961,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6065,7 +6107,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("input"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("input"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6111,7 +6158,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("input"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("input"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6156,7 +6208,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("input"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("input"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6202,7 +6259,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("input"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("input"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6234,7 +6296,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hello"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6276,7 +6343,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("start"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("start"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6311,7 +6383,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hello"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6354,7 +6431,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6390,7 +6472,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(42), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(42),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6443,7 +6530,12 @@ mod tests {
         let budget = ExecutionBudget::default().with_max_duration(Duration::from_millis(1));
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("data"), budget)
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("data"),
+                budget,
+            )
             .await
             .unwrap();
 
@@ -6477,7 +6569,12 @@ mod tests {
         let budget = ExecutionBudget::default().with_max_output_bytes(5);
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hello"), budget)
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hello"),
+                budget,
+            )
             .await
             .unwrap();
 
@@ -6530,7 +6627,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("data"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("data"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6578,7 +6680,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("data"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("data"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6599,7 +6706,10 @@ mod tests {
         let (engine, _) = make_engine(registry);
         // No execution / workflow store bundles attached.
         let err = engine
-            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
+            .resume_execution(
+                &crate::store_seam::single_tenant_scope(),
+                ExecutionId::new(),
+            )
             .await
             .unwrap_err();
         assert!(
@@ -6616,7 +6726,10 @@ mod tests {
         let engine = engine.with_execution_stores(stores.execution_stores());
         // No workflow store attached.
         let err = engine
-            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
+            .resume_execution(
+                &crate::store_seam::single_tenant_scope(),
+                ExecutionId::new(),
+            )
             .await
             .unwrap_err();
         assert!(
@@ -6639,7 +6752,10 @@ mod tests {
         let engine = stores.attach(engine);
 
         let err = engine
-            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
+            .resume_execution(
+                &crate::store_seam::single_tenant_scope(),
+                ExecutionId::new(),
+            )
             .await
             .unwrap_err();
         assert!(
@@ -6667,14 +6783,22 @@ mod tests {
 
         // Run to completion first.
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hi"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
         assert!(result.is_success());
 
         // Now resume the completed execution — should fail.
         let err = engine
-            .resume_execution(&crate::store_seam::test_scope(), result.execution_id)
+            .resume_execution(
+                &crate::store_seam::single_tenant_scope(),
+                result.execution_id,
+            )
             .await
             .unwrap_err();
         assert!(
@@ -6751,7 +6875,7 @@ mod tests {
 
         let engine = stores.attach(engine);
 
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let result = engine.resume_execution(&scope, execution_id).await.unwrap();
 
         assert!(result.is_success(), "resume should complete successfully");
@@ -6827,7 +6951,12 @@ mod tests {
         let engine1 = stores1.attach(engine1);
 
         let result = engine1
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -6897,7 +7026,7 @@ mod tests {
 
         let (engine2, _) = make_engine(registry);
         let engine2 = stores2.attach(engine2);
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let resumed = engine2
             .resume_execution(&scope, execution_id)
             .await
@@ -7116,7 +7245,12 @@ mod tests {
             .with_event_bus(event_bus);
 
         let _ = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await;
 
         // Drop engine so the event channel closes; drain.
@@ -7186,7 +7320,12 @@ mod tests {
         let engine = stores.attach(engine);
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -7281,7 +7420,12 @@ mod tests {
             .with_event_bus(event_bus);
 
         let _ = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await;
 
         drop(engine);
@@ -7341,7 +7485,12 @@ mod tests {
         let engine = stores.attach(engine);
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -7437,6 +7586,7 @@ mod tests {
         // should be recorded.
         let result1 = engine
             .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
                 &wf,
                 serde_json::json!("payload"),
                 ExecutionBudget::default(),
@@ -7586,7 +7736,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -7646,7 +7801,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("x"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("x"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -7696,6 +7856,7 @@ mod tests {
 
         let result = engine
             .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
                 &wf,
                 serde_json::json!("payload"),
                 ExecutionBudget::default(),
@@ -8129,7 +8290,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("x"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("x"),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult) even on node failure");
 
@@ -8268,7 +8434,12 @@ mod tests {
 
         let wf = probe_workflow("probe", "api_key");
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult) even on node failure");
 
@@ -8315,7 +8486,12 @@ mod tests {
 
         let wf = probe_workflow("probe", "api_key");
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult)");
 
@@ -8343,7 +8519,12 @@ mod tests {
 
         let wf = probe_workflow("probe", "cred_b");
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult) even on node failure");
 
@@ -8384,7 +8565,12 @@ mod tests {
         // probe_b tries shared_key → must fail even though probe_a has it declared.
         let wf = probe_workflow("probe_b", "shared_key");
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult)");
 
@@ -8413,7 +8599,12 @@ mod tests {
         // Probing "second" must succeed — the second call adds, not replaces.
         let wf = probe_workflow("probe", "second");
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("engine returns Ok(ExecutionResult)");
         assert!(
@@ -8461,7 +8652,12 @@ mod tests {
         let wf = make_workflow(vec![node], vec![]);
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("hello"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
 
@@ -8534,7 +8730,7 @@ mod tests {
 
         let engine = stores.attach(engine);
 
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let result = engine.resume_execution(&scope, execution_id).await.unwrap();
 
         assert!(result.is_success());
@@ -8600,7 +8796,7 @@ mod tests {
         // instance, no memory of the original budget).
         let (engine, _) = make_engine(registry);
         let engine = stores.attach(engine);
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let result = engine.resume_execution(&scope, execution_id).await.unwrap();
         assert!(result.is_success());
 
@@ -8676,7 +8872,7 @@ mod tests {
 
         // Resume must succeed despite the missing budget — the engine
         // logs a warning and falls back to the default.
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let result = engine.resume_execution(&scope, execution_id).await.unwrap();
         assert!(result.is_success());
     }
@@ -8763,6 +8959,7 @@ mod tests {
 
         let result = engine
             .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
                 &wf,
                 serde_json::json!("ignored"),
                 ExecutionBudget::default(),
@@ -8842,6 +9039,7 @@ mod tests {
         // First run: A emits Branch{selected=true}. Only B fires.
         let first = engine
             .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
                 &wf,
                 serde_json::json!("payload"),
                 ExecutionBudget::default(),
@@ -9082,7 +9280,12 @@ mod tests {
             .with_workflow_stores(stores.workflow_stores());
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
             .expect(
                 "execute_workflow should return Ok on external terminal override (§11.5, #333)",
@@ -9100,7 +9303,7 @@ mod tests {
 
         // The persisted row must carry `cancelled` — the engine must
         // NOT have overwritten it with its own `completed`.
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let record = inner
             .get(&scope, &result.execution_id.to_string())
             .await
@@ -9171,7 +9374,12 @@ mod tests {
         // Failed (node checkpoint aborted) or Cancelled (external).
         // Either way it MUST NOT claim Completed.
         let result = engine
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await;
 
         let execution_id_opt = match &result {
@@ -9197,7 +9405,7 @@ mod tests {
         // `cancelling` status — never overwritten. The engine's own
         // writes after CAS miss MUST NOT land.
         if let Some(execution_id) = execution_id_opt {
-            let scope = crate::store_seam::test_scope();
+            let scope = crate::store_seam::single_tenant_scope();
             let record = inner
                 .get(&scope, &execution_id.to_string())
                 .await
@@ -9240,7 +9448,7 @@ mod tests {
         // durably persisted.
         let stores = TestStores::new();
         let execution = stores.execution.clone();
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let token = nebula_storage_port::FencingToken::from_generation(0);
 
         let execution_id = ExecutionId::new();
@@ -9354,7 +9562,7 @@ mod tests {
         // decision must NOT overwrite the durable Cancelled row.
         let stores = TestStores::new();
         let execution = stores.execution.clone();
-        let scope = crate::store_seam::test_scope();
+        let scope = crate::store_seam::single_tenant_scope();
         let token = nebula_storage_port::FencingToken::from_generation(0);
 
         let execution_id = ExecutionId::new();
@@ -9502,12 +9710,12 @@ mod tests {
         // the other must see `EngineError::Leased`.
         let handle_a = tokio::spawn(async move {
             engine_a
-                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .resume_execution(&crate::store_seam::single_tenant_scope(), execution_id)
                 .await
         });
         let handle_b = tokio::spawn(async move {
             engine_b
-                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .resume_execution(&crate::store_seam::single_tenant_scope(), execution_id)
                 .await
         });
 
@@ -9607,7 +9815,7 @@ mod tests {
         let winner_engine = Arc::clone(&engine);
         let winner = tokio::spawn(async move {
             winner_engine
-                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .resume_execution(&crate::store_seam::single_tenant_scope(), execution_id)
                 .await
         });
 
@@ -9629,7 +9837,7 @@ mod tests {
         // Must fail fast with `Leased` — and crucially must NOT clobber
         // the registry entry the winner just published.
         let loser = engine
-            .resume_execution(&crate::store_seam::test_scope(), execution_id)
+            .resume_execution(&crate::store_seam::single_tenant_scope(), execution_id)
             .await;
         assert!(
             matches!(loser, Err(EngineError::Leased { .. })),
@@ -9692,7 +9900,12 @@ mod tests {
 
         // First run acquires + releases the lease on completion.
         let first = engine
-            .execute_workflow(&wf, serde_json::json!("v1"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("v1"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
         assert!(first.is_success());
@@ -9733,11 +9946,21 @@ mod tests {
         let engine = stores.attach(engine);
 
         let first = engine
-            .execute_workflow(&wf, serde_json::json!("v1"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("v1"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
         let second = engine
-            .execute_workflow(&wf, serde_json::json!("v2"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("v2"),
+                ExecutionBudget::default(),
+            )
             .await
             .unwrap();
         assert!(first.is_success());
@@ -9834,6 +10057,7 @@ mod tests {
 
         let result = engine
             .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
                 &wf,
                 serde_json::json!({"hello": "factory"}),
                 ExecutionBudget::default(),
@@ -9889,7 +10113,12 @@ mod tests {
         );
 
         let result = engine
-            .execute_workflow(&wf, serde_json::json!("ok"), ExecutionBudget::default())
+            .execute_workflow(
+                &crate::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!("ok"),
+                ExecutionBudget::default(),
+            )
             .await
             .expect("workflow should succeed via factory path");
         assert!(result.is_success());

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -49,6 +49,8 @@ use nebula_workflow::{Connection, DependencyGraph, NodeState, WorkflowDefinition
 use tokio::{sync::Semaphore, task::JoinSet};
 use tokio_util::sync::CancellationToken;
 
+use nebula_storage_port::Scope;
+
 use crate::{
     credential_accessor::EngineCredentialAccessor, error::EngineError, event::ExecutionEvent,
     resolver::ParamResolver, resource::ResourceActivatorRegistry,
@@ -1103,8 +1105,10 @@ impl WorkflowEngine {
 
         // Run the frontier loop — same as execute_workflow, just different seed + pre-populated
         // outputs.
+        let replay_scope = crate::store_seam::test_scope();
         let failed_node = self
             .run_frontier(
+                &replay_scope,
                 &graph,
                 &node_map,
                 &outputs,
@@ -1211,6 +1215,7 @@ impl WorkflowEngine {
     /// coordination seam, and the caller proceeds without a lease.
     async fn acquire_and_heartbeat_lease(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         frontier_cancel: CancellationToken,
     ) -> Result<Option<LeaseGuard>, EngineError> {
@@ -1224,10 +1229,9 @@ impl WorkflowEngine {
         // lease, no fencing). A live lease held by another runner
         // surfaces as `EngineError::Leased` on both paths.
         let backend: crate::store_seam::LeaseBackend = if let Some(stores) = self.stores.clone() {
-            let scope = crate::store_seam::engine_scope();
             let token = stores
                 .execution
-                .acquire_lease(&scope, &execution_id.to_string(), &holder, ttl)
+                .acquire_lease(scope, &execution_id.to_string(), &holder, ttl)
                 .await
                 .map_err(|e| EngineError::PlanningFailed(format!("acquire lease: {e}")))?;
             let Some(token) = token else {
@@ -1248,7 +1252,7 @@ impl WorkflowEngine {
                     holder,
                 });
             };
-            crate::store_seam::LeaseBackend::new(stores.execution.clone(), scope, token)
+            crate::store_seam::LeaseBackend::new(stores.execution.clone(), scope.clone(), token)
         } else {
             // No storage seam configured — single-process library mode,
             // proceed without a lease.
@@ -1377,23 +1381,52 @@ impl WorkflowEngine {
     ///
     /// Entry nodes receive the workflow-level `input`. Subsequent nodes
     /// receive the output of their activated predecessors.
+    ///
+    /// This method is used in tests and local library mode. Production code
+    /// enters the engine via [`Self::resume_execution`] (which carries the
+    /// real per-message tenant scope from the control-queue / job-dispatch row).
+    /// Tests use the in-memory adapters (no tenancy decorator) and call this
+    /// method with the fixed test scope so all adapters observe one coherent tenant.
     pub async fn execute_workflow(
         &self,
         workflow: &WorkflowDefinition,
         input: serde_json::Value,
         budget: ExecutionBudget,
     ) -> Result<ExecutionResult, EngineError> {
-        self.execute_workflow_with_acquire_scope(workflow, input, budget, None)
+        let scope = crate::store_seam::test_scope();
+        self.execute_workflow_scoped(&scope, workflow, input, budget, None)
             .await
     }
 
-    /// Like [`execute_workflow`](Self::execute_workflow) with per-run tenant scope.
+    /// Like [`execute_workflow`](Self::execute_workflow) with per-run resource-acquire scope.
     ///
-    /// `run_acquire_scope` supplies `org_id` / `workspace_id` for this execution.
+    /// `run_acquire_scope` supplies `org_id` / `workspace_id` for resource acquisition.
     /// Fields set here override the engine default from
     /// [`with_resource_acquire_scope`](Self::with_resource_acquire_scope).
+    ///
+    /// Storage port calls use the fixed test scope (same as
+    /// [`execute_workflow`](Self::execute_workflow)). Production code uses
+    /// [`resume_execution`](Self::resume_execution).
     pub async fn execute_workflow_with_acquire_scope(
         &self,
+        workflow: &WorkflowDefinition,
+        input: serde_json::Value,
+        budget: ExecutionBudget,
+        run_acquire_scope: Option<nebula_core::scope::Scope>,
+    ) -> Result<ExecutionResult, EngineError> {
+        let scope = crate::store_seam::test_scope();
+        self.execute_workflow_scoped(&scope, workflow, input, budget, run_acquire_scope)
+            .await
+    }
+
+    /// Internal implementation — thread `scope` through the storage port calls.
+    ///
+    /// Called by [`execute_workflow`], [`execute_workflow_with_acquire_scope`], and
+    /// [`replay_execution`] with the test scope; called by [`resume_execution`] with
+    /// the per-message tenant scope from the control-queue / job-dispatch row.
+    async fn execute_workflow_scoped(
+        &self,
+        scope: &Scope,
         workflow: &WorkflowDefinition,
         input: serde_json::Value,
         budget: ExecutionBudget,
@@ -1448,7 +1481,7 @@ impl WorkflowEngine {
             stores
                 .execution
                 .create(
-                    &crate::store_seam::engine_scope(),
+                    scope,
                     &execution_id.to_string(),
                     &workflow.id.to_string(),
                     state_json,
@@ -1472,7 +1505,7 @@ impl WorkflowEngine {
         // just died must not overwrite the canonical state a new
         // holder already began driving.
         let lease = self
-            .acquire_and_heartbeat_lease(execution_id, cancel_token.clone())
+            .acquire_and_heartbeat_lease(scope, execution_id, cancel_token.clone())
             .await?;
 
         // Fencing token threaded into every checkpoint / final-state
@@ -1521,6 +1554,7 @@ impl WorkflowEngine {
         let seed_nodes: Vec<NodeKey> = graph.entry_nodes();
         let failed_node = self
             .run_frontier(
+                scope,
                 &graph,
                 &node_map,
                 &outputs,
@@ -1601,7 +1635,13 @@ impl WorkflowEngine {
             // non-terminal conflicts before surfacing a typed
             // `CasConflict` error.
             match self
-                .persist_final_state(execution_id, &mut exec_state, &mut repo_version, fencing)
+                .persist_final_state(
+                    scope,
+                    execution_id,
+                    &mut exec_state,
+                    &mut repo_version,
+                    fencing,
+                )
                 .await
             {
                 Ok(None) => final_status,
@@ -1710,6 +1750,7 @@ impl WorkflowEngine {
     /// - The persisted state cannot be deserialized
     pub async fn resume_execution(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<ExecutionResult, EngineError> {
         let started = Instant::now();
@@ -1738,11 +1779,10 @@ impl WorkflowEngine {
                 .workflow_stores
                 .as_ref()
                 .ok_or_else(|| EngineError::PlanningFailed("no workflow_repo configured".into()))?;
-            let scope = crate::store_seam::engine_scope();
             let id = execution_id.to_string();
             let record = stores
                 .execution
-                .get(&scope, &id)
+                .get(scope, &id)
                 .await
                 .map_err(|e| EngineError::PlanningFailed(format!("load state: {e}")))?
                 .ok_or_else(|| {
@@ -1751,7 +1791,7 @@ impl WorkflowEngine {
             let workflow_id = record.workflow_id.clone();
             let workflow_json = workflow_stores
                 .versions
-                .get_published(&scope, &workflow_id)
+                .get_published(scope, &workflow_id)
                 .await
                 .map_err(|e| EngineError::PlanningFailed(format!("load workflow: {e}")))?
                 .ok_or_else(|| {
@@ -1765,7 +1805,7 @@ impl WorkflowEngine {
             // different value than a non-crashed run.
             let outputs = stores
                 .node_results
-                .load_all_node_outputs(&scope, &id)
+                .load_all_node_outputs(scope, &id)
                 .await
                 .map_err(|e| EngineError::PlanningFailed(format!("load outputs: {e}")))?
                 .into_iter()
@@ -1958,7 +1998,7 @@ impl WorkflowEngine {
         // with `EngineError::Leased` instead of running nodes in parallel
         // with the existing runner.
         let lease = self
-            .acquire_and_heartbeat_lease(execution_id, cancel_token.clone())
+            .acquire_and_heartbeat_lease(scope, execution_id, cancel_token.clone())
             .await?;
 
         // Fencing token threaded into every checkpoint / final-state
@@ -2004,6 +2044,7 @@ impl WorkflowEngine {
         };
         let failed_node = self
             .run_frontier(
+                scope,
                 &graph,
                 &node_map,
                 &outputs,
@@ -2072,7 +2113,13 @@ impl WorkflowEngine {
             // (issue #333). Mirrors `execute_workflow` — see its comment
             // for the full contract.
             match self
-                .persist_final_state(execution_id, &mut exec_state, &mut repo_version, fencing)
+                .persist_final_state(
+                    scope,
+                    execution_id,
+                    &mut exec_state,
+                    &mut repo_version,
+                    fencing,
+                )
                 .await
             {
                 Ok(None) => final_status,
@@ -2179,6 +2226,7 @@ impl WorkflowEngine {
     #[allow(clippy::too_many_arguments)]
     async fn run_frontier(
         &self,
+        scope: &Scope,
         graph: &DependencyGraph,
         node_map: &HashMap<NodeKey, &nebula_workflow::NodeDefinition>,
         outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
@@ -2356,6 +2404,7 @@ impl WorkflowEngine {
                 // mark it completed without re-dispatching.
                 if self
                     .check_and_apply_idempotency(
+                        scope,
                         execution_id,
                         node_key.clone(),
                         outputs,
@@ -2473,6 +2522,7 @@ impl WorkflowEngine {
                     {
                         if let Err(e) = self
                             .checkpoint_node(
+                                scope,
                                 execution_id,
                                 node_key.clone(),
                                 outputs,
@@ -2538,6 +2588,7 @@ impl WorkflowEngine {
 
                 if let Err(e) = self
                     .checkpoint_node(
+                        scope,
                         execution_id,
                         node_key.clone(),
                         outputs,
@@ -2769,6 +2820,7 @@ impl WorkflowEngine {
                     // on an undurable decision.
                     if let Err(e) = self
                         .checkpoint_node(
+                            scope,
                             execution_id,
                             node_key.clone(),
                             outputs,
@@ -2805,7 +2857,7 @@ impl WorkflowEngine {
                         cancel_token.cancel();
                         return Some((node_key.clone(), e.to_string()));
                     }
-                    self.record_idempotency(exec_state, execution_id, node_key.clone())
+                    self.record_idempotency(scope, exec_state, execution_id, node_key.clone())
                         .await;
 
                     // Persist the full ActionResult alongside the raw
@@ -2813,7 +2865,7 @@ impl WorkflowEngine {
                     // the exact routing semantics (issue #299).
                     //
                     // T4 — `attempt_count + 1` is the
-                    self.record_node_result(execution_id, node_key.clone(), &action_result)
+                    self.record_node_result(scope, execution_id, node_key.clone(), &action_result)
                         .await;
 
                     // T4 — push the success attempt
@@ -3035,6 +3087,7 @@ impl WorkflowEngine {
                                 // counter bump in one CAS write.
                                 if let Err(e) = self
                                     .checkpoint_node(
+                                        scope,
                                         execution_id,
                                         node_key.clone(),
                                         outputs,
@@ -3111,6 +3164,7 @@ impl WorkflowEngine {
 
                     if let Err(e) = self
                         .checkpoint_node(
+                            scope,
                             execution_id,
                             node_key.clone(),
                             outputs,
@@ -3154,6 +3208,7 @@ impl WorkflowEngine {
 
                     if let Some(node_key) = panicked_node {
                         self.handle_panicked_node(
+                            scope,
                             execution_id,
                             node_key.clone(),
                             &err_msg,
@@ -3390,6 +3445,7 @@ impl WorkflowEngine {
     #[allow(clippy::too_many_arguments)]
     async fn check_and_apply_idempotency(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         node_key: NodeKey,
         outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
@@ -3407,11 +3463,10 @@ impl WorkflowEngine {
         // re-execute). Without a store bundle there is no persistence,
         // so nothing can be replayed.
         let (output_value, stored_result) = if let Some(stores) = &self.stores {
-            let scope = crate::store_seam::engine_scope();
             let id = execution_id.to_string();
             let output_value = match stores
                 .node_results
-                .load_node_output(&scope, &id, node_key.as_str())
+                .load_node_output(scope, &id, node_key.as_str())
                 .await
             {
                 Ok(Some(record)) => record.json,
@@ -3428,7 +3483,7 @@ impl WorkflowEngine {
             };
             let stored_result = match stores
                 .node_results
-                .load_node_result(&scope, &id, node_key.as_str())
+                .load_node_result(scope, &id, node_key.as_str())
                 .await
             {
                 Ok(Some(record)) => deserialize_stored_result(record.json, execution_id, &node_key),
@@ -3487,6 +3542,7 @@ impl WorkflowEngine {
     /// implementation.
     async fn record_node_result(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         node_key: NodeKey,
         action_result: &ActionResult<serde_json::Value>,
@@ -3520,12 +3576,7 @@ impl WorkflowEngine {
             };
             if let Err(e) = stores
                 .node_results
-                .save_node_result(
-                    &crate::store_seam::engine_scope(),
-                    &execution_id.to_string(),
-                    node_key.as_str(),
-                    record,
-                )
+                .save_node_result(scope, &execution_id.to_string(), node_key.as_str(), record)
                 .await
             {
                 tracing::warn!(
@@ -3544,6 +3595,7 @@ impl WorkflowEngine {
     /// must not abort an otherwise healthy execution.
     async fn record_idempotency(
         &self,
+        scope: &Scope,
         exec_state: &ExecutionState,
         execution_id: ExecutionId,
         node_key: NodeKey,
@@ -3560,12 +3612,7 @@ impl WorkflowEngine {
                 .map_or(1, |ns| (ns.attempt_count() as u32).saturating_add(1));
             if let Err(e) = stores
                 .idempotency
-                .check_and_mark(
-                    &crate::store_seam::engine_scope(),
-                    &execution_id.to_string(),
-                    node_key.as_str(),
-                    attempt,
-                )
+                .check_and_mark(scope, &execution_id.to_string(), node_key.as_str(), attempt)
                 .await
             {
                 tracing::warn!(
@@ -3600,6 +3647,7 @@ impl WorkflowEngine {
     )]
     async fn handle_panicked_node(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         node_key: NodeKey,
         err_msg: &str,
@@ -3612,6 +3660,7 @@ impl WorkflowEngine {
         mark_node_failed(exec_state, node_key.clone(), &panic_err);
         let checkpoint_result = self
             .checkpoint_node(
+                scope,
                 execution_id,
                 node_key.clone(),
                 outputs,
@@ -3635,8 +3684,13 @@ impl WorkflowEngine {
         });
     }
 
+    // Private helper — scope was added for tenant isolation (U-D1.4c);
+    // combined with the fencing token this pushes past the 7-arg threshold
+    // that is designed for public APIs.
+    #[allow(clippy::too_many_arguments)]
     async fn checkpoint_node(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         node_key: NodeKey,
         outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
@@ -3664,6 +3718,7 @@ impl WorkflowEngine {
         // token is rejected even on a matching version (closes the
         // zombie-runner hole).
         self.checkpoint_node_port(
+            scope,
             stores,
             execution_id,
             node_key,
@@ -3685,6 +3740,7 @@ impl WorkflowEngine {
     #[allow(clippy::too_many_arguments)]
     async fn checkpoint_node_port(
         &self,
+        scope: &Scope,
         stores: &crate::store_seam::ExecutionStores,
         execution_id: ExecutionId,
         node_key: NodeKey,
@@ -3693,14 +3749,13 @@ impl WorkflowEngine {
         repo_version: &mut u64,
         token: nebula_storage_port::FencingToken,
     ) -> Result<(), EngineError> {
-        let scope = crate::store_seam::engine_scope();
         let id = execution_id.to_string();
 
         if let Some(output) = outputs.get(&node_key) {
             let record = crate::store_seam::node_output_record(output.value().clone());
             if let Err(e) = stores
                 .node_results
-                .save_node_output(&scope, &id, node_key.as_str(), record)
+                .save_node_output(scope, &id, node_key.as_str(), record)
                 .await
             {
                 return Err(EngineError::CheckpointFailed {
@@ -3750,7 +3805,7 @@ impl WorkflowEngine {
             Ok(nebula_storage_port::TransitionOutcome::VersionConflict { actual }) => {
                 let expected_version = *repo_version;
                 *repo_version = actual;
-                let observed_status = match stores.execution.get(&scope, &id).await {
+                let observed_status = match stores.execution.get(scope, &id).await {
                     Ok(Some(rec)) => {
                         *repo_version = rec.version;
                         parse_observed_status(&rec.state)
@@ -3825,6 +3880,7 @@ impl WorkflowEngine {
     ///   surfaces a typed failure instead of a silent success.
     async fn persist_final_state(
         &self,
+        scope: &Scope,
         execution_id: ExecutionId,
         exec_state: &mut ExecutionState,
         repo_version: &mut u64,
@@ -3841,8 +3897,15 @@ impl WorkflowEngine {
                 reason: "no fencing-gated store configured for final-state persist".to_owned(),
             });
         };
-        self.persist_final_state_port(&stores, execution_id, exec_state, repo_version, token)
-            .await
+        self.persist_final_state_port(
+            scope,
+            &stores,
+            execution_id,
+            exec_state,
+            repo_version,
+            token,
+        )
+        .await
     }
 
     /// Spec-16 port variant of [`Self::persist_final_state`]: the final
@@ -3853,13 +3916,13 @@ impl WorkflowEngine {
     /// holder owns the canonical state — ADR 0008, ).
     async fn persist_final_state_port(
         &self,
+        scope: &Scope,
         stores: &crate::store_seam::ExecutionStores,
         execution_id: ExecutionId,
         exec_state: &mut ExecutionState,
         repo_version: &mut u64,
         token: nebula_storage_port::FencingToken,
     ) -> Result<Option<ExecutionStatus>, EngineError> {
-        let scope = crate::store_seam::engine_scope();
         let id = execution_id.to_string();
 
         let build_batch = |version: u64,
@@ -3906,7 +3969,7 @@ impl WorkflowEngine {
             }),
             nebula_storage_port::TransitionOutcome::VersionConflict { actual } => {
                 let expected_version = *repo_version;
-                let observed = match stores.execution.get(&scope, &id).await {
+                let observed = match stores.execution.get(scope, &id).await {
                     Ok(Some(rec)) => rec,
                     Ok(None) => {
                         *repo_version = actual;
@@ -3981,7 +4044,7 @@ impl WorkflowEngine {
                         actual: retry_actual,
                     }) => {
                         let (latest_version, latest_status) =
-                            match stores.execution.get(&scope, &id).await {
+                            match stores.execution.get(scope, &id).await {
                                 Ok(Some(rec)) => {
                                     let s = parse_observed_status(&rec.state);
                                     (rec.version, s)
@@ -5431,8 +5494,8 @@ mod tests {
     /// `inject_state` / `inject_node_output` / `save_workflow`) so
     /// post-execution assertions read the durable state the same way
     /// they did against the old execution repo, mirroring the
-    /// production port path's scope/record semantics (the engine always
-    /// passes [`crate::store_seam::engine_scope`]).
+    /// production port path's scope/record semantics; test helpers call
+    /// [`crate::store_seam::test_scope`] for all store operations.
     ///
     /// This is test scaffolding, not a production shim: the bundle's
     /// fields are the same port traits production consumes; only the
@@ -5500,7 +5563,7 @@ mod tests {
         /// Persist a workflow definition as the published version 0 so the
         /// resume path's `get_published` lookup resolves it.
         async fn save_workflow(&self, wf: &WorkflowDefinition) {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             let definition = serde_json::to_value(wf).unwrap();
             self.versions
                 .create(
@@ -5524,7 +5587,7 @@ mod tests {
             &self,
             id: ExecutionId,
         ) -> Result<Option<(u64, serde_json::Value)>, StorageError> {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             Ok(self
                 .execution
                 .get(&scope, &id.to_string())
@@ -5539,7 +5602,7 @@ mod tests {
             id: ExecutionId,
             node: NodeKey,
         ) -> Result<Option<serde_json::Value>, StorageError> {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             Ok(self
                 .node_results
                 .load_node_output(&scope, &id.to_string(), node.as_str())
@@ -5558,7 +5621,7 @@ mod tests {
             workflow_id: WorkflowId,
             state: serde_json::Value,
         ) {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             self.execution
                 .create(&scope, &id.to_string(), &workflow_id.to_string(), state)
                 .await
@@ -5574,7 +5637,7 @@ mod tests {
             node: NodeKey,
             output: serde_json::Value,
         ) {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             self.node_results
                 .save_node_output(
                     &scope,
@@ -5596,7 +5659,7 @@ mod tests {
             id: ExecutionId,
             node: NodeKey,
         ) -> Result<Option<nebula_storage_port::dto::NodeResultRecord>, StorageError> {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             self.node_results
                 .load_node_result(&scope, &id.to_string(), node.as_str())
                 .await
@@ -5613,7 +5676,7 @@ mod tests {
             holder: &str,
             ttl: std::time::Duration,
         ) -> Result<bool, StorageError> {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             Ok(self
                 .execution
                 .acquire_lease(&scope, &id.to_string(), holder, ttl)
@@ -5622,11 +5685,11 @@ mod tests {
         }
 
         /// Non-mutating dedup-state read. Mirrors the production path's
-        /// idempotency mark (`engine_scope()` + `{execution_id}:{node}:
-        /// {attempt}`) without perturbing it — the port analog of the
+        /// idempotency mark (scope + `{execution_id}:{node}:{attempt}`)
+        /// without perturbing it — the port analog of the
         /// legacy `ExecutionRepo::check_idempotency`.
         fn is_idempotency_marked(&self, id: ExecutionId, node: NodeKey, attempt: u32) -> bool {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             self.idempotency
                 .is_marked(&scope, &id.to_string(), node.as_str(), attempt)
         }
@@ -6536,7 +6599,7 @@ mod tests {
         let (engine, _) = make_engine(registry);
         // No execution / workflow store bundles attached.
         let err = engine
-            .resume_execution(ExecutionId::new())
+            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
             .await
             .unwrap_err();
         assert!(
@@ -6553,7 +6616,7 @@ mod tests {
         let engine = engine.with_execution_stores(stores.execution_stores());
         // No workflow store attached.
         let err = engine
-            .resume_execution(ExecutionId::new())
+            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
             .await
             .unwrap_err();
         assert!(
@@ -6576,7 +6639,7 @@ mod tests {
         let engine = stores.attach(engine);
 
         let err = engine
-            .resume_execution(ExecutionId::new())
+            .resume_execution(&crate::store_seam::test_scope(), ExecutionId::new())
             .await
             .unwrap_err();
         assert!(
@@ -6611,7 +6674,7 @@ mod tests {
 
         // Now resume the completed execution — should fail.
         let err = engine
-            .resume_execution(result.execution_id)
+            .resume_execution(&crate::store_seam::test_scope(), result.execution_id)
             .await
             .unwrap_err();
         assert!(
@@ -6688,7 +6751,8 @@ mod tests {
 
         let engine = stores.attach(engine);
 
-        let result = engine.resume_execution(execution_id).await.unwrap();
+        let scope = crate::store_seam::test_scope();
+        let result = engine.resume_execution(&scope, execution_id).await.unwrap();
 
         assert!(result.is_success(), "resume should complete successfully");
         assert_eq!(result.execution_id, execution_id);
@@ -6833,7 +6897,11 @@ mod tests {
 
         let (engine2, _) = make_engine(registry);
         let engine2 = stores2.attach(engine2);
-        let resumed = engine2.resume_execution(execution_id).await.unwrap();
+        let scope = crate::store_seam::test_scope();
+        let resumed = engine2
+            .resume_execution(&scope, execution_id)
+            .await
+            .unwrap();
 
         // Resume must land in a terminal status — the Failed node is
         // already terminal, so the frontier has nothing to run.
@@ -6901,7 +6969,7 @@ mod tests {
     impl ExecutionStore for FailAtCommitN {
         async fn create(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             workflow_id: &str,
             initial_state: serde_json::Value,
@@ -6913,7 +6981,7 @@ mod tests {
 
         async fn get(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
         ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
             self.inner.get(scope, id).await
@@ -6934,7 +7002,7 @@ mod tests {
 
         async fn acquire_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             holder: &str,
             ttl: Duration,
@@ -6944,7 +7012,7 @@ mod tests {
 
         async fn renew_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             token: nebula_storage_port::FencingToken,
             ttl: Duration,
@@ -6954,23 +7022,20 @@ mod tests {
 
         async fn release_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             token: nebula_storage_port::FencingToken,
         ) -> Result<bool, StorageError> {
             self.inner.release_lease(scope, id, token).await
         }
 
-        async fn list_running(
-            &self,
-            scope: &nebula_storage_port::Scope,
-        ) -> Result<Vec<String>, StorageError> {
+        async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
             self.inner.list_running(scope).await
         }
 
         async fn list_running_for_workflow(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             workflow_id: &str,
         ) -> Result<Vec<String>, StorageError> {
             self.inner
@@ -6980,7 +7045,7 @@ mod tests {
 
         async fn count(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             workflow_id: Option<&str>,
         ) -> Result<u64, StorageError> {
             self.inner.count(scope, workflow_id).await
@@ -7404,7 +7469,7 @@ mod tests {
         let state_str = serde_json::to_string(&state_json).unwrap();
         let exec_state: ExecutionState =
             serde_json::from_str(&state_str).expect("deserialize persisted execution state");
-        // The engine marks idempotency under `engine_scope()` with the
+        // The engine marks idempotency under the test scope with the
         // attempt number it dispatched the node under (1 on the first
         // run). Assert that mark was recorded without perturbing it.
         let attempt = exec_state
@@ -8469,7 +8534,8 @@ mod tests {
 
         let engine = stores.attach(engine);
 
-        let result = engine.resume_execution(execution_id).await.unwrap();
+        let scope = crate::store_seam::test_scope();
+        let result = engine.resume_execution(&scope, execution_id).await.unwrap();
 
         assert!(result.is_success());
         // Echo pipes the input through — so n1's output is exactly
@@ -8534,7 +8600,8 @@ mod tests {
         // instance, no memory of the original budget).
         let (engine, _) = make_engine(registry);
         let engine = stores.attach(engine);
-        let result = engine.resume_execution(execution_id).await.unwrap();
+        let scope = crate::store_seam::test_scope();
+        let result = engine.resume_execution(&scope, execution_id).await.unwrap();
         assert!(result.is_success());
 
         // Re-load the persisted state and assert the budget survived
@@ -8609,7 +8676,8 @@ mod tests {
 
         // Resume must succeed despite the missing budget — the engine
         // logs a warning and falls back to the default.
-        let result = engine.resume_execution(execution_id).await.unwrap();
+        let scope = crate::store_seam::test_scope();
+        let result = engine.resume_execution(&scope, execution_id).await.unwrap();
         assert!(result.is_success());
     }
 
@@ -8854,7 +8922,7 @@ mod tests {
     impl ExecutionStore for ExternalMutateBeforeN {
         async fn create(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             workflow_id: &str,
             initial_state: serde_json::Value,
@@ -8866,7 +8934,7 @@ mod tests {
 
         async fn get(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
         ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
             self.inner.get(scope, id).await
@@ -8912,7 +8980,7 @@ mod tests {
 
         async fn acquire_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             holder: &str,
             ttl: Duration,
@@ -8922,7 +8990,7 @@ mod tests {
 
         async fn renew_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             token: nebula_storage_port::FencingToken,
             ttl: Duration,
@@ -8932,23 +9000,20 @@ mod tests {
 
         async fn release_lease(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             id: &str,
             token: nebula_storage_port::FencingToken,
         ) -> Result<bool, StorageError> {
             self.inner.release_lease(scope, id, token).await
         }
 
-        async fn list_running(
-            &self,
-            scope: &nebula_storage_port::Scope,
-        ) -> Result<Vec<String>, StorageError> {
+        async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
             self.inner.list_running(scope).await
         }
 
         async fn list_running_for_workflow(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             workflow_id: &str,
         ) -> Result<Vec<String>, StorageError> {
             self.inner
@@ -8958,7 +9023,7 @@ mod tests {
 
         async fn count(
             &self,
-            scope: &nebula_storage_port::Scope,
+            scope: &Scope,
             workflow_id: Option<&str>,
         ) -> Result<u64, StorageError> {
             self.inner.count(scope, workflow_id).await
@@ -9035,7 +9100,7 @@ mod tests {
 
         // The persisted row must carry `cancelled` — the engine must
         // NOT have overwritten it with its own `completed`.
-        let scope = crate::store_seam::engine_scope();
+        let scope = crate::store_seam::test_scope();
         let record = inner
             .get(&scope, &result.execution_id.to_string())
             .await
@@ -9132,7 +9197,7 @@ mod tests {
         // `cancelling` status — never overwritten. The engine's own
         // writes after CAS miss MUST NOT land.
         if let Some(execution_id) = execution_id_opt {
-            let scope = crate::store_seam::engine_scope();
+            let scope = crate::store_seam::test_scope();
             let record = inner
                 .get(&scope, &execution_id.to_string())
                 .await
@@ -9175,7 +9240,7 @@ mod tests {
         // durably persisted.
         let stores = TestStores::new();
         let execution = stores.execution.clone();
-        let scope = crate::store_seam::engine_scope();
+        let scope = crate::store_seam::test_scope();
         let token = nebula_storage_port::FencingToken::from_generation(0);
 
         let execution_id = ExecutionId::new();
@@ -9231,6 +9296,7 @@ mod tests {
 
         let outcome = engine
             .persist_final_state_port(
+                &scope,
                 &stores.execution_stores(),
                 execution_id,
                 &mut engine_final_state,
@@ -9288,7 +9354,7 @@ mod tests {
         // decision must NOT overwrite the durable Cancelled row.
         let stores = TestStores::new();
         let execution = stores.execution.clone();
-        let scope = crate::store_seam::engine_scope();
+        let scope = crate::store_seam::test_scope();
         let token = nebula_storage_port::FencingToken::from_generation(0);
 
         let execution_id = ExecutionId::new();
@@ -9350,6 +9416,7 @@ mod tests {
 
         let outcome = engine
             .persist_final_state_port(
+                &scope,
                 &stores.execution_stores(),
                 execution_id,
                 &mut engine_final_state,
@@ -9433,8 +9500,16 @@ mod tests {
 
         // Spawn both calls concurrently — whoever acquires first wins,
         // the other must see `EngineError::Leased`.
-        let handle_a = tokio::spawn(async move { engine_a.resume_execution(execution_id).await });
-        let handle_b = tokio::spawn(async move { engine_b.resume_execution(execution_id).await });
+        let handle_a = tokio::spawn(async move {
+            engine_a
+                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .await
+        });
+        let handle_b = tokio::spawn(async move {
+            engine_b
+                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .await
+        });
 
         let result_a = handle_a.await.unwrap();
         let result_b = handle_b.await.unwrap();
@@ -9530,8 +9605,11 @@ mod tests {
         // Winner: drive the workflow in the background. Its frontier loop
         // will be live (500ms sleep) long enough for the loser to race.
         let winner_engine = Arc::clone(&engine);
-        let winner =
-            tokio::spawn(async move { winner_engine.resume_execution(execution_id).await });
+        let winner = tokio::spawn(async move {
+            winner_engine
+                .resume_execution(&crate::store_seam::test_scope(), execution_id)
+                .await
+        });
 
         // Poll the registry until the winner has published its token.
         // This synchronises on the exact moment the race window opens.
@@ -9550,7 +9628,9 @@ mod tests {
         // Loser: a second resume call on the same engine for the same id.
         // Must fail fast with `Leased` — and crucially must NOT clobber
         // the registry entry the winner just published.
-        let loser = engine.resume_execution(execution_id).await;
+        let loser = engine
+            .resume_execution(&crate::store_seam::test_scope(), execution_id)
+            .await;
         assert!(
             matches!(loser, Err(EngineError::Leased { .. })),
             "overlapping resume must be fenced by the lease; got {loser:?}"

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -3686,9 +3686,11 @@ impl WorkflowEngine {
         });
     }
 
-    // Private helper — scope was added for tenant isolation (U-D1.4c);
-    // combined with the fencing token this pushes past the 7-arg threshold
-    // that is designed for public APIs.
+    // Private helper — `scope` carries the originating message's tenant so
+    // every port call enforces cross-tenant isolation (invariant #7); the
+    // borrow checker then prevents any caller from substituting an alternate
+    // scope. Combined with the fencing token this pushes past the 7-arg
+    // threshold that is designed for public APIs.
     #[allow(clippy::too_many_arguments)]
     async fn checkpoint_node(
         &self,

--- a/crates/engine/src/store_seam.rs
+++ b/crates/engine/src/store_seam.rs
@@ -17,7 +17,7 @@
 //! scope from the message DTO — cross-tenant isolation invariant #7.
 //!
 //! Tests use raw in-memory adapters (no decorator) and call
-//! [`test_scope`] so every engine call observes one coherent fake tenant.
+//! [`single_tenant_scope`] explicitly so every engine call observes one coherent fake tenant.
 //!
 //! ## Fencing
 //!
@@ -83,26 +83,30 @@ pub fn workflow_input_record(json: serde_json::Value) -> NodeResultRecord {
     }
 }
 
-/// Fixed fake scope used by tests, replay paths, and `execute_workflow`.
+/// The conventional single-tenant scope for embedded/library-mode and test
+/// callers that have no multi-tenant context.
 ///
-/// Production code threads the per-message scope (from the control-queue
-/// or job-dispatch row) directly into every engine port call via
-/// `resume_execution(scope, ...)`. This helper is used only where a real
-/// per-message scope is unavailable:
+/// Callers pass it **explicitly** — no engine method manufactures a scope
+/// internally. This keeps the contract honest: any future multi-tenant caller
+/// of `execute_workflow` / `replay_execution` must supply its own real scope
+/// without needing a signature change.
 ///
-/// - `execute_workflow` / `execute_workflow_with_acquire_scope` — test
-///   and local library mode entry points (no control-queue message).
-/// - `replay_execution` — mints a fresh `ExecutionId` and is lease-less;
-///   never crosses a tenant boundary.
-/// - All test wiring that bypasses the control queue.
+/// ## When to use this
 ///
-/// The value is `pub` because integration tests (compiled as separate crates)
-/// call it via `nebula_engine::store_seam::test_scope()`. `nebula-engine` is a
+/// - `execute_workflow` / `execute_workflow_with_acquire_scope` / `replay_execution`
+///   in tests and library mode (pass as the `scope` argument).
+/// - Test wiring that bypasses the control queue (control-consumer mock impls,
+///   `DispatchStores`, etc.) where a real per-message scope is unavailable.
+///
+/// ## Why `pub`
+///
+/// Integration tests compile as separate crates and access this via
+/// `nebula_engine::store_seam::single_tenant_scope()`. `nebula-engine` is a
 /// private impl-detail crate (not re-exported by `nebula-sdk`), so this is not
 /// a public semver surface — it is test wiring internal to the engine workspace
 /// member.
 #[must_use]
-pub fn test_scope() -> Scope {
+pub fn single_tenant_scope() -> Scope {
     Scope::new("nebula", "nebula")
 }
 

--- a/crates/engine/src/store_seam.rs
+++ b/crates/engine/src/store_seam.rs
@@ -10,14 +10,14 @@
 //!
 //! ## Tenancy
 //!
-//! The engine is tenant-agnostic. Every port call takes a `&Scope`, but the
-//! composition root wraps each store in `nebula_tenancy`'s scope-enforcing
-//! decorator, which **substitutes** the bound tenant scope and ignores
-//! whatever the engine passes. The engine therefore passes a single fixed
-//! [`engine_scope`] placeholder and structurally cannot reach across
-//! tenants (it never holds the raw adapter — only the decorated handle).
-//! Test wiring that uses raw in-memory adapters (no decorator) is internally
-//! consistent because every engine call uses the same placeholder scope.
+//! The engine is tenant-agnostic. Every port call takes a `&Scope`, which
+//! is threaded in from the per-message scope on the production path
+//! (control-queue / job-dispatch row). On the worker path there is no
+//! tenancy decorator, so the scope the engine passes is the real tenant
+//! scope from the message DTO — cross-tenant isolation invariant #7.
+//!
+//! Tests use raw in-memory adapters (no decorator) and call
+//! [`test_scope`] so every engine call observes one coherent fake tenant.
 //!
 //! ## Fencing
 //!
@@ -83,14 +83,26 @@ pub fn workflow_input_record(json: serde_json::Value) -> NodeResultRecord {
     }
 }
 
-/// The fixed placeholder scope every engine port call carries.
+/// Fixed fake scope used by tests, replay paths, and `execute_workflow`.
 ///
-/// The tenancy decorator substitutes the request's bound scope and ignores
-/// this value, so its concrete contents are irrelevant in production. In
-/// decorator-less test wiring every call uses this same scope, so the raw
-/// in-memory adapters behave as a single coherent tenant.
+/// Production code threads the per-message scope (from the control-queue
+/// or job-dispatch row) directly into every engine port call via
+/// `resume_execution(scope, ...)`. This helper is used only where a real
+/// per-message scope is unavailable:
+///
+/// - `execute_workflow` / `execute_workflow_with_acquire_scope` — test
+///   and local library mode entry points (no control-queue message).
+/// - `replay_execution` — mints a fresh `ExecutionId` and is lease-less;
+///   never crosses a tenant boundary.
+/// - All test wiring that bypasses the control queue.
+///
+/// The value is `pub` because integration tests (compiled as separate crates)
+/// call it via `nebula_engine::store_seam::test_scope()`. `nebula-engine` is a
+/// private impl-detail crate (not re-exported by `nebula-sdk`), so this is not
+/// a public semver surface — it is test wiring internal to the engine workspace
+/// member.
 #[must_use]
-pub fn engine_scope() -> Scope {
+pub fn test_scope() -> Scope {
     Scope::new("nebula", "nebula")
 }
 

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -57,7 +57,7 @@ fn port_msg(execution_id: &ExecutionId, command: ControlCommand, row_id: u8) -> 
         id: [row_id; 16],
         execution_id: execution_id.to_string(),
         command,
-        scope: nebula_engine::store_seam::test_scope(),
+        scope: nebula_engine::store_seam::single_tenant_scope(),
         w3c_traceparent: None,
         reclaim_count: 0,
     }

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -57,7 +57,7 @@ fn port_msg(execution_id: &ExecutionId, command: ControlCommand, row_id: u8) -> 
         id: [row_id; 16],
         execution_id: execution_id.to_string(),
         command,
-        scope: nebula_engine::store_seam::engine_scope(),
+        scope: nebula_engine::store_seam::test_scope(),
         w3c_traceparent: None,
         reclaim_count: 0,
     }
@@ -88,31 +88,45 @@ impl RecordingDispatch {
 
 #[async_trait]
 impl ControlDispatch for RecordingDispatch {
-    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_start(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Start, execution_id);
         Ok(())
     }
 
-    async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_cancel(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Cancel, execution_id);
         Ok(())
     }
 
     async fn dispatch_terminate(
         &self,
+        _scope: &nebula_storage_port::Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Terminate, execution_id);
         Ok(())
     }
 
-    async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_resume(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Resume, execution_id);
         Ok(())
     }
 
     async fn dispatch_restart(
         &self,
+        _scope: &nebula_storage_port::Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.record(ControlCommand::Restart, execution_id);
@@ -163,13 +177,21 @@ impl FlakyDispatch {
 
 #[async_trait]
 impl ControlDispatch for FlakyDispatch {
-    async fn dispatch_start(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_start(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
         self.record(ControlCommand::Start, execution_id);
         Ok(())
     }
 
-    async fn dispatch_cancel(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_cancel(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
         self.record(ControlCommand::Cancel, execution_id);
         Ok(())
@@ -177,6 +199,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_terminate(
         &self,
+        _scope: &nebula_storage_port::Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -184,7 +207,11 @@ impl ControlDispatch for FlakyDispatch {
         Ok(())
     }
 
-    async fn dispatch_resume(&self, execution_id: ExecutionId) -> Result<(), ControlDispatchError> {
+    async fn dispatch_resume(
+        &self,
+        _scope: &nebula_storage_port::Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
         self.record(ControlCommand::Resume, execution_id);
         Ok(())
@@ -192,6 +219,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_restart(
         &self,
+        _scope: &nebula_storage_port::Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;

--- a/crates/engine/tests/control_consumer_wiring.rs
+++ b/crates/engine/tests/control_consumer_wiring.rs
@@ -25,8 +25,11 @@ use nebula_metrics::{
     naming::{NEBULA_ENGINE_CONTROL_RECLAIM_TOTAL, control_reclaim_outcome},
 };
 use nebula_storage::{InMemoryControlQueue, InMemoryExecutionStore};
-use nebula_storage_port::dto::{ControlCommand, ControlMsg};
 use nebula_storage_port::store::ControlQueue;
+use nebula_storage_port::{
+    Scope,
+    dto::{ControlCommand, ControlMsg},
+};
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -65,9 +68,15 @@ fn port_msg(execution_id: &ExecutionId, command: ControlCommand, row_id: u8) -> 
 
 /// Records every dispatch invocation so tests can assert the consumer
 /// translated storage rows → typed engine calls correctly.
+///
+/// The `scope` from each dispatch call is captured in `observations` alongside
+/// the command and execution id. This pins the invariant that `ControlConsumer`
+/// threads `ClaimedRow.scope` through to each dispatch method — a future
+/// refactor that drops or hardcodes the scope would still leave all other
+/// wiring tests green, so the captured scope is the decisive witness.
 #[derive(Default)]
 struct RecordingDispatch {
-    observations: Mutex<Vec<(ControlCommand, ExecutionId)>>,
+    observations: Mutex<Vec<(ControlCommand, ExecutionId, Scope)>>,
     notify: Notify,
 }
 
@@ -76,12 +85,15 @@ impl RecordingDispatch {
         Arc::new(Self::default())
     }
 
-    fn record(&self, cmd: ControlCommand, id: ExecutionId) {
-        self.observations.lock().expect("poisoned").push((cmd, id));
+    fn record(&self, cmd: ControlCommand, id: ExecutionId, scope: Scope) {
+        self.observations
+            .lock()
+            .expect("poisoned")
+            .push((cmd, id, scope));
         self.notify.notify_waiters();
     }
 
-    fn snapshot(&self) -> Vec<(ControlCommand, ExecutionId)> {
+    fn snapshot(&self) -> Vec<(ControlCommand, ExecutionId, Scope)> {
         self.observations.lock().expect("poisoned").clone()
     }
 }
@@ -90,46 +102,46 @@ impl RecordingDispatch {
 impl ControlDispatch for RecordingDispatch {
     async fn dispatch_start(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        self.record(ControlCommand::Start, execution_id);
+        self.record(ControlCommand::Start, execution_id, scope.clone());
         Ok(())
     }
 
     async fn dispatch_cancel(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        self.record(ControlCommand::Cancel, execution_id);
+        self.record(ControlCommand::Cancel, execution_id, scope.clone());
         Ok(())
     }
 
     async fn dispatch_terminate(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        self.record(ControlCommand::Terminate, execution_id);
+        self.record(ControlCommand::Terminate, execution_id, scope.clone());
         Ok(())
     }
 
     async fn dispatch_resume(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        self.record(ControlCommand::Resume, execution_id);
+        self.record(ControlCommand::Resume, execution_id, scope.clone());
         Ok(())
     }
 
     async fn dispatch_restart(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        self.record(ControlCommand::Restart, execution_id);
+        self.record(ControlCommand::Restart, execution_id, scope.clone());
         Ok(())
     }
 }
@@ -179,7 +191,7 @@ impl FlakyDispatch {
 impl ControlDispatch for FlakyDispatch {
     async fn dispatch_start(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        _scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -189,7 +201,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_cancel(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        _scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -199,7 +211,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_terminate(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        _scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -209,7 +221,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_resume(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        _scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -219,7 +231,7 @@ impl ControlDispatch for FlakyDispatch {
 
     async fn dispatch_restart(
         &self,
-        _scope: &nebula_storage_port::Scope,
+        _scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
         self.maybe_stall(&execution_id).await;
@@ -325,11 +337,12 @@ async fn consumer_observes_each_command_variant_via_dispatch_trait() {
     handle.await.expect("graceful shutdown");
 
     let mut seen = recorder.snapshot();
-    seen.sort_by_key(|(cmd, _)| cmd.as_str());
+    seen.sort_by_key(|(cmd, _, _)| cmd.as_str());
     assert_eq!(seen.len(), 5, "all commands observed exactly once");
 
+    let expected_scope = nebula_engine::store_seam::single_tenant_scope();
     let has =
-        |cmd: ControlCommand, id: ExecutionId| seen.iter().any(|(c, i)| *c == cmd && *i == id);
+        |cmd: ControlCommand, id: ExecutionId| seen.iter().any(|(c, i, _)| *c == cmd && *i == id);
     assert!(has(ControlCommand::Start, exec_start), "Start observed");
     assert!(has(ControlCommand::Cancel, exec_cancel), "Cancel observed");
     assert!(
@@ -341,6 +354,19 @@ async fn consumer_observes_each_command_variant_via_dispatch_trait() {
         has(ControlCommand::Restart, exec_restart),
         "Restart observed"
     );
+
+    // Scope propagation: every captured dispatch must carry the scope that
+    // was stamped on the ControlMsg by port_msg() — i.e. single_tenant_scope().
+    // This pins the invariant that ControlConsumer::handle_entry threads
+    // ClaimedRow.scope into each dispatch_* call rather than discarding or
+    // hardcoding it. All five observations must agree.
+    for (cmd, id, scope) in &seen {
+        assert_eq!(
+            scope, &expected_scope,
+            "dispatch {cmd:?} for {id} carried scope {scope:?} \
+             instead of the expected {expected_scope:?} from the ControlMsg"
+        );
+    }
 
     // Every row the consumer observed was acked via `mark_completed`:
     // a second `claim_pending` call from a fresh processor returns nothing

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -816,6 +816,72 @@ async fn dispatch_cancel_rejects_nonexistent_execution() {
     }
 }
 
+/// Invariant #7 — fail-closed cross-tenant isolation on the CONTROL-DISPATCH
+/// path (`EngineControlDispatch::read_status` → `dispatch_start`).
+///
+/// This is the symmetric companion to `cross_tenant_dispatch_is_rejected` in
+/// `execution_sink.rs`, which covers the orchestrator-dispatch path.
+///
+/// The row is seeded under `single_tenant_scope()` = `("nebula","nebula")`,
+/// the exact value the old `engine_scope()` constant returned. A `dispatch_start`
+/// call carrying `scope_b = ("wsB","orgB")` is then issued.
+///
+/// **Why this is RED on the old `read_status` (constant scope):**
+/// `read_status` calls `self.execution.get(single_tenant_scope(), id)` — the row
+/// IS there, so `Some(Created)` is returned. The method then calls `drive`, which
+/// calls `engine.resume_execution(single_tenant_scope(), id)`. The harness has a
+/// full workflow store attached, so the engine runs the workflow and returns `Ok`.
+/// The overall dispatch returns `Ok(())` — NOT `Rejected`. The assertion
+/// `expect_err("cross-tenant dispatch must be rejected")` therefore panics → RED.
+///
+/// **Why this is GREEN on the new `read_status` (per-message scope):**
+/// `read_status` calls `self.execution.get(scope_b, id)`. The store holds no row
+/// under `("wsB","orgB")` → `None` → `Rejected("… not found …")` immediately,
+/// never reaching `drive` → assertion passes → GREEN.
+#[tokio::test]
+async fn cross_tenant_control_dispatch_is_rejected() {
+    use nebula_storage_port::Scope;
+
+    let harness = Harness::new().await;
+
+    // Seed a workflow definition and execution row under single_tenant_scope().
+    // This is the SAME value the old engine_scope() constant returned, so the
+    // old code's read_status finds the row and proceeds to drive the workflow —
+    // returning Ok(()) instead of Rejected (see doc comment above).
+    let workflow_id = harness.persist_echo_workflow().await;
+    let execution_id = harness
+        .persist_created_execution(workflow_id, serde_json::json!("cross-tenant"))
+        .await;
+
+    // Deliver dispatch_start under a DIFFERENT tenant scope.
+    let scope_b = Scope::new("wsB", "orgB");
+    let err = harness
+        .dispatch
+        .dispatch_start(&scope_b, execution_id)
+        .await
+        .expect_err("cross-tenant dispatch must be rejected");
+
+    // New code: read_status reads under scope_b → None → Rejected.
+    // Old code: read_status reads under ("nebula","nebula") → finds the row →
+    //   drive → resume_execution → Ok(()) — NOT Rejected → RED.
+    match err {
+        ControlDispatchError::Rejected(msg) => {
+            assert!(
+                msg.contains("not found"),
+                "rejection message must name the missing row, got: {msg}"
+            );
+        },
+        other => panic!("expected Rejected, got {other:?}"),
+    }
+
+    // No workflow action was dispatched — the engine was never entered.
+    assert_eq!(
+        harness.action_count.load(Ordering::SeqCst),
+        0,
+        "cross-tenant rejection must not dispatch any action"
+    );
+}
+
 /// `Terminate` is a synonym for `Cancel` until a forced-shutdown path is
 /// wired ( and the module doc). Same idempotency / orphan /
 /// cross-runner contracts apply — this smoke test just asserts the

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -94,7 +94,7 @@ impl DispatchStores {
     async fn save_workflow(&self, wf: &WorkflowDefinition) {
         self.versions
             .create(
-                &nebula_engine::store_seam::test_scope(),
+                &nebula_engine::store_seam::single_tenant_scope(),
                 WorkflowVersionRecord {
                     workflow_id: wf.id.to_string(),
                     number: 0,
@@ -287,7 +287,7 @@ impl Harness {
         self.stores
             .execution
             .create(
-                &nebula_engine::store_seam::test_scope(),
+                &nebula_engine::store_seam::single_tenant_scope(),
                 &execution_id.to_string(),
                 &workflow_id.to_string(),
                 state_json,
@@ -326,7 +326,10 @@ impl Harness {
         let record = self
             .stores
             .execution
-            .get(&nebula_engine::store_seam::test_scope(), &id.to_string())
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &id.to_string(),
+            )
             .await
             .unwrap()
             .expect("execution exists");
@@ -367,7 +370,10 @@ async fn dispatch_start_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("dispatch_start succeeds");
 
@@ -397,7 +403,10 @@ async fn dispatch_start_is_idempotent_on_redelivery() {
 
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .unwrap();
     assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
@@ -410,7 +419,10 @@ async fn dispatch_start_is_idempotent_on_redelivery() {
     // status and short-circuit; the engine must not be entered a second time.
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("redelivered Start is idempotent");
 
@@ -435,7 +447,10 @@ async fn dispatch_resume_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("dispatch_resume succeeds");
 
@@ -458,14 +473,20 @@ async fn dispatch_resume_is_idempotent_on_completed_execution() {
 
     harness
         .dispatch
-        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .unwrap();
     assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
 
     harness
         .dispatch
-        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("second resume is idempotent");
 
@@ -489,7 +510,10 @@ async fn dispatch_restart_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_restart(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_restart(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("dispatch_restart on a Created execution drives it to completion");
 
@@ -516,7 +540,10 @@ async fn dispatch_restart_rejects_terminal_execution() {
     // Drive it to Completed first.
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -529,7 +556,10 @@ async fn dispatch_restart_rejects_terminal_execution() {
     // support that yet — the dispatch must reject so operators can see the gap.
     let err = harness
         .dispatch
-        .dispatch_restart(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_restart(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect_err("restart of terminal execution rejects for A2");
     match err {
@@ -559,7 +589,7 @@ async fn dispatch_start_rejects_nonexistent_execution() {
 
     let err = harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), orphan)
+        .dispatch_start(&nebula_engine::store_seam::single_tenant_scope(), orphan)
         .await
         .expect_err("missing execution rejects");
     match err {
@@ -594,7 +624,10 @@ async fn dispatch_cancel_aborts_running_execution() {
     let engine = Arc::clone(&harness.engine);
     let run_handle = tokio::spawn(async move {
         engine
-            .resume_execution(&nebula_engine::store_seam::test_scope(), execution_id)
+            .resume_execution(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                execution_id,
+            )
             .await
     });
 
@@ -608,7 +641,10 @@ async fn dispatch_cancel_aborts_running_execution() {
     // handler exits via `ActionError::Cancelled`, frontier loop tears down.
     harness
         .dispatch
-        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_cancel(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("dispatch_cancel succeeds");
 
@@ -671,7 +707,10 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
     // Drive the run to Completed first.
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -686,7 +725,10 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
     // re-dispatched. The return value is `Ok(())`.
     harness
         .dispatch
-        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_cancel(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("re-delivered Cancel on terminal execution is Ok");
 
@@ -734,7 +776,10 @@ async fn dispatch_cancel_ok_when_execution_not_held_locally() {
 
     harness
         .dispatch
-        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_cancel(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("cross-runner Cancel is Ok — no local token is not an error");
 
@@ -755,7 +800,7 @@ async fn dispatch_cancel_rejects_nonexistent_execution() {
 
     let err = harness
         .dispatch
-        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), orphan)
+        .dispatch_cancel(&nebula_engine::store_seam::single_tenant_scope(), orphan)
         .await
         .expect_err("missing execution rejects");
     match err {
@@ -783,7 +828,7 @@ async fn dispatch_terminate_behaves_like_cancel() {
     // Orphan -> Rejected (same code path as dispatch_cancel).
     let err = harness
         .dispatch
-        .dispatch_terminate(&nebula_engine::store_seam::test_scope(), orphan)
+        .dispatch_terminate(&nebula_engine::store_seam::single_tenant_scope(), orphan)
         .await
         .expect_err("orphan terminate rejects");
     assert!(matches!(err, ControlDispatchError::Rejected(_)));
@@ -795,7 +840,10 @@ async fn dispatch_terminate_behaves_like_cancel() {
         .await;
     harness
         .dispatch
-        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .unwrap();
     assert_eq!(
@@ -804,7 +852,10 @@ async fn dispatch_terminate_behaves_like_cancel() {
     );
     harness
         .dispatch
-        .dispatch_terminate(&nebula_engine::store_seam::test_scope(), execution_id)
+        .dispatch_terminate(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
         .await
         .expect("terminal terminate is Ok");
 }

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -37,8 +37,8 @@ use nebula_workflow::{
 use tokio::sync::Notify;
 
 /// Bundled port adapters for one shared in-memory tenant (mirrors the
-/// in-source `TestStores` pattern). The engine threads the fixed
-/// `engine_scope()` placeholder, so the raw adapters behave as one tenant.
+/// in-source `TestStores` pattern). All store calls use `test_scope()` so
+/// the raw adapters behave as one coherent tenant.
 #[derive(Clone)]
 struct DispatchStores {
     execution: Arc<InMemoryExecutionStore>,
@@ -94,7 +94,7 @@ impl DispatchStores {
     async fn save_workflow(&self, wf: &WorkflowDefinition) {
         self.versions
             .create(
-                &nebula_engine::store_seam::engine_scope(),
+                &nebula_engine::store_seam::test_scope(),
                 WorkflowVersionRecord {
                     workflow_id: wf.id.to_string(),
                     number: 0,
@@ -287,7 +287,7 @@ impl Harness {
         self.stores
             .execution
             .create(
-                &nebula_engine::store_seam::engine_scope(),
+                &nebula_engine::store_seam::test_scope(),
                 &execution_id.to_string(),
                 &workflow_id.to_string(),
                 state_json,
@@ -326,7 +326,7 @@ impl Harness {
         let record = self
             .stores
             .execution
-            .get(&nebula_engine::store_seam::engine_scope(), &id.to_string())
+            .get(&nebula_engine::store_seam::test_scope(), &id.to_string())
             .await
             .unwrap()
             .expect("execution exists");
@@ -367,7 +367,7 @@ async fn dispatch_start_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_start(execution_id)
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("dispatch_start succeeds");
 
@@ -395,7 +395,11 @@ async fn dispatch_start_is_idempotent_on_redelivery() {
         .persist_created_execution(workflow_id, serde_json::json!(42))
         .await;
 
-    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    harness
+        .dispatch
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .await
+        .unwrap();
     assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
     assert_eq!(
         harness.status(execution_id).await,
@@ -406,7 +410,7 @@ async fn dispatch_start_is_idempotent_on_redelivery() {
     // status and short-circuit; the engine must not be entered a second time.
     harness
         .dispatch
-        .dispatch_start(execution_id)
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("redelivered Start is idempotent");
 
@@ -431,7 +435,7 @@ async fn dispatch_resume_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_resume(execution_id)
+        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("dispatch_resume succeeds");
 
@@ -454,14 +458,14 @@ async fn dispatch_resume_is_idempotent_on_completed_execution() {
 
     harness
         .dispatch
-        .dispatch_resume(execution_id)
+        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .unwrap();
     assert_eq!(harness.action_count.load(Ordering::SeqCst), 1);
 
     harness
         .dispatch
-        .dispatch_resume(execution_id)
+        .dispatch_resume(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("second resume is idempotent");
 
@@ -485,7 +489,7 @@ async fn dispatch_restart_drives_created_execution_to_completion() {
 
     harness
         .dispatch
-        .dispatch_restart(execution_id)
+        .dispatch_restart(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("dispatch_restart on a Created execution drives it to completion");
 
@@ -510,7 +514,11 @@ async fn dispatch_restart_rejects_terminal_execution() {
         .await;
 
     // Drive it to Completed first.
-    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    harness
+        .dispatch
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .await
+        .unwrap();
     assert_eq!(
         harness.status(execution_id).await,
         ExecutionStatus::Completed
@@ -521,7 +529,7 @@ async fn dispatch_restart_rejects_terminal_execution() {
     // support that yet — the dispatch must reject so operators can see the gap.
     let err = harness
         .dispatch
-        .dispatch_restart(execution_id)
+        .dispatch_restart(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect_err("restart of terminal execution rejects for A2");
     match err {
@@ -551,7 +559,7 @@ async fn dispatch_start_rejects_nonexistent_execution() {
 
     let err = harness
         .dispatch
-        .dispatch_start(orphan)
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), orphan)
         .await
         .expect_err("missing execution rejects");
     match err {
@@ -584,7 +592,11 @@ async fn dispatch_cancel_aborts_running_execution() {
     // Spawn the engine on a separate task so the test thread can drive the
     // `Cancel` dispatch while the frontier loop is live.
     let engine = Arc::clone(&harness.engine);
-    let run_handle = tokio::spawn(async move { engine.resume_execution(execution_id).await });
+    let run_handle = tokio::spawn(async move {
+        engine
+            .resume_execution(&nebula_engine::store_seam::test_scope(), execution_id)
+            .await
+    });
 
     // Wait for the slow handler to confirm it entered the `select!` — the
     // frontier loop is now observing the cancel token.
@@ -596,7 +608,7 @@ async fn dispatch_cancel_aborts_running_execution() {
     // handler exits via `ActionError::Cancelled`, frontier loop tears down.
     harness
         .dispatch
-        .dispatch_cancel(execution_id)
+        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("dispatch_cancel succeeds");
 
@@ -657,7 +669,11 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
         .await;
 
     // Drive the run to Completed first.
-    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    harness
+        .dispatch
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .await
+        .unwrap();
     assert_eq!(
         harness.status(execution_id).await,
         ExecutionStatus::Completed
@@ -670,7 +686,7 @@ async fn dispatch_cancel_is_idempotent_on_terminal() {
     // re-dispatched. The return value is `Ok(())`.
     harness
         .dispatch
-        .dispatch_cancel(execution_id)
+        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("re-delivered Cancel on terminal execution is Ok");
 
@@ -718,7 +734,7 @@ async fn dispatch_cancel_ok_when_execution_not_held_locally() {
 
     harness
         .dispatch
-        .dispatch_cancel(execution_id)
+        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("cross-runner Cancel is Ok — no local token is not an error");
 
@@ -739,7 +755,7 @@ async fn dispatch_cancel_rejects_nonexistent_execution() {
 
     let err = harness
         .dispatch
-        .dispatch_cancel(orphan)
+        .dispatch_cancel(&nebula_engine::store_seam::test_scope(), orphan)
         .await
         .expect_err("missing execution rejects");
     match err {
@@ -767,7 +783,7 @@ async fn dispatch_terminate_behaves_like_cancel() {
     // Orphan -> Rejected (same code path as dispatch_cancel).
     let err = harness
         .dispatch
-        .dispatch_terminate(orphan)
+        .dispatch_terminate(&nebula_engine::store_seam::test_scope(), orphan)
         .await
         .expect_err("orphan terminate rejects");
     assert!(matches!(err, ControlDispatchError::Rejected(_)));
@@ -777,14 +793,18 @@ async fn dispatch_terminate_behaves_like_cancel() {
     let execution_id = harness
         .persist_created_execution(workflow_id, serde_json::json!("t"))
         .await;
-    harness.dispatch.dispatch_start(execution_id).await.unwrap();
+    harness
+        .dispatch
+        .dispatch_start(&nebula_engine::store_seam::test_scope(), execution_id)
+        .await
+        .unwrap();
     assert_eq!(
         harness.status(execution_id).await,
         ExecutionStatus::Completed
     );
     harness
         .dispatch
-        .dispatch_terminate(execution_id)
+        .dispatch_terminate(&nebula_engine::store_seam::test_scope(), execution_id)
         .await
         .expect("terminal terminate is Ok");
 }

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -37,8 +37,8 @@ use nebula_workflow::{
 use tokio::sync::Notify;
 
 /// Bundled port adapters for one shared in-memory tenant (mirrors the
-/// in-source `TestStores` pattern). All store calls use `test_scope()` so
-/// the raw adapters behave as one coherent tenant.
+/// in-source `TestStores` pattern). All store calls use `single_tenant_scope()`
+/// so the raw adapters behave as one coherent tenant.
 #[derive(Clone)]
 struct DispatchStores {
     execution: Arc<InMemoryExecutionStore>,

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -288,7 +288,12 @@ async fn pipeline_resolves_expressions_before_handler_runs() {
     // Capture wall-clock before+after to bound the resolved timestamp.
     let before = chrono::Utc::now().timestamp();
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
     let after = chrono::Utc::now().timestamp();
@@ -403,7 +408,12 @@ async fn pipeline_with_resource_manager_resolves_and_executes() {
     let wf = make_workflow(vec![node_def]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
 
@@ -466,7 +476,12 @@ async fn pipeline_unresolvable_expression_fails_node_before_handler() {
     let wf = make_workflow(vec![node_def]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow finishes (the node fails, not the engine)");
 

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -274,7 +274,12 @@ async fn engine_and_runtime_share_metrics_registry() {
     );
 
     let _result = engine
-        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("hi"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -317,7 +322,12 @@ async fn linear_pipeline_data_flows_through() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(5), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(5),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -353,7 +363,12 @@ async fn fan_out_parallel_execution() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(7), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(7),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -394,7 +409,12 @@ async fn diamond_merge_receives_combined_outputs() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(3), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(3),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -438,7 +458,12 @@ async fn error_propagation_stops_downstream() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("data"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("data"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -493,7 +518,12 @@ async fn cancellation_via_sibling_failure() {
 
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        engine.execute_workflow(&wf, serde_json::json!("go"), ExecutionBudget::default()),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("go"),
+            ExecutionBudget::default(),
+        ),
     )
     .await
     .expect("should complete within 5s");
@@ -527,7 +557,12 @@ async fn metrics_cover_full_lifecycle() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(1), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(1),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -591,7 +626,12 @@ async fn bounded_concurrency_with_multiple_parallel_nodes() {
     let budget = ExecutionBudget::default().with_max_concurrent_nodes(2);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("parallel"), budget)
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("parallel"),
+            budget,
+        )
         .await
         .unwrap();
 
@@ -619,7 +659,12 @@ async fn zero_concurrency_budget_returns_planning_error() {
     };
 
     let err = engine
-        .execute_workflow(&wf, serde_json::json!({}), budget)
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!({}),
+            budget,
+        )
         .await
         .expect_err("zero permits must not deadlock behind Semaphore::new(0)");
 
@@ -658,7 +703,12 @@ async fn deep_chain_propagates_outputs() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(2), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(2),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -684,7 +734,12 @@ async fn metrics_accurate_on_failure() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -743,7 +798,12 @@ async fn disabled_node_is_skipped_and_successor_executes() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("hello"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("hello"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -816,7 +876,12 @@ async fn skip_propagates_transitively_through_three_hop_chain() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("hi"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -876,7 +941,12 @@ async fn diamond_with_one_skipped_branch_still_completes() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("hi"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -922,7 +992,12 @@ async fn aggregate_with_one_skipped_source_fires() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(42), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(42),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -966,7 +1041,12 @@ async fn aggregate_with_all_sources_skipped_propagates_skip() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(0), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(0),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -1028,7 +1108,12 @@ async fn multi_hop_skip_with_sibling_activation_still_runs() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("hi"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("hi"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -1083,7 +1168,12 @@ async fn duplicate_edges_from_skipped_source_count_per_edge() {
     );
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!("in"), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!("in"),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -135,7 +135,7 @@ impl LeaseStores {
     /// Persist a workflow definition as published version 0 so the
     /// resume path's `get_published` lookup resolves it.
     async fn save_workflow(&self, wf: &WorkflowDefinition) {
-        let scope = nebula_engine::store_seam::test_scope();
+        let scope = nebula_engine::store_seam::single_tenant_scope();
         let definition = serde_json::to_value(wf).unwrap();
         self.versions
             .create(
@@ -155,7 +155,7 @@ impl LeaseStores {
     /// Whether a stranger holder is blocked from acquiring the lease
     /// (the port analog of the legacy `!acquire_lease(...)` probe).
     async fn lease_held(&self, id: nebula_core::id::ExecutionId, ttl: Duration) -> bool {
-        let scope = nebula_engine::store_seam::test_scope();
+        let scope = nebula_engine::store_seam::single_tenant_scope();
         self.execution
             .acquire_lease(&scope, &id.to_string(), "lease-probe-stranger", ttl)
             .await
@@ -396,6 +396,7 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
         tokio::spawn(async move {
             engine_a
                 .execute_workflow(
+                    &nebula_engine::store_seam::single_tenant_scope(),
                     &wf,
                     serde_json::json!("payload"),
                     ExecutionBudget::default(),
@@ -462,7 +463,10 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
     // - drive the workflow to Succeeded.
     let result_b = tokio::time::timeout(
         Duration::from_secs(10),
-        engine_b.resume_execution(&nebula_engine::store_seam::test_scope(), execution_id),
+        engine_b.resume_execution(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        ),
     )
     .await
     .expect("resume_execution must complete within 10s")
@@ -606,6 +610,7 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
         tokio::spawn(async move {
             engine_a
                 .execute_workflow(
+                    &nebula_engine::store_seam::single_tenant_scope(),
                     &wf,
                     serde_json::json!("payload"),
                     ExecutionBudget::default(),
@@ -644,7 +649,7 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
             id: cancel_row_id,
             execution_id: execution_id.to_string(),
             command: ControlCommand::Cancel,
-            scope: nebula_engine::store_seam::test_scope(),
+            scope: nebula_engine::store_seam::single_tenant_scope(),
             w3c_traceparent: None,
             reclaim_count: 0,
         })
@@ -672,7 +677,10 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
         let engine_b = Arc::clone(&engine_b);
         tokio::spawn(async move {
             engine_b
-                .resume_execution(&nebula_engine::store_seam::test_scope(), execution_id)
+                .resume_execution(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    execution_id,
+                )
                 .await
         })
     };
@@ -860,7 +868,12 @@ async fn replay_does_not_contend_for_held_lease() {
         let wf_a = wf_a.clone();
         tokio::spawn(async move {
             engine_a
-                .execute_workflow(&wf_a, serde_json::json!("a"), ExecutionBudget::default())
+                .execute_workflow(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    &wf_a,
+                    serde_json::json!("a"),
+                    ExecutionBudget::default(),
+                )
                 .await
         })
     };
@@ -895,7 +908,12 @@ async fn replay_does_not_contend_for_held_lease() {
     let plan = ReplayPlan::new(execution_id_a, x_b.clone());
     let result_b = tokio::time::timeout(
         Duration::from_secs(10),
-        engine_b.replay_execution(&wf_b, plan, ExecutionBudget::default()),
+        engine_b.replay_execution(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf_b,
+            plan,
+            ExecutionBudget::default(),
+        ),
     )
     .await
     .expect("replay_execution must complete within 10s")

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -16,7 +16,7 @@
 //! via `WorkflowEngine::with_execution_stores`/`with_workflow_stores`,
 //! `EngineControlDispatch::new_port`, `ControlConsumer::new_port`). The
 //! engine threads the per-message scope from the DTO on the production
-//! path; test wiring uses `test_scope()` so the raw in-memory adapters
+//! path; test wiring uses `single_tenant_scope()` so the raw in-memory adapters
 //! behave as one coherent tenant — identical observable behaviour to the old single-tenant
 //! repos. The §M2.2 lease-handoff guarantees are unchanged and asserted
 //! verbatim:
@@ -77,7 +77,7 @@ fn proc16(label: &[u8]) -> [u8; 16] {
 
 /// Bundled port adapters for one shared in-memory tenant. Mirrors the
 /// in-source `TestStores` pattern: every field is a real port trait the
-/// engine consumes; `test_scope()` makes the raw adapters behave as a
+/// engine consumes; `single_tenant_scope()` makes the raw adapters behave as a
 /// single coherent tenant.
 #[derive(Clone)]
 struct LeaseStores {

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -15,9 +15,9 @@
 //! (`ExecutionStore` + `WorkflowVersionStore` + `ControlQueue`, bundled
 //! via `WorkflowEngine::with_execution_stores`/`with_workflow_stores`,
 //! `EngineControlDispatch::new_port`, `ControlConsumer::new_port`). The
-//! engine is tenant-agnostic and threads the fixed `engine_scope()`
-//! placeholder, so the raw in-memory adapters behave as one coherent
-//! tenant — identical observable behaviour to the old single-tenant
+//! engine threads the per-message scope from the DTO on the production
+//! path; test wiring uses `test_scope()` so the raw in-memory adapters
+//! behave as one coherent tenant — identical observable behaviour to the old single-tenant
 //! repos. The §M2.2 lease-handoff guarantees are unchanged and asserted
 //! verbatim:
 //! - heartbeat-loss → TTL-expiry takeover by a second runner with no
@@ -77,8 +77,8 @@ fn proc16(label: &[u8]) -> [u8; 16] {
 
 /// Bundled port adapters for one shared in-memory tenant. Mirrors the
 /// in-source `TestStores` pattern: every field is a real port trait the
-/// engine consumes; the `engine_scope()` placeholder makes the raw
-/// adapters behave as a single coherent tenant.
+/// engine consumes; `test_scope()` makes the raw adapters behave as a
+/// single coherent tenant.
 #[derive(Clone)]
 struct LeaseStores {
     execution: Arc<InMemoryExecutionStore>,
@@ -135,7 +135,7 @@ impl LeaseStores {
     /// Persist a workflow definition as published version 0 so the
     /// resume path's `get_published` lookup resolves it.
     async fn save_workflow(&self, wf: &WorkflowDefinition) {
-        let scope = nebula_engine::store_seam::engine_scope();
+        let scope = nebula_engine::store_seam::test_scope();
         let definition = serde_json::to_value(wf).unwrap();
         self.versions
             .create(
@@ -155,7 +155,7 @@ impl LeaseStores {
     /// Whether a stranger holder is blocked from acquiring the lease
     /// (the port analog of the legacy `!acquire_lease(...)` probe).
     async fn lease_held(&self, id: nebula_core::id::ExecutionId, ttl: Duration) -> bool {
-        let scope = nebula_engine::store_seam::engine_scope();
+        let scope = nebula_engine::store_seam::test_scope();
         self.execution
             .acquire_lease(&scope, &id.to_string(), "lease-probe-stranger", ttl)
             .await
@@ -462,7 +462,7 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
     // - drive the workflow to Succeeded.
     let result_b = tokio::time::timeout(
         Duration::from_secs(10),
-        engine_b.resume_execution(execution_id),
+        engine_b.resume_execution(&nebula_engine::store_seam::test_scope(), execution_id),
     )
     .await
     .expect("resume_execution must complete within 10s")
@@ -644,7 +644,7 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
             id: cancel_row_id,
             execution_id: execution_id.to_string(),
             command: ControlCommand::Cancel,
-            scope: nebula_engine::store_seam::engine_scope(),
+            scope: nebula_engine::store_seam::test_scope(),
             w3c_traceparent: None,
             reclaim_count: 0,
         })
@@ -670,7 +670,11 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
     // re-dispatches Y. Its parking handler signals started_b on entry.
     let task_b = {
         let engine_b = Arc::clone(&engine_b);
-        tokio::spawn(async move { engine_b.resume_execution(execution_id).await })
+        tokio::spawn(async move {
+            engine_b
+                .resume_execution(&nebula_engine::store_seam::test_scope(), execution_id)
+                .await
+        })
     };
 
     // Wait until engine_b's running registry has the entry (parking

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -205,7 +205,12 @@ async fn action_acquires_resource_through_engine() {
     ]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
 
@@ -258,7 +263,12 @@ async fn full_resource_lifecycle_with_shutdown() {
     ]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
 
@@ -439,7 +449,12 @@ async fn engine_acquires_org_scoped_resource_through_accessor() {
     ]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
 
@@ -490,7 +505,12 @@ async fn action_resource_fails_without_manager() {
     ]);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .expect("workflow execution");
 

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -383,6 +383,7 @@ async fn registrars_do_not_regress_dispatch() {
 
     let result = engine
         .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
             &wf,
             serde_json::json!({ "ok": true }),
             ExecutionBudget::default(),

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -445,9 +445,8 @@ async fn idempotency_key_differentiates_attempts() {
         },
     );
 
-    // Spec-16 port bundle (the engine always reads/commits at the
-    // fixed `engine_scope()` placeholder; this test inspects the same
-    // scope directly).
+    // Spec-16 port bundle (the engine threads the test scope; this test
+    // inspects the same scope directly).
     let execution = Arc::new(nebula_storage::InMemoryExecutionStore::new());
     let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
     let stores = nebula_engine::ExecutionStores {
@@ -475,7 +474,7 @@ async fn idempotency_key_differentiates_attempts() {
     // Pull the persisted state and inspect the attempts.
     let record = execution
         .get(
-            &nebula_engine::store_seam::engine_scope(),
+            &nebula_engine::store_seam::test_scope(),
             &result.execution_id.to_string(),
         )
         .await

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -207,6 +207,7 @@ async fn retry_succeeds_on_attempt_2() {
     let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
     let result = engine
         .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
             &wf,
             serde_json::json!("payload"),
             ExecutionBudget::default(),
@@ -239,7 +240,12 @@ async fn retry_exhausts_max_attempts() {
 
     let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -281,7 +287,12 @@ async fn cancel_during_retry_wait() {
     let engine_h = Arc::clone(&engine);
     let task = tokio::spawn(async move {
         engine_h
-            .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+            .execute_workflow(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
             .await
     });
 
@@ -363,7 +374,12 @@ async fn terminate_during_retry_wait() {
 
     let result = tokio::time::timeout(
         Duration::from_secs(5),
-        engine.execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default()),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        ),
     )
     .await
     .expect("workflow must wind down within 5s")
@@ -419,7 +435,12 @@ async fn execution_budget_max_total_retries_caps_globally() {
     let budget = ExecutionBudget::default().with_max_total_retries(1);
 
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), budget)
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            budget,
+        )
         .await
         .unwrap();
 
@@ -464,7 +485,12 @@ async fn idempotency_key_differentiates_attempts() {
 
     let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
     let result = engine
-        .execute_workflow(&wf, serde_json::json!({"v": 1}), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!({"v": 1}),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -474,7 +500,7 @@ async fn idempotency_key_differentiates_attempts() {
     // Pull the persisted state and inspect the attempts.
     let record = execution
         .get(
-            &nebula_engine::store_seam::test_scope(),
+            &nebula_engine::store_seam::single_tenant_scope(),
             &result.execution_id.to_string(),
         )
         .await
@@ -526,7 +552,12 @@ async fn per_node_retry_policy_overrides_workflow_default() {
 
     let wf = make_workflow(vec![node], vec![], config);
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -562,7 +593,12 @@ async fn workflow_default_applies_when_node_has_none() {
 
     let wf = make_workflow(vec![node], vec![], config);
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 
@@ -593,7 +629,12 @@ async fn no_retry_policy_means_one_shot_failure() {
 
     let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
     let result = engine
-        .execute_workflow(&wf, serde_json::json!(null), ExecutionBudget::default())
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
         .await
         .unwrap();
 

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -114,9 +114,9 @@ impl TestStores {
     }
 }
 
-/// Return `engine_scope()` via the public re-export.
+/// Return the test scope via the public re-export.
 fn scope() -> Scope {
-    nebula_engine::store_seam::engine_scope()
+    nebula_engine::store_seam::test_scope()
 }
 
 /// One-node echo workflow (StatelessAction that returns its input).

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -116,7 +116,7 @@ impl TestStores {
 
 /// Return the test scope via the public re-export.
 fn scope() -> Scope {
-    nebula_engine::store_seam::test_scope()
+    nebula_engine::store_seam::single_tenant_scope()
 }
 
 /// One-node echo workflow (StatelessAction that returns its input).

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -109,7 +109,7 @@ impl TestStores {
     }
 }
 
-/// Test scope used for worker integration tests. Matches `nebula_engine::store_seam::test_scope()`
+/// Test scope used for worker integration tests. Matches `nebula_engine::store_seam::single_tenant_scope()`
 /// (`("nebula","nebula")`) so the worker and engine observe the same in-memory rows.
 /// Production code uses the per-message scope from the control-queue / job-dispatch DTO.
 fn scope() -> Scope {

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -109,10 +109,9 @@ impl TestStores {
     }
 }
 
-/// Fixed placeholder scope — deliberately mirrors `engine_scope()` from `nebula-engine`
-/// (the same `("nebula","nebula")` placeholder the engine uses for every port call).
-/// The request-derived `Scope` wiring belongs to U-D1.4; do NOT re-export `engine_scope`
-/// from `nebula-engine` here — it is a placeholder slated to change.
+/// Test scope used for worker integration tests. Matches `nebula_engine::store_seam::test_scope()`
+/// (`("nebula","nebula")`) so the worker and engine observe the same in-memory rows.
+/// Production code uses the per-message scope from the control-queue / job-dispatch DTO.
 fn scope() -> Scope {
     Scope::new("nebula", "nebula")
 }


### PR DESCRIPTION
## ADR-0095 D1 — U-D1.4c: thread the real tenant `Scope`, delete the `engine_scope()` placeholder

The contract fix that makes the engine's execution path **tenant-correct** before any live trigger emitter is installed. Closes the `engine_scope()` placeholder hole structurally (no magic string, no new type).

### The problem
`engine_scope()` returned a **fake single tenant** `Scope::new("nebula","nebula")` for *every* engine port call (resume, status read, idempotency mark, checkpoints, …). On the webhook→worker path there is no tenancy decorator to substitute the real scope, so an installed emitter would emit — and the worker would resume — under that placeholder, **masking cross-tenant access**. The proposed mitigation (reserve a non-registerable `"nebula"` slug) is discipline, not structure.

### The fix — use the contract that's already correct
The storage-port already follows the Postgres-RLS model: **tenant ops take `scope: &Scope`; genuinely cross-tenant/system ops are separate scope-less methods** (`reclaim_stuck`, `list_for_org`, token-keyed claims). So `engine_scope()` was never a real "system" case — it was a fake tenant the engine fabricated because `resume_execution`/`read_status` were never handed the real scope. (An `enum Tenancy { System, Tenant(Scope) }` was considered and **rejected**: it would push a `System` variant into every tenant method — the accidental-bypass surface RLS's separate-role model exists to prevent.)

- Thread the real **per-message** `Scope` per-call through `resume_execution(&self, scope, id)`, the `ControlDispatch` trait, `EngineControlDispatch`/`EngineExecutionSink::{read_status,drive}`, and the lib-mode entry points `execute_workflow`/`execute_workflow_with_acquire_scope`/`replay_execution` (now take `scope` explicitly).
- Scope sourced from `JobDispatchMsg.scope` (orchestrator/sink path) and `ControlMsg.scope` (control-queue path; previously dropped in the consumer's `normalize()` — restored on `ClaimedRow`). Producers stamp the real request scope server-side (`api/state.rs`), round-tripped through DB columns.
- **`engine_scope()` deleted.** With no placeholder constructor the `("nebula","nebula")` value is unconstructable — invariant #8 closed by construction, no reserved string, no new type. `test_scope()` → `single_tenant_scope()`, the honest single-tenant/embedded convention, passed **explicitly** (no engine method manufactures a scope).

### Tests (both fail-closed paths, RED-on-revert verified)
- `cross_tenant_dispatch_is_rejected` (sink) and `cross_tenant_control_dispatch_is_rejected` (control-dispatch): seed under `single_tenant_scope()`, dispatch under a different scope → `Rejected("not found")`. Both proven RED when `read_status` is reverted to the constant (old code finds the row and drives it → `Internal`, not `Rejected`).
- `consumer_observes_each_command_variant_via_dispatch_trait` now asserts the scope `ControlConsumer::handle_entry` propagates equals the enqueued `ControlMsg.scope` — pinning the consumer scope thread against silent regressions.

### Verification
- `cargo nextest run -p nebula-engine -p nebula-orchestrator -p nebula-worker -p nebula-api` → **841 passed, 1 skipped**.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean.
- Pre-push CI mirror (clippy-full + crate-diff rustdoc on api/engine/worker) → green.
- Semver: engine-internal only; `nebula-sdk` (the sole public crate) re-exports none of the changed methods.

### Scope / follow-ups
- This unit makes the engine path placeholder-free. The webhook ingress (capability-token URL + Standard Webhooks HMAC) and the worker-side store decoration under `msg.scope` are the next units (U-D1.4b/c-resume); design captured in `.rust-studio/specs/d1-decomposition/u-d1.4-webhook-ingress.md`.
- A workspace-wide `publish = false` sweep (enforce "only `nebula-sdk` is public" in Cargo, not just convention) is flagged as a separate hygiene task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced multi-tenant isolation by threading per-message tenant scope throughout workflow execution and control dispatch paths, replacing placeholder scope handling with explicit scope parameters.
  * Updated storage and execution APIs to use caller-provided scope for stricter cross-tenant isolation guarantees.
  * Updated documentation to reflect new scope propagation patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->