### PR TITLE
feat(api): durable webhook dispatch — install DurableExecutionEmitter on the Prod path (ADR-0095 D1, U-D1.4b)

### DIFF
--- a/apps/server/src/transport.rs
+++ b/apps/server/src/transport.rs
@@ -8,7 +8,7 @@
 //! The [`Transport`] clap enum lets the single `nebula-server` binary select
 //! which profile to run via `--transport` / `NEBULA_TRANSPORT`.
 
-use std::net::SocketAddr;
+use std::{net::SocketAddr, sync::Arc};
 
 use axum::{Json, Router, http::StatusCode, routing::get};
 use clap::ValueEnum;
@@ -120,14 +120,23 @@ impl ServerTransport for WebhookIngressTransport {
             ..nebula_api::transport::webhook::WebhookTransportConfig::default()
         };
 
-        // Build the transport, then attach the durable activation store when
-        // the composition root has wired one (ADR-0096 D3 — `resolve_by_token`
-        // on the hot path).  The store is attached at construction (refcount 1
-        // before the transport is cloned into handlers) so `with_activation_store`
-        // takes the `Arc::try_unwrap` fast path and never rebuilds the routing map.
+        // Build the transport, then attach components in order (refcount 1
+        // at each step so `Arc::try_unwrap` takes the fast path and never
+        // rebuilds the routing map):
+        //   1. activation store  (ADR-0096 — token resolution)
+        //   2. durable dispatch  (ADR-0095 D1 U-D1.4b — Prod-mode spawning)
+        // All builders are called before the transport is distributed to
+        // handlers so refcount stays 1 throughout.
         let transport = nebula_api::transport::webhook::WebhookTransport::new(webhook_config);
         let transport = if let Some(store) = state.webhook_activation_store.clone() {
             transport.with_activation_store(store)
+        } else {
+            transport
+        };
+        let transport = if let Some(dedup) = state.trigger_dedup_inbox.clone() {
+            let resolver = nebula_api::transport::webhook::WebhookTransport::default_resolver();
+            let version_store = Arc::clone(&state.workflow_version_store);
+            transport.with_durable_dispatch(dedup, resolver, version_store)
         } else {
             transport
         };

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -15,8 +15,8 @@ use nebula_plugin::PluginRegistry;
 use nebula_storage::credential::InMemoryPendingStore;
 use nebula_storage_port::Scope;
 use nebula_storage_port::store::{
-    ControlQueue, ExecutionJournalReader, ExecutionStore, NodeResultStore, WebhookActivationStore,
-    WorkflowStore, WorkflowVersionStore,
+    ControlQueue, ExecutionJournalReader, ExecutionStore, NodeResultStore, TriggerDedupInbox,
+    WebhookActivationStore, WorkflowStore, WorkflowVersionStore,
 };
 use nebula_tenancy::{
     ScopedControlQueue, ScopedExecutionJournalReader, ScopedExecutionStore, ScopedNodeResultStore,
@@ -340,6 +340,18 @@ pub struct AppState {
     /// on restart — pre-ADR-0096 behaviour).
     pub webhook_activation_store: Option<Arc<dyn WebhookActivationStore>>,
 
+    /// Trigger dedup inbox for durable webhook dispatch (ADR-0095 D1, U-D1.4b).
+    ///
+    /// Shared with the orchestrator's `JobDispatchQueue` — both must wrap the
+    /// **same** underlying store so `claim_and_materialize_start` is atomic
+    /// across the dedup-guard, Created-execution-row, and Start-job writes.
+    ///
+    /// When `Some` and the activation row is `mode=Prod`, incoming webhook
+    /// events spawn durable executions via `DurableExecutionEmitter`.
+    /// When `None`, Prod-mode webhooks are rejected fail-closed (5xx) rather
+    /// than silently spawning dedup-blind.
+    pub trigger_dedup_inbox: Option<Arc<dyn TriggerDedupInbox>>,
+
     /// Optional lifecycle event bus (webhook activation — E2).
     ///
     /// Producers (storage CRUD callsites) emit
@@ -483,6 +495,7 @@ impl AppState {
             allow_insecure_tenant_rbac_bypass: false,
             idempotency_store: None,
             webhook_activation_store: None,
+            trigger_dedup_inbox: None,
             trigger_lifecycle_bus: None,
             webhook_secret_resolver: None,
             webhook_ctx_factory_b: None,
@@ -531,12 +544,22 @@ impl AppState {
     pub fn in_memory(jwt_secret: JwtSecret) -> Self {
         use nebula_storage::inmem::{
             InMemoryControlQueue, InMemoryExecutionStore, InMemoryJournalReader,
-            InMemoryNodeResultStore, InMemoryWorkflowStore, InMemoryWorkflowVersionStore,
+            InMemoryNodeResultStore, InMemoryTriggerDedupInbox, InMemoryWorkflowStore,
+            InMemoryWorkflowVersionStore,
         };
 
         let exec_store = InMemoryExecutionStore::new();
         let control_queue = InMemoryControlQueue::new(&exec_store);
         let journal = InMemoryJournalReader::new(&exec_store);
+        // TriggerDedupInbox must wrap the same shared core as the control
+        // queue and journal: `claim_and_materialize_start` writes the dedup
+        // guard, the Created execution row, and the Start job atomically in
+        // one critical section — only possible when all three share the same
+        // `Arc<Mutex<SharedState>>` (atomicity contract, durable_emitter.rs:106-108).
+        // `new(&exec_store)` must be called BEFORE `Arc::new(exec_store)` moves
+        // ownership — same ordering as `InMemoryControlQueue::new` and
+        // `InMemoryJournalReader::new` above.
+        let trigger_dedup_inbox = InMemoryTriggerDedupInbox::new(&exec_store);
         let node_results = InMemoryNodeResultStore::new();
         // The workflow-row store shares the version store's map so
         // `workflow_save`'s atomic `save_with_published_version` commits
@@ -555,6 +578,7 @@ impl AppState {
             Arc::new(control_queue),
             jwt_secret,
         )
+        .with_trigger_dedup_inbox(Arc::new(trigger_dedup_inbox))
     }
 
     /// Read a workflow's stored definition for the caller's tenant, or
@@ -1160,6 +1184,28 @@ impl AppState {
     #[must_use = "builder methods must be chained or built"]
     pub fn with_webhook_activation_store(mut self, store: Arc<dyn WebhookActivationStore>) -> Self {
         self.webhook_activation_store = Some(store);
+        self
+    }
+
+    /// Attach the trigger-dedup inbox for durable webhook dispatch (ADR-0095 D1,
+    /// U-D1.4b).
+    ///
+    /// **Atomicity requirement:** the inbox MUST share its underlying store with
+    /// the orchestrator's `JobDispatchQueue` — both must wrap the same
+    /// `Arc<Mutex<SharedState>>` (or equivalent transaction boundary) so
+    /// `claim_and_materialize_start` can write the dedup guard, the Created
+    /// execution row, and the Start job in one atomic critical section.
+    ///
+    /// [`AppState::in_memory`] wires this automatically via
+    /// `InMemoryTriggerDedupInbox::new(&exec_store)` before the exec-store is
+    /// moved into `Arc<dyn ExecutionStore>`.  Production composition roots must
+    /// supply the same atomic wiring over their chosen backend (SQLite / PG).
+    ///
+    /// When `None`, Prod-mode webhook dispatches are rejected fail-closed (5xx)
+    /// so dedup-blind spawns can never occur.
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_trigger_dedup_inbox(mut self, inbox: Arc<dyn TriggerDedupInbox>) -> Self {
+        self.trigger_dedup_inbox = Some(inbox);
         self
     }
 

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -213,24 +213,30 @@ pub(super) async fn dispatch_inner(
                 debug!("capability token not in port store — continuing via in-memory map");
             },
             Err(err) => {
-                // Storage error resolving the capability token. Now that durable
-                // dispatch is LIVE, we cannot determine the activation `mode`, so
-                // we MUST NOT silently downgrade a Prod trigger to the Noop path:
-                // that would 2xx the sender and lose the event (no retry). Fail
-                // closed with 503 so the sender retries; on store recovery the
-                // retry resolves and `claim_and_materialize_start` dedups by
-                // `event_id`. Availability of the durable contract > availability
-                // of the in-memory path once durable dispatch exists (Codex P1).
+                // Storage error resolving the capability token. When durable
+                // dispatch is WIRED, the row is the trusted source of
+                // mode/scope/workflow, so we MUST NOT silently downgrade a Prod
+                // trigger to the Noop in-memory path: that would 2xx the sender
+                // and lose the event (no retry). Fail closed with 503 so the
+                // sender retries; on store recovery the retry resolves and
+                // `claim_and_materialize_start` dedups by `event_id`. If durable
+                // dispatch is NOT wired there is no durable contract to protect —
+                // fall through to in-memory for availability (Codex P1, refined
+                // to gate on `durable_dispatch` per CodeRabbit).
+                let durable_wired = transport.inner.durable_dispatch.is_some();
                 warn!(
                     error = %err,
-                    "resolve_by_token storage error; failing closed (503) — \
-                     cannot verify durable dispatch contract"
+                    durable = durable_wired,
+                    "resolve_by_token storage error"
                 );
-                return (
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "webhook activation store unavailable; retry",
-                )
-                    .into_response();
+                if durable_wired {
+                    return (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        "webhook activation store unavailable; retry",
+                    )
+                        .into_response();
+                }
+                // No durable contract — continue via the in-memory routing map.
             },
         }
     }
@@ -261,8 +267,16 @@ pub(super) async fn dispatch_inner(
     // whitespace-only value is treated as absent (the Prod fail-closed check
     // below then requires a real id).
     const MAX_WEBHOOK_ID_LEN: usize = 256;
-    let event_id: Option<IdempotencyKey> = match headers
-        .get(&WEBHOOK_ID_HEADER)
+    // Reject DUPLICATE `webhook-id` headers: `HeaderMap::get` silently returns
+    // one of several values, which would let two conflicting delivery ids slip
+    // past dedup. Exactly one (or zero) is permitted (Codex/CodeRabbit).
+    let mut webhook_id_values = headers.get_all(&WEBHOOK_ID_HEADER).iter();
+    let first_webhook_id = webhook_id_values.next();
+    if webhook_id_values.next().is_some() {
+        warn!("webhook: duplicate `webhook-id` headers; rejecting ambiguous delivery id");
+        return (StatusCode::BAD_REQUEST, "duplicate webhook-id header").into_response();
+    }
+    let event_id: Option<IdempotencyKey> = match first_webhook_id
         .and_then(|v| v.to_str().ok())
         .map(str::trim)
         .filter(|s| !s.is_empty())
@@ -730,7 +744,7 @@ mod tests {
     use nebula_storage_port::{
         Scope,
         dto::{WebhookMode, WorkflowVersionRecord},
-        store::{TriggerDedupInbox, WebhookActivationStore, WorkflowVersionStore},
+        store::{ExecutionStore, TriggerDedupInbox, WebhookActivationStore, WorkflowVersionStore},
     };
     use nebula_workflow::{WorkflowBuilder, WorkflowDefinition, node::NodeDefinition};
     use parking_lot::Mutex;
@@ -963,6 +977,14 @@ mod tests {
             WebhookKey::programmatic(self.trigger_uuid, self.nonce.clone())
         }
 
+        /// The durable side effect: execution rows materialized under the
+        /// fixture's tenant scope. Asserting this (not just the HTTP status)
+        /// proves Prod Emit spawns exactly one, Test/Skip spawn zero, and
+        /// redelivery dedups to one (CodeRabbit).
+        async fn execution_count(&self) -> u64 {
+            self.exec_store.count(&self.scope, None).await.unwrap()
+        }
+
         async fn dispatch_with_id(&self, delivery_id: &str) -> Response {
             dispatch_inner(
                 self.transport.clone(),
@@ -1054,6 +1076,11 @@ mod tests {
             StatusCode::OK,
             "Prod emit must return 200 (Emit + durable inbox)"
         );
+        assert_eq!(
+            fix.execution_count().await,
+            1,
+            "Prod Emit must materialize exactly one execution (durable side effect, not just 200)"
+        );
     }
 
     // ── Test 2: Test mode spawns nothing, returns 200 (existing behaviour) ────
@@ -1075,6 +1102,11 @@ mod tests {
             StatusCode::OK,
             "Test-mode must return 200 via fallthrough path"
         );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "Test mode must spawn NO execution (durable side effect, not just 200)"
+        );
     }
 
     // ── Test 3: Same webhook-id twice → second is deduplicated ────────────────
@@ -1095,6 +1127,11 @@ mod tests {
             r2.status(),
             StatusCode::OK,
             "redelivery (dedup) must also succeed"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            1,
+            "redelivery with the same webhook-id must dedup to exactly ONE execution, not two"
         );
     }
 
@@ -1128,6 +1165,35 @@ mod tests {
             resp.status(),
             StatusCode::BAD_REQUEST,
             "oversized webhook-id must be a clean 400, not a backend 5xx"
+        );
+    }
+
+    /// Two `webhook-id` headers → 400. `HeaderMap::get` would silently pick one,
+    /// letting conflicting delivery ids bypass dedup; reject the ambiguity.
+    #[tokio::test]
+    async fn duplicate_webhook_id_headers_returns_400() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        let mut headers = HeaderMap::new();
+        headers.append(&WEBHOOK_ID_HEADER, HeaderValue::from_static("delivery-a"));
+        headers.append(&WEBHOOK_ID_HEADER, HeaderValue::from_static("delivery-b"));
+        let resp = dispatch_inner(
+            fix.transport.clone(),
+            fix.key(),
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers,
+            Bytes::from(b"{}" as &[u8]),
+        )
+        .await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "duplicate webhook-id headers must be a clean 400"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "duplicate webhook-id must spawn nothing"
         );
     }
 
@@ -1207,6 +1273,11 @@ mod tests {
             resp.status(),
             StatusCode::OK,
             "Skip in Prod must return 200"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "Skip must spawn NO execution (durable side effect, not just 200)"
         );
     }
 

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -213,14 +213,24 @@ pub(super) async fn dispatch_inner(
                 debug!("capability token not in port store — continuing via in-memory map");
             },
             Err(err) => {
-                // Storage errors on the read path are non-fatal: dispatch can
-                // still proceed through the in-memory routing map.  Log and
-                // continue; do NOT return 500 here (availability > durable
-                // resolution on the inbound webhook hot path).
+                // Storage error resolving the capability token. Now that durable
+                // dispatch is LIVE, we cannot determine the activation `mode`, so
+                // we MUST NOT silently downgrade a Prod trigger to the Noop path:
+                // that would 2xx the sender and lose the event (no retry). Fail
+                // closed with 503 so the sender retries; on store recovery the
+                // retry resolves and `claim_and_materialize_start` dedups by
+                // `event_id`. Availability of the durable contract > availability
+                // of the in-memory path once durable dispatch exists (Codex P1).
                 warn!(
                     error = %err,
-                    "resolve_by_token storage error; falling through to in-memory dispatch"
+                    "resolve_by_token storage error; failing closed (503) — \
+                     cannot verify durable dispatch contract"
                 );
+                return (
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "webhook activation store unavailable; retry",
+                )
+                    .into_response();
             },
         }
     }
@@ -237,8 +247,11 @@ pub(super) async fn dispatch_inner(
     // §4 — "webhook-id must be a unique identifier per message delivery") and
     // may be logged as a tracing field.
     //
-    // Fail-closed rule (inv #6): Prod-mode activations require `webhook-id`.
-    // Missing header in Prod → 400 (sender must supply a delivery id).
+    // Fail-closed rule (inv #6): an EMITTING Prod outcome requires `webhook-id`
+    // (the dedup key). The requirement is enforced AFTER dispatch, only on an
+    // `Emit` outcome — a provider verification probe (Slack `url_verification`,
+    // Stripe `pending_webhook`) returns `Skip` and needs no delivery id, so the
+    // header must NOT be required before the outcome is known (Codex P2).
     // Test mode / no-row → `event_id = None` is fine.
     // Bound the delivery-id length at the edge: an over-long `webhook-id`
     // would flow into the dedup-key PK and surface as a backend-dependent
@@ -265,22 +278,10 @@ pub(super) async fn dispatch_inner(
         None => None,
     };
 
-    if durable.is_some() && event_id.is_none() {
-        // Prod row resolved but `webhook-id` absent — fail closed.
-        // The sender must supply a delivery id for dedup correctness.
-        // Return 400 (bad request) so the sender is informed the header
-        // is required; a retry with the header will succeed.
-        warn!(
-            mode = "Prod",
-            "Prod-mode webhook: missing `webhook-id` header; \
-             fail-closed (dedup requires a delivery id)"
-        );
-        return (
-            StatusCode::BAD_REQUEST,
-            "missing webhook-id header for Prod-mode dispatch",
-        )
-            .into_response();
-    }
+    // NOTE: the `webhook-id` requirement is NOT enforced here — it is deferred
+    // to the post-dispatch `Emit` arm (see `dispatch_durable`), so a Prod
+    // verification probe that returns `Skip` is not rejected for lacking a
+    // delivery id it never needs.
 
     let request = match WebhookRequest::try_new(method, path, query, headers, body) {
         Ok(r) => r,
@@ -405,8 +406,9 @@ struct DurableTarget {
 ///   — one `event_id` cannot safely fan-out to N executions).
 /// - `Skip` → no emit; return the adapter's HTTP response.
 ///
-/// The `event_id` is guaranteed `Some` at call sites (enforced by the
-/// Prod+missing-header gate in `dispatch_inner`).
+/// The `event_id` is guaranteed `Some` here: the `Emit` arm in
+/// `dispatch_durable` rejects a missing `webhook-id` with 400 before calling
+/// this fn (an emitting outcome requires a dedup key; `Skip` does not).
 async fn dispatch_durable(
     target: DurableTarget,
     outcome: TriggerEventOutcome,
@@ -417,6 +419,23 @@ async fn dispatch_durable(
 
     match outcome {
         TriggerEventOutcome::Emit(payload) => {
+            // An emitting outcome needs a dedup key. The requirement applies
+            // ONLY here (not before dispatch): a verification probe returns
+            // `Skip` and never reaches this arm, so it is not rejected for a
+            // missing `webhook-id` it does not need (Codex P2).
+            if event_id.is_none() {
+                warn!(
+                    trigger_id = %row.trigger_id,
+                    mode = "Prod",
+                    "Prod-mode webhook Emit without `webhook-id`; \
+                     fail-closed (dedup requires a delivery id)"
+                );
+                return (
+                    StatusCode::BAD_REQUEST,
+                    "missing webhook-id header for Prod-mode emit",
+                )
+                    .into_response();
+            }
             let emit_result = do_emit_prod(&row, &components, payload, event_id.as_ref()).await;
             match emit_result {
                 Ok(()) => {
@@ -771,6 +790,63 @@ mod tests {
         }
     }
 
+    /// Activation store that delegates everything to an in-memory store EXCEPT
+    /// `resolve_by_token`, which errors — simulating a transient store outage on
+    /// the durable read path (Codex P1: must fail closed 503, not downgrade).
+    #[derive(Debug)]
+    struct FailingResolveStore(InMemoryWebhookActivationStore);
+
+    #[async_trait::async_trait]
+    impl WebhookActivationStore for FailingResolveStore {
+        async fn upsert(
+            &self,
+            scope: &Scope,
+            record: nebula_storage_port::dto::WebhookActivationRecord,
+        ) -> Result<(), nebula_storage_port::StorageError> {
+            self.0.upsert(scope, record).await
+        }
+
+        async fn resolve(
+            &self,
+            scope: &Scope,
+            slug: &str,
+        ) -> Result<
+            Option<nebula_storage_port::dto::WebhookActivationRecord>,
+            nebula_storage_port::StorageError,
+        > {
+            self.0.resolve(scope, slug).await
+        }
+
+        async fn deactivate(
+            &self,
+            scope: &Scope,
+            trigger_id: &str,
+        ) -> Result<(), nebula_storage_port::StorageError> {
+            self.0.deactivate(scope, trigger_id).await
+        }
+
+        async fn resolve_by_token(
+            &self,
+            _token_hash: &[u8; 32],
+        ) -> Result<
+            Option<nebula_storage_port::dto::WebhookActivationRecord>,
+            nebula_storage_port::StorageError,
+        > {
+            Err(nebula_storage_port::StorageError::Connection(
+                "injected resolve_by_token outage".into(),
+            ))
+        }
+
+        async fn list_all_active(
+            &self,
+        ) -> Result<
+            Vec<nebula_storage_port::dto::WebhookActivationRecord>,
+            nebula_storage_port::StorageError,
+        > {
+            self.0.list_all_active().await
+        }
+    }
+
     // ── TestFixture ───────────────────────────────────────────────────────────
 
     /// Fully-wired in-memory fixture for durable dispatch tests.
@@ -790,8 +866,17 @@ mod tests {
     }
 
     impl TestFixture {
-        /// Build a full Prod-mode fixture.
+        /// Build a full Prod-mode fixture (in-memory activation store).
         async fn prod(mode: WebhookMode) -> Self {
+            Self::prod_with_store(mode, Arc::new(InMemoryWebhookActivationStore::new())).await
+        }
+
+        /// Build a Prod-mode fixture with a caller-supplied activation store —
+        /// lets a test inject a store whose `resolve_by_token` errors.
+        async fn prod_with_store(
+            mode: WebhookMode,
+            activation_store: Arc<dyn WebhookActivationStore>,
+        ) -> Self {
             let scope = Scope::new("test-org", "test-ws");
             let workflow_id = WorkflowId::new();
             let trigger_id_key = node_key!("webhook_trigger");
@@ -801,8 +886,6 @@ mod tests {
             let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
             let exec_store = Arc::new(exec_store);
             let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
-            let activation_store: Arc<dyn WebhookActivationStore> =
-                Arc::new(InMemoryWebhookActivationStore::new());
 
             let outcome_cell = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"ok": true}))));
 
@@ -1045,6 +1128,45 @@ mod tests {
             resp.status(),
             StatusCode::BAD_REQUEST,
             "oversized webhook-id must be a clean 400, not a backend 5xx"
+        );
+    }
+
+    /// A Prod verification probe (`Skip` outcome) without a `webhook-id` must
+    /// NOT be rejected — the dedup key is only required for emitting outcomes
+    /// (Codex P2). Slack `url_verification` / Stripe `pending_webhook` return
+    /// Skip and carry no delivery id.
+    ///
+    /// Red-on-revert: the old pre-dispatch `durable && event_id.is_none()` →
+    /// 400 check would reject this probe with 400.
+    #[tokio::test]
+    async fn prod_mode_skip_without_webhook_id_returns_200() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        fix.set_outcome(TriggerEventOutcome::skip());
+        let resp = fix.dispatch_without_id().await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Prod Skip without webhook-id is a verification probe, must pass (not 400)"
+        );
+    }
+
+    /// A transient activation-store outage on the durable read path must fail
+    /// closed with 503 (sender retries) rather than silently downgrade a Prod
+    /// trigger to the Noop path and return 2xx (Codex P1 — that would lose the
+    /// event with no retry).
+    ///
+    /// Red-on-revert: the old `Err(_) => fall-through` arm returned the
+    /// handler's 200, hiding the store failure.
+    #[tokio::test]
+    async fn resolve_store_error_returns_503() {
+        let failing: Arc<dyn WebhookActivationStore> =
+            Arc::new(FailingResolveStore(InMemoryWebhookActivationStore::new()));
+        let fix = TestFixture::prod_with_store(WebhookMode::Prod, failing).await;
+        let resp = fix.dispatch_with_id("delivery-503").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::SERVICE_UNAVAILABLE,
+            "resolve_by_token outage must fail closed 503, not downgrade to 200"
         );
     }
 

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -240,10 +240,30 @@ pub(super) async fn dispatch_inner(
     // Fail-closed rule (inv #6): Prod-mode activations require `webhook-id`.
     // Missing header in Prod → 400 (sender must supply a delivery id).
     // Test mode / no-row → `event_id = None` is fine.
-    let event_id: Option<IdempotencyKey> = headers
+    // Bound the delivery-id length at the edge: an over-long `webhook-id`
+    // would flow into the dedup-key PK and surface as a backend-dependent
+    // failure (e.g. a Postgres btree index-row-too-large INSERT error → 5xx)
+    // instead of a clean rejection. 256 bytes is far above any real delivery
+    // id (Svix `msg_…`, Stripe `evt_…`, GitHub UUID are all < 64). An empty /
+    // whitespace-only value is treated as absent (the Prod fail-closed check
+    // below then requires a real id).
+    const MAX_WEBHOOK_ID_LEN: usize = 256;
+    let event_id: Option<IdempotencyKey> = match headers
         .get(&WEBHOOK_ID_HEADER)
         .and_then(|v| v.to_str().ok())
-        .map(|s| IdempotencyKey::new(s.trim()));
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(s) if s.len() > MAX_WEBHOOK_ID_LEN => {
+            warn!(
+                "webhook: `webhook-id` header exceeds {MAX_WEBHOOK_ID_LEN} bytes; \
+                 rejecting (delivery id never legitimately this long)"
+            );
+            return (StatusCode::BAD_REQUEST, "webhook-id header too long").into_response();
+        },
+        Some(s) => Some(IdempotencyKey::new(s)),
+        None => None,
+    };
 
     if durable.is_some() && event_id.is_none() {
         // Prod row resolved but `webhook-id` absent — fail closed.
@@ -1010,6 +1030,21 @@ mod tests {
             resp.status(),
             StatusCode::BAD_REQUEST,
             "Prod-mode without webhook-id must be 400"
+        );
+    }
+
+    /// An over-long `webhook-id` header is rejected at the edge with a clean
+    /// 400, rather than flowing into the dedup-key PK and surfacing as a
+    /// backend-dependent 5xx (e.g. Postgres index-row-too-large).
+    #[tokio::test]
+    async fn prod_mode_oversized_webhook_id_returns_400() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        let oversized = "x".repeat(300);
+        let resp = fix.dispatch_with_id(&oversized).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "oversized webhook-id must be a clean 400, not a backend 5xx"
         );
     }
 

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -13,20 +13,32 @@
 //!    unauthenticated churn never hits the DB (ADR-0096 security fix)
 //! 5. Construct [`WebhookRequest`] → 400 / 413
 //! 6. Signature enforcement ([`super::signature::enforce_signature`]) → 401 / 500
-//! 7. Dispatch via [`TriggerHandler::handle_event`] with timeout → 504 / 500 / handler response
+//! 7. Extract `webhook-id` header → `event_id: Option<IdempotencyKey>` (Commit 3)
+//! 8. Dispatch via [`TriggerHandler::handle_event`] with timeout → 504 / 500 / handler response
+//! 9. Mode-gate: Prod rows with `durable_dispatch` wired call
+//!    [`DurableExecutionEmitter::emit`] before acking the HTTP response (Commit 4)
 
 use std::sync::Arc;
 
 use axum::{
     body::Bytes,
     extract::{Path, State},
-    http::{HeaderMap, Method, StatusCode, Uri},
+    http::{HeaderMap, HeaderName, Method, StatusCode, Uri},
     response::{IntoResponse, Response},
 };
-use nebula_action::{TriggerEvent, WebhookHttpResponse, WebhookRequest};
+use nebula_action::{
+    ExecutionEmitter, IdempotencyKey, TriggerEvent, TriggerEventOutcome, WebhookHttpResponse,
+    WebhookRequest,
+};
+use nebula_core::NodeKey;
+use nebula_engine::DurableExecutionEmitter;
 use nebula_metrics::{
     NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, webhook_key_kind, webhook_signature_failure_reason,
 };
+use nebula_storage_port::dto::WebhookMode;
+use nebula_storage_port::store::WorkflowVersionStore;
+use nebula_tenancy::ScopedWorkflowVersionStore;
+use nebula_workflow::{ValidatedWorkflow, WorkflowDefinition};
 use tokio::sync::oneshot;
 use tracing::{debug, warn};
 
@@ -37,8 +49,14 @@ use super::{
         signature_rejected_response,
     },
     token::token_hash,
+    transport::DurableDispatchComponents,
 };
 use crate::transport::webhook::transport::WebhookTransport;
+
+/// Standard Webhooks delivery-id header (lowercase).
+/// Source: standardwebhooks.com — `webhook-id` is the canonical per-delivery
+/// idempotency key supplied by the sender; it is NOT a secret and may be logged.
+const WEBHOOK_ID_HEADER: HeaderName = HeaderName::from_static("webhook-id");
 
 /// Axum handler for `POST /{prefix}/{trigger_uuid}/{nonce}`.
 ///
@@ -82,8 +100,11 @@ pub(super) async fn webhook_handler(
 ///    unauthenticated churn never hits the DB (ADR-0096 security fix)
 /// 5. construct [`WebhookRequest`] → 400 / 413
 /// 6. [`enforce_signature`] (uses [`nebula_action::Clock`]) → 401 / 500
-/// 7. dispatch via [`TriggerHandler::handle_event`] with a response
+/// 7. extract `webhook-id` header → `event_id: Option<IdempotencyKey>`
+/// 8. dispatch via [`TriggerHandler::handle_event`] with a response
 ///    timeout → 504 / 500 / handler response
+/// 9. mode-gate: Prod rows call [`DurableExecutionEmitter::emit`] BEFORE
+///    returning the ack; emit failure → 5xx so the sender retries.
 pub(super) async fn dispatch_inner(
     transport: WebhookTransport,
     key: WebhookKey,
@@ -140,14 +161,14 @@ pub(super) async fn dispatch_inner(
     // key never triggers a DB query.  Only authenticated-enough requests
     // (registered key, under rate limit) reach the store.
     //
-    // Resolution proves the scope/workflow_id/mode tuple can be retrieved from
-    // the durable store.  Actual durable-emitter dispatch (installing a
-    // `DurableExecutionEmitter` under `row.scope`) is the NEXT sub-slice
-    // (U-D1.4b).  Until that lands the emitter remains Noop and dispatch
-    // continues via the in-memory routing map below.
-    //
     // nonce / hash are deliberately excluded from all log fields — the nonce
     // is the bearer token and must never appear in log aggregators or traces.
+    //
+    // U-D1.4b: when the row is Prod and `durable_dispatch` is wired, `durable`
+    // is set to `Some(DurableTarget { ... })` below.  Test mode and missing rows
+    // leave it `None` (no durable spawn, preserve today's behaviour).
+    let mut durable: Option<DurableTarget> = None;
+
     if let Some(store) = transport.inner.activation_store.as_deref() {
         let hash = token_hash(key.nonce());
         match store.resolve_by_token(&hash).await {
@@ -158,9 +179,30 @@ pub(super) async fn dispatch_inner(
                     mode = ?row.mode,
                     workflow_id = ?row.workflow_id,
                     // nonce / hash deliberately excluded
-                    "capability token resolved to durable row \
-                     (durable-dispatch deferred to U-D1.4b, emitter still Noop)"
+                    "capability token resolved to durable row"
                 );
+                // Mode gate: only Prod rows with a wired inbox spawn durable
+                // executions.  Fail-closed when inbox absent in Prod mode.
+                if row.mode == WebhookMode::Prod {
+                    if let Some(components) = transport.inner.durable_dispatch.as_ref() {
+                        durable = Some(DurableTarget {
+                            row,
+                            components: components.clone(),
+                        });
+                    } else {
+                        // Prod mode but no inbox wired — fail closed so a
+                        // misconfigured composition root never spawns
+                        // dedup-blind.
+                        warn!(
+                            mode = "Prod",
+                            "Prod-mode webhook: durable_dispatch not wired; \
+                             refusing to dispatch to prevent dedup-blind spawn"
+                        );
+                        return (StatusCode::INTERNAL_SERVER_ERROR, "").into_response();
+                    }
+                }
+                // Test mode: no durable spawn; fall through to in-memory
+                // dispatch with Noop emitter.
             },
             Ok(None) => {
                 // Row not found in port store.  This is expected during the
@@ -189,6 +231,37 @@ pub(super) async fn dispatch_inner(
     // exceed (rare; returns 400).
     let path = uri.path().to_string();
     let query = uri.query().map(String::from);
+
+    // Step 7 (Commit 3): extract `webhook-id` header before consuming `headers`
+    // into `WebhookRequest`.  The header is NOT a secret (Standard Webhooks spec
+    // §4 — "webhook-id must be a unique identifier per message delivery") and
+    // may be logged as a tracing field.
+    //
+    // Fail-closed rule (inv #6): Prod-mode activations require `webhook-id`.
+    // Missing header in Prod → 400 (sender must supply a delivery id).
+    // Test mode / no-row → `event_id = None` is fine.
+    let event_id: Option<IdempotencyKey> = headers
+        .get(&WEBHOOK_ID_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| IdempotencyKey::new(s.trim()));
+
+    if durable.is_some() && event_id.is_none() {
+        // Prod row resolved but `webhook-id` absent — fail closed.
+        // The sender must supply a delivery id for dedup correctness.
+        // Return 400 (bad request) so the sender is informed the header
+        // is required; a retry with the header will succeed.
+        warn!(
+            mode = "Prod",
+            "Prod-mode webhook: missing `webhook-id` header; \
+             fail-closed (dedup requires a delivery id)"
+        );
+        return (
+            StatusCode::BAD_REQUEST,
+            "missing webhook-id header for Prod-mode dispatch",
+        )
+            .into_response();
+    }
+
     let request = match WebhookRequest::try_new(method, path, query, headers, body) {
         Ok(r) => r,
         Err(nebula_action::ActionError::DataLimitExceeded { .. }) => {
@@ -230,40 +303,63 @@ pub(super) async fn dispatch_inner(
     let request = request.with_response_channel(tx);
     let event = TriggerEvent::new(None, request);
 
-    // 7. Dispatch with timeout. The handler sends the HTTP response
-    // through the oneshot; we race that against the configured
-    // `response_timeout`.
+    // 8+9. Dispatch with timeout.
+    //
+    // The combined future wraps BOTH `handle_event` AND the conditional
+    // `emitter.emit()` inside one `tokio::time::timeout` region.  This
+    // satisfies the "emit inside the timeout" invariant: a stuck DB write
+    // yields 504, not a hang.
+    //
+    // Ordering (research-confirmed at-least-once):
+    //
+    //   a. `handler.handle_event(event, &ctx)` → adapter sends HTTP response
+    //      via the oneshot BEFORE returning `Ok(outcome)`.
+    //   b. On `Emit(payload)` + `durable.is_some()`:
+    //      - Load ValidatedWorkflow under `row.scope`.
+    //      - Construct DurableExecutionEmitter.
+    //      - `emitter.emit(payload, Some(event_id)).await`.
+    //      - On emit Ok  → read the HTTP response from rx.
+    //      - On emit Err → return 5xx (discard oneshot's response so the
+    //        sender retries; same `webhook-id` → same `event_id` → dedup).
+    //   c. The adapter sends the response BEFORE returning, so `rx.await`
+    //      inside the combined future is non-blocking after `handle_event`
+    //      returns.  The combined timeout region correctly accounts for the
+    //      full wall-clock cost of dispatch + emit.
     let handler = Arc::clone(&entry.handler);
     let ctx = entry.ctx.clone();
     let timeout = transport.inner.config.response_timeout;
-    let dispatch_fut = async move { handler.handle_event(event, &ctx).await };
 
-    let dispatch_result = tokio::time::timeout(timeout, dispatch_fut).await;
+    let combined_fut = async move {
+        let outcome = match handler.handle_event(event, &ctx).await {
+            Ok(o) => o,
+            Err(e) => {
+                // Handler returned an error. The adapter ALREADY sent a
+                // response via the oneshot before returning Err.
+                debug!(error = %e, "webhook handler returned error");
+                let http = rx.await.unwrap_or_else(|_| {
+                    WebhookHttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "")
+                });
+                return http_response_to_axum(http);
+            },
+        };
 
-    match dispatch_result {
-        Ok(Ok(_outcome)) => {
-            // Outcome is the workflow-emission outcome; it's already
-            // been used by the adapter to record health. The HTTP
-            // response comes through the oneshot the adapter sent to
-            // right before returning Ok.
-            if let Ok(http) = rx.await {
-                http_response_to_axum(http)
-            } else {
-                warn!("webhook handler returned Ok but oneshot sender was dropped");
-                (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
-            }
-        },
-        Ok(Err(e)) => {
-            // Handler returned an error. The adapter (after H1 fix)
-            // ALREADY sent a 500 via the oneshot before returning
-            // Err. We just read it.
-            debug!(error = %e, "webhook handler returned error");
-            match rx.await {
-                Ok(http) => http_response_to_axum(http),
-                Err(_) => (StatusCode::INTERNAL_SERVER_ERROR, "").into_response(),
-            }
-        },
-        Err(_) => {
+        // Handler succeeded — durable emit (if applicable) runs here,
+        // still inside the timeout region.
+        if let Some(target) = durable {
+            return dispatch_durable(target, outcome, event_id, rx).await;
+        }
+
+        // No durable dispatch (Test mode / no-row / fall-through).
+        let http = rx.await.unwrap_or_else(|_| {
+            warn!("webhook handler returned Ok but oneshot sender was dropped");
+            WebhookHttpResponse::new(StatusCode::INTERNAL_SERVER_ERROR, "")
+        });
+        http_response_to_axum(http)
+    };
+
+    match tokio::time::timeout(timeout, combined_fut).await {
+        Ok(resp) => resp,
+        Err(_elapsed) => {
             warn!(
                 timeout_secs = timeout.as_secs(),
                 "webhook handler dispatch timed out"
@@ -271,6 +367,250 @@ pub(super) async fn dispatch_inner(
             (StatusCode::GATEWAY_TIMEOUT, "").into_response()
         },
     }
+}
+
+// ── Durable dispatch ─────────────────────────────────────────────────────────
+
+/// Bundle carrying all data needed for the Prod-mode durable emit path.
+struct DurableTarget {
+    row: nebula_storage_port::dto::WebhookActivationRecord,
+    components: DurableDispatchComponents,
+}
+
+/// Attempt to spawn a durable execution for a Prod-mode outcome.
+///
+/// Returns the axum `Response` to send back to the caller:
+/// - `Emit(payload)` → load workflow + emit → ack on success, 5xx on failure.
+/// - `EmitMany(_)` in Prod → fail-closed 5xx (dedup-collision data-loss bug
+///   — one `event_id` cannot safely fan-out to N executions).
+/// - `Skip` → no emit; return the adapter's HTTP response.
+///
+/// The `event_id` is guaranteed `Some` at call sites (enforced by the
+/// Prod+missing-header gate in `dispatch_inner`).
+async fn dispatch_durable(
+    target: DurableTarget,
+    outcome: TriggerEventOutcome,
+    event_id: Option<IdempotencyKey>,
+    rx: oneshot::Receiver<WebhookHttpResponse>,
+) -> Response {
+    let DurableTarget { row, components } = target;
+
+    match outcome {
+        TriggerEventOutcome::Emit(payload) => {
+            let emit_result = do_emit_prod(&row, &components, payload, event_id.as_ref()).await;
+            match emit_result {
+                Ok(()) => {
+                    // Emit succeeded — ack the HTTP response the adapter sent.
+                    if let Ok(http) = rx.await {
+                        http_response_to_axum(http)
+                    } else {
+                        warn!("durable emit ok but oneshot sender was dropped");
+                        (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+                    }
+                },
+                Err(err_response) => {
+                    // Emit failed — return the 5xx so the sender retries.
+                    // The adapter's oneshot response is discarded; the HTTP
+                    // ack is replaced with our 5xx.
+                    //
+                    // Retry delivers the same `webhook-id` → same `event_id`
+                    // → `claim_and_materialize_start` deduplicates.
+                    err_response
+                },
+            }
+        },
+        TriggerEventOutcome::EmitMany(_) => {
+            // Fail-closed: emitting N payloads under one `event_id` is a
+            // dedup-collision data-loss bug.  No first-party webhook action
+            // returns EmitMany; if one does, the operator must fix the action.
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?row.scope,
+                mode = "Prod",
+                "Prod-mode webhook: EmitMany outcome refused \
+                 (one event_id cannot safely fan-out to N executions; \
+                 action must not return EmitMany in Prod mode)"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+        },
+        TriggerEventOutcome::Skip => {
+            // Skip — no emit.  Return the adapter's HTTP response.
+            if let Ok(http) = rx.await {
+                http_response_to_axum(http)
+            } else {
+                warn!("webhook handler Skip but oneshot sender was dropped");
+                (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+            }
+        },
+        // `TriggerEventOutcome` is #[non_exhaustive] — any future variant
+        // whose semantics are unknown MUST be refused fail-closed.
+        _ => {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?row.scope,
+                "Prod-mode webhook: unknown TriggerEventOutcome variant; \
+                 fail-closed — no execution spawned"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+        },
+    }
+}
+
+/// Core Prod-mode emit path.
+///
+/// 1. Validates that `workflow_id` is present and parseable (fail-closed on
+///    `None` or malformed ULID — inv #5: single-row resolution must fully
+///    resolve the workflow).
+/// 2. Parses `trigger_id` as a [`NodeKey`] (fail-closed on parse failure).
+/// 3. Loads and validates the `ValidatedWorkflow` under `row.scope` via a
+///    freshly-bound `ScopedWorkflowVersionStore` (confused-deputy boundary is
+///    the scope carried in the row, never request-derived — inv #5).
+/// 4. Constructs [`DurableExecutionEmitter`] and calls `emit`.
+///
+/// Returns `Ok(())` on successful dispatch or `Err(Response)` with a 5xx
+/// response ready to return to the caller.
+///
+/// # Performance note
+///
+/// The per-delivery `ValidatedWorkflow` load+validate is on the request hot
+/// path; canonical webhook senders time out as low as ~3 s (Slack).  If this
+/// storage round-trip grows costly, cache `Arc<ValidatedWorkflow>` per
+/// activation or add a thinner raw-delivery inbox.  v1 ships the direct path.
+async fn do_emit_prod(
+    row: &nebula_storage_port::dto::WebhookActivationRecord,
+    components: &DurableDispatchComponents,
+    payload: serde_json::Value,
+    event_id: Option<&IdempotencyKey>,
+) -> Result<(), Response> {
+    let scope = &row.scope;
+
+    // Step 1a — workflow_id must be present (inv #5).
+    let workflow_id_str = if let Some(wid) = &row.workflow_id {
+        wid.as_str()
+    } else {
+        warn!(
+            trigger_id = %row.trigger_id,
+            scope = ?scope,
+            mode = "Prod",
+            "Prod-mode webhook: activation row has no workflow_id; \
+             fail-closed — no execution spawned"
+        );
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+    };
+
+    // Step 1b — workflow_id must parse as a valid ULID WorkflowId (correction C).
+    use nebula_core::id::WorkflowId;
+    let workflow_id: WorkflowId = match workflow_id_str.parse() {
+        Ok(id) => id,
+        Err(e) => {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?scope,
+                workflow_id = workflow_id_str,
+                error = %e,
+                "Prod-mode webhook: activation row workflow_id is not a valid WorkflowId; \
+                 fail-closed — no execution spawned"
+            );
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+        },
+    };
+
+    // Step 2 — trigger_id must parse as a NodeKey (fail-closed on invalid key).
+    let trigger_node_key = match NodeKey::new(&row.trigger_id) {
+        Ok(k) => k,
+        Err(e) => {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?scope,
+                error = %e,
+                "Prod-mode webhook: activation row trigger_id is not a valid NodeKey; \
+                 fail-closed — no execution spawned"
+            );
+            return Err((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+        },
+    };
+
+    // Step 3 — load and validate the workflow under the row's scope (inv #5).
+    // The confused-deputy boundary is the decorator: `ScopedWorkflowVersionStore`
+    // pins the scope to `row.scope`; no cross-scope lookup is possible.
+    let scoped_versions =
+        ScopedWorkflowVersionStore::new(Arc::clone(&components.version_store), scope.clone());
+    let version_record = scoped_versions
+        .get_published(scope, &workflow_id.to_string())
+        .await
+        .map_err(|e| {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?scope,
+                workflow_id = %workflow_id,
+                error = %e,
+                "Prod-mode webhook: storage error loading workflow version; \
+                 fail-closed — no execution spawned"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "storage error").into_response()
+        })?;
+
+    let version_record = if let Some(v) = version_record {
+        v
+    } else {
+        warn!(
+            trigger_id = %row.trigger_id,
+            scope = ?scope,
+            workflow_id = %workflow_id,
+            "Prod-mode webhook: workflow_id not found under row scope; \
+             fail-closed — no cross-scope lookup (inv #5)"
+        );
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
+    };
+
+    let def: WorkflowDefinition =
+        serde_json::from_value(version_record.definition).map_err(|e| {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?scope,
+                workflow_id = %workflow_id,
+                error = %e,
+                "Prod-mode webhook: workflow definition failed to deserialize; \
+                 fail-closed — no execution spawned"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+        })?;
+
+    let validated = ValidatedWorkflow::validate(def).map_err(|errors| {
+        warn!(
+            trigger_id = %row.trigger_id,
+            scope = ?scope,
+            workflow_id = %workflow_id,
+            errors = ?errors,
+            "Prod-mode webhook: workflow definition failed validation; \
+             fail-closed — no execution spawned"
+        );
+        (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+    })?;
+
+    // Step 4 — construct emitter and call emit.
+    let emitter = DurableExecutionEmitter::new(
+        Arc::clone(&components.dedup),
+        Arc::clone(&components.resolver),
+        Arc::new(validated),
+        trigger_node_key,
+        scope.clone(),
+    );
+
+    emitter
+        .emit(payload, event_id.cloned())
+        .await
+        .map(|_execution_id| ())
+        .map_err(|e| {
+            warn!(
+                trigger_id = %row.trigger_id,
+                scope = ?scope,
+                workflow_id = %workflow_id,
+                error = %e,
+                "Prod-mode webhook: durable emit failed; returning 5xx so sender retries"
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+        })
 }
 
 /// Convert a `nebula-action` `WebhookHttpResponse` into an axum

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -563,18 +563,34 @@ async fn do_emit_prod(
         return Err((StatusCode::INTERNAL_SERVER_ERROR, "").into_response());
     };
 
-    let def: WorkflowDefinition =
-        serde_json::from_value(version_record.definition).map_err(|e| {
-            warn!(
-                trigger_id = %row.trigger_id,
-                scope = ?scope,
-                workflow_id = %workflow_id,
-                error = %e,
-                "Prod-mode webhook: workflow definition failed to deserialize; \
-                 fail-closed — no execution spawned"
-            );
-            (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
-        })?;
+    // Deserialize via the JSON string path (not `from_value`) to allow
+    // `domain-key`'s serde impl to borrow `&str` slices from the input
+    // buffer.  `serde_json::from_value` runs through an owning `Value`
+    // deserializer that cannot satisfy `<&str>::deserialize` — the
+    // `is_human_readable()` branch in `domain-key` v0.6 uses zero-copy
+    // `&str` deserialization that requires a slice-backed reader.
+    let def_json = serde_json::to_string(&version_record.definition).map_err(|e| {
+        warn!(
+            trigger_id = %row.trigger_id,
+            scope = ?scope,
+            workflow_id = %workflow_id,
+            error = %e,
+            "Prod-mode webhook: workflow definition failed to serialize to JSON string; \
+             fail-closed — no execution spawned"
+        );
+        (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+    })?;
+    let def: WorkflowDefinition = serde_json::from_str(&def_json).map_err(|e| {
+        warn!(
+            trigger_id = %row.trigger_id,
+            scope = ?scope,
+            workflow_id = %workflow_id,
+            error = %e,
+            "Prod-mode webhook: workflow definition failed to deserialize; \
+             fail-closed — no execution spawned"
+        );
+        (StatusCode::INTERNAL_SERVER_ERROR, "").into_response()
+    })?;
 
     let validated = ValidatedWorkflow::validate(def).map_err(|errors| {
         warn!(
@@ -635,5 +651,577 @@ fn record_rate_limit_rejection(transport: &WebhookTransport, key: &WebhookKey) {
     ]);
     if let Ok(c) = reg.counter_labeled(NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, &labels) {
         c.inc();
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    //! Integration tests for the durable dispatch path introduced in U-D1.4b.
+    //!
+    //! Each test drives `dispatch_inner` directly — the same code path the
+    //! axum handler calls — so the assertions cover the real dispatch logic.
+    //!
+    //! # Test fixture overview
+    //!
+    //! `Fixture` wires a complete in-memory stack:
+    //! - `WebhookTransport` with `activation_store` + `durable_dispatch`
+    //! - `InMemoryWebhookActivationStore` (token resolution)
+    //! - `InMemoryTriggerDedupInbox` (atomic dedup + Start enqueue)
+    //! - `InMemoryWorkflowVersionStore` (workflow load)
+    //! - `InMemoryExecutionStore` (execution rows + job queue)
+    //! - `DefinitionRoutingResolver` (plugin-routing)
+    //! - `ConfigurableWebhookAction` — a `WebhookAction` whose outcome
+    //!   is set per-test via `Arc<Mutex<TriggerEventOutcome>>`.
+
+    use std::sync::Arc;
+
+    use axum::http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
+    use nebula_action::{
+        Action, ActionMetadata, SignaturePolicy, TriggerContext, TriggerEventOutcome,
+        TriggerHandler, WebhookAction, WebhookConfig, WebhookRequest, WebhookResponse,
+        WebhookTriggerAdapter,
+    };
+    use nebula_core::{BaseContext, Dependencies, NodeKey, WorkflowId, action_key, node_key};
+    use nebula_storage::inmem::{
+        InMemoryExecutionStore, InMemoryTriggerDedupInbox, InMemoryWebhookActivationStore,
+        InMemoryWorkflowVersionStore,
+    };
+    use nebula_storage_port::{
+        Scope,
+        dto::{WebhookMode, WorkflowVersionRecord},
+        store::{TriggerDedupInbox, WebhookActivationStore, WorkflowVersionStore},
+    };
+    use nebula_workflow::{WorkflowBuilder, WorkflowDefinition, node::NodeDefinition};
+    use parking_lot::Mutex;
+    use serde_json::json;
+    use tokio_util::sync::CancellationToken;
+
+    use super::*;
+    use crate::transport::webhook::transport::{
+        PersistParams, WebhookTransport, WebhookTransportConfig, activate_and_persist,
+    };
+
+    // ── TestWebhookAction ─────────────────────────────────────────────────────
+
+    /// Minimal `WebhookAction` whose `handle_request` returns whatever
+    /// `outcome_cell` says.  Signature checking is disabled so tests can
+    /// send unsigned bodies.
+    struct ConfigurableWebhookAction {
+        outcome_cell: Arc<Mutex<TriggerEventOutcome>>,
+    }
+
+    impl Action for ConfigurableWebhookAction {
+        type Input = serde_json::Value;
+        type Output = serde_json::Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                action_key!("test.dispatch.configurable"),
+                "ConfigurableWebhookAction",
+                "Test fixture",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static D: std::sync::OnceLock<Dependencies> = std::sync::OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl WebhookAction for ConfigurableWebhookAction {
+        type State = ();
+
+        async fn on_activate(
+            &self,
+            _ctx: &(impl TriggerContext + ?Sized),
+        ) -> Result<(), nebula_action::ActionError> {
+            Ok(())
+        }
+
+        async fn handle_request(
+            &self,
+            _request: &WebhookRequest,
+            _state: &(),
+            _ctx: &(impl TriggerContext + ?Sized),
+        ) -> Result<WebhookResponse, nebula_action::ActionError> {
+            let outcome = self.outcome_cell.lock().clone();
+            Ok(WebhookResponse::accept(outcome))
+        }
+    }
+
+    // ── TestFixture ───────────────────────────────────────────────────────────
+
+    /// Fully-wired in-memory fixture for durable dispatch tests.
+    ///
+    /// Stores the `ActivationHandle` so `dispatch_with_id` / `dispatch_without_id`
+    /// can derive the correct `(trigger_uuid, nonce)` webhook key.
+    #[allow(dead_code)]
+    struct TestFixture {
+        transport: WebhookTransport,
+        version_store: Arc<InMemoryWorkflowVersionStore>,
+        exec_store: Arc<InMemoryExecutionStore>,
+        outcome_cell: Arc<Mutex<TriggerEventOutcome>>,
+        scope: Scope,
+        workflow_id: WorkflowId,
+        trigger_uuid: uuid::Uuid,
+        nonce: String,
+    }
+
+    impl TestFixture {
+        /// Build a full Prod-mode fixture.
+        async fn prod(mode: WebhookMode) -> Self {
+            let scope = Scope::new("test-org", "test-ws");
+            let workflow_id = WorkflowId::new();
+            let trigger_id_key = node_key!("webhook_trigger");
+            let trigger_id = trigger_id_key.as_str().to_string();
+
+            let exec_store = InMemoryExecutionStore::new();
+            let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+            let exec_store = Arc::new(exec_store);
+            let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+            let activation_store: Arc<dyn WebhookActivationStore> =
+                Arc::new(InMemoryWebhookActivationStore::new());
+
+            let outcome_cell = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"ok": true}))));
+
+            let handler: Arc<dyn TriggerHandler> =
+                Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                    outcome_cell: Arc::clone(&outcome_cell),
+                }));
+            let ctx_template = base_ctx(workflow_id, trigger_id_key);
+
+            // `WebhookTriggerAdapter::handle_event` requires state populated by
+            // `start()`.  Call it before handing the handler to `activate_and_persist`
+            // so dispatch does not see `state = None` → Fatal/500.
+            handler
+                .start(&ctx_template)
+                .await
+                .expect("handler start must succeed");
+
+            let transport = WebhookTransport::new(WebhookTransportConfig::default())
+                .with_activation_store(Arc::clone(&activation_store))
+                .with_durable_dispatch(
+                    dedup as Arc<dyn TriggerDedupInbox>,
+                    WebhookTransport::default_resolver(),
+                    Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+                );
+
+            let handle = activate_and_persist(
+                &transport,
+                activation_store.as_ref(),
+                PersistParams {
+                    handler,
+                    action_config: WebhookConfig::default()
+                        .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                    ctx_template,
+                    trigger_id: trigger_id.clone(),
+                    scope: scope.clone(),
+                    workflow_id: Some(workflow_id.to_string()),
+                    mode,
+                },
+            )
+            .await
+            .expect("activate_and_persist must succeed");
+
+            // Publish a valid workflow definition
+            let def = minimal_workflow_def(workflow_id, trigger_id.clone());
+            version_store
+                .create(
+                    &scope,
+                    WorkflowVersionRecord {
+                        workflow_id: workflow_id.to_string(),
+                        number: 1,
+                        published: true,
+                        pinned: false,
+                        definition: serde_json::to_value(&def).unwrap(),
+                    },
+                )
+                .await
+                .expect("version store create");
+
+            let trigger_uuid = handle.trigger_uuid;
+            let nonce = handle.nonce.clone();
+
+            Self {
+                transport,
+                version_store,
+                exec_store,
+                outcome_cell,
+                scope,
+                workflow_id,
+                trigger_uuid,
+                nonce,
+            }
+        }
+
+        fn key(&self) -> WebhookKey {
+            WebhookKey::programmatic(self.trigger_uuid, self.nonce.clone())
+        }
+
+        async fn dispatch_with_id(&self, delivery_id: &str) -> Response {
+            dispatch_inner(
+                self.transport.clone(),
+                self.key(),
+                Method::POST,
+                Uri::from_static("http://localhost/webhooks/test"),
+                headers_with_delivery_id(delivery_id),
+                Bytes::from(b"{}" as &[u8]),
+            )
+            .await
+        }
+
+        async fn dispatch_without_id(&self) -> Response {
+            dispatch_inner(
+                self.transport.clone(),
+                self.key(),
+                Method::POST,
+                Uri::from_static("http://localhost/webhooks/test"),
+                HeaderMap::new(),
+                Bytes::from(b"{}" as &[u8]),
+            )
+            .await
+        }
+
+        fn set_outcome(&self, o: TriggerEventOutcome) {
+            *self.outcome_cell.lock() = o;
+        }
+    }
+
+    // ── Test helpers ──────────────────────────────────────────────────────────
+
+    fn headers_with_delivery_id(id: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(
+            WEBHOOK_ID_HEADER,
+            HeaderValue::from_str(id).expect("valid header value"),
+        );
+        h
+    }
+
+    fn base_ctx(
+        workflow_id: WorkflowId,
+        node_key: NodeKey,
+    ) -> nebula_action::TriggerRuntimeContext {
+        nebula_action::TriggerRuntimeContext::new(
+            Arc::new(
+                BaseContext::builder()
+                    .cancellation(CancellationToken::new())
+                    .build(),
+            ),
+            workflow_id,
+            node_key,
+        )
+    }
+
+    /// Build the minimal valid `WorkflowDefinition` referencing `trigger_id`
+    /// as the trigger binding.  The trigger node itself does not appear in
+    /// `nodes` (trigger bindings are separate in the definition schema).
+    fn minimal_workflow_def(workflow_id: WorkflowId, trigger_id: String) -> WorkflowDefinition {
+        let trigger_key: NodeKey = trigger_id.parse().unwrap_or_else(|_| node_key!("t"));
+        WorkflowBuilder::new("test-workflow")
+            .id(workflow_id)
+            .add_node(NodeDefinition::new(node_key!("step"), "Step", "core", "echo").unwrap())
+            .add_trigger(
+                trigger_key,
+                "test".parse().unwrap(),
+                "webhook".parse().unwrap(),
+                json!({}),
+            )
+            .build()
+            .expect("minimal workflow must be valid")
+    }
+
+    // ── Test 1: Prod-mode Emit spawns exactly one execution ───────────────────
+
+    /// Prod-mode activation + `webhook-id` header → emitter is called.
+    /// Verify the response is 200 OK.
+    ///
+    /// This is the nominal happy-path test.  Removing the mode gate or the
+    /// `durable_dispatch` wiring would cause this to still return 200 (via
+    /// the fallthrough path) — the behavioral assertion is that we get a 200
+    /// AND the inbox was hit (which we indirectly verify in test 3 via dedup).
+    #[tokio::test]
+    async fn prod_mode_emit_returns_200() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        let resp = fix.dispatch_with_id("delivery-001").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Prod emit must return 200 (Emit + durable inbox)"
+        );
+    }
+
+    // ── Test 2: Test mode spawns nothing, returns 200 (existing behaviour) ────
+
+    /// mode=Test → the durable path is NEVER taken even when `durable_dispatch`
+    /// is wired.  The fallthrough in-memory path returns 200.
+    ///
+    /// Red-on-revert: removing the `row.mode == WebhookMode::Prod` guard would
+    /// cause Test-mode activations to take the durable path, which would
+    /// fail (inbox claim) OR spawn unexpectedly.
+    #[tokio::test]
+    async fn test_mode_skips_durable_dispatch_returns_200() {
+        let fix = TestFixture::prod(WebhookMode::Test).await;
+        // Test-mode: no durable_dispatch wired means the mode guard must
+        // correctly NOT set durable = Some(...), so the fallthrough path runs.
+        let resp = fix.dispatch_with_id("delivery-002").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Test-mode must return 200 via fallthrough path"
+        );
+    }
+
+    // ── Test 3: Same webhook-id twice → second is deduplicated ────────────────
+
+    /// Delivering the same `webhook-id` twice: the first call spawns the
+    /// execution; the second is a duplicate from the inbox's perspective.
+    /// Both should return 200 (the second call is acked just like the first —
+    /// the dedup is at the storage layer, the HTTP response is always 200).
+    ///
+    /// This proves the dedup PK contract: `(scope, trigger_id, event_id)`.
+    #[tokio::test]
+    async fn redelivery_deduplicates() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        let r1 = fix.dispatch_with_id("delivery-003").await;
+        let r2 = fix.dispatch_with_id("delivery-003").await;
+        assert_eq!(r1.status(), StatusCode::OK, "first delivery must succeed");
+        assert_eq!(
+            r2.status(),
+            StatusCode::OK,
+            "redelivery (dedup) must also succeed"
+        );
+    }
+
+    // ── Test 4: Missing webhook-id in Prod → 400 ─────────────────────────────
+
+    /// Prod-mode activation without `webhook-id` header → fail-closed 400.
+    ///
+    /// Red-on-revert: removing the `durable.is_some() && event_id.is_none()`
+    /// guard would cause Prod-mode dispatch to proceed with `event_id = None`,
+    /// which defeats the dedup invariant.
+    #[tokio::test]
+    async fn prod_mode_missing_webhook_id_returns_400() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        let resp = fix.dispatch_without_id().await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Prod-mode without webhook-id must be 400"
+        );
+    }
+
+    // ── Test 5: EmitMany in Prod → 500 ────────────────────────────────────────
+
+    /// `EmitMany` outcome in Prod mode → fail-closed 500.
+    ///
+    /// One `event_id` cannot safely fan-out to N executions (dedup-collision
+    /// data-loss bug). No first-party webhook action returns EmitMany; if one
+    /// does, the operator must fix the action.
+    ///
+    /// Red-on-revert: removing the `EmitMany => 500` arm would allow partial
+    /// fan-out under one event_id, silently losing all but one execution.
+    #[tokio::test]
+    async fn prod_mode_emit_many_returns_500() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        fix.set_outcome(TriggerEventOutcome::emit_many(vec![json!(1), json!(2)]));
+        let resp = fix.dispatch_with_id("delivery-004").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "EmitMany in Prod must be 500"
+        );
+    }
+
+    // ── Test 6: Skip in Prod → 200, no execution ──────────────────────────────
+
+    /// `Skip` outcome in Prod mode → no execution spawned, HTTP 200.
+    ///
+    /// The adapter sends the HTTP response before returning; `dispatch_durable`
+    /// reads the oneshot and returns 200 without hitting the inbox.
+    #[tokio::test]
+    async fn prod_mode_skip_returns_200_no_spawn() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+        fix.set_outcome(TriggerEventOutcome::skip());
+        let resp = fix.dispatch_with_id("delivery-005").await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "Skip in Prod must return 200"
+        );
+    }
+
+    // ── Test 7: workflow_id None on activation row → 500 ─────────────────────
+
+    /// Prod-mode activation with `workflow_id = None` on the row → fail-closed 500.
+    ///
+    /// This covers inv #5: a Prod activation without a wired workflow_id must
+    /// never spawn a dedup-blind execution.
+    #[tokio::test]
+    async fn prod_mode_no_workflow_id_returns_500() {
+        // Build a transport with a Prod-mode row that has workflow_id = None.
+        let scope = Scope::new("test-org", "test-ws");
+        let workflow_id = WorkflowId::new();
+        let trigger_id = node_key!("webhook_trigger").as_str().to_string();
+
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store: Arc<dyn WorkflowVersionStore> =
+            Arc::new(InMemoryWorkflowVersionStore::new());
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+
+        let outcome_cell = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"ok": true}))));
+        let handler: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_cell),
+            }));
+        let ctx_template = base_ctx(workflow_id, node_key!("webhook_trigger"));
+        handler
+            .start(&ctx_template)
+            .await
+            .expect("handler start must succeed");
+
+        let transport = WebhookTransport::new(WebhookTransportConfig::default())
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store),
+            );
+
+        let handle = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template,
+                trigger_id,
+                scope: scope.clone(),
+                // Deliberately None — no workflow wired.
+                workflow_id: None,
+                mode: WebhookMode::Prod,
+            },
+        )
+        .await
+        .expect("activate_and_persist must succeed");
+
+        let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce.clone());
+        let resp = dispatch_inner(
+            transport,
+            key,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers_with_delivery_id("delivery-006"),
+            Bytes::from(b"{}" as &[u8]),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Prod-mode with workflow_id=None must be 500"
+        );
+    }
+
+    // ── Test 8: Tenant isolation — workflow in wrong scope → 500 ─────────────
+
+    /// Prod-mode activation whose activation-row scope is scope_A, but the
+    /// workflow version was stored under scope_B.
+    ///
+    /// `ScopedWorkflowVersionStore` pins the lookup to `row.scope` (scope_A),
+    /// so the version stored under scope_B is invisible → 500.
+    ///
+    /// This is the confused-deputy test (invariant #5).
+    ///
+    /// Red-on-revert: passing the request-derived scope (or no scoping) to
+    /// `get_published` would let a cross-scope lookup succeed, violating the
+    /// tenant boundary.
+    #[tokio::test]
+    async fn tenant_isolation_wrong_scope_returns_500() {
+        let scope_a = Scope::new("org-a", "ws-a");
+        let scope_b = Scope::new("org-b", "ws-b");
+        let workflow_id = WorkflowId::new();
+        let trigger_id = node_key!("webhook_trigger").as_str().to_string();
+
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+
+        let outcome_cell = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"ok": true}))));
+        let handler: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_cell),
+            }));
+        let ctx_template_a = base_ctx(workflow_id, node_key!("webhook_trigger"));
+        handler
+            .start(&ctx_template_a)
+            .await
+            .expect("handler start must succeed");
+
+        let transport = WebhookTransport::new(WebhookTransportConfig::default())
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+            );
+
+        // Activation row registered under scope_a.
+        let handle = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx_template_a,
+                trigger_id: trigger_id.clone(),
+                scope: scope_a.clone(),
+                workflow_id: Some(workflow_id.to_string()),
+                mode: WebhookMode::Prod,
+            },
+        )
+        .await
+        .expect("activate_and_persist");
+
+        // Workflow stored under scope_b — should NOT be visible to scope_a lookup.
+        let def = minimal_workflow_def(workflow_id, trigger_id);
+        version_store
+            .create(
+                &scope_b,
+                WorkflowVersionRecord {
+                    workflow_id: workflow_id.to_string(),
+                    number: 1,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(&def).unwrap(),
+                },
+            )
+            .await
+            .expect("version create");
+
+        let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce.clone());
+        let resp = dispatch_inner(
+            transport,
+            key,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers_with_delivery_id("delivery-007"),
+            Bytes::from(b"{}" as &[u8]),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "workflow stored in wrong scope must be invisible → 500"
+        );
     }
 }

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -138,10 +138,6 @@ pub(super) struct TransportInner {
 /// Grouped into one struct so `TransportInner` does not grow three
 /// independent `Option` fields whose validity is coupled — all three
 /// must be present together or absent together.
-// guard-justified: fields are read by `dispatch.rs` in commit 4 (same
-// webhook module); the lint fires on this intermediate commit only because
-// dispatch.rs does not yet consume them.  Remove this allow in commit 4.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub(super) struct DurableDispatchComponents {
     /// Atomic dedup + execution-row + job enqueue.  Shared with the

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -31,8 +31,9 @@ use nebula_action::{
     Clock, SystemClock, TriggerHandler, TriggerRuntimeContext, WebhookConfig,
     WebhookEndpointProvider,
 };
+use nebula_engine::{DefinitionRoutingResolver, RoutingResolver};
 use nebula_metrics::MetricsRegistry;
-use nebula_storage_port::store::WebhookActivationStore;
+use nebula_storage_port::store::{TriggerDedupInbox, WebhookActivationStore, WorkflowVersionStore};
 use url::Url;
 use uuid::Uuid;
 
@@ -120,8 +121,36 @@ pub(super) struct TransportInner {
     /// token to its durable row via `store.resolve_by_token(&hash)`,
     /// confirming the scope/workflow_id/mode tuple.  Dispatch still
     /// goes through the in-memory routing map — durable emitter install
-    /// is deferred to U-D1.4b (next sub-slice).
+    /// is handled in U-D1.4b (this sub-slice) via `durable_dispatch`.
     pub(super) activation_store: Option<Arc<dyn WebhookActivationStore>>,
+
+    /// Durable dispatch components (U-D1.4b).
+    ///
+    /// When `Some`, Prod-mode activation rows spawn durable executions
+    /// via `DurableExecutionEmitter`.  All three fields must be wired
+    /// together by the composition root; `None` means Prod-mode
+    /// dispatches fail closed (5xx).
+    pub(super) durable_dispatch: Option<DurableDispatchComponents>,
+}
+
+/// The three components required for durable webhook dispatch (U-D1.4b).
+///
+/// Grouped into one struct so `TransportInner` does not grow three
+/// independent `Option` fields whose validity is coupled — all three
+/// must be present together or absent together.
+// guard-justified: fields are read by `dispatch.rs` in commit 4 (same
+// webhook module); the lint fires on this intermediate commit only because
+// dispatch.rs does not yet consume them.  Remove this allow in commit 4.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(super) struct DurableDispatchComponents {
+    /// Atomic dedup + execution-row + job enqueue.  Shared with the
+    /// orchestrator's `JobDispatchQueue` (same underlying store / mutex).
+    pub(super) dedup: Arc<dyn TriggerDedupInbox>,
+    /// Maps `(validated_workflow, trigger_id)` → dispatch route.
+    pub(super) resolver: Arc<dyn RoutingResolver>,
+    /// Workflow-version store for per-request `ValidatedWorkflow` load.
+    pub(super) version_store: Arc<dyn WorkflowVersionStore>,
 }
 
 impl std::fmt::Debug for WebhookTransport {
@@ -180,6 +209,7 @@ impl WebhookTransport {
                 metrics,
                 clock,
                 activation_store: None,
+                durable_dispatch: None,
             }),
         }
     }
@@ -234,10 +264,84 @@ impl WebhookTransport {
                     metrics: arc.metrics.clone(),
                     clock: arc.clock.clone(),
                     activation_store: Some(store),
+                    durable_dispatch: arc.durable_dispatch.clone(),
                 })
             },
         };
         Self { inner }
+    }
+
+    /// Attach the durable-dispatch components for Prod-mode webhook
+    /// execution spawning (ADR-0095 D1, U-D1.4b).
+    ///
+    /// All three components must share the **same underlying store** so
+    /// `claim_and_materialize_start` is atomic (dedup guard + Created
+    /// execution row + Start job in one transaction).
+    ///
+    /// Returns a **new** `WebhookTransport` — same Arc-replacement contract
+    /// as [`Self::with_activation_store`]: call before distributing the
+    /// transport to handlers.  A refcount-1 `Arc::try_unwrap` is the fast
+    /// path; a pre-shared transport emits a warning and clones the routing
+    /// map (no activations lost).
+    ///
+    /// When `None` (default), Prod-mode dispatches fail closed (5xx) rather
+    /// than spawning dedup-blind.
+    #[must_use = "builder methods must be chained or the result used"]
+    pub fn with_durable_dispatch(
+        self,
+        dedup: Arc<dyn TriggerDedupInbox>,
+        resolver: Arc<dyn RoutingResolver>,
+        version_store: Arc<dyn WorkflowVersionStore>,
+    ) -> Self {
+        let components = DurableDispatchComponents {
+            dedup,
+            resolver,
+            version_store,
+        };
+        let inner = match Arc::try_unwrap(self.inner) {
+            Ok(mut i) => {
+                i.durable_dispatch = Some(components);
+                Arc::new(i)
+            },
+            Err(arc) => {
+                debug_assert!(
+                    false,
+                    "with_durable_dispatch called on a shared WebhookTransport (refcount > 1); \
+                     attach components before cloning the transport into handlers"
+                );
+                tracing::warn!(
+                    target: "nebula::api::webhook::transport",
+                    "with_durable_dispatch called on a shared transport; \
+                     existing routing entries are preserved but this indicates \
+                     a composition-root ordering bug"
+                );
+                let rate_limiter = arc
+                    .config
+                    .rate_limit_per_minute
+                    .map(WebhookRateLimiter::new);
+                Arc::new(TransportInner {
+                    config: arc.config.clone(),
+                    routing: arc.routing.clone(),
+                    rate_limiter,
+                    metrics: arc.metrics.clone(),
+                    clock: arc.clock.clone(),
+                    activation_store: arc.activation_store.clone(),
+                    durable_dispatch: Some(components),
+                })
+            },
+        };
+        Self { inner }
+    }
+
+    /// Build a `DefinitionRoutingResolver` with the slice flavor SHA and
+    /// return it as `Arc<dyn RoutingResolver>`.
+    ///
+    /// Convenience for composition roots that do not need to customize the
+    /// flavor SHA.  The `DefinitionRoutingResolver` is registry-free and
+    /// stateless; a single instance is safe to share across all dispatches.
+    #[must_use]
+    pub fn default_resolver() -> Arc<dyn RoutingResolver> {
+        Arc::new(DefinitionRoutingResolver::default())
     }
 
     /// Register a webhook trigger and allocate its public endpoint.


### PR DESCRIPTION
## ADR-0095 D1 / U-D1.4b — make webhook triggers spawn durable executions

Post-#823, the webhook dispatch path resolved the activation row but the emitter was Noop (logged only). This installs the durable path: a `mode=Prod` webhook spawns a real execution under the row's `scope`; `mode=Test` stays Noop.

### Mechanism (verified ground truth)
The webhook adapter `handle_event` does **not** call `ctx.emit_execution` (unlike the poll adapter) — it returns `TriggerEventOutcome::{Emit,EmitMany,Skip}` and acks the HTTP response via a oneshot. So the durable spawn **consumes the returned `Emit` outcome at the dispatch layer** and fires a `DurableExecutionEmitter` (atomic `claim_and_materialize_start`: dedup by `(scope,trigger_id,event_id)` + Created row + Start job), with the execution running async on a worker.

### Durability posture — research-confirmed industry-canonical
Surveyed 8 platforms (Stripe / GitHub / Svix / Slack / Shopify / Hookdeck / Inngest / Restate): the canon is **verify → dedup-check → thin durable capture → then 2xx → async process**. This PR implements **emit-before-ack, 5xx-on-emit-failure** (sender retries; the retry collapses via `event_id` dedup) = at-least-once + effectively-once. Emit is inside the existing `response_timeout` (stuck DB → 504, not a hang).

### Decisions
- **event_id** from the `webhook-id` delivery header (server-stamped, sole attacker-influenced dedup field); **bounded to 256 bytes** → clean 400 (not a backend index-row-too-large 5xx); absent-on-Prod → 400 (no dedup-blind spawn).
- **`ValidatedWorkflow` loaded under `row.scope`** via `ScopedWorkflowVersionStore` (scope OUT of the row — the decorator substitutes the bound scope; no cross-scope lookup). `workflow_id=None` / not-found-in-scope / `trigger_id` parse fail → fail-closed (no spawn).
- **`EmitMany` in Prod → fail-closed 5xx** (one event_id can't fan-out to N — dedup-collision data-loss; no first-party action returns it).

### Composition wiring
`AppState` gains `trigger_dedup_inbox` (over the shared exec core — atomicity with the job-dispatch queue); `WebhookTransport` gains `with_durable_dispatch(dedup, resolver, version_store)` attached at construction; `apps/server` threads them in.

### Security gate (HARD) — PASS
`security-auditor` reviewed the external-input → durable-spawn → tenant-isolation boundary: **no CRITICAL/HIGH; tenant isolation sound by construction**; the `tenant_isolation_wrong_scope_returns_500` test is genuinely red-on-revert. Token never logged (redaction preserved). 11 dispatch tests cover the full invariant matrix (tenant-iso, Test→no-spawn, redelivery-dedup, all fail-closed branches, oversized-id).

**Deferred sub-slices (armed-not-reachable — no live `mode=Prod` registration endpoint exists yet; only test callers):** rate-limit-by-default (inv #2) and Standard-Webhooks HMAC hardening (inv #1). ⚠️ The unit that first exposes a Prod-row registration endpoint **must ship per-token + per-tenant rate-limiting in that same unit**.

### Verification
- `cargo nextest` **1154 passed** (1 PG-gated skip) across api/engine/storage/server · `clippy --workspace --all-targets --all-features -D warnings` clean · rustdoc `-D` clean · pre-push CI-mirror green.
- Semver: api/engine internal (only `nebula-sdk` public); no external break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added durable webhook dispatch with idempotency support, enabling deduplication of duplicate webhook deliveries in production environments using unique identifiers
  * Enhanced error handling and timeout management for webhook operations, ensuring reliable delivery without redundant processing
  * Improved production-mode validation with fail-safe mechanisms for webhook dispatch operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->