### PR TITLE
feat(engine): plugin→engine action-wiring bridge + first first-party plugin (ADR-0095 D1/D2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3777,6 +3777,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nebula-plugin-core"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "nebula-action",
+ "nebula-core",
+ "nebula-engine",
+ "nebula-execution",
+ "nebula-metadata",
+ "nebula-metrics",
+ "nebula-plugin",
+ "nebula-schema",
+ "nebula-storage-port",
+ "nebula-workflow",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "nebula-plugin-macros"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ members = [
   "crates/action/macros",
   "crates/credential/macros",
   "crates/plugin/macros",
+  "crates/plugin-core",
   "crates/validator/macros",
   "examples",
 ]

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -456,11 +456,6 @@ impl WorkflowEngine {
         &self.plugin_registry
     }
 
-    /// Mutable access to the node registry.
-    pub fn plugin_registry_mut(&mut self) -> &mut PluginRegistry {
-        &mut self.plugin_registry
-    }
-
     /// The closed `kind → typed registrar` allowlist.
     ///
     /// This is the only path from a stored resource row (a `kind` string
@@ -741,6 +736,112 @@ impl WorkflowEngine {
     pub fn with_resource_registrars(mut self, registrars: ResourceActivatorRegistry) -> Self {
         self.resource_registrars = registrars;
         self
+    }
+
+    /// Wire a resolved plugin's actions into the engine's executable registry.
+    ///
+    /// Registers every action factory declared by `plugin` into the engine's
+    /// live [`ActionRegistry`](crate::ActionRegistry) (making those actions
+    /// dispatchable) **and** records the plugin in the engine's
+    /// [`PluginRegistry`] (making its metadata queryable).
+    ///
+    /// # Idempotency / duplicate policy
+    ///
+    /// - Registering the **same plugin key** twice is rejected with
+    ///   `PluginWiringError::DuplicatePlugin`.
+    /// - If any **action key** contributed by the plugin already exists in the
+    ///   `ActionRegistry`, wiring is aborted before any mutation and
+    ///   `PluginWiringError::DuplicateActionKey` is returned.
+    ///
+    /// # Out of scope (explicit deferrals)
+    ///
+    /// Resource and credential wiring are not handled here; see
+    /// `crate::plugin_wiring::PluginWiringError` doc for rationale. Actions
+    /// that require no resources or credentials work end-to-end via this path.
+    ///
+    /// # Errors
+    ///
+    /// Returns `PluginWiringError` on duplicate plugin or duplicate action key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,ignore
+    /// use std::sync::Arc;
+    /// use nebula_engine::{WorkflowEngine, PluginWiringError};
+    /// use nebula_plugin::ResolvedPlugin;
+    ///
+    /// let plugin = Arc::new(ResolvedPlugin::from(MyPlugin::new())?);
+    /// let engine = WorkflowEngine::new(runtime, metrics)?
+    ///     .with_plugin(plugin)?;
+    /// ```
+    pub fn with_plugin(
+        mut self,
+        plugin: Arc<nebula_plugin::ResolvedPlugin>,
+    ) -> Result<Self, crate::plugin_wiring::PluginWiringError> {
+        use crate::plugin_wiring::PluginWiringError;
+
+        let plugin_key = plugin.key().clone();
+
+        // Guard: duplicate plugin key in the plugin registry.
+        if self.plugin_registry.contains(&plugin_key) {
+            tracing::warn!(
+                target: "nebula_engine::plugin_wiring",
+                plugin_key = %plugin_key,
+                "with_plugin: rejected duplicate plugin key"
+            );
+            return Err(PluginWiringError::DuplicatePlugin { plugin_key });
+        }
+
+        // Guard: pre-flight check for duplicate action keys before any mutation.
+        // `ActionRegistry::get_factory` uses `&self` (interior-mutable DashMap),
+        // so we can probe without taking ownership of the registry.
+        for (action_key, _factory) in plugin.actions() {
+            if self.runtime.registry().get_factory(action_key).is_some() {
+                tracing::warn!(
+                    target: "nebula_engine::plugin_wiring",
+                    plugin_key = %plugin_key,
+                    action_key = %action_key,
+                    "with_plugin: rejected duplicate action key"
+                );
+                return Err(PluginWiringError::DuplicateActionKey {
+                    plugin_key,
+                    action_key: action_key.clone(),
+                });
+            }
+        }
+
+        // Both guards passed — commit the registrations.
+        let span = tracing::info_span!(
+            "nebula_engine::plugin_wiring::with_plugin",
+            plugin_key = %plugin_key,
+        );
+        let _guard = span.enter();
+
+        for (action_key, factory) in plugin.actions() {
+            let metadata = factory.metadata().clone();
+            self.runtime
+                .registry()
+                .register_factory(metadata, Arc::clone(factory));
+            tracing::debug!(
+                target: "nebula_engine::plugin_wiring",
+                %action_key,
+                "registered action factory from plugin"
+            );
+        }
+
+        // Register into the plugin registry for metadata / catalog queries.
+        // The duplicate-key guard above already confirmed this key is absent.
+        self.plugin_registry
+            .register(plugin)
+            .expect("plugin_registry.register must succeed after duplicate-key guard passed");
+
+        tracing::info!(
+            target: "nebula_engine::plugin_wiring",
+            plugin_key = %plugin_key,
+            "plugin wired into engine"
+        );
+
+        Ok(self)
     }
 
     /// Attach a credential resolver for providing credentials to actions.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -810,7 +810,22 @@ impl WorkflowEngine {
             }
         }
 
-        // Both guards passed — commit the registrations.
+        // on_load runs before any mutation: a failing hook aborts wiring with
+        // nothing registered (atomicity). ADR-0095 D2 load contract.
+        plugin.plugin().on_load().map_err(|source| {
+            tracing::warn!(
+                target: "nebula_engine::plugin_wiring",
+                plugin_key = %plugin_key,
+                error = %source,
+                "with_plugin: on_load hook failed — wiring aborted"
+            );
+            PluginWiringError::OnLoad {
+                plugin_key: plugin_key.clone(),
+                source,
+            }
+        })?;
+
+        // on_load succeeded — commit the registrations.
         let span = tracing::info_span!(
             "nebula_engine::plugin_wiring::with_plugin",
             plugin_key = %plugin_key,
@@ -830,10 +845,13 @@ impl WorkflowEngine {
         }
 
         // Register into the plugin registry for metadata / catalog queries.
-        // The duplicate-key guard above already confirmed this key is absent.
+        // Both guards above confirmed the key is absent; surface any unexpected
+        // registry fault as a typed error rather than a panic.
         self.plugin_registry
             .register(plugin)
-            .expect("plugin_registry.register must succeed after duplicate-key guard passed");
+            .map_err(|_| PluginWiringError::DuplicatePlugin {
+                plugin_key: plugin_key.clone(),
+            })?;
 
         tracing::info!(
             target: "nebula_engine::plugin_wiring",

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -69,6 +69,7 @@ pub mod engine;
 pub mod error;
 pub mod event;
 pub mod node_output;
+pub(crate) mod plugin_wiring;
 pub(crate) mod resolver;
 pub mod resource;
 pub mod resource_accessor;
@@ -100,6 +101,7 @@ pub use daemon::{
 pub use engine::{DEFAULT_EVENT_CHANNEL_CAPACITY, WorkflowEngine};
 pub use error::EngineError;
 pub use event::ExecutionEvent;
+pub use plugin_wiring::PluginWiringError;
 // Re-export plugin types for convenience.
 pub use nebula_plugin::{Plugin, PluginKey, PluginManifest, PluginRegistry, ResolvedPlugin};
 pub use node_output::NodeOutput;

--- a/crates/engine/src/plugin_wiring.rs
+++ b/crates/engine/src/plugin_wiring.rs
@@ -1,0 +1,58 @@
+//! Plugin → engine wiring: bridge a `ResolvedPlugin` into the engine's
+//! executable `ActionRegistry`.
+//!
+//! `WorkflowEngine::with_plugin` is the single entry point. It registers
+//! every action factory the plugin declares into the engine's live
+//! `ActionRegistry` (making the actions dispatchable) **and** records the
+//! plugin in the engine's `PluginRegistry` (making its metadata queryable).
+//!
+//! ## Out of scope (deliberate deferral)
+//!
+//! - **Resource wiring**: `Plugin::resources()` yields `Arc<dyn ResourceFactory>`
+//!   which carries introspection but not the typed `R + R::Topology` construction
+//!   surface the `ResourceActivatorRegistry` needs. Resource wiring requires a
+//!   per-kind `KindActivator` supplied by the composition root.
+//! - **Credential wiring**: credential kinds need a separate registration path
+//!   not yet exposed on the engine builder.
+//! - **Unload / removal**: `ActionRegistry` has no removal primitive. Unload
+//!   support requires an ADR decision on hot-reload safety.
+
+use nebula_core::ActionKey;
+use nebula_plugin::PluginKey;
+
+/// Error returned when wiring a plugin into the engine fails.
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum PluginWiringError {
+    /// The plugin key is already registered in the engine's plugin registry.
+    ///
+    /// Registering the same plugin twice is rejected rather than silently
+    /// replacing it, because an in-flight execution may be dispatching against
+    /// the existing factory set; silent replacement would create a race window.
+    #[error(
+        "plugin '{plugin_key}' is already registered in the engine; \
+         unload is not yet supported (see ADR-0095)"
+    )]
+    DuplicatePlugin {
+        /// The conflicting plugin key.
+        plugin_key: PluginKey,
+    },
+
+    /// An action key contributed by this plugin conflicts with an action already
+    /// registered in the `ActionRegistry`.
+    ///
+    /// Unlike `ActionRegistry::register_factory` (which replaces on same
+    /// `key+version`), `with_plugin` treats any pre-existing entry as a wiring
+    /// fault: two plugins must not claim the same action key, and a plugin must
+    /// not be partially registered if any of its actions conflict.
+    #[error(
+        "action key '{action_key}' from plugin '{plugin_key}' conflicts with \
+         an already-registered action in the engine's ActionRegistry"
+    )]
+    DuplicateActionKey {
+        /// The plugin declaring the conflicting action.
+        plugin_key: PluginKey,
+        /// The conflicting action key.
+        action_key: ActionKey,
+    },
+}

--- a/crates/engine/src/plugin_wiring.rs
+++ b/crates/engine/src/plugin_wiring.rs
@@ -6,6 +6,14 @@
 //! `ActionRegistry` (making the actions dispatchable) **and** records the
 //! plugin in the engine's `PluginRegistry` (making its metadata queryable).
 //!
+//! ## Load ordering
+//!
+//! `Plugin::on_load` runs **before** any factory or plugin-registry mutation.
+//! A failing `on_load` aborts wiring with nothing registered — the engine
+//! state is unchanged. `Plugin::on_unload` and rollback of a later-step
+//! failure (e.g. `ActionRegistry` mutation) require an `InstallTxn` abstraction;
+//! that is a named deferral beyond this bridge.
+//!
 //! ## Out of scope (deliberate deferral)
 //!
 //! - **Resource wiring**: `Plugin::resources()` yields `Arc<dyn ResourceFactory>`
@@ -18,7 +26,7 @@
 //!   support requires an ADR decision on hot-reload safety.
 
 use nebula_core::ActionKey;
-use nebula_plugin::PluginKey;
+use nebula_plugin::{PluginError, PluginKey};
 
 /// Error returned when wiring a plugin into the engine fails.
 #[derive(Debug, thiserror::Error)]
@@ -54,5 +62,19 @@ pub enum PluginWiringError {
         plugin_key: PluginKey,
         /// The conflicting action key.
         action_key: ActionKey,
+    },
+
+    /// `Plugin::on_load` returned an error.
+    ///
+    /// The engine state is unchanged: no action factories were registered and
+    /// the plugin was not recorded in the plugin registry. The plugin should
+    /// be considered unloaded.
+    #[error("plugin '{plugin_key}' on_load hook failed: {source}")]
+    OnLoad {
+        /// The plugin whose `on_load` failed.
+        plugin_key: PluginKey,
+        /// The underlying plugin error.
+        #[source]
+        source: PluginError,
     },
 }

--- a/crates/plugin-core/Cargo.toml
+++ b/crates/plugin-core/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "nebula-plugin-core"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+keywords.workspace = true
+authors.workspace = true
+description = "First-party core plugin for Nebula (SetFields and other utility actions)"
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+documentation.workspace = true
+
+[dependencies]
+nebula-action = { path = "../action" }
+nebula-core = { path = "../core" }
+nebula-plugin = { path = "../plugin" }
+nebula-schema = { path = "../schema" }
+nebula-metadata = { path = "../metadata" }
+nebula-workflow = { path = "../workflow" }
+
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+nebula-engine = { path = "../engine" }
+nebula-execution = { path = "../execution" }
+nebula-metrics = { path = "../metrics" }
+nebula-storage-port = { path = "../storage-port" }
+
+chrono = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/plugin-core/src/actions/mod.rs
+++ b/crates/plugin-core/src/actions/mod.rs
@@ -1,0 +1,5 @@
+//! Actions provided by the `core` plugin.
+
+pub mod set_fields;
+
+pub use set_fields::SetFields;

--- a/crates/plugin-core/src/actions/set_fields.rs
+++ b/crates/plugin-core/src/actions/set_fields.rs
@@ -1,0 +1,294 @@
+//! `core.set_fields` — merge a list of field assignments onto a JSON object.
+//!
+//! Semantics mirror the n8n "Edit Fields / Set" node: each `Assignment` in
+//! the `assignments` list names a top-level key and supplies a JSON value.
+//! The action merges those pairs onto the `data` object (defaulting to an
+//! empty object) and returns the merged result.
+//!
+//! ## Input
+//!
+//! ```json
+//! {
+//!   "data":        { /* optional base object */ },
+//!   "assignments": [ { "name": "field_name", "value": <any JSON> }, ... ]
+//! }
+//! ```
+//!
+//! ## Output
+//!
+//! ```json
+//! { "field_name": <value>, ...merged }
+//! ```
+//!
+//! The action is **pure** — no I/O, no credentials, no resources.
+
+use std::sync::OnceLock;
+
+use nebula_action::{ActionContext, ActionError, ActionMetadata, ActionResult, StatelessAction};
+use nebula_core::action_key;
+use nebula_schema::HasSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use tracing::instrument;
+
+// ── Config types ──────────────────────────────────────────────────────────────
+
+/// A single field assignment: `name → value`.
+///
+/// Both fields are always present on the wire; forward-compatibility for new
+/// optional fields is handled via `#[serde(default)]` in future versions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Assignment {
+    /// Top-level key to set on the output object.
+    pub name: String,
+    /// JSON value to assign.
+    pub value: Value,
+}
+
+/// Resolved input for `SetFields`.
+///
+/// The engine resolves `NodeDefinition::parameters` into this struct before
+/// dispatching. The `data` field is optional; if absent or `null` the
+/// assignments are merged onto an empty object.
+///
+/// Forward-compatibility for new optional fields is handled via
+/// `#[serde(default)]` on any additions, not `#[non_exhaustive]`, because
+/// these types are deserialized from workflow JSON rather than literal-
+/// constructed by external Rust code.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetFieldsInput {
+    /// Base object to merge assignments onto. `null` / absent → empty object.
+    #[serde(default)]
+    pub data: Option<Value>,
+    /// Ordered list of field assignments applied left-to-right.
+    #[serde(default)]
+    pub assignments: Vec<Assignment>,
+}
+
+// `assignments[*].value` is a fully dynamic JSON value, so a concrete typed
+// schema cannot enumerate its shape. Empty schema is the honest declaration;
+// the doc-comment above describes the expected structure out-of-band.
+impl HasSchema for SetFieldsInput {
+    fn schema() -> nebula_schema::validated::ValidSchema {
+        nebula_schema::validated::ValidSchema::empty()
+    }
+}
+
+// ── Action ────────────────────────────────────────────────────────────────────
+
+/// Pure action that merges a list of field assignments onto a JSON object.
+///
+/// Keyed `core.set_fields`. No I/O, no credentials, no resources.
+///
+/// # Example
+///
+/// Build the input by constructing `SetFieldsInput` directly (or deserialize
+/// it from workflow-node JSON via `serde_json`):
+///
+/// ```rust
+/// use nebula_plugin_core::actions::set_fields::{Assignment, SetFieldsInput};
+/// use serde_json::json;
+///
+/// let input = SetFieldsInput {
+///     data: Some(json!({"existing": 1})),
+///     assignments: vec![
+///         Assignment { name: "new_field".into(), value: json!(42) },
+///     ],
+/// };
+/// assert_eq!(input.assignments.len(), 1);
+/// ```
+///
+/// Wire the action into the engine via [`CorePlugin`](crate::CorePlugin) and
+/// `WorkflowEngine::with_plugin` — see the crate-level docs for a complete
+/// wiring example.
+#[derive(Debug)]
+pub struct SetFields;
+
+impl nebula_action::action::Action for SetFields {
+    type Input = SetFieldsInput;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("core.set_fields"),
+            "Set Fields",
+            "Merges a list of named field assignments onto a JSON object",
+        )
+    }
+
+    fn dependencies() -> &'static nebula_action::Dependencies {
+        static DEPS: OnceLock<nebula_action::Dependencies> = OnceLock::new();
+        DEPS.get_or_init(nebula_action::Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for SetFields {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(SetFields)
+    }
+}
+
+impl StatelessAction for SetFields {
+    #[instrument(
+        name = "core.set_fields",
+        skip_all,
+        fields(assignment_count = input.assignments.len())
+    )]
+    async fn execute(
+        &self,
+        input: SetFieldsInput,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        let mut out: Map<String, Value> = match input.data {
+            Some(Value::Object(map)) => map,
+            Some(Value::Null) | None => Map::new(),
+            Some(other) => {
+                return Err(ActionError::fatal(format!(
+                    "set_fields: `data` must be a JSON object or null, got {}",
+                    other.type_name_str()
+                )));
+            },
+        };
+
+        for Assignment { name, value } in input.assignments {
+            out.insert(name, value);
+        }
+
+        Ok(ActionResult::success(Value::Object(out)))
+    }
+}
+
+// ── Helper trait (local extension) ───────────────────────────────────────────
+
+/// Local extension on `serde_json::Value` to get a readable type name for
+/// error messages without pulling in an extra crate.
+trait ValueTypeNameStr {
+    fn type_name_str(&self) -> &'static str;
+}
+
+impl ValueTypeNameStr for Value {
+    fn type_name_str(&self) -> &'static str {
+        match self {
+            Value::Null => "null",
+            Value::Bool(_) => "bool",
+            Value::Number(_) => "number",
+            Value::String(_) => "string",
+            Value::Array(_) => "array",
+            Value::Object(_) => "object",
+        }
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use nebula_action::testing::TestContextBuilder;
+    use serde_json::json;
+
+    use super::*;
+
+    fn ctx() -> impl ActionContext {
+        TestContextBuilder::new().build()
+    }
+
+    #[tokio::test]
+    async fn merges_assignments_onto_empty_base() {
+        let action = SetFields;
+        let input = SetFieldsInput {
+            data: None,
+            assignments: vec![
+                Assignment {
+                    name: "a".into(),
+                    value: json!(1),
+                },
+                Assignment {
+                    name: "b".into(),
+                    value: json!("hello"),
+                },
+            ],
+        };
+        let result = action.execute(input, &ctx()).await.unwrap();
+        let out = result
+            .into_primary_output()
+            .and_then(nebula_action::ActionOutput::into_value)
+            .unwrap();
+        assert_eq!(out["a"], json!(1));
+        assert_eq!(out["b"], json!("hello"));
+    }
+
+    #[tokio::test]
+    async fn assignments_overlay_existing_keys() {
+        let action = SetFields;
+        let input = SetFieldsInput {
+            data: Some(json!({"existing": true, "overwritten": "old"})),
+            assignments: vec![Assignment {
+                name: "overwritten".into(),
+                value: json!("new"),
+            }],
+        };
+        let result = action.execute(input, &ctx()).await.unwrap();
+        let out = result
+            .into_primary_output()
+            .and_then(nebula_action::ActionOutput::into_value)
+            .unwrap();
+        assert_eq!(out["existing"], json!(true));
+        assert_eq!(out["overwritten"], json!("new"));
+    }
+
+    #[tokio::test]
+    async fn null_data_treated_as_empty_object() {
+        let action = SetFields;
+        let input = SetFieldsInput {
+            data: Some(Value::Null),
+            assignments: vec![Assignment {
+                name: "x".into(),
+                value: json!(99),
+            }],
+        };
+        let result = action.execute(input, &ctx()).await.unwrap();
+        let out = result
+            .into_primary_output()
+            .and_then(nebula_action::ActionOutput::into_value)
+            .unwrap();
+        assert_eq!(out["x"], json!(99));
+    }
+
+    #[tokio::test]
+    async fn non_object_data_returns_fatal_error() {
+        let action = SetFields;
+        let input = SetFieldsInput {
+            data: Some(json!([1, 2, 3])),
+            assignments: vec![],
+        };
+        let err = action.execute(input, &ctx()).await.unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    #[tokio::test]
+    async fn empty_assignments_returns_data_unchanged() {
+        let action = SetFields;
+        let data = json!({"keep": "this"});
+        let input = SetFieldsInput {
+            data: Some(data.clone()),
+            assignments: vec![],
+        };
+        let result = action.execute(input, &ctx()).await.unwrap();
+        let out = result
+            .into_primary_output()
+            .and_then(nebula_action::ActionOutput::into_value)
+            .unwrap();
+        assert_eq!(out, data);
+    }
+
+    #[test]
+    fn action_key_is_core_dot_set_fields() {
+        use nebula_action::action::Action;
+        assert_eq!(SetFields::metadata().base.key.as_str(), "core.set_fields");
+    }
+}

--- a/crates/plugin-core/src/lib.rs
+++ b/crates/plugin-core/src/lib.rs
@@ -1,0 +1,33 @@
+//! # nebula-plugin-core
+//!
+//! First-party **core** plugin for Nebula.
+//!
+//! Provides foundational utility actions available in every deployment without
+//! any external dependencies or credentials.
+//!
+//! ## Actions
+//!
+//! | Key | Description |
+//! |-----|-------------|
+//! | `core.set_fields` | Merge a list of named field assignments onto a JSON object |
+//!
+//! ## Usage
+//!
+//! Wire the plugin into the engine via `WorkflowEngine::with_plugin`:
+//!
+//! ```rust,ignore
+//! use nebula_engine::WorkflowEngine;
+//! use nebula_plugin::ResolvedPlugin;
+//! use nebula_plugin_core::CorePlugin;
+//!
+//! let plugin = ResolvedPlugin::from(CorePlugin::new()).expect("core plugin must resolve");
+//! let engine = engine.with_plugin(std::sync::Arc::new(plugin))?;
+//! ```
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+pub mod actions;
+mod plugin;
+
+pub use plugin::CorePlugin;

--- a/crates/plugin-core/src/lib.rs
+++ b/crates/plugin-core/src/lib.rs
@@ -20,7 +20,8 @@
 //! use nebula_plugin::ResolvedPlugin;
 //! use nebula_plugin_core::CorePlugin;
 //!
-//! let plugin = ResolvedPlugin::from(CorePlugin::new()).expect("core plugin must resolve");
+//! let plugin = ResolvedPlugin::from(CorePlugin::try_new()?)
+//!     .expect("core plugin must resolve");
 //! let engine = engine.with_plugin(std::sync::Arc::new(plugin))?;
 //! ```
 

--- a/crates/plugin-core/src/plugin.rs
+++ b/crates/plugin-core/src/plugin.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use nebula_action::ActionFactory;
 use nebula_action::factory::GenericStatelessFactory;
-use nebula_metadata::PluginManifest;
+use nebula_metadata::{ManifestError, PluginManifest};
 use nebula_plugin::Plugin;
 
 use crate::actions::SetFields;
@@ -20,7 +20,7 @@ use crate::actions::SetFields;
 /// use nebula_plugin::ResolvedPlugin;
 /// use nebula_plugin_core::CorePlugin;
 ///
-/// let plugin = Arc::new(ResolvedPlugin::from(CorePlugin::new())?);
+/// let plugin = Arc::new(ResolvedPlugin::from(CorePlugin::try_new()?)?);
 /// let engine = engine.with_plugin(plugin)?;
 /// ```
 #[derive(Debug)]
@@ -30,19 +30,16 @@ pub struct CorePlugin {
 
 impl CorePlugin {
     /// Construct the core plugin with its canonical manifest.
-    #[must_use]
-    pub fn new() -> Self {
+    ///
+    /// Returns `Err` if the plugin key or manifest is structurally invalid.
+    /// For the built-in `core` plugin this should never fail in practice;
+    /// the fallible return is required because `PluginManifest::builder().build()`
+    /// validates and normalizes the key at construction time.
+    pub fn try_new() -> Result<Self, ManifestError> {
         let manifest = PluginManifest::builder("core", "Core")
             .description("Built-in utility actions available in every Nebula deployment")
-            .build()
-            .expect("CorePlugin manifest is statically valid");
-        Self { manifest }
-    }
-}
-
-impl Default for CorePlugin {
-    fn default() -> Self {
-        Self::new()
+            .build()?;
+        Ok(Self { manifest })
     }
 }
 
@@ -64,14 +61,15 @@ mod tests {
 
     #[test]
     fn plugin_key_is_core() {
-        let plugin = CorePlugin::new();
+        let plugin = CorePlugin::try_new().expect("CorePlugin::try_new must succeed");
         assert_eq!(plugin.key().as_str(), "core");
     }
 
     #[test]
     fn resolves_set_fields_action() {
-        let resolved = ResolvedPlugin::from(CorePlugin::new())
-            .expect("CorePlugin must resolve without errors");
+        let resolved =
+            ResolvedPlugin::from(CorePlugin::try_new().expect("CorePlugin::try_new must succeed"))
+                .expect("CorePlugin must resolve without errors");
         let key = nebula_core::ActionKey::new("core.set_fields").unwrap();
         assert!(
             resolved.action(&key).is_some(),
@@ -83,7 +81,8 @@ mod tests {
     fn namespace_invariant_holds() {
         // ResolvedPlugin::from validates that every action key starts with
         // "core.". A construction failure here means a key was mis-prefixed.
-        let result = ResolvedPlugin::from(CorePlugin::new());
+        let core = CorePlugin::try_new().expect("CorePlugin::try_new must succeed");
+        let result = ResolvedPlugin::from(core);
         assert!(
             result.is_ok(),
             "CorePlugin must pass namespace validation: {result:?}"

--- a/crates/plugin-core/src/plugin.rs
+++ b/crates/plugin-core/src/plugin.rs
@@ -1,0 +1,92 @@
+//! `CorePlugin` — first-party `core` plugin implementation.
+
+use std::sync::Arc;
+
+use nebula_action::ActionFactory;
+use nebula_action::factory::GenericStatelessFactory;
+use nebula_metadata::PluginManifest;
+use nebula_plugin::Plugin;
+
+use crate::actions::SetFields;
+
+/// First-party core plugin.
+///
+/// Provides foundational utility actions under the `core` plugin key. Wire it
+/// into the engine with `WorkflowEngine::with_plugin`:
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use nebula_engine::WorkflowEngine;
+/// use nebula_plugin::ResolvedPlugin;
+/// use nebula_plugin_core::CorePlugin;
+///
+/// let plugin = Arc::new(ResolvedPlugin::from(CorePlugin::new())?);
+/// let engine = engine.with_plugin(plugin)?;
+/// ```
+#[derive(Debug)]
+pub struct CorePlugin {
+    manifest: PluginManifest,
+}
+
+impl CorePlugin {
+    /// Construct the core plugin with its canonical manifest.
+    #[must_use]
+    pub fn new() -> Self {
+        let manifest = PluginManifest::builder("core", "Core")
+            .description("Built-in utility actions available in every Nebula deployment")
+            .build()
+            .expect("CorePlugin manifest is statically valid");
+        Self { manifest }
+    }
+}
+
+impl Default for CorePlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for CorePlugin {
+    fn manifest(&self) -> &PluginManifest {
+        &self.manifest
+    }
+
+    fn actions(&self) -> Vec<Arc<dyn ActionFactory>> {
+        vec![Arc::new(GenericStatelessFactory::<SetFields>::new())]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nebula_plugin::ResolvedPlugin;
+
+    use super::*;
+
+    #[test]
+    fn plugin_key_is_core() {
+        let plugin = CorePlugin::new();
+        assert_eq!(plugin.key().as_str(), "core");
+    }
+
+    #[test]
+    fn resolves_set_fields_action() {
+        let resolved = ResolvedPlugin::from(CorePlugin::new())
+            .expect("CorePlugin must resolve without errors");
+        let key = nebula_core::ActionKey::new("core.set_fields").unwrap();
+        assert!(
+            resolved.action(&key).is_some(),
+            "core.set_fields must be registered in the resolved plugin"
+        );
+    }
+
+    #[test]
+    fn namespace_invariant_holds() {
+        // ResolvedPlugin::from validates that every action key starts with
+        // "core.". A construction failure here means a key was mis-prefixed.
+        let result = ResolvedPlugin::from(CorePlugin::new());
+        assert!(
+            result.is_ok(),
+            "CorePlugin must pass namespace validation: {result:?}"
+        );
+    }
+}

--- a/crates/plugin-core/tests/plugin_wiring_e2e.rs
+++ b/crates/plugin-core/tests/plugin_wiring_e2e.rs
@@ -1,0 +1,273 @@
+//! End-to-end keystone test: plugin → engine action wiring.
+//!
+//! ## Test plan
+//!
+//! `without_plugin_dispatch_fails`
+//!   RED witness: dispatching `core.set_fields` on an unwired engine returns
+//!   a `RuntimeError::ActionNotFound`-classified error. This test is the
+//!   falsifiable proof that the gap is real — removing `with_plugin` must
+//!   make the green test below turn red.
+//!
+//! `with_plugin_set_fields_executes_and_merges`
+//!   GREEN proof: after `engine.with_plugin(core_plugin)`, the same
+//!   workflow reaches `Completed` and the output contains the exact merged
+//!   fields. Asserts concrete output values, not `is_ok()`.
+//!
+//! `with_plugin_duplicate_key_returns_typed_error`
+//!   Unit: calling `with_plugin` twice with the same plugin key returns
+//!   `PluginWiringError::DuplicatePlugin`.
+//!
+//! `with_plugin_duplicate_action_key_returns_typed_error`
+//!   Unit: pre-registering an action with the same key as one inside the
+//!   plugin returns `PluginWiringError::DuplicateActionKey`.
+
+use std::{collections::HashMap, sync::Arc};
+
+use nebula_action::ActionResult;
+use nebula_engine::ActionExecutor;
+use nebula_engine::{
+    ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessRunner, PluginWiringError,
+    WorkflowEngine,
+};
+use nebula_execution::context::ExecutionBudget;
+use nebula_metrics::MetricsRegistry;
+use nebula_plugin::ResolvedPlugin;
+use nebula_plugin_core::CorePlugin;
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, NodeDefinition, ParamValue, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Engine builder helper ─────────────────────────────────────────────────────
+
+fn make_engine() -> WorkflowEngine {
+    let registry = Arc::new(ActionRegistry::new());
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .expect("ActionRuntime must build in tests"),
+    );
+    WorkflowEngine::new(runtime, metrics).expect("WorkflowEngine must build in tests")
+}
+
+fn core_plugin() -> Arc<ResolvedPlugin> {
+    Arc::new(
+        ResolvedPlugin::from(CorePlugin::new())
+            .expect("CorePlugin must resolve without namespace errors"),
+    )
+}
+
+// ── Workflow builder helper ───────────────────────────────────────────────────
+
+fn set_fields_workflow(assignments_json: serde_json::Value) -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    let node = NodeDefinition::new(
+        nebula_core::node_key!("step"),
+        "SetFields step",
+        "core",
+        "core.set_fields",
+    )
+    .expect("NodeDefinition must build with valid keys")
+    .with_parameter("assignments", ParamValue::literal(assignments_json));
+
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "test-set-fields".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![node],
+        connections: vec![],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: vec![],
+        tags: vec![],
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+fn scope() -> nebula_storage_port::Scope {
+    nebula_engine::store_seam::single_tenant_scope()
+}
+
+// ── RED witness ───────────────────────────────────────────────────────────────
+
+/// Without `with_plugin`, `core.set_fields` is not in the `ActionRegistry`.
+/// The engine records the node failure with an action-not-found error and
+/// returns `ExecutionStatus::Failed`.
+///
+/// This test is the falsifiable RED: removing `with_plugin` from the GREEN test
+/// below causes it to hit this same failure mode (the execution reaches `Failed`
+/// with an action-not-found node error instead of `Completed`).
+#[tokio::test]
+async fn without_plugin_dispatch_fails() {
+    let engine = make_engine(); // no with_plugin call
+
+    let workflow = set_fields_workflow(serde_json::json!([
+        {"name": "result", "value": 42}
+    ]));
+
+    let result = engine
+        .execute_workflow(
+            &scope(),
+            &workflow,
+            serde_json::json!({}),
+            ExecutionBudget::default(),
+        )
+        .await
+        .expect("execute_workflow itself must not error — failure is recorded in the result");
+
+    // The engine records action-not-found as a node error and sets status = Failed.
+    assert_eq!(
+        result.status,
+        nebula_execution::ExecutionStatus::Failed,
+        "execution without a wired plugin must reach Failed; got {:?}",
+        result.status
+    );
+
+    // At least one node error must mention "not found".
+    let error_texts: Vec<&str> = result.node_errors.values().map(String::as_str).collect();
+    assert!(
+        error_texts.iter().any(|s| s.contains("not found")),
+        "node_errors must contain an action-not-found message; got: {error_texts:?}"
+    );
+}
+
+// ── GREEN proof ───────────────────────────────────────────────────────────────
+
+/// After `with_plugin`, `core.set_fields` is executable. The output must
+/// contain exactly the merged fields — `is_ok()` alone does not prove correctness.
+#[tokio::test]
+async fn with_plugin_set_fields_executes_and_merges() {
+    let engine = make_engine()
+        .with_plugin(core_plugin())
+        .expect("with_plugin(CorePlugin) must succeed on a fresh engine");
+
+    let workflow = set_fields_workflow(serde_json::json!([
+        {"name": "greeting",  "value": "hello"},
+        {"name": "answer",    "value": 42},
+        {"name": "flag",      "value": true}
+    ]));
+
+    let result = engine
+        .execute_workflow(
+            &scope(),
+            &workflow,
+            // The workflow's node input is resolved from `parameters`; `data`
+            // defaults to null (empty base object) when not supplied.
+            serde_json::json!({}),
+            ExecutionBudget::default(),
+        )
+        .await
+        .expect("with_plugin(CorePlugin) + core.set_fields must succeed");
+
+    // The execution must complete.
+    assert_eq!(
+        result.status,
+        nebula_execution::ExecutionStatus::Completed,
+        "execution must reach Completed; got {:?}",
+        result.status
+    );
+
+    // The node output must contain the exact merged fields.
+    let node_key = nebula_core::node_key!("step");
+    let node_output = result
+        .node_outputs
+        .get(&node_key)
+        .expect("node 'step' must have output after Completed execution");
+
+    assert_eq!(
+        node_output["greeting"],
+        serde_json::json!("hello"),
+        "greeting field must be set"
+    );
+    assert_eq!(
+        node_output["answer"],
+        serde_json::json!(42),
+        "answer field must be set"
+    );
+    assert_eq!(
+        node_output["flag"],
+        serde_json::json!(true),
+        "flag field must be set"
+    );
+}
+
+// ── Duplicate-key unit tests ──────────────────────────────────────────────────
+
+/// Registering the same plugin twice returns `PluginWiringError::DuplicatePlugin`.
+#[tokio::test]
+async fn with_plugin_duplicate_plugin_key_returns_typed_error() {
+    let engine = make_engine()
+        .with_plugin(core_plugin())
+        .expect("first with_plugin must succeed");
+
+    let result = engine.with_plugin(core_plugin());
+    assert!(
+        result.is_err(),
+        "second with_plugin with same key must fail"
+    );
+    // WorkflowEngine does not implement Debug, so unwrap_err() is unavailable;
+    // extract the error via Result::err().
+    let err = result.err().expect("checked is_err() above");
+
+    assert!(
+        matches!(err, PluginWiringError::DuplicatePlugin { ref plugin_key } if plugin_key.as_str() == "core"),
+        "expected DuplicatePlugin{{plugin_key: 'core'}}; got: {err:?}"
+    );
+}
+
+/// Pre-registering an action with the same key as a plugin action returns
+/// `PluginWiringError::DuplicateActionKey`.
+#[tokio::test]
+async fn with_plugin_duplicate_action_key_returns_typed_error() {
+    use nebula_action::action::Action;
+    use nebula_plugin_core::actions::set_fields::SetFields;
+
+    // Build an engine whose ActionRegistry already contains core.set_fields.
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(SetFields::metadata(), SetFields);
+
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .expect("ActionRuntime must build"),
+    );
+    let engine = WorkflowEngine::new(runtime, metrics).expect("WorkflowEngine must build");
+
+    let result = engine.with_plugin(core_plugin());
+    assert!(
+        result.is_err(),
+        "with_plugin must fail when action key already registered"
+    );
+    // WorkflowEngine does not implement Debug, so unwrap_err() is unavailable;
+    // extract the error via Result::err().
+    let err = result.err().expect("checked is_err() above");
+
+    assert!(
+        matches!(
+            err,
+            PluginWiringError::DuplicateActionKey { ref action_key, .. }
+            if action_key.as_str() == "core.set_fields"
+        ),
+        "expected DuplicateActionKey{{action_key: 'core.set_fields'}}; got: {err:?}"
+    );
+}

--- a/crates/plugin-core/tests/plugin_wiring_e2e.rs
+++ b/crates/plugin-core/tests/plugin_wiring_e2e.rs
@@ -21,9 +21,11 @@
 //!   Unit: pre-registering an action with the same key as one inside the
 //!   plugin returns `PluginWiringError::DuplicateActionKey`.
 
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, future::Future, pin::Pin, sync::Arc};
 
-use nebula_action::ActionResult;
+use nebula_action::{
+    ActionContext, ActionError, ActionFactory, ActionHandle, ActionMetadata, ActionResult,
+};
 use nebula_engine::ActionExecutor;
 use nebula_engine::{
     ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessRunner, PluginWiringError,
@@ -31,7 +33,7 @@ use nebula_engine::{
 };
 use nebula_execution::context::ExecutionBudget;
 use nebula_metrics::MetricsRegistry;
-use nebula_plugin::ResolvedPlugin;
+use nebula_plugin::{Plugin, PluginError, PluginManifest, ResolvedPlugin};
 use nebula_plugin_core::CorePlugin;
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, NodeDefinition, ParamValue, Version, WorkflowConfig, WorkflowDefinition,
@@ -59,8 +61,10 @@ fn make_engine() -> WorkflowEngine {
 
 fn core_plugin() -> Arc<ResolvedPlugin> {
     Arc::new(
-        ResolvedPlugin::from(CorePlugin::new())
-            .expect("CorePlugin must resolve without namespace errors"),
+        ResolvedPlugin::from(
+            CorePlugin::try_new().expect("CorePlugin::try_new must succeed in tests"),
+        )
+        .expect("CorePlugin must resolve without namespace errors"),
     )
 }
 
@@ -224,6 +228,167 @@ async fn with_plugin_duplicate_plugin_key_returns_typed_error() {
     assert!(
         matches!(err, PluginWiringError::DuplicatePlugin { ref plugin_key } if plugin_key.as_str() == "core"),
         "expected DuplicatePlugin{{plugin_key: 'core'}}; got: {err:?}"
+    );
+}
+
+// ── on_load contract ─────────────────────────────────────────────────────────
+
+/// Minimal `ActionFactory` stub used by `FailOnLoadPlugin`.
+///
+/// The factory carries an action key under the `"failplugin."` namespace.
+/// Its `instantiate` is never called in this test — wiring aborts before
+/// registration.
+#[derive(Debug)]
+struct StubFactory {
+    meta: ActionMetadata,
+}
+
+impl StubFactory {
+    fn new() -> Self {
+        Self {
+            meta: ActionMetadata::new(
+                nebula_core::action_key!("failplugin.noop"),
+                "Noop",
+                "A stub action that is never dispatched",
+            ),
+        }
+    }
+}
+
+impl ActionFactory for StubFactory {
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+
+    fn instantiate<'a>(
+        &'a self,
+        _node: &'a NodeDefinition,
+        _ctx: &'a dyn ActionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
+        // This method must never be called: on_load fails before registration.
+        Box::pin(async { unreachable!("StubFactory::instantiate must not be called in this test") })
+    }
+}
+
+/// A plugin whose `on_load` always returns an error.
+///
+/// Used to prove that `with_plugin` honours the `on_load` contract: when the
+/// hook fails, no factories are registered and the error is surfaced as
+/// `PluginWiringError::OnLoad`.
+#[derive(Debug)]
+struct FailOnLoadPlugin {
+    manifest: PluginManifest,
+}
+
+impl FailOnLoadPlugin {
+    fn new() -> Self {
+        let manifest = PluginManifest::builder("failplugin", "Fail-on-load test plugin")
+            .build()
+            .expect("FailOnLoadPlugin manifest is a statically valid test fixture");
+        Self { manifest }
+    }
+}
+
+impl Plugin for FailOnLoadPlugin {
+    fn manifest(&self) -> &PluginManifest {
+        &self.manifest
+    }
+
+    fn actions(&self) -> Vec<Arc<dyn ActionFactory>> {
+        vec![Arc::new(StubFactory::new())]
+    }
+
+    fn on_load(&self) -> Result<(), PluginError> {
+        Err(PluginError::NotFound("failplugin".parse().unwrap()))
+    }
+}
+
+/// `Plugin::on_load` is load-bearing: when it returns `Err`, `with_plugin`
+/// must surface `PluginWiringError::OnLoad` and leave the engine state
+/// completely unchanged — the plugin's actions must not be dispatchable.
+///
+/// RED without the `on_load` call: `with_plugin` would succeed and the action
+/// would be registered.
+#[tokio::test]
+async fn with_plugin_on_load_failure_aborts_wiring() {
+    let plugin = Arc::new(
+        ResolvedPlugin::from(FailOnLoadPlugin::new())
+            .expect("FailOnLoadPlugin must pass namespace validation"),
+    );
+
+    let engine = make_engine();
+
+    // The wiring must fail with the typed OnLoad variant.
+    let result = engine.with_plugin(Arc::clone(&plugin));
+    assert!(
+        result.is_err(),
+        "with_plugin must fail when on_load returns Err"
+    );
+    let err = result.err().expect("checked is_err() above");
+
+    assert!(
+        matches!(
+            err,
+            PluginWiringError::OnLoad { ref plugin_key, .. }
+            if plugin_key.as_str() == "failplugin"
+        ),
+        "expected OnLoad{{plugin_key: 'failplugin'}}; got: {err:?}"
+    );
+
+    // Nothing must be registered: dispatching the action must fail with
+    // action-not-found, proving the engine state is unchanged.
+    let engine = make_engine(); // fresh engine after the failed wiring attempt
+    let action_key_str = "failplugin.noop";
+    let node = NodeDefinition::new(
+        nebula_core::node_key!("step"),
+        "Stub step",
+        "failplugin",
+        action_key_str,
+    )
+    .expect("NodeDefinition must build");
+
+    let workflow = WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "test-on-load-abort".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![node],
+        connections: vec![],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: vec![],
+        tags: vec![],
+        created_at: chrono::Utc::now(),
+        updated_at: chrono::Utc::now(),
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+
+    let dispatch_result = engine
+        .execute_workflow(
+            &scope(),
+            &workflow,
+            serde_json::json!({}),
+            ExecutionBudget::default(),
+        )
+        .await
+        .expect("execute_workflow itself must not error");
+
+    assert_eq!(
+        dispatch_result.status,
+        nebula_execution::ExecutionStatus::Failed,
+        "action must be absent from registry after failed on_load; got {:?}",
+        dispatch_result.status
+    );
+    let error_texts: Vec<&str> = dispatch_result
+        .node_errors
+        .values()
+        .map(String::as_str)
+        .collect();
+    assert!(
+        error_texts.iter().any(|s| s.contains("not found")),
+        "node_errors must show action-not-found; got: {error_texts:?}"
     );
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -93,6 +93,9 @@ deny = [
     # nebula-worker is the exec-layer composition root: it wires the engine into
     # the orchestrator pull-loop (ADR-0095 D1, U-D1.3).
     "nebula-worker",
+    # Dev-only: `crates/plugin-core/tests/plugin_wiring_e2e.rs` exercises the
+    # plugin→engine action-wiring bridge end-to-end.
+    "nebula-plugin-core",
   ], reason = "Engine is exec-layer orchestration; business/core crates must not depend on it" },
   { crate = "nebula-storage", wrappers = [
     "nebula-engine",
@@ -128,6 +131,8 @@ deny = [
     "nebula-orchestrator",
     # nebula-worker assembles the orchestrator + engine over the storage ports.
     "nebula-worker",
+    # Dev-only: e2e test uses `single_tenant_scope()` which returns `Scope` from storage-port.
+    "nebula-plugin-core",
   ], reason = "Storage port is a Core-tier contract; the adapter, tenancy decorator, exec/api consumers, and nebula-credential (which hosts the refresh coordinator and depends on RefreshClaimStore, ADR-0092) may depend on it" },
 
   # nebula-tenancy is the Business-tier multi-tenancy security boundary: it


### PR DESCRIPTION
## What (U-D1.F PR-A — the contract; the `apps/worker` binary is PR-B)

Unblocks the worker **flavor** model: a booted plugin's actions become **executable** by the engine.

- **`WorkflowEngine::with_plugin(Arc<ResolvedPlugin>) -> Result<Self, PluginWiringError>`** — a wire-time builder that registers the plugin's action factories into the engine's executable `ActionRegistry` and records the plugin in the node `PluginRegistry`. Pre-flight duplicate-key guard ⇒ all-or-nothing (no partial wiring). No adapter: `Plugin::actions()` already yields the exact `Arc<dyn ActionFactory>` `register_factory` consumes.
- **Why wire-time, not D2's runtime `load_plugin`:** the executable registry is sealed inside `Arc<ActionRuntime>` with no runtime mutation path. This supersedes ADR-0095 D2's literal `load_plugin` for 1.0 (ADR amendment to follow). Unload (`InstallTxn` — `ActionRegistry` has no removal primitive) and the resource bridge (needs the typed `KindActivator`) are **deferred, named** follow-ups.
- **`crates/plugin-core`** — the first genuine first-party plugin (`CorePlugin`, key `core`) with a real **`SetFields`** action (`core.set_fields`, n8n "Edit Fields" semantics: merge author-configured assignments onto the input object). Sets the authoring template every future plugin copies. Deserialized config/input grows via `#[serde(default)]`, not `#[non_exhaustive]`.

## Evidence
- Keystone red→green: `core.set_fields` is action-not-found **before** `with_plugin`; **after**, the execution reaches `Completed` with the real merged output. Typed `PluginWiringError` (duplicate plugin / action key) with red-able tests.
- 349/349 nextest, workspace clippy `-D`, rustdoc `-D`, **`cargo test --doc`** all green (the doctest is the one the pre-push gate doesn't run — verified locally).

## Next
PR-B: `apps/worker` flavor binary statically linking `plugin-core` on a SQLite durable claim-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced `core.set_fields` action—a new JSON field manipulation capability that enables merging multiple field assignments into a base object during workflow execution.
  * Added plugin wiring to `WorkflowEngine` with built-in safeguards against duplicate plugins and conflicting action keys.

* **Chores**
  * Updated workspace configuration and dependency allowlists to support the core plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->