### PR TITLE
feat(action): Stream kind foundation — collect-fold dispatch (ADR-0102 S1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3287,6 +3287,7 @@ dependencies = [
  "base64",
  "bytes",
  "chrono",
+ "futures",
  "hex",
  "hmac 0.13.0",
  "http 1.4.2",

--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 
 [dependencies]
 async-trait = { workspace = true }
+futures = { workspace = true }
 nebula-action-macros = { path = "macros" }
 nebula-core = { path = "../core" }
 nebula-credential = { path = "../credential" }

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -28,6 +28,8 @@ use nebula_workflow::NodeDefinition;
 use serde::{Serialize, de::DeserializeOwned};
 use serde_json::Value;
 
+use futures::StreamExt as _;
+
 use crate::{
     action::Action,
     context::{ActionContext, TriggerContext},
@@ -35,13 +37,15 @@ use crate::{
     error::{ActionError, ValidationReason},
     from_workflow_node::FromWorkflowNode,
     handle::{
-        ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, TriggerHandle,
+        ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, StreamHandle,
+        TriggerHandle,
     },
     metadata::{ActionKind, ActionMetadata},
     resource::ResourceAction,
     result::ActionResult,
     stateful::StatefulAction,
     stateless::StatelessAction,
+    stream::StreamAction,
     trigger::{TriggerAction, TriggerEvent, TriggerEventOutcome},
 };
 
@@ -688,5 +692,122 @@ where
             .evaluate(ControlInput::from_value(input), ctx)
             .await?;
         Ok(outcome.into())
+    }
+}
+
+// ── Stream ─────────────────────────────────────────────────────────────────
+
+/// Generic factory that produces [`ActionHandle::Stream`] for any type
+/// implementing [`StreamAction`] + [`FromWorkflowNode`].
+///
+/// The factory stamps [`ActionKind::Stream`] as the single writer of the kind
+/// on the stored metadata. The `StreamHandleImpl` adapter drives the chunk
+/// stream fully in-process and delivers a single folded value — identical to
+/// stateless from the engine's perspective.
+pub struct GenericStreamFactory<A> {
+    meta: OnceLock<ActionMetadata>,
+    _phantom: PhantomData<fn() -> A>,
+}
+
+impl<A> Default for GenericStreamFactory<A> {
+    fn default() -> Self {
+        Self {
+            meta: OnceLock::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<A> GenericStreamFactory<A> {
+    /// Construct a new stream factory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<A> ActionFactory for GenericStreamFactory<A>
+where
+    A: StreamAction + FromWorkflowNode<Error = ActionError>,
+    <A as Action>::Input: DeserializeOwned + Send + Sync,
+    <A as Action>::Output: Serialize + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        self.meta
+            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Stream))
+    }
+
+    fn instantiate<'a>(
+        &'a self,
+        node: &'a NodeDefinition,
+        ctx: &'a dyn ActionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
+        Box::pin(async move {
+            let action = A::from_workflow_node(node, ctx).await?;
+            let meta = self.metadata().clone();
+            let inner = StreamHandleImpl::<A>::new(action, meta);
+            Ok(ActionHandle::Stream(Box::new(inner)))
+        })
+    }
+}
+
+struct StreamHandleImpl<A> {
+    action: A,
+    meta: ActionMetadata,
+}
+
+impl<A> StreamHandleImpl<A> {
+    fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
+    }
+}
+
+#[async_trait]
+impl<A> StreamHandle for StreamHandleImpl<A>
+where
+    A: StreamAction,
+    <A as Action>::Input: DeserializeOwned + Send + Sync,
+    <A as Action>::Output: Serialize + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+
+    #[tracing::instrument(
+        name = "stream_handle.dispatch",
+        skip_all,
+        fields(
+            action.key = %self.meta.base.key.as_str(),
+            action.kind = "stream",
+        )
+    )]
+    async fn dispatch(
+        &self,
+        input: Value,
+        ctx: &dyn ActionContext,
+    ) -> Result<ActionResult<Value>, ActionError> {
+        let typed_input: <A as Action>::Input = serde_json::from_value(input).map_err(|e| {
+            ActionError::validation(
+                "input",
+                ValidationReason::MalformedJson,
+                Some(e.to_string()),
+            )
+        })?;
+
+        let chunk_stream = self.action.open_stream(typed_input, ctx);
+        tokio::pin!(chunk_stream);
+
+        let mut accumulator = self.action.init();
+
+        while let Some(chunk_result) = chunk_stream.next().await {
+            // D-4: first Err short-circuits with no partial output.
+            let chunk = chunk_result?;
+            accumulator = self.action.fold(accumulator, chunk);
+        }
+
+        let output_value = serde_json::to_value(accumulator)
+            .map_err(|e| ActionError::fatal(format!("output serialization failed: {e}")))?;
+
+        Ok(ActionResult::success(output_value))
     }
 }

--- a/crates/action/src/handle.rs
+++ b/crates/action/src/handle.rs
@@ -156,6 +156,38 @@ pub trait ResourceHandle: Send + Sync + 'static {
     ) -> Result<(), ActionError>;
 }
 
+/// Object-safe stream dispatch surface.
+///
+/// Mirrors [`StatelessHandle`] but is a **separate** trait so the streaming
+/// surface can later grow chunk-observing and persistence hooks (cursor-replay
+/// durability, live egress; see ADR-0102) without touching stateless dispatch.
+/// Today the engine sees only the folded [`ActionResult<Value>`] the adapter
+/// produces once the in-process stream completes.
+///
+/// Implementors are produced by [`GenericStreamFactory`](crate::factory::GenericStreamFactory).
+///
+/// # Errors
+///
+/// Returns [`ActionError`] on validation, retryable, or fatal failure. A chunk
+/// `Err` short-circuits without emitting partial output.
+#[async_trait]
+pub trait StreamHandle: Send + Sync + 'static {
+    /// Action metadata (key, version, ports, schemas), with `ActionKind::Stream` stamped.
+    fn metadata(&self) -> &ActionMetadata;
+
+    /// Drive the chunk stream to completion and return the folded value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ActionError`] if input deserialization fails, a chunk errors
+    /// out, or output serialization fails.
+    async fn dispatch(
+        &self,
+        input: Value,
+        ctx: &dyn ActionContext,
+    ) -> Result<ActionResult<Value>, ActionError>;
+}
+
 /// Object-safe control dispatch surface (flow-control desugared to stateless).
 #[async_trait]
 pub trait ControlHandle: Send + Sync + 'static {
@@ -186,6 +218,8 @@ pub enum ActionHandle {
     Stateless(Box<dyn StatelessHandle>),
     /// Iterative execution with mutable JSON state.
     Stateful(Box<dyn StatefulHandle>),
+    /// Async chunk stream, folded in-process to a single output value.
+    Stream(Box<dyn StreamHandle>),
     /// Workflow trigger (start/stop lifecycle).
     Trigger(Box<dyn TriggerHandle>),
     /// Graph-scoped resource (configure/cleanup).
@@ -201,6 +235,7 @@ impl ActionHandle {
         match self {
             Self::Stateless(h) => h.metadata(),
             Self::Stateful(h) => h.metadata(),
+            Self::Stream(h) => h.metadata(),
             Self::Trigger(h) => h.metadata(),
             Self::Resource(h) => h.metadata(),
             Self::Control(h) => h.metadata(),
@@ -217,6 +252,12 @@ impl ActionHandle {
     #[must_use]
     pub fn is_stateful(&self) -> bool {
         matches!(self, Self::Stateful(_))
+    }
+
+    /// Whether this is a stream action handle.
+    #[must_use]
+    pub fn is_stream(&self) -> bool {
+        matches!(self, Self::Stream(_))
     }
 
     /// Whether this is a trigger action handle.
@@ -243,6 +284,7 @@ impl fmt::Debug for ActionHandle {
         let (tag, key) = match self {
             Self::Stateless(h) => ("Stateless", h.metadata().base.key.as_str()),
             Self::Stateful(h) => ("Stateful", h.metadata().base.key.as_str()),
+            Self::Stream(h) => ("Stream", h.metadata().base.key.as_str()),
             Self::Trigger(h) => ("Trigger", h.metadata().base.key.as_str()),
             Self::Resource(h) => ("Resource", h.metadata().base.key.as_str()),
             Self::Control(h) => ("Control", h.metadata().base.key.as_str()),

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -79,6 +79,9 @@ pub mod stateful;
 /// [`StatelessAction`] DX trait, [`StatelessHandler`] dyn contract, adapter,
 /// and function-backed DX adapters.
 pub mod stateless;
+/// [`StreamAction`] author trait — opens an async chunk stream and folds it
+/// into a single output value in-process.
+pub mod stream;
 /// Test utilities for action authors.
 pub mod testing;
 /// Base [`TriggerAction`] trait, [`TriggerHandler`] dyn contract, the
@@ -107,11 +110,12 @@ pub use error::{
 };
 pub use factory::{
     ActionFactory, GenericControlFactory, GenericResourceFactory, GenericStatefulFactory,
-    GenericStatelessFactory, GenericTriggerFactory, InstanceFactory,
+    GenericStatelessFactory, GenericStreamFactory, GenericTriggerFactory, InstanceFactory,
 };
 pub use from_workflow_node::FromWorkflowNode;
 pub use handle::{
-    ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, TriggerHandle,
+    ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, StreamHandle,
+    TriggerHandle,
 };
 pub use idempotency::IdempotencyKey;
 pub use metadata::{
@@ -148,6 +152,7 @@ pub use stateful::{
     StatefulAction, StatefulActionAdapter, StatefulHandler,
 };
 pub use stateless::{StatelessAction, StatelessActionAdapter, StatelessHandler};
+pub use stream::StreamAction;
 pub use testing::{
     SpyEmission, SpyEmitter, SpyLogger, SpyScheduler, StatefulTestHarness, TestActionContext,
     TestContextBuilder, TestTriggerContext, TriggerTestHarness,

--- a/crates/action/src/prelude.rs
+++ b/crates/action/src/prelude.rs
@@ -39,6 +39,7 @@ pub use crate::{
         StatefulActionAdapter,
     },
     stateless::{StatelessAction, StatelessActionAdapter},
+    stream::StreamAction,
     testing::{
         SpyEmission, SpyEmitter, SpyLogger, SpyScheduler, StatefulTestHarness, TestContextBuilder,
         TriggerTestHarness,

--- a/crates/action/src/stream.rs
+++ b/crates/action/src/stream.rs
@@ -1,0 +1,372 @@
+//! Core [`StreamAction`] author trait.
+//!
+//! Stream actions open an async chunk stream and fold it into a single output
+//! value in-process. They share the same one-shot dispatch shape as
+//! [`StatelessAction`](crate::StatelessAction) but carry a distinct
+//! [`ActionKind::Stream`](crate::metadata::ActionKind::Stream) and a richer
+//! future seam — `open_stream` exposes the chunk boundary so later units
+//! (S3 cursor-replay, S4 egress) can observe chunks without touching stateless
+//! dispatch.
+//!
+//! ## Execution contract (S1)
+//!
+//! 1. The engine calls `StreamHandle::dispatch` once.
+//! 2. The adapter deserializes input → `Self::Input`, calls `open_stream`.
+//! 3. Every chunk is pulled in-process: `Ok(chunk)` is folded via `init`+`fold`;
+//!    the first `Err(e)` short-circuits and returns the error — no partial output.
+//! 4. The folded `Self::Output` is serialized → `Value` and wrapped in
+//!    [`ActionResult::success`](crate::result::ActionResult::success).
+//!
+//! ## Cancellation
+//!
+//! The stream future is driven inside the adapter; callers that need
+//! per-chunk cancellation should check `ctx.cancellation()` inside
+//! `open_stream` at natural yield points.
+//!
+//! ## Extension seam
+//!
+//! `StreamHandle` is a **separate** trait from `StatelessHandle` so that S3
+//! (cursor) and S4 (egress) can add chunk-observing methods to the handle
+//! surface without touching stateless dispatch.
+
+use futures::Stream;
+
+use crate::{action::Action, context::ActionContext, error::ActionError};
+
+/// Stream action: opens a chunk stream and folds it into a single output.
+///
+/// Authors implement `open_stream`, `init`, and `fold`. The engine adapter
+/// drives the stream fully in-process and delivers one folded `ActionResult`
+/// to the downstream node — identical to stateless from the engine's
+/// perspective, except the kind is `ActionKind::Stream`.
+///
+/// `Self::Chunk` is the per-step emission type. `Self::Output` (from
+/// [`Action`]) is the final accumulated value.
+///
+/// # Cancellation
+///
+/// Cancellation is handled by the runtime. To support cooperative cancellation,
+/// implementations can check `ctx.cancellation()` inside `open_stream` at
+/// natural suspension points.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use futures::stream;
+/// use nebula_action::prelude::*;
+/// use nebula_action::stream::StreamAction;
+///
+/// struct SumStream;
+///
+/// impl Action for SumStream {
+///     type Input  = serde_json::Value;
+///     type Output = u64;
+/// # fn metadata() -> nebula_action::ActionMetadata { todo!() }
+/// # fn dependencies() -> &'static nebula_core::Dependencies { todo!() }
+/// }
+///
+/// impl StreamAction for SumStream {
+///     type Chunk = u64;
+///
+///     fn open_stream(
+///         &self,
+///         _input: serde_json::Value,
+///         _ctx: &(impl ActionContext + ?Sized),
+///     ) -> impl futures::Stream<Item = Result<u64, ActionError>> + Send {
+///         stream::iter([Ok(1u64), Ok(2), Ok(3)])
+///     }
+///
+///     fn init(&self) -> u64 { 0 }
+///     fn fold(&self, acc: u64, chunk: u64) -> u64 { acc + chunk }
+/// }
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not implement StreamAction",
+    note = "implement `open_stream`, `init`, and `fold` (Chunk and Input/Output are associated types)"
+)]
+pub trait StreamAction: Action {
+    /// The per-step chunk type emitted by the stream.
+    type Chunk: Send;
+
+    /// Open the async chunk stream for the given input.
+    ///
+    /// The returned stream must be `Send` so the engine can drive it in a
+    /// Tokio task. Each `Ok(chunk)` is forwarded to [`Self::fold`]; the
+    /// first `Err(e)` short-circuits the fold and propagates the error with
+    /// no partial output emitted.
+    #[must_use = "the stream does nothing until it is driven to completion"]
+    fn open_stream(
+        &self,
+        input: <Self as Action>::Input,
+        ctx: &(impl ActionContext + ?Sized),
+    ) -> impl Stream<Item = Result<Self::Chunk, ActionError>> + Send;
+
+    /// Build the initial accumulator before any chunk arrives.
+    fn init(&self) -> <Self as Action>::Output;
+
+    /// Fold one chunk into the running accumulator.
+    fn fold(&self, acc: <Self as Action>::Output, chunk: Self::Chunk) -> <Self as Action>::Output;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::OnceLock;
+
+    use futures::stream;
+    use nebula_core::Dependencies;
+    use nebula_schema::{HasSchema, ValidSchema};
+    use nebula_workflow::NodeDefinition;
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    use super::*;
+    use crate::{
+        action::Action,
+        context::ActionContext,
+        error::ActionError,
+        factory::{ActionFactory, GenericStreamFactory},
+        from_workflow_node::FromWorkflowNode,
+        handle::ActionHandle,
+        metadata::{ActionKind, ActionMetadata},
+        result::ActionResult,
+        testing::TestContextBuilder,
+    };
+
+    fn make_ctx() -> crate::testing::TestActionContext {
+        TestContextBuilder::new().build()
+    }
+
+    fn make_node(action_key: &str) -> NodeDefinition {
+        NodeDefinition::new(
+            nebula_core::NodeKey::new("test_node").unwrap(),
+            action_key.to_owned(),
+            "test_plugin",
+            action_key,
+        )
+        .unwrap()
+    }
+
+    // ── SumStream fixture ────────────────────────────────────────────────────
+
+    /// Yields Ok(1), Ok(2), Ok(3) and folds by sum → total must be 6.
+    struct SumStream;
+
+    #[derive(Debug, Deserialize)]
+    struct SumInput {
+        start: u8,
+    }
+
+    impl HasSchema for SumInput {
+        fn schema() -> ValidSchema {
+            ValidSchema::empty()
+        }
+    }
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct SumOutput {
+        total: u64,
+    }
+
+    impl HasSchema for SumOutput {
+        fn schema() -> ValidSchema {
+            ValidSchema::empty()
+        }
+    }
+
+    impl Action for SumStream {
+        type Input = SumInput;
+        type Output = SumOutput;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.stream.sum"),
+                "SumStream",
+                "Yields three chunks and sums them",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static D: OnceLock<Dependencies> = OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl StreamAction for SumStream {
+        type Chunk = u8;
+
+        fn open_stream(
+            &self,
+            input: SumInput,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> impl Stream<Item = Result<Self::Chunk, ActionError>> + Send {
+            // Emit three chunks starting from input.start; test passes start=0.
+            stream::iter([
+                Ok(input.start.saturating_add(1)),
+                Ok(input.start.saturating_add(2)),
+                Ok(input.start.saturating_add(3)),
+            ])
+        }
+
+        fn init(&self) -> SumOutput {
+            SumOutput { total: 0 }
+        }
+
+        fn fold(&self, acc: SumOutput, chunk: u8) -> SumOutput {
+            SumOutput {
+                total: acc.total + u64::from(chunk),
+            }
+        }
+    }
+
+    impl FromWorkflowNode for SumStream {
+        type Error = ActionError;
+
+        async fn from_workflow_node(
+            _node: &NodeDefinition,
+            _ctx: &dyn ActionContext,
+        ) -> Result<Self, Self::Error> {
+            Ok(SumStream)
+        }
+    }
+
+    // ── ErrorStream fixture ──────────────────────────────────────────────────
+
+    /// Emits one chunk then an error — proves D-4 short-circuit with no partial output.
+    struct ErrorStream;
+
+    impl Action for ErrorStream {
+        type Input = Value;
+        type Output = Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.stream.error"),
+                "ErrorStream",
+                "Emits one chunk then fails",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static D: OnceLock<Dependencies> = OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl StreamAction for ErrorStream {
+        type Chunk = Value;
+
+        fn open_stream(
+            &self,
+            _input: Value,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> impl Stream<Item = Result<Self::Chunk, ActionError>> + Send {
+            stream::iter([
+                Ok(serde_json::json!(1)),
+                Err(ActionError::retryable("stream chunk failed")),
+            ])
+        }
+
+        fn init(&self) -> Value {
+            serde_json::json!(0)
+        }
+
+        fn fold(&self, _acc: Value, chunk: Value) -> Value {
+            chunk
+        }
+    }
+
+    impl FromWorkflowNode for ErrorStream {
+        type Error = ActionError;
+
+        async fn from_workflow_node(
+            _node: &NodeDefinition,
+            _ctx: &dyn ActionContext,
+        ) -> Result<Self, Self::Error> {
+            Ok(ErrorStream)
+        }
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /// Proves: factory produces `ActionHandle::Stream`, kind is `Stream`,
+    /// dispatch folds Ok(1)+Ok(2)+Ok(3) → `Success { Value({"total":6}) }`.
+    #[tokio::test]
+    async fn sum_stream_folds_to_six() {
+        let factory = GenericStreamFactory::<SumStream>::new();
+        let node = make_node("test.stream.sum");
+        let ctx = make_ctx();
+
+        let handle = factory
+            .instantiate(&node, &ctx)
+            .await
+            .expect("factory must produce a handle");
+
+        let ActionHandle::Stream(stream_handle) = handle else {
+            panic!("expected ActionHandle::Stream, got a different variant");
+        };
+
+        assert_eq!(
+            stream_handle.metadata().kind,
+            ActionKind::Stream,
+            "factory must stamp ActionKind::Stream"
+        );
+
+        let result = stream_handle
+            .dispatch(serde_json::json!({ "start": 0 }), &ctx)
+            .await
+            .expect("dispatch must succeed");
+
+        match result {
+            ActionResult::Success { output } => {
+                let value = output.into_value().expect("output must be an inline Value");
+                let out: SumOutput =
+                    serde_json::from_value(value).expect("output must deserialize to SumOutput");
+                assert_eq!(out.total, 6, "1+2+3 must fold to 6");
+            },
+            other => panic!("expected ActionResult::Success, got {other:?}"),
+        }
+    }
+
+    /// Proves: `is_stream()` and `kind == Stream` set via factory.
+    #[tokio::test]
+    async fn stream_metadata_kind_and_predicate() {
+        let factory = GenericStreamFactory::<SumStream>::new();
+        let node = make_node("test.stream.sum");
+        let ctx = make_ctx();
+
+        let handle = factory.instantiate(&node, &ctx).await.unwrap();
+
+        assert_eq!(
+            handle.metadata().kind,
+            ActionKind::Stream,
+            "GenericStreamFactory must stamp ActionKind::Stream on the stored metadata"
+        );
+        assert!(
+            handle.is_stream(),
+            "is_stream() predicate must return true for ActionHandle::Stream"
+        );
+    }
+
+    /// Proves D-4: a chunk `Err` short-circuits dispatch — no partial output, typed error returned.
+    #[tokio::test]
+    async fn error_chunk_short_circuits_with_no_partial_output() {
+        let factory = GenericStreamFactory::<ErrorStream>::new();
+        let node = make_node("test.stream.error");
+        let ctx = make_ctx();
+
+        let handle = factory.instantiate(&node, &ctx).await.unwrap();
+        let ActionHandle::Stream(stream_handle) = handle else {
+            panic!("expected ActionHandle::Stream");
+        };
+
+        let err = stream_handle
+            .dispatch(serde_json::json!(null), &ctx)
+            .await
+            .expect_err("dispatch must propagate the chunk error without partial output");
+
+        assert!(
+            matches!(err, ActionError::Retryable { .. }),
+            "the chunk error kind must be preserved; got {err:?}"
+        );
+    }
+}

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -23,8 +23,8 @@ use dashmap::DashMap;
 use nebula_action::{
     Action, ActionError, ActionFactory, ActionMetadata, ControlAction, FromWorkflowNode,
     GenericControlFactory, GenericResourceFactory, GenericStatefulFactory, GenericStatelessFactory,
-    GenericTriggerFactory, InstanceFactory, ResourceAction, StatefulAction, StatelessAction,
-    TriggerAction, WebhookActionFactory,
+    GenericStreamFactory, GenericTriggerFactory, InstanceFactory, ResourceAction, StatefulAction,
+    StatelessAction, StreamAction, TriggerAction, WebhookActionFactory,
 };
 use nebula_core::ActionKey;
 use semver::Version;
@@ -166,6 +166,23 @@ impl ActionRegistry {
         A: ResourceAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
     {
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericResourceFactory::<A>::new());
+        let metadata = factory.metadata().clone();
+        self.register_factory(metadata, factory);
+    }
+
+    /// Register a stream action via the factory pipeline (Variant A).
+    ///
+    /// The produced [`ActionHandle::Stream`](nebula_action::ActionHandle::Stream)
+    /// drives the chunk stream fully in-process and delivers one folded value
+    /// to the downstream node — identical to stateless dispatch from the
+    /// engine's perspective.
+    pub fn register_stream_factory<A>(&self)
+    where
+        A: StreamAction + FromWorkflowNode<Error = ActionError>,
+        <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
+        <A as Action>::Output: serde::Serialize + Send + Sync,
+    {
+        let factory: Arc<dyn ActionFactory> = Arc::new(GenericStreamFactory::<A>::new());
         let metadata = factory.metadata().clone();
         self.register_factory(metadata, factory);
     }

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use dashmap::DashMap;
 use nebula_action::{
     ActionContext, ActionError, ActionFactory, ActionHandle, ActionMetadata, IsolationLevel,
+    StreamHandle,
     output::{ActionOutput, DataReference},
     result::ActionResult,
 };
@@ -439,6 +440,13 @@ impl ActionRuntime {
                 self.observe_dispatched(started, &r);
                 r
             },
+            ActionHandle::Stream(inner) => {
+                let r = self
+                    .execute_stream_handle(&metadata, inner, input, context)
+                    .await;
+                self.observe_dispatched(started, &r);
+                r
+            },
             ActionHandle::Control(inner) => {
                 let r = self
                     .execute_control_handle(&metadata, inner, input, context)
@@ -506,6 +514,46 @@ impl ActionRuntime {
             // fail-closed until we explicitly wire dispatch for it.
             _ => Err(RuntimeError::Internal(format!(
                 "unknown isolation level for action '{}' — refusing to dispatch",
+                metadata.base.key.as_str()
+            ))),
+        }
+    }
+
+    /// Stream dispatch via `Box<dyn StreamHandle>`.
+    ///
+    /// Near-clone of [`Self::execute_stateless_handle`] — the only
+    /// difference is the handle trait (`StreamHandle` instead of
+    /// `StatelessHandle`). The stream is driven fully in-process inside
+    /// the adapter; the engine receives one folded value.
+    ///
+    /// Isolation contract mirrors stateless: `None` runs in-process;
+    /// `CapabilityGated` routes through the [`ActionRunner`]. Future
+    /// isolation variants fail-closed.
+    #[tracing::instrument(
+        name = "runtime.execute_stream_handle",
+        skip_all,
+        fields(
+            action.key = %metadata.base.key.as_str(),
+            action.kind = "stream",
+        )
+    )]
+    async fn execute_stream_handle(
+        &self,
+        metadata: &ActionMetadata,
+        handle: Box<dyn StreamHandle>,
+        input: serde_json::Value,
+        context: &dyn ActionContext,
+    ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
+        match metadata.isolation_level {
+            IsolationLevel::None => Ok(handle.dispatch(input, context).await?),
+            IsolationLevel::CapabilityGated => {
+                let run_ctx = ActionRunContext::new(context);
+                Ok(self.runner.execute(run_ctx, metadata, input).await?)
+            },
+            // IsolationLevel is `#[non_exhaustive]`. Any future variant must
+            // fail-closed until we explicitly wire dispatch for it.
+            _ => Err(RuntimeError::Internal(format!(
+                "unknown isolation level for stream action '{}' — refusing to dispatch",
                 metadata.base.key.as_str()
             ))),
         }
@@ -753,6 +801,14 @@ impl ActionRuntime {
                         ))
                     })?
                     .len() as u64,
+                // Intentional size-0: Deferred carries retry config + resolution
+                // metadata (no inline payload); Streaming carries a StreamOutput
+                // descriptor (mode + state tag, no inline bytes). The real payload
+                // for both is sized after resolution — either at the resolution site
+                // (Deferred resolved by the engine's resolution pass) or in the
+                // stream adapter (StreamAction::dispatch returns ActionOutput::Value
+                // once the fold completes, which IS measured above). Empty has no
+                // payload by definition.
                 ActionOutput::Deferred(_) | ActionOutput::Streaming(_) | ActionOutput::Empty => 0,
                 ActionOutput::Collection(_) => 0, // collections are flattened before this loop
                 _ => 0,
@@ -917,6 +973,8 @@ fn estimated_action_output_payload_bytes(slot: &ActionOutput<serde_json::Value>)
         ActionOutput::Reference(r) => r
             .size
             .unwrap_or_else(|| serde_json::to_vec(r).map_or(0, |b| b.len() as u64)),
+        // Size-0 is intentional — same rationale as enforce_data_limit:
+        // Deferred and Streaming carry descriptors, not inline payloads.
         ActionOutput::Deferred(_) => 0,
         ActionOutput::Streaming(_) => 0,
         ActionOutput::Collection(items) => items
@@ -2103,6 +2161,183 @@ mod tests {
                 .get(),
             0,
             "dispatch-rejected counter must stay at zero for successful dispatch"
+        );
+    }
+
+    // ── Stream action dispatch ───────────────────────────────────────────────
+
+    /// Prove the end-to-end stream dispatch path:
+    /// register via `register_stream_factory` → execute → folded value reaches
+    /// the result. If the `ActionHandle::Stream` arm in `dispatch_action` is
+    /// reverted, this test goes red (the action would hit `_ => UNKNOWN_VARIANT`
+    /// and return `RuntimeError::Internal`).
+    #[tokio::test]
+    async fn stream_action_dispatch_yields_folded_value() {
+        use futures::stream;
+        use nebula_action::{FromWorkflowNode, stream::StreamAction};
+
+        struct CountingStream;
+
+        impl Action for CountingStream {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(
+                    action_key!("test.stream.counting"),
+                    "CountingStream",
+                    "yields 1,2,3 and sums",
+                )
+            }
+
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+
+        impl StreamAction for CountingStream {
+            type Chunk = u64;
+
+            fn open_stream(
+                &self,
+                _input: serde_json::Value,
+                _ctx: &(impl ActionContext + ?Sized),
+            ) -> impl futures::Stream<Item = Result<u64, ActionError>> + Send {
+                stream::iter([Ok(1u64), Ok(2), Ok(3)])
+            }
+
+            fn init(&self) -> serde_json::Value {
+                serde_json::json!(0u64)
+            }
+
+            fn fold(&self, acc: serde_json::Value, chunk: u64) -> serde_json::Value {
+                let running = acc.as_u64().unwrap_or(0);
+                serde_json::json!(running + chunk)
+            }
+        }
+
+        impl FromWorkflowNode for CountingStream {
+            type Error = ActionError;
+
+            async fn from_workflow_node(
+                _node: &NodeDefinition,
+                _ctx: &dyn ActionContext,
+            ) -> Result<Self, Self::Error> {
+                Ok(CountingStream)
+            }
+        }
+
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stream_factory::<CountingStream>();
+        let rt = make_runtime(registry);
+
+        let result = rt
+            .execute_action(
+                "test.stream.counting",
+                serde_json::json!(null),
+                &test_context(),
+            )
+            .await
+            .expect("stream dispatch must succeed");
+
+        match result {
+            ActionResult::Success { output } => {
+                let value = output.into_value().expect("output must be inline Value");
+                assert_eq!(value, serde_json::json!(6u64), "1+2+3 must fold to 6");
+            },
+            other => panic!("expected Success, got {other:?}"),
+        }
+    }
+
+    /// D-2 regression: a stream-produced payload that exceeds the per-node
+    /// limit must be rejected (or spilled). The folded Value goes through
+    /// `ActionOutput::Value`, which IS measured by `enforce_data_limit`.
+    /// This test proves the D-2 path is not bypassed by the new kind.
+    #[tokio::test]
+    async fn stream_output_respects_data_limit() {
+        use futures::stream;
+        use nebula_action::{FromWorkflowNode, stream::StreamAction};
+
+        struct BigStream;
+
+        impl Action for BigStream {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new(
+                    action_key!("test.stream.big"),
+                    "BigStream",
+                    "produces an oversized folded value",
+                )
+            }
+
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+
+        impl StreamAction for BigStream {
+            type Chunk = String;
+
+            fn open_stream(
+                &self,
+                _input: serde_json::Value,
+                _ctx: &(impl ActionContext + ?Sized),
+            ) -> impl futures::Stream<Item = Result<String, ActionError>> + Send {
+                // One chunk whose folded form exceeds any tiny limit.
+                stream::iter([Ok("x".repeat(1024))])
+            }
+
+            fn init(&self) -> serde_json::Value {
+                serde_json::json!("")
+            }
+
+            fn fold(&self, _acc: serde_json::Value, chunk: String) -> serde_json::Value {
+                serde_json::json!(chunk)
+            }
+        }
+
+        impl FromWorkflowNode for BigStream {
+            type Error = ActionError;
+
+            async fn from_workflow_node(
+                _node: &NodeDefinition,
+                _ctx: &dyn ActionContext,
+            ) -> Result<Self, Self::Error> {
+                Ok(BigStream)
+            }
+        }
+
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stream_factory::<BigStream>();
+
+        let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+            Box::pin(async move { Ok(ActionResult::success(input)) })
+        });
+        let runner = Arc::new(InProcessRunner::new(executor));
+        let metrics = MetricsRegistry::new();
+        let rt = ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy {
+                max_node_output_bytes: 10, // far below the 1024-char chunk
+                ..Default::default()
+            },
+            metrics,
+        )
+        .unwrap();
+
+        let err = rt
+            .execute_action("test.stream.big", serde_json::json!(null), &test_context())
+            .await
+            .expect_err("oversized stream output must be rejected");
+
+        assert!(
+            matches!(err, RuntimeError::DataLimitExceeded { .. }),
+            "expected DataLimitExceeded, got {err:?}"
         );
     }
 

--- a/crates/sdk/src/prelude.rs
+++ b/crates/sdk/src/prelude.rs
@@ -14,8 +14,9 @@
 // Action traits and types
 pub use nebula_action::{
     Action, ActionContext, ActionError, ActionResult, Field, PollTriggerAdapter, Schema,
-    StatefulActionAdapter, StatelessAction, StatelessActionAdapter, TriggerContext, TriggerEvent,
-    TriggerEventOutcome, ValidSchema, WebhookRequest, WebhookTriggerAdapter, field_key,
+    StatefulActionAdapter, StatelessAction, StatelessActionAdapter, StreamAction, TriggerContext,
+    TriggerEvent, TriggerEventOutcome, ValidSchema, WebhookRequest, WebhookTriggerAdapter,
+    field_key,
     metadata::ActionMetadata,
     poll::{DeduplicatingCursor, PollAction, PollConfig, PollCursor, PollResult},
     port::{InputPort, OutputPort},


### PR DESCRIPTION
## What

First unit (**S1**) of the `Stream` node kind — the **collect-fold foundation** from [ADR-0102](https://github.com/vanyastaff/nebula) §Migration. A `StreamAction` opens an async chunk stream that the engine drives to completion and **folds in-process to `ActionOutput::Value`**; downstream nodes get the folded value. This is the complete first vertical slice — a usable Stream kind with **no durability capability yet** (those are additive follow-on units).

## Why this shape

- **Streaming is encapsulated in the adapter.** `StreamHandle::dispatch` mirrors `StatelessHandle::dispatch` (`Value → ActionResult<Value>`); `StreamHandleImpl` drives `open_stream` + `fold` internally. The engine sees only the folded value in S1. `StreamHandle` is a **distinct trait** (not a stateless alias) so cursor-replay durability and live egress can extend its surface later without touching stateless dispatch.
- **Additive & spine-clean:** `ActionHandle::Stream(Box<dyn StreamHandle>)` is additive under the existing `#[non_exhaustive]`; the new `dispatch_action` arm replaces the prior `UNKNOWN_VARIANT` reject for Stream. Single-writer `ActionKind::Stream` stamping in `GenericStreamFactory` only.

## Changes

- **nebula-action:** `StreamAction` author trait (RPITIT `open_stream` + `init`/`fold`), `StreamHandle` dyn (`#[async_trait]`), `GenericStreamFactory<A>`, `ActionHandle::Stream` + `StreamHandleImpl`.
- **nebula-engine:** `execute_stream_handle` (`#[tracing::instrument]`) + `dispatch_action` Stream arm + `register_stream_factory`.
- **Contracts:** a mid-stream `Err` short-circuits to a typed error with **no partial output**; the folded `Value` is size-checked, and the pre-existing `Deferred`/`Streaming` size-0 path in `enforce_data_limit` is documented (stream output flows through `Value`, which is measured).

## Out of scope (separate units, per ADR-0102)

`purity + content-cache` (S2), source-cursor durability + at-least-once replay (S3), ephemeral live-egress / LLM-token flavor (S4), multi-node `StreamPipeline` segment + TypeDAG + D7a isolate-guard (S5). `ActionOutput::Streaming` / `StreamOutput.state` are superseded and left untouched (removed in S5-cleanup).

## Evidence

- red→green: `stream_action_dispatch_yields_folded_value` (engine, end-to-end; goes red if the dispatch arm is reverted), `error_chunk_short_circuits_with_no_partial_output`, `stream_output_respects_data_limit`, + `StreamAction` unit tests.
- Gates green: `clippy --all-targets --all-features -D warnings`, `nextest` **785/785** (action+engine+sdk), `fmt`, `rustdoc -D warnings` (action+engine). Pre-push gate (clippy-full + crate-diff-gate) green.
- `rust-reviewer`: **CLEAN** (spec-compliance + code quality), tautology gate confirmed falsifiable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
