### PR TITLE
chore(build): shrink dev target/ — line-tables-only debuginfo + deps debug off

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -348,8 +348,19 @@ wildcard_in_or_patterns = "warn"
 [profile.dev]
 # Standard dev mode
 opt-level = 0
-incremental = true
-debug = 2
+# Off to match policy: sccache + incremental fight (stale fingerprints across
+# worktrees, lock hangs) — `.cargo/config.toml` and CARGO_INCREMENTAL=0 already
+# force this off, so `true` here was dead and misleading.
+incremental = false
+# Full debuginfo (debug = 2) emits a 300+ MB PDB per test/bench/example binary on
+# Windows and is never garbage-collected — the dominant cause of multi-hundred-GB
+# target/ dirs. line-tables-only keeps file:line in panic backtraces; set 0 if unused.
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+# Dependencies carry no debuginfo: you rarely step into them, and this drops the bulk
+# of the PDB weight. Step-debugging a dep? Temporarily raise this for that package.
+debug = false
 
 [profile.release]
 # Optimized release builds (tuned for Windows stability)


### PR DESCRIPTION
## Why

The dev profile carried `debug = 2` (full debuginfo). On Windows/MSVC that emits a
**300+ MB PDB per test/bench/example binary**, Cargo never garbage-collects stale
artifacts, and each worktree keeps its own `target/` — so build cache accreted into
**hundreds of GB** (the main checkout's `target/` had grown past 500 GB).

This isn't a Rust limitation or a crate-count problem (a 41-crate workspace shares one
`target/`); it was `debug = 2` × no-GC × per-worktree multiplication.

## What

`[profile.dev]`:
- `debug = 2` → **`debug = "line-tables-only"`** — keeps `file:line` in panic
  backtraces, drops the heavy variable/type debuginfo that dominates PDB size.
- `incremental = true` → **`incremental = false`** — this was dead/misleading:
  `.cargo/config.toml` (`[build] incremental = false`) and `CARGO_INCREMENTAL=0`
  already force it off (required with sccache). The manifest now states reality.

New `[profile.dev.package."*"]`:
- `debug = false` — dependencies carry no debuginfo (you rarely step into them; this
  drops the bulk of the PDB weight).

## Impact

- Source, tests, and runtime behavior **unchanged** — only build-artifact size.
- Dev `target/` should shrink ~5–10× on rebuild.
- Backtraces still show file:line; full step-debugging of a specific dep is a temporary
  per-package `debug` bump away.

`[profile.profiling]` and `[profile.bench]` keep `debug = 2` (intentional — profiling/
benches need symbols).

🤖 Generated with [Claude Code](https://claude.com/claude-code)