### PR TITLE
feat(action): FixedFactory — instance-carrying stateless factory (ADR-0098 D0, PR1)

### DIFF
--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -15,7 +15,13 @@
 //! [`FromWorkflowNode::from_workflow_node`](crate::FromWorkflowNode::from_workflow_node)
 //! and then erasing to the matching [`ActionHandle`] variant.
 
-use std::{any::Any, future::Future, marker::PhantomData, pin::Pin, sync::OnceLock};
+use std::{
+    any::Any,
+    future::Future,
+    marker::PhantomData,
+    pin::Pin,
+    sync::{Arc, OnceLock},
+};
 
 use async_trait::async_trait;
 use nebula_workflow::NodeDefinition;
@@ -127,6 +133,109 @@ impl<A> StatelessHandleImpl<A> {
 
 #[async_trait]
 impl<A> StatelessHandle for StatelessHandleImpl<A>
+where
+    A: StatelessAction,
+    <A as Action>::Input: DeserializeOwned + Send + Sync,
+    <A as Action>::Output: Serialize + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+
+    async fn dispatch(
+        &self,
+        input: Value,
+        ctx: &dyn ActionContext,
+    ) -> Result<ActionResult<Value>, ActionError> {
+        let typed_input: <A as Action>::Input = serde_json::from_value(input).map_err(|e| {
+            ActionError::validation(
+                "input",
+                ValidationReason::MalformedJson,
+                Some(e.to_string()),
+            )
+        })?;
+
+        let result = self.action.execute(typed_input, ctx).await?;
+
+        result.try_map_output(|output| {
+            serde_json::to_value(output)
+                .map_err(|e| ActionError::fatal(format!("output serialization failed: {e}")))
+        })
+    }
+}
+
+// ── FixedFactory (instance-carrying stateless factory) ──────────────────────
+
+/// Stateless [`ActionFactory`] that wraps a pre-built action **instance** plus
+/// caller-supplied [`ActionMetadata`], instead of building the action from the
+/// workflow node like [`GenericStatelessFactory`].
+///
+/// Two properties distinguish it from the generic factory:
+///
+/// - **Caller metadata.** The metadata is supplied per registration, so one
+///   action type can back many distinct catalog keys / port shapes. The generic
+///   factory derives a single static [`Action::metadata`] from the type and so
+///   binds one type to one key.
+/// - **Shared instance.** It holds the action in an `Arc` and hands every
+///   dispatch a handle over the *same* instance, so interior state (counters,
+///   spies, caches) is shared across dispatches — matching a directly
+///   constructed handler. The generic factory rebuilds a fresh action per
+///   dispatch via [`FromWorkflowNode`].
+///
+/// The produced [`ActionHandle::Stateless`] dispatches through the same engine
+/// path as any other factory — `FixedFactory` is a first-class member of the
+/// factory spine, not a wrapper around a separate dispatch path.
+pub struct FixedFactory<A> {
+    action: Arc<A>,
+    meta: Arc<ActionMetadata>,
+}
+
+impl<A> FixedFactory<A> {
+    /// Wrap a pre-built action instance with explicit metadata.
+    ///
+    /// The metadata's [`kind`](ActionMetadata::kind) is stamped to
+    /// [`ActionKind::Stateless`] — the factory is the single writer of the kind
+    /// for the handle it produces — while every other field is preserved as the
+    /// caller supplied it.
+    #[must_use]
+    pub fn new(metadata: ActionMetadata, action: A) -> Self {
+        Self {
+            action: Arc::new(action),
+            meta: Arc::new(metadata.with_kind(ActionKind::Stateless)),
+        }
+    }
+}
+
+impl<A> ActionFactory for FixedFactory<A>
+where
+    A: StatelessAction,
+    <A as Action>::Input: DeserializeOwned + Send + Sync,
+    <A as Action>::Output: Serialize + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+
+    fn instantiate<'a>(
+        &'a self,
+        _node: &'a NodeDefinition,
+        _ctx: &'a dyn ActionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
+        let inner = FixedStatelessHandle {
+            action: Arc::clone(&self.action),
+            meta: Arc::clone(&self.meta),
+        };
+        Box::pin(async move { Ok(ActionHandle::Stateless(Box::new(inner))) })
+    }
+}
+
+struct FixedStatelessHandle<A> {
+    action: Arc<A>,
+    meta: Arc<ActionMetadata>,
+}
+
+#[async_trait]
+impl<A> StatelessHandle for FixedStatelessHandle<A>
 where
     A: StatelessAction,
     <A as Action>::Input: DeserializeOwned + Send + Sync,

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -111,8 +111,8 @@ pub use error::{
     ActionError, ActionErrorExt, MAX_VALIDATION_DETAIL, RetryHintCode, ValidationReason,
 };
 pub use factory::{
-    ActionFactory, GenericControlFactory, GenericResourceFactory, GenericStatefulFactory,
-    GenericStatelessFactory, GenericTriggerFactory,
+    ActionFactory, FixedFactory, GenericControlFactory, GenericResourceFactory,
+    GenericStatefulFactory, GenericStatelessFactory, GenericTriggerFactory,
 };
 pub use from_workflow_node::FromWorkflowNode;
 pub use handle::{

--- a/crates/action/tests/fixed_factory.rs
+++ b/crates/action/tests/fixed_factory.rs
@@ -1,0 +1,141 @@
+//! Integration tests for [`FixedFactory`] — the instance-carrying stateless
+//! [`ActionFactory`].
+//!
+//! `FixedFactory` is the migration vehicle for the ADR-0098 D0 spine collapse:
+//! it lets a registry hold a pre-built action instance plus per-registration
+//! metadata on the surviving factory spine, where the generic factory (which
+//! ties one type to one static key and rebuilds the action per dispatch) cannot.
+//! These tests pin the two properties that distinguish it from
+//! `GenericStatelessFactory`: caller-supplied metadata, and a shared instance.
+
+use std::sync::{
+    Arc, OnceLock,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use nebula_action::{
+    Action, ActionContext, ActionError, ActionFactory, ActionHandle, ActionKind, ActionMetadata,
+    ActionResult, FixedFactory, StatelessAction, TestContextBuilder,
+};
+use nebula_core::{Dependencies, action_key, node_key};
+use nebula_workflow::NodeDefinition;
+
+/// Stateless action that counts every execution through a shared `Arc`, so a
+/// test can observe whether dispatches reuse one instance or rebuild it.
+struct CountingEcho {
+    hits: Arc<AtomicUsize>,
+}
+
+impl Action for CountingEcho {
+    type Input = serde_json::Value;
+    type Output = serde_json::Value;
+
+    fn metadata() -> ActionMetadata {
+        // A distinct type-level key, so a test can prove the factory does NOT
+        // fall back to this when caller metadata is supplied.
+        ActionMetadata::new(
+            action_key!("builtin.counting_echo"),
+            "CountingEcho",
+            "type-level metadata",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl StatelessAction for CountingEcho {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.hits.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+#[tokio::test]
+async fn fixed_factory_uses_caller_metadata_not_type_metadata() {
+    let factory = FixedFactory::new(
+        ActionMetadata::new(
+            action_key!("tenant.custom_echo"),
+            "Custom Echo",
+            "per-registration metadata",
+        ),
+        CountingEcho {
+            hits: Arc::new(AtomicUsize::new(0)),
+        },
+    );
+
+    // Caller metadata wins over the type's own `Action::metadata()` key — this
+    // is why one action type can back many distinct catalog keys.
+    assert_eq!(
+        factory.metadata().base.key,
+        action_key!("tenant.custom_echo")
+    );
+    assert_ne!(
+        factory.metadata().base.key,
+        <CountingEcho as Action>::metadata().base.key,
+        "FixedFactory must not fall back to the type's static metadata key"
+    );
+    // The factory is the single writer of the kind for the handle it produces.
+    assert_eq!(factory.metadata().kind, ActionKind::Stateless);
+}
+
+#[tokio::test]
+async fn fixed_factory_shares_one_instance_across_dispatches() {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let factory = FixedFactory::new(
+        ActionMetadata::new(action_key!("tenant.custom_echo"), "Custom Echo", ""),
+        CountingEcho {
+            hits: Arc::clone(&hits),
+        },
+    );
+
+    let node = NodeDefinition::new(
+        node_key!("n"),
+        "custom_echo",
+        "tenant",
+        "tenant.custom_echo",
+    )
+    .expect("node definition builds");
+    let ctx = TestContextBuilder::new().build();
+
+    // Two independent instantiate→dispatch cycles must hit the SAME underlying
+    // instance: the shared counter accumulates. A generic factory would rebuild
+    // a fresh action per dispatch and the count would not carry across cycles.
+    for expected in 1..=2u64 {
+        let handle = factory
+            .instantiate(&node, &ctx)
+            .await
+            .expect("instantiate succeeds");
+        let ActionHandle::Stateless(stateless) = handle else {
+            panic!("FixedFactory must produce ActionHandle::Stateless");
+        };
+
+        let result = stateless
+            .dispatch(serde_json::json!({ "n": expected }), &ctx)
+            .await
+            .expect("dispatch succeeds");
+
+        // Assert the echoed value (correctness), not merely that it succeeded.
+        match result {
+            ActionResult::Success { output } => {
+                assert_eq!(
+                    output.as_value(),
+                    Some(&serde_json::json!({ "n": expected }))
+                );
+            },
+            _ => panic!("expected ActionResult::Success"),
+        }
+
+        assert_eq!(
+            hits.load(Ordering::SeqCst),
+            expected as usize,
+            "shared instance: the counter must accumulate across dispatch cycles"
+        );
+    }
+}


### PR DESCRIPTION
## What — PR1 of 3 (ADR-0098 D0 dispatch-spine collapse)

Adds `FixedFactory<A>`: the migration vehicle that lets the engine registry move its ~140 legacy `ActionHandler` test fixtures onto the surviving `ActionFactory` spine. **Additive only** — nothing is deleted yet.

### Why the generic factory can't replace those fixtures
`GenericStatelessFactory<A>`:
- derives **one static key** from `A::metadata()` — but fixtures register one type under many keys;
- **rebuilds a fresh action per dispatch** via `FromWorkflowNode` — but fixtures rely on a **shared instance** (spy counters, caches).

### `FixedFactory<A>` closes both gaps, staying on the factory spine
- holds the action in `Arc<A>` and hands every dispatch a handle over the **same** instance → interior state persists across dispatches;
- carries **caller-supplied** `ActionMetadata` (kind stamped to `Stateless` — the factory is the single writer of the kind), so one type backs many keys;
- produces `ActionHandle::Stateless` and dispatches through the same `StatelessHandle` path — it **never** touches the legacy `run_handler`, so it is a first-class member of the surviving spine, not a shim;
- metadata stored as `Arc<ActionMetadata>` so `instantiate` clones an `Arc`, not the heap-owning metadata, on the per-dispatch path.

## The 3-PR stack (owner-approved: full collapse, stacked)
- **PR1 (this):** add `FixedFactory` + tests.
- **PR2:** migrate ~140 fixtures to factory registration (preserving each fixture's behavioral assertions); remove the dead trigger/resource factory surface (`ActionHandle::{Trigger,Resource}` variants, `Generic{Trigger,Resource}Factory`, `register_{trigger,resource}_factory`) + the 4 dead-but-public `register_{trigger,webhook,poll,resource_action}` methods + stale docs.
- **PR3:** delete the legacy node spine (`run_handler`/`execute_stateless`/`execute_stateful`/`legacy_register_*`/`ActionHandler` node role) + transform the precedence test into a single-spine DoD test. `TriggerHandler` (entry/lifecycle axis: EventSourceAdapter, API webhook, SDK harness) is **kept** throughout.

## Tests
`crates/action/tests/fixed_factory.rs` asserts the two distinguishing properties with **real values, not `is_ok()`**:
- **caller-metadata-wins** — the factory key is the caller's, not the type's static `Action::metadata()` key;
- **shared-instance** — a counter accumulates across two `instantiate`→`dispatch` cycles (a generic factory would reset it). This is the falsifiable guard: revert to per-dispatch rebuild and it goes red.

## Verification
- `cargo test -p nebula-action` green (269 lib + all integration suites + the 2 new tests)
- pre-push gate green: clippy-full (`--all-targets -D warnings`) + crate-diff-gate (rustdoc `-D warnings`)
- fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)