### PR TITLE
refactor(action)!: remove superseded ActionOutput::Streaming machinery (ADR-0102 D-1/D-2)

### DIFF
--- a/crates/action/docs/DESIGN.md
+++ b/crates/action/docs/DESIGN.md
@@ -55,7 +55,7 @@
 | `ActionError` + `RetryHintCode` (retryable vs fatal), `ValidationReason` | `src/error.rs:154,31,58` |
 | `ActionMetadata`, `ActionKind`, `CheckpointPolicy`, `IsolationLevel` | `src/metadata.rs:131,48,83,13` |
 | `ActionResult<T>`, `TerminationReason`, `WaitCondition`, `BranchKey` | `src/result.rs:40,195,297` |
-| `ActionOutput<T>`, `OutputEnvelope`, `DeferredOutput`, `StreamOutput` | `src/output.rs:506,465,86,206` |
+| `ActionOutput<T>`, `OutputEnvelope`, `DeferredOutput` | `src/output.rs` |
 | `ActionContext`/`TriggerContext` + `ActionRuntimeContext`/`TriggerRuntimeContext` | `src/context.rs:81,108,144,397` |
 | `#[derive(Action)]` + `#[action_phantom]` (proc-macro) | `macros/src/lib.rs` (re-export `lib.rs:126`) |
 | `TestActionContext`, `Spy*`, `StatefulTestHarness` | `src/testing.rs` |

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -131,10 +131,9 @@ pub use nebula_credential::{CredentialGuard, CredentialRef};
 pub use nebula_resource::ResourceRef;
 pub use nebula_schema::{Field, Schema, ValidSchema, field_key};
 pub use output::{
-    ActionOutput, BinaryData, BinaryStorage, BufferConfig, CacheInfo, Cost, DataReference,
-    DeferredOutput, DeferredRetryConfig, DeltaFormat, ExpectedOutput, OutputEnvelope, OutputMeta,
-    OutputOrigin, Overflow, PollTarget, Producer, ProducerKind, Progress, Resolution, StreamMode,
-    StreamOutput, StreamState, Timing, TokenUsage,
+    ActionOutput, BinaryData, BinaryStorage, CacheInfo, Cost, DataReference, DeferredOutput,
+    DeferredRetryConfig, ExpectedOutput, OutputEnvelope, OutputMeta, OutputOrigin, PollTarget,
+    Producer, ProducerKind, Progress, Resolution, Timing, TokenUsage,
 };
 pub use poll::{
     DeduplicatingCursor, EmitFailurePolicy, POLL_INTERVAL_FLOOR, PollAction, PollConfig,

--- a/crates/action/src/output.rs
+++ b/crates/action/src/output.rs
@@ -192,113 +192,8 @@ pub enum ExpectedOutput {
     },
     /// Will resolve to `ActionOutput::Reference`.
     Reference,
-    /// Will resolve to `ActionOutput::Streaming`.
-    Stream,
     /// Unknown at compile time.
     Dynamic,
-}
-
-/// A stream of output chunks arriving incrementally.
-///
-/// The engine can collect all chunks into a final value, forward the
-/// stream to a streaming-aware downstream node, or tap for progress.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct StreamOutput {
-    /// Unique stream identifier for subscription.
-    pub stream_id: String,
-    /// What kind of data is being streamed and how to consume it.
-    pub mode: StreamMode,
-    /// What the collected stream will produce.
-    pub expected: ExpectedOutput,
-    /// Current stream state (for serialization/checkpointing).
-    pub state: StreamState,
-    /// Backpressure configuration.
-    pub buffer: Option<BufferConfig>,
-}
-
-/// Streaming mode — determines how the engine processes chunks.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "mode", rename_all = "snake_case")]
-#[non_exhaustive]
-pub enum StreamMode {
-    /// LLM token stream. Engine concatenates tokens into final text.
-    Tokens {
-        /// Model producing tokens.
-        model: String,
-    },
-    /// Raw byte chunks (file download, binary generation).
-    Bytes {
-        /// MIME content type.
-        content_type: String,
-        /// Total expected size (for progress bars, pre-allocation).
-        total_size: Option<u64>,
-    },
-    /// JSON patches/deltas. Engine applies patches to build final Value.
-    Deltas {
-        /// Delta format.
-        format: DeltaFormat,
-    },
-    /// Server-Sent Events style: heterogeneous typed events.
-    Events,
-    /// Custom protocol — engine passes through, downstream interprets.
-    Custom {
-        /// Protocol identifier.
-        protocol: String,
-    },
-}
-
-/// Delta format for streaming patches.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub enum DeltaFormat {
-    /// RFC 7396.
-    JsonMergePatch,
-    /// RFC 6902.
-    JsonPatch,
-}
-
-/// Current state of a stream.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum StreamState {
-    /// Created but not started.
-    Pending,
-    /// Actively producing.
-    Active {
-        /// Number of chunks received so far.
-        chunks_received: u64,
-    },
-    /// Paused (backpressure, rate limit).
-    Paused,
-    /// Done — all data received.
-    Completed,
-    /// Error during streaming.
-    Failed {
-        /// Error description.
-        error: String,
-    },
-}
-
-/// Backpressure configuration for streams.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct BufferConfig {
-    /// Maximum number of buffered items.
-    pub capacity: usize,
-    /// What to do when buffer is full.
-    pub on_overflow: Overflow,
-}
-
-/// Overflow strategy when a stream buffer is full.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum Overflow {
-    /// Block the producer until space is available.
-    Block,
-    /// Drop the oldest item in the buffer.
-    DropOldest,
-    /// Drop the newest (incoming) item.
-    DropNewest,
-    /// Return an error to the producer.
-    Error,
 }
 
 /// Who/what is producing the output.
@@ -489,8 +384,8 @@ impl<T> OutputEnvelope<T> {
 /// First-class output type for actions.
 ///
 /// The engine dispatches on this enum to decide how to pass data between
-/// nodes. Variants cover immediate data, deferred (lazy) results, and
-/// streaming outputs.
+/// nodes. Variants cover immediate data, deferred (lazy) results, binary
+/// payloads, external references, collections, and empty outputs.
 ///
 /// ## Relationship with `ActionResult`
 ///
@@ -500,6 +395,13 @@ impl<T> OutputEnvelope<T> {
 /// An action can return `ActionResult::Success { output: ActionOutput::Deferred(..) }`
 /// meaning: "I successfully initiated generation — here's the handle."
 /// The engine resolves the Deferred before passing data to downstream nodes.
+///
+/// ## Stream kind
+///
+/// Stream actions fold their chunk stream into a single
+/// `ActionOutput::Value` before returning; there is no inline streaming
+/// variant on this enum. The fold happens inside the stream adapter and the
+/// engine receives a plain `Value`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 #[non_exhaustive]
@@ -516,11 +418,6 @@ pub enum ActionOutput<T> {
     /// but the result isn't ready yet. The engine resolves this before
     /// passing to downstream nodes.
     Deferred(Box<DeferredOutput>),
-    /// Output arriving as a stream of chunks.
-    ///
-    /// The engine can collect into a final value before passing downstream,
-    /// or forward the stream if downstream supports streaming.
-    Streaming(StreamOutput),
     /// Multiple outputs in one (batch results, fan-out).
     Collection(Vec<ActionOutput<T>>),
     /// No output produced.
@@ -535,7 +432,6 @@ impl<T> ActionOutput<T> {
             Self::Binary(b) => ActionOutput::Binary(b),
             Self::Reference(r) => ActionOutput::Reference(r),
             Self::Deferred(d) => ActionOutput::Deferred(d),
-            Self::Streaming(s) => ActionOutput::Streaming(s),
             Self::Collection(items) => {
                 ActionOutput::Collection(items.into_iter().map(|item| item.map(f)).collect())
             },
@@ -553,7 +449,6 @@ impl<T> ActionOutput<T> {
             Self::Binary(b) => Ok(ActionOutput::Binary(b)),
             Self::Reference(r) => Ok(ActionOutput::Reference(r)),
             Self::Deferred(d) => Ok(ActionOutput::Deferred(d)),
-            Self::Streaming(s) => Ok(ActionOutput::Streaming(s)),
             Self::Collection(items) => {
                 let mapped = items
                     .into_iter()
@@ -601,11 +496,6 @@ impl<T> ActionOutput<T> {
         matches!(self, Self::Deferred(_))
     }
 
-    /// Returns `true` if this is a `Streaming` variant.
-    pub fn is_streaming(&self) -> bool {
-        matches!(self, Self::Streaming(_))
-    }
-
     /// Returns `true` if this is a `Collection` variant.
     pub fn is_collection(&self) -> bool {
         matches!(self, Self::Collection(_))
@@ -620,7 +510,7 @@ impl<T> ActionOutput<T> {
     /// before passing to downstream nodes.
     pub fn needs_resolution(&self) -> bool {
         match self {
-            Self::Deferred(_) | Self::Streaming(_) => true,
+            Self::Deferred(_) => true,
             Self::Collection(items) => items.iter().any(ActionOutput::needs_resolution),
             _ => false,
         }
@@ -709,39 +599,6 @@ impl<T> ActionOutput<T> {
             timeout,
         }))
     }
-
-    /// Create an LLM token stream output.
-    pub fn llm_stream(stream_id: impl Into<String>, model: impl Into<String>) -> Self {
-        Self::Streaming(StreamOutput {
-            stream_id: stream_id.into(),
-            mode: StreamMode::Tokens {
-                model: model.into(),
-            },
-            expected: ExpectedOutput::Value { schema: None },
-            state: StreamState::Pending,
-            buffer: None,
-        })
-    }
-
-    /// Create a binary stream (file download, progressive render).
-    pub fn byte_stream(
-        stream_id: impl Into<String>,
-        content_type: impl Into<String>,
-        total_size: Option<u64>,
-    ) -> Self {
-        Self::Streaming(StreamOutput {
-            stream_id: stream_id.into(),
-            mode: StreamMode::Bytes {
-                content_type: content_type.into(),
-                total_size,
-            },
-            expected: ExpectedOutput::Binary {
-                content_type: "application/octet-stream".into(),
-            },
-            state: StreamState::Pending,
-            buffer: None,
-        })
-    }
 }
 
 /// Binary data carried inline or stored externally.
@@ -828,7 +685,6 @@ mod tests {
         assert!(!out.is_binary());
         assert!(!out.is_reference());
         assert!(!out.is_deferred());
-        assert!(!out.is_streaming());
         assert!(!out.is_collection());
         assert!(!out.is_empty());
         assert_eq!(out.as_value(), Some(&42));
@@ -877,23 +733,6 @@ mod tests {
         }));
         assert!(out.is_deferred());
         assert!(!out.is_value());
-        assert!(!out.is_streaming());
-        assert!(out.needs_resolution());
-    }
-
-    #[test]
-    fn action_output_streaming() {
-        let out: ActionOutput<i32> = ActionOutput::Streaming(StreamOutput {
-            stream_id: "stream-1".into(),
-            mode: StreamMode::Tokens {
-                model: "claude".into(),
-            },
-            expected: ExpectedOutput::Value { schema: None },
-            state: StreamState::Pending,
-            buffer: None,
-        });
-        assert!(out.is_streaming());
-        assert!(!out.is_deferred());
         assert!(out.needs_resolution());
     }
 
@@ -1124,44 +963,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn llm_stream_constructor() {
-        let out =
-            ActionOutput::<serde_json::Value>::llm_stream("stream-1", "claude-sonnet-4-20250514");
-        assert!(out.is_streaming());
-        assert!(out.needs_resolution());
-        match &out {
-            ActionOutput::Streaming(s) => {
-                assert_eq!(s.stream_id, "stream-1");
-                assert!(matches!(s.mode, StreamMode::Tokens { .. }));
-                assert_eq!(s.state, StreamState::Pending);
-            },
-            _ => panic!("expected Streaming"),
-        }
-    }
-
-    #[test]
-    fn byte_stream_constructor() {
-        let out =
-            ActionOutput::<serde_json::Value>::byte_stream("bs-1", "video/mp4", Some(1_000_000));
-        match &out {
-            ActionOutput::Streaming(s) => {
-                assert_eq!(s.stream_id, "bs-1");
-                match &s.mode {
-                    StreamMode::Bytes {
-                        content_type,
-                        total_size,
-                    } => {
-                        assert_eq!(content_type, "video/mp4");
-                        assert_eq!(*total_size, Some(1_000_000));
-                    },
-                    _ => panic!("expected Bytes mode"),
-                }
-            },
-            _ => panic!("expected Streaming"),
-        }
-    }
-
     // ── OutputEnvelope tests ────────────────────────────────────────
 
     #[test]
@@ -1219,28 +1020,6 @@ mod tests {
         let json = serde_json::to_string(&deferred).unwrap();
         let back: DeferredOutput = serde_json::from_str(&json).unwrap();
         assert_eq!(deferred, back);
-    }
-
-    #[test]
-    fn serde_stream_output_roundtrip() {
-        let stream = StreamOutput {
-            stream_id: "s-1".into(),
-            mode: StreamMode::Tokens {
-                model: "claude".into(),
-            },
-            expected: ExpectedOutput::Value { schema: None },
-            state: StreamState::Active {
-                chunks_received: 42,
-            },
-            buffer: Some(BufferConfig {
-                capacity: 100,
-                on_overflow: Overflow::DropOldest,
-            }),
-        };
-
-        let json = serde_json::to_string(&stream).unwrap();
-        let back: StreamOutput = serde_json::from_str(&json).unwrap();
-        assert_eq!(stream, back);
     }
 
     #[test]

--- a/crates/action/src/prelude.rs
+++ b/crates/action/src/prelude.rs
@@ -25,7 +25,6 @@ pub use crate::{
     metadata::{ActionMetadata, MetadataCompatibilityError},
     output::{
         ActionOutput, DeferredOutput, ExpectedOutput, Producer, ProducerKind, Progress, Resolution,
-        StreamMode, StreamOutput,
     },
     poll::{
         DeduplicatingCursor, EmitFailurePolicy, PollAction, PollConfig, PollCursor, PollOutcome,

--- a/crates/action/src/result.rs
+++ b/crates/action/src/result.rs
@@ -1304,25 +1304,6 @@ mod tests {
     }
 
     #[test]
-    fn map_output_with_streaming() {
-        use crate::output::{ExpectedOutput, StreamMode, StreamOutput, StreamState};
-        let r: ActionResult<i32> = ActionResult::Success {
-            output: ActionOutput::Streaming(StreamOutput {
-                stream_id: "s".into(),
-                mode: StreamMode::Events,
-                expected: ExpectedOutput::Dynamic,
-                state: StreamState::Pending,
-                buffer: None,
-            }),
-        };
-        let mapped = r.map_output(|n| n * 2);
-        match mapped {
-            ActionResult::Success { output } => assert!(output.is_streaming()),
-            _ => panic!("expected Success"),
-        }
-    }
-
-    #[test]
     fn map_output_with_collection() {
         let r: ActionResult<i32> = ActionResult::Success {
             output: ActionOutput::Collection(vec![ActionOutput::Value(1), ActionOutput::Value(2)]),

--- a/crates/action/tests/type_sizes.rs
+++ b/crates/action/tests/type_sizes.rs
@@ -16,7 +16,7 @@ use std::{collections::HashMap, mem::size_of, time::Duration};
 
 use nebula_action::{
     ActionError, ActionMetadata, ActionOutput, ActionResult, ActionRuntimeContext, BinaryData,
-    Cost, DeferredOutput, OutputEnvelope, OutputMeta, Progress, StreamOutput, Timing, TokenUsage,
+    Cost, DeferredOutput, OutputEnvelope, OutputMeta, Progress, Timing, TokenUsage,
     TriggerEventOutcome, WebhookRequest,
 };
 
@@ -39,7 +39,7 @@ fn top_level_type_sizes_are_stable() {
     );
     assert_eq!(
         size_of::<ActionOutput<serde_json::Value>>(),
-        144,
+        136,
         "ActionOutput<Value> grew — `BinaryData` is the inline variant \
          that drives this size, check it first."
     );
@@ -80,9 +80,8 @@ fn output_support_type_sizes_are_stable() {
     // sizes so the engine-side work that boxes or slims them later
     // has explicit before/after numbers.
     assert_eq!(size_of::<BinaryData>(), 136);
-    assert_eq!(size_of::<StreamOutput>(), 136);
     assert_eq!(size_of::<DeferredOutput>(), 360);
-    assert_eq!(size_of::<OutputEnvelope<serde_json::Value>>(), 416);
+    assert_eq!(size_of::<OutputEnvelope<serde_json::Value>>(), 408);
     assert_eq!(size_of::<OutputMeta>(), 272);
     assert_eq!(size_of::<Progress>(), 48);
     assert_eq!(size_of::<Timing>(), 56);
@@ -128,7 +127,6 @@ fn print_type_size_baseline() {
         ("WebhookRequest", size_of::<WebhookRequest>()),
         ("TriggerEventOutcome", size_of::<TriggerEventOutcome>()),
         ("BinaryData", size_of::<BinaryData>()),
-        ("StreamOutput", size_of::<StreamOutput>()),
         ("DeferredOutput", size_of::<DeferredOutput>()),
         (
             "OutputEnvelope<Value>",

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -802,14 +802,10 @@ impl ActionRuntime {
                     })?
                     .len() as u64,
                 // Intentional size-0: Deferred carries retry config + resolution
-                // metadata (no inline payload); Streaming carries a StreamOutput
-                // descriptor (mode + state tag, no inline bytes). The real payload
-                // for both is sized after resolution — either at the resolution site
-                // (Deferred resolved by the engine's resolution pass) or in the
-                // stream adapter (StreamAction::dispatch returns ActionOutput::Value
-                // once the fold completes, which IS measured above). Empty has no
-                // payload by definition.
-                ActionOutput::Deferred(_) | ActionOutput::Streaming(_) | ActionOutput::Empty => 0,
+                // metadata (no inline payload); the real payload is sized after
+                // resolution at the resolution site. Empty has no payload by
+                // definition.
+                ActionOutput::Deferred(_) | ActionOutput::Empty => 0,
                 ActionOutput::Collection(_) => 0, // collections are flattened before this loop
                 _ => 0,
             };
@@ -974,9 +970,9 @@ fn estimated_action_output_payload_bytes(slot: &ActionOutput<serde_json::Value>)
             .size
             .unwrap_or_else(|| serde_json::to_vec(r).map_or(0, |b| b.len() as u64)),
         // Size-0 is intentional — same rationale as enforce_data_limit:
-        // Deferred and Streaming carry descriptors, not inline payloads.
+        // Deferred carries retry config + resolution metadata, not inline
+        // payload bytes. The real payload is measured after resolution.
         ActionOutput::Deferred(_) => 0,
-        ActionOutput::Streaming(_) => 0,
         ActionOutput::Collection(items) => items
             .iter()
             .map(estimated_action_output_payload_bytes)

--- a/crates/engine/src/runtime/stream_backpressure.rs
+++ b/crates/engine/src/runtime/stream_backpressure.rs
@@ -5,10 +5,22 @@
 
 use std::{collections::VecDeque, sync::Arc};
 
-use nebula_action::Overflow;
 use tokio::sync::{Mutex, Notify};
 
 use crate::RuntimeError;
+
+/// Overflow policy for a bounded stream buffer when it is full.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Overflow {
+    /// Block the producer until buffer space is available.
+    Block,
+    /// Evict the oldest buffered item to make room.
+    DropOldest,
+    /// Drop the incoming item silently.
+    DropNewest,
+    /// Return an error to the producer.
+    Error,
+}
 
 /// Result of pushing an item into a bounded stream buffer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
## What

S5-cleanup (ADR-0102 §Execution-contract **D-1/D-2**): removes the **dead** `ActionOutput::Streaming` machinery. The Stream kind returns `ActionResult::Success{ActionOutput::Value(folded)}` (S1 collect-fold), so no prod action ever constructed `ActionOutput::Streaming` — verified by grep (all consumers were the definition + its own tests + two engine `match` arms). −272/+36.

## Removed

`ActionOutput::Streaming` variant · `StreamOutput`/`StreamMode`/`StreamState`/`DeltaFormat`/`BufferConfig`/`Overflow` · `ExpectedOutput::Stream` · `llm_stream`/`byte_stream`/`is_streaming` · the `Streaming` arms in `needs_resolution`/`map`/`try_map` · the dead Streaming tests · lib/prelude re-exports. This deletes the **"questionable shape"** ADR-0102 §Decision-3 flagged — `StreamState` execution state (e.g. `chunks_received`) baked into the *persisted* output value.

## D-2 (data-limit)

Dropped `Streaming(_)` from the engine `enforce_data_limit` / `estimated_action_output_payload_bytes` size-0 arms → `Deferred(_) | Empty => 0`. The Streaming size-0 bypass flagged in D-2 is gone; `Deferred|Empty => 0` is correct (no inline payload).

## `Overflow` relocation (the one non-removal change)

`Overflow` was **not** fully dead — the live engine module `runtime::stream_backpressure` (`BoundedStreamBuffer`/`PushOutcome`) imported `nebula_action::Overflow`. Relocated it to a local def in `stream_backpressure.rs` (same variants `Block`/`DropOldest`/`DropNewest`/`Error`, no behavior change). Backpressure policy belongs with the backpressure module; the output-descriptor crate no longer carries it.

## Semver

Breaking removal of `pub` items from **internal** `nebula-action` — **not re-exported by the public `nebula-sdk`** (grep-confirmed), so no external semver impact. `cargo-semver-checks` will flag the variant removal; acceptable per the #830 `ActionCategory`-removal precedent.

## Evidence

Removal ⇒ "whole workspace compiles + all tests green proves nothing real depended on it": `cargo check --workspace`, `clippy --workspace -D warnings`, `nextest` **791/791** (action+engine+sdk, incl. the kept Deferred `needs_resolution` tests), `fmt`, `rustdoc -D warnings` all green. `git grep` → zero remaining Streaming references. rust-reviewer **CLEAN** (7/7 scrutiny points, incl. nothing-live-deleted + the Overflow relocation soundness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated design documentation to reflect API surface changes.

* **Tests**
  * Updated type size regression tests; removed streaming-related test cases.

* **Refactor**
  * Removed streaming-related types and constructors from public API.
  * Internal stream handling reorganized; related type definitions now defined locally within runtime module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->