### PR TITLE
feat(engine): W-S2b — signal waits with timeout (timeout-as-failure + live-frontier resume) (ADR-0099)

### DIFF
--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -73,6 +73,8 @@ zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 # so the resolver exercises the same CAS path as production. `sqlite` is enough;
 # the nebula test-util feature was removed from nebula-storage (ADR-0092 step 8).
 nebula-storage = { path = "../storage", features = ["sqlite"] }
+# Used by the W-S2b ack-gating tests' fault-injecting `ExecutionStore` wrapper.
+async-trait = { workspace = true }
 chrono = { workspace = true }
 futures = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -24,12 +24,16 @@
 //!   [`EngineError::Leased`], which `drive()` maps to `Ok(())` so the same execution is not fenced
 //!   as a consumer failure.
 //!
-//! - **Resume** additionally calls `satisfy_signal_waits` for `Paused` executions before
-//!   re-driving. Because `satisfy_signal_waits` holds the execution lease for its CAS, errors
-//!   split by effect: `Leased` returns `Deferred` (B1 reclaim redelivers); any other error
-//!   (CAS conflict, checkpoint failure) re-reads the persisted status — terminal / `Cancelling`
-//!   → ack; still non-terminal → `Deferred`. This ensures the Resume is never silently dropped
-//!   when the satisfy did not durably land.
+//! - **Resume** splits by persisted status. For a `Paused` execution it calls
+//!   `satisfy_signal_waits` before re-driving (the no-live-runner path). Because
+//!   `satisfy_signal_waits` holds the execution lease for its CAS, errors split by effect:
+//!   `Leased` returns `Deferred` (B1 reclaim redelivers); any other error (CAS conflict,
+//!   checkpoint failure) re-reads the persisted status — terminal / `Cancelling` → ack; still
+//!   non-terminal → `Deferred`. This ensures the Resume is never silently dropped when the
+//!   satisfy did not durably land. For a `Running` execution (a signal wait parked with a
+//!   `timeout`, so the row never reached `Paused`) it delivers the Resume to the live frontier
+//!   loop's resume channel via `WorkflowEngine::resume_live` (W-S2b): a live entry on this
+//!   runner → ack; no live entry (cross-runner / just-paused) → `Deferred` for B1 reclaim.
 //!
 //! - **Cancel / Terminate** always signal the engine's cancel registry (except for orphan commands,
 //!   which are [`ControlDispatchError::Rejected`]). The underlying
@@ -279,9 +283,42 @@ impl ControlDispatch for EngineControlDispatch {
             None => Err(ControlDispatchError::Rejected(format!(
                 "execution {execution_id} not found — resume command orphaned"
             ))),
+            // `Running`: a signal wait parked with a `timeout` keeps the row
+            // `Running` with a LIVE frontier loop on the timeout timer (W-S2b).
+            // The durable satisfy-CAS path cannot be used here — it would
+            // acquire the lease the live loop already holds. Instead deliver
+            // the Resume to the live loop's resume channel; the loop self-arms
+            // its signal wait under its own lease and completes it.
+            //
+            // If no live entry exists on this runner (`resume_live` returns
+            // false), the execution is driven by another runner or has just
+            // transitioned to `Paused` — defer for B1 reclaim, which redelivers
+            // to the owning runner / the durable Paused satisfy-CAS path.
+            Some(ExecutionStatus::Running) => {
+                if self.engine.resume_live(execution_id) {
+                    tracing::info!(
+                        %execution_id,
+                        "dispatch_resume: delivered to live frontier resume channel"
+                    );
+                    Ok(())
+                } else {
+                    tracing::warn!(
+                        %execution_id,
+                        "dispatch_resume: execution is Running but has no live frontier on this \
+                         runner; deferring for B1 reclaim (cross-runner or just-paused)"
+                    );
+                    self.engine.emit_event(ExecutionEvent::ResumeDeferred {
+                        execution_id,
+                        reason: "Running with no live frontier on this runner".to_owned(),
+                    });
+                    Err(ControlDispatchError::Deferred(format!(
+                        "execution {execution_id} is Running but not live on this runner; \
+                         Resume deferred for B1 reclaim"
+                    )))
+                }
+            },
             Some(
-                ExecutionStatus::Running
-                | ExecutionStatus::Cancelling
+                ExecutionStatus::Cancelling
                 | ExecutionStatus::Completed
                 | ExecutionStatus::Failed
                 | ExecutionStatus::Cancelled

--- a/crates/engine/src/control_dispatch.rs
+++ b/crates/engine/src/control_dispatch.rs
@@ -32,8 +32,12 @@
 //!   non-terminal → `Deferred`. This ensures the Resume is never silently dropped when the
 //!   satisfy did not durably land. For a `Running` execution (a signal wait parked with a
 //!   `timeout`, so the row never reached `Paused`) it delivers the Resume to the live frontier
-//!   loop's resume channel via `WorkflowEngine::resume_live` (W-S2b): a live entry on this
-//!   runner → ack; no live entry (cross-runner / just-paused) → `Deferred` for B1 reclaim.
+//!   loop's resume channel via `WorkflowEngine::resume_live` (W-S2b) and gates the ack on the
+//!   loop's DURABLE self-arm (P1#1): the loop checkpoints the arm under its own lease and replies
+//!   with the outcome. The row is acked only when the arm durably landed (`Armed`) or there was
+//!   nothing to arm (`NothingToArm`); a failed arm checkpoint, a gone loop, an ack timeout, or no
+//!   live entry (cross-runner / just-paused) → `Deferred` for B1 reclaim, each with a distinct
+//!   `ResumeDeferred` reason. Redelivery is idempotent.
 //!
 //! - **Cancel / Terminate** always signal the engine's cancel registry (except for orphan commands,
 //!   which are [`ControlDispatchError::Rejected`]). The underlying
@@ -65,7 +69,7 @@ use nebula_storage_port::{Scope, store::ExecutionStore};
 use crate::{
     WorkflowEngine,
     control_consumer::{ControlDispatch, ControlDispatchError},
-    engine::{CancelDanglingOutcome, SatisfyOutcome},
+    engine::{CancelDanglingOutcome, ResumeDelivery, ResumeOutcome, SatisfyOutcome},
     error::EngineError,
     event::ExecutionEvent,
 };
@@ -138,6 +142,34 @@ impl EngineControlDispatch {
                 ))),
             },
         }
+    }
+
+    /// Emit a typed [`ExecutionEvent::ResumeDeferred`], log a warning, and
+    /// return [`ControlDispatchError::Deferred`] for a `Running` execution
+    /// whose live-frontier Resume did not durably arm.
+    ///
+    /// Centralises the not-durable arm of [`Self::dispatch_resume`]'s
+    /// `Running` branch so each cause (arm-checkpoint failed, loop gone, ack
+    /// timeout, no live entry) carries a distinct, observable `reason` while
+    /// the row stays un-acked in `Processing` for B1 reclaim. Deferring is
+    /// always safe: Resume redelivery is idempotent.
+    fn defer_running_resume(
+        engine: &WorkflowEngine,
+        execution_id: ExecutionId,
+        reason: &str,
+    ) -> Result<(), ControlDispatchError> {
+        tracing::warn!(
+            %execution_id,
+            reason,
+            "dispatch_resume: live-frontier Resume not durably armed; deferring for B1 reclaim"
+        );
+        engine.emit_event(ExecutionEvent::ResumeDeferred {
+            execution_id,
+            reason: reason.to_owned(),
+        });
+        Err(ControlDispatchError::Deferred(format!(
+            "execution {execution_id} Resume deferred for B1 reclaim: {reason}"
+        )))
     }
 
     /// Drive an execution that is `Created` or `Paused` through the engine's
@@ -288,34 +320,59 @@ impl ControlDispatch for EngineControlDispatch {
             // The durable satisfy-CAS path cannot be used here — it would
             // acquire the lease the live loop already holds. Instead deliver
             // the Resume to the live loop's resume channel; the loop self-arms
-            // its signal wait under its own lease and completes it.
+            // its signal wait under its own lease, DURABLY checkpoints the arm,
+            // and replies with the outcome.
             //
-            // If no live entry exists on this runner (`resume_live` returns
-            // false), the execution is driven by another runner or has just
-            // transitioned to `Paused` — defer for B1 reclaim, which redelivers
-            // to the owning runner / the durable Paused satisfy-CAS path.
-            Some(ExecutionStatus::Running) => {
-                if self.engine.resume_live(execution_id) {
+            // P1#1 ack-gating: the control-queue row is acked ONLY when the
+            // self-arm checkpoint durably landed (`Armed`) or there was nothing
+            // to arm (`NothingToArm` — an idempotent duplicate). Every
+            // not-durable outcome — the arm checkpoint failed (the loop lost its
+            // lease mid-iteration), the loop exited before replying, the ack
+            // timed out, or no live loop exists on this runner — leaves the row
+            // un-acked (`Deferred`) for B1 reclaim, with a distinct
+            // `ResumeDeferred` reason so the cause is observable. Deferring is
+            // always safe: Resume redelivery is idempotent.
+            //
+            // No-live-owner recovery (`NoLiveEntry`) keeps today's behavior:
+            // defer for B1 reclaim. Recovering a `Running` execution that has no
+            // live loop on ANY runner is a future (W-S3) slice.
+            Some(ExecutionStatus::Running) => match self.engine.resume_live(execution_id).await {
+                ResumeDelivery::Acked(ResumeOutcome::Armed { count }) => {
                     tracing::info!(
                         %execution_id,
-                        "dispatch_resume: delivered to live frontier resume channel"
+                        armed_count = count,
+                        "dispatch_resume: live frontier durably armed the signal wait(s)"
                     );
                     Ok(())
-                } else {
-                    tracing::warn!(
+                },
+                ResumeDelivery::Acked(ResumeOutcome::NothingToArm) => {
+                    tracing::info!(
                         %execution_id,
-                        "dispatch_resume: execution is Running but has no live frontier on this \
-                         runner; deferring for B1 reclaim (cross-runner or just-paused)"
+                        "dispatch_resume: live frontier had no signal-Waiting node to arm \
+                         (already armed / none parked); acking as idempotent no-op"
                     );
-                    self.engine.emit_event(ExecutionEvent::ResumeDeferred {
-                        execution_id,
-                        reason: "Running with no live frontier on this runner".to_owned(),
-                    });
-                    Err(ControlDispatchError::Deferred(format!(
-                        "execution {execution_id} is Running but not live on this runner; \
-                         Resume deferred for B1 reclaim"
-                    )))
-                }
+                    Ok(())
+                },
+                ResumeDelivery::Acked(ResumeOutcome::ArmFailed) => Self::defer_running_resume(
+                    &self.engine,
+                    execution_id,
+                    "live frontier self-arm checkpoint failed (lease lost mid-iteration)",
+                ),
+                ResumeDelivery::LoopGone => Self::defer_running_resume(
+                    &self.engine,
+                    execution_id,
+                    "live frontier loop exited before confirming the self-arm",
+                ),
+                ResumeDelivery::AckTimeout => Self::defer_running_resume(
+                    &self.engine,
+                    execution_id,
+                    "live frontier did not confirm the self-arm within the ack timeout",
+                ),
+                ResumeDelivery::NoLiveEntry => Self::defer_running_resume(
+                    &self.engine,
+                    execution_id,
+                    "Running with no live frontier on this runner (cross-runner or just-paused)",
+                ),
             },
             Some(
                 ExecutionStatus::Cancelling

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -36,7 +36,7 @@ use nebula_execution::{
     ExecutionStatus,
     context::ExecutionBudget,
     plan::ExecutionPlan,
-    state::{AttemptOutcome, ExecutionState},
+    state::{AttemptOutcome, ExecutionState, WaitWake},
     status::ExecutionTerminationReason,
 };
 use nebula_expression::ExpressionEngine;
@@ -48,7 +48,10 @@ use nebula_metrics::naming::{
 use nebula_metrics::{Counter, Histogram, MetricsRegistry};
 use nebula_plugin::PluginRegistry;
 use nebula_workflow::{Connection, DependencyGraph, NodeState, WorkflowDefinition};
-use tokio::{sync::Semaphore, task::JoinSet};
+use tokio::{
+    sync::{Notify, Semaphore},
+    task::JoinSet,
+};
 use tokio_util::sync::CancellationToken;
 
 use nebula_storage_port::Scope;
@@ -342,9 +345,22 @@ static NEXT_REGISTRATION_ID: AtomicU64 = AtomicU64::new(1);
 /// [`CancellationToken`] with the [`RunningRegistrationId`] nonce so the
 /// drop guard can use [`DashMap::remove_if`] instead of unconditional
 /// `remove`.
+///
+/// `resume_notify` is the live-frontier resume channel (ADR-0099 W-S2b): a
+/// payload-less [`Notify`] the running loop selects on. A `Resume` command
+/// for a still-`Running` execution (a signal wait parked with a `timeout`,
+/// so the row never reached `Paused`) cannot use the durable satisfy-CAS —
+/// that path acquires the lease the live loop already holds (two-writers-
+/// one-row). Instead [`WorkflowEngine::resume_live`] notifies this channel;
+/// the loop wakes, self-arms the parked signal node under its OWN lease, and
+/// completes it through Phase-0b. The notify carries no payload — the
+/// durable row remains the sole source of truth, so a lost notification on
+/// crash costs nothing (the armed node survives and a redelivered Resume
+/// re-wakes it).
 struct RunningEntry {
     registration_id: RunningRegistrationId,
     token: CancellationToken,
+    resume_notify: Arc<Notify>,
 }
 
 /// RAII guard that removes an execution from the [`WorkflowEngine::running`]
@@ -450,6 +466,50 @@ impl WorkflowEngine {
         match self.running.get(&execution_id) {
             Some(entry) => {
                 entry.value().token.cancel();
+                true
+            },
+            None => false,
+        }
+    }
+
+    /// Deliver a `Resume` to a LIVE frontier loop owned by THIS runner
+    /// (ADR-0099 W-S2b).
+    ///
+    /// Returns `true` if a live `RunningEntry` for `execution_id` was found
+    /// on this runner and its [`Notify`] was signalled; the loop wakes,
+    /// self-arms its signal-`Waiting{next_attempt_at: None}` node(s) under
+    /// its OWN lease, and completes them through Phase-0b. Returns `false`
+    /// when no live entry exists on this runner — the execution is either
+    /// driven by a different runner or has just transitioned to `Paused`
+    /// (no live frontier), in which case the caller must defer to the
+    /// durable satisfy-CAS path (case-a) / B1 reclaim.
+    ///
+    /// Notifying (rather than writing the row) is load-bearing: a `Running`
+    /// execution's lease is held by its own loop, so the durable satisfy-CAS
+    /// would deadlock/race that owner (two-writers-one-row). The live loop
+    /// remains the sole writer of its own row.
+    ///
+    /// `true` means the resume notification was DELIVERED to the live loop's
+    /// channel — NOT that the Resume has been durably applied. The loop may
+    /// still drop the wake: a timeout for the same node already being processed
+    /// in the same loop iteration can win the race, in which case the node
+    /// fails on its deadline and the notification is a no-op.
+    ///
+    /// Durable-ack caveat for a future inbound-resume transport: a `true`
+    /// return acks the control-queue row BEFORE the live loop's self-arm
+    /// checkpoint is durable. A real Resume producer wired onto this channel
+    /// must therefore gate the control-queue ack on the durable arm (ack only
+    /// after the loop confirms the self-arm checkpoint landed) — otherwise a
+    /// crash between the ack and the checkpoint loses an acked-but-not-landed
+    /// Resume. The path has no production Resume producer today, so the gap is
+    /// currently unreachable.
+    ///
+    /// [`Notify`]: tokio::sync::Notify
+    #[must_use]
+    pub fn resume_live(&self, execution_id: ExecutionId) -> bool {
+        match self.running.get(&execution_id) {
+            Some(entry) => {
+                entry.value().resume_notify.notify_one();
                 true
             },
             None => false,
@@ -1245,6 +1305,10 @@ impl WorkflowEngine {
 
         let semaphore = Arc::new(Semaphore::new(budget.max_concurrent_nodes));
         let cancel_token = CancellationToken::new();
+        // Replay is lease-less and not published into the `running` registry,
+        // so no `Resume` can target it — a local, never-signalled `Notify`
+        // satisfies `run_frontier`'s contract (the resume arm never fires).
+        let resume_notify = Arc::new(Notify::new());
         let mut repo_version = 0u64;
 
         // Determine seed nodes: nodes in rerun set whose predecessors are all pinned.
@@ -1272,6 +1336,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
+                &resume_notify,
                 &mut exec_state,
                 execution_id,
                 workflow.id,
@@ -1684,11 +1749,16 @@ impl WorkflowEngine {
         // clobbering a winner's registration if a losing attempt ever
         // slips through.
         let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+        // Live-frontier resume channel (W-S2b): published alongside the
+        // cancel token so a `Resume` for this still-`Running` execution
+        // (a signal wait parked with a timeout) reaches the live loop.
+        let resume_notify = Arc::new(Notify::new());
         self.running.insert(
             execution_id,
             RunningEntry {
                 registration_id,
                 token: cancel_token.clone(),
+                resume_notify: Arc::clone(&resume_notify),
             },
         );
         let _cancel_registration = RunningRegistration {
@@ -1720,6 +1790,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
+                &resume_notify,
                 &mut exec_state,
                 execution_id,
                 workflow.id,
@@ -2189,11 +2260,15 @@ impl WorkflowEngine {
         // `execute_workflow` — see its comment for the full rationale
         // and the #482 Copilot review context.
         let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+        // Live-frontier resume channel (W-S2b) — symmetric to
+        // `execute_workflow`; see its comment for the rationale.
+        let resume_notify = Arc::new(Notify::new());
         self.running.insert(
             execution_id,
             RunningEntry {
                 registration_id,
                 token: cancel_token.clone(),
+                resume_notify: Arc::clone(&resume_notify),
             },
         );
         let _cancel_registration = RunningRegistration {
@@ -2229,6 +2304,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
+                &resume_notify,
                 &mut exec_state,
                 execution_id,
                 workflow_id,
@@ -2601,7 +2677,12 @@ impl WorkflowEngine {
             // activates every outgoing edge (a multi-port wait would fire its
             // `error`/custom branch on a normal Resume).
             if let Some(ns) = exec_state.node_states.get_mut(node_key) {
-                ns.next_attempt_at = Some(now);
+                // Arm for COMPLETION: a satisfied signal wait wakes to
+                // complete the node (`Waiting → Completed`), never to fail.
+                // (case-a made explicit by W-S2b's `wait_wake` discriminator.)
+                // The paired write keeps the next_attempt_at/wait_wake
+                // invariant intact.
+                ns.arm_wait_completion(now);
             }
         }
 
@@ -2959,6 +3040,7 @@ impl WorkflowEngine {
         outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         semaphore: &Arc<Semaphore>,
         cancel_token: &CancellationToken,
+        resume_notify: &Arc<Notify>,
         exec_state: &mut ExecutionState,
         execution_id: ExecutionId,
         workflow_id: WorkflowId,
@@ -3116,17 +3198,27 @@ impl WorkflowEngine {
             // Phase 0b: Drain due timer-wakes from `wait_heap`.
             //
             // A `Waiting` node whose `next_attempt_at` has passed has its
-            // wait condition satisfied: the engine transitions it directly
-            // to `Completed` (the action's `partial_output` was already
-            // committed to the outputs map when the node was parked) and
-            // activates its downstream edges. This mirrors Phase 0 for
-            // retries but targets `Completed` instead of `Ready`.
+            // timer wake due. What the wake MEANS is read from the persisted
+            // `wait_wake` discriminator (W-S2b), re-read here under the
+            // single-threaded loop owner AFTER the pop — never acted on from
+            // the popped heap tuple alone, so a Resume-then-timeout race
+            // (which self-arms the node `Completion`) cannot be double-routed:
+            //   - `Completion` / legacy `None`: complete the node
+            //     (`Waiting → Completed`), activate `main`-port downstream.
+            //     The `partial_output` was committed at park time.
+            //   - `Timeout`: the signal wait's deadline elapsed with no
+            //     Resume — FAIL the node (`Waiting → Failed` with
+            //     `RuntimeError::WaitTimedOut`) and route its outgoing edges
+            //     through the failure path (OnError / Skip / FailFast).
             let now_wait_drain = Utc::now();
             while let Some(Reverse((when, _))) = wait_heap.peek() {
                 if *when > now_wait_drain {
                     break;
                 }
-                let Some(Reverse((_, node_key))) = wait_heap.pop() else {
+                // Capture the deadline from the POPPED tuple (owned), not the
+                // peek reference, so we may mutate `wait_heap` again below
+                // while still using it for the timeout-ms reconstruction.
+                let Some(Reverse((deadline, node_key))) = wait_heap.pop() else {
                     // Unreachable: peek-then-pop on a single-threaded
                     // owner cannot lose the entry. Surface defensively
                     // rather than panic (hot-path safety).
@@ -3137,80 +3229,202 @@ impl WorkflowEngine {
                     );
                     break;
                 };
-                let still_parked = exec_state
+                // Race-safe re-read (R2): both the state AND the wake
+                // discriminator come from the live `exec_state` AFTER the pop,
+                // so a stale `(deadline, key)` entry for a node a Resume
+                // already re-armed `Completion` is read as a completion, not a
+                // timeout — never double-routed.
+                let parked_wake = exec_state
                     .node_state(node_key.clone())
-                    .is_some_and(|ns| ns.state == NodeState::Waiting);
-                if still_parked {
-                    match exec_state.transition_node(node_key.clone(), NodeState::Completed) {
-                        Ok(()) => {
-                            if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
-                                ns.next_attempt_at = None;
-                                ns.completed_at = Some(Utc::now());
-                            }
-                            // Persist the `Completed` transition and the
-                            // cleared `next_attempt_at` atomically before
-                            // activating downstream — durability precedes
-                            // visibility.
-                            if let Err(e) = self
-                                .checkpoint_node(
-                                    scope,
-                                    execution_id,
-                                    node_key.clone(),
-                                    outputs,
-                                    exec_state,
-                                    repo_version,
-                                    fencing,
-                                )
-                                .await
-                            {
-                                cancel_token.cancel();
-                                return Some((node_key.clone(), e.to_string()));
-                            }
-                            self.emit_event(ExecutionEvent::NodeWaitCompleted {
-                                execution_id,
-                                node_key: node_key.clone(),
-                            });
-                            tracing::info!(
-                                target = "engine::wait",
-                                %execution_id,
-                                %node_key,
-                                "wait condition satisfied (timer); node completed"
-                            );
-                            // Activate downstream edges now that the node is
-                            // `Completed` — this is the point at which the
-                            // downstream gate lifts.
-                            process_outgoing_edges(
-                                node_key.clone(),
-                                None, // no live `ActionResult` for this synthetic completion
-                                None,
-                                graph,
-                                &mut activated_edges,
-                                &mut resolved_edges,
-                                &required_count,
-                                &mut ready_queue,
-                                exec_state,
-                            );
-                        },
-                        Err(err) => {
-                            // `Waiting → Completed` is in the canonical table;
-                            // this branch fires only if the node was concurrently
-                            // cancelled. Surface defensively.
-                            tracing::warn!(
-                                target = "engine::wait",
-                                %execution_id,
-                                %node_key,
-                                %err,
-                                "wait-heap wake: Waiting→Completed rejected; skipping"
-                            );
-                        },
-                    }
-                } else {
+                    .filter(|ns| ns.state == NodeState::Waiting)
+                    .map(|ns| ns.wait_wake);
+                let Some(wait_wake) = parked_wake else {
                     tracing::debug!(
                         target = "engine::wait",
                         %execution_id,
                         %node_key,
                         "wait heap drained but node no longer in Waiting; skipping"
                     );
+                    continue;
+                };
+                // Legacy `None` on an armed timer wait reads as `Completion`
+                // (preserves W-S1 timer-wake semantics for pre-W-S2b rows).
+                if matches!(wait_wake, Some(WaitWake::Timeout)) {
+                    // ── Timeout fail path ──
+                    //
+                    // The `WaitCondition` variant is not persisted on the node
+                    // (only `next_attempt_at` + `wait_wake` are) — so the exact
+                    // signal kind (`Webhook` / `Approval` / `Execution`) is not
+                    // recoverable here, especially after a crash + recovery.
+                    // Report the honest discriminator we DO have: a signal
+                    // wait. (Per-variant detail returns with W-S3's persisted
+                    // resume targeting.)
+                    let condition_kind = "signal".to_owned();
+                    // Best-effort declared-timeout reconstruction: the absolute
+                    // deadline `when` (== `next_attempt_at`) minus the node's
+                    // `started_at` (stamped just before it parked) approximates
+                    // the original `timeout` duration. It survives crash +
+                    // recovery (both fields are persisted) and is an
+                    // observability value, not a control input — a small
+                    // over-estimate (the node's pre-park run time) is acceptable.
+                    let timeout_ms = exec_state
+                        .node_state(node_key.clone())
+                        .and_then(|ns| ns.started_at)
+                        .map(|started| {
+                            deadline
+                                .signed_duration_since(started)
+                                .num_milliseconds()
+                                .max(0) as u64
+                        })
+                        .unwrap_or(0);
+                    let timed_out = crate::runtime::error::RuntimeError::WaitTimedOut {
+                        condition_kind: condition_kind.clone(),
+                        timeout_ms,
+                    };
+                    let engine_err = EngineError::Runtime(timed_out);
+                    let err_str = engine_err.to_string();
+                    // `Waiting → Failed` is the W-S2b timeout edge. A
+                    // WaitTimedOut is terminal and bypasses the retry decision
+                    // entirely (it never counts against the retry budget).
+                    mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                    if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
+                        // Resolved wait: drop the timer pair so the now-`Failed`
+                        // node carries no stale wake metadata.
+                        ns.clear_wait_timer();
+                    }
+                    // Route outgoing edges through the failure path BEFORE the
+                    // checkpoint so an OnError handler's input payload is
+                    // durably captured (reuse — same contract as the Phase-3
+                    // finalize path). `Fail` (not `Recover`): OnError handlers,
+                    // if wired, activate; otherwise dependents are Skipped and
+                    // FailFast aborts the frontier.
+                    //
+                    // `Fail` is deliberate even under an `ErrorStrategy::
+                    // IgnoreErrors` node strategy: a wait timeout is a real
+                    // negative outcome (a missed approval/signal), not a
+                    // swallowable transient fault. It must surface as a failure
+                    // rather than be coerced to `Completed` with a null output.
+                    let abort = route_failure_edges(
+                        FailureOutcome::Fail,
+                        node_key.clone(),
+                        &err_str,
+                        error_strategy,
+                        graph,
+                        outputs,
+                        &mut activated_edges,
+                        &mut resolved_edges,
+                        &required_count,
+                        &mut ready_queue,
+                        exec_state,
+                    );
+                    // Durably commit the `Failed` transition (+ any OnError
+                    // payload routing already staged) before any observer sees
+                    // the timeout.
+                    if let Err(e) = self
+                        .checkpoint_node(
+                            scope,
+                            execution_id,
+                            node_key.clone(),
+                            outputs,
+                            exec_state,
+                            repo_version,
+                            fencing,
+                        )
+                        .await
+                    {
+                        cancel_token.cancel();
+                        return Some((node_key.clone(), e.to_string()));
+                    }
+                    self.emit_event(ExecutionEvent::NodeWaitTimedOut {
+                        execution_id,
+                        node_key: node_key.clone(),
+                        condition_kind,
+                        timeout_ms,
+                    });
+                    tracing::info!(
+                        target = "engine::wait",
+                        %execution_id,
+                        %node_key,
+                        timeout_ms,
+                        "signal wait timed out; node failed and failure edges routed"
+                    );
+                    if let Some(err_msg) = abort {
+                        // FailFast (no OnError handler): abort the frontier and
+                        // surface the timeout as the `failed_node` so
+                        // `determine_final_status` priority-2 marks the
+                        // execution `Failed`.
+                        cancel_token.cancel();
+                        return Some((node_key.clone(), err_msg));
+                    }
+                    // OnError-handled / ContinueOnError: the failure was routed
+                    // to the error branch / dependents Skipped — the loop
+                    // continues so the error subtree runs.
+                    continue;
+                }
+                // ── Completion path (Completion / legacy None) ──
+                match exec_state.transition_node(node_key.clone(), NodeState::Completed) {
+                    Ok(()) => {
+                        if let Some(ns) = exec_state.node_states.get_mut(&node_key) {
+                            // Resolved wait: drop the timer pair on the now-
+                            // `Completed` node.
+                            ns.clear_wait_timer();
+                            ns.completed_at = Some(Utc::now());
+                        }
+                        // Persist the `Completed` transition and the cleared
+                        // timer fields atomically before activating downstream —
+                        // durability precedes visibility.
+                        if let Err(e) = self
+                            .checkpoint_node(
+                                scope,
+                                execution_id,
+                                node_key.clone(),
+                                outputs,
+                                exec_state,
+                                repo_version,
+                                fencing,
+                            )
+                            .await
+                        {
+                            cancel_token.cancel();
+                            return Some((node_key.clone(), e.to_string()));
+                        }
+                        self.emit_event(ExecutionEvent::NodeWaitCompleted {
+                            execution_id,
+                            node_key: node_key.clone(),
+                        });
+                        tracing::info!(
+                            target = "engine::wait",
+                            %execution_id,
+                            %node_key,
+                            "wait condition satisfied (timer); node completed"
+                        );
+                        // Activate downstream edges now that the node is
+                        // `Completed` — this is the point at which the
+                        // downstream gate lifts.
+                        process_outgoing_edges(
+                            node_key.clone(),
+                            None, // no live `ActionResult` for this synthetic completion
+                            None,
+                            graph,
+                            &mut activated_edges,
+                            &mut resolved_edges,
+                            &required_count,
+                            &mut ready_queue,
+                            exec_state,
+                        );
+                    },
+                    Err(err) => {
+                        // `Waiting → Completed` is in the canonical table;
+                        // this branch fires only if the node was concurrently
+                        // cancelled. Surface defensively.
+                        tracing::warn!(
+                            target = "engine::wait",
+                            %execution_id,
+                            %node_key,
+                            %err,
+                            "wait-heap wake: Waiting→Completed rejected; skipping"
+                        );
+                    },
                 }
             }
 
@@ -3593,6 +3807,7 @@ impl WorkflowEngine {
                 WaitTimer,
                 WallClock,
                 Cancel,
+                ResumeSignalled,
             }
 
             let join_next_fut: Pin<Box<dyn Future<Output = JoinedResult> + Send + '_>> =
@@ -3602,12 +3817,18 @@ impl WorkflowEngine {
                     Box::pin(join_set.join_next_with_id())
                 };
 
+            // `Notify::notified()` is cancellation-safe in this `select!`: a
+            // `notify_one()` that races the loop body (fired while we are not
+            // awaiting) stores a single permit, which the next iteration's
+            // fresh `notified()` consumes immediately — the Resume is never
+            // lost between iterations.
             let wake = tokio::select! {
                 result = join_next_fut => WakeReason::Joined(result),
                 () = &mut retry_sleep_fut, if next_retry_in.is_some() => WakeReason::RetryTimer,
                 () = &mut wait_sleep_fut, if next_wait_in.is_some() => WakeReason::WaitTimer,
                 () = &mut sleep_fut => WakeReason::WallClock,
                 () = cancel_token.cancelled() => WakeReason::Cancel,
+                () = resume_notify.notified() => WakeReason::ResumeSignalled,
             };
 
             let join_result = match wake {
@@ -3626,6 +3847,126 @@ impl WorkflowEngine {
                 WakeReason::WaitTimer => {
                     // Timer fired — loop back so Phase 0b drains due
                     // wait-wakes into completed + downstream edges.
+                    continue;
+                },
+                WakeReason::ResumeSignalled => {
+                    // A `Resume` command targeted this LIVE execution (W-S2b).
+                    // The row stayed `Running` (a signal wait was parked with a
+                    // `timeout`, so the loop holds the lease on the timeout
+                    // timer). The durable satisfy-CAS path cannot be used here —
+                    // it acquires the lease this loop already holds (two-writers-
+                    // one-row). Instead the live loop is the SOLE writer of its
+                    // own row: self-arm each signal-`Waiting{next_attempt_at:
+                    // None}` node for completion under the loop's OWN lease, then
+                    // loop back so Phase-0b completes it through the main port.
+                    //
+                    // Untargeted in v1 (mirrors case-a fork-2): a Resume arms
+                    // every signal wait. Per-callback_id targeting is W-S3
+                    // (carried in the durable CAS, not this volatile wake).
+                    //
+                    // A LIVE (`Running`) execution's signal waits are the
+                    // timeout-bearing ones: parked with `wait_wake == Timeout`
+                    // and a future `next_attempt_at` deadline. (A signal-only
+                    // wait, `next_attempt_at == None`, would have driven the row
+                    // to `Paused` — case-a, satisfied by the durable CAS, not
+                    // this channel.) We arm BOTH shapes defensively: re-stamp
+                    // `next_attempt_at = now` (overriding any future timeout
+                    // deadline so Phase-0b completes immediately) and flip
+                    // `wait_wake = Completion` (a Resume completes, never times
+                    // out). The stale future `(deadline, key)` heap entry pops
+                    // later, finds the node non-`Waiting`, and is skipped — the
+                    // race-safety the Phase-0b state re-read guarantees.
+                    let now = Utc::now();
+                    let to_arm: Vec<NodeKey> = exec_state
+                        .node_states
+                        .iter()
+                        .filter(|(_, ns)| ns.state == NodeState::Waiting && is_signal_wait(ns))
+                        .map(|(id, _)| id.clone())
+                        .collect();
+                    if to_arm.is_empty() {
+                        // Spurious or already-armed wake — nothing to do. Loop
+                        // back; the exit-condition / timers re-evaluate.
+                        tracing::debug!(
+                            target = "engine::wait",
+                            %execution_id,
+                            "resume signalled but no signal-Waiting node to arm; ignoring"
+                        );
+                        continue;
+                    }
+                    for node_key in &to_arm {
+                        if let Some(ns) = exec_state.node_states.get_mut(node_key) {
+                            // Arm for Phase-0b completion. The execution version
+                            // is bumped by the checkpoint below (this is a direct
+                            // field write on the loop's own in-memory state, the
+                            // same shape as `satisfy_signal_waits_under_lease`).
+                            // The paired write keeps the
+                            // next_attempt_at/wait_wake invariant intact.
+                            ns.arm_wait_completion(now);
+                        }
+                    }
+                    // Bump the version once so the checkpoint CAS advances and
+                    // any reader observes the arm. (`set_node_state`/direct field
+                    // writes do not bump; mirror the satisfy path's single bump.)
+                    exec_state.version += 1;
+                    exec_state.updated_at = Utc::now();
+                    // The single checkpoint below carries ALL armed nodes but is
+                    // attributed to `to_arm[0]` (a checkpoint takes one key).
+                    // Log the full armed set so a checkpoint failure with N>1
+                    // armed nodes is not misread as touching only the first key.
+                    tracing::debug!(
+                        target = "engine::wait",
+                        %execution_id,
+                        armed = ?to_arm,
+                        armed_count = to_arm.len(),
+                        "live-frontier resume: arming signal waits for Phase-0b completion"
+                    );
+                    // Durably commit the arm under the loop's OWN lease before
+                    // Phase-0b acts on it. On checkpoint failure, abort the
+                    // frontier rather than completing a wait whose arm did not
+                    // land.
+                    if let Err(e) = self
+                        .checkpoint_node(
+                            scope,
+                            execution_id,
+                            // No single node owns this multi-node arm; reuse the
+                            // first armed node as the checkpoint's attribution key.
+                            to_arm[0].clone(),
+                            outputs,
+                            exec_state,
+                            repo_version,
+                            fencing,
+                        )
+                        .await
+                    {
+                        cancel_token.cancel();
+                        return Some((to_arm[0].clone(), e.to_string()));
+                    }
+                    // Purge any stale future heap entry for the re-armed nodes
+                    // (e.g. a signal+timeout wait's original timeout deadline)
+                    // and replace it with a now-due entry, so Phase-0b completes
+                    // immediately and the loop does not idle until the old
+                    // deadline. `BinaryHeap` has no keyed remove, so rebuild it
+                    // without the re-armed keys (the heap is small — one entry
+                    // per parked node). Correctness does not depend on this
+                    // (the stale entry would pop later and be skipped via the
+                    // state re-read); it removes a spurious wait until the old
+                    // deadline.
+                    let armed: HashSet<&NodeKey> = to_arm.iter().collect();
+                    let retained: Vec<_> = std::mem::take(&mut wait_heap)
+                        .into_iter()
+                        .filter(|Reverse((_, key))| !armed.contains(key))
+                        .collect();
+                    wait_heap.extend(retained);
+                    for node_key in to_arm {
+                        wait_heap.push(Reverse((now, node_key.clone())));
+                        tracing::info!(
+                            target = "engine::wait",
+                            %execution_id,
+                            %node_key,
+                            "live-frontier resume: armed signal wait for Phase-0b completion"
+                        );
+                    }
+                    // Loop back so Phase-0b drains the armed waits → main port.
                     continue;
                 },
                 WakeReason::WallClock => {
@@ -3675,69 +4016,69 @@ impl WorkflowEngine {
                     // condition is satisfied.
                     //
                     // Conditions supported by this path:
-                    //   Timer: `Until` / `Duration` — push onto `wait_heap`;
-                    //     Phase-0b drains to `Completed` when the timer fires.
-                    //   Signal: `Webhook` / `Approval` / `Execution` (timeout:None) —
-                    //     `wake_at = None`, no heap entry; execution parks at `Paused`
-                    //     until a `Resume` command's durable satisfy-CAS arms it
-                    //     (sets `next_attempt_at`) for Phase-0b completion.
+                    //   Timer: `Until` / `Duration` (timeout:None) — `wake_at` is
+                    //     the condition's instant, `wait_wake = Completion`; pushed
+                    //     onto `wait_heap`; Phase-0b drains to `Completed`.
+                    //   Signal (timeout:None): `Webhook` / `Approval` / `Execution` —
+                    //     `wake_at = None`, `wait_wake = None`, no heap entry;
+                    //     execution parks at `Paused` until a `Resume` command's
+                    //     durable satisfy-CAS arms it for Phase-0b completion (case-a).
+                    //   Signal (timeout:Some(dur)): `Webhook` / `Approval` /
+                    //     `Execution` with a deadline — `wake_at = now + dur`,
+                    //     `wait_wake = Timeout`; pushed onto `wait_heap`; the row
+                    //     stays `Running` (a live loop on the timeout timer). A
+                    //     `Resume` reaches it through the live-frontier resume channel
+                    //     (W-S2b), NOT the Paused satisfy-CAS. If the timer fires
+                    //     first, Phase-0b FAILS the node (`WaitTimedOut`).
                     //
-                    // Not yet supported — still rejected:
-                    //   Any condition with `timeout: Some(..)`: the
-                    //   timeout-as-cancellation path requires a live-frontier
-                    //   resume channel that is not yet implemented.
+                    // Still rejected:
+                    //   Timer (`Until` / `Duration`) WITH `timeout:Some(..)`: two
+                    //     competing timers is ambiguous; silently honouring one and
+                    //     discarding the other is a correctness bug (W-S1 P2). A
+                    //     timeout on a timer wait stays an explicit error.
                     if let ActionResult::Wait {
                         ref condition,
                         timeout,
                         ..
                     } = action_result
                     {
-                        // Reject explicit timeouts: the timeout-as-cancellation
-                        // path belongs to W-S2. Silently ignoring a `timeout`
-                        // would mean the node waits the full condition duration
-                        // (up to hours) instead of the declared maximum, which
-                        // is a correctness bug, not a missing optimisation.
-                        if let Some(_timeout_dur) = timeout {
-                            let condition_kind = match condition {
-                                WaitCondition::Until { .. } => "Until with explicit timeout",
-                                WaitCondition::Duration { .. } => "Duration with explicit timeout",
-                                WaitCondition::Webhook { .. } => "Webhook with explicit timeout",
-                                WaitCondition::Approval { .. } => "Approval with explicit timeout",
-                                WaitCondition::Execution { .. } => {
-                                    "Execution with explicit timeout"
-                                },
-                                _ => "Unknown with explicit timeout",
-                            };
-                            let runtime_err =
-                                crate::runtime::error::RuntimeError::WaitConditionNotSupported {
-                                    condition_kind: condition_kind.to_owned(),
-                                };
-                            let engine_err = EngineError::Runtime(runtime_err);
-                            tracing::error!(
-                                target = "engine::wait",
-                                %execution_id,
-                                %node_key,
-                                condition_kind,
-                                error = %engine_err,
-                                "explicit timeout on WaitCondition not supported in W-S1; \
-                                 marking node Failed and returning error"
-                            );
-                            mark_node_failed(exec_state, node_key.clone(), &engine_err);
-                            cancel_token.cancel();
-                            return Some((node_key.clone(), engine_err.to_string()));
-                        }
-
-                        // Compute the timer wake instant for timer-based conditions.
-                        // Signal-driven conditions (Webhook / Approval / Execution) park
-                        // with `wake_at = None`: they hold no timer heap entry and remain
-                        // suspended until an explicit Resume command delivers the signal.
-                        // The frontier exits with all heaps empty while those nodes are
-                        // still `Waiting{next_attempt_at == None}`; `determine_final_status`
-                        // priority-4a recognises that as `Paused`, not a frontier bug.
                         let now = Utc::now();
-                        let wake_at: Option<DateTime<Utc>> = match condition {
-                            WaitCondition::Until { datetime } => Some(*datetime),
-                            WaitCondition::Duration { duration } => {
+                        // Compute the (wake_at, wait_wake) pair. `wait_wake` records
+                        // how a timer wake is to be read when it fires: `Completion`
+                        // for a timer-driven wait, `Timeout` for a signal wait whose
+                        // declared `timeout` is the wake. A signal-only park carries
+                        // neither (satisfied by an explicit Resume, not a timer); its
+                        // node stays `Waiting{None}` and `determine_final_status`
+                        // priority-4a recognises that as `Paused`, not a frontier bug.
+                        let wake_plan: (Option<DateTime<Utc>>, Option<WaitWake>) = match condition {
+                            WaitCondition::Until { .. } | WaitCondition::Duration { .. } => {
+                                // Timer wait. An explicit `timeout` on a timer is two
+                                // competing deadlines — reject (W-S1 P2 invariant).
+                                if timeout.is_some() {
+                                    let condition_kind = match condition {
+                                        WaitCondition::Until { .. } => {
+                                            "Until with explicit timeout"
+                                        },
+                                        _ => "Duration with explicit timeout",
+                                    };
+                                    let engine_err = EngineError::Runtime(
+                                        crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                            condition_kind: condition_kind.to_owned(),
+                                        },
+                                    );
+                                    tracing::error!(
+                                        target = "engine::wait",
+                                        %execution_id,
+                                        %node_key,
+                                        condition_kind,
+                                        error = %engine_err,
+                                        "explicit timeout on a TIMER WaitCondition is ambiguous \
+                                         (two competing deadlines); marking node Failed"
+                                    );
+                                    mark_node_failed(exec_state, node_key.clone(), &engine_err);
+                                    cancel_token.cancel();
+                                    return Some((node_key.clone(), engine_err.to_string()));
+                                }
                                 // FAIL CLOSED on an unrepresentable / overflowing timer
                                 // Duration. Mapping the error to `None` would silently
                                 // turn a TIMER wait into a signal-driven indefinite park
@@ -3754,38 +4095,98 @@ impl WorkflowEngine {
                                             %execution_id,
                                             %node_key,
                                             error = %engine_err,
-                                            "Duration WaitCondition cannot be scheduled; marking \
+                                            "timer WaitCondition cannot be scheduled; marking \
                                              node Failed (fail-closed)"
                                         );
                                         mark_node_failed(exec_state, node_key.clone(), &engine_err);
                                         cancel_token.cancel();
                                         engine_err.to_string()
                                     };
-                                let Ok(chrono_dur) = chrono::Duration::from_std(*duration) else {
-                                    let msg = fail_unschedulable(
-                                        exec_state,
-                                        format!("Duration wait not representable: {duration:?}"),
-                                    );
-                                    return Some((node_key.clone(), msg));
+                                let when = match condition {
+                                    WaitCondition::Until { datetime } => *datetime,
+                                    WaitCondition::Duration { duration } => {
+                                        let Ok(chrono_dur) = chrono::Duration::from_std(*duration)
+                                        else {
+                                            let msg = fail_unschedulable(
+                                                exec_state,
+                                                format!(
+                                                    "Duration wait not representable: {duration:?}"
+                                                ),
+                                            );
+                                            return Some((node_key.clone(), msg));
+                                        };
+                                        let Some(when) = now.checked_add_signed(chrono_dur) else {
+                                            let msg = fail_unschedulable(
+                                                exec_state,
+                                                "Duration wait overflows the scheduler timestamp"
+                                                    .to_owned(),
+                                            );
+                                            return Some((node_key.clone(), msg));
+                                        };
+                                        when
+                                    },
+                                    // Unreachable: outer arm is Until|Duration only.
+                                    _ => unreachable!("timer arm matched a non-timer condition"),
                                 };
-                                let Some(when) = now.checked_add_signed(chrono_dur) else {
-                                    let msg = fail_unschedulable(
-                                        exec_state,
-                                        "Duration wait overflows the scheduler timestamp"
-                                            .to_owned(),
-                                    );
-                                    return Some((node_key.clone(), msg));
-                                };
-                                Some(when)
+                                (Some(when), Some(WaitWake::Completion))
                             },
-                            // Signal-driven conditions: no timer wake — the park is
-                            // indefinite until a Resume command's durable satisfy-CAS
-                            // arms the node (sets `next_attempt_at`) for Phase-0b
-                            // completion. `wake_at = None` means the node is never
-                            // pushed onto `wait_heap` until a Resume arms it.
+                            // Signal-driven conditions.
                             WaitCondition::Webhook { .. }
                             | WaitCondition::Approval { .. }
-                            | WaitCondition::Execution { .. } => None,
+                            | WaitCondition::Execution { .. } => {
+                                match timeout {
+                                    // Signal + timeout (W-S2b): park with a timeout
+                                    // timer, `wait_wake = Timeout`. The row stays
+                                    // `Running`; Phase-0b FAILS the node if the timer
+                                    // fires before a Resume arrives.
+                                    Some(dur) => {
+                                        let Ok(chrono_dur) = chrono::Duration::from_std(dur) else {
+                                            let engine_err = EngineError::Runtime(
+                                                crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                                    condition_kind: format!(
+                                                        "signal wait timeout not representable: \
+                                                         {dur:?}"
+                                                    ),
+                                                },
+                                            );
+                                            mark_node_failed(
+                                                exec_state,
+                                                node_key.clone(),
+                                                &engine_err,
+                                            );
+                                            cancel_token.cancel();
+                                            return Some((
+                                                node_key.clone(),
+                                                engine_err.to_string(),
+                                            ));
+                                        };
+                                        let Some(deadline) = now.checked_add_signed(chrono_dur)
+                                        else {
+                                            let engine_err = EngineError::Runtime(
+                                                crate::runtime::error::RuntimeError::WaitConditionNotSupported {
+                                                    condition_kind:
+                                                        "signal wait timeout overflows the \
+                                                         scheduler timestamp"
+                                                            .to_owned(),
+                                                },
+                                            );
+                                            mark_node_failed(
+                                                exec_state,
+                                                node_key.clone(),
+                                                &engine_err,
+                                            );
+                                            cancel_token.cancel();
+                                            return Some((
+                                                node_key.clone(),
+                                                engine_err.to_string(),
+                                            ));
+                                        };
+                                        (Some(deadline), Some(WaitWake::Timeout))
+                                    },
+                                    // Signal only (case-a): no timer, parks at Paused.
+                                    None => (None, None),
+                                }
+                            },
                             _ => {
                                 // Unknown WaitCondition variant — FAIL CLOSED.
                                 // Parking with `wake_at = None` would let a generic
@@ -3793,8 +4194,7 @@ impl WorkflowEngine {
                                 // this engine cannot classify (a signal vs timer vs
                                 // something else). Until a variant is explicitly added
                                 // to the signal/timer arms above, reject it on the same
-                                // `WaitConditionNotSupported` path as an explicit timeout
-                                // rather than parking it.
+                                // `WaitConditionNotSupported` path rather than parking it.
                                 let runtime_err =
                                     crate::runtime::error::RuntimeError::WaitConditionNotSupported {
                                         condition_kind: "unrecognised WaitCondition variant"
@@ -3814,6 +4214,7 @@ impl WorkflowEngine {
                                 return Some((node_key.clone(), engine_err.to_string()));
                             },
                         };
+                        let (wake_at, wait_wake) = wake_plan;
 
                         // Budget enforcement for the partial output committed at park
                         // time. The normal success path increments `total_output_bytes`
@@ -3863,7 +4264,7 @@ impl WorkflowEngine {
                             }
                         }
 
-                        match exec_state.park_node(node_key.clone(), wake_at) {
+                        match exec_state.park_node(node_key.clone(), wake_at, wait_wake) {
                             Ok(()) => {
                                 // Signal park (no timer) that leaves NO other active
                                 // frontier work fully suspends the execution: persist
@@ -3879,6 +4280,11 @@ impl WorkflowEngine {
                                 // and ignored). The general crashed-`Running` recovery
                                 // gap (e.g. a sibling completing last) is tracked
                                 // separately.
+                                //
+                                // A signal + timeout park has `wake_at = Some(_)`, so it
+                                // is NOT covered here: the row stays `Running` with a
+                                // live loop on the timeout timer (W-S2b). Its Resume
+                                // arrives through the live-frontier resume channel.
                                 if wake_at.is_none()
                                     && join_set.is_empty()
                                     && ready_queue.is_empty()
@@ -3908,11 +4314,12 @@ impl WorkflowEngine {
                                     cancel_token.cancel();
                                     return Some((node_key.clone(), e.to_string()));
                                 }
-                                // Push onto the wait_heap for timer-driven conditions only.
-                                // Signal-driven conditions (`wake_at == None`) are never
-                                // pushed here; their node stays `Waiting` until a Resume
-                                // command's durable satisfy-CAS arms it (sets
-                                // `next_attempt_at`) for Phase-0b completion.
+                                // Push onto the wait_heap whenever there is a timer
+                                // (`wake_at == Some`): a timer-driven completion wait
+                                // (`Completion`) OR a signal+timeout wait
+                                // (`Timeout`). Signal-only conditions (`wake_at ==
+                                // None`) are never pushed; their node stays `Waiting`
+                                // until a Resume command's durable satisfy-CAS arms it.
                                 if let Some(when) = wake_at {
                                     wait_heap.push(Reverse((when, node_key.clone())));
                                 }
@@ -5675,7 +6082,13 @@ fn drain_pending_to_cancelled(
     while let Some(Reverse((_, waiting))) = wait_heap.pop() {
         let _ = exec_state.transition_node(waiting.clone(), NodeState::Cancelled);
         if let Some(ns) = exec_state.node_states.get_mut(&waiting) {
-            ns.next_attempt_at = None;
+            // Clear both timer fields together: a signal+timeout wait carries
+            // `wait_wake = Some(..)` as well as `next_attempt_at`, and the
+            // next_attempt_at/wait_wake invariant must hold even on a terminal
+            // Cancelled node. `clear_wait_timer` is safe here — wait_heap nodes
+            // are `Waiting` (not WaitingRetry), so `next_attempt_at` is a park
+            // timer, not a retry timer.
+            ns.clear_wait_timer();
         }
         tracing::debug!(
             target = "engine::wait",
@@ -6094,6 +6507,21 @@ fn deserialize_stored_result(
             None
         },
     }
+}
+
+/// Whether a parked [`NodeState::Waiting`] node is a **signal** wait — one a
+/// `Resume` can satisfy, as opposed to a pure timer wait that only a timer can.
+///
+/// Two shapes:
+/// - signal-only: `next_attempt_at == None` (case-a; the row went `Paused`).
+/// - signal + timeout: `wait_wake == Some(Timeout)` (W-S2b; the row stays
+///   `Running` with the timeout deadline in `next_attempt_at`).
+///
+/// A timer-driven completion wait (`Until` / `Duration`) carries
+/// `wait_wake == Some(Completion)` with a `next_attempt_at` — that is NOT a
+/// signal wait and a Resume must never re-arm it.
+fn is_signal_wait(ns: &nebula_execution::state::NodeExecutionState) -> bool {
+    ns.next_attempt_at.is_none() || ns.wait_wake == Some(WaitWake::Timeout)
 }
 
 /// Mark a node as failed in the execution state.

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -2686,6 +2686,17 @@ impl WorkflowEngine {
             }
         }
 
+        // Mirror `ExecutionState::transition_node`: direct field mutation must
+        // still advance `version`/`updated_at` so the serialized blob's
+        // denormalized version matches the row the store CAS produces. A reader
+        // that reconstructs `ExecutionState` from the blob and keys its own CAS
+        // on `exec_state.version` must not accept a stale snapshot whose version
+        // never moved. (The store CAS below keys on `repo_version`, so the
+        // commit is correct regardless; this keeps the in-blob copy honest —
+        // the same bump the W-S2b live-frontier self-arm performs.)
+        exec_state.version += 1;
+        exec_state.updated_at = now;
+
         // Persist the satisfy-CAS. This is the single discriminator between
         // a genuine Resume and a reclaim re-drive: only this code path arms
         // `next_attempt_at` on a signal-`Waiting{None}` node before `drive`

--- a/crates/engine/src/engine.rs
+++ b/crates/engine/src/engine.rs
@@ -49,7 +49,7 @@ use nebula_metrics::{Counter, Histogram, MetricsRegistry};
 use nebula_plugin::PluginRegistry;
 use nebula_workflow::{Connection, DependencyGraph, NodeState, WorkflowDefinition};
 use tokio::{
-    sync::{Notify, Semaphore},
+    sync::{Semaphore, mpsc, oneshot},
     task::JoinSet,
 };
 use tokio_util::sync::CancellationToken;
@@ -129,6 +129,27 @@ pub const DEFAULT_EXECUTION_LEASE_TTL: Duration = Duration::from_secs(30);
 /// heartbeat misses still leave the lease valid for at least another TTL
 /// cycle before acquire-on-expiry can kick in. See ADR 0008.
 pub const DEFAULT_EXECUTION_LEASE_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
+
+/// How long [`WorkflowEngine::resume_live`] waits for the live frontier loop
+/// to confirm a durable self-arm checkpoint before treating the Resume as
+/// undelivered (ADR-0099 W-S2b, P1#1).
+///
+/// Generously larger than the live loop's longest non-`await` span between two
+/// `recv()` polls (one frontier iteration), so a healthy loop always acks
+/// inside the window; well under [`DEFAULT_EXECUTION_LEASE_TTL`], so a runner
+/// that is genuinely wedged times out here long before its lease expires and
+/// B1 reclaim takes over. A timeout resolves to a `Deferred` control-queue
+/// outcome, which is safe because Resume redelivery is idempotent — the arm
+/// either has not landed (redelivery re-arms) or has landed and a duplicate
+/// Resume is a no-op on the already-armed node.
+const RESUME_ACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Bounded capacity of a live frontier loop's resume channel (ADR-0099
+/// W-S2b, P1#1). A Resume is rare relative to a loop iteration, so the loop
+/// drains each request well before another arrives; the small buffer absorbs
+/// a brief burst, and a full channel is treated by [`WorkflowEngine::resume_live`]
+/// as no-delivery (defer for B1 reclaim) rather than a blocking send.
+const RESUME_CHANNEL_CAPACITY: usize = 8;
 
 /// Type alias for the boxed async credential-refresh function stored on the engine.
 ///
@@ -341,26 +362,90 @@ type RunningRegistrationId = u64;
 /// Process-wide monotonic counter for registration nonces.
 static NEXT_REGISTRATION_ID: AtomicU64 = AtomicU64::new(1);
 
+/// A request to a live frontier loop to self-arm its parked signal waits for
+/// completion (ADR-0099 W-S2b, P1#1).
+///
+/// Carries a one-shot `ack` channel the loop fires AFTER it durably
+/// checkpoints the self-arm (or learns the arm failed). The request itself
+/// carries no node targeting — a Resume arms every signal wait (per-callback
+/// targeting is W-S3) — so the payload is purely the reply path.
+struct ResumeRequest {
+    /// The loop sends exactly one [`ResumeOutcome`] here once the self-arm
+    /// has durably landed or failed. A dropped sender (the loop exited
+    /// before replying) resolves the awaiting receiver to `Err`, which
+    /// [`WorkflowEngine::resume_live`] maps to [`ResumeDelivery::LoopGone`].
+    ack: oneshot::Sender<ResumeOutcome>,
+}
+
+/// The durable result of a live loop processing a [`ResumeRequest`].
+///
+/// Sent on the request's `ack` channel STRICTLY after the self-arm
+/// checkpoint resolves, so an `Armed` outcome is a durability guarantee, not
+/// a "the loop woke up" signal.
+#[derive(Debug)]
+pub(crate) enum ResumeOutcome {
+    /// The loop armed `count` signal waits and the arm checkpoint landed
+    /// durably. The control-queue row may be acked.
+    Armed {
+        /// Number of signal-`Waiting` nodes armed in this pass.
+        count: usize,
+    },
+    /// The loop woke but found no signal-`Waiting` node to arm (spurious or
+    /// already-armed wake). Nothing to do; the row may be acked.
+    NothingToArm,
+    /// The self-arm checkpoint failed (e.g. the loop lost its lease
+    /// mid-iteration: `FencedOut` / `CasConflict`). The arm did NOT land; the
+    /// row must NOT be acked.
+    ArmFailed,
+}
+
+/// The outcome of [`WorkflowEngine::resume_live`] delivering a Resume to a
+/// live frontier loop.
+///
+/// Distinguishes the durable-ack cases (`Acked`) from the no-delivery cases
+/// (`NoLiveEntry` / `LoopGone` / `AckTimeout`) so `dispatch_resume` can ack
+/// only when the arm is durable and otherwise defer for B1 reclaim.
+#[derive(Debug)]
+pub(crate) enum ResumeDelivery {
+    /// The live loop received the request and replied with a durable
+    /// [`ResumeOutcome`].
+    Acked(ResumeOutcome),
+    /// No live `RunningEntry` exists on this runner (cross-runner or
+    /// just-paused), or its resume channel is closed/full — treated as
+    /// no-delivery so the Resume defers rather than blocks.
+    NoLiveEntry,
+    /// A live entry existed and the request was sent, but the loop dropped
+    /// the `ack` sender before replying (it exited / panicked) — the arm did
+    /// not durably land.
+    LoopGone,
+    /// The loop did not reply within [`RESUME_ACK_TIMEOUT`] — it is wedged or
+    /// far behind. Treated as no-delivery (defer); redelivery is idempotent.
+    AckTimeout,
+}
+
 /// Value stored in [`WorkflowEngine::running`]. Pairs the live
 /// [`CancellationToken`] with the [`RunningRegistrationId`] nonce so the
 /// drop guard can use [`DashMap::remove_if`] instead of unconditional
 /// `remove`.
 ///
-/// `resume_notify` is the live-frontier resume channel (ADR-0099 W-S2b): a
-/// payload-less [`Notify`] the running loop selects on. A `Resume` command
-/// for a still-`Running` execution (a signal wait parked with a `timeout`,
-/// so the row never reached `Paused`) cannot use the durable satisfy-CAS —
-/// that path acquires the lease the live loop already holds (two-writers-
-/// one-row). Instead [`WorkflowEngine::resume_live`] notifies this channel;
-/// the loop wakes, self-arms the parked signal node under its OWN lease, and
-/// completes it through Phase-0b. The notify carries no payload — the
-/// durable row remains the sole source of truth, so a lost notification on
-/// crash costs nothing (the armed node survives and a redelivered Resume
-/// re-wakes it).
+/// `resume_tx` is the live-frontier resume channel (ADR-0099 W-S2b): a
+/// bounded [`mpsc::Sender<ResumeRequest>`] the running loop selects on. A
+/// `Resume` command for a still-`Running` execution (a signal wait parked
+/// with a `timeout`, so the row never reached `Paused`) cannot use the
+/// durable satisfy-CAS — that path acquires the lease the live loop already
+/// holds (two-writers-one-row). Instead [`WorkflowEngine::resume_live`] sends
+/// a [`ResumeRequest`] here; the loop wakes, self-arms the parked signal
+/// node(s) under its OWN lease, durably checkpoints the arm, then replies on
+/// the request's `ack` channel. The control-queue ack is gated on that
+/// durable reply (P1#1), so a crash between the notify and the checkpoint
+/// can no longer drop an acked-but-not-landed Resume — the durable row
+/// remains the sole source of truth and an un-acked Resume is redelivered.
+///
+/// [`mpsc::Sender<ResumeRequest>`]: tokio::sync::mpsc::Sender
 struct RunningEntry {
     registration_id: RunningRegistrationId,
     token: CancellationToken,
-    resume_notify: Arc<Notify>,
+    resume_tx: mpsc::Sender<ResumeRequest>,
 }
 
 /// RAII guard that removes an execution from the [`WorkflowEngine::running`]
@@ -472,47 +557,75 @@ impl WorkflowEngine {
         }
     }
 
-    /// Deliver a `Resume` to a LIVE frontier loop owned by THIS runner
-    /// (ADR-0099 W-S2b).
+    /// Deliver a `Resume` to a LIVE frontier loop owned by THIS runner and
+    /// wait for the loop's durable self-arm result (ADR-0099 W-S2b, P1#1).
     ///
-    /// Returns `true` if a live `RunningEntry` for `execution_id` was found
-    /// on this runner and its [`Notify`] was signalled; the loop wakes,
-    /// self-arms its signal-`Waiting{next_attempt_at: None}` node(s) under
-    /// its OWN lease, and completes them through Phase-0b. Returns `false`
-    /// when no live entry exists on this runner — the execution is either
-    /// driven by a different runner or has just transitioned to `Paused`
-    /// (no live frontier), in which case the caller must defer to the
-    /// durable satisfy-CAS path (case-a) / B1 reclaim.
+    /// Sends a [`ResumeRequest`] to the live `RunningEntry` for
+    /// `execution_id`; the loop wakes, self-arms its signal-`Waiting` node(s)
+    /// under its OWN lease, durably checkpoints the arm, then replies on the
+    /// request's `ack` channel. The returned [`ResumeDelivery`] reports
+    /// whether that durable arm landed:
     ///
-    /// Notifying (rather than writing the row) is load-bearing: a `Running`
-    /// execution's lease is held by its own loop, so the durable satisfy-CAS
-    /// would deadlock/race that owner (two-writers-one-row). The live loop
-    /// remains the sole writer of its own row.
+    /// - [`ResumeDelivery::Acked`] — the loop replied; the inner
+    ///   [`ResumeOutcome`] says whether the arm landed (`Armed` /
+    ///   `NothingToArm` — durably resolved, may ack) or failed (`ArmFailed` —
+    ///   the loop lost its lease mid-iteration; must defer).
+    /// - [`ResumeDelivery::NoLiveEntry`] — no live loop on this runner
+    ///   (cross-runner / just-paused), or the channel is closed/full. A full
+    ///   channel is treated as no-delivery (defer) rather than a blocking
+    ///   send, so a backed-up loop never stalls the control consumer.
+    /// - [`ResumeDelivery::LoopGone`] — the loop dropped the `ack` sender
+    ///   before replying (it exited / panicked); the arm did not land.
+    /// - [`ResumeDelivery::AckTimeout`] — no reply within
+    ///   [`RESUME_ACK_TIMEOUT`]; the loop is wedged or far behind.
     ///
-    /// `true` means the resume notification was DELIVERED to the live loop's
-    /// channel — NOT that the Resume has been durably applied. The loop may
-    /// still drop the wake: a timeout for the same node already being processed
-    /// in the same loop iteration can win the race, in which case the node
-    /// fails on its deadline and the notification is a no-op.
+    /// Routing the Resume through the live loop (rather than writing the row
+    /// directly) is load-bearing: a `Running` execution's lease is held by its
+    /// own loop, so the durable satisfy-CAS would deadlock/race that owner
+    /// (two-writers-one-row). The live loop remains the sole writer of its own
+    /// row.
     ///
-    /// Durable-ack caveat for a future inbound-resume transport: a `true`
-    /// return acks the control-queue row BEFORE the live loop's self-arm
-    /// checkpoint is durable. A real Resume producer wired onto this channel
-    /// must therefore gate the control-queue ack on the durable arm (ack only
-    /// after the loop confirms the self-arm checkpoint landed) — otherwise a
-    /// crash between the ack and the checkpoint loses an acked-but-not-landed
-    /// Resume. The path has no production Resume producer today, so the gap is
-    /// currently unreachable.
+    /// `Acked(Armed)` is returned ONLY after the live loop durably
+    /// checkpointed the arm; every other variant means the arm is not durable,
+    /// so the caller must defer (the control-queue row stays un-acked for B1
+    /// reclaim). Deferring is always safe: Resume redelivery is idempotent — a
+    /// duplicate Resume to an already-armed node is a [`ResumeOutcome::NothingToArm`]
+    /// no-op.
     ///
-    /// [`Notify`]: tokio::sync::Notify
-    #[must_use]
-    pub fn resume_live(&self, execution_id: ExecutionId) -> bool {
-        match self.running.get(&execution_id) {
-            Some(entry) => {
-                entry.value().resume_notify.notify_one();
-                true
-            },
-            None => false,
+    /// No-live-owner recovery (a `Running` execution with no live loop on ANY
+    /// runner) and cross-runner Resume routing/affinity remain a future
+    /// (W-S3) slice: today a `NoLiveEntry` simply defers for B1 reclaim.
+    pub(crate) async fn resume_live(&self, execution_id: ExecutionId) -> ResumeDelivery {
+        // Build the reply channel, then drop the `running` map guard BEFORE
+        // awaiting the ack — holding a `DashMap` ref across `.await` could
+        // block other shards' access to the same bucket.
+        let ack_rx = {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            let Some(entry) = self.running.get(&execution_id) else {
+                return ResumeDelivery::NoLiveEntry;
+            };
+            // `try_send` (not `send().await`): a full or closed channel is a
+            // no-delivery signal, not something to block the control consumer
+            // on. Capacity is small (a Resume is rare relative to a loop
+            // iteration); a full channel means a prior Resume is still
+            // un-drained, so deferring this one and letting B1 redeliver is
+            // both safe and idempotent.
+            if entry
+                .value()
+                .resume_tx
+                .try_send(ResumeRequest { ack: ack_tx })
+                .is_err()
+            {
+                return ResumeDelivery::NoLiveEntry;
+            }
+            ack_rx
+        };
+        match tokio::time::timeout(RESUME_ACK_TIMEOUT, ack_rx).await {
+            Ok(Ok(outcome)) => ResumeDelivery::Acked(outcome),
+            // The loop dropped the `ack` sender before replying (exited /
+            // panicked) — the self-arm checkpoint did not land.
+            Ok(Err(_)) => ResumeDelivery::LoopGone,
+            Err(_) => ResumeDelivery::AckTimeout,
         }
     }
 
@@ -1306,9 +1419,14 @@ impl WorkflowEngine {
         let semaphore = Arc::new(Semaphore::new(budget.max_concurrent_nodes));
         let cancel_token = CancellationToken::new();
         // Replay is lease-less and not published into the `running` registry,
-        // so no `Resume` can target it — a local, never-signalled `Notify`
-        // satisfies `run_frontier`'s contract (the resume arm never fires).
-        let resume_notify = Arc::new(Notify::new());
+        // so no `Resume` can target it. Drop the Sender immediately: the
+        // receiver's first `recv()` then yields `None` (the
+        // `ResumeChannelClosed` no-op arm), satisfying `run_frontier`'s
+        // contract without ever delivering a Resume.
+        let mut resume_rx = {
+            let (_resume_tx, resume_rx) = mpsc::channel::<ResumeRequest>(1);
+            resume_rx
+        };
         let mut repo_version = 0u64;
 
         // Determine seed nodes: nodes in rerun set whose predecessors are all pinned.
@@ -1336,7 +1454,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
-                &resume_notify,
+                &mut resume_rx,
                 &mut exec_state,
                 execution_id,
                 workflow.id,
@@ -1749,16 +1867,19 @@ impl WorkflowEngine {
         // clobbering a winner's registration if a losing attempt ever
         // slips through.
         let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
-        // Live-frontier resume channel (W-S2b): published alongside the
-        // cancel token so a `Resume` for this still-`Running` execution
-        // (a signal wait parked with a timeout) reaches the live loop.
-        let resume_notify = Arc::new(Notify::new());
+        // Live-frontier resume channel (W-S2b): the Sender is published on the
+        // `RunningEntry` alongside the cancel token so a `Resume` for this
+        // still-`Running` execution (a signal wait parked with a timeout)
+        // reaches the live loop; the Receiver is owned by `run_frontier`. The
+        // ack on each `ResumeRequest` gates the control-queue ack on the
+        // durable self-arm checkpoint (P1#1).
+        let (resume_tx, mut resume_rx) = mpsc::channel::<ResumeRequest>(RESUME_CHANNEL_CAPACITY);
         self.running.insert(
             execution_id,
             RunningEntry {
                 registration_id,
                 token: cancel_token.clone(),
-                resume_notify: Arc::clone(&resume_notify),
+                resume_tx,
             },
         );
         let _cancel_registration = RunningRegistration {
@@ -1790,7 +1911,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
-                &resume_notify,
+                &mut resume_rx,
                 &mut exec_state,
                 execution_id,
                 workflow.id,
@@ -2262,13 +2383,13 @@ impl WorkflowEngine {
         let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
         // Live-frontier resume channel (W-S2b) — symmetric to
         // `execute_workflow`; see its comment for the rationale.
-        let resume_notify = Arc::new(Notify::new());
+        let (resume_tx, mut resume_rx) = mpsc::channel::<ResumeRequest>(RESUME_CHANNEL_CAPACITY);
         self.running.insert(
             execution_id,
             RunningEntry {
                 registration_id,
                 token: cancel_token.clone(),
-                resume_notify: Arc::clone(&resume_notify),
+                resume_tx,
             },
         );
         let _cancel_registration = RunningRegistration {
@@ -2304,7 +2425,7 @@ impl WorkflowEngine {
                 &outputs,
                 &semaphore,
                 &cancel_token,
-                &resume_notify,
+                &mut resume_rx,
                 &mut exec_state,
                 execution_id,
                 workflow_id,
@@ -3051,7 +3172,7 @@ impl WorkflowEngine {
         outputs: &Arc<DashMap<NodeKey, serde_json::Value>>,
         semaphore: &Arc<Semaphore>,
         cancel_token: &CancellationToken,
-        resume_notify: &Arc<Notify>,
+        resume_rx: &mut mpsc::Receiver<ResumeRequest>,
         exec_state: &mut ExecutionState,
         execution_id: ExecutionId,
         workflow_id: WorkflowId,
@@ -3135,6 +3256,14 @@ impl WorkflowEngine {
             Result<ActionResult<serde_json::Value>, EngineError>,
         )> = JoinSet::new();
         let mut task_nodes: HashMap<tokio::task::Id, NodeKey> = HashMap::new();
+
+        // Disarms the `resume_rx.recv()` select! arm after the first `None`
+        // (channel closed). Without this guard the arm would poll `Ready(None)`
+        // on every iteration — a busy-spin for the full run duration. This
+        // fires immediately on the replay path (the Sender is dropped at the
+        // `RunningEntry` construction site) and also defends against any
+        // premature drop of the Running registration in the execute path.
+        let mut resume_rx_closed = false;
 
         // Main frontier loop
         loop {
@@ -3818,7 +3947,8 @@ impl WorkflowEngine {
                 WaitTimer,
                 WallClock,
                 Cancel,
-                ResumeSignalled,
+                ResumeSignalled(ResumeRequest),
+                ResumeChannelClosed,
             }
 
             let join_next_fut: Pin<Box<dyn Future<Output = JoinedResult> + Send + '_>> =
@@ -3828,18 +3958,31 @@ impl WorkflowEngine {
                     Box::pin(join_set.join_next_with_id())
                 };
 
-            // `Notify::notified()` is cancellation-safe in this `select!`: a
-            // `notify_one()` that races the loop body (fired while we are not
-            // awaiting) stores a single permit, which the next iteration's
-            // fresh `notified()` consumes immediately — the Resume is never
-            // lost between iterations.
+            // `mpsc::Receiver::recv()` is cancellation-safe in this `select!`:
+            // a `ResumeRequest` that is sent while another arm wins this
+            // iteration is NOT consumed — it stays buffered in the channel and
+            // the next iteration's fresh `recv()` delivers it. This is strictly
+            // better than the prior `Notify` permit-latch: the request (and its
+            // `ack` reply channel) is never dropped between iterations, so the
+            // caller's ack-await always resolves to a durable outcome.
+            //
+            // The `if !resume_rx_closed` guard is REQUIRED: once the channel is
+            // closed, `recv()` returns `Ready(None)` synchronously on every
+            // poll. Without the guard the closed arm would win the select! on
+            // every iteration regardless of wall-clock sleep — a busy-spin for
+            // the full run duration. After exactly one `None` the flag is set
+            // and the arm becomes permanently `Pending` (disabled), letting the
+            // other arms run at their natural pace.
             let wake = tokio::select! {
                 result = join_next_fut => WakeReason::Joined(result),
                 () = &mut retry_sleep_fut, if next_retry_in.is_some() => WakeReason::RetryTimer,
                 () = &mut wait_sleep_fut, if next_wait_in.is_some() => WakeReason::WaitTimer,
                 () = &mut sleep_fut => WakeReason::WallClock,
                 () = cancel_token.cancelled() => WakeReason::Cancel,
-                () = resume_notify.notified() => WakeReason::ResumeSignalled,
+                maybe_req = resume_rx.recv(), if !resume_rx_closed => match maybe_req {
+                    Some(req) => WakeReason::ResumeSignalled(req),
+                    None => WakeReason::ResumeChannelClosed,
+                },
             };
 
             let join_result = match wake {
@@ -3860,7 +4003,7 @@ impl WorkflowEngine {
                     // wait-wakes into completed + downstream edges.
                     continue;
                 },
-                WakeReason::ResumeSignalled => {
+                WakeReason::ResumeSignalled(req) => {
                     // A `Resume` command targeted this LIVE execution (W-S2b).
                     // The row stayed `Running` (a signal wait was parked with a
                     // `timeout`, so the loop holds the lease on the timeout
@@ -3870,6 +4013,14 @@ impl WorkflowEngine {
                     // own row: self-arm each signal-`Waiting{next_attempt_at:
                     // None}` node for completion under the loop's OWN lease, then
                     // loop back so Phase-0b completes it through the main port.
+                    //
+                    // P1#1 ack-gating: the caller's control-queue ack is gated
+                    // on the durable result we send on `req.ack`. The contract
+                    // is exactly one `send` per request, and `Armed` is sent
+                    // ONLY after the self-arm checkpoint lands `Ok` (strictly
+                    // after the version advances). A dropped `ack` Sender (this
+                    // loop exits before sending) resolves the caller's receiver
+                    // to `Err` → `LoopGone` → Deferred — a free fail-safe.
                     //
                     // Untargeted in v1 (mirrors case-a fork-2): a Resume arms
                     // every signal wait. Per-callback_id targeting is W-S3
@@ -3895,8 +4046,11 @@ impl WorkflowEngine {
                         .map(|(id, _)| id.clone())
                         .collect();
                     if to_arm.is_empty() {
-                        // Spurious or already-armed wake — nothing to do. Loop
-                        // back; the exit-condition / timers re-evaluate.
+                        // Spurious or already-armed wake — nothing to do. Ack as
+                        // `NothingToArm` (the caller may ack the row; a duplicate
+                        // Resume to an already-armed node is idempotent), then
+                        // loop back; the exit-condition / timers re-evaluate.
+                        let _ = req.ack.send(ResumeOutcome::NothingToArm);
                         tracing::debug!(
                             target = "engine::wait",
                             %execution_id,
@@ -3932,9 +4086,10 @@ impl WorkflowEngine {
                         "live-frontier resume: arming signal waits for Phase-0b completion"
                     );
                     // Durably commit the arm under the loop's OWN lease before
-                    // Phase-0b acts on it. On checkpoint failure, abort the
-                    // frontier rather than completing a wait whose arm did not
-                    // land.
+                    // Phase-0b acts on it. On checkpoint failure (incl.
+                    // FencedOut / CasConflict — the loop lost its lease
+                    // mid-iteration), ack `ArmFailed` BEFORE aborting so the
+                    // caller defers the Resume; NEVER `Armed` on a failed arm.
                     if let Err(e) = self
                         .checkpoint_node(
                             scope,
@@ -3949,9 +4104,16 @@ impl WorkflowEngine {
                         )
                         .await
                     {
+                        let _ = req.ack.send(ResumeOutcome::ArmFailed);
                         cancel_token.cancel();
                         return Some((to_arm[0].clone(), e.to_string()));
                     }
+                    // The arm is durable: ack `Armed` (the caller may now ack
+                    // the control-queue row), strictly after the version
+                    // advanced and the checkpoint landed `Ok`.
+                    let _ = req.ack.send(ResumeOutcome::Armed {
+                        count: to_arm.len(),
+                    });
                     // Purge any stale future heap entry for the re-armed nodes
                     // (e.g. a signal+timeout wait's original timeout deadline)
                     // and replace it with a now-due entry, so Phase-0b completes
@@ -3978,6 +4140,23 @@ impl WorkflowEngine {
                         );
                     }
                     // Loop back so Phase-0b drains the armed waits → main port.
+                    continue;
+                },
+                WakeReason::ResumeChannelClosed => {
+                    // Every `resume_tx` Sender has been dropped (the published
+                    // `RunningEntry` was removed / never published, as on the
+                    // lease-less replay path). No further Resume can arrive on
+                    // this channel. Set the guard flag so the `recv()` arm is
+                    // permanently disabled and the select! does not busy-spin on
+                    // the `Ready(None)` that a closed channel returns every poll.
+                    // Loop back so the other arms keep driving the frontier.
+                    // No `ack` to honor — `recv()` returned `None`, not a request.
+                    resume_rx_closed = true;
+                    tracing::trace!(
+                        target = "engine::wait",
+                        %execution_id,
+                        "resume channel closed; no live Resume producer remains — arm disarmed"
+                    );
                     continue;
                 },
                 WakeReason::WallClock => {
@@ -12244,6 +12423,102 @@ mod tests {
             NodeState::Cancelled,
             "a signal Waiting{{None}} node (not on wait_heap) must be cancelled by the \
              teardown scan"
+        );
+    }
+
+    // ── P1#1 resume_live channel mechanics (ADR-0099 W-S2b) ──────────────────
+    //
+    // These exercise `resume_live`'s request/reply channel directly, without a
+    // live frontier loop, so each not-durable outcome is fully deterministic.
+    // The loop-integration side (ack-after-checkpoint, fenced-out-arm,
+    // duplicate-resume) lives in `tests/wait_timeout.rs`.
+
+    /// Publish a `RunningEntry` for `execution_id` whose `resume_tx` is wired to
+    /// the returned receiver, so a test can simulate the loop side of the
+    /// channel. Returns the receiver and the registration guard (the entry is
+    /// removed when the guard drops).
+    fn publish_running_entry(
+        engine: &WorkflowEngine,
+        execution_id: ExecutionId,
+    ) -> (mpsc::Receiver<ResumeRequest>, RunningRegistration) {
+        let registration_id = NEXT_REGISTRATION_ID.fetch_add(1, Ordering::Relaxed);
+        let (resume_tx, resume_rx) = mpsc::channel::<ResumeRequest>(RESUME_CHANNEL_CAPACITY);
+        engine.running.insert(
+            execution_id,
+            RunningEntry {
+                registration_id,
+                token: CancellationToken::new(),
+                resume_tx,
+            },
+        );
+        let guard = RunningRegistration {
+            running: Arc::clone(&engine.running),
+            execution_id,
+            registration_id,
+        };
+        (resume_rx, guard)
+    }
+
+    /// `resume_live` returns `NoLiveEntry` when no `RunningEntry` exists for the
+    /// execution (the cross-runner / just-paused case). This is the preserved
+    /// no-live behavior the P1#1 channel rewrite must not regress.
+    #[tokio::test]
+    async fn resume_live_no_live_entry_when_absent() {
+        let (engine, _) = make_engine(Arc::new(ActionRegistry::new()));
+        let outcome = engine.resume_live(ExecutionId::new()).await;
+        assert!(
+            matches!(outcome, ResumeDelivery::NoLiveEntry),
+            "an absent execution must yield NoLiveEntry, got {outcome:?}"
+        );
+    }
+
+    /// `resume_live` returns `LoopGone` when the live loop receives the request
+    /// but drops the `ack` sender before replying (it exited / panicked). The
+    /// dropped sender resolves the awaiting receiver to `Err` — a free
+    /// fail-safe: a not-durable arm defers rather than acks.
+    #[tokio::test]
+    async fn resume_live_loop_gone_when_ack_dropped() {
+        let (engine, _) = make_engine(Arc::new(ActionRegistry::new()));
+        let engine = Arc::new(engine);
+        let execution_id = ExecutionId::new();
+        let (mut resume_rx, _guard) = publish_running_entry(&engine, execution_id);
+
+        // Simulate a loop that takes the request then dies before replying.
+        let loop_side = tokio::spawn(async move {
+            let req = resume_rx.recv().await.expect("request must arrive");
+            // Drop `req` (and its ack sender) without sending — models the loop
+            // exiting mid-iteration.
+            drop(req);
+        });
+
+        let outcome = engine.resume_live(execution_id).await;
+        loop_side.await.unwrap();
+        assert!(
+            matches!(outcome, ResumeDelivery::LoopGone),
+            "a dropped ack sender must yield LoopGone, got {outcome:?}"
+        );
+    }
+
+    /// `resume_live` returns `AckTimeout` when the loop never replies within
+    /// `RESUME_ACK_TIMEOUT`. Driven under paused time so the test is instant and
+    /// deterministic. A wedged loop defers rather than acks.
+    #[tokio::test(start_paused = true)]
+    async fn resume_live_ack_timeout_when_loop_silent() {
+        let (engine, _) = make_engine(Arc::new(ActionRegistry::new()));
+        let engine = Arc::new(engine);
+        let execution_id = ExecutionId::new();
+        // Keep the receiver alive but NEVER reply, so the request is delivered
+        // (channel open) yet the ack never resolves.
+        let (_resume_rx, _guard) = publish_running_entry(&engine, execution_id);
+
+        let engine_h = Arc::clone(&engine);
+        let resume = tokio::spawn(async move { engine_h.resume_live(execution_id).await });
+        // Advance past the ack timeout under paused time.
+        tokio::time::advance(RESUME_ACK_TIMEOUT + Duration::from_secs(1)).await;
+        let outcome = resume.await.unwrap();
+        assert!(
+            matches!(outcome, ResumeDelivery::AckTimeout),
+            "a silent loop must yield AckTimeout, got {outcome:?}"
         );
     }
 }

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -101,7 +101,9 @@ pub enum ExecutionEvent {
         /// once the timer fires only the generic discriminator is recoverable.
         /// Per-variant detail will arrive with persisted resume targeting.
         condition_kind: String,
-        /// The declared `timeout` that elapsed, in milliseconds.
+        /// Timeout duration reported for observability, in milliseconds.
+        /// Reconstructed from the persisted wait deadline and node
+        /// `started_at`, so it may slightly exceed the author-declared timeout.
         timeout_ms: u64,
     },
 

--- a/crates/engine/src/event.rs
+++ b/crates/engine/src/event.rs
@@ -80,6 +80,31 @@ pub enum ExecutionEvent {
         node_key: NodeKey,
     },
 
+    /// A signal-driven parked node (`Webhook` / `Approval` / `Execution`)
+    /// was parked with an explicit `timeout` and that deadline elapsed
+    /// before a Resume arrived. The engine has transitioned the node
+    /// `Waiting → Failed` (with `RuntimeError::WaitTimedOut`) and routed its
+    /// outgoing edges through the failure path (OnError / Skip / FailFast).
+    ///
+    /// The matched-pair partner of [`ExecutionEvent::NodeParked`] on the
+    /// timeout branch (where [`ExecutionEvent::NodeWaitCompleted`] is the
+    /// success-branch partner): `Parked` gates downstream, `WaitTimedOut`
+    /// fails the node and routes the failure edges.
+    NodeWaitTimedOut {
+        /// Execution this node belongs to.
+        execution_id: ExecutionId,
+        /// The node whose wait timed out.
+        node_key: NodeKey,
+        /// The parked signal-wait kind. Currently always the literal
+        /// `"signal"`: the parked node does not persist the exact
+        /// `WaitCondition` variant (`Webhook` / `Approval` / `Execution`), so
+        /// once the timer fires only the generic discriminator is recoverable.
+        /// Per-variant detail will arrive with persisted resume targeting.
+        condition_kind: String,
+        /// The declared `timeout` that elapsed, in milliseconds.
+        timeout_ms: u64,
+    },
+
     /// A node attempt failed but the engine scheduled a retry per
     /// (Layer 2 — engine-level retry). The node has
     /// transitioned to `WaitingRetry` and will be re-dispatched at

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -228,6 +228,38 @@ pub enum RuntimeError {
         condition_kind: String,
     },
 
+    /// A signal-driven `ActionResult::Wait` (`Webhook` / `Approval` /
+    /// `Execution`) was parked with an explicit `timeout` and that deadline
+    /// elapsed before a Resume arrived. The engine fails the node and routes
+    /// its outgoing edges through the failure path (OnError / Skip /
+    /// FailFast) — the timeout is the declared maximum the author asked the
+    /// engine to enforce (ADR-0099 W-S2b).
+    ///
+    /// Terminal and **not** retryable: a wait timeout is a deliberate
+    /// deadline, not a transient fault. The engine bypasses the retry
+    /// decision entirely for this error (it does not count against the
+    /// per-node or per-execution retry budget).
+    #[classify(
+        category = "exhausted",
+        code = "RUNTIME:WAIT_TIMED_OUT",
+        retryable = false
+    )]
+    #[error("ActionResult::Wait signal condition timed out after {timeout_ms}ms without a Resume")]
+    WaitTimedOut {
+        /// The parked signal-wait kind. Currently always the literal
+        /// `"signal"`: the parked node does not persist the exact
+        /// `WaitCondition` variant (`Webhook` / `Approval` / `Execution`), so
+        /// after the timer fires — and especially after a crash + recovery —
+        /// only the generic discriminator is recoverable. Per-variant detail
+        /// will arrive with persisted resume targeting. The field is retained
+        /// for that forward-compatible use and is emitted on the
+        /// `NodeWaitTimedOut` event; it is intentionally not interpolated into
+        /// the `Display` message while it is a constant.
+        condition_kind: String,
+        /// The declared `timeout` that elapsed, in milliseconds.
+        timeout_ms: u64,
+    },
+
     /// Internal runtime error.
     #[classify(category = "internal", code = "RUNTIME:INTERNAL")]
     #[error("runtime error: {0}")]
@@ -316,5 +348,45 @@ mod tests {
             max_turns: 3,
         };
         assert!(!err.is_retryable());
+    }
+
+    #[test]
+    fn wait_timed_out_not_retryable() {
+        // A wait timeout is a deliberate deadline, not a transient fault:
+        // `is_retryable()` must agree with the `retryable = false` classify
+        // attribute so retry policies never re-park a timed-out wait.
+        let err = RuntimeError::WaitTimedOut {
+            condition_kind: "Webhook".into(),
+            timeout_ms: 5_000,
+        };
+        assert!(!err.is_retryable(), "WaitTimedOut must not be retryable");
+    }
+
+    #[test]
+    fn wait_timed_out_display_carries_timeout_but_not_the_kind() {
+        // `condition_kind` is currently always the constant `"signal"`, so the
+        // Display deliberately does NOT interpolate it (that would render the
+        // tautology "signal condition 'signal' timed out"). The message must
+        // still carry the actionable timeout, and reference the signal
+        // condition in prose.
+        let err = RuntimeError::WaitTimedOut {
+            condition_kind: "signal".into(),
+            timeout_ms: 1_500,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("1500"),
+            "message must carry the timeout ms: {msg}"
+        );
+        assert!(
+            msg.contains("signal condition"),
+            "message must reference the signal condition: {msg}"
+        );
+        // The raw field value must NOT be echoed as a quoted token — a constant
+        // kind interpolated into the message reads as a tautology.
+        assert!(
+            !msg.contains("'signal'"),
+            "the constant condition_kind must not be interpolated into Display: {msg}"
+        );
     }
 }

--- a/crates/engine/src/runtime/error.rs
+++ b/crates/engine/src/runtime/error.rs
@@ -256,7 +256,9 @@ pub enum RuntimeError {
         /// `NodeWaitTimedOut` event; it is intentionally not interpolated into
         /// the `Display` message while it is a constant.
         condition_kind: String,
-        /// The declared `timeout` that elapsed, in milliseconds.
+        /// Timeout duration reported for observability, in milliseconds.
+        /// Reconstructed from the persisted wait deadline and node
+        /// `started_at`, so it may slightly exceed the author-declared timeout.
         timeout_ms: u64,
     },
 

--- a/crates/engine/tests/wait_timeout.rs
+++ b/crates/engine/tests/wait_timeout.rs
@@ -1,0 +1,1269 @@
+//! Integration tests for ADR-0099 **W-S2b** — signal-driven `ActionResult::Wait`
+//! conditions parked WITH an explicit `timeout`.
+//!
+//! A signal wait (`Webhook` / `Approval` / `Execution`) parked with
+//! `timeout: Some(dur)` keeps its execution **`Running`** (a live frontier loop
+//! sits on the timeout timer in `wait_heap`). Two outcomes:
+//!
+//! - **Timeout fires first** → the node FAILS with `RuntimeError::WaitTimedOut`,
+//!   its outgoing edges route through the failure path (OnError / Skip /
+//!   FailFast), and `ExecutionEvent::NodeWaitTimedOut` is emitted.
+//! - **Resume arrives first** → it reaches the LIVE loop through the resume
+//!   channel (`WorkflowEngine::resume_live`), which self-arms the node for
+//!   completion under the loop's own lease; Phase-0b completes it on the
+//!   `main` port and the timeout timer is discarded by the state re-check.
+//!
+//! The persisted `wait_wake = Timeout` discriminator survives a crash so a
+//! recovered runner re-seeds the timer and still times the wait out.
+//!
+//! ## Timing model
+//!
+//! The engine's `wait_heap` deadlines are **wall-clock** (`chrono::Utc`), not
+//! tokio timers, so `tokio::time::pause()`/`advance` cannot drive them. Mirroring
+//! the established convention in `wait.rs`, these tests use **real, short**
+//! durations with a generous outer `tokio::time::timeout` safety bound — the
+//! durations are small (sub-second) and the assertions are on settled state, so
+//! there is no wall-clock-flakiness window. Lease TTLs that gate crash recovery
+//! likewise use the in-mem store's clamp floor (1s) under real time.
+
+use std::{
+    collections::HashMap,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicU32, Ordering},
+    },
+    time::Duration,
+};
+
+use nebula_action::{
+    ActionError,
+    action::Action,
+    metadata::ActionMetadata,
+    result::{ActionResult, WaitCondition},
+    stateless::StatelessAction,
+};
+use nebula_core::{Dependencies, action_key, id::ExecutionId, node_key};
+use nebula_engine::{
+    ActionExecutor, ActionRegistry, ActionRuntime, ControlDispatch, DataPassingPolicy,
+    EngineControlDispatch, ExecutionEvent, InProcessRunner, WorkflowEngine,
+};
+use nebula_execution::{ExecutionState, ExecutionStatus};
+use nebula_metrics::MetricsRegistry;
+use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
+use nebula_storage_port::{
+    dto::WorkflowVersionRecord,
+    store::{ExecutionStore, WorkflowVersionStore},
+};
+use nebula_workflow::{
+    CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
+};
+
+// ── Action stubs ────────────────────────────────────────────────────────────
+
+macro_rules! static_action_impl {
+    ($ty:ty, $key:expr, $name:expr) => {
+        impl Action for $ty {
+            type Input = serde_json::Value;
+            type Output = serde_json::Value;
+
+            fn metadata() -> ActionMetadata {
+                ActionMetadata::new($key, $name, "wait_timeout integration test stub")
+            }
+            fn dependencies() -> &'static Dependencies {
+                static D: OnceLock<Dependencies> = OnceLock::new();
+                D.get_or_init(Dependencies::new)
+            }
+        }
+    };
+}
+
+/// Parks itself via `WaitCondition::Webhook` WITH an explicit `timeout`.
+/// This is the W-S2b signal+timeout case: the execution stays `Running` with
+/// the timeout timer on `wait_heap`.
+struct WebhookWaitWithTimeout {
+    timeout: Duration,
+}
+
+static_action_impl!(
+    WebhookWaitWithTimeout,
+    action_key!("test.wt.webhook_timeout"),
+    "WebhookWaitWithTimeout"
+);
+
+impl StatelessAction for WebhookWaitWithTimeout {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Webhook {
+                callback_id: "wt-webhook".to_owned(),
+            },
+            timeout: Some(self.timeout),
+            partial_output: None,
+        })
+    }
+}
+
+/// Counts invocations and succeeds. Main-port downstream gate probe.
+struct CountingEcho {
+    invocations: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingEcho,
+    action_key!("test.wt.main_echo"),
+    "CountingEcho"
+);
+
+impl StatelessAction for CountingEcho {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+/// Error-port probe under a distinct key.
+struct CountingError {
+    invocations: Arc<AtomicU32>,
+}
+
+static_action_impl!(
+    CountingError,
+    action_key!("test.wt.error_echo"),
+    "CountingError"
+);
+
+impl StatelessAction for CountingError {
+    async fn execute(
+        &self,
+        input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok(ActionResult::success(input))
+    }
+}
+
+// ── Shared store bundle ──────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct WtStores {
+    execution: Arc<InMemoryExecutionStore>,
+    journal: Arc<nebula_storage::InMemoryJournalReader>,
+    node_results: Arc<nebula_storage::InMemoryNodeResultStore>,
+    checkpoints: Arc<nebula_storage::InMemoryCheckpointStore>,
+    idempotency: Arc<nebula_storage::InMemoryIdempotencyGuard>,
+    workflow: Arc<nebula_storage::InMemoryWorkflowStore>,
+    versions: Arc<InMemoryWorkflowVersionStore>,
+}
+
+impl WtStores {
+    fn new() -> Self {
+        let execution = Arc::new(InMemoryExecutionStore::new());
+        let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&execution));
+        let versions = InMemoryWorkflowVersionStore::new();
+        let workflow = nebula_storage::InMemoryWorkflowStore::new_with_versions(&versions);
+        Self {
+            execution,
+            journal,
+            node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+            checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+            idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            workflow: Arc::new(workflow),
+            versions: Arc::new(versions),
+        }
+    }
+
+    fn execution_stores(&self) -> nebula_engine::ExecutionStores {
+        nebula_engine::ExecutionStores {
+            execution: self.execution.clone(),
+            journal: self.journal.clone(),
+            node_results: self.node_results.clone(),
+            checkpoints: self.checkpoints.clone(),
+            idempotency: self.idempotency.clone(),
+        }
+    }
+
+    fn workflow_stores(&self) -> nebula_engine::WorkflowStores {
+        nebula_engine::WorkflowStores {
+            workflow: self.workflow.clone(),
+            versions: self.versions.clone(),
+        }
+    }
+
+    fn attach(&self, engine: WorkflowEngine) -> WorkflowEngine {
+        engine
+            .with_execution_stores(self.execution_stores())
+            .with_workflow_stores(self.workflow_stores())
+    }
+
+    async fn save_workflow(&self, wf: &WorkflowDefinition) {
+        self.versions
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                WorkflowVersionRecord {
+                    workflow_id: wf.id.to_string(),
+                    number: 0,
+                    published: true,
+                    pinned: false,
+                    definition: serde_json::to_value(wf).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn persist_created_execution(&self, workflow_id: nebula_core::WorkflowId) -> ExecutionId {
+        let execution_id = ExecutionId::new();
+        let mut exec_state = ExecutionState::new(execution_id, workflow_id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        self.execution
+            .create(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+                &workflow_id.to_string(),
+                serde_json::to_value(&exec_state).unwrap(),
+            )
+            .await
+            .unwrap();
+        execution_id
+    }
+
+    async fn load_state(&self, execution_id: ExecutionId) -> ExecutionState {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        // ExecutionState has borrowed-string fields; round-trip via string the
+        // same way the engine's reload does.
+        let s = serde_json::to_string(&record.state).unwrap();
+        serde_json::from_str(&s).unwrap()
+    }
+
+    async fn persisted_status(&self, execution_id: ExecutionId) -> ExecutionStatus {
+        let record = self
+            .execution
+            .get(
+                &nebula_engine::store_seam::single_tenant_scope(),
+                &execution_id.to_string(),
+            )
+            .await
+            .unwrap()
+            .expect("execution row must exist");
+        serde_json::from_value(record.state.get("status").cloned().unwrap()).unwrap()
+    }
+}
+
+// ── Engine assembly ──────────────────────────────────────────────────────────
+
+/// Build a registry with the signal+timeout wait node, a main-port echo, and an
+/// error-port echo. The two echo counters are returned for assertions.
+fn build_registry(
+    timeout: Duration,
+    main_count: &Arc<AtomicU32>,
+    error_count: &Arc<AtomicU32>,
+) -> Arc<ActionRegistry> {
+    let registry = Arc::new(ActionRegistry::new());
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wt.webhook_timeout"),
+            "WebhookWaitWithTimeout",
+            "wait_timeout stub",
+        ),
+        WebhookWaitWithTimeout { timeout },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wt.main_echo"),
+            "CountingEcho",
+            "wait_timeout stub",
+        ),
+        CountingEcho {
+            invocations: Arc::clone(main_count),
+        },
+    );
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wt.error_echo"),
+            "CountingError",
+            "wait_timeout stub",
+        ),
+        CountingError {
+            invocations: Arc::clone(error_count),
+        },
+    );
+    registry
+}
+
+fn make_engine(registry: Arc<ActionRegistry>) -> WorkflowEngine {
+    let metrics = MetricsRegistry::new();
+    let executor: ActionExecutor =
+        Arc::new(|_ctx, _meta, input| Box::pin(async move { Ok(ActionResult::success(input)) }));
+    let runner = Arc::new(InProcessRunner::new(executor));
+    let runtime = Arc::new(
+        ActionRuntime::try_new(
+            registry,
+            runner,
+            DataPassingPolicy::default(),
+            metrics.clone(),
+        )
+        .unwrap(),
+    );
+    WorkflowEngine::new(runtime, metrics).unwrap()
+}
+
+/// Build a workflow `wait ──main──> main_node` and (optionally) `wait ──error──>
+/// error_node`. `wait` parks on a Webhook signal with a timeout.
+fn make_workflow(with_error_port: bool, timeout: Duration) -> WorkflowDefinition {
+    let _ = timeout; // timeout is configured on the action instance, not the def.
+    let now = chrono::Utc::now();
+    let wait = node_key!("wait_node");
+    let main_node = node_key!("main_node");
+    let error_node = node_key!("error_node");
+    let mut nodes = vec![
+        NodeDefinition::new(wait.clone(), "WaitNode", "core", "test.wt.webhook_timeout").unwrap(),
+        NodeDefinition::new(main_node.clone(), "MainNode", "core", "test.wt.main_echo").unwrap(),
+    ];
+    let mut connections = vec![Connection::new(wait.clone(), main_node)];
+    if with_error_port {
+        nodes.push(
+            NodeDefinition::new(
+                error_node.clone(),
+                "ErrorNode",
+                "core",
+                "test.wt.error_echo",
+            )
+            .unwrap(),
+        );
+        connections.push(Connection::new(wait, error_node).with_from_port("error"));
+    }
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "wait-timeout-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes,
+        connections,
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+/// Build a workflow with TWO parallel signal+timeout wait nodes, each with its
+/// own `main` and `error` downstream:
+///
+/// ```text
+/// wait_a ──main──> main_a       wait_b ──main──> main_b
+///        └─error─> error_a             └─error─> error_b
+/// ```
+///
+/// Both waits are entry nodes (no upstream), so they dispatch and park
+/// concurrently. The four downstreams share the two echo counters
+/// (`test.wt.main_echo` / `test.wt.error_echo`): a clean N=2 resume must drive
+/// `main_count == 2`, `error_count == 0`. This is the only workflow that
+/// exercises the resume self-arm `for node_key in &to_arm` loop, the
+/// heap purge/rebuild, and the multi-node checkpoint with `to_arm.len() > 1`.
+fn make_two_wait_workflow() -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    let wait_a = node_key!("wait_a");
+    let wait_b = node_key!("wait_b");
+    let main_a = node_key!("main_a");
+    let main_b = node_key!("main_b");
+    let error_a = node_key!("error_a");
+    let error_b = node_key!("error_b");
+    let nodes = vec![
+        NodeDefinition::new(wait_a.clone(), "WaitA", "core", "test.wt.webhook_timeout").unwrap(),
+        NodeDefinition::new(wait_b.clone(), "WaitB", "core", "test.wt.webhook_timeout").unwrap(),
+        NodeDefinition::new(main_a.clone(), "MainA", "core", "test.wt.main_echo").unwrap(),
+        NodeDefinition::new(main_b.clone(), "MainB", "core", "test.wt.main_echo").unwrap(),
+        NodeDefinition::new(error_a.clone(), "ErrorA", "core", "test.wt.error_echo").unwrap(),
+        NodeDefinition::new(error_b.clone(), "ErrorB", "core", "test.wt.error_echo").unwrap(),
+    ];
+    let connections = vec![
+        Connection::new(wait_a.clone(), main_a),
+        Connection::new(wait_a, error_a).with_from_port("error"),
+        Connection::new(wait_b.clone(), main_b),
+        Connection::new(wait_b, error_b).with_from_port("error"),
+    ];
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "two-wait-timeout-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes,
+        connections,
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
+/// Await `NodeParked` for the wait node from a subscribed event stream. Bounds
+/// the wait so a missing park fails fast instead of hanging.
+async fn await_parked(events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>) -> ExecutionId {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { execution_id, .. }) => break execution_id,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeParked"),
+            }
+        }
+    })
+    .await
+    .expect("engine must emit NodeParked for the signal+timeout wait")
+}
+
+/// Await `expected` distinct `NodeParked` events. Used by the N>1 self-arm test,
+/// where a single Resume must arm MULTIPLE parallel signal+timeout waits — every
+/// wait node must be `Waiting` before the Resume is delivered, otherwise the
+/// single `notify_one()` would arm only the nodes parked so far.
+async fn await_n_parked(
+    events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
+    expected: usize,
+) {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let mut parked = 0usize;
+        while parked < expected {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::NodeParked { .. }) => parked += 1,
+                Some(_) => continue,
+                None => panic!("event bus closed before all NodeParked"),
+            }
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("engine must emit {expected} NodeParked events"));
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+/// **W-S2b — a signal wait with timeout fires the error port on timeout.**
+///
+/// A `wait ──main──> main_node` / `wait ──error──> error_node` workflow where
+/// `wait` parks on a Webhook signal with a short timeout. No Resume arrives; the
+/// timeout fires. The wait node must FAIL (`WaitTimedOut`), the `error` branch
+/// must run, and the `main` branch must NOT.
+///
+/// **Falsifiability**: revert the Phase-0b `Timeout` branch to the unconditional
+/// `Waiting → Completed` completion → the wait completes on the main port →
+/// `main_count == 1`, `error_count == 0` → both asserts flip → RED.
+#[tokio::test]
+async fn signal_wait_with_timeout_fires_error_port_on_timeout() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_millis(120);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let engine = Arc::new(make_engine(registry));
+    let wf = Arc::new(make_workflow(/* with_error_port */ true, timeout));
+
+    let engine_h = Arc::clone(&engine);
+    let wf_h = Arc::clone(&wf);
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::spawn(async move {
+            engine_h
+                .execute_workflow(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    &wf_h,
+                    serde_json::json!(null),
+                    nebula_execution::context::ExecutionBudget::default(),
+                )
+                .await
+        }),
+    )
+    .await
+    .expect("execution must settle after the timeout fires")
+    .unwrap()
+    .unwrap();
+
+    // The error branch ran; the main branch never did.
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        1,
+        "the error-port branch must run on a wait timeout"
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        0,
+        "the main-port branch must NOT run on a wait timeout"
+    );
+    // The node error references the wait timeout (the error-port branch handled
+    // the failure, so the execution itself completes).
+    assert!(
+        result
+            .node_errors
+            .values()
+            .any(|e| e.contains("timed out") || e.contains("WAIT_TIMED_OUT")),
+        "node_errors must reference the wait timeout; got: {:?}",
+        result.node_errors
+    );
+}
+
+/// **W-S2b — Resume before the timeout completes the main port and the timer is
+/// discarded.**
+///
+/// The live frontier (Running) receives a Resume through the resume channel
+/// before the (long) timeout fires. The node completes on the `main` port; the
+/// timeout never fires.
+///
+/// **Falsifiability**: make the live-resume self-arm stamp `Timeout` instead of
+/// `Completion` (or never re-read state at the pop) → the node would fail
+/// instead of completing → `main_count == 0` and status `Failed` → the
+/// `Completed` + `main_count == 1` asserts flip → RED.
+#[tokio::test]
+async fn resume_before_timeout_completes_main_port_and_cancels_timer() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // Long timeout: it must NOT fire during the test — only the Resume completes.
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    // Spawn the drive (resume_execution drives a Created/Paused execution).
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+
+    await_parked(&mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "a signal+timeout wait must keep the execution Running (live timer), not Paused"
+    );
+
+    // Resume well before the 1h timeout. dispatch_resume reads `Running` and
+    // delivers to the live resume channel.
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume on a live Running execution must succeed");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("execution must complete after the live Resume")
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "a Resume before the timeout must complete the execution, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        1,
+        "the main-port branch must run exactly once on a pre-timeout Resume"
+    );
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        0,
+        "the error-port branch must NOT run on a pre-timeout Resume (no late timeout failure)"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "execution must be Completed (and the timeout discarded)"
+    );
+}
+
+/// **W-S2b — a Resume to a Running execution reaches the live loop.**
+///
+/// `dispatch_resume` on a `Running` execution must deliver to the live resume
+/// channel (NOT no-op as the pre-W-S2b code did). With a long timeout, only the
+/// live delivery can complete the node before the test bound.
+///
+/// **Falsifiability**: restore `dispatch_resume`'s `Running => Ok(())` no-op arm
+/// (drop the `resume_live` call) → the live loop never wakes → the node only
+/// times out at t=1h → the spawned drive never settles within 5s → the final
+/// `expect` fails → RED.
+#[tokio::test]
+async fn resume_to_running_execution_reaches_live_loop() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_workflow(/* with_error_port */ false, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+
+    await_parked(&mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running
+    );
+
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume to a Running execution must be Ok (delivered to live loop)");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect(
+            "the live loop must complete the node on Resume — without live delivery it would only \
+             time out at t=1h and this would elapse",
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "the live Resume must drive the execution to Completed without waiting for the timeout"
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        1,
+        "the main branch must run exactly once on the live Resume"
+    );
+}
+
+/// **W-S2b — crash mid-wait with a timeout recovers and can still time out.**
+///
+/// Runner A parks the signal+timeout wait, then "crashes" (its drive task is
+/// aborted). After the lease TTL expires, runner B resumes; the persisted
+/// `wait_wake = Timeout` re-seeds the timer, and because the (short) deadline
+/// has already passed in real time, runner B times the wait out.
+///
+/// **Falsifiability**: drop the `wait_wake` field (or its serde persistence) →
+/// after recovery the re-seeded wait reads `wait_wake = None` → Phase-0b
+/// COMPLETES it instead of failing → `error_count == 0`, `main_count == 1` →
+/// the timeout asserts flip → RED.
+#[tokio::test]
+async fn crash_mid_wait_with_timeout_recovers_and_can_still_timeout() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // Short timeout so that, by the time runner B recovers (after the lease TTL
+    // floor of ~1s), the deadline has already elapsed.
+    let timeout = Duration::from_millis(200);
+    // In-mem store clamps lease TTL to >= 1s.
+    let lease_ttl = Duration::from_secs(1);
+    let heartbeat = Duration::from_millis(300);
+
+    let stores = WtStores::new();
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_registry(timeout, &main_count, &error_count))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_registry(
+                timeout,
+                &main_count,
+                &error_count,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    // Runner A parks the wait. Capture the park, then crash A immediately so its
+    // own short timer does not fire before we abort.
+    let engine_a_h = Arc::clone(&engine_a);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task_a =
+        tokio::spawn(async move { engine_a_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+
+    // Confirm the persisted discriminator survived the park.
+    let parked = stores.load_state(execution_id).await;
+    assert!(
+        parked
+            .node_states
+            .values()
+            .any(|ns| ns.state == nebula_workflow::NodeState::Waiting
+                && ns.wait_wake == Some(nebula_execution::state::WaitWake::Timeout)),
+        "the parked node must persist wait_wake = Timeout"
+    );
+
+    // Crash runner A before its timer fires (the abort drops its drive future).
+    task_a.abort();
+    let _ = task_a.await;
+
+    // Wait out the lease TTL (real time) so runner B can take over. By now the
+    // 200ms wait deadline has long passed.
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+
+    // Runner B resumes: re-seeds the persisted Timeout wait, sees the deadline
+    // already past, and fails the node on the error branch.
+    let engine_b_h = Arc::clone(&engine_b);
+    let scope_b = nebula_engine::store_seam::single_tenant_scope();
+    let result_b = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::spawn(async move { engine_b_h.resume_execution(&scope_b, execution_id).await }),
+    )
+    .await
+    .expect("runner B must settle the recovered timeout within 10s")
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        1,
+        "the recovered wait must still time out on runner B and route the error branch"
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        0,
+        "the main branch must NOT run on a recovered timeout"
+    );
+    let _ = result_b;
+}
+
+/// **W-S2b — crash after a durable arm completes on recovery.**
+///
+/// A signal+timeout wait is parked, then armed for COMPLETION (a Resume) in the
+/// durable row under the lease. Simulate a crash AFTER the arm is durable but
+/// before Phase-0b drains it: runner B recovers, re-seeds the armed timer
+/// (`wait_wake = Completion`), and completes the node on the main port.
+///
+/// **Falsifiability**: make Phase-0b's recovery path read `wait_wake = Timeout`
+/// for an armed `Completion` wait (e.g. ignore the discriminator) → recovery
+/// would FAIL the node → `main_count == 0` and status `Failed` → the
+/// `Completed` + `main_count == 1` asserts flip → RED.
+#[tokio::test]
+async fn crash_after_durable_arm_completes_on_recovery() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // Long timeout: recovery must complete via the COMPLETION arm, never via the
+    // timeout (which would not have fired yet).
+    let timeout = Duration::from_hours(1);
+    let lease_ttl = Duration::from_secs(1);
+    let heartbeat = Duration::from_millis(300);
+    let stores = WtStores::new();
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    // Runner A parks the signal+timeout wait (Running), then we crash it.
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine_a = Arc::new(
+        stores
+            .attach(
+                make_engine(build_registry(timeout, &main_count, &error_count))
+                    .with_event_bus(event_bus),
+            )
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let engine_a_h = Arc::clone(&engine_a);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_a_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+    task.abort();
+    let _ = task.await;
+
+    // Expire A's lease, then manually arm the wait for COMPLETION in the durable
+    // row — models the live loop's self-arm checkpoint having landed before the
+    // crash (armed-but-not-yet-drained).
+    tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
+    arm_wait_for_completion(&stores, execution_id).await;
+
+    // Recover with a fresh runner B. The re-seed picks up the armed timer; since
+    // its `wait_wake = Completion`, Phase-0b COMPLETES the node (does not fail).
+    let engine_b = Arc::new(
+        stores
+            .attach(make_engine(build_registry(
+                timeout,
+                &main_count,
+                &error_count,
+            )))
+            .with_lease_ttl(lease_ttl)
+            .with_lease_heartbeat_interval(heartbeat),
+    );
+    let engine_b_h = Arc::clone(&engine_b);
+    let scope_b = nebula_engine::store_seam::single_tenant_scope();
+    let result = tokio::time::timeout(
+        Duration::from_secs(10),
+        tokio::spawn(async move { engine_b_h.resume_execution(&scope_b, execution_id).await }),
+    )
+    .await
+    .expect("recovery must settle within 10s")
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "an armed (Completion) wait must complete on recovery, not fail, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        1,
+        "the main branch must run exactly once after recovery completes the armed wait"
+    );
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        0,
+        "the error branch must NOT run when the armed wait completes"
+    );
+}
+
+/// Acquire the lease and rewrite the parked wait node to an armed Completion
+/// state (`next_attempt_at = now`, `wait_wake = Completion`). Models the live
+/// loop's self-arm checkpoint having landed before a crash.
+async fn arm_wait_for_completion(stores: &WtStores, execution_id: ExecutionId) {
+    use nebula_storage_port::{TransitionBatch, TransitionOutcome};
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let id = execution_id.to_string();
+    let token = stores
+        .execution
+        .acquire_lease(&scope, &id, "test-armer", Duration::from_secs(30))
+        .await
+        .unwrap()
+        .expect("abandoned lease must be free after TTL");
+    let record = stores
+        .execution
+        .get(&scope, &id)
+        .await
+        .unwrap()
+        .expect("row exists");
+    let s = serde_json::to_string(&record.state).unwrap();
+    let mut state: ExecutionState = serde_json::from_str(&s).unwrap();
+    let now = chrono::Utc::now();
+    for ns in state.node_states.values_mut() {
+        if ns.state == nebula_workflow::NodeState::Waiting {
+            ns.next_attempt_at = Some(now);
+            ns.wait_wake = Some(nebula_execution::state::WaitWake::Completion);
+        }
+    }
+    state.version += 1;
+    let batch = TransitionBatch::builder()
+        .scope(scope.clone())
+        .execution_id(&id)
+        .expected_version(record.version)
+        .fencing(token)
+        .new_state(serde_json::to_value(&state).unwrap())
+        .build()
+        .unwrap();
+    assert!(matches!(
+        stores.execution.commit(batch).await.unwrap(),
+        TransitionOutcome::Applied { .. }
+    ));
+    stores
+        .execution
+        .release_lease(&scope, &id, token)
+        .await
+        .unwrap();
+}
+
+/// **W-S2b — Resume wins, then the stale timeout timer fires: still exactly one
+/// terminal outcome.**
+///
+/// The load-bearing R2 race invariant, made deterministic by ordering rather
+/// than relying on a sub-millisecond tie: deliver the Resume first (it completes
+/// the node on the main port), THEN sleep past the original short timeout so the
+/// stale timeout heap entry's timer fires. The Phase-0b state re-read at the pop
+/// must recognise the node is no longer `Waiting` and skip it — the error branch
+/// must NEVER run. Exactly one of (main, error) ran.
+///
+/// This is the `Resume-then-timeout` ordering of the race; the
+/// `timeout-then-Resume` ordering is covered by
+/// [`resume_before_timeout_completes_main_port_and_cancels_timer`] (Resume wins)
+/// and [`signal_wait_with_timeout_fires_error_port_on_timeout`] (timeout wins),
+/// proving both orderings reach a single outcome.
+///
+/// **Falsifiability**: in the single-process path TWO independent guards keep
+/// the stale timeout from re-routing — the resume self-arm PURGES the stale
+/// future heap entry, and the Phase-0b pop RE-READS node state (a non-`Waiting`
+/// node is skipped). Dropping only the re-read leaves the purge, so the stale
+/// entry is already gone and the test can still pass. To turn it RED, drop the
+/// PURGE (the `wait_heap` rebuild that filters out the re-armed keys) — or both
+/// guards — so the stale `(deadline, key)` entry survives, pops after the node
+/// is `Completed`, and routes it through `route_failure_edges` → the error
+/// branch ALSO runs → `main + error == 2` → the `== 1` assert fails → RED.
+#[tokio::test]
+async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // A short timeout: after the Resume completes the node, we deliberately sleep
+    // past this deadline so the STALE timeout heap entry's timer fires. The R2
+    // state re-read must turn that stale wake into a no-op.
+    let timeout = Duration::from_millis(120);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+
+    // Resume wins: it self-arms the node for completion and Phase-0b completes it
+    // on the main port. The original (deadline) timeout entry remains on the heap
+    // until purged / re-read.
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume must deliver to the live loop");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("execution must complete after the Resume")
+        .unwrap()
+        .unwrap();
+
+    // The drive returned because the Resume completed the node. The original
+    // timeout deadline has, by construction, passed (the drive ran longer than
+    // 120ms is not guaranteed, so sleep to be sure the stale wall-clock deadline
+    // is in the past, then confirm no late routing could have fired).
+    tokio::time::sleep(timeout + Duration::from_millis(50)).await;
+
+    // Exactly one branch ran — the main completion; the stale timeout never
+    // re-routed the error branch (R2 state re-read turned it into a no-op).
+    let main_ran = main_count.load(Ordering::SeqCst);
+    let error_ran = error_count.load(Ordering::SeqCst);
+    assert_eq!(
+        main_ran + error_ran,
+        1,
+        "exactly one branch must run on a Resume-then-stale-timeout sequence; \
+         got main={main_ran}, error={error_ran}"
+    );
+    assert_eq!(
+        main_ran, 1,
+        "the Resume completion routes the MAIN branch; the stale timeout must not \
+         re-route the error branch"
+    );
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "the execution must reach a single coherent terminal outcome (Completed), got {:?}",
+        result.status
+    );
+}
+
+/// **W-S2b — a wait timeout does NOT count against the retry budget.**
+///
+/// A `WaitTimedOut` is terminal and bypasses the retry decision entirely. The
+/// timed-out node must NOT enter `WaitingRetry`, and `total_retries` must NOT
+/// bump.
+///
+/// **Falsifiability**: route the timeout through the retry path
+/// (`schedule_node_retry` / `compute_retry_decision`) instead of straight to
+/// `Failed` → the node would land in `WaitingRetry` and `total_retries` would
+/// bump → the `WaitingRetry`-absent / `total_retries == 0` asserts fail → RED.
+#[tokio::test]
+async fn timeout_does_not_count_against_retry_budget() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_millis(120);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry)));
+
+    // No error port: a top-level FailFast timeout fails the execution.
+    let wf = make_workflow(/* with_error_port */ false, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await }),
+    )
+    .await
+    .expect("execution must settle after the timeout")
+    .unwrap()
+    .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Failed,
+        "an unhandled wait timeout must fail the execution"
+    );
+
+    let state = stores.load_state(execution_id).await;
+    assert_eq!(
+        state.total_retries, 0,
+        "a wait timeout must not bump total_retries (bypasses the retry budget)"
+    );
+    assert!(
+        state
+            .node_states
+            .values()
+            .all(|ns| ns.state != nebula_workflow::NodeState::WaitingRetry),
+        "no node may be in WaitingRetry after a wait timeout"
+    );
+    // The timed-out wait node ends Failed.
+    assert!(
+        state
+            .node_states
+            .values()
+            .any(|ns| ns.state == nebula_workflow::NodeState::Failed),
+        "the timed-out wait node must be Failed; states: {:?}",
+        state
+            .node_states
+            .values()
+            .map(|ns| ns.state)
+            .collect::<Vec<_>>()
+    );
+}
+
+/// **W-S2b — only `resume_live` satisfies a live signal+timeout wait; a
+/// re-delivered `dispatch_start` / `dispatch_restart` does NOT (SECURITY test).**
+///
+/// A `Running` signal+timeout execution must be satisfied ONLY by the live
+/// resume channel (`dispatch_resume` → `resume_live`). The other control
+/// commands short-circuit on `Running` to an `Ok(())` no-op — they must NEVER
+/// reach into the live loop and complete the parked wait. (Mirrors the case-a
+/// `dispatch_start_redelivery_does_not_satisfy_signal_wait` security test for
+/// the Running/timeout shape.)
+///
+/// **Falsifiability**: wire `resume_live` (or a satisfy) into `dispatch_start` /
+/// `dispatch_restart`'s `Running` arm → the re-delivered Start/Restart completes
+/// the wait → the main branch runs → `main_count == 1` after the re-drive → the
+/// `== 0` assert before the genuine Resume fails → RED.
+#[tokio::test]
+async fn redelivered_start_restart_do_not_satisfy_live_signal_timeout_wait() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1); // long: must not fire during the test
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_workflow(/* with_error_port */ false, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "the signal+timeout wait must keep the execution Running"
+    );
+
+    // A re-delivered Start on a Running execution must be a no-op (it must NOT
+    // satisfy the wait). `dispatch_start` short-circuits `Running => Ok(())`.
+    dispatch
+        .dispatch_start(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("re-delivered Start on a Running execution must be an Ok no-op");
+    // A re-delivered Restart likewise short-circuits `Running => Ok(())`.
+    dispatch
+        .dispatch_restart(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("re-delivered Restart on a Running execution must be an Ok no-op");
+
+    // Neither re-drive may have completed the wait — give the runtime a tick to
+    // surface any erroneous wake, then assert the gate is still closed.
+    tokio::task::yield_now().await;
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        0,
+        "neither Start nor Restart re-delivery may satisfy a live signal+timeout wait — \
+         only resume_live does"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "the execution must still be Running (wait not satisfied) after Start/Restart re-drives"
+    );
+
+    // Wind the live loop down deterministically (the 1h timer would otherwise
+    // keep the drive alive). Cancel reaches the live frontier and tears it down.
+    assert!(
+        engine.cancel_execution(execution_id),
+        "cancel_execution must find the live frontier"
+    );
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("the cancelled execution must wind down within 5s")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Cancelled,
+        "the execution must end Cancelled after cancel teardown"
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        0,
+        "the main branch must never run — the wait was cancelled, never satisfied"
+    );
+}
+
+/// **W-S2b — ONE Resume arms MULTIPLE parallel signal+timeout waits (N>1
+/// self-arm).**
+///
+/// Two parallel signal+timeout wait nodes both park (the row stays `Running`).
+/// A single `dispatch_resume` reaches the live loop, whose `ResumeSignalled`
+/// arm self-arms BOTH `Waiting` nodes in one pass (`to_arm.len() == 2`),
+/// rebuilds the `wait_heap` purging the stale timeout entries, and commits the
+/// multi-node arm with a single checkpoint. Phase-0b then completes both nodes
+/// on their `main` ports. Every other test drives a single wait, so this is the
+/// only coverage of the `for node_key in &to_arm` loop, the heap purge, and the
+/// `to_arm[0]`-attributed multi-node checkpoint with len > 1.
+///
+/// **Falsifiability**: make the self-arm loop arm only `to_arm[0]` (e.g.
+/// `for node_key in to_arm.iter().take(1)`) → the second wait is never armed,
+/// its 1h timeout never fires within the bound → the spawned drive never settles
+/// → the outer `expect` elapses → RED. (Captured as the RED evidence for this
+/// change.)
+#[tokio::test]
+async fn one_resume_arms_multiple_parallel_signal_timeout_waits() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // Long timeout: neither wait may time out during the test — only the single
+    // Resume completes both. If the second node is not armed it would only fire
+    // at t=1h, past the 5s settle bound.
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_two_wait_workflow();
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+
+    // Both waits must be parked before the single Resume — otherwise the lone
+    // `notify_one()` would arm only the node(s) parked so far.
+    await_n_parked(&mut events_rx, 2).await;
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Running,
+        "two signal+timeout waits must keep the execution Running (live timers)"
+    );
+
+    // A single Resume reaches the live loop and arms BOTH parked waits in one
+    // `ResumeSignalled` pass.
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume on the live Running execution must succeed");
+
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect(
+            "both waits must complete on the single Resume — if only the first is armed the second \
+             only times out at t=1h and this bound elapses",
+        )
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(
+        result.status,
+        ExecutionStatus::Completed,
+        "one Resume must complete BOTH parallel waits, got {:?}",
+        result.status
+    );
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        2,
+        "both waits must complete on their MAIN ports exactly once each"
+    );
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        0,
+        "no wait may route its error port on a clean Resume"
+    );
+    assert_eq!(
+        stores.persisted_status(execution_id).await,
+        ExecutionStatus::Completed,
+        "the execution must reach a terminal Completed status"
+    );
+}

--- a/crates/engine/tests/wait_timeout.rs
+++ b/crates/engine/tests/wait_timeout.rs
@@ -27,10 +27,10 @@
 //! likewise use the in-mem store's clamp floor (1s) under real time.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc, OnceLock,
-        atomic::{AtomicU32, Ordering},
+        atomic::{AtomicBool, AtomicU32, Ordering},
     },
     time::Duration,
 };
@@ -51,8 +51,9 @@ use nebula_execution::{ExecutionState, ExecutionStatus};
 use nebula_metrics::MetricsRegistry;
 use nebula_storage::{InMemoryExecutionStore, InMemoryWorkflowVersionStore};
 use nebula_storage_port::{
-    dto::WorkflowVersionRecord,
-    store::{ExecutionStore, WorkflowVersionStore},
+    FencingToken, Scope, StorageError, TransitionBatch, TransitionOutcome,
+    dto::{ExecutionRecord, WorkflowVersionRecord},
+    store::{ExecutionStore, WorkflowStore, WorkflowVersionStore},
 };
 use nebula_workflow::{
     CURRENT_SCHEMA_VERSION, Connection, NodeDefinition, Version, WorkflowConfig, WorkflowDefinition,
@@ -147,6 +148,38 @@ impl StatelessAction for CountingError {
     ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
         self.invocations.fetch_add(1, Ordering::SeqCst);
         Ok(ActionResult::success(input))
+    }
+}
+
+/// Parks itself via `WaitCondition::Duration` (a TIMER wait, not a signal
+/// wait). It is NOT a signal wait per the engine's `is_signal_wait` filter, so
+/// a live-frontier Resume does NOT arm it — it stays parked until its own
+/// duration elapses. Used as a "blocker" that keeps the frontier loop ALIVE
+/// past another node's stale timeout deadline, so a stale timeout-heap entry
+/// actually pops in a live loop (CR#7).
+struct DurationWaitBlocker {
+    duration: Duration,
+}
+
+static_action_impl!(
+    DurationWaitBlocker,
+    action_key!("test.wt.duration_blocker"),
+    "DurationWaitBlocker"
+);
+
+impl StatelessAction for DurationWaitBlocker {
+    async fn execute(
+        &self,
+        _input: <Self as Action>::Input,
+        _ctx: &(impl nebula_action::ActionContext + ?Sized),
+    ) -> Result<ActionResult<<Self as Action>::Output>, ActionError> {
+        Ok(ActionResult::Wait {
+            condition: WaitCondition::Duration {
+                duration: self.duration,
+            },
+            timeout: None,
+            partial_output: None,
+        })
     }
 }
 
@@ -422,6 +455,75 @@ fn make_two_wait_workflow() -> WorkflowDefinition {
     }
 }
 
+/// Build a registry with the standard signal+timeout / echo nodes PLUS a
+/// `DurationWaitBlocker` parked for `blocker_for`. The blocker keeps the
+/// frontier loop alive past the signal wait's stale timeout deadline (CR#7).
+fn build_registry_with_blocker(
+    timeout: Duration,
+    blocker_for: Duration,
+    main_count: &Arc<AtomicU32>,
+    error_count: &Arc<AtomicU32>,
+) -> Arc<ActionRegistry> {
+    let registry = build_registry(timeout, main_count, error_count);
+    registry.register_stateless_instance(
+        ActionMetadata::new(
+            action_key!("test.wt.duration_blocker"),
+            "DurationWaitBlocker",
+            "wait_timeout stub",
+        ),
+        DurationWaitBlocker {
+            duration: blocker_for,
+        },
+    );
+    registry
+}
+
+/// Build a workflow `wait ──main──> main_node` / `wait ──error──> error_node`
+/// PLUS an independent `blocker` node that parks on a `Duration` wait. The
+/// blocker has no downstream — its sole job is to keep the frontier loop alive
+/// (the row stays `Running` on the blocker's timer) while the signal wait's
+/// stale timeout entry pops and is purged/re-read (CR#7).
+fn make_workflow_with_blocker() -> WorkflowDefinition {
+    let now = chrono::Utc::now();
+    let wait = node_key!("wait_node");
+    let main_node = node_key!("main_node");
+    let error_node = node_key!("error_node");
+    let blocker = node_key!("blocker_node");
+    let nodes = vec![
+        NodeDefinition::new(wait.clone(), "WaitNode", "core", "test.wt.webhook_timeout").unwrap(),
+        NodeDefinition::new(main_node.clone(), "MainNode", "core", "test.wt.main_echo").unwrap(),
+        NodeDefinition::new(
+            error_node.clone(),
+            "ErrorNode",
+            "core",
+            "test.wt.error_echo",
+        )
+        .unwrap(),
+        NodeDefinition::new(blocker, "Blocker", "core", "test.wt.duration_blocker").unwrap(),
+    ];
+    let connections = vec![
+        Connection::new(wait.clone(), main_node),
+        Connection::new(wait, error_node).with_from_port("error"),
+    ];
+    WorkflowDefinition {
+        id: nebula_core::WorkflowId::new(),
+        name: "wait-timeout-blocker-test".into(),
+        description: None,
+        version: Version::new(0, 1, 0),
+        nodes,
+        connections,
+        variables: HashMap::new(),
+        config: WorkflowConfig::default(),
+        trigger_bindings: Vec::new(),
+        tags: Vec::new(),
+        created_at: now,
+        updated_at: now,
+        owner_id: None,
+        ui_metadata: None,
+        schema_version: CURRENT_SCHEMA_VERSION,
+    }
+}
+
 /// Await `NodeParked` for the wait node from a subscribed event stream. Bounds
 /// the wait so a missing park fails fast instead of hanging.
 async fn await_parked(events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>) -> ExecutionId {
@@ -438,26 +540,170 @@ async fn await_parked(events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent
     .expect("engine must emit NodeParked for the signal+timeout wait")
 }
 
-/// Await `expected` distinct `NodeParked` events. Used by the N>1 self-arm test,
-/// where a single Resume must arm MULTIPLE parallel signal+timeout waits — every
-/// wait node must be `Waiting` before the Resume is delivered, otherwise the
-/// single `notify_one()` would arm only the nodes parked so far.
+/// Await `NodeParked` events until `expected` DISTINCT nodes have parked. Used
+/// by the N>1 self-arm test, where a single Resume must arm MULTIPLE parallel
+/// signal+timeout waits — every wait node must be `Waiting` before the Resume is
+/// delivered, otherwise the single delivery would arm only the nodes parked so
+/// far. Keyed on `node_key` so a duplicate `NodeParked` for one node cannot
+/// satisfy the count.
 async fn await_n_parked(
     events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
     expected: usize,
 ) {
     tokio::time::timeout(Duration::from_secs(5), async {
-        let mut parked = 0usize;
-        while parked < expected {
+        let mut parked: HashSet<nebula_core::NodeKey> = HashSet::new();
+        while parked.len() < expected {
             match events_rx.recv().await {
-                Some(ExecutionEvent::NodeParked { .. }) => parked += 1,
+                Some(ExecutionEvent::NodeParked { node_key, .. }) => {
+                    parked.insert(node_key);
+                },
                 Some(_) => continue,
                 None => panic!("event bus closed before all NodeParked"),
             }
         }
     })
     .await
-    .unwrap_or_else(|_| panic!("engine must emit {expected} NodeParked events"));
+    .unwrap_or_else(|_| panic!("engine must emit {expected} distinct NodeParked events"));
+}
+
+/// Await the `NodeWaitTimedOut` event from a subscribed stream, returning it so
+/// the caller can assert its fields. Bounds the wait so a missing event fails
+/// fast instead of hanging.
+async fn await_wait_timed_out(
+    events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
+) -> ExecutionEvent {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(event @ ExecutionEvent::NodeWaitTimedOut { .. }) => break event,
+                Some(_) => continue,
+                None => panic!("event bus closed before NodeWaitTimedOut"),
+            }
+        }
+    })
+    .await
+    .expect("engine must emit NodeWaitTimedOut when a signal+timeout wait elapses")
+}
+
+// ── Fault-injecting execution store (P1#1 fenced-out self-arm) ────────────────
+
+/// Wraps an [`InMemoryExecutionStore`] and forces the NEXT `commit` after
+/// `fence_next` is armed to report [`TransitionOutcome::FencedOut`] — modelling
+/// the live loop losing its lease mid-iteration so the self-arm checkpoint is
+/// fenced. The park checkpoint(s) run with `fence_next == false`; the test arms
+/// the flag after the park and before the Resume, so only the self-arm commit
+/// is fenced. All other methods delegate.
+#[derive(Debug)]
+struct FenceArmStore {
+    inner: Arc<InMemoryExecutionStore>,
+    fence_next: AtomicBool,
+}
+
+impl FenceArmStore {
+    fn new(inner: Arc<InMemoryExecutionStore>) -> Self {
+        Self {
+            inner,
+            fence_next: AtomicBool::new(false),
+        }
+    }
+
+    /// Arm the fence so the next `commit` reports `FencedOut` instead of
+    /// delegating.
+    fn arm_fence(&self) {
+        self.fence_next.store(true, Ordering::SeqCst);
+    }
+}
+
+#[async_trait::async_trait]
+impl ExecutionStore for FenceArmStore {
+    async fn create(
+        &self,
+        scope: &Scope,
+        id: &str,
+        workflow_id: &str,
+        initial_state: serde_json::Value,
+    ) -> Result<(), StorageError> {
+        self.inner
+            .create(scope, id, workflow_id, initial_state)
+            .await
+    }
+
+    async fn get(&self, scope: &Scope, id: &str) -> Result<Option<ExecutionRecord>, StorageError> {
+        self.inner.get(scope, id).await
+    }
+
+    async fn commit(&self, batch: TransitionBatch) -> Result<TransitionOutcome, StorageError> {
+        // Fence exactly one commit (the self-arm checkpoint) once armed.
+        if self.fence_next.swap(false, Ordering::SeqCst) {
+            return Ok(TransitionOutcome::FencedOut);
+        }
+        self.inner.commit(batch).await
+    }
+
+    async fn acquire_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        holder: &str,
+        ttl: Duration,
+    ) -> Result<Option<FencingToken>, StorageError> {
+        self.inner.acquire_lease(scope, id, holder, ttl).await
+    }
+
+    async fn renew_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+        ttl: Duration,
+    ) -> Result<bool, StorageError> {
+        self.inner.renew_lease(scope, id, token, ttl).await
+    }
+
+    async fn release_lease(
+        &self,
+        scope: &Scope,
+        id: &str,
+        token: FencingToken,
+    ) -> Result<bool, StorageError> {
+        self.inner.release_lease(scope, id, token).await
+    }
+
+    async fn list_running(&self, scope: &Scope) -> Result<Vec<String>, StorageError> {
+        self.inner.list_running(scope).await
+    }
+
+    async fn list_running_for_workflow(
+        &self,
+        scope: &Scope,
+        workflow_id: &str,
+    ) -> Result<Vec<String>, StorageError> {
+        self.inner
+            .list_running_for_workflow(scope, workflow_id)
+            .await
+    }
+
+    async fn count(&self, scope: &Scope, workflow_id: Option<&str>) -> Result<u64, StorageError> {
+        self.inner.count(scope, workflow_id).await
+    }
+}
+
+/// Await the `ResumeDeferred` event from a subscribed stream, returning its
+/// `reason`. Bounds the wait so a missing event fails fast.
+async fn await_resume_deferred(
+    events_rx: &mut nebula_eventbus::Subscriber<ExecutionEvent>,
+) -> String {
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match events_rx.recv().await {
+                Some(ExecutionEvent::ResumeDeferred { reason, .. }) => break reason,
+                Some(_) => continue,
+                None => panic!("event bus closed before ResumeDeferred"),
+            }
+        }
+    })
+    .await
+    .expect("engine must emit ResumeDeferred when a live-frontier Resume does not durably arm")
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────
@@ -479,7 +725,12 @@ async fn signal_wait_with_timeout_fires_error_port_on_timeout() {
     let timeout = Duration::from_millis(120);
     let registry = build_registry(timeout, &main_count, &error_count);
 
-    let engine = Arc::new(make_engine(registry));
+    // Subscribe to the event stream so the `NodeWaitTimedOut` contract is
+    // asserted, not just the downstream branch counters (CR#9): the engine
+    // could route the error port correctly yet regress the typed event.
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine = Arc::new(make_engine(registry).with_event_bus(event_bus));
     let wf = Arc::new(make_workflow(/* with_error_port */ true, timeout));
 
     let engine_h = Arc::clone(&engine);
@@ -522,6 +773,30 @@ async fn signal_wait_with_timeout_fires_error_port_on_timeout() {
             .any(|e| e.contains("timed out") || e.contains("WAIT_TIMED_OUT")),
         "node_errors must reference the wait timeout; got: {:?}",
         result.node_errors
+    );
+
+    // The typed `NodeWaitTimedOut` event must fire with the signal
+    // discriminator and a timeout reconstructed from the persisted deadline.
+    // These tests run under real wall-clock timers (not `tokio::time::pause`),
+    // so `timeout_ms` is reconstructed from `deadline - started_at` and may
+    // slightly exceed the declared timeout — assert `>=`.
+    let timed_out = await_wait_timed_out(&mut events_rx).await;
+    let ExecutionEvent::NodeWaitTimedOut {
+        condition_kind,
+        timeout_ms,
+        ..
+    } = timed_out
+    else {
+        unreachable!("await_wait_timed_out only returns NodeWaitTimedOut")
+    };
+    assert_eq!(
+        condition_kind, "signal",
+        "the timed-out wait must report the signal condition kind"
+    );
+    assert!(
+        timeout_ms >= timeout.as_millis() as u64,
+        "timeout_ms ({timeout_ms}) must be at least the declared timeout ({}ms)",
+        timeout.as_millis()
     );
 }
 
@@ -686,9 +961,11 @@ async fn resume_to_running_execution_reaches_live_loop() {
 async fn crash_mid_wait_with_timeout_recovers_and_can_still_timeout() {
     let main_count = Arc::new(AtomicU32::new(0));
     let error_count = Arc::new(AtomicU32::new(0));
-    // Short timeout so that, by the time runner B recovers (after the lease TTL
-    // floor of ~1s), the deadline has already elapsed.
-    let timeout = Duration::from_millis(200);
+    // A timeout short enough that the deadline has elapsed by the time runner B
+    // recovers (after the ~1s lease TTL floor), but long enough that it cannot
+    // fire in the brief window before we abort runner A — 200ms was fragile
+    // under CI load (CR#6). 400ms is comfortably below the lease-expiry wait.
+    let timeout = Duration::from_millis(400);
     // In-mem store clamps lease TTL to >= 1s.
     let lease_ttl = Duration::from_secs(1);
     let heartbeat = Duration::from_millis(300);
@@ -729,7 +1006,15 @@ async fn crash_mid_wait_with_timeout_recovers_and_can_still_timeout() {
         tokio::spawn(async move { engine_a_h.resume_execution(&scope, execution_id).await });
     await_parked(&mut events_rx).await;
 
-    // Confirm the persisted discriminator survived the park.
+    // Crash runner A IMMEDIATELY after the park event, before its timer can
+    // fire (CR#6): the park checkpoint already landed before `NodeParked` was
+    // emitted, so the durable row is intact and the abort cannot race the
+    // timer. The persisted-state assertion below reads that durable row.
+    task_a.abort();
+    let _ = task_a.await;
+
+    // Confirm the persisted discriminator survived the park (read from the
+    // durable row, unaffected by the abort).
     let parked = stores.load_state(execution_id).await;
     assert!(
         parked
@@ -740,12 +1025,8 @@ async fn crash_mid_wait_with_timeout_recovers_and_can_still_timeout() {
         "the parked node must persist wait_wake = Timeout"
     );
 
-    // Crash runner A before its timer fires (the abort drops its drive future).
-    task_a.abort();
-    let _ = task_a.await;
-
     // Wait out the lease TTL (real time) so runner B can take over. By now the
-    // 200ms wait deadline has long passed.
+    // wait deadline has long passed.
     tokio::time::sleep(lease_ttl + Duration::from_millis(300)).await;
 
     // Runner B resumes: re-seeds the persisted Timeout wait, sees the deadline
@@ -914,15 +1195,24 @@ async fn arm_wait_for_completion(stores: &WtStores, execution_id: ExecutionId) {
         .unwrap();
 }
 
-/// **W-S2b — Resume wins, then the stale timeout timer fires: still exactly one
-/// terminal outcome.**
+/// **W-S2b — Resume wins, then the stale timeout timer fires IN A LIVE LOOP:
+/// still exactly one terminal outcome.**
 ///
-/// The load-bearing R2 race invariant, made deterministic by ordering rather
-/// than relying on a sub-millisecond tie: deliver the Resume first (it completes
-/// the node on the main port), THEN sleep past the original short timeout so the
-/// stale timeout heap entry's timer fires. The Phase-0b state re-read at the pop
-/// must recognise the node is no longer `Waiting` and skip it — the error branch
-/// must NEVER run. Exactly one of (main, error) ran.
+/// The load-bearing R2 race invariant, made deterministic by ordering AND by
+/// keeping the frontier loop alive while the stale entry pops (CR#7). An
+/// independent `blocker` node parks on a long `Duration` wait, so the row stays
+/// `Running` and the loop keeps polling `wait_heap` long after the signal
+/// wait's short timeout deadline. The signal wait's stale `(deadline, key)`
+/// heap entry therefore pops in a LIVE loop; the purge (it should already be
+/// gone) and the Phase-0b state re-read (a non-`Waiting` node is skipped) must
+/// keep the error branch from EVER running. We assert no error routing fired
+/// while the drive is STILL alive, then let the blocker elapse so the drive
+/// settles.
+///
+/// Without the blocker the drive returns the instant the single wait completes,
+/// so the stale entry never pops in a live loop — the test could pass even if
+/// the purge/re-read were broken. The blocker makes the guard genuinely
+/// exercised.
 ///
 /// This is the `Resume-then-timeout` ordering of the race; the
 /// `timeout-then-Resume` ordering is covered by
@@ -930,24 +1220,27 @@ async fn arm_wait_for_completion(stores: &WtStores, execution_id: ExecutionId) {
 /// and [`signal_wait_with_timeout_fires_error_port_on_timeout`] (timeout wins),
 /// proving both orderings reach a single outcome.
 ///
-/// **Falsifiability**: in the single-process path TWO independent guards keep
-/// the stale timeout from re-routing — the resume self-arm PURGES the stale
-/// future heap entry, and the Phase-0b pop RE-READS node state (a non-`Waiting`
-/// node is skipped). Dropping only the re-read leaves the purge, so the stale
-/// entry is already gone and the test can still pass. To turn it RED, drop the
-/// PURGE (the `wait_heap` rebuild that filters out the re-armed keys) — or both
-/// guards — so the stale `(deadline, key)` entry survives, pops after the node
-/// is `Completed`, and routes it through `route_failure_edges` → the error
-/// branch ALSO runs → `main + error == 2` → the `== 1` assert fails → RED.
+/// **Falsifiability**: TWO independent guards keep the stale timeout from
+/// re-routing — the resume self-arm PURGES the stale future heap entry, and the
+/// Phase-0b pop RE-READS node state (a non-`Waiting` node is skipped). To turn
+/// it RED, drop BOTH guards (e.g. the `wait_heap` rebuild that filters out the
+/// re-armed keys AND the pop-time state re-read) → the stale `(deadline, key)`
+/// entry survives, pops while the loop is alive on the blocker, finds the node
+/// `Completed`, and routes it through `route_failure_edges` → the error branch
+/// runs → the `error_count == 0` assert fails → RED.
 #[tokio::test]
 async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
     let main_count = Arc::new(AtomicU32::new(0));
     let error_count = Arc::new(AtomicU32::new(0));
-    // A short timeout: after the Resume completes the node, we deliberately sleep
-    // past this deadline so the STALE timeout heap entry's timer fires. The R2
-    // state re-read must turn that stale wake into a no-op.
+    // A short signal timeout: after the Resume completes the node, its STALE
+    // timeout heap entry fires while the blocker keeps the loop alive. The R2
+    // purge + state re-read must turn that stale wake into a no-op.
     let timeout = Duration::from_millis(120);
-    let registry = build_registry(timeout, &main_count, &error_count);
+    // The blocker outlives the stale-timeout pop window (well past 120ms) so the
+    // loop is genuinely alive when the stale entry fires, then elapses so the
+    // execution can settle within the test bound.
+    let blocker_for = Duration::from_millis(900);
+    let registry = build_registry_with_blocker(timeout, blocker_for, &main_count, &error_count);
 
     let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
     let mut events_rx = event_bus.subscribe();
@@ -955,18 +1248,22 @@ async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
     let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
     let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
 
-    let wf = make_workflow(/* with_error_port */ true, timeout);
+    let wf = make_workflow_with_blocker();
     stores.save_workflow(&wf).await;
     let execution_id = stores.persist_created_execution(wf.id).await;
 
     let engine_h = Arc::clone(&engine);
     let scope = nebula_engine::store_seam::single_tenant_scope();
     let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
-    await_parked(&mut events_rx).await;
 
-    // Resume wins: it self-arms the node for completion and Phase-0b completes it
-    // on the main port. The original (deadline) timeout entry remains on the heap
-    // until purged / re-read.
+    // Both the signal wait and the Duration blocker must be parked before the
+    // Resume — the blocker is a timer wait (not a signal wait), so the Resume
+    // arms only the signal wait, leaving the blocker holding the loop open.
+    await_n_parked(&mut events_rx, 2).await;
+
+    // Resume wins: it self-arms the signal wait for completion and Phase-0b
+    // completes it on the main port. The signal wait's original timeout entry
+    // remains on the heap until purged / re-read.
     dispatch
         .dispatch_resume(
             &nebula_engine::store_seam::single_tenant_scope(),
@@ -975,20 +1272,39 @@ async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
         .await
         .expect("dispatch_resume must deliver to the live loop");
 
+    // Sleep past the signal wait's stale deadline WHILE THE LOOP IS STILL ALIVE
+    // (the blocker is still parked). The stale entry pops in the live loop here.
+    tokio::time::sleep(timeout + Duration::from_millis(80)).await;
+
+    // The drive must still be running (the blocker keeps it alive) — this is
+    // what makes the stale pop happen in a live loop, not after teardown.
+    assert!(
+        !task.is_finished(),
+        "the blocker must keep the frontier loop alive past the stale timeout deadline"
+    );
+    // The stale timeout did NOT re-route the error branch: the main completion
+    // ran exactly once and the error branch never did.
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        1,
+        "the Resume completion must route the MAIN branch exactly once"
+    );
+    assert_eq!(
+        error_count.load(Ordering::SeqCst),
+        0,
+        "the stale timeout must NOT re-route the error branch in the live loop"
+    );
+
+    // Release the loop: let the blocker's Duration elapse so the execution
+    // settles. (No external signal — the blocker completes on its own timer.)
     let result = tokio::time::timeout(Duration::from_secs(5), task)
         .await
-        .expect("execution must complete after the Resume")
+        .expect("execution must settle once the blocker's Duration elapses")
         .unwrap()
         .unwrap();
 
-    // The drive returned because the Resume completed the node. The original
-    // timeout deadline has, by construction, passed (the drive ran longer than
-    // 120ms is not guaranteed, so sleep to be sure the stale wall-clock deadline
-    // is in the past, then confirm no late routing could have fired).
-    tokio::time::sleep(timeout + Duration::from_millis(50)).await;
-
-    // Exactly one branch ran — the main completion; the stale timeout never
-    // re-routed the error branch (R2 state re-read turned it into a no-op).
+    // Final state: exactly one branch ran across the whole run, and the
+    // execution reached a single coherent terminal outcome.
     let main_ran = main_count.load(Ordering::SeqCst);
     let error_ran = error_count.load(Ordering::SeqCst);
     assert_eq!(
@@ -999,8 +1315,7 @@ async fn resume_and_timeout_race_reaches_single_terminal_outcome() {
     );
     assert_eq!(
         main_ran, 1,
-        "the Resume completion routes the MAIN branch; the stale timeout must not \
-         re-route the error branch"
+        "the surviving branch must be the main completion"
     );
     assert_eq!(
         result.status,
@@ -1266,4 +1581,299 @@ async fn one_resume_arms_multiple_parallel_signal_timeout_waits() {
         ExecutionStatus::Completed,
         "the execution must reach a terminal Completed status"
     );
+}
+
+// ── P1#1 ack-gating: dispatch_resume acks only after the durable self-arm ─────
+
+/// **W-S2b P1#1 — `dispatch_resume` acks ONLY after the self-arm checkpoint
+/// durably lands.**
+///
+/// When `dispatch_resume` returns `Ok` for a live `Running` execution, the
+/// self-arm MUST already be durable: a re-read of the persisted row shows the
+/// wait node armed (`wait_wake = Completion`, `next_attempt_at = Some`). The ack
+/// is gated on the loop's durable reply, so the arm cannot still be in flight.
+///
+/// **Falsifiability**: revert to the old notify-then-`Ok` path (ack at notify,
+/// before the loop wakes and checkpoints) → `dispatch_resume` returns `Ok`
+/// before the arm is durable → the immediate re-read finds the node still
+/// `wait_wake = Timeout` (unarmed) → the assertion flips → RED.
+#[tokio::test]
+async fn resume_acks_only_after_successful_checkpoint() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    // Long timeout: the only way the node arms is the Resume, never a timeout.
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = EngineControlDispatch::new(Arc::clone(&engine), stores.execution.clone());
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+
+    dispatch
+        .dispatch_resume(
+            &nebula_engine::store_seam::single_tenant_scope(),
+            execution_id,
+        )
+        .await
+        .expect("dispatch_resume on a live Running execution must succeed");
+
+    // The ack returned — therefore the self-arm checkpoint is DURABLE. Re-read
+    // the persisted row: NO node may still be the UNARMED signal+timeout wait
+    // (`Waiting` with `wait_wake = Timeout`). The arm flipped it to `Completion`
+    // before the ack, and Phase-0b may have already drained it to `Completed`;
+    // both prove the arm was durable when dispatch_resume returned. The old
+    // notify-then-Ok path acked before the loop woke, leaving the node still
+    // `Waiting` / `Timeout` here.
+    let state = stores.load_state(execution_id).await;
+    let still_unarmed = state.node_states.values().any(|ns| {
+        ns.state == nebula_workflow::NodeState::Waiting
+            && ns.wait_wake == Some(nebula_execution::state::WaitWake::Timeout)
+    });
+    assert!(
+        !still_unarmed,
+        "dispatch_resume returned Ok, so no node may still be the unarmed \
+         (Waiting, Timeout) wait — the self-arm must be durable; node_states: {:?}",
+        state
+            .node_states
+            .values()
+            .map(|ns| (ns.state, ns.wait_wake))
+            .collect::<Vec<_>>()
+    );
+    // The wait node must be armed-for-completion or already completed — never
+    // failed (a timeout) and never still unarmed.
+    let arm_durable = state.node_states.values().any(|ns| {
+        (ns.state == nebula_workflow::NodeState::Waiting
+            && ns.wait_wake == Some(nebula_execution::state::WaitWake::Completion))
+            || ns.state == nebula_workflow::NodeState::Completed
+    });
+    assert!(
+        arm_durable,
+        "the wait node must be armed (Waiting/Completion) or already Completed; node_states: {:?}",
+        state
+            .node_states
+            .values()
+            .map(|ns| (ns.state, ns.wait_wake))
+            .collect::<Vec<_>>()
+    );
+
+    // Let the armed wait drain to completion so the execution settles.
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("the armed wait must complete the execution")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.status, ExecutionStatus::Completed);
+    assert_eq!(main_count.load(Ordering::SeqCst), 1);
+    assert_eq!(error_count.load(Ordering::SeqCst), 0);
+}
+
+/// **W-S2b P1#1 — a fenced-out self-arm checkpoint defers (does NOT ack).**
+///
+/// When the live loop's self-arm checkpoint is FENCED (the loop lost its lease
+/// mid-iteration), the loop replies `ArmFailed`; `dispatch_resume` must return
+/// `Deferred` (NOT `Ok`), emit a `ResumeDeferred` event, and the wait node must
+/// NOT complete on the main port — the arm did not durably land, so the Resume
+/// is left for B1 reclaim.
+///
+/// **Falsifiability**: revert to the code that acked regardless of the
+/// checkpoint result → `dispatch_resume` returns `Ok` despite the fenced arm →
+/// the `Deferred` assertion flips → RED.
+#[tokio::test]
+async fn fenced_out_self_arm_sends_arm_failed_then_deferred() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    // Build stores with a fence-injecting execution store. The journal reads the
+    // SAME inner store, so status reads agree across the wrapper.
+    let inner = Arc::new(InMemoryExecutionStore::new());
+    let fenced = Arc::new(FenceArmStore::new(Arc::clone(&inner)));
+    let journal = Arc::new(nebula_storage::InMemoryJournalReader::new(&inner));
+    let versions = Arc::new(InMemoryWorkflowVersionStore::new());
+    let workflow = Arc::new(nebula_storage::InMemoryWorkflowStore::new_with_versions(
+        &versions,
+    ));
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let engine = Arc::new(
+        make_engine(registry)
+            .with_event_bus(event_bus)
+            .with_execution_stores(nebula_engine::ExecutionStores {
+                execution: Arc::clone(&fenced) as Arc<dyn ExecutionStore>,
+                journal,
+                node_results: Arc::new(nebula_storage::InMemoryNodeResultStore::new()),
+                checkpoints: Arc::new(nebula_storage::InMemoryCheckpointStore::new()),
+                idempotency: Arc::new(nebula_storage::InMemoryIdempotencyGuard::new()),
+            })
+            .with_workflow_stores(nebula_engine::WorkflowStores {
+                workflow: workflow as Arc<dyn WorkflowStore>,
+                versions: Arc::clone(&versions) as Arc<dyn WorkflowVersionStore>,
+            }),
+    );
+    let dispatch = EngineControlDispatch::new(
+        Arc::clone(&engine),
+        Arc::clone(&fenced) as Arc<dyn ExecutionStore>,
+    );
+
+    // Persist + save the workflow through the same scope the engine reads.
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    versions
+        .create(
+            &scope,
+            WorkflowVersionRecord {
+                workflow_id: wf.id.to_string(),
+                number: 0,
+                published: true,
+                pinned: false,
+                definition: serde_json::to_value(&wf).unwrap(),
+            },
+        )
+        .await
+        .unwrap();
+    let execution_id = ExecutionId::new();
+    {
+        let mut exec_state = ExecutionState::new(execution_id, wf.id, &[]);
+        exec_state.set_workflow_input(serde_json::json!(null));
+        fenced
+            .create(
+                &scope,
+                &execution_id.to_string(),
+                &wf.id.to_string(),
+                serde_json::to_value(&exec_state).unwrap(),
+            )
+            .await
+            .unwrap();
+    }
+
+    let engine_h = Arc::clone(&engine);
+    let drive_scope = scope.clone();
+    let task =
+        tokio::spawn(async move { engine_h.resume_execution(&drive_scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+
+    // Arm the fence so the NEXT commit (the self-arm checkpoint) reports
+    // FencedOut. The park checkpoint already landed before `NodeParked`.
+    fenced.arm_fence();
+
+    let dispatch_outcome = dispatch.dispatch_resume(&scope, execution_id).await;
+    assert!(
+        matches!(
+            dispatch_outcome,
+            Err(nebula_engine::ControlDispatchError::Deferred(_))
+        ),
+        "a fenced self-arm must defer the Resume, not ack it; got {dispatch_outcome:?}"
+    );
+
+    // A ResumeDeferred event is emitted with the fenced reason.
+    let reason = await_resume_deferred(&mut events_rx).await;
+    assert!(
+        reason.contains("self-arm") || reason.contains("checkpoint"),
+        "the ResumeDeferred reason must name the failed self-arm; got: {reason}"
+    );
+
+    // The fenced arm aborts the frontier (the loop returns). The wait node never
+    // completed on the main port.
+    let _ = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("the fenced frontier must wind down within 5s");
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        0,
+        "a fenced self-arm must NOT complete the wait on the main port"
+    );
+}
+
+/// **W-S2b P1#1 — two concurrent Resumes to the same parked node: one arms it
+/// (`Armed`), the other finds no signal-Waiting node and returns `NothingToArm`.**
+///
+/// Both dispatches reach the live `ResumeSignalled` arm in the frontier loop while
+/// the execution is `Running`.  The channel is bounded to 8, so both sends land
+/// before the loop consumes them.  The first one the loop processes arms the wait;
+/// the second finds `to_arm.is_empty()` → `NothingToArm` → `Ok(())`.  This is the
+/// genuine idempotent live-loop no-op path — the `ResumeSignalled` arm, not the
+/// terminal short-circuit that fires when the execution has already settled.
+///
+/// **Falsifiability**: make the live loop re-arm an already-armed/absent wait and
+/// route it again → `main_count == 2` → the `== 1` assertion flips → RED.
+#[tokio::test]
+async fn duplicate_resume_to_armed_node_is_noop() {
+    let main_count = Arc::new(AtomicU32::new(0));
+    let error_count = Arc::new(AtomicU32::new(0));
+    let timeout = Duration::from_hours(1);
+    let registry = build_registry(timeout, &main_count, &error_count);
+
+    let event_bus = nebula_eventbus::EventBus::<ExecutionEvent>::new(64);
+    let mut events_rx = event_bus.subscribe();
+    let stores = WtStores::new();
+    let engine = Arc::new(stores.attach(make_engine(registry).with_event_bus(event_bus)));
+    let dispatch = Arc::new(EngineControlDispatch::new(
+        Arc::clone(&engine),
+        stores.execution.clone(),
+    ));
+
+    let wf = make_workflow(/* with_error_port */ true, timeout);
+    stores.save_workflow(&wf).await;
+    let execution_id = stores.persist_created_execution(wf.id).await;
+
+    let engine_h = Arc::clone(&engine);
+    let scope = nebula_engine::store_seam::single_tenant_scope();
+    let task = tokio::spawn(async move { engine_h.resume_execution(&scope, execution_id).await });
+    await_parked(&mut events_rx).await;
+
+    // Issue two Resumes CONCURRENTLY while the execution is live and parked.
+    // Both sends land in the channel (capacity 8) before the loop processes
+    // either.  The first one the loop picks up arms the wait; the second finds
+    // `to_arm.is_empty()` (the node is no longer signal-Waiting) → `NothingToArm`
+    // → `Ok(())`.  Both return `Ok`: the first as `Armed`, the second as the
+    // idempotent live-loop no-op.
+    let dispatch_a = Arc::clone(&dispatch);
+    let dispatch_b = Arc::clone(&dispatch);
+    let (out_a, out_b) = tokio::join!(
+        async move {
+            dispatch_a
+                .dispatch_resume(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    execution_id,
+                )
+                .await
+        },
+        async move {
+            dispatch_b
+                .dispatch_resume(
+                    &nebula_engine::store_seam::single_tenant_scope(),
+                    execution_id,
+                )
+                .await
+        },
+    );
+    out_a.expect("first concurrent dispatch_resume must succeed");
+    out_b.expect("second concurrent dispatch_resume must succeed (NothingToArm)");
+
+    // Now let the frontier run to completion.
+    let result = tokio::time::timeout(Duration::from_secs(5), task)
+        .await
+        .expect("the armed wait must complete the execution")
+        .unwrap()
+        .unwrap();
+    assert_eq!(result.status, ExecutionStatus::Completed);
+    assert_eq!(
+        main_count.load(Ordering::SeqCst),
+        1,
+        "two concurrent Resumes must not double-route the downstream — main runs exactly once"
+    );
+    let _ = events_rx;
 }

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -46,6 +46,35 @@ pub enum AttemptOutcome {
     },
 }
 
+/// How a parked [`NodeState::Waiting`] node's timer wake should be
+/// interpreted when it fires.
+///
+/// A `Waiting` node carries an optional `next_attempt_at` timer (see
+/// [`NodeExecutionState::next_attempt_at`]). The timer alone cannot say
+/// *what the wake means*: a timer-driven wait (`Until` / `Duration`) and a
+/// satisfied signal wait both wake to **complete** the node, whereas a
+/// signal wait that was parked with an explicit `timeout` wakes to **fail**
+/// the node (the external signal never arrived in time). This enum is that
+/// missing discriminator, persisted alongside the timer so the wake's
+/// meaning survives a crash + recovery.
+///
+/// Extensible by design (not a `bool`): future wait-bearing kinds
+/// (Interactive / Delay / Agent-HITL) reuse the same park/resume machinery
+/// and may introduce further wake semantics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WaitWake {
+    /// The timer wake completes the node (`Waiting → Completed`) and
+    /// activates its `main`-port downstream edges. Used by timer-driven
+    /// waits (`Until` / `Duration`) and by a signal wait that an explicit
+    /// Resume has armed for completion.
+    Completion,
+    /// The timer wake fails the node (`Waiting → Failed` with
+    /// `RuntimeError::WaitTimedOut`) and routes its outgoing edges through
+    /// the failure path. Used by a signal wait parked with an explicit
+    /// `timeout` whose deadline elapsed before a Resume arrived.
+    Timeout,
+}
+
 /// The execution state of a single node within a running workflow.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NodeExecutionState {
@@ -90,6 +119,27 @@ pub struct NodeExecutionState {
     /// retry-exhausted policy).
     #[serde(default)]
     pub next_attempt_at: Option<DateTime<Utc>>,
+    /// How this node's parked-wait timer wake should be interpreted when it
+    /// fires — see [`WaitWake`].
+    ///
+    /// Paired with [`next_attempt_at`](Self::next_attempt_at): `wait_wake`
+    /// is `Some(_)` exactly when the node is parked with a timer wake
+    /// (`next_attempt_at.is_some()`), and `None` for a signal-only park (no
+    /// timer) or any non-`Waiting` state. [`park_node`] enforces the
+    /// `wait_wake.is_some() == wake_at.is_some()` invariant.
+    ///
+    /// `Completion` (or legacy `None` on an armed timer wait) drives the
+    /// wake through the completion path; `Timeout` drives it through the
+    /// failure path (a signal wait whose `timeout` elapsed).
+    ///
+    /// Forward-compat: legacy persisted states that predate this field
+    /// deserialize as `None`. A `None` on a still-`Waiting{Some}` timer node
+    /// is read as `Completion` — preserving W-S1 timer-wake semantics for
+    /// rows written before W-S2b.
+    ///
+    /// [`park_node`]: ExecutionState::park_node
+    #[serde(default)]
+    pub wait_wake: Option<WaitWake>,
 }
 
 impl NodeExecutionState {
@@ -105,6 +155,7 @@ impl NodeExecutionState {
             completed_at: None,
             error_message: None,
             next_attempt_at: None,
+            wait_wake: None,
         }
     }
 
@@ -163,6 +214,53 @@ impl NodeExecutionState {
                 to: NodeState::Running.to_string(),
             }),
         }
+    }
+
+    /// Arm a parked signal wait for **completion**: stamp the timer wake at
+    /// `when` and record [`WaitWake::Completion`] so the next Phase-0b drain
+    /// transitions the node `Waiting → Completed` on its main port.
+    ///
+    /// Writes the (`next_attempt_at`, `wait_wake`) pair together so the
+    /// `next_attempt_at.is_some() == wait_wake.is_some()` invariant cannot
+    /// drift — the same invariant [`ExecutionState::park_node`] asserts on the
+    /// park path. The node state and version are NOT touched here; the caller
+    /// leaves the node `Waiting` and bumps the execution version through the
+    /// checkpoint that commits the arm.
+    ///
+    /// The two fields cannot be merged into one to make desync structurally
+    /// impossible because `next_attempt_at` is also the retry-wake instant for
+    /// a `WaitingRetry` node (where no `wait_wake` applies). Pairing every write
+    /// behind this method is the next-best guard.
+    ///
+    /// [`WaitWake::Completion`]: WaitWake::Completion
+    /// [`ExecutionState::park_node`]: ExecutionState::park_node
+    pub fn arm_wait_completion(&mut self, when: DateTime<Utc>) {
+        self.next_attempt_at = Some(when);
+        self.wait_wake = Some(WaitWake::Completion);
+        debug_assert_eq!(
+            self.next_attempt_at.is_some(),
+            self.wait_wake.is_some(),
+            "arm_wait_completion must leave next_attempt_at and wait_wake both Some"
+        );
+    }
+
+    /// Clear a parked wait's timer fields after the wake has been resolved
+    /// (the node completed or timed out): drop both `next_attempt_at` and
+    /// `wait_wake` so a later terminal state carries no contradictory wake
+    /// metadata.
+    ///
+    /// Apply this only on the wait-cleanup paths (a resolved `Waiting` node).
+    /// It must NOT be used on a `WaitingRetry` node: there `next_attempt_at` is
+    /// the retry-wake instant and `wait_wake` is legitimately `None`, so
+    /// clearing the pair here would assert and would erase a live retry timer.
+    pub fn clear_wait_timer(&mut self) {
+        self.next_attempt_at = None;
+        self.wait_wake = None;
+        debug_assert_eq!(
+            self.next_attempt_at.is_some(),
+            self.wait_wake.is_some(),
+            "clear_wait_timer must leave next_attempt_at and wait_wake both None"
+        );
     }
 }
 
@@ -597,9 +695,20 @@ impl ExecutionState {
     /// Park a node that returned `ActionResult::Wait`.
     ///
     /// Promotes `Running → Waiting`, stamps `next_attempt_at` with the
-    /// timer wake instant (or clears it when no timer applies), and
-    /// bumps the execution version. Mirrors [`schedule_node_retry`] for
+    /// timer wake instant (or clears it when no timer applies), records
+    /// the wake discriminator [`wait_wake`](NodeExecutionState::wait_wake),
+    /// and bumps the execution version. Mirrors [`schedule_node_retry`] for
     /// the wait-park path.
+    ///
+    /// # Invariant
+    ///
+    /// `wait_wake.is_some() == wake_at.is_some()`. A timer wake (`wake_at`
+    /// `Some`) must declare what the wake means ([`WaitWake::Completion`]
+    /// for a timer-driven or armed-signal wait, [`WaitWake::Timeout`] for a
+    /// signal wait whose `timeout` is the wake), and a signal-only park (no
+    /// timer) must carry `None` (it is satisfied by a Resume, not a timer).
+    /// Enforced by a `debug_assert!`; callers within this crate are the sole
+    /// writers of the (`next_attempt_at`, `wait_wake`) pair.
     ///
     /// The caller is responsible for:
     /// - Persisting the node's `partial_output` through the normal
@@ -609,9 +718,9 @@ impl ExecutionState {
     ///   when `wake_at` is `Some` — that is the source of truth for
     ///   timer-driven wakes.
     ///
-    /// On success both the per-node `Running → Waiting` transition and
-    /// the `next_attempt_at` stamp are reflected in `version`. On `Err`
-    /// the state is left untouched.
+    /// On success the per-node `Running → Waiting` transition, the
+    /// `next_attempt_at` stamp, and the `wait_wake` discriminator are all
+    /// reflected in `version`. On `Err` the state is left untouched.
     ///
     /// # Errors
     /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
@@ -623,19 +732,28 @@ impl ExecutionState {
         &mut self,
         node_key: NodeKey,
         wake_at: Option<DateTime<Utc>>,
+        wait_wake: Option<WaitWake>,
     ) -> Result<(), ExecutionError> {
+        debug_assert_eq!(
+            wait_wake.is_some(),
+            wake_at.is_some(),
+            "park_node invariant: wait_wake must be Some iff a timer wake_at is present \
+             (timer waits declare a wake meaning; signal-only parks carry neither)"
+        );
         self.transition_node(node_key.clone(), NodeState::Waiting)?;
         // Stamp or clear the wake instant. `Waiting` with `wake_at ==
         // None` means the park is signal-driven (webhook/approval/
-        // execution): only an explicit Resume will satisfy the condition.
-        // Stale failure metadata is cleared for the same reason
-        // `schedule_node_retry` clears it — a later `Completed`
+        // execution) with no timeout: only an explicit Resume will satisfy
+        // the condition. `wait_wake` records how a timer wake (if any) is to
+        // be read when it fires. Stale failure metadata is cleared for the
+        // same reason `schedule_node_retry` clears it — a later `Completed`
         // transition must not carry contradictory persisted fields.
         let ns = self
             .node_states
             .get_mut(&node_key)
             .ok_or(ExecutionError::NodeNotFound(node_key))?;
         ns.next_attempt_at = wake_at;
+        ns.wait_wake = wait_wake;
         ns.error_message = None;
         ns.completed_at = None;
         self.version += 1;
@@ -840,6 +958,7 @@ impl ExecutionState {
             self.transition_node(node_key.clone(), NodeState::Cancelled)?;
             if let Some(ns) = self.node_states.get_mut(&node_key) {
                 ns.next_attempt_at = None;
+                ns.wait_wake = None;
             }
         }
         Ok(count)
@@ -1671,6 +1790,143 @@ mod tests {
         });
         let ns: NodeExecutionState = serde_json::from_value(legacy).unwrap();
         assert!(ns.next_attempt_at.is_none());
+    }
+
+    /// W-S2b — `park_node` stamps the (`next_attempt_at`, `wait_wake`) pair
+    /// together. A timer wake parked with `WaitWake::Timeout` records both
+    /// the deadline and the timeout discriminator so a post-crash recovery
+    /// reads the wake as a failure, not a completion.
+    ///
+    /// **Falsifiability**: drop the `wait_wake` field write from `park_node`
+    /// → `back.wait_wake` is `None` not `Some(Timeout)` → the assert fails.
+    #[test]
+    fn park_node_sets_wait_wake() {
+        let (mut state, n1, _n2) = make_state();
+        // Drive n1 to Running so the `Running → Waiting` park edge is legal.
+        state.start_node_attempt(n1.clone()).unwrap();
+
+        let wake_at = Utc::now() + chrono::Duration::seconds(30);
+        state
+            .park_node(n1.clone(), Some(wake_at), Some(WaitWake::Timeout))
+            .expect("Running → Waiting park must succeed");
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::Waiting);
+        assert_eq!(ns.next_attempt_at, Some(wake_at));
+        assert_eq!(
+            ns.wait_wake,
+            Some(WaitWake::Timeout),
+            "park_node must record the Timeout wake discriminator alongside the timer"
+        );
+    }
+
+    /// W-S2b — a signal-only park (no timer) carries neither a wake instant
+    /// nor a `wait_wake` discriminator. This is the case-a path: the node is
+    /// satisfied by an explicit Resume, never by a timer.
+    #[test]
+    fn park_node_signal_only_has_no_wait_wake() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+
+        state
+            .park_node(n1.clone(), None, None)
+            .expect("Running → Waiting signal-only park must succeed");
+
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(ns.state, NodeState::Waiting);
+        assert!(ns.next_attempt_at.is_none());
+        assert!(
+            ns.wait_wake.is_none(),
+            "a signal-only park must not carry a wake discriminator"
+        );
+    }
+
+    /// W-S2b — `wait_wake` round-trips through serde, and a legacy
+    /// `NodeExecutionState` JSON that predates the field deserializes as
+    /// `None` (read by the engine as `Completion` for an armed timer wait,
+    /// preserving W-S1 timer-wake semantics).
+    ///
+    /// **Falsifiability**: drop `#[serde(default)]` from `wait_wake` → the
+    /// legacy-JSON `from_value` errors (missing field) → the test panics.
+    #[test]
+    fn wait_wake_serde_roundtrip_and_legacy_default() {
+        // Round-trip a `Some(Timeout)`.
+        let mut ns = NodeExecutionState::new();
+        ns.wait_wake = Some(WaitWake::Timeout);
+        let json = serde_json::to_string(&ns).unwrap();
+        let back: NodeExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            back.wait_wake,
+            Some(WaitWake::Timeout),
+            "wait_wake must survive a serde roundtrip"
+        );
+
+        // Round-trip a `Some(Completion)`.
+        ns.wait_wake = Some(WaitWake::Completion);
+        let json = serde_json::to_string(&ns).unwrap();
+        let back: NodeExecutionState = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.wait_wake, Some(WaitWake::Completion));
+
+        // Legacy JSON without the field deserializes as `None`.
+        let legacy = serde_json::json!({
+            "state": "waiting",
+            "attempts": [],
+            "next_attempt_at": Utc::now(),
+        });
+        let ns: NodeExecutionState = serde_json::from_value(legacy).unwrap();
+        assert!(
+            ns.wait_wake.is_none(),
+            "legacy rows without wait_wake must deserialize as None"
+        );
+    }
+
+    /// W-S2b — `arm_wait_completion` and `clear_wait_timer` write the
+    /// (`next_attempt_at`, `wait_wake`) pair together, keeping the
+    /// `next_attempt_at.is_some() == wait_wake.is_some()` invariant the engine's
+    /// signal-wait routing relies on. These methods are the single paired-write
+    /// entry points the engine calls instead of touching the two fields raw, so
+    /// a future edit cannot desync them.
+    ///
+    /// **Falsifiability**: drop the `wait_wake` write from `arm_wait_completion`
+    /// → the `wait_wake == Some(Completion)` assert fails; drop the
+    /// `next_attempt_at` clear from `clear_wait_timer` → the `is_none` assert
+    /// fails.
+    #[test]
+    fn arm_and_clear_wait_timer_write_the_pair_together() {
+        let when = Utc::now();
+        let mut ns = NodeExecutionState::new();
+
+        ns.arm_wait_completion(when);
+        assert_eq!(
+            ns.next_attempt_at,
+            Some(when),
+            "arm must stamp the wake instant"
+        );
+        assert_eq!(
+            ns.wait_wake,
+            Some(WaitWake::Completion),
+            "arm must record the Completion discriminator"
+        );
+        assert_eq!(
+            ns.next_attempt_at.is_some(),
+            ns.wait_wake.is_some(),
+            "armed pair must satisfy the next_attempt_at/wait_wake invariant"
+        );
+
+        ns.clear_wait_timer();
+        assert!(
+            ns.next_attempt_at.is_none(),
+            "clear must drop the wake instant"
+        );
+        assert!(
+            ns.wait_wake.is_none(),
+            "clear must drop the wake discriminator"
+        );
+        assert_eq!(
+            ns.next_attempt_at.is_some(),
+            ns.wait_wake.is_some(),
+            "cleared pair must satisfy the next_attempt_at/wait_wake invariant"
+        );
     }
 
     /// `total_retries` round-trips and starts

--- a/crates/execution/src/state.rs
+++ b/crates/execution/src/state.rs
@@ -707,8 +707,11 @@ impl ExecutionState {
     /// for a timer-driven or armed-signal wait, [`WaitWake::Timeout`] for a
     /// signal wait whose `timeout` is the wake), and a signal-only park (no
     /// timer) must carry `None` (it is satisfied by a Resume, not a timer).
-    /// Enforced by a `debug_assert!`; callers within this crate are the sole
-    /// writers of the (`next_attempt_at`, `wait_wake`) pair.
+    /// `park_node` is the sole caller-facing writer of the
+    /// (`next_attempt_at`, `wait_wake`) pair, and it takes both from the
+    /// caller — so the pairing is enforced as a fallible runtime guard (not a
+    /// `debug_assert!`): a `Some(wake_at), None` desync would turn a timeout
+    /// into a completion, which is load-bearing rather than a debug-only check.
     ///
     /// The caller is responsible for:
     /// - Persisting the node's `partial_output` through the normal
@@ -723,6 +726,9 @@ impl ExecutionState {
     /// reflected in `version`. On `Err` the state is left untouched.
     ///
     /// # Errors
+    /// - [`ExecutionError::InvalidTransition`] if the (`wake_at`, `wait_wake`)
+    ///   pair is not both-`Some` or both-`None` — checked before any mutation,
+    ///   so a desync leaves the state untouched.
     /// - [`ExecutionError::NodeNotFound`] if `node_key` is unknown.
     /// - [`ExecutionError::InvalidTransition`] if the node is not in `Running`
     ///   (the engine may only call this immediately after dispatching the action).
@@ -734,12 +740,21 @@ impl ExecutionState {
         wake_at: Option<DateTime<Utc>>,
         wait_wake: Option<WaitWake>,
     ) -> Result<(), ExecutionError> {
-        debug_assert_eq!(
-            wait_wake.is_some(),
-            wake_at.is_some(),
-            "park_node invariant: wait_wake must be Some iff a timer wake_at is present \
-             (timer waits declare a wake meaning; signal-only parks carry neither)"
-        );
+        // Enforce the wake pairing BEFORE any mutation. A `Some(wake_at),
+        // None` (or the inverse) desync would persist a timer wake with no
+        // declared meaning — silently turning a timeout into a completion (or
+        // a completion into a timer with no deadline). The caller supplies
+        // both fields, so this is a real input-validation guard, not a
+        // surrounding-code invariant a `debug_assert!` may elide in release.
+        if wait_wake.is_some() != wake_at.is_some() {
+            return Err(ExecutionError::InvalidTransition {
+                from: self
+                    .node_states
+                    .get(&node_key)
+                    .map_or_else(|| NodeState::Running.to_string(), |ns| ns.state.to_string()),
+                to: "Waiting (wait_wake/wake_at must be paired)".to_owned(),
+            });
+        }
         self.transition_node(node_key.clone(), NodeState::Waiting)?;
         // Stamp or clear the wake instant. `Waiting` with `wake_at ==
         // None` means the park is signal-driven (webhook/approval/
@@ -1839,6 +1854,49 @@ mod tests {
             ns.wait_wake.is_none(),
             "a signal-only park must not carry a wake discriminator"
         );
+    }
+
+    /// W-S2b — `park_node` REJECTS a desynced (`wake_at`, `wait_wake`) pair
+    /// with a typed error and leaves the node untouched. A `Some(wake_at),
+    /// None` (or the inverse) would persist a timer wake with no declared
+    /// meaning — silently turning a timeout into a completion — so the pairing
+    /// is a load-bearing runtime guard, not a debug-only assert.
+    ///
+    /// **Falsifiability**: replace the runtime guard with the old
+    /// `debug_assert_eq!` → in a release/`cargo test --release` build the
+    /// desync slips through, `park_node` returns `Ok`, the node becomes
+    /// `Waiting` with a `Some(wake_at), None` desync → both asserts flip.
+    #[test]
+    fn park_node_rejects_wake_pairing_desync() {
+        let (mut state, n1, _n2) = make_state();
+        state.start_node_attempt(n1.clone()).unwrap();
+        let wake_at = Utc::now() + chrono::Duration::seconds(30);
+
+        // wake_at without a wait_wake meaning is a desync — must be rejected.
+        let err = state
+            .park_node(n1.clone(), Some(wake_at), None)
+            .expect_err("a Some(wake_at), None park must be rejected");
+        assert!(
+            matches!(err, ExecutionError::InvalidTransition { .. }),
+            "the desync must surface as a typed InvalidTransition, got {err:?}"
+        );
+
+        // The inverse desync (wait_wake without a timer) is equally rejected.
+        let err = state
+            .park_node(n1.clone(), None, Some(WaitWake::Timeout))
+            .expect_err("a None, Some(wait_wake) park must be rejected");
+        assert!(matches!(err, ExecutionError::InvalidTransition { .. }));
+
+        // The guard ran before any mutation: the node is still Running, never
+        // parked, and carries no stale wake metadata.
+        let ns = state.node_state(n1).unwrap();
+        assert_eq!(
+            ns.state,
+            NodeState::Running,
+            "a rejected park must leave the node untouched (still Running)"
+        );
+        assert!(ns.next_attempt_at.is_none());
+        assert!(ns.wait_wake.is_none());
     }
 
     /// W-S2b — `wait_wake` round-trips through serde, and a legacy

--- a/crates/execution/src/transition.rs
+++ b/crates/execution/src/transition.rs
@@ -62,13 +62,17 @@ pub fn validate_execution_transition(
 /// attempt's failure is already recorded in `NodeAttempt`.
 ///
 /// The wait-park edges (`Running → Waiting`, `Waiting → Completed`,
-/// `Waiting → Cancelled`) implement the durable park path: when an
-/// action returns `ActionResult::Wait`, the engine parks the node
-/// (`Running → Waiting`), releasing the worker and gating downstream
-/// edges until the wait condition is satisfied. Once the condition
-/// fires the engine transitions directly to `Completed` (`Waiting →
-/// Completed`) and activates downstream. A shutdown/cancel during the
-/// wait goes to `Cancelled` (`Waiting → Cancelled`).
+/// `Waiting → Failed`, `Waiting → Cancelled`) implement the durable park
+/// path: when an action returns `ActionResult::Wait`, the engine parks the
+/// node (`Running → Waiting`), releasing the worker and gating downstream
+/// edges until the wait condition is satisfied. Once the condition fires
+/// the engine transitions directly to `Completed` (`Waiting → Completed`)
+/// and activates downstream. A signal wait parked with an explicit
+/// `timeout` whose deadline elapses fails the node (`Waiting → Failed` with
+/// `RuntimeError::WaitTimedOut`) and routes its outgoing edges through the
+/// failure path — the explicit failure reason the `Waiting → Failed` edge
+/// requires (ADR-0099 W-S2b addendum). A shutdown/cancel during the wait
+/// goes to `Cancelled` (`Waiting → Cancelled`).
 #[must_use]
 pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
     matches!(
@@ -90,7 +94,7 @@ pub fn can_transition_node(from: NodeState, to: NodeState) -> bool {
             NodeState::Ready | NodeState::Cancelled
         ) | (
             NodeState::Waiting,
-            NodeState::Completed | NodeState::Cancelled
+            NodeState::Completed | NodeState::Failed | NodeState::Cancelled
         )
     )
 }
@@ -383,12 +387,17 @@ mod tests {
     }
 
     /// Illegal edges from `Waiting` must be rejected: the engine
-    /// must not be able to re-run a parked node (`Waiting → Running`)
-    /// or collapse it to `Failed` without an explicit failure reason.
+    /// must not be able to re-run a parked node (`Waiting → Running`),
+    /// re-queue it (`Waiting → Ready`), or push it onto the retry heap
+    /// (`Waiting → WaitingRetry`).
+    ///
+    /// Note: `Waiting → Failed` is now a **legal** edge (ADR-0099 W-S2b —
+    /// signal-wait timeout-as-failure supplies the explicit failure reason
+    /// the previous rejection demanded). See
+    /// [`waiting_can_transition_to_failed_on_timeout`].
     #[test]
     fn waiting_cannot_transition_to_illegal_states() {
         assert!(!can_transition_node(NodeState::Waiting, NodeState::Running));
-        assert!(!can_transition_node(NodeState::Waiting, NodeState::Failed));
         assert!(!can_transition_node(NodeState::Waiting, NodeState::Ready));
         assert!(!can_transition_node(
             NodeState::Waiting,
@@ -396,6 +405,17 @@ mod tests {
         ));
         // Self-loop is not a valid transition.
         assert!(!can_transition_node(NodeState::Waiting, NodeState::Waiting));
+    }
+
+    /// `Waiting → Failed` is the timeout-as-failure edge (ADR-0099 W-S2b):
+    /// a signal wait parked with an explicit `timeout` whose deadline
+    /// elapses fails the node with `RuntimeError::WaitTimedOut` — the
+    /// explicit failure reason that reverses the prior `Waiting → Failed`
+    /// rejection. The engine then routes the node's outgoing edges through
+    /// the failure path (OnError / Skip / FailFast).
+    #[test]
+    fn waiting_can_transition_to_failed_on_timeout() {
+        assert!(can_transition_node(NodeState::Waiting, NodeState::Failed));
     }
 
     /// `Completed → Waiting` must be rejected — a completed node


### PR DESCRIPTION
## What

ADR-0099 wait-state engine, phase **W-S2b** — the Running-execution counterpart to W-S2 case-a (#856). A signal-driven `WaitCondition` (`Webhook`/`Approval`/`Execution`) **with `timeout: Some(dur)`** was rejected by the park branch; it now parks, keeps the execution `Running` on a timeout timer, and resolves either way:

- **timeout fires** → the wait **fails** (routes the node's error port), or
- **a Resume arrives in time** → the wait **completes** (main port) and the timer is rendered inert.

## Three coupled pieces

1. **Persisted discriminator** — `WaitWake { Completion, Timeout }` as `#[serde(default)] Option<WaitWake>` on `NodeExecutionState` (JSONB blob, **no SQL migration**; legacy rows read `None` ⇒ `Completion`, preserving W-S1 semantics). Paired with `next_attempt_at` via `arm_wait_completion` / `clear_wait_timer` helpers that `debug_assert` the `next_attempt_at.is_some() == wait_wake.is_some()` invariant at every write site (the two fields can't merge — `next_attempt_at` is shared with `WaitingRetry`).

2. **Timeout-as-failure** — signal+timeout parks `wake_at = now+timeout`, `wait_wake = Timeout`, stays `Running` (timer on `wait_heap`). Phase-0b re-reads `wait_wake` from live state **after** the pop (race-safe): `Timeout` ⇒ `mark_node_failed(RuntimeError::WaitTimedOut)` ⇒ reuse `route_failure_edges(Fail, ..)` ⇒ emit `NodeWaitTimedOut`. Adds the `Waiting → Failed` transition edge (justified by the explicit timeout reason — **ADR-0099 addendum**). `Fail` not `Recover` is deliberate (a missed approval fails even under `IgnoreErrors`); `retryable = false`, never counts against the retry budget.

3. **Live-frontier resume channel** — a payload-less `Arc<Notify>` (`resume_notify`) on `RunningEntry`; the live `select!` gains a `ResumeSignalled` arm that **self-arms** signal-`Waiting` nodes to `Completion` and checkpoints **under the loop's own lease** — the live loop is the sole writer of its own row, designing out the two-writers-one-row hazard. `dispatch_resume`'s `Running` arm becomes `resume_live` (notify a live frontier, else `Deferred` so the control row stays redeliverable). The Notify one-permit latch makes the wake cancellation-safe; Resume-vs-timeout races resolve to exactly one terminal outcome via the Phase-0b state re-read + heap-entry purge.

## Verification

- **Maintainer pre-code verdict:** ACCEPTABLE (chief-architect), with a mandatory ASYNC-GATE.
- **Reviews:** spec-compliance ✅, code-quality ✅, **ASYNC-GATE** (concurrency-specialist + async-runtime-specialist) ✅ — single-writer-per-live-row invariant verified, Notify cancellation-safety confirmed, Resume-vs-timeout race resolves to one outcome.
- **4-lens final verification** (perf / observability / completeness / crash-recovery): 16 findings, **0 blocking** after independent adjudication; the non-blocking-but-cheap ones (honest `condition_kind` doc/Display, invariant helpers, N>1 self-arm test, contract docs) folded in.
- **Tests:** 8 `wait_timeout` integration tests (timeout→error port; resume→main port + timer cancelled; resume reaches the live loop; crash mid-wait recovers and still times out; crash after durable arm completes; resume/timeout race single outcome; timeout bypasses retry budget; **N>1 parallel self-arm**) + state/transition units. **547 engine+execution tests green** (cargo-verified). Pre-push CI-mirror (nextest, clippy-full, rustdoc `-D warnings`) green.

## Carry-forward (hard requirements for the future inbound-resume transport — all unreachable today; no production `ControlCommand::Resume` producer exists)

- **callback_id targeting** — a Resume must arm only the matching `WaitCondition` (closes the case-a double-satisfy).
- **Ack-gating on the durable self-arm** — `resume_live` returns `Ok` (acking the control row) on `notify_one()` **before** the self-arm checkpoint lands; a Resume producer must gate the ack on the durable arm to avoid an acked-but-not-landed loss across a crash. (Returning `Deferred` for `Running` is **not** a valid fix — it breaks the feature and livelocks.)
- **Cross-runner runner-affinity** — a Resume to a live `Running` exec on the wrong runner is `Deferred`; reclaim has no runner-affinity and would drop it after the reclaim budget. Route to the lease-holder, or exempt cross-runner-Running `Deferred` from the reclaim→Failed budget.

Builds on #856. Durable design record: vault `project_adr0099_wait_state.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Signal-driven wait actions (Webhook, Approval, Execution) now support explicit timeouts.
  * Timeouts now produce a dedicated timed-out wait event and terminal failure routing.
  * Resume signals can be delivered directly to live running executions (with delivery acknowledged before completion).

* **Bug Fixes**
  * Fixed resume/timeout race handling to ensure exactly one terminal outcome.
  * Added explicit support for `Waiting → Failed` on timeout with consistent state transitions.

* **Tests**
  * Added integration coverage for timeout vs resume behavior, crash recovery, and concurrent resume semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->