### PR TITLE
feat(plugin-core): add core.switch N-way branch action + extract shared Condition

### DIFF
--- a/crates/plugin-core/src/actions/if_action.rs
+++ b/crates/plugin-core/src/actions/if_action.rs
@@ -91,62 +91,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::instrument;
 
-use crate::util::ValueTypeNameStr;
+use crate::condition::{evaluate_condition, normalize_data};
+
+// Re-export shared types so the existing public path
+// `nebula_plugin_core::actions::if_action::{Condition, ConditionOp}` stays
+// valid for any downstream code that imported them from here.
+pub use crate::condition::{Condition, ConditionOp};
 
 // ── Wire types ────────────────────────────────────────────────────────────────
-
-/// The comparison operator applied to a single top-level field.
-///
-/// Variants without a `value` operand (`Exists`, `NotExists`, `Truthy`)
-/// ignore the `value` field in [`Condition`].
-///
-/// Forward-compatibility for new optional fields is handled via
-/// `#[serde(default)]` in future versions, not `#[non_exhaustive]`, because
-/// these types are deserialized from workflow JSON rather than
-/// literal-constructed by external Rust code.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum ConditionOp {
-    /// JSON deep-equality: missing field evaluates as `false`.
-    Eq,
-    /// Logical negation of `Eq`: missing field evaluates as `true`.
-    Ne,
-    /// Strictly greater than. Both operands must have the same JSON kind
-    /// (both numbers or both strings); missing field is a Fatal error.
-    Gt,
-    /// Greater than or equal. Same rules as `Gt`.
-    Gte,
-    /// Strictly less than. Same rules as `Gt`.
-    Lt,
-    /// Less than or equal. Same rules as `Gt`.
-    Lte,
-    /// True when the field key is present (any value, including `null`).
-    Exists,
-    /// True when the field key is absent.
-    NotExists,
-    /// True when the field value is truthy (see module doc table).
-    Truthy,
-}
-
-/// A single field-level predicate.
-///
-/// The `value` operand is required for `Eq`/`Ne`/`Gt`/`Gte`/`Lt`/`Lte`;
-/// it is ignored for `Exists`, `NotExists`, and `Truthy`.
-///
-/// `serde(default)` on `value` lets workflows omit it for operator kinds
-/// that do not use it.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Condition {
-    /// Top-level key to test in `data`.
-    pub field: String,
-    /// Comparison operator.
-    pub op: ConditionOp,
-    /// Right-hand operand. **Required** (enforced at runtime) for `Eq`, `Ne`,
-    /// `Gt`, `Gte`, `Lt`, and `Lte` — absence returns `ActionError::Fatal`.
-    /// Ignored for `Exists`, `NotExists`, and `Truthy`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub value: Option<Value>,
-}
 
 /// Resolved input for the `If` action.
 ///
@@ -259,7 +211,10 @@ impl ControlAction for CoreIf {
                 ))
             })?;
 
-        let data_object = normalize_data(data)?;
+        let data_object = normalize_data(data).map_err(|err| {
+            // Prefix the normalisation error with the action key for context.
+            ActionError::fatal(format!("core.if: {err}"))
+        })?;
         let branch_taken = evaluate_condition(&data_object, &condition)?;
         let selected_port = if branch_taken { "true" } else { "false" }.to_string();
 
@@ -267,153 +222,6 @@ impl ControlAction for CoreIf {
             selected: selected_port,
             output: data_object,
         })
-    }
-}
-
-// ── Condition evaluation ──────────────────────────────────────────────────────
-
-/// Normalise `data` to a JSON object.
-///
-/// `null` and absent values become `{}`. Any other non-object type is a Fatal
-/// error because field-level conditions require an object to index into.
-fn normalize_data(data: Option<Value>) -> Result<Value, ActionError> {
-    match data {
-        Some(Value::Object(_)) | None => Ok(data.unwrap_or(Value::Object(Default::default()))),
-        Some(Value::Null) => Ok(Value::Object(Default::default())),
-        Some(other) => Err(ActionError::fatal(format!(
-            "core.if: `data` must be a JSON object or null, got {}",
-            other.type_name_str()
-        ))),
-    }
-}
-
-/// Assert that `condition.value` is present for operators that require it.
-///
-/// `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte` all need a right-hand operand.
-/// Returning `None` from the workflow definition for those operators is a
-/// Fatal configuration error — the action fails closed instead of silently
-/// treating the missing value as `null`.
-fn require_value(op: ConditionOp, value: &Option<Value>) -> Result<&Value, ActionError> {
-    value.as_ref().ok_or_else(|| {
-        ActionError::fatal(format!(
-            "core.if: operator `{op:?}` requires a `value` field, but none was provided"
-        ))
-    })
-}
-
-/// Evaluate `cond` against the top-level fields of `data_object`.
-///
-/// See module doc for the full semantics per operator.
-pub(crate) fn evaluate_condition(
-    data_object: &Value,
-    cond: &Condition,
-) -> Result<bool, ActionError> {
-    let field_value = data_object.get(&cond.field);
-
-    match cond.op {
-        ConditionOp::Eq => {
-            let expected = require_value(ConditionOp::Eq, &cond.value)?;
-            let Some(actual) = field_value else {
-                return Ok(false);
-            };
-            Ok(actual == expected)
-        },
-
-        ConditionOp::Ne => {
-            let expected = require_value(ConditionOp::Ne, &cond.value)?;
-            let Some(actual) = field_value else {
-                // Missing field is "not equal" to anything.
-                return Ok(true);
-            };
-            Ok(actual != expected)
-        },
-
-        ConditionOp::Gt | ConditionOp::Gte | ConditionOp::Lt | ConditionOp::Lte => {
-            let expected = require_value(cond.op, &cond.value)?;
-            let Some(actual) = field_value else {
-                return Err(ActionError::fatal(format!(
-                    "core.if: ordered comparison requires field `{}` to be present, but it is missing",
-                    cond.field
-                )));
-            };
-            evaluate_ordered(cond.op, actual, expected)
-        },
-
-        ConditionOp::Exists => Ok(field_value.is_some()),
-
-        ConditionOp::NotExists => Ok(field_value.is_none()),
-
-        ConditionOp::Truthy => Ok(is_truthy(field_value)),
-    }
-}
-
-/// Evaluate an ordered operator (`Gt`/`Gte`/`Lt`/`Lte`) between two JSON values.
-///
-/// Both values must be the same JSON kind: both numbers (compared via f64) or
-/// both strings (lexicographic byte order). Any other combination is a Fatal
-/// error that names both types.
-fn evaluate_ordered(
-    op: ConditionOp,
-    actual: &Value,
-    expected: &Value,
-) -> Result<bool, ActionError> {
-    match (actual, expected) {
-        (Value::Number(lhs), Value::Number(rhs)) => {
-            // f64 is the common numeric type in serde_json; precision loss on
-            // integers larger than 2^53 is a known limitation (documented in
-            // the module doc; exact large-integer ops deferred to v2).
-            let lhs_f64 = lhs.as_f64().ok_or_else(|| {
-                ActionError::fatal(format!(
-                    "core.if: could not represent left-hand number `{lhs}` as f64"
-                ))
-            })?;
-            let rhs_f64 = rhs.as_f64().ok_or_else(|| {
-                ActionError::fatal(format!(
-                    "core.if: could not represent right-hand number `{rhs}` as f64"
-                ))
-            })?;
-            let result = match op {
-                ConditionOp::Gt => lhs_f64 > rhs_f64,
-                ConditionOp::Gte => lhs_f64 >= rhs_f64,
-                ConditionOp::Lt => lhs_f64 < rhs_f64,
-                ConditionOp::Lte => lhs_f64 <= rhs_f64,
-                _ => unreachable!("evaluate_ordered called with non-ordered op"),
-            };
-            Ok(result)
-        },
-        (Value::String(lhs), Value::String(rhs)) => {
-            let result = match op {
-                ConditionOp::Gt => lhs > rhs,
-                ConditionOp::Gte => lhs >= rhs,
-                ConditionOp::Lt => lhs < rhs,
-                ConditionOp::Lte => lhs <= rhs,
-                _ => unreachable!("evaluate_ordered called with non-ordered op"),
-            };
-            Ok(result)
-        },
-        (lhs_val, rhs_val) => Err(ActionError::fatal(format!(
-            "core.if: cannot apply ordered comparison to {} and {}",
-            lhs_val.type_name_str(),
-            rhs_val.type_name_str()
-        ))),
-    }
-}
-
-/// Truthiness per the table in the module doc.
-///
-/// Missing field (`None`) is falsy.
-fn is_truthy(field_value: Option<&Value>) -> bool {
-    match field_value {
-        None => false,
-        Some(Value::Bool(b)) => *b,
-        Some(Value::Null) => false,
-        Some(Value::Number(n)) => {
-            // Both 0 and 0.0 are falsy; any other number is truthy.
-            n.as_f64() != Some(0.0)
-        },
-        Some(Value::String(s)) => !s.is_empty(),
-        Some(Value::Array(arr)) => !arr.is_empty(),
-        Some(Value::Object(obj)) => !obj.is_empty(),
     }
 }
 

--- a/crates/plugin-core/src/actions/mod.rs
+++ b/crates/plugin-core/src/actions/mod.rs
@@ -3,7 +3,9 @@
 pub mod if_action;
 pub mod json_transform;
 pub mod set_fields;
+pub mod switch_action;
 
 pub use if_action::CoreIf;
 pub use json_transform::JsonTransform;
 pub use set_fields::SetFields;
+pub use switch_action::CoreSwitch;

--- a/crates/plugin-core/src/actions/switch_action.rs
+++ b/crates/plugin-core/src/actions/switch_action.rs
@@ -1,0 +1,493 @@
+//! `core.switch` — N-way control-flow branch on an ordered list of conditions.
+//!
+//! Evaluates a list of [`SwitchCase`]s **in order** against the `data` object.
+//! The first case whose [`Condition`] matches routes execution to that case's
+//! `port`. If no case matches (including an empty case list), execution routes
+//! to the `"default"` port. The `data` value is passed through unchanged on the
+//! selected port.
+//!
+//! ## Input
+//!
+//! ```json
+//! {
+//!   "data": { /* optional object; defaults to {} */ },
+//!   "cases": [
+//!     { "condition": { "field": "status", "op": "eq", "value": "active" },   "port": "a" },
+//!     { "condition": { "field": "score",  "op": "gt", "value": 90 },         "port": "b" }
+//!   ]
+//! }
+//! ```
+//!
+//! ## Output ports
+//!
+//! | Port       | Activated when |
+//! |------------|----------------|
+//! | `<port>`   | First matching case selects this port name |
+//! | `"default"` | No case matched (or cases list is empty) |
+//!
+//! Ports are declared as a single `Dynamic` output port template keyed
+//! `"case"` with `source_field = "cases"`, `label_field = "port"`, and
+//! `include_fallback = true` (which auto-generates the `"default"` port).
+//!
+//! ## Evaluation semantics
+//!
+//! - **First-match-wins**: cases are tested in declaration order. Once a
+//!   matching case is found, remaining cases are **not evaluated** — a later
+//!   case whose condition would cause a Fatal error is never reached.
+//! - **Case-Fatal propagates**: if an evaluated case's condition returns a
+//!   Fatal error (e.g. ordered comparison on a missing field), the error
+//!   propagates immediately; the switch does not skip to the next case.
+//! - **Duplicate port names** are allowed: the first matching case wins
+//!   regardless of whether later cases share the same port name.
+//! - **Data passthrough**: the normalized `data` object is emitted unchanged
+//!   on the selected port (matched case or `"default"`).
+//!
+//! ## Non-object `data`
+//!
+//! If `data` is anything other than a JSON object or `null`, every case
+//! evaluation returns a Fatal error. `null` and absent `data` normalize to `{}`.
+//!
+//! ## Field scoping
+//!
+//! `case.condition.field` is a top-level key in `data`, not a JSON pointer.
+//! A dot in the field name is literal.
+//!
+//! The action is **pure** — no I/O, no credentials, no resources.
+
+use std::sync::OnceLock;
+
+use nebula_action::{
+    ActionContext, ActionError, ActionMetadata,
+    control::{ControlAction, ControlInput, ControlOutcome},
+    port::{DynamicPort, OutputPort, default_input_ports},
+};
+use nebula_core::action_key;
+use nebula_schema::HasSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::instrument;
+
+use crate::condition::{Condition, evaluate_condition, normalize_data};
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+/// A single (condition → port) branch in a Switch node.
+///
+/// `condition` is evaluated; on a match, execution routes to `port`.
+/// `port` is the string name of the output port to activate — it does not
+/// need to be unique across cases (first-match-wins applies).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwitchCase {
+    /// The predicate to evaluate against `data`.
+    pub condition: Condition,
+    /// Output port to select when this case matches.
+    pub port: String,
+}
+
+/// Resolved input for the `Switch` action.
+///
+/// `data` defaults to an empty object when absent or `null`.
+/// `cases` defaults to an empty list when absent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwitchInput {
+    /// Object to evaluate case conditions against. `null` / absent → `{}`.
+    #[serde(default)]
+    pub data: Option<Value>,
+    /// Ordered list of (condition → port) cases. Evaluated first-to-last.
+    #[serde(default)]
+    pub cases: Vec<SwitchCase>,
+}
+
+// Dynamic `data` and runtime-polymorphic `condition.value` make a closed-form
+// schema impossible. `ValidSchema::empty()` is the honest declaration; the
+// module doc describes the expected structure out-of-band.
+impl HasSchema for SwitchInput {
+    fn schema() -> nebula_schema::validated::ValidSchema {
+        nebula_schema::validated::ValidSchema::empty()
+    }
+}
+
+// ── Action ────────────────────────────────────────────────────────────────────
+
+/// N-way control-flow branch on an ordered list of field conditions.
+///
+/// Keyed `core.switch`. Evaluates cases in order and routes to the first
+/// matching port, or `"default"` if no case matches.
+#[derive(Debug)]
+pub struct CoreSwitch;
+
+impl nebula_action::action::Action for CoreSwitch {
+    type Input = SwitchInput;
+    type Output = Value;
+
+    fn metadata() -> ActionMetadata {
+        ActionMetadata::new(
+            action_key!("core.switch"),
+            "Switch",
+            "Routes execution to the first matching case port, or 'default' if none match",
+        )
+        .with_inputs(default_input_ports())
+        .with_outputs(vec![OutputPort::Dynamic(DynamicPort {
+            key: "case".into(),
+            source_field: "cases".into(),
+            label_field: Some("port".into()),
+            include_fallback: true,
+        })])
+    }
+
+    fn dependencies() -> &'static nebula_action::Dependencies {
+        static DEPS: OnceLock<nebula_action::Dependencies> = OnceLock::new();
+        DEPS.get_or_init(nebula_action::Dependencies::new)
+    }
+}
+
+impl nebula_action::from_workflow_node::FromWorkflowNode for CoreSwitch {
+    type Error = ActionError;
+
+    async fn from_workflow_node(
+        _node: &nebula_workflow::NodeDefinition,
+        _ctx: &dyn ActionContext,
+    ) -> Result<Self, Self::Error> {
+        Ok(CoreSwitch)
+    }
+}
+
+impl ControlAction for CoreSwitch {
+    #[instrument(
+        name = "core.switch",
+        skip_all,
+        fields(case_count = input.as_value()
+            .get("cases")
+            .and_then(|c| c.as_array())
+            .map(Vec::len)
+            .unwrap_or(0))
+    )]
+    async fn evaluate(
+        &self,
+        input: ControlInput,
+        _ctx: &(impl ActionContext + ?Sized),
+    ) -> Result<ControlOutcome, ActionError> {
+        // The GenericControlFactory dispatch path passes the raw JSON value
+        // directly — it does NOT go through `CoreSwitch::Input`. Manual
+        // deserialization gives us typed access to `data` and `cases`.
+        let SwitchInput { data, cases } = serde_json::from_value::<SwitchInput>(input.into_value())
+            .map_err(|deserialization_err| {
+                ActionError::fatal(format!(
+                    "core.switch: invalid input shape — {deserialization_err}"
+                ))
+            })?;
+
+        let data_object = normalize_data(data)
+            .map_err(|err| ActionError::fatal(format!("core.switch: {err}")))?;
+
+        // Evaluate cases in order. First-match-wins; Fatal propagates immediately.
+        for case in &cases {
+            if evaluate_condition(&data_object, &case.condition)? {
+                return Ok(ControlOutcome::Branch {
+                    selected: case.port.clone(),
+                    output: data_object,
+                });
+            }
+        }
+
+        // No case matched (or cases list is empty) → route to "default".
+        Ok(ControlOutcome::Branch {
+            selected: "default".to_string(),
+            output: data_object,
+        })
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use nebula_action::{
+        ActionFactory,
+        control::{ControlInput, ControlOutcome},
+        testing::TestContextBuilder,
+    };
+    use serde_json::json;
+
+    use super::*;
+
+    fn ctx() -> impl ActionContext {
+        TestContextBuilder::new().build()
+    }
+
+    async fn run_switch(wire_json: Value) -> Result<ControlOutcome, ActionError> {
+        CoreSwitch
+            .evaluate(ControlInput::from_value(wire_json), &ctx())
+            .await
+    }
+
+    /// Assert the selected port from `ControlOutcome::Branch`.
+    fn assert_port(outcome: &ControlOutcome, expected_port: &str) {
+        match outcome {
+            ControlOutcome::Branch { selected, .. } => {
+                assert_eq!(
+                    selected, expected_port,
+                    "expected port `{expected_port}`, got `{selected}`"
+                );
+            },
+            other => panic!("expected ControlOutcome::Branch, got {other:?}"),
+        }
+    }
+
+    /// Extract the output value from `ControlOutcome::Branch`.
+    fn branch_output(outcome: ControlOutcome) -> Value {
+        match outcome {
+            ControlOutcome::Branch { output, .. } => output,
+            other => panic!("expected ControlOutcome::Branch, got {other:?}"),
+        }
+    }
+
+    // ── First-match-wins / short-circuit ─────────────────────────────────────
+
+    /// RED witness for short-circuit: case[1] has a `gt` on a MISSING field —
+    /// if the engine evaluates it, it fires a Fatal (ordered comparison on
+    /// missing field). The test proves case[1] is never reached because case[0]
+    /// matched first.
+    #[tokio::test]
+    async fn first_case_matches_selects_port_a_and_short_circuits() {
+        let outcome = run_switch(json!({
+            "data": { "status": "active" },
+            "cases": [
+                { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" },
+                // case[1]: gt on "missing_field" — Fatal if evaluated.
+                { "condition": { "field": "missing_field", "op": "gt", "value": 0 }, "port": "b" }
+            ]
+        }))
+        .await
+        // If both cases were evaluated, case[1] would produce Fatal and this .unwrap() would fail.
+        .unwrap();
+
+        assert_port(&outcome, "a");
+    }
+
+    /// RED witness: swap expected port — confirms the assertion distinguishes "a" from "b".
+    #[tokio::test]
+    async fn second_case_wins_when_first_does_not_match() {
+        let outcome = run_switch(json!({
+            "data": { "status": "inactive", "score": 95 },
+            "cases": [
+                { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" },
+                { "condition": { "field": "score",  "op": "gt", "value": 90 },       "port": "b" }
+            ]
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "b");
+    }
+
+    // ── Default fallback ──────────────────────────────────────────────────────
+
+    /// RED witness: if "default" were never returned (e.g. an error or wrong
+    /// port), the assert_port would catch the mismatch.
+    #[tokio::test]
+    async fn no_case_matches_selects_default() {
+        let outcome = run_switch(json!({
+            "data": { "status": "pending" },
+            "cases": [
+                { "condition": { "field": "status", "op": "eq", "value": "active" },   "port": "a" },
+                { "condition": { "field": "status", "op": "eq", "value": "inactive" }, "port": "b" }
+            ]
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "default");
+    }
+
+    #[tokio::test]
+    async fn empty_cases_selects_default() {
+        let outcome = run_switch(json!({
+            "data": { "x": 1 },
+            "cases": []
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "default");
+    }
+
+    // ── Fatal propagation ─────────────────────────────────────────────────────
+
+    /// A case condition that errors (Gt on missing field) propagates immediately
+    /// as Fatal — the switch does not skip to the next case.
+    #[tokio::test]
+    async fn case_condition_fatal_propagates() {
+        let err = run_switch(json!({
+            "data": { "other": 1 },
+            "cases": [
+                // "score" is missing → Fatal for ordered comparison.
+                { "condition": { "field": "score", "op": "gt", "value": 0 }, "port": "a" }
+            ]
+        }))
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ActionError::Fatal { .. }),
+            "expected ActionError::Fatal when a case condition is Fatal; got: {err:?}"
+        );
+    }
+
+    // ── Non-object data → Fatal ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn non_object_data_returns_fatal() {
+        let err = run_switch(json!({
+            "data": [1, 2, 3],
+            "cases": [
+                { "condition": { "field": "x", "op": "exists" }, "port": "a" }
+            ]
+        }))
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ActionError::Fatal { .. }),
+            "expected Fatal for array data; got: {err:?}"
+        );
+    }
+
+    // ── Null / absent data ────────────────────────────────────────────────────
+
+    /// Null data normalises to {} — empty cases → "default", output is {}.
+    ///
+    /// RED witness: if null data produced Fatal instead of normalising to {},
+    /// this would Err rather than returning default.
+    #[tokio::test]
+    async fn null_data_with_no_cases_selects_default_with_empty_output() {
+        let outcome = run_switch(json!({
+            "data": null,
+            "cases": []
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "default");
+        let output = branch_output(outcome);
+        assert_eq!(
+            output,
+            json!({}),
+            "normalized null data must produce {{}} output"
+        );
+    }
+
+    // ── Duplicate port names ──────────────────────────────────────────────────
+
+    /// Two cases sharing the same port name route to that port without error.
+    ///
+    /// This test proves that duplicate port names are accepted (no panic or
+    /// Fatal) and that the selected port is the shared name. It does NOT
+    /// distinguish which case fired — both conditions match `"tier"` and the
+    /// data passthrough is identical either way. First-match-wins behaviour is
+    /// separately proven by `first_case_matches_selects_port_a_and_short_circuits`.
+    #[tokio::test]
+    async fn duplicate_port_names_handled_without_error() {
+        let outcome = run_switch(json!({
+            "data": { "level": 5 },
+            "cases": [
+                { "condition": { "field": "level", "op": "gte", "value": 1 }, "port": "tier" },
+                { "condition": { "field": "level", "op": "gte", "value": 3 }, "port": "tier" }
+            ]
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "tier");
+    }
+
+    // ── Data passthrough ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn data_passes_through_on_matching_case() {
+        let data = json!({ "status": "active", "score": 42 });
+        let outcome = run_switch(json!({
+            "data": data,
+            "cases": [
+                { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" }
+            ]
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "a");
+        let output = branch_output(outcome);
+        assert_eq!(
+            output, data,
+            "data must pass through unchanged on a matched case"
+        );
+    }
+
+    #[tokio::test]
+    async fn data_passes_through_on_default() {
+        let data = json!({ "status": "unknown" });
+        let outcome = run_switch(json!({
+            "data": data,
+            "cases": [
+                { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" }
+            ]
+        }))
+        .await
+        .unwrap();
+
+        assert_port(&outcome, "default");
+        let output = branch_output(outcome);
+        assert_eq!(
+            output, data,
+            "data must pass through unchanged when routing to default"
+        );
+    }
+
+    // ── Metadata ──────────────────────────────────────────────────────────────
+
+    #[test]
+    fn action_key_is_core_switch() {
+        use nebula_action::action::Action;
+        assert_eq!(CoreSwitch::metadata().base.key.as_str(), "core.switch");
+    }
+
+    #[test]
+    fn metadata_has_one_dynamic_output_port_with_source_field_cases() {
+        use nebula_action::action::Action;
+        let meta = CoreSwitch::metadata();
+        assert_eq!(
+            meta.outputs.len(),
+            1,
+            "must have exactly one output port declaration"
+        );
+        match &meta.outputs[0] {
+            OutputPort::Dynamic(dynamic_port) => {
+                assert_eq!(
+                    dynamic_port.source_field, "cases",
+                    "dynamic port source_field must be 'cases'"
+                );
+                assert!(
+                    dynamic_port.include_fallback,
+                    "include_fallback must be true to generate the 'default' port"
+                );
+                assert_eq!(
+                    dynamic_port.label_field.as_deref(),
+                    Some("port"),
+                    "label_field must be 'port'"
+                );
+            },
+            other => panic!("expected OutputPort::Dynamic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn action_kind_is_control_after_factory_stamp() {
+        use nebula_action::factory::GenericControlFactory;
+        let factory = GenericControlFactory::<CoreSwitch>::new();
+        assert_eq!(
+            factory.metadata().kind,
+            nebula_action::metadata::ActionKind::Control,
+            "GenericControlFactory must stamp ActionKind::Control on CoreSwitch"
+        );
+    }
+}

--- a/crates/plugin-core/src/condition.rs
+++ b/crates/plugin-core/src/condition.rs
@@ -1,0 +1,552 @@
+//! Shared condition model used by `core.if` and `core.switch`.
+//!
+//! A [`Condition`] is a single field-level predicate evaluated against the
+//! top-level keys of a JSON object. `evaluate_condition` dispatches over
+//! [`ConditionOp`] and returns a `bool` or an `ActionError::Fatal` for
+//! configuration errors (missing required value, type mismatch, missing field
+//! on ordered comparisons).
+//!
+//! ## Normalising `data`
+//!
+//! Call `normalize_data` before calling `evaluate_condition`:
+//! - `None` / `null` → `{}`
+//! - non-object → `ActionError::Fatal` naming the actual type
+//!
+//! ## Operators
+//!
+//! See the `core.if` module doc for the full per-operator semantics table.
+
+use nebula_action::ActionError;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::util::ValueTypeNameStr;
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+/// The comparison operator applied to a single top-level field.
+///
+/// Variants without a `value` operand (`Exists`, `NotExists`, `Truthy`)
+/// ignore the `value` field in [`Condition`].
+///
+/// Forward-compatibility for new optional fields is handled via
+/// `#[serde(default)]` in future versions, not `#[non_exhaustive]`, because
+/// these types are deserialized from workflow JSON rather than
+/// literal-constructed by external Rust code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConditionOp {
+    /// JSON deep-equality: missing field evaluates as `false`.
+    Eq,
+    /// Logical negation of `Eq`: missing field evaluates as `true`.
+    Ne,
+    /// Strictly greater than. Both operands must have the same JSON kind
+    /// (both numbers or both strings); missing field is a Fatal error.
+    Gt,
+    /// Greater than or equal. Same rules as `Gt`.
+    Gte,
+    /// Strictly less than. Same rules as `Gt`.
+    Lt,
+    /// Less than or equal. Same rules as `Gt`.
+    Lte,
+    /// True when the field key is present (any value, including `null`).
+    Exists,
+    /// True when the field key is absent.
+    NotExists,
+    /// True when the field value is truthy (see `core.if` module doc table).
+    Truthy,
+}
+
+/// A single field-level predicate.
+///
+/// The `value` operand is required for `Eq`/`Ne`/`Gt`/`Gte`/`Lt`/`Lte`;
+/// it is ignored for `Exists`, `NotExists`, and `Truthy`.
+///
+/// `serde(default)` on `value` lets workflows omit it for operator kinds
+/// that do not use it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Condition {
+    /// Top-level key to test in `data`.
+    pub field: String,
+    /// Comparison operator.
+    pub op: ConditionOp,
+    /// Right-hand operand. **Required** (enforced at runtime) for `Eq`, `Ne`,
+    /// `Gt`, `Gte`, `Lt`, and `Lte` — absence returns `ActionError::Fatal`.
+    /// Ignored for `Exists`, `NotExists`, and `Truthy`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub value: Option<Value>,
+}
+
+// ── Data normalisation ────────────────────────────────────────────────────────
+
+/// Normalise `data` to a JSON object.
+///
+/// `null` and absent values become `{}`. Any other non-object type is a Fatal
+/// error because field-level conditions require an object to index into.
+pub(crate) fn normalize_data(data: Option<Value>) -> Result<Value, ActionError> {
+    match data {
+        Some(Value::Object(_)) | None => Ok(data.unwrap_or(Value::Object(Default::default()))),
+        Some(Value::Null) => Ok(Value::Object(Default::default())),
+        Some(other) => Err(ActionError::fatal(format!(
+            "`data` must be a JSON object or null, got {}",
+            other.type_name_str()
+        ))),
+    }
+}
+
+// ── Condition evaluation ──────────────────────────────────────────────────────
+
+/// Assert that `condition.value` is present for operators that require it.
+///
+/// `Eq`, `Ne`, `Gt`, `Gte`, `Lt`, `Lte` all need a right-hand operand.
+/// Returning `None` from the workflow definition for those operators is a
+/// Fatal configuration error — the action fails closed instead of silently
+/// treating the missing value as `null`.
+pub(crate) fn require_value(op: ConditionOp, value: &Option<Value>) -> Result<&Value, ActionError> {
+    value.as_ref().ok_or_else(|| {
+        ActionError::fatal(format!(
+            "operator `{op:?}` requires a `value` field, but none was provided"
+        ))
+    })
+}
+
+/// Evaluate `cond` against the top-level fields of `data_object`.
+///
+/// See the `core.if` module doc for the full semantics per operator.
+pub(crate) fn evaluate_condition(
+    data_object: &Value,
+    cond: &Condition,
+) -> Result<bool, ActionError> {
+    let field_value = data_object.get(&cond.field);
+
+    match cond.op {
+        ConditionOp::Eq => {
+            let expected = require_value(ConditionOp::Eq, &cond.value)?;
+            let Some(actual) = field_value else {
+                return Ok(false);
+            };
+            Ok(actual == expected)
+        },
+
+        ConditionOp::Ne => {
+            let expected = require_value(ConditionOp::Ne, &cond.value)?;
+            let Some(actual) = field_value else {
+                // Missing field is "not equal" to anything.
+                return Ok(true);
+            };
+            Ok(actual != expected)
+        },
+
+        ConditionOp::Gt | ConditionOp::Gte | ConditionOp::Lt | ConditionOp::Lte => {
+            let expected = require_value(cond.op, &cond.value)?;
+            let Some(actual) = field_value else {
+                return Err(ActionError::fatal(format!(
+                    "ordered comparison requires field `{}` to be present, but it is missing",
+                    cond.field
+                )));
+            };
+            evaluate_ordered(cond.op, actual, expected)
+        },
+
+        ConditionOp::Exists => Ok(field_value.is_some()),
+
+        ConditionOp::NotExists => Ok(field_value.is_none()),
+
+        ConditionOp::Truthy => Ok(is_truthy(field_value)),
+    }
+}
+
+/// Evaluate an ordered operator (`Gt`/`Gte`/`Lt`/`Lte`) between two JSON values.
+///
+/// Both values must be the same JSON kind: both numbers (compared via f64) or
+/// both strings (lexicographic byte order). Any other combination is a Fatal
+/// error that names both types.
+pub(crate) fn evaluate_ordered(
+    op: ConditionOp,
+    actual: &Value,
+    expected: &Value,
+) -> Result<bool, ActionError> {
+    match (actual, expected) {
+        (Value::Number(lhs), Value::Number(rhs)) => {
+            // f64 is the common numeric type in serde_json; precision loss on
+            // integers larger than 2^53 is a known limitation (documented in
+            // the core.if module doc; exact large-integer ops deferred to v2).
+            let lhs_f64 = lhs.as_f64().ok_or_else(|| {
+                ActionError::fatal(format!(
+                    "could not represent left-hand number `{lhs}` as f64"
+                ))
+            })?;
+            let rhs_f64 = rhs.as_f64().ok_or_else(|| {
+                ActionError::fatal(format!(
+                    "could not represent right-hand number `{rhs}` as f64"
+                ))
+            })?;
+            let result = match op {
+                ConditionOp::Gt => lhs_f64 > rhs_f64,
+                ConditionOp::Gte => lhs_f64 >= rhs_f64,
+                ConditionOp::Lt => lhs_f64 < rhs_f64,
+                ConditionOp::Lte => lhs_f64 <= rhs_f64,
+                _ => unreachable!("evaluate_ordered called with non-ordered op"),
+            };
+            Ok(result)
+        },
+        (Value::String(lhs), Value::String(rhs)) => {
+            let result = match op {
+                ConditionOp::Gt => lhs > rhs,
+                ConditionOp::Gte => lhs >= rhs,
+                ConditionOp::Lt => lhs < rhs,
+                ConditionOp::Lte => lhs <= rhs,
+                _ => unreachable!("evaluate_ordered called with non-ordered op"),
+            };
+            Ok(result)
+        },
+        (lhs_val, rhs_val) => Err(ActionError::fatal(format!(
+            "cannot apply ordered comparison to {} and {}",
+            lhs_val.type_name_str(),
+            rhs_val.type_name_str()
+        ))),
+    }
+}
+
+/// Truthiness per the table in the `core.if` module doc.
+///
+/// Missing field (`None`) is falsy.
+pub(crate) fn is_truthy(field_value: Option<&Value>) -> bool {
+    match field_value {
+        None => false,
+        Some(Value::Bool(b)) => *b,
+        Some(Value::Null) => false,
+        Some(Value::Number(n)) => {
+            // Both 0 and 0.0 are falsy; any other number is truthy.
+            n.as_f64() != Some(0.0)
+        },
+        Some(Value::String(s)) => !s.is_empty(),
+        Some(Value::Array(arr)) => !arr.is_empty(),
+        Some(Value::Object(obj)) => !obj.is_empty(),
+    }
+}
+
+// ── Unit tests ────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use nebula_action::ActionError;
+    use serde_json::json;
+
+    use super::*;
+
+    // ── normalize_data ────────────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_none_yields_empty_object() {
+        let result = normalize_data(None).unwrap();
+        assert_eq!(result, json!({}));
+    }
+
+    #[test]
+    fn normalize_null_yields_empty_object() {
+        let result = normalize_data(Some(json!(null))).unwrap();
+        assert_eq!(result, json!({}));
+    }
+
+    #[test]
+    fn normalize_object_passes_through() {
+        let obj = json!({"a": 1});
+        let result = normalize_data(Some(obj.clone())).unwrap();
+        assert_eq!(result, obj);
+    }
+
+    #[test]
+    fn normalize_array_returns_fatal() {
+        let err = normalize_data(Some(json!([1, 2]))).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    #[test]
+    fn normalize_string_returns_fatal() {
+        let err = normalize_data(Some(json!("hello"))).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    #[test]
+    fn normalize_number_returns_fatal() {
+        let err = normalize_data(Some(json!(42))).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    #[test]
+    fn normalize_bool_returns_fatal() {
+        let err = normalize_data(Some(json!(true))).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    // ── is_truthy ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn truthy_none_is_false() {
+        assert!(!is_truthy(None));
+    }
+
+    #[test]
+    fn truthy_false_bool_is_false() {
+        assert!(!is_truthy(Some(&json!(false))));
+    }
+
+    #[test]
+    fn truthy_true_bool_is_true() {
+        assert!(is_truthy(Some(&json!(true))));
+    }
+
+    #[test]
+    fn truthy_null_is_false() {
+        assert!(!is_truthy(Some(&json!(null))));
+    }
+
+    #[test]
+    fn truthy_zero_int_is_false() {
+        assert!(!is_truthy(Some(&json!(0))));
+    }
+
+    #[test]
+    fn truthy_zero_float_is_false() {
+        assert!(!is_truthy(Some(&json!(0.0))));
+    }
+
+    #[test]
+    fn truthy_nonzero_int_is_true() {
+        assert!(is_truthy(Some(&json!(42))));
+    }
+
+    #[test]
+    fn truthy_empty_string_is_false() {
+        assert!(!is_truthy(Some(&json!(""))));
+    }
+
+    #[test]
+    fn truthy_non_empty_string_is_true() {
+        assert!(is_truthy(Some(&json!("hi"))));
+    }
+
+    #[test]
+    fn truthy_empty_array_is_false() {
+        assert!(!is_truthy(Some(&json!([]))));
+    }
+
+    #[test]
+    fn truthy_non_empty_array_is_true() {
+        assert!(is_truthy(Some(&json!([1]))));
+    }
+
+    #[test]
+    fn truthy_empty_object_is_false() {
+        assert!(!is_truthy(Some(&json!({}))));
+    }
+
+    #[test]
+    fn truthy_non_empty_object_is_true() {
+        assert!(is_truthy(Some(&json!({"k": 1}))));
+    }
+
+    // ── evaluate_condition — Eq ───────────────────────────────────────────────
+
+    #[test]
+    fn eq_matching_field_is_true() {
+        let data = json!({"status": "active"});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Eq,
+            value: Some(json!("active")),
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn eq_non_matching_field_is_false() {
+        let data = json!({"status": "inactive"});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Eq,
+            value: Some(json!("active")),
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn eq_missing_field_is_false() {
+        let data = json!({"other": 1});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Eq,
+            value: Some(json!("active")),
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    // RED witness: absent `value` for Eq must Fatal, not silently compare as null.
+    #[test]
+    fn eq_missing_value_returns_fatal() {
+        let data = json!({"x": "hello"});
+        let cond = Condition {
+            field: "x".into(),
+            op: ConditionOp::Eq,
+            value: None,
+        };
+        let err = evaluate_condition(&data, &cond).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    // ── evaluate_condition — Ne ───────────────────────────────────────────────
+
+    #[test]
+    fn ne_different_is_true() {
+        let data = json!({"status": "inactive"});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Ne,
+            value: Some(json!("active")),
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn ne_same_is_false() {
+        let data = json!({"status": "active"});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Ne,
+            value: Some(json!("active")),
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn ne_missing_field_is_true() {
+        let data = json!({});
+        let cond = Condition {
+            field: "status".into(),
+            op: ConditionOp::Ne,
+            value: Some(json!("active")),
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    // ── evaluate_condition — Gt / ordered ────────────────────────────────────
+
+    #[test]
+    fn gt_numbers_true() {
+        let data = json!({"score": 10});
+        let cond = Condition {
+            field: "score".into(),
+            op: ConditionOp::Gt,
+            value: Some(json!(5)),
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn gt_numbers_false() {
+        let data = json!({"score": 3});
+        let cond = Condition {
+            field: "score".into(),
+            op: ConditionOp::Gt,
+            value: Some(json!(5)),
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    // RED witness: type mismatch must Fatal, not silently return false.
+    #[test]
+    fn gt_type_mismatch_returns_fatal() {
+        let data = json!({"score": 10});
+        let cond = Condition {
+            field: "score".into(),
+            op: ConditionOp::Gt,
+            value: Some(json!("five")),
+        };
+        let err = evaluate_condition(&data, &cond).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    // RED witness: missing field on ordered op must Fatal, not return false.
+    #[test]
+    fn gt_missing_field_returns_fatal() {
+        let data = json!({});
+        let cond = Condition {
+            field: "score".into(),
+            op: ConditionOp::Gt,
+            value: Some(json!(5)),
+        };
+        let err = evaluate_condition(&data, &cond).unwrap_err();
+        assert!(matches!(err, ActionError::Fatal { .. }));
+    }
+
+    // ── evaluate_condition — Exists / NotExists ───────────────────────────────
+
+    #[test]
+    fn exists_present_is_true() {
+        let data = json!({"key": null});
+        let cond = Condition {
+            field: "key".into(),
+            op: ConditionOp::Exists,
+            value: None,
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn exists_absent_is_false() {
+        let data = json!({});
+        let cond = Condition {
+            field: "missing".into(),
+            op: ConditionOp::Exists,
+            value: None,
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn not_exists_absent_is_true() {
+        let data = json!({});
+        let cond = Condition {
+            field: "missing".into(),
+            op: ConditionOp::NotExists,
+            value: None,
+        };
+        assert!(evaluate_condition(&data, &cond).unwrap());
+    }
+
+    #[test]
+    fn not_exists_present_is_false() {
+        let data = json!({"key": "val"});
+        let cond = Condition {
+            field: "key".into(),
+            op: ConditionOp::NotExists,
+            value: None,
+        };
+        assert!(!evaluate_condition(&data, &cond).unwrap());
+    }
+
+    // ── ConditionOp serde ────────────────────────────────────────────────────
+
+    #[test]
+    fn condition_op_serde_roundtrip() {
+        for op in [
+            ConditionOp::Eq,
+            ConditionOp::Ne,
+            ConditionOp::Gt,
+            ConditionOp::Gte,
+            ConditionOp::Lt,
+            ConditionOp::Lte,
+            ConditionOp::Exists,
+            ConditionOp::NotExists,
+            ConditionOp::Truthy,
+        ] {
+            let serialized = serde_json::to_string(&op).unwrap();
+            let round_tripped: ConditionOp = serde_json::from_str(&serialized).unwrap();
+            assert_eq!(
+                round_tripped, op,
+                "ConditionOp::{op:?} must survive a serde round-trip"
+            );
+        }
+    }
+}

--- a/crates/plugin-core/src/lib.rs
+++ b/crates/plugin-core/src/lib.rs
@@ -12,6 +12,7 @@
 //! | `core.set_fields`      | Merge a list of named field assignments onto a JSON object      |
 //! | `core.json_transform`  | Apply pick/omit/rename operations to a JSON object             |
 //! | `core.if`              | Binary branch: route to `"true"` or `"false"` port on a field condition |
+//! | `core.switch`          | N-way branch: route to the first matching case port, or `"default"` |
 //!
 //! ## Usage
 //!
@@ -31,6 +32,7 @@
 #![warn(missing_docs)]
 
 pub mod actions;
+pub mod condition;
 mod plugin;
 mod util;
 

--- a/crates/plugin-core/src/plugin.rs
+++ b/crates/plugin-core/src/plugin.rs
@@ -7,7 +7,7 @@ use nebula_action::factory::{GenericControlFactory, GenericStatelessFactory};
 use nebula_metadata::{ManifestError, PluginManifest};
 use nebula_plugin::Plugin;
 
-use crate::actions::{CoreIf, JsonTransform, SetFields};
+use crate::actions::{CoreIf, CoreSwitch, JsonTransform, SetFields};
 
 /// First-party core plugin.
 ///
@@ -53,6 +53,7 @@ impl Plugin for CorePlugin {
             Arc::new(GenericStatelessFactory::<SetFields>::new()),
             Arc::new(GenericStatelessFactory::<JsonTransform>::new()),
             Arc::new(GenericControlFactory::<CoreIf>::new()),
+            Arc::new(GenericControlFactory::<CoreSwitch>::new()),
         ]
     }
 }
@@ -102,6 +103,18 @@ mod tests {
         assert!(
             resolved.action(&key).is_some(),
             "core.if must be registered in the resolved plugin"
+        );
+    }
+
+    #[test]
+    fn resolves_switch_action() {
+        let resolved =
+            ResolvedPlugin::from(CorePlugin::try_new().expect("CorePlugin::try_new must succeed"))
+                .expect("CorePlugin must resolve without errors");
+        let key = nebula_core::ActionKey::new("core.switch").unwrap();
+        assert!(
+            resolved.action(&key).is_some(),
+            "core.switch must be registered in the resolved plugin"
         );
     }
 

--- a/crates/plugin-core/tests/plugin_wiring_e2e.rs
+++ b/crates/plugin-core/tests/plugin_wiring_e2e.rs
@@ -725,6 +725,247 @@ async fn if_action_false_condition_executes_false_branch_skips_true() {
     );
 }
 
+// ── core.switch e2e ───────────────────────────────────────────────────────────
+
+/// Build a 4-node workflow:
+///
+/// ```text
+/// [switch_node] --"a"-------> [node_a]
+///               --"b"-------> [node_b]
+///               --"default"--> [node_default]
+/// ```
+///
+/// All three branch nodes are `core.set_fields` nodes that stamp a distinct
+/// `branch_taken` marker so we can tell which ran. The switch `data` and
+/// `cases` are wired as `ParamValue::literal` parameters.
+///
+/// `cases` ports use the literal string names "a" and "b". Edges reference
+/// those same strings via `with_from_port`. The engine routes via the
+/// `ControlOutcome::Branch { selected }` value; since the port is matched by
+/// string name the dynamic metadata is not consulted at runtime.
+///
+/// Returns `(workflow, key_a, key_b, key_default)`.
+fn switch_branch_workflow(
+    data_json: serde_json::Value,
+    cases_json: serde_json::Value,
+) -> (
+    WorkflowDefinition,
+    nebula_core::NodeKey,
+    nebula_core::NodeKey,
+    nebula_core::NodeKey,
+) {
+    let now = chrono::Utc::now();
+
+    let switch_node_key = nebula_core::node_key!("switch_step");
+    let node_a_key = nebula_core::node_key!("node_a");
+    let node_b_key = nebula_core::node_key!("node_b");
+    let node_default_key = nebula_core::node_key!("node_default");
+
+    let switch_node = NodeDefinition::new(
+        switch_node_key.clone(),
+        "Switch step",
+        "core",
+        "core.switch",
+    )
+    .expect("NodeDefinition must build with valid keys")
+    .with_parameter("data", ParamValue::literal(data_json))
+    .with_parameter("cases", ParamValue::literal(cases_json));
+
+    let node_a = NodeDefinition::new(node_a_key.clone(), "Branch A", "core", "core.set_fields")
+        .expect("NodeDefinition must build")
+        .with_parameter(
+            "assignments",
+            ParamValue::literal(serde_json::json!([{"name": "branch_taken", "value": "a"}])),
+        );
+
+    let node_b = NodeDefinition::new(node_b_key.clone(), "Branch B", "core", "core.set_fields")
+        .expect("NodeDefinition must build")
+        .with_parameter(
+            "assignments",
+            ParamValue::literal(serde_json::json!([{"name": "branch_taken", "value": "b"}])),
+        );
+
+    let node_default = NodeDefinition::new(
+        node_default_key.clone(),
+        "Branch default",
+        "core",
+        "core.set_fields",
+    )
+    .expect("NodeDefinition must build")
+    .with_parameter(
+        "assignments",
+        ParamValue::literal(serde_json::json!([{"name": "branch_taken", "value": "default"}])),
+    );
+
+    // Wire switch output ports to the three branch nodes.
+    let edge_to_a =
+        Connection::new(switch_node_key.clone(), node_a_key.clone()).with_from_port("a");
+    let edge_to_b =
+        Connection::new(switch_node_key.clone(), node_b_key.clone()).with_from_port("b");
+    let edge_to_default =
+        Connection::new(switch_node_key, node_default_key.clone()).with_from_port("default");
+
+    let workflow = WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "test-core-switch-branch".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![switch_node, node_a, node_b, node_default],
+        connections: vec![edge_to_a, edge_to_b, edge_to_default],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: vec![],
+        tags: vec![],
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+
+    (workflow, node_a_key, node_b_key, node_default_key)
+}
+
+/// GREEN proof — second case matches (`port "b"`): engine routes to node_b,
+/// marks node_a and node_default as Skipped.
+///
+/// RED witness for Skipped proof: if the engine ran all branches, node_a and
+/// node_default would have outputs and the `contains_key` asserts would fail.
+/// If the engine selected the wrong port, the `branch_taken` assertion fails.
+#[tokio::test]
+async fn switch_action_second_case_matches_routes_to_b_skips_others() {
+    let engine = make_engine()
+        .with_plugin(core_plugin())
+        .expect("with_plugin(CorePlugin) must succeed");
+
+    let (workflow, node_a_key, node_b_key, node_default_key) = switch_branch_workflow(
+        serde_json::json!({ "status": "pending", "score": 95 }),
+        serde_json::json!([
+            // case[0]: status == "active" — does NOT match ("pending")
+            { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" },
+            // case[1]: score > 90 — MATCHES (95 > 90)
+            { "condition": { "field": "score",  "op": "gt", "value": 90 },       "port": "b" }
+        ]),
+    );
+
+    let result = engine
+        .execute_workflow(
+            &scope(),
+            &workflow,
+            serde_json::json!({}),
+            ExecutionBudget::default(),
+        )
+        .await
+        .expect("execute_workflow must not error");
+
+    assert_eq!(
+        result.status,
+        nebula_execution::ExecutionStatus::Completed,
+        "execution must reach Completed; got {:?} (node_errors: {:?})",
+        result.status,
+        result.node_errors
+    );
+
+    // node_b must have run and stamped its marker.
+    let b_output = result
+        .node_outputs
+        .get(&node_b_key)
+        .expect("node_b must have output (it ran)");
+    assert_eq!(
+        b_output["branch_taken"],
+        serde_json::json!("b"),
+        "node_b must have set branch_taken = 'b'"
+    );
+
+    // node_a and node_default must be Skipped: no output and no error entry.
+    assert!(
+        !result.node_outputs.contains_key(&node_a_key),
+        "node_a must be Skipped (absent from node_outputs)"
+    );
+    assert!(
+        !result.node_errors.contains_key(&node_a_key),
+        "node_a must be Skipped (absent from node_errors)"
+    );
+    assert!(
+        !result.node_outputs.contains_key(&node_default_key),
+        "node_default must be Skipped (absent from node_outputs)"
+    );
+    assert!(
+        !result.node_errors.contains_key(&node_default_key),
+        "node_default must be Skipped (absent from node_errors)"
+    );
+}
+
+/// GREEN proof — no case matches: engine routes to node_default, marks
+/// node_a and node_b as Skipped.
+///
+/// RED witness: if the engine did not honour `"default"` routing, node_default
+/// would be absent from node_outputs or the status would be Failed.
+#[tokio::test]
+async fn switch_action_no_match_routes_to_default_skips_others() {
+    let engine = make_engine()
+        .with_plugin(core_plugin())
+        .expect("with_plugin(CorePlugin) must succeed");
+
+    let (workflow, node_a_key, node_b_key, node_default_key) = switch_branch_workflow(
+        // Neither "active" nor score > 90 — no case matches.
+        serde_json::json!({ "status": "unknown", "score": 50 }),
+        serde_json::json!([
+            { "condition": { "field": "status", "op": "eq", "value": "active" }, "port": "a" },
+            { "condition": { "field": "score",  "op": "gt", "value": 90 },       "port": "b" }
+        ]),
+    );
+
+    let result = engine
+        .execute_workflow(
+            &scope(),
+            &workflow,
+            serde_json::json!({}),
+            ExecutionBudget::default(),
+        )
+        .await
+        .expect("execute_workflow must not error");
+
+    assert_eq!(
+        result.status,
+        nebula_execution::ExecutionStatus::Completed,
+        "execution must reach Completed; got {:?} (node_errors: {:?})",
+        result.status,
+        result.node_errors
+    );
+
+    // node_default must have run.
+    let default_output = result
+        .node_outputs
+        .get(&node_default_key)
+        .expect("node_default must have output (it ran)");
+    assert_eq!(
+        default_output["branch_taken"],
+        serde_json::json!("default"),
+        "node_default must have set branch_taken = 'default'"
+    );
+
+    // node_a and node_b must be Skipped.
+    assert!(
+        !result.node_outputs.contains_key(&node_a_key),
+        "node_a must be Skipped (absent from node_outputs)"
+    );
+    assert!(
+        !result.node_errors.contains_key(&node_a_key),
+        "node_a must be Skipped (absent from node_errors)"
+    );
+    assert!(
+        !result.node_outputs.contains_key(&node_b_key),
+        "node_b must be Skipped (absent from node_outputs)"
+    );
+    assert!(
+        !result.node_errors.contains_key(&node_b_key),
+        "node_b must be Skipped (absent from node_errors)"
+    );
+}
+
+// ── Duplicate-key unit tests ──────────────────────────────────────────────────
+
 /// Pre-registering an action with the same key as a plugin action returns
 /// `PluginWiringError::DuplicateActionKey`.
 #[tokio::test]


### PR DESCRIPTION
## What

Generalizes `core.if` to an **N-way branch**: `core.switch` evaluates an ordered list of `{condition, port}` cases and routes execution to the **first matching** case's port, or `"default"` if none match. No more nested IFs for multi-way routing.

- `SwitchInput { data, cases: Vec<SwitchCase{condition, port}> }`. First-match-wins (later cases not evaluated — proven by a short-circuit test whose next case would Fatal if reached); a case condition error **propagates** (not swallowed); no match → `"default"`; data passthrough; non-object data → Fatal.
- Declares one `OutputPort::Dynamic { source_field:"cases", label_field:"port", include_fallback:true }` — the engine resolves the concrete port set from the node's `cases` array + an auto `"default"` port. Verified the action's `"default"` literal **agrees** with the engine's fallback port (routing is `from_port == selected` string match).
- **Extracts the shared `Condition`/`ConditionOp`/`evaluate_condition`** out of `if_action.rs` into `condition.rs` (re-exported → existing public path unchanged); both `core.if` and `core.switch` consume it — single definition for the catalog.
- 13 unit tests + a **3-case plugin-wiring e2e** proving the engine routes to one port and marks the other branch nodes `Skipped` (N-way routing proof, red→green).

## Verification
clippy `--all-features -D` clean; nextest 132/132 (incl. the e2e + the moved Condition tests + IF tests still green post-extraction); doc-test ✓; rustdoc `-D` ✓. Purely additive — no contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)