### PR TITLE
feat(worker): config-driven Postgres store backend for apps/worker (ADR-0095 D1)

### DIFF
--- a/apps/worker/Cargo.toml
+++ b/apps/worker/Cargo.toml
@@ -24,6 +24,10 @@ nebula-plugin-core = { path = "../../crates/plugin-core" }
 # ResolvedPlugin::from wraps the concrete plugin for the engine.
 nebula-plugin = { path = "../../crates/plugin" }
 # SQLite-backed stores (ExecutionStore, WorkflowVersionStore, JobDispatchQueue).
+# The `postgres` feature (below) adds `nebula-storage/postgres` at feature-selection time,
+# which transitively enables `sqlx/postgres` + `sqlx/tls-rustls-ring-native-roots` in the
+# workspace crate so `compose_main.rs` can use `sqlx::postgres::PgPoolOptions` without
+# declaring those features directly here.
 nebula-storage = { path = "../../crates/storage", features = ["sqlite"] }
 # Metrics registry shared across ActionRuntime and WorkerRuntime.
 nebula-metrics = { path = "../../crates/metrics" }
@@ -31,6 +35,8 @@ nebula-metrics = { path = "../../crates/metrics" }
 nebula-storage-port = { path = "../../crates/storage-port" }
 
 # sqlx for SqlitePool construction; features forwarded to match nebula-storage/sqlite.
+# The postgres driver features come transitively via nebula-storage/postgres (activated
+# by the `postgres` cargo feature below) — no separate entry needed.
 sqlx = { workspace = true, features = ["sqlite", "runtime-tokio"] }
 # Random v4 UUID for ephemeral processor-id generation when NEBULA_WORKER_PROCESSOR_ID is unset.
 uuid = { workspace = true, features = ["v4"] }
@@ -39,6 +45,17 @@ tokio-util = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi"] }
+
+[features]
+# Opt-in Postgres backend. When this feature is enabled:
+#   - `nebula-storage/postgres` is activated, which transitively enables
+#     `sqlx/postgres` + `sqlx/tls-rustls-ring-native-roots`.
+#   - `compose_main::build_pg_stores` is compiled and reachable.
+#   - Setting `NEBULA_WORKER_DATABASE_URL` will use the Postgres path.
+#
+# Without this feature, setting `NEBULA_WORKER_DATABASE_URL` causes a
+# fail-closed startup error rather than a silent SQLite fallback.
+postgres = ["nebula-storage/postgres"]
 
 [dev-dependencies]
 # In-memory adapters for the smoke test (avoids SQLite file I/O in tests).

--- a/apps/worker/src/compose.rs
+++ b/apps/worker/src/compose.rs
@@ -280,6 +280,14 @@ pub enum WorkerConfigError {
          causes a tight busy-loop hammering the job-dispatch store"
     )]
     PollIntervalNotPositive,
+
+    /// `NEBULA_WORKER_DATABASE_URL` is set but its value is not valid UTF-8.
+    ///
+    /// `.ok()` would silently swallow this as `None` and fall back to SQLite —
+    /// a contradiction of the fail-closed contract. This variant ensures a
+    /// set-but-malformed DSN is always a hard startup error.
+    #[error("NEBULA_WORKER_DATABASE_URL is set but not valid UTF-8")]
+    DatabaseUrlNotUnicode,
 }
 
 impl WorkerConfig {
@@ -294,7 +302,7 @@ impl WorkerConfig {
     /// `NEBULA_WORKER_POLL_INTERVAL_MS` at parse time — both would silently
     /// break the claim-loop at runtime.
     pub fn from_env() -> Result<Self, WorkerConfigError> {
-        let database_url = std::env::var("NEBULA_WORKER_DATABASE_URL").ok();
+        let database_url = parse_database_url(std::env::var("NEBULA_WORKER_DATABASE_URL"))?;
 
         let db_path = std::env::var("NEBULA_WORKER_DB_PATH")
             .unwrap_or_else(|_| "nebula-worker.db".to_owned());
@@ -329,6 +337,26 @@ impl WorkerConfig {
             batch_size,
             poll_interval_ms,
         })
+    }
+}
+
+/// Parse the raw result of `std::env::var("NEBULA_WORKER_DATABASE_URL")` into
+/// an `Option<String>`, distinguishing the three meaningful cases:
+///
+/// - `Ok(url)` — variable is set and valid UTF-8 → `Ok(Some(url))`
+/// - `Err(VarError::NotPresent)` — variable is unset → `Ok(None)` (SQLite default)
+/// - `Err(VarError::NotUnicode(_))` — variable is set but not valid UTF-8 →
+///   `Err(WorkerConfigError::DatabaseUrlNotUnicode)` (fail-closed)
+///
+/// Using `.ok()` instead would collapse the `NotUnicode` case into `None`,
+/// silently falling back to SQLite when the operator clearly intended Postgres.
+fn parse_database_url(
+    raw: Result<String, std::env::VarError>,
+) -> Result<Option<String>, WorkerConfigError> {
+    match raw {
+        Ok(url) => Ok(Some(url)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => Err(WorkerConfigError::DatabaseUrlNotUnicode),
     }
 }
 
@@ -482,6 +510,73 @@ mod tests {
         assert!(
             matches!(err, WorkerConfigError::ProcessorIdAscii),
             "expected ProcessorIdAscii for non-ASCII input, got: {err}"
+        );
+    }
+
+    // ── NEBULA_WORKER_DATABASE_URL parsing ───────────────────────────────────
+    //
+    // Tests drive `parse_database_url` directly — no env-var mutation, no
+    // `unsafe`. The helper has real branching across three cases, so each gets
+    // its own test.
+    //
+    // Red-able: replacing the helper with `.ok()` collapses `NotUnicode` into
+    // `None` and makes `database_url_not_unicode_is_fail_closed` fail — it
+    // would receive `Ok(None)` instead of `Err(DatabaseUrlNotUnicode)`.
+
+    #[test]
+    fn database_url_present_passes_through() {
+        let result = parse_database_url(Ok("postgres://localhost/nebula".to_owned()));
+        assert_eq!(
+            result.unwrap(),
+            Some("postgres://localhost/nebula".to_owned()),
+            "a valid DSN must be forwarded as Some so the Postgres arm is selected"
+        );
+    }
+
+    #[test]
+    fn database_url_not_present_yields_none() {
+        let result = parse_database_url(Err(std::env::VarError::NotPresent));
+        assert_eq!(
+            result.unwrap(),
+            None,
+            "an absent variable must yield None, keeping the SQLite default"
+        );
+    }
+
+    /// A set-but-non-UTF-8 variable must fail closed — not silently fall back
+    /// to SQLite. Runs on all platforms: `VarError::NotUnicode` can be
+    /// constructed with any `OsString`; the helper matches on the variant
+    /// discriminant, not the byte content, so a UTF-8-clean `OsString` is
+    /// sufficient to exercise the `NotUnicode` branch cross-platform.
+    ///
+    /// Red-able: with `.ok()` instead of `parse_database_url`, the `NotUnicode`
+    /// case collapses to `None` and this test fails — it receives `Ok(None)`
+    /// where it expects `Err(DatabaseUrlNotUnicode)`.
+    #[test]
+    fn database_url_not_unicode_is_fail_closed() {
+        // `VarError::NotUnicode(OsString)` can be constructed on any platform;
+        // the `OsString` content is irrelevant — the match arm fires on the
+        // variant, not the payload.
+        let os_str = std::ffi::OsString::from("any-value");
+        let result = parse_database_url(Err(std::env::VarError::NotUnicode(os_str)));
+        assert!(
+            matches!(result, Err(WorkerConfigError::DatabaseUrlNotUnicode)),
+            "a set-but-non-UTF-8 variable must yield DatabaseUrlNotUnicode, not Ok(None)"
+        );
+    }
+
+    /// Additional unix-only test: verifies the same branch with a genuinely
+    /// invalid-UTF-8 byte sequence, proving the real-world trigger path also
+    /// reaches `DatabaseUrlNotUnicode` and not a silent `Ok(None)`.
+    #[cfg(unix)]
+    #[test]
+    fn database_url_invalid_utf8_bytes_is_fail_closed() {
+        use std::os::unix::ffi::OsStringExt as _;
+        let not_utf8 = std::ffi::OsString::from_vec(vec![0xFF]);
+        let result = parse_database_url(Err(std::env::VarError::NotUnicode(not_utf8)));
+        assert!(
+            matches!(result, Err(WorkerConfigError::DatabaseUrlNotUnicode)),
+            "invalid-UTF-8 bytes must yield DatabaseUrlNotUnicode, not Ok(None)"
         );
     }
 

--- a/apps/worker/src/compose.rs
+++ b/apps/worker/src/compose.rs
@@ -168,11 +168,24 @@ fn hex_id(bytes: &[u8]) -> String {
 /// All fields are optional with sensible defaults for local/dev runs.
 #[derive(Debug)]
 pub struct WorkerConfig {
+    /// Postgres connection URL.
+    ///
+    /// Set `NEBULA_WORKER_DATABASE_URL` to a `postgres://` DSN to use the
+    /// Postgres backend. When unset the worker uses SQLite (see `db_path`).
+    ///
+    /// The binary must be compiled with `--features postgres` (i.e. the
+    /// `postgres` cargo feature) for the Postgres path to be available. If
+    /// `NEBULA_WORKER_DATABASE_URL` is set on a binary built without that
+    /// feature, startup fails with an explicit error rather than silently
+    /// falling back to SQLite.
+    pub database_url: Option<String>,
+
     /// Path to the SQLite database file.
     ///
     /// Defaults to `nebula-worker.db` in the current working directory.
     /// Set `NEBULA_WORKER_DB_PATH` to override. An in-memory database is not
     /// suitable for production because durability is lost on process restart.
+    /// Ignored when `database_url` is `Some` (Postgres path takes precedence).
     pub db_path: String,
 
     /// 16-byte processor identity, hex-encoded (32 hex chars).
@@ -281,6 +294,8 @@ impl WorkerConfig {
     /// `NEBULA_WORKER_POLL_INTERVAL_MS` at parse time — both would silently
     /// break the claim-loop at runtime.
     pub fn from_env() -> Result<Self, WorkerConfigError> {
+        let database_url = std::env::var("NEBULA_WORKER_DATABASE_URL").ok();
+
         let db_path = std::env::var("NEBULA_WORKER_DB_PATH")
             .unwrap_or_else(|_| "nebula-worker.db".to_owned());
 
@@ -308,6 +323,7 @@ impl WorkerConfig {
             reject_zero_u64(poll_interval_ms, WorkerConfigError::PollIntervalNotPositive)?;
 
         Ok(Self {
+            database_url,
             db_path,
             processor_id,
             batch_size,

--- a/apps/worker/src/compose_main.rs
+++ b/apps/worker/src/compose_main.rs
@@ -17,6 +17,8 @@ use thiserror::Error;
 use tokio_util::sync::CancellationToken;
 use tracing_subscriber::{EnvFilter, fmt};
 
+use nebula_engine::{ExecutionStores, WorkflowStores};
+use nebula_storage_port::store::JobDispatchQueue;
 use nebula_worker_bin::compose::{
     ComposeError, WorkerConfig, WorkerConfigError, build_core_flavor_runtime,
 };
@@ -34,13 +36,41 @@ pub(crate) enum WorkerRunError {
     Config(#[from] WorkerConfigError),
 
     /// SQLite pool construction or `connect()` failed.
+    ///
+    /// Uses an explicit `.map_err(WorkerRunError::SqliteDatabase)` at the pool
+    /// build site rather than `#[from]` so the Postgres variant can reuse the
+    /// same `sqlx::Error` without a type-level conflict.
     #[error(
-        "database connection failed — check NEBULA_WORKER_DB_PATH and directory permissions: {0}"
+        "SQLite connection failed — check NEBULA_WORKER_DB_PATH and directory permissions: {0}"
     )]
-    Database(#[from] sqlx::Error),
+    SqliteDatabase(sqlx::Error),
+
+    /// Postgres pool construction or `connect()` failed.
+    ///
+    /// Only compiled when the `postgres` cargo feature is enabled.
+    #[cfg(feature = "postgres")]
+    #[error(
+        "Postgres connection failed — check NEBULA_WORKER_DATABASE_URL and network/TLS settings: {0}"
+    )]
+    PostgresDatabase(sqlx::Error),
+
+    /// `NEBULA_WORKER_DATABASE_URL` is set but this binary was compiled without
+    /// the `postgres` cargo feature.
+    ///
+    /// Gated to `#[cfg(not(feature = "postgres"))]` so it only EXISTS when its
+    /// sole constructor — the `#[cfg(not(feature = "postgres"))]` twin of
+    /// `build_pg_stores` — is also compiled in. When `--features postgres` is
+    /// enabled both are absent and operators hitting the Postgres path get
+    /// `PostgresDatabase` instead.
+    #[cfg(not(feature = "postgres"))]
+    #[error(
+        "NEBULA_WORKER_DATABASE_URL is set but this binary was not compiled with the `postgres` \
+         feature — rebuild with `--features postgres` or unset the variable to use SQLite"
+    )]
+    PostgresFeatureNotEnabled,
 
     /// Schema DDL (`CREATE TABLE IF NOT EXISTS`) failed.
-    #[error("schema init failed — the SQLite file may be corrupt or read-only: {0}")]
+    #[error("schema init failed — the database file may be corrupt or read-only: {0}")]
     Schema(#[from] nebula_storage_port::StorageError),
 
     /// Plugin wiring or worker runtime assembly failed.
@@ -54,6 +84,182 @@ pub(crate) enum WorkerRunError {
     /// Signal listener setup failed (OS-level error).
     #[error("signal handler setup failed: {0}")]
     Signal(#[from] std::io::Error),
+}
+
+/// Build the durable store bundle for the configured backend.
+///
+/// When `config.database_url` is `None`, the SQLite path is used (WAL +
+/// NORMAL synchronous; single connection; `init_schema` applied). This is the
+/// default and the only path exercised by CI integration tests.
+///
+/// When `config.database_url` is `Some`, the Postgres path is used — but
+/// only when the binary is compiled with `--features postgres`. Without that
+/// feature the call returns [`WorkerRunError::PostgresFeatureNotEnabled`]
+/// immediately, never silently falling back to SQLite.
+///
+/// The Postgres path is compile-verified (`cargo check --all-features`) but is
+/// NOT integration-tested in CI (no DATABASE_URL available in the CI
+/// environment). SQLite is the default and the tested path.
+async fn build_stores(
+    config: &WorkerConfig,
+) -> Result<(ExecutionStores, WorkflowStores, Arc<dyn JobDispatchQueue>), WorkerRunError> {
+    if config.database_url.is_none() {
+        // ── SQLite path (default, CI-tested) ─────────────────────────────────
+        //
+        // `BEGIN IMMEDIATE` CAS + claim-fencing in the store are only correct
+        // when a single connection serialises all writes. WAL + NORMAL
+        // synchronous gives read/write concurrency without fsync on every
+        // commit; busy_timeout prevents instant SQLITE_BUSY errors if another
+        // tool (e.g. a CLI probe) briefly holds the WAL write lock.
+        //
+        // **This SQLite file is not shareable across processes or hosts.** For
+        // multi-worker deployments, configure the Postgres backend and share
+        // the connection string via NEBULA_WORKER_DATABASE_URL.
+        let opts = SqliteConnectOptions::new()
+            .filename(&config.db_path)
+            .create_if_missing(true)
+            .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .busy_timeout(Duration::from_secs(5));
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(opts)
+            .await
+            .map_err(WorkerRunError::SqliteDatabase)?;
+
+        // Apply the port-scoped DDL — idempotent `CREATE TABLE IF NOT EXISTS`.
+        init_schema(&pool).await?;
+
+        tracing::info!(db_path = %config.db_path, "SQLite schema applied");
+
+        // Every store clone holds the same `SqlitePool` `Arc`; single
+        // max_connections serialises writes at the connection level.
+        let execution_store = Arc::new(SqliteExecutionStore::new(pool.clone()));
+        let journal_reader = Arc::new(SqliteJournalReader::new(pool.clone()));
+        // NodeResultStore and CheckpointStore have no SQLite-backed
+        // implementation yet; both store transient in-process data (node
+        // output slots and stateful checkpoints) that are written and read
+        // within a single execution lifetime. Durability is provided by the
+        // ExecutionStore single-JSON-blob state machine, not by these auxiliary
+        // stores. On a crash, the reclaim sweep re-delivers the job and the
+        // engine re-executes the affected nodes from the last persisted state.
+        let node_results = Arc::new(InMemoryNodeResultStore::new());
+        let checkpoints = Arc::new(InMemoryCheckpointStore::new());
+        tracing::warn!(
+            "node-result and checkpoint stores are in-memory (not persisted across restarts); \
+             crash-recovery re-executes affected nodes via the reclaim sweep — \
+             authoritative execution state is the SQLite execution row"
+        );
+        let idempotency = Arc::new(SqliteIdempotencyGuard::new(pool.clone()));
+        let workflow_store = Arc::new(SqliteWorkflowStore::new(pool.clone()));
+        let versions_store = Arc::new(SqliteWorkflowVersionStore::new(pool.clone()));
+        let queue = Arc::new(SqliteJobDispatchQueue::new(pool));
+
+        let execution_stores = ExecutionStores {
+            execution: execution_store,
+            journal: journal_reader,
+            node_results,
+            checkpoints,
+            idempotency,
+        };
+        let workflow_stores = WorkflowStores {
+            workflow: workflow_store,
+            versions: versions_store,
+        };
+
+        return Ok((execution_stores, workflow_stores, queue));
+    }
+
+    // ── Postgres path (opt-in; compile-verified but not CI-integration-tested) ──
+    //
+    // `database_url` is `Some` here — the `is_none()` early-return above means
+    // this branch is only reached when a DSN was supplied. Extract it once and
+    // pass the `&str` in so `build_pg_stores` never needs to touch `Option`.
+    let dsn = config
+        .database_url
+        .as_deref()
+        .unwrap_or_else(|| unreachable!("database_url is Some — checked above"));
+    build_pg_stores(dsn).await
+}
+
+/// Postgres store assembly — compiled only when `--features postgres` is
+/// present, and called only when `NEBULA_WORKER_DATABASE_URL` is set.
+///
+/// `dsn` is the already-extracted connection string. `build_stores` owns the
+/// `Option` unwrap and passes the inner `&str` here, so this function never
+/// touches `Option` and carries no panic path.
+///
+/// The `#[cfg(not(feature = "postgres"))]` twin always returns
+/// `WorkerRunError::PostgresFeatureNotEnabled` so the fail-closed invariant
+/// holds regardless of which binary was deployed.
+#[cfg(feature = "postgres")]
+async fn build_pg_stores(
+    dsn: &str,
+) -> Result<(ExecutionStores, WorkflowStores, Arc<dyn JobDispatchQueue>), WorkerRunError> {
+    use nebula_storage::postgres::{
+        PgExecutionStore, PgIdempotencyGuard, PgJobDispatchQueue, PgJournalReader, PgWorkflowStore,
+        PgWorkflowVersionStore, init_schema as pg_init_schema,
+    };
+    use sqlx::postgres::PgPoolOptions;
+
+    let pool = PgPoolOptions::new()
+        .max_connections(8)
+        .connect(dsn)
+        .await
+        .map_err(WorkerRunError::PostgresDatabase)?;
+
+    // Apply the port-scoped DDL — idempotent (`CREATE TABLE IF NOT EXISTS`).
+    pg_init_schema(&pool).await?;
+
+    tracing::info!("Postgres schema applied (ADR-0095 D3/D5 durable backend)");
+
+    // Every store clone shares the same `PgPool` `Arc`; the pool manages
+    // connections internally (max_connections(8)).
+    let execution_store = Arc::new(PgExecutionStore::new(pool.clone()));
+    let journal_reader = Arc::new(PgJournalReader::new(pool.clone()));
+    // NodeResult and Checkpoint have no PG implementation — they store
+    // transient in-process data (node output slots and stateful checkpoints)
+    // within a single execution lifetime. Same rationale as the SQLite path.
+    let node_results = Arc::new(InMemoryNodeResultStore::new());
+    let checkpoints = Arc::new(InMemoryCheckpointStore::new());
+    tracing::warn!(
+        "node-result and checkpoint stores are in-memory (not persisted across restarts); \
+         crash-recovery re-executes affected nodes via the reclaim sweep — \
+         authoritative execution state is the Postgres execution row"
+    );
+    let idempotency = Arc::new(PgIdempotencyGuard::new(pool.clone()));
+    let workflow_store = Arc::new(PgWorkflowStore::new(pool.clone()));
+    let versions_store = Arc::new(PgWorkflowVersionStore::new(pool.clone()));
+    let queue = Arc::new(PgJobDispatchQueue::new(pool));
+
+    let execution_stores = ExecutionStores {
+        execution: execution_store,
+        journal: journal_reader,
+        node_results,
+        checkpoints,
+        idempotency,
+    };
+    let workflow_stores = WorkflowStores {
+        workflow: workflow_store,
+        versions: versions_store,
+    };
+
+    Ok((execution_stores, workflow_stores, queue))
+}
+
+/// Fail-closed twin compiled when the `postgres` feature is absent.
+///
+/// Returns [`WorkerRunError::PostgresFeatureNotEnabled`] so the binary never
+/// silently falls back to SQLite when the operator explicitly set
+/// `NEBULA_WORKER_DATABASE_URL`. The `_dsn` parameter mirrors the postgres
+/// twin's signature so the call site in `build_stores` compiles under both
+/// feature states.
+#[cfg(not(feature = "postgres"))]
+async fn build_pg_stores(
+    _dsn: &str,
+) -> Result<(ExecutionStores, WorkflowStores, Arc<dyn JobDispatchQueue>), WorkerRunError> {
+    Err(WorkerRunError::PostgresFeatureNotEnabled)
 }
 
 /// Async startup, claim-loop, and graceful shutdown.
@@ -74,79 +280,28 @@ pub(crate) async fn run() -> Result<(), WorkerRunError> {
 
     let config = WorkerConfig::from_env()?;
 
-    tracing::info!(
-        db_path = %config.db_path,
-        batch_size = ?config.batch_size,
-        poll_interval_ms = ?config.poll_interval_ms,
-        "worker config loaded"
-    );
+    // Log the active backend. Only emit `db_path` on the SQLite path — on the
+    // Postgres path it is the ignored default "nebula-worker.db" and emitting
+    // it would mislead operators into thinking the file is in use.
+    if config.database_url.is_some() {
+        tracing::info!(
+            backend = "postgres",
+            batch_size = ?config.batch_size,
+            poll_interval_ms = ?config.poll_interval_ms,
+            "worker config loaded"
+        );
+    } else {
+        tracing::info!(
+            backend = "sqlite",
+            db_path = %config.db_path,
+            batch_size = ?config.batch_size,
+            poll_interval_ms = ?config.poll_interval_ms,
+            "worker config loaded"
+        );
+    }
 
-    // Build the SQLite pool (max 1 connection — SQLite single-writer contract).
-    //
-    // `BEGIN IMMEDIATE` CAS + claim-fencing in the store are only correct when a
-    // single connection serialises all writes. WAL + NORMAL synchronous gives
-    // read/write concurrency without fsync on every commit; busy_timeout prevents
-    // instant SQLITE_BUSY errors if another tool (e.g. a CLI probe) briefly holds
-    // the WAL write lock.
-    //
-    // **This SQLite file is not shareable across processes or hosts.** For
-    // multi-worker deployments, configure the Postgres backend (future) and share
-    // the connection string via the environment.
-    //
-    // **Windows note:** `tokio::signal::unix` is compiled out on Windows; only
-    // Ctrl-C (SIGINT equivalent) triggers graceful shutdown.
-    let opts = SqliteConnectOptions::new()
-        .filename(&config.db_path)
-        .create_if_missing(true)
-        .journal_mode(SqliteJournalMode::Wal)
-        .synchronous(SqliteSynchronous::Normal)
-        .busy_timeout(Duration::from_secs(5));
-
-    let pool = SqlitePoolOptions::new()
-        .max_connections(1)
-        .connect_with(opts)
-        .await?;
-
-    // Apply the port-scoped DDL — idempotent `CREATE TABLE IF NOT EXISTS`.
-    init_schema(&pool).await?;
-
-    tracing::info!(db_path = %config.db_path, "SQLite schema applied");
-
-    // Build the durable store bundle.
-    //
-    // Every store clone holds the same `SqlitePool` `Arc`; single max_connections
-    // serialises writes at the connection level.
-    let execution_store = Arc::new(SqliteExecutionStore::new(pool.clone()));
-    let journal_reader = Arc::new(SqliteJournalReader::new(pool.clone()));
-    // NodeResultStore and CheckpointStore have no SQLite-backed implementation yet;
-    // both store transient in-process data (node output slots and stateful
-    // checkpoints) that are written and read within a single execution lifetime.
-    // Durability is provided by the ExecutionStore single-JSON-blob state machine,
-    // not by these auxiliary stores. On a crash, the reclaim sweep re-delivers the
-    // job and the engine re-executes the affected nodes from the last persisted state.
-    let node_results = Arc::new(InMemoryNodeResultStore::new());
-    let checkpoints = Arc::new(InMemoryCheckpointStore::new());
-    tracing::warn!(
-        "node-result and checkpoint stores are in-memory (not persisted across restarts); \
-         crash-recovery re-executes affected nodes via the reclaim sweep — \
-         authoritative execution state is the SQLite execution row"
-    );
-    let idempotency = Arc::new(SqliteIdempotencyGuard::new(pool.clone()));
-    let workflow_store = Arc::new(SqliteWorkflowStore::new(pool.clone()));
-    let versions_store = Arc::new(SqliteWorkflowVersionStore::new(pool.clone()));
-    let queue = Arc::new(SqliteJobDispatchQueue::new(pool));
-
-    let execution_stores = nebula_engine::ExecutionStores {
-        execution: execution_store,
-        journal: journal_reader,
-        node_results,
-        checkpoints,
-        idempotency,
-    };
-    let workflow_stores = nebula_engine::WorkflowStores {
-        workflow: workflow_store,
-        versions: versions_store,
-    };
+    // Build the store bundle — SQLite or Postgres depending on config.
+    let (execution_stores, workflow_stores, queue) = build_stores(&config).await?;
 
     // Assemble the core-flavor builder (boots CorePlugin + wires into engine).
     // The returned MetricsRegistry is the same instance the engine's ActionRuntime
@@ -211,4 +366,48 @@ async fn wait_for_shutdown_signal(token: CancellationToken) -> Result<(), std::i
     }
     token.cancel();
     Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    // ── Fail-closed routing test ──────────────────────────────────────────────
+    //
+    // Runs under the DEFAULT (no-postgres) feature set — the same path CI uses.
+    // Proves two routing invariants in one shot:
+    //
+    //   1. `database_url = Some(dsn)` routes to the Postgres arm (not SQLite).
+    //   2. Without `--features postgres`, that arm returns
+    //      `WorkerRunError::PostgresFeatureNotEnabled` — never falls back to
+    //      SQLite silently.
+    //
+    // Red-able: if `build_stores` ignored `database_url` and fell through to the
+    // SQLite arm, it would attempt to open
+    // "nebula-worker-MUST-NOT-BE-OPENED.db" and return `Ok(...)` or
+    // `Err(SqliteDatabase(_))` — not `PostgresFeatureNotEnabled` — causing the
+    // `matches!` assertion to fail.
+
+    /// DSN set on a no-postgres binary must fail closed, never silently open SQLite.
+    #[cfg(not(feature = "postgres"))]
+    #[tokio::test]
+    async fn database_url_set_without_postgres_feature_is_fail_closed() {
+        use super::{WorkerConfig, WorkerRunError, build_stores};
+
+        let config = WorkerConfig {
+            database_url: Some("postgres://localhost/nebula_test".to_owned()),
+            // A file name that would be obviously wrong if SQLite opened it.
+            db_path: "nebula-worker-MUST-NOT-BE-OPENED.db".to_owned(),
+            processor_id: [0u8; 16],
+            batch_size: None,
+            poll_interval_ms: None,
+        };
+
+        let result = build_stores(&config).await;
+
+        assert!(
+            matches!(result, Err(WorkerRunError::PostgresFeatureNotEnabled)),
+            "expected WorkerRunError::PostgresFeatureNotEnabled, got: {result:?}"
+        );
+    }
 }

--- a/apps/worker/src/main.rs
+++ b/apps/worker/src/main.rs
@@ -7,7 +7,8 @@
 //!
 //! | Variable | Default | Description |
 //! |---|---|---|
-//! | `NEBULA_WORKER_DB_PATH` | `nebula-worker.db` | SQLite database file path |
+//! | `NEBULA_WORKER_DATABASE_URL` | unset | Postgres DSN; when set, uses Postgres backend (requires `--features postgres`). Unset = SQLite default. |
+//! | `NEBULA_WORKER_DB_PATH` | `nebula-worker.db` | SQLite database file path (ignored when `NEBULA_WORKER_DATABASE_URL` is set) |
 //! | `NEBULA_WORKER_PROCESSOR_ID` | random UUID v4 per boot | 32 hex chars (16 bytes); set explicitly for stable fence identity |
 //! | `NEBULA_WORKER_BATCH_SIZE` | orchestrator default (32) | Jobs per claim batch |
 //! | `NEBULA_WORKER_POLL_INTERVAL_MS` | 100 | Idle poll interval (ms) |


### PR DESCRIPTION
## What

Makes the `apps/worker` flavor binary's store backend **config-driven** so the leaderless multi-worker fleet becomes real — a single SQLite file is single-process/single-host; multiple worker processes need a network-shared store.

- A single `build_stores(config)` factory returns identical `Arc<dyn>` store trait objects for either backend → `build_core_flavor_runtime` and the rest of the binary are **untouched**. New `NEBULA_WORKER_DATABASE_URL` config selects the backend.
- **PG opt-in behind a `postgres` cargo feature** (mirrors apps/server). Default build = SQLite-only (no sqlx-postgres). When the feature is on + DSN set → the 6 durable `Pg*` stores + `init_schema`; NodeResult/Checkpoint stay in-process on both backends (intentional).
- **Fail-closed:** DSN set but binary built without `--features postgres` ⇒ typed `WorkerRunError::PostgresFeatureNotEnabled` — never a silent SQLite fallback. Proven by a red→green test on the default (CI) build.
- The SQLite arm is a **verbatim extraction** of the prior inline wiring; the smoke test is unchanged.

## Verification
- Default build (SQLite-only) + `--features postgres` build both compile; `cargo clippy --workspace --all-features -D` clean (CI's Check+Clippy compile-checks the PG path); nextest 14/14 (smoke + the fail-closed test); rustdoc `-D`; DSN never logged.

## Honest caveat
The PG path is **compile-verified only** — CI has no `DATABASE_URL`, so PG behaviour is not integration-tested (same accepted posture as the rest of storage-PG / roadmap M7). SQLite stays the default + tested path; the working SQLite binary is never regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Postgres database backend support as an alternative to SQLite
  * New `NEBULA_WORKER_DATABASE_URL` environment variable enables Postgres connection configuration
  * Runtime automatically selects backend based on which environment variable is set

* **Documentation**
  * Updated configuration documentation with Postgres setup instructions and feature requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->