### PR TITLE
chore(workspace): mark internal exec/server/storage crates publish=false

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-api"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 keywords.workspace = true
 authors.workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-engine"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 authors.workspace = true
 description = "Workflow execution engine for Nebula"

--- a/crates/env/Cargo.toml
+++ b/crates/env/Cargo.toml
@@ -3,6 +3,7 @@
 name = "nebula-env"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 description = "Typed, cross-cutting environment-variable reader for the Nebula workflow engine"
 keywords.workspace = true

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-execution"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 keywords.workspace = true
 authors.workspace = true

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-orchestrator"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 authors.workspace = true
 description = "Capability-routed job-dispatch pull loop for the Nebula orchestration layer (ADR-0095)"

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-storage"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 description = "Storage abstraction for Nebula: key-value backends (memory, Redis, Postgres, S3)"
 keywords.workspace = true

--- a/crates/tenancy/Cargo.toml
+++ b/crates/tenancy/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-tenancy"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 description = "Multi-tenancy security boundary (ScopeResolver + scope-enforcing decorators) for Nebula"
 keywords.workspace = true

--- a/crates/worker/Cargo.toml
+++ b/crates/worker/Cargo.toml
@@ -2,6 +2,7 @@
 name = "nebula-worker"
 version.workspace = true
 edition.workspace = true
+publish = false
 rust-version.workspace = true
 authors.workspace = true
 description = "Generic worker runtime that wires a WorkflowEngine into an Orchestrator pull-loop (ADR-0095 D1)"


### PR DESCRIPTION
Prevents an accidental `cargo publish` from leaking the truly-internal crates (security-auditor follow-up from the ADR-0096 review).

## Scope — non-`nebula-sdk`-tree crates only
`publish = false` added to the 8 internal exec/server/storage crates that are **outside** `nebula-sdk`'s dependency tree:
`storage`, `tenancy`, `engine`, `env`, `execution`, `orchestrator`, `worker`, `api`.

**Deliberately untouched:** every crate IN `nebula-sdk`'s dependency tree (action, core, credential, crypto, error, eventbus, expression, log, metadata, metrics, plugin, resilience, resource, schema, storage-port, validator, workflow + their macros) stays publishable — cargo refuses to publish a crate with unpublished deps, so blanket `publish=false` would silently break a future `nebula-sdk` release. The sdk-tree publish posture is a separate release decision, left as-is. Already-set crates (resilience, storage-loom-probe, apps/server, examples, expression/fuzz) unchanged.

## Verification
- `cargo metadata`: the 8 crates report `"publish": []`; `nebula-sdk` + its deps still `"publish": null` (publishable).
- `cargo build --workspace --locked` green; `cargo check --workspace --all-targets` green; `cargo deny check` ok; `taplo fmt` clean; pre-push gate green.
- `publish = false` is a manifest-only annotation — zero effect on the build/dependency graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)