### PR TITLE
feat(engine): control-queue Resume for signal wait-conditions (ADR-0099 W-S2)

### DIFF
--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -103,6 +103,18 @@ pub enum ControlDispatchError {
     /// legitimate domain-level reject. Also recorded via `mark_failed`.
     #[error("control dispatch failed: {0}")]
     Internal(String),
+
+    /// A transient contention condition prevented dispatch — the control-queue
+    /// row should be left in `Processing` so the B1 reclaim sweep redelivers
+    /// it once the contention clears.
+    ///
+    /// Unlike `Rejected` and `Internal` (which call `mark_failed`), this
+    /// variant causes the consumer to call neither `mark_completed` nor
+    /// `mark_failed`, relying on the reclaim sweep to move the row back to
+    /// `Pending`. Use only for conditions that are guaranteed to resolve
+    /// (e.g. lease contention), not for permanent failures.
+    #[error("control dispatch deferred (transient contention): {0}")]
+    Deferred(String),
 }
 
 /// Engine-owned dispatch surface for control commands.
@@ -682,6 +694,20 @@ impl ControlConsumer {
 
         match dispatch_result {
             Ok(()) => self.ack_completed(&row_id).await,
+            Err(ControlDispatchError::Deferred(ref reason)) => {
+                // Transient contention: leave the row in `Processing` so the
+                // B1 reclaim sweep moves it back to `Pending` for redelivery.
+                // Calling `mark_failed` here would permanently record the row as
+                // failed — redelivery under B1 is only for `Processing` rows.
+                tracing::warn!(
+                    id = %hex_display(&row_id),
+                    %execution_id,
+                    command = command.as_str(),
+                    reason = %reason,
+                    "control-queue dispatch deferred (transient contention); \
+                     leaving row in Processing for B1 reclaim"
+                );
+            },
             Err(e) => {
                 tracing::error!(
                                    id = %hex_display(&row_id),

--- a/crates/engine/src/control_consumer.rs
+++ b/crates/engine/src/control_consumer.rs
@@ -104,15 +104,17 @@ pub enum ControlDispatchError {
     #[error("control dispatch failed: {0}")]
     Internal(String),
 
-    /// A transient contention condition prevented dispatch — the control-queue
-    /// row should be left in `Processing` so the B1 reclaim sweep redelivers
-    /// it once the contention clears.
+    /// A retriable dispatch condition prevented a safe ack/fail decision — the
+    /// control-queue row should be left in `Processing` so the B1 reclaim sweep
+    /// redelivers it once the condition clears or the state can be re-checked.
     ///
     /// Unlike `Rejected` and `Internal` (which call `mark_failed`), this
     /// variant causes the consumer to call neither `mark_completed` nor
     /// `mark_failed`, relying on the reclaim sweep to move the row back to
-    /// `Pending`. Use only for conditions that are guaranteed to resolve
-    /// (e.g. lease contention), not for permanent failures.
+    /// `Pending`. Use only when at-least-once redelivery is the correct recovery
+    /// path — e.g. lease contention, or a `dispatch_resume` whose `satisfy`
+    /// write did not durably land (and must not be acked while the wait may
+    /// still be pending) — never for permanent failures.
     #[error("control dispatch deferred (transient contention): {0}")]
     Deferred(String),
 }

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -54,6 +54,7 @@ use nebula_storage_port::{Scope, store::ExecutionStore};
 use crate::{
     WorkflowEngine,
     control_consumer::{ControlDispatch, ControlDispatchError},
+    engine::SatisfyOutcome,
     error::EngineError,
     event::ExecutionEvent,
 };
@@ -220,30 +221,71 @@ impl ControlDispatch for EngineControlDispatch {
             // so a crashed-and-reclaimed Paused execution re-parks its wait nodes
             // rather than auto-completing them — the structural discriminator that
             // prevents an unintended auto-approval on crash recovery.
+            //
+            // `satisfy_signal_waits` now holds the execution lease for its CAS, so
+            // errors split into two classes with different ack semantics:
+            //
+            // - `Leased` → another runner holds the lease and is actively driving this
+            //   execution. The control-queue row must NOT be acked — returning
+            //   `ControlDispatchError::Deferred` leaves the row in `Processing` so the
+            //   B1 reclaim sweep redelivers it once the lease expires.
+            //
+            // - `CasConflict` / other → a concurrent actor completed or cancelled the
+            //   execution between our status read and the CAS. Idempotency applies: ack
+            //   the row (`Ok(())`) because the concurrent actor owns the terminal
+            //   transition and we must not redeliver.
             Some(ExecutionStatus::Paused) => {
                 match self.engine.satisfy_signal_waits(scope, execution_id).await {
-                    Ok(satisfied_count) => {
+                    Ok(SatisfyOutcome::Satisfied(satisfied_count)) => {
                         tracing::info!(
                             %execution_id,
                             satisfied_count,
                             "dispatch_resume: signal waits satisfied; driving execution"
                         );
                     },
-                    Err(e) => {
-                        // Version conflict or fencing rejection: another runner
-                        // concurrently resumed (or cancelled) the execution. The
-                        // idempotency contract treats this as a no-op — the
-                        // concurrent actor owns the terminal transition.
+                    Ok(SatisfyOutcome::NothingToSatisfy) => {
+                        tracing::info!(
+                            %execution_id,
+                            "dispatch_resume: no signal-driven wait nodes found (already satisfied \
+                             or execution has no wait nodes); driving execution"
+                        );
+                    },
+                    Err(EngineError::Leased { ref holder, .. }) => {
+                        // Transient lease contention — another runner is actively
+                        // driving this execution. Leave the control-queue row in
+                        // `Processing` for B1 reclaim to redeliver.
                         //
-                        // The drop must be OBSERVABLE (observability-DoD): a typed
-                        // `ResumeDeferred` event + `tracing::warn` let operators
-                        // distinguish transient CAS races (expected; low rate) from
-                        // systematic drops (routing or lease bug; high rate).
+                        // Observable: typed `ResumeDeferred` event + `tracing::warn`
+                        // let operators distinguish expected transient contention (low
+                        // rate) from systematic drops due to a routing bug (high rate).
+                        tracing::warn!(
+                            %execution_id,
+                            %holder,
+                            "dispatch_resume: satisfy_signal_waits deferred — execution lease \
+                             held by another runner; leaving control-queue row for B1 reclaim"
+                        );
+                        self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                            execution_id,
+                            reason: format!("lease held by {holder}"),
+                        });
+                        return Err(ControlDispatchError::Deferred(format!(
+                            "execution {execution_id} lease held by {holder}; \
+                             Resume deferred for B1 reclaim"
+                        )));
+                    },
+                    Err(e) => {
+                        // CAS conflict or internal error: a concurrent actor
+                        // concurrently resumed or cancelled the execution. The
+                        // idempotency contract treats this as a no-op — the
+                        // concurrent actor owns the terminal transition. Ack the row
+                        // so redelivery does not occur on an already-resolved state.
+                        //
+                        // Observable: typed `ResumeDeferred` event + `tracing::warn`.
                         tracing::warn!(
                             %execution_id,
                             error = %e,
-                            "dispatch_resume: satisfy_signal_waits rejected; \
-                             treating as already-satisfied (idempotent Resume)"
+                            "dispatch_resume: satisfy_signal_waits rejected by CAS conflict; \
+                             treating as already-satisfied (concurrent actor owns transition)"
                         );
                         self.engine.emit_event(ExecutionEvent::ResumeDeferred {
                             execution_id,

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -17,12 +17,19 @@
 //! redeliver. Each dispatch method guards against re-delivery through one of
 //! two mechanisms:
 //!
-//! - **Start / Resume / Restart** short-circuit on persisted status. A command arriving for an
+//! - **Start / Restart** short-circuit on persisted status. A command arriving for an
 //!   already-terminal execution is `Ok(())`; a command arriving for a `Running` / `Cancelling`
 //!   execution is `Ok(())` (a sibling runner already owns the dispatch). A race where a second
 //!   dispatcher wins the lease between our read and the engine's own lease acquire surfaces as
-//!   [`EngineError::Leased`], which this impl maps to `Ok(())` so the same execution is not fenced
+//!   [`EngineError::Leased`], which `drive()` maps to `Ok(())` so the same execution is not fenced
 //!   as a consumer failure.
+//!
+//! - **Resume** additionally calls `satisfy_signal_waits` for `Paused` executions before
+//!   re-driving. Because `satisfy_signal_waits` holds the execution lease for its CAS, errors
+//!   split by effect: `Leased` returns `Deferred` (B1 reclaim redelivers); any other error
+//!   (CAS conflict, checkpoint failure) re-reads the persisted status — terminal / `Cancelling`
+//!   → ack; still non-terminal → `Deferred`. This ensures the Resume is never silently dropped
+//!   when the satisfy did not durably land.
 //!
 //! - **Cancel / Terminate** always signal the engine's cancel registry (except for orphan commands,
 //!   which are [`ControlDispatchError::Rejected`]). The underlying
@@ -230,10 +237,15 @@ impl ControlDispatch for EngineControlDispatch {
             //   `ControlDispatchError::Deferred` leaves the row in `Processing` so the
             //   B1 reclaim sweep redelivers it once the lease expires.
             //
-            // - `CasConflict` / other → a concurrent actor completed or cancelled the
-            //   execution between our status read and the CAS. Idempotency applies: ack
-            //   the row (`Ok(())`) because the concurrent actor owns the terminal
-            //   transition and we must not redeliver.
+            // - Any other error (`CasConflict` / `CheckpointFailed` / etc.) → the
+            //   satisfy did NOT durably land.  The correct action depends on the
+            //   *current* persisted status (re-read after the error):
+            //   · terminal / Cancelling → concurrent actor owns the transition → ack.
+            //   · still non-terminal (Paused / Running) → the wait may still be
+            //     pending → `Deferred` so B1 reclaim redelivers the Resume.
+            //   Acking unconditionally here would permanently drop the Resume when a
+            //   lease TTL-expiry causes a FencedOut (surfaced as CasConflict) while
+            //   the execution is still Paused — bounded lost-Resume.
             Some(ExecutionStatus::Paused) => {
                 match self.engine.satisfy_signal_waits(scope, execution_id).await {
                     Ok(SatisfyOutcome::Satisfied(satisfied_count)) => {
@@ -274,24 +286,87 @@ impl ControlDispatch for EngineControlDispatch {
                         )));
                     },
                     Err(e) => {
-                        // CAS conflict or internal error: a concurrent actor
-                        // concurrently resumed or cancelled the execution. The
-                        // idempotency contract treats this as a no-op — the
-                        // concurrent actor owns the terminal transition. Ack the row
-                        // so redelivery does not occur on an already-resolved state.
+                        // CAS conflict / fencing / checkpoint failure: the satisfy
+                        // did NOT durably land. The idempotency rule is:
+                        //   - ack ONLY when a post-error status re-read confirms the
+                        //     execution is now terminal (concurrent actor owns the
+                        //     transition) or Cancelling (cancel already in flight).
+                        //   - Defer otherwise — the wait may still be pending and the
+                        //     Resume must not be lost.
                         //
-                        // Observable: typed `ResumeDeferred` event + `tracing::warn`.
-                        tracing::warn!(
-                            %execution_id,
-                            error = %e,
-                            "dispatch_resume: satisfy_signal_waits rejected by CAS conflict; \
-                             treating as already-satisfied (concurrent actor owns transition)"
-                        );
-                        self.engine.emit_event(ExecutionEvent::ResumeDeferred {
-                            execution_id,
-                            reason: e.to_string(),
-                        });
-                        return Ok(());
+                        // Rationale: if our lease TTL-expires mid-commit, another runner
+                        // acquires the lease, bumps the generation, and our write is
+                        // FencedOut (surfaced here as CasConflict) — the wait node is
+                        // still Waiting and the execution is still Paused.  Acking here
+                        // would permanently drop the Resume (bounded lost-Resume of the
+                        // same class as the P1 bug).
+                        match self.read_status(scope, execution_id).await {
+                            Ok(Some(status))
+                                if status.is_terminal()
+                                    || matches!(status, ExecutionStatus::Cancelling) =>
+                            {
+                                // Concurrent actor drove the execution to a genuine
+                                // terminal or cancelling state — ack is safe here.
+                                tracing::info!(
+                                    %execution_id,
+                                    %status,
+                                    satisfy_error = %e,
+                                    "dispatch_resume: satisfy_signal_waits did not land but \
+                                     execution is now {status}; acking as idempotent"
+                                );
+                                return Ok(());
+                            },
+                            Ok(status) => {
+                                // Execution is not yet terminal (Paused / Running / Created
+                                // or row missing): the wait may still be pending.
+                                // Defer so B1 reclaim redelivers the Resume.
+                                let status_desc = status
+                                    .map(|s| s.to_string())
+                                    .unwrap_or_else(|| "not found".to_owned());
+                                tracing::warn!(
+                                    %execution_id,
+                                    %status_desc,
+                                    satisfy_error = %e,
+                                    "dispatch_resume: satisfy_signal_waits did not land and \
+                                     execution is still non-terminal ({status_desc}); \
+                                     deferring Resume for B1 reclaim"
+                                );
+                                self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                                    execution_id,
+                                    reason: format!(
+                                        "satisfy did not land ({e}); status={status_desc}"
+                                    ),
+                                });
+                                return Err(ControlDispatchError::Deferred(format!(
+                                    "execution {execution_id}: satisfy_signal_waits did not \
+                                     durably commit ({e}); status={status_desc}; \
+                                     Resume deferred for B1 reclaim"
+                                )));
+                            },
+                            Err(read_err) => {
+                                // Status re-read itself failed — conservative: Defer so
+                                // B1 reclaim redelivers; don't ack an unverified state.
+                                tracing::warn!(
+                                    %execution_id,
+                                    satisfy_error = %e,
+                                    read_error = %read_err,
+                                    "dispatch_resume: satisfy_signal_waits did not land and \
+                                     status re-read also failed; deferring Resume conservatively"
+                                );
+                                self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                                    execution_id,
+                                    reason: format!(
+                                        "satisfy did not land ({e}); status re-read failed: \
+                                         {read_err}"
+                                    ),
+                                });
+                                return Err(ControlDispatchError::Deferred(format!(
+                                    "execution {execution_id}: satisfy_signal_waits did not land \
+                                     ({e}) and status re-read failed ({read_err}); \
+                                     Resume deferred conservatively for B1 reclaim"
+                                )));
+                            },
+                        }
                     },
                 }
                 self.drive(scope, execution_id).await

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -262,6 +262,21 @@ impl ControlDispatch for EngineControlDispatch {
                              or execution has no wait nodes); driving execution"
                         );
                     },
+                    Ok(SatisfyOutcome::ExecutionNotResumable) => {
+                        // A concurrent Cancel/Terminate moved the execution off
+                        // `Paused` between our pre-lease status read and the
+                        // under-lease reload inside `satisfy_signal_waits`. The
+                        // Resume is moot — ack WITHOUT driving, mirroring the
+                        // up-front terminal/`Cancelling` handling above. Driving
+                        // here would re-enter the engine on a terminating
+                        // execution; satisfy already made no durable write.
+                        tracing::info!(
+                            %execution_id,
+                            "dispatch_resume: execution left Paused before satisfy (concurrent \
+                             cancel/terminate); acking Resume as idempotent no-op"
+                        );
+                        return Ok(());
+                    },
                     Err(EngineError::Leased { ref holder, .. }) => {
                         // Transient lease contention — another runner is actively
                         // driving this execution. Leave the control-queue row in

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -172,6 +172,74 @@ impl EngineControlDispatch {
             },
         }
     }
+
+    /// Drive an execution whose signal wait `satisfy_signal_waits` has already
+    /// **armed** (`next_attempt_at = Some`), keeping the Resume redeliverable
+    /// until the armed wait is actually completed.
+    ///
+    /// Unlike [`Self::drive`], a drive that cannot run to a durable outcome —
+    /// lease contention (`EngineError::Leased`), a CAS conflict, or any other
+    /// non-terminal error — returns [`ControlDispatchError::Deferred`], NOT
+    /// `Ok`. The wait has been durably armed but not completed; acking the
+    /// control-queue row here would strand the paused execution when the lease
+    /// holder is a crashed/stalled runner whose TTL has not expired yet (it
+    /// never completes the armed wait, and no redelivery remains). Deferring
+    /// leaves the row in `Processing` for the B1 reclaim sweep to redeliver
+    /// once the lease frees, and a later drive completes the armed wait.
+    ///
+    /// The Resume is acked ONLY when a post-error status re-read shows the
+    /// execution is genuinely terminal or `Cancelling` (a concurrent actor owns
+    /// the outcome, so the Resume is moot).
+    async fn drive_armed_resume(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<(), ControlDispatchError> {
+        match self.engine.resume_execution(scope, execution_id).await {
+            Ok(_) => Ok(()),
+            Err(e) => match self.read_status(scope, execution_id).await {
+                Ok(Some(status))
+                    if status.is_terminal() || matches!(status, ExecutionStatus::Cancelling) =>
+                {
+                    tracing::info!(
+                        %execution_id,
+                        %status,
+                        drive_error = %e,
+                        "dispatch_resume: post-satisfy drive did not complete but execution \
+                         is now {status}; acking as idempotent"
+                    );
+                    Ok(())
+                },
+                other => {
+                    let status_desc = match other {
+                        Ok(s) => s
+                            .map(|s| s.to_string())
+                            .unwrap_or_else(|| "not found".to_owned()),
+                        Err(read_err) => format!("status re-read failed: {read_err}"),
+                    };
+                    tracing::warn!(
+                        %execution_id,
+                        %status_desc,
+                        drive_error = %e,
+                        "dispatch_resume: post-satisfy drive did not complete and execution is \
+                         not terminal ({status_desc}); deferring Resume (armed wait still \
+                         pending) for B1 reclaim"
+                    );
+                    self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                        execution_id,
+                        reason: format!(
+                            "post-satisfy drive did not complete ({e}); status={status_desc}; \
+                                 armed wait deferred for B1 reclaim"
+                        ),
+                    });
+                    Err(ControlDispatchError::Deferred(format!(
+                        "execution {execution_id}: post-satisfy drive did not complete ({e}); \
+                             status={status_desc}; armed wait deferred for B1 reclaim"
+                    )))
+                },
+            },
+        }
+    }
 }
 
 #[async_trait]
@@ -384,7 +452,10 @@ impl ControlDispatch for EngineControlDispatch {
                         }
                     },
                 }
-                self.drive(scope, execution_id).await
+                // Post-satisfy drive: keep the Resume redeliverable until the
+                // armed wait is actually completed (a Leased/CAS-conflict drive
+                // must Defer, not ack — see `drive_armed_resume`).
+                self.drive_armed_resume(scope, execution_id).await
             },
         }
     }

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -526,12 +526,55 @@ impl ControlDispatch for EngineControlDispatch {
             Some(status) => {
                 let signalled = self.engine.cancel_execution(execution_id);
                 tracing::debug!(
-                                   %execution_id,
-                                   %status,
-                                   signalled,
-                "control-queue: Cancel dispatched — signalled local runner={signalled}"
-                               );
-                Ok(())
+                    %execution_id,
+                    %status,
+                    signalled,
+                    "control-queue: Cancel dispatched — signalled local runner={signalled}"
+                );
+                if signalled {
+                    // A live in-process frontier owns this execution: its loop
+                    // teardown (`drain_pending_to_cancelled`) terminalizes the
+                    // parked/queued nodes. Ack — nothing more to do here.
+                    return Ok(());
+                }
+                // No in-process runner: either a `Paused` (signal-wait)
+                // execution with no live frontier, or a cross-runner live
+                // execution. Durably terminalize any parked nodes so a
+                // `Cancelled` execution never retains a non-terminal node.
+                // Lease-guarded: a held lease means a live frontier (this is the
+                // cross-runner case) is tearing down or another runner owns it →
+                // Defer for B1 reclaim rather than racing its node writes.
+                match self.engine.cancel_dangling_nodes(scope, execution_id).await {
+                    Ok(_) => Ok(()),
+                    Err(EngineError::Leased { ref holder, .. }) => {
+                        tracing::debug!(
+                            %execution_id,
+                            %holder,
+                            "dispatch_cancel: dangling-node cleanup deferred — execution lease \
+                             held by another runner (its teardown or B1 reclaim completes the cancel)"
+                        );
+                        Err(ControlDispatchError::Deferred(format!(
+                            "execution {execution_id} cancel dangling-node cleanup deferred; \
+                             lease held by {holder}"
+                        )))
+                    },
+                    Err(e) => {
+                        // The cleanup did not durably land; the execution is
+                        // already `Cancelled` but its parked nodes are still
+                        // non-terminal. Defer so B1 reclaim retries — never ack a
+                        // cleanup whose effect did not land.
+                        tracing::warn!(
+                            %execution_id,
+                            error = %e,
+                            "dispatch_cancel: dangling-node cleanup did not land; deferring for \
+                             B1 reclaim"
+                        );
+                        Err(ControlDispatchError::Deferred(format!(
+                            "execution {execution_id} cancel dangling-node cleanup did not land \
+                             ({e}); deferred for B1 reclaim"
+                        )))
+                    },
+                }
             },
         }
     }

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -290,8 +290,11 @@ impl ControlDispatch for EngineControlDispatch {
             // `Created`: no signal-driven waits exist yet — drive directly.
             Some(ExecutionStatus::Created) => self.drive(scope, execution_id).await,
             // `Paused`: the execution is suspended awaiting an external signal.
-            // Satisfy all signal-driven waits (Waiting{next_attempt_at==None}→Completed)
-            // via durable CAS BEFORE re-driving. This is the only code path that
+            // Arm all signal-driven waits (Waiting{next_attempt_at == None}
+            // → Waiting{next_attempt_at = now}) via durable CAS BEFORE re-driving;
+            // Phase-0b then completes each armed wait through PORT-AWARE edge
+            // routing (completing it here would route port-blind). This is the
+            // only code path that
             // calls `satisfy_signal_waits`; Start / Restart / worker re-drives do not,
             // so a crashed-and-reclaimed Paused execution re-parks its wait nodes
             // rather than auto-completing them — the structural discriminator that

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -61,7 +61,7 @@ use nebula_storage_port::{Scope, store::ExecutionStore};
 use crate::{
     WorkflowEngine,
     control_consumer::{ControlDispatch, ControlDispatchError},
-    engine::SatisfyOutcome,
+    engine::{CancelDanglingOutcome, SatisfyOutcome},
     error::EngineError,
     event::ExecutionEvent,
 };
@@ -545,7 +545,26 @@ impl ControlDispatch for EngineControlDispatch {
                 // cross-runner case) is tearing down or another runner owns it →
                 // Defer for B1 reclaim rather than racing its node writes.
                 match self.engine.cancel_dangling_nodes(scope, execution_id).await {
-                    Ok(_) => Ok(()),
+                    Ok(
+                        CancelDanglingOutcome::Cancelled(_)
+                        | CancelDanglingOutcome::NothingToCancel,
+                    ) => Ok(()),
+                    Ok(CancelDanglingOutcome::StatusNotCancelled) => {
+                        // The cancel is not yet durably recorded on the execution
+                        // (the API writes `Cancelled` before enqueuing `Cancel`,
+                        // so this is a producer-ordering anomaly). Defer rather
+                        // than ack-and-drop the node cleanup — B1 reclaim
+                        // redelivers until the status reflects the cancel.
+                        tracing::warn!(
+                            %execution_id,
+                            "dispatch_cancel: cancel not yet durably recorded on the execution; \
+                             deferring node cleanup for B1 reclaim"
+                        );
+                        Err(ControlDispatchError::Deferred(format!(
+                            "execution {execution_id} cancel not yet durably recorded; node \
+                             cleanup deferred for B1 reclaim"
+                        )))
+                    },
                     Err(EngineError::Leased { ref holder, .. }) => {
                         tracing::debug!(
                             %execution_id,

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -544,9 +544,16 @@ impl ControlDispatch for EngineControlDispatch {
                 // execution with no live frontier, or a cross-runner live
                 // execution. Durably terminalize any parked nodes so a
                 // `Cancelled` execution never retains a non-terminal node.
-                // Lease-guarded: a held lease means a live frontier (this is the
-                // cross-runner case) is tearing down or another runner owns it →
-                // Defer for B1 reclaim rather than racing its node writes.
+                // Lease-guarded: a held lease (acquire fails ⇒ TTL not expired)
+                // means another runner is alive and owns this execution. That
+                // owner observes the API's durable `Cancelled` write via its next
+                // checkpoint CAS and tears its own frontier down — so we ACK
+                // (below) rather than Defer. Deferring would churn the
+                // control-queue row through untargeted, budget-capped B1 reclaim
+                // (which cannot route to the lease holder) until it is marked
+                // failed, while never delivering anything to the owner. A
+                // genuinely no-live-runner Paused execution has a FREE lease, so
+                // `cancel_dangling_nodes` acquires it and terminalizes there.
                 match self.engine.cancel_dangling_nodes(scope, execution_id).await {
                     Ok(
                         CancelDanglingOutcome::Cancelled(_)
@@ -569,16 +576,24 @@ impl ControlDispatch for EngineControlDispatch {
                         )))
                     },
                     Err(EngineError::Leased { ref holder, .. }) => {
+                        // A live owner holds the lease — it will observe the
+                        // durable `Cancelled` status on its next checkpoint CAS
+                        // and tear its own frontier down. ACK: there is no
+                        // targeted cross-runner cancel delivery, so churning the
+                        // row through reclaim would only burn the budget and mark
+                        // it failed without ever reaching the owner. (Prompt
+                        // cross-process cancel delivery — and recovery of a holder
+                        // that crashed before its TTL — is the general
+                        // crashed-runner / multi-runner follow-up, tracked
+                        // separately.)
                         tracing::debug!(
                             %execution_id,
                             %holder,
-                            "dispatch_cancel: dangling-node cleanup deferred — execution lease \
-                             held by another runner (its teardown or B1 reclaim completes the cancel)"
+                            "dispatch_cancel: execution lease held by a live owner; acking — the \
+                             owner tears down via its checkpoint CAS against the durable Cancelled \
+                             status"
                         );
-                        Err(ControlDispatchError::Deferred(format!(
-                            "execution {execution_id} cancel dangling-node cleanup deferred; \
-                             lease held by {holder}"
-                        )))
+                        Ok(())
                     },
                     Err(e) => {
                         // The cleanup did not durably land; the execution is

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -55,6 +55,7 @@ use crate::{
     WorkflowEngine,
     control_consumer::{ControlDispatch, ControlDispatchError},
     error::EngineError,
+    event::ExecutionEvent,
 };
 
 /// Engine-owned [`ControlDispatch`] implementation.
@@ -198,8 +199,6 @@ impl ControlDispatch for EngineControlDispatch {
         scope: &Scope,
         execution_id: ExecutionId,
     ) -> Result<(), ControlDispatchError> {
-        // `Resume` and `Start` converge on the same engine entry today — see
-        // the `drive` docs. The idempotency read mirrors `dispatch_start`.
         match self.read_status(scope, execution_id).await? {
             None => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} not found — resume command orphaned"
@@ -212,7 +211,47 @@ impl ControlDispatch for EngineControlDispatch {
                 | ExecutionStatus::Cancelled
                 | ExecutionStatus::TimedOut,
             ) => Ok(()),
-            Some(ExecutionStatus::Created | ExecutionStatus::Paused) => {
+            // `Created`: no signal-driven waits exist yet — drive directly.
+            Some(ExecutionStatus::Created) => self.drive(scope, execution_id).await,
+            // `Paused`: the execution is suspended awaiting an external signal.
+            // Satisfy all signal-driven waits (Waiting{next_attempt_at==None}→Completed)
+            // via durable CAS BEFORE re-driving. This is the only code path that
+            // calls `satisfy_signal_waits`; Start / Restart / worker re-drives do not,
+            // so a crashed-and-reclaimed Paused execution re-parks its wait nodes
+            // rather than auto-completing them — the structural discriminator that
+            // prevents an unintended auto-approval on crash recovery.
+            Some(ExecutionStatus::Paused) => {
+                match self.engine.satisfy_signal_waits(scope, execution_id).await {
+                    Ok(satisfied_count) => {
+                        tracing::info!(
+                            %execution_id,
+                            satisfied_count,
+                            "dispatch_resume: signal waits satisfied; driving execution"
+                        );
+                    },
+                    Err(e) => {
+                        // Version conflict or fencing rejection: another runner
+                        // concurrently resumed (or cancelled) the execution. The
+                        // idempotency contract treats this as a no-op — the
+                        // concurrent actor owns the terminal transition.
+                        //
+                        // The drop must be OBSERVABLE (observability-DoD): a typed
+                        // `ResumeDeferred` event + `tracing::warn` let operators
+                        // distinguish transient CAS races (expected; low rate) from
+                        // systematic drops (routing or lease bug; high rate).
+                        tracing::warn!(
+                            %execution_id,
+                            error = %e,
+                            "dispatch_resume: satisfy_signal_waits rejected; \
+                             treating as already-satisfied (idempotent Resume)"
+                        );
+                        self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                            execution_id,
+                            reason: e.to_string(),
+                        });
+                        return Ok(());
+                    },
+                }
                 self.drive(scope, execution_id).await
             },
         }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -78,11 +78,13 @@ pub const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
 /// Outcome of [`WorkflowEngine::satisfy_signal_waits`].
 ///
-/// Distinguishes "nodes transitioned to `Completed`" from "nothing to do"
+/// Distinguishes "signal waits armed for completion" from "nothing to do"
 /// so callers can log counts accurately without treating zero as an error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum SatisfyOutcome {
-    /// `n` signal-driven `Waiting` nodes were transitioned to `Completed`.
+    /// `n` signal-driven `Waiting` nodes were armed for completion (their
+    /// `next_attempt_at` was set so the follow-up drive's Phase-0b completes
+    /// them on the main port).
     Satisfied(usize),
     /// No signal-driven `Waiting` nodes existed — execution was already
     /// satisfied, cancelled, or never had wait nodes.
@@ -3215,26 +3217,30 @@ impl WorkflowEngine {
                 }
             }
 
-            // Phase 2: Wait for one completion or for the next timer.
-            // Exit only when join_set, retry_heap, AND wait_heap are
-            // all drained — a non-empty heap with an empty join_set
-            // is a legal "everything paused for a timer" state.
-            if join_set.is_empty() && retry_heap.is_empty() && wait_heap.is_empty() {
-                break;
-            }
-
+            // Phase 2: tear-down / exit.
+            //
+            // The cancel check MUST run BEFORE the empty-heap exit: a
+            // signal-parked execution has all heaps empty and an empty
+            // join_set, so the empty-heap exit would fire first and skip
+            // the cancel teardown — leaving the signal-`Waiting{None}` node
+            // non-terminal under a `Cancelled` execution. Checking cancel
+            // first routes a cancel-during-signal-park through
+            // `drain_pending_to_cancelled` (which also cancels signal waits
+            // that are not on any heap). A clean (non-cancelled) finish
+            // still exits via the empty-heap break below.
             if cancel_token.is_cancelled() {
                 join_set.abort_all();
                 while join_set.join_next_with_id().await.is_some() {}
                 task_nodes.clear();
                 // Tear down parked retries (WaitingRetry → Cancelled),
-                // parked wait nodes (Waiting → Cancelled), AND the
-                // ready_queue (Ready → Cancelled). The previous failure
-                // already lives in `NodeAttempt`; the cancel terminates
-                // the wait, not the attempt (operational honesty).
-                // Without draining `ready_queue`, a node Phase 0 already
-                // promoted to `Ready` would stay non-terminal after the
-                // loop exits, tripping the frontier integrity check.
+                // parked wait nodes (Waiting → Cancelled, incl. signal
+                // waits not on `wait_heap`), AND the ready_queue
+                // (Ready → Cancelled). The previous failure already lives
+                // in `NodeAttempt`; the cancel terminates the wait, not the
+                // attempt (operational honesty). Without draining
+                // `ready_queue`, a node Phase 0 already promoted to `Ready`
+                // would stay non-terminal after the loop exits, tripping
+                // the frontier integrity check.
                 drain_pending_to_cancelled(
                     &mut retry_heap,
                     &mut wait_heap,
@@ -3242,6 +3248,13 @@ impl WorkflowEngine {
                     exec_state,
                     execution_id,
                 );
+                break;
+            }
+
+            // Exit only when join_set, retry_heap, AND wait_heap are
+            // all drained — a non-empty heap with an empty join_set
+            // is a legal "everything paused for a timer" state.
+            if join_set.is_empty() && retry_heap.is_empty() && wait_heap.is_empty() {
                 break;
             }
 
@@ -3410,7 +3423,8 @@ impl WorkflowEngine {
                     //     Phase-0b drains to `Completed` when the timer fires.
                     //   Signal: `Webhook` / `Approval` / `Execution` (timeout:None) —
                     //     `wake_at = None`, no heap entry; execution parks at `Paused`
-                    //     until a `Resume` command's durable satisfy-CAS completes it.
+                    //     until a `Resume` command's durable satisfy-CAS arms it
+                    //     (sets `next_attempt_at`) for Phase-0b completion.
                     //
                     // Not yet supported — still rejected:
                     //   Any condition with `timeout: Some(..)`: the
@@ -3472,23 +3486,38 @@ impl WorkflowEngine {
                             },
                             // Signal-driven conditions: no timer wake — the park is
                             // indefinite until a Resume command's durable satisfy-CAS
-                            // transitions the node to Completed. `wake_at = None` means
-                            // the node is never pushed onto `wait_heap`.
+                            // arms the node (sets `next_attempt_at`) for Phase-0b
+                            // completion. `wake_at = None` means the node is never
+                            // pushed onto `wait_heap` until a Resume arms it.
                             WaitCondition::Webhook { .. }
                             | WaitCondition::Approval { .. }
                             | WaitCondition::Execution { .. } => None,
                             _ => {
-                                // Unknown future condition variant. Park with no timer so
-                                // the node is at least durable; a Resume will satisfy it.
-                                // Emit a warning so the operator can diagnose the gap.
-                                tracing::warn!(
+                                // Unknown WaitCondition variant — FAIL CLOSED.
+                                // Parking with `wake_at = None` would let a generic
+                                // execution-level Resume satisfy a wait whose semantics
+                                // this engine cannot classify (a signal vs timer vs
+                                // something else). Until a variant is explicitly added
+                                // to the signal/timer arms above, reject it on the same
+                                // `WaitConditionNotSupported` path as an explicit timeout
+                                // rather than parking it.
+                                let runtime_err =
+                                    crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                        condition_kind: "unrecognised WaitCondition variant"
+                                            .to_owned(),
+                                    };
+                                let engine_err = EngineError::Runtime(runtime_err);
+                                tracing::error!(
                                     target = "engine::wait",
                                     %execution_id,
                                     %node_key,
-                                    "unrecognised WaitCondition variant; parking with no \
-                                     timer — a Resume command is required to satisfy it"
+                                    error = %engine_err,
+                                    "unrecognised WaitCondition variant; marking node Failed \
+                                     (fail-closed — a Resume must not satisfy an unclassified wait)"
                                 );
-                                None
+                                mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                                cancel_token.cancel();
+                                return Some((node_key.clone(), engine_err.to_string()));
                             },
                         };
 
@@ -3542,6 +3571,28 @@ impl WorkflowEngine {
 
                         match exec_state.park_node(node_key.clone(), wake_at) {
                             Ok(()) => {
+                                // Signal park (no timer) that leaves NO other active
+                                // frontier work fully suspends the execution: persist
+                                // `Paused` atomically in this park checkpoint batch
+                                // (`checkpoint_node` serialises `exec_state`, status
+                                // included). Otherwise the row would sit durably
+                                // `Running` + `Waiting{next_attempt_at: None}` until the
+                                // frontier exit's `persist_final_state` writes `Paused`;
+                                // a crash in that window is unrecoverable because
+                                // `dispatch_start`/`dispatch_resume` short-circuit on
+                                // `Running`. The exit's `transition_status(Paused)` is a
+                                // no-op once we set it here (`Paused→Paused` is rejected
+                                // and ignored). The general crashed-`Running` recovery
+                                // gap (e.g. a sibling completing last) is tracked
+                                // separately.
+                                if wake_at.is_none()
+                                    && join_set.is_empty()
+                                    && ready_queue.is_empty()
+                                    && retry_heap.is_empty()
+                                    && wait_heap.is_empty()
+                                {
+                                    let _ = exec_state.transition_status(ExecutionStatus::Paused);
+                                }
                                 // Durably commit the `Waiting` state and the
                                 // already-staged `partial_output` before any
                                 // observer sees the node is parked. On
@@ -3566,7 +3617,8 @@ impl WorkflowEngine {
                                 // Push onto the wait_heap for timer-driven conditions only.
                                 // Signal-driven conditions (`wake_at == None`) are never
                                 // pushed here; their node stays `Waiting` until a Resume
-                                // command's durable satisfy-CAS transitions it to Completed.
+                                // command's durable satisfy-CAS arms it (sets
+                                // `next_attempt_at`) for Phase-0b completion.
                                 if let Some(when) = wake_at {
                                     wait_heap.push(Reverse((when, node_key.clone())));
                                 }
@@ -5338,6 +5390,30 @@ fn drain_pending_to_cancelled(
             "Waiting → Cancelled (cancel observed while parked)"
         );
     }
+    // Signal-driven waits (`next_attempt_at == None`) are intentionally NOT on
+    // `wait_heap`, so the heap drain above never visits them. Scan `node_states`
+    // for any node still `Waiting` and cancel it too — otherwise a cancel
+    // observed while a signal wait is parked would leave the node non-terminal
+    // under a `Cancelled` execution (a state-machine leak). Timer waits already
+    // cancelled by the heap drain are skipped (no longer `Waiting`).
+    let stranded_signal_waits: Vec<NodeKey> = exec_state
+        .node_states
+        .iter()
+        .filter(|(_, ns)| ns.state == NodeState::Waiting)
+        .map(|(id, _)| id.clone())
+        .collect();
+    for waiting in stranded_signal_waits {
+        let _ = exec_state.transition_node(waiting.clone(), NodeState::Cancelled);
+        if let Some(ns) = exec_state.node_states.get_mut(&waiting) {
+            ns.next_attempt_at = None;
+        }
+        tracing::debug!(
+            target = "engine::wait",
+            %execution_id,
+            node_key = %waiting,
+            "signal Waiting → Cancelled (cancel observed while parked; not on wait_heap)"
+        );
+    }
     while let Some(queued) = ready_queue.pop_front() {
         // `Ready → Cancelled` is in the canonical transition table.
         // Pending nodes that landed here straight from the seed
@@ -5983,17 +6059,27 @@ fn determine_final_status(
     // Guards that must BOTH hold:
     //   1. `!non_terminal_signal_waits.is_empty()` — an all-terminal run
     //      must still fall through to Priority-5 `Completed`, never `Paused`.
-    //   2. No non-terminal node is `Running` or `WaitingRetry` — those states
-    //      indicate a genuine frontier bug, not a benign park:
+    //   2. No non-terminal node is `Running`, `Ready`, or `WaitingRetry` —
+    //      those states indicate a genuine frontier bug, not a benign park:
     //        - `Running`: the frontier exited while a worker was still live.
+    //        - `Ready`: the node was activated and queued for dispatch but the
+    //          frontier exited without spawning it — runnable work was
+    //          stranded. (A node merely *blocked behind* a signal wait stays
+    //          `Pending`: its wait predecessor is non-terminal, so it is never
+    //          activated/enqueued and never reaches `Ready`.)
     //        - `WaitingRetry`: the frontier exit condition requires
     //          `retry_heap.is_empty()`; a `WaitingRetry` node present at
     //          exit means its heap entry was lost — an anomaly that must
     //          surface as a `FrontierIntegrityViolation`, not be masked as
     //          `Paused`.
-    //      `Pending` and `Ready` nodes blocked behind a signal-`Waiting`
-    //      upstream are expected and safe (they will activate once the wait
-    //      is satisfied via `dispatch_resume`).
+    //        - timer `Waiting{next_attempt_at: Some(_)}`: the loop only exits
+    //          once `wait_heap.is_empty()`, and every timer wait is drained to
+    //          `Completed` by Phase-0b before that. A timer wait still present
+    //          at exit means its `wait_heap` entry was lost — same lost-entry
+    //          anomaly as `WaitingRetry`.
+    //      Only genuinely-blocked `Pending` nodes are expected alongside a
+    //      signal wait (they activate once the wait is satisfied via
+    //      `dispatch_resume`).
     {
         let non_terminal_signal_waits: Vec<NodeKey> = exec_state
             .node_states
@@ -6002,12 +6088,17 @@ fn determine_final_status(
             .filter(|(_, ns)| ns.state == NodeState::Waiting && ns.next_attempt_at.is_none())
             .map(|(id, _)| id.clone())
             .collect();
-        let has_active_non_signal_node = exec_state
+        let has_non_benign_non_terminal_node = exec_state
             .node_states
             .values()
             .filter(|ns| !ns.state.is_terminal())
-            .any(|ns| matches!(ns.state, NodeState::Running | NodeState::WaitingRetry));
-        if !non_terminal_signal_waits.is_empty() && !has_active_non_signal_node {
+            .any(|ns| {
+                matches!(
+                    ns.state,
+                    NodeState::Running | NodeState::Ready | NodeState::WaitingRetry
+                ) || (ns.state == NodeState::Waiting && ns.next_attempt_at.is_some())
+            });
+        if !non_terminal_signal_waits.is_empty() && !has_non_benign_non_terminal_node {
             tracing::info!(
                 target = "engine::final_status",
                 execution_id = %exec_state.execution_id,
@@ -11270,6 +11361,154 @@ mod tests {
         assert!(
             decision.integrity_violation.is_some(),
             "integrity_violation must be populated: WaitingRetry at frontier-exit is a bug"
+        );
+    }
+
+    /// **Priority-4a guard 2: `Waiting{None} + Ready` triggers integrity violation.**
+    ///
+    /// A `Ready` node at frontier-exit means the node was activated and queued
+    /// for dispatch but the frontier exited without spawning it — runnable work
+    /// was stranded. (A node merely *blocked behind* a signal wait stays
+    /// `Pending`; it never reaches `Ready` because its wait predecessor is
+    /// non-terminal and so never activates it.) Priority-4a MUST NOT mask this
+    /// stranded-work bug as `Paused`.
+    ///
+    /// **Falsifiability**: drop `NodeState::Ready` from `has_non_benign_non_terminal_node`
+    /// → priority-4a fires on the mixed set → `decision.status == Paused` →
+    /// `!= Failed` assertion fails → RED.
+    #[test]
+    fn final_status_waiting_plus_ready_triggers_integrity_violation() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let signal_node = node_key!("signal");
+        let ready_node = node_key!("ready");
+
+        let mut exec_state =
+            ExecutionState::new(exec_id, wf_id, &[signal_node.clone(), ready_node.clone()]);
+        // Override both nodes — bypassing the FSM to construct the impossible-at-
+        // runtime (frontier exited leaving a Ready node unspawned) anomaly.
+        exec_state.node_states.get_mut(&signal_node).unwrap().state = NodeState::Waiting;
+        exec_state.node_states.get_mut(&ready_node).unwrap().state = NodeState::Ready;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Failed,
+            "Waiting{{None}} + Ready is stranded runnable work — must be an integrity \
+             violation, not masked as Paused"
+        );
+        assert!(
+            decision.integrity_violation.is_some(),
+            "integrity_violation must be populated: a Ready node at frontier-exit is a bug"
+        );
+    }
+
+    /// **Priority-4a guard 2: `Waiting{None} + timer Waiting{Some}` triggers integrity
+    /// violation.**
+    ///
+    /// The frontier loop only exits once `wait_heap.is_empty()`, and Phase-0b
+    /// drains every due timer wait to `Completed` before that. A timer wait
+    /// (`next_attempt_at == Some`) still present at frontier-exit therefore means
+    /// its `wait_heap` entry was lost — the same lost-entry anomaly as
+    /// `WaitingRetry`. Priority-4a MUST NOT mask it as a benign signal `Paused`.
+    ///
+    /// **Falsifiability**: drop the `Waiting && next_attempt_at.is_some()` clause
+    /// from `has_non_benign_non_terminal_node` → priority-4a fires → `decision.status
+    /// == Paused` → `!= Failed` assertion fails → RED.
+    #[test]
+    fn final_status_signal_wait_plus_timer_wait_triggers_integrity_violation() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let signal_node = node_key!("signal");
+        let timer_node = node_key!("timer");
+
+        let mut exec_state =
+            ExecutionState::new(exec_id, wf_id, &[signal_node.clone(), timer_node.clone()]);
+        // signal wait: Waiting{next_attempt_at: None}; timer wait: Waiting{Some}.
+        // A timer wait left at frontier-exit is a lost wait_heap entry (the loop
+        // only exits when wait_heap is empty).
+        exec_state.node_states.get_mut(&signal_node).unwrap().state = NodeState::Waiting;
+        {
+            let timer_ns = exec_state.node_states.get_mut(&timer_node).unwrap();
+            timer_ns.state = NodeState::Waiting;
+            timer_ns.next_attempt_at = Some(Utc::now());
+        }
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Failed,
+            "a timer Waiting{{Some}} node at frontier-exit is a lost wait_heap entry — must be \
+             an integrity violation, not masked as Paused by the co-present signal wait"
+        );
+        assert!(
+            decision.integrity_violation.is_some(),
+            "integrity_violation must be populated: a timer wait at frontier-exit is a bug"
+        );
+    }
+
+    /// **Cancel teardown cancels signal waits that are not on `wait_heap`.**
+    ///
+    /// Signal-driven waits (`next_attempt_at == None`) are intentionally not
+    /// heap-tracked, so the `wait_heap` drain in `drain_pending_to_cancelled`
+    /// never visits them. The added `node_states` scan must still transition
+    /// them `Waiting → Cancelled`, otherwise a cancel observed while a signal
+    /// wait is parked leaves the node non-terminal under a `Cancelled`
+    /// execution (a state-machine leak).
+    ///
+    /// **Falsifiability**: remove the signal-wait scan from
+    /// `drain_pending_to_cancelled` → the node stays `Waiting` → the
+    /// `== Cancelled` assertion fails → RED.
+    #[test]
+    fn drain_pending_to_cancelled_cancels_signal_waits_not_on_heap() {
+        use std::cmp::Reverse;
+        use std::collections::{BinaryHeap, VecDeque};
+
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let signal_node = node_key!("signal");
+
+        let mut exec_state =
+            ExecutionState::new(exec_id, wf_id, std::slice::from_ref(&signal_node));
+        // Signal wait: `Waiting{next_attempt_at: None}`, NOT on any heap.
+        {
+            let ns = exec_state.node_states.get_mut(&signal_node).unwrap();
+            ns.state = NodeState::Waiting;
+            ns.next_attempt_at = None;
+        }
+
+        // All heaps + ready_queue empty — the signal node is reachable only via
+        // the node_states scan, not the heap drains.
+        let mut retry_heap: BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>> = BinaryHeap::new();
+        let mut wait_heap: BinaryHeap<Reverse<(DateTime<Utc>, NodeKey)>> = BinaryHeap::new();
+        let mut ready_queue: VecDeque<NodeKey> = VecDeque::new();
+
+        drain_pending_to_cancelled(
+            &mut retry_heap,
+            &mut wait_heap,
+            &mut ready_queue,
+            &mut exec_state,
+            exec_id,
+        );
+
+        assert_eq!(
+            exec_state.node_states.get(&signal_node).unwrap().state,
+            NodeState::Cancelled,
+            "a signal Waiting{{None}} node (not on wait_heap) must be cancelled by the \
+             teardown scan"
         );
     }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -76,6 +76,19 @@ type EventBus = nebula_eventbus::EventBus<ExecutionEvent>;
 /// the workspace-standard fan-out primitive.
 pub const DEFAULT_EVENT_CHANNEL_CAPACITY: usize = 1024;
 
+/// Outcome of [`WorkflowEngine::satisfy_signal_waits`].
+///
+/// Distinguishes "nodes transitioned to `Completed`" from "nothing to do"
+/// so callers can log counts accurately without treating zero as an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum SatisfyOutcome {
+    /// `n` signal-driven `Waiting` nodes were transitioned to `Completed`.
+    Satisfied(usize),
+    /// No signal-driven `Waiting` nodes existed — execution was already
+    /// satisfied, cancelled, or never had wait nodes.
+    NothingToSatisfy,
+}
+
 /// Default execution-lease TTL.
 ///
 /// Long enough to survive a GC pause or a slow checkpoint write; short
@@ -2371,31 +2384,116 @@ impl WorkflowEngine {
     /// That structural discriminator prevents a crashed Paused execution from
     /// auto-completing its wait on reclaim (data-corruption / security class bug).
     ///
+    /// # Lease contract
+    ///
+    /// This method acquires the execution lease for the duration of the
+    /// read-modify-write cycle so that the CAS token is always fresh and
+    /// authoritative. Acquiring a lease prevents concurrent runners from
+    /// modifying the execution row between our read and our commit:
+    ///
+    /// - If the lease is held elsewhere, returns [`EngineError::Leased`] —
+    ///   the caller must defer and let the current lease holder finish.
+    /// - On success, the lease is released (best-effort) after the commit.
+    ///
     /// # Returns
     ///
-    /// The number of nodes transitioned to `Completed`. Zero means the execution
-    /// had no signal-driven waiting nodes (already satisfied, or no store configured).
+    /// [`SatisfyOutcome::Satisfied(n)`] when `n` nodes were transitioned to
+    /// `Completed`, or [`SatisfyOutcome::NothingToSatisfy`] when no
+    /// signal-driven waiting nodes exist.
     ///
     /// # Errors
     ///
+    /// - [`EngineError::Leased`] if the lease is held by another runner —
+    ///   callers should defer (redeliver) rather than treating this as a
+    ///   permanent failure.
     /// - [`EngineError::PlanningFailed`] if the execution row cannot be loaded or
     ///   its state cannot be deserialised.
-    /// - [`EngineError::CasConflict`] / [`EngineError::CheckpointFailed`] if the
-    ///   durable write is rejected (lease superseded, version mismatch).
-    pub async fn satisfy_signal_waits(
+    /// - [`EngineError::CasConflict`] if the durable write is rejected by a
+    ///   concurrent transition (version or fencing mismatch after our lease was
+    ///   released by another path — should not happen under normal flow).
+    /// - [`EngineError::CheckpointFailed`] on serialisation or store errors.
+    pub(crate) async fn satisfy_signal_waits(
         &self,
         scope: &Scope,
         execution_id: ExecutionId,
-    ) -> Result<usize, EngineError> {
+    ) -> Result<SatisfyOutcome, EngineError> {
         let Some(stores) = &self.stores else {
             // Library mode (no storage) — signal-park resume is a no-op.
-            return Ok(0);
+            return Ok(SatisfyOutcome::NothingToSatisfy);
         };
 
         let id = execution_id.to_string();
+        let holder = self.instance_id.to_string();
+
+        // Acquire the execution lease before the read-modify-write. This
+        // ensures the fencing token we commit with is the authoritative
+        // current generation — no stale token from a previous runner can
+        // slip through under concurrent lease acquisition.
+        //
+        // A live lease held elsewhere means another runner is already driving
+        // this execution. Return `Leased` so the caller defers the Resume
+        // rather than racing the CAS and potentially dropping the signal.
+        let lease_token = stores
+            .execution
+            .acquire_lease(scope, &id, &holder, self.lease_ttl)
+            .await
+            .map_err(|e| {
+                EngineError::PlanningFailed(format!(
+                    "satisfy_signal_waits: acquire lease for {execution_id}: {e}"
+                ))
+            })?;
+        let Some(lease_token) = lease_token else {
+            tracing::warn!(
+                %execution_id,
+                %holder,
+                "satisfy_signal_waits: execution lease held by another runner; \
+                 deferring Resume (will redeliver)"
+            );
+            return Err(EngineError::Leased {
+                execution_id,
+                holder,
+            });
+        };
+
+        // Lease acquired — proceed under mutual exclusion.
+        let outcome = self
+            .satisfy_signal_waits_under_lease(stores, scope, execution_id, &id, lease_token)
+            .await;
+
+        // Release the lease best-effort. The commit already wrote the new
+        // fencing generation, so a release failure leaves the lease to expire
+        // at TTL — the correct fail-safe behaviour (another runner can then
+        // re-acquire after TTL rather than being blocked indefinitely).
+        if let Err(e) = stores
+            .execution
+            .release_lease(scope, &id, lease_token)
+            .await
+        {
+            tracing::warn!(
+                %execution_id,
+                error = %e,
+                "satisfy_signal_waits: best-effort lease release failed (will expire at TTL)"
+            );
+        }
+
+        outcome
+    }
+
+    /// Inner read-modify-write under an already-held lease.
+    ///
+    /// Extracted so the lease release in `satisfy_signal_waits` is guaranteed
+    /// to run even when this inner path errors.
+    async fn satisfy_signal_waits_under_lease(
+        &self,
+        stores: &crate::store_seam::ExecutionStores,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        id: &str,
+        lease_token: nebula_storage_port::FencingToken,
+    ) -> Result<SatisfyOutcome, EngineError> {
         let record = stores
             .execution
-            .get(scope, &id)
+            .get(scope, id)
             .await
             .map_err(|e| {
                 EngineError::PlanningFailed(format!(
@@ -2409,11 +2507,6 @@ impl WorkflowEngine {
             })?;
 
         let repo_version = record.version;
-        // The fencing generation last written to the row. Before any lease is
-        // acquired the generation is 0 (the store initialises `fencing_generation`
-        // at 0 and `record.fencing` carries `None` until a lease write bumps it).
-        let current_fencing =
-            nebula_storage_port::FencingToken::from_generation(record.fencing.unwrap_or(0));
 
         let state_str = serde_json::to_string(&record.state).map_err(|e| {
             EngineError::PlanningFailed(format!(
@@ -2439,7 +2532,7 @@ impl WorkflowEngine {
             .collect();
 
         if signal_waiting_nodes.is_empty() {
-            return Ok(0);
+            return Ok(SatisfyOutcome::NothingToSatisfy);
         }
 
         let satisfied_count = signal_waiting_nodes.len();
@@ -2471,12 +2564,11 @@ impl WorkflowEngine {
         // see the nodes still `Waiting` and re-park, returning the execution
         // to `Paused` without completing the wait.
         //
-        // We use the fencing generation we read from the record (`current_fencing`).
-        // This matches the generation that was written when the row was last
-        // modified (by `park_node` via `checkpoint_node`). If another runner
-        // acquired a new lease and bumped the generation between our read and
-        // this write, the store rejects the commit as `FencedOut` — the
-        // correct outcome (the other runner now owns the execution).
+        // We use the freshly-acquired lease token — not the stale generation
+        // read from the row — so the CAS is always guarded by the
+        // authoritative current generation. A concurrent runner that acquired
+        // the lease between our read and this write would be blocked because
+        // we hold the lease here.
         let state_json =
             serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {
                 node_key: final_state_node_key(),
@@ -2485,9 +2577,9 @@ impl WorkflowEngine {
 
         let batch = nebula_storage_port::TransitionBatch::builder()
             .scope(scope.clone())
-            .execution_id(&id)
+            .execution_id(id)
             .expected_version(repo_version)
-            .fencing(current_fencing)
+            .fencing(lease_token)
             .new_state(state_json)
             .build()
             .map_err(|e| EngineError::CheckpointFailed {
@@ -2520,17 +2612,16 @@ impl WorkflowEngine {
                         node_key: node_key.clone(),
                     });
                 }
-                Ok(satisfied_count)
+                Ok(SatisfyOutcome::Satisfied(satisfied_count))
             },
             Ok(nebula_storage_port::TransitionOutcome::FencedOut) => {
-                // No lease was held at this point, so FencedOut means the
-                // execution store rejected the write on a stale token from
-                // a previous runner. Treat as a CAS conflict and let the
-                // caller abort the Resume (another runner re-drove it).
+                // We hold the lease, so FencedOut should not occur in normal
+                // flow — it would mean the store rejected our own lease token.
+                // Surface as a CAS conflict so the caller can redeliver.
                 tracing::warn!(
                     %execution_id,
-                    "satisfy_signal_waits: CAS fenced out — another runner may have \
-                     resumed this execution concurrently"
+                    "satisfy_signal_waits: CAS fenced out under our own lease — \
+                     store inconsistency or lease TTL expired during commit"
                 );
                 Err(EngineError::CasConflict {
                     execution_id,
@@ -2540,16 +2631,16 @@ impl WorkflowEngine {
                 })
             },
             Ok(nebula_storage_port::TransitionOutcome::VersionConflict { actual }) => {
-                // The row moved between our read and the write — a concurrent
-                // Resume (or cancel) beat us. Idempotency is preserved: if
-                // another Resume already satisfied the wait, the next
-                // `dispatch_resume` read will short-circuit on the new status.
+                // The row version advanced between our read and the commit —
+                // a concurrent transition (outside our lease window) beat us.
+                // Surface as a CAS conflict; the caller decides whether to
+                // redeliver or treat as already-satisfied.
                 tracing::warn!(
                     %execution_id,
                     expected_version = repo_version,
                     actual_version = actual,
-                    "satisfy_signal_waits: version conflict — concurrent Resume or \
-                     external transition; this Resume is a no-op"
+                    "satisfy_signal_waits: version conflict — concurrent transition \
+                     occurred inside our lease window"
                 );
                 Err(EngineError::CasConflict {
                     execution_id,

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -96,6 +96,16 @@ pub(crate) enum SatisfyOutcome {
     ExecutionNotResumable,
 }
 
+/// Outcome of [`WorkflowEngine::cancel_dangling_nodes`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CancelDanglingOutcome {
+    /// `n` non-terminal nodes were transitioned to `Cancelled`.
+    Cancelled(usize),
+    /// Nothing to do — the execution is not in a cancel context, or every node
+    /// is already terminal (idempotent re-delivery).
+    NothingToCancel,
+}
+
 /// Default execution-lease TTL.
 ///
 /// Long enough to survive a GC pause or a slow checkpoint write; short
@@ -2674,6 +2684,211 @@ impl WorkflowEngine {
             Err(e) => Err(EngineError::CheckpointFailed {
                 node_key: final_state_node_key(),
                 reason: format!("satisfy_signal_waits: store commit: {e}"),
+            }),
+        }
+    }
+
+    /// Durably terminalize the dangling non-terminal nodes of a cancelled,
+    /// no-live-runner execution (e.g. a signal-`Paused` execution).
+    ///
+    /// The API cancel path writes the execution status `Cancelled` and enqueues
+    /// `Cancel`; `dispatch_cancel` signals the live frontier's `CancellationToken`
+    /// so a running execution tears its nodes down via the loop teardown. But a
+    /// `Paused` (signal-wait) execution has NO live frontier — nothing tears
+    /// down its parked `Waiting` nodes — so a `Cancelled` execution is left with
+    /// non-terminal nodes (terminal-execution ⇒ all-nodes-terminal invariant
+    /// violation). This method closes that gap.
+    ///
+    /// # Lease contract
+    ///
+    /// Acquires the execution lease for the read-modify-write. A live runner
+    /// (in-process or cross-runner) holds the lease, so a held lease means a
+    /// frontier is still driving — we must NOT terminalize nodes it owns;
+    /// returns [`EngineError::Leased`] so the caller defers (the live runner's
+    /// own teardown, or B1 reclaim, completes the cancel). Only acts when the
+    /// execution is itself `Cancelled`/`Cancelling` (the cancel was durably
+    /// recorded); idempotent — a re-delivered Cancel finds all nodes terminal
+    /// and returns [`CancelDanglingOutcome::NothingToCancel`].
+    ///
+    /// # Errors
+    ///
+    /// - [`EngineError::Leased`] if the lease is held by another runner.
+    /// - [`EngineError::PlanningFailed`] if the row cannot be loaded/deserialised.
+    /// - [`EngineError::CasConflict`] / [`EngineError::CheckpointFailed`] on a
+    ///   rejected or failed durable commit.
+    pub(crate) async fn cancel_dangling_nodes(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<CancelDanglingOutcome, EngineError> {
+        let Some(stores) = &self.stores else {
+            // Library mode (no storage) — no durable row to repair.
+            return Ok(CancelDanglingOutcome::NothingToCancel);
+        };
+
+        let id = execution_id.to_string();
+        let holder = self.instance_id.to_string();
+
+        let lease_token = stores
+            .execution
+            .acquire_lease(scope, &id, &holder, self.lease_ttl)
+            .await
+            .map_err(|e| {
+                EngineError::PlanningFailed(format!(
+                    "cancel_dangling_nodes: acquire lease for {execution_id}: {e}"
+                ))
+            })?;
+        let Some(lease_token) = lease_token else {
+            tracing::warn!(
+                %execution_id,
+                %holder,
+                "cancel_dangling_nodes: execution lease held by another runner; deferring \
+                 (live frontier teardown or B1 reclaim will complete the cancel)"
+            );
+            return Err(EngineError::Leased {
+                execution_id,
+                holder,
+            });
+        };
+
+        let outcome = self
+            .cancel_dangling_nodes_under_lease(stores, scope, execution_id, &id, lease_token)
+            .await;
+
+        if let Err(e) = stores
+            .execution
+            .release_lease(scope, &id, lease_token)
+            .await
+        {
+            tracing::warn!(
+                %execution_id,
+                error = %e,
+                "cancel_dangling_nodes: best-effort lease release failed (will expire at TTL)"
+            );
+        }
+
+        outcome
+    }
+
+    /// Inner read-modify-write under an already-held lease (extracted so the
+    /// lease release in [`Self::cancel_dangling_nodes`] always runs).
+    async fn cancel_dangling_nodes_under_lease(
+        &self,
+        stores: &crate::store_seam::ExecutionStores,
+        scope: &Scope,
+        execution_id: ExecutionId,
+        id: &str,
+        lease_token: nebula_storage_port::FencingToken,
+    ) -> Result<CancelDanglingOutcome, EngineError> {
+        let record = stores
+            .execution
+            .get(scope, id)
+            .await
+            .map_err(|e| {
+                EngineError::PlanningFailed(format!(
+                    "cancel_dangling_nodes: load execution {execution_id}: {e}"
+                ))
+            })?
+            .ok_or_else(|| {
+                EngineError::PlanningFailed(format!(
+                    "cancel_dangling_nodes: execution not found: {execution_id}"
+                ))
+            })?;
+
+        let repo_version = record.version;
+        let state_str = serde_json::to_string(&record.state).map_err(|e| {
+            EngineError::PlanningFailed(format!(
+                "cancel_dangling_nodes: serialise state for {execution_id}: {e}"
+            ))
+        })?;
+        let mut exec_state: ExecutionState = serde_json::from_str(&state_str).map_err(|e| {
+            EngineError::PlanningFailed(format!(
+                "cancel_dangling_nodes: deserialise state for {execution_id}: {e}"
+            ))
+        })?;
+
+        // Only terminalize in a genuine cancel context: the cancel must already
+        // be durably recorded on the execution. A non-cancel status (e.g. a
+        // `Paused` execution that a concurrent Resume re-activated to `Running`)
+        // must be left to its live drive — we are not the owner of those nodes.
+        if !matches!(
+            exec_state.status,
+            ExecutionStatus::Cancelled | ExecutionStatus::Cancelling
+        ) {
+            return Ok(CancelDanglingOutcome::NothingToCancel);
+        }
+
+        // `Waiting → Cancelled` (and every other non-terminal `→ Cancelled`) is
+        // in the node transition table; a transition error here is a table
+        // regression, surfaced not swallowed.
+        let count = exec_state.cancel_nonterminal_nodes().map_err(|e| {
+            EngineError::PlanningFailed(format!(
+                "cancel_dangling_nodes: terminalize nodes for {execution_id}: {e}"
+            ))
+        })?;
+        if count == 0 {
+            // Idempotent: a re-delivered Cancel finds all nodes already terminal.
+            return Ok(CancelDanglingOutcome::NothingToCancel);
+        }
+
+        let state_json =
+            serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("cancel_dangling_nodes: serialise updated state: {e}"),
+            })?;
+        let batch = nebula_storage_port::TransitionBatch::builder()
+            .scope(scope.clone())
+            .execution_id(id)
+            .expected_version(repo_version)
+            .fencing(lease_token)
+            .new_state(state_json)
+            .build()
+            .map_err(|e| EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("cancel_dangling_nodes: build batch: {e}"),
+            })?;
+
+        match stores.execution.commit(batch).await {
+            Ok(nebula_storage_port::TransitionOutcome::Applied { new_version }) => {
+                tracing::info!(
+                    target = "engine::wait",
+                    %execution_id,
+                    cancelled_count = count,
+                    new_version,
+                    "cancel_dangling_nodes: terminalized parked nodes of a cancelled \
+                     no-live-runner execution"
+                );
+                Ok(CancelDanglingOutcome::Cancelled(count))
+            },
+            Ok(nebula_storage_port::TransitionOutcome::FencedOut) => {
+                tracing::warn!(
+                    %execution_id,
+                    "cancel_dangling_nodes: CAS fenced out under our own lease"
+                );
+                Err(EngineError::CasConflict {
+                    execution_id,
+                    expected_version: repo_version,
+                    observed_version: repo_version,
+                    observed_status: "fenced_out".to_owned(),
+                })
+            },
+            Ok(nebula_storage_port::TransitionOutcome::VersionConflict { actual }) => {
+                tracing::warn!(
+                    %execution_id,
+                    expected_version = repo_version,
+                    actual_version = actual,
+                    "cancel_dangling_nodes: version conflict inside our lease window"
+                );
+                Err(EngineError::CasConflict {
+                    execution_id,
+                    expected_version: repo_version,
+                    observed_version: actual,
+                    observed_status: "version_conflict".to_owned(),
+                })
+            },
+            Err(e) => Err(EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("cancel_dangling_nodes: store commit: {e}"),
             }),
         }
     }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -1058,7 +1058,7 @@ impl WorkflowEngine {
     /// a dead or backed-up subscriber surfaces as a drop in its
     /// `EventBusStats::dropped_count`, never as back-pressure on the
     /// engine itself.
-    fn emit_event(&self, event: ExecutionEvent) {
+    pub(crate) fn emit_event(&self, event: ExecutionEvent) {
         if let Some(bus) = &self.event_bus {
             let _ = bus.emit(event);
         }
@@ -2349,6 +2349,222 @@ impl WorkflowEngine {
         })
     }
 
+    /// Durably satisfy all signal-driven waits on a `Paused` execution.
+    ///
+    /// A signal-driven wait is a node in `Waiting` state with `next_attempt_at == None`
+    /// (no timer). The node was parked by a `Webhook` / `Approval` / `Execution`
+    /// `WaitCondition` and released its worker; the execution sits at `Paused` waiting
+    /// for an external Resume signal.
+    ///
+    /// This method transitions every such node `Waiting → Completed` (setting
+    /// `completed_at`) and persists the result via the spec-16 `ExecutionStore`
+    /// with a version-CAS + fencing batch — the same durability contract as
+    /// `checkpoint_node`. The CAS serialises concurrent Resume calls: a second
+    /// caller sees the nodes already `Completed` (or the execution already
+    /// `Running`) and the status short-circuit in `dispatch_resume` makes it a
+    /// no-op without re-running downstream.
+    ///
+    /// A signal-driven wait is satisfied ONLY by this method — a reclaim
+    /// re-drive (`dispatch_start`, `dispatch_restart`, worker `EngineExecutionSink`)
+    /// enters `resume_execution` without calling this method first, so it
+    /// re-parks the nodes and the execution returns to `Paused` unchanged.
+    /// That structural discriminator prevents a crashed Paused execution from
+    /// auto-completing its wait on reclaim (data-corruption / security class bug).
+    ///
+    /// # Returns
+    ///
+    /// The number of nodes transitioned to `Completed`. Zero means the execution
+    /// had no signal-driven waiting nodes (already satisfied, or no store configured).
+    ///
+    /// # Errors
+    ///
+    /// - [`EngineError::PlanningFailed`] if the execution row cannot be loaded or
+    ///   its state cannot be deserialised.
+    /// - [`EngineError::CasConflict`] / [`EngineError::CheckpointFailed`] if the
+    ///   durable write is rejected (lease superseded, version mismatch).
+    pub async fn satisfy_signal_waits(
+        &self,
+        scope: &Scope,
+        execution_id: ExecutionId,
+    ) -> Result<usize, EngineError> {
+        let Some(stores) = &self.stores else {
+            // Library mode (no storage) — signal-park resume is a no-op.
+            return Ok(0);
+        };
+
+        let id = execution_id.to_string();
+        let record = stores
+            .execution
+            .get(scope, &id)
+            .await
+            .map_err(|e| {
+                EngineError::PlanningFailed(format!(
+                    "satisfy_signal_waits: load execution {execution_id}: {e}"
+                ))
+            })?
+            .ok_or_else(|| {
+                EngineError::PlanningFailed(format!(
+                    "satisfy_signal_waits: execution not found: {execution_id}"
+                ))
+            })?;
+
+        let repo_version = record.version;
+        // The fencing generation last written to the row. Before any lease is
+        // acquired the generation is 0 (the store initialises `fencing_generation`
+        // at 0 and `record.fencing` carries `None` until a lease write bumps it).
+        let current_fencing =
+            nebula_storage_port::FencingToken::from_generation(record.fencing.unwrap_or(0));
+
+        let state_str = serde_json::to_string(&record.state).map_err(|e| {
+            EngineError::PlanningFailed(format!(
+                "satisfy_signal_waits: serialise state for {execution_id}: {e}"
+            ))
+        })?;
+        let mut exec_state: ExecutionState = serde_json::from_str(&state_str).map_err(|e| {
+            EngineError::PlanningFailed(format!(
+                "satisfy_signal_waits: deserialise state for {execution_id}: {e}"
+            ))
+        })?;
+
+        // Collect nodes that are signal-driven waits. We identify them by
+        // `state == Waiting` AND `next_attempt_at == None` (no timer wake).
+        // Timer-driven waits (`next_attempt_at == Some(_)`) are already on
+        // `wait_heap` and will be handled by Phase-0b when the frontier
+        // resumes — satisfying them here would duplicate the completion.
+        let signal_waiting_nodes: Vec<NodeKey> = exec_state
+            .node_states
+            .iter()
+            .filter(|(_, ns)| ns.state == NodeState::Waiting && ns.next_attempt_at.is_none())
+            .map(|(id, _)| id.clone())
+            .collect();
+
+        if signal_waiting_nodes.is_empty() {
+            return Ok(0);
+        }
+
+        let satisfied_count = signal_waiting_nodes.len();
+        let now = Utc::now();
+
+        for node_key in &signal_waiting_nodes {
+            // `Waiting → Completed` is in the valid transition table.
+            exec_state
+                .transition_node(node_key.clone(), NodeState::Completed)
+                .map_err(|e| {
+                    EngineError::PlanningFailed(format!(
+                        "satisfy_signal_waits: transition {node_key} Waiting→Completed: {e}"
+                    ))
+                })?;
+            // Stamp completion time on the satisfied node.
+            if let Some(ns) = exec_state.node_states.get_mut(node_key) {
+                ns.next_attempt_at = None;
+                ns.completed_at = Some(now);
+            }
+            // Events are emitted AFTER the CAS commit succeeds (see below) so
+            // that observers never see a `NodeWaitCompleted` for a transition
+            // that was rejected by a concurrent actor.
+        }
+
+        // Persist the satisfy-CAS. This is the single discriminator between
+        // a genuine Resume and a reclaim re-drive: only this code path writes
+        // the `Completed` transition before `drive` runs. A reclaim that
+        // re-enters `resume_execution` without calling this method first will
+        // see the nodes still `Waiting` and re-park, returning the execution
+        // to `Paused` without completing the wait.
+        //
+        // We use the fencing generation we read from the record (`current_fencing`).
+        // This matches the generation that was written when the row was last
+        // modified (by `park_node` via `checkpoint_node`). If another runner
+        // acquired a new lease and bumped the generation between our read and
+        // this write, the store rejects the commit as `FencedOut` — the
+        // correct outcome (the other runner now owns the execution).
+        let state_json =
+            serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("satisfy_signal_waits: serialise updated state: {e}"),
+            })?;
+
+        let batch = nebula_storage_port::TransitionBatch::builder()
+            .scope(scope.clone())
+            .execution_id(&id)
+            .expected_version(repo_version)
+            .fencing(current_fencing)
+            .new_state(state_json)
+            .build()
+            .map_err(|e| EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("satisfy_signal_waits: build batch: {e}"),
+            })?;
+
+        match stores.execution.commit(batch).await {
+            Ok(nebula_storage_port::TransitionOutcome::Applied { new_version }) => {
+                tracing::info!(
+                    target = "engine::wait",
+                    %execution_id,
+                    satisfied_count,
+                    new_version,
+                    "satisfy_signal_waits: committed — Resume will activate downstream nodes"
+                );
+                // Emit events only after the durable write succeeds.  Emitting
+                // before commit would let observers see `NodeWaitCompleted` for
+                // a transition that was later rejected by a concurrent CAS.
+                for node_key in &signal_waiting_nodes {
+                    tracing::info!(
+                        target = "engine::wait",
+                        %execution_id,
+                        %node_key,
+                        "signal-driven wait satisfied by Resume command — node transitioned \
+                         Waiting→Completed via durable CAS; downstream will activate on re-drive"
+                    );
+                    self.emit_event(ExecutionEvent::NodeWaitCompleted {
+                        execution_id,
+                        node_key: node_key.clone(),
+                    });
+                }
+                Ok(satisfied_count)
+            },
+            Ok(nebula_storage_port::TransitionOutcome::FencedOut) => {
+                // No lease was held at this point, so FencedOut means the
+                // execution store rejected the write on a stale token from
+                // a previous runner. Treat as a CAS conflict and let the
+                // caller abort the Resume (another runner re-drove it).
+                tracing::warn!(
+                    %execution_id,
+                    "satisfy_signal_waits: CAS fenced out — another runner may have \
+                     resumed this execution concurrently"
+                );
+                Err(EngineError::CasConflict {
+                    execution_id,
+                    expected_version: repo_version,
+                    observed_version: repo_version,
+                    observed_status: "fenced_out".to_owned(),
+                })
+            },
+            Ok(nebula_storage_port::TransitionOutcome::VersionConflict { actual }) => {
+                // The row moved between our read and the write — a concurrent
+                // Resume (or cancel) beat us. Idempotency is preserved: if
+                // another Resume already satisfied the wait, the next
+                // `dispatch_resume` read will short-circuit on the new status.
+                tracing::warn!(
+                    %execution_id,
+                    expected_version = repo_version,
+                    actual_version = actual,
+                    "satisfy_signal_waits: version conflict — concurrent Resume or \
+                     external transition; this Resume is a no-op"
+                );
+                Err(EngineError::CasConflict {
+                    execution_id,
+                    expected_version: repo_version,
+                    observed_version: actual,
+                    observed_status: "version_conflict".to_owned(),
+                })
+            },
+            Err(e) => Err(EngineError::CheckpointFailed {
+                node_key: final_state_node_key(),
+                reason: format!("satisfy_signal_waits: store commit: {e}"),
+            }),
+        }
+    }
+
     /// Execute all reachable nodes using a frontier-based approach.
     ///
     /// Nodes are spawned as soon as all their incoming edges have been resolved
@@ -3075,17 +3291,20 @@ impl WorkflowEngine {
                     // by `extract_primary_output` in the dispatch future, so
                     // `checkpoint_node` will commit it alongside the `Waiting`
                     // state in one atomic write. Downstream edges are NOT
-                    // activated here — they remain gated until Phase 0b
-                    // transitions this node to `Completed` when the timer
-                    // fires.
+                    // activated here — they remain gated until the wait
+                    // condition is satisfied.
                     //
-                    // W-S1 boundary conditions rejected here (both marked
-                    // `WaitConditionNotSupported`):
-                    //   1. Signal-driven conditions (Webhook/Approval/Execution):
-                    //      W-S2 will wire the Resume signal path.
-                    //   2. Timer conditions with an explicit `timeout`: the
-                    //      fail-on-timeout enforcement path is also W-S2.
-                    //      Only `timeout: None` timer waits are supported.
+                    // Conditions supported by this path:
+                    //   Timer: `Until` / `Duration` — push onto `wait_heap`;
+                    //     Phase-0b drains to `Completed` when the timer fires.
+                    //   Signal: `Webhook` / `Approval` / `Execution` (timeout:None) —
+                    //     `wake_at = None`, no heap entry; execution parks at `Paused`
+                    //     until a `Resume` command's durable satisfy-CAS completes it.
+                    //
+                    // Not yet supported — still rejected:
+                    //   Any condition with `timeout: Some(..)`: the
+                    //   timeout-as-cancellation path requires a live-frontier
+                    //   resume channel that is not yet implemented.
                     if let ActionResult::Wait {
                         ref condition,
                         timeout,
@@ -3128,40 +3347,37 @@ impl WorkflowEngine {
                         }
 
                         // Compute the timer wake instant for timer-based conditions.
-                        // Signal-driven conditions (Webhook / Approval / Execution)
-                        // require an explicit Resume signal that W-S2 will implement —
-                        // reject them with a typed error rather than parking with no
-                        // timer entry and permanently stalling the execution.
+                        // Signal-driven conditions (Webhook / Approval / Execution) park
+                        // with `wake_at = None`: they hold no timer heap entry and remain
+                        // suspended until an explicit Resume command delivers the signal.
+                        // The frontier exits with all heaps empty while those nodes are
+                        // still `Waiting{next_attempt_at == None}`; `determine_final_status`
+                        // priority-4a recognises that as `Paused`, not a frontier bug.
                         let now = Utc::now();
                         let wake_at: Option<DateTime<Utc>> = match condition {
                             WaitCondition::Until { datetime } => Some(*datetime),
                             WaitCondition::Duration { duration } => {
                                 chrono::Duration::from_std(*duration).ok().map(|d| now + d)
                             },
-                            other => {
-                                let condition_kind = match other {
-                                    WaitCondition::Webhook { .. } => "Webhook",
-                                    WaitCondition::Approval { .. } => "Approval",
-                                    WaitCondition::Execution { .. } => "Execution",
-                                    _ => "Unknown",
-                                };
-                                let runtime_err =
-                                    crate::runtime::error::RuntimeError::WaitConditionNotSupported {
-                                        condition_kind: condition_kind.to_owned(),
-                                    };
-                                let engine_err = EngineError::Runtime(runtime_err);
-                                tracing::error!(
+                            // Signal-driven conditions: no timer wake — the park is
+                            // indefinite until a Resume command's durable satisfy-CAS
+                            // transitions the node to Completed. `wake_at = None` means
+                            // the node is never pushed onto `wait_heap`.
+                            WaitCondition::Webhook { .. }
+                            | WaitCondition::Approval { .. }
+                            | WaitCondition::Execution { .. } => None,
+                            _ => {
+                                // Unknown future condition variant. Park with no timer so
+                                // the node is at least durable; a Resume will satisfy it.
+                                // Emit a warning so the operator can diagnose the gap.
+                                tracing::warn!(
                                     target = "engine::wait",
                                     %execution_id,
                                     %node_key,
-                                    condition_kind,
-                                    error = %engine_err,
-                                    "signal-driven WaitCondition not supported in W-S1; \
-                                     marking node Failed and returning error"
+                                    "unrecognised WaitCondition variant; parking with no \
+                                     timer — a Resume command is required to satisfy it"
                                 );
-                                mark_node_failed(exec_state, node_key.clone(), &engine_err);
-                                cancel_token.cancel();
-                                return Some((node_key.clone(), engine_err.to_string()));
+                                None
                             },
                         };
 
@@ -3236,10 +3452,10 @@ impl WorkflowEngine {
                                     cancel_token.cancel();
                                     return Some((node_key.clone(), e.to_string()));
                                 }
-                                // Push onto the wait_heap only for timer-driven
-                                // conditions; signal-driven conditions with no
-                                // timeout stay parked indefinitely until a
-                                // Resume arrives.
+                                // Push onto the wait_heap for timer-driven conditions only.
+                                // Signal-driven conditions (`wake_at == None`) are never
+                                // pushed here; their node stays `Waiting` until a Resume
+                                // command's durable satisfy-CAS transitions it to Completed.
                                 if let Some(when) = wake_at {
                                     wait_heap.push(Reverse((when, node_key.clone())));
                                 }
@@ -5641,6 +5857,59 @@ fn determine_final_status(
             termination_reason: Some(ExecutionTerminationReason::Cancelled),
             integrity_violation: None,
         };
+    }
+
+    // Priority 4a — at least one signal-driven `Waiting` node exists and no
+    // non-terminal node is actively in-flight (`Running` / `WaitingRetry`).
+    //
+    // A signal-driven wait has `next_attempt_at == None`; the node holds no
+    // worker and will not be driven by the timer arm. The frontier exits
+    // naturally (all heaps empty, join-set empty) with these nodes still
+    // non-terminal — which the old Priority-4 arm would falsely report as a
+    // `FrontierIntegrityViolation`. The correct status is `Paused`: the
+    // execution is durably suspended awaiting an external signal, not broken.
+    //
+    // Guards that must BOTH hold:
+    //   1. `!non_terminal_signal_waits.is_empty()` — an all-terminal run
+    //      must still fall through to Priority-5 `Completed`, never `Paused`.
+    //   2. No non-terminal node is `Running` or `WaitingRetry` — those states
+    //      indicate a genuine frontier bug, not a benign park:
+    //        - `Running`: the frontier exited while a worker was still live.
+    //        - `WaitingRetry`: the frontier exit condition requires
+    //          `retry_heap.is_empty()`; a `WaitingRetry` node present at
+    //          exit means its heap entry was lost — an anomaly that must
+    //          surface as a `FrontierIntegrityViolation`, not be masked as
+    //          `Paused`.
+    //      `Pending` and `Ready` nodes blocked behind a signal-`Waiting`
+    //      upstream are expected and safe (they will activate once the wait
+    //      is satisfied via `dispatch_resume`).
+    {
+        let non_terminal_signal_waits: Vec<NodeKey> = exec_state
+            .node_states
+            .iter()
+            .filter(|(_, ns)| !ns.state.is_terminal())
+            .filter(|(_, ns)| ns.state == NodeState::Waiting && ns.next_attempt_at.is_none())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let has_active_non_signal_node = exec_state
+            .node_states
+            .values()
+            .filter(|ns| !ns.state.is_terminal())
+            .any(|ns| matches!(ns.state, NodeState::Running | NodeState::WaitingRetry));
+        if !non_terminal_signal_waits.is_empty() && !has_active_non_signal_node {
+            tracing::info!(
+                target = "engine::final_status",
+                execution_id = %exec_state.execution_id,
+                parked_node_count = non_terminal_signal_waits.len(),
+                "final_status_decided (priority 4a: signal-driven waits present, \
+                 no in-flight nodes — execution paused awaiting external signal)"
+            );
+            return FinalStatusDecision {
+                status: ExecutionStatus::Paused,
+                termination_reason: None,
+                integrity_violation: None,
+            };
+        }
     }
 
     // Priority 4 — frontier integrity violation (frontier integrity (CAS on version)).
@@ -10684,4 +10953,212 @@ mod tests {
     // structurally impossible now that the engine has a single dispatch spine.
     // The surviving guarantee — factory dispatch is the sole execution path — is
     // covered by `workflow_node_dispatches_through_factory_path`.
+
+    // ── determine_final_status priority-4a unit tests ─────────────────────
+
+    // `determine_final_status` is a pure function — these unit tests construct
+    // the `ExecutionState` by direct field override, bypassing the FSM transition
+    // table. This is the same pattern the `final_status_*` tests above use for
+    // constructing terminal states. `park_node` requires `Running` as a
+    // precondition (the engine-level invariant), which we don't need to enforce
+    // in a pure-function test. We set `.state` and `.next_attempt_at` directly.
+
+    /// **Priority-4a: single `Waiting{next_attempt_at:None}` → `Paused`.**
+    ///
+    /// The frontier exits with one signal-driven waiting node (no timer wake).
+    /// Priority-4a must fire before priority-4 and return `Paused`, not
+    /// `Failed+FrontierIntegrityViolation`.
+    ///
+    /// **Falsifiability (red-on-revert)**: remove priority-4a (or rename it
+    /// to emit `FrontierIntegrityViolation`) → the old priority-4 fires →
+    /// `decision.status == Failed` → the `== Paused` assertion fails.
+    #[test]
+    fn final_status_signal_waiting_node_returns_paused() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let n1 = node_key!("n1");
+
+        let mut exec_state = ExecutionState::new(exec_id, wf_id, std::slice::from_ref(&n1));
+        // Direct override — `next_attempt_at` defaults to None, so only the
+        // state field needs to be set to model a signal-driven Waiting node.
+        exec_state.node_states.get_mut(&n1).unwrap().state = NodeState::Waiting;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Paused,
+            "a single signal-driven Waiting node must yield Paused, not Failed or Completed"
+        );
+        assert!(
+            decision.integrity_violation.is_none(),
+            "priority-4a must not populate integrity_violation — that is only for real bugs"
+        );
+        assert!(
+            decision.termination_reason.is_none(),
+            "Paused awaiting signal carries no engine-attributed termination reason"
+        );
+    }
+
+    /// **Priority-4a guard 1: all-terminal run must NOT become `Paused`.**
+    ///
+    /// If every node is terminal the frontier reached natural completion.
+    /// Priority-4a requires `!non_terminal_signal_waits.is_empty()`, so an
+    /// all-terminal state must fall through to priority-5 `Completed`.
+    #[test]
+    fn final_status_all_terminal_does_not_become_paused() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let n1 = node_key!("n1");
+
+        let mut exec_state = ExecutionState::new(exec_id, wf_id, std::slice::from_ref(&n1));
+        // Manually set terminal state — bypass normal transition rules so we can
+        // construct the all-terminal scenario for a pure function test.
+        exec_state.node_states.get_mut(&n1).unwrap().state = NodeState::Completed;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Completed,
+            "an all-terminal run must reach Completed, never Paused (guard 1)"
+        );
+    }
+
+    /// **Priority-4a guard 2: `Waiting{None} + Running` falls through to integrity violation.**
+    ///
+    /// One `Waiting{next_attempt_at:None}` node PLUS one `Running` node is a
+    /// mixed set that indicates a real frontier bug (the loop exited while a
+    /// node was still dispatched). Priority-4a must NOT fire — the integrity
+    /// violation arm (priority-4) must catch it.
+    ///
+    /// **Falsifiability**: remove the `has_active_non_signal_node` guard →
+    /// priority-4a fires on the mixed set → `decision.status == Paused` →
+    /// `!= Failed` assertion fails.
+    #[test]
+    fn final_status_mixed_waiting_and_running_triggers_integrity_violation() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let waiting_node = node_key!("waiting");
+        let running_node = node_key!("running");
+
+        let mut exec_state = ExecutionState::new(
+            exec_id,
+            wf_id,
+            &[waiting_node.clone(), running_node.clone()],
+        );
+        // Override both nodes — bypassing the FSM to construct the impossible-at-
+        // runtime (frontier exited with a live Running node) bug scenario.
+        exec_state.node_states.get_mut(&waiting_node).unwrap().state = NodeState::Waiting;
+        exec_state.node_states.get_mut(&running_node).unwrap().state = NodeState::Running;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Failed,
+            "a mixed Waiting+Running frontier must trigger the integrity violation (guard 2)"
+        );
+        assert!(
+            decision.integrity_violation.is_some(),
+            "integrity_violation must be populated for the mixed-frontier bug"
+        );
+    }
+
+    /// **Priority-4a guard 2: `Waiting{None} + Pending` returns `Paused`.**
+    ///
+    /// A `Pending` downstream node that hasn't been activated yet (because its
+    /// upstream dependency is parked) is NOT a frontier bug — it is the normal
+    /// blocked-downstream state. Priority-4a must fire and return `Paused`
+    /// even when `Pending` nodes are present alongside signal-driven `Waiting`
+    /// nodes.
+    ///
+    /// **Falsifiability**: revert guard-2 to the old `len == count` check →
+    /// the `Pending` node inflates `non_terminal_count` → `1 != 2` → guard-2
+    /// fails → priority-4 fires → `decision.status == Failed` → `!= Paused`
+    /// assertion fails.
+    #[test]
+    fn final_status_waiting_plus_pending_returns_paused() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let webhook_node = node_key!("webhook");
+        let downstream_node = node_key!("downstream");
+
+        let mut exec_state =
+            ExecutionState::new(exec_id, wf_id, &[webhook_node.clone(), downstream_node]);
+        // Upstream is a signal-driven Waiting node; downstream stays Pending
+        // (never activated because its upstream dependency is still waiting).
+        exec_state.node_states.get_mut(&webhook_node).unwrap().state = NodeState::Waiting;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Paused,
+            "Waiting{{None}} + Pending downstream must be Paused, not a frontier violation"
+        );
+        assert!(
+            decision.integrity_violation.is_none(),
+            "no integrity violation expected when the only non-wait nodes are Pending"
+        );
+    }
+
+    /// **Priority-4a guard 2: `Waiting{None} + WaitingRetry` triggers integrity violation.**
+    ///
+    /// A `WaitingRetry` node at frontier-exit is ANOMALOUS, not a benign park.
+    /// The frontier's exit condition requires `retry_heap.is_empty()`: a
+    /// `WaitingRetry` node present when the loop exits means its heap entry
+    /// was lost — a genuine frontier bug. Priority-4a MUST NOT mask this by
+    /// returning `Paused`; the integrity violation arm (priority-4) must catch it.
+    ///
+    /// **Falsifiability**: narrow the `has_active_non_signal_node` check to
+    /// `Running`-only (drop `WaitingRetry`) → priority-4a fires on the mixed
+    /// set → `decision.status == Paused` → `!= Failed` assertion fails → RED.
+    #[test]
+    fn final_status_waiting_plus_waiting_retry_triggers_integrity_violation() {
+        use nebula_core::id::WorkflowId;
+        use nebula_core::node_key;
+
+        let exec_id = ExecutionId::new();
+        let wf_id = WorkflowId::new();
+        let signal_node = node_key!("signal");
+        let retry_node = node_key!("retry");
+
+        let mut exec_state =
+            ExecutionState::new(exec_id, wf_id, &[signal_node.clone(), retry_node.clone()]);
+        // Override both nodes — bypassing the FSM to construct the impossible-at-
+        // runtime (retry_heap lost its entry) anomaly scenario.
+        exec_state.node_states.get_mut(&signal_node).unwrap().state = NodeState::Waiting;
+        exec_state.node_states.get_mut(&retry_node).unwrap().state = NodeState::WaitingRetry;
+
+        let cancel_token = CancellationToken::new();
+        let decision = determine_final_status(&None, &cancel_token, &exec_state);
+
+        assert_eq!(
+            decision.status,
+            ExecutionStatus::Failed,
+            "Waiting{{None}} + WaitingRetry is a lost heap-entry anomaly — must be an \
+             integrity violation, not masked as Paused"
+        );
+        assert!(
+            decision.integrity_violation.is_some(),
+            "integrity_violation must be populated: WaitingRetry at frontier-exit is a bug"
+        );
+    }
 }

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -87,6 +87,11 @@ pub(crate) enum SatisfyOutcome {
     /// No signal-driven `Waiting` nodes existed — execution was already
     /// satisfied, cancelled, or never had wait nodes.
     NothingToSatisfy,
+    /// The execution left the `Paused` state (terminal or `Cancelling`) between
+    /// the caller's pre-lease status read and the under-lease reload — a
+    /// concurrent Cancel/Terminate won the race. No nodes were touched; the
+    /// Resume is moot and the caller should ack it without driving.
+    ExecutionNotResumable,
 }
 
 /// Default execution-lease TTL.
@@ -2518,6 +2523,24 @@ impl WorkflowEngine {
                 "satisfy_signal_waits: deserialise state for {execution_id}: {e}"
             ))
         })?;
+
+        // Re-check the execution status under the lease before satisfying any
+        // node. `dispatch_resume` read `Paused` BEFORE acquiring the lease; a
+        // concurrent Cancel/Terminate may have committed a terminal (or
+        // `Cancelling`) status in that window. The per-node `Waiting → Completed`
+        // CAS below guards only the node version, not the execution status, so
+        // without this gate we would flip — and durably commit — a wait node on
+        // an already-cancelled execution, corrupting its terminal audit state.
+        // Treat it as an idempotent no-op; the caller acks the Resume.
+        if exec_state.status.is_terminal() || exec_state.status == ExecutionStatus::Cancelling {
+            tracing::info!(
+                %execution_id,
+                status = %exec_state.status,
+                "satisfy_signal_waits: execution left Paused before the under-lease reload \
+                 (concurrent cancel/terminate); skipping satisfy as idempotent no-op"
+            );
+            return Ok(SatisfyOutcome::ExecutionNotResumable);
+        }
 
         // Collect nodes that are signal-driven waits. We identify them by
         // `state == Waiting` AND `next_attempt_at == None` (no timer wake).

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2856,6 +2856,22 @@ impl WorkflowEngine {
             ))
         })?;
 
+        // If the execution was mid-cancel (`Cancelling`), finalize it to the
+        // terminal `Cancelled` in the SAME commit as the node cleanup —
+        // otherwise a no-live-runner repair would ack while the execution stayed
+        // non-terminal `Cancelling` forever (`Cancelling → Cancelled` is in the
+        // execution transition table).
+        if exec_state.status == ExecutionStatus::Cancelling {
+            exec_state
+                .transition_status(ExecutionStatus::Cancelled)
+                .map_err(|e| {
+                    EngineError::PlanningFailed(format!(
+                        "cancel_dangling_nodes: finalize Cancelling→Cancelled for \
+                         {execution_id}: {e}"
+                    ))
+                })?;
+        }
+
         let state_json =
             serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {
                 node_key: final_state_node_key(),
@@ -3722,7 +3738,45 @@ impl WorkflowEngine {
                         let wake_at: Option<DateTime<Utc>> = match condition {
                             WaitCondition::Until { datetime } => Some(*datetime),
                             WaitCondition::Duration { duration } => {
-                                chrono::Duration::from_std(*duration).ok().map(|d| now + d)
+                                // FAIL CLOSED on an unrepresentable / overflowing timer
+                                // Duration. Mapping the error to `None` would silently
+                                // turn a TIMER wait into a signal-driven indefinite park
+                                // that a generic `Resume` could satisfy — wrong semantics.
+                                let fail_unschedulable =
+                                    |exec_state: &mut ExecutionState, reason: String| {
+                                        let engine_err = EngineError::Runtime(
+                                            crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                                condition_kind: reason,
+                                            },
+                                        );
+                                        tracing::error!(
+                                            target = "engine::wait",
+                                            %execution_id,
+                                            %node_key,
+                                            error = %engine_err,
+                                            "Duration WaitCondition cannot be scheduled; marking \
+                                             node Failed (fail-closed)"
+                                        );
+                                        mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                                        cancel_token.cancel();
+                                        engine_err.to_string()
+                                    };
+                                let Ok(chrono_dur) = chrono::Duration::from_std(*duration) else {
+                                    let msg = fail_unschedulable(
+                                        exec_state,
+                                        format!("Duration wait not representable: {duration:?}"),
+                                    );
+                                    return Some((node_key.clone(), msg));
+                                };
+                                let Some(when) = now.checked_add_signed(chrono_dur) else {
+                                    let msg = fail_unschedulable(
+                                        exec_state,
+                                        "Duration wait overflows the scheduler timestamp"
+                                            .to_owned(),
+                                    );
+                                    return Some((node_key.clone(), msg));
+                                };
+                                Some(when)
                             },
                             // Signal-driven conditions: no timer wake — the park is
                             // indefinite until a Resume command's durable satisfy-CAS
@@ -5630,28 +5684,30 @@ fn drain_pending_to_cancelled(
             "Waiting → Cancelled (cancel observed while parked)"
         );
     }
-    // Signal-driven waits (`next_attempt_at == None`) are intentionally NOT on
-    // `wait_heap`, so the heap drain above never visits them. Scan `node_states`
-    // for any node still `Waiting` and cancel it too — otherwise a cancel
-    // observed while a signal wait is parked would leave the node non-terminal
-    // under a `Cancelled` execution (a state-machine leak). Timer waits already
-    // cancelled by the heap drain are skipped (no longer `Waiting`).
-    let stranded_signal_waits: Vec<NodeKey> = exec_state
+    // Signal-driven waits (`next_attempt_at == None`) AND their blocked
+    // downstream `Pending` nodes are intentionally NOT represented in the timer
+    // heaps or the ready_queue, so the drains above never visit them. Scan
+    // `node_states` for ANY remaining non-terminal node and cancel it —
+    // otherwise a cancel observed while a signal wait is parked would leave the
+    // wait node and/or its blocked downstream non-terminal under a `Cancelled`
+    // execution (a state-machine leak). Nodes already cancelled above (heaps /
+    // ready_queue) are terminal and skipped.
+    let stranded_non_terminal: Vec<NodeKey> = exec_state
         .node_states
         .iter()
-        .filter(|(_, ns)| ns.state == NodeState::Waiting)
+        .filter(|(_, ns)| !ns.state.is_terminal())
         .map(|(id, _)| id.clone())
         .collect();
-    for waiting in stranded_signal_waits {
-        let _ = exec_state.transition_node(waiting.clone(), NodeState::Cancelled);
-        if let Some(ns) = exec_state.node_states.get_mut(&waiting) {
+    for node_key in stranded_non_terminal {
+        let _ = exec_state.transition_node(node_key.clone(), NodeState::Cancelled);
+        if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
             ns.next_attempt_at = None;
         }
         tracing::debug!(
             target = "engine::wait",
             %execution_id,
-            node_key = %waiting,
-            "signal Waiting → Cancelled (cancel observed while parked; not on wait_heap)"
+            %node_key,
+            "stranded non-terminal node → Cancelled (cancel teardown; not on heap/queue)"
         );
     }
     while let Some(queued) = ready_queue.pop_front() {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -101,9 +101,16 @@ pub(crate) enum SatisfyOutcome {
 pub(crate) enum CancelDanglingOutcome {
     /// `n` non-terminal nodes were transitioned to `Cancelled`.
     Cancelled(usize),
-    /// Nothing to do — the execution is not in a cancel context, or every node
-    /// is already terminal (idempotent re-delivery).
+    /// Nothing to do — every node is already terminal (idempotent re-delivery),
+    /// or the execution reached a non-cancel terminal outcome before the cancel
+    /// landed. The caller may ack.
     NothingToCancel,
+    /// The cancel is NOT yet durably recorded on the execution (status is still
+    /// non-terminal and not `Cancelling`). The API writes `Cancelled` before
+    /// enqueuing `Cancel`, so this is a producer-ordering anomaly — the caller
+    /// must DEFER (not ack), so B1 reclaim redelivers until the status reflects
+    /// the cancel and the node cleanup can run, rather than silently dropping it.
+    StatusNotCancelled,
 }
 
 /// Default execution-lease TTL.
@@ -2807,29 +2814,47 @@ impl WorkflowEngine {
             ))
         })?;
 
-        // Only terminalize in a genuine cancel context: the cancel must already
-        // be durably recorded on the execution. A non-cancel status (e.g. a
-        // `Paused` execution that a concurrent Resume re-activated to `Running`)
-        // must be left to its live drive — we are not the owner of those nodes.
+        // Nothing to clean: every node is already terminal — idempotent
+        // re-delivery, OR a `Created` cold-start execution (empty `node_states`,
+        // vacuously all-terminal) that a cross-runner / early Cancel reached
+        // before any node was parked. Ack; there are no dangling nodes to
+        // terminalize regardless of status.
+        if exec_state.all_nodes_terminal() {
+            return Ok(CancelDanglingOutcome::NothingToCancel);
+        }
+
+        // Dangling non-terminal nodes exist. Act only in a genuine cancel
+        // context — three cases on the persisted status (read under the lease):
+        //   - `Cancelled` / `Cancelling`: the cancel is durably recorded —
+        //     proceed to terminalize the parked nodes (below).
+        //   - any OTHER terminal status (`Completed` / `Failed` / `TimedOut`):
+        //     the execution finished on a non-cancel path — anomalous with
+        //     dangling nodes, but the run is over; ack.
+        //   - a non-terminal, non-`Cancelling` status (`Paused` / `Running`):
+        //     the cancel is NOT yet durably recorded. The API writes `Cancelled`
+        //     before enqueuing `Cancel`, so a `Cancel` reaching here with parked
+        //     nodes but no recorded cancel is a transient producer-ordering
+        //     window — DEFER (not ack-and-silently-drop) so B1 reclaim
+        //     redelivers until the status reflects the cancel.
         if !matches!(
             exec_state.status,
             ExecutionStatus::Cancelled | ExecutionStatus::Cancelling
         ) {
-            return Ok(CancelDanglingOutcome::NothingToCancel);
+            if exec_state.status.is_terminal() {
+                return Ok(CancelDanglingOutcome::NothingToCancel);
+            }
+            return Ok(CancelDanglingOutcome::StatusNotCancelled);
         }
 
         // `Waiting → Cancelled` (and every other non-terminal `→ Cancelled`) is
         // in the node transition table; a transition error here is a table
-        // regression, surfaced not swallowed.
+        // regression, surfaced not swallowed. `count > 0` (the all-terminal
+        // early-return above ruled out zero).
         let count = exec_state.cancel_nonterminal_nodes().map_err(|e| {
             EngineError::PlanningFailed(format!(
                 "cancel_dangling_nodes: terminalize nodes for {execution_id}: {e}"
             ))
         })?;
-        if count == 0 {
-            // Idempotent: a re-delivered Cancel finds all nodes already terminal.
-            return Ok(CancelDanglingOutcome::NothingToCancel);
-        }
 
         let state_json =
             serde_json::to_value(&exec_state).map_err(|e| EngineError::CheckpointFailed {

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2374,20 +2374,29 @@ impl WorkflowEngine {
     /// `WaitCondition` and released its worker; the execution sits at `Paused` waiting
     /// for an external Resume signal.
     ///
-    /// This method transitions every such node `Waiting → Completed` (setting
-    /// `completed_at`) and persists the result via the spec-16 `ExecutionStore`
-    /// with a version-CAS + fencing batch — the same durability contract as
-    /// `checkpoint_node`. The CAS serialises concurrent Resume calls: a second
-    /// caller sees the nodes already `Completed` (or the execution already
-    /// `Running`) and the status short-circuit in `dispatch_resume` makes it a
-    /// no-op without re-running downstream.
+    /// This method *arms* every such node for completion by setting its
+    /// `next_attempt_at = now` while LEAVING it `Waiting`, persisted via the
+    /// spec-16 `ExecutionStore` with a version-CAS + fencing batch (the same
+    /// durability contract as `checkpoint_node`). The subsequent `drive`
+    /// re-seeds the armed node into the frontier `wait_heap` and Phase-0b
+    /// transitions it `Waiting → Completed` and activates its downstream edges
+    /// through the **port-aware** `process_outgoing_edges` — exactly the path a
+    /// timer wait takes. Completing the node here instead would route its edges
+    /// through `resume_execution`'s port-blind rebuild, which activates *every*
+    /// outgoing edge (so a multi-port wait would fire its `error`/custom branch
+    /// on a normal Resume). The CAS serialises concurrent Resume calls: a
+    /// second caller sees the node already armed (`next_attempt_at == Some`) or
+    /// `Completed` and returns `NothingToSatisfy`, and the status short-circuit
+    /// in `dispatch_resume` makes a post-completion duplicate a no-op.
     ///
-    /// A signal-driven wait is satisfied ONLY by this method — a reclaim
+    /// A signal-driven wait is satisfied ONLY by this method — it is the sole
+    /// writer of `next_attempt_at` on a signal-`Waiting{None}` node. A reclaim
     /// re-drive (`dispatch_start`, `dispatch_restart`, worker `EngineExecutionSink`)
-    /// enters `resume_execution` without calling this method first, so it
-    /// re-parks the nodes and the execution returns to `Paused` unchanged.
-    /// That structural discriminator prevents a crashed Paused execution from
-    /// auto-completing its wait on reclaim (data-corruption / security class bug).
+    /// enters `resume_execution` without calling this method first, so the node
+    /// stays `Waiting{next_attempt_at == None}`, is never wait-heap-seeded, and
+    /// the execution returns to `Paused` unchanged. That structural
+    /// discriminator prevents a crashed Paused execution from auto-completing
+    /// its wait on reclaim (data-corruption / security class bug).
     ///
     /// # Lease contract
     ///
@@ -2402,9 +2411,9 @@ impl WorkflowEngine {
     ///
     /// # Returns
     ///
-    /// [`SatisfyOutcome::Satisfied(n)`] when `n` nodes were transitioned to
-    /// `Completed`, or [`SatisfyOutcome::NothingToSatisfy`] when no
-    /// signal-driven waiting nodes exist.
+    /// [`SatisfyOutcome::Satisfied(n)`] when `n` signal-driven waiting nodes
+    /// were armed for completion, or [`SatisfyOutcome::NothingToSatisfy`] when
+    /// none exist.
     ///
     /// # Errors
     ///
@@ -2562,30 +2571,28 @@ impl WorkflowEngine {
         let now = Utc::now();
 
         for node_key in &signal_waiting_nodes {
-            // `Waiting → Completed` is in the valid transition table.
-            exec_state
-                .transition_node(node_key.clone(), NodeState::Completed)
-                .map_err(|e| {
-                    EngineError::PlanningFailed(format!(
-                        "satisfy_signal_waits: transition {node_key} Waiting→Completed: {e}"
-                    ))
-                })?;
-            // Stamp completion time on the satisfied node.
+            // Arm the node for Phase-0b completion: set the wake instant to
+            // `now` and LEAVE the node `Waiting`. The subsequent `drive`
+            // re-seeds it into the frontier `wait_heap` (its `next_attempt_at`
+            // is now `Some`) and Phase-0b transitions it `Waiting → Completed`
+            // and activates downstream through the PORT-AWARE
+            // `process_outgoing_edges` — the same path a timer wait takes.
+            // Transitioning to `Completed` HERE would instead route the node's
+            // edges through `resume_execution`'s port-blind rebuild, which
+            // activates every outgoing edge (a multi-port wait would fire its
+            // `error`/custom branch on a normal Resume).
             if let Some(ns) = exec_state.node_states.get_mut(node_key) {
-                ns.next_attempt_at = None;
-                ns.completed_at = Some(now);
+                ns.next_attempt_at = Some(now);
             }
-            // Events are emitted AFTER the CAS commit succeeds (see below) so
-            // that observers never see a `NodeWaitCompleted` for a transition
-            // that was rejected by a concurrent actor.
         }
 
         // Persist the satisfy-CAS. This is the single discriminator between
-        // a genuine Resume and a reclaim re-drive: only this code path writes
-        // the `Completed` transition before `drive` runs. A reclaim that
-        // re-enters `resume_execution` without calling this method first will
-        // see the nodes still `Waiting` and re-park, returning the execution
-        // to `Paused` without completing the wait.
+        // a genuine Resume and a reclaim re-drive: only this code path arms
+        // `next_attempt_at` on a signal-`Waiting{None}` node before `drive`
+        // runs. A reclaim that re-enters `resume_execution` without calling
+        // this method first sees the node still `Waiting{next_attempt_at ==
+        // None}`, never wait-heap-seeds it, and re-parks — returning the
+        // execution to `Paused` without completing the wait.
         //
         // We use the freshly-acquired lease token — not the stale generation
         // read from the row — so the CAS is always guarded by the
@@ -2617,24 +2624,14 @@ impl WorkflowEngine {
                     %execution_id,
                     satisfied_count,
                     new_version,
-                    "satisfy_signal_waits: committed — Resume will activate downstream nodes"
+                    "satisfy_signal_waits: armed signal waits for Phase-0b completion — \
+                     drive will complete them and activate downstream on the main port"
                 );
-                // Emit events only after the durable write succeeds.  Emitting
-                // before commit would let observers see `NodeWaitCompleted` for
-                // a transition that was later rejected by a concurrent CAS.
-                for node_key in &signal_waiting_nodes {
-                    tracing::info!(
-                        target = "engine::wait",
-                        %execution_id,
-                        %node_key,
-                        "signal-driven wait satisfied by Resume command — node transitioned \
-                         Waiting→Completed via durable CAS; downstream will activate on re-drive"
-                    );
-                    self.emit_event(ExecutionEvent::NodeWaitCompleted {
-                        execution_id,
-                        node_key: node_key.clone(),
-                    });
-                }
+                // No `NodeWaitCompleted` is emitted here: the node is still
+                // `Waiting`. Phase-0b emits that event when it transitions the
+                // node `Waiting → Completed` (the single completion site shared
+                // with timer waits), so observers never see a completion for a
+                // node that is not yet durably `Completed`.
                 Ok(SatisfyOutcome::Satisfied(satisfied_count))
             },
             Ok(nebula_storage_port::TransitionOutcome::FencedOut) => {

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -166,16 +166,23 @@ pub enum ExecutionEvent {
         termination_reason: Option<ExecutionTerminationReason>,
     },
 
-    /// A `dispatch_resume` command's durable `satisfy_signal_waits` step could
-    /// not land — the execution lease was held by another runner, or the CAS was
-    /// rejected by a concurrent actor (version conflict or fencing rejection) —
-    /// so the signal-driven wait nodes were not armed for completion.
+    /// A `dispatch_resume` command could not durably complete and is being
+    /// redelivered (NOT dropped). Emitted on two paths, both leaving the
+    /// control-queue row unacked for at-least-once (B1 reclaim) redelivery:
     ///
-    /// The Resume is NOT dropped: the control-queue row is left unacked so
-    /// at-least-once redelivery (B1 reclaim) retries it once the competing actor
-    /// releases the lease. If that actor was a reclaim re-drive it re-parks
-    /// (leaving the wait for the redelivered Resume to arm); if it was a genuine
-    /// concurrent Resume that already armed the wait, the redelivery is a no-op.
+    /// 1. **Satisfy did not arm** — `satisfy_signal_waits` could not land
+    ///    (the execution lease was held by another runner, or the CAS was
+    ///    rejected by a concurrent actor): the signal waits were NOT armed.
+    /// 2. **Armed, but the drive deferred** — `satisfy_signal_waits` DID
+    ///    durably arm the wait (`next_attempt_at = Some`), but the follow-up
+    ///    `drive_armed_resume` could not acquire the lease (e.g. a
+    ///    crashed/stalled holder whose TTL has not expired) or hit a CAS
+    ///    conflict, so the armed wait is not yet completed.
+    ///
+    /// In both cases the redelivery converges: a reclaim re-drive re-parks an
+    /// un-armed wait (the redelivered Resume re-arms it); an already-armed wait
+    /// is completed by the next drive once the lease frees; a wait already
+    /// completed makes the redelivery a no-op via the status short-circuit.
     ///
     /// # Observability
     ///

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -166,6 +166,29 @@ pub enum ExecutionEvent {
         termination_reason: Option<ExecutionTerminationReason>,
     },
 
+    /// A `dispatch_resume` command's durable `satisfy_signal_waits` CAS was
+    /// rejected by a concurrent actor (version conflict or fencing rejection)
+    /// before the signal-driven wait nodes could be transitioned to `Completed`.
+    ///
+    /// The Resume is treated as a no-op at-least-once semantics: the competing
+    /// actor owns the execution, so this Resume is deferred/dropped safely.
+    /// At-least-once redelivery will retry if the competing actor was a reclaim
+    /// re-drive (re-parks rather than completing); a genuine concurrent Resume
+    /// makes this event vacuous.
+    ///
+    /// # Observability
+    ///
+    /// A `tracing::warn!` fires on the same code path immediately before this
+    /// event is bus-emitted. Together they allow operators to distinguish a
+    /// transient CAS race (expected; low rate) from a systematic drop (unexpected;
+    /// high rate suggests a lease or routing bug).
+    ResumeDeferred {
+        /// Execution whose Resume was deferred due to a CAS conflict.
+        execution_id: ExecutionId,
+        /// Human-readable reason from the `EngineError` that caused the deferral.
+        reason: String,
+    },
+
     /// A scoped resource's `Resource::destroy` future overran its
     /// configured cleanup budget (default
     /// [`crate::scoped_resources::DEFAULT_CLEANUP_TIMEOUT`]).

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -166,15 +166,16 @@ pub enum ExecutionEvent {
         termination_reason: Option<ExecutionTerminationReason>,
     },
 
-    /// A `dispatch_resume` command's durable `satisfy_signal_waits` CAS was
-    /// rejected by a concurrent actor (version conflict or fencing rejection)
-    /// before the signal-driven wait nodes could be transitioned to `Completed`.
+    /// A `dispatch_resume` command's durable `satisfy_signal_waits` step could
+    /// not land — the execution lease was held by another runner, or the CAS was
+    /// rejected by a concurrent actor (version conflict or fencing rejection) —
+    /// so the signal-driven wait nodes were not armed for completion.
     ///
-    /// The Resume is treated as a no-op at-least-once semantics: the competing
-    /// actor owns the execution, so this Resume is deferred/dropped safely.
-    /// At-least-once redelivery will retry if the competing actor was a reclaim
-    /// re-drive (re-parks rather than completing); a genuine concurrent Resume
-    /// makes this event vacuous.
+    /// The Resume is NOT dropped: the control-queue row is left unacked so
+    /// at-least-once redelivery (B1 reclaim) retries it once the competing actor
+    /// releases the lease. If that actor was a reclaim re-drive it re-parks
+    /// (leaving the wait for the redelivered Resume to arm); if it was a genuine
+    /// concurrent Resume that already armed the wait, the redelivery is a no-op.
     ///
     /// # Observability
     ///

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -2694,13 +2694,22 @@ async fn dispatch_cancel_defers_when_cancel_not_yet_recorded() {
     );
 }
 
-/// **Lease contention — `dispatch_cancel` DEFERS when the execution lease is
-/// held** (cancel-vs-resume / cross-runner serialization): with the lease held
-/// externally, `cancel_dangling_nodes` returns `Leased`; `dispatch_cancel` must
-/// `Deferred` (B1 reclaim) and mutate no node state. Releasing the lease and
-/// redelivering then terminalizes the parked nodes.
+/// **Lease held by a live owner — `dispatch_cancel` ACKS (does not churn) and
+/// the owner cleans up; once the lease frees, a Cancel terminalizes the parked
+/// nodes.** A held lease (acquire fails ⇒ TTL not expired) means a live runner
+/// owns the execution: it observes the durable `Cancelled` status via its next
+/// checkpoint CAS and tears its own frontier down. `dispatch_cancel` must ACK
+/// rather than Defer — there is no targeted cross-runner cancel delivery, so
+/// deferring would only churn the row through budget-capped reclaim and mark it
+/// failed without reaching the owner. A genuinely no-live-runner Paused
+/// execution has a FREE lease, so `cancel_dangling_nodes` acquires it and
+/// terminalizes (proven by the second half + by
+/// `cancel_of_paused_signal_execution_terminalizes_parked_nodes`).
+///
+/// **Falsifiability**: revert the `Leased` arm to `Deferred` → the held-lease
+/// `dispatch_cancel` returns `Err(Deferred)` → the `Ok` assertion fails → RED.
 #[tokio::test]
-async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
+async fn dispatch_cancel_acks_when_lease_held_then_terminalizes_once_free() {
     let harness = SignalHarness::new().await;
     let workflow_id = harness.persist_signal_workflow().await;
     let execution_id = harness.persist_created_execution(workflow_id).await;
@@ -2716,27 +2725,30 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
         .force_status(execution_id, ExecutionStatus::Cancelled)
         .await;
 
-    // A concurrent runner holds the execution lease.
+    // A live owner holds the execution lease.
     let blocker = harness
         .stores
         .execution
         .acquire_lease(
             &scope,
             &execution_id.to_string(),
-            "foreign-runner",
+            "live-owner-runner",
             Duration::from_secs(30),
         )
         .await
         .unwrap()
         .expect("lease must be free before the contention test");
 
-    let result = harness.dispatch.dispatch_cancel(&scope, execution_id).await;
-    assert!(
-        matches!(result, Err(ControlDispatchError::Deferred(_))),
-        "dispatch_cancel must Defer when the execution lease is held; got {result:?}"
-    );
+    // dispatch_cancel must ACK (the live owner handles its own teardown), NOT
+    // churn the row through reclaim.
+    harness
+        .dispatch
+        .dispatch_cancel(&scope, execution_id)
+        .await
+        .expect("dispatch_cancel must ACK when a live owner holds the lease (no reclaim churn)");
 
-    // Nodes not yet terminalized (cleanup deferred).
+    // This dispatcher did not touch node state (the owner owns cleanup) — the
+    // wait node is still Waiting from its perspective.
     let record = harness
         .stores
         .execution
@@ -2748,10 +2760,11 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
         serde_json::from_str(&serde_json::to_string(&record.state).unwrap()).unwrap();
     assert!(
         state.node_states.values().any(|ns| ns.state.is_waiting()),
-        "the parked node must still be Waiting while the cleanup is deferred"
+        "the non-owner dispatcher must not have mutated node state while the owner holds the lease"
     );
 
-    // Release the lease and redeliver → cleanup completes.
+    // Once the lease frees (the owner is gone / done), a Cancel terminalizes the
+    // parked nodes via the lease-free `cancel_dangling_nodes` path.
     harness
         .stores
         .execution
@@ -2762,7 +2775,7 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
         .dispatch
         .dispatch_cancel(&scope, execution_id)
         .await
-        .expect("redelivered dispatch_cancel must complete the node cleanup");
+        .expect("dispatch_cancel must terminalize the parked nodes once the lease is free");
 
     let record2 = harness
         .stores
@@ -2775,7 +2788,7 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
         serde_json::from_str(&serde_json::to_string(&record2.state).unwrap()).unwrap();
     assert!(
         state2.node_states.values().all(|ns| ns.state.is_terminal()),
-        "after the lease frees and the Cancel redelivers, every node must be terminal"
+        "once the lease is free, the Cancel must terminalize every node"
     );
 }
 

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -384,6 +384,52 @@ impl SignalHarness {
             .expect("execution row must exist when reading status");
         serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
     }
+
+    /// Force the persisted execution status to `Cancelled`, mirroring how the
+    /// API `cancel_execution` handler writes the terminal status (a raw-JSON
+    /// `status` write committed under a fencing token) before the `Cancel`
+    /// control command is drained. The node states are left untouched — exactly
+    /// the state the engine's `cancel_dangling_nodes` must repair.
+    async fn force_cancelled(&self, execution_id: ExecutionId) {
+        let scope = nebula_engine::store_seam::single_tenant_scope();
+        let id = execution_id.to_string();
+        let token = self
+            .stores
+            .execution
+            .acquire_lease(&scope, &id, "test-api-cancel", Duration::from_secs(30))
+            .await
+            .unwrap()
+            .expect("lease must be free for the simulated API cancel write");
+        let record = self
+            .stores
+            .execution
+            .get(&scope, &id)
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        let mut state = record.state;
+        state.as_object_mut().unwrap().insert(
+            "status".to_owned(),
+            serde_json::json!(ExecutionStatus::Cancelled.to_string()),
+        );
+        let batch = TransitionBatch::builder()
+            .scope(scope.clone())
+            .execution_id(&id)
+            .expected_version(record.version)
+            .fencing(token)
+            .new_state(state)
+            .build()
+            .unwrap();
+        assert!(matches!(
+            self.stores.execution.commit(batch).await.unwrap(),
+            TransitionOutcome::Applied { .. }
+        ));
+        self.stores
+            .execution
+            .release_lease(&scope, &id, token)
+            .await
+            .unwrap();
+    }
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -2525,5 +2571,80 @@ async fn signal_park_persists_paused_atomically_no_running_waiting_window() {
             .any(|(status, waiting)| status == "running" && *waiting),
         "SHIP-C: no durable commit may pair status=running with a signal-Waiting{{None}} node \
          (that would be the unrecoverable crash window); commits = {commits:?}"
+    );
+}
+
+/// **P1 — cancelling a no-live-runner `Paused` execution terminalizes its parked
+/// nodes** (regression guard for the Codex P1 on commit `f8bce5c3`):
+///
+/// A signal-`Paused` execution has no live frontier. The API cancel path writes
+/// `status = Cancelled` but cannot terminalize the engine-owned node states;
+/// `dispatch_cancel`'s `cancel_execution` signal returns false (no live runner),
+/// so the in-loop teardown never runs. Without the engine's `cancel_dangling_nodes`
+/// the `Cancelled` execution would keep a non-terminal `Waiting` node — a
+/// terminal-execution ⇒ all-nodes-terminal invariant violation.
+///
+/// Test mechanics: park a signal node (`Paused`), simulate the API's `Cancelled`
+/// status write (`force_cancelled`), then drain `Cancel` via `dispatch_cancel`.
+/// Assert every node is terminal (`Cancelled`), not left `Waiting`.
+///
+/// **Falsifiability**: drop the `cancel_dangling_nodes` call from `dispatch_cancel`
+/// → the parked `Waiting` node stays non-terminal → the all-terminal assertion
+/// fails → RED.
+#[tokio::test]
+async fn cancel_of_paused_signal_execution_terminalizes_parked_nodes() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    // Park the signal node → execution Paused, no live runner.
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    // The API cancel path writes the terminal status (but not the node states).
+    harness.force_cancelled(execution_id).await;
+
+    // Drain the Cancel command. No live runner → engine terminalizes the parked
+    // nodes under the lease.
+    harness
+        .dispatch
+        .dispatch_cancel(&scope, execution_id)
+        .await
+        .expect("dispatch_cancel must succeed (no live runner; durable node cleanup)");
+
+    // Every node must be terminal — no dangling `Waiting` under a `Cancelled` execution.
+    let record = harness
+        .stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .expect("execution row must exist");
+    let state_str = serde_json::to_string(&record.state).unwrap();
+    let state: ExecutionState = serde_json::from_str(&state_str).unwrap();
+    let non_terminal: Vec<String> = state
+        .node_states
+        .iter()
+        .filter(|(_, ns)| !ns.state.is_terminal())
+        .map(|(k, ns)| format!("{k}={}", ns.state))
+        .collect();
+    assert!(
+        non_terminal.is_empty(),
+        "a cancelled no-live-runner execution must have NO non-terminal nodes; found: {non_terminal:?}"
+    );
+    assert!(
+        state
+            .node_states
+            .values()
+            .any(|ns| ns.state.to_string() == "cancelled"),
+        "the parked signal node must have been transitioned to Cancelled"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -2648,3 +2648,129 @@ async fn cancel_of_paused_signal_execution_terminalizes_parked_nodes() {
         "the parked signal node must have been transitioned to Cancelled"
     );
 }
+
+/// **C1 — `dispatch_cancel` DEFERS (does not silently ack) when the cancel is
+/// not yet durably recorded** (concurrency-hardening for the cancel-of-paused
+/// fix): the API writes `status = Cancelled` BEFORE enqueuing `Cancel`, so by
+/// drain time the status is `Cancelled`. If a producer-ordering regression ever
+/// delivered the `Cancel` while the execution were still `Paused`,
+/// `cancel_dangling_nodes` must return `StatusNotCancelled` and `dispatch_cancel`
+/// must `Deferred` (so B1 reclaim redelivers) rather than ack-and-drop the node
+/// cleanup.
+///
+/// **Falsifiability**: make `cancel_dangling_nodes` return `NothingToCancel`
+/// (ack) for a non-terminal non-cancel status → `dispatch_cancel` returns `Ok`
+/// → the `Deferred` assertion fails → RED.
+#[tokio::test]
+async fn dispatch_cancel_defers_when_cancel_not_yet_recorded() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    // NOTE: deliberately do NOT call `force_cancelled` — the status is still
+    // `Paused` (the cancel has not been durably recorded).
+    let result = harness.dispatch.dispatch_cancel(&scope, execution_id).await;
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "dispatch_cancel must Defer when the cancel is not yet durably recorded; got {result:?}"
+    );
+    // No node cleanup happened — the wait node is still Waiting, execution Paused.
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+}
+
+/// **Lease contention — `dispatch_cancel` DEFERS when the execution lease is
+/// held** (cancel-vs-resume / cross-runner serialization): with the lease held
+/// externally, `cancel_dangling_nodes` returns `Leased`; `dispatch_cancel` must
+/// `Deferred` (B1 reclaim) and mutate no node state. Releasing the lease and
+/// redelivering then terminalizes the parked nodes.
+#[tokio::test]
+async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+    // The API cancel path records the terminal status.
+    harness.force_cancelled(execution_id).await;
+
+    // A concurrent runner holds the execution lease.
+    let blocker = harness
+        .stores
+        .execution
+        .acquire_lease(
+            &scope,
+            &execution_id.to_string(),
+            "foreign-runner",
+            Duration::from_secs(30),
+        )
+        .await
+        .unwrap()
+        .expect("lease must be free before the contention test");
+
+    let result = harness.dispatch.dispatch_cancel(&scope, execution_id).await;
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "dispatch_cancel must Defer when the execution lease is held; got {result:?}"
+    );
+
+    // Nodes not yet terminalized (cleanup deferred).
+    let record = harness
+        .stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let state: ExecutionState =
+        serde_json::from_str(&serde_json::to_string(&record.state).unwrap()).unwrap();
+    assert!(
+        state.node_states.values().any(|ns| ns.state.is_waiting()),
+        "the parked node must still be Waiting while the cleanup is deferred"
+    );
+
+    // Release the lease and redeliver → cleanup completes.
+    harness
+        .stores
+        .execution
+        .release_lease(&scope, &execution_id.to_string(), blocker)
+        .await
+        .unwrap();
+    harness
+        .dispatch
+        .dispatch_cancel(&scope, execution_id)
+        .await
+        .expect("redelivered dispatch_cancel must complete the node cleanup");
+
+    let record2 = harness
+        .stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let state2: ExecutionState =
+        serde_json::from_str(&serde_json::to_string(&record2.state).unwrap()).unwrap();
+    assert!(
+        state2.node_states.values().all(|ns| ns.state.is_terminal()),
+        "after the lease frees and the Cancel redelivers, every node must be terminal"
+    );
+}

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -1,0 +1,972 @@
+//! Integration tests for W-S2.2 — the `satisfy_signal_waits` + `dispatch_resume`
+//! contract that unparks signal-driven waiting executions.
+//!
+//! Each test uses a store-backed engine (via [`SignalHarness`]) so that the
+//! durable CAS written by `satisfy_signal_waits` is observable via the
+//! `InMemoryExecutionStore`.  Library-mode behaviour is covered by `wait.rs`.
+//!
+//! ## Security invariant (explicitly tested)
+//!
+//! A signal-driven wait must be satisfied **only** by `dispatch_resume` — the
+//! sole caller of `satisfy_signal_waits`.  All other re-entry paths
+//! (`dispatch_start`, `dispatch_restart`, the worker `EngineExecutionSink`)
+//! must leave the nodes `Waiting` and the execution `Paused`.
+//!
+//! Every test has a **falsifiability clause** naming the regression it catches.
+//!
+//! ## Timing discipline
+//!
+//! `dispatch_start` and `dispatch_resume` both call `drive()`, which runs the
+//! frontier loop synchronously to completion (park or terminal).  No wall-clock
+//! sleeps are needed — assertions follow immediately after the dispatch call.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+};
+
+use chrono::Utc;
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, DataPassingPolicy,
+    EngineControlDispatch, InProcessRunner, WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
+use nebula_storage_port::{
+    dto::WorkflowVersionRecord,
+    store::{ExecutionStore, WorkflowVersionStore},
+};
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Action stubs ──────────────────────────────────────────────────────────────
+
+macro_rules! static_action_impl {
+    ($ty:ty, $key:expr, $name:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, "signal_resume integration test stub")
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+/// Parks itself via `WaitCondition::Webhook` with no timeout.
+/// This produces `next_attempt_at == None` after park — the discriminator
+/// that `satisfy_signal_waits` uses to identify signal-driven waits.
+struct WebhookWaitNode;
+
+static_action_impl!(
+    WebhookWaitNode,
+    action_key!("test.signal.webhook_wait"),
+    "WebhookWaitNode"
+);
+
+impl StatelessAction for WebhookWaitNode {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "test-webhook-signal".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// A second distinct webhook-wait action key for the multi-node test.
+/// Must be registered separately so the `ActionRegistry` can look it up
+/// under a different key while sharing the same execution logic.
+struct WebhookWaitNodeB;
+
+static_action_impl!(
+    WebhookWaitNodeB,
+    action_key!("test.signal.webhook_wait_b"),
+    "WebhookWaitNodeB"
+);
+
+impl StatelessAction for WebhookWaitNodeB {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "test-webhook-signal-b".to_owned(),
+            },
+            timeout: None,
+            partial_output: None,
+        })
+    }
+}
+
+/// Counts invocations and succeeds.  Used as the downstream gate probe — the
+/// test asserts on the exact invocation count to verify edge activation.
+struct CountingEchoNode {
+    invocation_count: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingEchoNode,
+    action_key!("test.signal.counting_echo"),
+    "CountingEchoNode"
+);
+
+impl StatelessAction for CountingEchoNode {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocation_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Shared harness ────────────────────────────────────────────────────────────
+
+/// In-memory port adapters wired to one store-backed `WorkflowEngine`.
+/// Mirrors the `DispatchStores` pattern from `control_dispatch.rs`.
+struct SignalStores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl SignalStores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+
+    async fn save_workflow(&self, wf: &WorkflowDefinition) {
+        self.versions
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                WorkflowVersionRecord {
+                    workflow_id: wf.id.to_string(),
+                    number: 0,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(wf).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+}
+
+/// Test fixture for signal-wait + resume integration tests.
+///
+/// Wires a two-action registry (`WebhookWaitNode`, `CountingEchoNode`) to a
+/// store-backed engine.  The downstream invocation counter is exposed for
+/// per-test assertions.
+struct SignalHarness {
+    dispatch: EngineControlDispatch,
+    stores: SignalStores,
+    downstream_invocations: Arc<AtomicU32>,
+}
+
+impl SignalHarness {
+    async fn new() -> Self {
+        let downstream_invocations = Arc::new(AtomicU32::new(0));
+        let registry = Arc::new(ActionRegistry::new());
+        registry.register_stateless_instance(
+            ActionMetadata::new(
+                action_key!("test.signal.webhook_wait"),
+                "WebhookWaitNode",
+                "signal_resume integration test stub",
+            ),
+            WebhookWaitNode,
+        );
+        registry.register_stateless_instance(
+            ActionMetadata::new(
+                action_key!("test.signal.counting_echo"),
+                "CountingEchoNode",
+                "signal_resume integration test stub",
+            ),
+            CountingEchoNode {
+                invocation_count: Arc::clone(&downstream_invocations),
+            },
+        );
+
+        let executor: ActionExecutor = Arc::new(|_ctx, _meta, input| {
+            Box::pin(async move { Ok(ActionResult::success(input)) })
+        });
+        let runner = Arc::new(InProcessRunner::new(executor));
+        let metrics = MetricsRegistry::new();
+        let runtime = Arc::new(
+            ActionRuntime::try_new(
+                registry,
+                runner,
+                DataPassingPolicy::default(),
+                metrics.clone(),
+            )
+            .unwrap(),
+        );
+
+        let stores = SignalStores::new();
+        let engine = Arc::new(stores.attach(WorkflowEngine::new(runtime, metrics).unwrap()));
+        let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+        Self {
+            dispatch,
+            stores,
+            downstream_invocations,
+        }
+    }
+
+    /// Persist a two-node workflow `webhook_wait → counting_echo` and return its id.
+    ///
+    /// `webhook_wait` parks on a `Webhook` signal (no timer); `counting_echo`
+    /// is the downstream gate probe whose invocation count tests assert on.
+    async fn persist_signal_workflow(&self) -> nebula_core::WorkflowId {
+        let workflow_id = nebula_core::WorkflowId::new();
+        let now = Utc::now();
+        let wait_node = node_key!("signal_node");
+        let downstream_node = node_key!("downstream_node");
+        let wf = WorkflowDefinition {
+            id: workflow_id,
+            name: "signal-resume-test".into(),
+            description: None,
+            version: Version::new(0, 1, 0),
+            nodes: vec![
+                NodeDefinition::new(
+                    wait_node.clone(),
+                    "SignalNode",
+                    "core",
+                    "test.signal.webhook_wait",
+                )
+                .unwrap(),
+                NodeDefinition::new(
+                    downstream_node.clone(),
+                    "DownstreamNode",
+                    "core",
+                    "test.signal.counting_echo",
+                )
+                .unwrap(),
+            ],
+            connections: vec![Connection::new(wait_node, downstream_node)],
+            variables: HashMap::new(),
+            config: WorkflowConfig::default(),
+            trigger_bindings: Vec::new(),
+            tags: Vec::new(),
+            created_at: now,
+            updated_at: now,
+            owner_id: None,
+            ui_metadata: None,
+            schema_version: CURRENT_SCHEMA_VERSION,
+        };
+        self.stores.save_workflow(&wf).await;
+        workflow_id
+    }
+
+    /// Persist a `Created` execution row, mirroring how the API handler writes
+    /// the row before enqueueing the `Start` control command.
+    async fn persist_created_execution(&self, workflow_id: nebula_core::WorkflowId) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        let state_json = serde_json::to_value(&exec_state).unwrap();
+        self.stores
+            .execution
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+                &workflow_id.to_string(),
+                state_json,
+            )
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    /// Read the persisted `ExecutionStatus` for the given execution.
+    async fn persisted_status(&self, execution_id: ExecutionId) -> ExecutionStatus {
+        let record = self
+            .stores
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist when reading status");
+        serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+/// **W-S2.2 — satisfy (red-on-revert)**:
+/// `dispatch_start` parks the signal node → execution `Paused` in the store →
+/// `dispatch_resume` calls `satisfy_signal_waits` (durable CAS: `Waiting→Completed`)
+/// → frontier re-drives → downstream runs exactly once → execution `Completed`.
+///
+/// **Falsifiability**: remove the `satisfy_signal_waits` call from
+/// `dispatch_resume` (replace with a plain `drive`) → the frontier re-encounters
+/// the `Waiting` node, re-parks it, and exits again → execution stays `Paused` →
+/// `downstream_invocations == 0` → the `== 1` assertion fails → RED.
+#[tokio::test]
+async fn dispatch_resume_satisfies_signal_wait_and_drives_to_completed() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    // Park: signal_node returns Webhook wait → frontier exits → Paused persisted.
+    // `dispatch_start` runs `drive()` synchronously to completion, so `Paused`
+    // is already persisted by the time this call returns.
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_start must park the signal node and persist Paused");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after the signal node parks"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must NOT run while the signal node is Waiting"
+    );
+
+    // Resume: satisfy_signal_waits writes Waiting→Completed (CAS), then drive
+    // re-runs the frontier, activates the downstream edge, and completes.
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume must satisfy the signal wait and drive to completion");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed after dispatch_resume satisfies the wait"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once after dispatch_resume satisfies the wait"
+    );
+}
+
+/// **W-S2.2 — crash re-entry does NOT satisfy (SECURITY test)**:
+/// after a signal-wait park (execution `Paused`), a re-delivered `dispatch_start`
+/// simulating a reclaim / crash re-drive must NOT auto-complete the signal wait.
+///
+/// This is the load-bearing security invariant for W-S2: a crashed Paused
+/// execution auto-completing its wait on reclaim would be a data-corruption /
+/// security-class bug (human approval never arrived; node auto-completes anyway).
+///
+/// **Falsifiability**: call `satisfy_signal_waits` inside `dispatch_start`
+/// (or inside `resume_execution`) → the reclaim re-drive satisfies the wait →
+/// downstream runs → `downstream_invocations == 1` after the re-drive →
+/// the `== 0` assertion before the genuine `dispatch_resume` fails → RED.
+#[tokio::test]
+async fn dispatch_start_redelivery_does_not_satisfy_signal_wait() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    // Initial park.
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("initial dispatch_start must park the signal node");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after the initial park"
+    );
+
+    // Simulate a crash + reclaim: the at-least-once control queue re-delivers
+    // the original `Start` command.  `dispatch_start` on a `Paused` execution
+    // must re-drive without satisfying — the frontier re-parks and returns Paused.
+    //
+    // Note: `dispatch_start` checks the persisted status.  `Paused` is non-terminal
+    // and non-Running, so the short-circuit does not apply — the engine re-enters
+    // `resume_execution`, encounters the still-Waiting node, re-parks it, and
+    // exits.  The execution returns to Paused unchanged.
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("re-delivered Start on a Paused execution must re-park without error");
+
+    // drive() is synchronous: by the time dispatch_start returns, the frontier
+    // has re-run and either parked again or completed.  No sleep needed.
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "a reclaim re-drive (Start redelivery) must NOT satisfy the signal wait — \
+         downstream must stay gated until a genuine dispatch_resume arrives"
+    );
+
+    // After re-park the execution must still be Paused (not Completed).
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must remain Paused after a crash re-drive — the wait is not satisfied"
+    );
+
+    // The genuine Resume arrives: only now the wait is satisfied.
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("genuine dispatch_resume must satisfy the wait and complete the execution");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed after the genuine dispatch_resume"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — triggered only by the genuine Resume"
+    );
+}
+
+/// **W-S2.2 — idempotency**:
+/// a second `dispatch_resume` after the execution has already `Completed`
+/// must be a strict no-op — downstream must NOT run a second time.
+///
+/// **Falsifiability**: remove the terminal-status short-circuit from
+/// `dispatch_resume` → the second Resume calls `satisfy_signal_waits` (finds
+/// no Waiting nodes — already Completed), then calls `drive`, which re-processes
+/// already-terminal nodes; if that causes a double dispatch, `invocation_count`
+/// reaches 2 → the `== 1` assertion fails → RED.
+#[tokio::test]
+async fn dispatch_resume_is_idempotent_after_signal_wait_satisfied() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    // Park and satisfy.
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("first dispatch_resume must satisfy the wait");
+    assert_eq!(harness.downstream_invocations.load(Ordering::SeqCst), 1);
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+
+    // Re-deliver the Resume (e.g. duplicate message on the control queue).
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("second dispatch_resume on a Completed execution must be idempotent");
+
+    // drive() is synchronous — by the time dispatch_resume returns, any
+    // re-dispatch would already have incremented the counter.
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — a duplicate Resume must be a no-op"
+    );
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must remain Completed after a duplicate Resume"
+    );
+}
+
+/// **W-S2.2 — multi-node: two parallel signal waits, one Resume satisfies both**:
+/// a workflow with two parallel root `webhook_wait` nodes merging to one shared
+/// `counting_echo` downstream.  After both wait nodes park (execution `Paused`),
+/// a single `dispatch_resume` must transition BOTH `Waiting→Completed` in one
+/// `satisfy_signal_waits` pass, then activate the downstream exactly once.
+///
+/// The downstream node has `required_count == 2` (two incoming edges from `wait_a`
+/// and `wait_b`).  The engine pushes it to the `ready_queue` only when BOTH
+/// incoming edges are resolved — so it runs exactly once, not twice.
+///
+/// **Falsifiability**: change `satisfy_signal_waits` to stop after the first
+/// waiting node → the second node stays `Waiting` → the frontier exits again
+/// with one Waiting node → execution re-parks at `Paused` → downstream never
+/// activates (both incoming edges are never fully resolved) → `status != Completed`
+/// AND `downstream_invocations == 0` → both assertions fail → RED.
+#[tokio::test]
+async fn dispatch_resume_satisfies_all_signal_waits_in_one_pass() {
+    // Build a dedicated registry with two independent webhook-wait action keys
+    // plus the shared downstream echo.
+    let downstream_invocations = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "signal_resume integration test stub",
+        ),
+        WebhookWaitNode,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait_b"),
+            "WebhookWaitNodeB",
+            "signal_resume integration test stub",
+        ),
+        WebhookWaitNodeB,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_echo"),
+            "CountingEchoNode",
+            "signal_resume integration test stub",
+        ),
+        CountingEchoNode {
+            invocation_count: Arc::clone(&downstream_invocations),
+        },
+    );
+
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+
+    let stores = SignalStores::new();
+    let engine = Arc::new(stores.attach(WorkflowEngine::new(runtime, metrics).unwrap()));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    // Workflow: `wait_a` and `wait_b` both feed into one `downstream` node.
+    // The downstream has `required_count == 2`; both incoming edges must resolve
+    // before it enters the ready queue.
+    let wait_a = node_key!("wait_a");
+    let wait_b = node_key!("wait_b");
+    let downstream_node = node_key!("downstream");
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "multi-signal-resume-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(wait_a.clone(), "WaitA", "core", "test.signal.webhook_wait")
+                .unwrap(),
+            NodeDefinition::new(
+                wait_b.clone(),
+                "WaitB",
+                "core",
+                "test.signal.webhook_wait_b",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                downstream_node.clone(),
+                "Downstream",
+                "core",
+                "test.signal.counting_echo",
+            )
+            .unwrap(),
+        ],
+        connections: vec![
+            Connection::new(wait_a, downstream_node.clone()),
+            Connection::new(wait_b, downstream_node),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    // Persist the Created execution row.
+    let execution_id = ExecutionId::new();
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    exec_state.set_workflow_input(serde_json::json!(null));
+    let state_json = serde_json::to_value(&exec_state).unwrap();
+    stores
+        .execution
+        .create(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            &execution_id.to_string(),
+            &workflow_id.to_string(),
+            state_json,
+        )
+        .await
+        .unwrap();
+
+    // Park both wait nodes.  drive() is synchronous — Paused is persisted on return.
+    dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_start must park both signal nodes without error");
+
+    let status_after_park = {
+        let record = stores
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let status: ExecutionStatus =
+            serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap();
+        status
+    };
+    assert_eq!(
+        status_after_park,
+        ExecutionStatus::Paused,
+        "both signal nodes must park and execution must be Paused"
+    );
+    assert_eq!(
+        downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must NOT run while both signal nodes are Waiting"
+    );
+
+    // One Resume satisfies ALL signal-waiting nodes atomically.
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume must satisfy all signal waits in one pass");
+
+    let status_after_resume = {
+        let record = stores
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let status: ExecutionStatus =
+            serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap();
+        status
+    };
+    assert_eq!(
+        status_after_resume,
+        ExecutionStatus::Completed,
+        "execution must be Completed after one dispatch_resume satisfies all signal waits"
+    );
+    // The downstream node has two incoming edges; the engine only dispatches
+    // it after BOTH edges are resolved (required_count == resolved_count),
+    // so it runs exactly once regardless of how many activating edges there are.
+    assert_eq!(
+        downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — dispatched only when ALL incoming edges resolve"
+    );
+}
+
+/// **W-S2.2 — `dispatch_resume` on a `Created` execution still works**:
+/// the W-S2.2 changes must not regress the pre-existing behaviour where
+/// `dispatch_resume` delivered against a `Created` (never-started) execution
+/// drives it to completion just like `dispatch_start` (covered separately in
+/// `control_dispatch.rs`; reproduced here to pin the signal path does not
+/// break the `Created` arm).
+///
+/// **Falsifiability**: add an unconditional error return from
+/// `satisfy_signal_waits` on `Created` status → `dispatch_resume` errors →
+/// `expect("dispatch_resume on Created")` panics → RED.
+#[tokio::test]
+async fn dispatch_resume_on_created_execution_still_completes() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+
+    // Workflow has a Webhook wait, so a fresh dispatch_resume on a Created
+    // execution drives to Paused (the signal node parks immediately).
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume on a Created execution must not error");
+
+    // The signal workflow has a Webhook node, so this always ends at Paused
+    // on the first drive (no timer to fire, no Resume yet).
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "dispatch_resume on Created drives to Paused for a signal workflow \
+         (the signal node parks; downstream waits for a real Resume)"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must remain gated after the initial park"
+    );
+}
+
+/// **W-S2.2 — `dispatch_restart` does NOT satisfy signal waits (SECURITY test)**:
+/// after a signal-wait park (execution `Paused`), a `dispatch_restart` must NOT
+/// auto-complete the signal-driven wait nodes.  `dispatch_restart` calls
+/// `drive()` directly — it does NOT call `satisfy_signal_waits` — so the
+/// frontier re-encounters the still-`Waiting` node, re-parks it, and leaves
+/// the execution `Paused`.
+///
+/// This closes the third re-entry path against future refactors.  If anyone
+/// wires `satisfy_signal_waits` into `dispatch_restart`, this test turns RED.
+///
+/// **Falsifiability**: call `satisfy_signal_waits` inside `dispatch_restart`
+/// → the restart auto-satisfies the wait → downstream runs → `downstream_
+/// invocations == 1` after the restart → the `== 0` assertion fails → RED.
+#[tokio::test]
+async fn dispatch_restart_does_not_satisfy_signal_wait() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    // Initial park.
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("initial dispatch_start must park the signal node");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused after the initial park"
+    );
+
+    // `dispatch_restart` on a `Paused` execution must re-drive without
+    // satisfying — the frontier re-encounters the still-Waiting node, re-parks,
+    // and leaves the execution Paused.  No sleep is needed: drive() is synchronous.
+    harness
+        .dispatch
+        .dispatch_restart(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_restart on a Paused execution must re-park without error");
+
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "dispatch_restart must NOT satisfy the signal wait — \
+         downstream must stay gated until a genuine dispatch_resume arrives"
+    );
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must remain Paused after a restart re-drive — the wait is not satisfied"
+    );
+
+    // The genuine Resume arrives: only now the wait is satisfied.
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("genuine dispatch_resume must satisfy the wait and complete the execution");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed after the genuine dispatch_resume"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — triggered only by the genuine Resume"
+    );
+}
+
+// ── Round-trip: park → resume → park (duplicate Resume guard) ────────────────
+
+/// **W-S2.2 — duplicate Resume on a Paused execution is handled gracefully**:
+/// if two `dispatch_resume` calls race (one wins the CAS, one gets a conflict),
+/// the execution must still complete and downstream must run exactly once.
+///
+/// This test is inherently sequential (single tokio task), so it exercises the
+/// "second Resume sees Completed via the status short-circuit" path rather than
+/// an actual concurrent CAS race.  Concurrent-CAS correctness is a property of
+/// the `InMemoryExecutionStore.commit()` CAS which is tested separately in
+/// `nebula-storage`.
+///
+/// **Falsifiability**: if the second `dispatch_resume` re-satisfies the wait
+/// (because `satisfy_signal_waits` is not idempotent on already-Completed
+/// nodes) → downstream runs twice → `invocation_count == 2` → the `== 1`
+/// assertion fails → RED.
+#[tokio::test]
+async fn two_sequential_resumes_produce_exactly_one_downstream_run() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+
+    harness
+        .dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    // First Resume: satisfies the wait, drives to Completed.
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("first Resume must satisfy the wait");
+    assert_eq!(harness.downstream_invocations.load(Ordering::SeqCst), 1);
+
+    // Second Resume: must be a no-op (status short-circuit on Completed).
+    harness
+        .dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("second Resume must be idempotent");
+
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — second Resume is a no-op"
+    );
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+}

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -23,7 +23,7 @@
 use std::{
     collections::HashMap,
     sync::{
-        Arc, OnceLock,
+        Arc, Mutex, OnceLock,
         atomic::{AtomicBool, AtomicU32, Ordering},
     },
     time::Duration,
@@ -2266,5 +2266,259 @@ async fn armed_signal_wait_is_completed_by_reclaim_drive_not_lost() {
         downstream.load(Ordering::SeqCst),
         1,
         "downstream must run exactly once — the armed Resume's work was recovered, not lost"
+    );
+}
+
+/// Wraps an [`InMemoryExecutionStore`] and records, for every `commit`, a pair
+/// `(status, has_signal_waiting_node)` parsed from the committed state snapshot.
+/// Lets a test assert the SHIP-C invariant: no durable commit ever pairs
+/// `status == "running"` with a signal-`Waiting{next_attempt_at: null}` node.
+#[derive(Debug)]
+struct CommitStatusRecorder {
+    inner: Arc<InMemoryExecutionStore>,
+    /// `(status_string, any signal-Waiting node present)` per commit.
+    commits: Mutex<Vec<(String, bool)>>,
+}
+
+impl CommitStatusRecorder {
+    fn new(inner: Arc<InMemoryExecutionStore>) -> Self {
+        Self {
+            inner,
+            commits: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for CommitStatusRecorder {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &Scope,
+        id: &str,
+    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        self.inner.get(scope, id).await
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        let state = batch.new_state();
+        let status = state
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("<missing>")
+            .to_owned();
+        // A signal wait is a node `state == "waiting"` with `next_attempt_at` null.
+        let has_signal_waiting = state
+            .get("node_states")
+            .and_then(|m| m.as_object())
+            .is_some_and(|m| {
+                m.values().any(|ns| {
+                    ns.get("state").and_then(|s| s.as_str()) == Some("waiting")
+                        && ns
+                            .get("next_attempt_at")
+                            .is_some_and(serde_json::Value::is_null)
+                })
+            });
+        self.commits
+            .lock()
+            .unwrap()
+            .push((status, has_signal_waiting));
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        self.inner.acquire_lease(scope, id, holder, ttl).await
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
+
+/// **P1 SHIP-C — a signal park persists `Paused` atomically, never a durable
+/// `Running` + signal-`Waiting{None}` window** (regression guard for the Codex P1
+/// on commit `fb39ef08`):
+///
+/// When a signal park leaves no other active frontier work, the park's
+/// `checkpoint_node` batch must already carry `status == Paused` — otherwise the
+/// row sits durably `Running` + `Waiting{next_attempt_at: None}` until the
+/// frontier-exit `persist_final_state`, and a crash in that window is
+/// unrecoverable (`dispatch_start`/`dispatch_resume` short-circuit on `Running`,
+/// and a Resume only satisfies a `Paused` execution).
+///
+/// Test mechanics: a single signal-wait node (the park IS the last work), driven
+/// through a `CommitStatusRecorder`. Assert NO commit ever pairs
+/// `status == "running"` with a signal-`Waiting{None}` node present.
+///
+/// **Falsifiability**: drop the `transition_status(Paused)` from the signal-park
+/// branch → the park checkpoint commits `("running", true)` → the invariant
+/// assertion fails → RED.
+#[tokio::test]
+async fn signal_park_persists_paused_atomically_no_running_waiting_window() {
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let stores = SignalStores::new();
+    let recorder = Arc::new(CommitStatusRecorder::new(Arc::clone(&stores.execution)));
+    let recorder_as_store: Arc<dyn ExecutionStore> = Arc::clone(&recorder) as _;
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "SHIP-C atomic-Paused test stub",
+        ),
+        WebhookWaitNode,
+    );
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+
+    let execution_stores = nebula_engine::ExecutionStores {
+        execution: Arc::clone(&recorder) as _,
+        journal: stores.journal.clone(),
+        node_results: stores.node_results.clone(),
+        checkpoints: stores.checkpoints.clone(),
+        idempotency: stores.idempotency.clone(),
+    };
+    let engine = Arc::new(
+        WorkflowEngine::new(runtime, metrics)
+            .unwrap()
+            .with_execution_stores(execution_stores)
+            .with_workflow_stores(stores.workflow_stores()),
+    );
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), recorder_as_store.clone());
+
+    // Single signal-wait node — the park is the last (and only) frontier work.
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wait_node = node_key!("signal_node");
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "ship-c-atomic-paused-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(wait_node, "SignalNode", "core", "test.signal.webhook_wait")
+                .unwrap(),
+        ],
+        connections: vec![],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let execution_id = ExecutionId::new();
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    exec_state.set_workflow_input(serde_json::json!(null));
+    stores
+        .execution
+        .create(
+            &scope,
+            &execution_id.to_string(),
+            &workflow_id.to_string(),
+            serde_json::to_value(&exec_state).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+
+    // The execution ends Paused.
+    let record = stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .expect("execution row must exist");
+    assert_eq!(
+        serde_json::from_value::<ExecutionStatus>(record.state.get("status").cloned().unwrap())
+            .unwrap(),
+        ExecutionStatus::Paused,
+        "execution must be Paused after the signal park"
+    );
+
+    // SHIP-C invariant: no durable commit pairs `Running` with a signal-`Waiting{None}` node.
+    let commits = recorder.commits.lock().unwrap().clone();
+    assert!(
+        commits.iter().any(|(_, waiting)| *waiting),
+        "the park must have committed a signal-Waiting node (invariant is not vacuous); \
+         commits = {commits:?}"
+    );
+    assert!(
+        !commits
+            .iter()
+            .any(|(status, waiting)| status == "running" && *waiting),
+        "SHIP-C: no durable commit may pair status=running with a signal-Waiting{{None}} node \
+         (that would be the unrecoverable crash window); commits = {commits:?}"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -150,6 +150,30 @@ impl StatelessAction for CountingEchoNode {
     }
 }
 
+/// Error-branch probe: a second counting node under a distinct action key so a
+/// multi-port wait test can assert the `error`-port branch's invocation count
+/// independently of the `main`-port branch.
+struct CountingErrorNode {
+    invocation_count: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingErrorNode,
+    action_key!("test.signal.counting_error"),
+    "CountingErrorNode"
+);
+
+impl StatelessAction for CountingErrorNode {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocation_count.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
 // ── Shared harness ────────────────────────────────────────────────────────────
 
 /// In-memory port adapters wired to one store-backed `WorkflowEngine`.
@@ -366,8 +390,9 @@ impl SignalHarness {
 
 /// **W-S2.2 — satisfy (red-on-revert)**:
 /// `dispatch_start` parks the signal node → execution `Paused` in the store →
-/// `dispatch_resume` calls `satisfy_signal_waits` (durable CAS: `Waiting→Completed`)
-/// → frontier re-drives → downstream runs exactly once → execution `Completed`.
+/// `dispatch_resume` calls `satisfy_signal_waits` (durable CAS arming the wait's
+/// `next_attempt_at`) → frontier re-drives → Phase-0b completes the node and runs
+/// downstream exactly once → execution `Completed`.
 ///
 /// **Falsifiability**: remove the `satisfy_signal_waits` call from
 /// `dispatch_resume` (replace with a plain `drive`) → the frontier re-encounters
@@ -402,8 +427,9 @@ async fn dispatch_resume_satisfies_signal_wait_and_drives_to_completed() {
         "downstream must NOT run while the signal node is Waiting"
     );
 
-    // Resume: satisfy_signal_waits writes Waiting→Completed (CAS), then drive
-    // re-runs the frontier, activates the downstream edge, and completes.
+    // Resume: satisfy_signal_waits arms the wait (CAS on next_attempt_at), then
+    // drive re-runs the frontier; Phase-0b completes the node, activates the
+    // downstream edge, and the execution completes.
     harness
         .dispatch
         .dispatch_resume(
@@ -584,8 +610,8 @@ async fn dispatch_resume_is_idempotent_after_signal_wait_satisfied() {
 /// **W-S2.2 — multi-node: two parallel signal waits, one Resume satisfies both**:
 /// a workflow with two parallel root `webhook_wait` nodes merging to one shared
 /// `counting_echo` downstream.  After both wait nodes park (execution `Paused`),
-/// a single `dispatch_resume` must transition BOTH `Waiting→Completed` in one
-/// `satisfy_signal_waits` pass, then activate the downstream exactly once.
+/// a single `dispatch_resume` must arm BOTH waits in one `satisfy_signal_waits`
+/// pass; Phase-0b then completes both and activates the downstream exactly once.
 ///
 /// The downstream node has `required_count == 2` (two incoming edges from `wait_a`
 /// and `wait_b`).  The engine pushes it to the `ready_queue` only when BOTH
@@ -1082,7 +1108,7 @@ async fn dispatch_resume_defers_when_execution_lease_is_held() {
 
 /// **P1 #1 — satisfy_signal_waits acquires lease before CAS (no stale token)**:
 /// verifies that `satisfy_signal_waits` holds the execution lease while committing
-/// the `Waiting→Completed` CAS, so a concurrent runner that acquired the lease
+/// the arming CAS (next_attempt_at), so a concurrent runner that acquired the lease
 /// just before us cannot slip a stale token through.
 ///
 /// This test exercises the "lease handoff" path: the engine acquires the lease for
@@ -1121,7 +1147,8 @@ async fn satisfy_signal_waits_releases_lease_after_commit() {
         ExecutionStatus::Paused
     );
 
-    // First Resume: acquires lease, commits Waiting→Completed, releases lease, drives.
+    // First Resume: acquires lease, commits the arm (next_attempt_at), releases
+    // lease, drives (Phase-0b completes the node).
     harness
         .dispatch
         .dispatch_resume(&scope, execution_id)
@@ -1711,5 +1738,533 @@ async fn satisfy_signal_waits_skips_when_execution_cancelled_under_lease() {
         downstream_invocations_2.load(Ordering::SeqCst),
         0,
         "downstream must not run when the satisfy was skipped on a cancelled execution"
+    );
+}
+
+/// **P2 — a satisfied signal wait routes on the `main` port only** (regression
+/// guard for the Codex finding on commit `9b1c2457`):
+///
+/// A signal-wait node wired with both a `main` and an `error` outgoing port must,
+/// on a normal Resume, activate ONLY the `main` branch — the `error` branch must
+/// be `Skipped`, exactly as a timer wait's Phase-0b completion routes via the
+/// port-aware `process_outgoing_edges(None)` → main.
+///
+/// The bug: `satisfy_signal_waits` used to transition the node `Waiting →
+/// Completed`, after which `resume_execution`'s rebuild activated EVERY outgoing
+/// edge of a `Completed` node (port-blind), firing the `error` branch too. The
+/// fix arms `next_attempt_at = now` and leaves the node `Waiting`, so Phase-0b
+/// completes it through the main-port-only path.
+///
+/// **Falsifiability**: revert `satisfy_signal_waits` to transition the node
+/// `Waiting → Completed` (so the port-blind resume rebuild routes its edges) →
+/// the `error` branch runs → `error_invocations == 1` and the node is
+/// `Completed` not `Skipped` → the assertions fail → RED.
+#[tokio::test]
+async fn satisfied_signal_wait_activates_main_port_only_not_error_branch() {
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let stores = SignalStores::new();
+
+    let main_invocations = Arc::new(AtomicU32::new(0));
+    let error_invocations = Arc::new(AtomicU32::new(0));
+
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "multi-port signal-wait test stub",
+        ),
+        WebhookWaitNode,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_echo"),
+            "CountingEchoNode",
+            "main-port downstream probe",
+        ),
+        CountingEchoNode {
+            invocation_count: Arc::clone(&main_invocations),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_error"),
+            "CountingErrorNode",
+            "error-port downstream probe",
+        ),
+        CountingErrorNode {
+            invocation_count: Arc::clone(&error_invocations),
+        },
+    );
+
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    let engine = Arc::new(stores.attach(WorkflowEngine::new(runtime, metrics).unwrap()));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    // Workflow: wait_node ──main──> main_node
+    //                    └─error──> error_node
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wait_node = node_key!("signal_node");
+    let main_node = node_key!("main_node");
+    let error_node = node_key!("error_node");
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "signal-resume-multiport-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                wait_node.clone(),
+                "SignalNode",
+                "core",
+                "test.signal.webhook_wait",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                main_node.clone(),
+                "MainNode",
+                "core",
+                "test.signal.counting_echo",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                error_node.clone(),
+                "ErrorNode",
+                "core",
+                "test.signal.counting_error",
+            )
+            .unwrap(),
+        ],
+        connections: vec![
+            // main port (default) → main_node
+            Connection::new(wait_node.clone(), main_node.clone()),
+            // error port → error_node
+            Connection::new(wait_node.clone(), error_node.clone()).with_from_port("error"),
+        ],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let execution_id = ExecutionId::new();
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    exec_state.set_workflow_input(serde_json::json!(null));
+    stores
+        .execution
+        .create(
+            &scope,
+            &execution_id.to_string(),
+            &workflow_id.to_string(),
+            serde_json::to_value(&exec_state).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Park the signal node.
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+    assert_eq!(
+        stores
+            .execution
+            .get(&scope, &execution_id.to_string())
+            .await
+            .unwrap()
+            .map(|r| serde_json::from_value::<ExecutionStatus>(
+                r.state.get("status").cloned().unwrap()
+            )
+            .unwrap()),
+        Some(ExecutionStatus::Paused),
+        "execution must be Paused after parking the signal node"
+    );
+
+    // Resume: satisfy arms the wait, Phase-0b completes it on the main port.
+    dispatch
+        .dispatch_resume(&scope, execution_id)
+        .await
+        .expect("dispatch_resume must succeed");
+
+    // The main branch ran exactly once; the error branch never ran.
+    assert_eq!(
+        main_invocations.load(Ordering::SeqCst),
+        1,
+        "the main-port downstream must run exactly once on Resume"
+    );
+    assert_eq!(
+        error_invocations.load(Ordering::SeqCst),
+        0,
+        "the error-port branch must NOT run on a normal Resume (port-blind routing bug)"
+    );
+
+    // Durable state: wait + main Completed, error Skipped, execution Completed.
+    let record = stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .expect("execution row must exist");
+    let state_str = serde_json::to_string(&record.state).unwrap();
+    let state: ExecutionState = serde_json::from_str(&state_str).unwrap();
+    let node_display = |k: &nebula_core::NodeKey| {
+        state
+            .node_states
+            .get(k)
+            .map(|ns| ns.state.to_string())
+            .unwrap_or_else(|| "<missing>".to_owned())
+    };
+    assert_eq!(
+        node_display(&main_node),
+        "completed",
+        "main_node must be Completed"
+    );
+    assert_eq!(
+        node_display(&error_node),
+        "skipped",
+        "error_node must be Skipped (its edge was never activated on the main-port completion)"
+    );
+    assert_eq!(
+        serde_json::from_value::<ExecutionStatus>(record.state.get("status").cloned().unwrap())
+            .unwrap(),
+        ExecutionStatus::Completed,
+        "execution must be Completed after the main branch runs"
+    );
+}
+
+/// Wraps an [`InMemoryExecutionStore`] and, once armed, lets the next
+/// `acquire_lease` succeed and fails the one after that (returns `Ok(None)` =
+/// lease held elsewhere), then self-disarms. Used to fail the `drive`'s lease
+/// acquisition that follows a successful `satisfy_signal_waits` arm, leaving the
+/// wait node armed-but-not-completed so a later reclaim can finish it.
+#[derive(Debug)]
+struct LeaseFailAfterArmInterceptor {
+    inner: Arc<InMemoryExecutionStore>,
+    armed: AtomicBool,
+    /// While armed, this many `acquire_lease` calls succeed before one fails.
+    successes_before_fail: AtomicU32,
+}
+
+impl LeaseFailAfterArmInterceptor {
+    fn new(inner: Arc<InMemoryExecutionStore>) -> Self {
+        Self {
+            inner,
+            armed: AtomicBool::new(false),
+            successes_before_fail: AtomicU32::new(0),
+        }
+    }
+
+    /// Arm so the NEXT lease acquisition succeeds (satisfy's) and the one after
+    /// it fails (the drive's), then disarms.
+    fn arm_to_fail_the_drive(&self) {
+        self.successes_before_fail.store(1, Ordering::SeqCst);
+        self.armed.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for LeaseFailAfterArmInterceptor {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &Scope,
+        id: &str,
+    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        self.inner.get(scope, id).await
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        if self.armed.load(Ordering::SeqCst) {
+            if self.successes_before_fail.load(Ordering::SeqCst) == 0 {
+                // Fail this acquisition (the drive's, after satisfy's arm).
+                self.armed.store(false, Ordering::SeqCst);
+                return Ok(None);
+            }
+            self.successes_before_fail.fetch_sub(1, Ordering::SeqCst);
+        }
+        self.inner.acquire_lease(scope, id, holder, ttl).await
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
+
+/// **Q2c — an armed signal wait survives a failed Resume drive and is completed
+/// by a later reclaim drive, never lost** (concurrency hardening for the
+/// satisfy/lease seam, per the W-S2 fix-A review):
+///
+/// `satisfy_signal_waits` arms the wait (`next_attempt_at = now`) under its own
+/// lease and commits. If the genuine Resume's follow-up `drive` then fails to
+/// acquire the lease (a concurrent runner grabbed it), the control-queue row is
+/// acked but the node is durably `Waiting{next_attempt_at = Some}`. A later
+/// reclaim drive (`dispatch_start`, which does NOT call satisfy) re-seeds the
+/// armed node into the `wait_heap` and Phase-0b completes it — the Resume's work
+/// is guaranteed, not lost. This is correct recovery, not a discriminator
+/// breach: only `satisfy_signal_waits` ever arms `next_attempt_at` on a
+/// `Waiting{None}` node (a never-armed wait stays parked under any reclaim — see
+/// `dispatch_start_redelivery_does_not_satisfy_signal_wait`).
+///
+/// **Falsifiability**: if a reclaim drive did not complete an armed wait (e.g.
+/// the wait-heap resume-seed at `resume_execution` excluded armed nodes), the
+/// downstream would never run → the `== 1` assertion fails → RED.
+#[tokio::test]
+async fn armed_signal_wait_is_completed_by_reclaim_drive_not_lost() {
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let stores = SignalStores::new();
+    let interceptor = Arc::new(LeaseFailAfterArmInterceptor::new(Arc::clone(
+        &stores.execution,
+    )));
+    let interceptor_as_store: Arc<dyn ExecutionStore> = Arc::clone(&interceptor) as _;
+
+    let downstream = Arc::new(AtomicU32::new(0));
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "armed-wait reclaim test stub",
+        ),
+        WebhookWaitNode,
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_echo"),
+            "CountingEchoNode",
+            "armed-wait reclaim downstream probe",
+        ),
+        CountingEchoNode {
+            invocation_count: Arc::clone(&downstream),
+        },
+    );
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let metrics = MetricsRegistry::new();
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+
+    let execution_stores = nebula_engine::ExecutionStores {
+        execution: Arc::clone(&interceptor) as _,
+        journal: stores.journal.clone(),
+        node_results: stores.node_results.clone(),
+        checkpoints: stores.checkpoints.clone(),
+        idempotency: stores.idempotency.clone(),
+    };
+    let engine = Arc::new(
+        WorkflowEngine::new(runtime, metrics)
+            .unwrap()
+            .with_execution_stores(execution_stores)
+            .with_workflow_stores(stores.workflow_stores()),
+    );
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), interceptor_as_store.clone());
+
+    // Two-node workflow: webhook_wait → counting_echo.
+    let workflow_id = nebula_core::WorkflowId::new();
+    let now = Utc::now();
+    let wait_node = node_key!("signal_node");
+    let downstream_node = node_key!("downstream_node");
+    let wf = WorkflowDefinition {
+        id: workflow_id,
+        name: "armed-wait-reclaim-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes: vec![
+            NodeDefinition::new(
+                wait_node.clone(),
+                "SignalNode",
+                "core",
+                "test.signal.webhook_wait",
+            )
+            .unwrap(),
+            NodeDefinition::new(
+                downstream_node.clone(),
+                "DownstreamNode",
+                "core",
+                "test.signal.counting_echo",
+            )
+            .unwrap(),
+        ],
+        connections: vec![Connection::new(wait_node.clone(), downstream_node.clone())],
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    };
+    stores.save_workflow(&wf).await;
+
+    let execution_id = ExecutionId::new();
+    let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+    exec_state.set_workflow_input(serde_json::json!(null));
+    stores
+        .execution
+        .create(
+            &scope,
+            &execution_id.to_string(),
+            &workflow_id.to_string(),
+            serde_json::to_value(&exec_state).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Park (interceptor not armed → normal lease behaviour).
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park");
+
+    let read_state = |stores: &SignalStores, eid: ExecutionId| {
+        let stores = stores.execution.clone();
+        async move {
+            let rec = stores
+                .get(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    &eid.to_string(),
+                )
+                .await
+                .unwrap()
+                .unwrap();
+            let s = serde_json::to_string(&rec.state).unwrap();
+            serde_json::from_str::<ExecutionState>(&s).unwrap()
+        }
+    };
+
+    let parked = read_state(&stores, execution_id).await;
+    assert_eq!(
+        parked.status,
+        ExecutionStatus::Paused,
+        "execution must be Paused after park"
+    );
+
+    // Resume: satisfy arms (lease #1 succeeds), the drive's lease (#2) fails →
+    // node left armed-but-not-completed.
+    interceptor.arm_to_fail_the_drive();
+    dispatch
+        .dispatch_resume(&scope, execution_id)
+        .await
+        .expect("dispatch_resume returns Ok even when the post-satisfy drive defers on Leased");
+
+    let armed = read_state(&stores, execution_id).await;
+    assert_eq!(
+        armed.status,
+        ExecutionStatus::Paused,
+        "execution stays Paused — the drive deferred before completing the armed wait"
+    );
+    let wait_ns = armed.node_states.get(&wait_node).unwrap();
+    assert!(
+        wait_ns.state.is_waiting(),
+        "the wait node must still be Waiting (armed, not yet completed)"
+    );
+    assert!(
+        wait_ns.next_attempt_at.is_some(),
+        "satisfy must have armed next_attempt_at on the wait node"
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        0,
+        "downstream must not run while the armed wait is uncompleted"
+    );
+
+    // Reclaim drive (dispatch_start, no satisfy) completes the armed wait.
+    dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("reclaim drive must succeed");
+
+    let done = read_state(&stores, execution_id).await;
+    assert_eq!(
+        done.status,
+        ExecutionStatus::Completed,
+        "the reclaim drive must complete the armed wait via Phase-0b"
+    );
+    assert_eq!(
+        downstream.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — the armed Resume's work was recovered, not lost"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -26,6 +26,7 @@ use std::{
         Arc, OnceLock,
         atomic::{AtomicU32, Ordering},
     },
+    time::Duration,
 };
 
 use chrono::Utc;
@@ -38,8 +39,8 @@ use nebula_action::{
 };
 use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
 use nebula_engine::{
-    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, DataPassingPolicy,
-    EngineControlDispatch, InProcessRunner, WorkflowEngine,
+    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, ControlDispatchError,
+    DataPassingPolicy, EngineControlDispatch, InProcessRunner, WorkflowEngine,
 };
 use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_metrics::MetricsRegistry;
@@ -968,5 +969,180 @@ async fn two_sequential_resumes_produce_exactly_one_downstream_run() {
     assert_eq!(
         harness.persisted_status(execution_id).await,
         ExecutionStatus::Completed
+    );
+}
+
+// ── Lease-contention deterministic race tests (P1 #1 / P1 #2) ────────────────
+
+/// **P1 #2 — dispatch_resume returns `Deferred` when execution lease is held**:
+/// Pre-acquire the execution lease with a "foreign-runner" holder to simulate
+/// concurrent lease contention.  `dispatch_resume` must:
+///
+/// 1. Detect the contention in `satisfy_signal_waits` (`Leased` error).
+/// 2. Return `ControlDispatchError::Deferred` — NOT `Ok(())` (which would ack
+///    the control-queue row and permanently lose the Resume).
+/// 3. Leave the wait nodes `Waiting` and the execution `Paused`.
+///
+/// After the lease is released and the Resume is "redelivered", the execution
+/// must complete normally.
+///
+/// **Falsifiability**:
+/// - If `dispatch_resume` returns `Ok(())` on lease contention → the
+///   `Err(ControlDispatchError::Deferred(_))` assertion fails → RED.
+/// - If the first `dispatch_resume` satisfies the wait despite contention →
+///   `persisted_status == Paused` assertion fails → RED.
+/// - If the redelivered `dispatch_resume` fails → final `Completed` assertion
+///   fails → RED.
+#[tokio::test]
+async fn dispatch_resume_defers_when_execution_lease_is_held() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    // Park the execution so it is `Paused` with signal-driven wait nodes.
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused before the lease-contention test"
+    );
+
+    // Simulate a concurrent runner holding the execution lease.  `acquire_lease`
+    // is exclusive: any second acquire (including by the engine's own instance)
+    // returns `None` while this token is live.
+    let blocker_token = harness
+        .stores
+        .execution
+        .acquire_lease(
+            &scope,
+            &execution_id.to_string(),
+            "foreign-runner",
+            Duration::from_secs(30),
+        )
+        .await
+        .expect("acquire_lease must not error")
+        .expect("lease must be available before the contention test");
+
+    // With the lease held externally, `dispatch_resume` must NOT succeed —
+    // `satisfy_signal_waits` will find the lease busy and return `Leased`.
+    // `dispatch_resume` must propagate this as `ControlDispatchError::Deferred`
+    // so the consumer leaves the control-queue row in `Processing` for B1 reclaim.
+    let result = harness.dispatch.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "dispatch_resume must return Deferred when the execution lease is held; got {result:?}"
+    );
+
+    // The wait nodes must still be `Waiting` — the deferred Resume must not have
+    // mutated any node state.
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must remain Paused after a deferred Resume (lease still held)"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must not run while the lease is held and the Resume is deferred"
+    );
+
+    // Release the lease (simulating the concurrent runner completing its work).
+    harness
+        .stores
+        .execution
+        .release_lease(&scope, &execution_id.to_string(), blocker_token)
+        .await
+        .expect("release_lease must not error");
+
+    // The B1 reclaim path would redeliver the Resume command.  Simulate redelivery.
+    harness
+        .dispatch
+        .dispatch_resume(&scope, execution_id)
+        .await
+        .expect("redelivered dispatch_resume must succeed after the lease is released");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed after the redelivered dispatch_resume"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — triggered only by the redelivered Resume"
+    );
+}
+
+/// **P1 #1 — satisfy_signal_waits acquires lease before CAS (no stale token)**:
+/// verifies that `satisfy_signal_waits` holds the execution lease while committing
+/// the `Waiting→Completed` CAS, so a concurrent runner that acquired the lease
+/// just before us cannot slip a stale token through.
+///
+/// This test exercises the "lease handoff" path: the engine acquires the lease for
+/// `satisfy_signal_waits` using its own instance_id.  Because `InMemoryExecutionStore`
+/// blocks concurrent acquires, the second `dispatch_resume` (after the lease from
+/// the first has been released by the committed batch) succeeds via the terminal
+/// status short-circuit — proving the lease was released after commit.
+///
+/// **Falsifiability**: remove the `acquire_lease` call from `satisfy_signal_waits`
+/// and use the stale fencing token from the record → the `InMemoryExecutionStore`
+/// CAS may accept the stale token (no fencing rejection on the in-mem store when
+/// the token matches the stored generation) — but the REAL story is that with a
+/// live lease held by a concurrent runner, the store rejects the commit as
+/// `FencedOut` → the CAS fails → the wait is not satisfied → `dispatch_resume`
+/// would previously return `Ok(())` (wrong) → the row gets acked → Resume lost.
+/// With the fix: the engine tries `acquire_lease` first, gets `None`, returns
+/// `Deferred` → previous test catches it → RED.
+#[tokio::test]
+async fn satisfy_signal_waits_releases_lease_after_commit() {
+    // This test drives two consecutive dispatch_resume calls to verify that the
+    // lease acquired by the first satisfy_signal_waits is released after commit,
+    // so the idempotency short-circuit on the second Resume can read the row.
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    // Park the signal node.
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park");
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused
+    );
+
+    // First Resume: acquires lease, commits Waiting→Completed, releases lease, drives.
+    harness
+        .dispatch
+        .dispatch_resume(&scope, execution_id)
+        .await
+        .expect("first dispatch_resume must succeed");
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed
+    );
+
+    // Second Resume (duplicate delivery): status short-circuit on Completed.
+    // If the lease were still held after the first commit, this would deadlock or
+    // return Deferred — it returns Ok(()) proving the lease was released.
+    harness
+        .dispatch
+        .dispatch_resume(&scope, execution_id)
+        .await
+        .expect("duplicate dispatch_resume on Completed must be a no-op, not Deferred");
+
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once across two dispatch_resume calls"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -385,12 +385,12 @@ impl SignalHarness {
         serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
     }
 
-    /// Force the persisted execution status to `Cancelled`, mirroring how the
-    /// API `cancel_execution` handler writes the terminal status (a raw-JSON
-    /// `status` write committed under a fencing token) before the `Cancel`
-    /// control command is drained. The node states are left untouched — exactly
-    /// the state the engine's `cancel_dangling_nodes` must repair.
-    async fn force_cancelled(&self, execution_id: ExecutionId) {
+    /// Force the persisted execution `status`, mirroring how the API
+    /// `cancel_execution` handler writes a raw-JSON `status` under a fencing
+    /// token before the `Cancel` control command is drained. The node states are
+    /// left untouched — exactly the state the engine's `cancel_dangling_nodes`
+    /// must repair.
+    async fn force_status(&self, execution_id: ExecutionId, status: ExecutionStatus) {
         let scope = nebula_engine::store_seam::single_tenant_scope();
         let id = execution_id.to_string();
         let token = self
@@ -408,10 +408,10 @@ impl SignalHarness {
             .unwrap()
             .expect("execution row must exist");
         let mut state = record.state;
-        state.as_object_mut().unwrap().insert(
-            "status".to_owned(),
-            serde_json::json!(ExecutionStatus::Cancelled.to_string()),
-        );
+        state
+            .as_object_mut()
+            .unwrap()
+            .insert("status".to_owned(), serde_json::json!(status.to_string()));
         let batch = TransitionBatch::builder()
             .scope(scope.clone())
             .execution_id(&id)
@@ -2610,7 +2610,9 @@ async fn cancel_of_paused_signal_execution_terminalizes_parked_nodes() {
     );
 
     // The API cancel path writes the terminal status (but not the node states).
-    harness.force_cancelled(execution_id).await;
+    harness
+        .force_status(execution_id, ExecutionStatus::Cancelled)
+        .await;
 
     // Drain the Cancel command. No live runner → engine terminalizes the parked
     // nodes under the lease.
@@ -2710,7 +2712,9 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
         .await
         .expect("dispatch_start must park the signal node");
     // The API cancel path records the terminal status.
-    harness.force_cancelled(execution_id).await;
+    harness
+        .force_status(execution_id, ExecutionStatus::Cancelled)
+        .await;
 
     // A concurrent runner holds the execution lease.
     let blocker = harness
@@ -2772,5 +2776,60 @@ async fn dispatch_cancel_defers_when_lease_held_then_completes_on_redeliver() {
     assert!(
         state2.node_states.values().all(|ns| ns.state.is_terminal()),
         "after the lease frees and the Cancel redelivers, every node must be terminal"
+    );
+}
+
+/// **CodeRabbit — a `Cancelling` no-live-runner execution is FINALIZED to
+/// `Cancelled`** (not left non-terminal): a runner that began a cancel
+/// (`Running → Cancelling`) and then crashed leaves the execution `Cancelling`
+/// with no live frontier. A redelivered `Cancel` must terminalize the parked
+/// nodes AND move the execution `Cancelling → Cancelled` in the same cleanup
+/// commit, or the execution stays non-terminal `Cancelling` forever.
+///
+/// **Falsifiability**: drop the `Cancelling → Cancelled` finalize from
+/// `cancel_dangling_nodes` → the execution stays `Cancelling` → the
+/// `== Cancelled` assertion fails → RED.
+#[tokio::test]
+async fn cancel_of_cancelling_no_live_runner_finalizes_to_cancelled() {
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+
+    // Simulate a runner that began the cancel then crashed: status `Cancelling`,
+    // parked Waiting node intact, no live frontier.
+    harness
+        .force_status(execution_id, ExecutionStatus::Cancelling)
+        .await;
+
+    harness
+        .dispatch
+        .dispatch_cancel(&scope, execution_id)
+        .await
+        .expect("dispatch_cancel must finalize a Cancelling no-live-runner execution");
+
+    let record = harness
+        .stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .unwrap();
+    let state: ExecutionState =
+        serde_json::from_str(&serde_json::to_string(&record.state).unwrap()).unwrap();
+    assert_eq!(
+        state.status,
+        ExecutionStatus::Cancelled,
+        "a Cancelling no-live-runner execution must be finalized to Cancelled"
+    );
+    assert!(
+        state.node_states.values().all(|ns| ns.state.is_terminal()),
+        "all parked nodes must be terminal after the cancel finalization"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -24,7 +24,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, OnceLock,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
     time::Duration,
 };
@@ -46,6 +46,7 @@ use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_metrics::MetricsRegistry;
 use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
 use nebula_storage_port::{
+    FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome,
     dto::WorkflowVersionRecord,
     store::{ExecutionStore, WorkflowVersionStore},
 };
@@ -1144,5 +1145,280 @@ async fn satisfy_signal_waits_releases_lease_after_commit() {
         harness.downstream_invocations.load(Ordering::SeqCst),
         1,
         "downstream must run exactly once across two dispatch_resume calls"
+    );
+}
+
+// ── Deferred-on-non-landed-satisfy (P2 regression) ───────────────────────────
+
+/// Wraps an [`ExecutionStore`] and intercepts the first `commit()` call after
+/// `arm()` has been called, returning `FencedOut` WITHOUT applying the batch.
+/// All other calls — including `get`, lease operations, and subsequent commits
+/// — delegate transparently to the inner store.
+///
+/// This lets a test verify that `dispatch_resume` returns `Deferred` (and does
+/// not silently ack) when `satisfy_signal_waits` fails to land its CAS while
+/// the execution is still `Paused`.
+#[derive(Debug)]
+struct CommitFenceInterceptor {
+    inner: Arc<InMemoryExecutionStore>,
+    /// When `true`, the next `commit()` call returns `FencedOut` and disarms.
+    armed: AtomicBool,
+}
+
+impl CommitFenceInterceptor {
+    fn new(inner: Arc<InMemoryExecutionStore>) -> Self {
+        Self {
+            inner,
+            armed: AtomicBool::new(false),
+        }
+    }
+
+    /// Arm the interceptor so the NEXT `commit()` call is sabotaged.
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for CommitFenceInterceptor {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &Scope,
+        id: &str,
+    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        self.inner.get(scope, id).await
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        // On the first armed commit, return FencedOut without touching the row.
+        if self
+            .armed
+            .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            return Ok(TransitionOutcome::FencedOut);
+        }
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        self.inner.acquire_lease(scope, id, holder, ttl).await
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
+
+/// **P2 — dispatch_resume defers when satisfy_signal_waits is FencedOut and
+/// execution is still Paused** (regression guard for the "bounded lost-Resume"
+/// bug class):
+///
+/// When `satisfy_signal_waits` acquires the lease but its `commit()` is
+/// rejected as `FencedOut` (TTL-expired and superseded generation), and the
+/// execution remains `Paused`, `dispatch_resume` MUST return
+/// `ControlDispatchError::Deferred` rather than `Ok(())`.  Returning `Ok(())`
+/// would silently ack the control-queue row, losing the Resume permanently.
+///
+/// Test mechanics:
+/// 1. Park the execution with a real store (`Paused` persisted).
+/// 2. Wire a second engine against a `CommitFenceInterceptor` wrapping the
+///    SAME underlying `InMemoryExecutionStore`, so lease + status reads go
+///    through to the shared row, but the first `commit()` inside
+///    `satisfy_signal_waits` is returned as `FencedOut` without mutating state.
+/// 3. Call `dispatch_resume` on the interceptor-backed dispatch.
+/// 4. Assert `Deferred` is returned.
+/// 5. Assert the execution is still `Paused` (wait node not satisfied).
+/// 6. Assert downstream ran 0 times (gate not unblocked).
+/// 7. Disarm the interceptor and redeliver the Resume — execution must complete.
+///
+/// **Falsifiability**: revert the `Err(e)` arm of `dispatch_resume`'s `Paused`
+/// match to return `Ok(())` unconditionally → step 4 assertion fails → RED.
+#[tokio::test]
+async fn dispatch_resume_defers_when_satisfy_commit_is_fenced_out_and_execution_is_paused() {
+    // ── Phase 1: park with a real store ──────────────────────────────────────
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused before the FencedOut test"
+    );
+    assert_eq!(
+        harness.downstream_invocations.load(Ordering::SeqCst),
+        0,
+        "downstream must not run before the signal wait is satisfied"
+    );
+
+    // ── Phase 2: wire a second engine with the commit interceptor ────────────
+    //
+    // The interceptor wraps the SAME inner store the harness uses, so:
+    //   - status reads (via `get`) see the real Paused row
+    //   - lease operations go through to the real store
+    //   - the first `commit()` inside `satisfy_signal_waits` returns FencedOut
+    //     without mutating the row → execution stays Paused
+    //
+    // Downstream invocations from this second engine's frontier loop are
+    // captured by the same `downstream_invocations` counter because the
+    // ActionRuntime instance is shared (same Arc).
+    let interceptor = Arc::new(CommitFenceInterceptor::new(Arc::clone(
+        &harness.stores.execution,
+    )));
+    let interceptor_as_store: Arc<dyn ExecutionStore> = Arc::clone(&interceptor) as _;
+
+    let downstream_invocations_2 = Arc::new(AtomicU32::new(0));
+    let registry2 = Arc::new(ActionRegistry::new());
+    registry2.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "signal_resume deferred test stub",
+        ),
+        WebhookWaitNode,
+    );
+    registry2.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_echo"),
+            "CountingEchoNode",
+            "signal_resume deferred test stub",
+        ),
+        CountingEchoNode {
+            invocation_count: Arc::clone(&downstream_invocations_2),
+        },
+    );
+    let executor2: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner2 = Arc::new(InProcessRunner::new(executor2));
+    let metrics2 = MetricsRegistry::new();
+    let runtime2 = Arc::new(
+        ActionRuntime::try_new(
+            registry2,
+            runner2,
+            DataPassingPolicy::default(),
+            metrics2.clone(),
+        )
+        .unwrap(),
+    );
+
+    let execution_stores_with_interceptor = nebula_engine::ExecutionStores {
+        execution: Arc::clone(&interceptor) as _,
+        journal: harness.stores.journal.clone(),
+        node_results: harness.stores.node_results.clone(),
+        checkpoints: harness.stores.checkpoints.clone(),
+        idempotency: harness.stores.idempotency.clone(),
+    };
+
+    let engine2 = Arc::new(
+        WorkflowEngine::new(runtime2, metrics2)
+            .unwrap()
+            .with_execution_stores(execution_stores_with_interceptor)
+            .with_workflow_stores(harness.stores.workflow_stores()),
+    );
+    // The dispatch must read status via the same raw inner store so the
+    // post-error re-read sees the real (still-Paused) row.
+    let dispatch2 = EngineControlDispatch::new(Arc::clone(&engine2), interceptor_as_store.clone());
+
+    // ── Phase 3: arm the interceptor and call dispatch_resume ─────────────────
+    interceptor.arm();
+
+    let result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        matches!(result, Err(ControlDispatchError::Deferred(_))),
+        "dispatch_resume must return Deferred when satisfy_signal_waits is FencedOut \
+         and execution is still Paused; got {result:?}"
+    );
+
+    // ── Phase 4: assert no state was mutated ──────────────────────────────────
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must remain Paused after a FencedOut satisfy (wait not satisfied)"
+    );
+    assert_eq!(
+        downstream_invocations_2.load(Ordering::SeqCst),
+        0,
+        "downstream must not run when the satisfy did not land"
+    );
+
+    // ── Phase 5: redeliver the Resume (interceptor disarmed) → must complete ──
+    //
+    // The interceptor self-disarmed after the first intercept, so this
+    // redelivery goes through to the real store and the wait is properly satisfied.
+    let redeliver_result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        redeliver_result.is_ok(),
+        "redelivered dispatch_resume must succeed after the interceptor disarms; \
+         got {redeliver_result:?}"
+    );
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed after the redelivered dispatch_resume satisfies the wait"
+    );
+    assert_eq!(
+        downstream_invocations_2.load(Ordering::SeqCst),
+        1,
+        "downstream must run exactly once — triggered only by the redelivered Resume"
     );
 }

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -2222,12 +2222,17 @@ async fn armed_signal_wait_is_completed_by_reclaim_drive_not_lost() {
     );
 
     // Resume: satisfy arms (lease #1 succeeds), the drive's lease (#2) fails →
-    // node left armed-but-not-completed.
+    // node left armed-but-not-completed. The post-satisfy drive must DEFER (not
+    // ack) so the Resume is redelivered — acking here would strand the paused
+    // execution when the lease holder is a crashed runner whose TTL has not
+    // expired yet (P1: keep Resume redeliverable after drive lease contention).
     interceptor.arm_to_fail_the_drive();
-    dispatch
-        .dispatch_resume(&scope, execution_id)
-        .await
-        .expect("dispatch_resume returns Ok even when the post-satisfy drive defers on Leased");
+    let deferred = dispatch.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        matches!(deferred, Err(ControlDispatchError::Deferred(_))),
+        "post-satisfy drive that fails to acquire the lease must Defer (keep the Resume \
+         redeliverable), not ack; got {deferred:?}"
+    );
 
     let armed = read_state(&stores, execution_id).await;
     assert_eq!(

--- a/crates/engine/tests/signal_resume.rs
+++ b/crates/engine/tests/signal_resume.rs
@@ -1422,3 +1422,294 @@ async fn dispatch_resume_defers_when_satisfy_commit_is_fenced_out_and_execution_
         "downstream must run exactly once — triggered only by the redelivered Resume"
     );
 }
+
+/// Wraps an [`InMemoryExecutionStore`] and simulates a **concurrent Cancel
+/// landing during lease acquisition**: once `acquire_lease` has run, the next
+/// `get` (the under-lease reload inside `satisfy_signal_waits`) returns a record
+/// whose execution status is rewritten to `Cancelled`, while the earlier status
+/// read (`dispatch_resume`'s pre-lease `read_status`) still observes the real
+/// `Paused` row. Records whether any `commit` was attempted.
+#[derive(Debug)]
+struct CancelDuringSatisfyInterceptor {
+    inner: Arc<InMemoryExecutionStore>,
+    /// When `true`, the first `get` AFTER `acquire_lease` returns a `Cancelled`
+    /// view of the row (then self-disarms).
+    armed: AtomicBool,
+    /// Set once `acquire_lease` has been called, so only the under-lease reload
+    /// (not the pre-lease `read_status`) sees the injected cancel.
+    lease_acquired: AtomicBool,
+    /// Set if any `commit` is attempted — the fix must prevent a durable write
+    /// once the under-lease reload observes a terminal status.
+    commit_attempted: AtomicBool,
+}
+
+impl CancelDuringSatisfyInterceptor {
+    fn new(inner: Arc<InMemoryExecutionStore>) -> Self {
+        Self {
+            inner,
+            armed: AtomicBool::new(false),
+            lease_acquired: AtomicBool::new(false),
+            commit_attempted: AtomicBool::new(false),
+        }
+    }
+
+    /// Arm the injection: the first `get` after the lease is acquired returns a
+    /// `Cancelled` view.
+    fn arm(&self) {
+        self.armed.store(true, Ordering::SeqCst);
+    }
+
+    fn commit_attempted(&self) -> bool {
+        self.commit_attempted.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for CancelDuringSatisfyInterceptor {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(
+        &self,
+        scope: &Scope,
+        id: &str,
+    ) -> Result<Option<nebula_storage_port::dto::ExecutionRecord>, StorageError> {
+        let rec = self.inner.get(scope, id).await?;
+        // Inject the concurrent cancel only on the under-lease reload (after
+        // acquire_lease), and only once.
+        if self.lease_acquired.load(Ordering::SeqCst)
+            && self
+                .armed
+                .compare_exchange(true, false, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        {
+            return Ok(rec.map(|mut record| {
+                if let Some(obj) = record.state.as_object_mut() {
+                    obj.insert(
+                        "status".to_owned(),
+                        serde_json::to_value(ExecutionStatus::Cancelled)
+                            .expect("serialize ExecutionStatus::Cancelled"),
+                    );
+                }
+                record
+            }));
+        }
+        Ok(rec)
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        self.commit_attempted.store(true, Ordering::SeqCst);
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        let token = self.inner.acquire_lease(scope, id, holder, ttl).await?;
+        self.lease_acquired.store(true, Ordering::SeqCst);
+        Ok(token)
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
+
+/// **P2 — satisfy_signal_waits must guard the execution status under the lease**
+/// (regression guard for the Codex finding on commit `d8814879`):
+///
+/// `dispatch_resume` reads `Paused` BEFORE acquiring the execution lease. If a
+/// concurrent Cancel/Terminate commits `Cancelled` in the window before
+/// `satisfy_signal_waits` reloads under the lease, the per-node `Waiting →
+/// Completed` CAS (which guards only the node version, not the execution status)
+/// would flip — and durably commit — a wait node on an already-cancelled
+/// execution, corrupting its terminal audit state. `drive()` then only observes
+/// the terminal status and acks the Resume.
+///
+/// The fix: `satisfy_signal_waits` re-checks `exec_state.status` under the lease
+/// and returns `ExecutionNotResumable` (idempotent no-op, no commit) when the
+/// execution is terminal/`Cancelling`; `dispatch_resume` acks without driving.
+///
+/// Test mechanics:
+/// 1. Park with a real store (`Paused` persisted, signal node `Waiting`).
+/// 2. Wire a second engine against a `CancelDuringSatisfyInterceptor`: the
+///    pre-lease `read_status` sees `Paused`, but the under-lease reload inside
+///    `satisfy_signal_waits` sees an injected `Cancelled` status.
+/// 3. Call `dispatch_resume` → must return `Ok` (idempotent ack).
+/// 4. Assert NO commit was attempted (the durable-write invariant).
+/// 5. Assert the signal node is still `Waiting` in the real row (not flipped).
+/// 6. Assert downstream ran 0 times.
+///
+/// **Falsifiability**: remove the under-lease status guard in
+/// `satisfy_signal_waits` → satisfy collects the `Waiting` node and commits it
+/// `Completed` → step 4 (`commit_attempted == false`) and step 5 (node still
+/// `Waiting`) both fail → RED.
+#[tokio::test]
+async fn satisfy_signal_waits_skips_when_execution_cancelled_under_lease() {
+    // ── Phase 1: park with a real store ──────────────────────────────────────
+    let harness = SignalHarness::new().await;
+    let workflow_id = harness.persist_signal_workflow().await;
+    let execution_id = harness.persist_created_execution(workflow_id).await;
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+
+    harness
+        .dispatch
+        .dispatch_start(&scope, execution_id)
+        .await
+        .expect("dispatch_start must park the signal node");
+
+    assert_eq!(
+        harness.persisted_status(execution_id).await,
+        ExecutionStatus::Paused,
+        "execution must be Paused before the cancel-under-lease test"
+    );
+
+    // ── Phase 2: wire a second engine with the cancel-injecting interceptor ───
+    let interceptor = Arc::new(CancelDuringSatisfyInterceptor::new(Arc::clone(
+        &harness.stores.execution,
+    )));
+    let interceptor_as_store: Arc<dyn ExecutionStore> = Arc::clone(&interceptor) as _;
+
+    let downstream_invocations_2 = Arc::new(AtomicU32::new(0));
+    let registry2 = Arc::new(ActionRegistry::new());
+    registry2.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.webhook_wait"),
+            "WebhookWaitNode",
+            "signal_resume cancel-under-lease test stub",
+        ),
+        WebhookWaitNode,
+    );
+    registry2.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.signal.counting_echo"),
+            "CountingEchoNode",
+            "signal_resume cancel-under-lease test stub",
+        ),
+        CountingEchoNode {
+            invocation_count: Arc::clone(&downstream_invocations_2),
+        },
+    );
+    let executor2: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner2 = Arc::new(InProcessRunner::new(executor2));
+    let metrics2 = MetricsRegistry::new();
+    let runtime2 = Arc::new(
+        ActionRuntime::try_new(
+            registry2,
+            runner2,
+            DataPassingPolicy::default(),
+            metrics2.clone(),
+        )
+        .unwrap(),
+    );
+
+    let execution_stores_with_interceptor = nebula_engine::ExecutionStores {
+        execution: Arc::clone(&interceptor) as _,
+        journal: harness.stores.journal.clone(),
+        node_results: harness.stores.node_results.clone(),
+        checkpoints: harness.stores.checkpoints.clone(),
+        idempotency: harness.stores.idempotency.clone(),
+    };
+
+    let engine2 = Arc::new(
+        WorkflowEngine::new(runtime2, metrics2)
+            .unwrap()
+            .with_execution_stores(execution_stores_with_interceptor)
+            .with_workflow_stores(harness.stores.workflow_stores()),
+    );
+    let dispatch2 = EngineControlDispatch::new(Arc::clone(&engine2), interceptor_as_store.clone());
+
+    // ── Phase 3: arm the injection and call dispatch_resume ───────────────────
+    interceptor.arm();
+
+    let result = dispatch2.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        result.is_ok(),
+        "dispatch_resume must ack (Ok) when the execution was cancelled before satisfy; \
+         got {result:?}"
+    );
+
+    // ── Phase 4: the durable-write invariant — NO commit on a terminal exec ───
+    assert!(
+        !interceptor.commit_attempted(),
+        "satisfy_signal_waits must NOT commit any transition once the under-lease reload \
+         observes a terminal status (would corrupt a cancelled execution's audit state)"
+    );
+
+    // ── Phase 5: the signal node must remain Waiting (not flipped) ────────────
+    let record = harness
+        .stores
+        .execution
+        .get(&scope, &execution_id.to_string())
+        .await
+        .unwrap()
+        .expect("execution row must exist");
+    // `from_value` cannot satisfy ExecutionState's borrowed-string fields; go
+    // through a string the same way the engine's reload does.
+    let state_str = serde_json::to_string(&record.state).unwrap();
+    let state: ExecutionState = serde_json::from_str(&state_str).unwrap();
+    let waiting_nodes = state
+        .node_states
+        .values()
+        .filter(|ns| ns.state.is_waiting())
+        .count();
+    assert_eq!(
+        waiting_nodes, 1,
+        "the signal node must remain Waiting after a cancel-under-lease race \
+         (the satisfy must not have flipped it to Completed)"
+    );
+
+    // ── Phase 6: downstream gate stays closed ─────────────────────────────────
+    assert_eq!(
+        downstream_invocations_2.load(Ordering::SeqCst),
+        0,
+        "downstream must not run when the satisfy was skipped on a cancelled execution"
+    );
+}

--- a/crates/engine/tests/wait.rs
+++ b/crates/engine/tests/wait.rs
@@ -127,8 +127,8 @@ impl StatelessAction for WaitUntilHandler {
 }
 
 /// Returns `ActionResult::Wait` with `WaitCondition::Webhook` — a
-/// signal-driven condition that W-S1 does not support. Used to verify
-/// `WaitConditionNotSupported` is returned rather than silently parking.
+/// signal-driven condition. Used to verify that the node parks successfully
+/// (execution → `Paused`) and does NOT immediately fail with an error.
 struct WebhookWaitHandler;
 
 /// Returns `ActionResult::Wait` with a timer condition AND an explicit
@@ -616,67 +616,108 @@ async fn cancel_during_wait_drains_heap() {
     );
 }
 
-/// 5) **Signal-driven condition rejected (W-S1 boundary)**:
-/// a node returning `ActionResult::Wait` with `WaitCondition::Webhook`
-/// must fail with a `WaitConditionNotSupported` error rather than parking
-/// without a timer entry and stalling the execution indefinitely.
+/// 5) **Webhook signal-park → `Paused`, downstream gated (W-S2.1 gate test)**:
+/// a two-node workflow `webhook_node → downstream` where `webhook_node` parks
+/// itself via `WaitCondition::Webhook` (no timeout). The test asserts:
 ///
-/// **Falsifiability**: change the park branch to handle `Webhook` the same
-/// as `Duration` (with `wake_at = None`) → the node parks, the frontier
-/// empties with a non-terminal `Waiting` node, and the engine either hangs
-/// (no timer to fire) or triggers `FrontierIntegrityViolation`. Restore the
-/// typed error return → the node fails immediately → `Failed` status → green.
+/// - At the instant `NodeParked` is received, `downstream_calls == 0` — the
+///   downstream edge is gated, not already activated.
+/// - After the frontier exits, `downstream_calls` is still 0 — the execution
+///   parked, not silently ran the edge.
+/// - The execution returns `Paused` (not `Failed`, not `Completed`, not hung).
+///
+/// **Falsifiability (gate assertion)**:
+/// - Re-introduce the W-S1 reject for Webhook → the node fails immediately →
+///   `result.status == Failed` → the `== Paused` assertion fails.
+/// - Remove priority-4a from `determine_final_status` → the engine returns
+///   `Failed+FrontierIntegrityViolation` → `== Paused` assertion fails.
+/// - Remove the `continue` from the park path → downstream runs before park →
+///   `downstream_calls == 1` at `NodeParked` → the `== 0` assertion fails.
 #[tokio::test]
-async fn webhook_wait_condition_returns_unsupported_error() {
+async fn webhook_wait_condition_parks_execution_as_paused() {
+    let downstream_calls = Arc::new(AtomicU32::new(0));
+
     let registry = Arc::new(ActionRegistry::new());
     registry.register_stateless_instance(
         ActionMetadata::new(
             action_key!("webhook_waiter"),
             "WebhookWaiter",
-            "waits for webhook callback",
+            "parks on webhook callback",
         ),
         WebhookWaitHandler,
     );
+    registry.register_stateless_instance(
+        ActionMetadata::new(action_key!("ds_webhook"), "DsWebhook", "downstream echo"),
+        EchoHandler {
+            invocations: Arc::clone(&downstream_calls),
+        },
+    );
 
-    let engine = make_engine(registry);
-    let n = node_key!("webhook_node");
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine = Arc::new(make_engine(registry).with_event_bus(event_bus));
+
+    let n1 = node_key!("webhook_node");
+    let n2 = node_key!("ds_node");
     let wf = make_workflow(
-        vec![NodeDefinition::new(n, "webhook_wait_node", "core", "webhook_waiter").unwrap()],
-        vec![],
+        vec![
+            NodeDefinition::new(n1.clone(), "webhook_wait_node", "core", "webhook_waiter").unwrap(),
+            NodeDefinition::new(n2, "ds_node", "core", "ds_webhook").unwrap(),
+        ],
+        vec![Connection::new(n1.clone(), node_key!("ds_node"))],
         WorkflowConfig::default(),
     );
 
-    let result = tokio::time::timeout(
-        Duration::from_secs(5),
-        engine.execute_workflow(
-            &nebula_engine::store_seam::single_tenant_scope(),
-            &wf,
-            serde_json::json!(null),
-            ExecutionBudget::default(),
-        ),
-    )
-    .await
-    .expect("workflow must settle quickly — Webhook condition must be rejected immediately")
-    .unwrap();
+    let engine_h = Arc::clone(&engine);
+    let task = tokio::spawn(async move {
+        engine_h
+            .execute_workflow(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &wf,
+                serde_json::json!(null),
+                ExecutionBudget::default(),
+            )
+            .await
+    });
 
-    // The workflow must end in Failed (not hung, not Completed, not Cancelled).
+    // Wait for `NodeParked` — webhook_node is now `Waiting`, downstream gated.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { node_key, .. }) if node_key == n1 => break,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeParked"),
+            }
+        }
+    })
+    .await
+    .expect("engine must emit NodeParked for a Webhook wait condition");
+
+    // Mid-park gate assertion: downstream must NOT have run at the instant of park.
     assert_eq!(
-        result.status,
-        ExecutionStatus::Failed,
-        "Webhook WaitCondition must cause a Failed execution, got {:?}",
-        result.status
+        downstream_calls.load(Ordering::SeqCst),
+        0,
+        "downstream must NOT run while webhook_node is Waiting — downstream gate broken"
     );
 
-    // At least one node error must reference the unsupported condition.
-    let all_errors: String = result
-        .node_errors
-        .values()
-        .cloned()
-        .collect::<Vec<_>>()
-        .join("; ");
-    assert!(
-        all_errors.contains("Webhook") || all_errors.contains("not supported"),
-        "node errors must reference 'Webhook' or 'not supported', got: {all_errors}"
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("execute_workflow must return promptly once all nodes have parked or finished")
+        .unwrap()
+        .unwrap();
+
+    // Signal-driven park → Paused, not Failed, not Completed, not hung.
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Paused,
+        "a signal-driven Wait must park the execution as Paused, not {:?}",
+        result.status
+    );
+    // Downstream must still be gated after the frontier exits.
+    assert_eq!(
+        downstream_calls.load(Ordering::SeqCst),
+        0,
+        "downstream must NEVER run until a Resume arrives (W-S2.2 responsibility)"
     );
 }
 

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -808,6 +808,43 @@ impl ExecutionState {
             .collect()
     }
 
+    /// Terminalize every non-terminal node as `Cancelled` (clearing any
+    /// `next_attempt_at`), returning how many nodes were transitioned.
+    ///
+    /// Used when an execution is cancelled with **no live frontier** to tear
+    /// down: the in-loop teardown (`drain_pending_to_cancelled`) only sees nodes
+    /// on its heaps/queues, so a signal-`Waiting{next_attempt_at: None}` node
+    /// (never heap-tracked) — or any node parked while the frontier was alive
+    /// and then exited (a `Paused` execution) — would otherwise remain
+    /// non-terminal under a `Cancelled` execution, violating the
+    /// terminal-execution ⇒ all-nodes-terminal invariant.
+    ///
+    /// Every non-terminal node state has a valid `→ Cancelled` edge (see
+    /// `can_transition_node`), so each transition goes through the checked
+    /// `transition_node` (not a silent field write) and a transition error
+    /// would be a transition-table regression, surfaced not swallowed.
+    ///
+    /// # Errors
+    ///
+    /// Propagates any [`ExecutionError`] from [`Self::transition_node`] (a
+    /// missing node or an unexpected illegal `→ Cancelled` edge).
+    pub fn cancel_nonterminal_nodes(&mut self) -> Result<usize, ExecutionError> {
+        let targets: Vec<NodeKey> = self
+            .node_states
+            .iter()
+            .filter(|(_, ns)| !ns.state.is_terminal())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let count = targets.len();
+        for node_key in targets {
+            self.transition_node(node_key.clone(), NodeState::Cancelled)?;
+            if let Some(ns) = self.node_states.get_mut(&node_key) {
+                ns.next_attempt_at = None;
+            }
+        }
+        Ok(count)
+    }
+
     /// Transition the execution status, validating the transition and bumping the version.
     pub fn transition_status(&mut self, new_status: ExecutionStatus) -> Result<(), ExecutionError> {
         validate_execution_transition(self.status, new_status)?;
@@ -937,6 +974,37 @@ mod tests {
         state.transition_status(ExecutionStatus::Running).unwrap();
         state.transition_status(ExecutionStatus::Completed).unwrap();
         assert!(state.completed_at.is_some());
+    }
+
+    #[test]
+    fn cancel_nonterminal_nodes_terminalizes_all_active_and_is_idempotent() {
+        let (mut state, n1, n2) = make_state();
+        // n1: a parked wait carrying a wake timer; n2: a blocked Pending node.
+        {
+            let ns1 = state.node_states.get_mut(&n1).unwrap();
+            ns1.state = NodeState::Waiting;
+            ns1.next_attempt_at = Some(Utc::now());
+        }
+        // n2 stays Pending (its upstream is the parked wait).
+
+        let count = state.cancel_nonterminal_nodes().unwrap();
+        assert_eq!(count, 2, "both non-terminal nodes must be cancelled");
+        assert!(
+            state.all_nodes_terminal(),
+            "no non-terminal node may survive cancel-of-no-live-runner"
+        );
+        assert_eq!(
+            state.node_state(n1.clone()).unwrap().state,
+            NodeState::Cancelled
+        );
+        assert_eq!(state.node_state(n2).unwrap().state, NodeState::Cancelled);
+        assert!(
+            state.node_state(n1).unwrap().next_attempt_at.is_none(),
+            "the wake timer must be cleared on cancel"
+        );
+
+        // Idempotent: a re-delivered Cancel finds everything terminal.
+        assert_eq!(state.cancel_nonterminal_nodes().unwrap(), 0);
     }
 
     #[test]


### PR DESCRIPTION
> ⚠️ **HELD FOR OWNER DECISION — do not merge yet.** Two design choices need your sign-off (see *Notes for reviewers*): (1) reuse `ExecutionStatus::Paused` as the public/persisted name for "awaiting external signal" (a persisted-enum migration if changed later), and (2) execution-level Resume wakes *all* signal-`Waiting` nodes (no per-`callback_id` targeting in v1). The code is built on the architect's recommended path for both; both are ADR-recordable, not code forks. Built + reviewed autonomously overnight per `/loop`.

## Summary

Second slice (W-S2 case-a) of the wait-state engine: wire `ControlCommand::Resume` to wake a node parked in `NodeState::Waiting` by a **signal-driven** wait condition (`Webhook`/`Approval`/`Execution`, no timeout). On Resume the parked node completes and downstream runs; without a Resume the execution sits durably `Paused`, holding no worker. This is the path `Interactive` HITL (Agent A-S3) and human-approval steps build on.

## Linked issue

Design in the maintainers' private vault: ADR-0099 (Wait-state engine), W-S2. Mechanism hardened by a chief-architect pass (the naive "re-entry completes the wait" was unsound — see Notes).

- Refs: ADR-0099

## Type of change

- [x] `feat` — new capability

## Affected crates / areas

- `nebula-engine` (`satisfy_signal_waits`, `dispatch_resume` wiring, `determine_final_status` priority-4a, signal-park, events)

## Changes

- **Signal-park**: signal conditions with `timeout: None` now park (were rejected); `timeout: Some` still rejected (W-S2b). A timer-less park makes the frontier exit `Paused`.
- **`determine_final_status` priority-4a**: an all-`Waiting{next_attempt_at: None}` non-terminal frontier ⇒ `Paused` (not a false `FrontierIntegrityViolation`); a mixed set (a `Running`/`WaitingRetry` node alongside) still surfaces the integrity violation (a `WaitingRetry` node at frontier-exit is anomalous — the exit invariant requires an empty retry-heap).
- **`WorkflowEngine::satisfy_signal_waits`**: flips each signal-`Waiting` node `Waiting → Completed` via a durable **version-CAS + fencing token**; `dispatch_resume` runs it **before** `drive`. This is the sole discriminator between a genuine Resume and a reclaim/`Start`/worker re-drive (which never call it) — so a crash-recovery re-drive re-parks (`Paused`) instead of auto-granting the wait. `NodeWaitCompleted` is emitted only after the CAS commits.
- **Idempotency / observability**: duplicate/late Resume short-circuits on status; a concurrent Resume loses the CAS (no-op); a fencing/version conflict returns `Ok` and emits a typed `ExecutionEvent::ResumeDeferred` (recovered by at-least-once redelivery).

## Test plan

`crates/engine/tests/signal_resume.rs` (7) + `wait.rs` + 4 `final_status` unit tests:
- signal-Wait parks → execution `Paused`, downstream gated (asserted at the moment of park).
- `dispatch_resume` → node `Completed` → downstream runs once → execution `Completed`.
- **Security discriminator (both re-entry paths):** `dispatch_start_redelivery_does_not_satisfy_signal_wait` and `dispatch_restart_does_not_satisfy_signal_wait` — a reclaim/restart re-drive of a Paused signal-park does NOT satisfy the wait (stays `Paused`, downstream never runs); a genuine `dispatch_resume` then completes it.
- Idempotent sequential Resume (`two_sequential_resumes_produce_exactly_one_downstream_run`); multi-node one-pass (`dispatch_resume_satisfies_all_signal_waits_in_one_pass`).
- `determine_final_status` matrix incl. `Waiting + WaitingRetry` ⇒ integrity violation, `Waiting + Pending` ⇒ `Paused`.

### Local verification

- [x] `cargo fmt` — clean (scoped `-p`; `--all` hits the Windows cmdline limit)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean (pre-push `clippy-full`)
- [x] `cargo nextest run` — 364/364 (pre-push), 635/635 across the 3 wait-state crates
- [x] `cargo test --doc` — rustdoc `-D warnings` clean (crate-diff-gate)
- [ ] `cargo deny check` — N/A (no `Cargo.toml` change)

## Breaking changes

None. Additive: `satisfy_signal_waits`, the `ResumeDeferred` event, and the relaxed park branch. `dispatch_resume` now satisfies signal-waits before `drive` (previously a plain drive). No public signature changed. `ExecutionStatus::Paused` now arises from a new cause (awaiting-signal) — see fork 1.

## Docs checklist

- [x] Reviewed `docs/PRODUCT_CANON.md` — the Resume/satisfy lifecycle is documented (function docs + ADR-0099); no silent drift.
- [x] Layer direction preserved (engine → execution → workflow).
- [x] L2 seam covered by the engine integration tests in this PR.
- [ ] `docs/MATURITY.md` — unchanged.
- [ ] `docs/INTEGRATION_MODEL.md` — deferred until the API resume transport (W-S3).
- [x] Plan/spec recorded: ADR-0099 (private vault).

## Safety / security impact

- [x] No new `unwrap()`/`expect()`/`panic!()` in library code.
- [x] No silent error suppression — the satisfy-CAS conflict path returns `Ok` (at-least-once recovery) AND emits a typed `ResumeDeferred` event for observability.
- [x] Engine state transitions go through `transition_node` / the CAS (no direct field writes for the durable transition).
- [x] No credential/secret paths touched.
- [x] No new `unsafe`.

## Notes for reviewers

- **The mechanism (read first):** a signal-wait is satisfied ONLY by `dispatch_resume`'s durable `satisfy_signal_waits` CAS, run BEFORE `drive`. All three re-entry paths (`dispatch_resume`, `dispatch_start`/`dispatch_restart`, worker `EngineExecutionSink`) reach `resume_execution` on `Paused` identically, so inferring "satisfy" from re-entry would let a **crash/reclaim re-drive auto-complete a human's wait** (data-corruption/security-class bug). The CAS-before-drive is the discriminator; the two `*_does_not_satisfy_*` tests lock it.
- **OWNER FORK 1 — is `Paused` the public/persisted name for "awaiting external signal"?** Reusing `Paused` is the smallest surface (architect's recommendation, implemented here) but conflates operator-pause with awaiting-signal; choosing a distinct status later is a persisted-enum migration. Your call.
- **OWNER FORK 2 — execution-level Resume wakes ALL signal-`Waiting` nodes** (no per-`callback_id` targeting in v1). Additive to refine, but it shapes the W-S3 resume-transport API (execution-scoped vs callback-scoped `POST .../resume`). Worth a conscious nod.
- **Deferred (W-S2b / W-S3+):** signal conditions WITH a timeout (timeout-as-failure + a live-frontier resume channel — a *different* discriminator since the row stays `Running`); per-`callback_id` targeting; the API resume transport; `Interactive` payload + `WaitCondition::Signal{schema}` (W-S4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal-driven workflows can pause for external triggers (webhooks, approvals, executions) and be resumed durably.
* **Improvements**
  * Resume now has clearer idempotent behavior and can safely defer when another runner holds the execution lease, ensuring redelivery instead of silently dropping progress.
  * Webhook-based waiting is now parked correctly and downstream execution remains gated until satisfied.
* **Bug Fixes**
  * Cancel/teardown now cleans up stranded signal waits that weren’t on the normal timer path.
* **Tests**
  * Added/expanded integration tests covering lease contention, idempotency, and redelivery recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->