### PR TITLE
feat(api): credential-backed webhook signing-secret resolver + round-trip proof (ADR-0095 D1)

### DIFF
--- a/apps/server/src/compose.rs
+++ b/apps/server/src/compose.rs
@@ -235,7 +235,17 @@ impl ServerRuntime {
             nebula_api::ports::credential_service_factory::try_default_credential_service()
                 .await
                 .map_err(|e| TransportInitError::CredentialServiceInit(e.to_string()))?;
-        state = state.with_credential_service(credential_service);
+        // Install the webhook secret resolver before consuming `credential_service`
+        // into AppState — clone the Arc so both the state and the resolver share
+        // a single CredentialService instance (no second construction).
+        let webhook_secret_resolver = Arc::new(
+            nebula_api::transport::webhook::CredentialBackedWebhookSecretResolver::new(Arc::clone(
+                &credential_service,
+            )),
+        );
+        state = state
+            .with_credential_service(credential_service)
+            .with_webhook_secret_resolver(webhook_secret_resolver);
         // Build ONE shared `Arc<dyn EmailPort>` and pass the same Arc
         // to both `AppState::email_port` and the selected auth backend.
         // `API_SMTP_HOST` unset → dev `EchoSink` (unchanged local-first

--- a/crates/api/src/ports/credential_schema_registry.rs
+++ b/crates/api/src/ports/credential_schema_registry.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 use nebula_credential::{
     AnyCredential, ApiKeyCredential, BasicAuthCredential, Capabilities, CredentialRegistry,
-    OAuth2Credential,
+    OAuth2Credential, SigningKeyCredential,
 };
 use nebula_schema::FieldValues;
 
@@ -203,6 +203,9 @@ pub(crate) fn default_registry() -> Result<CredentialRegistry, nebula_credential
     registry.register(ApiKeyCredential, "nebula-credential")?;
     registry.register(BasicAuthCredential, "nebula-credential")?;
     registry.register(OAuth2Credential, "nebula-credential")?;
+    // signing_key: static non-interactive credential used for webhook HMAC
+    // secrets (Standard Webhooks `whsec_` format).
+    registry.register(SigningKeyCredential, "nebula-credential")?;
     Ok(registry)
 }
 
@@ -282,10 +285,10 @@ mod tests {
         );
         assert!(p.get_type("nope").is_none());
 
-        // The composition default registers all three first-party types.
+        // The composition default registers all first-party types.
         let default = try_default_registry_port().expect("first-party set registers (unique KEYs)");
         let listed = default.list_types();
-        for k in ["api_key", "basic_auth", "oauth2"] {
+        for k in ["api_key", "basic_auth", "oauth2", "signing_key"] {
             assert!(
                 listed.iter().any(|t| t.key == k),
                 "default port must register {k}; got {:?}",

--- a/crates/api/src/ports/credential_service_factory.rs
+++ b/crates/api/src/ports/credential_service_factory.rs
@@ -24,6 +24,7 @@ use std::sync::Arc;
 use nebula_credential::provider::ExternalProvider;
 use nebula_credential::{
     ApiKeyCredential, BasicAuthCredential, CredentialStore, ErasedPendingStore, OAuth2Credential,
+    SigningKeyCredential,
 };
 use nebula_credential::{
     CredentialRegistry, CredentialService, CredentialServiceError, DispatchError, DispatchOps,
@@ -237,6 +238,10 @@ pub fn with_store<S: CredentialStore + 'static>(
     register_runtime_ops::<ApiKeyCredential, ErasedPendingStore>(&mut ops)?;
     register_runtime_ops::<BasicAuthCredential, ErasedPendingStore>(&mut ops)?;
     register_runtime_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
+    // signing_key: static non-interactive credential (HMAC webhook secret).
+    // No capability ops beyond base runtime ops — it carries no
+    // INTERACTIVE/REFRESHABLE/REVOCABLE/TESTABLE caps in the registry.
+    register_runtime_ops::<SigningKeyCredential, ErasedPendingStore>(&mut ops)?;
     register_interactive_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
     register_refreshable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;
     register_revocable_ops::<OAuth2Credential, ErasedPendingStore>(&mut ops)?;

--- a/crates/api/src/transport/webhook/bootstrap.rs
+++ b/crates/api/src/transport/webhook/bootstrap.rs
@@ -37,7 +37,8 @@ use nebula_storage::rows::{
 };
 use nebula_storage_port::store::WebhookActivationStore;
 use nebula_storage_port::{
-    StorageError as PortStorageError, dto::WebhookActivationRecord as PortWebhookActivationRecord,
+    Scope, StorageError as PortStorageError,
+    dto::WebhookActivationRecord as PortWebhookActivationRecord,
 };
 use thiserror::Error;
 
@@ -49,20 +50,31 @@ pub type SecretResolutionError = Box<dyn std::error::Error + Send + Sync>;
 /// Resolves a credential identifier (storage-layer string) to the
 /// raw HMAC secret bytes consumed by the factory.
 ///
-/// Production deployments wire this through `nebula-credential`'s
-/// snapshot path; tests wire an in-memory map. Returning an empty
-/// `Vec` is **not** allowed — the factory would then build a
-/// fail-closed handler. Surface the misconfiguration as a typed
-/// error inside the boxed return.
+/// Production deployments wire this through [`nebula_credential::CredentialService`]
+/// via [`crate::transport::webhook::secret_resolver::CredentialBackedWebhookSecretResolver`];
+/// tests wire an in-memory map. Returning an empty `Vec` is **not** allowed —
+/// the factory would then build a fail-closed handler.  Surface the
+/// misconfiguration as a typed error inside the boxed return.
+///
+/// # Tenant isolation
+///
+/// `scope` is mandatory: [`nebula_credential::CredentialService::resolve_for_slot`]
+/// requires a [`nebula_credential::TenantScope`] derived from the B-world
+/// activation row's `scope`.  Without it the credential layer cannot enforce
+/// the owner check.
 #[async_trait]
 pub trait WebhookSecretResolver: Send + Sync {
-    /// Resolve `secret_id` to raw secret bytes.
+    /// Resolve `secret_id` to raw secret bytes, scoped to `scope`.
     ///
     /// # Errors
     ///
     /// Returns a boxed error on lookup failure. The bootstrap wraps
     /// it in [`BootstrapError::SecretResolution`].
-    async fn resolve(&self, secret_id: &str) -> Result<Vec<u8>, SecretResolutionError>;
+    async fn resolve(
+        &self,
+        scope: &Scope,
+        secret_id: &str,
+    ) -> Result<Vec<u8>, SecretResolutionError>;
 }
 
 /// Result of [`bootstrap_webhook_activations`].
@@ -267,12 +279,13 @@ async fn validate_one(
             trigger_id: record.trigger_id.clone(),
         })?;
 
-    let secret = secrets.resolve(&spec.secret_id).await.map_err(|source| {
-        BootstrapError::SecretResolution {
+    let secret = secrets
+        .resolve(&record.scope, &spec.secret_id)
+        .await
+        .map_err(|source| BootstrapError::SecretResolution {
             secret_id: spec.secret_id.clone(),
             source,
-        }
-    })?;
+        })?;
 
     let action_spec = into_action_spec(&spec, secret);
 

--- a/crates/api/src/transport/webhook/mod.rs
+++ b/crates/api/src/transport/webhook/mod.rs
@@ -33,6 +33,7 @@ pub mod provider;
 pub mod ratelimit;
 pub(super) mod replay;
 pub(crate) mod routing;
+pub mod secret_resolver;
 pub(super) mod signature;
 pub mod token;
 pub mod transport;
@@ -45,6 +46,7 @@ pub use events::{TriggerLifecycleBus, TriggerLifecycleEvent, TriggerLifecycleEve
 pub use key::WebhookKey;
 pub use provider::EndpointProviderImpl;
 pub use ratelimit::{RateLimitExceeded, WebhookRateLimiter};
+pub use secret_resolver::{CredentialBackedWebhookSecretResolver, mint_whsec};
 pub use transport::{
     ActivateAndPersistError, ActivationError, ActivationHandle, PersistParams, WebhookTransport,
     WebhookTransportConfig, activate_and_persist,

--- a/crates/api/src/transport/webhook/secret_resolver.rs
+++ b/crates/api/src/transport/webhook/secret_resolver.rs
@@ -1,0 +1,322 @@
+//! Production [`WebhookSecretResolver`] backed by [`CredentialService`], plus
+//! the [`mint_whsec`] factory for fresh signing secrets.
+//!
+//! [`CredentialBackedWebhookSecretResolver`] converts a `signing_key` credential
+//! stored with a `whsec_<base64>` key string into the raw HMAC key bytes that
+//! the Standard Webhooks verifier consumes — stripping the `whsec_` prefix and
+//! base64-decoding the remainder.
+//!
+//! [`mint_whsec`] generates a fresh CSPRNG-backed secret in that format,
+//! suitable for creating a new `signing_key` credential via
+//! [`nebula_credential::CredentialService::create`].
+//!
+//! # Tenant isolation
+//!
+//! Resolution goes through
+//! [`CredentialService::validate_credential_binding`] →
+//! [`CredentialService::resolve_for_slot`], which enforces the owner check at
+//! both the binding-validation step (cross-tenant id → typed error rather than
+//! `NotFound`) and the guard-acquire step (fingerprint re-check in depth).
+//! There is no raw-resolve-by-id path.
+//!
+//! # Secret discipline
+//!
+//! The `whsec_` string and the decoded key bytes never appear in tracing
+//! fields or error messages.  Typed errors on decode failure name the
+//! structural problem (missing prefix, invalid base64, empty result) without
+//! echoing the material.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use nebula_credential::{
+    CredentialService, SigningKeyCredential, TenantScope, ValidatedCredentialBindingError,
+};
+use nebula_storage_port::Scope;
+use rand::Rng as _;
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+
+use super::bootstrap::{SecretResolutionError, WebhookSecretResolver};
+
+// ── Typed error ───────────────────────────────────────────────────────────────
+
+/// Errors that can occur inside [`CredentialBackedWebhookSecretResolver::resolve`].
+///
+/// Every failure out of [`resolve`](WebhookSecretResolver::resolve) is a
+/// `ResolverError` boxed into [`SecretResolutionError`].  The messages
+/// intentionally contain NO secret material — only structural descriptions.
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub(crate) enum ResolverError {
+    /// The binding-validation step rejected the credential id (not found,
+    /// cross-tenant, or tombstoned).
+    #[error("credential binding validation failed: {0}")]
+    Binding(#[from] ValidatedCredentialBindingError),
+    /// The credential guard-acquire or decryption step failed.
+    #[error("credential resolution failed: {0}")]
+    Credential(#[from] nebula_credential::CredentialServiceError),
+    /// The stored key value does not start with the expected `whsec_` prefix.
+    #[error("signing key does not carry the required 'whsec_' prefix")]
+    MissingWhsecPrefix,
+    /// The base64 portion after the `whsec_` prefix is not valid standard
+    /// base64.
+    #[error("signing key base64 payload is not valid base64")]
+    InvalidBase64(#[from] base64::DecodeError),
+    /// The decoded key is zero-length; the verifier would build a fail-closed
+    /// handler.  Reject before handing back to the bootstrap.
+    #[error("signing key decoded to zero bytes; a non-empty key is required")]
+    EmptyKey,
+}
+
+// ── Prod resolver ─────────────────────────────────────────────────────────────
+
+/// Production [`WebhookSecretResolver`] that resolves a `signing_key`
+/// credential from [`CredentialService`] and decodes its `whsec_<base64>` key
+/// to the raw HMAC bytes consumed by the Standard Webhooks verifier.
+///
+/// Construction is cheap — just an `Arc` clone of the service.
+#[derive(Clone)]
+pub struct CredentialBackedWebhookSecretResolver {
+    service: Arc<CredentialService>,
+}
+
+impl CredentialBackedWebhookSecretResolver {
+    /// Wrap an existing `CredentialService`.
+    #[must_use]
+    pub fn new(service: Arc<CredentialService>) -> Self {
+        Self { service }
+    }
+}
+
+impl std::fmt::Debug for CredentialBackedWebhookSecretResolver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CredentialBackedWebhookSecretResolver")
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait]
+impl WebhookSecretResolver for CredentialBackedWebhookSecretResolver {
+    #[tracing::instrument(
+        name = "webhook.secret_resolver.resolve",
+        skip_all,
+        fields(secret_id = %secret_id)
+    )]
+    async fn resolve(
+        &self,
+        scope: &Scope,
+        secret_id: &str,
+    ) -> Result<Vec<u8>, SecretResolutionError> {
+        let tenant_scope = TenantScope::from_scope(scope);
+
+        // Step 1: validate the binding (owner check, tombstone check).
+        // All three failure modes (NotFound / ScopeMismatch / CredentialTombstoned)
+        // are routed through `ResolverError::Binding` so every failure out of
+        // this function is a `ResolverError` behind the box.
+        let binding = self
+            .service
+            .validate_credential_binding(&tenant_scope, secret_id)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    target: "nebula::api::webhook::secret_resolver",
+                    error = %e,
+                    "credential binding validation failed for webhook secret"
+                );
+                Box::new(ResolverError::Binding(e)) as SecretResolutionError
+            })?;
+
+        // Step 2: acquire the typed guard (decrypt + cache hit).
+        let guard = self
+            .service
+            .resolve_for_slot::<SigningKeyCredential>(
+                &tenant_scope,
+                &binding,
+                // Unlinked token is intentional: bootstrap and reload callers
+                // have no cancellation context, and resolution is a bounded
+                // store-load + decrypt (no unbounded wait).
+                CancellationToken::new(),
+            )
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    target: "nebula::api::webhook::secret_resolver",
+                    error = %e,
+                    "credential slot resolution failed for webhook secret"
+                );
+                Box::new(ResolverError::Credential(e)) as SecretResolutionError
+            })?;
+
+        // Step 3: expose the raw string and decode the whsec_ payload.
+        // Intentionally NOT tracing the secret value.
+        let raw = guard.key().expose_secret();
+        let raw_bytes = decode_whsec(raw).map_err(|e| Box::new(e) as SecretResolutionError)?;
+
+        tracing::debug!(
+            target: "nebula::api::webhook::secret_resolver",
+            key_len = raw_bytes.len(),
+            "webhook signing secret resolved and decoded"
+        );
+
+        Ok(raw_bytes)
+    }
+}
+
+// ── Secret minting ────────────────────────────────────────────────────────────
+
+/// Mint a fresh Standard-Webhooks signing secret.
+///
+/// Returns a `whsec_<base64>` string suitable for use as the `key` field
+/// when creating a `signing_key` credential.  The prefix follows the
+/// [Standard Webhooks](https://www.standardwebhooks.com/) convention;
+/// [`CredentialBackedWebhookSecretResolver`] strips the prefix and
+/// base64-decodes the remainder to produce the raw HMAC key bytes consumed
+/// by the verifier.
+///
+/// # Entropy
+///
+/// Uses 32 bytes from the OS CSPRNG (`rand::rng()`).  32 bytes = 256
+/// bits of entropy, well above the HMAC-SHA256 key-length recommendation.
+#[must_use]
+pub fn mint_whsec() -> String {
+    let mut raw = [0u8; 32];
+    rand::rng().fill_bytes(&mut raw);
+    format!("whsec_{}", BASE64_STANDARD.encode(raw))
+}
+
+// ── Decode helper ─────────────────────────────────────────────────────────────
+
+/// Decode a `whsec_<base64>` string to the raw key bytes.
+///
+/// Strips the `whsec_` prefix, base64-decodes the remainder using
+/// **standard** (not URL-safe) base64, and rejects an empty result.
+/// Errors carry no secret material.
+///
+/// # Errors
+///
+/// - [`ResolverError::MissingWhsecPrefix`] when the string lacks the prefix.
+/// - [`ResolverError::InvalidBase64`] when the payload is malformed base64,
+///   including URL-safe base64 characters (`-` or `_`) not present in the
+///   standard alphabet.
+/// - [`ResolverError::EmptyKey`] when the decoded bytes are empty.
+pub(crate) fn decode_whsec(s: &str) -> Result<Vec<u8>, ResolverError> {
+    let b64 = s
+        .strip_prefix("whsec_")
+        .ok_or(ResolverError::MissingWhsecPrefix)?;
+    let bytes = BASE64_STANDARD.decode(b64)?;
+    if bytes.is_empty() {
+        return Err(ResolverError::EmptyKey);
+    }
+    Ok(bytes)
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── mint_whsec ────────────────────────────────────────────────────────────
+
+    /// `mint_whsec` returns a `whsec_`-prefixed string that is base64-decodable
+    /// to exactly 32 bytes.
+    #[test]
+    fn mint_whsec_prefix_and_length() {
+        let secret = mint_whsec();
+        assert!(
+            secret.starts_with("whsec_"),
+            "mint_whsec must start with 'whsec_'; got {secret:?}"
+        );
+        let b64_part = secret.strip_prefix("whsec_").unwrap();
+        let decoded = BASE64_STANDARD
+            .decode(b64_part)
+            .expect("base64 portion must be valid standard base64");
+        assert_eq!(decoded.len(), 32, "decoded key must be exactly 32 bytes");
+    }
+
+    /// Two consecutive calls produce different values (entropy).
+    #[test]
+    fn mint_whsec_is_random() {
+        let a = mint_whsec();
+        let b = mint_whsec();
+        assert_ne!(
+            a, b,
+            "consecutive mint_whsec calls must produce distinct values"
+        );
+    }
+
+    // ── decode_whsec ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_whsec_round_trips_known_vector() {
+        // Standard Webhooks example key: 32 zero bytes base64-encoded.
+        let raw = [0u8; 32];
+        let encoded = BASE64_STANDARD.encode(raw);
+        let whsec = format!("whsec_{encoded}");
+        let decoded = decode_whsec(&whsec).expect("known-vector must decode");
+        assert_eq!(decoded, raw, "decoded bytes must match original");
+    }
+
+    #[test]
+    fn decode_whsec_rejects_missing_prefix() {
+        let err = decode_whsec("AAAA").expect_err("no prefix must fail");
+        assert!(
+            matches!(err, ResolverError::MissingWhsecPrefix),
+            "expected MissingWhsecPrefix, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_whsec_rejects_invalid_base64() {
+        let err = decode_whsec("whsec_!!!notbase64").expect_err("bad base64 must fail");
+        assert!(
+            matches!(err, ResolverError::InvalidBase64(_)),
+            "expected InvalidBase64, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_whsec_rejects_empty_payload() {
+        // base64("") == "" — produces zero bytes after decoding.
+        let err = decode_whsec("whsec_").expect_err("empty payload must fail");
+        assert!(
+            matches!(err, ResolverError::EmptyKey),
+            "expected EmptyKey, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn decode_whsec_rejects_empty_bytes_after_decode() {
+        // Explicit: the empty string encodes to "" in standard base64.
+        let encoded = BASE64_STANDARD.encode(b"");
+        let whsec = format!("whsec_{encoded}");
+        let err = decode_whsec(&whsec).expect_err("zero-length decoded bytes must fail");
+        assert!(
+            matches!(err, ResolverError::EmptyKey),
+            "expected EmptyKey, got {err:?}"
+        );
+    }
+
+    /// A `whsec_` payload encoded with URL-safe base64 (`-` / `_` chars) must
+    /// fail with `InvalidBase64`, not silently produce wrong bytes.
+    ///
+    /// `mint_whsec` always emits standard base64 (`+` / `/`); this test confirms
+    /// the decoder rejects the URL-safe variant a caller might accidentally
+    /// produce from a different base64 library.
+    #[test]
+    fn decode_whsec_rejects_url_safe_base64() {
+        // Craft a payload that contains URL-safe characters not in the standard
+        // alphabet.  A 3-byte sequence encodes to base64 containing characters
+        // from the full 64-char set; we inject '-' and '_' explicitly.
+        let url_safe_payload = "whsec_abc-def_ghi";
+        let err = decode_whsec(url_safe_payload)
+            .expect_err("URL-safe base64 chars must be rejected by the standard decoder");
+        assert!(
+            matches!(err, ResolverError::InvalidBase64(_)),
+            "expected InvalidBase64 for URL-safe base64 input, got {err:?}"
+        );
+    }
+}

--- a/crates/api/src/transport/webhook/token.rs
+++ b/crates/api/src/transport/webhook/token.rs
@@ -1,9 +1,14 @@
-//! API-edge bearer-token hashing.
+//! API-edge bearer-token hashing for webhook activations.
 //!
 //! The plaintext capability token is hashed here at the API edge and never
 //! crosses into `nebula-storage-port`.  Only the 32-byte SHA-256 digest is
 //! persisted (as `WebhookActivationRecord::token_hash`).  This is the single
 //! seam between the plaintext URL surface and the durable store.
+//!
+//! For `whsec_<base64>` signing-secret minting see
+//! [`super::secret_resolver::mint_whsec`], which lives alongside
+//! [`super::secret_resolver::decode_whsec`] where the `whsec_` format is
+//! owned and tested.
 //!
 //! # Security
 //!

--- a/crates/api/src/transport/webhook/token.rs
+++ b/crates/api/src/transport/webhook/token.rs
@@ -6,9 +6,9 @@
 //! seam between the plaintext URL surface and the durable store.
 //!
 //! For `whsec_<base64>` signing-secret minting see
-//! [`super::secret_resolver::mint_whsec`], which lives alongside
-//! [`super::secret_resolver::decode_whsec`] where the `whsec_` format is
-//! owned and tested.
+//! [`super::secret_resolver::mint_whsec`], which lives in
+//! [`super::secret_resolver`] alongside the `decode_whsec` helper where the
+//! `whsec_` format is owned and tested.
 //!
 //! # Security
 //!

--- a/crates/api/tests/webhook_secret_round_trip.rs
+++ b/crates/api/tests/webhook_secret_round_trip.rs
@@ -1,0 +1,272 @@
+//! End-to-end byte-consistency proof for the webhook signing-secret path.
+//!
+//! Scope: mint → store(signing_key credential) → resolve → decode → sign →
+//! verify.  This test is the regression guard for the **silent-fail seam**:
+//! if the resolver returned the `whsec_` literal string instead of the decoded
+//! HMAC key bytes, the HMAC would be computed over the wrong material and
+//! `RequiredPolicy::verify_with` would return `SignatureInvalid`.
+//!
+//! Backend: `with_memory_store` — a durable `SqliteCredentialStore` on an
+//! ephemeral `:memory:` DB.  The real adapter code path, not an in-memory
+//! double (AGENTS.md / ADR-0092 "no in-memory doubles" rule).
+
+use std::sync::Arc;
+
+use axum::http::{HeaderMap, HeaderValue, Method};
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use nebula_action::{
+    MockClock, RequiredPolicy, SignatureError, SignatureScheme, WebhookRequest, hmac_sha256_compute,
+};
+use nebula_api::{
+    ports::credential_service_factory::with_memory_store,
+    transport::webhook::{
+        CredentialBackedWebhookSecretResolver, WebhookSecretResolver, mint_whsec,
+    },
+};
+use nebula_credential::{CredentialDisplay, TenantScope};
+use nebula_storage::credential::EnvKeyProvider;
+use nebula_storage_port::Scope;
+use serde_json::json;
+
+/// Fixed 32-byte AES-256 test key — mirrors the factory dev constant.
+/// 32 `0x42` bytes, base64.  Not a secret: a test fixture.
+const TEST_KEY_B64: &str = "QkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkI=";
+
+/// Anchored Unix timestamp for the deterministic `MockClock`.
+/// All requests carry this timestamp and the clock is anchored to the same
+/// second → skew = 0 → always within the 5-minute Standard Webhooks default
+/// replay window.
+const FIXED_TS_SECS: u64 = 1_700_000_000;
+
+/// Direct decode of a `whsec_<base64>` string without going through the
+/// production resolver.
+///
+/// Purpose: the round-trip test uses this to assert byte-value identity
+/// between the resolver output and a direct decode of the original string.
+/// This catches the **literal-string-vs-decoded-bytes** seam: if the resolver
+/// returned the `whsec_` string unchanged, the `assert_eq!` would fail because
+/// the resolver would return ~50 bytes of ASCII while this function would
+/// return 32 raw bytes.
+///
+/// This function applies the **same algorithm** as the production `decode_whsec`
+/// (standard base64, same prefix strip), so it is NOT an algorithm-independent
+/// oracle.  It does NOT detect a production bug that uses URL-safe base64 —
+/// that seam is covered by the unit test in `secret_resolver.rs`.  What it
+/// does pin down is the byte identity: resolver output == direct decode of the
+/// stored string.
+fn direct_decode_whsec(s: &str) -> Vec<u8> {
+    let b64 = s
+        .strip_prefix("whsec_")
+        .expect("direct_decode_whsec: whsec_ prefix expected");
+    BASE64_STANDARD
+        .decode(b64)
+        .expect("direct_decode_whsec: valid standard base64 payload expected")
+}
+
+/// Build a Standard Webhooks-format signed request.
+///
+/// Signed content = `{webhook-id}.{webhook-timestamp}.{body}` (spec §4).
+/// HMAC-SHA256 over signed content → `v1,<base64>` in `webhook-signature`.
+fn swh_signed_request(webhook_id: &str, body: &[u8], secret: &[u8]) -> WebhookRequest {
+    let ts_str = FIXED_TS_SECS.to_string();
+
+    // Signed content per Standard Webhooks spec §4.
+    let mut signed: Vec<u8> =
+        Vec::with_capacity(webhook_id.len() + 1 + ts_str.len() + 1 + body.len());
+    signed.extend_from_slice(webhook_id.as_bytes());
+    signed.push(b'.');
+    signed.extend_from_slice(ts_str.as_bytes());
+    signed.push(b'.');
+    signed.extend_from_slice(body);
+
+    let mac: [u8; 32] = hmac_sha256_compute(secret, &signed);
+    let sig_token = format!("v1,{}", BASE64_STANDARD.encode(mac));
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "webhook-id",
+        HeaderValue::from_str(webhook_id).expect("static webhook-id is a valid header value"),
+    );
+    headers.insert(
+        "webhook-timestamp",
+        HeaderValue::from_str(&ts_str).expect("unix timestamp is a valid header value"),
+    );
+    headers.insert(
+        "webhook-signature",
+        HeaderValue::from_str(&sig_token).expect("v1,<base64> is a valid header value"),
+    );
+
+    WebhookRequest::try_new(
+        Method::POST,
+        "/webhook/test-path",
+        None::<String>,
+        headers,
+        body.to_vec(),
+    )
+    .expect("test body is within DEFAULT_MAX_BODY_BYTES; headers within MAX_HEADER_COUNT")
+}
+
+/// Full mint → store → resolve → decode → sign → verify round-trip.
+///
+/// The acceptance criterion: `resolve()` must return the **decoded** raw bytes
+/// (i.e. `base64_decode(whsec_<base64>.strip_prefix("whsec_"))`), not the
+/// encoded string.  The test fails — at step 4 or step 5 with
+/// `SignatureInvalid` — if the resolver passes through the literal `whsec_`
+/// string, because:
+///
+/// - Step 4 `assert_eq!` catches the byte-value mismatch directly.
+/// - Step 5 `verify_with` would also fail because the HMAC key material is wrong.
+#[tokio::test]
+async fn webhook_secret_mint_store_resolve_verify_round_trip() {
+    let key_provider =
+        Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+    let svc = with_memory_store(key_provider)
+        .await
+        .expect("service builds (advertised caps match ops)");
+
+    // Storage-port Scope → TenantScope through `from_scope` — the one canonical
+    // derivation used at both the create and resolve sides, so the owner key
+    // cannot drift between them.
+    let storage_scope = Scope::new("ws-round-trip", "org-round-trip");
+    let tenant_scope = TenantScope::from_scope(&storage_scope);
+
+    // 1. Mint a fresh `whsec_<base64>` signing secret.
+    let whsec = mint_whsec();
+    assert!(
+        whsec.starts_with("whsec_"),
+        "mint_whsec must return a whsec_-prefixed string; got {whsec:?}"
+    );
+
+    // 2. Store it as a `signing_key` credential.  The credential layer persists
+    //    the verbatim `whsec_<base64>` string; it never decodes it.
+    let head = svc
+        .create(
+            &tenant_scope,
+            "signing_key",
+            json!({ "key": whsec, "algorithm": "hmac-sha256" }),
+            CredentialDisplay {
+                display_name: Some("round-trip test signing key".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("signing_key create must succeed — ops include signing_key after factory edit");
+    assert_eq!(
+        head.credential_key, "signing_key",
+        "created head must carry the signing_key type key"
+    );
+
+    // 3. Resolve through the production path.
+    let resolver = CredentialBackedWebhookSecretResolver::new(svc);
+    let resolved_bytes = resolver
+        .resolve(&storage_scope, &head.id)
+        .await
+        .expect("signing_key credential must resolve successfully");
+
+    // 4. Byte-identity check: resolved bytes == direct decode of the stored string.
+    //    This assertion catches the silent-fail seam: if the resolver returned the
+    //    `whsec_` literal instead of decoded bytes, `direct_decode_whsec` would
+    //    produce 32 raw bytes while `resolved_bytes` would be ~50 ASCII bytes, and
+    //    the `assert_eq!` would fail.  See `direct_decode_whsec` doc for the scope
+    //    of what this covers vs. the URL-safe base64 unit test.
+    let expected = direct_decode_whsec(&whsec);
+    assert_eq!(
+        resolved_bytes, expected,
+        "resolved bytes must equal direct base64-decode of the original whsec_ payload; \
+         a mismatch means the resolver returned the encoded string rather than decoded bytes"
+    );
+
+    // 5. Prove the resolved bytes work as a Standard Webhooks HMAC key.
+    let body = br#"{"event":"test.delivered"}"#;
+    let webhook_id = "msg-round-trip-001";
+    let request = swh_signed_request(webhook_id, body, &resolved_bytes);
+    let clock = MockClock::at_unix_secs(FIXED_TS_SECS);
+
+    RequiredPolicy::new()
+        .with_secret(resolved_bytes.clone())
+        .with_scheme(SignatureScheme::StandardWebhooks)
+        .verify_with(&request, &clock)
+        .expect(
+            "Standard Webhooks verify must pass: resolved bytes are the correct decoded HMAC key",
+        );
+
+    // 6. Negative guard: a DIFFERENT key must not verify the same request.
+    //    This confirms the test is sensitive to key identity — it catches the
+    //    case where the resolver returns the whsec_ literal (wrong key) that
+    //    accidentally signs correctly (impossible by HMAC collision probability,
+    //    but the test makes that explicit).
+    let wrong_key: Vec<u8> = vec![0xFFu8; 32];
+    let request_wrong_key = swh_signed_request(webhook_id, body, &wrong_key);
+    let neg_result = RequiredPolicy::new()
+        .with_secret(resolved_bytes)
+        .with_scheme(SignatureScheme::StandardWebhooks)
+        .verify_with(&request_wrong_key, &clock);
+    assert!(
+        matches!(neg_result, Err(SignatureError::SignatureInvalid)),
+        "verify with wrong signing key must return SignatureInvalid; got {neg_result:?}"
+    );
+}
+
+/// Cross-tenant isolation: a credential created under tenant A must NOT be
+/// resolvable under tenant B.
+///
+/// `validate_credential_binding` enforces the owner check before returning a
+/// `ValidatedCredentialBinding`; the error surfaces as `ScopeMismatch`
+/// (not `NotFound`) so the resolver fails closed and leaks no information
+/// about credential existence in the other tenant's namespace.
+#[tokio::test]
+async fn webhook_secret_resolver_rejects_cross_tenant_credential_id() {
+    let key_provider =
+        Arc::new(EnvKeyProvider::from_base64(TEST_KEY_B64).expect("valid 32-byte AES key"));
+    let svc = with_memory_store(key_provider)
+        .await
+        .expect("service builds");
+
+    // Create a signing_key credential under tenant A.
+    let scope_a = Scope::new("ws-tenant-a", "org-tenant-a");
+    let tenant_a = TenantScope::from_scope(&scope_a);
+    let whsec = mint_whsec();
+    let head = svc
+        .create(
+            &tenant_a,
+            "signing_key",
+            json!({ "key": whsec, "algorithm": "hmac-sha256" }),
+            CredentialDisplay::default(),
+        )
+        .await
+        .expect("create under tenant A");
+
+    // Attempt to resolve it under tenant B using A's credential id.
+    let scope_b = Scope::new("ws-tenant-b", "org-tenant-b");
+    let resolver = CredentialBackedWebhookSecretResolver::new(svc);
+    let result = resolver.resolve(&scope_b, &head.id).await;
+
+    // Assert: (a) the call fails (binding gate holds), (b) the error identifies
+    // a binding/scope failure, (c) the error message contains no secret material.
+    let err = result
+        .expect_err("cross-tenant resolution must fail; Ok(_) means tenant isolation is broken");
+    let err_str = err.to_string();
+
+    // The error must be a binding failure, not a lower-level I/O or decrypt error.
+    // `ResolverError::Binding` wraps `ValidatedCredentialBindingError::ScopeMismatch`
+    // whose Display reads "credential binding validation failed: credential `<id>` belongs
+    // to tenant `<actual>`; caller requested tenant `<requested>`".
+    assert!(
+        err_str.contains("binding") || err_str.contains("tenant") || err_str.contains("scope"),
+        "error must identify a binding/scope failure; got: {err_str:?}"
+    );
+
+    // The error must NOT contain the minted `whsec_` string or any key material.
+    assert!(
+        !err_str.contains("whsec_"),
+        "error message must not contain the whsec_ secret literal; got: {err_str:?}"
+    );
+    // The credential id (non-secret) may appear; the secret key never should.
+    // Verify none of the base64 portion of the minted secret leaks into the error.
+    let whsec_b64 = whsec.strip_prefix("whsec_").unwrap_or("");
+    assert!(
+        whsec_b64.is_empty() || !err_str.contains(whsec_b64),
+        "error message must not contain the base64 key payload; got: {err_str:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Builds the production `WebhookSecretResolver` (previously a stub trait with no impl) so a Standard-Webhooks `whsec_` signing secret stored as a `signing_key` credential resolves to the raw HMAC key bytes the dispatch-side verifier consumes. This **de-risks the highest-risk seam** of the Prod webhook producer — *does store→resolve hand the verifier decoded bytes, or the literal `whsec_` string?* — before any HTTP surface is designed.

PR-2 of the webhook-producer work (PR-1 = rate-limit + Standard-Webhooks HMAC, merged in [#826](https://github.com/vanyastaff/nebula/pull/826)). A research + nebula-grounding analysis (adversarially critiqued, verified against `main`) reshaped the original plan; this PR is the result.

## What the analysis settled (and changed vs the first plan)

- **Activation model is already decided in merged code, not an open fork.** ADR-0096 ([#823](https://github.com/vanyastaff/nebula/pull/823)) made the port-store `WebhookActivationRecord` row (keyed by `token_hash`) the single durable seam. The producer, the `/internal/v1/webhooks/reload` endpoint (which *reloads* the row), and the future `events.rs` lifecycle bus all converge on that one row.
- **Secret provenance: nebula generates `whsec_`/SWH — the only v1 provenance. The `{provenance, scheme}` axis is cut** (no speculative discriminator). A tenant-supplied SaaS secret (Stripe/GitHub) routes by author-chosen URL, not the token-keyed row, so it is a *separate future endpoint*, additive via `#[non_exhaustive]`.
- **`whsec_` key derivation (definitive, proven by the round-trip):** the HMAC key is `base64_decode(secret.strip_prefix("whsec_"))` — decoded bytes, not the literal string. The decode happens once, in the resolver.

## What changed

- **`CredentialBackedWebhookSecretResolver`** — resolves a `signing_key` credential via `CredentialService::validate_credential_binding` + `resolve_for_slot`, then strips `whsec_` and base64-decodes to the raw key bytes. **Reuses the existing `signing_key` credential kind** (sealed at rest via the credential encryption layer) — no new kind, no row column. Typed errors carry no secret material; the secret never reaches a log/span/metric.
- **`WebhookSecretResolver::resolve` gains a `scope: &Scope` param** — necessary, because credential resolution requires a `TenantScope` and there is no raw-resolve-by-id path. Cross-tenant secret resolution is therefore **structurally impossible** (dual-gate: binding owner-check + load-time `verify_owner` backstop). `bootstrap::validate_one` passes the row's real `record.scope`.
- **`mint_whsec()`** — `whsec_` + base64(32 CSPRNG bytes).
- Registers `signing_key` symmetrically in the api credential schema registry + service ops.
- Installs the resolver in the composition root (`compose.rs`), sharing the composed `CredentialService` via `Arc::clone` (the reload endpoint previously failed closed on `None`).

## Round-trip proof (the acceptance gate)

A durable-SQLite-backed (no in-memory double) test: **mint → store(credential) → resolve → decode → sign a Standard-Webhooks delivery → verify passes.** An oracle pins the resolver output to the directly-decoded bytes (catches a literal-string regression); a wrong key fails; a cross-tenant credential id fails closed. **security-auditor: PASS** (dual-gate tenant isolation, no secret leak, 256-bit CSPRNG, symmetric registry).

## Deferred to the next PR (PR-3)

The HTTP registration endpoint `POST /api/v1/orgs/{org}/workspaces/{ws}/webhooks` (auth via `request_scope`, ownership validated under scope, `activate_and_persist(mode=Prod)`, writing `secret_id` into the trigger config, return URL + `whsec_` once). The byte-seam it depends on is now proven.

## Evidence

`nebula-api` + `nebula-server`: **533/533** (`cargo nextest`), `clippy -D` clean, workspace `cargo check --all-targets` clean, rustdoc `-D warnings` clean. rust-reviewer findings (error-model unification, cohesion, test rigor) addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook secret resolution powered by credential management.
  * Enabled tenant-scoped access control for webhook authentication secrets.
  * Introduced webhook secret minting and validation utilities.

* **Tests**
  * Added integration tests validating webhook signing-secret round-trip behavior and tenant isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->