### PR TITLE
refactor(action)!: migrate stateless fixtures onto InstanceFactory; rename FixedFactory (ADR-0098 D0, PR2)

### DIFF
--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -164,11 +164,16 @@ where
     }
 }
 
-// ── FixedFactory (instance-carrying stateless factory) ──────────────────────
+// ── InstanceFactory (instance-backed stateless factory) ─────────────────────
 
-/// Stateless [`ActionFactory`] that wraps a pre-built action **instance** plus
+/// Stateless [`ActionFactory`] backed by a pre-built action **instance** plus
 /// caller-supplied [`ActionMetadata`], instead of building the action from the
 /// workflow node like [`GenericStatelessFactory`].
+///
+/// This is the `useValue` half of the dependency-injection dichotomy
+/// (a pre-instantiated value) to [`GenericStatelessFactory`]'s `useFactory`
+/// half (construct-on-demand): the same action instance is shared across every
+/// dispatch, and the catalog metadata is supplied per registration.
 ///
 /// Two properties distinguish it from the generic factory:
 ///
@@ -183,14 +188,14 @@ where
 ///   dispatch via [`FromWorkflowNode`].
 ///
 /// The produced [`ActionHandle::Stateless`] dispatches through the same engine
-/// path as any other factory — `FixedFactory` is a first-class member of the
+/// path as any other factory — `InstanceFactory` is a first-class member of the
 /// factory spine, not a wrapper around a separate dispatch path.
-pub struct FixedFactory<A> {
+pub struct InstanceFactory<A> {
     action: Arc<A>,
     meta: Arc<ActionMetadata>,
 }
 
-impl<A> FixedFactory<A> {
+impl<A> InstanceFactory<A> {
     /// Wrap a pre-built action instance with explicit metadata.
     ///
     /// The metadata's [`kind`](ActionMetadata::kind) is stamped to
@@ -206,7 +211,7 @@ impl<A> FixedFactory<A> {
     }
 }
 
-impl<A> ActionFactory for FixedFactory<A>
+impl<A> ActionFactory for InstanceFactory<A>
 where
     A: StatelessAction,
     <A as Action>::Input: DeserializeOwned + Send + Sync,
@@ -221,7 +226,7 @@ where
         _node: &'a NodeDefinition,
         _ctx: &'a dyn ActionContext,
     ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
-        let inner = FixedStatelessHandle {
+        let inner = InstanceStatelessHandle {
             action: Arc::clone(&self.action),
             meta: Arc::clone(&self.meta),
         };
@@ -229,13 +234,13 @@ where
     }
 }
 
-struct FixedStatelessHandle<A> {
+struct InstanceStatelessHandle<A> {
     action: Arc<A>,
     meta: Arc<ActionMetadata>,
 }
 
 #[async_trait]
-impl<A> StatelessHandle for FixedStatelessHandle<A>
+impl<A> StatelessHandle for InstanceStatelessHandle<A>
 where
     A: StatelessAction,
     <A as Action>::Input: DeserializeOwned + Send + Sync,

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -111,8 +111,8 @@ pub use error::{
     ActionError, ActionErrorExt, MAX_VALIDATION_DETAIL, RetryHintCode, ValidationReason,
 };
 pub use factory::{
-    ActionFactory, FixedFactory, GenericControlFactory, GenericResourceFactory,
-    GenericStatefulFactory, GenericStatelessFactory, GenericTriggerFactory,
+    ActionFactory, GenericControlFactory, GenericResourceFactory, GenericStatefulFactory,
+    GenericStatelessFactory, GenericTriggerFactory, InstanceFactory,
 };
 pub use from_workflow_node::FromWorkflowNode;
 pub use handle::{

--- a/crates/action/tests/instance_factory.rs
+++ b/crates/action/tests/instance_factory.rs
@@ -1,7 +1,7 @@
-//! Integration tests for [`FixedFactory`] — the instance-carrying stateless
+//! Integration tests for [`InstanceFactory`] — the instance-backed stateless
 //! [`ActionFactory`].
 //!
-//! `FixedFactory` is the migration vehicle for the ADR-0098 D0 spine collapse:
+//! `InstanceFactory` is the migration vehicle for the ADR-0098 D0 spine collapse:
 //! it lets a registry hold a pre-built action instance plus per-registration
 //! metadata on the surviving factory spine, where the generic factory (which
 //! ties one type to one static key and rebuilds the action per dispatch) cannot.
@@ -15,7 +15,7 @@ use std::sync::{
 
 use nebula_action::{
     Action, ActionContext, ActionError, ActionFactory, ActionHandle, ActionKind, ActionMetadata,
-    ActionResult, FixedFactory, StatelessAction, TestContextBuilder,
+    ActionResult, InstanceFactory, StatelessAction, TestContextBuilder,
 };
 use nebula_core::{Dependencies, action_key, node_key};
 use nebula_workflow::NodeDefinition;
@@ -58,8 +58,8 @@ impl StatelessAction for CountingEcho {
 }
 
 #[tokio::test]
-async fn fixed_factory_uses_caller_metadata_not_type_metadata() {
-    let factory = FixedFactory::new(
+async fn instance_factory_uses_caller_metadata_not_type_metadata() {
+    let factory = InstanceFactory::new(
         ActionMetadata::new(
             action_key!("tenant.custom_echo"),
             "Custom Echo",
@@ -79,16 +79,16 @@ async fn fixed_factory_uses_caller_metadata_not_type_metadata() {
     assert_ne!(
         factory.metadata().base.key,
         <CountingEcho as Action>::metadata().base.key,
-        "FixedFactory must not fall back to the type's static metadata key"
+        "InstanceFactory must not fall back to the type's static metadata key"
     );
     // The factory is the single writer of the kind for the handle it produces.
     assert_eq!(factory.metadata().kind, ActionKind::Stateless);
 }
 
 #[tokio::test]
-async fn fixed_factory_shares_one_instance_across_dispatches() {
+async fn instance_factory_shares_one_instance_across_dispatches() {
     let hits = Arc::new(AtomicUsize::new(0));
-    let factory = FixedFactory::new(
+    let factory = InstanceFactory::new(
         ActionMetadata::new(action_key!("tenant.custom_echo"), "Custom Echo", ""),
         CountingEcho {
             hits: Arc::clone(&hits),
@@ -113,7 +113,7 @@ async fn fixed_factory_shares_one_instance_across_dispatches() {
             .await
             .expect("instantiate succeeds");
         let ActionHandle::Stateless(stateless) = handle else {
-            panic!("FixedFactory must produce ActionHandle::Stateless");
+            panic!("InstanceFactory must produce ActionHandle::Stateless");
         };
 
         let result = stateless

--- a/crates/api/tests/common/mod.rs
+++ b/crates/api/tests/common/mod.rs
@@ -998,7 +998,7 @@ pub(crate) mod engine_seam {
     pub(crate) fn spawn_engine_consumer(state: &AppState) -> EngineSeam {
         let slow_started = Arc::new(tokio::sync::Notify::new());
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             nebula_action::metadata::ActionMetadata::new(
                 action_key!("slow"),
                 "slow",

--- a/crates/api/tests/knife.rs
+++ b/crates/api/tests/knife.rs
@@ -506,7 +506,7 @@ async fn knife_step3_engine_dispatches_start_end_to_end() {
     // ── Build the engine bound to the same scoped port handles the API
     // wrote to ──────────────────────────────────────────────────────────────
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         nebula_action::metadata::ActionMetadata::new(
             action_key!("echo"),
             "echo",

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -5331,7 +5331,7 @@ mod tests {
     // ── Variant A test fixtures ───────────────────────────────────────────
     //
     // Per Plan-agent R-NEW-7, fixtures register through
-    // [`ActionRegistry::legacy_register_stateless_with_metadata`] (the
+    // [`ActionRegistry::register_stateless_instance`] (the
     // test-only escape) so each test can vary key/version while the static
     // `<X as Action>::metadata()` keeps a placeholder default.
 
@@ -5704,7 +5704,7 @@ mod tests {
     #[tokio::test]
     async fn single_node_workflow() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -5734,7 +5734,7 @@ mod tests {
     #[tokio::test]
     async fn linear_two_node_workflow() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -5770,7 +5770,7 @@ mod tests {
     #[tokio::test]
     async fn diamond_workflow() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -5819,11 +5819,11 @@ mod tests {
     #[tokio::test]
     async fn failing_node_stops_execution() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -5907,7 +5907,7 @@ mod tests {
     #[tokio::test]
     async fn telemetry_events_emitted() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -5949,7 +5949,7 @@ mod tests {
     #[tokio::test]
     async fn metrics_recorded_on_failure() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6076,11 +6076,11 @@ mod tests {
     #[tokio::test]
     async fn branch_workflow_only_selected_path_executes() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
             BranchHandler {
                 selected: "true".into(),
@@ -6133,11 +6133,11 @@ mod tests {
     #[tokio::test]
     async fn skip_propagation() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("skip"), "Skip", "always skips"),
             SkipHandler,
         );
@@ -6183,11 +6183,11 @@ mod tests {
     #[tokio::test]
     async fn error_routing_with_handler() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6234,11 +6234,11 @@ mod tests {
     #[tokio::test]
     async fn error_without_handler_fails_fast() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6280,7 +6280,7 @@ mod tests {
     #[tokio::test]
     async fn conditional_edge_on_result() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6318,7 +6318,7 @@ mod tests {
     #[tokio::test]
     async fn diamond_with_mixed_conditions() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6369,7 +6369,7 @@ mod tests {
     #[tokio::test]
     async fn persists_execution_state_on_success() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6417,7 +6417,7 @@ mod tests {
     #[tokio::test]
     async fn persists_execution_state_on_failure() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6454,7 +6454,7 @@ mod tests {
     #[tokio::test]
     async fn persists_node_outputs_for_multi_node_workflow() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6505,13 +6505,13 @@ mod tests {
     #[tokio::test]
     async fn budget_max_duration_exceeded() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("slow"), "Slow", "sleeps"),
             SlowHandler {
                 delay: Duration::from_millis(100),
             },
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6549,7 +6549,7 @@ mod tests {
     #[tokio::test]
     async fn budget_max_output_bytes_exceeded() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6589,11 +6589,11 @@ mod tests {
     #[tokio::test]
     async fn error_strategy_continue_on_error_skips_dependents() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6651,11 +6651,11 @@ mod tests {
     #[tokio::test]
     async fn error_strategy_ignore_errors_continues_downstream() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "always fails"),
             FailHandler,
         );
@@ -6769,7 +6769,7 @@ mod tests {
     #[tokio::test]
     async fn resume_returns_error_for_terminal_execution() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6815,7 +6815,7 @@ mod tests {
         // before the crash. We manually inject the partially completed state into
         // the repos and verify that resume runs n2 and n3.
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -6921,7 +6921,7 @@ mod tests {
         use nebula_workflow::ParamValue;
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -7197,11 +7197,11 @@ mod tests {
     #[tokio::test]
     async fn runtime_failure_checkpoint_error_aborts_before_edge_routing() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "fails"),
             FailHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes"),
             EchoHandler,
         );
@@ -7301,7 +7301,7 @@ mod tests {
     #[tokio::test]
     async fn ignore_errors_persists_recovered_completed_state() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "fails"),
             FailHandler,
         );
@@ -7380,7 +7380,7 @@ mod tests {
     async fn setup_failure_checkpoint_error_aborts_before_edge_routing() {
         use nebula_workflow::ParamValue;
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes"),
             EchoHandler,
         );
@@ -7458,11 +7458,11 @@ mod tests {
     #[tokio::test]
     async fn on_error_payload_is_persisted_before_checkpoint_commits() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("fail"), "Fail", "fails"),
             FailHandler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes"),
             EchoHandler,
         );
@@ -7567,7 +7567,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("counting"), "Counting", "counts calls"),
             CountingHandler {
                 count: call_count_clone,
@@ -7709,12 +7709,12 @@ mod tests {
         let v1 = Version::new(1, 0, 0);
         let v2 = Version::new(2, 0, 0);
         // Register v1 first; v2 will become the "latest" (handlers map entry).
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("versioned"), "V1", "v1 handler")
                 .with_version_full(v1.clone()),
             V1Handler,
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("versioned"), "V2", "v2 handler")
                 .with_version_full(v2.clone()),
             V2Handler,
@@ -7771,7 +7771,7 @@ mod tests {
         let refresh_count_clone = refresh_count.clone();
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -7834,7 +7834,7 @@ mod tests {
     #[tokio::test]
     async fn multi_edge_from_same_source_executes_target() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -8264,7 +8264,7 @@ mod tests {
 
         let invoked = Arc::new(AtomicU32::new(0));
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("never"), "Never", "must not run"),
             NeverRunHandler {
                 invoked: invoked.clone(),
@@ -8629,7 +8629,7 @@ mod tests {
         // Force parameter resolution to fail by referencing a node
         // that has no output in the shared outputs map.
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -8703,7 +8703,7 @@ mod tests {
     #[tokio::test]
     async fn resume_restores_original_workflow_input() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -8757,7 +8757,7 @@ mod tests {
         use std::time::Duration;
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -8837,7 +8837,7 @@ mod tests {
     #[tokio::test]
     async fn resume_falls_back_to_default_budget_on_legacy_state() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -8944,7 +8944,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("boom"), "Boom", "panics"),
             PanicHandler,
         );
@@ -9007,13 +9007,13 @@ mod tests {
     #[tokio::test]
     async fn idempotency_replay_preserves_branch_routing() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("branch"), "Branch", "branches"),
             BranchHandler {
                 selected: "true".into(),
             },
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -9244,7 +9244,7 @@ mod tests {
     #[tokio::test]
     async fn final_cas_conflict_with_external_cancel_honors_external_status() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes"),
             EchoHandler,
         );
@@ -9332,7 +9332,7 @@ mod tests {
     #[tokio::test]
     async fn node_checkpoint_cas_conflict_surfaces_observed_status() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes"),
             EchoHandler,
         );
@@ -9673,7 +9673,7 @@ mod tests {
         let registry = Arc::new(ActionRegistry::new());
         // Slow echo so the first runner is still inside the frontier
         // loop when the second call arrives.
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("slow"), "Slow", "slow echoes"),
             SlowHandler {
                 delay: Duration::from_millis(300),
@@ -9779,7 +9779,7 @@ mod tests {
     #[tokio::test]
     async fn overlapping_resume_losers_do_not_clobber_winners_registry_entry() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("slow"), "Slow", "slow echoes"),
             SlowHandler {
                 delay: Duration::from_millis(500),
@@ -9885,7 +9885,7 @@ mod tests {
     #[tokio::test]
     async fn lease_is_released_after_terminal_completion_so_next_runner_can_acquire() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -9932,7 +9932,7 @@ mod tests {
     #[tokio::test]
     async fn execute_workflow_produces_independent_lease_per_execution_id() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("echo"), "Echo", "echoes input"),
             EchoHandler,
         );
@@ -10091,16 +10091,20 @@ mod tests {
 
         let registry = Arc::new(ActionRegistry::new());
         registry.register_stateless_factory::<FactoryEcho>();
-        // Legacy registration with a *different* handler (FailHandler) so
-        // we can tell which path actually ran — if dispatch routed through
-        // the legacy path, the workflow would fail.
-        registry.legacy_register_stateless_with_metadata(
+        // Register a *legacy* `ActionHandler` (NOT a factory) for the same key
+        // via the low-level `register` primitive (the surviving legacy spine
+        // until PR3) with a different handler (FailHandler). If dispatch routed
+        // through the legacy path instead of preferring the factory, FailHandler
+        // would run and the workflow would fail.
+        registry.register(
             ActionMetadata::new(
                 action_key!("test.factory.echo"),
                 "LegacyEcho",
                 "legacy fallback",
             ),
-            FailHandler,
+            nebula_action::ActionHandler::Stateless(Arc::new(
+                nebula_action::StatelessActionAdapter::new(FailHandler),
+            )),
         );
 
         let (engine, _) = make_engine(registry);

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -23,10 +23,10 @@ use dashmap::DashMap;
 use nebula_action::{
     Action, ActionError, ActionFactory, ActionHandler, ActionMetadata, ControlAction,
     FromWorkflowNode, GenericControlFactory, GenericResourceFactory, GenericStatefulFactory,
-    GenericStatelessFactory, GenericTriggerFactory, PollAction, PollTriggerAdapter, ResourceAction,
-    ResourceActionAdapter, StatefulAction, StatefulActionAdapter, StatelessAction,
-    StatelessActionAdapter, TriggerAction, TriggerActionAdapter, WebhookAction,
-    WebhookActionFactory, WebhookTriggerAdapter,
+    GenericStatelessFactory, GenericTriggerFactory, InstanceFactory, PollAction,
+    PollTriggerAdapter, ResourceAction, ResourceActionAdapter, StatefulAction,
+    StatefulActionAdapter, StatelessAction, StatelessActionAdapter, TriggerAction,
+    TriggerActionAdapter, WebhookAction, WebhookActionFactory, WebhookTriggerAdapter,
 };
 use nebula_core::ActionKey;
 use semver::Version;
@@ -303,6 +303,26 @@ impl ActionRegistry {
         self.register_factory(metadata, factory);
     }
 
+    /// Register a pre-built stateless action **instance** with caller-supplied
+    /// metadata, via the factory pipeline.
+    ///
+    /// The `useValue` complement to [`register_stateless_factory`](Self::register_stateless_factory)'s
+    /// `useFactory`: instead of constructing a fresh `A` from the node per
+    /// dispatch, this shares the one instance across dispatches and lets the
+    /// caller vary the catalog metadata (key / version / ports) per
+    /// registration — so one action type can back many distinct nodes. Backed
+    /// by [`InstanceFactory`].
+    pub fn register_stateless_instance<A>(&self, metadata: ActionMetadata, action: A)
+    where
+        A: StatelessAction + Send + Sync + 'static,
+        <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
+        <A as Action>::Output: serde::Serialize + Send + Sync,
+    {
+        let factory: Arc<dyn ActionFactory> = Arc::new(InstanceFactory::new(metadata, action));
+        let meta = factory.metadata().clone();
+        self.register_factory(meta, factory);
+    }
+
     /// Register a stateful action via the factory pipeline (Variant A).
     pub fn register_stateful_factory<A>(&self)
     where
@@ -421,20 +441,6 @@ impl std::fmt::Debug for ActionRegistry {
 /// Production callers should not invoke them — the doc strings explicitly say "LEGACY test-only".
 #[allow(dead_code, reason = "test escape API; not all variants used yet")]
 impl ActionRegistry {
-    /// Register a stateless action with caller-supplied metadata.
-    ///
-    /// Bypasses `<A as Action>::metadata()` so tests can vary key/version
-    /// per fixture without redeclaring an entire `impl Action`.
-    pub fn legacy_register_stateless_with_metadata<A>(&self, metadata: ActionMetadata, action: A)
-    where
-        A: StatelessAction + Send + Sync + 'static,
-        <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
-        <A as Action>::Output: serde::Serialize + Send + Sync,
-    {
-        let handler = ActionHandler::Stateless(Arc::new(StatelessActionAdapter::new(action)));
-        self.register(metadata, handler);
-    }
-
     /// Register a stateful action with caller-supplied metadata.
     pub fn legacy_register_stateful_with_metadata<A>(&self, metadata: ActionMetadata, action: A)
     where
@@ -577,36 +583,45 @@ mod tests {
 
     #[test]
     fn register_and_get_action() {
+        // `register_stateless_instance` lands on the factory spine, so assert
+        // via the factory lookup (the surviving registration path).
         let registry = ActionRegistry::new();
-        registry.legacy_register_stateless_with_metadata(meta_with("test.noop", 1, 0), NoopAction);
-        assert_eq!(registry.len(), 1);
+        registry.register_stateless_instance(meta_with("test.noop", 1, 0), NoopAction);
         let key = ActionKey::new("test.noop").unwrap();
-        let result = registry.get(&key);
-        assert!(result.is_some());
+        assert!(registry.get_factory(&key).is_some());
+        assert_eq!(registry.factories.len(), 1);
     }
 
     #[test]
     fn register_replaces_same_version() {
         let registry = ActionRegistry::new();
-        registry.legacy_register_stateless_with_metadata(meta_with("test.noop", 1, 0), NoopAction);
-        registry.legacy_register_stateless_with_metadata(meta_with("test.noop", 1, 0), NoopAction);
-        assert_eq!(registry.len(), 1);
+        registry.register_stateless_instance(meta_with("test.noop", 1, 0), NoopAction);
+        registry.register_stateless_instance(meta_with("test.noop", 1, 0), NoopAction);
+        let key = ActionKey::new("test.noop").unwrap();
+        assert_eq!(
+            registry.factories.get(&key).map(|entries| entries.len()),
+            Some(1),
+            "same (key, version) must replace in place, not append a duplicate"
+        );
     }
 
     #[test]
     fn versioned_lookup() {
         let registry = ActionRegistry::new();
-        registry.legacy_register_stateless_with_metadata(meta_with("test.noop", 1, 0), NoopAction);
-        registry.legacy_register_stateless_with_metadata(meta_with("test.noop", 2, 0), NoopAction);
+        registry.register_stateless_instance(meta_with("test.noop", 1, 0), NoopAction);
+        registry.register_stateless_instance(meta_with("test.noop", 2, 0), NoopAction);
 
         let key = ActionKey::new("test.noop").unwrap();
         let v1 = Version::new(1, 0, 0);
         let v2 = Version::new(2, 0, 0);
 
-        assert!(registry.get_versioned(&key, &v1).is_some());
-        assert!(registry.get_versioned(&key, &v2).is_some());
+        assert!(registry.get_factory_versioned(&key, &v1).is_some());
+        assert!(registry.get_factory_versioned(&key, &v2).is_some());
 
-        let (meta, _) = registry.get(&key).unwrap();
-        assert_eq!(meta.base.version, v2);
+        let (meta, _) = registry.get_factory(&key).unwrap();
+        assert_eq!(
+            meta.base.version, v2,
+            "get_factory returns the latest version"
+        );
     }
 }

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -1365,7 +1365,7 @@ mod tests {
     use super::*;
 
     /// Echo fixture — Variant A unit struct. Per-test metadata is supplied
-    /// via [`ActionRegistry::legacy_register_stateless_with_metadata`] (the
+    /// via [`ActionRegistry::register_stateless_instance`] (the
     /// R-NEW-7 test escape), so the static `<Self as Action>::metadata()`
     /// is only consulted when the test escape is bypassed.
     struct EchoAction;
@@ -1469,7 +1469,7 @@ mod tests {
     #[tokio::test]
     async fn max_total_execution_bytes_across_dispatches() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.echo"), "Echo", "echoes input"),
             EchoAction,
         );
@@ -1525,7 +1525,7 @@ mod tests {
     #[tokio::test]
     async fn execute_trusted_action() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.echo"), "Echo", "echoes input"),
             EchoAction,
         );
@@ -1557,7 +1557,7 @@ mod tests {
     #[tokio::test]
     async fn execute_failing_action_propagates_error() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.fail"), "Fail", "always fails"),
             FailAction,
         );
@@ -1573,7 +1573,7 @@ mod tests {
     #[tokio::test]
     async fn data_limit_enforcement() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.big"), "Big", "returns big output"),
             EchoAction,
         );
@@ -1606,7 +1606,7 @@ mod tests {
     #[tokio::test]
     async fn metrics_recorded_on_execution() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.tele"), "Tele", "test"),
             EchoAction,
         );
@@ -1674,7 +1674,7 @@ mod tests {
         let runner = Arc::new(InProcessRunner::new(executor));
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.gated"), "Gated", "capability gated")
                 .with_isolation_level(IsolationLevel::CapabilityGated),
             EchoAction,
@@ -1701,7 +1701,7 @@ mod tests {
     #[tokio::test]
     async fn spill_to_blob_rejects_when_no_storage() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.spill"), "Spill", "large output"),
             EchoAction,
         );
@@ -1760,7 +1760,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(
                 action_key!("test.spill_ok"),
                 "SpillOk",
@@ -1861,7 +1861,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(
                 action_key!("test.multi_out"),
                 "MultiOut",
@@ -1941,7 +1941,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.branch"), "Branch", "branch with alts"),
             BranchAction,
         );
@@ -2007,7 +2007,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(
                 action_key!("test.collection"),
                 "Collection",
@@ -2079,7 +2079,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.binary"), "Binary", "inline bytes"),
             BinaryAction,
         );
@@ -2144,7 +2144,7 @@ mod tests {
         }
 
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.ref"), "Reference", "large metadata"),
             RefAction,
         );
@@ -2355,7 +2355,7 @@ mod tests {
     #[tokio::test]
     async fn dispatched_stateless_observes_histogram_and_counter() {
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             ActionMetadata::new(action_key!("test.dispatched"), "Disp", "dispatched"),
             EchoAction,
         );

--- a/crates/engine/tests/control_dispatch.rs
+++ b/crates/engine/tests/control_dispatch.rs
@@ -205,13 +205,13 @@ impl Harness {
         let slow_count = Arc::new(AtomicU32::new(0));
         let slow_started = Arc::new(Notify::new());
         let registry = Arc::new(ActionRegistry::new());
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             meta(action_key!("echo")),
             CountingEchoHandler {
                 count: Arc::clone(&action_count),
             },
         );
-        registry.legacy_register_stateless_with_metadata(
+        registry.register_stateless_instance(
             meta(action_key!("slow")),
             SlowCancellableHandler {
                 started: Arc::clone(&slow_started),

--- a/crates/engine/tests/end_to_end_pipeline.rs
+++ b/crates/engine/tests/end_to_end_pipeline.rs
@@ -243,7 +243,7 @@ fn meta(key: ActionKey) -> ActionMetadata {
 async fn pipeline_resolves_expressions_before_handler_runs() {
     let seen_input = Arc::new(parking_lot::Mutex::new(None::<serde_json::Value>));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("phase9.witness")),
         PipelineWitness {
             seen_input: Arc::clone(&seen_input),
@@ -370,7 +370,7 @@ async fn pipeline_with_resource_manager_resolves_and_executes() {
 
     let seen_input = Arc::new(parking_lot::Mutex::new(None::<serde_json::Value>));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("phase9.witness")),
         PipelineWitness {
             seen_input: Arc::clone(&seen_input),
@@ -443,7 +443,7 @@ async fn pipeline_with_resource_manager_resolves_and_executes() {
 async fn pipeline_unresolvable_expression_fails_node_before_handler() {
     let seen_input = Arc::new(parking_lot::Mutex::new(None::<serde_json::Value>));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("phase9.witness")),
         PipelineWitness {
             seen_input: Arc::clone(&seen_input),

--- a/crates/engine/tests/integration.rs
+++ b/crates/engine/tests/integration.rs
@@ -250,7 +250,7 @@ async fn engine_and_runtime_share_metrics_registry() {
     let metrics = MetricsRegistry::new();
 
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
 
     let executor: ActionExecutor =
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
@@ -306,8 +306,8 @@ fn meta(key: ActionKey) -> ActionMetadata {
 #[tokio::test]
 async fn linear_pipeline_data_flows_through() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("double")), DoubleHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("double")), DoubleHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -341,9 +341,9 @@ async fn linear_pipeline_data_flows_through() {
 #[tokio::test]
 async fn fan_out_parallel_execution() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("double")), DoubleHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("add10")), Add10Handler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("double")), DoubleHandler);
+    registry.register_stateless_instance(meta(action_key!("add10")), Add10Handler);
 
     let (engine, _) = make_engine(registry);
 
@@ -383,9 +383,9 @@ async fn fan_out_parallel_execution() {
 #[tokio::test]
 async fn diamond_merge_receives_combined_outputs() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("double")), DoubleHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("add10")), Add10Handler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("double")), DoubleHandler);
+    registry.register_stateless_instance(meta(action_key!("add10")), Add10Handler);
 
     let (engine, _) = make_engine(registry);
 
@@ -437,8 +437,8 @@ async fn diamond_merge_receives_combined_outputs() {
 #[tokio::test]
 async fn error_propagation_stops_downstream() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("fail")), FailHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("fail")), FailHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -483,14 +483,14 @@ async fn error_propagation_stops_downstream() {
 #[tokio::test]
 async fn cancellation_via_sibling_failure() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("slow")),
         SlowHandler {
             delay: Duration::from_secs(10),
         },
     );
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("fail")), FailHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("fail")), FailHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -542,7 +542,7 @@ async fn cancellation_via_sibling_failure() {
 #[tokio::test]
 async fn metrics_cover_full_lifecycle() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
 
     let (engine, metrics) = make_engine(registry);
 
@@ -598,7 +598,7 @@ async fn bounded_concurrency_with_multiple_parallel_nodes() {
     let counter = Arc::new(AtomicUsize::new(0));
 
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("counter")),
         CounterHandler {
             count: counter.clone(),
@@ -643,7 +643,7 @@ async fn bounded_concurrency_with_multiple_parallel_nodes() {
 #[tokio::test]
 async fn zero_concurrency_budget_returns_planning_error() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -679,8 +679,8 @@ async fn zero_concurrency_budget_returns_planning_error() {
 #[tokio::test]
 async fn deep_chain_propagates_outputs() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("double")), DoubleHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("double")), DoubleHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -723,7 +723,7 @@ async fn deep_chain_propagates_outputs() {
 #[tokio::test]
 async fn metrics_accurate_on_failure() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("fail")), FailHandler);
+    registry.register_stateless_instance(meta(action_key!("fail")), FailHandler);
 
     let (engine, metrics) = make_engine(registry);
 
@@ -775,7 +775,7 @@ async fn metrics_accurate_on_failure() {
 #[tokio::test]
 async fn disabled_node_is_skipped_and_successor_executes() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
 
     let (engine, _) = make_engine(registry);
 
@@ -852,8 +852,8 @@ async fn disabled_node_is_skipped_and_successor_executes() {
 #[tokio::test]
 async fn skip_propagates_transitively_through_three_hop_chain() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
     let (engine, _) = make_engine(registry);
 
     let a = node_key!("a");
@@ -916,8 +916,8 @@ async fn skip_propagates_transitively_through_three_hop_chain() {
 #[tokio::test]
 async fn diamond_with_one_skipped_branch_still_completes() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
     let (engine, _) = make_engine(registry);
 
     let a = node_key!("a");
@@ -971,8 +971,8 @@ async fn diamond_with_one_skipped_branch_still_completes() {
 #[tokio::test]
 async fn aggregate_with_one_skipped_source_fires() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
     let (engine, _) = make_engine(registry);
 
     let x = node_key!("x");
@@ -1020,8 +1020,8 @@ async fn aggregate_with_one_skipped_source_fires() {
 #[tokio::test]
 async fn aggregate_with_all_sources_skipped_propagates_skip() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
     let (engine, _) = make_engine(registry);
 
     let x = node_key!("x");
@@ -1081,8 +1081,8 @@ async fn aggregate_with_all_sources_skipped_propagates_skip() {
 #[tokio::test]
 async fn multi_hop_skip_with_sibling_activation_still_runs() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
     let (engine, _) = make_engine(registry);
 
     let a = node_key!("a");
@@ -1148,8 +1148,8 @@ async fn multi_hop_skip_with_sibling_activation_still_runs() {
 #[tokio::test]
 async fn duplicate_edges_from_skipped_source_count_per_edge() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("skip")), SkipHandler);
-    registry.legacy_register_stateless_with_metadata(meta(action_key!("echo")), EchoHandler);
+    registry.register_stateless_instance(meta(action_key!("skip")), SkipHandler);
+    registry.register_stateless_instance(meta(action_key!("echo")), EchoHandler);
     let (engine, _) = make_engine(registry);
 
     let x = node_key!("x");

--- a/crates/engine/tests/lease_takeover.rs
+++ b/crates/engine/tests/lease_takeover.rs
@@ -169,7 +169,7 @@ impl LeaseStores {
 // ---------------------------------------------------------------------------
 
 /// Macro to emit Variant A `impl Action` with placeholder static metadata.
-/// Real per-instance metadata flows through `legacy_register_stateless_with_metadata`.
+/// Real per-instance metadata flows through `register_stateless_instance`.
 macro_rules! placeholder_action_impl {
     ($ty:ty, $key:expr, $name:expr, $desc:expr) => {
         impl Action for $ty {
@@ -326,13 +326,13 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
 
     // Runner A — has a parking handler for "park" so it holds the lease.
     let registry_a = Arc::new(ActionRegistry::new());
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),
         },
     );
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("park")),
         ParkHandler {
             started: Arc::clone(&started_a),
@@ -343,13 +343,13 @@ async fn engine_b_takes_over_after_engine_a_runner_dies() {
     // Runner B — same action_keys, but "park" is a fast-completing
     // handler so the resumed workflow can finish.
     let registry_b = Arc::new(ActionRegistry::new());
-    registry_b.legacy_register_stateless_with_metadata(
+    registry_b.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),
         },
     );
-    registry_b.legacy_register_stateless_with_metadata(
+    registry_b.register_stateless_instance(
         meta(action_key!("park")),
         CountingEchoHandler {
             invocations: Arc::clone(&park_invocations),
@@ -544,13 +544,13 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
 
     // engine_a — parking Y so it holds the lease.
     let registry_a = Arc::new(ActionRegistry::new());
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),
         },
     );
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("park")),
         ParkHandler {
             started: Arc::clone(&started_a),
@@ -560,13 +560,13 @@ async fn engine_b_cancels_execution_after_runner_a_death_via_reclaim_redeliver()
 
     // engine_b — also parking Y so the cancel signal has somewhere to land.
     let registry_b = Arc::new(ActionRegistry::new());
-    registry_b.legacy_register_stateless_with_metadata(
+    registry_b.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),
         },
     );
-    registry_b.legacy_register_stateless_with_metadata(
+    registry_b.register_stateless_instance(
         meta(action_key!("park")),
         ParkHandler {
             started: Arc::clone(&started_b),
@@ -796,13 +796,13 @@ async fn replay_does_not_contend_for_held_lease() {
 
     // engine_a — parking workflow to hold the lease.
     let registry_a = Arc::new(ActionRegistry::new());
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),
         },
     );
-    registry_a.legacy_register_stateless_with_metadata(
+    registry_a.register_stateless_instance(
         meta(action_key!("park")),
         ParkHandler {
             started: Arc::clone(&started_a),
@@ -812,7 +812,7 @@ async fn replay_does_not_contend_for_held_lease() {
 
     // engine_b — only needs the echo handler for its replay workflow.
     let registry_b = Arc::new(ActionRegistry::new());
-    registry_b.legacy_register_stateless_with_metadata(
+    registry_b.register_stateless_instance(
         meta(action_key!("echo")),
         CountingEchoHandler {
             invocations: Arc::clone(&echo_invocations),

--- a/crates/engine/tests/resource_integration.rs
+++ b/crates/engine/tests/resource_integration.rs
@@ -174,7 +174,7 @@ async fn action_acquires_resource_through_engine() {
 
     // 2. Build the action registry
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("resource-consumer")),
         ResourceConsumerHandler,
     );
@@ -232,7 +232,7 @@ async fn full_resource_lifecycle_with_shutdown() {
 
     // 2. Build the action registry
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("resource-consumer")),
         ResourceConsumerHandler,
     );
@@ -415,7 +415,7 @@ async fn engine_acquires_org_scoped_resource_through_accessor() {
         .expect("register org-scoped resource");
 
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         meta(action_key!("engine-integration-acquire")),
         IntegrationAcquireHandler,
     );
@@ -476,10 +476,7 @@ async fn engine_acquires_org_scoped_resource_through_accessor() {
 #[tokio::test]
 async fn action_resource_fails_without_manager() {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
-        meta(action_key!("resource-probe")),
-        ResourceProbeHandler,
-    );
+    registry.register_stateless_instance(meta(action_key!("resource-probe")), ResourceProbeHandler);
 
     let executor: ActionExecutor =
         Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));

--- a/crates/engine/tests/resource_registrar_from_plugins.rs
+++ b/crates/engine/tests/resource_registrar_from_plugins.rs
@@ -244,7 +244,7 @@ impl StatelessAction for NoopHandler {
 
 fn build_engine(registrars: ResourceActivatorRegistry) -> WorkflowEngine {
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("test.noop"), "Noop", "noop"),
         NoopHandler,
     );

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -37,7 +37,7 @@ use nebula_workflow::{
 // ---------------------------------------------------------------------------
 // Test handlers — Variant A trait shape with placeholder static metadata.
 // Real per-instance metadata (varying action_key per test) flows through
-// `legacy_register_stateless_with_metadata` test escape (R-NEW-7).
+// `register_stateless_instance` test escape (R-NEW-7).
 // ---------------------------------------------------------------------------
 
 /// Macro to emit Variant A `impl Action` with placeholder static metadata.
@@ -191,7 +191,7 @@ fn make_workflow(
 async fn retry_succeeds_on_attempt_2() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("flaky"), "Flaky", "fails once"),
         FlakyHandler {
             fail_count: 1,
@@ -226,7 +226,7 @@ async fn retry_succeeds_on_attempt_2() {
 async fn retry_exhausts_max_attempts() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("doomed"), "Doomed", "always fails"),
         AlwaysFailingHandler {
             invocations: Arc::clone(&invocations),
@@ -266,7 +266,7 @@ async fn retry_exhausts_max_attempts() {
 async fn cancel_during_retry_wait() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("flaky_long"), "FlakyLong", "fails forever"),
         AlwaysFailingHandler {
             invocations: Arc::clone(&invocations),
@@ -344,13 +344,13 @@ async fn cancel_during_retry_wait() {
 async fn terminate_during_retry_wait() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("flaky_t"), "FlakyT", "fails forever"),
         AlwaysFailingHandler {
             invocations: Arc::clone(&invocations),
         },
     );
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("term"), "Term", "terminates"),
         TerminateHandler,
     );
@@ -419,7 +419,7 @@ async fn terminate_during_retry_wait() {
 async fn execution_budget_max_total_retries_caps_globally() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("doomed_g"), "DoomedG", "always fails"),
         AlwaysFailingHandler {
             invocations: Arc::clone(&invocations),
@@ -458,7 +458,7 @@ async fn execution_budget_max_total_retries_caps_globally() {
 async fn idempotency_key_differentiates_attempts() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("flaky_idem"), "FlakyIdem", "fails once"),
         FlakyHandler {
             fail_count: 1,
@@ -528,7 +528,7 @@ async fn idempotency_key_differentiates_attempts() {
 async fn per_node_retry_policy_overrides_workflow_default() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(
             action_key!("flaky_o"),
             "FlakyO",
@@ -574,7 +574,7 @@ async fn per_node_retry_policy_overrides_workflow_default() {
 async fn workflow_default_applies_when_node_has_none() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("flaky_d"), "FlakyD", "fails once"),
         FlakyHandler {
             fail_count: 1,
@@ -616,7 +616,7 @@ async fn workflow_default_applies_when_node_has_none() {
 async fn no_retry_policy_means_one_shot_failure() {
     let invocations = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("oneshot"), "OneShot", "fails"),
         AlwaysFailingHandler {
             invocations: Arc::clone(&invocations),

--- a/crates/engine/tests/trigger_dispatch_slice.rs
+++ b/crates/engine/tests/trigger_dispatch_slice.rs
@@ -152,7 +152,7 @@ impl StatelessAction for EchoHandler {
 async fn make_engine(stores: &TestStores) -> (Arc<WorkflowEngine>, Arc<AtomicU32>) {
     let count = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("test.echo.dispatch_slice"), "Echo", "echo"),
         EchoHandler {
             count: count.clone(),

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -157,7 +157,7 @@ impl StatelessAction for EchoHandler {
 async fn make_engine(stores: &TestStores) -> (Arc<WorkflowEngine>, Arc<AtomicU32>) {
     let count = Arc::new(AtomicU32::new(0));
     let registry = Arc::new(ActionRegistry::new());
-    registry.legacy_register_stateless_with_metadata(
+    registry.register_stateless_instance(
         ActionMetadata::new(action_key!("test.echo.worker"), "Echo", "echo"),
         EchoHandler {
             count: count.clone(),


### PR DESCRIPTION
## What — PR2 of 3 (ADR-0098 D0 dispatch-spine collapse)

Moves the **~147 stateless test fixtures** off the legacy `ActionHandler` registration onto the surviving **factory spine**, and renames the PR1 vehicle to a permanent, self-documenting name.

### Rename: `FixedFactory` → `InstanceFactory` (folded in, no separate PR)
"Fixed" read as transitional. `InstanceFactory` names what it *is* — the **`useValue`** half of the DI dichotomy (a pre-instantiated, shared instance) to `GenericStatelessFactory`'s **`useFactory`** half (construct-from-node per dispatch). Grounded in the standard DI vocabulary (Angular/NestJS `useValue`/`useFactory`, .NET `AddSingleton(instance)`/`AddTransient`). Also: `FixedStatelessHandle` → `InstanceStatelessHandle`; `tests/fixed_factory.rs` → `tests/instance_factory.rs`.

### Migration
`ActionRegistry::legacy_register_stateless_with_metadata` (legacy `ActionHandler` spine) → **`register_stateless_instance`** (factory spine, backed by `InstanceFactory`). All ~147 call sites across engine / engine tests / worker tests / api tests repointed. Fixtures now dispatch through `run_factory` → `ActionHandle::Stateless`, **never** the legacy `run_handler`. Behavior is identical — `InstanceFactory` reuses the shared `Arc<A>`, so spy/counter semantics are preserved.

### Test reconciliation (no assertions weakened)
- `factory_path_takes_precedence_over_legacy_handler` registers its legacy competitor via the low-level `register(meta, ActionHandler::Stateless(..))` primitive (legacy spine survives until PR3) — still proves factory-wins-over-legacy.
- the three `runtime::registry::tests` assert via the factory map (`get_factory` / `get_factory_versioned` / dedup count) — the surviving spine.

### Out of scope — KEPT (corrected)
The forward factory-side trigger/resource scaffolding (`ActionHandle::{Trigger,Resource}`, `Generic{Trigger,Resource}Factory`, `register_{trigger,resource}_factory`) is **not dead** — it's the future trigger/resource-as-node path (dispatch rejection at `runtime.rs` is "not yet wired", like Stream/Agent). Only the legacy `ActionHandler` node-execution spine retires, in **PR3**.

## Verification
- `cargo test -p nebula-action -p nebula-engine` green (incl. the 4 reconciled tests)
- pre-push gate green: clippy-full (`--all-targets -D warnings`) + crate-diff-gate (rustdoc `-D warnings`, 4 crates)
- `cargo check --workspace --all-targets` clean; fmt clean

Stacked on [#831](https://github.com/vanyastaff/nebula/pull/831) (merged). PR3 will delete the legacy `ActionHandler` node-execution spine (`run_handler`/`execute_stateless`/`execute_stateful`/`register`-legacy) + transform the precedence test into a single-spine DoD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `register_stateless_instance` method for streamlined stateless action registration.

* **Refactor**
  * Modernized action factory implementation and removed legacy registration helper.
  * Updated internal factory naming for consistency with instance-based approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->