### PR TITLE
test(worker): worker-level liveness coverage + document long-job reclaim artifact (ADR-0095 D1)

### DIFF
--- a/crates/orchestrator/src/orchestrator.rs
+++ b/crates/orchestrator/src/orchestrator.rs
@@ -63,12 +63,52 @@ pub const MAX_CLAIM_ERROR_BACKOFF: Duration = Duration::from_secs(30);
 ///
 /// Matches `ControlConsumer` — 5× a 30-second lease TTL so a runner that
 /// has missed 15 heartbeats is presumed dead.
+///
+/// ## Relationship between the job-dispatch claim and execution liveness
+///
+/// The job-dispatch claim is held for the **entire synchronous drive** of a
+/// workflow: the orchestrator claims the row, hands it to the sink, and only
+/// marks it `Dispatched` or `Failed` after `ExecutionSink::dispatch` returns.
+/// There is no heartbeat on the claim while the sink is running.
+///
+/// Execution liveness is tracked separately: the engine issues a per-execution
+/// lease (renewed by `nebula-engine`'s `acquire_and_heartbeat_lease` loop) whose
+/// TTL is the authoritative signal that a runner has crashed.  The
+/// job-dispatch `reclaim_stuck` sweep is a **routing-layer** recovery
+/// mechanism, not an execution-failure detector.
+///
+/// **Implication for long-running, non-parking workflows:** if a workflow
+/// drives synchronously from `Created` to `Completed` in a single
+/// `resume_execution` call and that drive takes longer than
+/// `reclaim_after × max_reclaim_count`, the orchestrator's reclaim sweep
+/// will eventually mark the dispatch row `Failed` — even though the execution
+/// itself completed correctly.  This is a routing-row observability artifact,
+/// not an execution failure; the execution status in the execution store is
+/// unaffected.
+///
+/// Operators expecting workflows whose single synchronous drive exceeds
+/// `reclaim_after × max_reclaim_count` should increase `max_reclaim_count`
+/// via [`Orchestrator::with_max_reclaim_count`] (or the corresponding builder
+/// method on `WorkerRuntimeBuilder` in `nebula-worker`).
+/// Long workflows that park at a checkpoint do not trigger this: parking
+/// returns control to the engine, the sink returns `Ok(())`, and the dispatch
+/// row is marked `Dispatched` promptly.
+///
+/// See ADR-0017 (execution lease contract) and ADR-0095 (job-dispatch
+/// routing) for the full context.
 pub const DEFAULT_RECLAIM_AFTER: Duration = Duration::from_secs(150);
 
 /// Default cadence of the reclaim sweep.
 pub const DEFAULT_RECLAIM_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Default retry budget before a reclaim-eligible row moves to `Failed`.
+///
+/// A row that has been reclaimed this many times transitions to `Failed` on
+/// the next sweep, preventing unbounded redelivery of permanently stuck jobs.
+///
+/// As noted on [`DEFAULT_RECLAIM_AFTER`], operators running long synchronous
+/// workflows should raise this value; the dispatch `Failed` status is a
+/// routing artifact and does not indicate execution failure.
 pub const DEFAULT_MAX_RECLAIM_COUNT: u32 = 3;
 
 /// Capability-routed job-dispatch pull loop (ADR-0095).

--- a/crates/worker/tests/worker_integration.rs
+++ b/crates/worker/tests/worker_integration.rs
@@ -1,4 +1,6 @@
-//! Integration test for `nebula-worker` — U-D1.3 acceptance proof.
+//! Integration tests for `nebula-worker`: the worker-runtime claim→drive→complete
+//! happy path, plus the reclaim / redelivery / reclaim-exhaustion liveness
+//! properties of the job-dispatch claim.
 //!
 //! Verifies the full path:
 //!   `WorkerRuntimeBuilder::build` → `.spawn(cancel)` →
@@ -397,5 +399,369 @@ async fn builder_rejects_empty_plugins() {
     assert!(
         matches!(result, Err(WorkerBuildError::NoPlugins)),
         "empty available_plugins must produce WorkerBuildError::NoPlugins; got {result:?}"
+    );
+}
+
+// ── Reclaim + re-run tests ────────────────────────────────────────────────────
+
+/// A job-dispatch row that was reclaimed (reset to `Pending`) by a crashed
+/// runner is picked up by a live worker and driven to `Completed` exactly once
+/// through the real `EngineExecutionSink`.
+///
+/// Sequence:
+/// 1. Seed a `Created` execution row + enqueue a `Start` job.
+/// 2. Directly claim the row as `proc_a` (simulates a worker that claims but
+///    then crashes before returning).
+/// 3. Advance virtual time past `reclaim_after` and call `reclaim_stuck`
+///    directly — this is the same code the orchestrator's sweep executes.
+///    The row goes back to `Pending` (`reclaim_count` → 1).
+/// 4. Build and spawn a `WorkerRuntime` (proc_b) that claims the reclaimed
+///    row and drives it through the real `EngineExecutionSink`.
+/// 5. Assert execution reaches `Completed` AND the echo handler ran exactly
+///    once — ruling out spurious "already-terminal, idempotent no-op" false-greens.
+#[tokio::test(start_paused = true)]
+async fn reclaim_then_rerun_drives_exactly_once_via_real_sink() {
+    let stores = TestStores::new();
+    let (engine, echo_count) = make_engine(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
+
+    // Seed a Created execution row.
+    let execution_id = ExecutionId::new();
+    persist_created(
+        &stores,
+        workflow_id,
+        execution_id,
+        serde_json::json!({"trigger": "reclaim-rerun"}),
+    )
+    .await;
+
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
+    let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
+
+    // Enqueue a Start job.
+    let job_id = [0xAAu8; 16];
+    let msg = JobDispatchMsg::new(
+        job_id,
+        execution_id.to_string(),
+        ControlCommand::Start,
+        scope(),
+        serde_json::json!({}),
+        None::<String>,
+        "sha-reclaim-test",
+        plugin_key.clone(),
+        vec![plugin_key.clone()],
+        None::<String>,
+        0,
+    );
+    queue.enqueue(&msg).await.expect("enqueue Start job");
+
+    // Step 2: claim as proc_a (simulates a worker that crashed before dispatching).
+    let proc_a = proc16(0xAA);
+    let claimed = queue
+        .claim_pending(&proc_a, 1, std::slice::from_ref(&plugin_key))
+        .await
+        .expect("claim as proc_a");
+    assert_eq!(claimed.len(), 1, "proc_a must claim the row");
+
+    // Step 3: advance past reclaim_after and call reclaim_stuck directly.
+    // Use a tiny reclaim_after so a small virtual-time advance suffices.
+    let tiny_reclaim_after = Duration::from_millis(5);
+    tokio::time::advance(Duration::from_millis(10)).await;
+    let outcome = queue
+        .reclaim_stuck(tiny_reclaim_after, 3)
+        .await
+        .expect("reclaim_stuck");
+    assert_eq!(
+        outcome.reclaimed, 1,
+        "the Processing row must be reclaimed to Pending"
+    );
+    assert_eq!(
+        outcome.exhausted, 0,
+        "budget=3 > reclaim_count=0; must not exhaust"
+    );
+
+    // The execution row must still be Created — reclaim does not touch it.
+    let status_after_reclaim = read_status(&stores, execution_id)
+        .await
+        .expect("execution row must exist after reclaim");
+    assert_eq!(
+        status_after_reclaim,
+        ExecutionStatus::Created,
+        "execution row must remain Created after job-dispatch reclaim; got {status_after_reclaim:?}"
+    );
+
+    // Step 4: build a worker (proc_b) and let it claim + drive the reclaimed row.
+    let proc_b = proc16(0xBB);
+    let runtime = WorkerRuntimeBuilder::from_wired_engine(
+        Arc::clone(&engine),
+        stores.execution_stores(),
+        Arc::clone(&queue) as Arc<dyn JobDispatchQueue>,
+        vec![plugin_key],
+        proc_b,
+    )
+    .with_poll_interval(Duration::from_millis(10))
+    .build()
+    .expect("WorkerRuntimeBuilder::build must succeed");
+
+    let cancel = CancellationToken::new();
+    let handle = runtime.spawn(cancel.clone());
+
+    // Step 5: wait for the execution to reach Completed.
+    let mut completed = false;
+    for _ in 0..200 {
+        tokio::task::yield_now().await;
+        if read_status(&stores, execution_id).await == Some(ExecutionStatus::Completed) {
+            completed = true;
+            break;
+        }
+        tokio::time::advance(Duration::from_millis(10)).await;
+    }
+    assert!(
+        completed,
+        "reclaimed job was not driven to Completed within the poll budget"
+    );
+
+    cancel.cancel();
+    handle.await.expect("worker task must not panic");
+
+    // Echo handler must have fired exactly once — confirms the real sink ran and
+    // did not short-circuit on an idempotent no-op for an already-terminal status.
+    assert_eq!(
+        echo_count.load(Ordering::SeqCst),
+        1,
+        "echo handler must be invoked exactly once after reclaim+redispatch; got {}",
+        echo_count.load(Ordering::SeqCst)
+    );
+}
+
+/// A second `EngineExecutionSink::dispatch` of the same `Start` job on an
+/// execution that is already `Completed` is a safe no-op: it returns `Ok(())`
+/// and does NOT re-run the action handler (echo counter stays at 1).
+///
+/// This directly exercises the `read_status` → terminal → `Ok(())` guard in
+/// `EngineExecutionSink::dispatch` (the idempotency contract documented in
+/// `execution_sink.rs`).  The test dispatches twice on a `Completed` execution
+/// because driving to a clean intermediate `Running` state is not possible with
+/// the synchronous echo engine (the engine drives from `Created` to `Completed`
+/// in one call).
+#[tokio::test(start_paused = true)]
+async fn redelivered_start_on_running_or_terminal_is_noop() {
+    use nebula_engine::EngineExecutionSink;
+    use nebula_orchestrator::ExecutionSink;
+
+    let stores = TestStores::new();
+    let (engine, echo_count) = make_engine(&stores).await;
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
+
+    // Seed a Created execution row.
+    let execution_id = ExecutionId::new();
+    persist_created(
+        &stores,
+        workflow_id,
+        execution_id,
+        serde_json::json!({"trigger": "idempotency-test"}),
+    )
+    .await;
+
+    // Build the real EngineExecutionSink (same wiring as WorkerRuntimeBuilder).
+    let sink = EngineExecutionSink::new(
+        Arc::clone(&engine),
+        Arc::clone(&stores.execution) as Arc<dyn ExecutionStore>,
+    );
+
+    let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
+    let job_id = [0xCCu8; 16];
+    let msg = JobDispatchMsg::new(
+        job_id,
+        execution_id.to_string(),
+        ControlCommand::Start,
+        scope(),
+        serde_json::json!({}),
+        None::<String>,
+        "sha-idem-test",
+        plugin_key.clone(),
+        vec![plugin_key],
+        None::<String>,
+        0,
+    );
+
+    // First dispatch: drives Created → Completed; handler runs once.
+    let result1 = sink.dispatch(&msg).await;
+    assert!(
+        result1.is_ok(),
+        "first dispatch must succeed; got {result1:?}"
+    );
+    assert_eq!(
+        echo_count.load(Ordering::SeqCst),
+        1,
+        "echo handler must run exactly once on first dispatch"
+    );
+
+    let status_after_first = read_status(&stores, execution_id)
+        .await
+        .expect("execution row must exist");
+    assert_eq!(
+        status_after_first,
+        ExecutionStatus::Completed,
+        "execution must be Completed after first dispatch; got {status_after_first:?}"
+    );
+
+    // Second dispatch: execution is already Completed; must be a no-op.
+    let result2 = sink.dispatch(&msg).await;
+    assert!(
+        result2.is_ok(),
+        "re-delivered Start on a Completed execution must return Ok(()); got {result2:?}"
+    );
+
+    // The echo handler must NOT have been invoked a second time.
+    assert_eq!(
+        echo_count.load(Ordering::SeqCst),
+        1,
+        "echo handler must NOT run again on re-delivered Start (idempotency guard); count={}",
+        echo_count.load(Ordering::SeqCst)
+    );
+
+    // Execution status must be unchanged.
+    let status_after_second = read_status(&stores, execution_id)
+        .await
+        .expect("execution row must still exist");
+    assert_eq!(
+        status_after_second,
+        ExecutionStatus::Completed,
+        "execution status must remain Completed after second dispatch; got {status_after_second:?}"
+    );
+
+    // Verify result2 is specifically Ok, not an error disguised as ok.
+    result2.expect("re-delivered Start must be Ok(())");
+}
+
+/// When a job-dispatch row is reclaimed `max_reclaim_count` times its status
+/// moves to `Failed`.  This does NOT affect the execution row.
+///
+/// This test documents the "long-job artifact" as a property: a dispatch row
+/// can reach `Failed` while the execution it represents is `Completed`.
+/// `claim_pending` no longer returns the exhausted row.
+///
+/// Seeded execution is `Completed` from the start to make the independence
+/// of the two tables concrete and visible in the assertion.
+#[tokio::test(start_paused = true)]
+async fn job_dispatch_row_exhausted_to_failed_leaves_execution_intact() {
+    let stores = TestStores::new();
+    let workflow = save_echo_workflow(&stores).await;
+    let workflow_id = workflow.definition().id;
+
+    // Seed the execution already Completed (via an engine run).
+    let (engine, _echo_count) = make_engine(&stores).await;
+    let execution_id = ExecutionId::new();
+    persist_created(
+        &stores,
+        workflow_id,
+        execution_id,
+        serde_json::json!({"trigger": "exhaustion-test"}),
+    )
+    .await;
+
+    // Drive to Completed via the engine so the status is durable.
+    engine
+        .resume_execution(&scope(), execution_id)
+        .await
+        .expect("initial engine run to Completed");
+
+    let status_before = read_status(&stores, execution_id)
+        .await
+        .expect("execution row must exist");
+    assert_eq!(
+        status_before,
+        ExecutionStatus::Completed,
+        "execution must start Completed for this property test; got {status_before:?}"
+    );
+
+    // Enqueue a separate job-dispatch row (simulates a Start that was issued
+    // but whose job row is now being reclaimed repeatedly).
+    let queue = Arc::new(InMemoryJobDispatchQueue::new(&stores.execution));
+    let plugin_key: PluginKey = TEST_PLUGIN_KEY.parse().unwrap();
+    let job_id = [0xDDu8; 16];
+    let msg = JobDispatchMsg::new(
+        job_id,
+        execution_id.to_string(),
+        ControlCommand::Start,
+        scope(),
+        serde_json::json!({}),
+        None::<String>,
+        "sha-exhaust-test",
+        plugin_key.clone(),
+        vec![plugin_key.clone()],
+        None::<String>,
+        0,
+    );
+    queue.enqueue(&msg).await.expect("enqueue job");
+
+    // max_reclaim_count = 2: the row exhausts after being reclaimed twice.
+    let max_reclaim_count: u32 = 2;
+    let tiny = Duration::from_millis(1);
+    let tags = vec![plugin_key.clone()];
+    let crasher = proc16(0xDD);
+
+    // Reclaim loop: claim, advance time, reclaim_stuck, repeat until exhausted.
+    let mut exhausted = false;
+    for i in 0..=max_reclaim_count {
+        // Claim (puts row Processing).
+        let claimed = queue
+            .claim_pending(&crasher, 1, &tags)
+            .await
+            .expect("claim");
+        if claimed.is_empty() {
+            // Row is no longer Pending (it must be Failed/exhausted).
+            exhausted = true;
+            break;
+        }
+        assert_eq!(
+            claimed.len(),
+            1,
+            "must claim exactly one row on iteration {i}"
+        );
+
+        // Do NOT mark dispatched — simulate a crash.
+        // Advance virtual time past reclaim_after so the row becomes stale.
+        tokio::time::advance(Duration::from_millis(5)).await;
+
+        let outcome = queue
+            .reclaim_stuck(tiny, max_reclaim_count)
+            .await
+            .expect("reclaim_stuck");
+
+        // When reclaim_count reaches max_reclaim_count the sweep exhausts the row.
+        if outcome.exhausted >= 1 {
+            exhausted = true;
+            break;
+        }
+    }
+    assert!(
+        exhausted,
+        "job-dispatch row must exhaust to Failed within max_reclaim_count reclaims"
+    );
+
+    // Execution row must be unaffected — still Completed.
+    let status_after = read_status(&stores, execution_id)
+        .await
+        .expect("execution row must still exist after job-dispatch exhaustion");
+    assert_eq!(
+        status_after,
+        ExecutionStatus::Completed,
+        "execution status must remain Completed after job-dispatch row exhausts; \
+         dispatch-row failure is a routing artifact, not an execution failure; \
+         got {status_after:?}"
+    );
+
+    // The exhausted (Failed) row must no longer be returned by claim_pending.
+    let leftover = queue
+        .claim_pending(&proc16(0xEE), 8, &tags)
+        .await
+        .expect("probe claim");
+    assert!(
+        leftover.is_empty(),
+        "exhausted (Failed) job-dispatch row must not be returned by claim_pending"
     );
 }


### PR DESCRIPTION
## What

ADR-0095 D1 **worker liveness (U-D1.6)** — **verify + document only, no contract change**. The dead-worker reclaim machinery already lives in `main` (`JobDispatchQueue::reclaim_stuck` wired into the orchestrator sweep; processor-fenced claims; the engine's per-execution lease heartbeat). This unit closes the missing **worker-level** test coverage and documents a known artifact.

## Tests (durable in-memory, `crates/worker/tests/worker_integration.rs`)
- `reclaim_then_rerun_drives_exactly_once_via_real_sink` — a reclaimed (Pending-again) job-dispatch row is picked up by a worker and driven to `Completed` exactly once through the **real** `EngineExecutionSink` (asserts the action ran once; RED if it double-runs or the reclaim is cosmetic).
- `redelivered_start_on_running_or_terminal_is_noop` — a redelivered `Start` on a terminal execution hits the `read_status` idempotency guard → `Ok`, no re-run.
- `job_dispatch_row_exhausted_to_failed_leaves_execution_intact` — reclaim-to-exhaustion marks the dispatch row `Failed` while the execution row is untouched (the long-job artifact, asserted as a property).

## Docs
`DEFAULT_RECLAIM_AFTER` / `DEFAULT_MAX_RECLAIM_COUNT` now explain the claim-vs-execution-lease liveness split and the long-job artifact (a non-parking run exceeding `reclaim_after × max_reclaim_count` has its dispatch row marked `Failed` while the execution completes — mitigated by raising `max_reclaim_count`).

## Out of scope (deferred by design)
The job-dispatch **claim heartbeat** / claim-release-after-start fix for long non-parking runs is deferred to the dispatch-model rearchitecture (ADR-0101 Bind seam) — bolting a heartbeat onto the current synchronous-drive model would be throwaway. U-D1.F (real flavor worker binary) stays blocked on the absence of a first-party plugin set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)