### PR TITLE
feat(api): webhook ingress hardening — Standard-Webhooks HMAC + per-token/per-tenant rate-limit (ADR-0095 D1)

### DIFF
--- a/apps/server/src/transport.rs
+++ b/apps/server/src/transport.rs
@@ -127,6 +127,13 @@ impl ServerTransport for WebhookIngressTransport {
         //   2. durable dispatch  (ADR-0095 D1 U-D1.4b — Prod-mode spawning)
         // All builders are called before the transport is distributed to
         // handlers so refcount stays 1 throughout.
+        //
+        // Rate-limiting: `..default()` leaves `rate_limit_per_minute` and
+        // `tenant_rate_limit_per_minute` as `None`, which is correct here.
+        // `with_durable_dispatch` installs DEFAULT_PER_TOKEN_RPM /
+        // DEFAULT_PER_TENANT_RPM automatically — no composition-root discipline
+        // required.  Override the limits by setting them in `webhook_config`
+        // before calling the builder.
         let transport = nebula_api::transport::webhook::WebhookTransport::new(webhook_config);
         let transport = if let Some(store) = state.webhook_activation_store.clone() {
             transport.with_activation_store(store)

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -2400,7 +2400,13 @@ fn verify_standard_webhooks(
     let id_str = match single_header_value(request.headers(), &ID_HEADER) {
         HeaderLookup::One(v) => v,
         HeaderLookup::Missing => {
-            // No id → treat as Missing (signature cannot be verified without id).
+            // No `webhook-id` → `SignatureOutcome::Missing`.
+            //
+            // Telemetry-granularity note: this conflates two distinct caller
+            // situations — (a) absent delivery id only, and (b) absent both
+            // `webhook-id` AND `webhook-signature` — under the same `Missing`
+            // outcome.  A dedicated `missing_delivery_id` failure reason for
+            // dashboards is deferred; the current surface is correct and safe.
             return Ok(SignatureOutcome::Missing);
         },
         HeaderLookup::Multiple => return Ok(SignatureOutcome::Invalid),
@@ -2459,13 +2465,11 @@ fn verify_standard_webhooks(
             continue;
         }
         any_v1_candidate = true;
-        // Decode — failure is a non-match (substitute zeroes for constant time).
-        let (candidate_bytes, decode_ok) = match BASE64_STANDARD.decode(b64_sig) {
-            Ok(v) => (v, true),
-            Err(_) => (vec![0u8; 32], false),
+        // Decode — a malformed token simply does not match; skip it.
+        let Ok(candidate_bytes) = BASE64_STANDARD.decode(b64_sig) else {
+            continue;
         };
-        // Constant-time compare.
-        if decode_ok && verify_tag_constant_time(&expected_mac, &candidate_bytes) {
+        if verify_tag_constant_time(&expected_mac, &candidate_bytes) {
             return Ok(SignatureOutcome::Valid);
         }
     }

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -1155,7 +1155,14 @@ impl RequiredPolicy {
             return Err(SignatureError::SecretMissing);
         }
 
-        if let Some(name) = self.timestamp_header.as_ref() {
+        // `StandardWebhooks` ignores `timestamp_header` / `timestamp_format` —
+        // it uses fixed `webhook-timestamp` and validates inside
+        // `verify_standard_webhooks`.  Skipping the generic pre-check here
+        // prevents a stale custom `timestamp_header` value from triggering
+        // `TimestampMissing` before the SWH path runs its own check.
+        if !matches!(self.scheme, SignatureScheme::StandardWebhooks)
+            && let Some(name) = self.timestamp_header.as_ref()
+        {
             validate_timestamp(
                 request.headers(),
                 name,
@@ -2425,6 +2432,7 @@ fn verify_standard_webhooks(
 
     // 3. Validate timestamp (reuse the shared helper that understands replay_window
     //    and FUTURE_SKEW_SECS). Format is always Unix seconds for Standard Webhooks.
+    //    Cheap check — runs before the body HMAC.
     validate_timestamp(
         request.headers(),
         &TS_HEADER,
@@ -2433,54 +2441,68 @@ fn verify_standard_webhooks(
         clock,
     )?;
 
-    // 4. Build signed content: "{webhook-id}.{webhook-timestamp}.{body}".
-    //    Allocate once; avoid a format! with a Copy-heavy body clone.
-    let prefix = format!("{id_str}.{ts_str}.");
-    let mut signed_content = Vec::with_capacity(prefix.len() + request.body().len());
-    signed_content.extend_from_slice(prefix.as_bytes());
-    signed_content.extend_from_slice(request.body());
-
-    // 5. Compute expected MAC over the signed content. Done ONCE before any
-    //    candidate loop — ensures constant MAC-compute time regardless of how
-    //    many candidates pass or fail.
-    let expected_mac: [u8; 32] = hmac_sha256_compute(secret, &signed_content);
-
-    // 6. Parse webhook-signature header: SPACE-separated "version,base64" tokens.
+    // 4. Parse and pre-screen the webhook-signature header BEFORE doing any
+    //    body HMAC work.  A request without a signature header (or with no v1
+    //    candidate) exits here cheaply — no HMAC is wasted.  This mirrors the
+    //    hex/base64 verifiers which reject a missing header before MAC work.
     let sig_header_str = match single_header_value(request.headers(), &SIG_HEADER) {
         HeaderLookup::One(v) => v,
         HeaderLookup::Missing => return Ok(SignatureOutcome::Missing),
         HeaderLookup::Multiple => return Ok(SignatureOutcome::Invalid),
     };
 
-    let mut any_v1_candidate = false;
+    // Collect valid-format v1 candidates (decoded bytes) and detect whether any
+    // v1 token was present.  Tokens are collected BEFORE building signed_content
+    // so the HMAC is only computed when there is at least one candidate to compare.
+    let mut candidates: Vec<Vec<u8>> = Vec::new();
+    let mut any_v1_seen = false;
     for token in sig_header_str.split_ascii_whitespace() {
-        // Each token is "version,base64sig".
         let Some((version, b64_sig)) = token.split_once(',') else {
-            // Malformed token — ignore (not a valid candidate, not a hard failure).
+            // Malformed token — not a valid candidate; skip.
             continue;
         };
         if version != "v1" {
-            // Non-v1 algorithm — algorithm-confusion guard: skip entirely.
-            // Never select a weaker or unknown path.
+            // Non-v1 algorithm — algorithm-confusion guard; skip entirely.
             continue;
         }
-        any_v1_candidate = true;
-        // Decode — a malformed token simply does not match; skip it.
-        let Ok(candidate_bytes) = BASE64_STANDARD.decode(b64_sig) else {
-            continue;
-        };
-        if verify_tag_constant_time(&expected_mac, &candidate_bytes) {
+        any_v1_seen = true;
+        // Decode — a malformed base64 token simply does not contribute a candidate.
+        if let Ok(bytes) = BASE64_STANDARD.decode(b64_sig) {
+            candidates.push(bytes);
+        }
+    }
+
+    if !any_v1_seen {
+        // No v1 token at all (only non-v1 or malformed) — treat as Missing.
+        return Ok(SignatureOutcome::Missing);
+    }
+
+    if candidates.is_empty() {
+        // v1 tokens were present but all had invalid base64 — treat as Invalid.
+        return Ok(SignatureOutcome::Invalid);
+    }
+
+    // 5. Build signed content: "{webhook-id}.{webhook-timestamp}.{body}".
+    //    Only reached when there is at least one decodable v1 candidate.
+    let prefix = format!("{id_str}.{ts_str}.");
+    let mut signed_content = Vec::with_capacity(prefix.len() + request.body().len());
+    signed_content.extend_from_slice(prefix.as_bytes());
+    signed_content.extend_from_slice(request.body());
+
+    // 6. Compute expected MAC over the signed content. Done ONCE before the
+    //    candidate loop — constant MAC-compute time regardless of candidate count.
+    let expected_mac: [u8; 32] = hmac_sha256_compute(secret, &signed_content);
+
+    // 7. Constant-time compare each decoded candidate against the expected MAC.
+    //    Any match is a pass; no short-circuit across candidates.
+    for candidate_bytes in &candidates {
+        if verify_tag_constant_time(&expected_mac, candidate_bytes) {
             return Ok(SignatureOutcome::Valid);
         }
     }
 
-    if any_v1_candidate {
-        // v1 tokens present but none matched.
-        Ok(SignatureOutcome::Invalid)
-    } else {
-        // No v1 token at all — treat as Missing.
-        Ok(SignatureOutcome::Missing)
-    }
+    // v1 candidates present but none matched.
+    Ok(SignatureOutcome::Invalid)
 }
 
 /// Compute a raw HMAC-SHA256 tag over arbitrary bytes.
@@ -2837,6 +2859,41 @@ mod swh_tests {
     }
 
     /// Only `v2,<x>` token present → no v1 candidate → `SignatureMissing`.
+    /// A `RequiredPolicy` with a custom `timestamp_header` switched to
+    /// `StandardWebhooks` must NOT apply the generic timestamp pre-check.
+    ///
+    /// Before the fix, `verify_with` ran `validate_timestamp(custom_header, …)`
+    /// BEFORE dispatching to `verify_standard_webhooks`, so a valid SWH
+    /// request (which carries `webhook-timestamp`, not the custom header)
+    /// returned `TimestampMissing` for the absent custom header.
+    ///
+    /// RED-on-revert: removing the `!matches!(self.scheme, StandardWebhooks)`
+    /// guard causes `validate_timestamp` to run for the custom header, which
+    /// is absent from the request → `TimestampMissing` → test fails.
+    #[test]
+    fn swh_stale_custom_timestamp_header_does_not_reject_valid_request() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        let msg_id = "msg_custom_ts";
+        let sig = sign(msg_id, &ts, body);
+
+        // A policy that previously had a custom timestamp header, then was
+        // switched to StandardWebhooks. The stale `timestamp_header` is set.
+        let policy = RequiredPolicy::new()
+            .with_secret(KEY)
+            .with_timestamp_header(HeaderName::from_static("x-my-custom-ts"))
+            .with_scheme(SignatureScheme::StandardWebhooks);
+
+        // Request carries the Standard Webhooks headers, NOT the custom ts header.
+        let req = make_request(msg_id, &ts, &sig, body);
+
+        // Must succeed: SWH validates webhook-timestamp; the custom header is irrelevant.
+        policy
+            .verify_with(&req, &clock)
+            .expect("valid SWH request with stale custom timestamp_header must pass");
+    }
+
     #[test]
     fn swh_only_v2_no_v1_is_missing() {
         let clock = MockClock::at_unix_secs(NOW_SECS);

--- a/crates/action/src/webhook/mod.rs
+++ b/crates/action/src/webhook/mod.rs
@@ -1192,6 +1192,9 @@ impl RequiredPolicy {
                     },
                 }
             },
+            SignatureScheme::StandardWebhooks => {
+                verify_standard_webhooks(request, &self.secret, self.replay_window, clock)?
+            },
         };
 
         match outcome {
@@ -1463,6 +1466,7 @@ fn days_from_civil(y: i64, m: i32, d: i32) -> i64 {
 ///   automatically)
 /// - Shopify `X-Shopify-Hmac-SHA256: <base64>` → [`Self::Sha256Base64`]
 /// - Nebula canonical `X-Nebula-Signature: sha256=<hex>` → [`Self::Sha256Hex`] (default)
+/// - Standard Webhooks (standardwebhooks.com) → [`Self::StandardWebhooks`]
 ///
 /// Providers whose signature is not a raw HMAC over the request body
 /// (Stripe, Slack) require [`SignaturePolicy::Custom`].
@@ -1474,6 +1478,31 @@ pub enum SignatureScheme {
     Sha256Hex,
     /// Base64-encoded HMAC-SHA256 (standard alphabet). Shopify, Square.
     Sha256Base64,
+    /// Standard Webhooks (standardwebhooks.com) interoperability scheme.
+    ///
+    /// Uses **fixed** header names regardless of [`RequiredPolicy::header`] or
+    /// [`RequiredPolicy::timestamp_header`]:
+    ///
+    /// | Header               | Role                         |
+    /// |----------------------|------------------------------|
+    /// | `webhook-id`         | Per-delivery idempotency key |
+    /// | `webhook-timestamp`  | Unix-epoch seconds           |
+    /// | `webhook-signature`  | Space-separated `version,base64sig` tokens |
+    ///
+    /// Timestamp validation is **mandatory** for this scheme (not opt-in):
+    /// the replay window and future-skew cap from [`RequiredPolicy`] apply.
+    ///
+    /// The signed content is `{webhook-id}.{webhook-timestamp}.{raw-body}` —
+    /// matching the Standard Webhooks `to_sign = "{msg_id}.{timestamp}.{payload}"`.
+    ///
+    /// The secret stored in [`RequiredPolicy`] is the **raw HMAC key bytes**.
+    /// Decoding a `whsec_` base64-encoded secret is a registration concern;
+    /// the verify path operates on already-decoded bytes.
+    ///
+    /// Multi-signature (`v1,<base64> v1,<base64>`) is supported for
+    /// key-rotation grace: any matching `v1` token passes. Non-`v1`
+    /// tokens (e.g. `v2,…`) are ignored — never selected as a weaker path.
+    StandardWebhooks,
 }
 
 // ── WebhookEndpointProvider ──────────────────────────────────────────────
@@ -2315,6 +2344,141 @@ pub fn verify_hmac_sha256_with_timestamp(
     ))
 }
 
+/// Standard Webhooks (standardwebhooks.com) signature verification.
+///
+/// Called by [`RequiredPolicy::verify_with`] when the scheme is
+/// [`SignatureScheme::StandardWebhooks`].
+///
+/// # Fixed header names
+///
+/// This function ignores [`RequiredPolicy::header`] and
+/// [`RequiredPolicy::timestamp_header`]. Standard Webhooks mandates:
+///
+/// | Header               | Role                                               |
+/// |----------------------|----------------------------------------------------|
+/// | `webhook-id`         | Per-delivery idempotency key (NOT a secret)        |
+/// | `webhook-timestamp`  | Unix-epoch seconds (mandatory)                     |
+/// | `webhook-signature`  | Space-separated `version,base64sig` tokens         |
+///
+/// # Signed content
+///
+/// The bytes fed to HMAC-SHA256 are `{webhook-id}.{webhook-timestamp}.{raw-body}`,
+/// matching the Standard Webhooks spec's `to_sign = "{msg_id}.{timestamp}.{payload}"`.
+///
+/// # Secret
+///
+/// `secret` is the **raw HMAC key bytes**. `whsec_` prefix decoding is a
+/// registration concern; verify operates on already-decoded bytes.
+///
+/// # Multi-signature / key rotation
+///
+/// `webhook-signature` is a SPACE-separated list of `version,base64sig` tokens.
+/// Any `v1` token whose decoded bytes constant-time-match the computed MAC passes.
+/// Non-`v1` tokens are ignored (algorithm-confusion guard — never fall through to a
+/// weaker path). A decode failure for a candidate token is a non-match, not an error.
+/// Absence of any `v1` token → `Missing`; all `v1` tokens fail → `Invalid`.
+///
+/// # Errors
+///
+/// Returns [`SignatureError`] when:
+/// - `webhook-timestamp` is absent → `TimestampMissing`
+/// - `webhook-timestamp` is malformed / outside the replay window → timestamp errors
+///
+/// Absent or all-failed `webhook-signature` returns `Ok(Missing/Invalid)`.
+fn verify_standard_webhooks(
+    request: &WebhookRequest,
+    secret: &[u8],
+    replay_window: Duration,
+    clock: &dyn Clock,
+) -> Result<SignatureOutcome, SignatureError> {
+    // Fixed Standard Webhooks header names (spec §4).
+    const ID_HEADER: HeaderName = HeaderName::from_static("webhook-id");
+    const TS_HEADER: HeaderName = HeaderName::from_static("webhook-timestamp");
+    const SIG_HEADER: HeaderName = HeaderName::from_static("webhook-signature");
+
+    // 1. Extract webhook-id.
+    let id_str = match single_header_value(request.headers(), &ID_HEADER) {
+        HeaderLookup::One(v) => v,
+        HeaderLookup::Missing => {
+            // No id → treat as Missing (signature cannot be verified without id).
+            return Ok(SignatureOutcome::Missing);
+        },
+        HeaderLookup::Multiple => return Ok(SignatureOutcome::Invalid),
+    };
+
+    // 2. Extract webhook-timestamp — mandatory for StandardWebhooks.
+    let ts_str = match single_header_value(request.headers(), &TS_HEADER) {
+        HeaderLookup::One(v) => v,
+        HeaderLookup::Missing => return Err(SignatureError::TimestampMissing),
+        HeaderLookup::Multiple => {
+            return Err(SignatureError::TimestampMalformed {
+                reason: "multiple webhook-timestamp headers".to_string(),
+            });
+        },
+    };
+
+    // 3. Validate timestamp (reuse the shared helper that understands replay_window
+    //    and FUTURE_SKEW_SECS). Format is always Unix seconds for Standard Webhooks.
+    validate_timestamp(
+        request.headers(),
+        &TS_HEADER,
+        TimestampFormat::UnixSeconds,
+        replay_window,
+        clock,
+    )?;
+
+    // 4. Build signed content: "{webhook-id}.{webhook-timestamp}.{body}".
+    //    Allocate once; avoid a format! with a Copy-heavy body clone.
+    let prefix = format!("{id_str}.{ts_str}.");
+    let mut signed_content = Vec::with_capacity(prefix.len() + request.body().len());
+    signed_content.extend_from_slice(prefix.as_bytes());
+    signed_content.extend_from_slice(request.body());
+
+    // 5. Compute expected MAC over the signed content. Done ONCE before any
+    //    candidate loop — ensures constant MAC-compute time regardless of how
+    //    many candidates pass or fail.
+    let expected_mac: [u8; 32] = hmac_sha256_compute(secret, &signed_content);
+
+    // 6. Parse webhook-signature header: SPACE-separated "version,base64" tokens.
+    let sig_header_str = match single_header_value(request.headers(), &SIG_HEADER) {
+        HeaderLookup::One(v) => v,
+        HeaderLookup::Missing => return Ok(SignatureOutcome::Missing),
+        HeaderLookup::Multiple => return Ok(SignatureOutcome::Invalid),
+    };
+
+    let mut any_v1_candidate = false;
+    for token in sig_header_str.split_ascii_whitespace() {
+        // Each token is "version,base64sig".
+        let Some((version, b64_sig)) = token.split_once(',') else {
+            // Malformed token — ignore (not a valid candidate, not a hard failure).
+            continue;
+        };
+        if version != "v1" {
+            // Non-v1 algorithm — algorithm-confusion guard: skip entirely.
+            // Never select a weaker or unknown path.
+            continue;
+        }
+        any_v1_candidate = true;
+        // Decode — failure is a non-match (substitute zeroes for constant time).
+        let (candidate_bytes, decode_ok) = match BASE64_STANDARD.decode(b64_sig) {
+            Ok(v) => (v, true),
+            Err(_) => (vec![0u8; 32], false),
+        };
+        // Constant-time compare.
+        if decode_ok && verify_tag_constant_time(&expected_mac, &candidate_bytes) {
+            return Ok(SignatureOutcome::Valid);
+        }
+    }
+
+    if any_v1_candidate {
+        // v1 tokens present but none matched.
+        Ok(SignatureOutcome::Invalid)
+    } else {
+        // No v1 token at all — treat as Missing.
+        Ok(SignatureOutcome::Missing)
+    }
+}
+
 /// Compute a raw HMAC-SHA256 tag over arbitrary bytes.
 ///
 /// Escape hatch for signature schemes not handled by
@@ -2428,4 +2592,260 @@ pub fn webhook_request_for_test_with_limits(
         max_body,
         max_headers,
     )
+}
+
+// ── Unit tests: Standard Webhooks HMAC scheme ─────────────────────────────────
+
+#[cfg(test)]
+mod swh_tests {
+    //! Unit tests for [`SignatureScheme::StandardWebhooks`] via
+    //! [`RequiredPolicy::verify_with`].
+    //!
+    //! All tests use a deterministic [`MockClock`] so replay-window
+    //! assertions are immune to wall-clock drift.
+
+    use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
+
+    use super::*;
+
+    /// Fixed Unix-epoch anchor shared across tests.
+    const NOW_SECS: u64 = 1_700_000_000;
+
+    /// Test HMAC key (raw bytes — no whsec_ prefix).
+    const KEY: &[u8] = b"test-secret-key-for-standard-webhooks";
+
+    /// Build a [`RequiredPolicy`] configured for Standard Webhooks.
+    fn swh_policy() -> RequiredPolicy {
+        RequiredPolicy::new()
+            .with_secret(KEY)
+            .with_scheme(SignatureScheme::StandardWebhooks)
+    }
+
+    /// Compute a valid Standard Webhooks signature token for the given
+    /// message-id, timestamp-string, and body.
+    ///
+    /// Returns a `webhook-signature` header value of the form `v1,<base64>`.
+    fn sign(msg_id: &str, ts_str: &str, body: &[u8]) -> String {
+        let prefix = format!("{msg_id}.{ts_str}.");
+        let mut content = Vec::with_capacity(prefix.len() + body.len());
+        content.extend_from_slice(prefix.as_bytes());
+        content.extend_from_slice(body);
+        let mac = hmac_sha256_compute(KEY, &content);
+        format!("v1,{}", B64.encode(mac))
+    }
+
+    fn make_request(msg_id: &str, ts_str: &str, sig: &str, body: &[u8]) -> WebhookRequest {
+        webhook_request_for_test(
+            body,
+            &[
+                ("webhook-id", msg_id),
+                ("webhook-timestamp", ts_str),
+                ("webhook-signature", sig),
+            ],
+        )
+        .expect("test request must be constructable")
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    /// Valid Standard Webhooks request → `Ok(())`.
+    #[test]
+    fn swh_valid_signature_passes() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{\"event\":\"test\"}";
+        let sig = sign("msg_abc123", &ts, body);
+        let req = make_request("msg_abc123", &ts, &sig, body);
+        swh_policy()
+            .verify_with(&req, &clock)
+            .expect("valid SWH signature must pass");
+    }
+
+    // ── Tampering ─────────────────────────────────────────────────────────────
+
+    /// Tampered body → signature mismatch → `SignatureInvalid`.
+    ///
+    /// Red-on-revert: removing the body from the signed content makes a
+    /// body-tamper undetectable.
+    #[test]
+    fn swh_tampered_body_is_invalid() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let original_body = b"{\"event\":\"test\"}";
+        let tampered_body = b"{\"event\":\"hacked\"}";
+        let sig = sign("msg_abc123", &ts, original_body);
+        // Request body differs from what was signed.
+        let req = make_request("msg_abc123", &ts, &sig, tampered_body);
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("tampered body must fail verification");
+        assert!(
+            matches!(err, SignatureError::SignatureInvalid),
+            "expected SignatureInvalid, got {err:?}"
+        );
+    }
+
+    /// Tampered timestamp → signature mismatch → `SignatureInvalid`.
+    ///
+    /// The timestamp is part of the signed content, so changing it after
+    /// signing invalidates the MAC.
+    #[test]
+    fn swh_tampered_timestamp_is_invalid() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let tampered_ts = (NOW_SECS - 10).to_string(); // different ts sent in header
+        let body = b"{\"event\":\"test\"}";
+        let sig = sign("msg_abc123", &ts, body);
+        // Header has a different timestamp than what was signed.
+        let req = make_request("msg_abc123", &tampered_ts, &sig, body);
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("tampered timestamp must fail verification");
+        assert!(
+            matches!(err, SignatureError::SignatureInvalid),
+            "expected SignatureInvalid, got {err:?}"
+        );
+    }
+
+    // ── Replay window ─────────────────────────────────────────────────────────
+
+    /// Timestamp older than the replay window → `TimestampOutOfWindow`.
+    #[test]
+    fn swh_expired_timestamp_rejected() {
+        // Advance clock 6 minutes past the request timestamp.
+        let req_ts = NOW_SECS;
+        let clock_now = NOW_SECS + 360; // 6 min later, outside 5-min window
+        let clock = MockClock::at_unix_secs(clock_now);
+        let ts = req_ts.to_string();
+        let body = b"{}";
+        let sig = sign("msg_exp", &ts, body);
+        let req = make_request("msg_exp", &ts, &sig, body);
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("expired timestamp must be rejected");
+        assert!(
+            matches!(err, SignatureError::TimestampOutOfWindow { .. }),
+            "expected TimestampOutOfWindow, got {err:?}"
+        );
+    }
+
+    /// Timestamp more than 60 s in the future → `TimestampOutOfWindow`.
+    ///
+    /// The future-skew cap (`FUTURE_SKEW_SECS = 60`) applies independently of
+    /// the configured replay window, preventing tokens pre-dated in the future.
+    #[test]
+    fn swh_future_skew_beyond_cap_rejected() {
+        let req_ts = NOW_SECS + 120; // 2 min ahead — exceeds the 60-s cap
+        let clock_now = NOW_SECS;
+        let clock = MockClock::at_unix_secs(clock_now);
+        let ts = req_ts.to_string();
+        let body = b"{}";
+        let sig = sign("msg_future", &ts, body);
+        let req = make_request("msg_future", &ts, &sig, body);
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("far-future timestamp must be rejected");
+        assert!(
+            matches!(err, SignatureError::TimestampOutOfWindow { .. }),
+            "expected TimestampOutOfWindow, got {err:?}"
+        );
+    }
+
+    // ── Missing headers ───────────────────────────────────────────────────────
+
+    /// Missing `webhook-timestamp` → `TimestampMissing` (mandatory for SWH).
+    #[test]
+    fn swh_missing_timestamp_is_error() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        let sig = sign("msg_nots", &ts, body);
+        // No webhook-timestamp header.
+        let req = webhook_request_for_test(
+            body,
+            &[("webhook-id", "msg_nots"), ("webhook-signature", &sig)],
+        )
+        .expect("request build");
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("missing timestamp must error");
+        assert!(
+            matches!(err, SignatureError::TimestampMissing),
+            "expected TimestampMissing, got {err:?}"
+        );
+    }
+
+    /// Missing `webhook-signature` → `SignatureMissing`.
+    #[test]
+    fn swh_missing_signature_header() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        // No webhook-signature header.
+        let req = webhook_request_for_test(
+            body,
+            &[("webhook-id", "msg_nosig"), ("webhook-timestamp", &ts)],
+        )
+        .expect("request build");
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("missing signature must error");
+        assert!(
+            matches!(err, SignatureError::SignatureMissing),
+            "expected SignatureMissing, got {err:?}"
+        );
+    }
+
+    // ── Multi-signature scenarios ─────────────────────────────────────────────
+
+    /// `v1,<bad> v1,<good>` → first candidate fails, second succeeds → `Valid`.
+    ///
+    /// Proves the candidate loop does not short-circuit on a bad token.
+    #[test]
+    fn swh_multi_sig_bad_then_good_passes() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        let good = sign("msg_multi", &ts, body);
+        let bad = "v1,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let sig_header = format!("{bad} {good}");
+        let req = make_request("msg_multi", &ts, &sig_header, body);
+        swh_policy()
+            .verify_with(&req, &clock)
+            .expect("bad-then-good multi-sig must pass");
+    }
+
+    /// `v2,<x> v1,<good>` → non-v1 ignored, v1 accepted → `Valid`.
+    ///
+    /// Proves algorithm-confusion guard: `v2` is never selected even if it
+    /// appears first.
+    #[test]
+    fn swh_v2_ignored_v1_accepted() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        let good = sign("msg_v2v1", &ts, body);
+        let sig_header = format!("v2,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA= {good}");
+        let req = make_request("msg_v2v1", &ts, &sig_header, body);
+        swh_policy()
+            .verify_with(&req, &clock)
+            .expect("v2 must be ignored; v1 must pass");
+    }
+
+    /// Only `v2,<x>` token present → no v1 candidate → `SignatureMissing`.
+    #[test]
+    fn swh_only_v2_no_v1_is_missing() {
+        let clock = MockClock::at_unix_secs(NOW_SECS);
+        let ts = NOW_SECS.to_string();
+        let body = b"{}";
+        let sig_header = "v2,AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+        let req = make_request("msg_v2only", &ts, sig_header, body);
+        let err = swh_policy()
+            .verify_with(&req, &clock)
+            .expect_err("only-v2 must be SignatureMissing");
+        assert!(
+            matches!(err, SignatureError::SignatureMissing),
+            "expected SignatureMissing, got {err:?}"
+        );
+    }
 }

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -33,7 +33,8 @@ use nebula_action::{
 use nebula_core::NodeKey;
 use nebula_engine::DurableExecutionEmitter;
 use nebula_metrics::{
-    NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, webhook_key_kind, webhook_signature_failure_reason,
+    NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, webhook_key_kind, webhook_rate_limit_tier,
+    webhook_signature_failure_reason,
 };
 use nebula_storage_port::dto::WebhookMode;
 use nebula_storage_port::store::WorkflowVersionStore;
@@ -138,19 +139,16 @@ pub(super) async fn dispatch_inner(
         return (StatusCode::NOT_FOUND, "").into_response();
     };
 
-    // 4. Rate limit (if configured) — only for keys that resolve to a
-    // registered handler.
+    // 4. Per-token rate limit (if configured) — only for keys that resolve to a
+    // registered handler. Placed pre-resolution so unauthenticated churn against
+    // registered keys never reaches the DB.
     if let Some(limiter) = &transport.inner.rate_limiter {
         let bucket = key.rate_limit_key();
         if let Err(e) = limiter.check(&bucket).await {
             // `bucket` uses the trigger uuid only — nonce (bearer token) excluded.
-            debug!(bucket = %bucket, retry_after = e.retry_after_secs, "webhook rate limited");
-            record_rate_limit_rejection(&transport, &key);
-            let mut resp = (StatusCode::TOO_MANY_REQUESTS, "").into_response();
-            if let Ok(v) = e.retry_after_secs.to_string().parse() {
-                resp.headers_mut().insert("retry-after", v);
-            }
-            return resp;
+            debug!(bucket = %bucket, retry_after = e.retry_after_secs, "webhook per-token rate limited");
+            record_rate_limit_rejection(&transport, &key, webhook_rate_limit_tier::PER_TOKEN);
+            return rate_limit_429(e.retry_after_secs);
         }
     }
 
@@ -181,6 +179,22 @@ pub(super) async fn dispatch_inner(
                     // nonce / hash deliberately excluded
                     "capability token resolved to durable row"
                 );
+
+                // 4.5 — Per-tenant-aggregate rate limit (post-resolution).
+                //
+                // Placed here — after token resolution yielded the scope —
+                // so the stable tenant key is available without a second DB
+                // lookup. Enforced before the durable target is set so a
+                // tenant flooding across many tokens is capped even though
+                // each token is individually within its own per-token quota.
+                //
+                // Key: `Scope::credential_owner_id()` — length-prefixed,
+                // injective across arbitrary (org_id, workspace_id) pairs,
+                // same derivation every plane uses (ADR-0088 D7).
+                if let Some(resp) = check_tenant_rate_limit(&transport, &key, &row.scope).await {
+                    return resp;
+                }
+
                 // Mode gate: only Prod rows with a wired inbox spawn durable
                 // executions.  Fail-closed when inbox absent in Prod mode.
                 if row.mode == WebhookMode::Prod {
@@ -688,9 +702,45 @@ fn http_response_to_axum(resp: WebhookHttpResponse) -> Response {
     (resp.status, resp.headers, resp.body).into_response()
 }
 
-/// Record a per-key rate-limit rejection. Labelset:
-/// `(tenant_id, webhook_key_kind)`.
-fn record_rate_limit_rejection(transport: &WebhookTransport, key: &WebhookKey) {
+/// Build a `429 Too Many Requests` response with a `Retry-After` header.
+fn rate_limit_429(retry_after_secs: u64) -> Response {
+    let mut resp = (StatusCode::TOO_MANY_REQUESTS, "").into_response();
+    if let Ok(v) = retry_after_secs.to_string().parse() {
+        resp.headers_mut().insert("retry-after", v);
+    }
+    resp
+}
+
+/// Check the per-tenant-aggregate rate limiter for the resolved `scope`.
+///
+/// Returns `Some(Response)` (a 429) when the tenant aggregate is exceeded,
+/// `None` when the request is within quota or no tenant limiter is configured.
+///
+/// Extracted into a free function to keep the deeply-nested `Ok(Some(row))`
+/// arm under clippy's `excessive_nesting` threshold.
+async fn check_tenant_rate_limit(
+    transport: &WebhookTransport,
+    key: &WebhookKey,
+    scope: &nebula_storage_port::Scope,
+) -> Option<Response> {
+    let limiter = transport.inner.tenant_rate_limiter.as_ref()?;
+    let tenant_key = scope.credential_owner_id();
+    let err = limiter.check(&tenant_key).await.err()?;
+    debug!(
+        tenant_key = %tenant_key,
+        retry_after = err.retry_after_secs,
+        "webhook per-tenant-aggregate rate limited"
+    );
+    record_rate_limit_rejection(transport, key, webhook_rate_limit_tier::PER_TENANT);
+    Some(rate_limit_429(err.retry_after_secs))
+}
+
+/// Record a rate-limit rejection. Labelset:
+/// `(tenant_id, webhook_key_kind, tier)`.
+///
+/// `tier` must be one of [`webhook_rate_limit_tier::PER_TOKEN`] or
+/// [`webhook_rate_limit_tier::PER_TENANT`].
+fn record_rate_limit_rejection(transport: &WebhookTransport, key: &WebhookKey, tier: &'static str) {
     let Some(reg) = &transport.inner.metrics else {
         return;
     };
@@ -701,6 +751,7 @@ fn record_rate_limit_rejection(transport: &WebhookTransport, key: &WebhookKey) {
     let labels = interner.label_set(&[
         ("webhook_key_kind", kind),
         ("tenant_id", tenant_id.as_str()),
+        ("tier", tier),
     ]);
     if let Ok(c) = reg.counter_labeled(NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, &labels) {
         c.inc();
@@ -1450,6 +1501,287 @@ mod tests {
             resp.status(),
             StatusCode::INTERNAL_SERVER_ERROR,
             "workflow stored in wrong scope must be invisible → 500"
+        );
+    }
+
+    // ── Rate-limit tier tests ─────────────────────────────────────────────────
+
+    /// Helper: build a transport with a *very* tight per-tenant limit (1 req/min)
+    /// but a generous per-token limit (1 000 req/min), then register two activations
+    /// under the same scope with distinct tokens.  Returns (transport, key_a, key_b,
+    /// activation_store) so callers can drive dispatches.
+    async fn two_token_same_scope_fixture(
+        tenant_rpm: u64,
+        per_token_rpm: u64,
+    ) -> (
+        WebhookTransport,
+        WebhookKey,
+        WebhookKey,
+        Arc<dyn WebhookActivationStore>,
+    ) {
+        let scope = Scope::new("same-org", "same-ws");
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+
+        // Build transport with explicit tight limits so the test is deterministic.
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: Some(per_token_rpm),
+            tenant_rate_limit_per_minute: Some(tenant_rpm),
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg)
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+            );
+
+        // Register activation A under the shared scope.
+        let outcome_a = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler_a: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_a),
+            }));
+        let wf_a = WorkflowId::new();
+        let ctx_a = base_ctx(wf_a, node_key!("trigger_a"));
+        handler_a.start(&ctx_a).await.unwrap();
+        let handle_a = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler: handler_a,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx_a,
+                trigger_id: node_key!("trigger_a").as_str().to_string(),
+                scope: scope.clone(),
+                workflow_id: Some(wf_a.to_string()),
+                mode: WebhookMode::Test, // Test mode: no durable emit needed
+            },
+        )
+        .await
+        .unwrap();
+
+        // Register activation B — different token, same scope.
+        let outcome_b = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler_b: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_b),
+            }));
+        let wf_b = WorkflowId::new();
+        let ctx_b = base_ctx(wf_b, node_key!("trigger_b"));
+        handler_b.start(&ctx_b).await.unwrap();
+        let handle_b = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler: handler_b,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx_b,
+                trigger_id: node_key!("trigger_b").as_str().to_string(),
+                scope: scope.clone(),
+                workflow_id: Some(wf_b.to_string()),
+                mode: WebhookMode::Test,
+            },
+        )
+        .await
+        .unwrap();
+
+        let key_a = WebhookKey::programmatic(handle_a.trigger_uuid, handle_a.nonce);
+        let key_b = WebhookKey::programmatic(handle_b.trigger_uuid, handle_b.nonce);
+        (transport, key_a, key_b, activation_store)
+    }
+
+    async fn dispatch_skip(
+        transport: &WebhookTransport,
+        key: WebhookKey,
+    ) -> axum::http::StatusCode {
+        dispatch_inner(
+            transport.clone(),
+            key,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            HeaderMap::new(),
+            Bytes::from(b"{}" as &[u8]),
+        )
+        .await
+        .status()
+    }
+
+    /// Per-tenant-aggregate 429.
+    ///
+    /// Two activations share the SAME scope (tenant).  The per-tenant quota
+    /// is 1 req/min; per-token quota is generous (1 000 req/min).  The first
+    /// request from token A succeeds (per-token OK, per-tenant OK).  The
+    /// second request — from token B, a DIFFERENT token, so per-token is
+    /// fresh — must be rate-limited at the per-tenant tier and return 429.
+    ///
+    /// RED-on-revert: before the per-tenant limiter exists, both requests
+    /// succeed (200) because each token is within its own per-token quota.
+    #[tokio::test]
+    async fn per_tenant_aggregate_429() {
+        // per-tenant limit = 1 req/min; per-token limit = 1 000 req/min
+        let (transport, key_a, key_b, _store) = two_token_same_scope_fixture(1, 1_000).await;
+
+        // First request (token A) — should succeed.
+        let r1 = dispatch_skip(&transport, key_a).await;
+        assert_eq!(r1, StatusCode::OK, "first request (token A) must succeed");
+
+        // Second request (token B) — different token, fresh per-token window,
+        // but the tenant aggregate was exhausted by the first request.
+        let r2 = dispatch_skip(&transport, key_b).await;
+        assert_eq!(
+            r2,
+            StatusCode::TOO_MANY_REQUESTS,
+            "second request under a different token but same tenant must be 429 \
+             (per-tenant-aggregate limit exceeded)"
+        );
+    }
+
+    /// Per-token quotas remain independent across different scopes (tenants).
+    ///
+    /// Two tokens in DIFFERENT scopes each start with a fresh per-token window
+    /// and a fresh per-tenant aggregate — no cross-contamination.
+    ///
+    /// RED-on-revert: a bug that keys the per-tenant limiter by a constant
+    /// or by the trigger UUID would cause cross-scope contamination.
+    #[tokio::test]
+    async fn per_token_independent_scopes() {
+        let scope_x = Scope::new("org-x", "ws-x");
+        let scope_y = Scope::new("org-y", "ws-y");
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+
+        // 1 req/min per-tenant; 1 000 per-token — tight enough to prove isolation.
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: Some(1_000),
+            tenant_rate_limit_per_minute: Some(1),
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg)
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+            );
+
+        // Register one activation in scope_x.
+        let outcome_x = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler_x: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_x),
+            }));
+        let wf_x = WorkflowId::new();
+        let ctx_x = base_ctx(wf_x, node_key!("trigger_x"));
+        handler_x.start(&ctx_x).await.unwrap();
+        let handle_x = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler: handler_x,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx_x,
+                trigger_id: node_key!("trigger_x").as_str().to_string(),
+                scope: scope_x.clone(),
+                workflow_id: Some(wf_x.to_string()),
+                mode: WebhookMode::Test,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Register one activation in scope_y.
+        let outcome_y = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler_y: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_y),
+            }));
+        let wf_y = WorkflowId::new();
+        let ctx_y = base_ctx(wf_y, node_key!("trigger_y"));
+        handler_y.start(&ctx_y).await.unwrap();
+        let handle_y = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler: handler_y,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx_y,
+                trigger_id: node_key!("trigger_y").as_str().to_string(),
+                scope: scope_y.clone(),
+                workflow_id: Some(wf_y.to_string()),
+                mode: WebhookMode::Test,
+            },
+        )
+        .await
+        .unwrap();
+
+        let key_x = WebhookKey::programmatic(handle_x.trigger_uuid, handle_x.nonce.clone());
+        let key_y = WebhookKey::programmatic(handle_y.trigger_uuid, handle_y.nonce.clone());
+
+        // Each tenant gets one allowed request — they should NOT interfere.
+        let r_x = dispatch_skip(&transport, key_x).await;
+        let r_y = dispatch_skip(&transport, key_y).await;
+        assert_eq!(r_x, StatusCode::OK, "scope_x first request must succeed");
+        assert_eq!(
+            r_y,
+            StatusCode::OK,
+            "scope_y first request must succeed independently of scope_x"
+        );
+    }
+
+    /// Structural coupling proof (anti-discipline, RED-on-revert).
+    ///
+    /// A transport built from a `None`-rate-limit config and then passed to
+    /// `with_durable_dispatch` must have BOTH `rate_limiter` and
+    /// `tenant_rate_limiter` populated — the defaults are installed
+    /// automatically by the builder, not by composition-root discipline.
+    ///
+    /// RED-on-revert: removing the `if i.rate_limiter.is_none()` /
+    /// `if i.tenant_rate_limiter.is_none()` installs in `with_durable_dispatch`
+    /// causes both `is_some()` assertions to fail.
+    #[tokio::test]
+    async fn structural_coupling_durable_dispatch_installs_both_limiters() {
+        use nebula_storage::inmem::{InMemoryTriggerDedupInbox, InMemoryWorkflowVersionStore};
+        use nebula_storage_port::store::{TriggerDedupInbox, WorkflowVersionStore};
+
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup: Arc<dyn TriggerDedupInbox> =
+            Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store: Arc<dyn WorkflowVersionStore> =
+            Arc::new(InMemoryWorkflowVersionStore::new());
+
+        // Config with both rate limits as None — no explicit operator override.
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: None,
+            tenant_rate_limit_per_minute: None,
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg).with_durable_dispatch(
+            dedup,
+            WebhookTransport::default_resolver(),
+            version_store,
+        );
+
+        assert!(
+            transport.inner.rate_limiter.is_some(),
+            "with_durable_dispatch must install per-token rate_limiter even when \
+             config.rate_limit_per_minute is None (structural guarantee)"
+        );
+        assert!(
+            transport.inner.tenant_rate_limiter.is_some(),
+            "with_durable_dispatch must install per-tenant tenant_rate_limiter even when \
+             config.tenant_rate_limit_per_minute is None (structural guarantee)"
         );
     }
 }

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -147,7 +147,7 @@ pub(super) async fn dispatch_inner(
         if let Err(e) = limiter.check(&bucket).await {
             // `bucket` uses the trigger uuid only — nonce (bearer token) excluded.
             debug!(bucket = %bucket, retry_after = e.retry_after_secs, "webhook per-token rate limited");
-            record_rate_limit_rejection(&transport, &key, webhook_rate_limit_tier::PER_TOKEN);
+            record_rate_limit_rejection(&transport, &key, webhook_rate_limit_tier::PER_TOKEN, None);
             return rate_limit_429(e.retry_after_secs);
         }
     }
@@ -362,6 +362,12 @@ pub(super) async fn dispatch_inner(
     ) {
         SignatureVerdict::Pass => {},
         SignatureVerdict::MissingSecret => {
+            // `key.rate_limit_key()` is the trigger UUID only — nonce excluded.
+            warn!(
+                bucket = %key.rate_limit_key(),
+                "webhook signature secret not configured; action must supply a secret \
+                 or explicitly opt into OptionalAcceptUnsigned"
+            );
             record_signature_failure(
                 &transport.inner.metrics,
                 webhook_signature_failure_reason::MISSING_SECRET,
@@ -369,6 +375,12 @@ pub(super) async fn dispatch_inner(
             return missing_secret_response(uri.path());
         },
         SignatureVerdict::Fail(reason) => {
+            // `key.rate_limit_key()` is the trigger UUID only — nonce excluded.
+            warn!(
+                bucket = %key.rate_limit_key(),
+                reason,
+                "webhook signature verification failed"
+            );
             record_signature_failure(&transport.inner.metrics, reason);
             return signature_rejected_response(uri.path(), reason);
         },
@@ -754,32 +766,52 @@ async fn check_tenant_rate_limit(
     let tenant_key = scope.credential_owner_id();
     let err = limiter.check(&tenant_key).await.err()?;
     debug!(
-        tenant_key = %tenant_key,
+        tenant_id = %tenant_key,
         retry_after = err.retry_after_secs,
         "webhook per-tenant-aggregate rate limited"
     );
-    record_rate_limit_rejection(transport, key, webhook_rate_limit_tier::PER_TENANT);
+    record_rate_limit_rejection(
+        transport,
+        key,
+        webhook_rate_limit_tier::PER_TENANT,
+        Some(&tenant_key),
+    );
     Some(rate_limit_429(err.retry_after_secs))
 }
 
-/// Record a rate-limit rejection. Labelset:
-/// `(tenant_id, webhook_key_kind, tier)`.
+/// Record a rate-limit rejection. Labelset: `(webhook_key_kind, tier)`; plus
+/// an optional `tenant_id` label when the rejection is post-resolution.
+///
+/// - `tier = PER_TOKEN` (step 4, pre-resolution): pass `tenant_id = None`.
+///   The trigger UUID is NOT emitted as `tenant_id` — it is unbounded in
+///   cardinality and would create one series per registered webhook.
+/// - `tier = PER_TENANT` (step 4.5, post-resolution): pass `tenant_id =
+///   Some(&scope.credential_owner_id())`. The tenant key is the bounded
+///   `(org, workspace)` slug pair — bounded per deployment.
 ///
 /// `tier` must be one of [`webhook_rate_limit_tier::PER_TOKEN`] or
 /// [`webhook_rate_limit_tier::PER_TENANT`].
-fn record_rate_limit_rejection(transport: &WebhookTransport, key: &WebhookKey, tier: &'static str) {
+fn record_rate_limit_rejection(
+    transport: &WebhookTransport,
+    key: &WebhookKey,
+    tier: &'static str,
+    tenant_id: Option<&str>,
+) {
     let Some(reg) = &transport.inner.metrics else {
         return;
     };
     let interner = reg.interner();
-    let WebhookKey::Programmatic { uuid, .. } = key;
+    let WebhookKey::Programmatic { .. } = key;
     let kind = webhook_key_kind::PROGRAMMATIC;
-    let tenant_id = uuid.to_string();
-    let labels = interner.label_set(&[
-        ("webhook_key_kind", kind),
-        ("tenant_id", tenant_id.as_str()),
-        ("tier", tier),
-    ]);
+    let labels = if let Some(tid) = tenant_id {
+        interner.label_set(&[
+            ("webhook_key_kind", kind),
+            ("tenant_id", tid),
+            ("tier", tier),
+        ])
+    } else {
+        interner.label_set(&[("webhook_key_kind", kind), ("tier", tier)])
+    };
     if let Ok(c) = reg.counter_labeled(NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL, &labels) {
         c.inc();
     }
@@ -833,7 +865,8 @@ mod tests {
 
     use super::*;
     use crate::transport::webhook::transport::{
-        PersistParams, WebhookTransport, WebhookTransportConfig, activate_and_persist,
+        DEFAULT_PER_TOKEN_RPM, PersistParams, WebhookTransport, WebhookTransportConfig,
+        activate_and_persist,
     };
 
     // ── Standard Webhooks test signing ────────────────────────────────────────
@@ -1950,6 +1983,341 @@ mod tests {
             transport.inner.tenant_rate_limiter.is_some(),
             "with_durable_dispatch must install per-tenant tenant_rate_limiter even when \
              config.tenant_rate_limit_per_minute is None (structural guarantee)"
+        );
+    }
+
+    // ── F: structural_coupling behavioral — per-token rate enforced at DEFAULT_PER_TOKEN_RPM ─
+    //
+    // The `structural_coupling_durable_dispatch_installs_both_limiters` test above proves
+    // `is_some()`.  This test proves the installed limiter is *behaviorally* active: a
+    // transport with `rate_limit_per_minute = Some(2)` allows exactly 2 requests then
+    // rejects the 3rd with 429.
+    //
+    // RED-on-revert: set `rate_limit_per_minute: None` without the structural guarantee
+    // → no limiter → all requests succeed → 429 assertion fails.
+
+    /// The per-token limiter installed by `with_durable_dispatch` actually
+    /// rejects requests once the quota is exhausted.
+    ///
+    /// Uses `rate_limit_per_minute: Some(2)` for a deterministic in-test
+    /// quota (driving `DEFAULT_PER_TOKEN_RPM` = 600 requests is impractical).
+    /// The constant value is verified by a separate assertion to pin the default.
+    #[tokio::test]
+    async fn structural_coupling_per_token_limiter_is_behaviorally_active() {
+        use nebula_storage::inmem::{InMemoryTriggerDedupInbox, InMemoryWorkflowVersionStore};
+        use nebula_storage_port::store::{TriggerDedupInbox, WorkflowVersionStore};
+
+        // Pin the default value so a silent change is caught here.
+        assert_eq!(
+            DEFAULT_PER_TOKEN_RPM, 600,
+            "DEFAULT_PER_TOKEN_RPM must be 600"
+        );
+
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup: Arc<dyn TriggerDedupInbox> =
+            Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let version_store: Arc<dyn WorkflowVersionStore> =
+            Arc::new(InMemoryWorkflowVersionStore::new());
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+
+        // Tight per-token quota (2 req/min) for a fast, deterministic test.
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: Some(2),
+            tenant_rate_limit_per_minute: Some(10_000), // generous so per-tenant does not fire
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg)
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(dedup, WebhookTransport::default_resolver(), version_store);
+
+        // Register one Test-mode activation (OptionalAcceptUnsigned, no SWH needed).
+        let outcome = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome),
+            }));
+        let wf = WorkflowId::new();
+        let ctx = base_ctx(wf, node_key!("trigger_rl"));
+        handler.start(&ctx).await.unwrap();
+        let handle = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx,
+                trigger_id: node_key!("trigger_rl").as_str().to_string(),
+                scope: Scope::new("rl-org", "rl-ws"),
+                workflow_id: Some(wf.to_string()),
+                mode: WebhookMode::Test,
+            },
+        )
+        .await
+        .unwrap();
+        let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce);
+
+        // First two requests must pass (quota = 2).
+        assert_eq!(
+            dispatch_skip(&transport, key.clone()).await,
+            StatusCode::OK,
+            "first request within quota must succeed"
+        );
+        assert_eq!(
+            dispatch_skip(&transport, key.clone()).await,
+            StatusCode::OK,
+            "second request within quota must succeed"
+        );
+        // Third request must be rate-limited.
+        assert_eq!(
+            dispatch_skip(&transport, key).await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "third request over per-token quota must return 429 \
+             (RED-on-revert: structural guarantee missing → no limiter → 200)"
+        );
+    }
+
+    // ── E: with_activation_store preserves both rate limiters (structural) ───
+    //
+    // The fast path (`Arc::try_unwrap` succeeds) moves `TransportInner` in-place
+    // and does not touch the rate limiters — correct by construction.
+    //
+    // The slow path (shared Arc, refcount > 1) previously dropped `rate_limiter`
+    // while `tenant_rate_limiter` had an `.or_else()` fallback.  The fix adds
+    // `.or_else(|| arc.rate_limiter.clone())` to the slow path too.
+    //
+    // The slow path is guarded by `debug_assert!(false, …)` so it cannot be
+    // triggered in test/debug builds without a panic.  This test verifies the
+    // structural invariant instead: the normal fast-path composition
+    // `.with_durable_dispatch(...).with_activation_store(...)` must leave BOTH
+    // limiters populated, and must enforce them behaviorally.
+    //
+    // RED-on-revert of the fast path: the fast path preserves limiters because
+    // `with_activation_store` mutates the existing `TransportInner` field —
+    // it does NOT construct a new one, so there is nothing to revert on the fast
+    // path.  The slow-path fix is a code-level defence for the rare misuse case
+    // (composition-root ordering bug); its correctness is verified by code review.
+
+    /// `with_durable_dispatch().with_activation_store()` (fast path) leaves
+    /// both rate limiters intact and behaviorally enforced.
+    #[tokio::test]
+    async fn with_activation_store_fast_path_preserves_both_rate_limiters() {
+        use nebula_storage::inmem::{InMemoryTriggerDedupInbox, InMemoryWorkflowVersionStore};
+        use nebula_storage_port::store::{TriggerDedupInbox, WorkflowVersionStore};
+
+        let exec_store_inner = InMemoryExecutionStore::new();
+        let dedup: Arc<dyn TriggerDedupInbox> =
+            Arc::new(InMemoryTriggerDedupInbox::new(&exec_store_inner));
+        let version_store: Arc<dyn WorkflowVersionStore> =
+            Arc::new(InMemoryWorkflowVersionStore::new());
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+
+        // Standard composition order: durable_dispatch first, then activation_store.
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: Some(1), // 1 req/min — fires on second dispatch
+            tenant_rate_limit_per_minute: Some(10_000), // generous
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg)
+            .with_durable_dispatch(dedup, WebhookTransport::default_resolver(), version_store)
+            .with_activation_store(Arc::clone(&activation_store));
+
+        // Both limiters must be present.
+        assert!(
+            transport.inner.rate_limiter.is_some(),
+            "with_activation_store must preserve the per-token rate_limiter \
+             installed by with_durable_dispatch"
+        );
+        assert!(
+            transport.inner.tenant_rate_limiter.is_some(),
+            "with_activation_store must preserve the per-tenant rate_limiter \
+             installed by with_durable_dispatch"
+        );
+
+        // Behavioral check: the preserved per-token limiter is actually enforced.
+        let outcome = Arc::new(Mutex::new(TriggerEventOutcome::skip()));
+        let handler: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome),
+            }));
+        let wf = WorkflowId::new();
+        let ctx = base_ctx(wf, node_key!("trigger_e"));
+        handler.start(&ctx).await.unwrap();
+        let handle = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template: ctx,
+                trigger_id: node_key!("trigger_e").as_str().to_string(),
+                scope: Scope::new("e-org", "e-ws"),
+                workflow_id: Some(wf.to_string()),
+                mode: WebhookMode::Test,
+            },
+        )
+        .await
+        .unwrap();
+        let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce);
+
+        // First request within quota — must pass.
+        assert_eq!(
+            dispatch_skip(&transport, key.clone()).await,
+            StatusCode::OK,
+            "first request must succeed (per-token quota = 1, not yet exhausted)"
+        );
+        // Second request exceeds the 1 req/min quota — must be rejected.
+        assert_eq!(
+            dispatch_skip(&transport, key).await,
+            StatusCode::TOO_MANY_REQUESTS,
+            "second request must be rate-limited (429) — proves per-token limiter \
+             is behaviorally active after with_activation_store"
+        );
+    }
+
+    // ── G: Prod + SWH per-tenant 429 — step 4.5 fires before B2 at step 5.5 ──
+    //
+    // Two Prod-mode activations share the same tenant scope, both using
+    // `SignaturePolicy::Required` + StandardWebhooks.  The per-tenant quota is 1
+    // req/min.  The first signed request succeeds.  The second signed request —
+    // from a different token (fresh per-token quota) but the same tenant — must
+    // return 429 at step 4.5 (tenant rate limit), NOT 500 from the B2 guard
+    // at step 5.5, and NOT 200 (both exhausted).
+    //
+    // This proves the ordering: tenant-rate-limit check (step 4.5) comes before
+    // signature enforcement (step 5.5 B2 guard) and before durable dispatch.
+
+    /// Two Prod+SWH activations under the same tenant: per-tenant aggregate
+    /// 429 fires correctly before the B2 guard.
+    #[tokio::test]
+    async fn prod_swh_per_tenant_429_fires_before_b2_guard() {
+        use nebula_storage::inmem::{InMemoryTriggerDedupInbox, InMemoryWorkflowVersionStore};
+        use nebula_storage_port::store::{TriggerDedupInbox, WorkflowVersionStore};
+
+        let scope = Scope::new("tenant-org", "tenant-ws");
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let exec_store = Arc::new(exec_store);
+        let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+
+        let cfg = WebhookTransportConfig {
+            rate_limit_per_minute: Some(1_000),    // generous per-token
+            tenant_rate_limit_per_minute: Some(1), // 1 req/min per tenant — fires on second
+            ..WebhookTransportConfig::default()
+        };
+        let transport = WebhookTransport::new(cfg)
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+            );
+
+        // Register two Prod activations under the same scope.
+        let mut handles = vec![];
+        for (trig, wf_id) in [
+            (node_key!("trigger_g1"), WorkflowId::new()),
+            (node_key!("trigger_g2"), WorkflowId::new()),
+        ] {
+            let outcome = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"g": true}))));
+            let handler: Arc<dyn TriggerHandler> =
+                Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                    outcome_cell: Arc::clone(&outcome),
+                }));
+            let ctx = base_ctx(wf_id, trig.clone());
+            handler.start(&ctx).await.unwrap();
+
+            // Both must carry the published workflow so if the rate-limit check
+            // somehow fails the emit would succeed — proving it's the 429 stopping it.
+            let def = minimal_workflow_def(wf_id, trig.as_str().to_string());
+            version_store
+                .create(
+                    &scope,
+                    WorkflowVersionRecord {
+                        workflow_id: wf_id.to_string(),
+                        number: 1,
+                        published: true,
+                        pinned: false,
+                        definition: serde_json::to_value(&def).unwrap(),
+                    },
+                )
+                .await
+                .unwrap();
+
+            let handle = activate_and_persist(
+                &transport,
+                activation_store.as_ref(),
+                PersistParams {
+                    handler,
+                    action_config: WebhookConfig::default()
+                        .with_signature_policy(swh_required_policy()),
+                    ctx_template: ctx,
+                    trigger_id: trig.as_str().to_string(),
+                    scope: scope.clone(),
+                    workflow_id: Some(wf_id.to_string()),
+                    mode: WebhookMode::Prod,
+                },
+            )
+            .await
+            .unwrap();
+            handles.push((handle, wf_id));
+        }
+
+        let body = b"{}";
+        let msg_id_1 = "g-msg-001";
+        let msg_id_2 = "g-msg-002";
+
+        // Request 1 — token A, fully signed → must pass (per-token OK, per-tenant OK).
+        let headers_1 = swh_headers(msg_id_1, body);
+        let key_1 = WebhookKey::programmatic(handles[0].0.trigger_uuid, handles[0].0.nonce.clone());
+        let r1 = dispatch_inner(
+            transport.clone(),
+            key_1,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers_1,
+            Bytes::from(body as &[u8]),
+        )
+        .await;
+        assert_eq!(
+            r1.status(),
+            StatusCode::OK,
+            "first Prod+SWH request must succeed"
+        );
+
+        // Request 2 — token B (fresh per-token window), signed, same tenant.
+        // Per-tenant aggregate is now exhausted → must return 429.
+        // Must NOT return 500 (B2 guard) or 200 (emit).
+        let headers_2 = swh_headers(msg_id_2, body);
+        let key_2 = WebhookKey::programmatic(handles[1].0.trigger_uuid, handles[1].0.nonce.clone());
+        let r2 = dispatch_inner(
+            transport.clone(),
+            key_2,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers_2,
+            Bytes::from(body as &[u8]),
+        )
+        .await;
+        assert_eq!(
+            r2.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "second Prod+SWH request same tenant must be per-tenant 429 \
+             (step 4.5 before B2 at 5.5 and before durable emit)"
+        );
+
+        // Zero executions spawned for the rejected request.
+        // One execution from the first request (Prod emit succeeded).
+        assert_eq!(
+            exec_store.count(&scope, None).await.unwrap(),
+            1,
+            "only the first Prod request should have spawned an execution; \
+             the 429 must not reach the durable emit path"
         );
     }
 

--- a/crates/api/src/transport/webhook/dispatch.rs
+++ b/crates/api/src/transport/webhook/dispatch.rs
@@ -27,8 +27,8 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use nebula_action::{
-    ExecutionEmitter, IdempotencyKey, TriggerEvent, TriggerEventOutcome, WebhookHttpResponse,
-    WebhookRequest,
+    ExecutionEmitter, IdempotencyKey, SignaturePolicy, TriggerEvent, TriggerEventOutcome,
+    WebhookHttpResponse, WebhookRequest,
 };
 use nebula_core::NodeKey;
 use nebula_engine::DurableExecutionEmitter;
@@ -46,8 +46,8 @@ use tracing::{debug, warn};
 use super::{
     key::WebhookKey,
     signature::{
-        SignatureVerdict, enforce_signature, missing_secret_response, record_signature_failure,
-        signature_rejected_response,
+        SignatureVerdict, enforce_signature, missing_secret_response,
+        prod_requires_signature_response, record_signature_failure, signature_rejected_response,
     },
     token::token_hash,
     transport::DurableDispatchComponents,
@@ -322,12 +322,39 @@ pub(super) async fn dispatch_inner(
         },
     };
 
-    // 5.5. Signature enforcement. The `Required` default
-    // means an action that forgot to configure a secret trips a 500
-    // here; an action that explicitly opted into
-    // `OptionalAcceptUnsigned` passes through; everything else
-    // (hex / base64 / custom) runs through the existing constant-time
-    // primitives before the handler sees the request.
+    // 5.5. Signature enforcement.
+    //
+    // B2 split-brain guard: a Prod-mode row (durable dispatch will spawn)
+    // MUST NOT be verifiable under `OptionalAcceptUnsigned`.  An unsigned
+    // Prod activation is an operator/composition-root misconfiguration — it
+    // would let an unverified caller spawn durable executions.  Fail closed
+    // with 500 (same surface as `missing_secret`) so dashboards see it.
+    // `durable.is_some()` ⟺ Prod row that resolved to a durable target.
+    if durable.is_some()
+        && matches!(
+            entry.config.signature_policy(),
+            SignaturePolicy::OptionalAcceptUnsigned
+        )
+    {
+        warn!(
+            mode = "Prod",
+            "Prod-mode webhook: signature policy is OptionalAcceptUnsigned; \
+             Prod activations must use SignaturePolicy::Required — \
+             refusing to dispatch (composition-root misconfiguration)"
+        );
+        record_signature_failure(
+            &transport.inner.metrics,
+            webhook_signature_failure_reason::PROD_UNSIGNED,
+        );
+        return prod_requires_signature_response(uri.path());
+    }
+
+    // The `Required` default means an action that forgot to configure a
+    // secret trips a 500 here; an action that explicitly opted into
+    // `OptionalAcceptUnsigned` passes through (for non-Prod paths only —
+    // the Prod guard above already rejected Prod+unsigned); everything else
+    // (hex / base64 / Standard Webhooks / custom) runs through the existing
+    // constant-time primitives before the handler sees the request.
     match enforce_signature(
         entry.config.signature_policy(),
         &request,
@@ -780,12 +807,14 @@ mod tests {
     //!   is set per-test via `Arc<Mutex<TriggerEventOutcome>>`.
 
     use std::sync::Arc;
+    use std::time::SystemTime;
 
     use axum::http::{HeaderMap, HeaderValue, Method, StatusCode, Uri};
+    use base64::{Engine as _, engine::general_purpose::STANDARD as B64};
     use nebula_action::{
-        Action, ActionMetadata, SignaturePolicy, TriggerContext, TriggerEventOutcome,
-        TriggerHandler, WebhookAction, WebhookConfig, WebhookRequest, WebhookResponse,
-        WebhookTriggerAdapter,
+        Action, ActionMetadata, RequiredPolicy, SignaturePolicy, SignatureScheme, TriggerContext,
+        TriggerEventOutcome, TriggerHandler, WebhookAction, WebhookConfig, WebhookRequest,
+        WebhookResponse, WebhookTriggerAdapter, hmac_sha256_compute,
     };
     use nebula_core::{BaseContext, Dependencies, NodeKey, WorkflowId, action_key, node_key};
     use nebula_storage::inmem::{
@@ -807,11 +836,73 @@ mod tests {
         PersistParams, WebhookTransport, WebhookTransportConfig, activate_and_persist,
     };
 
+    // ── Standard Webhooks test signing ────────────────────────────────────────
+
+    /// HMAC key used by all Prod-mode test fixtures.
+    ///
+    /// Raw bytes — no `whsec_` prefix. The verify path operates on
+    /// already-decoded bytes (registration concern is out of scope here).
+    const TEST_SWH_SECRET: &[u8] = b"nebula-dispatch-test-secret";
+
+    /// Build the SWH `SignaturePolicy` used by Prod fixtures.
+    fn swh_required_policy() -> SignaturePolicy {
+        SignaturePolicy::Required(
+            RequiredPolicy::new()
+                .with_secret(TEST_SWH_SECRET)
+                .with_scheme(SignatureScheme::StandardWebhooks),
+        )
+    }
+
+    /// Compute a valid Standard Webhooks `webhook-signature` header value.
+    ///
+    /// `to_sign = "{msg_id}.{ts_secs}.{body}"`
+    fn sign_swh(msg_id: &str, ts_secs: u64, body: &[u8]) -> String {
+        let prefix = format!("{msg_id}.{ts_secs}.");
+        let mut content = Vec::with_capacity(prefix.len() + body.len());
+        content.extend_from_slice(prefix.as_bytes());
+        content.extend_from_slice(body);
+        format!(
+            "v1,{}",
+            B64.encode(hmac_sha256_compute(TEST_SWH_SECRET, &content))
+        )
+    }
+
+    /// Unix seconds for the current wall time — used when constructing
+    /// test requests so the signature is valid against `SystemClock`.
+    fn now_secs() -> u64 {
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .expect("system time after epoch")
+            .as_secs()
+    }
+
+    /// Build a header map with `webhook-id`, `webhook-timestamp`, and a
+    /// valid `webhook-signature` for the given body.
+    fn swh_headers(msg_id: &str, body: &[u8]) -> HeaderMap {
+        let ts = now_secs();
+        let sig = sign_swh(msg_id, ts, body);
+        let mut h = HeaderMap::new();
+        h.insert(WEBHOOK_ID_HEADER, HeaderValue::from_str(msg_id).unwrap());
+        h.insert(
+            HeaderName::from_static("webhook-timestamp"),
+            HeaderValue::from_str(&ts.to_string()).unwrap(),
+        );
+        h.insert(
+            HeaderName::from_static("webhook-signature"),
+            HeaderValue::from_str(&sig).unwrap(),
+        );
+        h
+    }
+
     // ── TestWebhookAction ─────────────────────────────────────────────────────
 
     /// Minimal `WebhookAction` whose `handle_request` returns whatever
-    /// `outcome_cell` says.  Signature checking is disabled so tests can
-    /// send unsigned bodies.
+    /// `outcome_cell` says.
+    ///
+    /// The `config` method returns the caller-supplied `WebhookConfig`, which
+    /// carries the `SignaturePolicy` for the test.  Prod-mode fixtures supply
+    /// `SignaturePolicy::Required` (SWH); non-Prod / legacy fixtures may use
+    /// `OptionalAcceptUnsigned`.
     struct ConfigurableWebhookAction {
         outcome_cell: Arc<Mutex<TriggerEventOutcome>>,
     }
@@ -976,13 +1067,20 @@ mod tests {
                     Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
                 );
 
+            // Prod rows must carry `Required`+SWH (B2 split-brain guard).
+            // Test rows can remain unsigned for simplicity.
+            let sig_policy = if mode == WebhookMode::Prod {
+                swh_required_policy()
+            } else {
+                SignaturePolicy::OptionalAcceptUnsigned
+            };
+
             let handle = activate_and_persist(
                 &transport,
                 activation_store.as_ref(),
                 PersistParams {
                     handler,
-                    action_config: WebhookConfig::default()
-                        .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                    action_config: WebhookConfig::default().with_signature_policy(sig_policy),
                     ctx_template,
                     trigger_id: trigger_id.clone(),
                     scope: scope.clone(),
@@ -1036,19 +1134,55 @@ mod tests {
             self.exec_store.count(&self.scope, None).await.unwrap()
         }
 
+        /// Dispatch with a fully-signed SWH request including `webhook-id`.
+        ///
+        /// The body is `{}`.  The headers include `webhook-id`,
+        /// `webhook-timestamp` (current wall time), and a valid
+        /// `webhook-signature` computed with [`TEST_SWH_SECRET`].
         async fn dispatch_with_id(&self, delivery_id: &str) -> Response {
+            let body = b"{}";
+            let headers = swh_headers(delivery_id, body);
             dispatch_inner(
                 self.transport.clone(),
                 self.key(),
                 Method::POST,
                 Uri::from_static("http://localhost/webhooks/test"),
-                headers_with_delivery_id(delivery_id),
+                headers,
+                Bytes::from(body as &[u8]),
+            )
+            .await
+        }
+
+        /// Dispatch with `webhook-timestamp` + `webhook-signature` but WITHOUT
+        /// `webhook-id`.
+        ///
+        /// With StandardWebhooks, the absence of `webhook-id` means the
+        /// signed content cannot be constructed → `SignatureOutcome::Missing`
+        /// → 401 (not 400 as in the pre-B2 dedup-key guard).
+        async fn dispatch_without_id(&self) -> Response {
+            // Only timestamp + signature, no id — SWH will return Missing → 401.
+            let ts = now_secs();
+            let mut headers = HeaderMap::new();
+            headers.insert(
+                HeaderName::from_static("webhook-timestamp"),
+                HeaderValue::from_str(&ts.to_string()).unwrap(),
+            );
+            // Omit webhook-signature too: no id → no canonical content → no sig.
+            dispatch_inner(
+                self.transport.clone(),
+                self.key(),
+                Method::POST,
+                Uri::from_static("http://localhost/webhooks/test"),
+                headers,
                 Bytes::from(b"{}" as &[u8]),
             )
             .await
         }
 
-        async fn dispatch_without_id(&self) -> Response {
+        /// Dispatch without ANY SWH headers.  For tests that expect the raw
+        /// behavior when neither id nor timestamp is present (e.g., Test-mode
+        /// routes with `OptionalAcceptUnsigned`).
+        async fn dispatch_bare(&self) -> Response {
             dispatch_inner(
                 self.transport.clone(),
                 self.key(),
@@ -1066,15 +1200,6 @@ mod tests {
     }
 
     // ── Test helpers ──────────────────────────────────────────────────────────
-
-    fn headers_with_delivery_id(id: &str) -> HeaderMap {
-        let mut h = HeaderMap::new();
-        h.insert(
-            WEBHOOK_ID_HEADER,
-            HeaderValue::from_str(id).expect("valid header value"),
-        );
-        h
-    }
 
     fn base_ctx(
         workflow_id: WorkflowId,
@@ -1111,13 +1236,14 @@ mod tests {
 
     // ── Test 1: Prod-mode Emit spawns exactly one execution ───────────────────
 
-    /// Prod-mode activation + `webhook-id` header → emitter is called.
-    /// Verify the response is 200 OK.
+    /// Prod-mode activation + valid SWH `webhook-id` header → emitter is
+    /// called. Verify the response is 200 OK and one execution was spawned.
     ///
-    /// This is the nominal happy-path test.  Removing the mode gate or the
-    /// `durable_dispatch` wiring would cause this to still return 200 (via
-    /// the fallthrough path) — the behavioral assertion is that we get a 200
-    /// AND the inbox was hit (which we indirectly verify in test 3 via dedup).
+    /// This is the nominal happy-path test (B1 + B2).  The fixture is wired
+    /// with `SignaturePolicy::Required(StandardWebhooks)` and the request
+    /// carries a valid HMAC signature.  Removing the mode gate, the
+    /// `durable_dispatch` wiring, OR the signature policy would break the
+    /// behavioral assertion (execution_count == 1 AND 200).
     #[tokio::test]
     async fn prod_mode_emit_returns_200() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
@@ -1125,7 +1251,7 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::OK,
-            "Prod emit must return 200 (Emit + durable inbox)"
+            "Prod emit must return 200 (Emit + durable inbox, SWH-signed)"
         );
         assert_eq!(
             fix.execution_count().await,
@@ -1139,15 +1265,17 @@ mod tests {
     /// mode=Test → the durable path is NEVER taken even when `durable_dispatch`
     /// is wired.  The fallthrough in-memory path returns 200.
     ///
+    /// Test-mode activations use `OptionalAcceptUnsigned` (the B2 guard only
+    /// fires for Prod rows), so requests can be sent bare (no signature).
+    ///
     /// Red-on-revert: removing the `row.mode == WebhookMode::Prod` guard would
     /// cause Test-mode activations to take the durable path, which would
     /// fail (inbox claim) OR spawn unexpectedly.
     #[tokio::test]
     async fn test_mode_skips_durable_dispatch_returns_200() {
         let fix = TestFixture::prod(WebhookMode::Test).await;
-        // Test-mode: no durable_dispatch wired means the mode guard must
-        // correctly NOT set durable = Some(...), so the fallthrough path runs.
-        let resp = fix.dispatch_with_id("delivery-002").await;
+        // Test-mode: OptionalAcceptUnsigned → no B2 guard, no sig check.
+        let resp = fix.dispatch_bare().await;
         assert_eq!(
             resp.status(),
             StatusCode::OK,
@@ -1162,10 +1290,10 @@ mod tests {
 
     // ── Test 3: Same webhook-id twice → second is deduplicated ────────────────
 
-    /// Delivering the same `webhook-id` twice: the first call spawns the
-    /// execution; the second is a duplicate from the inbox's perspective.
-    /// Both should return 200 (the second call is acked just like the first —
-    /// the dedup is at the storage layer, the HTTP response is always 200).
+    /// Delivering the same `webhook-id` twice with valid SWH signatures: the
+    /// first call spawns the execution; the second is deduplicated by the inbox.
+    /// Both should return 200 (the dedup is at the storage layer; the HTTP ack
+    /// is always 200).
     ///
     /// This proves the dedup PK contract: `(scope, trigger_id, event_id)`.
     #[tokio::test]
@@ -1186,31 +1314,50 @@ mod tests {
         );
     }
 
-    // ── Test 4: Missing webhook-id in Prod → 400 ─────────────────────────────
+    // ── Test 4: Missing webhook-id in Prod → 401 (SWH requires id for sig) ────
 
-    /// Prod-mode activation without `webhook-id` header → fail-closed 400.
+    /// Prod-mode activation without `webhook-id` header → 401 (SWH signature
+    /// missing, because the id is part of the signed content and cannot be
+    /// constructed without it).
     ///
-    /// Red-on-revert: removing the `durable.is_some() && event_id.is_none()`
-    /// guard would cause Prod-mode dispatch to proceed with `event_id = None`,
-    /// which defeats the dedup invariant.
+    /// Pre-B2 behaviour: the dedup-key guard returned 400 ("missing
+    /// webhook-id").  Post-B2: the SWH signature check fires first at step
+    /// 5.5 — no id means no signed content → `SignatureOutcome::Missing` → 401.
+    /// The dedup invariant is still protected: a request that fails sig
+    /// verification never reaches the emit path.
+    ///
+    /// Red-on-revert (B1): removing `SignatureScheme::StandardWebhooks` from
+    /// the required-policy arm causes `verify_standard_webhooks` to be
+    /// unreachable; the request would fall through to the old path and return
+    /// a different status.
     #[tokio::test]
-    async fn prod_mode_missing_webhook_id_returns_400() {
+    async fn prod_mode_missing_webhook_id_returns_401() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
+        // dispatch_without_id: has webhook-timestamp but no webhook-id or
+        // webhook-signature → SWH can't build signed content → Missing → 401.
         let resp = fix.dispatch_without_id().await;
         assert_eq!(
             resp.status(),
-            StatusCode::BAD_REQUEST,
-            "Prod-mode without webhook-id must be 400"
+            StatusCode::UNAUTHORIZED,
+            "Prod-mode without webhook-id must return 401 (SWH signature missing)"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "sig-failed request must not spawn any execution"
         );
     }
 
     /// An over-long `webhook-id` header is rejected at the edge with a clean
-    /// 400, rather than flowing into the dedup-key PK and surfacing as a
-    /// backend-dependent 5xx (e.g. Postgres index-row-too-large).
+    /// 400 (overflow guard fires before signature enforcement — the id
+    /// extraction happens before `WebhookRequest::try_new` and signature
+    /// check, so the 400 is independent of SWH policy).
     #[tokio::test]
     async fn prod_mode_oversized_webhook_id_returns_400() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
         let oversized = "x".repeat(300);
+        // dispatch_with_id includes valid SWH headers, but the oversized-id
+        // guard (step 7) fires before signature enforcement (step 5.5).
         let resp = fix.dispatch_with_id(&oversized).await;
         assert_eq!(
             resp.status(),
@@ -1221,6 +1368,10 @@ mod tests {
 
     /// Two `webhook-id` headers → 400. `HeaderMap::get` would silently pick one,
     /// letting conflicting delivery ids bypass dedup; reject the ambiguity.
+    ///
+    /// The duplicate-id check fires at step 7 (header extraction), before
+    /// signature enforcement (step 5.5), so this returns 400 regardless of
+    /// the SWH policy.
     #[tokio::test]
     async fn duplicate_webhook_id_headers_returns_400() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
@@ -1248,22 +1399,34 @@ mod tests {
         );
     }
 
-    /// A Prod verification probe (`Skip` outcome) without a `webhook-id` must
-    /// NOT be rejected — the dedup key is only required for emitting outcomes
-    /// (Codex P2). Slack `url_verification` / Stripe `pending_webhook` return
-    /// Skip and carry no delivery id.
+    /// A Prod verification probe (`Skip` outcome) with a valid SWH signature
+    /// must return 200 — the dedup key (`webhook-id`) is present (SWH requires
+    /// it for signing), and the `Emit` guard fires only on `Emit` outcomes
+    /// (Codex P2).
     ///
-    /// Red-on-revert: the old pre-dispatch `durable && event_id.is_none()` →
-    /// 400 check would reject this probe with 400.
+    /// Post-B2: Prod rows require `Required`+SWH.  A verification probe from a
+    /// well-behaved provider will include a valid SWH signature; the probe's
+    /// `Skip` outcome does NOT hit the "missing webhook-id" dedup guard because
+    /// that guard is in the `Emit` arm of `dispatch_durable`, not before.
+    ///
+    /// Red-on-revert (B2): removing the split-brain guard and reverting to
+    /// `OptionalAcceptUnsigned` for Prod rows would cause the B2 500 to
+    /// disappear from the split-brain test (separate test below).
     #[tokio::test]
-    async fn prod_mode_skip_without_webhook_id_returns_200() {
+    async fn prod_mode_skip_with_signed_id_returns_200() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
         fix.set_outcome(TriggerEventOutcome::skip());
-        let resp = fix.dispatch_without_id().await;
+        // Use dispatch_with_id: provides webhook-id + timestamp + valid sig.
+        let resp = fix.dispatch_with_id("probe-001").await;
         assert_eq!(
             resp.status(),
             StatusCode::OK,
-            "Prod Skip without webhook-id is a verification probe, must pass (not 400)"
+            "Prod Skip with valid SWH signature must return 200 (no dedup-key guard on Skip)"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "Skip must spawn NO execution"
         );
     }
 
@@ -1289,7 +1452,7 @@ mod tests {
 
     // ── Test 5: EmitMany in Prod → 500 ────────────────────────────────────────
 
-    /// `EmitMany` outcome in Prod mode → fail-closed 500.
+    /// `EmitMany` outcome in Prod mode → fail-closed 500 (with valid SWH sig).
     ///
     /// One `event_id` cannot safely fan-out to N executions (dedup-collision
     /// data-loss bug). No first-party webhook action returns EmitMany; if one
@@ -1319,6 +1482,7 @@ mod tests {
     async fn prod_mode_skip_returns_200_no_spawn() {
         let fix = TestFixture::prod(WebhookMode::Prod).await;
         fix.set_outcome(TriggerEventOutcome::skip());
+        // Signed request with a valid webhook-id.
         let resp = fix.dispatch_with_id("delivery-005").await;
         assert_eq!(
             resp.status(),
@@ -1377,7 +1541,7 @@ mod tests {
             PersistParams {
                 handler,
                 action_config: WebhookConfig::default()
-                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                    .with_signature_policy(swh_required_policy()),
                 ctx_template,
                 trigger_id,
                 scope: scope.clone(),
@@ -1390,13 +1554,15 @@ mod tests {
         .expect("activate_and_persist must succeed");
 
         let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce.clone());
+        let body = b"{}";
+        let headers = swh_headers("delivery-006", body);
         let resp = dispatch_inner(
             transport,
             key,
             Method::POST,
             Uri::from_static("http://localhost/webhooks/test"),
-            headers_with_delivery_id("delivery-006"),
-            Bytes::from(b"{}" as &[u8]),
+            headers,
+            Bytes::from(body as &[u8]),
         )
         .await;
 
@@ -1452,14 +1618,14 @@ mod tests {
                 Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
             );
 
-        // Activation row registered under scope_a.
+        // Activation row registered under scope_a, with SWH policy (Prod).
         let handle = activate_and_persist(
             &transport,
             activation_store.as_ref(),
             PersistParams {
                 handler,
                 action_config: WebhookConfig::default()
-                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                    .with_signature_policy(swh_required_policy()),
                 ctx_template: ctx_template_a,
                 trigger_id: trigger_id.clone(),
                 scope: scope_a.clone(),
@@ -1487,13 +1653,15 @@ mod tests {
             .expect("version create");
 
         let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce.clone());
+        let body = b"{}";
+        let headers = swh_headers("delivery-007", body);
         let resp = dispatch_inner(
             transport,
             key,
             Method::POST,
             Uri::from_static("http://localhost/webhooks/test"),
-            headers_with_delivery_id("delivery-007"),
-            Bytes::from(b"{}" as &[u8]),
+            headers,
+            Bytes::from(body as &[u8]),
         )
         .await;
 
@@ -1782,6 +1950,189 @@ mod tests {
             transport.inner.tenant_rate_limiter.is_some(),
             "with_durable_dispatch must install per-tenant tenant_rate_limiter even when \
              config.tenant_rate_limit_per_minute is None (structural guarantee)"
+        );
+    }
+
+    // ── B1: SWH tampered body → 401 ──────────────────────────────────────────
+
+    /// A Prod request with a valid SWH signature over the ORIGINAL body, but
+    /// the body has been tampered with in transit → 401 (SignatureInvalid).
+    ///
+    /// Red-on-revert (B1): removing `SignatureScheme::StandardWebhooks` from
+    /// `verify_with` reverts to the default `Sha256Hex` scheme, which checks a
+    /// different header and different content — the tampered body would slip
+    /// through whatever the routing-entry config says.
+    #[tokio::test]
+    async fn prod_mode_swh_tampered_body_returns_401() {
+        let fix = TestFixture::prod(WebhookMode::Prod).await;
+
+        let msg_id = "msg-tamper-001";
+        let ts = now_secs();
+        let original_body = b"{\"original\":true}";
+        let tampered_body = b"{\"tampered\":true}";
+
+        // Sign over the ORIGINAL body.
+        let sig = sign_swh(msg_id, ts, original_body);
+
+        // But send the TAMPERED body.
+        let mut headers = HeaderMap::new();
+        headers.insert(WEBHOOK_ID_HEADER, HeaderValue::from_str(msg_id).unwrap());
+        headers.insert(
+            HeaderName::from_static("webhook-timestamp"),
+            HeaderValue::from_str(&ts.to_string()).unwrap(),
+        );
+        headers.insert(
+            HeaderName::from_static("webhook-signature"),
+            HeaderValue::from_str(&sig).unwrap(),
+        );
+
+        let resp = dispatch_inner(
+            fix.transport.clone(),
+            fix.key(),
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers,
+            Bytes::from(tampered_body as &[u8]),
+        )
+        .await;
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "tampered body with valid sig (over original) must return 401"
+        );
+        assert_eq!(
+            fix.execution_count().await,
+            0,
+            "tampered-body request must not spawn any execution"
+        );
+    }
+
+    // ── B2: Split-brain guard — Prod + OptionalAcceptUnsigned → 500 ──────────
+
+    /// A Prod-mode activation whose **in-memory routing entry** carries
+    /// `SignaturePolicy::OptionalAcceptUnsigned` → 500 (misconfiguration
+    /// detected at dispatch time, no execution spawned).
+    ///
+    /// This is the B2 split-brain guard: `durable.is_some()` (Prod row that
+    /// will spawn) AND `OptionalAcceptUnsigned` is a composition-root
+    /// misconfiguration.  The invariant is enforced at the transport layer,
+    /// not only at activation time, so a stale in-memory routing entry cannot
+    /// silently downgrade a durable Prod path to unsigned acceptance.
+    ///
+    /// RED-on-revert: removing the B2 guard (the `if durable.is_some() &&
+    /// matches!(…OptionalAcceptUnsigned)` block in `dispatch_inner`) causes the
+    /// unsigned request to pass sig enforcement (`OptionalAcceptUnsigned →
+    /// Pass`) and the action to emit, materializing an execution.  The
+    /// `execution_count == 1` assertion below FAILS → test is RED.
+    #[tokio::test]
+    async fn prod_unsigned_policy_returns_500_and_spawns_nothing() {
+        // Build a Prod-mode fixture that DELIBERATELY uses OptionalAcceptUnsigned.
+        // This is the misconfiguration scenario: the activation row is Prod but
+        // the in-memory routing entry's action_config has no sig policy.
+        let scope = Scope::new("test-org", "test-ws");
+        let workflow_id = WorkflowId::new();
+        let trigger_id_key = node_key!("webhook_trigger");
+        let trigger_id = trigger_id_key.as_str().to_string();
+
+        let exec_store = InMemoryExecutionStore::new();
+        let dedup = Arc::new(InMemoryTriggerDedupInbox::new(&exec_store));
+        let exec_store = Arc::new(exec_store);
+        let version_store = Arc::new(InMemoryWorkflowVersionStore::new());
+        let activation_store: Arc<dyn WebhookActivationStore> =
+            Arc::new(InMemoryWebhookActivationStore::new());
+
+        let outcome_cell = Arc::new(Mutex::new(TriggerEventOutcome::emit(json!({"ok": true}))));
+        let handler: Arc<dyn TriggerHandler> =
+            Arc::new(WebhookTriggerAdapter::new(ConfigurableWebhookAction {
+                outcome_cell: Arc::clone(&outcome_cell),
+            }));
+        let ctx_template = base_ctx(workflow_id, trigger_id_key);
+        handler.start(&ctx_template).await.expect("handler start");
+
+        let transport = WebhookTransport::new(WebhookTransportConfig::default())
+            .with_activation_store(Arc::clone(&activation_store))
+            .with_durable_dispatch(
+                dedup as Arc<dyn TriggerDedupInbox>,
+                WebhookTransport::default_resolver(),
+                Arc::clone(&version_store) as Arc<dyn WorkflowVersionStore>,
+            );
+
+        // Deliberately misconfiguged: Prod mode row + OptionalAcceptUnsigned.
+        let handle = activate_and_persist(
+            &transport,
+            activation_store.as_ref(),
+            PersistParams {
+                handler,
+                action_config: WebhookConfig::default()
+                    .with_signature_policy(SignaturePolicy::OptionalAcceptUnsigned),
+                ctx_template,
+                trigger_id: trigger_id.clone(),
+                scope: scope.clone(),
+                workflow_id: Some(workflow_id.to_string()),
+                mode: WebhookMode::Prod, // Prod row — durable path will be taken
+            },
+        )
+        .await
+        .expect("activate_and_persist must succeed");
+
+        // Publish a valid workflow definition (so if the guard were missing,
+        // the emit would succeed — proving the guard is what stops it).
+        let def = minimal_workflow_def(workflow_id, trigger_id);
+        version_store
+            .create(
+                &scope,
+                WorkflowVersionRecord {
+                    workflow_id: workflow_id.to_string(),
+                    number: 1,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(&def).unwrap(),
+                },
+            )
+            .await
+            .expect("version store create");
+
+        let key = WebhookKey::programmatic(handle.trigger_uuid, handle.nonce.clone());
+
+        // Request carries `webhook-id` (satisfying the dedup-key requirement in
+        // `dispatch_durable`) but NO signature (correct for `OptionalAcceptUnsigned`
+        // — no sig is required when that policy is active).
+        //
+        // Why `webhook-id` is mandatory here: without it the request hits the
+        // 400-missing-dedup-key guard in `dispatch_durable`, and `execution_count`
+        // stays 0 on revert for the wrong reason — masking the B2 spawn-prevention
+        // property.  With `webhook-id` present, on revert: `OptionalAcceptUnsigned`
+        // → sig-enforcement Pass → handler emits → `do_emit_prod` spawns →
+        // `execution_count == 1` → the count assertion below goes RED.
+        let mut headers_with_id = HeaderMap::new();
+        headers_with_id.insert(
+            WEBHOOK_ID_HEADER,
+            HeaderValue::from_static("b2-revert-probe-001"),
+        );
+        let resp = dispatch_inner(
+            transport,
+            key,
+            Method::POST,
+            Uri::from_static("http://localhost/webhooks/test"),
+            headers_with_id,
+            Bytes::from(b"{}" as &[u8]),
+        )
+        .await;
+
+        // Count checked FIRST so both assertions are visible in revert runs.
+        // RED-on-revert: without B2, `OptionalAcceptUnsigned`→Pass, handler
+        // emits, `do_emit_prod` materializes one execution → count == 1 → FAIL.
+        assert_eq!(
+            exec_store.count(&scope, None).await.unwrap(),
+            0,
+            "B2 guard must prevent ANY execution from being spawned \
+             (RED-on-revert: execution_count becomes 1 without the guard)"
+        );
+        assert_eq!(
+            resp.status(),
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Prod row with OptionalAcceptUnsigned must return 500 (B2 split-brain guard)"
         );
     }
 }

--- a/crates/api/src/transport/webhook/ratelimit.rs
+++ b/crates/api/src/transport/webhook/ratelimit.rs
@@ -54,6 +54,17 @@ pub struct RateLimitExceeded {
 /// rate-limited the same way; the cap does not create a bypass. A window that
 /// has been idle for longer than twice the request window is also eligible
 /// for eviction so paths decommissioned by operators do not linger.
+///
+/// # Per-replica limitation
+///
+/// The sliding-window state is **process-local** (held in an in-process
+/// `moka::Cache`). Under a horizontally-scaled deployment with `N` replicas
+/// the effective cap is `N ×` the configured RPM — a sender that spreads
+/// requests round-robin across replicas can sustain `N ×` the nominal limit
+/// before any single replica rejects it. A distributed rate-limit store
+/// (e.g. Redis `INCR` + TTL) is deferred; operators running multiple replicas
+/// should set `rate_limit_per_minute` conservatively (`target_rpm / N`)
+/// until a global-state backend is wired.
 #[derive(Debug, Clone)]
 pub struct WebhookRateLimiter {
     windows: Cache<String, Arc<SlidingWindow>>,

--- a/crates/api/src/transport/webhook/signature.rs
+++ b/crates/api/src/transport/webhook/signature.rs
@@ -195,3 +195,31 @@ pub(super) fn missing_secret_response(instance_path: &str) -> Response {
     .with_instance(instance_path.to_string());
     problem_response(StatusCode::INTERNAL_SERVER_ERROR, problem)
 }
+
+/// 500 response for a Prod-mode activation whose in-memory routing entry
+/// carries `SignaturePolicy::OptionalAcceptUnsigned`.
+///
+/// A Prod row dispatching unsigned is a composition-root misconfiguration:
+/// the activation was registered without a `Required` signature policy.
+/// Returned as 500 so the sender retries (the misconfiguration must be
+/// fixed on the operator side); the event is NOT accepted.
+///
+/// Distinct from [`missing_secret_response`] (which fires when `Required`
+/// policy has an empty secret) so dashboards can separately alert on
+/// "Prod row has no signature policy at all".
+pub(super) fn prod_requires_signature_response(instance_path: &str) -> Response {
+    let problem = ProblemDetails::new(
+        "https://nebula.dev/problems/webhook-prod-requires-signature",
+        "Prod Webhook Activation Requires Signature Policy",
+        StatusCode::INTERNAL_SERVER_ERROR,
+    )
+    .with_detail(
+        "Prod-mode webhook activation is configured with \
+         SignaturePolicy::OptionalAcceptUnsigned; Prod activations must \
+         use SignaturePolicy::Required with an HMAC secret to prevent \
+         unsigned requests from spawning executions"
+            .to_string(),
+    )
+    .with_instance(instance_path.to_string());
+    problem_response(StatusCode::INTERNAL_SERVER_ERROR, problem)
+}

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -45,6 +45,24 @@ use super::{
     routing::{ActivationEntry, RoutingMap},
 };
 
+/// Default per-token (per-trigger-UUID) requests-per-minute limit installed
+/// automatically when `with_durable_dispatch` is called and the config did
+/// not set `rate_limit_per_minute`.
+///
+/// Operator-tunable starting point: 600 req/min (10 req/s) per token.
+/// Override via `WebhookTransportConfig { rate_limit_per_minute: Some(n), .. }`.
+pub const DEFAULT_PER_TOKEN_RPM: u64 = 600;
+
+/// Default per-tenant-aggregate requests-per-minute limit installed
+/// automatically when `with_durable_dispatch` is called and the config did
+/// not set `tenant_rate_limit_per_minute`.
+///
+/// Operator-tunable starting point: 3 000 req/min (50 req/s) per tenant.
+/// This cap bounds a single tenant flooding across many distinct tokens
+/// while keeping each token under its own independent quota.
+/// Override via `WebhookTransportConfig { tenant_rate_limit_per_minute: Some(n), .. }`.
+pub const DEFAULT_PER_TENANT_RPM: u64 = 3_000;
+
 /// Configuration for the webhook HTTP transport.
 #[derive(Debug, Clone)]
 pub struct WebhookTransportConfig {
@@ -61,9 +79,17 @@ pub struct WebhookTransportConfig {
     /// dispatching to `handle_event` before returning
     /// `504 Gateway Timeout`.
     pub response_timeout: Duration,
-    /// Per-path requests-per-minute cap. `None` disables per-path
-    /// rate limiting entirely.
+    /// Per-token (per-trigger-UUID) requests-per-minute cap.
+    ///
+    /// `None` — no explicit operator override; when `with_durable_dispatch`
+    /// is called, [`DEFAULT_PER_TOKEN_RPM`] is installed automatically.
+    /// For non-durable transports this stays `None` (no per-token limiter).
     pub rate_limit_per_minute: Option<u64>,
+    /// Per-tenant-aggregate requests-per-minute cap.
+    ///
+    /// `None` — no explicit operator override; when `with_durable_dispatch`
+    /// is called, [`DEFAULT_PER_TENANT_RPM`] is installed automatically.
+    pub tenant_rate_limit_per_minute: Option<u64>,
 }
 
 impl Default for WebhookTransportConfig {
@@ -76,6 +102,7 @@ impl Default for WebhookTransportConfig {
             body_limit_bytes: 1024 * 1024, // 1 MiB matches nebula-action default
             response_timeout: Duration::from_secs(10),
             rate_limit_per_minute: None,
+            tenant_rate_limit_per_minute: None,
         }
     }
 }
@@ -105,7 +132,21 @@ pub struct WebhookTransport {
 pub(super) struct TransportInner {
     pub(super) config: WebhookTransportConfig,
     pub(super) routing: RoutingMap,
+    /// Per-token (per-trigger-UUID) sliding-window rate limiter.
+    ///
+    /// Enforced at step 4 (pre-resolution) so unauthenticated churn
+    /// against registered keys never reaches the DB.
     pub(super) rate_limiter: Option<WebhookRateLimiter>,
+    /// Per-tenant-aggregate sliding-window rate limiter.
+    ///
+    /// Enforced at step 4.5 (post-resolution, post-token-lookup) so
+    /// the scope-key is available. Caps a single tenant flooding across
+    /// many distinct tokens while each token stays under its own quota.
+    ///
+    /// Structurally mandatory when `durable_dispatch` is wired:
+    /// `with_durable_dispatch` installs [`DEFAULT_PER_TENANT_RPM`] when
+    /// this field is `None`, so no disciplined opt-in is needed.
+    pub(super) tenant_rate_limiter: Option<WebhookRateLimiter>,
     /// Optional metrics registry. When `Some`, signature-failure
     /// outcomes increment [`NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL`]
     ///. `None` means the transport runs without emitting
@@ -197,11 +238,15 @@ impl WebhookTransport {
         clock: Arc<dyn Clock>,
     ) -> Self {
         let rate_limiter = config.rate_limit_per_minute.map(WebhookRateLimiter::new);
+        // `tenant_rate_limiter` is intentionally None here: it is installed
+        // structurally in `with_durable_dispatch`, not in the constructor.
+        // Non-durable transports (plain `new`) do not need the per-tenant tier.
         Self {
             inner: Arc::new(TransportInner {
                 config,
                 routing: RoutingMap::new(),
                 rate_limiter,
+                tenant_rate_limiter: None,
                 metrics,
                 clock,
                 activation_store: None,
@@ -252,11 +297,19 @@ impl WebhookTransport {
                     .config
                     .rate_limit_per_minute
                     .map(WebhookRateLimiter::new);
+                // Preserve the existing tenant_rate_limiter: it may have been
+                // installed by a prior `with_durable_dispatch` call.
+                let tenant_rate_limiter = arc
+                    .config
+                    .tenant_rate_limit_per_minute
+                    .map(WebhookRateLimiter::new)
+                    .or_else(|| arc.tenant_rate_limiter.clone());
                 Arc::new(TransportInner {
                     config: arc.config.clone(),
                     // Clone the existing routing map so live activations are not lost.
                     routing: arc.routing.clone(),
                     rate_limiter,
+                    tenant_rate_limiter,
                     metrics: arc.metrics.clone(),
                     clock: arc.clock.clone(),
                     activation_store: Some(store),
@@ -282,6 +335,16 @@ impl WebhookTransport {
     ///
     /// When `None` (default), Prod-mode dispatches fail closed (5xx) rather
     /// than spawning dedup-blind.
+    ///
+    /// # Rate-limit structural guarantee
+    ///
+    /// Installing durable dispatch is the point at which rate-limiting becomes
+    /// mandatory — it is impossible to have a durable transport without both
+    /// tiers.  This method installs [`DEFAULT_PER_TOKEN_RPM`] (per-token) and
+    /// [`DEFAULT_PER_TENANT_RPM`] (per-tenant-aggregate) when the config did
+    /// not supply an explicit override.  Operators can still tune via
+    /// `WebhookTransportConfig::rate_limit_per_minute` /
+    /// `tenant_rate_limit_per_minute` — a `Some(n)` in the config wins.
     #[must_use = "builder methods must be chained or the result used"]
     pub fn with_durable_dispatch(
         self,
@@ -296,6 +359,23 @@ impl WebhookTransport {
         };
         let inner = match Arc::try_unwrap(self.inner) {
             Ok(mut i) => {
+                // Structural guarantee: both limiters are mandatory with
+                // durable dispatch. Install the defaults when the config
+                // did not supply an explicit override.
+                if i.rate_limiter.is_none() {
+                    let rpm = i
+                        .config
+                        .rate_limit_per_minute
+                        .unwrap_or(DEFAULT_PER_TOKEN_RPM);
+                    i.rate_limiter = Some(WebhookRateLimiter::new(rpm));
+                }
+                if i.tenant_rate_limiter.is_none() {
+                    let rpm = i
+                        .config
+                        .tenant_rate_limit_per_minute
+                        .unwrap_or(DEFAULT_PER_TENANT_RPM);
+                    i.tenant_rate_limiter = Some(WebhookRateLimiter::new(rpm));
+                }
                 i.durable_dispatch = Some(components);
                 Arc::new(i)
             },
@@ -311,14 +391,22 @@ impl WebhookTransport {
                      existing routing entries are preserved but this indicates \
                      a composition-root ordering bug"
                 );
-                let rate_limiter = arc
-                    .config
-                    .rate_limit_per_minute
-                    .map(WebhookRateLimiter::new);
+                // Structural guarantee preserved on the slow path too.
+                let rate_limiter = Some(WebhookRateLimiter::new(
+                    arc.config
+                        .rate_limit_per_minute
+                        .unwrap_or(DEFAULT_PER_TOKEN_RPM),
+                ));
+                let tenant_rate_limiter = Some(WebhookRateLimiter::new(
+                    arc.config
+                        .tenant_rate_limit_per_minute
+                        .unwrap_or(DEFAULT_PER_TENANT_RPM),
+                ));
                 Arc::new(TransportInner {
                     config: arc.config.clone(),
                     routing: arc.routing.clone(),
                     rate_limiter,
+                    tenant_rate_limiter,
                     metrics: arc.metrics.clone(),
                     clock: arc.clock.clone(),
                     activation_store: arc.activation_store.clone(),

--- a/crates/api/src/transport/webhook/transport.rs
+++ b/crates/api/src/transport/webhook/transport.rs
@@ -293,12 +293,16 @@ impl WebhookTransport {
                      existing routing entries are preserved but this indicates \
                      a composition-root ordering bug"
                 );
+                // Preserve both rate limiters: they may have been installed by
+                // a prior `with_durable_dispatch` call.  Config override wins;
+                // if the config field is None, fall back to the already-running
+                // limiter so an in-flight `with_durable_dispatch` guarantee is
+                // not silently lost.
                 let rate_limiter = arc
                     .config
                     .rate_limit_per_minute
-                    .map(WebhookRateLimiter::new);
-                // Preserve the existing tenant_rate_limiter: it may have been
-                // installed by a prior `with_durable_dispatch` call.
+                    .map(WebhookRateLimiter::new)
+                    .or_else(|| arc.rate_limiter.clone());
                 let tenant_rate_limiter = arc
                     .config
                     .tenant_rate_limit_per_minute
@@ -345,6 +349,10 @@ impl WebhookTransport {
     /// not supply an explicit override.  Operators can still tune via
     /// `WebhookTransportConfig::rate_limit_per_minute` /
     /// `tenant_rate_limit_per_minute` — a `Some(n)` in the config wins.
+    ///
+    /// **Per-replica note:** both limiters are process-local; under `N`
+    /// replicas the effective cap is `N ×` the configured RPM.  See
+    /// [`WebhookRateLimiter`] for the full per-replica limitation note.
     #[must_use = "builder methods must be chained or the result used"]
     pub fn with_durable_dispatch(
         self,

--- a/crates/api/tests/webhook_transport_integration.rs
+++ b/crates/api/tests/webhook_transport_integration.rs
@@ -172,6 +172,7 @@ fn make_transport(rate_limit: Option<u64>, body_limit: usize) -> WebhookTranspor
         body_limit_bytes: body_limit,
         response_timeout: Duration::from_secs(5),
         rate_limit_per_minute: rate_limit,
+        tenant_rate_limit_per_minute: None,
     })
 }
 
@@ -463,6 +464,7 @@ async fn handler_timeout_returns_504() {
         body_limit_bytes: 1024 * 1024,
         response_timeout: Duration::from_millis(200),
         rate_limit_per_minute: None,
+        tenant_rate_limit_per_minute: None,
     });
 
     let hanging_adapter = WebhookTriggerAdapter::new(HangingWebhook);
@@ -812,6 +814,7 @@ async fn signature_failures_total_metric_increments_per_reason() {
             body_limit_bytes: 1024 * 1024,
             response_timeout: Duration::from_secs(5),
             rate_limit_per_minute: None,
+            tenant_rate_limit_per_minute: None,
         },
         registry.clone(),
     );
@@ -874,6 +877,7 @@ async fn signature_failures_total_metric_increments_missing_secret() {
             body_limit_bytes: 1024 * 1024,
             response_timeout: Duration::from_secs(5),
             rate_limit_per_minute: None,
+            tenant_rate_limit_per_minute: None,
         },
         registry.clone(),
     );
@@ -1009,6 +1013,7 @@ async fn token_resolution_skipped_on_unregistered_key_404() {
         body_limit_bytes: 1024 * 1024,
         response_timeout: Duration::from_secs(5),
         rate_limit_per_minute: None,
+        tenant_rate_limit_per_minute: None,
     })
     .with_activation_store(store);
 
@@ -1044,6 +1049,7 @@ async fn token_resolution_skipped_on_rate_limited_key_429() {
         body_limit_bytes: 1024 * 1024,
         response_timeout: Duration::from_secs(5),
         rate_limit_per_minute: Some(1),
+        tenant_rate_limit_per_minute: None,
     })
     .with_activation_store(store);
 
@@ -1094,6 +1100,7 @@ async fn token_resolution_called_exactly_once_on_registered_under_limit_key() {
         body_limit_bytes: 1024 * 1024,
         response_timeout: Duration::from_secs(5),
         rate_limit_per_minute: None,
+        tenant_rate_limit_per_minute: None,
     })
     .with_activation_store(Arc::clone(&store));
 

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -402,8 +402,11 @@ pub const NEBULA_WEBHOOK_REPLAY_REJECTIONS_TOTAL: &str = "nebula_webhook_replay_
 
 /// Counter: requests rejected by rate-limit enforcement.
 ///
-/// Labeled by `tenant_id`, `webhook_key_kind`, and `tier`
-/// (see [`webhook_rate_limit_tier`]).
+/// Labeled by `webhook_key_kind` and `tier` (see [`webhook_rate_limit_tier`]);
+/// `tenant_id` is included **only** for `tier="per_tenant"` rejections
+/// (post-resolution, where the bounded `(org, workspace)` slug is available).
+/// `tier="per_token"` rejections omit `tenant_id` — the trigger UUID would
+/// create one series per registered webhook, causing unbounded cardinality.
 ///
 /// - `tier="per_token"` — per-trigger-token sliding-window rejection
 ///   (pre-resolution; protects the DB lookup from unauthenticated churn).

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -390,10 +390,28 @@ pub const NEBULA_WEBHOOK_LATENCY_SECONDS: &str = "nebula_webhook_latency_seconds
 /// [`webhook_replay_rejection_reason`]).
 pub const NEBULA_WEBHOOK_REPLAY_REJECTIONS_TOTAL: &str = "nebula_webhook_replay_rejections_total";
 
-/// Counter: requests rejected by per-key rate-limit enforcement
-///. Labels: `tenant_id`, `webhook_key_kind`.
+/// Counter: requests rejected by rate-limit enforcement.
+///
+/// Labeled by `tenant_id`, `webhook_key_kind`, and `tier`
+/// (see [`webhook_rate_limit_tier`]).
+///
+/// - `tier="per_token"` — per-trigger-token sliding-window rejection
+///   (pre-resolution; protects the DB lookup from unauthenticated churn).
+/// - `tier="per_tenant"` — per-tenant-aggregate sliding-window rejection
+///   (post-resolution; caps a single tenant flooding across many tokens).
 pub const NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL: &str =
     "nebula_webhook_rate_limit_rejections_total";
+
+/// Tier labels for [`NEBULA_WEBHOOK_RATE_LIMIT_REJECTIONS_TOTAL`].
+///
+/// Closed two-value set — adding a label permanently inflates the
+/// cardinality floor.
+pub mod webhook_rate_limit_tier {
+    /// Per-trigger-token rate-limit tier (step 4, pre-resolution).
+    pub const PER_TOKEN: &str = "per_token";
+    /// Per-tenant-aggregate rate-limit tier (step 4.5, post-resolution).
+    pub const PER_TENANT: &str = "per_tenant";
+}
 
 /// Counter: storage-driven bootstrap rows that failed to register
 /// in the transport ( / E1). Labeled by `reason` (see

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -903,7 +903,7 @@ mod tests {
         auth_outcome, idempotency_reject_reason, orchestrator_dispatch_outcome,
         orchestrator_reclaim_outcome, recycle_outcome, refresh_coord_claim_outcome,
         refresh_coord_coalesced_tier, refresh_coord_reclaim_outcome, refresh_coord_sentinel_action,
-        rotation_outcome,
+        rotation_outcome, webhook_rate_limit_tier, webhook_signature_failure_reason,
     };
 
     const RESOURCE_METRIC_NAMES: [&str; 22] = [
@@ -1438,5 +1438,55 @@ mod tests {
         }
 
         assert_eq!(unique.len(), 4);
+    }
+
+    #[test]
+    fn webhook_signature_failure_reason_labels_are_closed_set() {
+        // Closed label set — adding a value permanently inflates cardinality on
+        // the signature-failure counter; this test is the CI gate against silent
+        // expansion.  The full set must stay in sync with the counter's doc
+        // comment (currently seven values).
+        let labels = [
+            webhook_signature_failure_reason::MISSING,
+            webhook_signature_failure_reason::INVALID,
+            webhook_signature_failure_reason::MISSING_SECRET,
+            webhook_signature_failure_reason::TIMESTAMP_MISSING,
+            webhook_signature_failure_reason::TIMESTAMP_MALFORMED,
+            webhook_signature_failure_reason::TIMESTAMP_OUT_OF_WINDOW,
+            webhook_signature_failure_reason::PROD_UNSIGNED,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            7,
+            "signature_failure_reason labels must be unique"
+        );
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(
+                label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'),
+                "label {label:?} must match [a-z_]+"
+            );
+        }
+    }
+
+    #[test]
+    fn webhook_rate_limit_tier_labels_are_closed_set() {
+        // Closed label set — adding a value permanently inflates cardinality on
+        // the rate-limit-rejection counter; this test is the CI gate against
+        // silent expansion.
+        let labels = [
+            webhook_rate_limit_tier::PER_TOKEN,
+            webhook_rate_limit_tier::PER_TENANT,
+        ];
+        let unique: HashSet<&str> = labels.iter().copied().collect();
+        assert_eq!(unique.len(), 2, "rate_limit_tier labels must be unique");
+        for label in labels {
+            assert!(!label.is_empty());
+            assert!(
+                label.chars().all(|ch| ch.is_ascii_lowercase() || ch == '_'),
+                "label {label:?} must match [a-z_]+"
+            );
+        }
     }
 }

--- a/crates/metrics/src/naming.rs
+++ b/crates/metrics/src/naming.rs
@@ -324,15 +324,17 @@ pub mod auth_oauth_provider {
 ///
 /// Labeled by `reason` (see [`webhook_signature_failure_reason`]). Low
 /// cardinality by design — the label set is a small closed set of
-/// static strings (currently six: `missing`, `invalid`,
+/// static strings (currently seven: `missing`, `invalid`,
 /// `missing_secret`, `timestamp_missing`, `timestamp_malformed`,
-/// `timestamp_out_of_window`), no per-trigger dimension. Any non-zero
-/// value is an operational signal worth dashboarding: a
+/// `timestamp_out_of_window`, `prod_unsigned`), no per-trigger dimension.
+/// Any non-zero value is an operational signal worth dashboarding: a
 /// `missing_secret` crossing means an action shipped with a
 /// `SignaturePolicy::Required` it did not populate; `missing` /
 /// `invalid` means a provider is mis-signing or a caller is probing
 /// the endpoint; `timestamp_*` indicates clock skew, replay attacks,
-/// or a misconfigured `timestamp_format`.
+/// or a misconfigured `timestamp_format`; `prod_unsigned` means a Prod
+/// activation row was registered without a `Required` signature policy
+/// (composition-root misconfiguration).
 pub const NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL: &str = "nebula_webhook_signature_failures_total";
 
 /// Reason labels for [`NEBULA_WEBHOOK_SIGNATURE_FAILURES_TOTAL`].
@@ -364,6 +366,14 @@ pub mod webhook_signature_failure_reason {
     /// outside the configured window (likely a replay attack or
     /// significant clock skew).
     pub const TIMESTAMP_OUT_OF_WINDOW: &str = "timestamp_out_of_window";
+    /// A Prod-mode activation resolved to `SignaturePolicy::OptionalAcceptUnsigned`
+    /// — the composition root failed to configure a secret. Returns 500 (operator
+    /// misconfiguration, not a caller fault).
+    ///
+    /// Distinct from `missing_secret` (which fires when `Required` has an empty
+    /// secret) so dashboards can separately track "wrong policy on Prod row" vs.
+    /// "right policy but no secret".
+    pub const PROD_UNSIGNED: &str = "prod_unsigned";
 }
 
 /// Counter: webhook requests entering the transport.


### PR DESCRIPTION
## Summary

Closes the two security debts deferred when the durable webhook dispatch landed (#825): **Standard-Webhooks HMAC (inv #1)** and **mandatory rate-limiting (inv #2)**. Both harden the already-Prod-capable dispatch path. PR-1 of the 2-PR webhook-prod unit (this = hardening; PR-2 = the `mode=Prod` registration/producer endpoint, which the owner-ratified gate requires to land only on top of this).

This is `nebula-api`/`nebula-action`/`nebula-metrics`/`apps-server` — all `publish = false`, so no public (nebula-sdk) semver impact.

## What changed

**1. Rate-limit — per-token + per-tenant-aggregate, structurally mandatory (`4c6159e6`)**
Rate-limiting was silently **off** in prod: the composition root built the transport via `..default()`, leaving `rate_limit_per_minute: None`. Now `WebhookTransport::with_durable_dispatch` installs **both** a per-token limiter (keyed by trigger uuid, checked pre-resolution) and a per-tenant-aggregate limiter (keyed by the injective `Scope::credential_owner_id()`, checked post-resolution) when either is absent — the guarantee lives in the builder, not in composition-root discipline. New `tenant_rate_limit_per_minute` knob; rejection metric gained a `tier` label.

**2. Standard-Webhooks HMAC + split-brain collapse (`c6acbd5e`)**
New `SignatureScheme::StandardWebhooks` (`#[non_exhaustive]`, additive): HMAC-SHA256 over `{webhook-id}.{webhook-timestamp}.{raw-body}` with the fixed SWH header names, mandatory ±5 min timestamp window (timestamp is inside the signed content, so tampering invalidates the MAC), `webhook-signature: v1,<base64>` space-separated multi-sig — only `v1` honored (algorithm-confusion guard), constant-time, MAC computed once before the candidate loop, operates on raw key bytes. Plus the **policy split-brain collapse**: a Prod row (durable dispatch will spawn) MUST NOT be verifiable under `OptionalAcceptUnsigned` — the signature policy was read from the mutable in-memory routing entry while `mode` came from the resolved row; now `durable.is_some()` + Optional → fail-closed 500.

**3. Review fixes (`261b2b71`)** — from a multi-lens adversarial review (spec / correctness / security / observability + per-finding refutation):
- **Metric cardinality (high):** the rejection metric emitted the per-trigger UUID under a label named `tenant_id` — an unbounded series + a mislabel. Now the per_tenant tier emits the bounded `(org, workspace)` key and the per_token tier emits no per-entity label; the UUID is never a metric label.
- SWH candidate loop: removed a dead zero-fill + misleading "constant time" comment (a cargo-cult footgun) for a clean `let Ok(..) else { continue }` + unconditional constant-time compare.
- Signature-rejection paths now `warn!` (nonce-free) so failures are visible in logs, not only the metric.
- Documented the in-process (per-replica) rate-limit limitation: effective cap is N× under N replicas; a global counter is a multi-replica-Prod prerequisite (deferred).
- Made the `with_activation_store` slow path symmetric so the structural "durable ⇒ both limiters" guarantee holds on every builder ordering.

## Security note (caught during review)

The reviewers' first suggestion was to log `uri.path()` on signature failure — but the webhook URL is `/hooks/{trigger_uuid}/{nonce}` and **the nonce is the bearer secret**. Logging the path would leak the token into log aggregators (inv #4). Every new log/span field uses the nonce-free `key.rate_limit_key()` (trigger uuid only) instead.

## Out of scope (PR-2 / deferred, noted in code)

- The `mode=Prod` registration/producer endpoint (`webhook:activate`) + `whsec_` minting/persistence via the nebula-credential seam.
- Multi-secret rotation grace (~24 h) — single-secret now; the verify loop is structured to extend.
- A **global** rate-limit counter — in-process v1 is per-replica (documented).

## Test evidence

`nebula-action` + `nebula-api`: **1035/1035** (`cargo nextest`), `clippy -D` clean, workspace `cargo check --all-targets` clean, rustdoc `-D warnings` (pre-push crate-diff-gate) clean. Behavior tests are red→green; the split-brain and structural-coupling proofs are red-on-revert (the B2 guard test fails with `execution_count == 1` when the guard is removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Standard Webhooks signature verification scheme with HMAC validation
  * Implemented per-tenant rate limiting alongside existing per-token rate limits

* **Security Improvements**
  * Hardened Prod mode to enforce signatures and reject unsigned requests with fail-closed behavior

* **Configuration**
  * Added configurable per-tenant rate limit settings with sensible defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->