### PR TITLE
feat(action): output_schema in ActionMetadata — single-writer stamp (ADR-0100 T2)

### DIFF
--- a/crates/action/Cargo.toml
+++ b/crates/action/Cargo.toml
@@ -53,6 +53,7 @@ subtle = { workspace = true }
 
 [dev-dependencies]
 nebula-core = { path = "../core" }
+nebula-schema = { path = "../schema" }
 nebula-credential-macros = { path = "../credential/macros" }
 # Phase 9 / Task 9.1: pipeline test exercises the expression engine end-to-end.
 nebula-expression = { path = "../expression", default-features = false, features = ["cache"] }

--- a/crates/action/src/control.rs
+++ b/crates/action/src/control.rs
@@ -471,6 +471,7 @@ impl<A: ControlAction> ControlActionAdapter<A> {
     pub fn new(action: A) -> Self {
         let mut meta = <A as Action>::metadata();
         meta.kind = ActionKind::Control;
+        meta.output_schema = <A::Output as nebula_schema::HasSchema>::schema();
         Self {
             action,
             cached_metadata: Arc::new(meta),

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -106,8 +106,11 @@ where
     <A as Action>::Output: Serialize + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Stateless))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Stateless)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(
@@ -199,18 +202,23 @@ pub struct InstanceFactory<A> {
     meta: Arc<ActionMetadata>,
 }
 
-impl<A> InstanceFactory<A> {
+impl<A: Action> InstanceFactory<A> {
     /// Wrap a pre-built action instance with explicit metadata.
     ///
     /// The metadata's [`kind`](ActionMetadata::kind) is stamped to
-    /// [`ActionKind::Stateless`] — the factory is the single writer of the kind
-    /// for the handle it produces — while every other field is preserved as the
-    /// caller supplied it.
+    /// [`ActionKind::Stateless`] and `output_schema` is stamped from
+    /// `<A::Output as HasSchema>::schema()` — the factory is the single writer
+    /// of both fields — while every other field is preserved as the caller
+    /// supplied it.
     #[must_use]
     pub fn new(metadata: ActionMetadata, action: A) -> Self {
         Self {
             action: Arc::new(action),
-            meta: Arc::new(metadata.with_kind(ActionKind::Stateless)),
+            meta: Arc::new(
+                metadata
+                    .with_kind(ActionKind::Stateless)
+                    .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema()),
+            ),
         }
     }
 }
@@ -310,8 +318,11 @@ where
     A::State: Serialize + DeserializeOwned + Clone + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Stateful))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Stateful)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(
@@ -446,8 +457,11 @@ where
     <A as TriggerAction>::Error: Into<ActionError>,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Trigger))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Trigger)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(
@@ -550,8 +564,11 @@ where
     A: ResourceAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Resource))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Resource)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(
@@ -644,8 +661,11 @@ where
     A: ControlAction + FromWorkflowNode<Error = ActionError> + Send + Sync + 'static,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Control))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Control)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(
@@ -733,8 +753,11 @@ where
     <A as Action>::Output: Serialize + Send + Sync,
 {
     fn metadata(&self) -> &ActionMetadata {
-        self.meta
-            .get_or_init(|| <A as Action>::metadata().with_kind(ActionKind::Stream))
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Stream)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
     }
 
     fn instantiate<'a>(

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -103,7 +103,8 @@ fn default_action_kind() -> ActionKind {
 /// Compatibility validation errors for action metadata evolution.
 ///
 /// Wraps [`nebula_metadata::BaseCompatError`] (shared catalog-entity rules)
-/// and layers the action-specific port-change rule on top.
+/// and layers action-specific rules on top: port-change and output-schema
+/// narrowing (TypeDAG producer→consumer assignability).
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 #[non_exhaustive]
 pub enum MetadataCompatibilityError {
@@ -114,6 +115,19 @@ pub enum MetadataCompatibilityError {
     /// Input or output ports changed without a major version bump.
     #[error("action ports changed without a major version bump")]
     PortsChangeWithoutMajorBump,
+
+    /// The action's output schema was narrowed (a field required by downstream
+    /// consumers was dropped or changed type) without a major version bump.
+    ///
+    /// TypeDAG edge checks use `output_schema` to validate producer→consumer
+    /// assignability. Narrowing the output on a same-major upgrade silently
+    /// breaks any typed downstream node that was bound against the old schema.
+    /// A major version bump is required to signal the breaking contract change.
+    #[error(
+        "action output schema narrowed without a major version bump: \
+         a field required by downstream consumers was dropped or changed type"
+    )]
+    OutputSchemaNarrowedWithoutMajorBump,
 }
 
 /// Static metadata describing an action type.
@@ -427,9 +441,26 @@ impl ActionMetadata {
     ) -> Result<(), MetadataCompatibilityError> {
         nebula_metadata::validate_base_compat(&self.base, &previous.base)?;
 
+        let same_major = self.base.version.major == previous.base.version.major;
+
         let ports_changed = self.inputs != previous.inputs || self.outputs != previous.outputs;
-        if ports_changed && self.base.version.major == previous.base.version.major {
+        if ports_changed && same_major {
             return Err(MetadataCompatibilityError::PortsChangeWithoutMajorBump);
+        }
+
+        // TypeDAG output-schema assignability: the NEW output is the producer;
+        // the OLD output is the consumer (downstream nodes were typed against it).
+        // If `is_assignable` returns Err the new output dropped or changed a field
+        // that old consumers required — that is a silent breaking change on a
+        // same-major upgrade. A major version bump is required.
+        if same_major
+            && nebula_schema::is_assignable(
+                self.output_schema.fields(),
+                previous.output_schema.fields(),
+            )
+            .is_err()
+        {
+            return Err(MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump);
         }
 
         Ok(())
@@ -969,5 +1000,119 @@ mod tests {
         let json = serde_json::to_string(&original).expect("serialize succeeds");
         let decoded: ActionMetadata = serde_json::from_str(&json).expect("deserialize succeeds");
         assert_eq!(original, decoded);
+    }
+
+    // ── validate_compatibility: output_schema narrowing ─────────────────────
+
+    #[test]
+    fn output_schema_narrowed_same_major_is_rejected() {
+        // v1.0 produces {result, status}; v1.1 drops `status` — downstream
+        // consumers that required `status` will break. Must be rejected on a
+        // same-major upgrade. Goes RED if the output-schema check is removed.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, field_key};
+        let two_field_schema = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("status"), StringBuilder::required)
+            .build()
+            .unwrap();
+        let one_field_schema = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(two_field_schema);
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 1)
+            .with_output_schema(one_field_schema);
+
+        let err = next
+            .validate_compatibility(&prev)
+            .expect_err("narrowing output on same major must be rejected");
+        assert_eq!(
+            err,
+            MetadataCompatibilityError::OutputSchemaNarrowedWithoutMajorBump,
+            "expected OutputSchemaNarrowedWithoutMajorBump"
+        );
+    }
+
+    #[test]
+    fn output_schema_widened_same_major_is_allowed() {
+        // v1.0 produces {result}; v1.1 adds `extra` — existing consumers only
+        // required `result`, so width subtyping allows the addition.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, field_key};
+        let narrow = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .build()
+            .unwrap();
+        let wide = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("extra"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(narrow);
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 1)
+            .with_output_schema(wide);
+
+        assert!(
+            next.validate_compatibility(&prev).is_ok(),
+            "widening the output schema on a same-major bump must be allowed"
+        );
+    }
+
+    #[test]
+    fn output_schema_narrowed_with_major_bump_is_allowed() {
+        // A major version bump signals a breaking contract change — narrowing
+        // the output is permitted regardless of what fields disappear.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, field_key};
+        let two_field_schema = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("status"), StringBuilder::required)
+            .build()
+            .unwrap();
+        let one_field_schema = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(two_field_schema);
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(2, 0)
+            .with_output_schema(one_field_schema);
+
+        assert!(
+            next.validate_compatibility(&prev).is_ok(),
+            "narrowing output with a major version bump must be allowed"
+        );
+    }
+
+    #[test]
+    fn output_schema_unchanged_same_major_is_allowed() {
+        // Identical output schema — the common no-op case must pass.
+        use nebula_schema::{FieldCollector, Schema, StringBuilder, field_key};
+        let schema = Schema::builder()
+            .string(field_key!("result"), StringBuilder::required)
+            .string(field_key!("status"), StringBuilder::required)
+            .build()
+            .unwrap();
+
+        let prev = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 0)
+            .with_output_schema(schema.clone());
+        let next = ActionMetadata::new(action_key!("svc.action"), "A", "d")
+            .with_version(1, 1)
+            .with_output_schema(schema);
+
+        assert!(
+            next.validate_compatibility(&prev).is_ok(),
+            "identical output schemas must be compatible on a same-major bump"
+        );
     }
 }

--- a/crates/action/src/metadata.rs
+++ b/crates/action/src/metadata.rs
@@ -173,6 +173,17 @@ pub struct ActionMetadata {
     /// Per Tech Spec §15.12 F9 + PRODUCT_ backpressure.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_concurrent: Option<core::num::NonZeroU32>,
+    /// Schema describing the type this action produces as output.
+    ///
+    /// Stamped by the factory or DX adapter from `<A::Output as HasSchema>::schema()`
+    /// — the single writer is the factory, mirroring how `kind` is stamped.
+    /// TypeDAG edge checks (`T3+`) read this field to validate that the
+    /// producer's output is assignable to the consumer's input.
+    ///
+    /// Defaults to [`ValidSchema::empty`] for metadata persisted before this
+    /// field existed (back-compat), and for actions with an untyped output.
+    #[serde(default = "ValidSchema::empty")]
+    pub output_schema: ValidSchema,
 }
 
 impl Metadata for ActionMetadata {
@@ -194,6 +205,7 @@ impl ActionMetadata {
             kind: ActionKind::Stateless,
             checkpoint_policy: CheckpointPolicy::Inherit,
             max_concurrent: None,
+            output_schema: ValidSchema::empty(),
         }
     }
 
@@ -258,6 +270,7 @@ impl ActionMetadata {
     {
         Self::new(key, name, description)
             .with_schema(<A::Input as nebula_schema::HasSchema>::schema())
+            .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
     }
 
     /// Set the interface version from `(major, minor)` components.
@@ -331,6 +344,28 @@ impl ActionMetadata {
     pub fn with_schema(mut self, schema: ValidSchema) -> Self {
         self.base.schema = schema;
         self
+    }
+
+    /// Set the output schema for this action.
+    ///
+    /// The single writer is the factory or DX adapter (via
+    /// `<A::Output as HasSchema>::schema()`); action authors rarely call
+    /// this directly. Symmetric with [`with_schema`](Self::with_schema).
+    #[must_use = "builder methods must be chained or built"]
+    pub fn with_output_schema(mut self, schema: ValidSchema) -> Self {
+        self.output_schema = schema;
+        self
+    }
+
+    /// The schema describing what this action produces.
+    ///
+    /// Stamped from `<A::Output as HasSchema>::schema()` by the factory.
+    /// TypeDAG edge checks read this to validate producer→consumer
+    /// assignability. Returns an empty schema for actions that predated
+    /// this field or have an untyped output.
+    #[must_use]
+    pub fn output_schema(&self) -> &ValidSchema {
+        &self.output_schema
     }
 
     /// Set the isolation level for dispatch routing.
@@ -795,5 +830,144 @@ mod tests {
             err,
             MetadataCompatibilityError::Base(BaseCompatError::VersionRegressed { .. })
         ));
+    }
+
+    // ── output_schema field ─────────────────────────────────────────────
+
+    /// Fixture output type with a named field so the schema is non-empty and
+    /// the assertion `field_present` is non-vacuous (not just `is_empty()==false`).
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct EchoOutput {
+        message: String,
+    }
+
+    impl nebula_schema::HasSchema for EchoOutput {
+        fn schema() -> ValidSchema {
+            use nebula_schema::{FieldCollector, Schema, field_key};
+            Schema::builder()
+                .string(
+                    field_key!("message"),
+                    nebula_schema::StringBuilder::required,
+                )
+                .build()
+                .expect("EchoOutput schema is valid")
+        }
+    }
+
+    // Minimal Action impl used only to drive `for_action` / factory tests.
+    struct EchoAction;
+
+    #[derive(Debug, serde::Serialize, serde::Deserialize)]
+    struct EchoInput {
+        text: String,
+    }
+
+    impl nebula_schema::HasSchema for EchoInput {
+        fn schema() -> ValidSchema {
+            use nebula_schema::{FieldCollector, Schema, field_key};
+            Schema::builder()
+                .string(field_key!("text"), nebula_schema::StringBuilder::required)
+                .build()
+                .expect("EchoInput schema is valid")
+        }
+    }
+
+    impl crate::action::Action for EchoAction {
+        type Input = EchoInput;
+        type Output = EchoOutput;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::for_action::<Self>(action_key!("test.echo"), "Echo", "Echoes input")
+        }
+
+        fn dependencies() -> &'static nebula_core::Dependencies {
+            use std::sync::OnceLock;
+            static DEPS: OnceLock<nebula_core::Dependencies> = OnceLock::new();
+            DEPS.get_or_init(nebula_core::Dependencies::new)
+        }
+    }
+
+    #[test]
+    fn new_initialises_output_schema_to_empty() {
+        let meta = ActionMetadata::new(action_key!("test"), "T", "d");
+        assert!(
+            meta.output_schema.fields().is_empty(),
+            "output_schema must default to empty"
+        );
+    }
+
+    #[test]
+    fn with_output_schema_builder_stores_schema() {
+        use nebula_schema::{FieldCollector, Schema, field_key};
+        let schema = Schema::builder()
+            .string(
+                field_key!("message"),
+                nebula_schema::StringBuilder::required,
+            )
+            .build()
+            .unwrap();
+        let meta = ActionMetadata::new(action_key!("test"), "T", "d").with_output_schema(schema);
+        assert!(
+            !meta.output_schema.fields().is_empty(),
+            "output_schema must store the provided schema"
+        );
+        assert!(
+            meta.output_schema
+                .fields()
+                .iter()
+                .any(|f| f.key().as_str() == "message"),
+            "output_schema must contain the `message` field"
+        );
+    }
+
+    #[test]
+    fn for_action_stamps_output_schema_from_action_output_type() {
+        let meta = ActionMetadata::for_action::<EchoAction>(
+            action_key!("test.echo"),
+            "Echo",
+            "Echoes input",
+        );
+        // Non-vacuous: assert the `message` field is present in the output schema.
+        assert!(
+            meta.output_schema
+                .fields()
+                .iter()
+                .any(|f| f.key().as_str() == "message"),
+            "for_action must stamp output_schema from A::Output — `message` field missing"
+        );
+    }
+
+    #[test]
+    fn output_schema_back_compat_missing_field_deserializes_to_empty() {
+        // Metadata serialized before `output_schema` existed must still load,
+        // defaulting the field to an empty schema — mirrors kind_backward_compat_without_field.
+        let legacy = ActionMetadata::new(action_key!("http.request"), "HTTP", "desc");
+        let mut as_value: serde_json::Value = serde_json::to_value(&legacy).unwrap();
+        as_value
+            .as_object_mut()
+            .unwrap()
+            .remove("output_schema")
+            .expect("output_schema must be present after serialize");
+        let json_string = serde_json::to_string(&as_value).unwrap();
+        let decoded: ActionMetadata = serde_json::from_str(&json_string)
+            .expect("legacy metadata without output_schema must deserialize");
+        assert!(
+            decoded.output_schema.fields().is_empty(),
+            "missing output_schema field should default to empty"
+        );
+    }
+
+    #[test]
+    fn output_schema_serde_roundtrip() {
+        use nebula_schema::{FieldCollector, Schema, field_key};
+        let schema = Schema::builder()
+            .string(field_key!("result"), nebula_schema::StringBuilder::required)
+            .build()
+            .unwrap();
+        let original =
+            ActionMetadata::new(action_key!("test"), "T", "d").with_output_schema(schema);
+        let json = serde_json::to_string(&original).expect("serialize succeeds");
+        let decoded: ActionMetadata = serde_json::from_str(&json).expect("deserialize succeeds");
+        assert_eq!(original, decoded);
     }
 }

--- a/crates/action/tests/dx_control.rs
+++ b/crates/action/tests/dx_control.rs
@@ -23,6 +23,7 @@ use nebula_action::{
     OutputPort, StatelessHandler, TerminationReason, ValidationReason, testing::TestContextBuilder,
 };
 use nebula_core::{Dependencies, action_key};
+use nebula_schema::{FieldCollector, HasSchema, Schema, StringBuilder, ValidSchema, field_key};
 
 // ── Test helpers ───────────────────────────────────────────────────────────
 
@@ -749,4 +750,95 @@ async fn pass_and_drop_have_distinct_runtime_shapes() {
 
     let drop_result = run(&filter, serde_json::json!({ "score": 0 })).await;
     assert!(drop_result.into_primary_output().is_none());
+}
+
+// ── output_schema stamp: ControlActionAdapter ──────────────────────────────
+//
+// Every control action wrapped by `ControlActionAdapter` must carry a
+// non-empty `output_schema` when its `Output` type has typed fields.
+// T3 (TypeDAG edge check) reads `metadata().output_schema()` to validate
+// producer→consumer assignability; an empty schema here silently bypasses
+// the check for every control node.
+//
+// The fixture below uses a typed `Output` struct so the assertion is
+// non-vacuous: removing the `output_schema` stamp from
+// `ControlActionAdapter::new` causes this test to go RED.
+
+/// Typed output for the control-adapter stamp test.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TypedBranchOutput {
+    /// The selected branch label, carried downstream for audit / tracing.
+    selected: String,
+}
+
+impl HasSchema for TypedBranchOutput {
+    fn schema() -> ValidSchema {
+        Schema::builder()
+            .string(field_key!("selected"), StringBuilder::required)
+            .build()
+            .expect("TypedBranchOutput schema is valid")
+    }
+}
+
+/// Control action that returns a typed `Output` so the factory-stamped
+/// `output_schema` is non-empty and the red-on-revert assertion is non-vacuous.
+struct DemoTypedBranch;
+
+impl Action for DemoTypedBranch {
+    type Input = serde_json::Value;
+    type Output = TypedBranchOutput;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("demo.typed_branch"),
+            "TypedBranch",
+            "Branch with typed output",
+        )
+        .with_outputs(vec![OutputPort::flow("true"), OutputPort::flow("false")])
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl ControlAction for DemoTypedBranch {
+    async fn evaluate(
+        &self,
+        input: ControlInput,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ControlOutcome, ActionError> {
+        let selected = if input.get_bool("/condition").unwrap_or(false) {
+            "true"
+        } else {
+            "false"
+        };
+        Ok(ControlOutcome::Branch {
+            selected: selected.into(),
+            output: serde_json::to_value(TypedBranchOutput {
+                selected: selected.into(),
+            })
+            .unwrap_or_default(),
+        })
+    }
+}
+
+#[test]
+fn control_action_adapter_stamps_output_schema_from_action_output_type() {
+    // Non-vacuous: `TypedBranchOutput` has a `selected` field.
+    // Removing the `output_schema` stamp from `ControlActionAdapter::new`
+    // causes this test to go RED — the schema will be empty and the `any()`
+    // predicate will return false.
+    let adapter = ControlActionAdapter::new(DemoTypedBranch);
+    let output_schema = adapter.metadata().output_schema();
+
+    assert!(
+        output_schema
+            .fields()
+            .iter()
+            .any(|f| f.key().as_str() == "selected"),
+        "ControlActionAdapter must stamp output_schema from A::Output — \
+         `selected` field missing; revert the stamp in ControlActionAdapter::new to see this fail"
+    );
 }

--- a/crates/action/tests/instance_factory.rs
+++ b/crates/action/tests/instance_factory.rs
@@ -20,6 +20,83 @@ use nebula_action::{
 use nebula_core::{Dependencies, action_key, node_key};
 use nebula_workflow::NodeDefinition;
 
+// ── TypedEcho — fixture with a named Output field ──────────────────────────
+//
+// Used to assert that `InstanceFactory` stamps `output_schema` from `A::Output`.
+// `CountingEcho` cannot catch a missing stamp because its `Output = Value` whose
+// schema is empty — removing the stamp would leave the assertion vacuously true.
+
+/// Output type with a named field so the schema is non-empty and the assertion
+/// is non-vacuous (removing the `output_schema` stamp makes the test fail).
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TypedEchoOutput {
+    message: String,
+}
+
+impl nebula_schema::HasSchema for TypedEchoOutput {
+    fn schema() -> nebula_action::ValidSchema {
+        use nebula_schema::{FieldCollector, Schema, field_key};
+        Schema::builder()
+            .string(
+                field_key!("message"),
+                nebula_schema::StringBuilder::required,
+            )
+            .build()
+            .expect("TypedEchoOutput schema is valid")
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct TypedEchoInput {
+    text: String,
+}
+
+impl nebula_schema::HasSchema for TypedEchoInput {
+    fn schema() -> nebula_action::ValidSchema {
+        use nebula_schema::{FieldCollector, Schema, field_key};
+        Schema::builder()
+            .string(field_key!("text"), nebula_schema::StringBuilder::required)
+            .build()
+            .expect("TypedEchoInput schema is valid")
+    }
+}
+
+/// Stateless action with a typed `Output` struct, so the factory-stamped
+/// `output_schema` is non-empty and the red-on-revert assertion is non-vacuous.
+struct TypedEcho;
+
+impl Action for TypedEcho {
+    type Input = TypedEchoInput;
+    type Output = TypedEchoOutput;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("builtin.typed_echo"),
+            "TypedEcho",
+            "fixture with typed output",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl StatelessAction for TypedEcho {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::success(TypedEchoOutput {
+            message: input.text,
+        }))
+    }
+}
+
+// ── CountingEcho — shared-instance fixture ─────────────────────────────────
+
 /// Stateless action that counts every execution through a shared `Arc`, so a
 /// test can observe whether dispatches reuse one instance or rebuild it.
 struct CountingEcho {
@@ -138,4 +215,29 @@ async fn instance_factory_shares_one_instance_across_dispatches() {
             "shared instance: the counter must accumulate across dispatch cycles"
         );
     }
+}
+
+#[tokio::test]
+async fn instance_factory_stamps_output_schema_from_action_output_type() {
+    // TypedEcho.Output has a `message` field — the schema is non-empty.
+    // If the `output_schema` stamp is removed from `InstanceFactory::new`,
+    // this test goes RED (the field will not be present).
+    let factory = InstanceFactory::new(
+        ActionMetadata::new(
+            action_key!("tenant.typed_echo"),
+            "Typed Echo",
+            "per-registration metadata",
+        ),
+        TypedEcho,
+    );
+
+    let output_schema = factory.metadata().output_schema();
+    assert!(
+        output_schema
+            .fields()
+            .iter()
+            .any(|f| f.key().as_str() == "message"),
+        "InstanceFactory must stamp output_schema from A::Output — `message` field missing; \
+         revert the output_schema stamp in InstanceFactory::new to see this fail"
+    );
 }

--- a/crates/action/tests/type_sizes.rs
+++ b/crates/action/tests/type_sizes.rs
@@ -45,11 +45,12 @@ fn top_level_type_sizes_are_stable() {
     );
     // NOTE: ActionMetadata is a composed `BaseMetadata<ActionKey>` plus
     // action-specific fields (version / inputs / outputs / isolation / kind /
-    // checkpoint_policy / max_concurrent). The shared prefix brings Icon,
-    // documentation_url, tags (Box<[String]>), MaturityLevel, and
+    // checkpoint_policy / max_concurrent / output_schema). The shared prefix
+    // brings Icon, documentation_url, tags (Box<[String]>), MaturityLevel, and
     // Option<DeprecationNotice>. Allocation is once-per-action type — not a hot
     // path — so we accept the size in exchange for the unified catalog contract.
-    assert_eq!(size_of::<ActionMetadata>(), 376);
+    // T2 (TypeDAG): +8 bytes for `output_schema: ValidSchema` (one Arc<_>).
+    assert_eq!(size_of::<ActionMetadata>(), 384);
     assert_eq!(size_of::<ActionError>(), 72);
 
     // `WebhookRequest` contains a `SystemTime`, which is 8 bytes on


### PR DESCRIPTION
## What

Second unit (**T2**) of [ADR-0100 TypeDAG](https://github.com/vanyastaff/nebula). `ActionMetadata` carried only the input/parameters schema (`base.schema`); the per-edge connection check (T3) also needs the **producer's Output schema**. T2 adds `output_schema`, stamped from `Action::Output` by the **single-writer factory path** (next to the `kind` stamp, so it can't drift from the dispatched action). Additive to `nebula-action`; no other crate changes.

## Stamp sites (single-writer, all dispatched-action paths)

`with_output_schema(<A::Output as HasSchema>::schema())` at all 8 sites: `GenericStateless`/`Stateful`/`Trigger`/`Resource`/`Control`/`Stream` factories + `InstanceFactory` + **`ControlActionAdapter`** (the adapter bypasses the factory spine and caches its own metadata — it was the one site the first pass missed; a miss = empty output schema → T3 silently treats the edge as `Any`). `for_action::<A>()` also stamps it for direct authoring.

## Back-compat

`#[serde(default = "ValidSchema::empty")]` — metadata persisted before this field deserializes to an empty schema (which T3 treats as the `Any` gradual-typing escape). `ActionMetadata` size 376→384 (one `Arc`).

## Out of scope

T3 (`NodeSchemaResolver` trait + per-edge `is_assignable` check in `nebula-workflow` + api load wiring) — the consumer of this field.

## Evidence

- Tests (red→green): per-factory + `ControlActionAdapter` stamp tests use a typed `Output{field}` and assert the field is present in `metadata().output_schema()` (go RED if the stamp is reverted); back-compat deserialize (omits the field → empty); serde round-trip.
- rust-reviewer round 1 → NEEDS WORK (caught the `ControlActionAdapter` stamp miss + a non-typed-`Output` test that couldn't catch a missing stamp); both fixed.
- Gates: `clippy --workspace -D warnings`, `nextest` **792/792** (action+engine+sdk), `fmt`, `rustdoc -D warnings`, `cargo check --workspace` (zero ripple). Pre-push gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
