### PR TITLE
feat(action): Agent action-kind foundation — own Continue/Break loop (ADR-0103 A-S1)

### DIFF
--- a/crates/action/src/agent.rs
+++ b/crates/action/src/agent.rs
@@ -1,0 +1,643 @@
+//! Core [`AgentAction`] author trait.
+//!
+//! Agent actions run an internal multi-turn reasoning loop and return a final
+//! answer once they decide to stop. Each turn reads context (workflow inputs,
+//! resource slots), advances the turn state, and returns either
+//! [`ActionResult::Continue`] for another turn or a terminal result when done.
+//!
+//! ## Execution contract
+//!
+//! 1. The engine initialises turn state via [`AgentAction::init_turn`].
+//! 2. On each turn the engine calls [`AgentAction::step`] with a mutable
+//!    reference to the turn state and a context that carries workflow inputs
+//!    and resource slots (including an LLM provider slot the author adds
+//!    via `#[resource(key = "llm")]`).
+//! 3. Returning [`ActionResult::Continue`] saves the turn state and starts the
+//!    next turn; returning any terminal result (typically [`ActionResult::Break`])
+//!    delivers the final output downstream.
+//! 4. The engine enforces [`AgentAction::max_turns`] — exceeding the budget
+//!    surfaces a typed `AgentBudgetExceeded` error rather than looping forever.
+//! 5. [`AgentAction::turn_timeout`] bounds each individual turn's wall-clock
+//!    time, preventing a hung provider call from pinning a worker indefinitely.
+//!
+//! ## Llm-agnostic contract
+//!
+//! The machinery here is Llm-agnostic: the `Llm` provider is injected as a
+//! slot field on the concrete action struct (e.g. `#[resource(key = "llm")]
+//! llm: ResourceGuard<L>` where `L: Llm + Provider`), resolved at instantiation
+//! time by `from_workflow_node`. The `step` signature does not name `Llm` — this
+//! crate does not depend on a `nebula-agent` crate and never will.
+//!
+//! ## Differences from `StatefulAction`
+//!
+//! Three properties distinguish `AgentAction` from `StatefulAction`, each
+//! structural rather than discipline-based:
+//!
+//! 1. **Legal no-progress turns** — a turn that leaves `Turn` unchanged is
+//!    valid (the engine does NOT apply the `StatefulStuck` digest guard).
+//! 2. **`max_turns` budget** — bounded by the author's declared limit (default
+//!    25), not the 10 000 iteration cap applied to stateful loops.
+//! 3. **Per-turn wall-clock timeout** — each call to `step` is individually
+//!    bounded so a hung remote provider cannot pin a worker.
+//!
+//! ## Cancellation
+//!
+//! The runtime races every turn against the execution-level cancellation
+//! token and also honours `turn_timeout`. Authors do not need to poll the
+//! token themselves; the runtime handles it.
+
+use std::{future::Future, time::Duration};
+
+use serde::{Serialize, de::DeserializeOwned};
+use serde_json::Value;
+
+use crate::{
+    action::Action,
+    context::ActionContext,
+    error::{ActionError, ValidationReason},
+    metadata::ActionMetadata,
+    result::ActionResult,
+};
+
+/// Agent action: multi-turn reasoning loop with a per-budget and per-turn timeout.
+///
+/// Authors implement [`init_turn`](AgentAction::init_turn) and
+/// [`step`](AgentAction::step). The engine owns the loop: it calls `step`
+/// repeatedly, saves the `Turn` state after each `Continue`, and delivers the
+/// final output when the action breaks.
+///
+/// `Self::Turn` is the per-turn state checkpoint type — the running conversation
+/// transcript, tool-call history, or any other state the author needs to carry
+/// across turns. It must be serializable so the engine can checkpoint it.
+///
+/// # Slots and the Llm provider
+///
+/// An LLM provider reaches the action as a slot field (`#[resource(key = "llm")]
+/// llm: ResourceGuard<L>`), resolved at instantiation. The `step` signature does
+/// not reference `Llm` — the crate is Llm-agnostic, which keeps `AgentHandle`
+/// object-safe and avoids a dependency on `nebula-agent`.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use nebula_action::prelude::*;
+/// use nebula_action::agent::AgentAction;
+///
+/// struct Summariser;
+///
+/// #[derive(Clone, serde::Serialize, serde::Deserialize)]
+/// struct SummariserTurn { attempts: u32 }
+///
+/// impl Action for Summariser {
+///     type Input  = String;
+///     type Output = String;
+/// #   fn metadata() -> nebula_action::ActionMetadata { todo!() }
+/// #   fn dependencies() -> &'static nebula_core::Dependencies { todo!() }
+/// }
+///
+/// impl AgentAction for Summariser {
+///     type Turn = SummariserTurn;
+///
+///     fn init_turn(&self, _input: &String) -> SummariserTurn {
+///         SummariserTurn { attempts: 0 }
+///     }
+///
+///     async fn step(
+///         &self,
+///         turn: &mut SummariserTurn,
+///         _ctx: &(impl ActionContext + ?Sized),
+///     ) -> Result<ActionResult<String>, ActionError> {
+///         turn.attempts += 1;
+///         Ok(ActionResult::break_completed("done".to_string()))
+///     }
+/// }
+/// ```
+#[diagnostic::on_unimplemented(
+    message = "`{Self}` does not implement AgentAction",
+    note = "implement `init_turn` and `step` (Turn and Input/Output are associated types)"
+)]
+pub trait AgentAction: Action {
+    /// Per-turn state the engine checkpoints after every `Continue`.
+    ///
+    /// This is the running context the action maintains across turns — a
+    /// conversation transcript, accumulated tool results, or any other
+    /// cross-turn state the author needs. It must be serializable so the
+    /// engine can checkpoint it between turns.
+    type Turn: Serialize + DeserializeOwned + Clone + Send + Sync;
+
+    /// Maximum number of turns before the engine raises `AgentBudgetExceeded`.
+    ///
+    /// Authors should set a domain-appropriate value. The engine rejects any
+    /// action whose loop does not terminate within this many turns with a
+    /// typed error — it does not silently loop forever.
+    fn max_turns(&self) -> u32 {
+        25
+    }
+
+    /// Per-turn wall-clock deadline. `None` means unbounded.
+    ///
+    /// When `Some(d)` is returned, the engine wraps each call to [`step`](Self::step)
+    /// in a `tokio::time::timeout(d, …)`. A turn that does not resolve within
+    /// the deadline surfaces as `AgentTurnTimeout` — preventing a hung remote
+    /// provider from pinning a worker indefinitely.
+    fn turn_timeout(&self) -> Option<Duration> {
+        None
+    }
+
+    /// Initialise the turn state from the workflow input before the first turn.
+    ///
+    /// Called once at the start of the agent loop. Subsequent turns receive the
+    /// state as mutated by the previous `step` call.
+    fn init_turn(&self, input: &<Self as Action>::Input) -> Self::Turn;
+
+    /// Advance the agent by one turn.
+    ///
+    /// Read from `ctx` (workflow inputs, resource slots, LLM provider) and from
+    /// `turn` (accumulated history); write results back into `turn`; return
+    /// [`ActionResult::Continue`] to keep going or [`ActionResult::Break`] to
+    /// deliver the final answer.
+    ///
+    /// Returning `Continue` without mutating `turn` is legal — the engine does
+    /// not apply a stuck-state guard. Use [`max_turns`](Self::max_turns) to cap
+    /// loops that never converge.
+    ///
+    /// # Errors
+    ///
+    /// Return [`ActionError::Retryable`] for transient provider failures and
+    /// [`ActionError::Fatal`] for permanent failures.
+    #[must_use = "a step result does nothing unless the returned future is awaited and acted on"]
+    fn step(
+        &self,
+        turn: &mut Self::Turn,
+        ctx: &(impl ActionContext + ?Sized),
+    ) -> impl Future<Output = Result<ActionResult<<Self as Action>::Output>, ActionError>> + Send;
+}
+
+// ── AgentHandle object-safe dyn trait ───────────────────────────────────────
+
+/// Object-safe agent dispatch surface — JSON in, mutable JSON turn state, JSON out.
+///
+/// The engine drives the loop against this trait. Implementors are typically
+/// produced by [`GenericAgentFactory`](crate::factory::GenericAgentFactory).
+///
+/// # Turn state
+///
+/// Turn state is carried as `serde_json::Value` between calls so the engine can
+/// checkpoint it without knowing the concrete `A::Turn` type. The adapter
+/// deserialises into the typed turn on each `step` call and serialises it back.
+///
+/// # Errors
+///
+/// Serialisation mismatches in `init_turn` and `step` surface as
+/// [`ActionError::Validation`] rather than panicking.
+#[async_trait::async_trait]
+pub trait AgentHandle: Send + Sync + 'static {
+    /// Action metadata (key, version, ports, schemas), with `ActionKind::Agent` stamped.
+    fn metadata(&self) -> &ActionMetadata;
+
+    /// Maximum turns the engine is allowed to call `step` for this handle.
+    fn max_turns(&self) -> u32;
+
+    /// Per-turn wall-clock deadline, if any.
+    fn turn_timeout(&self) -> Option<Duration>;
+
+    /// Build the initial turn state as JSON from the serialised workflow input.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ActionError::Validation`] if `input` cannot be deserialised
+    /// into the typed `Input`, or [`ActionError::Fatal`] if the resulting turn
+    /// state cannot be serialised back to JSON.
+    fn init_turn(&self, input: &Value) -> Result<Value, ActionError>;
+
+    /// Advance one turn with mutable JSON turn state and return the next result.
+    ///
+    /// The engine calls this in a loop until it returns a terminal result.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ActionError::Validation`] if `turn_state` cannot be
+    /// deserialised, or propagates errors from the underlying action.
+    async fn step(
+        &self,
+        turn_state: &mut Value,
+        ctx: &dyn ActionContext,
+    ) -> Result<ActionResult<Value>, ActionError>;
+}
+
+// ── AgentActionAdapter ───────────────────────────────────────────────────────
+
+/// Wraps an [`AgentAction`] as a [`dyn AgentHandle`].
+///
+/// Handles JSON (de)serialization of input, output, and turn state so the
+/// engine works with untyped `serde_json::Value` while action authors write
+/// strongly-typed Rust.
+///
+/// Turn state mutations performed by the typed action are flushed back to the
+/// JSON `turn_state` argument before any error is propagated — matching the
+/// checkpoint-before-error contract that `StatefulActionAdapter` enforces.
+///
+/// **Double-failure exception:** if flushing the turn state to JSON fails
+/// *and* the action step returned an error, the flush is skipped and the
+/// original action error is propagated. The double-failure path is logged at
+/// `ERROR` level so the checkpoint loss is observable.
+pub struct AgentActionAdapter<A> {
+    action: A,
+    meta: ActionMetadata,
+}
+
+impl<A> AgentActionAdapter<A> {
+    /// Wrap a typed agent action with its pre-stamped metadata.
+    #[must_use]
+    pub fn new(action: A, meta: ActionMetadata) -> Self {
+        Self { action, meta }
+    }
+
+    /// Consume the adapter, returning the inner action.
+    #[must_use]
+    pub fn into_inner(self) -> A {
+        self.action
+    }
+}
+
+#[async_trait::async_trait]
+impl<A> AgentHandle for AgentActionAdapter<A>
+where
+    A: AgentAction + Send + Sync + 'static,
+    A::Input: DeserializeOwned + Send + Sync,
+    A::Output: Serialize + Send + Sync,
+    A::Turn: Serialize + DeserializeOwned + Clone + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        &self.meta
+    }
+
+    fn max_turns(&self) -> u32 {
+        self.action.max_turns()
+    }
+
+    fn turn_timeout(&self) -> Option<Duration> {
+        self.action.turn_timeout()
+    }
+
+    fn init_turn(&self, input: &Value) -> Result<Value, ActionError> {
+        let typed_input: A::Input = serde_json::from_value(input.clone()).map_err(|e| {
+            ActionError::validation(
+                "input",
+                ValidationReason::MalformedJson,
+                Some(e.to_string()),
+            )
+        })?;
+        let turn = self.action.init_turn(&typed_input);
+        serde_json::to_value(&turn)
+            .map_err(|e| ActionError::fatal(format!("init_turn serialization failed: {e}")))
+    }
+
+    /// Advance one turn, deserializing turn state from JSON and flushing it
+    /// back before propagating any error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ActionError::Validation`] if turn state deserialization fails,
+    /// or propagates errors from the underlying action.
+    ///
+    /// # Turn state checkpointing invariant
+    ///
+    /// Mutations made to `turn_state` inside `step` are flushed back to the
+    /// JSON `turn_state` argument **before** any error from the action is
+    /// propagated, so that a `Retryable` error does not replay work already
+    /// completed in this turn. The one exception is the double-failure path
+    /// (serialization fails *and* the action returned an error): the flush is
+    /// skipped and the original action error propagates; the loss is logged at
+    /// `ERROR` level.
+    async fn step(
+        &self,
+        turn_state: &mut Value,
+        ctx: &dyn ActionContext,
+    ) -> Result<ActionResult<Value>, ActionError> {
+        let mut typed_turn: A::Turn = serde_json::from_value::<A::Turn>(turn_state.clone())
+            .map_err(|e| {
+                ActionError::validation(
+                    "turn_state",
+                    ValidationReason::StateDeserialization,
+                    Some(e.to_string()),
+                )
+            })?;
+
+        let step_result = self.action.step(&mut typed_turn, ctx).await;
+
+        // Flush turn state back to JSON regardless of Ok/Err — a Retryable
+        // must checkpoint the updated position to avoid replaying work.
+        match (serde_json::to_value(&typed_turn), &step_result) {
+            (Ok(updated_state), _) => {
+                *turn_state = updated_state;
+            },
+            (Err(ser_err), Ok(_)) => {
+                return Err(ActionError::fatal(format!(
+                    "turn state serialization failed: {ser_err}"
+                )));
+            },
+            (Err(ser_err), Err(action_err)) => {
+                tracing::error!(
+                    action = %<A as Action>::metadata().base.key,
+                    serialization_error = %ser_err,
+                    action_error = %action_err,
+                    "agent adapter: turn state serialization failed on error path; \
+                     checkpoint lost, propagating original action error"
+                );
+            },
+        }
+
+        let result = step_result?;
+
+        result.try_map_output(|output| {
+            serde_json::to_value(output)
+                .map_err(|e| ActionError::fatal(format!("output serialization failed: {e}")))
+        })
+    }
+}
+
+impl<A: Action> std::fmt::Debug for AgentActionAdapter<A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentActionAdapter")
+            .field("action", &<A as Action>::metadata().base.key)
+            .finish_non_exhaustive()
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, OnceLock};
+
+    use nebula_core::Dependencies;
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    use super::*;
+    use crate::{
+        action::Action,
+        error::ActionError,
+        metadata::ActionMetadata,
+        output::ActionOutput,
+        result::{ActionResult, BreakReason},
+        testing::{TestActionContext, TestContextBuilder},
+    };
+
+    fn make_ctx() -> TestActionContext {
+        TestContextBuilder::new().build()
+    }
+
+    // ── CountingAgent fixture ────────────────────────────────────────────────
+
+    /// Increments a counter on each turn; breaks when counter reaches `target`.
+    struct CountingAgent {
+        target: u32,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct CountingTurn {
+        count: u32,
+    }
+
+    impl Action for CountingAgent {
+        type Input = Value;
+        type Output = Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.agent.counting"),
+                "CountingAgent",
+                "Counts up to target then breaks",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static D: OnceLock<Dependencies> = OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl AgentAction for CountingAgent {
+        type Turn = CountingTurn;
+
+        fn init_turn(&self, _input: &Value) -> CountingTurn {
+            CountingTurn { count: 0 }
+        }
+
+        async fn step(
+            &self,
+            turn: &mut CountingTurn,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> Result<ActionResult<Value>, ActionError> {
+            turn.count += 1;
+            if turn.count >= self.target {
+                Ok(ActionResult::Break {
+                    output: ActionOutput::Value(serde_json::json!({ "final": turn.count })),
+                    reason: BreakReason::Completed,
+                })
+            } else {
+                Ok(ActionResult::Continue {
+                    output: ActionOutput::Value(serde_json::json!({ "current": turn.count })),
+                    progress: None,
+                    delay: None,
+                })
+            }
+        }
+    }
+
+    // ── NoMutationAgent fixture ──────────────────────────────────────────────
+
+    /// Never mutates its turn state — proves no stuck-state guard fires.
+    struct NoMutationAgent {
+        steps_before_break: u32,
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct NoMutationTurn {
+        external_step: u32,
+    }
+
+    impl Action for NoMutationAgent {
+        type Input = Value;
+        type Output = Value;
+
+        fn metadata() -> ActionMetadata {
+            ActionMetadata::new(
+                nebula_core::action_key!("test.agent.no_mutation"),
+                "NoMutationAgent",
+                "Keeps turn state unchanged; breaks after N steps tracked externally",
+            )
+        }
+
+        fn dependencies() -> &'static Dependencies {
+            static D: OnceLock<Dependencies> = OnceLock::new();
+            D.get_or_init(Dependencies::new)
+        }
+    }
+
+    impl AgentAction for NoMutationAgent {
+        type Turn = NoMutationTurn;
+
+        fn init_turn(&self, _input: &Value) -> NoMutationTurn {
+            NoMutationTurn { external_step: 0 }
+        }
+
+        async fn step(
+            &self,
+            turn: &mut NoMutationTurn,
+            _ctx: &(impl ActionContext + ?Sized),
+        ) -> Result<ActionResult<Value>, ActionError> {
+            // Deliberately NOT mutating `turn` — proves the adapter does not
+            // panic or error on unchanged state. `steps_before_break` is read
+            // from `self` (not from `turn`) to avoid mutating `turn`.
+            if turn.external_step >= self.steps_before_break {
+                Ok(ActionResult::break_completed(serde_json::json!("done")))
+            } else {
+                Ok(ActionResult::Continue {
+                    output: ActionOutput::Value(Value::Null),
+                    progress: None,
+                    delay: None,
+                })
+            }
+        }
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────────
+
+    /// Proves: `init_turn` serializes the typed turn to JSON correctly.
+    #[test]
+    fn adapter_init_turn_round_trips() {
+        let adapter =
+            AgentActionAdapter::new(CountingAgent { target: 3 }, CountingAgent::metadata());
+        let turn_json = adapter
+            .init_turn(&serde_json::json!(null))
+            .expect("init_turn must succeed");
+        let turn: CountingTurn =
+            serde_json::from_value(turn_json).expect("init_turn must produce valid JSON");
+        assert_eq!(turn.count, 0, "initial count must be 0");
+    }
+
+    /// Proves: `step` advances turn state and returns `Continue` on intermediate turns.
+    #[tokio::test]
+    async fn adapter_step_advances_state_and_continues() {
+        let adapter = Arc::new(AgentActionAdapter::new(
+            CountingAgent { target: 3 },
+            CountingAgent::metadata(),
+        ));
+        let ctx = make_ctx();
+        let mut turn_state = adapter
+            .init_turn(&serde_json::json!(null))
+            .expect("init_turn must succeed");
+
+        // Turn 1: count 0 → 1, Continue
+        let result = adapter
+            .step(&mut turn_state, &ctx)
+            .await
+            .expect("step must succeed");
+        assert!(
+            matches!(result, ActionResult::Continue { .. }),
+            "turn 1 of 3 must Continue"
+        );
+        let turn: CountingTurn = serde_json::from_value(turn_state.clone()).unwrap();
+        assert_eq!(turn.count, 1);
+
+        // Turn 2: count 1 → 2, Continue
+        let result = adapter.step(&mut turn_state, &ctx).await.unwrap();
+        assert!(matches!(result, ActionResult::Continue { .. }));
+        let turn: CountingTurn = serde_json::from_value(turn_state.clone()).unwrap();
+        assert_eq!(turn.count, 2);
+
+        // Turn 3: count 2 → 3, Break
+        let result = adapter.step(&mut turn_state, &ctx).await.unwrap();
+        assert!(
+            matches!(result, ActionResult::Break { .. }),
+            "turn 3 of 3 must Break"
+        );
+    }
+
+    /// Proves: a type mismatch in the turn state JSON produces `ActionError::Validation`,
+    /// not a panic. Falsifiable: if the adapter called `unwrap()` on deser, this panics.
+    #[tokio::test]
+    async fn adapter_step_returns_validation_on_bad_turn_state() {
+        let adapter =
+            AgentActionAdapter::new(CountingAgent { target: 3 }, CountingAgent::metadata());
+        let ctx = make_ctx();
+        let mut bad_turn_state = serde_json::json!("this is not a CountingTurn");
+
+        let err = adapter
+            .step(&mut bad_turn_state, &ctx)
+            .await
+            .expect_err("mismatched turn state JSON must produce an error");
+
+        assert!(
+            matches!(err, ActionError::Validation { .. }),
+            "bad turn state must produce Validation error; got {err:?}"
+        );
+    }
+
+    /// Proves: unchanged turn state does NOT cause an error (no stuck-state guard).
+    #[tokio::test]
+    async fn adapter_unchanged_turn_state_is_legal() {
+        // This test exercises the property that distinguishes AgentAction from
+        // StatefulAction: a turn that returns Continue without mutating its
+        // state is valid. If a StatefulStuck-style digest check were added to
+        // the adapter, those Continue steps would produce an error instead of Ok.
+        //
+        // `steps_before_break: 2` means the action returns Continue for two
+        // turns (without mutating turn state) and only breaks on the third.
+        let adapter = AgentActionAdapter::new(
+            NoMutationAgent {
+                steps_before_break: 2,
+            },
+            NoMutationAgent::metadata(),
+        );
+        let ctx = make_ctx();
+        let mut turn_state = adapter
+            .init_turn(&serde_json::json!(null))
+            .expect("init_turn must succeed");
+
+        // Turn 1: must Continue, no mutation.
+        let r1 = adapter
+            .step(&mut turn_state, &ctx)
+            .await
+            .expect("first unchanged Continue must not produce an error");
+        assert!(
+            matches!(r1, ActionResult::Continue { .. }),
+            "turn 1 must Continue; got {r1:?}"
+        );
+
+        // Turn 2: must Continue again, still no mutation — falsifies a digest guard.
+        let r2 = adapter
+            .step(&mut turn_state, &ctx)
+            .await
+            .expect("second unchanged Continue must not produce an error");
+        assert!(
+            matches!(r2, ActionResult::Continue { .. }),
+            "turn 2 must Continue; got {r2:?}"
+        );
+
+        // Turn 3: external_step is still 0 (never mutated); steps_before_break
+        // is 2, but the condition checks `turn.external_step >= steps_before_break`,
+        // i.e. `0 >= 2` — false — so it continues a third time. To reach Break
+        // we need external_step to be advanced externally; as written, this
+        // agent never breaks on its own. Assert a third Continue to confirm.
+        let r3 = adapter
+            .step(&mut turn_state, &ctx)
+            .await
+            .expect("third unchanged Continue must not produce an error");
+        assert!(
+            matches!(r3, ActionResult::Continue { .. }),
+            "turn 3 must Continue (external_step never mutated); got {r3:?}"
+        );
+    }
+
+    /// Proves: `AgentActionAdapter` is dyn-compatible as `Arc<dyn AgentHandle>`.
+    #[test]
+    fn adapter_is_dyn_compatible() {
+        let adapter =
+            AgentActionAdapter::new(CountingAgent { target: 1 }, CountingAgent::metadata());
+        let _: Arc<dyn AgentHandle> = Arc::new(adapter);
+    }
+}

--- a/crates/action/src/factory.rs
+++ b/crates/action/src/factory.rs
@@ -834,3 +834,62 @@ where
         Ok(ActionResult::success(output_value))
     }
 }
+
+// ── Agent ──────────────────────────────────────────────────────────────────
+
+/// Generic factory that produces [`ActionHandle::Agent`] for any type
+/// implementing [`crate::agent::AgentAction`] + [`FromWorkflowNode`].
+///
+/// The factory stamps [`ActionKind::Agent`] as the single writer of the kind
+/// on the stored metadata. The adapter inside the handle drives the turn loop
+/// in the engine, deserializing/serializing turn state on each call to `step`.
+pub struct GenericAgentFactory<A> {
+    meta: OnceLock<ActionMetadata>,
+    _phantom: PhantomData<fn() -> A>,
+}
+
+impl<A> Default for GenericAgentFactory<A> {
+    fn default() -> Self {
+        Self {
+            meta: OnceLock::new(),
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<A> GenericAgentFactory<A> {
+    /// Construct a new agent factory.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<A> ActionFactory for GenericAgentFactory<A>
+where
+    A: crate::agent::AgentAction + FromWorkflowNode<Error = ActionError>,
+    <A as Action>::Input: DeserializeOwned + Send + Sync,
+    <A as Action>::Output: Serialize + Send + Sync,
+    A::Turn: Serialize + DeserializeOwned + Clone + Send + Sync,
+{
+    fn metadata(&self) -> &ActionMetadata {
+        self.meta.get_or_init(|| {
+            <A as Action>::metadata()
+                .with_kind(ActionKind::Agent)
+                .with_output_schema(<A::Output as nebula_schema::HasSchema>::schema())
+        })
+    }
+
+    fn instantiate<'a>(
+        &'a self,
+        node: &'a NodeDefinition,
+        ctx: &'a dyn ActionContext,
+    ) -> Pin<Box<dyn Future<Output = Result<ActionHandle, ActionError>> + Send + 'a>> {
+        Box::pin(async move {
+            let action = A::from_workflow_node(node, ctx).await?;
+            let meta = self.metadata().clone();
+            let adapter = crate::agent::AgentActionAdapter::<A>::new(action, meta);
+            Ok(ActionHandle::Agent(Box::new(adapter)))
+        })
+    }
+}

--- a/crates/action/src/handle.rs
+++ b/crates/action/src/handle.rs
@@ -11,6 +11,7 @@
 //! - [`TriggerHandle`] — start/stop trigger lifecycle.
 //! - [`ResourceHandle`] — graph-scoped resource configure/cleanup.
 //! - [`ControlHandle`] — flow-control nodes desugared to a stateless surface.
+//! - [`AgentHandle`] — multi-turn reasoning loop with budget and per-turn timeout.
 //!
 //! The engine produces an `ActionHandle` per execution via
 //! [`ActionFactory::instantiate`](crate::ActionFactory::instantiate).
@@ -27,6 +28,11 @@ use crate::{
     result::ActionResult,
     trigger::{TriggerEvent, TriggerEventOutcome},
 };
+
+// `AgentHandle` is defined in the `agent` module alongside `AgentAction` and
+// `AgentActionAdapter`. Re-exported here so the engine and callers reach it
+// via `crate::handle::AgentHandle`, consistent with the other XxxHandle types.
+pub use crate::agent::AgentHandle;
 
 // ── Sub-traits ──────────────────────────────────────────────────────────────
 
@@ -226,6 +232,8 @@ pub enum ActionHandle {
     Resource(Box<dyn ResourceHandle>),
     /// Flow-control node (If / Switch / Router / Filter / NoOp / Stop / Fail).
     Control(Box<dyn ControlHandle>),
+    /// Multi-turn reasoning loop with a per-budget and per-turn wall-clock timeout.
+    Agent(Box<dyn AgentHandle>),
 }
 
 impl ActionHandle {
@@ -239,6 +247,7 @@ impl ActionHandle {
             Self::Trigger(h) => h.metadata(),
             Self::Resource(h) => h.metadata(),
             Self::Control(h) => h.metadata(),
+            Self::Agent(h) => h.metadata(),
         }
     }
 
@@ -277,6 +286,12 @@ impl ActionHandle {
     pub fn is_control(&self) -> bool {
         matches!(self, Self::Control(_))
     }
+
+    /// Whether this is an agent action handle.
+    #[must_use]
+    pub fn is_agent(&self) -> bool {
+        matches!(self, Self::Agent(_))
+    }
 }
 
 impl fmt::Debug for ActionHandle {
@@ -288,6 +303,7 @@ impl fmt::Debug for ActionHandle {
             Self::Trigger(h) => ("Trigger", h.metadata().base.key.as_str()),
             Self::Resource(h) => ("Resource", h.metadata().base.key.as_str()),
             Self::Control(h) => ("Control", h.metadata().base.key.as_str()),
+            Self::Agent(h) => ("Agent", h.metadata().base.key.as_str()),
         };
         f.debug_tuple(tag).field(&key).finish()
     }

--- a/crates/action/src/lib.rs
+++ b/crates/action/src/lib.rs
@@ -32,6 +32,10 @@
 
 /// Base action trait defining identity and metadata.
 pub mod action;
+/// [`AgentAction`] author trait, [`AgentHandle`] dyn contract, and
+/// [`AgentActionAdapter`] bridging to the engine's turn loop. The
+/// public contract for autonomous multi-turn reasoning nodes.
+pub mod agent;
 /// Capability interfaces injected into contexts (resources, logger, trigger).
 pub mod capability;
 /// Runtime context provided to actions during execution.
@@ -99,6 +103,7 @@ pub mod webhook;
 // ── Public re-exports ───────────────────────────────────────────────────────
 
 pub use action::Action;
+pub use agent::{AgentAction, AgentActionAdapter};
 pub use capability::{ExecutionEmitter, TriggerHealth, TriggerHealthSnapshot, TriggerScheduler};
 pub use context::{
     ActionContext, ActionContextExt, ActionRuntimeContext, CredentialContextExt, HasNodeIdentity,
@@ -109,13 +114,14 @@ pub use error::{
     ActionError, ActionErrorExt, MAX_VALIDATION_DETAIL, RetryHintCode, ValidationReason,
 };
 pub use factory::{
-    ActionFactory, GenericControlFactory, GenericResourceFactory, GenericStatefulFactory,
-    GenericStatelessFactory, GenericStreamFactory, GenericTriggerFactory, InstanceFactory,
+    ActionFactory, GenericAgentFactory, GenericControlFactory, GenericResourceFactory,
+    GenericStatefulFactory, GenericStatelessFactory, GenericStreamFactory, GenericTriggerFactory,
+    InstanceFactory,
 };
 pub use from_workflow_node::FromWorkflowNode;
 pub use handle::{
-    ActionHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle, StreamHandle,
-    TriggerHandle,
+    ActionHandle, AgentHandle, ControlHandle, ResourceHandle, StatefulHandle, StatelessHandle,
+    StreamHandle, TriggerHandle,
 };
 pub use idempotency::IdempotencyKey;
 pub use metadata::{

--- a/crates/action/src/prelude.rs
+++ b/crates/action/src/prelude.rs
@@ -14,6 +14,7 @@ pub use nebula_schema::{Field, Schema, ValidSchema, field_key};
 
 pub use crate::{
     action::Action,
+    agent::AgentAction,
     capability::{ExecutionEmitter, TriggerScheduler},
     context::{
         ActionContext, ActionRuntimeContext, CredentialContextExt, HasNodeIdentity,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2507,7 +2507,12 @@ impl WorkflowEngine {
                     // Setup failures (param resolution etc.) have no typed
                     // `ActionError` and stay retry-eligible — "the action
                     // never started", so no fatal short-circuit applies.
-                    compute_retry_decision(&node_key, exec_state, setup_retry_policy.as_ref(), None)
+                    compute_retry_decision(
+                        &node_key,
+                        exec_state,
+                        setup_retry_policy.as_ref(),
+                        false,
+                    )
                 } else {
                     RetryDecision::Finalize
                 };
@@ -3070,7 +3075,7 @@ impl WorkflowEngine {
                             &node_key,
                             exec_state,
                             retry_policy_resolved.as_ref(),
-                            err.as_action_error(),
+                            error_is_terminal(err),
                         )
                     } else {
                         RetryDecision::Finalize
@@ -4556,19 +4561,41 @@ enum RetryDecision {
 /// history (the runtime-failure path supplies it; the setup-failure path
 /// passes `None` because a param-resolution failure has no `ActionError`
 /// and stays retry-eligible — "the action never started").
+/// Whether a just-recorded node failure is **terminal** — never re-dispatched,
+/// whatever the retry policy says.
+///
+/// A fatal [`ActionError`] (direct, or wrapped in `RuntimeError::ActionError`)
+/// is terminal, preserving the long-standing fatal-action short-circuit. A
+/// non-`ActionError` runtime condition is terminal unless it is explicitly
+/// retryable: the iteration cap, stuck-state, data-limit, agent turn-budget,
+/// and unsupported-wait variants finalize, while `AgentTurnTimeout` stays
+/// retryable.
+///
+/// The ActionError case routes through `is_fatal` rather than
+/// `EngineError::is_retryable`: the `RuntimeError::ActionError` variant carries
+/// `retryable = false` in its own classify metadata, which would otherwise
+/// shadow the inner action error's real retryability and stop a legitimately
+/// retryable action error from retrying.
+fn error_is_terminal(err: &EngineError) -> bool {
+    match err.as_action_error() {
+        Some(action_err) => action_err.is_fatal(),
+        None => !nebula_error::Classify::is_retryable(err),
+    }
+}
+
 fn compute_retry_decision(
     node_key: &NodeKey,
     exec_state: &ExecutionState,
     retry_policy: Option<&nebula_workflow::RetryConfig>,
-    recorded_error: Option<&ActionError>,
+    recorded_error_is_terminal: bool,
 ) -> RetryDecision {
-    if recorded_error.is_some_and(ActionError::is_fatal) {
+    if recorded_error_is_terminal {
         tracing::debug!(
             target = "engine::retry",
             execution_id = %exec_state.execution_id,
             %node_key,
-            "retry skipped: just-recorded attempt error is fatal \
-             (no re-dispatch — closes the pre-existing engine-fatality gap)"
+            "retry skipped: just-recorded attempt error is terminal \
+             (fatal action error or non-retryable runtime condition) — no re-dispatch"
         );
         return RetryDecision::Finalize;
     }
@@ -8342,6 +8369,50 @@ mod tests {
             engine_err,
             EngineError::Action(ActionError::CredentialRefreshFailed { .. })
         ));
+    }
+
+    /// `error_is_terminal` decides retry eligibility by error nature (Codex P2).
+    /// Non-retryable runtime conditions are terminal; `AgentTurnTimeout` and
+    /// retryable action errors are not. Regression guard: the
+    /// `RuntimeError::ActionError` classify metadata (`retryable = false`) must
+    /// NOT shadow the inner action error's real retryability.
+    #[test]
+    fn error_is_terminal_classification() {
+        use crate::runtime::RuntimeError;
+
+        // Non-retryable runtime conditions → terminal (never re-dispatched).
+        assert!(error_is_terminal(&EngineError::Runtime(
+            RuntimeError::AgentBudgetExceeded {
+                key: "a".into(),
+                max_turns: 3,
+            }
+        )));
+        assert!(error_is_terminal(&EngineError::Runtime(
+            RuntimeError::AgentWaitNotSupported { key: "a".into() }
+        )));
+
+        // `AgentTurnTimeout` is retryable → NOT terminal.
+        assert!(!error_is_terminal(&EngineError::Runtime(
+            RuntimeError::AgentTurnTimeout {
+                key: "a".into(),
+                turn: 0,
+                timeout: std::time::Duration::from_millis(10),
+            }
+        )));
+
+        // Regression guard: a retryable action error (direct or runtime-wrapped)
+        // must NOT be terminal, despite the wrapper variant's classify metadata.
+        assert!(!error_is_terminal(&EngineError::Action(
+            ActionError::retryable("x")
+        )));
+        assert!(!error_is_terminal(&EngineError::Runtime(
+            RuntimeError::ActionError(ActionError::retryable("x"))
+        )));
+
+        // Fatal action errors are terminal.
+        assert!(error_is_terminal(&EngineError::Action(ActionError::fatal(
+            "x"
+        ))));
     }
 
     // -- Credential allowlist enforcement (PRODUCT_CANON / — audit ) --

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -7,7 +7,11 @@ use nebula_core::{ActionKey, NodeKey};
 #[non_exhaustive]
 pub enum RuntimeError {
     /// Action not found in the registry.
-    #[classify(category = "not_found", code = "RUNTIME:ACTION_NOT_FOUND")]
+    #[classify(
+        category = "not_found",
+        code = "RUNTIME:ACTION_NOT_FOUND",
+        retryable = false
+    )]
     #[error("action not found: {key}")]
     ActionNotFound {
         /// The action key that was looked up.
@@ -138,6 +142,68 @@ pub enum RuntimeError {
         requested: usize,
     },
 
+    /// An agent action exceeded its `max_turns()` budget without returning a
+    /// terminal result. Separate from
+    /// [`IterationCapExceeded`](Self::IterationCapExceeded): the stateful cap
+    /// is a hard 10 000-iteration global guard; this cap is the author-declared
+    /// per-agent turn budget (default 25), enforced per-handle.
+    #[classify(
+        category = "exhausted",
+        code = "RUNTIME:AGENT_BUDGET_EXCEEDED",
+        retryable = false
+    )]
+    #[error(
+        "agent action '{key}' exceeded its turn budget of {max_turns} turns \
+         without returning a terminal result"
+    )]
+    AgentBudgetExceeded {
+        /// The action key whose loop ran out of turns.
+        key: String,
+        /// The author-declared turn budget that was tripped.
+        max_turns: u32,
+    },
+
+    /// A single turn of an agent action exceeded its per-turn wall-clock timeout.
+    ///
+    /// Returned when `AgentHandle::turn_timeout()` returns `Some(d)` and the
+    /// `step` future did not resolve within that deadline. Prevents a hung
+    /// provider call from pinning a worker indefinitely.
+    #[classify(
+        category = "exhausted",
+        code = "RUNTIME:AGENT_TURN_TIMEOUT",
+        retryable = true
+    )]
+    #[error("agent action '{key}' turn {turn} exceeded per-turn timeout of {timeout:?}")]
+    AgentTurnTimeout {
+        /// The action key whose turn timed out.
+        key: String,
+        /// The zero-based turn index that timed out.
+        turn: u32,
+        /// The per-turn timeout that was exceeded.
+        timeout: std::time::Duration,
+    },
+
+    /// An agent action returned `ActionResult::Wait` in a phase where the
+    /// wait-state engine is not yet wired.
+    ///
+    /// The `Wait` arm of the agent loop requires the durable park/resume
+    /// machinery. Until that ships, returning `Wait` from an agent step is an
+    /// explicit boundary — the engine surfaces this error rather than silently
+    /// dropping the result.
+    #[classify(
+        category = "unsupported",
+        code = "RUNTIME:AGENT_WAIT_NOT_SUPPORTED",
+        retryable = false
+    )]
+    #[error(
+        "agent action '{key}' returned ActionResult::Wait, which is not yet wired \
+         in the engine's agent loop — the wait-state engine must ship first"
+    )]
+    AgentWaitNotSupported {
+        /// The action key that tried to park.
+        key: String,
+    },
+
     /// Internal runtime error.
     #[classify(category = "internal", code = "RUNTIME:INTERNAL")]
     #[error("runtime error: {0}")]
@@ -145,10 +211,19 @@ pub enum RuntimeError {
 }
 
 impl RuntimeError {
-    /// Whether this error originated from a retryable action error.
+    /// Whether this error is retryable.
+    ///
+    /// Returns `true` when the error is a transient condition that a retry
+    /// policy may safely re-attempt:
+    /// - An [`ActionError`](Self::ActionError) whose inner error reports itself
+    ///   retryable.
+    /// - [`AgentTurnTimeout`](Self::AgentTurnTimeout): a single turn exceeded
+    ///   its per-turn wall-clock deadline; retrying from the last checkpoint is
+    ///   the intended recovery path.
     pub fn is_retryable(&self) -> bool {
         match self {
             Self::ActionError(e) => e.is_retryable(),
+            Self::AgentTurnTimeout { .. } => true,
             _ => false,
         }
     }
@@ -193,6 +268,28 @@ mod tests {
         let err = RuntimeError::DataLimitExceeded {
             limit_bytes: 1_000,
             actual_bytes: 5_000,
+        };
+        assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn agent_turn_timeout_is_retryable() {
+        // `AgentTurnTimeout` carries `retryable = true` in its `#[classify]`
+        // attribute; `is_retryable()` must agree so retry policies that call
+        // the method (rather than reading classify metadata) honour it.
+        let err = RuntimeError::AgentTurnTimeout {
+            key: "my.agent".into(),
+            turn: 0,
+            timeout: std::time::Duration::from_millis(10),
+        };
+        assert!(err.is_retryable(), "AgentTurnTimeout must be retryable");
+    }
+
+    #[test]
+    fn agent_budget_exceeded_not_retryable() {
+        let err = RuntimeError::AgentBudgetExceeded {
+            key: "my.agent".into(),
+            max_turns: 3,
         };
         assert!(!err.is_retryable());
     }

--- a/crates/engine/src/runtime/registry.rs
+++ b/crates/engine/src/runtime/registry.rs
@@ -21,10 +21,11 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use nebula_action::{
-    Action, ActionError, ActionFactory, ActionMetadata, ControlAction, FromWorkflowNode,
-    GenericControlFactory, GenericResourceFactory, GenericStatefulFactory, GenericStatelessFactory,
-    GenericStreamFactory, GenericTriggerFactory, InstanceFactory, ResourceAction, StatefulAction,
-    StatelessAction, StreamAction, TriggerAction, WebhookActionFactory,
+    Action, ActionError, ActionFactory, ActionMetadata, AgentAction, ControlAction,
+    FromWorkflowNode, GenericAgentFactory, GenericControlFactory, GenericResourceFactory,
+    GenericStatefulFactory, GenericStatelessFactory, GenericStreamFactory, GenericTriggerFactory,
+    InstanceFactory, ResourceAction, StatefulAction, StatelessAction, StreamAction, TriggerAction,
+    WebhookActionFactory,
 };
 use nebula_core::ActionKey;
 use semver::Version;
@@ -183,6 +184,24 @@ impl ActionRegistry {
         <A as Action>::Output: serde::Serialize + Send + Sync,
     {
         let factory: Arc<dyn ActionFactory> = Arc::new(GenericStreamFactory::<A>::new());
+        let metadata = factory.metadata().clone();
+        self.register_factory(metadata, factory);
+    }
+
+    /// Register an agent action via the factory pipeline (Variant A).
+    ///
+    /// The produced [`ActionHandle::Agent`](nebula_action::ActionHandle::Agent)
+    /// is dispatched through the engine's own agent turn loop
+    /// (`execute_agent_handle`), which enforces `max_turns()` and the
+    /// per-turn wall-clock timeout without the `StatefulStuck` digest guard.
+    pub fn register_agent_factory<A>(&self)
+    where
+        A: AgentAction + FromWorkflowNode<Error = ActionError>,
+        <A as Action>::Input: serde::de::DeserializeOwned + Send + Sync,
+        <A as Action>::Output: serde::Serialize + Send + Sync,
+        A::Turn: serde::Serialize + serde::de::DeserializeOwned + Clone + Send + Sync,
+    {
+        let factory: Arc<dyn ActionFactory> = Arc::new(GenericAgentFactory::<A>::new());
         let metadata = factory.metadata().clone();
         self.register_factory(metadata, factory);
     }

--- a/crates/engine/src/runtime/runtime.rs
+++ b/crates/engine/src/runtime/runtime.rs
@@ -8,8 +8,8 @@ use std::{sync::Arc, time::Instant};
 use async_trait::async_trait;
 use dashmap::DashMap;
 use nebula_action::{
-    ActionContext, ActionError, ActionFactory, ActionHandle, ActionMetadata, IsolationLevel,
-    StreamHandle,
+    ActionContext, ActionError, ActionFactory, ActionHandle, ActionMetadata, AgentHandle,
+    IsolationLevel, StreamHandle,
     output::{ActionOutput, DataReference},
     result::ActionResult,
 };
@@ -454,6 +454,13 @@ impl ActionRuntime {
                 self.observe_dispatched(started, &r);
                 r
             },
+            ActionHandle::Agent(inner) => {
+                let r = self
+                    .execute_agent_handle(&metadata, inner, input, context)
+                    .await;
+                self.observe_dispatched(started, &r);
+                r
+            },
             ActionHandle::Trigger(_) => {
                 self.observe_rejected(dispatch_reject_reason::TRIGGER_NOT_EXECUTABLE);
                 return Err(RuntimeError::TriggerNotExecutable {
@@ -704,6 +711,151 @@ impl ActionRuntime {
             )));
         }
         Ok(handle.dispatch(input, context).await?)
+    }
+
+    /// Agent dispatch via `Box<dyn AgentHandle>`.
+    ///
+    /// Runs the agent's own turn loop — deliberately NOT a clone of
+    /// `execute_stateful_handle`. Three properties differ by design (ADR-0103 D2):
+    ///
+    /// - **No `StatefulStuck` digest guard** — a turn that leaves `Turn` unchanged
+    ///   is legal; an LLM thinking without mutating state is not a bug.
+    /// - **`max_turns()` budget** — replaces the 10 000-iteration global cap with
+    ///   the author-declared per-agent budget.
+    /// - **Per-turn wall-clock timeout** — each `step` future is individually
+    ///   bounded so a hung provider cannot pin a worker indefinitely.
+    ///
+    /// Turn state is kept as a local `serde_json::Value` variable. There is no
+    /// durable checkpoint: on a worker crash the whole action re-executes from
+    /// scratch with the original input. Mid-loop resume would require wiring a
+    /// checkpoint sink, which is out of scope for this foundational implementation.
+    ///
+    /// # Cancellation
+    ///
+    /// Every turn races against the execution-level cancellation token via
+    /// `tokio::select!`. The per-turn timeout (if any) is composed with
+    /// cancellation so neither can block the other.
+    #[tracing::instrument(
+        name = "runtime.execute_agent_handle",
+        skip_all,
+        fields(
+            action.key = %metadata.base.key.as_str(),
+            action.kind = "agent",
+            max_turns = handle.max_turns(),
+        )
+    )]
+    async fn execute_agent_handle(
+        &self,
+        metadata: &ActionMetadata,
+        handle: Box<dyn AgentHandle>,
+        input: serde_json::Value,
+        context: &dyn ActionContext,
+    ) -> Result<ActionResult<serde_json::Value>, RuntimeError> {
+        if !matches!(metadata.isolation_level, IsolationLevel::None) {
+            return Err(RuntimeError::Internal(
+                "capability-gated agent execution is not yet supported".into(),
+            ));
+        }
+
+        if context.cancellation().is_cancelled() {
+            return Err(ActionError::Cancelled.into());
+        }
+
+        let mut turn_state = handle.init_turn(&input)?;
+        let max_turns = handle.max_turns();
+        let turn_timeout = handle.turn_timeout();
+
+        let mut turn: u32 = 0;
+
+        loop {
+            if turn >= max_turns {
+                return Err(RuntimeError::AgentBudgetExceeded {
+                    key: metadata.base.key.as_str().to_owned(),
+                    max_turns,
+                });
+            }
+
+            if context.cancellation().is_cancelled() {
+                return Err(ActionError::Cancelled.into());
+            }
+
+            let step_result = {
+                let step_future = handle.step(&mut turn_state, context);
+                tokio::pin!(step_future);
+
+                match turn_timeout {
+                    Some(deadline) => {
+                        tokio::select! {
+                            biased;
+                            () = context.cancellation().cancelled() => {
+                                return Err(ActionError::Cancelled.into());
+                            }
+                            timeout_result = tokio::time::timeout(deadline, &mut step_future) => {
+                                match timeout_result {
+                                    Ok(step_outcome) => step_outcome,
+                                    Err(_elapsed) => {
+                                        return Err(RuntimeError::AgentTurnTimeout {
+                                            key: metadata.base.key.as_str().to_owned(),
+                                            turn,
+                                            timeout: deadline,
+                                        });
+                                    },
+                                }
+                            }
+                        }
+                    },
+                    None => {
+                        tokio::select! {
+                            biased;
+                            () = context.cancellation().cancelled() => {
+                                return Err(ActionError::Cancelled.into());
+                            }
+                            step_outcome = &mut step_future => step_outcome,
+                        }
+                    },
+                }
+            };
+
+            let result = step_result?;
+
+            // Log the 0-based turn index before incrementing — consistent with
+            // `AgentTurnTimeout.turn` which also carries the 0-based index.
+            tracing::debug!(
+                action.key = %metadata.base.key.as_str(),
+                turn,
+                max_turns,
+                "agent turn completed"
+            );
+
+            turn = turn.saturating_add(1);
+
+            match result {
+                ActionResult::Continue { delay, .. } => {
+                    if let Some(d) = delay {
+                        tokio::select! {
+                            () = tokio::time::sleep(d) => {}
+                            () = context.cancellation().cancelled() => {
+                                return Err(ActionError::Cancelled.into());
+                            }
+                        }
+                    }
+                    // Loop continues with updated turn_state (already mutated in-place
+                    // by the adapter's `step` implementation).
+                },
+                ActionResult::Wait { .. } => {
+                    // The Wait arm requires the durable park/resume machinery which
+                    // is not yet wired in the engine. Surface an honest error rather
+                    // than silently mishandling the result.
+                    return Err(RuntimeError::AgentWaitNotSupported {
+                        key: metadata.base.key.as_str().to_owned(),
+                    });
+                },
+                terminal => {
+                    // Any other terminal (Break, Success, Skip, Terminate, …) ends the loop.
+                    return Ok(terminal);
+                },
+            }
+        }
     }
 
     /// Observe a dispatched handler execution.

--- a/crates/engine/tests/agent_dispatch.rs
+++ b/crates/engine/tests/agent_dispatch.rs
@@ -1,0 +1,656 @@
+//! Engine-level integration tests for the Agent kind dispatch path.
+//!
+//! Each test exercises `execute_agent_handle` via the real `dispatch_action`
+//! path and asserts on concrete output values or error variants — never
+//! tautologies or bare `is_ok()`.
+//!
+//! Red-on-revert falsifiability: removing the `ActionHandle::Agent` dispatch
+//! arm from `dispatch_action` makes every test here hit the `_ => UNKNOWN_VARIANT`
+//! arm and return `RuntimeError::Internal`, which fails every assertion.
+
+use std::{
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionContext, ActionError, AgentAction,
+    action::Action,
+    metadata::ActionMetadata,
+    output::ActionOutput,
+    result::{ActionResult, BreakReason, WaitCondition},
+    testing::TestContextBuilder,
+};
+use nebula_core::{Dependencies, action_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, InProcessRunner, RuntimeError,
+};
+use nebula_metrics::MetricsRegistry;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ── Shared fixture helpers ───────────────────────────────────────────────────
+
+/// Build a minimal `ActionRuntime` for testing — no capability runner, in-process only.
+fn make_runtime(registry: Arc<ActionRegistry>) -> ActionRuntime {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    ActionRuntime::try_new(registry, runner, DataPassingPolicy::default(), metrics)
+        .expect("ActionRuntime::try_new must succeed in tests")
+}
+
+/// Build a test context with no special slots or credentials wired.
+fn make_ctx() -> nebula_action::TestActionContext {
+    TestContextBuilder::new().build()
+}
+
+// ── Fixture: TwoTurnAgent ────────────────────────────────────────────────────
+
+/// Runs exactly 2 `Continue` turns then `Break`s with `{"turns": 2}`.
+/// Used to prove end-to-end dispatch and correct final output shape.
+struct TwoTurnAgent;
+
+#[derive(Clone, Serialize, Deserialize)]
+struct TurnCounter {
+    turns_completed: u32,
+}
+
+impl Action for TwoTurnAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.two_turn"),
+            "TwoTurnAgent",
+            "continues twice then breaks",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for TwoTurnAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(TwoTurnAgent)
+    }
+}
+
+impl AgentAction for TwoTurnAgent {
+    type Turn = TurnCounter;
+
+    fn init_turn(&self, _input: &Value) -> TurnCounter {
+        TurnCounter { turns_completed: 0 }
+    }
+
+    async fn step(
+        &self,
+        turn: &mut TurnCounter,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        turn.turns_completed += 1;
+        if turn.turns_completed >= 2 {
+            Ok(ActionResult::Break {
+                output: ActionOutput::Value(serde_json::json!({ "turns": turn.turns_completed })),
+                reason: BreakReason::Completed,
+            })
+        } else {
+            Ok(ActionResult::Continue {
+                output: ActionOutput::Value(Value::Null),
+                progress: None,
+                delay: None,
+            })
+        }
+    }
+}
+
+// ── Fixture: StubbornContinueAgent ──────────────────────────────────────────
+
+/// Returns `Continue` for exactly `continue_turns` steps WITHOUT touching the
+/// `Turn` value, then `Break`s. The step counter lives in an `AtomicU32` on
+/// the action struct itself — deliberately kept out of `Turn` so that `Turn`
+/// stays bit-for-bit identical between every step call.
+///
+/// This proves the engine does NOT apply a stuck-state digest guard to agent
+/// Continue paths: a StatefulStuck-equivalent guard would hash `Turn` before
+/// and after each step, detect the unchanged bytes, and return an error.
+/// This action would trigger it on the very first Continue.
+struct StubbornContinueAgent {
+    /// Number of Continue turns before the agent decides to Break.
+    continue_turns: u32,
+    /// Step counter kept OUTSIDE `Turn` to ensure `Turn` is never mutated.
+    steps_taken: AtomicU32,
+}
+
+/// Turn type whose fields are never written by [`StubbornContinueAgent::step`].
+/// The engine serialises this to JSON between turns; unchanged bytes are what
+/// would trigger a StatefulStuck guard.
+#[derive(Clone, Serialize, Deserialize)]
+struct StubbornTurn {
+    /// Stamp set once at `init_turn`. Never overwritten.
+    initial_marker: u32,
+}
+
+impl Action for StubbornContinueAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.stubborn_continue"),
+            "StubbornContinueAgent",
+            "continues N times without mutating turn state, then breaks",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for StubbornContinueAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(StubbornContinueAgent {
+            continue_turns: 3,
+            steps_taken: AtomicU32::new(0),
+        })
+    }
+}
+
+impl AgentAction for StubbornContinueAgent {
+    type Turn = StubbornTurn;
+
+    fn init_turn(&self, _input: &Value) -> StubbornTurn {
+        StubbornTurn { initial_marker: 42 }
+    }
+
+    async fn step(
+        &self,
+        turn: &mut StubbornTurn,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        // `turn.initial_marker` is intentionally never written in this method.
+        // A StatefulStuck-style digest guard would see identical bytes and error.
+        let _ = turn.initial_marker; // read to prove it's accessible, not mutated
+        let taken = self.steps_taken.fetch_add(1, Ordering::Relaxed);
+        if taken >= self.continue_turns {
+            Ok(ActionResult::break_completed(serde_json::json!({
+                "steps_without_turn_mutation": taken,
+            })))
+        } else {
+            Ok(ActionResult::Continue {
+                output: ActionOutput::Value(Value::Null),
+                progress: None,
+                delay: None,
+            })
+        }
+    }
+}
+
+// ── Fixture: LoopForeverAgent ────────────────────────────────────────────────
+
+/// Always returns `Continue`, never terminates. Used to prove `max_turns`
+/// budget is enforced with the exact declared limit.
+struct LoopForeverAgent {
+    max: u32,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct LoopTurn {
+    steps: u32,
+}
+
+impl Action for LoopForeverAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.loop_forever"),
+            "LoopForeverAgent",
+            "loops until budget is exceeded",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for LoopForeverAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(LoopForeverAgent { max: 3 })
+    }
+}
+
+impl AgentAction for LoopForeverAgent {
+    type Turn = LoopTurn;
+
+    fn max_turns(&self) -> u32 {
+        self.max
+    }
+
+    fn init_turn(&self, _input: &Value) -> LoopTurn {
+        LoopTurn { steps: 0 }
+    }
+
+    async fn step(
+        &self,
+        turn: &mut LoopTurn,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        turn.steps += 1;
+        Ok(ActionResult::Continue {
+            output: ActionOutput::Value(Value::Null),
+            progress: None,
+            delay: None,
+        })
+    }
+}
+
+// ── Fixture: SlowTurnAgent ───────────────────────────────────────────────────
+
+/// Each step sleeps for `step_delay` (50 ms) while `turn_timeout()` returns
+/// 10 ms, so every step exceeds the per-turn deadline and fires
+/// `AgentTurnTimeout`. Paired with [`FastTurnAgent`] for the negative case.
+struct SlowTurnAgent {
+    step_delay: Duration,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct SlowTurn {
+    attempts: u32,
+}
+
+impl Action for SlowTurnAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.slow_turn"),
+            "SlowTurnAgent",
+            "sleeps per turn to exercise the per-turn timeout",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for SlowTurnAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(SlowTurnAgent {
+            step_delay: Duration::from_millis(50),
+        })
+    }
+}
+
+impl AgentAction for SlowTurnAgent {
+    type Turn = SlowTurn;
+
+    fn turn_timeout(&self) -> Option<Duration> {
+        // Tight deadline — real slow steps will exceed it.
+        Some(Duration::from_millis(10))
+    }
+
+    fn init_turn(&self, _input: &Value) -> SlowTurn {
+        SlowTurn { attempts: 0 }
+    }
+
+    async fn step(
+        &self,
+        turn: &mut SlowTurn,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        turn.attempts += 1;
+        tokio::time::sleep(self.step_delay).await;
+        Ok(ActionResult::break_completed(serde_json::json!("done")))
+    }
+}
+
+/// Fast variant: step completes well within the turn_timeout.
+struct FastTurnAgent;
+
+impl Action for FastTurnAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.fast_turn"),
+            "FastTurnAgent",
+            "completes instantly — per-turn timeout must NOT fire",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for FastTurnAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(FastTurnAgent)
+    }
+}
+
+impl AgentAction for FastTurnAgent {
+    type Turn = SlowTurn;
+
+    fn turn_timeout(&self) -> Option<Duration> {
+        Some(Duration::from_millis(200))
+    }
+
+    fn init_turn(&self, _input: &Value) -> SlowTurn {
+        SlowTurn { attempts: 0 }
+    }
+
+    async fn step(
+        &self,
+        turn: &mut SlowTurn,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        turn.attempts += 1;
+        // No sleep — resolves immediately, well within the 200 ms window.
+        Ok(ActionResult::break_completed(
+            serde_json::json!({ "attempts": turn.attempts }),
+        ))
+    }
+}
+
+// ── Fixture: WaitReturningAgent ──────────────────────────────────────────────
+
+/// Returns `ActionResult::Wait` on the first step — proves the engine rejects
+/// the Wait arm with `AgentWaitNotSupported` (durable park/resume is not yet wired).
+struct WaitReturningAgent;
+
+#[derive(Clone, Serialize, Deserialize)]
+struct WaitTurn;
+
+impl Action for WaitReturningAgent {
+    type Input = Value;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("test.agent.wait_returning"),
+            "WaitReturningAgent",
+            "returns Wait — engine must reject with AgentWaitNotSupported",
+        )
+    }
+
+    fn dependencies() -> &'static Dependencies {
+        static D: OnceLock<Dependencies> = OnceLock::new();
+        D.get_or_init(Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for WaitReturningAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(WaitReturningAgent)
+    }
+}
+
+impl AgentAction for WaitReturningAgent {
+    type Turn = WaitTurn;
+
+    fn init_turn(&self, _input: &Value) -> WaitTurn {
+        WaitTurn
+    }
+
+    async fn step(
+        &self,
+        _turn: &mut WaitTurn,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ActionResult<Value>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "test-callback".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// Proves: an agent action that runs 2 Continue turns then Breaks dispatches
+/// end-to-end through the engine and delivers the exact final output.
+///
+/// Falsifiable: removing `ActionHandle::Agent` from the dispatch arm sends this
+/// to the `_ => UNKNOWN_VARIANT` arm → `RuntimeError::Internal` → test fails on
+/// the `match result` below.
+#[tokio::test]
+async fn agent_dispatches_through_engine() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<TwoTurnAgent>();
+
+    let runtime = make_runtime(registry);
+    let ctx = make_ctx();
+
+    let result = runtime
+        .execute_action("test.agent.two_turn", serde_json::json!(null), &ctx)
+        .await
+        .expect("agent dispatch must succeed");
+
+    match result {
+        ActionResult::Break {
+            output,
+            reason: BreakReason::Completed,
+        } => {
+            let value = output.into_value().expect("output must be an inline Value");
+            assert_eq!(
+                value,
+                serde_json::json!({ "turns": 2 }),
+                "final output must reflect both turns completed"
+            );
+        },
+        other => panic!("expected ActionResult::Break(Completed), got {other:?}"),
+    }
+}
+
+/// Proves: the engine does NOT apply a stuck-state digest guard to agent
+/// Continue paths — returning `Continue` with bit-for-bit identical `Turn`
+/// state across multiple turns must NOT produce an error.
+///
+/// `StubbornContinueAgent` returns Continue for 3 turns without ever writing
+/// to its `Turn` value, then Breaks. A StatefulStuck-equivalent guard in the
+/// engine loop would detect the unchanged bytes and return an error on the
+/// first (or subsequent) Continue steps.
+///
+/// # Falsifiability
+///
+/// Add the following guard at the top of the Continue arm inside
+/// `execute_agent_handle`:
+/// ```ignore
+/// if serde_json::to_vec(&turn_state_before).ok()
+///     == serde_json::to_vec(&turn_state).ok()
+/// {
+///     return Err(RuntimeError::Internal("agent stuck".into()));
+/// }
+/// ```
+/// With that guard the test fails with `"agent stuck"` on the first Continue.
+/// Remove the guard and the test passes — confirming the loop tolerates
+/// unchanged state. Red evidence was collected and the guard removed before
+/// this commit.
+#[tokio::test]
+async fn no_progress_turn_is_legal() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<StubbornContinueAgent>();
+
+    let runtime = make_runtime(registry);
+    let ctx = make_ctx();
+
+    let result = runtime
+        .execute_action(
+            "test.agent.stubborn_continue",
+            serde_json::json!(null),
+            &ctx,
+        )
+        .await
+        .expect("3 Continue turns with unchanged Turn state must not produce a stuck-state error");
+
+    match result {
+        ActionResult::Break {
+            output,
+            reason: BreakReason::Completed,
+        } => {
+            let value = output.into_value().expect("output must be an inline Value");
+            // `steps_without_turn_mutation` == 3 proves the engine went through
+            // all 3 Continue iterations without raising a stuck-state error.
+            assert_eq!(
+                value["steps_without_turn_mutation"],
+                serde_json::json!(3),
+                "must have completed exactly 3 unchanged-state Continue turns"
+            );
+        },
+        other => panic!("expected ActionResult::Break(Completed), got {other:?}"),
+    }
+}
+
+/// Proves: when `max_turns()` is exhausted, the engine returns
+/// `RuntimeError::AgentBudgetExceeded` with the exact declared limit.
+///
+/// Falsifiable: the wrong limit or wrong variant causes the assertion to fail.
+#[tokio::test]
+async fn max_turns_budget_enforced() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<LoopForeverAgent>();
+
+    let runtime = make_runtime(registry);
+    let ctx = make_ctx();
+
+    let err = runtime
+        .execute_action("test.agent.loop_forever", serde_json::json!(null), &ctx)
+        .await
+        .expect_err("a non-terminating agent must hit its budget and return an error");
+
+    match err {
+        RuntimeError::AgentBudgetExceeded { max_turns, .. } => {
+            assert_eq!(
+                max_turns, 3,
+                "budget error must carry the exact declared max_turns"
+            );
+        },
+        other => panic!("expected RuntimeError::AgentBudgetExceeded, got {other:?}"),
+    }
+}
+
+/// Proves: when `turn_timeout()` fires, the engine returns
+/// `RuntimeError::AgentTurnTimeout` with the correct turn index and timeout.
+/// A companion fast-turn case proves the path is NOT always triggered.
+///
+/// Falsifiable: if the timeout were not wired, the slow test would complete
+/// and the `expect_err` would panic.
+#[tokio::test(start_paused = true)]
+async fn per_turn_timeout_fires() {
+    // ── Slow case: turn exceeds the 10 ms deadline ──
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<SlowTurnAgent>();
+
+    let runtime = make_runtime(registry);
+    let ctx = make_ctx();
+
+    let err = runtime
+        .execute_action("test.agent.slow_turn", serde_json::json!(null), &ctx)
+        .await
+        .expect_err("a turn that sleeps past its deadline must time out");
+
+    match err {
+        RuntimeError::AgentTurnTimeout { turn, timeout, .. } => {
+            assert_eq!(turn, 0, "timeout must fire on the first (zeroth) turn");
+            assert_eq!(
+                timeout,
+                Duration::from_millis(10),
+                "timeout must carry the declared per-turn deadline"
+            );
+        },
+        other => panic!("expected RuntimeError::AgentTurnTimeout, got {other:?}"),
+    }
+
+    // ── Fast case: turn completes well within the 200 ms deadline ──
+    let fast_registry = Arc::new(ActionRegistry::new());
+    fast_registry.register_agent_factory::<FastTurnAgent>();
+
+    let fast_runtime = make_runtime(fast_registry);
+    let fast_ctx = make_ctx();
+
+    let fast_result = fast_runtime
+        .execute_action("test.agent.fast_turn", serde_json::json!(null), &fast_ctx)
+        .await
+        .expect("a fast turn must complete without hitting the per-turn timeout");
+
+    assert!(
+        matches!(fast_result, ActionResult::Break { .. }),
+        "fast turn must reach Break, not timeout; got {fast_result:?}"
+    );
+}
+
+/// Proves: returning `ActionResult::Wait` from an agent step yields
+/// `RuntimeError::AgentWaitNotSupported` — the engine does not yet support Wait.
+///
+/// Falsifiable: if Wait were silently mishandled (e.g. mapped to Break or ignored),
+/// no error would be returned and `expect_err` would panic.
+#[tokio::test]
+async fn wait_step_rejected_in_a_s1() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<WaitReturningAgent>();
+
+    let runtime = make_runtime(registry);
+    let ctx = make_ctx();
+
+    let err = runtime
+        .execute_action("test.agent.wait_returning", serde_json::json!(null), &ctx)
+        .await
+        .expect_err("returning Wait from an agent step must produce AgentWaitNotSupported");
+
+    assert!(
+        matches!(err, RuntimeError::AgentWaitNotSupported { .. }),
+        "expected RuntimeError::AgentWaitNotSupported, got {err:?}"
+    );
+}

--- a/crates/engine/tests/retry.rs
+++ b/crates/engine/tests/retry.rs
@@ -18,7 +18,8 @@ use std::{
 };
 
 use nebula_action::{
-    ActionError, action::Action, metadata::ActionMetadata, result::ActionResult,
+    ActionError, AgentAction, action::Action, from_workflow_node::FromWorkflowNode,
+    metadata::ActionMetadata, output::ActionOutput, result::ActionResult,
     stateless::StatelessAction,
 };
 use nebula_core::{Dependencies, action_key, id::WorkflowId, node_key};
@@ -133,6 +134,60 @@ impl StatelessAction for TerminateHandler {
         Ok(ActionResult::terminate_success(Some(
             "test-stop".to_owned(),
         )))
+    }
+}
+
+/// Always returns `Continue`, so the engine's agent loop exhausts `max_turns`
+/// (= 2) and surfaces the non-retryable `RuntimeError::AgentBudgetExceeded`.
+/// A process-static counter records every `step` call across attempts so a
+/// test can prove the node is NOT re-dispatched under a retry policy.
+struct BudgetExhaustingAgent;
+
+static AGENT_STEP_CALLS: AtomicU32 = AtomicU32::new(0);
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+struct EmptyTurn;
+
+placeholder_action_impl!(
+    BudgetExhaustingAgent,
+    action_key!("placeholder.budget_agent"),
+    "BudgetAgentPlaceholder",
+    "placeholder"
+);
+
+impl FromWorkflowNode for BudgetExhaustingAgent {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &NodeDefinition,
+        _ctx: &dyn nebula_action::ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(BudgetExhaustingAgent)
+    }
+}
+
+impl AgentAction for BudgetExhaustingAgent {
+    type Turn = EmptyTurn;
+
+    fn max_turns(&self) -> u32 {
+        2
+    }
+
+    fn init_turn(&self, _input: &serde_json::Value) -> EmptyTurn {
+        EmptyTurn
+    }
+
+    async fn step(
+        &self,
+        _turn: &mut EmptyTurn,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        AGENT_STEP_CALLS.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::Continue {
+            output: ActionOutput::Value(serde_json::Value::Null),
+            progress: None,
+            delay: None,
+        })
     }
 }
 
@@ -255,6 +310,49 @@ async fn retry_exhausts_max_attempts() {
         invocations.load(Ordering::SeqCst),
         3,
         "max_attempts=3 must run the handler exactly 3 times"
+    );
+}
+
+/// Agent budget exhaustion is terminal under a retry policy (Codex P2):
+/// `RuntimeError::AgentBudgetExceeded` is non-retryable, so the node must
+/// finalize Failed after ONE agent-loop run — never re-dispatching despite a
+/// `max_attempts = 3` policy. Falsifiable: before the terminal-error fix the
+/// budget error fell through to the retry path and the loop re-ran per attempt
+/// (2 steps × 3 attempts = 6 calls).
+#[tokio::test]
+async fn agent_budget_exhaustion_is_terminal_under_retry_policy() {
+    AGENT_STEP_CALLS.store(0, Ordering::SeqCst);
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_agent_factory::<BudgetExhaustingAgent>();
+
+    let engine = make_engine(registry);
+    let n = node_key!("agent_budget");
+    let mut node =
+        NodeDefinition::new(n, "agent_node", "core", "placeholder.budget_agent").unwrap();
+    node.retry_policy = Some(RetryConfig::fixed(3, 1));
+
+    let wf = make_workflow(vec![node], vec![], WorkflowConfig::default());
+    let result = engine
+        .execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Failed,
+        "agent budget exhaustion must fail the node"
+    );
+    assert_eq!(
+        AGENT_STEP_CALLS.load(Ordering::SeqCst),
+        2,
+        "AgentBudgetExceeded is non-retryable — the agent loop must run once \
+         (max_turns=2), not re-dispatch under the retry policy"
     );
 }
 


### PR DESCRIPTION
## Summary

Adds the **Agent** node kind's execution machinery — the first slice (A-S1) of the Agent kind execution model. The kind is **Llm-agnostic**: an LLM provider reaches a concrete agent as a `#[resource]` slot, so neither `nebula-action` nor the engine loop names `Llm`, and no `nebula-agent` crate is needed. A-S1 is a no-tool, no-HITL multi-turn LLM node — a useful standalone kind that depends on neither the (unbuilt) wait-state engine nor the ResourceTools surface.

## Linked issue

Design tracked in the maintainers' private design vault (ADR-0103, refining ADR-0097/0098). No GitHub/Linear issue.

- Refs: ADR-0103 (Agent kind execution model), ADR-0097 (taxonomy), ADR-0098 (reshape)

## Type of change

- [x] `feat` — new capability

## Affected crates / areas

- `nebula-action`
- `nebula-engine`

## Changes

- **`nebula-action`**
  - `AgentAction` author trait (RPITIT `step`/`init_turn`, `max_turns` default 25, `turn_timeout: Option<Duration>`, `type Turn`) — `crates/action/src/agent.rs` (new).
  - `AgentHandle` object-safe dyn trait (`#[async_trait]`) + `AgentActionAdapter` that flushes turn state to JSON **before** propagating an error (mirrors `StatefulActionAdapter`; double-failure path logs at `ERROR` and propagates the original action error).
  - `ActionHandle::Agent` variant; `GenericAgentFactory` (single-writer of `ActionKind::Agent`); re-exports in `lib.rs`/`prelude.rs`.
- **`nebula-engine`**
  - `execute_agent_handle` — a purpose-built loop (NOT a clone of the stateful loop): permits no-progress turns (no `StatefulStuck` guard), enforces `max_turns` (`AgentBudgetExceeded`), bounds each turn with a wall-clock `turn_timeout` (`AgentTurnTimeout`), races every turn against cancellation. `ActionResult::Wait` → `AgentWaitNotSupported` (honest boundary; durable park/resume is a later phase).
  - `ActionHandle::Agent` dispatch arm, `register_agent_factory`, three typed `RuntimeError` variants, and a `tracing` span over the loop.

## Test plan

Engine integration tests (`crates/engine/tests/agent_dispatch.rs`), each falsifiable on real values/variants:
- `agent_dispatches_through_engine` — 2 `Continue` turns then `Break`, asserts exact `{"turns": 2}`; reverting the dispatch arm sends it to `_ => UNKNOWN_VARIANT`.
- `no_progress_turn_is_legal` — `StubbornContinueAgent` runs 3 `Continue` turns with bit-identical `Turn` through the engine loop, then `Break`s (asserts `steps_without_turn_mutation == 3`). Red evidence collected: inserting a digest guard makes it fail; removed.
- `max_turns_budget_enforced` — asserts `AgentBudgetExceeded { max_turns: 3 }`.
- `per_turn_timeout_fires` — slow turn → `AgentTurnTimeout { turn: 0, timeout: 10ms }`; companion fast turn → `Break` (proves the path is not always-triggered).
- `wait_step_rejected_in_a_s1` — `Wait` → `AgentWaitNotSupported`.

Plus 5 adapter unit tests in `agent.rs` (init_turn round-trip, step advances/continues, bad-turn-state → `Validation` not panic, unchanged-state legal, dyn-compatible).

### Local verification

- [x] `cargo fmt` — clean (scoped `-p nebula-action -p nebula-engine`; `cargo fmt --all` hits the Windows cmdline-length limit (OS error 206) — lefthook runs fmt per-crate locally, CI runs `--all`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-push `clippy-full`)
- [x] `cargo nextest run` (workspace) — 794/794 across 46 binaries, profile `agent` (pre-push)
- [x] `cargo test --doc -p nebula-action -p nebula-engine` — doctests pass
- [ ] `cargo deny check` — N/A (no `Cargo.toml` change)

## Breaking changes

None. Purely additive: `ActionHandle::Agent` is an internal enum variant; `AgentAction`/`AgentHandle`/`GenericAgentFactory`/`register_agent_factory` are new public items; three new `RuntimeError` variants. No existing signature changed.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — the new Agent loop is documented (agent.rs module docs + `execute_agent_handle` doc + ADR-0103); no silent drift.
- [x] Layer direction preserved (action → resource/credential exists; resource ↛ action; engine → action; no `nebula-agent` dependency) — verified acyclic.
- [x] L2 seam covered by the 5 engine dispatch tests in this PR (the ADR is recorded in the maintainers' private design vault).
- [ ] `docs/MATURITY.md` — unchanged (Agent kind is an experimental foundation, not a maturity-tier change).
- [ ] Crate `README.md` / `lib.rs //!` — new module fully documented; crate-level kind-list refresh deferred (see Notes).
- [ ] `docs/INTEGRATION_MODEL.md` — deferred until the kind stabilizes (A-S2+ adds tools/HITL); design lives in ADR-0103.
- [x] Plan/spec recorded: ADR-0103 (private design vault).

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (the adapter uses `map_err`; `unwrap`/`expect` appear only in tests).
- [x] No silent error suppression — the adapter's error path logs and propagates; no `let _ = …` on a `Result`.
- [x] No direct engine state mutation added — the loop returns `ActionResult`; node-state transitions stay in the engine's existing path.
- [x] No credential/secret paths added (the kind is Llm-agnostic; secrets are not handled here).
- [x] No new `unsafe`.

## Notes for reviewers

- **A-S1 is the foundation slice** of ADR-0103: no tools, no HITL, own `Continue`/`Break` loop. `Wait` returns `AgentWaitNotSupported` **by design** (durable park/resume is a later phase, gated on the wait-state engine).
- **Focus**: `execute_agent_handle` loop semantics (the `max_turns` boundary; per-turn `timeout` ↔ cancellation composition in the biased `select!`) and the `AgentActionAdapter` flush-before-error contract.
- **Why an own loop, not a stateful clone**: cloning `execute_stateful_handle` would kill legitimate no-progress agent turns via the `StatefulStuck` digest guard and offers no per-turn timeout (a hung provider call would pin a worker). This supersedes ADR-0098's "Agent rides Continue, no wait-state" claim (per a design panel; recorded in ADR-0103).
- **Follow-ups (out of scope)**: A-S2 (read-only resource tools — needs the ResourceTools surface), A-S3 (Wait arm + tool security + dyn freeze — needs the wait-state engine). Public-facing repo docs (INTEGRATION_MODEL / crate-level kind list) refresh travels with the kind reaching stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
