### PR TITLE
refactor(action)!: rename dispatch surface Erased* -> *Handle (ADR-0098 D3)

### DIFF
--- a/crates/action/AGENTS.md
+++ b/crates/action/AGENTS.md
@@ -10,7 +10,7 @@
 |------|-------|
 | Add a new action type | 1. Implement one of the trait variants (`StatelessAction`, etc.) 2. Define `Input`/`Output` types with `HasSchema` 3. Add `#[resource]`/`#[credential]` slots if needed 4. Register in `PluginRegistry` |
 | Add a webhook action | Implement `WebhookAction` — defaults to `SignaturePolicy::Required` (fail-closed). Secret material never flows through dyn `TriggerHandler`. |
-| Understand action dispatch | `Action: Sized` is NOT object-safe. Engine dispatch goes through `Arc<dyn ActionFactory>` + `Box<dyn ErasedXxx>`. See `src/erased.rs` + `src/factory.rs`. |
+| Understand action dispatch | `Action: Sized` is NOT object-safe. Engine dispatch goes through `Arc<dyn ActionFactory>` + `Box<dyn XxxHandle>`. See `src/handle.rs` + `src/factory.rs`. |
 | Add retry hints | Use `ActionError` + `RetryHintCode` in `src/error.rs` — retryable vs fatal. The engine's Layer 2 retry handles the rest. |
 | Run derive tests | `cargo nextest run -p nebula-action` + trybuild probes in `tests/probes/`. Trybuild can false-TIMEOUT under nextest `agent` profile — warm cache + plain `cargo test` to confirm. |
 
@@ -22,14 +22,14 @@
 ## Key files
 - `src/lib.rs` — public re-export surface + module map (`#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`)
 - `src/action.rs` — base `Action` trait (`Sized`, `type Input/Output: HasSchema`, static `metadata()`/`dependencies()`); NOT object-safe
-- `src/erased.rs` + `src/factory.rs` — `ErasedAction` per-variant trait objects + `ActionFactory`/`Generic*Factory` engine-side dispatch
+- `src/handle.rs` + `src/factory.rs` — `ActionHandle` enum + per-variant `XxxHandle` trait objects + `ActionFactory`/`Generic*Factory` engine-side dispatch
 - `src/from_workflow_node.rs` — `FromWorkflowNode` async slot-binding factory (derive emits the body)
 - `src/error.rs` — `ActionError` + `RetryHintCode` (retryable vs fatal)
 - `src/result.rs` / `src/output.rs` — `ActionResult` flow-control intent + `ActionOutput` (inline/blob/stream)
 - `src/webhook/` — `WebhookAction` + HMAC signature primitives (ADR-0022 fail-closed)
 
 ## Conventions & never-do
-- `Action: Sized` is **not** object-safe — never write `dyn Action`; engine dispatch goes through `Arc<dyn ActionFactory>` + `Box<dyn ErasedXxx>`.
+- `Action: Sized` is **not** object-safe — never write `dyn Action`; engine dispatch goes through `Arc<dyn ActionFactory>` + `Box<dyn XxxHandle>`.
 - No `schema` method — `Input`/`Output: HasSchema` is the single source of truth; read via `nebula_schema::schema_of::<A::Input>()` (ADR-0052 P3). Don't add per-trait `*_schema`.
 - Action structs hold **only** slot fields (`#[resource]`/`#[credential]`); user form data lives on a separate `Self::Input` companion struct. `#[credential]` slots hold `CredentialGuard<C::Scheme>`, not `CredentialGuard<C>`.
 - `CheckpointPolicy` is a field on `ActionMetadata` (`checkpoint_policy`, default `Inherit`); engine enforcement of non-`Inherit` cadences is not yet wired — treat a non-default policy as declared intent, not a runtime guarantee.

--- a/crates/action/README.md
+++ b/crates/action/README.md
@@ -38,7 +38,7 @@ pub trait Action: Sized + Send + Sync + 'static {
 // (ADR-0052 P3).
 ```
 
-`Action` is **not object-safe** — `dyn Action` will not compile. Engine dispatch goes through `ActionFactory` + `ErasedAction` (see below).
+`Action` is **not object-safe** — `dyn Action` will not compile. Engine dispatch goes through `ActionFactory` + `ActionHandle` (see below).
 
 ### Sub-traits — execution shapes inherit `<Self as Action>::Input/Output`
 
@@ -135,17 +135,17 @@ pub trait FromWorkflowNode: Sized + Send + 'static {
 
 `#[derive(Action)]` emits the body — read `node.resource_binding(slot)` / `node.credential_binding(slot)` (falling back to the slot's `default_id`), call `ctx.acquire_resource_by_id::<R>(id)` / `ctx.resolve_credential_by_id::<C>(id)`, assemble `Self`. Plugin authors never write the body by hand.
 
-### Engine-side dispatch — `ActionFactory` + `ErasedAction`
+### Engine-side dispatch — `ActionFactory` + `ActionHandle`
 
-Because `Action: Sized` is not object-safe, the engine's registry holds `Arc<dyn ActionFactory>` (object-safe, generic over factory variant) and dispatches through `Box<dyn ErasedXxx>` per-variant trait objects:
+Because `Action: Sized` is not object-safe, the engine's registry holds `Arc<dyn ActionFactory>` (object-safe, generic over factory variant) and dispatches through `ActionHandle` over `Box<dyn XxxHandle>` per-variant trait objects:
 
-| Erased trait | Mirrors |
+| Handle trait | Mirrors |
 |---|---|
-| `ErasedStateless` | `StatelessHandler` (legacy) |
-| `ErasedStateful`  | `StatefulHandler` |
-| `ErasedTrigger`   | `TriggerHandler` |
-| `ErasedResource`  | `ResourceHandler` |
-| `ErasedControl`   | dyn-erased control flow |
+| `StatelessHandle` | `StatelessHandler` (legacy) |
+| `StatefulHandle`  | `StatefulHandler` |
+| `TriggerHandle`   | `TriggerHandler` |
+| `ResourceHandle`  | `ResourceHandler` |
+| `ControlHandle`   | dyn control flow |
 
 Generic factories (`GenericStatelessFactory<A>`, `GenericStatefulFactory<A>`, …) wrap any `A: Action + FromWorkflowNode + StatelessAction` (etc.) into an `ActionFactory` automatically — see `crates/action/src/factory.rs`.
 
@@ -179,7 +179,7 @@ The v4 surface is a hard break per `feedback_no_shims.md` / `feedback_hard_break
 2. **Drop `metadata()` boilerplate from `Self`.** The derive emits a `OnceLock` `metadata()` from the `#[action(key, version, …)]` arguments. Delete the manual `impl Action::metadata` block.
 3. **Replace `dependencies()` macros with field attributes.** Old: a separate `DeclaresDependencies` impl listing `ResourceKey`s and `CredentialKey`s. New: `#[resource(key = "…")]` / `#[credential(key = "…")]` per field on the struct.
 4. **Update sub-trait method signatures** to take `Self::Input` explicitly: `execute(&self, input: SendTelegramInput, ctx)` not `execute(&self, ctx)`.
-5. **Replace `dyn Action` with `Arc<dyn ActionFactory>`** anywhere the engine or plugin loader stored an erased action. Existing transports / SDK harnesses that wrap `Arc<dyn StatelessHandler>` continue to work — four production paths intentionally stay on the legacy handler surface: webhook routing, plugin discovery, SDK runtime, EventSource adapter. The original architectural rationale survives in `git log` (commits up to the retire-AI-Factory pass).
+5. **Replace `dyn Action` with `Arc<dyn ActionFactory>`** anywhere the engine or plugin loader stored a dynamic action handle. Existing transports / SDK harnesses that wrap `Arc<dyn StatelessHandler>` continue to work — four production paths intentionally stay on the legacy handler surface: webhook routing, plugin discovery, SDK runtime, EventSource adapter. The original architectural rationale survives in `git log` (commits up to the retire-AI-Factory pass).
 6. **For `ResourceAction` impls**, set `type Output = ResourceProduces<Self::Resource>`. The marker auto-derives `HasSchema`.
 7. **For `Resource` impls**, drop `type Credential` (per ADR-0044) and declare credential deps via `#[credential(key = "…")]` field attributes — see `crates/resource/README.md` for the resource-side migration.
 
@@ -222,7 +222,7 @@ The examples deliberately wire slot resolution manually (no `#[derive(Action)]`)
 
 See `docs/MATURITY.md` row for `nebula-action`.
 
-- API stability: `frontier` — Variant A trait shape (Sized + type Input/Output + static metadata + slot-binding derive + FromWorkflowNode factory + ErasedAction dispatch) shipped under M6 / §M11 (2026-04-29). The `ActionHandler` enum and per-variant `XxxHandler` traits remain part of the public surface for transports / SDK harnesses / event sources that operate outside the workflow-node dispatch loop — the four production paths kept on the legacy handler surface are enumerated in the migration recipe above.
+- API stability: `frontier` — Variant A trait shape (Sized + type Input/Output + static metadata + slot-binding derive + FromWorkflowNode factory + ActionHandle dispatch) shipped under M6 / §M11 (2026-04-29). The `ActionHandler` enum and per-variant `XxxHandler` traits remain part of the public surface for transports / SDK harnesses / event sources that operate outside the workflow-node dispatch loop — the four production paths kept on the legacy handler surface are enumerated in the migration recipe above.
 - `#![forbid(unsafe_code)]`, `#![warn(missing_docs)]` enforced.
 - `CheckpointPolicy`: persisted on `ActionMetadata` (`checkpoint_policy`, default `Inherit`); engine enforcement of non-`Inherit` cadences not yet wired end-to-end.
 - DX specializations (`PaginatedAction`, `BatchAction`, `WebhookAction`, `PollAction`) are implemented and tested; cross-action-type integration tests: partial.

--- a/crates/action/docs/DESIGN.md
+++ b/crates/action/docs/DESIGN.md
@@ -14,13 +14,13 @@
 `nebula-action` определяет **типизированное семейство трейтов действий** (Action Trait Family) плюс
 статический дескриптор исполнения (`ActionMetadata`) — контракт между «что делает узел workflow»
 и «как движок его оркестрирует». Авторы пишут typed-трейты; движок диспатчит **in-process** через
-`ActionFactory` → `ErasedAction`.
+`ActionFactory` → `ActionHandle`.
 
 **Владеет:**
 - Базовым трейтом `Action` (Sized, identity + статич. метаданные) и под-трейтами
   `StatelessAction` / `StatefulAction` / `TriggerAction` / `ResourceAction` / `ControlAction`.
 - DX-надстройками: `PaginatedAction` / `BatchAction` (над Stateful), `WebhookAction` / `PollAction` (над Trigger).
-- Engine-side стиранием типов: `ErasedAction` enum + per-variant `Erased*` + `Generic*Factory`.
+- Engine-side стиранием типов: `ActionHandle` enum + per-variant `XxxHandle` + `Generic*Factory`.
 - Slot-binding фабрикой `FromWorkflowNode` (тело генерит derive).
 - Типизированной моделью результата/ошибки/выхода: `ActionResult` (flow-control intent),
   `ActionError` + `RetryHintCode`, `ActionOutput` (inline/blob/stream/deferred).
@@ -50,7 +50,7 @@
 | `WebhookAction` + HMAC (`verify_hmac_sha256*`, `SignaturePolicy` fail-closed `Required`) | `src/webhook/mod.rs` (2431 строк) |
 | `PollAction`, `PollTriggerAdapter`, `POLL_INTERVAL_FLOOR`, `DeduplicatingCursor` | `src/poll/mod.rs` |
 | `ActionHandler` — top-level enum-диспетчер над `Arc<dyn XxxHandler>` | `src/handler.rs:41` |
-| `ErasedAction` enum + `ErasedStateless/Stateful/Trigger/Resource/Control` | `src/erased.rs:185,40-162` |
+| `ActionHandle` enum + `StatelessHandle/StatefulHandle/TriggerHandle/ResourceHandle/ControlHandle` | `src/handle.rs:184,40-176` |
 | `ActionFactory` + `Generic{Stateless,Stateful,Trigger,Resource,Control}Factory` | `src/factory.rs:53,69-497` |
 | `FromWorkflowNode` (async slot-binding фабрика; тело генерит derive) | `src/from_workflow_node.rs:61` |
 | `ActionError` + `RetryHintCode` (retryable vs fatal), `ValidationReason` | `src/error.rs:154,31,58` |
@@ -83,7 +83,7 @@ Dev: `nebula-credential-macros`, `nebula-expression`, `trybuild`, `insta`, `rste
 - `poll/` — `PollAction` поверх Trigger: interval floor, warn-throttle, cursor-дедуп.
 - `resource.rs` + `resource_produces.rs` — `ResourceAction` (graph-DI) и Output-маркер.
 - `control.rs` — flow-control узлы, desugar в stateless-поверхность.
-- `erased.rs` + `factory.rs` — engine-side стирание типов и per-исполнение фабрики (т.к. `dyn Action` невозможен).
+- `handle.rs` + `factory.rs` — engine-side стирание типов (`ActionHandle` + `XxxHandle`) и per-исполнение фабрики (т.к. `dyn Action` невозможен).
 - `from_workflow_node.rs` — async-резолв slot-bindings из узла workflow.
 - `handler.rs` — суммирующий enum `ActionHandler`; домены ре-экспортируются «for backwards compatibility».
 - `context.rs` — capability-трейты контекстов + runtime-реализации.
@@ -94,7 +94,7 @@ Dev: `nebula-credential-macros`, `nebula-expression`, `trybuild`, `insta`, `rste
 ## 5. Инварианты и контракты
 
 - **`Action` не object-safe by construction.** `dyn Action` не компилируется; engine-диспатч идёт
-  через `Arc<dyn ActionFactory>` + per-variant `Box<dyn Erased*>`. Это структурный инвариант, не дисциплина.
+  через `Arc<dyn ActionFactory>` + `ActionHandle` над per-variant `Box<dyn XxxHandle>`. Это структурный инвариант, не дисциплина.
 - **Slots-only на `Self`, form-data на `Self::Input`** (canon §3.5). Action-структура держит только
   slot-поля (`#[resource]`/`#[credential]`); пользовательские данные — на отдельной `Self::Input: HasSchema`.
   Устраняет `self.text` vs `input.text`-неоднозначность на этапе компиляции.

--- a/crates/action/src/action.rs
+++ b/crates/action/src/action.rs
@@ -22,8 +22,8 @@ use crate::metadata::ActionMetadata;
 /// # Object safety
 ///
 /// **Not object-safe.** `dyn Action` does not compile. Engine dispatch uses
-/// per-execution factories (`ActionFactory` — Phase 3 / Session 4)
-/// returning `Box<dyn ErasedAction>` for JSON-erased dispatch.
+/// per-execution factories (`ActionFactory`) returning an
+/// [`ActionHandle`](crate::ActionHandle) for JSON-erased dispatch.
 ///
 /// # Example
 ///

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -6,14 +6,14 @@
 //! [`instantiate`](ActionFactory::instantiate) with the current
 //! [`NodeDefinition`](nebula_workflow::NodeDefinition) + an
 //! [`ActionContext`](crate::ActionContext); the factory builds a fresh
-//! [`ErasedAction`](crate::ErasedAction) ready for dispatch.
+//! [`ActionHandle`](crate::ActionHandle) ready for dispatch.
 //!
 //! The default `GenericStatelessFactory<A>` / `GenericStatefulFactory<A>` /
 //! `GenericTriggerFactory<A>` / `GenericResourceFactory<A>` /
 //! `GenericControlFactory<A>` types wrap any `A: Action + FromWorkflowNode`
 //! into an [`ActionFactory`] by routing through
 //! [`FromWorkflowNode::from_workflow_node`](crate::FromWorkflowNode::from_workflow_node)
-//! and then erasing to the matching [`ErasedAction`] variant.
+//! and then erasing to the matching [`ActionHandle`] variant.
 
 use std::{any::Any, future::Future, marker::PhantomData, pin::Pin, sync::OnceLock};
 
@@ -26,11 +26,11 @@ use crate::{
     action::Action,
     context::{ActionContext, TriggerContext},
     control::{ControlAction, ControlInput},
-    erased::{
-        ErasedAction, ErasedControl, ErasedResource, ErasedStateful, ErasedStateless, ErasedTrigger,
-    },
     error::{ActionError, ValidationReason},
     from_workflow_node::FromWorkflowNode,
+    handle::{
+        ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, TriggerHandle,
+    },
     metadata::{ActionKind, ActionMetadata},
     resource::ResourceAction,
     result::ActionResult,
@@ -54,18 +54,18 @@ pub trait ActionFactory: Send + Sync + 'static {
     /// Static metadata describing the action this factory produces.
     fn metadata(&self) -> &ActionMetadata;
 
-    /// Build an [`ErasedAction`] for the given workflow node + context.
+    /// Build an [`ActionHandle`] for the given workflow node + context.
     #[must_use = "the instantiated action handle must be dispatched, not discarded"]
     fn instantiate<'a>(
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>>;
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>>;
 }
 
 // ── Stateless ──────────────────────────────────────────────────────────────
 
-/// Generic factory that produces [`ErasedAction::Stateless`] for any type
+/// Generic factory that produces [`ActionHandle::Stateless`] for any type
 /// implementing [`StatelessAction`] + [`FromWorkflowNode`].
 pub struct GenericStatelessFactory<A> {
     meta: OnceLock<ActionMetadata>,
@@ -104,29 +104,29 @@ where
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
-            let inner = ErasedStatelessImpl::<A>::new(action, meta);
-            Ok(ErasedAction::Stateless(Box::new(inner)))
+            let inner = StatelessHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Stateless(Box::new(inner)))
         })
     }
 }
 
-struct ErasedStatelessImpl<A> {
+struct StatelessHandleImpl<A> {
     action: A,
     meta: ActionMetadata,
 }
 
-impl<A> ErasedStatelessImpl<A> {
+impl<A> StatelessHandleImpl<A> {
     fn new(action: A, meta: ActionMetadata) -> Self {
         Self { action, meta }
     }
 }
 
 #[async_trait]
-impl<A> ErasedStateless for ErasedStatelessImpl<A>
+impl<A> StatelessHandle for StatelessHandleImpl<A>
 where
     A: StatelessAction,
     <A as Action>::Input: DeserializeOwned + Send + Sync,
@@ -160,7 +160,7 @@ where
 
 // ── Stateful ───────────────────────────────────────────────────────────────
 
-/// Generic factory that produces [`ErasedAction::Stateful`] for any type
+/// Generic factory that produces [`ActionHandle::Stateful`] for any type
 /// implementing [`StatefulAction`] + [`FromWorkflowNode`].
 pub struct GenericStatefulFactory<A> {
     meta: OnceLock<ActionMetadata>,
@@ -200,29 +200,29 @@ where
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
-            let inner = ErasedStatefulImpl::<A>::new(action, meta);
-            Ok(ErasedAction::Stateful(Box::new(inner)))
+            let inner = StatefulHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Stateful(Box::new(inner)))
         })
     }
 }
 
-struct ErasedStatefulImpl<A> {
+struct StatefulHandleImpl<A> {
     action: A,
     meta: ActionMetadata,
 }
 
-impl<A> ErasedStatefulImpl<A> {
+impl<A> StatefulHandleImpl<A> {
     fn new(action: A, meta: ActionMetadata) -> Self {
         Self { action, meta }
     }
 }
 
 #[async_trait]
-impl<A> ErasedStateful for ErasedStatefulImpl<A>
+impl<A> StatefulHandle for StatefulHandleImpl<A>
 where
     A: StatefulAction,
     <A as Action>::Input: DeserializeOwned + Send + Sync,
@@ -298,7 +298,7 @@ where
 
 // ── Trigger ────────────────────────────────────────────────────────────────
 
-/// Generic factory that produces [`ErasedAction::Trigger`] for any type
+/// Generic factory that produces [`ActionHandle::Trigger`] for any type
 /// implementing [`TriggerAction`] + [`FromWorkflowNode`].
 pub struct GenericTriggerFactory<A> {
     meta: OnceLock<ActionMetadata>,
@@ -336,29 +336,29 @@ where
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
-            let inner = ErasedTriggerImpl::<A>::new(action, meta);
-            Ok(ErasedAction::Trigger(Box::new(inner)))
+            let inner = TriggerHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Trigger(Box::new(inner)))
         })
     }
 }
 
-struct ErasedTriggerImpl<A> {
+struct TriggerHandleImpl<A> {
     action: A,
     meta: ActionMetadata,
 }
 
-impl<A> ErasedTriggerImpl<A> {
+impl<A> TriggerHandleImpl<A> {
     fn new(action: A, meta: ActionMetadata) -> Self {
         Self { action, meta }
     }
 }
 
 #[async_trait]
-impl<A> ErasedTrigger for ErasedTriggerImpl<A>
+impl<A> TriggerHandle for TriggerHandleImpl<A>
 where
     A: TriggerAction + Send + Sync + 'static,
     <A as TriggerAction>::Error: Into<ActionError>,
@@ -403,7 +403,7 @@ where
 
 // ── Resource ───────────────────────────────────────────────────────────────
 
-/// Generic factory that produces [`ErasedAction::Resource`] for any type
+/// Generic factory that produces [`ActionHandle::Resource`] for any type
 /// implementing [`ResourceAction`] + [`FromWorkflowNode`].
 pub struct GenericResourceFactory<A> {
     meta: OnceLock<ActionMetadata>,
@@ -440,29 +440,29 @@ where
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
-            let inner = ErasedResourceImpl::<A>::new(action, meta);
-            Ok(ErasedAction::Resource(Box::new(inner)))
+            let inner = ResourceHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Resource(Box::new(inner)))
         })
     }
 }
 
-struct ErasedResourceImpl<A> {
+struct ResourceHandleImpl<A> {
     action: A,
     meta: ActionMetadata,
 }
 
-impl<A> ErasedResourceImpl<A> {
+impl<A> ResourceHandleImpl<A> {
     fn new(action: A, meta: ActionMetadata) -> Self {
         Self { action, meta }
     }
 }
 
 #[async_trait]
-impl<A> ErasedResource for ErasedResourceImpl<A>
+impl<A> ResourceHandle for ResourceHandleImpl<A>
 where
     A: ResourceAction + Send + Sync + 'static,
 {
@@ -487,7 +487,7 @@ where
     ) -> Result<(), ActionError> {
         let typed = instance.downcast::<A::Resource>().map_err(|_| {
             ActionError::fatal(format!(
-                "ErasedResourceImpl: downcast invariant violated for {}",
+                "ResourceHandleImpl: downcast invariant violated for {}",
                 std::any::type_name::<A::Resource>()
             ))
         })?;
@@ -497,7 +497,7 @@ where
 
 // ── Control ────────────────────────────────────────────────────────────────
 
-/// Generic factory that produces [`ErasedAction::Control`] for any type
+/// Generic factory that produces [`ActionHandle::Control`] for any type
 /// implementing [`ControlAction`] + [`FromWorkflowNode`].
 pub struct GenericControlFactory<A> {
     meta: OnceLock<ActionMetadata>,
@@ -534,29 +534,29 @@ where
         &'a self,
         node: &'a NodeDefinition,
         ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async move {
             let action = A::from_workflow_node(node, ctx).await?;
             let meta = self.metadata().clone();
-            let inner = ErasedControlImpl::<A>::new(action, meta);
-            Ok(ErasedAction::Control(Box::new(inner)))
+            let inner = ControlHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Control(Box::new(inner)))
         })
     }
 }
 
-struct ErasedControlImpl<A> {
+struct ControlHandleImpl<A> {
     action: A,
     meta: ActionMetadata,
 }
 
-impl<A> ErasedControlImpl<A> {
+impl<A> ControlHandleImpl<A> {
     fn new(action: A, meta: ActionMetadata) -> Self {
         Self { action, meta }
     }
 }
 
 #[async_trait]
-impl<A> ErasedControl for ErasedControlImpl<A>
+impl<A> ControlHandle for ControlHandleImpl<A>
 where
     A: ControlAction + Send + Sync + 'static,
 {

--- a/crates/action/src/from_workflow_node.rs
+++ b/crates/action/src/from_workflow_node.rs
@@ -36,7 +36,7 @@ use crate::context::ActionContext;
 /// **Not object-safe** — the trait carries `Sized` via the implementor
 /// bound and an associated `Error` type. Engine dispatch calls a thin
 /// non-generic wrapper ([`ActionFactory`](crate::ActionFactory) — Session 4)
-/// that erases this typed surface to a `Box<dyn ErasedAction>`.
+/// that erases this typed surface to an [`ActionHandle`](crate::ActionHandle).
 ///
 /// # Example (derive expansion sketch)
 ///

--- a/crates/action/src/handle.rs
+++ b/crates/action/src/handle.rs
@@ -1,20 +1,19 @@
-//! `ErasedAction` enum + object-safe per-variant sub-traits.
+//! `ActionHandle` enum + object-safe per-variant sub-traits.
 //!
 //! The engine cannot dispatch on the
 //! `Sized` [`Action`](crate::Action) trait directly because Variant A makes
 //! it object-unsafe. Instead, the engine works against an enum
-//! [`ErasedAction`] whose variants wrap `Box<dyn ErasedXxx>` trait objects
+//! [`ActionHandle`] whose variants wrap `Box<dyn XxxHandle>` trait objects
 //! — one per execution-shape kind:
 //!
-//! - [`ErasedStateless`] — one-shot JSON in / JSON out (mirrors today's `StatelessHandler`).
-//! - [`ErasedStateful`] — iterative with mutable JSON state.
-//! - [`ErasedTrigger`] — start/stop trigger lifecycle.
-//! - [`ErasedResource`] — graph-scoped resource configure/cleanup.
-//! - [`ErasedControl`] — flow-control nodes desugared to a stateless surface.
+//! - [`StatelessHandle`] — one-shot JSON in / JSON out.
+//! - [`StatefulHandle`] — iterative with mutable JSON state.
+//! - [`TriggerHandle`] — start/stop trigger lifecycle.
+//! - [`ResourceHandle`] — graph-scoped resource configure/cleanup.
+//! - [`ControlHandle`] — flow-control nodes desugared to a stateless surface.
 //!
-//! These mirror the existing `XxxHandler` family one-for-one. Until the
-//! engine fully migrates to factory-based dispatch (later in this phase),
-//! both layers coexist; the Variant A foundation is what we ship.
+//! The engine produces an `ActionHandle` per execution via
+//! [`ActionFactory::instantiate`](crate::ActionFactory::instantiate).
 
 use std::{any::Any, fmt};
 
@@ -37,7 +36,7 @@ use crate::{
 /// on `Value` to/from for engine erasure. Implementors are typically
 /// generic wrappers produced by an [`ActionFactory`](crate::ActionFactory).
 #[async_trait]
-pub trait ErasedStateless: Send + Sync + 'static {
+pub trait StatelessHandle: Send + Sync + 'static {
     /// Action metadata (key, version, ports, schemas).
     fn metadata(&self) -> &ActionMetadata;
 
@@ -55,7 +54,7 @@ pub trait ErasedStateless: Send + Sync + 'static {
 
 /// Object-safe stateful dispatch surface.
 #[async_trait]
-pub trait ErasedStateful: Send + Sync + 'static {
+pub trait StatefulHandle: Send + Sync + 'static {
     /// Action metadata.
     fn metadata(&self) -> &ActionMetadata;
 
@@ -87,7 +86,7 @@ pub trait ErasedStateful: Send + Sync + 'static {
 
 /// Object-safe trigger dispatch surface (start / stop / handle_event).
 #[async_trait]
-pub trait ErasedTrigger: Send + Sync + 'static {
+pub trait TriggerHandle: Send + Sync + 'static {
     /// Action metadata.
     fn metadata(&self) -> &ActionMetadata;
 
@@ -130,7 +129,7 @@ pub trait ErasedTrigger: Send + Sync + 'static {
 
 /// Object-safe resource dispatch surface (configure/cleanup lifecycle).
 #[async_trait]
-pub trait ErasedResource: Send + Sync + 'static {
+pub trait ResourceHandle: Send + Sync + 'static {
     /// Action metadata.
     fn metadata(&self) -> &ActionMetadata;
 
@@ -159,7 +158,7 @@ pub trait ErasedResource: Send + Sync + 'static {
 
 /// Object-safe control dispatch surface (flow-control desugared to stateless).
 #[async_trait]
-pub trait ErasedControl: Send + Sync + 'static {
+pub trait ControlHandle: Send + Sync + 'static {
     /// Action metadata (with `ActionCategory::Control` or `Terminal` stamped).
     fn metadata(&self) -> &ActionMetadata;
 
@@ -177,25 +176,25 @@ pub trait ErasedControl: Send + Sync + 'static {
 
 // ── Top-level enum ──────────────────────────────────────────────────────────
 
-/// Top-level erased action enum — engine dispatches on the variant.
+/// Top-level action-handle enum — engine dispatches on the variant.
 ///
-/// Each variant wraps a `Box<dyn ErasedXxx>`. The engine produces these
+/// Each variant wraps a `Box<dyn XxxHandle>`. The engine produces these
 /// per-execution via [`ActionFactory::instantiate`](crate::ActionFactory::instantiate).
 #[non_exhaustive]
-pub enum ErasedAction {
+pub enum ActionHandle {
     /// One-shot stateless execution.
-    Stateless(Box<dyn ErasedStateless>),
+    Stateless(Box<dyn StatelessHandle>),
     /// Iterative execution with mutable JSON state.
-    Stateful(Box<dyn ErasedStateful>),
+    Stateful(Box<dyn StatefulHandle>),
     /// Workflow trigger (start/stop lifecycle).
-    Trigger(Box<dyn ErasedTrigger>),
+    Trigger(Box<dyn TriggerHandle>),
     /// Graph-scoped resource (configure/cleanup).
-    Resource(Box<dyn ErasedResource>),
+    Resource(Box<dyn ResourceHandle>),
     /// Flow-control node (If / Switch / Router / Filter / NoOp / Stop / Fail).
-    Control(Box<dyn ErasedControl>),
+    Control(Box<dyn ControlHandle>),
 }
 
-impl ErasedAction {
+impl ActionHandle {
     /// Get metadata regardless of variant.
     #[must_use]
     pub fn metadata(&self) -> &ActionMetadata {
@@ -208,38 +207,38 @@ impl ErasedAction {
         }
     }
 
-    /// Whether this is a stateless erased action.
+    /// Whether this is a stateless action handle.
     #[must_use]
     pub fn is_stateless(&self) -> bool {
         matches!(self, Self::Stateless(_))
     }
 
-    /// Whether this is a stateful erased action.
+    /// Whether this is a stateful action handle.
     #[must_use]
     pub fn is_stateful(&self) -> bool {
         matches!(self, Self::Stateful(_))
     }
 
-    /// Whether this is a trigger erased action.
+    /// Whether this is a trigger action handle.
     #[must_use]
     pub fn is_trigger(&self) -> bool {
         matches!(self, Self::Trigger(_))
     }
 
-    /// Whether this is a resource erased action.
+    /// Whether this is a resource action handle.
     #[must_use]
     pub fn is_resource(&self) -> bool {
         matches!(self, Self::Resource(_))
     }
 
-    /// Whether this is a control erased action.
+    /// Whether this is a control action handle.
     #[must_use]
     pub fn is_control(&self) -> bool {
         matches!(self, Self::Control(_))
     }
 }
 
-impl fmt::Debug for ErasedAction {
+impl fmt::Debug for ActionHandle {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let (tag, key) = match self {
             Self::Stateless(h) => ("Stateless", h.metadata().base.key.as_str()),

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -42,17 +42,17 @@ pub mod context;
 /// public contract for flow-control nodes (If, Switch, Router, Filter,
 /// NoOp, Stop, Fail).
 pub mod control;
-/// `ErasedAction` enum + per-variant object-safe sub-traits + `ActionFactory`
-/// (Phase 3 / Session 4) — engine-side dispatch facade.
-pub mod erased;
 /// Error types distinguishing retryable from fatal failures.
 pub mod error;
-/// `ActionFactory` — engine-side per-execution factory that produces a
-/// `Box<dyn ErasedAction>` from a workflow node + context.
+/// `ActionFactory` — engine-side per-execution factory that produces an
+/// `ActionHandle` from a workflow node + context.
 pub mod factory;
 /// `FromWorkflowNode` async factory trait — resolves slot bindings against
 /// a workflow node + action context (Phase 3 / Session 2).
 pub mod from_workflow_node;
+/// `ActionHandle` enum + per-variant object-safe `XxxHandle` sub-traits —
+/// the engine-side dynamic dispatch surface produced by `ActionFactory`.
+pub mod handle;
 /// Top-level [`ActionHandler`] enum dispatcher. Domain handler traits and
 /// adapters live in their respective domain files and are re-exported here
 /// for backwards compatibility of the `nebula_action::handler::*` path space.
@@ -107,9 +107,6 @@ pub use context::{
     HasTriggerScheduling, HasWebhookEndpoint, TriggerContext, TriggerRuntimeContext,
 };
 pub use control::{ControlAction, ControlActionAdapter, ControlInput, ControlOutcome};
-pub use erased::{
-    ErasedAction, ErasedControl, ErasedResource, ErasedStateful, ErasedStateless, ErasedTrigger,
-};
 pub use error::{
     ActionError, ActionErrorExt, MAX_VALIDATION_DETAIL, RetryHintCode, ValidationReason,
 };
@@ -118,6 +115,9 @@ pub use factory::{
     GenericStatelessFactory, GenericTriggerFactory,
 };
 pub use from_workflow_node::FromWorkflowNode;
+pub use handle::{
+    ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, TriggerHandle,
+};
 pub use handler::ActionHandler;
 pub use idempotency::IdempotencyKey;
 pub use metadata::{

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -8,7 +8,7 @@ use std::{sync::Arc, time::Instant};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use nebula_action::{
-    ActionContext, ActionError, ActionFactory, ActionHandler, ActionMetadata, ErasedAction,
+    ActionContext, ActionError, ActionFactory, ActionHandle, ActionHandler, ActionMetadata,
     IsolationLevel, StatefulHandler, StatelessHandler,
     output::{ActionOutput, DataReference},
     result::ActionResult,
@@ -30,7 +30,7 @@ use super::{
     runner::{ActionRunContext, ActionRunner},
 };
 
-/// Compute a digest of the erased stateful state for stuck-state detection.
+/// Compute a digest of the serialized stateful state for stuck-state detection.
 ///
 /// The runtime sees `state` as `serde_json::Value` — not `Hash`, but always
 /// serialisable. We route through `serde_json::to_vec` and hash the bytes.
@@ -487,7 +487,7 @@ impl ActionRuntime {
     }
 
     /// Dispatch through the factory path — instantiate a fresh
-    /// [`ErasedAction`] for the supplied workflow node and dispatch it.
+    /// [`ActionHandle`] for the supplied workflow node and dispatch it.
     ///
     /// Mirrors [`Self::run_handler`]'s metric contract:
     ///
@@ -529,7 +529,7 @@ impl ActionRuntime {
 
         // Instantiate the action via the factory. Slot-binding resolution
         // (and any FromWorkflowNode user code) runs here.
-        let erased = match factory.instantiate(node, context).await {
+        let handle = match factory.instantiate(node, context).await {
             Ok(e) => e,
             Err(e) => {
                 let result: Result<ActionResult<serde_json::Value>, RuntimeError> =
@@ -539,47 +539,47 @@ impl ActionRuntime {
             },
         };
 
-        let result = match erased {
-            ErasedAction::Stateless(inner) => {
+        let result = match handle {
+            ActionHandle::Stateless(inner) => {
                 let r = self
-                    .execute_erased_stateless(&metadata, inner, input, context)
+                    .execute_stateless_handle(&metadata, inner, input, context)
                     .await;
                 self.observe_dispatched(started, &r);
                 r
             },
-            ErasedAction::Stateful(inner) => {
+            ActionHandle::Stateful(inner) => {
                 let r = self
-                    .execute_erased_stateful(&metadata, inner, input, context, checkpoint)
+                    .execute_stateful_handle(&metadata, inner, input, context, checkpoint)
                     .await;
                 self.observe_dispatched(started, &r);
                 r
             },
-            ErasedAction::Control(inner) => {
+            ActionHandle::Control(inner) => {
                 let r = self
-                    .execute_erased_control(&metadata, inner, input, context)
+                    .execute_control_handle(&metadata, inner, input, context)
                     .await;
                 self.observe_dispatched(started, &r);
                 r
             },
-            ErasedAction::Trigger(_) => {
+            ActionHandle::Trigger(_) => {
                 self.observe_rejected(dispatch_reject_reason::TRIGGER_NOT_EXECUTABLE);
                 return Err(RuntimeError::TriggerNotExecutable {
                     key: action_key.to_owned(),
                 });
             },
-            ErasedAction::Resource(_) => {
+            ActionHandle::Resource(_) => {
                 self.observe_rejected(dispatch_reject_reason::RESOURCE_NOT_EXECUTABLE);
                 return Err(RuntimeError::ResourceNotExecutable {
                     key: action_key.to_owned(),
                 });
             },
-            // `ErasedAction` is `#[non_exhaustive]`. Unknown future variants
+            // `ActionHandle` is `#[non_exhaustive]`. Unknown future variants
             // surface as an internal runtime error rather than silently
             // succeeding.
             _ => {
                 self.observe_rejected(dispatch_reject_reason::UNKNOWN_VARIANT);
                 return Err(RuntimeError::Internal(format!(
-                    "unknown ErasedAction variant for action '{action_key}'"
+                    "unknown ActionHandle variant for action '{action_key}'"
                 )));
             },
         };
@@ -599,20 +599,20 @@ impl ActionRuntime {
         }
     }
 
-    /// Stateless dispatch via `Box<dyn ErasedStateless>`.
+    /// Stateless dispatch via `Box<dyn StatelessHandle>`.
     ///
     /// Mirrors [`Self::execute_stateless`] for the factory path. Honours
     /// the same isolation contract (`None` runs in-process; capability-gated
     /// dispatch routes through [`ActionRunner`] using the same `metadata`).
-    async fn execute_erased_stateless(
+    async fn execute_stateless_handle(
         &self,
         metadata: &ActionMetadata,
-        erased: Box<dyn nebula_action::ErasedStateless>,
+        handle: Box<dyn nebula_action::StatelessHandle>,
         input: serde_json::Value,
         context: &dyn ActionContext,
     ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
         match metadata.isolation_level {
-            IsolationLevel::None => Ok(erased.dispatch(input, context).await?),
+            IsolationLevel::None => Ok(handle.dispatch(input, context).await?),
             IsolationLevel::CapabilityGated => {
                 let run_ctx = ActionRunContext::new(context);
                 Ok(self.runner.execute(run_ctx, metadata, input).await?)
@@ -626,17 +626,17 @@ impl ActionRuntime {
         }
     }
 
-    /// Stateful dispatch via `Box<dyn ErasedStateful>`.
+    /// Stateful dispatch via `Box<dyn StatefulHandle>`.
     ///
     /// Mirrors [`Self::execute_stateful`] for the factory path. The
-    /// erased trait works on `Value` state so the iteration body matches
+    /// handle trait works on `Value` state so the iteration body matches
     /// 1:1 with the legacy `Arc<dyn StatefulHandler>` path — same cancel
     /// race, same checkpoint contract, same iteration cap, same
     /// stuck-state guard.
-    async fn execute_erased_stateful(
+    async fn execute_stateful_handle(
         &self,
         metadata: &ActionMetadata,
-        erased: Box<dyn nebula_action::ErasedStateful>,
+        handle: Box<dyn nebula_action::StatefulHandle>,
         input: serde_json::Value,
         context: &dyn ActionContext,
         checkpoint: Option<Arc<dyn StatefulCheckpointSink>>,
@@ -655,7 +655,7 @@ impl ActionRuntime {
         let (mut state, mut iteration) = match checkpoint.as_deref() {
             Some(sink) => match sink.load().await {
                 Ok(Some(cp)) => (cp.state, cp.iteration),
-                Ok(None) => (erased.init_state()?, 0u32),
+                Ok(None) => (handle.init_state()?, 0u32),
                 Err(load_err) => {
                     tracing::warn!(
                         action_key = %metadata.base.key.as_str(),
@@ -665,10 +665,10 @@ impl ActionRuntime {
                         "stateful checkpoint load failed — falling back to init_state, \
                          iteration progress (if any) is lost"
                     );
-                    (erased.init_state()?, 0u32)
+                    (handle.init_state()?, 0u32)
                 },
             },
-            None => (erased.init_state()?, 0u32),
+            None => (handle.init_state()?, 0u32),
         };
 
         const MAX_ITERATIONS: u32 = 10_000;
@@ -689,7 +689,7 @@ impl ActionRuntime {
             let state_digest_before = stateful_state_digest(&state);
 
             let iteration_result = {
-                let exec_fut = erased.dispatch(&input, &mut state, context);
+                let exec_fut = handle.dispatch(&input, &mut state, context);
                 tokio::pin!(exec_fut);
 
                 tokio::select! {
@@ -748,17 +748,17 @@ impl ActionRuntime {
         }
     }
 
-    /// Control dispatch via `Box<dyn ErasedControl>`.
+    /// Control dispatch via `Box<dyn ControlHandle>`.
     ///
     /// Control nodes (If / Switch / Router / Filter / NoOp / Stop / Fail)
     /// dispatch as one-shot evaluators and never run through the runner —
     /// they produce flow-control [`ActionResult`] variants but no I/O. The
-    /// erased surface is intentionally identical to stateless from the
+    /// handle surface is intentionally identical to stateless from the
     /// runtime's POV.
-    async fn execute_erased_control(
+    async fn execute_control_handle(
         &self,
         metadata: &ActionMetadata,
-        erased: Box<dyn nebula_action::ErasedControl>,
+        handle: Box<dyn nebula_action::ControlHandle>,
         input: serde_json::Value,
         context: &dyn ActionContext,
     ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
@@ -770,7 +770,7 @@ impl ActionRuntime {
                 metadata.base.key.as_str()
             )));
         }
-        Ok(erased.dispatch(input, context).await?)
+        Ok(handle.dispatch(input, context).await?)
     }
 
     /// Observe a dispatched handler execution.

--- a/crates/plugin/src/plugin.rs
+++ b/crates/plugin/src/plugin.rs
@@ -33,10 +33,9 @@ pub trait Plugin: Send + Sync + Debug + 'static {
     /// Called once at registration time by [`crate::ResolvedPlugin::from`].
     /// Returns an empty list by default.
     ///
-    /// Each entry is a typed factory that the engine registry will use to
-    /// construct an [`nebula_action::ActionHandle`] per dispatch (per
-    ///
-    /// is `Sized`/object-unsafe, so plugins return factories not actions).
+    /// Each entry is a typed factory that the engine registry uses to
+    /// construct an [`nebula_action::ActionHandle`] per dispatch (`Action`
+    /// is `Sized`/object-unsafe, so plugins return factories, not actions).
     fn actions(&self) -> Vec<Arc<dyn nebula_action::ActionFactory>> {
         vec![]
     }

--- a/crates/plugin/src/plugin.rs
+++ b/crates/plugin/src/plugin.rs
@@ -34,7 +34,7 @@ pub trait Plugin: Send + Sync + Debug + 'static {
     /// Returns an empty list by default.
     ///
     /// Each entry is a typed factory that the engine registry will use to
-    /// construct an [`nebula_action::ErasedAction`] per dispatch (per
+    /// construct an [`nebula_action::ActionHandle`] per dispatch (per
     ///
     /// is `Sized`/object-unsafe, so plugins return factories not actions).
     fn actions(&self) -> Vec<Arc<dyn nebula_action::ActionFactory>> {

--- a/crates/plugin/tests/resolved_plugin.rs
+++ b/crates/plugin/tests/resolved_plugin.rs
@@ -2,7 +2,7 @@
 
 use std::{future::Future, pin::Pin, sync::Arc};
 
-use nebula_action::{ActionContext, ActionError, ActionFactory, ActionMetadata, ErasedAction};
+use nebula_action::{ActionContext, ActionError, ActionFactory, ActionHandle, ActionMetadata};
 use nebula_core::{ActionKey, CredentialKey, ResourceKey};
 use nebula_credential::{AnyCredential, AuthPattern, CredentialMetadata};
 use nebula_metadata::PluginManifest;
@@ -54,7 +54,7 @@ impl ActionFactory for StubAction {
         &'a self,
         _node: &'a NodeDefinition,
         _ctx: &'a dyn ActionContext,
-    ) -> Pin<Box<dyn Future<Output = Result<ErasedAction, ActionError>> + Send + 'a>> {
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
         Box::pin(async {
             Err(ActionError::fatal(
                 "StubAction::instantiate is a test stub — should never be invoked",


### PR DESCRIPTION
## What

Pure rename, **no behavior change**. Drops the `Erased` naming on the engine-side dynamic dispatch surface of `nebula-action` in favor of `Handle` (ADR-0098 D3).

| Before | After |
|---|---|
| `ErasedAction` (enum) | `ActionHandle` |
| `ErasedStateless` / `ErasedStateful` / `ErasedTrigger` / `ErasedResource` / `ErasedControl` | `StatelessHandle` / `StatefulHandle` / `TriggerHandle` / `ResourceHandle` / `ControlHandle` |
| module `src/erased.rs` | `src/handle.rs` |
| `Generic*Factory` private impls `Erased*Impl` | `*HandleImpl` |
| engine methods `execute_erased_*` | `execute_*_handle` |

The chain now reads: author writes `StatelessAction` → `GenericStatelessFactory` produces a `StatelessHandle` → engine matches `ActionHandle`.

## Scope

`nebula-action` dispatch surface + its consumers: engine runtime dispatch (`runtime.rs`), the plugin factory stub/test, and crate docs (README / AGENTS / DESIGN). Other crates' unrelated `Erased*` types (credential, resource) are **not** touched.

## Sequencing note

ADR-0098 sequences the dispatch-spine **collapse** (D0) before this rename (D3) so the new `*Handle` types never coexist with the legacy `*Handler` author-side traits. This PR reorders the rename first (owner-requested: drop `Erased`). As a result the legacy `ActionHandler` enum and `*Handler` dyn traits sit beside the new `*Handle` types until the follow-up collapse removes the legacy node-execution path — a transient, intentional state.

## Verification

All green on this branch:

- `cargo build -p nebula-action -p nebula-engine -p nebula-plugin`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run -p nebula-action -p nebula-engine -p nebula-plugin` → 838 passed
- `cargo fmt -p nebula-action -p nebula-engine -p nebula-plugin -- --check`
- `RUSTDOCFLAGS=-D warnings cargo doc -p nebula-action -p nebula-engine -p nebula-plugin --no-deps`
- pre-push lefthook: 840 nextest passed, clippy-full, crate-diff-gate rustdoc (action/engine/plugin) — all green

## Next

ADR-0098 D0 — collapse the legacy `ActionHandler` node-execution dual spine (mapping done; the trigger/webhook/EventSource/SDK handler axis stays as the separate entry/lifecycle surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Refactor**
  * Refactored internal action dispatch architecture for improved type safety and system clarity.

* **Documentation**
  * Updated documentation across action system modules to reflect architectural improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->