### PR TITLE
feat(engine): durable wait-state park + downstream gate (ADR-0099 W-S1)

### DIFF
--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -3077,16 +3077,61 @@ impl WorkflowEngine {
                     // state in one atomic write. Downstream edges are NOT
                     // activated here — they remain gated until Phase 0b
                     // transitions this node to `Completed` when the timer
-                    // fires (or until an explicit Resume signal arrives for
-                    // signal-driven conditions).
-                    if let ActionResult::Wait { ref condition, .. } = action_result {
-                        // Compute the timer wake instant.
-                        // Only `Until{datetime}` and `Duration{d}` are wired in
-                        // W-S1. Signal-driven conditions (Webhook / Approval /
-                        // Execution) require an explicit Resume signal that W-S2
-                        // will implement — reject them here with a typed error
-                        // rather than parking with no timer entry and permanently
-                        // stalling the execution.
+                    // fires.
+                    //
+                    // W-S1 boundary conditions rejected here (both marked
+                    // `WaitConditionNotSupported`):
+                    //   1. Signal-driven conditions (Webhook/Approval/Execution):
+                    //      W-S2 will wire the Resume signal path.
+                    //   2. Timer conditions with an explicit `timeout`: the
+                    //      fail-on-timeout enforcement path is also W-S2.
+                    //      Only `timeout: None` timer waits are supported.
+                    if let ActionResult::Wait {
+                        ref condition,
+                        timeout,
+                        ..
+                    } = action_result
+                    {
+                        // Reject explicit timeouts: the timeout-as-cancellation
+                        // path belongs to W-S2. Silently ignoring a `timeout`
+                        // would mean the node waits the full condition duration
+                        // (up to hours) instead of the declared maximum, which
+                        // is a correctness bug, not a missing optimisation.
+                        if let Some(_timeout_dur) = timeout {
+                            let condition_kind = match condition {
+                                WaitCondition::Until { .. } => "Until with explicit timeout",
+                                WaitCondition::Duration { .. } => "Duration with explicit timeout",
+                                WaitCondition::Webhook { .. } => "Webhook with explicit timeout",
+                                WaitCondition::Approval { .. } => "Approval with explicit timeout",
+                                WaitCondition::Execution { .. } => {
+                                    "Execution with explicit timeout"
+                                },
+                                _ => "Unknown with explicit timeout",
+                            };
+                            let runtime_err =
+                                crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                    condition_kind: condition_kind.to_owned(),
+                                };
+                            let engine_err = EngineError::Runtime(runtime_err);
+                            tracing::error!(
+                                target = "engine::wait",
+                                %execution_id,
+                                %node_key,
+                                condition_kind,
+                                error = %engine_err,
+                                "explicit timeout on WaitCondition not supported in W-S1; \
+                                 marking node Failed and returning error"
+                            );
+                            mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                            cancel_token.cancel();
+                            return Some((node_key.clone(), engine_err.to_string()));
+                        }
+
+                        // Compute the timer wake instant for timer-based conditions.
+                        // Signal-driven conditions (Webhook / Approval / Execution)
+                        // require an explicit Resume signal that W-S2 will implement —
+                        // reject them with a typed error rather than parking with no
+                        // timer entry and permanently stalling the execution.
                         let now = Utc::now();
                         let wake_at: Option<DateTime<Utc>> = match condition {
                             WaitCondition::Until { datetime } => Some(*datetime),
@@ -3114,16 +3159,59 @@ impl WorkflowEngine {
                                     "signal-driven WaitCondition not supported in W-S1; \
                                      marking node Failed and returning error"
                                 );
-                                // Stamp the node as Failed with the typed error so
-                                // `node_errors` in the returned `ExecutionResult`
-                                // carries the diagnostic message. Without this, the
-                                // node stays `Running` in `exec_state` and the
-                                // error map is empty even though the execution is Failed.
                                 mark_node_failed(exec_state, node_key.clone(), &engine_err);
                                 cancel_token.cancel();
                                 return Some((node_key.clone(), engine_err.to_string()));
                             },
                         };
+
+                        // Budget enforcement for the partial output committed at park
+                        // time. The normal success path increments `total_output_bytes`
+                        // AFTER the node completes; Phase 1's `check_budget` catches
+                        // the violation before the next downstream node is dispatched.
+                        // The park path's `continue` skips Phase 3 output accounting
+                        // entirely — so we must enforce the budget HERE, before park,
+                        // or a large `partial_output` bypasses the limit silently.
+                        //
+                        // If the partial output is over-budget, fail the node (do NOT
+                        // park) so the downstream child is never dispatched.
+                        let partial_output_bytes: u64 = outputs
+                            .get(&node_key)
+                            .and_then(|v| serde_json::to_string(v.value()).ok())
+                            .map_or(0, |s| s.len() as u64);
+                        if partial_output_bytes > 0 {
+                            let new_total = total_output_bytes
+                                .fetch_add(partial_output_bytes, Ordering::Relaxed)
+                                + partial_output_bytes;
+                            if let Some(max_bytes) = budget.max_output_bytes
+                                && new_total > max_bytes
+                            {
+                                let budget_err = "execution budget exceeded: max_output_bytes \
+                                                  (partial_output at park time)";
+                                tracing::error!(
+                                    target = "engine::wait",
+                                    %execution_id,
+                                    %node_key,
+                                    partial_output_bytes,
+                                    new_total,
+                                    max_bytes,
+                                    "partial_output at park exceeds max_output_bytes budget; \
+                                     failing node instead of parking"
+                                );
+                                // Restore the counter — the node is being failed, not
+                                // committed, so its bytes should not count against the
+                                // budget for the remaining nodes.
+                                total_output_bytes
+                                    .fetch_sub(partial_output_bytes, Ordering::Relaxed);
+                                mark_node_failed(
+                                    exec_state,
+                                    node_key.clone(),
+                                    &EngineError::BudgetExceeded(budget_err.to_owned()),
+                                );
+                                cancel_token.cancel();
+                                return Some((node_key.clone(), budget_err.to_owned()));
+                            }
+                        }
 
                         match exec_state.park_node(node_key.clone(), wake_at) {
                             Ok(()) => {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -19,7 +19,9 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use dashmap::DashMap;
-use nebula_action::{ActionError, ActionResult, capability::default_resource_accessor};
+use nebula_action::{
+    ActionError, ActionResult, capability::default_resource_accessor, result::WaitCondition,
+};
 use nebula_core::{
     ActionKey, NodeKey, ResourceKey,
     accessor::{CredentialAccessor, ResourceAccessor},
@@ -1993,10 +1995,21 @@ impl WorkflowEngine {
         // immediately on resume, defeating T2's
         // resume guarantee. (Crashed `Running` attempts have no
         // such timestamp and must be re-driven from `Pending`.)
+        //
+        // `Waiting` nodes are excluded for the same reason: they are
+        // durably parked for an external wait condition (timer or
+        // signal). Their `next_attempt_at` is the timer wake instant;
+        // the Phase-0b drain re-seeds `wait_heap` from them below.
+        // Resetting a `Waiting` node to `Pending` would immediately
+        // re-dispatch it, defeating the durable park guarantee.
         let non_terminal: Vec<NodeKey> = exec_state
             .node_states
             .iter()
-            .filter(|(_, ns)| !ns.state.is_terminal() && ns.state != NodeState::WaitingRetry)
+            .filter(|(_, ns)| {
+                !ns.state.is_terminal()
+                    && ns.state != NodeState::WaitingRetry
+                    && ns.state != NodeState::Waiting
+            })
             .map(|(id, _)| id.clone())
             .collect();
         for id in non_terminal {
@@ -2076,6 +2089,14 @@ impl WorkflowEngine {
             // separately; including them here would re-dispatch
             // immediately and bypass the persisted backoff timer.
             if ns.state == NodeState::WaitingRetry {
+                continue;
+            }
+            // `Waiting` nodes are durably parked for an external
+            // wait condition. Like `WaitingRetry`, they must NOT
+            // enter the seed/ready_queue. The Phase-0b wait drain
+            // re-seeds `wait_heap` from these nodes and drives
+            // timer-based `Waiting→Completed` transitions.
+            if ns.state == NodeState::Waiting {
                 continue;
             }
             let incoming = graph.incoming_connections(node_key.clone());
@@ -2406,6 +2427,27 @@ impl WorkflowEngine {
             }
         }
 
+        // Min-heap of `(wake_at, NodeKey)` for nodes parked in `Waiting`
+        // with a timer-based condition (`Until` / `Duration`). Mirrors
+        // `retry_heap` but drains to `Completed` instead of `Ready` —
+        // a satisfied wait condition means the node is done, not
+        // restarted. Signal-only parked nodes (webhook/approval/execution
+        // with no timeout) are NOT on this heap; they stay parked until
+        // a `Resume` signal arrives (built separately).
+        let mut wait_heap: BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>> = BinaryHeap::new();
+
+        // Resume seeding for `Waiting` nodes: a crashed engine may have
+        // persisted a node in `Waiting` with a `next_attempt_at` timer;
+        // re-seed the heap so the wake fires without requiring a fresh
+        // `ActionResult::Wait` dispatch.
+        for (key, ns) in &exec_state.node_states {
+            if ns.state == NodeState::Waiting
+                && let Some(when) = ns.next_attempt_at
+            {
+                wait_heap.push(Reverse((when, key.clone())));
+            }
+        }
+
         // In-flight tasks + a side map from tokio task id → NodeKey so
         // that panics (where the inner future's `(NodeKey, _)` payload
         // is lost) can still be attributed to the real node instead
@@ -2482,6 +2524,107 @@ impl WorkflowEngine {
                         %execution_id,
                         %node_key,
                         "retry drained but node no longer in WaitingRetry; skipping"
+                    );
+                }
+            }
+
+            // Phase 0b: Drain due timer-wakes from `wait_heap`.
+            //
+            // A `Waiting` node whose `next_attempt_at` has passed has its
+            // wait condition satisfied: the engine transitions it directly
+            // to `Completed` (the action's `partial_output` was already
+            // committed to the outputs map when the node was parked) and
+            // activates its downstream edges. This mirrors Phase 0 for
+            // retries but targets `Completed` instead of `Ready`.
+            let now_wait_drain = Utc::now();
+            while let Some(Reverse((when, _))) = wait_heap.peek() {
+                if *when > now_wait_drain {
+                    break;
+                }
+                let Some(Reverse((_, node_key))) = wait_heap.pop() else {
+                    // Unreachable: peek-then-pop on a single-threaded
+                    // owner cannot lose the entry. Surface defensively
+                    // rather than panic (hot-path safety).
+                    tracing::warn!(
+                        target = "engine::wait",
+                        %execution_id,
+                        "wait heap became empty after peek; aborting wait drain"
+                    );
+                    break;
+                };
+                let still_parked = exec_state
+                    .node_state(node_key.clone())
+                    .is_some_and(|ns| ns.state == NodeState::Waiting);
+                if still_parked {
+                    match exec_state.transition_node(node_key.clone(), NodeState::Completed) {
+                        Ok(()) => {
+                            if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
+                                ns.next_attempt_at = None;
+                                ns.completed_at = Some(Utc::now());
+                            }
+                            // Persist the `Completed` transition and the
+                            // cleared `next_attempt_at` atomically before
+                            // activating downstream — durability precedes
+                            // visibility.
+                            if let Err(e) = self
+                                .checkpoint_node(
+                                    scope,
+                                    execution_id,
+                                    node_key.clone(),
+                                    outputs,
+                                    exec_state,
+                                    repo_version,
+                                    fencing,
+                                )
+                                .await
+                            {
+                                cancel_token.cancel();
+                                return Some((node_key.clone(), e.to_string()));
+                            }
+                            self.emit_event(ExecutionEvent::NodeWaitCompleted {
+                                execution_id,
+                                node_key: node_key.clone(),
+                            });
+                            tracing::info!(
+                                target = "engine::wait",
+                                %execution_id,
+                                %node_key,
+                                "wait condition satisfied (timer); node completed"
+                            );
+                            // Activate downstream edges now that the node is
+                            // `Completed` — this is the point at which the
+                            // downstream gate lifts.
+                            process_outgoing_edges(
+                                node_key.clone(),
+                                None, // no live `ActionResult` for this synthetic completion
+                                None,
+                                graph,
+                                &mut activated_edges,
+                                &mut resolved_edges,
+                                &required_count,
+                                &mut ready_queue,
+                                exec_state,
+                            );
+                        },
+                        Err(err) => {
+                            // `Waiting → Completed` is in the canonical table;
+                            // this branch fires only if the node was concurrently
+                            // cancelled. Surface defensively.
+                            tracing::warn!(
+                                target = "engine::wait",
+                                %execution_id,
+                                %node_key,
+                                %err,
+                                "wait-heap wake: Waiting→Completed rejected; skipping"
+                            );
+                        },
+                    }
+                } else {
+                    tracing::debug!(
+                        target = "engine::wait",
+                        %execution_id,
+                        %node_key,
+                        "wait heap drained but node no longer in Waiting; skipping"
                     );
                 }
             }
@@ -2745,12 +2888,11 @@ impl WorkflowEngine {
                 }
             }
 
-            // Phase 2: Wait for one completion or for the next retry
-            // timer. Exit only when both join_set and retry_heap are
-            // drained — `retry_heap` non-empty with `join_set` empty
-            // is a legal "everything paused for backoff" state per
-            // T5.
-            if join_set.is_empty() && retry_heap.is_empty() {
+            // Phase 2: Wait for one completion or for the next timer.
+            // Exit only when join_set, retry_heap, AND wait_heap are
+            // all drained — a non-empty heap with an empty join_set
+            // is a legal "everything paused for a timer" state.
+            if join_set.is_empty() && retry_heap.is_empty() && wait_heap.is_empty() {
                 break;
             }
 
@@ -2758,19 +2900,17 @@ impl WorkflowEngine {
                 join_set.abort_all();
                 while join_set.join_next_with_id().await.is_some() {}
                 task_nodes.clear();
-                // Tear down parked retries (WaitingRetry → Cancelled)
-                // AND the ready_queue (Ready → Cancelled). The
-                // previous failure already lives in `NodeAttempt`;
-                // the cancel terminates the wait, not the attempt
-                // (operational honesty). Without draining `ready_queue`, a
-                // node Phase 0 already promoted to `Ready` would
-                // stay non-terminal after the loop exits, tripping
-                // the frontier integrity (CAS on version) check. Best-
-                // effort persist is covered by the final-status
-                // checkpoint in the outer caller — failures here
-                // only affect post-mortem log fidelity.
+                // Tear down parked retries (WaitingRetry → Cancelled),
+                // parked wait nodes (Waiting → Cancelled), AND the
+                // ready_queue (Ready → Cancelled). The previous failure
+                // already lives in `NodeAttempt`; the cancel terminates
+                // the wait, not the attempt (operational honesty).
+                // Without draining `ready_queue`, a node Phase 0 already
+                // promoted to `Ready` would stay non-terminal after the
+                // loop exits, tripping the frontier integrity check.
                 drain_pending_to_cancelled(
                     &mut retry_heap,
+                    &mut wait_heap,
                     &mut ready_queue,
                     exec_state,
                     execution_id,
@@ -2811,11 +2951,27 @@ impl WorkflowEngine {
             };
             tokio::pin!(retry_sleep_fut);
 
-            // If join_set is empty but retry_heap has work, we still
-            // need to sleep until the timer (or cancel / wall-clock).
-            // Pre-pin a boxed future per branch so `select!` never has
-            // to enter an `unreachable!()` placeholder — library code
-            // must not panic on hot paths (hot-path safety).
+            // Compute the sleep until the earliest parked-wait timer fires.
+            // This drives Phase 0b drains when `join_set` is otherwise idle.
+            let next_wait_in: Option<Duration> = wait_heap.peek().map(|Reverse((when, _))| {
+                when.signed_duration_since(Utc::now())
+                    .to_std()
+                    .unwrap_or(Duration::ZERO)
+            });
+            let wait_sleep_fut = async {
+                if let Some(d) = next_wait_in {
+                    tokio::time::sleep(d).await;
+                } else {
+                    std::future::pending::<()>().await;
+                }
+            };
+            tokio::pin!(wait_sleep_fut);
+
+            // If join_set is empty but retry_heap or wait_heap has work,
+            // we still need to sleep until the timer (or cancel /
+            // wall-clock). Pre-pin a boxed future per branch so `select!`
+            // never has to enter an `unreachable!()` placeholder — library
+            // code must not panic on hot paths (hot-path safety).
             let join_set_empty = join_set.is_empty();
 
             type JoinedResult = Option<
@@ -2838,6 +2994,7 @@ impl WorkflowEngine {
             enum WakeReason {
                 Joined(JoinedResult),
                 RetryTimer,
+                WaitTimer,
                 WallClock,
                 Cancel,
             }
@@ -2852,6 +3009,7 @@ impl WorkflowEngine {
             let wake = tokio::select! {
                 result = join_next_fut => WakeReason::Joined(result),
                 () = &mut retry_sleep_fut, if next_retry_in.is_some() => WakeReason::RetryTimer,
+                () = &mut wait_sleep_fut, if next_wait_in.is_some() => WakeReason::WaitTimer,
                 () = &mut sleep_fut => WakeReason::WallClock,
                 () = cancel_token.cancelled() => WakeReason::Cancel,
             };
@@ -2860,13 +3018,18 @@ impl WorkflowEngine {
                 WakeReason::Joined(Some(r)) => r,
                 WakeReason::Joined(None) => {
                     // join_set drained mid-iteration — loop back so
-                    // Phase 0 / Phase 1 / exit-condition observe the
-                    // current retry_heap state.
+                    // Phase 0 / Phase 0b / Phase 1 / exit-condition
+                    // observe the current heap state.
                     continue;
                 },
                 WakeReason::RetryTimer => {
                     // Timer fired — loop back so Phase 0 drains due
                     // retries into ready_queue.
+                    continue;
+                },
+                WakeReason::WaitTimer => {
+                    // Timer fired — loop back so Phase 0b drains due
+                    // wait-wakes into completed + downstream edges.
                     continue;
                 },
                 WakeReason::WallClock => {
@@ -2876,6 +3039,7 @@ impl WorkflowEngine {
                     task_nodes.clear();
                     drain_pending_to_cancelled(
                         &mut retry_heap,
+                        &mut wait_heap,
                         &mut ready_queue,
                         exec_state,
                         execution_id,
@@ -2891,6 +3055,7 @@ impl WorkflowEngine {
                     task_nodes.clear();
                     drain_pending_to_cancelled(
                         &mut retry_heap,
+                        &mut wait_heap,
                         &mut ready_queue,
                         exec_state,
                         execution_id,
@@ -2903,6 +3068,128 @@ impl WorkflowEngine {
             match join_result {
                 Ok((task_id, (node_key, Ok(action_result)))) => {
                     task_nodes.remove(&task_id);
+
+                    // Park path: action returned `ActionResult::Wait`.
+                    //
+                    // The `partial_output` was already written into `outputs`
+                    // by `extract_primary_output` in the dispatch future, so
+                    // `checkpoint_node` will commit it alongside the `Waiting`
+                    // state in one atomic write. Downstream edges are NOT
+                    // activated here — they remain gated until Phase 0b
+                    // transitions this node to `Completed` when the timer
+                    // fires (or until an explicit Resume signal arrives for
+                    // signal-driven conditions).
+                    if let ActionResult::Wait { ref condition, .. } = action_result {
+                        // Compute the timer wake instant.
+                        // Only `Until{datetime}` and `Duration{d}` are wired in
+                        // W-S1. Signal-driven conditions (Webhook / Approval /
+                        // Execution) require an explicit Resume signal that W-S2
+                        // will implement — reject them here with a typed error
+                        // rather than parking with no timer entry and permanently
+                        // stalling the execution.
+                        let now = Utc::now();
+                        let wake_at: Option<DateTime<Utc>> = match condition {
+                            WaitCondition::Until { datetime } => Some(*datetime),
+                            WaitCondition::Duration { duration } => {
+                                chrono::Duration::from_std(*duration).ok().map(|d| now + d)
+                            },
+                            other => {
+                                let condition_kind = match other {
+                                    WaitCondition::Webhook { .. } => "Webhook",
+                                    WaitCondition::Approval { .. } => "Approval",
+                                    WaitCondition::Execution { .. } => "Execution",
+                                    _ => "Unknown",
+                                };
+                                let runtime_err =
+                                    crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                        condition_kind: condition_kind.to_owned(),
+                                    };
+                                let engine_err = EngineError::Runtime(runtime_err);
+                                tracing::error!(
+                                    target = "engine::wait",
+                                    %execution_id,
+                                    %node_key,
+                                    condition_kind,
+                                    error = %engine_err,
+                                    "signal-driven WaitCondition not supported in W-S1; \
+                                     marking node Failed and returning error"
+                                );
+                                // Stamp the node as Failed with the typed error so
+                                // `node_errors` in the returned `ExecutionResult`
+                                // carries the diagnostic message. Without this, the
+                                // node stays `Running` in `exec_state` and the
+                                // error map is empty even though the execution is Failed.
+                                mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                                cancel_token.cancel();
+                                return Some((node_key.clone(), engine_err.to_string()));
+                            },
+                        };
+
+                        match exec_state.park_node(node_key.clone(), wake_at) {
+                            Ok(()) => {
+                                // Durably commit the `Waiting` state and the
+                                // already-staged `partial_output` before any
+                                // observer sees the node is parked. On
+                                // checkpoint failure, abort: the task slot
+                                // was already removed above and cannot be
+                                // re-dispatched, so abort is the honest path.
+                                if let Err(e) = self
+                                    .checkpoint_node(
+                                        scope,
+                                        execution_id,
+                                        node_key.clone(),
+                                        outputs,
+                                        exec_state,
+                                        repo_version,
+                                        fencing,
+                                    )
+                                    .await
+                                {
+                                    cancel_token.cancel();
+                                    return Some((node_key.clone(), e.to_string()));
+                                }
+                                // Push onto the wait_heap only for timer-driven
+                                // conditions; signal-driven conditions with no
+                                // timeout stay parked indefinitely until a
+                                // Resume arrives.
+                                if let Some(when) = wake_at {
+                                    wait_heap.push(Reverse((when, node_key.clone())));
+                                }
+                                self.emit_event(ExecutionEvent::NodeParked {
+                                    execution_id,
+                                    node_key: node_key.clone(),
+                                    wake_at,
+                                });
+                                tracing::info!(
+                                    target = "engine::wait",
+                                    %execution_id,
+                                    %node_key,
+                                    ?wake_at,
+                                    "node parked for external wait condition"
+                                );
+                                // Skip the normal completion path — downstream
+                                // gate holds until the wait is satisfied.
+                                continue;
+                            },
+                            Err(park_err) => {
+                                // park_node rejected the transition; treat as a
+                                // system failure rather than silently dropping
+                                // the node (the task slot was already removed,
+                                // so the engine cannot re-dispatch it). Surface
+                                // the error through the frontier abort path.
+                                tracing::error!(
+                                    target = "engine::wait",
+                                    %execution_id,
+                                    %node_key,
+                                    error = %park_err,
+                                    "park_node rejected Running→Waiting; aborting frontier"
+                                );
+                                cancel_token.cancel();
+                                return Some((node_key.clone(), park_err.to_string()));
+                            },
+                        }
+                    }
+
                     mark_node_completed(exec_state, node_key.clone());
 
                     // Track output size for budget enforcement.
@@ -3103,6 +3390,7 @@ impl WorkflowEngine {
                             task_nodes.clear();
                             drain_pending_to_cancelled(
                                 &mut retry_heap,
+                                &mut wait_heap,
                                 &mut ready_queue,
                                 exec_state,
                                 execution_id,
@@ -4459,6 +4747,11 @@ fn process_outgoing_edges(
 ///
 /// Rules:
 /// - `Skip` / `Drop` / `Terminate` → no edges activate on any port.
+/// - `Wait` → no edges activate from the `Wait` result; downstream edges
+///   are gated until the node reaches `Completed` (when the wait condition
+///   is satisfied). This is defense-in-depth: the park path in Phase 3
+///   structurally skips `process_outgoing_edges` on `Wait`, so this guard
+///   fires only if that skip is somehow bypassed.
 /// - Failed node → only edges with `from_port == "error"` activate; action authors wire their
 ///   failure path to whichever `ControlAction` fits (typically a `Switch` keyed on error class) or
 ///   to a recovery node.
@@ -4468,7 +4761,7 @@ fn process_outgoing_edges(
 /// - `Route { port }` → activates edges whose effective source port equals `port`.
 /// - `MultiOutput { outputs }` → activates edges whose effective source port is present in
 ///   `outputs`.
-/// - `Continue` / `Break` / `Wait` → engine treats these like `Success` for edge activation (they
+/// - `Continue` / `Break` → engine treats these like `Success` for edge activation (they
 ///   hit the main port); persistent state handling lives outside this routing decision.
 fn evaluate_edge(
     conn: &Connection,
@@ -4479,6 +4772,13 @@ fn evaluate_edge(
 
     // Skip / Drop / Terminate never activate any edge.
     if matches!(result, Some(Skip { .. } | Drop { .. } | Terminate { .. })) {
+        return false;
+    }
+
+    // Wait gates all downstream edges until the wait condition is
+    // satisfied (the park path in Phase 3 structurally skips
+    // `process_outgoing_edges`, so this is defense-in-depth).
+    if matches!(result, Some(Wait { .. })) {
         return false;
     }
 
@@ -4591,6 +4891,7 @@ fn check_budget(
 /// here only affect post-mortem log fidelity.
 fn drain_pending_to_cancelled(
     retry_heap: &mut BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>>,
+    wait_heap: &mut BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>>,
     ready_queue: &mut VecDeque<NodeKey>,
     exec_state: &mut ExecutionState,
     execution_id: ExecutionId,
@@ -4605,6 +4906,21 @@ fn drain_pending_to_cancelled(
             %execution_id,
             node_key = %parked,
             "WaitingRetry → Cancelled (cancel observed during backoff)"
+        );
+    }
+    // Drain parked wait nodes — `Waiting → Cancelled` lets a cancelled
+    // execution tear down nodes that were parked for an external
+    // condition without observing a phantom `Completed` step.
+    while let Some(Reverse((_, waiting))) = wait_heap.pop() {
+        let _ = exec_state.transition_node(waiting.clone(), NodeState::Cancelled);
+        if let Some(ns) = exec_state.node_states.get_mut(&waiting) {
+            ns.next_attempt_at = None;
+        }
+        tracing::debug!(
+            target = "engine::wait",
+            %execution_id,
+            node_key = %waiting,
+            "Waiting → Cancelled (cancel observed while parked)"
         );
     }
     while let Some(queued) = ready_queue.pop_front() {

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -47,6 +47,39 @@ pub enum ExecutionEvent {
         error: String,
     },
 
+    /// A node returned `ActionResult::Wait` and has been durably parked
+    /// pending an external condition (timer, webhook, or human approval).
+    ///
+    /// The node has transitioned to `Waiting`, the worker has been
+    /// released, and downstream edges are gated until
+    /// [`ExecutionEvent::NodeWaitCompleted`] fires.
+    ///
+    /// `wake_at` is `Some` for timer-driven conditions (`Until` /
+    /// `Duration`) and `None` for signal-driven conditions (`Webhook` /
+    /// `Approval` / `Execution`) that have no timeout.
+    NodeParked {
+        /// Execution this node belongs to.
+        execution_id: ExecutionId,
+        /// The node that was parked.
+        node_key: NodeKey,
+        /// Wall-clock instant the engine plans to satisfy the wait, or
+        /// `None` for signal-only conditions.
+        wake_at: Option<DateTime<Utc>>,
+    },
+
+    /// A parked node's wait condition was satisfied and the node has
+    /// been transitioned to `Completed`. Downstream edges are now active.
+    ///
+    /// Subscribers should treat [`ExecutionEvent::NodeParked`] and this
+    /// event as a matched pair: `Parked` gates downstream, `WaitCompleted`
+    /// unblocks it.
+    NodeWaitCompleted {
+        /// Execution this node belongs to.
+        execution_id: ExecutionId,
+        /// The node whose wait condition was satisfied.
+        node_key: NodeKey,
+    },
+
     /// A node attempt failed but the engine scheduled a retry per
     /// (Layer 2 — engine-level retry). The node has
     /// transitioned to `WaitingRetry` and will be re-dispatched at

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -204,6 +204,30 @@ pub enum RuntimeError {
         key: String,
     },
 
+    /// An action returned `ActionResult::Wait` with a signal-driven condition
+    /// (`Webhook`, `Approval`, or `Execution`) that requires an explicit Resume
+    /// signal to satisfy. The W-S1 slice only wires timer-based conditions
+    /// (`Until` / `Duration`). Signal-driven resume is the W-S2 work item.
+    ///
+    /// The engine surfaces this error rather than parking the node with
+    /// `wake_at = None` and no timer entry — which would permanently stall
+    /// the execution until a Resume signal arrived through an unimplemented
+    /// path.
+    #[classify(
+        category = "unsupported",
+        code = "RUNTIME:WAIT_CONDITION_NOT_SUPPORTED",
+        retryable = false
+    )]
+    #[error(
+        "ActionResult::Wait with condition '{condition_kind}' is not yet supported — \
+         only 'Until' and 'Duration' (timer-based) conditions are wired in W-S1; \
+         signal-driven resume (Webhook/Approval/Execution) ships in W-S2"
+    )]
+    WaitConditionNotSupported {
+        /// The `WaitCondition` variant name that was rejected.
+        condition_kind: String,
+    },
+
     /// Internal runtime error.
     #[classify(category = "internal", code = "RUNTIME:INTERNAL")]
     #[error("runtime error: {0}")]

--- a/crates/engine/tests/wait.rs
+++ b/crates/engine/tests/wait.rs
@@ -1,0 +1,616 @@
+//! Engine-level wait-state integration tests.
+//!
+//! Covers the timer-wake park path: a node returning `ActionResult::Wait`
+//! with `WaitCondition::Duration` or `WaitCondition::Until` must:
+//!
+//! 1. Park itself in `Waiting` (releasing the worker) without activating
+//!    downstream edges.
+//! 2. Transition directly to `Completed` once the timer fires.
+//! 3. Activate downstream edges only after that `Completed` transition.
+//!
+//! Every test has a **falsifiability clause**: a comment naming the
+//! regression it catches and how to make it go red.
+
+use std::{
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use chrono::Utc;
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    output::ActionOutput,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::WorkflowId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, DataPassingPolicy, ExecutionEvent,
+    InProcessRunner, WorkflowEngine,
+};
+use nebula_execution::{ExecutionStatus, context::ExecutionBudget};
+use nebula_metrics::MetricsRegistry;
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ---------------------------------------------------------------------------
+// Macro — Variant A trait shape with placeholder static metadata
+// (same convention as retry.rs; real metadata flows through
+// `register_stateless_instance`).
+// ---------------------------------------------------------------------------
+
+macro_rules! placeholder_action_impl {
+    ($ty:ty, $key:expr, $name:expr, $desc:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, $desc)
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Test handlers
+// ---------------------------------------------------------------------------
+
+/// Immediately returns `ActionResult::Wait { condition: Duration(wait_for),
+/// timeout: None, partial_output: Some(value) }`.
+/// Simulates any action that parks itself for a timer-based condition.
+struct WaitingHandler {
+    wait_for: Duration,
+    partial_output: serde_json::Value,
+}
+
+placeholder_action_impl!(
+    WaitingHandler,
+    action_key!("placeholder.waiting"),
+    "WaitingPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for WaitingHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Duration {
+                duration: self.wait_for,
+            },
+            timeout: None,
+            partial_output: Some(ActionOutput::Value(self.partial_output.clone())),
+        })
+    }
+}
+
+/// Immediately returns `ActionResult::Wait` using `WaitCondition::Until`.
+struct WaitUntilHandler {
+    wake_at: chrono::DateTime<Utc>,
+    partial_output: serde_json::Value,
+}
+
+placeholder_action_impl!(
+    WaitUntilHandler,
+    action_key!("placeholder.wait_until"),
+    "WaitUntilPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for WaitUntilHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Until {
+                datetime: self.wake_at,
+            },
+            timeout: None,
+            partial_output: Some(ActionOutput::Value(self.partial_output.clone())),
+        })
+    }
+}
+
+/// Returns `ActionResult::Wait` with `WaitCondition::Webhook` — a
+/// signal-driven condition that W-S1 does not support. Used to verify
+/// `WaitConditionNotSupported` is returned rather than silently parking.
+struct WebhookWaitHandler;
+
+placeholder_action_impl!(
+    WebhookWaitHandler,
+    action_key!("placeholder.webhook_wait"),
+    "WebhookWaitPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for WebhookWaitHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "test-callback-id".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Simple echo: records how many times it was called and succeeds.
+struct EchoHandler {
+    invocations: Arc<AtomicU32>,
+}
+
+placeholder_action_impl!(
+    EchoHandler,
+    action_key!("placeholder.echo"),
+    "EchoPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for EchoHandler {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine / workflow assembly helpers (mirrors retry.rs)
+// ---------------------------------------------------------------------------
+
+fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
+}
+
+fn make_workflow(
+    nodes: Vec<NodeDefinition>,
+    connections: Vec<Connection>,
+    config: WorkflowConfig,
+) -> WorkflowDefinition {
+    let now = Utc::now();
+    WorkflowDefinition {
+        id: WorkflowId::new(),
+        name: "wait-test".to_owned(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes,
+        connections,
+        variables: Default::default(),
+        config,
+        trigger_bindings: Vec::new(),
+        tags: vec![],
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// 1) **Timer-based gate with mid-park `downstream_calls == 0` assertion**:
+/// a two-node workflow `node1 → node2` where `node1` parks itself via
+/// `WaitCondition::Duration`. The test asserts:
+///
+/// - While `node1` is `Waiting` (at the moment `NodeParked` is received),
+///   `downstream_calls == 0` — downstream is gated by the park.
+/// - A `NodeWaitCompleted` event is subsequently emitted.
+/// - After the workflow finishes, `downstream_calls == 1`.
+///
+/// **Falsifiability (gate assertion)**:
+/// - Remove the `continue` in the park path (letting it fall through to
+///   `mark_node_completed` + `process_outgoing_edges`) → `node2` runs
+///   before the timer fires → `downstream_calls == 1` at the `NodeParked`
+///   instant → the `== 0` assertion fails. Restore the `continue` → green.
+/// - Remove the `continue` in the park path entirely → no `NodeParked`
+///   event is emitted → the event-wait loop never receives it → the
+///   `tokio::time::timeout` on the event-wait fires → test fails.
+#[tokio::test]
+async fn wait_node_gates_downstream_until_timer_then_resumes() {
+    let downstream_calls = Arc::new(AtomicU32::new(0));
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("waiter"), "Waiter", "parks for 60ms"),
+        WaitingHandler {
+            wait_for: Duration::from_millis(60),
+            partial_output: serde_json::json!({ "stage": "parked" }),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("downstream"), "Downstream", "echo"),
+        EchoHandler {
+            invocations: Arc::clone(&downstream_calls),
+        },
+    );
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(128);
+    let mut events_rx = event_bus.subscribe();
+    let engine = Arc::new(make_engine(registry).with_event_bus(event_bus));
+
+    let n1 = node_key!("node1");
+    let n2 = node_key!("node2");
+    let node1 = NodeDefinition::new(n1.clone(), "waiter_node", "core", "waiter").unwrap();
+    let node2 = NodeDefinition::new(n2.clone(), "downstream_node", "core", "downstream").unwrap();
+    let conn = Connection::new(n1.clone(), n2.clone());
+    let wf = make_workflow(vec![node1, node2], vec![conn], WorkflowConfig::default());
+
+    // Spawn the workflow so we can observe events while it runs.
+    let engine_h = Arc::clone(&engine);
+    let wf_arc = Arc::new(wf);
+    let wf_for_task = Arc::clone(&wf_arc);
+    let task = tokio::spawn(async move {
+        engine_h
+            .execute_workflow(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &wf_for_task,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
+            .await
+    });
+
+    // Wait for `NodeParked` — node1 is now in `Waiting`, downstream gated.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { node_key, .. }) if node_key == n1 => break,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeParked"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for NodeParked event");
+
+    // Mid-park gate assertion: downstream must NOT have run yet.
+    // This is the falsifiable core: if `process_outgoing_edges` fires in
+    // the park path, `downstream_calls` will already be 1 here.
+    assert_eq!(
+        downstream_calls.load(Ordering::SeqCst),
+        0,
+        "downstream must NOT run while node1 is Waiting — gate is broken if this fails"
+    );
+
+    // Now wait for the workflow to complete (the 60ms timer fires).
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("workflow must complete within 5s after NodeParked")
+        .unwrap()
+        .unwrap();
+
+    // Final assertions.
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "workflow must complete successfully after wait timer fires"
+    );
+    assert_eq!(
+        downstream_calls.load(Ordering::SeqCst),
+        1,
+        "downstream node must run exactly once after the wait is satisfied"
+    );
+
+    // Verify both lifecycle events were emitted.
+    let mut saw_node_parked = false;
+    let mut saw_node_wait_completed = false;
+    while let Some(event) = events_rx.try_recv() {
+        match event {
+            ExecutionEvent::NodeParked { node_key, .. } if node_key == n1 => {
+                saw_node_parked = true;
+            },
+            ExecutionEvent::NodeWaitCompleted { node_key, .. } if node_key == n1 => {
+                saw_node_wait_completed = true;
+            },
+            _ => {},
+        }
+    }
+    // `NodeParked` was consumed from the live stream above; confirm either
+    // it was also queued for the drain OR re-assert we observed it above.
+    // The live-stream receive already proved the event fired; this drain
+    // catches `NodeWaitCompleted` which arrives after the timer.
+    let _ = saw_node_parked; // already asserted live above
+    assert!(
+        saw_node_wait_completed,
+        "a NodeWaitCompleted event must be emitted when the timer fires"
+    );
+}
+
+/// 2) **`WaitCondition::Until` path**: same structural proof but via the
+/// absolute-datetime variant. Verifies the `wake_at = Some(datetime)`
+/// branch in the park-path compute.
+#[tokio::test]
+async fn wait_until_condition_gates_and_resumes() {
+    let downstream_calls = Arc::new(AtomicU32::new(0));
+
+    let registry = Arc::new(ActionRegistry::new());
+    // Wake 80ms from now.
+    let wake_at = Utc::now() + chrono::Duration::milliseconds(80);
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("waiter_until"), "WaiterUntil", "parks Until"),
+        WaitUntilHandler {
+            wake_at,
+            partial_output: serde_json::json!("from_wait"),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("ds_until"), "DsUntil", "downstream echo"),
+        EchoHandler {
+            invocations: Arc::clone(&downstream_calls),
+        },
+    );
+
+    let engine = make_engine(registry);
+    let n1 = node_key!("w1");
+    let n2 = node_key!("d1");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(n1.clone(), "waiter_until_node", "core", "waiter_until").unwrap(),
+            NodeDefinition::new(n2, "ds_until_node", "core", "ds_until").unwrap(),
+        ],
+        vec![Connection::new(n1, node_key!("d1"))],
+        WorkflowConfig::default(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        ),
+    )
+    .await
+    .expect("workflow must complete within 5s")
+    .unwrap();
+
+    assert_eq!(result.status, ExecutionStatus::Completed);
+    assert_eq!(
+        downstream_calls.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once after Until fires"
+    );
+}
+
+/// 3) **No-worker-held proof**: a sibling node completes while `node1` is
+/// parked in `Waiting`. If the park path held the worker semaphore (i.e.
+/// a worker slot was not released), a single-slot semaphore would deadlock
+/// and the sibling would never complete. The test passes only if the
+/// engine released the worker on park.
+///
+/// **Falsifiability**: add a `semaphore.acquire().await` in the park path
+/// without releasing it → the sibling blocks forever → `tokio::time::timeout`
+/// fires → test fails with "timed out". Restore the release to go green.
+#[tokio::test]
+async fn parked_wait_node_holds_no_worker_sibling_completes() {
+    let sibling_calls = Arc::new(AtomicU32::new(0));
+
+    let registry = Arc::new(ActionRegistry::new());
+    // 150ms park — long enough that the sibling can complete first.
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("slow_waiter"), "SlowWaiter", "parks for 150ms"),
+        WaitingHandler {
+            wait_for: Duration::from_millis(150),
+            partial_output: serde_json::json!(null),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("sibling"), "Sibling", "completes immediately"),
+        EchoHandler {
+            invocations: Arc::clone(&sibling_calls),
+        },
+    );
+
+    let engine = make_engine(registry);
+    let waiter = node_key!("waiter");
+    let sibling = node_key!("sibling");
+
+    // Two independent root nodes — no connection between them.
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(waiter, "waiter_node", "core", "slow_waiter").unwrap(),
+            NodeDefinition::new(sibling, "sibling_node", "core", "sibling").unwrap(),
+        ],
+        vec![],
+        WorkflowConfig::default(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        ),
+    )
+    .await
+    .expect("sibling must complete while waiter is parked — timeout means worker was held")
+    .unwrap();
+
+    assert_eq!(result.status, ExecutionStatus::Completed);
+    assert_eq!(
+        sibling_calls.load(Ordering::SeqCst),
+        1,
+        "sibling must complete exactly once while the other node is parked"
+    );
+}
+
+/// 4) **Cancel during wait**: `cancel_execution` while a node is in
+/// `Waiting` must drain the `wait_heap` (Waiting → Cancelled) and
+/// return `Cancelled` status without hanging.
+///
+/// **Falsifiability**: remove the `wait_heap` drain from
+/// `drain_pending_to_cancelled` → the `Waiting` node stays non-terminal
+/// → the frontier integrity check fires, OR the engine loops forever
+/// waiting for the heap to drain → timeout.
+#[tokio::test]
+async fn cancel_during_wait_drains_heap() {
+    let registry = Arc::new(ActionRegistry::new());
+    // 1-minute park — will not fire naturally during the test.
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("long_waiter"), "LongWaiter", "parks for 1 min"),
+        WaitingHandler {
+            wait_for: Duration::from_mins(1),
+            partial_output: serde_json::json!(null),
+        },
+    );
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine = Arc::new(make_engine(registry).with_event_bus(event_bus));
+
+    let n = node_key!("long_wait");
+    let wf = make_workflow(
+        vec![NodeDefinition::new(n, "long_wait_node", "core", "long_waiter").unwrap()],
+        vec![],
+        WorkflowConfig::default(),
+    );
+
+    let engine_h = Arc::clone(&engine);
+    let task = tokio::spawn(async move {
+        engine_h
+            .execute_workflow(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
+            .await
+    });
+
+    // Wait for the NodeParked event so we know the node is in Waiting
+    // before we cancel (otherwise the cancel races the park).
+    let execution_id = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked {
+                    execution_id: id, ..
+                }) => break id,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeParked"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for NodeParked event");
+
+    let cancelled = engine.cancel_execution(execution_id);
+    assert!(cancelled, "cancel_execution must find the live frontier");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("workflow must wind down within 5s after cancel")
+        .unwrap()
+        .unwrap();
+
+    assert!(
+        matches!(result.status, ExecutionStatus::Cancelled),
+        "expected Cancelled, got {:?}",
+        result.status
+    );
+}
+
+/// 5) **Signal-driven condition rejected (W-S1 boundary)**:
+/// a node returning `ActionResult::Wait` with `WaitCondition::Webhook`
+/// must fail with a `WaitConditionNotSupported` error rather than parking
+/// without a timer entry and stalling the execution indefinitely.
+///
+/// **Falsifiability**: change the park branch to handle `Webhook` the same
+/// as `Duration` (with `wake_at = None`) → the node parks, the frontier
+/// empties with a non-terminal `Waiting` node, and the engine either hangs
+/// (no timer to fire) or triggers `FrontierIntegrityViolation`. Restore the
+/// typed error return → the node fails immediately → `Failed` status → green.
+#[tokio::test]
+async fn webhook_wait_condition_returns_unsupported_error() {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("webhook_waiter"),
+            "WebhookWaiter",
+            "waits for webhook callback",
+        ),
+        WebhookWaitHandler,
+    );
+
+    let engine = make_engine(registry);
+    let n = node_key!("webhook_node");
+    let wf = make_workflow(
+        vec![NodeDefinition::new(n, "webhook_wait_node", "core", "webhook_waiter").unwrap()],
+        vec![],
+        WorkflowConfig::default(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        ),
+    )
+    .await
+    .expect("workflow must settle quickly — Webhook condition must be rejected immediately")
+    .unwrap();
+
+    // The workflow must end in Failed (not hung, not Completed, not Cancelled).
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Failed,
+        "Webhook WaitCondition must cause a Failed execution, got {:?}",
+        result.status
+    );
+
+    // At least one node error must reference the unsupported condition.
+    let all_errors: String = result
+        .node_errors
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        all_errors.contains("Webhook") || all_errors.contains("not supported"),
+        "node errors must reference 'Webhook' or 'not supported', got: {all_errors}"
+    );
+}

--- a/crates/engine/tests/wait.rs
+++ b/crates/engine/tests/wait.rs
@@ -131,6 +131,71 @@ impl StatelessAction for WaitUntilHandler {
 /// `WaitConditionNotSupported` is returned rather than silently parking.
 struct WebhookWaitHandler;
 
+/// Returns `ActionResult::Wait` with a timer condition AND an explicit
+/// `timeout`. W-S1 does not wire timeout-as-cancellation — parking while
+/// silently ignoring the timeout would let the full timer run (potentially
+/// hours) instead of the declared maximum. Must be rejected with a typed error.
+struct WaitWithTimeoutHandler {
+    wait_for: Duration,
+    timeout: Duration,
+}
+
+placeholder_action_impl!(
+    WaitWithTimeoutHandler,
+    action_key!("placeholder.wait_with_timeout"),
+    "WaitWithTimeoutPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for WaitWithTimeoutHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Duration {
+                duration: self.wait_for,
+            },
+            timeout: Some(self.timeout),
+            partial_output: None,
+        })
+    }
+}
+
+/// Returns `ActionResult::Wait` with a timer condition and a large
+/// `partial_output` that exceeds a tight `ExecutionBudget::max_output_bytes`.
+/// Used to verify that the park path enforces the output-size budget before
+/// committing the park, rather than letting an over-budget output sneak through.
+struct WaitWithOversizedOutputHandler {
+    wait_for: Duration,
+    /// The output value; its JSON serialization intentionally exceeds the test budget.
+    output: serde_json::Value,
+}
+
+placeholder_action_impl!(
+    WaitWithOversizedOutputHandler,
+    action_key!("placeholder.wait_oversized_output"),
+    "WaitOversizedOutputPlaceholder",
+    "placeholder"
+);
+
+impl StatelessAction for WaitWithOversizedOutputHandler {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Duration {
+                duration: self.wait_for,
+            },
+            timeout: None,
+            partial_output: Some(ActionOutput::Value(self.output.clone())),
+        })
+    }
+}
+
 placeholder_action_impl!(
     WebhookWaitHandler,
     action_key!("placeholder.webhook_wait"),
@@ -612,5 +677,157 @@ async fn webhook_wait_condition_returns_unsupported_error() {
     assert!(
         all_errors.contains("Webhook") || all_errors.contains("not supported"),
         "node errors must reference 'Webhook' or 'not supported', got: {all_errors}"
+    );
+}
+
+/// 6) **Explicit `timeout` on a timer `Wait` is rejected (P2-1)**:
+/// an action returning `ActionResult::Wait` with `WaitCondition::Duration`
+/// AND `timeout: Some(5s)` must fail with `WaitConditionNotSupported` rather
+/// than parking for the full duration while silently discarding the timeout.
+///
+/// **Falsifiability**: change the park branch to strip the `timeout` field
+/// from the destructure (via `..`) → the engine parks the node for the full
+/// `wait_for` duration → the 5s test timeout fires first → the test panics
+/// with "workflow must settle quickly". Restore the `timeout` capture and
+/// rejection → the node fails immediately → `Failed` status → green.
+#[tokio::test]
+async fn explicit_timeout_on_timer_wait_returns_unsupported_error() {
+    let registry = Arc::new(ActionRegistry::new());
+    // The action requests a 1-minute park but also declares a 5-second
+    // timeout. Without the rejection fix, the engine would ignore the 5s
+    // timeout and park for the full minute, breaking the test budget.
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("timeout_waiter"),
+            "TimeoutWaiter",
+            "parks with an explicit timeout",
+        ),
+        WaitWithTimeoutHandler {
+            wait_for: Duration::from_mins(1),
+            timeout: Duration::from_secs(5),
+        },
+    );
+
+    let engine = make_engine(registry);
+    let n = node_key!("timeout_node");
+    let wf = make_workflow(
+        vec![NodeDefinition::new(n, "timeout_wait_node", "core", "timeout_waiter").unwrap()],
+        vec![],
+        WorkflowConfig::default(),
+    );
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            ExecutionBudget::default(),
+        ),
+    )
+    .await
+    .expect(
+        "workflow must fail immediately (timeout rejection) — \
+         if the engine silently parks for 1 min, the 5s test deadline fires first",
+    )
+    .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Failed,
+        "explicit timeout on WaitCondition must cause a Failed execution, got {:?}",
+        result.status
+    );
+
+    let all_errors: String = result
+        .node_errors
+        .values()
+        .cloned()
+        .collect::<Vec<_>>()
+        .join("; ");
+    assert!(
+        all_errors.contains("timeout") || all_errors.contains("not supported"),
+        "node errors must reference 'timeout' or 'not supported', got: {all_errors}"
+    );
+}
+
+/// 7) **Over-budget `partial_output` fails the node, not parks it (P2-2)**:
+/// a two-node workflow `node1 → node2` where `node1` parks itself with a
+/// `partial_output` larger than `ExecutionBudget::max_output_bytes`. The
+/// engine must fail `node1` (not park it) so `node2` is NEVER dispatched.
+///
+/// **Falsifiability**: remove the budget enforcement block from the park path
+/// (the `partial_output_bytes > 0` block) → `node1` parks successfully →
+/// the timer fires → `node2` is dispatched → `downstream_calls == 1` →
+/// the `== 0` assertion fails. Restore the budget check → `node1` fails
+/// immediately → `downstream_calls` stays 0 → green.
+#[tokio::test]
+async fn oversized_partial_output_fails_node_not_parks_downstream_blocked() {
+    let downstream_calls = Arc::new(AtomicU32::new(0));
+
+    let registry = Arc::new(ActionRegistry::new());
+    // The partial output is 50 bytes of JSON; the budget allows only 10.
+    let big_output = serde_json::json!("this-string-is-longer-than-ten-bytes");
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("oversized_waiter"),
+            "OversizedWaiter",
+            "parks with an oversized partial output",
+        ),
+        WaitWithOversizedOutputHandler {
+            wait_for: Duration::from_millis(60),
+            output: big_output,
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("ds_oversized"),
+            "DsOversized",
+            "downstream echo",
+        ),
+        EchoHandler {
+            invocations: Arc::clone(&downstream_calls),
+        },
+    );
+
+    let engine = make_engine(registry);
+    let n1 = node_key!("big_waiter");
+    let n2 = node_key!("ds_big");
+    let wf = make_workflow(
+        vec![
+            NodeDefinition::new(n1.clone(), "big_waiter_node", "core", "oversized_waiter").unwrap(),
+            NodeDefinition::new(n2, "ds_big_node", "core", "ds_oversized").unwrap(),
+        ],
+        vec![Connection::new(n1, node_key!("ds_big"))],
+        WorkflowConfig::default(),
+    );
+
+    // Budget of 10 bytes; the partial_output JSON is longer than that.
+    let budget = ExecutionBudget::default().with_max_output_bytes(10);
+
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        engine.execute_workflow(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &wf,
+            serde_json::json!(null),
+            budget,
+        ),
+    )
+    .await
+    .expect("workflow must settle quickly — budget violation fails the node immediately")
+    .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Failed,
+        "over-budget partial_output must cause a Failed execution, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        downstream_calls.load(Ordering::SeqCst),
+        0,
+        "downstream must NEVER run when node1 fails due to budget violation \
+         (falsifiability: without budget check, node1 parks and timer fires → ds runs → count=1)"
     );
 }

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -594,6 +594,55 @@ impl ExecutionState {
         Ok(())
     }
 
+    /// Park a node that returned `ActionResult::Wait`.
+    ///
+    /// Promotes `Running → Waiting`, stamps `next_attempt_at` with the
+    /// timer wake instant (or clears it when no timer applies), and
+    /// bumps the execution version. Mirrors [`schedule_node_retry`] for
+    /// the wait-park path.
+    ///
+    /// The caller is responsible for:
+    /// - Persisting the node's `partial_output` through the normal
+    ///   outputs map before calling this method (so `checkpoint_node`
+    ///   commits both the output and the `Waiting` state atomically).
+    /// - Pushing `(wake_at, node_key)` onto the engine's `wait_heap`
+    ///   when `wake_at` is `Some` — that is the source of truth for
+    ///   timer-driven wakes.
+    ///
+    /// On success both the per-node `Running → Waiting` transition and
+    /// the `next_attempt_at` stamp are reflected in `version`. On `Err`
+    /// the state is left untouched.
+    ///
+    /// # Errors
+    /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
+    /// - [`ExecutionError::InvalidTransition`] if the node is not in `Running`
+    ///   (the engine may only call this immediately after dispatching the action).
+    ///
+    /// [`schedule_node_retry`]: Self::schedule_node_retry
+    pub fn park_node(
+        &mut self,
+        node_key: NodeKey,
+        wake_at: Option<DateTime<Utc>>,
+    ) -> Result<(), ExecutionError> {
+        self.transition_node(node_key.clone(), NodeState::Waiting)?;
+        // Stamp or clear the wake instant. `Waiting` with `wake_at ==
+        // None` means the park is signal-driven (webhook/approval/
+        // execution): only an explicit Resume will satisfy the condition.
+        // Stale failure metadata is cleared for the same reason
+        // `schedule_node_retry` clears it — a later `Completed`
+        // transition must not carry contradictory persisted fields.
+        let ns = self
+            .node_states
+            .get_mut(&node_key)
+            .ok_or(ExecutionError::NodeNotFound(node_key))?;
+        ns.next_attempt_at = wake_at;
+        ns.error_message = None;
+        ns.completed_at = None;
+        self.version += 1;
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
     /// Set a node's execution state directly.
     ///
     /// **This bypasses transition validation and the parent version

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -60,6 +60,15 @@ pub fn validate_execution_transition(
 /// next attempt. A cancel signal during the wait shortcuts directly to
 /// `Cancelled` without observing another `Failed` — the previous
 /// attempt's failure is already recorded in `NodeAttempt`.
+///
+/// The wait-park edges (`Running → Waiting`, `Waiting → Completed`,
+/// `Waiting → Cancelled`) implement the durable park path: when an
+/// action returns `ActionResult::Wait`, the engine parks the node
+/// (`Running → Waiting`), releasing the worker and gating downstream
+/// edges until the wait condition is satisfied. Once the condition
+/// fires the engine transitions directly to `Completed` (`Waiting →
+/// Completed`) and activates downstream. A shutdown/cancel during the
+/// wait goes to `Cancelled` (`Waiting → Cancelled`).
 #[must_use]
 pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
     matches!(
@@ -72,13 +81,16 @@ pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
             NodeState::Running | NodeState::Skipped | NodeState::Cancelled
         ) | (
             NodeState::Running,
-            NodeState::Completed | NodeState::Failed | NodeState::Cancelled
+            NodeState::Completed | NodeState::Failed | NodeState::Cancelled | NodeState::Waiting
         ) | (
             NodeState::Failed,
             NodeState::Cancelled | NodeState::WaitingRetry
         ) | (
             NodeState::WaitingRetry,
             NodeState::Ready | NodeState::Cancelled
+        ) | (
+            NodeState::Waiting,
+            NodeState::Completed | NodeState::Cancelled
         )
     )
 }
@@ -338,6 +350,61 @@ mod tests {
         assert!(can_transition_node(
             NodeState::WaitingRetry,
             NodeState::Cancelled
+        ));
+    }
+
+    /// `Running → Waiting` is the park step: the action returned
+    /// `ActionResult::Wait`; the engine releases the worker and parks
+    /// the node.
+    #[test]
+    fn running_can_transition_to_waiting() {
+        assert!(can_transition_node(NodeState::Running, NodeState::Waiting));
+    }
+
+    /// `Waiting → Completed` fires when the wait condition is satisfied
+    /// (timer expires, external resume arrives). Downstream edges
+    /// activate from `Completed`, not from `Waiting`.
+    #[test]
+    fn waiting_can_transition_to_completed() {
+        assert!(can_transition_node(
+            NodeState::Waiting,
+            NodeState::Completed
+        ));
+    }
+
+    /// `Waiting → Cancelled` lets a shutdown/cancel drain the parked
+    /// node without a phantom `Waiting → Completed` step.
+    #[test]
+    fn waiting_can_transition_to_cancelled() {
+        assert!(can_transition_node(
+            NodeState::Waiting,
+            NodeState::Cancelled
+        ));
+    }
+
+    /// Illegal edges from `Waiting` must be rejected: the engine
+    /// must not be able to re-run a parked node (`Waiting → Running`)
+    /// or collapse it to `Failed` without an explicit failure reason.
+    #[test]
+    fn waiting_cannot_transition_to_illegal_states() {
+        assert!(!can_transition_node(NodeState::Waiting, NodeState::Running));
+        assert!(!can_transition_node(NodeState::Waiting, NodeState::Failed));
+        assert!(!can_transition_node(NodeState::Waiting, NodeState::Ready));
+        assert!(!can_transition_node(
+            NodeState::Waiting,
+            NodeState::WaitingRetry
+        ));
+        // Self-loop is not a valid transition.
+        assert!(!can_transition_node(NodeState::Waiting, NodeState::Waiting));
+    }
+
+    /// `Completed → Waiting` must be rejected — a completed node
+    /// cannot be parked retroactively.
+    #[test]
+    fn completed_cannot_transition_to_waiting() {
+        assert!(!can_transition_node(
+            NodeState::Completed,
+            NodeState::Waiting
         ));
     }
 }

--- a/crates/workflow/src/state.rs
+++ b/crates/workflow/src/state.rs
@@ -28,6 +28,17 @@ pub enum NodeState {
     /// transition back to `Ready`/`Running` (retry attempt) or to
     /// `Cancelled` (shutdown / explicit cancel during the wait).
     WaitingRetry,
+
+    /// Parked pending an external wait condition (timer, webhook, or
+    /// human approval). `NodeExecutionState::next_attempt_at` holds
+    /// the timer wake instant when the condition is timer-based; it is
+    /// `None` for conditions that require an explicit `Resume` signal.
+    ///
+    /// Not terminal: a `Waiting` node will eventually transition to
+    /// `Completed` (condition satisfied) or `Cancelled` (shutdown /
+    /// explicit cancel during the wait). Downstream edges are gated
+    /// until the transition to `Completed` fires.
+    Waiting,
 }
 
 impl NodeState {
@@ -38,6 +49,16 @@ impl NodeState {
             self,
             Self::Completed | Self::Failed | Self::Skipped | Self::Cancelled
         )
+    }
+
+    /// Returns `true` if the node is parked pending an external wait condition.
+    ///
+    /// A `Waiting` node holds no worker: the engine released the worker
+    /// when it parked the node and will re-complete it when the condition
+    /// is satisfied. Downstream edges remain gated until `Completed`.
+    #[must_use]
+    pub fn is_waiting(&self) -> bool {
+        matches!(self, Self::Waiting)
     }
 
     /// Returns `true` if the node is currently doing work.
@@ -83,6 +104,7 @@ impl std::fmt::Display for NodeState {
             Self::Skipped => write!(f, "skipped"),
             Self::Cancelled => write!(f, "cancelled"),
             Self::WaitingRetry => write!(f, "waiting_retry"),
+            Self::Waiting => write!(f, "waiting"),
         }
     }
 }
@@ -106,6 +128,11 @@ mod tests {
             "WaitingRetry must be non-terminal — engine flips it back \
              to Ready when next_attempt_at fires"
         );
+        assert!(
+            !NodeState::Waiting.is_terminal(),
+            "Waiting must be non-terminal — engine transitions it to \
+             Completed when the wait condition is satisfied"
+        );
     }
 
     #[test]
@@ -123,6 +150,11 @@ mod tests {
             "WaitingRetry is parked between attempts; the work is not \
              running — frontier loop's max_concurrent guard must not \
              count it toward active concurrency"
+        );
+        assert!(
+            !NodeState::Waiting.is_active(),
+            "Waiting is parked for an external condition; the worker was \
+             released — must not count toward active concurrency"
         );
     }
 
@@ -165,6 +197,7 @@ mod tests {
         assert_eq!(NodeState::Skipped.to_string(), "skipped");
         assert_eq!(NodeState::Cancelled.to_string(), "cancelled");
         assert_eq!(NodeState::WaitingRetry.to_string(), "waiting_retry");
+        assert_eq!(NodeState::Waiting.to_string(), "waiting");
     }
 
     #[test]
@@ -178,6 +211,7 @@ mod tests {
             NodeState::Skipped,
             NodeState::Cancelled,
             NodeState::WaitingRetry,
+            NodeState::Waiting,
         ];
 
         for state in &states {
@@ -207,6 +241,28 @@ mod tests {
 
         let json = serde_json::to_string(&NodeState::Failed).unwrap();
         assert_eq!(json, "\"failed\"");
+    }
+
+    /// `Waiting` is the parked-for-external-condition state. It is non-terminal
+    /// (the engine will transition it to `Completed` on satisfaction or
+    /// `Cancelled` on shutdown) and not active (the worker was released when
+    /// the node was parked). `is_failure()` returns `false`.
+    #[test]
+    fn waiting_is_non_terminal_non_active_non_failure() {
+        assert!(!NodeState::Waiting.is_terminal());
+        assert!(!NodeState::Waiting.is_active());
+        assert!(!NodeState::Waiting.is_failure());
+        assert!(NodeState::Waiting.is_waiting());
+        assert!(!NodeState::WaitingRetry.is_waiting());
+        assert!(!NodeState::Running.is_waiting());
+    }
+
+    #[test]
+    fn serde_waiting_uses_snake_case() {
+        let json = serde_json::to_string(&NodeState::Waiting).unwrap();
+        assert_eq!(json, "\"waiting\"");
+        let back: NodeState = serde_json::from_str("\"waiting\"").unwrap();
+        assert_eq!(back, NodeState::Waiting);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

First slice (W-S1) of the durable **wait-state engine**. On `ActionResult::Wait` with a **timer** condition (`Until` / `Duration`) the frontier parks the node in a new `NodeState::Waiting`, **releases the worker**, checkpoints atomically, and **gates downstream edges** until the timer fires — then wakes the node `Waiting → Completed` and only then activates downstream. This is the park/resume mechanic the `Interactive`/`Delay` kinds (and the Agent A-S3 HITL path) build on. Signal-driven conditions (`Webhook`/`Approval`/`Execution`) and the control-queue `Resume` path are a later slice (W-S2) — until then they surface a typed error rather than stalling.

## Linked issue

Design in the maintainers' private design vault: ADR-0099 (Wait-state engine), sibling of ADR-0097/0098.

- Refs: ADR-0099, ADR-0097

## Type of change

- [x] `feat` — new capability

## Affected crates / areas

- `nebula-engine` (frontier park/wake, resume preservation, `evaluate_edge` gate, events, typed error)
- `nebula-execution` (`park_node`, `Running→Waiting`/`Waiting→Completed`/`Waiting→Cancelled` transitions)
- `nebula-workflow` (`NodeState::Waiting`)

## Changes

- **`nebula-workflow`**: `NodeState::Waiting` — non-terminal, distinct from `WaitingRetry` (parked for an external wait condition; `next_attempt_at` holds the timer wake instant). `is_waiting()` + `Display` arm.
- **`nebula-execution`**: `park_node(node_key, wake_at: Option<DateTime<Utc>>)` (mirrors `schedule_node_retry`); transition edges `Running→Waiting`, `Waiting→Completed`, `Waiting→Cancelled`.
- **`nebula-engine`**:
  - `wait_heap` parallel to `retry_heap`, resume-seeded from persisted `Waiting` nodes; a `select!` `WaitTimer` wake arm driven by the earliest entry.
  - Frontier **park branch** on `ActionResult::Wait`: compute `wake_at` from `Until`/`Duration`, persist the partial output, `park_node` + `checkpoint_node` atomically, drop the worker task, push to `wait_heap` — and **skip** downstream edge processing (the gate).
  - **Wait-drain phase**: a due node transitions `Waiting → Completed`, checkpoints, emits `NodeWaitCompleted`, then activates downstream.
  - `resume_execution` **preserves `Waiting`** (excluded from the `Pending` reset and the immediate re-seed, exactly like `WaitingRetry`) so a crash/resume re-parks on the persisted timer rather than re-running pre-wait work.
  - `evaluate_edge` returns `false` for `Wait` (defense-in-depth alongside the structural skip).
  - Signal conditions (`Webhook`/`Approval`/`Execution`) → typed `RuntimeError::WaitConditionNotSupported` (the honest W-S1/W-S2 boundary), surfaced in `node_errors`.
  - Observability: `ExecutionEvent::{NodeParked, NodeWaitCompleted}`.

## Test plan

`crates/engine/tests/wait.rs` (engine integration) + transition unit tests:
- `wait_node_gates_downstream_until_timer_then_resumes` — **the DoD gate**: at the moment `NodeParked` fires, asserts `downstream_calls == 0` (downstream blocked **while parked**); after the timer, `== 1`. Red-on-revert: dropping the park-path `continue` lets downstream run before the timer → the mid-park `== 0` assertion fails.
- `wait_until_condition_gates_and_resumes` — the `Until` (absolute datetime) path.
- `parked_wait_node_holds_no_worker_sibling_completes` — a sibling completes while the node is parked (proves the worker was released; a held worker would deadlock a single slot → timeout).
- `cancel_during_wait_drains_heap` — cancel while parked drains the wait heap → `Cancelled`, no hang.
- `webhook_wait_condition_returns_unsupported_error` — a signal condition surfaces the typed `WaitConditionNotSupported` in `node_errors` (no false-failure stall).
- Transition units: `Running→Waiting`/`Waiting→Completed`/`Waiting→Cancelled` allowed, illegal transitions rejected, `Waiting` non-terminal.

### Local verification

- [x] `cargo fmt` — clean (scoped `-p nebula-workflow -p nebula-execution -p nebula-engine`; `cargo fmt --all` hits the Windows cmdline limit — lefthook runs fmt per-crate)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-push `clippy-full`)
- [x] `cargo nextest run` — 621/621 across 26 binaries (pre-push)
- [x] `cargo test --doc` — rustdoc `-D warnings` clean (crate-diff-gate)
- [ ] `cargo deny check` — N/A (no `Cargo.toml` change)

## Breaking changes

None. `NodeState::Waiting` is an additive variant on a `#[non_exhaustive]` enum; `park_node`, the new transition edges, the `RuntimeError::WaitConditionNotSupported` variant, and the two `ExecutionEvent`s are additive. No existing signature changed.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — the wait/park lifecycle is documented (state.rs doc + frontier comments + ADR-0099); no silent drift.
- [x] Layer direction preserved (engine → execution → workflow; no upward deps).
- [x] L2 seam covered by the engine integration tests in this PR (ADR recorded in the private design vault).
- [ ] `docs/MATURITY.md` — unchanged (wait-state is a foundational engine slice, not a maturity-tier change).
- [ ] `docs/INTEGRATION_MODEL.md` — deferred; the Interactive/Delay author surface lands in later slices (W-S4/W-S5).
- [x] Plan/spec recorded: ADR-0099 (private design vault).

## Safety / security impact

- [x] No new `unwrap()` / `expect()` / `panic!()` in library code (tests excepted).
- [x] No silent error suppression — signal conditions surface a typed error; checkpoint failures on park abort honestly.
- [x] Engine state transitions go through `transition_node` / `park_node` (no direct `node_state.state = …`).
- [x] No credential/secret paths touched.
- [x] No new `unsafe`.

## Notes for reviewers

- **DoD red-on-revert** is the mid-park `downstream_calls == 0` assertion in test 1 (the ADR explicitly warns against the weaker "leaves the node Pending" tautology).
- Two correctness bugs were caught by review **before** this PR and are fixed here: (1) `resume_execution` previously reset `Waiting` nodes to `Pending` (would re-run pre-wait work on crash/resume) — now preserved + re-seeded into the wait heap; (2) a signal-condition wait with no timeout would park with no wake entry and the frontier would exit reporting a false `FrontierIntegrityViolation` — now rejected with a typed error.
- **W-S1 scope is timer-wake only.** Follow-ups: W-S2 control-queue `Resume` (signal conditions: webhook/approval) + timeout-as-failure semantics; W-S3 api inbound resume transport; W-S4 `Interactive` payload + `WaitCondition::Signal{schema}` + trait; W-S5 `Delay` kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
